### PR TITLE
slightly improve squeezed fonts in colorpicker and blender

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -522,10 +522,15 @@ overshoot.right
   margin-left: 2px
 }
 
-/* Adjust add button in picker module */
+/* Adjust add and remove buttons in picker module */
 .picker-module button
 {
-  padding: 0 3px;
+  padding: 0px;
+}
+
+.picker-module label
+{
+  padding-right: 3px;
 }
 
 /* Set history (darkroom) and recent collections (lighttable) modules, that make use of a
@@ -1675,7 +1680,7 @@ cell:selected
 
 #live-sample
 {
-  padding: 2px;
+  padding: 0px;
   min-height: 1em;
   min-width: 3em;
 }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1579,19 +1579,28 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
 
-      GtkWidget *label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      GtkWidget *label_box = gtk_grid_new();
+      gtk_grid_set_column_homogeneous(GTK_GRID(label_box), TRUE);
 
       sl->head = GTK_LABEL(dt_ui_label_new(in_out ? _("output") : _("input")));
-      gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->head), FALSE, FALSE, 0);
+      gtk_grid_attach(GTK_GRID(label_box), GTK_WIDGET(sl->head), 0, 0, 1, 1);
+
+      GtkWidget *overlay = gtk_overlay_new();
+      gtk_grid_attach(GTK_GRID(label_box), overlay, 1, 0, 3, 1);
 
       sl->picker_label = GTK_LABEL(gtk_label_new(""));
-      gtk_label_set_ellipsize(GTK_LABEL(sl->picker_label), PANGO_ELLIPSIZE_END);
-      gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->picker_label), TRUE, TRUE, 0);
+      gtk_widget_set_name(GTK_WIDGET(sl->picker_label), "blend-data");
+      gtk_label_set_xalign(sl->picker_label, .0);
+      gtk_label_set_yalign(sl->picker_label, 1.0);
+      gtk_container_add(GTK_CONTAINER(overlay), GTK_WIDGET(sl->picker_label));
 
       for(int k = 0; k < 4; k++)
       {
-        sl->label[k] = GTK_LABEL(dt_ui_label_new(NULL));
-        gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->label[k]), FALSE, FALSE, 0);
+        sl->label[k] = GTK_LABEL(gtk_label_new(NULL));
+        gtk_widget_set_name(GTK_WIDGET(sl->label[k]), "blend-data");
+        gtk_label_set_xalign(sl->label[k], .35 + k * .65/3);
+        gtk_label_set_yalign(sl->label[k], k % 2);
+        gtk_overlay_add_overlay(GTK_OVERLAY(overlay), GTK_WIDGET(sl->label[k]));
       }
 
       gtk_widget_set_tooltip_text(GTK_WIDGET(sl->slider), _("double click to reset. press 'a' to toggle available slider modes.\npress 'c' to toggle view of channel data. press 'm' to toggle mask view."));

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -318,20 +318,19 @@ static void _label_size_allocate_callback(GtkWidget *widget, GdkRectangle *alloc
 {
   gint label_width;
   gtk_label_set_attributes(GTK_LABEL(widget), NULL);
-  gtk_widget_get_preferred_width(widget, NULL, &label_width);
 
-  double scale = (double)allocation->width / label_width;
+  PangoStretch stretch = PANGO_STRETCH_NORMAL;
 
-  while(label_width > allocation->width && scale > .25)
+  while(gtk_widget_get_preferred_width(widget, NULL, &label_width),
+        label_width > allocation->width && stretch != PANGO_STRETCH_ULTRA_CONDENSED)
   {
+    stretch--;
+
     PangoAttrList *attrlist = pango_attr_list_new();
-    PangoAttribute *attr = pango_attr_scale_new(scale);
+    PangoAttribute *attr = pango_attr_stretch_new(stretch);
     pango_attr_list_insert(attrlist, attr);
     gtk_label_set_attributes(GTK_LABEL(widget), attrlist);
     pango_attr_list_unref(attrlist);
-
-    gtk_widget_get_preferred_width(widget, NULL, &label_width);
-    scale *= 0.95; // find first discrete font that's small enough
   }
 }
 


### PR DESCRIPTION
fixes #6407

rather than reducing font size, when there is not enough space for all three values in the color picker module, this attempts to reduce font width only. This works for fonts that have (semi-) condensed versions installed on the system. This doesn't include the Monospace font on mine. The NK57 Monospace font works well. I can be downloaded here:
https://www.fontspring.com/fonts/typodermic/nk57-monospace
https://www.fontspring.com/fonts/typodermic/nk57-monospace-semi-condensed
https://www.fontspring.com/fonts/typodermic/nk57-monospace-condensed

and then after installation the following css tweak will activate it:
```
#live-sample-data
{
  font-family: NK57 Monospace;
}
```
Monospace:
![image](https://user-images.githubusercontent.com/1549490/95110796-7b1c1b00-0736-11eb-81bf-bb8633275171.png)
NK57 Monospace:
![image](https://user-images.githubusercontent.com/1549490/95110754-6ccdff00-0736-11eb-9bb3-88276bacd8ed.png)
Wider panel:
![image](https://user-images.githubusercontent.com/1549490/95110990-c46c6a80-0736-11eb-8253-65fc1b11d266.png)

The other place where a lot of numbers get squeezed with a narrow panel is above the parametric blending gradient slider. Those numbers get ellipsized quite quickly and are then basically unreadable. Monospaced fonts make this worse, because they make everything wider, but with normal fonts the numbers all move around when one of them changes.

I've tried to improve this here by using an overlay widget, which allows assigning each number a fixed proportion of the width (so they don't jump around). When the panel is too narrow, they start to overlap and become unreadable. There is really no one-size fits all here, so unless we want to provide a lot of configuration options, letting the user specify their preferred fonts type (for example condensed) and size gives the most flexibility. The #blend-data name is now set for all number labels to make this easier. Their vertical alignment is set alternatingly to top and bottom, so by increasing the min-height, reducing the font-size, or a combination, they can be made to not clash when the panel width is reduced. I am using 
```
#blend-data
{
  font-size: 10px;
  min-height: 22px;
}
```
which looks like this:
![image](https://user-images.githubusercontent.com/1549490/95111981-36917f00-0738-11eb-9e8d-eef540cdc5a9.png)
without css tweaks it would look like this:
![image](https://user-images.githubusercontent.com/1549490/95112236-99831600-0738-11eb-8050-a01b45405ffb.png)
which isn't pretty, but previously it would have look something like this:
![image](https://user-images.githubusercontent.com/1549490/95112774-4a89b080-0739-11eb-969a-1d2c00562c0e.png)
which is just as useless.

I think the changes here will allow more flexibility to finetune the display to personal preferences.