### PR TITLE
common:imageio: Add support for libavif >= 0.8.2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,7 +327,7 @@ if(USE_WEBP)
 endif(USE_WEBP)
 
 if (USE_AVIF)
-    find_package(libavif 0.7.2 CONFIG)
+    find_package(libavif 0.8.2 CONFIG)
     if (TARGET avif)
         list(APPEND LIBS avif)
         add_definitions(-DHAVE_LIBAVIF=1)

--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -40,94 +40,18 @@
 
 #include <avif/avif.h>
 
-static dt_imageio_retval_t read_image(const char *filename, avifROData *raw)
-{
-  size_t nread;
-  size_t avif_file_size;
-  FILE *f = NULL;
-  avifRWData raw_data = AVIF_DATA_EMPTY;
-  dt_imageio_retval_t ret;
-  int rc;
-  const char *ext = strrchr(filename, '.');
-  int cmp;
-
-  cmp = strncmp(ext, ".avif", 5);
-  if (cmp != 0) {
-    return DT_IMAGEIO_FILE_CORRUPTED;
-  }
-
-  f = g_fopen(filename, "rb");
-  if (f == NULL) {
-    return DT_IMAGEIO_FILE_NOT_FOUND;
-  }
-
-  rc = fseek(f, 0, SEEK_END);
-  if (rc != 0) {
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-  avif_file_size = ftell(f);
-  if (avif_file_size < 10) {
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-  rc = fseek(f, 0, SEEK_SET);
-  if (rc != 0) {
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-
-  avifRWDataRealloc(&raw_data, avif_file_size);
-  if (raw_data.data == NULL) {
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-
-  nread = fread(raw_data.data, 1, raw_data.size, f);
-  if (nread != avif_file_size) {
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-
-  raw->data = raw_data.data;
-  raw->size = raw_data.size;
-
-  ret = DT_IMAGEIO_OK;
-out:
-  fclose(f);
-
-  return ret;
-}
-
 dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
                                          const char *filename,
                                          dt_mipmap_buffer_t *mbuf)
 {
   dt_imageio_retval_t ret;
-  avifROData raw = AVIF_DATA_EMPTY;
+  avifImage avif_image = {0};
   avifImage *avif = NULL;
   avifRGBImage rgb = {
       .format = AVIF_RGB_FORMAT_RGB,
   };
   avifDecoder *decoder = NULL;
   avifResult result;
-
-  ret = read_image(filename, &raw);
-  if (ret != DT_IMAGEIO_OK) {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to read image [%s]\n",
-             filename);
-    return ret;
-  }
-
-  avifBool ok = avifPeekCompatibleFileType(&raw);
-  if (!ok) {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "Invalid avif image [%s]\n",
-             filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
 
   decoder = avifDecoderCreate();
   if (decoder == NULL) {
@@ -138,7 +62,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
     goto out;
   }
 
-  result = avifDecoderParse(decoder, &raw);
+  result = avifDecoderReadFile(decoder, &avif_image, filename);
   if (result != AVIF_RESULT_OK) {
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to parse AVIF image [%s]: %s\n",
@@ -146,19 +70,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
-  if (decoder->imageCount > 1) {
-    dt_control_log(_("image '%s' has more than one frame!"), filename);
-  }
-  result = avifDecoderNthImage(decoder, 0);
-  if (result != AVIF_RESULT_OK) {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to decode first frame of AVIF image [%s]: %s\n",
-             filename, avifResultToString(result));
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-
-  avif = decoder->image;
+  avif = &avif_image;
 
   /* This will set the depth from the avif */
   avifRGBImageSetDefaults(&rgb, avif);
@@ -268,7 +180,6 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
 out:
   avifRGBImageFreePixels(&rgb);
   avifDecoderDestroy(decoder);
-  avifFree((void *)raw.data); /* discard const */
 
   return ret;
 }
@@ -276,26 +187,10 @@ out:
 dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, struct avif_color_profile *cp)
 {
   dt_imageio_retval_t ret;
-  avifROData raw = AVIF_DATA_EMPTY;
   avifDecoder *decoder = NULL;
+  avifImage avif_image = {0};
+  avifImage *avif = NULL;
   avifResult result;
-
-  ret = read_image(filename, &raw);
-  if (ret != DT_IMAGEIO_OK) {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to read image [%s]\n",
-             filename);
-    return ret;
-  }
-
-  avifBool ok = avifPeekCompatibleFileType(&raw);
-  if (!ok) {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "Invalid avif image [%s]\n",
-             filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
 
   decoder = avifDecoderCreate();
   if (decoder == NULL) {
@@ -306,7 +201,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
     goto out;
   }
 
-  result = avifDecoderParse(decoder, &raw);
+  result = avifDecoderReadFile(decoder, &avif_image, filename);
   if (result != AVIF_RESULT_OK) {
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to parse AVIF image [%s]: %s\n",
@@ -314,23 +209,10 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
     ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
+  avif = &avif_image;
 
-  if (decoder->imageCount > 1) {
-    dt_control_log(_("image '%s' has more than one frame!"), filename);
-  }
-
-  result = avifDecoderNthImage(decoder, 0);
-  if (result != AVIF_RESULT_OK) {
-    dt_print(DT_DEBUG_IMAGEIO,
-             "Failed to decode first frame of AVIF image [%s]: %s\n",
-             filename, avifResultToString(result));
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
-    goto out;
-  }
-
-#if AVIF_VERSION >= 800
-  if (decoder->image->icc.size > 0) {
-    avifRWData icc = decoder->image->icc;
+  if (avif->icc.size > 0) {
+    avifRWData icc = avif->icc;
 
     if (icc.data == NULL || icc.size == 0) {
       ret = DT_IMAGEIO_FILE_CORRUPTED;
@@ -350,19 +232,19 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
     cp->icc_profile_size = icc.size;
     cp->icc_profile = data;
   } else {
-    switch(decoder->image->colorPrimaries) {
+    switch(avif->colorPrimaries) {
     /*
      * BT709
      */
     case AVIF_COLOR_PRIMARIES_BT709:
 
-      switch (decoder->image->transferCharacteristics) {
+      switch (avif->transferCharacteristics) {
       /*
        * SRGB
        */
       case AVIF_TRANSFER_CHARACTERISTICS_SRGB:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_BT709:
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_SRGB;
@@ -378,7 +260,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
        */
       case AVIF_TRANSFER_CHARACTERISTICS_BT470M:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_BT709:
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_REC709;
@@ -394,7 +276,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
        */
       case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_BT709:
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_LIN_REC709;
@@ -416,13 +298,13 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
      */
     case AVIF_COLOR_PRIMARIES_BT2020:
 
-      switch (decoder->image->transferCharacteristics) {
+      switch (avif->transferCharacteristics) {
       /*
        * LINEAR BT2020
        */
       case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_LIN_REC2020;
@@ -438,7 +320,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
        */
       case AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_PQ_REC2020;
@@ -454,7 +336,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
        */
       case AVIF_TRANSFER_CHARACTERISTICS_HLG:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_HLG_REC2020;
@@ -476,13 +358,13 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
      */
     case AVIF_COLOR_PRIMARIES_SMPTE432:
 
-      switch (decoder->image->transferCharacteristics) {
+      switch (avif->transferCharacteristics) {
       /*
        * PQ P3
        */
       case AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_PQ_P3;
           break;
@@ -497,7 +379,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
        */
       case AVIF_TRANSFER_CHARACTERISTICS_HLG:
 
-        switch (decoder->image->matrixCoefficients) {
+        switch (avif->matrixCoefficients) {
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_PQ_P3;
           break;
@@ -520,214 +402,10 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       break;
     }
   }
-#else /* AVIF_VERSION 700 */
-  switch(decoder->image->profileFormat) {
-  case AVIF_PROFILE_FORMAT_NCLX: {
-    avifNclxColorProfile nclx = decoder->image->nclx;
-
-    switch(nclx.colourPrimaries) {
-    /*
-     * BT709
-     */
-    case AVIF_NCLX_COLOUR_PRIMARIES_BT709:
-
-      switch (nclx.transferCharacteristics) {
-      /*
-       * SRGB
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT709:
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_SRGB;
-          break;
-        default:
-          break;
-        }
-
-        break; /* SRGB */
-
-      /*
-       * GAMMA22 BT709
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT470M:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT709:
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_REC709;
-          break;
-        default:
-          break;
-        }
-
-        break; /* GAMMA22 BT709 */
-
-      /*
-       * LINEAR BT709
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT709:
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_LIN_REC709;
-          break;
-        default:
-          break;
-        }
-
-        break; /* LINEAR BT709 */
-
-      default:
-        break;
-      }
-
-      break; /* BT709 */
-
-    /*
-     * BT2020
-     */
-    case AVIF_NCLX_COLOUR_PRIMARIES_BT2020:
-
-      switch (nclx.transferCharacteristics) {
-      /*
-       * LINEAR BT2020
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL:
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_LIN_REC2020;
-          break;
-        default:
-          break;
-        }
-
-        break; /* LINEAR BT2020 */
-
-      /*
-       * PQ BT2020
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL:
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_PQ_REC2020;
-          break;
-        default:
-          break;
-        }
-
-        break; /* PQ BT2020 */
-
-      /*
-       * HLG BT2020
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL:
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_HLG_REC2020;
-          break;
-        default:
-          break;
-        }
-
-        break; /* HLG BT2020 */
-
-      default:
-        break;
-      }
-
-      break; /* BT2020 */
-
-    /*
-     * P3
-     */
-    case AVIF_NCLX_COLOUR_PRIMARIES_SMPTE432:
-
-      switch (nclx.transferCharacteristics) {
-      /*
-       * PQ P3
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_PQ_P3;
-          break;
-        default:
-          break;
-        }
-
-        break; /* PQ P3 */
-
-      /*
-       * HLG P3
-       */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG:
-
-        switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_PQ_P3;
-          break;
-        default:
-          break;
-        }
-
-        break; /* HLG P3 */
-
-      default:
-        break;
-      }
-
-      break; /* P3 */
-
-    default:
-      dt_print(DT_DEBUG_IMAGEIO,
-               "Unsupported color profile for %s\n",
-               filename);
-      break;
-    }
-
-    break; /* AVIF_PROFILE_FORMAT_NCLX */
-  }
-  case AVIF_PROFILE_FORMAT_ICC: {
-    avifRWData icc = decoder->image->icc;
-
-    if (icc.data == NULL || icc.size == 0) {
-      ret = DT_IMAGEIO_FILE_CORRUPTED;
-      goto out;
-    }
-
-    uint8_t *data = (uint8_t *)g_malloc0(icc.size * sizeof(uint8_t));
-    if (data == NULL) {
-      dt_print(DT_DEBUG_IMAGEIO,
-               "Failed to allocate ICC buffer for AVIF image [%s]\n",
-               filename);
-      ret = DT_IMAGEIO_FILE_CORRUPTED;
-      goto out;
-    }
-    memcpy(data, icc.data, icc.size);
-
-    cp->icc_profile_size = icc.size;
-    cp->icc_profile = data;
-    break;
-  }
-  case AVIF_PROFILE_FORMAT_NONE:
-    break;
-  }
-#endif /* AVIF_VERSION */
 
   ret = DT_IMAGEIO_OK;
 out:
   avifDecoderDestroy(decoder);
-  avifFree((void *)raw.data); /* discard const */
 
   return ret;
 }


### PR DESCRIPTION
This gets us a bit deeper into #ifdef hell. We could also require libavif 0.8.2 and remove all of that. The questions when is the right time to require a newer libavif version :-)