### PR TITLE
Monochrome workflow supporting presets

### DIFF
--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -1,12 +1,16 @@
 #pragma once
 
-// format flags stored into the presets database
+// format flags stored into the presets database; the FOR_NOT_ variants are negated to keep existing presets
 typedef enum dt_gui_presets_format_flag_t
 {
   FOR_LDR = 1 << 0,
   FOR_RAW = 1 << 1,
-  FOR_HDR = 1 << 2
+  FOR_HDR = 1 << 2,
+  FOR_NOT_MONO = 1 << 3,
+  FOR_NOT_COLOR = 1 << 4
 } dt_gui_presets_format_flag_t;
+
+#define DT_PRESETS_FOR_NOT (FOR_NOT_MONO | FOR_NOT_COLOR);
 
 /** create a db table with presets for all operations. */
 void dt_gui_presets_init();


### PR DESCRIPTION
As we now have detection of monochrome images the next obvious step is to
make presets to be aware of monochrome images.

On the gui side: whenever we make/modify a preset we had flags for normal, raw and hdr
images. **Added** are flags for `monochrome` and `color` so as an example you can create specific presets for monochrome raw and can auto apply them.

In `gui/presets.h` you find the bitmask extended
```
...
  FOR_NOT_MONO = 1 << 3,
  FOR_NOT_COLOR = 1 << 4
} dt_gui_presets_format_flag_t;

```
Please note the new bits are used as excluded, the gui side takes care of this.
Implementing it this way means no hassle with existing presets.