### PR TITLE
Making imgid signed all over for consistency

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -569,7 +569,7 @@ void dt_collection_set_extended_where(const dt_collection_t *collection, gchar *
   ((dt_collection_t *)collection)->where_ext = g_strdupv(extended_where);
 }
 
-void dt_collection_set_film_id(const dt_collection_t *collection, const uint32_t film_id)
+void dt_collection_set_film_id(const dt_collection_t *collection, const int32_t film_id)
 {
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
   params->film_id = film_id;

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -206,7 +206,7 @@ uint32_t dt_collection_get_query_flags(const dt_collection_t *collection);
 void dt_collection_set_query_flags(const dt_collection_t *collection, uint32_t flags);
 
 /** set the film_id of collection */
-void dt_collection_set_film_id(const dt_collection_t *collection, const uint32_t film_id);
+void dt_collection_set_film_id(const dt_collection_t *collection, const int32_t film_id);
 /** set the tagid of collection */
 void dt_collection_set_tag_id(dt_collection_t *collection, const uint32_t tagid);
 /** set the star level for filter */

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -318,17 +318,17 @@ void dt_free_align(void *mem);
 #define dt_free_align_ptr free
 #endif
 
-static inline void dt_lock_image(uint32_t imgid) ACQUIRE(darktable.db_image[imgid & (DT_IMAGE_DBLOCKS-1)])
+static inline void dt_lock_image(int32_t imgid) ACQUIRE(darktable.db_image[imgid & (DT_IMAGE_DBLOCKS-1)])
 {
   dt_pthread_mutex_lock(&(darktable.db_image[imgid & (DT_IMAGE_DBLOCKS-1)]));
 }
 
-static inline void dt_unlock_image(uint32_t imgid) RELEASE(darktable.db_image[imgid & (DT_IMAGE_DBLOCKS-1)])
+static inline void dt_unlock_image(int32_t imgid) RELEASE(darktable.db_image[imgid & (DT_IMAGE_DBLOCKS-1)])
 {
   dt_pthread_mutex_unlock(&(darktable.db_image[imgid & (DT_IMAGE_DBLOCKS-1)]));
 }
 
-static inline void dt_lock_image_pair(uint32_t imgid1, uint32_t imgid2) ACQUIRE(darktable.db_image[imgid1 & (DT_IMAGE_DBLOCKS-1)], darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)])
+static inline void dt_lock_image_pair(int32_t imgid1, int32_t imgid2) ACQUIRE(darktable.db_image[imgid1 & (DT_IMAGE_DBLOCKS-1)], darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)])
 {
   if(imgid1 < imgid2)
   {
@@ -342,7 +342,7 @@ static inline void dt_lock_image_pair(uint32_t imgid1, uint32_t imgid2) ACQUIRE(
   }
 }
 
-static inline void dt_unlock_image_pair(uint32_t imgid1, uint32_t imgid2) RELEASE(darktable.db_image[imgid1 & (DT_IMAGE_DBLOCKS-1)], darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)])
+static inline void dt_unlock_image_pair(int32_t imgid1, int32_t imgid2) RELEASE(darktable.db_image[imgid1 & (DT_IMAGE_DBLOCKS-1)], darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)])
 {
   dt_pthread_mutex_unlock(&(darktable.db_image[imgid1 & (DT_IMAGE_DBLOCKS-1)]));
   dt_pthread_mutex_unlock(&(darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)]));

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -380,7 +380,7 @@ void dt_film_remove(const int id)
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    int imgid = sqlite3_column_int(stmt, 0);
+    int32_t imgid = sqlite3_column_int(stmt, 0);
     if(!dt_image_safe_remove(imgid))
     {
       remove_ok = FALSE;
@@ -437,7 +437,7 @@ void dt_film_remove(const int id)
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, id);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    const uint32_t imgid = sqlite3_column_int(stmt, 0);
+    const int32_t imgid = sqlite3_column_int(stmt, 0);
     dt_image_local_copy_reset(imgid);
     dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
     dt_image_cache_remove(darktable.image_cache, imgid);

