### PR TITLE
Monochrome workflow 3: user can change monochrome image status

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1434,7 +1434,7 @@ int dt_exif_read(dt_image_t *img, const char *path)
         !(oldmono & DT_IMAGE_MONOCHROME_PREVIEW))
       {
         if(dt_imageio_has_mono_preview(path))
-          img->flags |= DT_IMAGE_MONOCHROME_PREVIEW;
+          img->flags |= (DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
       }
       if(oldmono != dt_image_monochrome_flags(img))
         dt_imageio_update_monochrome_workflow_tag(img->id, dt_image_monochrome_flags(img));

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1427,17 +1427,17 @@ int dt_exif_read(dt_image_t *img, const char *path)
     if(!exifData.empty())
     {
       res = _exif_decode_exif_data(img, exifData);
- 
-      const int oldmono = dt_image_monochrome_flags(img);
-
-      if(dt_conf_get_bool("ui/detect_mono_exif") &&
-        !(oldmono & DT_IMAGE_MONOCHROME_PREVIEW))
+      if(dt_conf_get_bool("ui/detect_mono_exif"))
       {
+        const int oldflags = dt_image_monochrome_flags(img) | (img->flags & DT_IMAGE_MONOCHROME_WORKFLOW);
         if(dt_imageio_has_mono_preview(path))
           img->flags |= (DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
+        else
+          img->flags &= ~(DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
+
+        if(oldflags != (dt_image_monochrome_flags(img) | (img->flags & DT_IMAGE_MONOCHROME_WORKFLOW)))
+          dt_imageio_update_monochrome_workflow_tag(img->id, dt_image_monochrome_flags(img));
       }
-      if(oldmono != dt_image_monochrome_flags(img))
-        dt_imageio_update_monochrome_workflow_tag(img->id, dt_image_monochrome_flags(img));
     }
     else
       img->exif_inited = 1;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -140,8 +140,8 @@ int dt_image_is_rawprepare_supported(const dt_image_t *img)
 
 gboolean dt_image_use_monochrome_workflow(const dt_image_t *img)
 {
-  return ((img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_BAYER)) &&
-          (img->flags & DT_IMAGE_MONOCHROME_WORKFLOW));
+  return ((img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) ||
+          ((img->flags & DT_IMAGE_MONOCHROME_PREVIEW) && (img->flags & DT_IMAGE_MONOCHROME_WORKFLOW)));
 }
 
 int dt_image_monochrome_flags(const dt_image_t *img)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -588,7 +588,7 @@ static int32_t dt_control_monochrome_images_job_run(dt_job_t *job)
   const guint total = g_list_length(t);
   char message[512] = { 0 };
 
-  dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
+  dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY | DT_UNDO_TAGS);
 
   if(mode == 0)
     snprintf(message, sizeof(message), ngettext("set %d color image", "setting %d color images", total), total);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1275,6 +1275,9 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
   }
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  dt_control_queue_redraw_center();
   return 0;
 }
 

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -604,11 +604,8 @@ static int32_t dt_control_monochrome_images_job_run(dt_job_t *job)
     if(mode == 0)
       img->flags &= ~(DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
     else
-    {
-      img->flags |= DT_IMAGE_MONOCHROME_PREVIEW;
-      if(mode == 2)
-        img->flags |= DT_IMAGE_MONOCHROME_WORKFLOW;
-    }
+      img->flags |= (DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
+
     const int mask_bw = dt_image_monochrome_flags(img);
     dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
     dt_imageio_update_monochrome_workflow_tag(imgid, mask_bw);

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -35,6 +35,7 @@ void dt_control_delete_images();
 void dt_control_delete_image(int imgid);
 void dt_control_duplicate_images();
 void dt_control_flip_images(const int32_t cw);
+void dt_control_monochrome_images(const int32_t mode);
 gboolean dt_control_remove_images();
 void dt_control_move_images();
 void dt_control_copy_images();

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -147,6 +147,7 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
     thumb->has_localcopy = (img->flags & DT_IMAGE_LOCAL_COPY);
     thumb->rating = img->flags & DT_IMAGE_REJECTED ? DT_VIEW_REJECT : (img->flags & DT_VIEW_RATINGS_MASK);
     thumb->is_bw = dt_image_monochrome_flags(img);
+    thumb->is_bw_flow = dt_image_use_monochrome_workflow(img);
     thumb->is_hdr = dt_image_is_hdr(img);
 
     thumb->groupid = img->group_id;
@@ -249,7 +250,7 @@ static void _thumb_write_extension(dt_thumbnail_t *thumb)
   gchar *ext2 = NULL;
   while(ext > thumb->filename && *ext != '.') ext--;
   ext++;
-  gchar *uext = dt_view_extend_modes_str(ext, thumb->is_hdr, thumb->is_bw);
+  gchar *uext = dt_view_extend_modes_str(ext, thumb->is_hdr, thumb->is_bw, thumb->is_bw_flow);
   ext2 = dt_util_dstrcat(ext2, "%s", uext);
   gtk_label_set_text(GTK_LABEL(thumb->w_ext), ext2);
   g_free(uext);

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -71,6 +71,7 @@ typedef struct
   gboolean has_audio;
   gboolean is_grouped;
   gboolean is_bw;
+  gboolean is_bw_flow;
   gboolean is_hdr;
   gboolean has_localcopy;
   int groupid;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -50,7 +50,7 @@ typedef struct dt_lib_image_t
   GtkWidget *rotate_cw_button, *rotate_ccw_button, *remove_button, *delete_button, *create_hdr_button,
       *duplicate_button, *reset_button, *move_button, *copy_button, *group_button, *ungroup_button,
       *cache_button, *uncache_button, *refresh_button,
-      *set_monochrome_button, *set_color_button, *set_monoflow_button,
+      *set_monochrome_button, *set_color_button,
       *copy_metadata_button, *paste_metadata_button, *clear_metadata_button,
       *ratings_flag, *colors_flag, *metadata_flag, *geotags_flag, *tags_flag;
   GtkWidget *page1; // saved here for lua extensions
@@ -215,8 +215,6 @@ static void _update(dt_lib_module_t *self)
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), act_on_cnt > 0);
   gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->set_monoflow_button), act_on_cnt > 0);
