### PR TITLE
[db_snap] try to improve snap behaviour on windows

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1307,8 +1307,12 @@ void dt_cleanup()
       int i = 0;
       while(snaps_to_remove[i])
       {
-        dt_print(DT_DEBUG_SQL, "[db backup] removing old snap: %s.\n", snaps_to_remove[i]);
-        g_unlink(snaps_to_remove[i++]);
+        // make file to remove writable, mostly problem on windows.
+        g_chmod(snaps_to_remove[i], S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+
+        dt_print(DT_DEBUG_SQL, "[db backup] removing old snap: %s... ", snaps_to_remove[i]);
+        const int retunlink = g_remove(snaps_to_remove[i++]);
+        dt_print(DT_DEBUG_SQL, "%s\n", retunlink == 0 ? "success" : "failed!");
       }
     }
   }

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3501,7 +3501,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   g_free(lib_basename);
 
   GError *error = NULL;
-  GFileEnumerator *library_dir_files = g_file_enumerate_children(parent, G_FILE_ATTRIBUTE_TIME_MODIFIED, G_FILE_QUERY_INFO_NONE, NULL, &error);
+  GFileEnumerator *library_dir_files = g_file_enumerate_children(parent, G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_TIME_MODIFIED, G_FILE_QUERY_INFO_NONE, NULL, &error);
 
   if(library_dir_files == NULL)
   {
@@ -3940,7 +3940,7 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename)
   g_free(db_basename);
 
   GError *error = NULL;
-  GFileEnumerator *db_dir_files = g_file_enumerate_children(parent, G_FILE_ATTRIBUTE_TIME_MODIFIED, G_FILE_QUERY_INFO_NONE, NULL, &error);
+  GFileEnumerator *db_dir_files = g_file_enumerate_children(parent, G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_TIME_MODIFIED, G_FILE_QUERY_INFO_NONE, NULL, &error);
 
   if(db_dir_files == NULL)
   {


### PR DESCRIPTION
Try to fix #6579 

Let's see if this works

@phrrk - can you check it? we'll try make it this time.

please run test runs with `-d sql`, not `-d all`.