--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -24,7 +24,7 @@
 #include "gui/gtk.h"
 
 /** add an image to a group */
-void dt_grouping_add_to_group(const int group_id, const int image_id)
+void dt_grouping_add_to_group(const int group_id, const int32_t image_id)
 {
   // remove from old group
   dt_grouping_remove_from_group(image_id);
@@ -38,7 +38,7 @@ void dt_grouping_add_to_group(const int group_id, const int image_id)
 }
 
 /** remove an image from a group */
-int dt_grouping_remove_from_group(const int image_id)
+int dt_grouping_remove_from_group(const int32_t image_id)
 {
   sqlite3_stmt *stmt;
   int new_group_id = -1;
@@ -91,7 +91,7 @@ int dt_grouping_remove_from_group(const int image_id)
 }
 
 /** make an image the representative of the group it is in */
-int dt_grouping_change_representative(const int image_id)
+int dt_grouping_change_representative(const int32_t image_id)
 {
   sqlite3_stmt *stmt;
 
@@ -118,7 +118,7 @@ int dt_grouping_change_representative(const int image_id)
 }
 
 /** get images of the group */
-GList *dt_grouping_get_group_images(const int imgid)
+GList *dt_grouping_get_group_images(const int32_t imgid)
 {
   GList *imgs = NULL;
   const dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');

--- a/src/common/grouping.h
+++ b/src/common/grouping.h
@@ -21,16 +21,16 @@
 #include <glib.h>
 
 /** add an image to a group */
-void dt_grouping_add_to_group(int group_id, int image_id);
+void dt_grouping_add_to_group(int group_id, int32_t image_id);
 
 /** remove an image from a group. returns the new group_id of the other images. */
-int dt_grouping_remove_from_group(int image_id);
+int dt_grouping_remove_from_group(int32_t image_id);
 
 /** make an image the representative of the group it is in. returns the new group_id. */
-int dt_grouping_change_representative(int image_id);
+int dt_grouping_change_representative(int32_t image_id);
 
 /** get images of the group */
-GList *dt_grouping_get_group_images(const int imgid);
+GList *dt_grouping_get_group_images(const int32_t imgid);
 
 /** add grouped images to images list */
 void dt_grouping_add_grouped_images(GList **images);

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -195,7 +195,7 @@ void dt_image_cache_print(dt_image_cache_t *cache)
          (float)cache->cache.cost / (float)cache->cache.cost_quota);
 }
 
-dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const uint32_t imgid, char mode)
+dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const int32_t imgid, char mode)
 {
   if(imgid <= 0) return NULL;
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, mode);
@@ -205,9 +205,9 @@ dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const uint32_t imgid, ch
   return img;
 }
 
-dt_image_t *dt_image_cache_testget(dt_image_cache_t *cache, const uint32_t imgid, char mode)
+dt_image_t *dt_image_cache_testget(dt_image_cache_t *cache, const int32_t imgid, char mode)
 {
-  if(imgid <= 0) return 0;
+  if(imgid <= 0) return NULL;
   dt_cache_entry_t *entry = dt_cache_testget(&cache->cache, imgid, mode);
   if(!entry) return 0;
   ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
@@ -303,13 +303,13 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
 
 
 // remove the image from the cache
-void dt_image_cache_remove(dt_image_cache_t *cache, const uint32_t imgid)
+void dt_image_cache_remove(dt_image_cache_t *cache, const int32_t imgid)
 {
   dt_cache_remove(&cache->cache, imgid);
 }
 
 /* set timestamps */
-void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const uint32_t imgid)
+void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const int32_t imgid)
 {
   if(imgid <= 0) return;
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, DT_IMAGE_CACHE_SAFE);
@@ -321,7 +321,7 @@ void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const uint32_t
   dt_image_cache_write_release(cache, img, DT_IMAGE_CACHE_SAFE);
 }
 
-void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const uint32_t imgid)
+void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const int32_t imgid)
 {
   if(imgid <= 0) return;
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, DT_IMAGE_CACHE_SAFE);
@@ -333,7 +333,7 @@ void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const uint32
   dt_image_cache_write_release(cache, img, DT_IMAGE_CACHE_SAFE);
 }
 
