### PR TITLE
do not treat enabling dynamic shortcuts as special

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -191,11 +191,6 @@ void dt_control_cleanup(dt_control_t *s)
   {
     g_slist_free_full(s->accelerator_list, g_free);
   }
-  if(s->dynamic_accelerator_list)
-  {
-    g_slist_free(s->dynamic_accelerator_valid);
-    g_slist_free_full(s->dynamic_accelerator_list, g_free);
-  }
 }
 
 
@@ -711,25 +706,6 @@ int dt_control_key_pressed_override(guint key, guint state)
 
   /* check if key accelerators are enabled*/
   if(darktable.control->key_accelerators_on != 1) return 0;
-
-  // dynamic accels
-  darktable.view_manager->current_view->dynamic_accel_current = dt_dynamic_accel_find_by_key(key, state);
-  if(darktable.view_manager->current_view->dynamic_accel_current)
-  {
-    gchar **vals = g_strsplit_set(darktable.view_manager->current_view->dynamic_accel_current->translated_path, "/", -1);
-    dt_iop_module_so_t *mod_so = darktable.view_manager->current_view->dynamic_accel_current->mod_so;
-    dt_iop_module_t *mod = dt_iop_get_module_accel_curr(mod_so);
-    if(vals[0] && vals[1] && vals[2] && vals[3])
-    {
-      gchar *txt = dt_util_dstrcat(NULL, _("scroll to change <b>%s</b> of %s %s module"), vals[3], vals[2], mod->multi_name);
-      dt_control_hinter_message(darktable.control, txt);
-      g_free(txt);
-    }
-    else
-      dt_control_hinter_message(darktable.control, "");
-    g_strfreev(vals);
-    return 1;
-  }
 
   if(key == accels->global_sideborders.accel_key && state == accels->global_sideborders.accel_mods)
   {

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -150,8 +150,6 @@ typedef struct dt_control_t
 
   // Accelerator group path lists
   GSList *accelerator_list;
-  GSList *dynamic_accelerator_list;
-  GSList *dynamic_accelerator_valid;
 
   // Cached accelerator keys for key_pressed shortcuts
   dt_control_accels_t accels;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2985,8 +2985,6 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
       if(accel_mod_new->connect_key_accels) accel_mod_new->connect_key_accels(accel_mod_new);
       dt_iop_connect_common_accels(accel_mod_new);
     }
-
-    dt_dynamic_accel_get_valid_list();
   }
 }
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -36,20 +36,6 @@ typedef struct dt_accel_t
 
 } dt_accel_t;
 
-typedef struct dt_accel_dynamic_t
-{
-
-  gchar path[256];
-  gchar translated_path[256];
-  gchar module[256];
-  gboolean local;
-  dt_view_type_flags_t views;
-  GtkAccelKey accel_key;
-  GtkWidget *widget;
-  dt_iop_module_so_t *mod_so;
-
-} dt_accel_dynamic_t;
-
 typedef enum dt_accel_iop_slider_scale_t
 {
   DT_IOP_PRECISION_NORMAL = 0,
@@ -75,8 +61,6 @@ void dt_accel_path_manual(char *s, size_t n, const char *full_path);
 void dt_accel_paths_slider_iop(char *s[], size_t n, char *module, const char *path);
 
 // Accelerator search functions
-dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierType mods);
-void dt_dynamic_accel_get_valid_list();
 dt_accel_t *dt_accel_find_by_path(const gchar *path);
 
 // Accelerator registration functions

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1273,7 +1273,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   darktable.control->accelerators = gtk_accel_group_new();
 
   darktable.control->accelerator_list = NULL;
-  darktable.control->dynamic_accelerator_list = NULL;
 
   // Connecting the callback to update keyboard accels for key_pressed
   g_signal_connect(G_OBJECT(gtk_accel_map_get()), "changed", G_CALLBACK(key_accel_changed), NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1917,9 +1917,6 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_no_show_all(display_intent, TRUE);
     gtk_widget_set_visible(display_intent, FALSE);
   }
-
-  // reconstruct dynamic accels list
-  dt_dynamic_accel_get_valid_list();
 }
 
 static void _preference_prev_downsample_change(gpointer instance, gpointer user_data)
@@ -3450,9 +3447,9 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
   int handled = 0;
   // dynamic accels
-  if(self->dynamic_accel_current && self->dynamic_accel_current->widget)
+  if(self->dynamic_accel_current)
   {
-    GtkWidget *widget = self->dynamic_accel_current->widget;
+    GtkWidget *widget = self->dynamic_accel_current;
     dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
 
     if(w->type == DT_BAUHAUS_SLIDER)
@@ -3466,9 +3463,9 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
         multiplier = min_visible / fabsf(step);
 
       if(up)
-        dt_bauhaus_slider_set(self->dynamic_accel_current->widget, value + step * multiplier);
+        dt_bauhaus_slider_set(widget, value + step * multiplier);
       else
-        dt_bauhaus_slider_set(self->dynamic_accel_current->widget, value - step * multiplier);
+        dt_bauhaus_slider_set(widget, value - step * multiplier);
     }
     else
     {
@@ -3486,8 +3483,8 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       }
 
     }
-    g_signal_emit_by_name(G_OBJECT(self->dynamic_accel_current->widget), "value-changed");
-    dt_accel_widget_toast(self->dynamic_accel_current->widget);
+    g_signal_emit_by_name(G_OBJECT(widget), "value-changed");
+    dt_accel_widget_toast(widget);
     return;
   }
   // masks
@@ -3955,9 +3952,6 @@ void connect_key_accels(dt_view_t *self)
   // change the precision for adjusting sliders with keyboard shortcuts
   closure = g_cclosure_new(G_CALLBACK(change_slider_accel_precision), (gpointer)self, NULL);
   dt_accel_connect_view(self, "change keyboard shortcut slider precision", closure);
-
-  // dynamics accels
-  dt_dynamic_accel_get_valid_list();
 }
 
 GSList *mouse_actions(const dt_view_t *self)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -168,7 +168,7 @@ typedef struct dt_view_t
   GSList *(*mouse_actions)(const struct dt_view_t *self);
 
   GSList *accel_closures;
-  struct dt_accel_dynamic_t *dynamic_accel_current;
+  GtkWidget *dynamic_accel_current;
 } dt_view_t;
 
 typedef enum dt_view_image_over_t


### PR DESCRIPTION
dynamic shortcuts were implemented using a different approach from all other shortcuts. A separate list is maintained and scanned every time an unmapped key is pressed. I'm not sure why this approach was chosen, but I changed this, ripping out all the dedicated data structures and just using a normal shortcut with callback function to enable the dynamic mode. This mode is then disabled, as before, when a key release is received.

The testing I have done shows no change in behavior at all, but less code and no special case so easier to maintain/extend.

@elstoc can I ask you to hammer on this a bit, since you know shortcuts. If this works for you, it will make the other cleanups I'm working on much easier. Thanks!

(As a reward, I'll give you "processing modules" and "utility modules" as top level names in shortcut settings, without changes to keyboardrc)