### PR TITLE
Fixing size for g_file_get_contents

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1030,7 +1030,7 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
     CameraFile* camfile;
     int res = GP_OK;
     char *data = NULL;
-    unsigned long int size;
+    gsize size;
     time_t exif_time;
     if(!sdcard)
     {
@@ -1041,12 +1041,15 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
         gp_file_free(camfile);
         continue;
       }
-      if((res = gp_file_get_data_and_size(camfile, (const char**)&data, &size)) < GP_OK)
+      unsigned long int gpsize;
+      if((res = gp_file_get_data_and_size(camfile, (const char**)&data, &gpsize)) < GP_OK)
       {
         dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto import failed: %s\n", gp_result_as_string(res));
         gp_file_free(camfile);
         continue;
       }
+      else
+        size = (gsize) gpsize;
     }
     else
     {

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1030,7 +1030,7 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
     CameraFile* camfile;
     int res = GP_OK;
     char *data = NULL;
-    size_t size;
+    unsigned long int size;
     time_t exif_time;
     if(!sdcard)
     {

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1030,7 +1030,7 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
     CameraFile* camfile;
     int res = GP_OK;
     char *data = NULL;
-    gsize size;
+    gsize size = 0;
     time_t exif_time;
     if(!sdcard)
     {
@@ -1041,7 +1041,7 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
         gp_file_free(camfile);
         continue;
       }
-      unsigned long int gpsize;
+      unsigned long int gpsize = 0;
       if((res = gp_file_get_data_and_size(camfile, (const char**)&data, &gpsize)) < GP_OK)
       {
         dt_print(DT_DEBUG_CAMCTL, "[camera_control] gphoto import failed: %s\n", gp_result_as_string(res));


### PR DESCRIPTION
Indeed in gphoto2-file.h for `gp_file_get_data_and_size` the size is defined as
unsigned long int. This is also fine for g_file_get_contents

Partly fixing #6487