### PR TITLE
iop_layouts : fix dialog creation as child of main window

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1214,11 +1214,21 @@ dialog scrollbar
   - module layouts manager dialog -
   --------------------------------*/
 
+#modulegroups_manager box
+{
+  margin: 0;
+}
+
 #modulegroups_editor
 {
   color: @fg_color;
   background-color: @plugin_bg_color;
   padding-left: 0.5em;
+}
+
+#modulegroups-presets-list
+{
+  background-color: @bg_color;
 }
 
 #modulegroups-preset,
@@ -1624,6 +1634,11 @@ cell:selected
 #usercss_box textview
 {
   font-family: monospace;
+}
+
+#quick-presets_manager box
+{
+  margin: 0;
 }
 
 /*---------------------

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -843,7 +843,11 @@ static void menuitem_manage_quick_presets_toggle(GtkCellRendererToggle *cell_ren
 static void menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
 {
   sqlite3_stmt *stmt;
-  GtkWidget *dialog = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("manage modules layouts"), win,
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, NULL, NULL);
+
+  gtk_window_set_default_size(GTK_WINDOW(dialog), DT_PIXEL_APPLY_DPI(400), DT_PIXEL_APPLY_DPI(500));
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
 #endif
@@ -923,15 +927,12 @@ static void menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
   g_object_unref(model);
 
   gtk_container_add(GTK_CONTAINER(sw), view);
-  gtk_container_add(GTK_CONTAINER(dialog), sw);
+  gtk_widget_set_vexpand(sw, TRUE);
+  gtk_widget_set_hexpand(sw, TRUE);
+  gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), sw);
 
-  gtk_window_set_default_size(GTK_WINDOW(dialog), 300, 500);
-  // g_signal_connect(d->dialog, "destroy", G_CALLBACK(_manage_editor_destroy), self);
   gtk_window_set_resizable(GTK_WINDOW(dialog), TRUE);
-  gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  gtk_window_set_keep_above(GTK_WINDOW(dialog), TRUE);
 
-  gtk_window_set_gravity(GTK_WINDOW(dialog), GDK_GRAVITY_STATIC);
   gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ON_PARENT);
   gtk_widget_show_all(dialog);
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1946,7 +1946,12 @@ static void _manage_show_window(dt_lib_module_t *self)
 {
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
 
-  d->dialog = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
+  d->dialog = gtk_dialog_new_with_buttons(_("manage modules layouts"), win,
+                                          GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, NULL, NULL);
+
+  gtk_window_set_default_size(GTK_WINDOW(d->dialog), DT_PIXEL_APPLY_DPI(1100), DT_PIXEL_APPLY_DPI(700));
+
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(d->dialog);
 #endif
@@ -2004,15 +2009,11 @@ static void _manage_show_window(dt_lib_module_t *self)
     }
   }
 
-  gtk_container_add(GTK_CONTAINER(d->dialog), hb);
+  gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(d->dialog))), hb);
 
-  gtk_window_set_default_size(GTK_WINDOW(d->dialog), 1100, 700);
   g_signal_connect(d->dialog, "destroy", G_CALLBACK(_manage_editor_destroy), self);
   gtk_window_set_resizable(GTK_WINDOW(d->dialog), TRUE);
-  gtk_window_set_transient_for(GTK_WINDOW(d->dialog), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  gtk_window_set_keep_above(GTK_WINDOW(d->dialog), TRUE);
 
-  gtk_window_set_gravity(GTK_WINDOW(d->dialog), GDK_GRAVITY_STATIC);
   gtk_window_set_position(GTK_WINDOW(d->dialog), GTK_WIN_POS_CENTER_ON_PARENT);
   gtk_widget_show(d->dialog);
 }


### PR DESCRIPTION
same for quick presets

@TurboGit : at the same time, in french translation I think that there's a typo : "disposition originelle" is better than "disposition originel"...