### PR TITLE
Add LLVM 11 as supported version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ if(TESTBUILD_OPENCL_PROGRAMS)
   endmacro()
 
   # 3.9 is the first version with which this works.
-  find_llvm("10;9;8;7;6.0;5.0;4.0;3.9")
+  find_llvm("11;10;9;8;7;6.0;5.0;4.0;3.9")
 
   if (LLVM_FOUND)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
Fedora 33 uses LLVM 11.

This change appears to change the following message:

```
-- The following OPTIONAL packages have been found:

 * LLVM (required version >= 11)
```

while it should be 3.9, I don't understand why for now.