-
 }
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
@@ -346,17 +344,13 @@ static void clear_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
 
 static void set_monochrome_callback(GtkWidget *widget, dt_lib_module_t *self)
 {
-  dt_control_monochrome_images(1);
+
+  dt_control_monochrome_images(2);
 }
 
 static void set_color_callback(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_control_monochrome_images(0);
-}
-
-static void set_monochrome_workflow_callback(GtkWidget *widget, dt_lib_module_t *self)
-{
-  dt_control_monochrome_images(2);
 }
 
 static void ratings_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
@@ -549,17 +543,13 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->refresh_button, 0, line++, 6, 1);
   g_signal_connect(G_OBJECT(d->refresh_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(14));
 
-  d->set_monochrome_button = dt_ui_button_new(_("monochrome"), _("set selection as monochrome images"), NULL);
-  gtk_grid_attach(grid, d->set_monochrome_button, 0, line, 2, 1);
+  d->set_monochrome_button = dt_ui_button_new(_("monochrome"), _("set selection as monochrome images and activate monochrome workflow"), NULL);
+  gtk_grid_attach(grid, d->set_monochrome_button, 0, line, 3, 1);
   g_signal_connect(G_OBJECT(d->set_monochrome_button), "clicked", G_CALLBACK(set_monochrome_callback), self);
 
   d->set_color_button = dt_ui_button_new(_("color"), _("set selection as color images"), NULL);
-  gtk_grid_attach(grid, d->set_color_button, 2, line, 2, 1);
+  gtk_grid_attach(grid, d->set_color_button, 3, line++, 3, 1);
   g_signal_connect(G_OBJECT(d->set_color_button), "clicked", G_CALLBACK(set_color_callback), self);
-
-  d->set_monoflow_button = dt_ui_button_new(_("mono workflow"), _("set selection as monochrome images and activate monochrome optimised code on supported modules"), NULL);
-  gtk_grid_attach(grid, d->set_monoflow_button, 4, line++, 2, 1);
-  g_signal_connect(G_OBJECT(d->set_monoflow_button), "clicked", G_CALLBACK(set_monochrome_workflow_callback), self);
 
   /* connect preference changed signal */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(
@@ -639,7 +629,6 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_button_lib(self, "refresh exif", d->refresh_button);
   dt_accel_connect_button_lib(self, "set monochrome image", d->set_monochrome_button);
   dt_accel_connect_button_lib(self, "set color image", d->set_color_button);
-  dt_accel_connect_button_lib(self, "set monochrome workflow", d->set_monoflow_button);
   dt_accel_connect_button_lib(self, "copy metadata", d->copy_metadata_button);
   dt_accel_connect_button_lib(self, "paste metadata", d->paste_metadata_button);
   dt_accel_connect_button_lib(self, "clear metadata", d->clear_metadata_button);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -212,9 +212,24 @@ static void _update(dt_lib_module_t *self)
   gtk_widget_set_sensitive(GTK_WIDGET(d->clear_metadata_button), act_on_cnt > 0);
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->refresh_button), act_on_cnt > 0);
-
-  gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), act_on_cnt > 0);
+  if(act_on_cnt > 1)
+  {
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), true);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), true);
+  }
+  else if(act_on_cnt == 0)
+  {
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), false);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), false);
+  }
+  else
+  {
+    dt_image_t *img = dt_image_cache_get(darktable.image_cache, dt_view_get_image_to_act_on(), 'r');
+    const gboolean is_bw = (dt_image_monochrome_flags(img) != 0);
+    dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), !is_bw);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), is_bw);
+  }
 }
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
@@ -602,7 +617,8 @@ void init_key_accels(dt_lib_module_t *self)
   dt_accel_register_lib(self, NC_("accel", "copy the image locally"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "resync the local copy"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "refresh exif"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "copy metadata"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "set monochrome image"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "set color image"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "replace metadata"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "paste metadata"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "clear metadata"), 0, 0);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -50,6 +50,7 @@ typedef struct dt_lib_image_t
   GtkWidget *rotate_cw_button, *rotate_ccw_button, *remove_button, *delete_button, *create_hdr_button,
       *duplicate_button, *reset_button, *move_button, *copy_button, *group_button, *ungroup_button,
       *cache_button, *uncache_button, *refresh_button,