-void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const uint32_t imgid)
+void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const int32_t imgid)
 {
   if(imgid <= 0) return;
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, DT_IMAGE_CACHE_SAFE);
@@ -345,7 +345,7 @@ void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const uint32_t
   dt_image_cache_write_release(cache, img, DT_IMAGE_CACHE_SAFE);
 }
 
-void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const uint32_t imgid)
+void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const int32_t imgid)
 {
   if(imgid <= 0) return;
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, DT_IMAGE_CACHE_SAFE);

--- a/src/common/image_cache.h
+++ b/src/common/image_cache.h
@@ -49,11 +49,11 @@ void dt_image_cache_print(dt_image_cache_t *cache);
 // cachelines to free up space if necessary.
 // if an entry is swapped out like this in the background, this is the latest
 // point where sql and xmp can be synched (unsafe setting).
-dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const uint32_t imgid, char mode);
+dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const int32_t imgid, char mode);
 
 // same as read_get, but doesn't block and returns NULL if the image
 // is currently unavailable.
-dt_image_t *dt_image_cache_testget(dt_image_cache_t *cache, const uint32_t imgid, char mode);
+dt_image_t *dt_image_cache_testget(dt_image_cache_t *cache, const int32_t imgid, char mode);
 
 // drops the read lock on an image struct
 void dt_image_cache_read_release(dt_image_cache_t *cache, const dt_image_t *img);
@@ -64,13 +64,13 @@ void dt_image_cache_read_release(dt_image_cache_t *cache, const dt_image_t *img)
 void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_image_cache_write_mode_t mode);
 
 // remove the image from the cache
-void dt_image_cache_remove(dt_image_cache_t *cache, const uint32_t imgid);
+void dt_image_cache_remove(dt_image_cache_t *cache, const int32_t imgid);
 
 // register timestamps in cache
-void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
-void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
-void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
-void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
+void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const int32_t imgid);
+void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const int32_t imgid);
+void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const int32_t imgid);
+void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -629,7 +629,7 @@ void dt_imageio_to_fractional(float in, uint32_t *num, uint32_t *den)
   }
 }
 
