### PR TITLE
Adjusting case for true -> TRUE, false -> FALSE

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -603,7 +603,7 @@ static int32_t dt_control_monochrome_images_job_run(dt_job_t *job)
     if(imgid >= 0)
     {
       dt_image_t *img = NULL;
-      gboolean changed = false;
+      gboolean changed = FALSE;
 
       img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
       if(img)
@@ -616,14 +616,14 @@ static int32_t dt_control_monochrome_images_job_run(dt_job_t *job)
           // wanting it to be color found preview
           img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
           img->flags &= ~(DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
-          changed = true;
+          changed = TRUE;
         }
         if((mode != 0) && ((mask_bw == 0) || (mask_bw == DT_IMAGE_MONOCHROME_PREVIEW)))
         {
           // wanting monochrome and found color or just preview without workflow activation
           img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
           img->flags |= (DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_WORKFLOW);
-          changed = true;
+          changed = TRUE;
         }
         if(changed)
         {

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -214,13 +214,13 @@ static void _update(dt_lib_module_t *self)
   gtk_widget_set_sensitive(GTK_WIDGET(d->refresh_button), act_on_cnt > 0);
   if(act_on_cnt > 1)
   {
-    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), true);
-    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), true);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), TRUE);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), TRUE);
   }
   else if(act_on_cnt == 0)
   {
-    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), false);
-    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), false);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), FALSE);
+    gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), FALSE);
   }
   else
   {


### PR DESCRIPTION
the gboolean type uses TRUE/FALSE, and this is what is used everywhere
else in the C code. The lower case versions, for some reason, were
causing build to fail on ppc64le, so it seems reasonable to switch them
for consistency.

Deeper investigation has identified that the absence of Lua on an x86_64 build would trigger a build failure on x86_64. I am not currently building ppc64le with Lua support.