+      *set_monochrome_button, *set_color_button, *set_monoflow_button,
       *copy_metadata_button, *paste_metadata_button, *clear_metadata_button,
       *ratings_flag, *colors_flag, *metadata_flag, *geotags_flag, *tags_flag;
   GtkWidget *page1; // saved here for lua extensions
@@ -211,6 +212,11 @@ static void _update(dt_lib_module_t *self)
   gtk_widget_set_sensitive(GTK_WIDGET(d->clear_metadata_button), act_on_cnt > 0);
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->refresh_button), act_on_cnt > 0);
+
+  gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->set_monoflow_button), act_on_cnt > 0);
+
 }
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
@@ -336,6 +342,21 @@ static void paste_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
 static void clear_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
 {
   _execute_metadata(self, DT_MA_CLEAR);
+}
+
+static void set_monochrome_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_control_monochrome_images(1);
+}
+
+static void set_color_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_control_monochrome_images(0);
+}
+
+static void set_monochrome_workflow_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_control_monochrome_images(2);
 }
 
 static void ratings_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
@@ -528,6 +549,18 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->refresh_button, 0, line++, 6, 1);
   g_signal_connect(G_OBJECT(d->refresh_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(14));
 
+  d->set_monochrome_button = dt_ui_button_new(_("monochrome"), _("set selection as monochrome images"), NULL);
+  gtk_grid_attach(grid, d->set_monochrome_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->set_monochrome_button), "clicked", G_CALLBACK(set_monochrome_callback), self);
+
+  d->set_color_button = dt_ui_button_new(_("color"), _("set selection as color images"), NULL);
+  gtk_grid_attach(grid, d->set_color_button, 2, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->set_color_button), "clicked", G_CALLBACK(set_color_callback), self);
+
+  d->set_monoflow_button = dt_ui_button_new(_("mono workflow"), _("set selection as monochrome images and activate monochrome optimised code on supported modules"), NULL);
+  gtk_grid_attach(grid, d->set_monoflow_button, 4, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->set_monoflow_button), "clicked", G_CALLBACK(set_monochrome_workflow_callback), self);
+
   /* connect preference changed signal */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(
       darktable.signals,
@@ -604,6 +637,9 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_button_lib(self, "copy the image locally", d->cache_button);
   dt_accel_connect_button_lib(self, "resync the local copy", d->uncache_button);
   dt_accel_connect_button_lib(self, "refresh exif", d->refresh_button);
+  dt_accel_connect_button_lib(self, "set monochrome image", d->set_monochrome_button);
+  dt_accel_connect_button_lib(self, "set color image", d->set_color_button);
+  dt_accel_connect_button_lib(self, "set monochrome workflow", d->set_monoflow_button);
   dt_accel_connect_button_lib(self, "copy metadata", d->copy_metadata_button);
   dt_accel_connect_button_lib(self, "paste metadata", d->paste_metadata_button);
   dt_accel_connect_button_lib(self, "clear metadata", d->clear_metadata_button);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -226,7 +226,7 @@ static void _update(dt_lib_module_t *self)
   {
     dt_image_t *img = dt_image_cache_get(darktable.image_cache, dt_view_get_image_to_act_on(), 'r');
     const gboolean is_bw = (dt_image_monochrome_flags(img) != 0);
-    dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
+    dt_image_cache_read_release(darktable.image_cache, img);
     gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), !is_bw);
     gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), is_bw);
   }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1082,21 +1082,21 @@ char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const g
 
   if(is_hdr)
   {
-    gchar* fullname = g_strdup_printf("%s HDR",upcase);
+    gchar* fullname = g_strdup_printf("%s HDR", upcase);
     g_free(upcase);
     upcase = fullname;
   }
   if(is_bw)
   {
-    gchar* fullname = g_strdup_printf("%s B&W",upcase);
+    gchar* fullname = g_strdup_printf("%s B&W", upcase);
     g_free(upcase);
     upcase = fullname;
-  }
-  if(is_bw_flow)
-  {
-    gchar* fullname = g_strdup_printf("%s+",upcase);
-    g_free(upcase);
-    upcase = fullname;
+    if(!is_bw_flow)
+    {
+      fullname = g_strdup_printf("%s-", upcase);
+      g_free(upcase);
+      upcase = fullname;
+    }
   }
 
   return upcase;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1076,7 +1076,7 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
   return 0;
 }
 
