### PR TITLE
using glib function to trash files in windows

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -855,8 +855,6 @@ static enum _dt_delete_status delete_file_from_disk(const char *filename, gboole
     {
 #ifdef __APPLE__
       delete_success = dt_osx_file_trash(filename, &gerror);
-#elif defined(_WIN32)
-      delete_success = dt_win_file_trash(gfile, NULL /*cancellable*/, &gerror);
 #else
       delete_success = g_file_trash(gfile, NULL /*cancellable*/, &gerror);
 #endif
@@ -971,10 +969,6 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     gboolean from_cache = FALSE;
     dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
 
-#ifdef _WIN32
-    char *dirname = g_path_get_dirname(filename);
-#endif
-
     int duplicates = 0;
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     if(sqlite3_step(stmt) == SQLITE_ROW) duplicates = sqlite3_column_int(stmt, 0);
@@ -1032,9 +1026,6 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     }
 
 delete_next_file:
-#ifdef _WIN32
-    g_free(dirname);
-#endif
     t = g_list_next(t);
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);

--- a/src/win/dtwin.c
+++ b/src/win/dtwin.c
@@ -343,43 +343,6 @@ void dtwin_set_thread_name(DWORD dwThreadID, const char *threadName)
   RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(DWORD), (const ULONG_PTR *)&info);
 }
 
-// This is taken from: https://git.gnome.org/browse/glib/tree/gio/glocalfile.c#n2269
-// The glib version of this function unfortunately shows always confirmation dialog boxes
-// This version does thrashing silently, without dialog boxes: FOF_SILENT | FOF_NOCONFIRMATION
-// When glib version on Windows will do silent trashing we can remove this function
-boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error)
-{
-  SHFILEOPSTRUCTW op = { 0 };
-  gboolean success;
-  wchar_t *wfilename;
-  long len;
-
-  wfilename = g_utf8_to_utf16(g_file_get_parse_name(file), -1, NULL, &len, NULL);
-  /* SHFILEOPSTRUCT.pFrom is double-zero-terminated */
-  wfilename = g_renew(wchar_t, wfilename, len + 2);
-  wfilename[len + 1] = 0;
-
-  op.wFunc = FO_DELETE;
-  op.pFrom = wfilename;
-  op.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION;
-
-  success = SHFileOperationW(&op) == 0;
-
-  if(success && op.fAnyOperationsAborted)
-  {
-    if(cancellable && !g_cancellable_is_cancelled(cancellable)) g_cancellable_cancel(cancellable);
-    g_set_error(error, G_IO_ERROR, g_io_error_from_errno(ECANCELED),
-                g_strdup_printf("Unable to trash file %s: %s", file, ECANCELED), g_file_get_parse_name(file),
-                g_strerror(ECANCELED));
-    success = FALSE;
-  }
-  else if(!success)
-    g_set_error(error, G_IO_ERROR, g_io_error_from_errno(0), g_strdup_printf("Unable to trash file %s", file),
-                g_file_get_parse_name(file), g_strerror(0));
-
-  g_free(wfilename);
-  return success;
-}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/win/dtwin.h
+++ b/src/win/dtwin.h
@@ -23,7 +23,6 @@
 
 const wchar_t *dtwin_get_locale();
 void dtwin_set_thread_name(DWORD dwThreadID, const char *threadName);
-boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Continues from #4131 (rebased)

For me using the glib function to trash files in windows is working fine, there are no confirmation dialogs, so we can drop the special function used before and simplify the code.
But if someone else tests the PR, that would be nice.