### PR TITLE
Workaround for lensfun no longer required on windows

### DIFF
--- a/.ci/ci-script-windows.sh
+++ b/.ci/ci-script-windows.sh
@@ -82,14 +82,8 @@ cat > "$FONTCONFIG_FILE" <<EOF
 EOF
 
 execute 'Installing base-devel and toolchain'  pacman -S --needed --noconfirm mingw-w64-x86_64-{toolchain,clang,cmake}
-execute 'Installing dependencies (except lensfun)' pacman -S --needed --noconfirm  mingw-w64-x86_64-{exiv2,lcms2,dbus-glib,openexr,sqlite3,libxslt,libsoup,libavif,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes}
+execute 'Installing dependencies' pacman -S --needed --noconfirm  mingw-w64-x86_64-{exiv2,lcms2,dbus-glib,openexr,sqlite3,libxslt,libsoup,libavif,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes,lensfun}
 
-# Lensfun must be dealt with separately in an MSYS64 environment per note in Windows build instructions added in commit ca5a4fb
-execute 'Downloading known good lensfun 0.3.2-4' curl -fSs -o mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz
-execute 'Installing known good lensfun' pacman -U --needed --noconfirm mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz
-# Downgraded lensfun package is explicitly packaged to python 3.6 directories
-# but fortunately compatible with 3.8
-execute 'Copying python 3.6 lensfun libraries to 3.8' cp -R /mingw64/lib/python3.6/site-packages/lensfun* /mingw64/lib/python3.8/site-packages
 execute 'Updating lensfun databse' lensfun-update-data
 
 execute 'Installing additional OpenMP library for clang' pacman -S --needed --noconfirm mingw-w64-x86_64-openmp

--- a/packaging/windows/BUILD.txt
+++ b/packaging/windows/BUILD.txt
@@ -27,17 +27,7 @@ A) Native compile using MSYS2:  How to make a darktable windows installer (64 bi
 	export CAMLIBS="/mingw64/lib/libgphoto2/2.5.23/"
 	export IOLIBS="/mingw64/lib/libgphoto2_port/0.12.0/"
 
-   	NOTE: at the moment, the lensfun version provided by MSYS2 (0.3.95-1) is broken. If you get errors in the build process, manually downgrade lensfun to version 0.3.2-4:
-    Download the file mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz from http://repo.msys2.org/mingw/x86_64/
-    Put the file in your MSYS2 home folder, then from MSYS2 terminal:
-    $ pacman -U mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz
-    Also in order to prevent pacman from updating the lensfun package, open the file /etc/pacman.conf, find the line:
-	#Pacman won’t upgrade packages listed in IgnorePkg and members of IgnoreGroup
-    and below, add the following line
-	IgnorePkg = mingw-w64-x86_64-lensfun
-    Copy the lensfun folder and the lensfun-0.3.2-py3.6.egg-info file from /mingw64/lib/python3.6/site-packages to /mingw64/lib/python3.8/site-packages.
-
-	From MINGW64 terminal, update your lensfun database:
+ 	From MINGW64 terminal, update your lensfun database:
 	$ lensfun-update-data
 
     Also use this program to install USB driver on Windows for your camera:


### PR DESCRIPTION
The MSYS repository has reverted lensfun  to version 0.3.2 from broken 0.3.95 version and hence workaround is no longer required