### PR TITLE
Fix/windows msys build

### DIFF
--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tools/
-  COMMAND ${CMAKE_COMMAND} -E env LANG=C LC_ALL=C bash ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
+  COMMAND ${CMAKE_COMMAND} -E env LANG=C LC_ALL=C /usr/bin/bash ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
   COMMENT "Generating authors.h for about dialog."
 )
 

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tools/
-  COMMAND ${CMAKE_COMMAND} -E env LANG=C LC_ALL=C /usr/bin/bash ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
+  COMMAND ${CMAKE_COMMAND} -E env LANG=C LC_ALL=C ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
   COMMENT "Generating authors.h for about dialog."
 )
 


### PR DESCRIPTION
Having the latest MSYS2 environment and Pacman updated without this change CMake does fail when trying to invoke a bash shell to call authors_h.sh. This is a workaround for compiling locally from @dterrahe. However, he thinks this might be not correct upstream. 
@dterrahe is it because we cannot guarantee that /usr/bin/bash is correct for all systems? What about removing `bash` and let shebang handle finding the correct interpreter? 