### PR TITLE
Quick presets fix + docs

### DIFF
--- a/doc/usermanual/darkroom/panels/bottom_panel.xml
+++ b/doc/usermanual/darkroom/panels/bottom_panel.xml
@@ -25,8 +25,13 @@
     <para>
       Clicking the
       <inlinegraphic fileref="&icon_module_presets;"  scalefit="1" width="2%" align="center"/>
-      icon opens a combobox that gives you quick access to your favorite module's presets. Click
+      icon opens a menu that gives you quick access to your favorite presets. Click
       on the preset name to apply it to the image.
+    </para>
+
+    <para>
+      You can define the list of your favorite presets by using the last menu entry
+      <emphasis>manage quick presets list...</emphasis>
     </para>
 
   </sect3>

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -895,7 +895,7 @@ static void menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
 
   renderer = gtk_cell_renderer_text_new();
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
-  gtk_tree_view_column_add_attribute(col, renderer, "text", 0);
+  gtk_tree_view_column_add_attribute(col, renderer, "markup", 0);
 
   col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(GTK_TREE_VIEW(view), col);
@@ -1002,7 +1002,7 @@ void dt_gui_favorite_presets_menu_show()
   else
     config = dt_conf_get_string("plugins/darkroom/quick_preset_list");
 
-  GList *modules = darktable.develop->iop;
+  GList *modules = g_list_last(darktable.develop->iop);
   if(modules)
   {
     do
@@ -1034,6 +1034,9 @@ void dt_gui_favorite_presets_menu_show()
           if(config && strstr(config, txt))
           {
             GtkMenuItem *mi = (GtkMenuItem *)gtk_menu_item_new_with_label(name);
+            gchar *tt = dt_util_dstrcat(NULL, "<b>%s %s</b> %s", iop->name(), iop->multi_name, name);
+            gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), tt);
+            g_free(tt);
             g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
             g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_pick_preset), iop);
             gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(mi));
@@ -1044,7 +1047,7 @@ void dt_gui_favorite_presets_menu_show()
         sqlite3_finalize(stmt);
       }
 
-    } while((modules = g_list_next(modules)) != NULL);
+    } while((modules = g_list_previous(modules)) != NULL);
   }
   if(retrieve_list) dt_conf_set_string("plugins/darkroom/quick_preset_list", config);
   g_free(config);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -911,6 +911,8 @@ static void menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
 
   treestore = gtk_tree_store_new(5, G_TYPE_STRING, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_STRING);
 
+  gchar *config = dt_conf_get_string("plugins/darkroom/quick_preset_list");
+
   GList *m2 = g_list_copy(darktable.iop);
   GList *modules = g_list_sort(m2, menuitem_manage_quick_presets_sort);
   while(modules)
@@ -938,8 +940,12 @@ static void menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
       {
         nb++;
         char *name = (char *)sqlite3_column_text(stmt, 0);
+        // is this preset part of the list ?
+        gchar *txt = dt_util_dstrcat(NULL, "ꬹ%s|%sꬹ", iop->op, name);
+        gboolean inlist = (config && strstr(config, txt));
+        g_free(txt);
         gtk_tree_store_append(treestore, &child, &toplevel);
-        gtk_tree_store_set(treestore, &child, 0, name, 1, FALSE, 2, TRUE, 3, g_strdup(iop->op), 4, g_strdup(name),
+        gtk_tree_store_set(treestore, &child, 0, name, 1, inlist, 2, TRUE, 3, g_strdup(iop->op), 4, g_strdup(name),
                            -1);
       }
 
@@ -951,6 +957,7 @@ static void menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
 
     modules = g_list_next(modules);
   }
+  g_free(config);
   g_list_free(m2);
 
   model = GTK_TREE_MODEL(treestore);


### PR DESCRIPTION
Some work on the "quick" presets : 
- fix : only show modules with presets in the manager (and in alphabetical order)
- fix : remember the state of presets in the manager
- docs : slightly change the usermanual to reflect the change from 3.2