-int dt_imageio_export(const uint32_t imgid, const char *filename, dt_imageio_module_format_t *format,
+int dt_imageio_export(const int32_t imgid, const char *filename, dt_imageio_module_format_t *format,
                       dt_imageio_module_data_t *format_params, const gboolean high_quality, const gboolean upscale,
                       const gboolean copy_metadata, const gboolean export_masks,
                       dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
@@ -647,7 +647,7 @@ int dt_imageio_export(const uint32_t imgid, const char *filename, dt_imageio_mod
 }
 
 // internal function: to avoid exif blob reading + 8-bit byteorder flag + high-quality override
-int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
+int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  dt_imageio_module_format_t *format, dt_imageio_module_data_t *format_params,
                                  const gboolean ignore_exif, const gboolean display_byteorder,
                                  const gboolean high_quality, const gboolean upscale, const gboolean thumbnail_export,

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -71,14 +71,14 @@ dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename
 
 struct dt_imageio_module_format_t;
 struct dt_imageio_module_data_t;
-int dt_imageio_export(const uint32_t imgid, const char *filename, struct dt_imageio_module_format_t *format,
+int dt_imageio_export(const int32_t imgid, const char *filename, struct dt_imageio_module_format_t *format,
                       struct dt_imageio_module_data_t *format_params, const gboolean high_quality,
                       const gboolean upscale, const gboolean copy_metadata, const gboolean export_masks,
                       dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                       dt_iop_color_intent_t icc_intent, dt_imageio_module_storage_t *storage,
                       dt_imageio_module_data_t *storage_params, int num, int total, dt_export_metadata_t *metadata);
 
-int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
+int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  struct dt_imageio_module_format_t *format,
                                  struct dt_imageio_module_data_t *format_params, const gboolean ignore_exif,
                                  const gboolean display_byteorder, const gboolean high_quality, const gboolean upscale,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -100,7 +100,7 @@ static void _update_softproof_gamut_checking(dt_develop_t *d);
 /* signal handler for filmstrip image switching */
 static void _view_darkroom_filmstrip_activate_callback(gpointer instance, int imgid, gpointer user_data);
 
-static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid);
+static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid);
 
 static void _darkroom_display_second_window(dt_develop_t *dev);
 static void _darkroom_ui_second_window_write_config(GtkWidget *widget);
@@ -699,7 +699,7 @@ void reset(dt_view_t *self)
 
 int try_enter(dt_view_t *self)
 {
-  int imgid = dt_view_get_image_to_act_on();
+  int32_t imgid = dt_view_get_image_to_act_on();
 
   if(imgid < 0)
   {
@@ -733,7 +733,7 @@ static void dt_dev_cleanup_module_accels(dt_iop_module_t *module)
   dt_accel_cleanup_locals_iop(module);
 }
 
-static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
+static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
 {
   // stop crazy users from sleeping on key-repeat spacebar:
   if(dev->image_loading) return;
@@ -1023,7 +1023,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   dt_iop_connect_accels_all();
 }
 
-static void _view_darkroom_filmstrip_activate_callback(gpointer instance, int imgid, gpointer user_data)
+static void _view_darkroom_filmstrip_activate_callback(gpointer instance, int32_t imgid, gpointer user_data)
 {
   if(imgid > 0)
   {
@@ -1043,7 +1043,7 @@ static void dt_dev_jump_image(dt_develop_t *dev, int diff, gboolean by_key)
 {
   if(dev->image_loading) return;
 
-  const int imgid = dev->image_storage.id;
+  const int32_t imgid = dev->image_storage.id;
   int new_offset = 1;
   int new_id = -1;
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -974,7 +974,7 @@ static gboolean _accel_culling_zoom_fit(GtkAccelGroup *accel_group, GObject *acc
 static gboolean _accel_select_toggle(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  const uint32_t id = dt_control_get_mouse_over_id();
+  const int32_t id = dt_control_get_mouse_over_id();
   dt_selection_toggle(darktable.selection, id);
   return TRUE;
 }
@@ -982,7 +982,7 @@ static gboolean _accel_select_toggle(GtkAccelGroup *accel_group, GObject *accele
 static gboolean _accel_select_single(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  const uint32_t id = dt_control_get_mouse_over_id();
+  const int32_t id = dt_control_get_mouse_over_id();
   dt_selection_select_single(darktable.selection, id);
   return TRUE;
 }

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -94,7 +94,7 @@ static void _view_capture_filmstrip_activate_callback(gpointer instance, int img
 
 static void _capture_view_set_jobcode(const dt_view_t *view, const char *name);
 static const char *_capture_view_get_jobcode(const dt_view_t *view);
-static uint32_t _capture_view_get_selected_imgid(const dt_view_t *view);
+static int32_t _capture_view_get_selected_imgid(const dt_view_t *view);
 
 const char *name(const dt_view_t *self)
 {
@@ -140,7 +140,7 @@ void cleanup(dt_view_t *self)
 }
 
 
-static uint32_t _capture_view_get_selected_imgid(const dt_view_t *view)
+static int32_t _capture_view_get_selected_imgid(const dt_view_t *view)
 {
   g_assert(view != NULL);
   dt_capture_t *cv = (dt_capture_t *)view->data;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -334,7 +334,7 @@ typedef struct dt_view_manager_t
       struct dt_view_t *view;
       const char *(*get_job_code)(const dt_view_t *view);
       void (*set_job_code)(const dt_view_t *view, const char *name);
-      uint32_t (*get_selected_imgid)(const dt_view_t *view);
+      int32_t (*get_selected_imgid)(const dt_view_t *view);
     } tethering;
 
     /* timeline module proxy */


### PR DESCRIPTION
While debugging the monochrome workflow there was an error detected because imgid was used as an unsigned int32_t. For consistency and maintaining fixed all over.

Some might be a real problem, some are just cleanup.