### PR TITLE
thumbnail: record expose_again source ID and cancel timeout on destroy

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -198,8 +198,8 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
 static gboolean _thumb_expose_again(gpointer user_data)
 {
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
-  gpointer w_image = thumb->w_image;
   if(!thumb) return FALSE;
+  gpointer w_image = thumb->w_image;
   if(!w_image || !GTK_IS_WIDGET(w_image)) return FALSE;
 
   thumb->expose_again_timeout_id = 0;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -422,7 +422,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       {
         // if the image is missing, we reload it again
         if(!thumb->expose_again_timeout_id)
-          thumb->expose_again_timeout_id = g_timeout_add(10, _thumb_expose_again, thumb);
+          thumb->expose_again_timeout_id = g_timeout_add(250, _thumb_expose_again, thumb);
 
         // we still draw the thumb to avoid flickering
         _thumb_draw_image(thumb, cr);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -197,10 +197,13 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
 
 static gboolean _thumb_expose_again(gpointer user_data)
 {
-  if(!user_data || !GTK_IS_WIDGET(user_data)) return FALSE;
+  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+  gpointer w_image = thumb->w_image;
+  if(!thumb) return FALSE;
+  if(!w_image || !GTK_IS_WIDGET(w_image)) return FALSE;
 
-  GtkWidget *widget = (GtkWidget *)user_data;
-  gtk_widget_queue_draw(widget);
+  thumb->expose_again_timeout_id = 0;
+  gtk_widget_queue_draw((GtkWidget *)w_image);
   return FALSE;
 }
 
@@ -418,7 +421,9 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       if(res)
       {
         // if the image is missing, we reload it again
-        g_timeout_add(250, _thumb_expose_again, widget);
+        if(!thumb->expose_again_timeout_id)
+          thumb->expose_again_timeout_id = g_timeout_add(10, _thumb_expose_again, thumb);
+
         // we still draw the thumb to avoid flickering
         _thumb_draw_image(thumb, cr);
         return TRUE;
@@ -1226,6 +1231,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
   thumb->zoom = 1.0f;
   thumb->overlay_timeout_duration = dt_conf_get_int("plugins/lighttable/overlay_timeout");
   thumb->tooltip = tooltip;
+  thumb->expose_again_timeout_id = 0;
 
   // we read and cache all the infos from dt_image_t that we need
   const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->imgid, 'r');
@@ -1280,6 +1286,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
 void dt_thumbnail_destroy(dt_thumbnail_t *thumb)
 {
   if(thumb->overlay_timeout_id > 0) g_source_remove(thumb->overlay_timeout_id);
+  if(thumb->expose_again_timeout_id != 0) g_source_remove(thumb->expose_again_timeout_id);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_selection_changed_callback), thumb);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_active_images_callback), thumb);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_mipmaps_updated_callback), thumb);

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -117,6 +117,8 @@ typedef struct
   int overlay_timeout_id;       // id of the g_source timeout fct
   gboolean tooltip;             // should we show the tooltip ?
 
+  int expose_again_timeout_id;  // source id of the expose_again timeout
+
   // specific for culling and preview
   gboolean zoomable;   // can we zoom in/out the thumbnail (used for culling/preview)
   double aspect_ratio; // aspect ratio of the image


### PR DESCRIPTION
This resolves a race condition where a thumbnail widget may be destroyed before the expose_again timeout is triggered, causing a use-after-free problem. In particular, this commit fixes #6620.