### PR TITLE
[Issue #2451] Styles dialog updates

### DIFF
--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -289,8 +289,11 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
         gint dlg_ret = gtk_dialog_run(GTK_DIALOG(dlg_overwrite));
         gtk_widget_destroy(dlg_overwrite);
 
-        // if result is BUTTON_NO exit without destroy dialog, to permit other name
-        if(dlg_ret == GTK_RESPONSE_NO) return;
+        // if result is BUTTON_NO or ESCAPE keypress exit without destroying dialog, to permit other name
+        if(dlg_ret != GTK_RESPONSE_YES) 
+        {
+          return;
+        }
       }
       else
       {

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -196,6 +196,35 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
     const gchar *name = gtk_entry_get_text(GTK_ENTRY(g->name));
     if(name && *name)
     {
+        
+      /* style already exists */
+      if(name && (dt_styles_exists(name)) != 0)
+      {
+        GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+        GtkWidget *dlg_overwrite = gtk_message_dialog_new(
+            GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING, GTK_BUTTONS_YES_NO,
+            _("style `%s' already exists.\ndo you want to overwrite?"), name);
+#ifdef GDK_WINDOWING_QUARTZ
+        dt_osx_disallow_fullscreen(dlg_overwrite);
+#endif
+
+        gtk_window_set_title(GTK_WINDOW(dlg_overwrite), _("overwrite style?"));
+
+        gint dlg_ret = gtk_dialog_run(GTK_DIALOG(dlg_overwrite));
+        gtk_widget_destroy(dlg_overwrite);
+
+
+        // if result is BUTTON_NO exit without destroy dialog, to permit other name
+        if(dlg_ret == GTK_RESPONSE_NO)
+        {
+          return;
+        }
+        else if(dlg_ret == GTK_RESPONSE_YES) {
+          // delete style
+          dt_styles_delete_by_name(name);
+        }
+      }
+
       if(dt_styles_create_from_image(name, gtk_entry_get_text(GTK_ENTRY(g->description)),
                                      g->imgid, result, _gui_styles_is_copy_module_order_set(g)))
       {

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -195,11 +195,27 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
     /* create the style from imageid */
     const gchar *name = gtk_entry_get_text(GTK_ENTRY(g->name));
     if(name && *name)
+    {
       if(dt_styles_create_from_image(name, gtk_entry_get_text(GTK_ENTRY(g->description)),
                                      g->imgid, result, _gui_styles_is_copy_module_order_set(g)))
       {
         dt_control_log(_("style named '%s' successfully created"), name);
       };
+    }
+    else
+    {
+      GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+      GtkWidget *dlg_changename
+                    = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
+                                             GTK_BUTTONS_OK, _("please give style a name"));
+#ifdef GDK_WINDOWING_QUARTZ
+      dt_osx_disallow_fullscreen(dlg_changename);
+#endif
+      gtk_window_set_title(GTK_WINDOW(dlg_changename), _("unnamed style"));
+      gtk_dialog_run(GTK_DIALOG(dlg_changename));
+      gtk_widget_destroy(dlg_changename);
+      return;
+    }
   }
   gtk_widget_destroy(GTK_WIDGET(dialog));
   g_free(g->nameorig);
@@ -243,6 +259,20 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
                          _gui_styles_is_update_module_order_set(g));
       }
       dt_control_log(_("style %s was successfully saved"), name);
+    }
+    else
+    {
+      GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+      GtkWidget *dlg_changename
+                    = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
+                                             GTK_BUTTONS_OK, _("please give style a name"));
+#ifdef GDK_WINDOWING_QUARTZ
+      dt_osx_disallow_fullscreen(dlg_changename);
+#endif
+      gtk_window_set_title(GTK_WINDOW(dlg_changename), _("unnamed style"));
+      gtk_dialog_run(GTK_DIALOG(dlg_changename));
+      gtk_widget_destroy(dlg_changename);
+      return;
     }
   }
   gtk_widget_destroy(GTK_WIDGET(dialog));

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -214,14 +214,16 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
         gtk_widget_destroy(dlg_overwrite);
 
 
-        // if result is BUTTON_NO exit without destroy dialog, to permit other name
-        if(dlg_ret == GTK_RESPONSE_NO)
+        /* on button yes delete style name for overwriting
+         * else statement: on RESPONSE_NO and escape key
+         */
+        if(dlg_ret == GTK_RESPONSE_YES) 
+        {
+          dt_styles_delete_by_name(name);
+        }
+        else 
         {
           return;
-        }
-        else if(dlg_ret == GTK_RESPONSE_YES) {
-          // delete style
-          dt_styles_delete_by_name(name);
         }
       }
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -197,7 +197,7 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
     if(name && *name)
     {
         
-      /* style already exists */
+      /* show prompt dialog when style already exists */
       if(name && (dt_styles_exists(name)) != 0)
       {
         GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
@@ -213,16 +213,14 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
         gint dlg_ret = gtk_dialog_run(GTK_DIALOG(dlg_overwrite));
         gtk_widget_destroy(dlg_overwrite);
 
-
-        /* on button yes delete style name for overwriting
-         * else statement: on RESPONSE_NO and escape key
-         */
+        /* on button yes delete style name for overwriting */
         if(dlg_ret == GTK_RESPONSE_YES) 
         {
           dt_styles_delete_by_name(name);
         }
         else 
         {
+         /* on RESPONSE_NO and escape key return to dialog */
           return;
         }
       }
@@ -235,6 +233,7 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
     }
     else
     {
+      /* show dialog if name is missing from entry */
       GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
       GtkWidget *dlg_changename
                     = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
@@ -293,6 +292,7 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
     }
     else
     {
+      /* show dialog if name is missing from entry */
       GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
       GtkWidget *dlg_changename
                     = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -536,6 +536,7 @@ void gui_init(dt_lib_module_t *self)
   /* filter entry */
   w = gtk_entry_new();
   d->entry = GTK_ENTRY(w);
+  gtk_entry_set_placeholder_text(GTK_ENTRY(d->entry), _("filter styles name"));
   gtk_widget_set_tooltip_text(w, _("filter style names"));
   gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
   g_signal_connect(d->entry, "changed", G_CALLBACK(entry_callback), d);


### PR DESCRIPTION
1. This implements/fixes #2451 an outstanding feature mentioned in the referenced issue for the overwrite dialog on style name existence.

2. Makes sure the overwrite dialog in both __create new style__ and __edit  presets__ do not continue to overwrite when the ESC  key is pressed.

3. Added a placeholder for the filter entry of styles in lighttable.