-char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const gboolean is_bw)
+char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const gboolean is_bw, const gboolean is_bw_flow)
 {
   char* upcase = g_ascii_strup(name, -1);  // extension in capital letters to avoid character descenders
 
@@ -1092,6 +1092,13 @@ char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const g
     g_free(upcase);
     upcase = fullname;
   }
+  if(is_bw_flow)
+  {
+    gchar* fullname = g_strdup_printf("%s+",upcase);
+    g_free(upcase);
+    upcase = fullname;
+  }
+
   return upcase;
 }
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -194,7 +194,7 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
 int dt_view_get_image_to_act_on();
 
 /** returns an uppercase string of file extension **plus** some flag information **/
-char* dt_view_extend_modes_str(const char * name, const int is_hdr, const int is_bw);
+char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const gboolean is_bw, const gboolean is_bw_flow);
 /** expose an image and return a cairi_surface. return != 0 if thumbnail wasn't loaded yet. */
 int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface, const gboolean quality);
 


### PR DESCRIPTION
We might wish to change the color/monochrome image status later on after import to override the automatic status we got via reading exif preview data.

This pr introduces 3 new buttons in the selected-images metadata section allowing selected images
1) to be set to "color image". This of course is not possible if
   it is a true monochrome or if the demosaicer defines it to be a monochrome.

2) to be set as monochrome

3) to be set as monochrome and have the `DT_IMAGE_MONOCHROME_WORKFLOW` bit flag set  for modules to check via `dt_image_use_monochrome_workflow`. So far no module supports this feature but that's coming.

Of course the monochrome tag is set correctly and in lighttable mode we see the B&W information if set as monochrome.