### PR TITLE
Automatically set up accelerators for all widgets in iop gui_init

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -855,28 +855,31 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
 
   if(w->module)
   {
-    if(!darktable.bauhaus->skip_accel)
+    if(!darktable.bauhaus->skip_accel && (!section_orig || strcmp("blend", section_orig)))
     {
+      gchar *combined_label = section_orig
+                            ? g_strdup_printf("%s¬%s", section_orig, label_orig)
+                            : g_strdup(label_orig);
       if(darktable.control->accel_initialising)
       {
         if(w->type == DT_BAUHAUS_SLIDER)
         {
-          dt_accel_register_slider_iop(w->module->so, FALSE, label_orig);
+          dt_accel_register_slider_iop(w->module->so, FALSE, combined_label);
         }
         else if(w->type == DT_BAUHAUS_COMBOBOX)
         {
-          dt_accel_register_combobox_iop(w->module->so, FALSE, label_orig);
+          dt_accel_register_combobox_iop(w->module->so, FALSE, combined_label);
         }
       }
       else
       {
         if(w->type == DT_BAUHAUS_SLIDER)
         {
-          dt_accel_connect_slider_iop(w->module, label_orig, widget);
+          dt_accel_connect_slider_iop(w->module, combined_label, widget);
         }
         else if(w->type == DT_BAUHAUS_COMBOBOX)
         {
-          dt_accel_connect_combobox_iop(w->module, label_orig, widget);
+          dt_accel_connect_combobox_iop(w->module, combined_label, widget);
         }
       }
     }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -857,22 +857,22 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
     {
       if(w->type == DT_BAUHAUS_SLIDER)
       {
-        dt_accel_register_slider_iop(w->module->so, FALSE, label);
+        dt_accel_register_slider_iop(w->module->so, FALSE, label_orig);
       }
       else if(w->type == DT_BAUHAUS_COMBOBOX)
       {
-        dt_accel_register_combobox_iop(w->module->so, FALSE, label);
+        dt_accel_register_combobox_iop(w->module->so, FALSE, label_orig);
       }
     }
     else
     {
       if(w->type == DT_BAUHAUS_SLIDER)
       {
-        dt_accel_connect_slider_iop(w->module, label, widget);
+        dt_accel_connect_slider_iop(w->module, label_orig, widget);
       }
       else if(w->type == DT_BAUHAUS_COMBOBOX)
       {
-        dt_accel_connect_combobox_iop(w->module, label, widget);
+        dt_accel_connect_combobox_iop(w->module, label_orig, widget);
       }
     }
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -583,6 +583,8 @@ void dt_bauhaus_init()
   darktable.bauhaus->key_val = NULL;
   memset(darktable.bauhaus->key_history, 0, sizeof(darktable.bauhaus->key_history));
 
+  darktable.bauhaus->skip_accel = 0;
+
   // this easily gets keyboard input:
   // darktable.bauhaus->popup_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
   // but this doesn't flicker, and the above hack with key input seems to work well.
@@ -853,26 +855,29 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
 
   if(w->module)
   {
-    if(darktable.control->accel_initialising)
+    if(!darktable.bauhaus->skip_accel)
     {
-      if(w->type == DT_BAUHAUS_SLIDER)
+      if(darktable.control->accel_initialising)
       {
-        dt_accel_register_slider_iop(w->module->so, FALSE, label_orig);
+        if(w->type == DT_BAUHAUS_SLIDER)
+        {
+          dt_accel_register_slider_iop(w->module->so, FALSE, label_orig);
+        }
+        else if(w->type == DT_BAUHAUS_COMBOBOX)
+        {
+          dt_accel_register_combobox_iop(w->module->so, FALSE, label_orig);
+        }
       }
-      else if(w->type == DT_BAUHAUS_COMBOBOX)
+      else
       {
-        dt_accel_register_combobox_iop(w->module->so, FALSE, label_orig);
-      }
-    }
-    else
-    {
-      if(w->type == DT_BAUHAUS_SLIDER)
-      {
-        dt_accel_connect_slider_iop(w->module, label_orig, widget);
-      }
-      else if(w->type == DT_BAUHAUS_COMBOBOX)
-      {
-        dt_accel_connect_combobox_iop(w->module, label_orig, widget);
+        if(w->type == DT_BAUHAUS_SLIDER)
+        {
+          dt_accel_connect_slider_iop(w->module, label_orig, widget);
+        }
+        else if(w->type == DT_BAUHAUS_COMBOBOX)
+        {
+          dt_accel_connect_combobox_iop(w->module, label_orig, widget);
+        }
       }
     }
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -22,6 +22,7 @@
 #include "control/conf.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
+#include "gui/accelerators.h"
 #include "gui/gtk.h"
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
@@ -852,6 +853,29 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
 
   if(w->module)
   {
+    if(darktable.control->accel_initialising)
+    {
+      if(w->type == DT_BAUHAUS_SLIDER)
+      {
+        dt_accel_register_slider_iop(w->module->so, FALSE, label);
+      }
+      else if(w->type == DT_BAUHAUS_COMBOBOX)
+      {
+        dt_accel_register_combobox_iop(w->module->so, FALSE, label);
+      }
+    }
+    else
+    {
+      if(w->type == DT_BAUHAUS_SLIDER)
+      {
+        dt_accel_connect_slider_iop(w->module, label, widget);
+      }
+      else if(w->type == DT_BAUHAUS_COMBOBOX)
+      {
+        dt_accel_connect_combobox_iop(w->module, label, widget);
+      }
+    }
+
     // construct control path name and insert into keymap:
     gchar *path;
     if(section && section[0] != '\0')

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -841,8 +841,11 @@ void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min,
   d->hard_max = hard_max;
 }
 
-void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const char *label)
+void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, const char *label_orig)
 {
+  const char *section = _(section_orig);
+  const char *label = _(label_orig);
+
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   memset(w->label, 0, sizeof(w->label)); // keep valgrind happy
   g_strlcpy(w->label, label, sizeof(w->label));

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -858,7 +858,7 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
     if(!darktable.bauhaus->skip_accel && (!section_orig || strcmp("blend", section_orig)))
     {
       gchar *combined_label = section_orig
-                            ? g_strdup_printf("%s¬%s", section_orig, label_orig)
+                            ? g_strdup_printf("%s`%s", section_orig, label_orig)
                             : g_strdup(label_orig);
       if(darktable.control->accel_initialising)
       {

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -203,6 +203,9 @@ typedef struct dt_bauhaus_t
   GList *key_val;     // for autocomplete, after the point: .value
   char key_history[64][256];
 
+  // initialise or connect accelerators in set_label
+  int skip_accel;
+
   // appearance relevant stuff:
   // sizes and fonts:
   float scale;                           // gui scale multiplier

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -151,6 +151,8 @@ typedef struct dt_control_t
   // Accelerator group path lists
   GSList *accelerator_list;
 
+  gboolean accel_initialising;
+
   // Cached accelerator keys for key_pressed shortcuts
   dt_control_accels_t accels;
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1696,7 +1696,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
     GtkWidget *abox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
     bd->masks_combo = dt_bauhaus_combobox_new(module);
-    dt_bauhaus_widget_set_label(bd->masks_combo, _("blend"), _("drawn mask"));
+    dt_bauhaus_widget_set_label(bd->masks_combo, N_("blend"), N_("drawn mask"));
     dt_bauhaus_combobox_add(bd->masks_combo, _("no mask used"));
     dt_bauhaus_combobox_set(bd->masks_combo, 0);
     g_signal_connect(G_OBJECT(bd->masks_combo), "value-changed",
@@ -1902,7 +1902,7 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
     GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
     bd->raster_combo = dt_bauhaus_combobox_new(module);
-    dt_bauhaus_widget_set_label(bd->raster_combo, _("blend"), _("raster mask"));
+    dt_bauhaus_widget_set_label(bd->raster_combo, N_("blend"), N_("raster mask"));
     dt_bauhaus_combobox_add(bd->raster_combo, _("no mask used"));
     dt_bauhaus_combobox_set(bd->raster_combo, 0);
     g_signal_connect(G_OBJECT(bd->raster_combo), "value-changed",
@@ -1964,7 +1964,7 @@ static GtkWidget *_combobox_new_from_list(dt_iop_module_t *module, const gchar *
 {
   GtkWidget *combo = dt_bauhaus_combobox_new(module);
 
-  dt_bauhaus_widget_set_label(combo, _("blend"), label);
+  dt_bauhaus_widget_set_label(combo, N_("blend"), label);
   gtk_widget_set_tooltip_text(combo, tooltip);
   for(; *list->name; list++)
     dt_bauhaus_combobox_add_full(combo, _(list->name), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
@@ -2263,7 +2263,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                         g_list_index(bd->masks_modes, (gconstpointer)DEVELOP_MASK_DISABLED)));
 
     bd->blend_modes_combo = dt_bauhaus_combobox_new(module);
-    dt_bauhaus_widget_set_label(bd->blend_modes_combo, _("blend"), _("blend mode"));
+    dt_bauhaus_widget_set_label(bd->blend_modes_combo, N_("blend"), N_("blend mode"));
     gtk_widget_set_tooltip_text(bd->blend_modes_combo, _("choose blending mode"));
 
     if(bd->csp == iop_cs_Lab ||
@@ -2333,7 +2333,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     dt_gui_add_help_link(GTK_WIDGET(bd->blend_modes_combo), "blending.html#blending_operators");
 
     bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 1, 100.0, 0);
-    dt_bauhaus_widget_set_label(bd->opacity_slider, _("blend"), _("opacity"));
+    dt_bauhaus_widget_set_label(bd->opacity_slider, N_("blend"), N_("opacity"));
     dt_bauhaus_slider_set_format(bd->opacity_slider, "%.0f%%");
     module->fusion_slider = bd->opacity_slider;
     gtk_widget_set_tooltip_text(bd->opacity_slider, _("set the opacity of the blending"));
@@ -2355,21 +2355,21 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                      G_CALLBACK(dt_iop_combobox_enum_callback), &module->blend_params->feathering_guide);
 
     bd->feathering_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 250.0, 0.1, 0.0, 1);
-    dt_bauhaus_widget_set_label(bd->feathering_radius_slider, _("blend"), _("feathering radius"));
+    dt_bauhaus_widget_set_label(bd->feathering_radius_slider, N_("blend"), N_("feathering radius"));
     dt_bauhaus_slider_set_format(bd->feathering_radius_slider, "%.1f");
     gtk_widget_set_tooltip_text(bd->feathering_radius_slider, _("spatial radius of feathering"));
     g_signal_connect(G_OBJECT(bd->feathering_radius_slider), "value-changed",
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->feathering_radius);
 
     bd->blur_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0.1, 0.0, 1);
-    dt_bauhaus_widget_set_label(bd->blur_radius_slider, _("blend"), _("mask blur"));
+    dt_bauhaus_widget_set_label(bd->blur_radius_slider, N_("blend"), N_("mask blur"));
     dt_bauhaus_slider_set_format(bd->blur_radius_slider, "%.1f");
     gtk_widget_set_tooltip_text(bd->blur_radius_slider, _("radius for gaussian blur of blend mask"));
     g_signal_connect(G_OBJECT(bd->blur_radius_slider), "value-changed",
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->blur_radius);
 
     bd->brightness_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
-    dt_bauhaus_widget_set_label(bd->brightness_slider, _("blend"), _("mask opacity"));
+    dt_bauhaus_widget_set_label(bd->brightness_slider, N_("blend"), N_("mask opacity"));
     dt_bauhaus_slider_set_format(bd->brightness_slider, "%.2f");
     gtk_widget_set_tooltip_text(bd->brightness_slider, _("shifts and tilts the tone curve of the blend mask to adjust its "
                                                          "brightness without affecting fully transparent/fully opaque "
@@ -2378,7 +2378,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->brightness);
 
     bd->contrast_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
-    dt_bauhaus_widget_set_label(bd->contrast_slider, _("blend"), _("mask contrast"));
+    dt_bauhaus_widget_set_label(bd->contrast_slider, N_("blend"), N_("mask contrast"));
     dt_bauhaus_slider_set_format(bd->contrast_slider, "%.2f");
     gtk_widget_set_tooltip_text(bd->contrast_slider, _("gives the tone curve of the blend mask an s-like shape to "
                                                        "adjust its contrast"));

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1534,7 +1534,7 @@ static void init_key_accels(dt_iop_module_so_t *module)
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     char path[1024];
-    snprintf(path, sizeof(path), "%s¬%s", N_("preset"), (const char *)sqlite3_column_text(stmt, 0));
+    snprintf(path, sizeof(path), "%s`%s", N_("preset"), (const char *)sqlite3_column_text(stmt, 0));
     dt_accel_register_iop(module, FALSE, path, 0, 0);
   }
   sqlite3_finalize(stmt);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -718,8 +718,8 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   // rebuild the accelerators (to point to an extant module)
   dt_iop_connect_accels_multi(module->so);
 
-  dt_accel_cleanup_locals_iop(module);
-  module->accel_closures = NULL;
+  dt_accel_cleanup_closures_iop(module);
+
   // don't delete the module, a pipe may still need it
   dev->alliop = g_list_append(dev->alliop, module);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1522,6 +1522,9 @@ static void init_presets(dt_iop_module_so_t *module_so)
 
 static void init_key_accels(dt_iop_module_so_t *module)
 {
+  // Calling the accelerator initialization callback, if present
+  if(module->init_key_accels) (module->init_key_accels)(module);
+
   // create a gui and have the widgets register their accelerators
   if(module->gui_init)
   {
@@ -2975,7 +2978,9 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
   {
     //add accelerators to new module
     dt_accel_connect_list_iop(accel_mod_new);
+
     // FIXME: not special case? i.e. make sure they are in list
+    if(accel_mod_new->connect_key_accels) accel_mod_new->connect_key_accels(accel_mod_new);
     dt_iop_connect_common_accels(accel_mod_new);
   }
 }

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -134,6 +134,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   dt_iop_params_t *d = (dt_iop_params_t *)self->default_params;
 
   size_t param_index = 0;
+  gboolean skip_label = FALSE;
 
   const size_t param_length = strlen(param) + 1;
   char *param_name = g_malloc(param_length);
@@ -141,6 +142,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   if(sscanf(param, "%[^[][%zu]", base_name, &param_index) == 2)
   {
     sprintf(param_name, "%s[0]", base_name);
+    skip_label = TRUE;
   }
   else
   {
@@ -226,19 +228,22 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
 
   if(f)
   {
-    if (*f->header.description)
+    if(!skip_label)
     {
-      // we do not want to support a context as it break all translations see #5498
-      // dt_bauhaus_widget_set_label(slider, NULL, g_dpgettext2(NULL, "introspection description", f->header.description));
-      dt_bauhaus_widget_set_label(slider, NULL, gettext(f->header.description));
-    }
-    else
-    {
-      str = dt_util_str_replace(f->header.field_name, "_", " ");
+      if (*f->header.description)
+      {
+        // we do not want to support a context as it break all translations see #5498
+        // dt_bauhaus_widget_set_label(slider, NULL, g_dpgettext2(NULL, "introspection description", f->header.description));
+        dt_bauhaus_widget_set_label(slider, NULL, f->header.description);
+      }
+      else
+      {
+        str = dt_util_str_replace(f->header.field_name, "_", " ");
 
-      dt_bauhaus_widget_set_label(slider, NULL, _(str));
+        dt_bauhaus_widget_set_label(slider,  NULL, str);
 
-      g_free(str);
+        g_free(str);
+      }
     }
   }
   else
@@ -276,13 +281,13 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
     {
       // we do not want to support a context as it break all translations see #5498
       // dt_bauhaus_widget_set_label(combobox, NULL, g_dpgettext2(NULL, "introspection description", f->header.description));
-      dt_bauhaus_widget_set_label(combobox, NULL, gettext(f->header.description));
+      dt_bauhaus_widget_set_label(combobox, NULL, f->header.description);
     }
     else
     {
       str = dt_util_str_replace(f->header.field_name, "_", " ");
 
-      dt_bauhaus_widget_set_label(combobox, NULL, _(str));
+      dt_bauhaus_widget_set_label(combobox,  NULL, str);
 
       g_free(str);
     }

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -19,7 +19,9 @@
 #include "develop/imageop_gui.h"
 #include "develop/imageop.h"
 #include "bauhaus/bauhaus.h"
+#include "dtgtk/button.h"
 #include "gui/color_picker_proxy.h"
+#include "gui/accelerators.h"
 
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
@@ -377,6 +379,108 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
 
   if(!self->widget) self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   gtk_box_pack_start(GTK_BOX(self->widget), button, FALSE, FALSE, 0);
+
+  return button;
+}
+
+static void _send_button_press_event(GtkWidget *w, guint state)
+{
+  if(!(GTK_IS_BUTTON(w))) return;
+
+  GdkEvent *event = gdk_event_new(GDK_BUTTON_PRESS);
+  event->button.state = state;
+  event->button.button = 1;
+  event->button.window = gtk_widget_get_window(w);
+  g_object_ref(event->button.window);
+
+  gtk_widget_event(w, event);
+
+  gdk_event_free(event);
+}
+
+static gboolean _press_button_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                       GdkModifierType modifier, gpointer widget)
+{
+  _send_button_press_event(widget, 0);
+  return TRUE;
+}
+
+static gboolean _ctrl_press_button_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                             GdkModifierType modifier, gpointer widget)
+{
+  _send_button_press_event(widget, GDK_CONTROL_MASK);
+  return TRUE;
+}
+
+GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const gchar *label, const gchar *ctrl_label,
+                                   GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
+                                   DTGTKCairoPaintIconFunc paint, GtkWidget *box)
+{
+  GtkWidget *w = dtgtk_togglebutton_new(paint, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(w), "button-press-event", callback, self);
+
+  if(!ctrl_label)
+    gtk_widget_set_tooltip_text(w, _(label));
+  else
+  {
+    gchar *tooltip = g_strdup_printf(_("%s\nctrl+click to %s"), _(label), _(ctrl_label));
+    gtk_widget_set_tooltip_text(w, tooltip);
+    g_free(tooltip);
+  }
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), FALSE);
+  if(GTK_IS_BOX(box)) gtk_box_pack_end(GTK_BOX(box), w, FALSE, FALSE, 0);
+
+  gchar *label_first_line = g_strdelimit(g_strdup(label), "\n", '\0');
+  if(darktable.control->accel_initialising)
+  {
+    dt_accel_register_iop(self->so, local, label_first_line, accel_key, mods);
+    if(ctrl_label) dt_accel_register_iop(self->so, local, ctrl_label, 0, 0);
+  }
+  else
+  {
+    GClosure *closure = g_cclosure_new(G_CALLBACK(_press_button_callback), (gpointer)w, NULL);
+    dt_accel_connect_iop(self, label_first_line, closure);
+    if(ctrl_label)
+    {
+      closure = g_cclosure_new(G_CALLBACK(_ctrl_press_button_callback), (gpointer)w, NULL);
+      dt_accel_connect_iop(self, ctrl_label, closure);
+    }
+  }
+  g_free(label_first_line);
+
+  return w;
+}
+
+GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
+                             GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
+                             DTGTKCairoPaintIconFunc paint, gint paintflags, GtkWidget *box)
+{
+  GtkWidget *button = NULL;
+
+  if(paint)
+  {
+    button = dtgtk_button_new(paint, CPF_STYLE_FLAT | paintflags, NULL);
+    gtk_widget_set_tooltip_text(button, _(label));
+  }
+  else
+  {
+    button = gtk_button_new_with_label(_(label));
+    gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
+  }
+
+  g_signal_connect(G_OBJECT(button), "clicked", callback, (gpointer)self);
+
+  if(darktable.control->accel_initialising)
+  {
+    dt_accel_register_iop(self->so, local, label, accel_key, mods);
+  }
+  else
+  {
+    dt_accel_connect_button_iop(self, label, button);
+  }
+
+  if(GTK_IS_BOX(box)) gtk_box_pack_start(GTK_BOX(box), button, TRUE, TRUE, 0);
 
   return button;
 }

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -26,6 +26,14 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param);
 
+GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const gchar *label, const gchar *ctrl_label,
+                                   GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
+                                   DTGTKCairoPaintIconFunc paint, GtkWidget *box);
+
+GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
+                             GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
+                             DTGTKCairoPaintIconFunc paint, gint paintflags, GtkWidget *box);
+
 void dt_iop_slider_float_callback(GtkWidget *slider, float *field);
 void dt_iop_slider_int_callback(GtkWidget *slider, int *field);
 void dt_iop_slider_ushort_callback(GtkWidget *slider, unsigned short *field);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -46,16 +46,18 @@ void dt_accel_path_view(char *s, size_t n, char *module, const char *path)
 
 void dt_accel_path_iop(char *s, size_t n, char *module, const char *path)
 {
-  snprintf(s, n, "<Darktable>/%s/%s/%s", "image operations", module, path);
-}
-
-void dt_accel_path_sub_iop(char *s, size_t n, char *module, const char *path, const char *sub)
-{
-  gchar *path_fixed = g_strdelimit(g_strdup(path), "/", '-');
-  gchar *sub_fixed = g_strdelimit(g_strdup(sub), "/", '-');
-  snprintf(s, n, "<Darktable>/%s/%s/%s/%s", "image operations", module, path_fixed, sub);
-  g_free(sub_fixed);
-  g_free(path_fixed);
+  if(path)
+  {
+    gchar **split_paths = g_strsplit(path, "¬", 4);
+    for(gchar **cur_path = split_paths; *cur_path; cur_path++)
+      g_strdelimit(*cur_path, "/¬", '-');
+    gchar *joined_paths = g_strjoinv("/", split_paths);
+    snprintf(s, n, "<Darktable>/%s/%s/%s", "image operations", module, joined_paths);
+    g_free(joined_paths);
+    g_strfreev(split_paths);
+  }
+  else
+    snprintf(s, n, "<Darktable>/%s/%s", "image operations", module);
 }
 
 void dt_accel_path_lib(char *s, size_t n, char *module, const char *path)
@@ -86,21 +88,40 @@ static void dt_accel_path_view_translated(char *s, size_t n, dt_view_t *module, 
 
 static void dt_accel_path_iop_translated(char *s, size_t n, dt_iop_module_so_t *module, const char *path)
 {
-  gchar *module_name_fixed = g_strdelimit(g_strdup(module->name()), "/", '-');
-  snprintf(s, n, "<Darktable>/%s/%s/%s", C_("accel", "processing modules"), module_name_fixed, _(path));
-  g_free(module_name_fixed);
-}
+  gchar *module_clean = g_strdelimit(g_strdup(module->name()), "/", '-');
 
-static void dt_accel_path_sub_iop_translated(char *s, size_t n, dt_iop_module_so_t *module, const char *path, const char *sub)
-{
-  gchar *module_fixed = g_strdelimit(g_strdup(module->name()), "/", '-');
-  gchar *path_fixed = g_strdelimit(g_strdup(Q_(path)), "/", '-');
-  gchar *sub_fixed = g_strdelimit(g_strdup(sub), "/", '-');
-  snprintf(s, n, "<Darktable>/%s/%s/%s/%s", C_("accel", "processing modules"), module_fixed, path_fixed, sub_fixed);
-  if(!*sub) s[strlen(s) - 1] = '\0';
-  g_free(sub_fixed);
-  g_free(path_fixed);
-  g_free(module_fixed);
+  if(path)
+  {
+    gchar **split_paths = g_strsplit(path, "¬", 4);
+    for(gchar **cur_path = split_paths; *cur_path; cur_path++)
+    {
+      gchar *saved_path = *cur_path;
+      *cur_path = g_strdelimit(g_strdup(Q_(*cur_path)), "/¬", '-');
+      g_free(saved_path);
+    }
+    gchar *joined_paths = g_strjoinv("/", split_paths);
+    snprintf(s, n, "<Darktable>/%s/%s/%s", C_("accel", "processing modules"), module_clean, joined_paths);
+    g_free(joined_paths);
+    g_strfreev(split_paths);
+  }
+  else
+    snprintf(s, n, "<Darktable>/%s/%s", C_("accel", "processing modules"), module_clean);
+
+  g_free(module_clean);
+
+/*
+  gchar **split_paths = g_strsplit(path, "¬", 4);
+  gchar **cleaned_paths = g_malloc0_n(g_strv_length(split_paths) + 2, sizeof(gchar*));
+  gchar **add_path = cleaned_paths;
+  *(add_path++) = g_strdelimit(g_strdup(module->name()), "/", '-');
+  for(gchar **cur_path = split_paths; *cur_path; cur_path++)
+    *(add_path++) = g_strdelimit(g_strdup(Q_(*cur_path)), "/¬", '-');
+  gchar *joined_paths = g_strjoinv("/", cleaned_paths);
+  snprintf(s, n, "<Darktable>/%s/%s", C_("accel", "processing modules"), joined_paths);
+  g_free(joined_paths);
+  g_strfreev(cleaned_paths);
+  g_strfreev(split_paths);
+*/
 }
 
 static void dt_accel_path_lib_translated(char *s, size_t n, dt_lib_module_t *module, const char *path)
@@ -254,6 +275,14 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
   dt_accel_register_lib_for_views(self, v, path, accel_key, mods);
 }
 
+const gchar *_common_actions[]
+  = { NC_("accel", "show module"),
+      NC_("accel", "enable module"),
+      NC_("accel", "focus module"),
+      NC_("accel", "reset module parameters"),
+      NC_("accel", "show preset menu"),
+      NULL };
+
 const gchar *_slider_actions[]
   = { NC_("accel", "increase"),
       NC_("accel", "decrease"),
@@ -268,15 +297,20 @@ const gchar *_combobox_actions[]
       NC_("accel", "dynamic"),
       NULL };
 
-void _accel_register_widget_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path, const char **actions)
+void _accel_register_actions_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path, const char **actions)
 {
+  gchar accel_path[256];
+  gchar accel_path_trans[256];
+  dt_accel_path_iop(accel_path, sizeof(accel_path), so->op, path);
+  dt_accel_path_iop_translated(accel_path_trans, sizeof(accel_path_trans), so, path);
+
   for(const char **action = actions; *action; action++)
   {
     dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
-    dt_accel_path_sub_iop(accel->path, sizeof(accel->path), so->op, path, *action);
+    snprintf(accel->path, sizeof(accel->path), "%s/%s", accel_path, *action);
     gtk_accel_map_add_entry(accel->path, 0, 0);
-    dt_accel_path_sub_iop_translated(accel->translated_path, sizeof(accel->translated_path), so, path,
-                                     g_dpgettext2(NULL, "accel", *action));
+    snprintf(accel->translated_path, sizeof(accel->translated_path), "%s/%s", accel_path_trans,
+             g_dpgettext2(NULL, "accel", *action));
     g_strlcpy(accel->module, so->op, sizeof(accel->module));
     accel->local = local;
     accel->views = DT_VIEW_DARKROOM;
@@ -285,14 +319,19 @@ void _accel_register_widget_iop(dt_iop_module_so_t *so, gboolean local, const gc
   }
 }
 
+void dt_accel_register_common_iop(dt_iop_module_so_t *so)
+{
+  _accel_register_actions_iop(so, FALSE, NULL, _common_actions);
+}
+
 void dt_accel_register_combobox_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)
 {
-  _accel_register_widget_iop(so, local, path, _combobox_actions);
+  _accel_register_actions_iop(so, local, path, _combobox_actions);
 }
 
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)
 {
-  _accel_register_widget_iop(so, local, path, _slider_actions);
+  _accel_register_actions_iop(so, local, path, _slider_actions);
 }
 
 void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType mods)
@@ -701,19 +740,21 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
   return TRUE;
 }
 
-void _accel_connect_widget_iop(dt_iop_module_t *module, const gchar *path,
+void _accel_connect_actions_iop(dt_iop_module_t *module, const gchar *path,
                                GtkWidget *w, const gchar *actions[], void *callbacks[])
 {
-  while(*actions)
+  gchar accel_path[256];
+  dt_accel_path_iop(accel_path, sizeof(accel_path) - 1, module->op, path);
+  size_t path_len = strlen(accel_path);
+  accel_path[path_len++] = '/';
+
+  for(const char **action = actions; *action; action++, callbacks++)
   {
-    gchar accel_path[256];
-    dt_accel_path_sub_iop(accel_path, sizeof(accel_path), module->op, path, *actions);
+    strncpy(accel_path + path_len, *action, sizeof(accel_path) - path_len);
+
     GClosure *closure = g_cclosure_new(G_CALLBACK(*callbacks), (gpointer)w, NULL);
 
     _store_iop_accel_closure(module, accel_path, closure);
-
-    actions++;
-    callbacks++;
   }
 }
 
@@ -726,7 +767,7 @@ void dt_accel_connect_combobox_iop(dt_iop_module_t *module, const gchar *path, G
         bauhaus_combobox_prev_callback,
         bauhaus_dynamic_callback };
 
-  _accel_connect_widget_iop(module, path, combobox, _combobox_actions, combobox_callbacks);
+  _accel_connect_actions_iop(module, path, combobox, _combobox_actions, combobox_callbacks);
 }
 
 void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *slider)
@@ -740,7 +781,7 @@ void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, Gtk
         bauhaus_slider_edit_callback,
         bauhaus_dynamic_callback };
 
-  _accel_connect_widget_iop(module, path, slider, _slider_actions, slider_callbacks);
+  _accel_connect_actions_iop(module, path, slider, _slider_actions, slider_callbacks);
 }
 
 void dt_accel_connect_list_iop(dt_iop_module_t *module)
@@ -886,7 +927,7 @@ void dt_accel_connect_preset_iop(dt_iop_module_t *module, const gchar *path)
 {
   char build_path[1024];
   gchar *name = g_strdelimit(g_strdup(path), "/", '-');
-  snprintf(build_path, sizeof(build_path), "%s/%s", _("preset"), name);
+  snprintf(build_path, sizeof(build_path), "%s/%s", "preset", name);
   preset_iop_module_callback_description *callback_description
       = g_malloc(sizeof(preset_iop_module_callback_description));
   callback_description->module = module;
@@ -1156,8 +1197,7 @@ gboolean find_accel_internal(GtkAccelKey *key, GClosure *closure, gpointer data)
 
 void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, const gchar *new_path)
 {
-  char *path_fixed =  g_strdelimit(g_strdup(path), "/", '-');
-  char *path_preset = g_strdup_printf("%s/%s", _("preset"), path_fixed);
+  char *path_preset = g_strdup_printf("%s¬%s", N_("preset"), path);
 
   char build_path[1024];
   dt_accel_path_iop(build_path, sizeof(build_path), module->op, path_preset);
@@ -1171,13 +1211,9 @@ void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, cons
           = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
       gboolean local = accel->local;
       dt_accel_deregister_iop(module, path_preset);
-      g_free(path_preset);
-      g_free(path_fixed);
-      char *new_path_fixed = g_strdelimit(g_strdup(new_path), "/", '-');
-      snprintf(build_path, sizeof(build_path), "%s/%s", _("preset"), new_path_fixed);
+      snprintf(build_path, sizeof(build_path), "%s¬%s", N_("preset"), new_path);
       dt_accel_register_iop(module->so, local, build_path, tmp_key.accel_key, tmp_key.accel_mods);
-      dt_accel_connect_preset_iop(module, new_path_fixed);
-      g_free(new_path_fixed);
+      dt_accel_connect_preset_iop(module, new_path);
       l = NULL;
     }
     else
@@ -1185,6 +1221,7 @@ void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, cons
       l = g_slist_next(l);
     }
   }
+      g_free(path_preset);
 }
 
 void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, const gchar *new_path)
@@ -1203,10 +1240,8 @@ void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, cons
       GtkAccelKey tmp_key
           = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
       dt_accel_deregister_lib(module, path_preset);
-      g_free(path_preset);
-      g_free(path_fixed);
       char *new_path_fixed = g_strdelimit(g_strdup(new_path), "/", '-');
-      snprintf(build_path, sizeof(build_path), "%s/%s", _("preset"), new_path_fixed);
+      snprintf(build_path, sizeof(build_path), "%s/%s", N_("preset"), new_path_fixed);
       dt_accel_register_lib(module, build_path, tmp_key.accel_key, tmp_key.accel_mods);
       dt_accel_connect_preset_lib(module, new_path_fixed);
       g_free(new_path_fixed);
@@ -1217,6 +1252,8 @@ void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, cons
       l = g_slist_next(l);
     }
   }
+  g_free(path_preset);
+  g_free(path_fixed);
 }
 
 void dt_accel_rename_global(const gchar *path, const gchar *new_path)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -294,7 +294,7 @@ void _accel_register_actions_iop(dt_iop_module_so_t *so, gboolean local, const g
     dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
     snprintf(accel->path, sizeof(accel->path), "%s/%s", accel_path, *action);
     gtk_accel_map_add_entry(accel->path, 0, 0);
-    snprintf(accel->translated_path, sizeof(accel->translated_path), "%s/%s", accel_path_trans,
+    snprintf(accel->translated_path, sizeof(accel->translated_path), "%s/%s ", accel_path_trans,
              g_dpgettext2(NULL, "accel", *action));
     g_strlcpy(accel->module, so->op, sizeof(accel->module));
     accel->local = local;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -48,9 +48,8 @@ void dt_accel_path_iop(char *s, size_t n, char *module, const char *path)
 {
   if(path)
   {
-    gchar **split_paths = g_strsplit(path, "¬", 4);
-    for(gchar **cur_path = split_paths; *cur_path; cur_path++)
-      g_strdelimit(*cur_path, "/¬", '-');
+
+    gchar **split_paths = g_strsplit(path, "`", 4);
     gchar *joined_paths = g_strjoinv("/", split_paths);
     snprintf(s, n, "<Darktable>/%s/%s/%s", "image operations", module, joined_paths);
     g_free(joined_paths);
@@ -92,11 +91,11 @@ static void dt_accel_path_iop_translated(char *s, size_t n, dt_iop_module_so_t *
 
   if(path)
   {
-    gchar **split_paths = g_strsplit(path, "¬", 4);
+    gchar **split_paths = g_strsplit(path, "`", 4);
     for(gchar **cur_path = split_paths; *cur_path; cur_path++)
     {
       gchar *saved_path = *cur_path;
-      *cur_path = g_strdelimit(g_strdup(Q_(*cur_path)), "/¬", '-');
+      *cur_path = g_strdelimit(g_strdup(Q_(*cur_path)), "/", '`');
       g_free(saved_path);
     }
     gchar *joined_paths = g_strjoinv("/", split_paths);
@@ -1204,7 +1203,7 @@ gboolean find_accel_internal(GtkAccelKey *key, GClosure *closure, gpointer data)
 
 void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, const gchar *new_path)
 {
-  char *path_preset = g_strdup_printf("%s¬%s", N_("preset"), path);
+  char *path_preset = g_strdup_printf("%s`%s", N_("preset"), path);
 
   char build_path[1024];
   dt_accel_path_iop(build_path, sizeof(build_path), module->op, path_preset);
@@ -1218,7 +1217,7 @@ void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, cons
           = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
       gboolean local = accel->local;
       dt_accel_deregister_iop(module, path_preset);
-      snprintf(build_path, sizeof(build_path), "%s¬%s", N_("preset"), new_path);
+      snprintf(build_path, sizeof(build_path), "%s`%s", N_("preset"), new_path);
       dt_accel_register_iop(module->so, local, build_path, tmp_key.accel_key, tmp_key.accel_mods);
       dt_accel_connect_preset_iop(module, new_path);
       l = NULL;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -108,20 +108,6 @@ static void dt_accel_path_iop_translated(char *s, size_t n, dt_iop_module_so_t *
     snprintf(s, n, "<Darktable>/%s/%s", C_("accel", "processing modules"), module_clean);
 
   g_free(module_clean);
-
-/*
-  gchar **split_paths = g_strsplit(path, "¬", 4);
-  gchar **cleaned_paths = g_malloc0_n(g_strv_length(split_paths) + 2, sizeof(gchar*));
-  gchar **add_path = cleaned_paths;
-  *(add_path++) = g_strdelimit(g_strdup(module->name()), "/", '-');
-  for(gchar **cur_path = split_paths; *cur_path; cur_path++)
-    *(add_path++) = g_strdelimit(g_strdup(Q_(*cur_path)), "/¬", '-');
-  gchar *joined_paths = g_strjoinv("/", cleaned_paths);
-  snprintf(s, n, "<Darktable>/%s/%s", C_("accel", "processing modules"), joined_paths);
-  g_free(joined_paths);
-  g_strfreev(cleaned_paths);
-  g_strfreev(split_paths);
-*/
 }
 
 static void dt_accel_path_lib_translated(char *s, size_t n, dt_lib_module_t *module, const char *path)
@@ -447,6 +433,7 @@ static dt_accel_t *_store_iop_accel_closure(dt_iop_module_t *module, gchar *acce
   stored_accel->closure = closure;
 
   g_closure_ref(closure);
+  g_closure_sink(closure);
   *save_list = g_slist_prepend(*save_list, stored_accel);
 
   return accel;
@@ -784,13 +771,14 @@ void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, Gtk
   _accel_connect_actions_iop(module, path, slider, _slider_actions, slider_callbacks);
 }
 
-void dt_accel_connect_list_iop(dt_iop_module_t *module)
+void dt_accel_connect_instance_iop(dt_iop_module_t *module)
 {
   for(GSList *l = module->accel_closures; l; l = g_slist_next(l))
   {
     _accel_iop_t *stored_accel = (_accel_iop_t *)l->data;
     if(stored_accel && stored_accel->accel && stored_accel->closure)
     {
+
       if(stored_accel->accel->closure)
         gtk_accel_group_disconnect(darktable.control->accelerators, stored_accel->accel->closure);
 
@@ -808,7 +796,10 @@ void dt_accel_connect_locals_iop(dt_iop_module_t *module)
   while(l)
   {
     _accel_iop_t *accel = (_accel_iop_t *)l->data;
-    if(accel) gtk_accel_group_connect_by_path(darktable.control->accelerators, accel->accel->path, accel->closure);
+    if(accel)
+    {
+      gtk_accel_group_connect_by_path(darktable.control->accelerators, accel->accel->path, accel->closure);
+    }
     l = g_slist_next(l);
   }
 
@@ -837,7 +828,6 @@ void dt_accel_disconnect_locals_iop(dt_iop_module_t *module)
     _accel_iop_t *accel = (_accel_iop_t *)l->data;
     if(accel)
     {
-      g_closure_ref(accel->closure);
       gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
     }
     l = g_slist_next(l);
@@ -846,16 +836,33 @@ void dt_accel_disconnect_locals_iop(dt_iop_module_t *module)
   module->local_closures_connected = FALSE;
 }
 
-void dt_accel_cleanup_locals_iop(dt_iop_module_t *module)
+void _free_iop_accel(gpointer data)
+{
+  _accel_iop_t *accel = (_accel_iop_t *) data;
+
+  if(accel->accel->closure == accel->closure)
+  {
+    gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
+    accel->accel->closure = NULL;
+  }
+
+  if(accel->closure->ref_count != 1)
+    fprintf(stderr, "iop accel refcount %d %s\n", accel->closure->ref_count, accel->accel->path);
+
+  g_closure_unref(accel->closure);
+
+  g_free(accel);
+}
+
+void dt_accel_cleanup_closures_iop(dt_iop_module_t *module)
 {
   dt_accel_disconnect_locals_iop(module);
 
-  g_slist_free_full(module->accel_closures_local, g_free);
+  g_slist_free_full(module->accel_closures, _free_iop_accel);
+  g_slist_free_full(module->accel_closures_local, _free_iop_accel);
+  module->accel_closures = NULL;
   module->accel_closures_local = NULL;
-  //FIXME:   g_closure_unref(closure);
 }
-
-// FIXME: cleanup accel_closures
 
 typedef struct
 {
@@ -870,9 +877,9 @@ static void preset_iop_module_callback_destroyer(gpointer data, GClosure *closur
   g_free(callback_description->name);
   g_free(data);
 }
+
 static gboolean preset_iop_module_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                            GdkModifierType modifier, gpointer data)
-
 {
   preset_iop_module_callback_description *callback_description
       = (preset_iop_module_callback_description *)data;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -50,6 +50,13 @@ void dt_accel_path_iop(char *s, size_t n, char *module, const char *path)
   {
 
     gchar **split_paths = g_strsplit(path, "`", 4);
+    // transitionally keep "preset" translated in keyboardrc to avoid breakage for now
+    // this also needs to be amended in preferences
+    if(!strcmp(split_paths[0], "preset"))
+    {
+      g_free(split_paths[0]);
+      split_paths[0] = g_strdup(_("preset"));
+    }
     gchar *joined_paths = g_strjoinv("/", split_paths);
     snprintf(s, n, "<Darktable>/%s/%s/%s", "image operations", module, joined_paths);
     g_free(joined_paths);
@@ -95,7 +102,7 @@ static void dt_accel_path_iop_translated(char *s, size_t n, dt_iop_module_so_t *
     for(gchar **cur_path = split_paths; *cur_path; cur_path++)
     {
       gchar *saved_path = *cur_path;
-      *cur_path = g_strdelimit(g_strdup(Q_(*cur_path)), "/", '`');
+      *cur_path = g_strdelimit(g_strconcat(Q_(*cur_path), (strcmp(*cur_path, "preset") ? NULL : " "), NULL), "/", '`');
       g_free(saved_path);
     }
     gchar *joined_paths = g_strjoinv("/", split_paths);
@@ -932,8 +939,8 @@ static gboolean preset_iop_module_callback(GtkAccelGroup *accel_group, GObject *
 void dt_accel_connect_preset_iop(dt_iop_module_t *module, const gchar *path)
 {
   char build_path[1024];
-  gchar *name = g_strdelimit(g_strdup(path), "/", '-');
-  snprintf(build_path, sizeof(build_path), "%s/%s", "preset", name);
+  gchar *name = g_strdup(path);
+  snprintf(build_path, sizeof(build_path), "%s`%s", N_("preset"), name);
   preset_iop_module_callback_description *callback_description
       = g_malloc(sizeof(preset_iop_module_callback_description));
   callback_description->module = module;
@@ -1016,7 +1023,7 @@ static gboolean preset_lib_module_callback(GtkAccelGroup *accel_group, GObject *
 void dt_accel_connect_preset_lib(dt_lib_module_t *module, const gchar *path)
 {
   char build_path[1024];
-  gchar *name = g_strdelimit(g_strdup(path), "/", '-');
+  gchar *name = g_strdup(path);
   snprintf(build_path, sizeof(build_path), "%s/%s", _("preset"), name);
   preset_lib_module_callback_description *callback_description
       = g_malloc(sizeof(preset_lib_module_callback_description));
@@ -1030,52 +1037,53 @@ void dt_accel_connect_preset_lib(dt_lib_module_t *module, const gchar *path)
 
 void dt_accel_deregister_iop(dt_iop_module_t *module, const gchar *path)
 {
-  GSList *l = module->accel_closures_local;
   char build_path[1024];
   dt_accel_path_iop(build_path, sizeof(build_path), module->op, path);
-  while(l)
+
+  dt_accel_t *accel = NULL;
+
+  GList *modules = g_list_first(darktable.develop->iop);
+  while(modules)
   {
-    dt_accel_t *accel = (dt_accel_t *)l->data;
-    if(accel && !strncmp(accel->path, build_path, 1024))
+    dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
+
+    if(mod->so == module->so)
     {
-      module->accel_closures_local = g_slist_delete_link(module->accel_closures_local, l);
-      l = NULL;
+      GSList **current_list = &mod->accel_closures;
+      GSList *l = *current_list;
+      while(l)
+      {
+        _accel_iop_t *iop_accel = (_accel_iop_t *)l->data;
+
+        if(iop_accel && iop_accel->accel && !strncmp(iop_accel->accel->path, build_path, 1024))
+        {
+          accel = iop_accel->accel;
+
+          if(iop_accel->closure == accel->closure || (accel->local && module->local_closures_connected))
+            gtk_accel_group_disconnect(darktable.control->accelerators, iop_accel->closure);
+
+          *current_list = g_slist_delete_link(*current_list, l);
+
+          g_closure_unref(iop_accel->closure);
+
+          g_free(iop_accel);
+
+          break;
+        }
+
+        l = g_slist_next(l);
+        if(!l && current_list == &mod->accel_closures) l = *(current_list = &module->accel_closures_local);
+      }
     }
-    else
-    {
-      l = g_slist_next(l);
-    }
+
+    modules = g_list_next(modules);
   }
-  l = module->accel_closures;
-  while(l)
+
+  if(accel)
   {
-    dt_accel_t *accel = (dt_accel_t *)l->data;
-    if(accel && !strncmp(accel->path, build_path, 1024))
-    {
-      if(!accel->local || !module->local_closures_connected)
-        gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
-      module->accel_closures = g_slist_delete_link(module->accel_closures, l);
-      l = NULL;
-    }
-    else
-    {
-      l = g_slist_next(l);
-    }
-  }
-  l = darktable.control->accelerator_list;
-  while(l)
-  {
-    dt_accel_t *accel = (dt_accel_t *)l->data;
-    if(accel && !strncmp(accel->path, build_path, 1024))
-    {
-      darktable.control->accelerator_list = g_slist_delete_link(darktable.control->accelerator_list, l);
-      l = NULL;
+      darktable.control->accelerator_list = g_slist_remove(darktable.control->accelerator_list, accel);
+
       g_free(accel);
-    }
-    else
-    {
-      l = g_slist_next(l);
-    }
   }
 }
 
@@ -1207,36 +1215,47 @@ void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, cons
 
   char build_path[1024];
   dt_accel_path_iop(build_path, sizeof(build_path), module->op, path_preset);
+
   GSList *l = module->accel_closures;
   while(l)
   {
-    dt_accel_t *accel = (dt_accel_t *)l->data;
-    if(accel && !strncmp(accel->path, build_path, 1024))
+    _accel_iop_t *iop_accel = (_accel_iop_t *)l->data;
+    if(iop_accel && iop_accel->accel && !strncmp(iop_accel->accel->path, build_path, 1024))
     {
       GtkAccelKey tmp_key
-          = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
-      gboolean local = accel->local;
+          = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, iop_accel->closure));
+      gboolean local = iop_accel->accel->local;
+
       dt_accel_deregister_iop(module, path_preset);
+
       snprintf(build_path, sizeof(build_path), "%s`%s", N_("preset"), new_path);
       dt_accel_register_iop(module->so, local, build_path, tmp_key.accel_key, tmp_key.accel_mods);
-      dt_accel_connect_preset_iop(module, new_path);
-      l = NULL;
+
+      GList *modules = g_list_first(darktable.develop->iop);
+      while(modules)
+      {
+        dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
+
+        if(mod->so == module->so) dt_accel_connect_preset_iop(mod, new_path);
+
+        modules = g_list_next(modules);
+      }
+
+      break;
     }
-    else
-    {
-      l = g_slist_next(l);
-    }
+
+    l = g_slist_next(l);
   }
-      g_free(path_preset);
+
+  g_free(path_preset);
+
+  dt_accel_connect_instance_iop(module);
 }
 
 void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, const gchar *new_path)
 {
-  char *path_fixed = g_strdelimit(g_strdup(path), "/", '-');
-  char *path_preset = g_strdup_printf("%s/%s", _("preset"), path_fixed);
-
   char build_path[1024];
-  dt_accel_path_lib(build_path, sizeof(build_path), module->plugin_name, path_preset);
+  dt_accel_path_lib(build_path, sizeof(build_path), module->plugin_name, path);
   GSList *l = module->accel_closures;
   while(l)
   {
@@ -1245,12 +1264,10 @@ void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, cons
     {
       GtkAccelKey tmp_key
           = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
-      dt_accel_deregister_lib(module, path_preset);
-      char *new_path_fixed = g_strdelimit(g_strdup(new_path), "/", '-');
-      snprintf(build_path, sizeof(build_path), "%s/%s", N_("preset"), new_path_fixed);
+      dt_accel_deregister_lib(module, path);
+      snprintf(build_path, sizeof(build_path), "%s/%s", _("preset"), new_path);
       dt_accel_register_lib(module, build_path, tmp_key.accel_key, tmp_key.accel_mods);
-      dt_accel_connect_preset_lib(module, new_path_fixed);
-      g_free(new_path_fixed);
+      dt_accel_connect_preset_lib(module, new_path);
       l = NULL;
     }
     else
@@ -1258,8 +1275,6 @@ void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, cons
       l = g_slist_next(l);
     }
   }
-  g_free(path_preset);
-  g_free(path_fixed);
 }
 
 void dt_accel_rename_global(const gchar *path, const gchar *new_path)

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -85,7 +85,7 @@ void dt_accel_connect_button_iop(dt_iop_module_t *module, const gchar *path, Gtk
 void dt_accel_connect_button_lib(dt_lib_module_t *module, const gchar *path, GtkWidget *button);
 void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *slider);
 void dt_accel_connect_combobox_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *combobox);
-void dt_accel_connect_list_iop(dt_iop_module_t *module);
+void dt_accel_connect_instance_iop(dt_iop_module_t *module);
 void dt_accel_connect_locals_iop(dt_iop_module_t *module);
 void dt_accel_connect_preset_iop(dt_iop_module_t *so, const gchar *path);
 void dt_accel_connect_preset_lib(dt_lib_module_t *so, const gchar *path);
@@ -95,7 +95,7 @@ void dt_accel_connect_manual(GSList **list_ptr, const gchar *full_path, GClosure
 // Disconnect function
 void dt_accel_disconnect_list(GSList **accels_ptr);
 void dt_accel_disconnect_locals_iop(dt_iop_module_t *module);
-void dt_accel_cleanup_locals_iop(dt_iop_module_t *module);
+void dt_accel_cleanup_closures_iop(dt_iop_module_t *module);
 
 // Deregister functions
 void dt_accel_deregister_iop(dt_iop_module_t *module, const gchar *path);

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -46,7 +46,7 @@ typedef enum dt_accel_iop_slider_scale_t
 // Accel path string building functions
 void dt_accel_path_global(char *s, size_t n, const char *path);
 void dt_accel_path_view(char *s, size_t n, char *module, const char *path);
-void dt_accel_path_sub_iop(char *s, size_t n, char *module, const char *path, const char *sub);
+void dt_accel_path_iop(char *s, size_t n, char *module, const char *path);
 void dt_accel_path_lib(char *s, size_t n, char *module, const char *path);
 void dt_accel_path_lua(char *s, size_t n, const char *path);
 void dt_accel_path_manual(char *s, size_t n, const char *full_path);
@@ -64,6 +64,7 @@ void dt_accel_register_lib_for_views(dt_lib_module_t *self, dt_view_type_flags_t
                                      guint accel_key, GdkModifierType mods);
 //register lib shortcut but make it look like a view shortcut
 void dt_accel_register_lib_as_view(gchar *view_name, const gchar *path, guint accel_key, GdkModifierType mods);
+void dt_accel_register_common_iop(dt_iop_module_so_t *so);
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path);
 void dt_accel_register_combobox_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path);
 void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType mods);

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -46,19 +46,10 @@ typedef enum dt_accel_iop_slider_scale_t
 // Accel path string building functions
 void dt_accel_path_global(char *s, size_t n, const char *path);
 void dt_accel_path_view(char *s, size_t n, char *module, const char *path);
-void dt_accel_path_iop(char *s, size_t n, char *module, const char *path);
+void dt_accel_path_sub_iop(char *s, size_t n, char *module, const char *path, const char *sub);
 void dt_accel_path_lib(char *s, size_t n, char *module, const char *path);
 void dt_accel_path_lua(char *s, size_t n, const char *path);
 void dt_accel_path_manual(char *s, size_t n, const char *full_path);
-/**
- * Accepts an array of 5 char*, writes the following paths to them
- * 0 - Slider increase path
- * 1 - Slider decrease path
- * 2 - Slider reset path
- * 3 - Slider edit path
- * 4 - Slider dynamic path
- */
-void dt_accel_paths_slider_iop(char *s[], size_t n, char *module, const char *path);
 
 // Accelerator search functions
 dt_accel_t *dt_accel_find_by_path(const gchar *path);
@@ -93,6 +84,7 @@ void dt_accel_connect_button_iop(dt_iop_module_t *module, const gchar *path, Gtk
 void dt_accel_connect_button_lib(dt_lib_module_t *module, const gchar *path, GtkWidget *button);
 void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *slider);
 void dt_accel_connect_combobox_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *combobox);
+void dt_accel_connect_list_iop(dt_iop_module_t *module);
 void dt_accel_connect_locals_iop(dt_iop_module_t *module);
 void dt_accel_connect_preset_iop(dt_iop_module_t *so, const gchar *path);
 void dt_accel_connect_preset_lib(dt_lib_module_t *so, const gchar *path);

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -105,21 +105,21 @@ static GtkWidget *_guides_gui_grid(dt_iop_module_t *self, void *user_data)
 
   GtkWidget *grid_horizontal = dt_bauhaus_slider_new_with_range(self, 0, 12, 1, data->horizontal, 0);
   dt_bauhaus_slider_set_hard_max(grid_horizontal, 36);
-  dt_bauhaus_widget_set_label(grid_horizontal, NULL, _("horizontal lines"));
+  dt_bauhaus_widget_set_label(grid_horizontal, NULL, N_("horizontal lines"));
   gtk_widget_set_tooltip_text(grid_horizontal, _("number of horizontal guide lines"));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(grid_horizontal), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(grid_horizontal), "value-changed", G_CALLBACK(_grid_horizontal_changed), user_data);
 
   GtkWidget *grid_vertical = dt_bauhaus_slider_new_with_range(self, 0, 12, 1, data->vertical, 0);
   dt_bauhaus_slider_set_hard_max(grid_vertical, 36);
-  dt_bauhaus_widget_set_label(grid_vertical, NULL, _("vertical lines"));
+  dt_bauhaus_widget_set_label(grid_vertical, NULL, N_("vertical lines"));
   gtk_widget_set_tooltip_text(grid_vertical, _("number of vertical guide lines"));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(grid_vertical), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(grid_vertical), "value-changed", G_CALLBACK(_grid_vertical_changed), user_data);
 
   GtkWidget *grid_subdiv = dt_bauhaus_slider_new_with_range(self, 0, 10, 1, data->subdiv, 0);
   dt_bauhaus_slider_set_hard_max(grid_subdiv, 30);
-  dt_bauhaus_widget_set_label(grid_subdiv, NULL, _("subdivisions"));
+  dt_bauhaus_widget_set_label(grid_subdiv, NULL, N_("subdivisions"));
   gtk_widget_set_tooltip_text(grid_subdiv, _("number of subdivisions per grid rectangle"));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(grid_subdiv), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(grid_subdiv), "value-changed", G_CALLBACK(_grid_subdiv_changed), user_data);
@@ -437,7 +437,7 @@ static GtkWidget *_guides_gui_golden_mean(dt_iop_module_t *self, void *user_data
 {
   _golden_mean_t *data = (_golden_mean_t *)user_data;
   GtkWidget *golden_extras = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(golden_extras, NULL, _("extra"));
+  dt_bauhaus_widget_set_label(golden_extras, NULL, N_("extra"));
   dt_bauhaus_combobox_add(golden_extras, _("golden sections"));
   dt_bauhaus_combobox_add(golden_extras, _("golden spiral sections"));
   dt_bauhaus_combobox_add(golden_extras, _("golden spiral"));

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1020,10 +1020,7 @@ static void tree_insert_rec(GtkTreeStore *model, GtkTreeIter *parent, const gcha
   }
   else
   {
-    const int add_space = strstr(accel_path, "preset/") == accel_path ? 1 : 0;
-    gchar *trans_node = g_strndup(translated_path, trans_end - translated_path + add_space);
-    if(add_space) trans_node[trans_end - translated_path] = ' ';
-
+    gchar *trans_node = g_strndup(translated_path, trans_end - translated_path);
     gchar *trans_scan = trans_node;
     while((trans_scan = strchr(trans_scan, '`')))
     {
@@ -1541,7 +1538,7 @@ static gboolean tree_key_press_presets(GtkWidget *widget, GdkEventKey *event, gp
           dt_loc_get_user_config_dir(datadir, sizeof(datadir));
           snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", datadir);
 
-          gchar *preset_name = g_strdup_printf("%s`%s", "preset", name);
+          gchar *preset_name = g_strdup_printf("%s`%s", N_("preset"), name);
           dt_accel_path_iop(accel, sizeof(accel), operation, preset_name);
           g_free(preset_name);
 
@@ -1776,7 +1773,7 @@ static gint compare_rows_presets(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
     gtk_tree_model_get(model, b, P_NAME_COLUMN, &b_text, -1);
   }
 
-  const int res = strcasecmp(a_text, b_text);
+  const int res = strcoll(a_text, b_text);
 
   g_free(a_text);
   g_free(b_text);
@@ -2094,7 +2091,7 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
           dt_loc_get_user_config_dir(datadir, sizeof(datadir));
           snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", datadir);
 
-          gchar *preset_name = g_strdup_printf("%s`%s", "preset", name);
+          gchar *preset_name = g_strdup_printf("%s`%s", N_("preset"), name);
           dt_accel_path_iop(accel, sizeof(accel), operation, preset_name);
           g_free(preset_name);
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1527,10 +1527,7 @@ static gboolean tree_key_press_presets(GtkWidget *widget, GdkEventKey *event, gp
           dt_loc_get_user_config_dir(datadir, sizeof(datadir));
           snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", datadir);
 
-          gchar* tmp_path = g_strdup_printf("%s/%s", _("preset"), name);
-          g_strlcpy(accel, "<Darktable>", sizeof(accel));
-          dt_accel_path_iop(accel, sizeof(accel), operation, tmp_path);
-          g_free(tmp_path);
+          dt_accel_path_sub_iop(accel, sizeof(accel), operation, "preset", name);
           gtk_accel_map_change_entry(accel, 0, 0, TRUE);
 
           // Saving the changed bindings
@@ -2075,10 +2072,7 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
           dt_loc_get_user_config_dir(datadir, sizeof(datadir));
           snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", datadir);
 
-          gchar* tmp_path = g_strdup_printf("%s/%s", _("preset"), name);
-          g_strlcpy(accel, "<Darktable>", sizeof(accel));
-          dt_accel_path_iop(accel, sizeof(accel), operation, tmp_path);
-          g_free(tmp_path);
+          dt_accel_path_sub_iop(accel, sizeof(accel), operation, "preset", name);
           gtk_accel_map_change_entry(accel, 0, 0, TRUE);
 
           // Saving the changed bindings

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1527,7 +1527,10 @@ static gboolean tree_key_press_presets(GtkWidget *widget, GdkEventKey *event, gp
           dt_loc_get_user_config_dir(datadir, sizeof(datadir));
           snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", datadir);
 
-          dt_accel_path_sub_iop(accel, sizeof(accel), operation, "preset", name);
+          gchar *preset_name = g_strdup_printf("%s¬%s", "preset", name);
+          dt_accel_path_iop(accel, sizeof(accel), operation, preset_name);
+          g_free(preset_name);
+
           gtk_accel_map_change_entry(accel, 0, 0, TRUE);
 
           // Saving the changed bindings
@@ -2072,7 +2075,10 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
           dt_loc_get_user_config_dir(datadir, sizeof(datadir));
           snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", datadir);
 
-          dt_accel_path_sub_iop(accel, sizeof(accel), operation, "preset", name);
+          gchar *preset_name = g_strdup_printf("%s¬%s", "preset", name);
+          dt_accel_path_iop(accel, sizeof(accel), operation, preset_name);
+          g_free(preset_name);
+
           gtk_accel_map_change_entry(accel, 0, 0, TRUE);
 
           // Saving the changed bindings

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -332,9 +332,7 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
     }
 
     // rename accelerators
-    char path[1024];
-    snprintf(path, sizeof(path), "%s/%s", _("preset"), g->original_name);
-    dt_accel_rename_preset_iop(g->module, path, name);
+    dt_accel_rename_preset_iop(g->module, g->original_name, name);
     // commit all the user input fields
     DT_DEBUG_SQLITE3_PREPARE_V2(
         dt_database_get(darktable.db),

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -709,9 +709,9 @@ static void menuitem_new_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
   sqlite3_finalize(stmt);
   // create a shortcut for the new entry
   char path[1024];
-  snprintf(path, sizeof(path), "%s/%s", _("preset"), _("new preset"));
+  snprintf(path, sizeof(path), "%s¬%s", N_("preset"), N_("new preset"));
   dt_accel_register_iop(module->so, FALSE, path, 0, 0);
-  dt_accel_connect_preset_iop(module, _("new preset"));
+  dt_accel_connect_preset_iop(module, N_("new preset"));
   // then show edit dialog
   edit_preset(_("new preset"), module);
 }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -213,7 +213,7 @@ static void menuitem_delete_preset(GtkMenuItem *menuitem, dt_iop_module_t *modul
   if(res == GTK_RESPONSE_YES)
   {
     char tmp_path[1024];
-    snprintf(tmp_path, sizeof(tmp_path), "%s/%s", _("preset"), name);
+    snprintf(tmp_path, sizeof(tmp_path), "%s¬%s", _("preset"), name);
     dt_accel_deregister_iop(module, tmp_path);
     DT_DEBUG_SQLITE3_PREPARE_V2(
         dt_database_get(darktable.db),

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -213,7 +213,7 @@ static void menuitem_delete_preset(GtkMenuItem *menuitem, dt_iop_module_t *modul
   if(res == GTK_RESPONSE_YES)
   {
     char tmp_path[1024];
-    snprintf(tmp_path, sizeof(tmp_path), "%s¬%s", _("preset"), name);
+    snprintf(tmp_path, sizeof(tmp_path), "%s`%s", _("preset"), name);
     dt_accel_deregister_iop(module, tmp_path);
     DT_DEBUG_SQLITE3_PREPARE_V2(
         dt_database_get(darktable.db),
@@ -709,7 +709,7 @@ static void menuitem_new_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
   sqlite3_finalize(stmt);
   // create a shortcut for the new entry
   char path[1024];
-  snprintf(path, sizeof(path), "%s¬%s", N_("preset"), N_("new preset"));
+  snprintf(path, sizeof(path), "%s`%s", N_("preset"), N_("new preset"));
   dt_accel_register_iop(module->so, FALSE, path, 0, 0);
   dt_accel_connect_preset_iop(module, N_("new preset"));
   // then show edit dialog

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -213,7 +213,7 @@ static void menuitem_delete_preset(GtkMenuItem *menuitem, dt_iop_module_t *modul
   if(res == GTK_RESPONSE_YES)
   {
     char tmp_path[1024];
-    snprintf(tmp_path, sizeof(tmp_path), "%s`%s", _("preset"), name);
+    snprintf(tmp_path, sizeof(tmp_path), "%s`%s", N_("preset"), name);
     dt_accel_deregister_iop(module, tmp_path);
     DT_DEBUG_SQLITE3_PREPARE_V2(
         dt_database_get(darktable.db),
@@ -428,6 +428,7 @@ static void edit_preset(const char *name_in, dt_iop_module_t *module)
   snprintf(title, sizeof(title), _("edit `%s' for module `%s'"), name, module->name());
   dialog = gtk_dialog_new_with_buttons(title, GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT,
                                        _("_cancel"), GTK_RESPONSE_REJECT, _("_ok"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
 #endif
@@ -443,10 +444,12 @@ static void edit_preset(const char *name_in, dt_iop_module_t *module)
   g->module = module;
   g->name = GTK_ENTRY(gtk_entry_new());
   gtk_entry_set_text(g->name, name);
+  gtk_entry_set_activates_default(g->name, TRUE);
   gtk_box_pack_start(box, GTK_WIDGET(g->name), FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->name), _("name of the preset"));
 
   g->description = GTK_ENTRY(gtk_entry_new());
+  gtk_entry_set_activates_default(g->description, TRUE);
   gtk_box_pack_start(box, GTK_WIDGET(g->description), FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->description), _("description or further information"));
 
@@ -709,9 +712,10 @@ static void menuitem_new_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
   sqlite3_finalize(stmt);
   // create a shortcut for the new entry
   char path[1024];
-  snprintf(path, sizeof(path), "%s`%s", N_("preset"), N_("new preset"));
+  snprintf(path, sizeof(path), "%s`%s", N_("preset"), _("new preset"));
   dt_accel_register_iop(module->so, FALSE, path, 0, 0);
-  dt_accel_connect_preset_iop(module, N_("new preset"));
+  dt_accel_connect_preset_iop(module, _("new preset"));
+  dt_accel_connect_instance_iop(module);
   // then show edit dialog
   edit_preset(_("new preset"), module);
 }

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -804,7 +804,7 @@ void gui_init(dt_imageio_module_format_t *self)
    */
   gui->bit_depth = dt_bauhaus_combobox_new(NULL);
 
-  dt_bauhaus_widget_set_label(gui->bit_depth, NULL, _("bit depth"));
+  dt_bauhaus_widget_set_label(gui->bit_depth, NULL, N_("bit depth"));
   size_t idx = 0;
   for (size_t i = 0; avif_bit_depth[i].name != NULL; i++) {
     dt_bauhaus_combobox_add(gui->bit_depth,  _(avif_bit_depth[i].name));
@@ -846,7 +846,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gui->tiling = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(gui->tiling,
                               NULL,
-                              _("tiling"));
+                              N_("tiling"));
   dt_bauhaus_combobox_add(gui->tiling,
                           _("on"));
   dt_bauhaus_combobox_add(gui->tiling,
@@ -871,7 +871,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gui->compression_type = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(gui->compression_type,
                               NULL,
-                              _("compression type"));
+                              N_("compression type"));
   dt_bauhaus_combobox_add(gui->compression_type,
                           _(avif_get_compression_string(AVIF_COMP_LOSSLESS)));
   dt_bauhaus_combobox_add(gui->compression_type,
@@ -896,7 +896,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   1, /* step */
                                                   92, /* default */
                                                   0); /* digits */
-  dt_bauhaus_widget_set_label(gui->quality, NULL, _("quality"));
+  dt_bauhaus_widget_set_label(gui->quality,  NULL, N_("quality"));
   dt_bauhaus_slider_set_default(gui->quality, 95);
   dt_bauhaus_slider_set_format(gui->quality, "%.2f%%");
 

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -371,7 +371,7 @@ void gui_init(dt_imageio_module_format_t *self)
   const int compression_last = dt_conf_get_int("plugins/imageio/format/exr/compression");
 
   gui->compression = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->compression, NULL, _("compression mode"));
+  dt_bauhaus_widget_set_label(gui->compression, NULL, N_("compression mode"));
 
   dt_bauhaus_combobox_add(gui->compression, _("off"));
   dt_bauhaus_combobox_add(gui->compression, _("RLE"));

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -642,7 +642,7 @@ void gui_init(dt_imageio_module_format_t *self)
   const int quality_last = dt_conf_get_int("plugins/imageio/format/j2k/quality");
 
   gui->format = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->format, NULL, _("format"));
+  dt_bauhaus_widget_set_label(gui->format, NULL, N_("format"));
   dt_bauhaus_combobox_add(gui->format, _("J2K"));
   dt_bauhaus_combobox_add(gui->format, _("jp2"));
   dt_bauhaus_combobox_set(gui->format, format_last);
@@ -650,14 +650,14 @@ void gui_init(dt_imageio_module_format_t *self)
   g_signal_connect(G_OBJECT(gui->format), "value-changed", G_CALLBACK(format_changed), NULL);
 
   gui->quality = dt_bauhaus_slider_new_with_range(NULL, 5, 100, 1, 95, 0);
-  dt_bauhaus_widget_set_label(gui->quality, NULL, _("quality"));
+  dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set_default(gui->quality, 95);
   if(quality_last > 0 && quality_last <= 100) dt_bauhaus_slider_set(gui->quality, quality_last);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
 
   gui->preset = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->preset, NULL, _("DCP mode"));
+  dt_bauhaus_widget_set_label(gui->preset, NULL, N_("DCP mode"));
   dt_bauhaus_combobox_add(gui->preset, _("off"));
   dt_bauhaus_combobox_add(gui->preset, _("Cinema2K, 24FPS"));
   dt_bauhaus_combobox_add(gui->preset, _("Cinema2K, 48FPS"));

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -589,7 +589,7 @@ void gui_init(dt_imageio_module_format_t *self)
   self->widget = box;
   // quality slider
   g->quality = dt_bauhaus_slider_new_with_range(NULL, 5, 100, 1, 95, 0);
-  dt_bauhaus_widget_set_label(g->quality, NULL, _("quality"));
+  dt_bauhaus_widget_set_label(g->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set_default(g->quality, 95);
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->quality), "value-changed", G_CALLBACK(quality_changed), NULL);

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -604,7 +604,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   d->size = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_combobox_set_editable(d->size, 1);
-  dt_bauhaus_widget_set_label(d->size, NULL, _("paper size"));
+  dt_bauhaus_widget_set_label(d->size, NULL, N_("paper size"));
   for(int i = 0; dt_pdf_paper_sizes[i].name; i++)
     dt_bauhaus_combobox_add(d->size, _(dt_pdf_paper_sizes[i].name));
   gtk_grid_attach(grid, GTK_WIDGET(d->size), 0, ++line, 2, 1);
@@ -619,7 +619,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // orientation
 
   d->orientation = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->orientation, NULL, _("page orientation"));
+  dt_bauhaus_widget_set_label(d->orientation, NULL, N_("page orientation"));
   dt_bauhaus_combobox_add(d->orientation, _("portrait"));
   dt_bauhaus_combobox_add(d->orientation, _("landscape"));
   gtk_grid_attach(grid, GTK_WIDGET(d->orientation), 0, ++line, 2, 1);
@@ -666,7 +666,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // rotate images yes|no
 
   d->rotate = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->rotate, NULL, _("rotate images"));
+  dt_bauhaus_widget_set_label(d->rotate, NULL, N_("rotate images"));
   dt_bauhaus_combobox_add(d->rotate, _("no"));
   dt_bauhaus_combobox_add(d->rotate, _("yes"));
   gtk_grid_attach(grid, GTK_WIDGET(d->rotate), 0, ++line, 2, 1);
@@ -678,7 +678,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // pages all|single images|contact sheet
 
   d->pages = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->pages, NULL, _("TODO: pages"));
+  dt_bauhaus_widget_set_label(d->pages, NULL, N_("TODO: pages"));
   dt_bauhaus_combobox_add(d->pages, _("all"));
   dt_bauhaus_combobox_add(d->pages, _("single images"));
   dt_bauhaus_combobox_add(d->pages, _("contact sheet"));
@@ -691,7 +691,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // embedded icc profile yes|no
 
   d->icc = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->icc, NULL, _("embed icc profiles"));
+  dt_bauhaus_widget_set_label(d->icc, NULL, N_("embed icc profiles"));
   dt_bauhaus_combobox_add(d->icc, _("no"));
   dt_bauhaus_combobox_add(d->icc, _("yes"));
   gtk_grid_attach(grid, GTK_WIDGET(d->icc), 0, ++line, 2, 1);
@@ -702,7 +702,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // bpp
 
   d->bpp = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->bpp, NULL, _("bit depth"));
+  dt_bauhaus_widget_set_label(d->bpp, NULL, N_("bit depth"));
   int sel = 0;
   int bpp = dt_conf_get_int("plugins/imageio/format/pdf/bpp");
   for(int i = 0; _pdf_bpp[i].name; i++)
@@ -718,7 +718,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // compression
 
   d->compression = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->compression, NULL, _("compression"));
+  dt_bauhaus_widget_set_label(d->compression, NULL, N_("compression"));
   dt_bauhaus_combobox_add(d->compression, _("uncompressed"));
   dt_bauhaus_combobox_add(d->compression, _("deflate"));
   gtk_grid_attach(grid, GTK_WIDGET(d->compression), 0, ++line, 2, 1);
@@ -731,7 +731,7 @@ void gui_init(dt_imageio_module_format_t *self)
   // image mode normal|draft|debug
 
   d->mode = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->mode, NULL, _("image mode"));
+  dt_bauhaus_widget_set_label(d->mode, NULL, N_("image mode"));
   dt_bauhaus_combobox_add(d->mode, _("normal"));
   dt_bauhaus_combobox_add(d->mode, _("draft"));
   dt_bauhaus_combobox_add(d->mode, _("debug"));

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -522,7 +522,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // Bit depth combo box
   gui->bit_depth = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->bit_depth, NULL, _("bit depth"));
+  dt_bauhaus_widget_set_label(gui->bit_depth, NULL, N_("bit depth"));
   dt_bauhaus_combobox_add(gui->bit_depth, _("8 bit"));
   dt_bauhaus_combobox_add(gui->bit_depth, _("16 bit"));
   if(bpp == 16)
@@ -536,7 +536,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // Compression level slider
   gui->compression = dt_bauhaus_slider_new_with_range(NULL, 0, 9, 1, 5, 0);
-  dt_bauhaus_widget_set_label(gui->compression, NULL, _("compression"));
+  dt_bauhaus_widget_set_label(gui->compression, NULL, N_("compression"));
   dt_bauhaus_slider_set(gui->compression, compression);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->compression), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->compression), "value-changed", G_CALLBACK(compression_level_changed), NULL);

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -807,7 +807,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // Bit depth combo box
   gui->bpp = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->bpp, NULL, _("bit depth"));
+  dt_bauhaus_widget_set_label(gui->bpp, NULL, N_("bit depth"));
   dt_bauhaus_combobox_add(gui->bpp, _("8 bit"));
   dt_bauhaus_combobox_add(gui->bpp, _("16 bit"));
   dt_bauhaus_combobox_add(gui->bpp, _("32 bit (float)"));
@@ -822,7 +822,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // Compression method combo box
   gui->compress = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->compress, NULL, _("compression"));
+  dt_bauhaus_widget_set_label(gui->compress, NULL, N_("compression"));
   dt_bauhaus_combobox_add(gui->compress, _("uncompressed"));
   dt_bauhaus_combobox_add(gui->compress, _("deflate"));
   dt_bauhaus_combobox_add(gui->compress, _("deflate with predictor"));
@@ -831,7 +831,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // Compression level slider
   gui->compresslevel = dt_bauhaus_slider_new_with_range(NULL, 0, 9, 1, 6, 0);
-  dt_bauhaus_widget_set_label(gui->compresslevel, NULL, _("compression level"));
+  dt_bauhaus_widget_set_label(gui->compresslevel, NULL, N_("compression level"));
   dt_bauhaus_slider_set(gui->compresslevel, compresslevel);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->compresslevel), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->compresslevel), "value-changed", G_CALLBACK(compress_level_changed), NULL);
@@ -843,7 +843,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // shortfile option combo box
   gui->shortfiles = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->shortfiles, NULL, _("b&w image"));
+  dt_bauhaus_widget_set_label(gui->shortfiles, NULL, N_("b&w image"));
   dt_bauhaus_combobox_add(gui->shortfiles, _("write rgb colors"));
   dt_bauhaus_combobox_add(gui->shortfiles, _("write grayscale"));
   dt_bauhaus_combobox_set(gui->shortfiles, shortmode);

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -322,14 +322,14 @@ void gui_init(dt_imageio_module_format_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   gui->compression = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->compression, NULL, _("compression type"));
+  dt_bauhaus_widget_set_label(gui->compression, NULL, N_("compression type"));
   dt_bauhaus_combobox_add(gui->compression, _("lossy"));
   dt_bauhaus_combobox_add(gui->compression, _("lossless"));
   dt_bauhaus_combobox_set(gui->compression, comp_type);
   gtk_box_pack_start(GTK_BOX(self->widget), gui->compression, TRUE, TRUE, 0);
 
   gui->quality = dt_bauhaus_slider_new_with_range(NULL, 5, 100, 1, 95, 0);
-  dt_bauhaus_widget_set_label(gui->quality, NULL, _("quality"));
+  dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set_default(gui->quality, 95);
   dt_bauhaus_slider_set_format(gui->quality, "%.2f%%");
   gtk_widget_set_tooltip_text(gui->quality, _("applies only to lossy setting"));
@@ -343,7 +343,7 @@ void gui_init(dt_imageio_module_format_t *self)
     gtk_widget_set_sensitive(gui->quality, FALSE);
 
   gui->hint = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->hint, NULL, _("image hint"));
+  dt_bauhaus_widget_set_label(gui->hint, NULL, N_("image hint"));
   gtk_widget_set_tooltip_text(gui->hint,
                _("image characteristics hint for the underlying encoder.\n"
                "picture : digital picture, like portrait, inner shot\n"

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -333,7 +333,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // Bit depth combo box
   gui->bpp = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(gui->bpp, NULL, _("bit depth"));
+  dt_bauhaus_widget_set_label(gui->bpp, NULL, N_("bit depth"));
   dt_bauhaus_combobox_add(gui->bpp, _("8 bit"));
   dt_bauhaus_combobox_add(gui->bpp, _("16 bit"));
   dt_bauhaus_combobox_add(gui->bpp, _("32 bit (float)"));

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -199,7 +199,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(button_clicked), self);
 
   d->onsave_action = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->onsave_action, NULL, _("on conflict"));
+  dt_bauhaus_widget_set_label(d->onsave_action, NULL, N_("on conflict"));
   dt_bauhaus_combobox_add(d->onsave_action, _("create unique filename"));
   dt_bauhaus_combobox_add(d->onsave_action, _("overwrite"));
   dt_bauhaus_combobox_add(d->onsave_action, _("skip"));

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -745,7 +745,7 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   // account
   ui->account_list = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(ui->account_list, NULL, _("accounts"));
+  dt_bauhaus_widget_set_label(ui->account_list, NULL, N_("accounts"));
   GList *a = ui->accounts;
   int account_index = -1, index=0;
   while(a)
@@ -822,7 +822,7 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   // permissions list
   ui->permission_list = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(ui->permission_list, NULL, _("visible to"));
+  dt_bauhaus_widget_set_label(ui->permission_list, NULL, N_("visible to"));
   dt_bauhaus_combobox_add(ui->permission_list, _("everyone"));
   dt_bauhaus_combobox_add(ui->permission_list, _("contacts"));
   dt_bauhaus_combobox_add(ui->permission_list, _("friends"));
@@ -835,7 +835,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   ui->album_list = dt_bauhaus_combobox_new(NULL); // Available albums
-  dt_bauhaus_widget_set_label(ui->album_list, NULL, _("album"));
+  dt_bauhaus_widget_set_label(ui->album_list, NULL, N_("album"));
   g_signal_connect(G_OBJECT(ui->album_list), "value-changed", G_CALLBACK(_piwigo_album_changed), (gpointer)ui);
   gtk_widget_set_sensitive(ui->album_list, FALSE);
   gtk_box_pack_start(GTK_BOX(hbox), ui->album_list, TRUE, TRUE, 0);
@@ -868,7 +868,7 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   // parent album list
   ui->parent_album_list = dt_bauhaus_combobox_new(NULL); // Available albums
-  dt_bauhaus_widget_set_label(ui->parent_album_list, NULL, _("parent album"));
+  dt_bauhaus_widget_set_label(ui->parent_album_list, NULL, N_("parent album"));
   gtk_widget_set_sensitive(ui->parent_album_list, TRUE);
   gtk_box_pack_start(ui->create_box, ui->parent_album_list, TRUE, TRUE, 0);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -529,36 +529,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "rotation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lens shift (v)"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lens shift (h)"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shear"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "focal length"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop factor"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "aspect adjust"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "guides"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "automatic cropping"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "lens model"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "rotation", GTK_WIDGET(g->rotation));
-  dt_accel_connect_slider_iop(self, "lens shift (v)", GTK_WIDGET(g->lensshift_v));
-  dt_accel_connect_slider_iop(self, "lens shift (h)", GTK_WIDGET(g->lensshift_h));
-  dt_accel_connect_slider_iop(self, "shear", GTK_WIDGET(g->shear));
-  dt_accel_connect_slider_iop(self, "focal length", GTK_WIDGET(g->f_length));
-  dt_accel_connect_slider_iop(self, "crop factor", GTK_WIDGET(g->crop_factor));
-  dt_accel_connect_slider_iop(self, "aspect adjust", GTK_WIDGET(g->aspect));
-  dt_accel_connect_combobox_iop(self, "guides", GTK_WIDGET(g->guide_lines));
-  dt_accel_connect_combobox_iop(self, "automatic cropping", GTK_WIDGET(g->cropmode));
-  dt_accel_connect_combobox_iop(self, "lens model", GTK_WIDGET(g->mode));
-}
-
 // multiply 3x3 matrix with 3x1 vector
 // dst needs to be different from v
 static inline void mat3mulv(float *dst, const float *const mat, const float *const v)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4771,7 +4771,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->shear, -SHEAR_RANGE, SHEAR_RANGE);
 
   g->guide_lines = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->guide_lines, NULL, _("guides"));
+  dt_bauhaus_widget_set_label(g->guide_lines, NULL, N_("guides"));
   dt_bauhaus_combobox_add(g->guide_lines, _("off"));
   dt_bauhaus_combobox_add(g->guide_lines, _("on"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->guide_lines, TRUE, TRUE, 0);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1863,7 +1863,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // mix slider
   c->mix = dt_bauhaus_slider_new_with_range(self, -2.0f, 2.0f, 0.1f, 1.0f, 3);
-  dt_bauhaus_widget_set_label(c->mix, NULL, _("mix"));
+  dt_bauhaus_widget_set_label(c->mix, NULL, N_("mix"));
   gtk_widget_set_tooltip_text(c->mix, _("make effect stronger or weaker"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->mix, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->mix), "value-changed", G_CALLBACK(mix_callback), self);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -142,17 +142,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mix"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_accel_connect_slider_iop(self, "mix", ((dt_iop_atrous_gui_data_t *)self->gui_data)->mix);
-}
-
-
 #if defined(__SSE2__)
 
 #define ALIGNED(a) __attribute__((aligned(a)))

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -198,22 +198,6 @@ typedef struct dt_iop_basecurve_gui_data_t
   GtkWidget *logbase;
 } dt_iop_basecurve_gui_data_t;
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "graph scale"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "exposure fusion"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "graph scale", GTK_WIDGET(g->logbase));
-  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
-  dt_accel_connect_combobox_iop(self, "exposure fusion", GTK_WIDGET(g->fusion));
-}
-
 static const char neutral[] = N_("neutral");
 static const char canon_eos[] = N_("canon eos like");
 static const char canon_eos_alt[] = N_("canon eos like alternate");

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -2129,7 +2129,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_no_show_all(c->exposure_bias, TRUE);
   gtk_widget_set_visible(c->exposure_bias, p->exposure_fusion != 0 ? TRUE : FALSE);
   c->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0.5f, 0.0f, 2);
-  dt_bauhaus_widget_set_label(c->logbase, NULL, _("scale for graph"));
+  dt_bauhaus_widget_set_label(c->logbase, NULL, N_("scale for graph"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);  g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -159,36 +159,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black level correction"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlight compression"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vibrance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clip"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "black level correction", GTK_WIDGET(g->sl_black_point));
-  dt_accel_connect_slider_iop(self, "exposure", GTK_WIDGET(g->sl_exposure));
-  dt_accel_connect_slider_iop(self, "highlight compression", GTK_WIDGET(g->sl_hlcompr));
-  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->sl_contrast));
-  dt_accel_connect_slider_iop(self, "middle grey", GTK_WIDGET(g->sl_middle_grey));
-  dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->sl_brightness));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->sl_saturation));
-  dt_accel_connect_slider_iop(self, "vibrance", GTK_WIDGET(g->sl_vibrance));
-  dt_accel_connect_slider_iop(self, "clip", GTK_WIDGET(g->sl_clip));
-  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
-}
-
 static void _turn_select_region_off(struct dt_iop_module_t *self)
 {
   dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -119,30 +119,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "detail"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "coarseness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "midtone range"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "detail", GTK_WIDGET(g->detail));
-  dt_accel_connect_slider_iop(self, "coarseness", GTK_WIDGET(g->spatial));
-  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->range));
-  dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
-  dt_accel_connect_slider_iop(self, "shadows", GTK_WIDGET(g->shadows));
-  dt_accel_connect_slider_iop(self, "midtone range", GTK_WIDGET(g->midtone));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
-}
-
 int legacy_params(
     dt_iop_module_t *self, const void *const old_params, const int old_version,
     void *new_params, const int new_version)
@@ -434,26 +410,29 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->detail, "%.0f%%");
   gtk_widget_set_tooltip_text(g->detail, _("changes the local contrast"));
 
+  ++darktable.bauhaus->skip_accel;
   g->spatial = dt_bauhaus_slider_from_params(self, "sigma_s");
+  g->range = dt_bauhaus_slider_from_params(self, "sigma_r");
+  g->highlights = dt_bauhaus_slider_from_params(self, "sigma_r");
+  g->shadows = dt_bauhaus_slider_from_params(self, "sigma_s");
+  --darktable.bauhaus->skip_accel;
+
   dt_bauhaus_slider_set_default(g->spatial, 50.0);
   dt_bauhaus_slider_set_digits(g->spatial, 0);
   dt_bauhaus_widget_set_label(g->spatial, NULL, N_("coarseness"));
   gtk_widget_set_tooltip_text(g->spatial, _("feature size of local details (spatial sigma of bilateral filter)"));
 
-  g->range = dt_bauhaus_slider_from_params(self, "sigma_r");
   dt_bauhaus_slider_set_default(g->range, 20.0);
   dt_bauhaus_slider_set_digits(g->range, 0);
   dt_bauhaus_widget_set_label(g->range, NULL, N_("contrast"));
   gtk_widget_set_tooltip_text(g->range, _("L difference to detect edges (range sigma of bilateral filter)"));
 
-  g->highlights = dt_bauhaus_slider_from_params(self, "sigma_r");
   dt_bauhaus_slider_set_step(g->highlights, 0.01);
   dt_bauhaus_widget_set_label(g->highlights, NULL, N_("highlights"));
   dt_bauhaus_slider_set_factor(g->highlights, 100);
   dt_bauhaus_slider_set_format(g->highlights, "%.0f%%");
   gtk_widget_set_tooltip_text(g->highlights, _("changes the local contrast of highlights"));
 
-  g->shadows = dt_bauhaus_slider_from_params(self, "sigma_s");
   dt_bauhaus_slider_set_step(g->shadows, 0.01);
   dt_bauhaus_widget_set_label(g->shadows, NULL, N_("shadows"));
   dt_bauhaus_slider_set_factor(g->shadows, 100);

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -437,25 +437,25 @@ void gui_init(dt_iop_module_t *self)
   g->spatial = dt_bauhaus_slider_from_params(self, "sigma_s");
   dt_bauhaus_slider_set_default(g->spatial, 50.0);
   dt_bauhaus_slider_set_digits(g->spatial, 0);
-  dt_bauhaus_widget_set_label(g->spatial, NULL, _("coarseness"));
+  dt_bauhaus_widget_set_label(g->spatial, NULL, N_("coarseness"));
   gtk_widget_set_tooltip_text(g->spatial, _("feature size of local details (spatial sigma of bilateral filter)"));
 
   g->range = dt_bauhaus_slider_from_params(self, "sigma_r");
   dt_bauhaus_slider_set_default(g->range, 20.0);
   dt_bauhaus_slider_set_digits(g->range, 0);
-  dt_bauhaus_widget_set_label(g->range, NULL, _("contrast"));
+  dt_bauhaus_widget_set_label(g->range, NULL, N_("contrast"));
   gtk_widget_set_tooltip_text(g->range, _("L difference to detect edges (range sigma of bilateral filter)"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "sigma_r");
   dt_bauhaus_slider_set_step(g->highlights, 0.01);
-  dt_bauhaus_widget_set_label(g->highlights, NULL, _("highlights"));
+  dt_bauhaus_widget_set_label(g->highlights, NULL, N_("highlights"));
   dt_bauhaus_slider_set_factor(g->highlights, 100);
   dt_bauhaus_slider_set_format(g->highlights, "%.0f%%");
   gtk_widget_set_tooltip_text(g->highlights, _("changes the local contrast of highlights"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "sigma_s");
   dt_bauhaus_slider_set_step(g->shadows, 0.01);
-  dt_bauhaus_widget_set_label(g->shadows, NULL, _("shadows"));
+  dt_bauhaus_widget_set_label(g->shadows, NULL, N_("shadows"));
   dt_bauhaus_slider_set_factor(g->shadows, 100);
   dt_bauhaus_slider_set_format(g->shadows, "%.0f%%");
   gtk_widget_set_tooltip_text(g->shadows, _("changes the local contrast of shadows"));

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -87,23 +87,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "radius"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "red"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_bilateral_gui_data_t *g = (dt_iop_bilateral_gui_data_t *)self->gui_data;
-  dt_accel_connect_slider_iop(self, "radius", GTK_WIDGET(g->radius));
-  dt_accel_connect_slider_iop(self, "red", GTK_WIDGET(g->red));
-  dt_accel_connect_slider_iop(self, "green", GTK_WIDGET(g->green));
-  dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->blue));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -100,21 +100,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "size"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  const dt_iop_bloom_gui_data_t *g = (dt_iop_bloom_gui_data_t *)self->gui_data;
-  dt_accel_connect_slider_iop(self, "size", GTK_WIDGET(g->size));
-  dt_accel_connect_slider_iop(self, "threshold", GTK_WIDGET(g->threshold));
-  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
-}
-
 #define GAUSS(a, b, c, x) (a * pow(2.718281828, (-pow((x - b), 2) / (pow(c, 2)))))
 
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -197,33 +197,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "border size"));
-  dt_accel_register_iop(self, FALSE, NC_("accel", "pick border color from image"), 0, 0);
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "frame line size"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "frame line offset"));
-  dt_accel_register_iop(self, FALSE, NC_("accel", "pick frame line color from image"), 0, 0);
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "aspect"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "orientation"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "horizontal position"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "vertical position"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
-  dt_accel_connect_button_iop(self, "pick border color from image", GTK_WIDGET(g->colorpick));
-  dt_accel_connect_slider_iop(self, "border size", GTK_WIDGET(g->size));
-  dt_accel_connect_button_iop(self, "pick frame line color from image", GTK_WIDGET(g->frame_colorpick));
-  dt_accel_connect_slider_iop(self, "frame line size", GTK_WIDGET(g->frame_size));
-  dt_accel_connect_slider_iop(self, "frame line offset", GTK_WIDGET(g->frame_offset));
-  dt_accel_connect_combobox_iop(self, "aspect", GTK_WIDGET(g->aspect));
-  dt_accel_connect_combobox_iop(self, "orientation", GTK_WIDGET(g->aspect_orient));
-  dt_accel_connect_combobox_iop(self, "horizontal position", GTK_WIDGET(g->pos_h));
-  dt_accel_connect_combobox_iop(self, "vertical position", GTK_WIDGET(g->pos_v));
-}
-
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -920,7 +920,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->aspect = dt_bauhaus_combobox_new(self);
   dt_bauhaus_combobox_set_editable(g->aspect, 1);
-  dt_bauhaus_widget_set_label(g->aspect, NULL, _("aspect"));
+  dt_bauhaus_widget_set_label(g->aspect, NULL, N_("aspect"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
   gui_init_aspect(self);
   g_signal_connect(G_OBJECT(g->aspect), "value-changed", G_CALLBACK(aspect_changed), self);
@@ -936,7 +936,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->pos_h = dt_bauhaus_combobox_new(self);
   dt_bauhaus_combobox_set_editable(g->pos_h, 1);
-  dt_bauhaus_widget_set_label(g->pos_h, NULL, _("horizontal position"));
+  dt_bauhaus_widget_set_label(g->pos_h, NULL, N_("horizontal position"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_h, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->pos_h), "value-changed", G_CALLBACK(position_h_changed), self);
   gtk_widget_set_tooltip_text(g->pos_h, _("select the horizontal position ratio relative to top "
@@ -947,7 +947,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->pos_v = dt_bauhaus_combobox_new(self);
   dt_bauhaus_combobox_set_editable(g->pos_v, 1);
-  dt_bauhaus_widget_set_label(g->pos_v, NULL, _("vertical position"));
+  dt_bauhaus_widget_set_label(g->pos_v, NULL, N_("vertical position"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_v, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->pos_v), "value-changed", G_CALLBACK(position_v_changed), self);
   gtk_widget_set_tooltip_text(g->pos_v, _("select the vertical position ratio relative to left "

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -140,25 +140,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "red"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "destination"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_channelmixer_gui_data_t *g =
-    (dt_iop_channelmixer_gui_data_t*)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "red", GTK_WIDGET(g->scale_red));
-  dt_accel_connect_slider_iop(self, "green", GTK_WIDGET(g->scale_green));
-  dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->scale_blue));
-  dt_accel_connect_combobox_iop(self, "destination", GTK_WIDGET(g->output_channel));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
                   const int new_version)
 {

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -629,7 +629,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   /* output */
   g->output_channel = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->output_channel, NULL, _("destination"));
+  dt_bauhaus_widget_set_label(g->output_channel, NULL, N_("destination"));
   dt_bauhaus_combobox_add(g->output_channel, _("hue"));
   dt_bauhaus_combobox_add(g->output_channel, _("saturation"));
   dt_bauhaus_combobox_add(g->output_channel, _("lightness"));
@@ -643,19 +643,19 @@ void gui_init(struct dt_iop_module_t *self)
   /* red */
   g->scale_red = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->red[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_red, _("amount of red channel in the output channel"));
-  dt_bauhaus_widget_set_label(g->scale_red, NULL, _("red"));
+  dt_bauhaus_widget_set_label(g->scale_red, NULL, N_("red"));
   g_signal_connect(G_OBJECT(g->scale_red), "value-changed", G_CALLBACK(red_callback), self);
 
   /* green */
   g->scale_green = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->green[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_green, _("amount of green channel in the output channel"));
-  dt_bauhaus_widget_set_label(g->scale_green, NULL, _("green"));
+  dt_bauhaus_widget_set_label(g->scale_green, NULL, N_("green"));
   g_signal_connect(G_OBJECT(g->scale_green), "value-changed", G_CALLBACK(green_callback), self);
 
   /* blue */
   g->scale_blue = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->blue[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_blue, _("amount of blue channel in the output channel"));
-  dt_bauhaus_widget_set_label(g->scale_blue, NULL, _("blue"));
+  dt_bauhaus_widget_set_label(g->scale_blue, NULL, N_("blue"));
   g_signal_connect(G_OBJECT(g->scale_blue), "value-changed", G_CALLBACK(blue_callback), self);
 
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2139,7 +2139,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, _("main"), NULL);
 
   g->hvflip = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->hvflip, NULL, _("flip"));
+  dt_bauhaus_widget_set_label(g->hvflip, NULL, N_("flip"));
   dt_bauhaus_combobox_add(g->hvflip, _("none"));
   dt_bauhaus_combobox_add(g->hvflip, _("horizontal"));
   dt_bauhaus_combobox_add(g->hvflip, _("vertical"));
@@ -2155,7 +2155,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->angle, _("right-click and drag a line on the image to drag a straight line"));
 
   g->keystone_type = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->keystone_type, NULL, _("keystone"));
+  dt_bauhaus_widget_set_label(g->keystone_type, NULL, N_("keystone"));
   dt_bauhaus_combobox_add(g->keystone_type, _("none"));
   dt_bauhaus_combobox_add(g->keystone_type, _("vertical"));
   dt_bauhaus_combobox_add(g->keystone_type, _("horizontal"));
@@ -2266,7 +2266,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->aspect_presets = dt_bauhaus_combobox_new(self);
   dt_bauhaus_combobox_set_editable(g->aspect_presets, 1);
-  dt_bauhaus_widget_set_label(g->aspect_presets, NULL, _("aspect"));
+  dt_bauhaus_widget_set_label(g->aspect_presets, NULL, N_("aspect"));
 
   for(GList *iter = g->aspect_list; iter; iter = g_list_next(iter))
   {
@@ -2284,7 +2284,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect_presets, TRUE, TRUE, 0);
 
   g->guide_lines = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->guide_lines, NULL, _("guides"));
+  dt_bauhaus_widget_set_label(g->guide_lines, NULL, N_("guides"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->guide_lines, TRUE, TRUE, 0);
 
   g->guides_widgets = gtk_stack_new();
@@ -2317,7 +2317,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->guide_lines), "value-changed", G_CALLBACK(guides_presets_changed), self);
 
   g->flip_guides = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->flip_guides, NULL, _("flip guides"));
+  dt_bauhaus_widget_set_label(g->flip_guides, NULL, N_("flip guides"));
   dt_bauhaus_combobox_add(g->flip_guides, _("none"));
   dt_bauhaus_combobox_add(g->flip_guides, _("horizontally"));
   dt_bauhaus_combobox_add(g->flip_guides, _("vertically"));

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3451,37 +3451,12 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_iop(self, TRUE, NC_("accel", "commit"), GDK_KEY_Return, 0);
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "angle"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "left"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "top"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "right"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bottom"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "aspect ratio"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "guide lines"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "flip"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "keystone"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "automatic cropping"));
+  dt_accel_register_iop(self, TRUE, N_("commit"), GDK_KEY_Return, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
-  GClosure *closure;
-
-  closure = g_cclosure_new(G_CALLBACK(key_commit_callback), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "commit", closure);
-
-  dt_accel_connect_slider_iop(self, "angle", GTK_WIDGET(g->angle));
-  dt_accel_connect_slider_iop(self, "left", GTK_WIDGET(g->cx));
-  dt_accel_connect_slider_iop(self, "top", GTK_WIDGET(g->cy));
-  dt_accel_connect_slider_iop(self, "right", GTK_WIDGET(g->cw));
-  dt_accel_connect_slider_iop(self, "bottom", GTK_WIDGET(g->ch));
-  dt_accel_connect_combobox_iop(self, "guide lines", GTK_WIDGET(g->guide_lines));
-  dt_accel_connect_combobox_iop(self, "aspect ratio", GTK_WIDGET(g->aspect_presets));
-  dt_accel_connect_combobox_iop(self, "flip", GTK_WIDGET(g->hvflip));
-  dt_accel_connect_combobox_iop(self, "keystone", GTK_WIDGET(g->keystone_type));
-  dt_accel_connect_combobox_iop(self, "automatic cropping", GTK_WIDGET(g->crop_auto));
+  dt_accel_connect_iop(self, "commit", g_cclosure_new(G_CALLBACK(key_commit_callback), (gpointer)self, NULL));
 }
 
 GSList *mouse_actions(struct dt_iop_module_t *self)

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -94,24 +94,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colisa_gui_data_t *g = (dt_iop_colisa_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->contrast));
-  dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->brightness));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->saturation));
-}
-
-
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -976,15 +976,15 @@ static inline void _check_tuner_picker_labels(dt_iop_module_t *self)
 
   if(g->luma_patches_flags[GAIN] == USER_SELECTED && g->luma_patches_flags[GAMMA] == USER_SELECTED
      && g->luma_patches_flags[LIFT] == USER_SELECTED)
-    dt_bauhaus_widget_set_label(g->auto_luma, NULL, _("optimize luma from patches"));
+    dt_bauhaus_widget_set_label(g->auto_luma, NULL, N_("optimize luma from patches"));
   else
-    dt_bauhaus_widget_set_label(g->auto_luma, NULL, _("optimize luma"));
+    dt_bauhaus_widget_set_label(g->auto_luma, NULL, N_("optimize luma"));
 
   if(g->color_patches_flags[GAIN] == USER_SELECTED && g->color_patches_flags[GAMMA] == USER_SELECTED
      && g->color_patches_flags[LIFT] == USER_SELECTED)
-    dt_bauhaus_widget_set_label(g->auto_color, NULL, _("neutralize colors from patches"));
+    dt_bauhaus_widget_set_label(g->auto_color, NULL, N_("neutralize colors from patches"));
   else
-    dt_bauhaus_widget_set_label(g->auto_color, NULL, _("neutralize colors"));
+    dt_bauhaus_widget_set_label(g->auto_color, NULL, N_("neutralize colors"));
 }
 
 
@@ -1921,7 +1921,7 @@ void gui_init(dt_iop_module_t *self)
 
   // control choice
   g->controls = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->controls, NULL, _("color control sliders"));
+  dt_bauhaus_widget_set_label(g->controls, NULL, N_("color control sliders"));
   dt_bauhaus_combobox_add(g->controls, _("HSL"));
   dt_bauhaus_combobox_add(g->controls, _("RGBL"));
   dt_bauhaus_combobox_add(g->controls, _("both"));
@@ -2035,7 +2035,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_offset(g->which##_##c, -1.0);                       \
   dt_bauhaus_slider_set_feedback(g->which##_##c, 0);                        \
   gtk_widget_set_tooltip_text(g->which##_##c, _(text[CHANNEL_##N]));        \
-  dt_bauhaus_widget_set_label(g->which##_##c, _(#which), _(#n));            \
+  dt_bauhaus_widget_set_label(g->which##_##c, #which, #n);                  \
 
 #define ADD_BLOCK(blk, which, text, span, satspan)                          \
   g->blocks[blk] = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0); \
@@ -2053,12 +2053,12 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(g->which##_factor, 0.0, 0.0, 0.0, 0.0);        \
   dt_bauhaus_slider_set_stop(g->which##_factor, 1.0, 1.0, 1.0, 1.0);        \
   gtk_widget_set_tooltip_text(g->which##_factor, _(text[CHANNEL_FACTOR]));  \
-  dt_bauhaus_widget_set_label(g->which##_factor, _(#which), _("factor"));   \
+  dt_bauhaus_widget_set_label(g->which##_factor, #which, N_("factor"));     \
                                                                             \
   g->hue_##which = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,          \
                    dt_bauhaus_slider_new_with_range_and_feedback(self,      \
                    0.0f, 360.0f, 1.0f, 0.0f, 2, 0));                        \
-  dt_bauhaus_widget_set_label(g->hue_##which, NULL, _("hue"));              \
+  dt_bauhaus_widget_set_label(g->hue_##which, NULL, N_("hue"));             \
   dt_bauhaus_slider_set_format(g->hue_##which, "%.2f °");                   \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.0f,   1.0f, 0.0f, 0.0f);     \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.166f, 1.0f, 1.0f, 0.0f);     \
@@ -2075,7 +2075,7 @@ void gui_init(dt_iop_module_t *self)
   g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(self,      \
                    0.0f, 100.0f, 0.05f, 0.0f, 2, 0);                        \
   dt_bauhaus_slider_set_soft_max(g->sat_##which, satspan);                  \
-  dt_bauhaus_widget_set_label(g->sat_##which, NULL, _("saturation"));       \
+  dt_bauhaus_widget_set_label(g->sat_##which, NULL, N_("saturation"));      \
   dt_bauhaus_slider_set_format(g->sat_##which, "%.2f %%");                  \
   dt_bauhaus_slider_set_stop(g->sat_##which, 0.0f, 0.2f, 0.2f, 0.2f);       \
   dt_bauhaus_slider_set_stop(g->sat_##which, 1.0f, 1.0f, 1.0f, 1.0f);       \
@@ -2126,13 +2126,13 @@ void gui_init(dt_iop_module_t *self)
 
   g->auto_luma = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                  dt_bauhaus_combobox_new(self));
-  dt_bauhaus_widget_set_label(g->auto_luma, NULL, _("optimize luma"));
+  dt_bauhaus_widget_set_label(g->auto_luma, NULL, N_("optimize luma"));
   gtk_widget_set_tooltip_text(g->auto_luma, _("fit the whole histogram and center the average luma"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->auto_luma, FALSE, FALSE, 0);
 
   g->auto_color = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                   dt_bauhaus_combobox_new(self));
-  dt_bauhaus_widget_set_label(g->auto_color, NULL, _("neutralize colors"));
+  dt_bauhaus_widget_set_label(g->auto_color, NULL, N_("neutralize colors"));
   gtk_widget_set_tooltip_text(g->auto_color, _("optimize the RGB curves to remove color casts"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->auto_color, FALSE, FALSE, 0);
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -290,46 +290,6 @@ void init_presets(dt_iop_module_so_t *self)
              "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "input saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "output saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast fulcrum"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows factor"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mid-tones factor"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mid-tones hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mid-tones saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights factor"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights saturation"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color control sliders"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "input saturation", GTK_WIDGET(g->saturation));
-  dt_accel_connect_slider_iop(self, "output saturation", GTK_WIDGET(g->saturation_out));
-  dt_accel_connect_slider_iop(self, "contrast fulcrum", GTK_WIDGET(g->grey));
-  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->contrast));
-  dt_accel_connect_slider_iop(self, "shadows factor", GTK_WIDGET(g->lift_factor));
-  dt_accel_connect_slider_iop(self, "shadows hue", GTK_WIDGET(g->hue_lift));
-  dt_accel_connect_slider_iop(self, "shadows saturation", GTK_WIDGET(g->sat_lift));
-  dt_accel_connect_slider_iop(self, "mid-tones factor", GTK_WIDGET(g->gamma_factor));
-  dt_accel_connect_slider_iop(self, "mid-tones hue", GTK_WIDGET(g->hue_gamma));
-  dt_accel_connect_slider_iop(self, "mid-tones saturation", GTK_WIDGET(g->sat_gamma));
-  dt_accel_connect_slider_iop(self, "highlights factor", GTK_WIDGET(g->gain_factor));
-  dt_accel_connect_slider_iop(self, "highlights hue", GTK_WIDGET(g->hue_gain));
-  dt_accel_connect_slider_iop(self, "highlights saturation", GTK_WIDGET(g->sat_gain));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
-  dt_accel_connect_combobox_iop(self, "color control sliders", GTK_WIDGET(g->controls));
-}
-
 static inline float CDL(float x, float slope, float offset, float power)
 {
   float out;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1986,7 +1986,7 @@ void gui_init(dt_iop_module_t *self)
 
   char field_name[10];
 
-#define ADD_CHANNEL(which, c, n, N, text, span)                             \
+#define ADD_CHANNEL(which, section, c, n, N, text, span)                    \
   sprintf(field_name, "%s[%d]", #which, CHANNEL_##N);                       \
   g->which##_##c = dt_bauhaus_slider_from_params(self, field_name);         \
   dt_bauhaus_slider_set_soft_range(g->which##_##c, -span+1.0, span+1.0);    \
@@ -1995,9 +1995,9 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_offset(g->which##_##c, -1.0);                       \
   dt_bauhaus_slider_set_feedback(g->which##_##c, 0);                        \
   gtk_widget_set_tooltip_text(g->which##_##c, _(text[CHANNEL_##N]));        \
-  dt_bauhaus_widget_set_label(g->which##_##c, #which, #n);                  \
+  dt_bauhaus_widget_set_label(g->which##_##c, section, #n);                 \
 
-#define ADD_BLOCK(blk, which, text, span, satspan)                          \
+#define ADD_BLOCK(blk, which, section, text, span, satspan)                 \
   g->blocks[blk] = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0); \
                                                                             \
   sprintf(field_name, "%s[%d]", #which, CHANNEL_FACTOR);                    \
@@ -2013,12 +2013,12 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(g->which##_factor, 0.0, 0.0, 0.0, 0.0);        \
   dt_bauhaus_slider_set_stop(g->which##_factor, 1.0, 1.0, 1.0, 1.0);        \
   gtk_widget_set_tooltip_text(g->which##_factor, _(text[CHANNEL_FACTOR]));  \
-  dt_bauhaus_widget_set_label(g->which##_factor, #which, N_("factor"));     \
+  dt_bauhaus_widget_set_label(g->which##_factor, section, N_("factor"));    \
                                                                             \
   g->hue_##which = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,          \
                    dt_bauhaus_slider_new_with_range_and_feedback(self,      \
                    0.0f, 360.0f, 1.0f, 0.0f, 2, 0));                        \
-  dt_bauhaus_widget_set_label(g->hue_##which, NULL, N_("hue"));             \
+  dt_bauhaus_widget_set_label(g->hue_##which, section, N_("hue"));          \
   dt_bauhaus_slider_set_format(g->hue_##which, "%.2f °");                   \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.0f,   1.0f, 0.0f, 0.0f);     \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.166f, 1.0f, 1.0f, 0.0f);     \
@@ -2035,7 +2035,7 @@ void gui_init(dt_iop_module_t *self)
   g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(self,      \
                    0.0f, 100.0f, 0.05f, 0.0f, 2, 0);                        \
   dt_bauhaus_slider_set_soft_max(g->sat_##which, satspan);                  \
-  dt_bauhaus_widget_set_label(g->sat_##which, NULL, N_("saturation"));      \
+  dt_bauhaus_widget_set_label(g->sat_##which, section, N_("saturation"));   \
   dt_bauhaus_slider_set_format(g->sat_##which, "%.2f %%");                  \
   dt_bauhaus_slider_set_stop(g->sat_##which, 0.0f, 0.2f, 0.2f, 0.2f);       \
   dt_bauhaus_slider_set_stop(g->sat_##which, 1.0f, 1.0f, 1.0f, 1.0f);       \
@@ -2044,15 +2044,15 @@ void gui_init(dt_iop_module_t *self)
                    G_CALLBACK(which##_callback), self);                     \
   gtk_box_pack_start(GTK_BOX(self->widget), g->sat_##which, TRUE, TRUE, 0); \
                                                                             \
-  ADD_CHANNEL(which, r, red, RED, text, span)                               \
+  ADD_CHANNEL(which, section, r, red, RED, text, span)                      \
   dt_bauhaus_slider_set_stop(g->which##_r, 0.0, 0.0, 1.0, 1.0);             \
   dt_bauhaus_slider_set_stop(g->which##_r, 0.5, 1.0, 1.0, 1.0);             \
   dt_bauhaus_slider_set_stop(g->which##_r, 1.0, 1.0, 0.0, 0.0);             \
-  ADD_CHANNEL(which, g, green, GREEN, text, span)                           \
+  ADD_CHANNEL(which, section, g, green, GREEN, text, span)                  \
   dt_bauhaus_slider_set_stop(g->which##_g, 0.0, 1.0, 0.0, 1.0);             \
   dt_bauhaus_slider_set_stop(g->which##_g, 0.5, 1.0, 1.0, 1.0);             \
   dt_bauhaus_slider_set_stop(g->which##_g, 1.0, 0.0, 1.0, 0.0);             \
-  ADD_CHANNEL(which, b, blue, BLUE, text, span)                             \
+  ADD_CHANNEL(which, section, b, blue, BLUE, text, span)                    \
   dt_bauhaus_slider_set_stop(g->which##_b, 0.0, 1.0, 1.0, 0.0);             \
   dt_bauhaus_slider_set_stop(g->which##_b, 0.5, 1.0, 1.0, 1.0);             \
   dt_bauhaus_slider_set_stop(g->which##_b, 1.0, 0.0, 0.0, 1.0);             \
@@ -2075,9 +2075,9 @@ void gui_init(dt_iop_module_t *self)
         N_("factor of green for gain/slope"),
         N_("factor of blue for gain/slope") };
 
-  ADD_BLOCK(0, lift,  lift_messages, 0.05f,  5.0f)
-  ADD_BLOCK(1, gamma, gamma_messages, 0.5f, 20.0f)
-  ADD_BLOCK(2, gain,  gain_messages,  0.5f, 25.0f)
+  ADD_BLOCK(0, lift,  N_("shadows"), lift_messages, 0.05f,  5.0f)
+  ADD_BLOCK(1, gamma, N_("mid-tones"), gamma_messages, 0.5f, 20.0f)
+  ADD_BLOCK(2, gain,  N_("highlights"), gain_messages,  0.5f, 25.0f)
   _configure_slider_blocks(NULL, self);
 
   g->optimizer_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -129,27 +129,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green-red"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue-yellow"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "target color"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "lightness", GTK_WIDGET(g->scale_L));
-  dt_accel_connect_slider_iop(self, "green-red", GTK_WIDGET(g->scale_a));
-  dt_accel_connect_slider_iop(self, "blue-yellow", GTK_WIDGET(g->scale_b));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->scale_C));
-  dt_accel_connect_combobox_iop(self, "target color", GTK_WIDGET(g->combobox_target));
-}
-
-
 int legacy_params(
     dt_iop_module_t  *self,
     const void *const old_params,

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1356,7 +1356,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->patch = 0;
   g->drawn_patch = -1;
   g->combobox_patch = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->combobox_patch, NULL, _("patch"));
+  dt_bauhaus_widget_set_label(g->combobox_patch, NULL, N_("patch"));
   gtk_widget_set_tooltip_text(g->combobox_patch, _("color checker patch"));
   char cboxentry[1024];
   for(int k=0;k<p->num_patches;k++)
@@ -1369,29 +1369,29 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->scale_L = dt_bauhaus_slider_new_with_range(self, -100.0, 200.0, 1.0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_L, _("lightness offset"));
-  dt_bauhaus_widget_set_label(g->scale_L, NULL, _("lightness"));
+  dt_bauhaus_widget_set_label(g->scale_L, NULL, N_("lightness"));
 
   g->scale_a = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_a, _("chroma offset green/red"));
-  dt_bauhaus_widget_set_label(g->scale_a, NULL, _("green/red"));
+  dt_bauhaus_widget_set_label(g->scale_a, NULL, N_("green/red"));
   dt_bauhaus_slider_set_stop(g->scale_a, 0.0, 0.0, 1.0, 0.2);
   dt_bauhaus_slider_set_stop(g->scale_a, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_a, 1.0, 1.0, 0.0, 0.2);
 
   g->scale_b = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_b, _("chroma offset blue/yellow"));
-  dt_bauhaus_widget_set_label(g->scale_b, NULL, _("blue/yellow"));
+  dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue/yellow"));
   dt_bauhaus_slider_set_stop(g->scale_b, 0.0, 0.0, 0.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 1.0, 1.0, 1.0, 0.0);
 
   g->scale_C = dt_bauhaus_slider_new_with_range(self, -128.0, 128.0, 1.0f, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_C, _("saturation offset"));
-  dt_bauhaus_widget_set_label(g->scale_C, NULL, _("saturation"));
+  dt_bauhaus_widget_set_label(g->scale_C, NULL, N_("saturation"));
 
   g->absolute_target = 0;
   g->combobox_target = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->combobox_target, 0, _("target color"));
+  dt_bauhaus_widget_set_label(g->combobox_target, 0, N_("target color"));
   gtk_widget_set_tooltip_text(g->combobox_target, _("control target color of the patches via relative offsets or via absolute Lab values"));
   dt_bauhaus_combobox_add(g->combobox_target, _("relative"));
   dt_bauhaus_combobox_add(g->combobox_target, _("absolute"));

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -121,23 +121,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green-magenta contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue-yellow contrast"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorcontrast_gui_data_t *g =
-    (dt_iop_colorcontrast_gui_data_t*)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "green-magenta contrast",
-                              GTK_WIDGET(g->a_scale));
-  dt_accel_connect_slider_iop(self, "blue-yellow contrast",
-                              GTK_WIDGET(g->b_scale));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -112,17 +112,6 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("cooling filter"), self->op, self->version(), &p, sizeof(p), 1);
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->slider));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2089,11 +2089,11 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->profile_combobox = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->profile_combobox, NULL, _("input profile"));
+  dt_bauhaus_widget_set_label(g->profile_combobox, NULL, N_("input profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile_combobox, TRUE, TRUE, 0);
 
   g->work_combobox = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->work_combobox, NULL, _("working profile"));
+  dt_bauhaus_widget_set_label(g->work_combobox, NULL, N_("working profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->work_combobox, TRUE, TRUE, 0);
 
   // now generate the list of profiles applicable to the current image and update the list

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -158,22 +158,6 @@ int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "input profile"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "working profile"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "gamut clipping"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_combobox_iop(self, "input profile", GTK_WIDGET(g->profile_combobox));
-  dt_accel_connect_combobox_iop(self, "working profile", GTK_WIDGET(g->work_combobox));
-  dt_accel_connect_combobox_iop(self, "gamut clipping", GTK_WIDGET(g->clipping_combobox));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2097,7 +2097,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->work_combobox, TRUE, TRUE, 0);
 
   // now generate the list of profiles applicable to the current image and update the list
-  update_profile_list(self);
+//  update_profile_list(self);
 
   dt_bauhaus_combobox_set(g->profile_combobox, 0);
   {

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -117,24 +117,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "source mix"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "hue", GTK_WIDGET(g->hue));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->saturation));
-  dt_accel_connect_slider_iop(self, "lightness", GTK_WIDGET(g->lightness));
-  dt_accel_connect_slider_iop(self, "source mix", GTK_WIDGET(g->source_mix));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1074,24 +1074,20 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->target_area, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->target_area), "draw", G_CALLBACK(cluster_preview_draw), self);
 
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+  gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
 
-  GtkBox *box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
-  GtkWidget *button;
+  g->acquire_source_button = dt_iop_button_new(self, N_("acquire as source"),
+                                               G_CALLBACK(acquire_source_button_pressed), FALSE, 0, 0,
+                                               NULL, 0, box);
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->acquire_source_button))), PANGO_ELLIPSIZE_START);
+  gtk_widget_set_tooltip_text(g->acquire_source_button, _("analyze this image as a source image"));
 
-  button = gtk_button_new_with_label(_("acquire as source"));
-  g->acquire_source_button = button;
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_START);
-  gtk_widget_set_tooltip_text(button, _("analyze this image as a source image"));
-  gtk_box_pack_start(box, button, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(acquire_source_button_pressed), (gpointer)self);
-
-  button = gtk_button_new_with_label(_("acquire as target"));
-  g->acquire_target_button = button;
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_START);
-  gtk_widget_set_tooltip_text(button, _("analyze this image as a target image"));
-  gtk_box_pack_start(box, button, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(acquire_target_button_pressed), (gpointer)self);
+  g->acquire_target_button = dt_iop_button_new(self, N_("acquire as target"),
+                                               G_CALLBACK(acquire_target_button_pressed), FALSE, 0, 0,
+                                               NULL, 0, box);
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->acquire_target_button))), PANGO_ELLIPSIZE_START);
+  gtk_widget_set_tooltip_text(g->acquire_target_button, _("analyze this image as a target image"));
 
   g->clusters = dt_bauhaus_slider_from_params(self, "n");
   gtk_widget_set_tooltip_text(g->clusters, _("number of clusters to find in image. value change resets all clusters"));
@@ -1108,7 +1104,6 @@ void gui_init(struct dt_iop_module_t *self)
   /* add signal handler for preview pipe finished: process clusters if requested */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
                             G_CALLBACK(process_clusters), self);
-
 
   FILE *f = g_fopen("/tmp/dt_colormapping_loaded", "rb");
   if(f)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -161,30 +161,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "number of clusters"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "color dominance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "histogram equalization"));
-
-  dt_accel_register_iop(self, FALSE, NC_("accel", "acquire as source"), 0, 0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "acquire as target"), 0, 0);
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "number of clusters", GTK_WIDGET(g->clusters));
-  dt_accel_connect_slider_iop(self, "color dominance", GTK_WIDGET(g->dominance));
-  dt_accel_connect_slider_iop(self, "histogram equalization", GTK_WIDGET(g->equalization));
-
-  dt_accel_connect_button_iop(self, "acquire as source", g->acquire_source_button);
-  dt_accel_connect_button_iop(self, "acquire as target", g->acquire_target_button);
-}
-
-
 static void capture_histogram(const float *col, const int width, const int height, int *hist)
 {
   // build separate histogram

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -118,18 +118,6 @@ int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
   return cst;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "export profile"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorout_gui_data_t *g = (dt_iop_colorout_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_combobox_iop(self, "export profile", GTK_WIDGET(g->output_profile));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -863,7 +863,7 @@ void gui_init(struct dt_iop_module_t *self)
   // TODO:
   g->output_intent = dt_bauhaus_combobox_new(self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->output_intent, TRUE, TRUE, 0);
-  dt_bauhaus_widget_set_label(g->output_intent, NULL, _("output intent"));
+  dt_bauhaus_widget_set_label(g->output_intent, NULL, N_("output intent"));
   dt_bauhaus_combobox_add(g->output_intent, _("perceptual"));
   dt_bauhaus_combobox_add(g->output_intent, _("relative colorimetric"));
   dt_bauhaus_combobox_add(g->output_intent, C_("rendering intent", "saturation"));
@@ -876,7 +876,7 @@ void gui_init(struct dt_iop_module_t *self)
   }
 
   g->output_profile = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->output_profile, NULL, _("export profile"));
+  dt_bauhaus_widget_set_label(g->output_profile, NULL, N_("export profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->output_profile, TRUE, TRUE, 0);
   for(GList *l = darktable.color_profiles->profiles; l; l = g_list_next(l))
   {

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -174,26 +174,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "spatial extent"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "range extent"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hue"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "precedence"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "threshold", GTK_WIDGET(g->threshold));
-  dt_accel_connect_slider_iop(self, "spatial extent", GTK_WIDGET(g->spatial));
-  dt_accel_connect_slider_iop(self, "range extent", GTK_WIDGET(g->range));
-  dt_accel_connect_slider_iop(self, "hue", GTK_WIDGET(g->hue));
-  dt_accel_connect_combobox_iop(self, "precedence", GTK_WIDGET(g->precedence));
-}
-
 typedef struct dt_iop_colorreconstruct_bilateral_t
 {
   size_t size_x, size_y, size_z;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -153,24 +153,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mix"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "select by"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "process mode"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation method"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "mix", GTK_WIDGET(g->strength));
-  dt_accel_connect_combobox_iop(self, "select by", GTK_WIDGET(g->select_by));
-  dt_accel_connect_combobox_iop(self, "process mode", GTK_WIDGET(g->mode));
-  dt_accel_connect_combobox_iop(self, "interpolation method", GTK_WIDGET(g->interpolator));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
                   const int new_version)
 {

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2456,7 +2456,7 @@ void gui_init(struct dt_iop_module_t *self)
     #define MONOTONE_HERMITE 2
   */
   c->interpolator = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(c->interpolator, NULL, _("interpolation method"));
+  dt_bauhaus_widget_set_label(c->interpolator, NULL, N_("interpolation method"));
   dt_bauhaus_combobox_add(c->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("monotonic spline"));

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -110,22 +110,6 @@ const dt_iop_roi_t *roi_out, dt_develop_tiling_t *tiling)
 }
 */
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edge detection radius"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "operation mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_defringe_gui_data_t *g = (dt_iop_defringe_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "edge detection radius", GTK_WIDGET(g->radius_scale));
-  dt_accel_connect_slider_iop(self, "threshold", GTK_WIDGET(g->thresh_scale));
-  dt_accel_connect_combobox_iop(self, "operation mode", GTK_WIDGET(g->mode_select));
-}
-
 // fibonacci lattice to select surrounding pixels for different cases
 static const float fib[] = { 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233 };
 // 0,1,2,3,4,5,6, 7, 8, 9,10,11, 12, 13

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -185,22 +185,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_RAW;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edge threshold"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color smoothing"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "match greens"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "edge threshold", GTK_WIDGET(g->median_thrs));
-  dt_accel_connect_combobox_iop(self, "color smoothing", GTK_WIDGET(g->color_smoothing));
-  dt_accel_connect_combobox_iop(self, "match greens", GTK_WIDGET(g->greeneq));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {
@@ -4996,7 +4980,7 @@ void gui_update(struct dt_iop_module_t *self)
      (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX))
     img->flags |= DT_IMAGE_MONOCHROME_BAYER;
   else
-    img->flags &= ~DT_IMAGE_MONOCHROME_BAYER;   
+    img->flags &= ~DT_IMAGE_MONOCHROME_BAYER;
   const int mask_bw = dt_image_monochrome_flags(img);
   changed ^= img->flags & DT_IMAGE_MONOCHROME_BAYER;
 
@@ -5049,7 +5033,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
      (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX))
     img->flags |= DT_IMAGE_MONOCHROME_BAYER;
   else
-    img->flags &= ~DT_IMAGE_MONOCHROME_BAYER;   
+    img->flags &= ~DT_IMAGE_MONOCHROME_BAYER;
   const int mask_bw = dt_image_monochrome_flags(img);
   changed ^= img->flags & DT_IMAGE_MONOCHROME_BAYER;
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -206,9 +206,9 @@ typedef struct dt_iop_denoiseprofile_params_t
   float bias;       /* allows to reduce backtransform bias
                        $MIN: -1000.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION: "bias correction" */
   float scattering; /* spread the patch search zone without increasing number of patches
-                       $MIN: 0.0 $MAX: 20.0 $DEFAULT: 0.0 $DESCRIPTION: "scattering (coarse-grain noise)" */
+                       $MIN: 0.0 $MAX: 20.0 $DEFAULT: 0.0 $DESCRIPTION: "scattering" */
   float central_pixel_weight; /* increase central pixel's weight in patch comparison
-                       $MIN: 0.0 $MAX: 10.0 $DEFAULT: 0.1 $DESCRIPTION: "central pixel weight (details)" */
+                       $MIN: 0.0 $MAX: 10.0 $DEFAULT: 0.1 $DESCRIPTION: "central pixel weight" */
   float overshooting; /* adjusts the way parameters are autoset
                          $MIN: 0.001 $MAX: 1000.0 $DEFAULT: 1.0 $DESCRIPTION: "adjust autoset parameters" */
   float a[3], b[3]; // fit for poissonian-gaussian noise per color channel.

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -610,34 +610,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "adjust autoset parameters"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "preserve shadows"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bias correction"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "patch size"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "search radius"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scattering"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "central pixel weight"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
-  dt_accel_connect_slider_iop(self, "adjust autoset parameters", GTK_WIDGET(g->overshooting));
-  dt_accel_connect_slider_iop(self, "preserve shadows", GTK_WIDGET(g->shadows));
-  dt_accel_connect_slider_iop(self, "bias correction", GTK_WIDGET(g->bias));
-  dt_accel_connect_slider_iop(self, "patch size", GTK_WIDGET(g->radius));
-  dt_accel_connect_slider_iop(self, "search radius", GTK_WIDGET(g->nbhood));
-  dt_accel_connect_slider_iop(self, "scattering", GTK_WIDGET(g->scattering));
-  dt_accel_connect_slider_iop(self, "central pixel weight", GTK_WIDGET(g->central_pixel_weight));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
-}
-
 typedef union floatint_t
 {
   float f;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3933,14 +3933,14 @@ void gui_init(dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->profile = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->profile, NULL, _("profile"));
+  dt_bauhaus_widget_set_label(g->profile, NULL, N_("profile"));
   g_signal_connect(G_OBJECT(g->profile), "value-changed", G_CALLBACK(profile_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile, TRUE, TRUE, 0);
 
   g->wb_adaptive_anscombe = dt_bauhaus_toggle_from_params(self, "wb_adaptive_anscombe");
 
   g->mode = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));
+  dt_bauhaus_widget_set_label(g->mode, NULL, N_("mode"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means auto"));
   dt_bauhaus_combobox_add(g->mode, _("wavelets"));

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -767,7 +767,7 @@ void gui_init(struct dt_iop_module_t *self)
 #if 0
   g->radius = dt_bauhaus_slider_new_with_range(self, 0.0, 200.0, 0.1, p->random.radius, 2);
   gtk_widget_set_tooltip_text(g->radius, _("radius for blurring step"));
-  dt_bauhaus_widget_set_label(g->radius, NULL, _("radius"));
+  dt_bauhaus_widget_set_label(g->radius, NULL, N_("radius"));
 
   g->range = dtgtk_gradient_slider_multivalue_new(4);
   dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->range), GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -119,18 +119,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_combobox_iop(self, "method", GTK_WIDGET(g->dither_type));
-}
-
 void init_presets(dt_iop_module_so_t *self)
 {
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -877,7 +877,7 @@ void gui_init(struct dt_iop_module_t *self)
                 dt_bauhaus_slider_new_with_range(self, 0.0, 0.2, .001, 0.01, 3));
   gtk_widget_set_tooltip_text(g->autoexpp, _("percentage of bright values clipped out, toggle color picker to activate"));
   dt_bauhaus_slider_set_format(g->autoexpp, "%.3f%%");
-  dt_bauhaus_widget_set_label(g->autoexpp, NULL, _("clipping threshold"));
+  dt_bauhaus_widget_set_label(g->autoexpp, NULL, N_("clipping threshold"));
   g_signal_connect(G_OBJECT(g->autoexpp), "value-changed", G_CALLBACK(autoexpp_callback), self);
   gtk_box_pack_start(GTK_BOX(vbox_manual), GTK_WIDGET(g->autoexpp), TRUE, TRUE, 0);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -128,27 +128,8 @@ static float dt_iop_exposure_get_exposure(struct dt_iop_module_t *self);
 static void dt_iop_exposure_set_black(struct dt_iop_module_t *self, const float black);
 static float dt_iop_exposure_get_black(struct dt_iop_module_t *self);
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "auto-exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "percentile"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target level"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
 void connect_key_accels(dt_iop_module_t *self)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "black", GTK_WIDGET(g->black));
-  dt_accel_connect_slider_iop(self, "exposure", GTK_WIDGET(g->exposure));
-  dt_accel_connect_slider_iop(self, "auto-exposure", GTK_WIDGET(g->autoexpp));
-  dt_accel_connect_slider_iop(self, "percentile", GTK_WIDGET(g->deflicker_percentile));
-  dt_accel_connect_slider_iop(self, "target level", GTK_WIDGET(g->deflicker_target_level));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
-
   /* register hooks with current dev so that  histogram
      can interact with this module.
   */

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1620,7 +1620,7 @@ void gui_init(dt_iop_module_t *self)
   // grey_point_source slider
   g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.1, 36., 0.1, p->grey_point_source, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->grey_point_source, 0.0, 100.0);
-  dt_bauhaus_widget_set_label(g->grey_point_source, NULL, _("middle grey luminance"));
+  dt_bauhaus_widget_set_label(g->grey_point_source, NULL, N_("middle grey luminance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
@@ -1631,7 +1631,7 @@ void gui_init(dt_iop_module_t *self)
   // White slider
   g->white_point_source = dt_bauhaus_slider_new_with_range(self, 2.0, 8.0, 0.1, p->white_point_source, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->white_point_source, 0.0, 16.0);
-  dt_bauhaus_widget_set_label(g->white_point_source, NULL, _("white relative exposure"));
+  dt_bauhaus_widget_set_label(g->white_point_source, NULL, N_("white relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->white_point_source, "%.2f EV");
   gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between middle grey and pure white.\n"
@@ -1643,7 +1643,7 @@ void gui_init(dt_iop_module_t *self)
   // Black slider
   g->black_point_source = dt_bauhaus_slider_new_with_range(self, -14.0, -3.0, 0.1, p->black_point_source, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->black_point_source, -16.0, -0.1);
-  dt_bauhaus_widget_set_label(g->black_point_source, NULL, _("black relative exposure"));
+  dt_bauhaus_widget_set_label(g->black_point_source, NULL, N_("black relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->black_point_source, "%.2f EV");
   gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle grey and pure black.\n"
@@ -1654,7 +1654,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->security_factor, 2);
-  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("safety factor"));
+  dt_bauhaus_widget_set_label(g->security_factor, NULL, N_("safety factor"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range.\n"
@@ -1663,7 +1663,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Auto tune slider
   g->auto_button = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->auto_button, NULL, _("auto tune levels"));
+  dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->auto_button);
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some guessing.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
@@ -1675,7 +1675,7 @@ void gui_init(dt_iop_module_t *self)
   // contrast slider
   g->contrast = dt_bauhaus_slider_new_with_range(self, 1., 2., 0.01, p->contrast, 3);
   dt_bauhaus_slider_enable_soft_boundaries(g->contrast, 0.0, 5.0);
-  dt_bauhaus_widget_set_label(g->contrast, NULL, _("contrast"));
+  dt_bauhaus_widget_set_label(g->contrast, NULL, N_("contrast"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
                                              "affects mostly the mid-tones"));
@@ -1684,7 +1684,7 @@ void gui_init(dt_iop_module_t *self)
   // latitude slider
   g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 2., 8.0, 0.05, p->latitude_stops, 3);
   dt_bauhaus_slider_enable_soft_boundaries(g->latitude_stops, 0.01, 16.0);
-  dt_bauhaus_widget_set_label(g->latitude_stops, NULL, _("latitude"));
+  dt_bauhaus_widget_set_label(g->latitude_stops, NULL, N_("latitude"));
   dt_bauhaus_slider_set_format(g->latitude_stops, "%.2f EV");
   gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->latitude_stops, _("width of the linear domain in the middle of the curve.\n"
@@ -1694,7 +1694,7 @@ void gui_init(dt_iop_module_t *self)
 
   // balance slider
   g->balance = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->balance, 2);
-  dt_bauhaus_widget_set_label(g->balance, NULL, _("shadows/highlights balance"));
+  dt_bauhaus_widget_set_label(g->balance, NULL, N_("shadows/highlights balance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->balance, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->balance, "%.2f %%");
   gtk_widget_set_tooltip_text(g->balance, _("slides the latitude along the slope\nto give more room to shadows or highlights.\n"
@@ -1703,7 +1703,7 @@ void gui_init(dt_iop_module_t *self)
 
   // saturation slider
   g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 200., 0.5, p->global_saturation, 2);
-  dt_bauhaus_widget_set_label(g->global_saturation, NULL, _("global saturation"));
+  dt_bauhaus_widget_set_label(g->global_saturation, NULL, N_("global saturation"));
   dt_bauhaus_slider_enable_soft_boundaries(g->global_saturation, 0.0, 1000.0);
   dt_bauhaus_slider_set_format(g->global_saturation, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(self->widget), g->global_saturation, TRUE, TRUE, 0);
@@ -1713,7 +1713,7 @@ void gui_init(dt_iop_module_t *self)
 
   // saturation slider
   g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 200., 0.5, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
-  dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
+  dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
   dt_bauhaus_slider_enable_soft_boundaries(g->saturation, 0.0, 1000.0);
   dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(self->widget), g->saturation, TRUE, TRUE, 0);
@@ -1727,7 +1727,7 @@ void gui_init(dt_iop_module_t *self)
     #define MONOTONE_HERMITE 2
   */
   g->interpolator = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->interpolator, NULL, _("intent"));
+  dt_bauhaus_widget_set_label(g->interpolator, NULL, N_("intent"));
   dt_bauhaus_combobox_add(g->interpolator, _("contrasted")); // cubic spline
   dt_bauhaus_combobox_add(g->interpolator, _("faded")); // centripetal spline
   dt_bauhaus_combobox_add(g->interpolator, _("linear")); // monotonic spline
@@ -1765,7 +1765,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->black_point_target, 2);
-  dt_bauhaus_widget_set_label(g->black_point_target, NULL, _("target black luminance"));
+  dt_bauhaus_widget_set_label(g->black_point_target, NULL, N_("target black luminance"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->black_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->black_point_target, "%.2f %%");
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
@@ -1774,7 +1774,7 @@ void gui_init(dt_iop_module_t *self)
 
   // grey_point_source slider
   g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0.5, p->grey_point_target, 2);
-  dt_bauhaus_widget_set_label(g->grey_point_target, NULL, _("target middle grey"));
+  dt_bauhaus_widget_set_label(g->grey_point_target, NULL, N_("target middle grey"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->grey_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_target, "%.2f %%");
   gtk_widget_set_tooltip_text(g->grey_point_target, _("midde grey value of the target display or color space.\n"
@@ -1783,7 +1783,7 @@ void gui_init(dt_iop_module_t *self)
 
   // White slider
   g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1., p->white_point_target, 2);
-  dt_bauhaus_widget_set_label(g->white_point_target, NULL, _("target white luminance"));
+  dt_bauhaus_widget_set_label(g->white_point_target, NULL, N_("target white luminance"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->white_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->white_point_target, "%.2f %%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "
@@ -1792,7 +1792,7 @@ void gui_init(dt_iop_module_t *self)
 
   // power/gamma slider
   g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 2.4, 0.1, p->output_power, 2);
-  dt_bauhaus_widget_set_label(g->output_power, NULL, _("target gamma"));
+  dt_bauhaus_widget_set_label(g->output_power, NULL, N_("target gamma"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->output_power, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->output_power, _("power or gamma of the transfer function\nof the display or color space.\n"
                                                  "you should never touch that unless you know what you are doing."));

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -528,43 +528,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 }
 
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey luminance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dynamic range scaling"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "latitude"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows highlights balance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "extreme luminance saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target black luminance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target middle grey"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target white luminance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target power transfer function"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve chrominance"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "white exposure", GTK_WIDGET(g->white_point_source));
-  dt_accel_connect_slider_iop(self, "black exposure", GTK_WIDGET(g->black_point_source));
-  dt_accel_connect_slider_iop(self, "middle grey luminance", GTK_WIDGET(g->grey_point_source));
-  dt_accel_connect_slider_iop(self, "dynamic range scaling", GTK_WIDGET(g->security_factor));
-  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->contrast));
-  dt_accel_connect_slider_iop(self, "latitude", GTK_WIDGET(g->latitude));
-  dt_accel_connect_slider_iop(self, "shadows highlights balance", GTK_WIDGET(g->balance));
-  dt_accel_connect_slider_iop(self, "extreme luminance saturation", GTK_WIDGET(g->saturation));
-  dt_accel_connect_slider_iop(self, "target black luminance", GTK_WIDGET(g->black_point_target));
-  dt_accel_connect_slider_iop(self, "target middle grey", GTK_WIDGET(g->grey_point_target));
-  dt_accel_connect_slider_iop(self, "target white luminance", GTK_WIDGET(g->white_point_target));
-  dt_accel_connect_slider_iop(self, "target power transfer function", GTK_WIDGET(g->output_power));
-  dt_accel_connect_combobox_iop(self, "preserve chrominance", GTK_WIDGET(g->preserve_color));
-}
-
-
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3478,7 +3478,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Auto tune slider
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
-  dt_bauhaus_widget_set_label(g->auto_button, NULL, _("auto tune levels"));
+  dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\n"
@@ -3514,7 +3514,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Highlight Reconstruction Mask
   g->show_highlight_mask = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->show_highlight_mask, NULL, _("display highlight reconstruction mask"));
+  dt_bauhaus_widget_set_label(g->show_highlight_mask, NULL, N_("display highlight reconstruction mask"));
   dt_bauhaus_widget_set_quad_paint(g->show_highlight_mask, dtgtk_cairo_paint_showmask,
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->show_highlight_mask, TRUE);
@@ -3744,9 +3744,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   if(!w || w == g->version)
   {
     if(p->version == DT_FILMIC_COLORSCIENCE_V1)
-      dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
+      dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
     else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
-      dt_bauhaus_widget_set_label(g->saturation, NULL, _("middle tones saturation"));
+      dt_bauhaus_widget_set_label(g->saturation, NULL, N_("middle tones saturation"));
   }
 
   if(!w || w == g->reconstruct_bloom_vs_details)

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -491,18 +491,6 @@ static void rotate_ccw(GtkWidget *widget, dt_iop_module_t *self)
 {
   do_rotate(self, 0);
 }
-static gboolean rotate_cw_key(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                              GdkModifierType modifier, dt_iop_module_t *self)
-{
-  do_rotate(self, 1);
-  return TRUE;
-}
-static gboolean rotate_ccw_key(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                               GdkModifierType modifier, dt_iop_module_t *self)
-{
-  do_rotate(self, 0);
-  return TRUE;
-}
 
 void gui_init(struct dt_iop_module_t *self)
 {
@@ -526,21 +514,6 @@ void gui_init(struct dt_iop_module_t *self)
 void gui_cleanup(struct dt_iop_module_t *self)
 {
   self->gui_data = NULL;
-}
-
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_iop(self, TRUE, NC_("accel", "rotate 90 degrees CCW"), GDK_KEY_bracketleft, 0);
-  dt_accel_register_iop(self, TRUE, NC_("accel", "rotate 90 degrees CW"), GDK_KEY_bracketright, 0);
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  GClosure *closure;
-  closure = g_cclosure_new(G_CALLBACK(rotate_cw_key), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "rotate 90 degrees CW", closure);
-  closure = g_cclosure_new(G_CALLBACK(rotate_ccw_key), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "rotate 90 degrees CCW", closure);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -33,7 +33,7 @@
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "dtgtk/button.h"
+#include "develop/imageop_gui.h"
 #include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
 #include "gui/draw.h"
@@ -514,15 +514,13 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *label = dtgtk_reset_label_new(_("rotate"), self, &p->orientation, sizeof(int32_t));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
-  GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(button, _("rotate 90 degrees CCW"));
-  gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(rotate_ccw), (gpointer)self);
+  dt_iop_button_new(self, N_("rotate 90 degrees CCW"),
+                    G_CALLBACK(rotate_ccw), FALSE, GDK_KEY_bracketleft, 0,
+                    dtgtk_cairo_paint_refresh, 0, self->widget);
 
-  button = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_STYLE_FLAT | 1, NULL);
-  gtk_widget_set_tooltip_text(button, _("rotate 90 degrees CW"));
-  gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(rotate_cw), (gpointer)self);
+  dt_iop_button_new(self, N_("rotate 90 degrees CW"),
+                    G_CALLBACK(rotate_cw), FALSE, GDK_KEY_bracketright, 0,
+                    dtgtk_cairo_paint_refresh, 1, self->widget);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -118,24 +118,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bias"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "detail"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "operator"));
- }
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "bias", GTK_WIDGET(g->drago.bias));
-  dt_accel_connect_slider_iop(self, "target", GTK_WIDGET(g->drago.max_light));
-  dt_accel_connect_slider_iop(self, "detail", GTK_WIDGET(g->detail));
-  dt_accel_connect_combobox_iop(self, "operator", GTK_WIDGET(g->operator));
- }
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -157,26 +157,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "density"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hardness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "rotation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "density", GTK_WIDGET(g->density));
-  dt_accel_connect_slider_iop(self, "hardness", GTK_WIDGET(g->hardness));
-  dt_accel_connect_slider_iop(self, "rotation", GTK_WIDGET(g->rotation));
-  dt_accel_connect_slider_iop(self, "hue", GTK_WIDGET(g->hue));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->saturation));
-}
-
 static inline float f(const float t, const float c, const float x)
 {
   return (t / (1.0f + powf(c, -x * 6.0f)) + (1.0f - t) * (x * .5f + .5f));

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -435,22 +435,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "coarseness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "midtones bias"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_grain_gui_data_t *g = (dt_iop_grain_gui_data_t*)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "coarseness", GTK_WIDGET(g->scale));
-  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
-  dt_accel_connect_slider_iop(self, "midtones bias", GTK_WIDGET(g->midtones_bias));
-}
-
 // see: http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
 // this is the modified bernstein
 static unsigned int _hash_string(char *s)

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -117,19 +117,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "distance"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
-  dt_accel_connect_slider_iop(self, "distance", GTK_WIDGET(g->distance));
-}
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -96,20 +96,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_RAW;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clipping threshold"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "clipping threshold", GTK_WIDGET(g->clip));
-  dt_accel_connect_combobox_iop(self, "method", GTK_WIDGET(g->mode));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -90,21 +90,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "sharpness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast boost"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_highpass_gui_data_t *g =
-    (dt_iop_highpass_gui_data_t*)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "sharpness", GTK_WIDGET(g->sharpness));
-  dt_accel_connect_slider_iop(self, "contrast boost", GTK_WIDGET(g->contrast));
-}
-
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling)

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -81,20 +81,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_RAW;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "threshold", GTK_WIDGET(g->threshold));
-  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
-}
-
 /* Detect hot sensor pixels based on the 4 surrounding sites. Pixels
  * having 3 or 4 (depending on permissive setting) surrounding pixels that
  * than value*multiplier are considered "hot", and are replaced by the maximum of

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -127,7 +127,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_iop(self, FALSE, NC_("accel", "pick color of film material from image"), 0, 0);
+  dt_accel_register_iop(self, FALSE, N_("pick color of film material from image"), 0, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -103,9 +103,9 @@ typedef struct dt_iop_lensfun_gui_data_t
   GtkWidget *lens_param_box;
   GtkWidget *detection_warning;
   GtkWidget *cbe[3];
-  GtkButton *camera_model;
+  GtkWidget *camera_model;
   GtkMenu *camera_menu;
-  GtkButton *lens_model;
+  GtkWidget *lens_model;
   GtkMenu *lens_menu;
   GtkWidget *modflags, *target_geom, *reverse, *tca_r, *tca_b, *scale;
   GtkWidget *find_lens_button;
@@ -2301,28 +2301,26 @@ void gui_init(struct dt_iop_module_t *self)
 
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  g->camera_model = GTK_BUTTON(gtk_button_new_with_label(""));
+  g->camera_model = dt_iop_button_new(self, N_("camera model"),
+                                      G_CALLBACK(camera_menusearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                      NULL, 0, hbox);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(g->camera_model));
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), PANGO_ELLIPSIZE_END);
-  g_signal_connect(G_OBJECT(g->camera_model), "clicked", G_CALLBACK(camera_menusearch_clicked), self);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->camera_model), TRUE, TRUE, 0);
-  g->find_camera_button = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle, CPF_STYLE_FLAT | CPF_DIRECTION_DOWN, NULL);
+  g->find_camera_button = dt_iop_button_new(self, N_("find camera"),
+                                            G_CALLBACK(camera_autosearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                            dtgtk_cairo_paint_solid_triangle, CPF_DIRECTION_DOWN, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), g->find_camera_button, FALSE, FALSE, 0);
-  gtk_widget_set_tooltip_text(g->find_camera_button, _("find camera"));
-  g_signal_connect(G_OBJECT(g->find_camera_button), "clicked", G_CALLBACK(camera_autosearch_clicked), self);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
   // lens selector
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  g->lens_model = GTK_BUTTON(gtk_button_new_with_label(""));
+  g->lens_model = dt_iop_button_new(self, N_("lens model"),
+                                    G_CALLBACK(lens_menusearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                    NULL, 0, hbox);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(g->lens_model));
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), PANGO_ELLIPSIZE_END);
-  g_signal_connect(G_OBJECT(g->lens_model), "clicked", G_CALLBACK(lens_menusearch_clicked), self);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->lens_model), TRUE, TRUE, 0);
-  g->find_lens_button = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle, CPF_STYLE_FLAT | CPF_DIRECTION_DOWN, NULL);
+  g->find_lens_button = dt_iop_button_new(self, N_("find lens"),
+                                          G_CALLBACK(lens_autosearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                          dtgtk_cairo_paint_solid_triangle, CPF_DIRECTION_DOWN, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), g->find_lens_button, FALSE, FALSE, 0);
-  gtk_widget_set_tooltip_text(g->find_lens_button, _("find lens"));
-  g_signal_connect(G_OBJECT(g->find_lens_button), "clicked", G_CALLBACK(lens_autosearch_clicked), self);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
   // lens properties
@@ -2442,12 +2440,12 @@ void gui_update(struct dt_iop_module_t *self)
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
   // these are the wrong (untranslated) strings in general but that's ok, they will be overwritten further
   // down
-  gtk_button_set_label(g->camera_model, p->camera);
-  gtk_button_set_label(g->lens_model, p->lens);
+  gtk_button_set_label(GTK_BUTTON(g->camera_model), p->camera);
+  gtk_button_set_label(GTK_BUTTON(g->lens_model), p->lens);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), PANGO_ELLIPSIZE_END);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), PANGO_ELLIPSIZE_END);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->camera_model), "");
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->lens_model), "");
+  gtk_widget_set_tooltip_text(g->camera_model, "");
+  gtk_widget_set_tooltip_text(g->lens_model, "");
 
   int modflag = p->modify_flags & LENSFUN_MODFLAG_MASK;
   GList *modifiers = g->modifiers;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2301,7 +2301,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  g->camera_model = GTK_BUTTON(gtk_button_new_with_label(self->dev->image_storage.exif_model));
+  g->camera_model = GTK_BUTTON(gtk_button_new_with_label(""));
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(g->camera_model));
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), PANGO_ELLIPSIZE_END);
   g_signal_connect(G_OBJECT(g->camera_model), "clicked", G_CALLBACK(camera_menusearch_clicked), self);
@@ -2314,7 +2314,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // lens selector
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  g->lens_model = GTK_BUTTON(gtk_button_new_with_label(self->dev->image_storage.exif_lens));
+  g->lens_model = GTK_BUTTON(gtk_button_new_with_label(""));
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(g->lens_model));
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), PANGO_ELLIPSIZE_END);
   g_signal_connect(G_OBJECT(g->lens_model), "clicked", G_CALLBACK(lens_menusearch_clicked), self);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -169,42 +169,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scale"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "TCA R"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "TCA B"));
-
-  dt_accel_register_iop(self, FALSE, NC_("accel", "find camera"), 0, (GdkModifierType)0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "find lens"), 0, (GdkModifierType)0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "camera model"), 0, (GdkModifierType)0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "lens model"), 0, (GdkModifierType)0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "select corrections"), 0, (GdkModifierType)0);
-
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "corrections"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "geometry"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_button_iop(self, "find camera", GTK_WIDGET(g->find_camera_button));
-  dt_accel_connect_button_iop(self, "find lens", GTK_WIDGET(g->find_lens_button));
-  dt_accel_connect_button_iop(self, "camera model", GTK_WIDGET(g->camera_model));
-  dt_accel_connect_button_iop(self, "lens model", GTK_WIDGET(g->lens_model));
-  dt_accel_connect_button_iop(self, "select corrections", GTK_WIDGET(g->modflags));
-
-  dt_accel_connect_slider_iop(self, "scale", GTK_WIDGET(g->scale));
-  dt_accel_connect_slider_iop(self, "TCA R", GTK_WIDGET(g->tca_r));
-  dt_accel_connect_slider_iop(self, "TCA B", GTK_WIDGET(g->tca_b));
-
-  dt_accel_connect_combobox_iop(self, "corrections", GTK_WIDGET(g->modflags));
-  dt_accel_connect_combobox_iop(self, "geometry", GTK_WIDGET(g->target_geom));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->reverse));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1904,7 +1904,7 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
 
   // focal length
   w = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(w, NULL, _("mm"));
+  dt_bauhaus_widget_set_label(w, NULL, N_("mm"));
   gtk_widget_set_tooltip_text(w, _("focal length (mm)"));
   snprintf(txt, sizeof(txt), "%.*f", precision(p->focal, 10.0), p->focal);
   dt_bauhaus_combobox_add(w, txt);
@@ -1929,7 +1929,7 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   }
 
   w = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(w, NULL, _("f/"));
+  dt_bauhaus_widget_set_label(w, NULL, N_("f/"));
   gtk_widget_set_tooltip_text(w, _("f-number (aperture)"));
   snprintf(txt, sizeof(txt), "%.*f", precision(p->aperture, 10.0), p->aperture);
   dt_bauhaus_combobox_add(w, txt);
@@ -1944,7 +1944,7 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   g->cbe[1] = w;
 
   w = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(w, NULL, _("d"));
+  dt_bauhaus_widget_set_label(w, NULL, N_("d"));
   gtk_widget_set_tooltip_text(w, _("distance to subject"));
   snprintf(txt, sizeof(txt), "%.*f", precision(p->distance, 10.0), p->distance);
   dt_bauhaus_combobox_add(w, txt);
@@ -2352,7 +2352,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // selector for correction type (modflags): one or more out of distortion, TCA, vignetting
   g->modflags = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->modflags, NULL, _("corrections"));
+  dt_bauhaus_widget_set_label(g->modflags, NULL, N_("corrections"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->modflags, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->modflags, _("which corrections to apply"));
   GList *l = g->modifiers;
@@ -2367,7 +2367,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // target geometry
   g->target_geom = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->target_geom, NULL, _("geometry"));
+  dt_bauhaus_widget_set_label(g->target_geom, NULL, N_("geometry"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->target_geom, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->target_geom, _("target geometry"));
   dt_bauhaus_combobox_add(g->target_geom, _("rectilinear"));

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -125,24 +125,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gray"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "black", GTK_WIDGET(g->percentile_black));
-  dt_accel_connect_slider_iop(self, "gray", GTK_WIDGET(g->percentile_grey));
-  dt_accel_connect_slider_iop(self, "white", GTK_WIDGET(g->percentile_white));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3612,24 +3612,6 @@ void gui_cleanup(dt_iop_module_t *self)
   IOP_GUI_FREE;
 }
 
-void init_key_accels(dt_iop_module_so_t *module)
-{
-  dt_accel_register_iop(module, FALSE, NC_("accel", "point tool"),     0, 0);
-  dt_accel_register_iop(module, FALSE, NC_("accel", "line tool"),      0, 0);
-  dt_accel_register_iop(module, FALSE, NC_("accel", "curve tool"),     0, 0);
-  dt_accel_register_iop(module, FALSE, NC_("accel", "node tool"),      0, 0);
-}
-
-void connect_key_accels(dt_iop_module_t *module)
-{
-  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
-
-  dt_accel_connect_button_iop(module, "point tool",    GTK_WIDGET(g->btn_point_tool));
-  dt_accel_connect_button_iop(module, "line tool",     GTK_WIDGET(g->btn_line_tool));
-  dt_accel_connect_button_iop(module, "curve tool",    GTK_WIDGET(g->btn_curve_tool));
-  dt_accel_connect_button_iop(module, "node tool",     GTK_WIDGET(g->btn_node_tool));
-}
-
 // defgroup Button paint functions
 
 #define PREAMBLE                                       \

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -101,18 +101,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue shift"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_lowlight_gui_data_t *g = (dt_iop_lowlight_gui_data_t *)self->gui_data;
-  dt_accel_connect_slider_iop(self, "blue shift", g->scale_blueness);
-}
-
 static float lookup(const float *lut, const float i)
 {
   const int bin0 = MIN(0xffff, MAX(0, DT_IOP_LOWLIGHT_LUT_RES * i));

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -192,24 +192,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "radius"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_lowpass_gui_data_t *g = (dt_iop_lowpass_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "radius", GTK_WIDGET(g->radius));
-  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->contrast));
-  dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->brightness));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->saturation));
-}
-
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -601,7 +601,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
 
-  dt_bauhaus_widget_set_label(g->brightness, NULL, C_("lowpass", "brightness"));
+  dt_bauhaus_widget_set_label(g->brightness, NULL, NC_("lowpass", "brightness"));
 
   gtk_widget_set_tooltip_text(g->radius, _("radius of gaussian/bilateral blur"));
   gtk_widget_set_tooltip_text(g->contrast, _("contrast of lowpass filter"));

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -158,7 +158,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
 
   dt_accel_connect_combobox_iop(self, "application color space", GTK_WIDGET(g->colorspace));
-  dt_accel_connect_combobox_iop(self, "interpolation ", GTK_WIDGET(g->interpolation ));
+  dt_accel_connect_combobox_iop(self, "interpolation", GTK_WIDGET(g->interpolation ));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -147,20 +147,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "application color space"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_combobox_iop(self, "application color space", GTK_WIDGET(g->colorspace));
-  dt_accel_connect_combobox_iop(self, "interpolation", GTK_WIDGET(g->interpolation ));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
                   const int new_version)
 {

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -92,18 +92,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -481,13 +481,13 @@ static void toggle_stock_controls(dt_iop_module_t *const self)
   {
     // Hide color controls
     setup_color_variables(g, FALSE);
-    dt_bauhaus_widget_set_label(g->Dmin_R, NULL, _("D min"));
+    dt_bauhaus_widget_set_label(g->Dmin_R, NULL, N_("D min"));
   }
   else if(p->film_stock == DT_FILMSTOCK_COLOR)
   {
     // Show color controls
     setup_color_variables(g, TRUE);
-    dt_bauhaus_widget_set_label(g->Dmin_R, NULL, _("D min red component"));
+    dt_bauhaus_widget_set_label(g->Dmin_R, NULL, N_("D min red component"));
   }
   else
   {
@@ -873,7 +873,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->Dmin_R, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_R, "%.2f %%");
   dt_bauhaus_slider_set_factor(g->Dmin_R, 100);
-  dt_bauhaus_widget_set_label(g->Dmin_R, NULL, _("D min red component"));
+  dt_bauhaus_widget_set_label(g->Dmin_R, NULL, N_("D min red component"));
   gtk_widget_set_tooltip_text(g->Dmin_R, _("adjust the color and shade of the film transparent base.\n"
                                            "this value depends on the film material, \n"
                                            "the chemical fog produced while developing the film,\n"
@@ -884,7 +884,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->Dmin_G, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_G, "%.2f %%");
   dt_bauhaus_slider_set_factor(g->Dmin_G, 100);
-  dt_bauhaus_widget_set_label(g->Dmin_G, NULL, _("D min green component"));
+  dt_bauhaus_widget_set_label(g->Dmin_G, NULL, N_("D min green component"));
   gtk_widget_set_tooltip_text(g->Dmin_G, _("adjust the color and shade of the film transparent base.\n"
                                            "this value depends on the film material, \n"
                                            "the chemical fog produced while developing the film,\n"
@@ -895,7 +895,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->Dmin_B, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_B, "%.2f %%");
   dt_bauhaus_slider_set_factor(g->Dmin_B, 100);
-  dt_bauhaus_widget_set_label(g->Dmin_B, NULL, _("D min blue component"));
+  dt_bauhaus_widget_set_label(g->Dmin_B, NULL, N_("D min blue component"));
   gtk_widget_set_tooltip_text(g->Dmin_B, _("adjust the color and shade of the film transparent base.\n"
                                            "this value depends on the film material, \n"
                                            "the chemical fog produced while developing the film,\n"
@@ -939,21 +939,21 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(row3), FALSE, FALSE, 0);
 
   g->wb_low_R = dt_bauhaus_slider_from_params(self, "wb_low[0]");
-  dt_bauhaus_widget_set_label(g->wb_low_R, NULL, _("shadows red offset"));
+  dt_bauhaus_widget_set_label(g->wb_low_R, NULL, N_("shadows red offset"));
   gtk_widget_set_tooltip_text(g->wb_low_R, _("correct the color cast in shadows so blacks are\n"
                                              "truly achromatic. Setting this value before\n"
                                              "the highlights illuminant white balance will help\n"
                                              "recovering the global white balance in difficult cases."));
 
   g->wb_low_G = dt_bauhaus_slider_from_params(self, "wb_low[1]");
-  dt_bauhaus_widget_set_label(g->wb_low_G, NULL, _("shadows green offset"));
+  dt_bauhaus_widget_set_label(g->wb_low_G, NULL, N_("shadows green offset"));
   gtk_widget_set_tooltip_text(g->wb_low_G, _("correct the color cast in shadows so blacks are\n"
                                              "truly achromatic. Setting this value before\n"
                                              "the highlights illuminant white balance will help\n"
                                              "recovering the global white balance in difficult cases."));
 
   g->wb_low_B = dt_bauhaus_slider_from_params(self, "wb_low[2]");
-  dt_bauhaus_widget_set_label(g->wb_low_B, NULL, _("shadows blue offset"));
+  dt_bauhaus_widget_set_label(g->wb_low_B, NULL, N_("shadows blue offset"));
   gtk_widget_set_tooltip_text(g->wb_low_B, _("correct the color cast in shadows so blacks are\n"
                                              "truly achromatic. Setting this value before\n"
                                              "the highlights illuminant white balance will help\n"
@@ -976,21 +976,21 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(row2), FALSE, FALSE, 0);
 
   g->wb_high_R = dt_bauhaus_slider_from_params(self, "wb_high[0]");
-  dt_bauhaus_widget_set_label(g->wb_high_R, NULL, _("illuminant red gain"));
+  dt_bauhaus_widget_set_label(g->wb_high_R, NULL, N_("illuminant red gain"));
   gtk_widget_set_tooltip_text(g->wb_high_R, _("correct the color of the illuminant so whites are\n"
                                               "truly achromatic. Setting this value after\n"
                                               "the shadows color cast will help\n"
                                               "recovering the global white balance in difficult cases."));
 
   g->wb_high_G = dt_bauhaus_slider_from_params(self, "wb_high[1]");
-  dt_bauhaus_widget_set_label(g->wb_high_G, NULL, _("illuminant green gain"));
+  dt_bauhaus_widget_set_label(g->wb_high_G, NULL, N_("illuminant green gain"));
   gtk_widget_set_tooltip_text(g->wb_high_G, _("correct the color of the illuminant so whites are\n"
                                               "truly achromatic. Setting this value after\n"
                                               "the shadows color cast will help\n"
                                               "recovering the global white balance in difficult cases."));
 
   g->wb_high_B = dt_bauhaus_slider_from_params(self, "wb_high[2]");
-  dt_bauhaus_widget_set_label(g->wb_high_B, NULL, _("illuminant blue gain"));
+  dt_bauhaus_widget_set_label(g->wb_high_B, NULL, N_("illuminant blue gain"));
   gtk_widget_set_tooltip_text(g->wb_high_B, _("correct the color of the illuminant so whites are\n"
                                               "truly achromatic. Setting this value after\n"
                                               "the shadows color cast will help\n"
@@ -1011,7 +1011,7 @@ void gui_init(dt_iop_module_t *self)
                                           "to adjust the global contrast while avoiding clipping shadows."));
 
   g->gamma = dt_bauhaus_slider_from_params(self, "gamma");
-  dt_bauhaus_widget_set_label(g->gamma, NULL, _("paper grade (gamma)"));
+  dt_bauhaus_widget_set_label(g->gamma, NULL, N_("paper grade (gamma)"));
   gtk_widget_set_tooltip_text(g->gamma, _("select the grade of the virtual paper, which is actually\n"
                                           "equivalent to applying a gamma. it compensates the film D max\n"
                                           "and recovers the contrast. use a high grade for high D max."));

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -119,24 +119,6 @@ int flags()
   return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "patch size"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "luma"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "chroma"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "patch size", GTK_WIDGET(g->radius));
-  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
-  dt_accel_connect_slider_iop(self, "luma", GTK_WIDGET(g->luma));
-  dt_accel_connect_slider_iop(self, "chroma", GTK_WIDGET(g->chroma));
-}
-
 #if defined(HAVE_OPENCL) && !USE_NEW_IMPL_CL
 static int bucket_next(unsigned int *state, unsigned int max)
 {

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -731,7 +731,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is useful when noise perturbates the measurements"));
 
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
-  dt_bauhaus_widget_set_label(g->auto_button, NULL, _("auto tune levels"));
+  dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   gtk_widget_set_tooltip_text(g->auto_button, _("make an optimization with some guessing"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->auto_button, TRUE, TRUE, 0);
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -110,30 +110,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "linear"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gamma"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dynamic range"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey luma"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black relative exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "safety factor"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "linear", GTK_WIDGET(g->linear));
-  dt_accel_connect_slider_iop(self, "gamma", GTK_WIDGET(g->gamma));
-  dt_accel_connect_slider_iop(self, "dynamic range", GTK_WIDGET(g->dynamic_range));
-  dt_accel_connect_slider_iop(self, "middle grey luma", GTK_WIDGET(g->grey_point));
-  dt_accel_connect_slider_iop(self, "black relative exposure", GTK_WIDGET(g->shadows_range));
-  dt_accel_connect_slider_iop(self, "safety factor", GTK_WIDGET(g->security_factor));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
-}
-
 void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_profilegamma_params_t p;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -136,18 +136,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_RAW;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "noise threshold"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_rawdenoise_gui_data_t *g = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "noise threshold", GTK_WIDGET(g->threshold));
-}
-
 // transposes image, it is faster to read columns than to write them.
 static void hat_transform(float *temp, const float *const base, int stride, int size, int scale)
 {

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -777,6 +777,12 @@ void gui_update(dt_iop_module_t *self)
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
+const gchar *black_label[]
+  =  { N_("black level 0"),
+       N_("black level 1"),
+       N_("black level 2"),
+       N_("black level 3") };
+
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rawprepare_gui_data_t *g = IOP_GUI_ALLOC(rawprepare);
@@ -786,14 +792,12 @@ void gui_init(dt_iop_module_t *self)
   for(int i = 0; i < 4; i++)
   {
     gchar *par = g_strdup_printf("raw_black_level_separate[%i]", i);
-    gchar *label = g_strdup_printf(_("black level %i"), i);
 
     g->black_level_separate[i] = dt_bauhaus_slider_from_params(self, par);
-    dt_bauhaus_widget_set_label(g->black_level_separate[i], NULL, label);
-    gtk_widget_set_tooltip_text(g->black_level_separate[i], label);
+    dt_bauhaus_widget_set_label(g->black_level_separate[i], NULL, black_label[i]);
+    gtk_widget_set_tooltip_text(g->black_level_separate[i], _(black_label[i]));
     dt_bauhaus_slider_set_soft_max(g->black_level_separate[i], 16384);
 
-    g_free(label);
     g_free(par);
   }
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -125,48 +125,6 @@ void init_presets(dt_iop_module_so_t *self)
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  for(int i = 0; i < 4; i++)
-  {
-    gchar *label = g_strdup_printf(_("black level %i"), i);
-    dt_accel_register_slider_iop(self, FALSE, NC_("accel", label));
-    g_free(label);
-  }
-
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white point"));
-
-  if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
-  {
-    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop x"));
-    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop y"));
-    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop width"));
-    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop height"));
-  }
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)self->gui_data;
-
-  for(int i = 0; i < 4; i++)
-  {
-    gchar *label = g_strdup_printf(_("black level %i"), i);
-    dt_accel_connect_slider_iop(self, label, g->black_level_separate[i]);
-    g_free(label);
-  }
-
-  dt_accel_connect_slider_iop(self, "white point", g->white_point);
-
-  if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
-  {
-    dt_accel_connect_slider_iop(self, "crop x", g->x);
-    dt_accel_connect_slider_iop(self, "crop y", g->y);
-    dt_accel_connect_slider_iop(self, "crop width", g->width);
-    dt_accel_connect_slider_iop(self, "crop height", g->height);
-  }
-}
-
 // value to round,   reference on how to round:
 //  if ref was even, returned value will be even
 //  if ref was odd,  returned value will be odd

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -103,21 +103,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "exposure"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "width"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "exposure", GTK_WIDGET(g->exposure));
-  dt_accel_connect_slider_iop(self, "width", GTK_WIDGET(g->width));
-}
-
-
 #define GAUSS(a, b, c, x) (a * pow(2.718281828, (-pow((x - b), 2) / (pow(c, 2)))))
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2254,7 +2254,7 @@ void gui_init(dt_iop_module_t *self)
 
   // mask opacity
   g->sl_mask_opacity = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.05, 1., 3);
-  dt_bauhaus_widget_set_label(g->sl_mask_opacity, _("mask opacity"), _("mask opacity"));
+  dt_bauhaus_widget_set_label(g->sl_mask_opacity, N_("mask opacity"), N_("mask opacity"));
   gtk_widget_set_tooltip_text(g->sl_mask_opacity, _("set the opacity on the selected shape"));
   g_signal_connect(G_OBJECT(g->sl_mask_opacity), "value-changed", G_CALLBACK(rt_mask_opacity_callback), self);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2227,7 +2227,7 @@ void gui_init(dt_iop_module_t *self)
 
   // mask opacity
   g->sl_mask_opacity = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.05, 1., 3);
-  dt_bauhaus_widget_set_label(g->sl_mask_opacity, N_("mask opacity"), N_("mask opacity"));
+  dt_bauhaus_widget_set_label(g->sl_mask_opacity, NULL, N_("mask opacity"));
   gtk_widget_set_tooltip_text(g->sl_mask_opacity, _("set the opacity on the selected shape"));
   g_signal_connect(G_OBJECT(g->sl_mask_opacity), "value-changed", G_CALLBACK(rt_mask_opacity_callback), self);
 
@@ -2603,153 +2603,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
 void init_key_accels(dt_iop_module_so_t *module)
 {
-  dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool circle"), 0, 0);
-  dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool ellipse"), 0, 0);
-  dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool path"), 0, 0);
-  dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool brush"), 0, 0);
-
-  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add circle"), 0, 0);
-  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add ellipse"), 0, 0);
-  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add path"), 0, 0);
-  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add brush"), 0, 0);
-
-  dt_accel_register_iop(module, TRUE, NC_("accel", "show or hide shapes"), 0, 0);
-}
-
-static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                      GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_circle), FALSE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_being_added(module, DT_MASKS_CIRCLE));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                       GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_ellipse), FALSE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_being_added(module, DT_MASKS_ELLIPSE));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _add_brush_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_brush), FALSE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_being_added(module, DT_MASKS_BRUSH));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                    GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_path), FALSE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_being_added(module, DT_MASKS_PATH));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                                 GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_circle), TRUE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_being_added(module, DT_MASKS_CIRCLE));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                                  GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_ellipse), TRUE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_being_added(module, DT_MASKS_ELLIPSE));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _continuous_add_brush_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                                GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_brush), TRUE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_being_added(module, DT_MASKS_BRUSH));
-
-  --darktable.gui->reset;
-
-  return TRUE;
-}
-
-static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                               GdkModifierType modifier, gpointer data)
-{
-  ++darktable.gui->reset;
-
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-
-  rt_add_shape(GTK_WIDGET(g->bt_path), TRUE, module);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_being_added(module, DT_MASKS_PATH));
-
-  --darktable.gui->reset;
-
-  return TRUE;
+  dt_accel_register_iop(module, TRUE, N_("show or hide shapes"), 0, 0);
 }
 
 static gboolean _show_or_hide_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -2810,32 +2664,6 @@ static gboolean _show_or_hide_accel(GtkAccelGroup *accel_group, GObject *acceler
 void connect_key_accels(dt_iop_module_t *module)
 {
   GClosure *closure;
-
-  // single add
-  closure = g_cclosure_new(G_CALLBACK(_add_circle_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "retouch tool circle", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_add_ellipse_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "retouch tool elipse", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_add_brush_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "retouch tool brush", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_add_path_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "retouch tool path", closure);
-
-  // continuous add
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_circle_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "continuous add circle", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_ellipse_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "continuous add ellipse", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_brush_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "continuous add brush", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_path_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop(module, "continuous add path", closure);
 
   //show or hide
   closure = g_cclosure_new(G_CALLBACK(_show_or_hide_accel), (gpointer)module, NULL);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -290,47 +290,49 @@ static void rt_display_selected_fill_color(dt_iop_retouch_gui_data_t *g, dt_iop_
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpick), &c);
 }
 
-static void rt_show_hide_controls(const dt_iop_module_t *self, const dt_iop_retouch_gui_data_t *d,
-                                  dt_iop_retouch_params_t *p, dt_iop_retouch_gui_data_t *g)
+static void rt_show_hide_controls(const dt_iop_module_t *self)
 {
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
+
   const int creation_continuous = (darktable.develop->form_gui && darktable.develop->form_gui->creation_continuous
                                    && darktable.develop->form_gui->creation_continuous_module == self);
 
   switch(p->algorithm)
   {
     case DT_IOP_RETOUCH_HEAL:
-      gtk_widget_hide(GTK_WIDGET(d->vbox_blur));
-      gtk_widget_hide(GTK_WIDGET(d->vbox_fill));
+      gtk_widget_hide(GTK_WIDGET(g->vbox_blur));
+      gtk_widget_hide(GTK_WIDGET(g->vbox_fill));
       break;
     case DT_IOP_RETOUCH_BLUR:
-      gtk_widget_show(GTK_WIDGET(d->vbox_blur));
-      gtk_widget_hide(GTK_WIDGET(d->vbox_fill));
+      gtk_widget_show(GTK_WIDGET(g->vbox_blur));
+      gtk_widget_hide(GTK_WIDGET(g->vbox_fill));
       break;
     case DT_IOP_RETOUCH_FILL:
-      gtk_widget_hide(GTK_WIDGET(d->vbox_blur));
-      gtk_widget_show(GTK_WIDGET(d->vbox_fill));
+      gtk_widget_hide(GTK_WIDGET(g->vbox_blur));
+      gtk_widget_show(GTK_WIDGET(g->vbox_fill));
       if(p->fill_mode == DT_IOP_RETOUCH_FILL_COLOR)
-        gtk_widget_show(GTK_WIDGET(d->hbox_color_pick));
+        gtk_widget_show(GTK_WIDGET(g->hbox_color_pick));
       else
-        gtk_widget_hide(GTK_WIDGET(d->hbox_color_pick));
+        gtk_widget_hide(GTK_WIDGET(g->hbox_color_pick));
       break;
     case DT_IOP_RETOUCH_CLONE:
     default:
-      gtk_widget_hide(GTK_WIDGET(d->vbox_blur));
-      gtk_widget_hide(GTK_WIDGET(d->vbox_fill));
+      gtk_widget_hide(GTK_WIDGET(g->vbox_blur));
+      gtk_widget_hide(GTK_WIDGET(g->vbox_fill));
       break;
   }
 
   if(g->display_wavelet_scale)
-    gtk_widget_show(GTK_WIDGET(d->vbox_preview_scale));
+    gtk_widget_show(GTK_WIDGET(g->vbox_preview_scale));
   else
-    gtk_widget_hide(GTK_WIDGET(d->vbox_preview_scale));
+    gtk_widget_hide(GTK_WIDGET(g->vbox_preview_scale));
 
   const dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, rt_get_selected_shape_id());
   if(form && !creation_continuous)
-    gtk_widget_show(GTK_WIDGET(d->sl_mask_opacity));
+    gtk_widget_show(GTK_WIDGET(g->sl_mask_opacity));
   else
-    gtk_widget_hide(GTK_WIDGET(d->sl_mask_opacity));
+    gtk_widget_hide(GTK_WIDGET(g->sl_mask_opacity));
 }
 
 static void rt_display_selected_shapes_lbl(dt_iop_retouch_gui_data_t *g)
@@ -398,7 +400,7 @@ static void rt_shape_selection_changed(dt_iop_module_t *self)
       selection_changed = 1;
     }
 
-    if(selection_changed) rt_show_hide_controls(self, g, p, g);
+    if(selection_changed) rt_show_hide_controls(self);
   }
 
   rt_display_selected_shapes_lbl(g);
@@ -1327,13 +1329,14 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void rt_copypaste_scale_callback(GtkToggleButton *togglebutton, dt_iop_module_t *self)
+static gboolean rt_copypaste_scale_callback(GtkToggleButton *togglebutton, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return TRUE;
+
   ++darktable.gui->reset;
 
   int scale_copied = 0;
-  const int active = gtk_toggle_button_get_active(togglebutton);
+  const int active = !gtk_toggle_button_get_active(togglebutton);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
 
@@ -1357,11 +1360,13 @@ static void rt_copypaste_scale_callback(GtkToggleButton *togglebutton, dt_iop_mo
   --darktable.gui->reset;
 
   if(scale_copied) dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  return TRUE;
 }
 
-static void rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, dt_iop_module_t *self)
+static gboolean rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return TRUE;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
@@ -1374,15 +1379,15 @@ static void rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, dt_
     ++darktable.gui->reset;
     gtk_toggle_button_set_active(togglebutton, FALSE);
     --darktable.gui->reset;
-    return;
+    return TRUE;
   }
 
   if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
   dt_iop_request_focus(self);
 
-  g->display_wavelet_scale = gtk_toggle_button_get_active(togglebutton);
+  g->display_wavelet_scale = !gtk_toggle_button_get_active(togglebutton);
 
-  rt_show_hide_controls(self, g, p, g);
+  rt_show_hide_controls(self);
 
   // compute auto levels only the first time display wavelet scale is used,
   // only if levels values are the default
@@ -1398,6 +1403,9 @@ static void rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, dt_
   dt_pthread_mutex_unlock(&g->lock);
 
   dt_iop_refresh_center(self);
+
+  gtk_toggle_button_set_active(togglebutton, g->display_wavelet_scale);
+  return TRUE;
 }
 
 static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
@@ -1443,9 +1451,9 @@ static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer use
   gtk_widget_queue_draw(GTK_WIDGET(g->wd_bar));
 }
 
-static void rt_auto_levels_callback(GtkToggleButton *togglebutton, dt_iop_module_t *self)
+static gboolean rt_auto_levels_callback(GtkToggleButton *togglebutton, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return FALSE;
 
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
 
@@ -1462,6 +1470,8 @@ static void rt_auto_levels_callback(GtkToggleButton *togglebutton, dt_iop_module
   gtk_toggle_button_set_active(togglebutton, FALSE);
 
   dt_iop_refresh_center(self);
+
+  return TRUE;
 }
 
 static void rt_mask_opacity_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -1572,12 +1582,21 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
 
 static gboolean rt_add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *self)
 {
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+
   if(darktable.gui->reset) return FALSE;
 
   GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
   const int creation_continuous = ((e->state & modifiers) == GDK_CONTROL_MASK);
 
-  return rt_add_shape(widget, creation_continuous, self);
+  rt_add_shape(widget, creation_continuous, self);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_being_added(self, DT_MASKS_CIRCLE));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_being_added(self, DT_MASKS_PATH));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_being_added(self, DT_MASKS_ELLIPSE));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_being_added(self, DT_MASKS_BRUSH));
+
+  return TRUE;
 }
 
 static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkEventButton *e,
@@ -1628,7 +1647,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_blur), (p->algorithm == DT_IOP_RETOUCH_BLUR));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_fill), (p->algorithm == DT_IOP_RETOUCH_FILL));
 
-  rt_show_hide_controls(self, g, p, g);
+  rt_show_hide_controls(self);
 
   if(!accept)
   {
@@ -1673,12 +1692,13 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
   return TRUE;
 }
 
-static void rt_showmask_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
+static gboolean rt_showmask_callback(GtkToggleButton *togglebutton, GdkEventButton *event, dt_iop_module_t *module)
 {
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return TRUE;
 
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
 
@@ -1687,31 +1707,35 @@ static void rt_showmask_callback(GtkToggleButton *togglebutton, dt_iop_module_t 
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
 
-    ++darktable.gui->reset;
     gtk_toggle_button_set_active(togglebutton, FALSE);
-    --darktable.gui->reset;
-    return;
+    return TRUE;
   }
 
-  g->mask_display = gtk_toggle_button_get_active(togglebutton);
+  g->mask_display = !gtk_toggle_button_get_active(togglebutton);
 
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
   dt_iop_request_focus(module);
 
   dt_iop_refresh_center(module);
+
+  gtk_toggle_button_set_active(togglebutton, g->mask_display);
+  return TRUE;
 }
 
-static void rt_suppress_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
+static gboolean rt_suppress_callback(GtkToggleButton *togglebutton, GdkEventButton *event, dt_iop_module_t *module)
 {
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return TRUE;
 
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-  g->suppress_mask = gtk_toggle_button_get_active(togglebutton);
+  g->suppress_mask = !gtk_toggle_button_get_active(togglebutton);
 
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
   dt_iop_request_focus(module);
 
   dt_iop_refresh_center(module);
+
+  gtk_toggle_button_set_active(togglebutton, g->suppress_mask);
+  return TRUE;
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
@@ -1722,7 +1746,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   if(w == g->cmb_fill_mode)
   {
     ++darktable.gui->reset;
-    rt_show_hide_controls(self, g, p, g);
+    rt_show_hide_controls(self);
     --darktable.gui->reset;
   }
   else
@@ -1939,7 +1963,7 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_set_sensitive(g->bt_paste_scale, g->copied_scale >= 0);
 
   // show/hide some fields
-  rt_show_hide_controls(self, g, p, g);
+  rt_show_hide_controls(self);
 
   // update edit shapes status
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
@@ -2005,73 +2029,46 @@ void gui_init(dt_iop_module_t *self)
                _("to add a shape select an algorithm and a shape type and click on the image.\n"
                  "shapes are added to the current scale"));
 
-  g->bt_edit_masks
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_eye, CPF_STYLE_FLAT, NULL);
-  g_signal_connect(G_OBJECT(g->bt_edit_masks), "button-press-event", G_CALLBACK(rt_edit_masks_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_edit_masks, _("show and edit shapes on the current scale"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
-  gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_edit_masks, FALSE, FALSE, 0);
+  g->bt_edit_masks = dt_iop_togglebutton_new(self, N_("show and edit shapes on the current scale"), NULL,
+                                             G_CALLBACK(rt_edit_masks_callback), TRUE, 0, 0,
+                                             dtgtk_cairo_paint_masks_eye, hbox_shapes);
 
-  g->bt_brush
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, CPF_STYLE_FLAT, NULL);
-  g_signal_connect(G_OBJECT(g->bt_brush), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_brush, _("add brush\nctrl+click to add multiple brush strokes"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), FALSE);
-  gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_brush, FALSE, FALSE, 0);
+  g->bt_brush = dt_iop_togglebutton_new(self, N_("add brush"), N_("add multiple brush strokes"),
+                                        G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
+                                        dtgtk_cairo_paint_masks_brush, hbox_shapes);
 
-  g->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT, NULL);
-  g_signal_connect(G_OBJECT(g->bt_path), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_path, _("add path\nctrl+click to add multiple paths"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
-  gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_path, FALSE, FALSE, 0);
+  g->bt_path = dt_iop_togglebutton_new(self, N_("add path"), N_("add multiple paths"),
+                                       G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
+                                       dtgtk_cairo_paint_masks_path, hbox_shapes);
 
-  g->bt_ellipse
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, CPF_STYLE_FLAT, NULL);
-  g_signal_connect(G_OBJECT(g->bt_ellipse), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_ellipse, _("add ellipse\nctrl+click to add multiple ellipses"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
-  gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_ellipse, FALSE, FALSE, 0);
+  g->bt_ellipse = dt_iop_togglebutton_new(self, N_("add ellipse"), N_("add multiple ellipses"),
+                                          G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
+                                          dtgtk_cairo_paint_masks_ellipse, hbox_shapes);
 
-  g->bt_circle
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, CPF_STYLE_FLAT, NULL);
-  g_signal_connect(G_OBJECT(g->bt_circle), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_circle, _("add circle\nctrl+click to add multiple circles"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
-  gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_circle, FALSE, FALSE, 0);
+  g->bt_circle = dt_iop_togglebutton_new(self, N_("add circle"), N_("add multiple circles"),
+                                         G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
+                                         dtgtk_cairo_paint_masks_circle, hbox_shapes);
 
   // algorithm toolbar
   GtkWidget *hbox_algo = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   gtk_box_pack_start(GTK_BOX(hbox_algo), dt_ui_label_new(_("algorithms:")), FALSE, TRUE, 0);
 
-  g->bt_fill
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_fill, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_fill, _("activates fill tool"));
-  g_signal_connect(G_OBJECT(g->bt_fill), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_fill), FALSE);
+  g->bt_blur = dt_iop_togglebutton_new(self, N_("activate blur tool"), NULL,
+                                       G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
+                                       dtgtk_cairo_paint_tool_blur, hbox_algo);
 
-  g->bt_blur
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_blur, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_blur, _("activates blur tool"));
-  g_signal_connect(G_OBJECT(g->bt_blur), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_blur), FALSE);
+  g->bt_fill = dt_iop_togglebutton_new(self, N_("activate fill tool"), NULL,
+                                       G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
+                                       dtgtk_cairo_paint_tool_fill, hbox_algo);
 
-  g->bt_heal
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_heal, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_heal, _("activates healing tool"));
-  g_signal_connect(G_OBJECT(g->bt_heal), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_heal), FALSE);
+  g->bt_clone = dt_iop_togglebutton_new(self, N_("activate cloning tool"), NULL,
+                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
+                                        dtgtk_cairo_paint_tool_clone, hbox_algo);
 
-  g->bt_clone
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_clone, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_clone, _("activates cloning tool"));
-  g_signal_connect(G_OBJECT(g->bt_clone), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_clone), FALSE);
-
-  gtk_box_pack_end(GTK_BOX(hbox_algo), g->bt_blur, FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(hbox_algo), g->bt_fill, FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(hbox_algo), g->bt_clone, FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(hbox_algo), g->bt_heal, FALSE, FALSE, 0);
+  g->bt_heal = dt_iop_togglebutton_new(self, N_("activate healing tool"), NULL,
+                                       G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
+                                       dtgtk_cairo_paint_tool_heal, hbox_algo);
 
   // wavelet decompose bar labels
   GtkWidget *grid_wd_labels = gtk_grid_new();
@@ -2116,52 +2113,31 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *hbox_scale = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
   // display & suppress masks
-  g->bt_showmask
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_showmask, _("display masks"));
-  g_signal_connect(G_OBJECT(g->bt_showmask), "toggled", G_CALLBACK(rt_showmask_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_showmask), FALSE);
+  g->bt_showmask = dt_iop_togglebutton_new(self, N_("display masks"), NULL,
+                                           G_CALLBACK(rt_showmask_callback), TRUE, 0, 0,
+                                           dtgtk_cairo_paint_showmask, hbox_scale);
 
-  g->bt_suppress
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye_toggle, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_suppress, _("temporarily switch off shapes"));
-  g_signal_connect(G_OBJECT(g->bt_suppress), "toggled", G_CALLBACK(rt_suppress_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_suppress), FALSE);
+  g->bt_suppress = dt_iop_togglebutton_new(self, N_("temporarily switch off shapes"), NULL,
+                                           G_CALLBACK(rt_suppress_callback), TRUE, 0, 0,
+                                           dtgtk_cairo_paint_eye_toggle, hbox_scale);
 
-  // display final image/current scale
-  g->bt_display_wavelet_scale = dtgtk_togglebutton_new(dtgtk_cairo_paint_display_wavelet_scale,
-                                                       CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_display_wavelet_scale, _("display wavelet scale"));
-  g_signal_connect(G_OBJECT(g->bt_display_wavelet_scale), "toggled", G_CALLBACK(rt_display_wavelet_scale_callback),
-                   self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_display_wavelet_scale), FALSE);
+  gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   // copy/paste shapes
-  g->bt_copy_scale
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_cut_forms, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_copy_scale, _("cut shapes from current scale"));
-  g_signal_connect(G_OBJECT(g->bt_copy_scale), "toggled", G_CALLBACK(rt_copypaste_scale_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_copy_scale), FALSE);
-  gtk_widget_set_sensitive(g->bt_copy_scale, FALSE);
+  g->bt_paste_scale = dt_iop_togglebutton_new(self, N_("paste cut shapes to current scale"), NULL,
+                                              G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
+                                              dtgtk_cairo_paint_paste_forms, hbox_scale);
 
-  g->bt_paste_scale
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_paste_forms, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_paste_scale, _("paste cut shapes to current scale"));
-  g_signal_connect(G_OBJECT(g->bt_paste_scale), "toggled", G_CALLBACK(rt_copypaste_scale_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), FALSE);
-  gtk_widget_set_sensitive(g->bt_paste_scale, FALSE);
-
-  gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_showmask, FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_suppress, FALSE, FALSE, 0);
+  g->bt_copy_scale = dt_iop_togglebutton_new(self, N_("cut shapes from current scale"), NULL,
+                                             G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
+                                             dtgtk_cairo_paint_cut_forms, hbox_scale);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
-  gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_paste_scale, FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_copy_scale, FALSE, FALSE, 0);
-
-  gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
-
-  gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_display_wavelet_scale, FALSE, FALSE, 0);
+  // display final image/current scale
+  g->bt_display_wavelet_scale = dt_iop_togglebutton_new(self, N_("display wavelet scale"), NULL,
+                                                        G_CALLBACK(rt_display_wavelet_scale_callback), TRUE, 0, 0,
+                                                        dtgtk_cairo_paint_display_wavelet_scale, hbox_scale);
 
   // preview single scale
   g->vbox_preview_scale = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -2189,15 +2165,12 @@ void gui_init(dt_iop_module_t *self)
   (g->preview_levels_gslider)->min_spacing = 0.05;
   g_signal_connect(G_OBJECT(g->preview_levels_gslider), "value-changed", G_CALLBACK(rt_gslider_changed), self);
 
-  // auto-levels button
-  g->bt_auto_levels
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_auto_levels, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->bt_auto_levels, _("auto levels"));
-  g_signal_connect(G_OBJECT(g->bt_auto_levels), "toggled", G_CALLBACK(rt_auto_levels_callback), self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_auto_levels), FALSE);
-
   gtk_box_pack_start(GTK_BOX(prev_lvl), GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(prev_lvl), g->bt_auto_levels, FALSE, FALSE, 0);
+
+  // auto-levels button
+  g->bt_auto_levels = dt_iop_togglebutton_new(self, N_("auto levels"), NULL,
+                                              G_CALLBACK(rt_auto_levels_callback), TRUE, 0, 0,
+                                              dtgtk_cairo_paint_auto_levels, prev_lvl);
 
   gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), prev_lvl, TRUE, TRUE, 0);
 

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1437,7 +1437,7 @@ void gui_init(struct dt_iop_module_t *self)
     #define MONOTONE_HERMITE 2
   */
   g->interpolator = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->interpolator, NULL, _("interpolation method"));
+  dt_bauhaus_widget_set_label(g->interpolator, NULL, N_("interpolation method"));
   dt_bauhaus_combobox_add(g->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(g->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(g->interpolator, _("monotonic spline"));

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -133,22 +133,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation method"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_combobox_iop(self, "interpolation method", GTK_WIDGET(g->interpolator));
-  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
-  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->autoscale));
-}
-
 void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_rgbcurve_params_t p;

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -116,18 +116,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
-}
-
 static void _turn_select_region_off(struct dt_iop_module_t *self)
 {
   dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -272,34 +272,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 }
 
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white point adjustment"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "radius"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "compress"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows color correction"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights color correction"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "soften with"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_shadhi_gui_data_t *g = (dt_iop_shadhi_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "shadows", GTK_WIDGET(g->shadows));
-  dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
-  dt_accel_connect_slider_iop(self, "white point adjustment", GTK_WIDGET(g->whitepoint));
-  dt_accel_connect_slider_iop(self, "radius", GTK_WIDGET(g->radius));
-  dt_accel_connect_slider_iop(self, "compress", GTK_WIDGET(g->compress));
-  dt_accel_connect_slider_iop(self, "shadows color correction", GTK_WIDGET(g->shadows_ccorrect));
-  dt_accel_connect_slider_iop(self, "highlights color correction", GTK_WIDGET(g->highlights_ccorrect));
-  dt_accel_connect_combobox_iop(self, "soften with", GTK_WIDGET(g->shadhi_algo));
-}
-
-
-
 static inline void _Lab_scale(const float *i, float *o)
 {
   o[0] = i[0] / 100.0f;

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -100,22 +100,6 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_update_ldr(_("sharpen"), self->op, self->version(), FOR_RAW);
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "radius"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "amount"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_sharpen_gui_data_t *g = (dt_iop_sharpen_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "radius", g->radius);
-  dt_accel_connect_slider_iop(self, "amount", g->amount);
-  dt_accel_connect_slider_iop(self, "threshold", g->threshold);
-}
-
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -100,24 +100,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "size"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mix"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_soften_gui_data_t *g = (dt_iop_soften_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "size", GTK_WIDGET(g->size));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->saturation));
-  dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->brightness));
-  dt_accel_connect_slider_iop(self, "mix", GTK_WIDGET(g->amount));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -454,7 +454,7 @@ void gui_update(struct dt_iop_module_t *self)
 static inline void gui_init_section(struct dt_iop_module_t *self, char *section, GtkWidget *slider_box,
                                     GtkWidget *hue, GtkWidget *saturation, GtkWidget **picker, gboolean top)
 {
-  GtkWidget *label = dt_ui_section_label_new(section);
+  GtkWidget *label = dt_ui_section_label_new(_(section));
 
   if(top)
   {
@@ -464,6 +464,7 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
 
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
+  dt_bauhaus_widget_set_label(hue, section, N_("hue"));
   dt_bauhaus_slider_set_feedback(hue, 0);
   dt_bauhaus_slider_set_stop(hue, 0.0f  , 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(hue, 0.166f, 1.0f, 1.0f, 0.0f);
@@ -475,6 +476,7 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
   gtk_widget_set_tooltip_text(hue, _("select the hue tone"));
   dt_color_picker_new(self, DT_COLOR_PICKER_POINT, hue);
 
+  dt_bauhaus_widget_set_label(saturation, section, N_("saturation"));
   dt_bauhaus_slider_set_stop(saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   gtk_widget_set_tooltip_text(saturation, _("select the saturation tone"));
@@ -494,6 +496,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_splittoning_gui_data_t *g = IOP_GUI_ALLOC(splittoning);
 
+  ++darktable.bauhaus->skip_accel;
   GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->shadow_hue_gslider = dt_bauhaus_slider_from_params(self, "shadow_hue");
   g->shadow_sat_gslider = dt_bauhaus_slider_from_params(self, "shadow_saturation");
@@ -501,13 +504,14 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *highlights_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->highlight_hue_gslider = dt_bauhaus_slider_from_params(self, "highlight_hue");
   g->highlight_sat_gslider = dt_bauhaus_slider_from_params(self, "highlight_saturation");
+  --darktable.bauhaus->skip_accel;
 
   // start building top level widget
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  gui_init_section(self, _("shadows"), shadows_box, g->shadow_hue_gslider, g->shadow_sat_gslider, &g->shadow_colorpick, TRUE);
+  gui_init_section(self, N_("shadows"), shadows_box, g->shadow_hue_gslider, g->shadow_sat_gslider, &g->shadow_colorpick, TRUE);
 
-  gui_init_section(self, _("highlights"), highlights_box, g->highlight_hue_gslider, g->highlight_sat_gslider, &g->highlight_colorpick, FALSE);
+  gui_init_section(self, N_("highlights"), highlights_box, g->highlight_hue_gslider, g->highlight_sat_gslider, &g->highlight_colorpick, FALSE);
 
   // Additional parameters
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("properties")), FALSE, FALSE, 0);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -97,34 +97,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_iop(self, FALSE, NC_("accel", "pick primary color"), 0, 0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "pick secondary color"), 0, 0);
-
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows-hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows-saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights-hue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights-saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "balance"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "compress"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_button_iop(self, "pick primary color", GTK_WIDGET(g->shadow_colorpick));
-  dt_accel_connect_button_iop(self, "pick secondary color", GTK_WIDGET(g->highlight_colorpick));
-
-  dt_accel_connect_slider_iop(self, "shadows-hue", GTK_WIDGET(g->shadow_hue_gslider));
-  dt_accel_connect_slider_iop(self, "shadows-saturation", GTK_WIDGET(g->shadow_sat_gslider));
-  dt_accel_connect_slider_iop(self, "highlights-hue", GTK_WIDGET(g->highlight_hue_gslider));
-  dt_accel_connect_slider_iop(self, "highlights-saturation", GTK_WIDGET(g->highlight_sat_gslider));
-  dt_accel_connect_slider_iop(self, "balance", GTK_WIDGET(g->balance_scale));
-  dt_accel_connect_slider_iop(self, "compress", GTK_WIDGET(g->compress_scale));
-}
-
 void init_presets(dt_iop_module_so_t *self)
 {
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -816,27 +816,6 @@ void gui_reset(struct dt_iop_module_t *self)
   dt_masks_reset_form_gui();
 }
 
-void init_key_accels (dt_iop_module_so_t *module)
-{
-  dt_accel_register_iop (module, TRUE, N_("show or hide shapes"),  0, 0);
-}
-
-static gboolean _show_hide_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  return _edit_masks(g->bt_edit_masks, NULL, module);
-}
-
-void connect_key_accels (dt_iop_module_t *module)
-{
-  GClosure *closure;
-
-  closure = g_cclosure_new(G_CALLBACK(_show_hide_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "show or hide shapes", closure);
-}
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -818,73 +818,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
 void init_key_accels (dt_iop_module_so_t *module)
 {
-  dt_accel_register_iop (module, TRUE, NC_("accel", "spot circle tool"),   0, 0);
-  dt_accel_register_iop (module, TRUE, NC_("accel", "spot ellipse tool"),   0, 0);
-  dt_accel_register_iop (module, TRUE, NC_("accel", "spot path tool"),     0, 0);
-  dt_accel_register_iop (module, TRUE, NC_("accel", "continuous add circle"),   0, 0);
-  dt_accel_register_iop (module, TRUE, NC_("accel", "continuous add ellipse"),   0, 0);
-  dt_accel_register_iop (module, TRUE, NC_("accel", "continuous add path"),     0, 0);
-  dt_accel_register_iop (module, TRUE, NC_("accel", "show or hide shapes"),  0, 0);
-}
-
-static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                      GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_shape(GTK_WIDGET(g->bt_circle), 0, module);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), TRUE);
-  return TRUE;
-}
-
-static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                       GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_shape(GTK_WIDGET(g->bt_ellipse), 0, module);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), TRUE);
-  return TRUE;
-}
-
-static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                    GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_shape(GTK_WIDGET(g->bt_path), 0, module);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), TRUE);
-  return TRUE;
-}
-
-static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                      GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_shape(GTK_WIDGET(g->bt_circle), 1, module);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), _shape_is_being_added(module, DT_MASKS_CIRCLE));
-  return TRUE;
-}
-
-static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                       GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_shape(GTK_WIDGET(g->bt_ellipse), 1, module);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), _shape_is_being_added(module, DT_MASKS_ELLIPSE));
-  return TRUE;
-}
-
-static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                    GdkModifierType modifier, gpointer data)
-{
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_shape(GTK_WIDGET(g->bt_path), 1, module);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), _shape_is_being_added(module, DT_MASKS_PATH));
-  return TRUE;
+  dt_accel_register_iop (module, TRUE, N_("show or hide shapes"),  0, 0);
 }
 
 static gboolean _show_hide_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -898,24 +832,6 @@ static gboolean _show_hide_key_accel(GtkAccelGroup *accel_group, GObject *accele
 void connect_key_accels (dt_iop_module_t *module)
 {
   GClosure *closure;
-
-  closure = g_cclosure_new(G_CALLBACK(_add_circle_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "spot circle tool", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_add_ellipse_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "spot ellipse tool", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_add_path_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "spot path tool", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_circle_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "continuous add circle", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_ellipse_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "continuous add ellipse", closure);
-
-  closure = g_cclosure_new(G_CALLBACK(_continuous_add_path_key_accel), (gpointer)module, NULL);
-  dt_accel_connect_iop (module, "continuous add path", closure);
 
   closure = g_cclosure_new(G_CALLBACK(_show_hide_key_accel), (gpointer)module, NULL);
   dt_accel_connect_iop (module, "show or hide shapes", closure);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -217,36 +217,12 @@ static gboolean _set_preset_spot(GtkAccelGroup *accel_group, GObject *accelerata
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "tint"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "temperature"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "red"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "emerald"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "settings"));
-
-  dt_accel_register_iop(self, FALSE, NC_("accel", "settings/as shot"), 0, 0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "settings/from image area"), 0, 0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "settings/user modified"), 0, 0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "settings/camera reference"), 0, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "tint", GTK_WIDGET(g->scale_tint));
-  dt_accel_connect_slider_iop(self, "temperature", GTK_WIDGET(g->scale_k));
-  dt_accel_connect_slider_iop(self, "red", GTK_WIDGET(g->scale_r));
-  dt_accel_connect_slider_iop(self, "green", GTK_WIDGET(g->scale_g));
-  dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->scale_b));
-  dt_accel_connect_slider_iop(self, "emerald", GTK_WIDGET(g->scale_g2));
-  dt_accel_connect_combobox_iop(self, "settings", GTK_WIDGET(g->presets));
-
-  dt_accel_connect_button_iop(self, "settings/as shot", GTK_WIDGET(g->btn_asshot));
   dt_accel_connect_iop(self, "settings/from image area", g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL));
-  dt_accel_connect_button_iop(self, "settings/user modified", GTK_WIDGET(g->btn_user));
-  dt_accel_connect_button_iop(self, "settings/camera reference", GTK_WIDGET(g->btn_d65));
 }
 
 /*
@@ -1958,11 +1934,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _(color_picker_label));
-
-  if(darktable.control->accel_initialising)
-    dt_accel_register_iop(self->so, FALSE, color_picker_label, 0, 0);
-  else
-    dt_accel_connect_iop(self, color_picker_label, g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL));
 
   g->btn_asshot = dt_iop_togglebutton_new(self, N_("set white balance to as shot"), NULL,
                                           G_CALLBACK(btn_toggled), FALSE, 0, 0,

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -215,14 +215,17 @@ static gboolean _set_preset_spot(GtkAccelGroup *accel_group, GObject *accelerata
   return TRUE;
 }
 
+// allow autoconcatenation. use #pragma push_macro("N_") #pragma pop_macro("N_") if needed
+#undef N_
+#define N_(String) String
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_iop(self, FALSE, NC_("accel", "settings/from image area"), 0, 0);
+  dt_accel_register_iop(self, FALSE, N_("settings") "¬" N_("from image area"), 0, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
-  dt_accel_connect_iop(self, "settings/from image area", g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL));
+  dt_accel_connect_iop(self, "settings¬from image area", g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL));
 }
 
 /*
@@ -1929,21 +1932,26 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(box_enabled, dt_ui_section_label_new(_("white balance settings")), TRUE, TRUE, 0);
 
-  // create color picker to be able to send its signal when spot selected
-  char *color_picker_label = N_("set white balance to detected from area");
-  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->colorpicker, _(color_picker_label));
-
-  g->btn_asshot = dt_iop_togglebutton_new(self, N_("set white balance to as shot"), NULL,
+  g->btn_asshot = dt_iop_togglebutton_new(self, N_("settings") "¬" N_("as shot"), NULL,
                                           G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                           dtgtk_cairo_paint_camera, NULL);
-  g->btn_user = dt_iop_togglebutton_new(self, N_("set white balance to user modified"), NULL,
+  gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance to as shot"));
+
+  // create color picker to be able to send its signal when spot selected
+  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
+
+  g->btn_user = dt_iop_togglebutton_new(self, N_("settings") "¬" N_("user modified"), NULL,
                                         G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                         dtgtk_cairo_paint_masks_drawn, NULL);
-  g->btn_d65 = dt_iop_togglebutton_new(self, N_("set white balance to camera reference point\nin most cases it should be D65"), NULL,
+  gtk_widget_set_tooltip_text(g->btn_user, _("set white balance to user modified"));
+
+
+  g->btn_d65 = dt_iop_togglebutton_new(self, N_("settings") "¬" N_("camera reference"), NULL,
                                        G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                        dtgtk_cairo_paint_bulb, NULL);
+  gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance to camera reference point\nin most cases it should be D65"));
 
   g->buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_d65, TRUE, TRUE, 0);
@@ -1955,7 +1963,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
 
   g->presets = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->presets, NULL, N_("setting")); // relabel to setting to remove confusion between module presets and white balance settings
+  dt_bauhaus_widget_set_label(g->presets, NULL, N_("settings")); // relabel to settings to remove confusion between module presets and white balance settings
   gtk_widget_set_tooltip_text(g->presets, _("choose white balance setting"));
   gtk_box_pack_start(box_enabled, g->presets, TRUE, TRUE, 0);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1783,13 +1783,13 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
 
   if(FILTERS_ARE_CYGM(img->buf_dsc.filters))
   {
-    dt_bauhaus_widget_set_label(g->scale_r, NULL, _("green"));
+    dt_bauhaus_widget_set_label(g->scale_r, NULL, N_("green"));
     gtk_widget_set_tooltip_text(g->scale_r, _("green channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_g, NULL, _("magenta"));
+    dt_bauhaus_widget_set_label(g->scale_g, NULL, N_("magenta"));
     gtk_widget_set_tooltip_text(g->scale_g, _("magenta channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_b, NULL, _("cyan"));
+    dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("cyan"));
     gtk_widget_set_tooltip_text(g->scale_b, _("cyan channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_g2, NULL, _("yellow"));
+    dt_bauhaus_widget_set_label(g->scale_g2, NULL, N_("yellow"));
     gtk_widget_set_tooltip_text(g->scale_g2, _("yellow channel coefficient"));
 
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_b, 0);
@@ -1799,13 +1799,13 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
   }
   else
   {
-    dt_bauhaus_widget_set_label(g->scale_r, NULL, _("red"));
+    dt_bauhaus_widget_set_label(g->scale_r, NULL, N_("red"));
     gtk_widget_set_tooltip_text(g->scale_r, _("red channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_g, NULL, _("green"));
+    dt_bauhaus_widget_set_label(g->scale_g, NULL, N_("green"));
     gtk_widget_set_tooltip_text(g->scale_g, _("green channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_b, NULL, _("blue"));
+    dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue"));
     gtk_widget_set_tooltip_text(g->scale_b, _("blue channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_g2, NULL, _("emerald"));
+    dt_bauhaus_widget_set_label(g->scale_g2, NULL, N_("emerald"));
     gtk_widget_set_tooltip_text(g->scale_g2, _("emerald channel coefficient"));
 
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_r, 0);
@@ -1901,13 +1901,13 @@ void gui_init(struct dt_iop_module_t *self)
   g->scale_k = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,
                                                              10., 5000.0, 0, feedback);
   dt_bauhaus_slider_set_format(g->scale_k, "%.0f K");
-  dt_bauhaus_widget_set_label(g->scale_k, NULL, _("temperature"));
+  dt_bauhaus_widget_set_label(g->scale_k, NULL, N_("temperature"));
   gtk_widget_set_tooltip_text(g->scale_k, _("color temperature (in Kelvin)"));
   gtk_box_pack_start(box_enabled, g->scale_k, TRUE, TRUE, 0);
 
   g->scale_tint = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TINT, DT_IOP_HIGHEST_TINT,
                                                                 .01, 1.0, 3, feedback);
-  dt_bauhaus_widget_set_label(g->scale_tint, NULL, _("tint"));
+  dt_bauhaus_widget_set_label(g->scale_tint, NULL, N_("tint"));
   gtk_widget_set_tooltip_text(g->scale_tint, _("color tint of the image, from magenta (value < 1) to green (value > 1)"));
   gtk_box_pack_start(box_enabled, g->scale_tint, TRUE, TRUE, 0);
 
@@ -1977,12 +1977,12 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
 
   g->presets = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->presets, NULL, _("setting")); // relabel to setting to remove confusion between module presets and white balance settings
+  dt_bauhaus_widget_set_label(g->presets, NULL, N_("setting")); // relabel to setting to remove confusion between module presets and white balance settings
   gtk_widget_set_tooltip_text(g->presets, _("choose white balance setting"));
   gtk_box_pack_start(box_enabled, g->presets, TRUE, TRUE, 0);
 
   g->finetune = dt_bauhaus_slider_new_with_range_and_feedback(self, -9.0, 9.0, 1.0, 0.0, 0, feedback);
-  dt_bauhaus_widget_set_label(g->finetune, NULL, _("finetune"));
+  dt_bauhaus_widget_set_label(g->finetune, NULL, N_("finetune"));
   dt_bauhaus_slider_set_format(g->finetune, _("%.0f mired"));
   gtk_widget_set_tooltip_text(g->finetune, _("fine tune camera's white balance setting"));
   gtk_box_pack_start(box_enabled, g->finetune, TRUE, TRUE, 0);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -220,12 +220,12 @@ static gboolean _set_preset_spot(GtkAccelGroup *accel_group, GObject *accelerata
 #define N_(String) String
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_iop(self, FALSE, N_("settings") "¬" N_("from image area"), 0, 0);
+  dt_accel_register_iop(self, FALSE, N_("settings") "`" N_("from image area"), 0, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
-  dt_accel_connect_iop(self, "settings¬from image area", g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL));
+  dt_accel_connect_iop(self, "settings" "`" "from image area", g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL));
 }
 
 /*
@@ -1932,7 +1932,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(box_enabled, dt_ui_section_label_new(_("white balance settings")), TRUE, TRUE, 0);
 
-  g->btn_asshot = dt_iop_togglebutton_new(self, N_("settings") "¬" N_("as shot"), NULL,
+  g->btn_asshot = dt_iop_togglebutton_new(self, N_("settings") "`" N_("as shot"), NULL,
                                           G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                           dtgtk_cairo_paint_camera, NULL);
   gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance to as shot"));
@@ -1942,13 +1942,13 @@ void gui_init(struct dt_iop_module_t *self)
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
 
-  g->btn_user = dt_iop_togglebutton_new(self, N_("settings") "¬" N_("user modified"), NULL,
+  g->btn_user = dt_iop_togglebutton_new(self, N_("settings") "`" N_("user modified"), NULL,
                                         G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                         dtgtk_cairo_paint_masks_drawn, NULL);
   gtk_widget_set_tooltip_text(g->btn_user, _("set white balance to user modified"));
 
 
-  g->btn_d65 = dt_iop_togglebutton_new(self, N_("settings") "¬" N_("camera reference"), NULL,
+  g->btn_d65 = dt_iop_togglebutton_new(self, N_("settings") "`" N_("camera reference"), NULL,
                                        G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                        dtgtk_cairo_paint_bulb, NULL);
   gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance to camera reference point\nin most cases it should be D65"));

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1210,7 +1210,7 @@ void gui_init(struct dt_iop_module_t *self)
     #define MONOTONE_HERMITE 2
   */
   c->interpolator = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(c->interpolator, NULL, _("interpolation method"));
+  dt_bauhaus_widget_set_label(c->interpolator, NULL, N_("interpolation method"));
   dt_bauhaus_combobox_add(c->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("monotonic spline"));
@@ -1225,7 +1225,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(c->preserve_colors, _("method to preserve colors when applying contrast"));
 
   c->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0.5f, 0.0f, 2);
-  dt_bauhaus_widget_set_label(c->logbase, NULL, _("scale for graph"));
+  dt_bauhaus_widget_set_label(c->logbase, NULL, N_("scale for graph"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -207,24 +207,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scale for graph"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation method"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color space"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "graph scale", GTK_WIDGET(g->logbase));
-  dt_accel_connect_combobox_iop(self, "interpolation method", GTK_WIDGET(g->interpolator));
-  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->preserve_colors));
-  dt_accel_connect_combobox_iop(self, "color space", GTK_WIDGET(g->autoscale_ab));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -322,50 +322,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blacks"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "deep shadows"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "light shadows"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "midtones"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dark highlights"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "whites"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "speculars"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "filter diffusion"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "smoothing diameter"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edges refinement or feathering"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mask quantization"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mask exposure compensation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mask contrast compensation"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "luminance estimator"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve details"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "blacks", GTK_WIDGET(g->noise));
-  dt_accel_connect_slider_iop(self, "deep shadows", GTK_WIDGET(g->ultra_deep_blacks));
-  dt_accel_connect_slider_iop(self, "shadows", GTK_WIDGET(g->deep_blacks));
-  dt_accel_connect_slider_iop(self, "light shadows", GTK_WIDGET(g->blacks));
-  dt_accel_connect_slider_iop(self, "midtones", GTK_WIDGET(g->shadows));
-  dt_accel_connect_slider_iop(self, "dark highlights", GTK_WIDGET(g->midtones));
-  dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
-  dt_accel_connect_slider_iop(self, "whites", GTK_WIDGET(g->whites));
-  dt_accel_connect_slider_iop(self, "speculars", GTK_WIDGET(g->speculars));
-  dt_accel_connect_slider_iop(self, "filter diffusion", GTK_WIDGET(g->iterations));
-  dt_accel_connect_slider_iop(self, "smoothing diameter", GTK_WIDGET(g->blending));
-  dt_accel_connect_slider_iop(self, "edges refinement or feathering", GTK_WIDGET(g->feathering));
-  dt_accel_connect_slider_iop(self, "mask quantization", GTK_WIDGET(g->quantization));
-  dt_accel_connect_slider_iop(self, "mask exposure compensation", GTK_WIDGET(g->exposure_boost));
-  dt_accel_connect_slider_iop(self, "mask contrast compensation", GTK_WIDGET(g->contrast_boost));
-  dt_accel_connect_combobox_iop(self, "luminance estimator", GTK_WIDGET(g->method));
-  dt_accel_connect_combobox_iop(self, "preserve details", GTK_WIDGET(g->details));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
                   const int new_version)
 {
@@ -3074,47 +3030,50 @@ void gui_init(struct dt_iop_module_t *self)
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
   dt_bauhaus_slider_set_step(g->noise, .05);
   dt_bauhaus_slider_set_format(g->noise, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->noise, NULL, N_("-8 EV"));
 
   g->ultra_deep_blacks = dt_bauhaus_slider_from_params(self, "ultra_deep_blacks");
   dt_bauhaus_slider_set_step(g->ultra_deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->ultra_deep_blacks, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->ultra_deep_blacks, NULL, N_("-7 EV"));
 
   g->deep_blacks = dt_bauhaus_slider_from_params(self, "deep_blacks");
   dt_bauhaus_slider_set_step(g->deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->deep_blacks, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->deep_blacks, NULL, N_("-6 EV"));
 
   g->blacks = dt_bauhaus_slider_from_params(self, "blacks");
   dt_bauhaus_slider_set_step(g->blacks, .05);
   dt_bauhaus_slider_set_format(g->blacks, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->blacks, NULL, N_("-5 EV"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
   dt_bauhaus_slider_set_step(g->shadows, .05);
   dt_bauhaus_slider_set_format(g->shadows, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->shadows, NULL, N_("-4 EV"));
 
   g->midtones = dt_bauhaus_slider_from_params(self, "midtones");
   dt_bauhaus_slider_set_step(g->midtones, .05);
   dt_bauhaus_slider_set_format(g->midtones, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->midtones, NULL, N_("-3 EV"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "highlights");
   dt_bauhaus_slider_set_step(g->highlights, .05);
   dt_bauhaus_slider_set_format(g->highlights, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->highlights, NULL, N_("-2 EV"));
 
   g->whites = dt_bauhaus_slider_from_params(self, "whites");
   dt_bauhaus_slider_set_step(g->whites, .05);
   dt_bauhaus_slider_set_format(g->whites, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->whites, NULL, N_("-1 EV"));
 
   g->speculars = dt_bauhaus_slider_from_params(self, "speculars");
   dt_bauhaus_slider_set_step(g->speculars, .05);
   dt_bauhaus_slider_set_format(g->speculars, _("%+.2f EV"));
+
+  ++darktable.bauhaus->skip_accel;
+  dt_bauhaus_widget_set_label(g->noise, NULL, N_("-8 EV"));
+  dt_bauhaus_widget_set_label(g->ultra_deep_blacks, NULL, N_("-7 EV"));
+  dt_bauhaus_widget_set_label(g->deep_blacks, NULL, N_("-6 EV"));
+  dt_bauhaus_widget_set_label(g->blacks, NULL, N_("-5 EV"));
+  dt_bauhaus_widget_set_label(g->shadows, NULL, N_("-4 EV"));
+  dt_bauhaus_widget_set_label(g->midtones, NULL, N_("-3 EV"));
+  dt_bauhaus_widget_set_label(g->highlights, NULL, N_("-2 EV"));
+  dt_bauhaus_widget_set_label(g->whites, NULL, N_("-1 EV"));
   dt_bauhaus_widget_set_label(g->speculars, NULL, N_("+0 EV"));
+  --darktable.bauhaus->skip_accel;
 
   // Advanced view
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -166,7 +166,15 @@ typedef enum dt_iop_toneequalizer_filter_t
 
 typedef struct dt_iop_toneequalizer_params_t
 {
-  float noise, ultra_deep_blacks, deep_blacks, blacks, shadows, midtones, highlights, whites, speculars; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0
+  float noise; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "blacks"
+  float ultra_deep_blacks; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "deep shadows"
+  float deep_blacks; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "shadows"
+  float blacks; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "light shadows"
+  float shadows; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "midtones"
+  float midtones; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "dark highlights"
+  float highlights; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "highlights"
+  float whites; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "whites"
+  float speculars; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0  $DESCRIPTION: "speculars"
   float blending; // $MIN: 0.01 $MAX: 100.0 $DEFAULT: 5.0 $DESCRIPTION: "smoothing diameter"
   float smoothing; // $DEFAULT: 1.414213562 sqrtf(2.0f)
   float feathering; // $MIN: 0.01 $MAX: 10000.0 $DEFAULT: 1.0 $DESCRIPTION: "edges refinement/feathering"
@@ -3066,47 +3074,47 @@ void gui_init(struct dt_iop_module_t *self)
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
   dt_bauhaus_slider_set_step(g->noise, .05);
   dt_bauhaus_slider_set_format(g->noise, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->noise, NULL, _("-8 EV"));
+  dt_bauhaus_widget_set_label(g->noise, NULL, N_("-8 EV"));
 
   g->ultra_deep_blacks = dt_bauhaus_slider_from_params(self, "ultra_deep_blacks");
   dt_bauhaus_slider_set_step(g->ultra_deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->ultra_deep_blacks, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->ultra_deep_blacks, NULL, _("-7 EV"));
+  dt_bauhaus_widget_set_label(g->ultra_deep_blacks, NULL, N_("-7 EV"));
 
   g->deep_blacks = dt_bauhaus_slider_from_params(self, "deep_blacks");
   dt_bauhaus_slider_set_step(g->deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->deep_blacks, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->deep_blacks, NULL, _("-6 EV"));
+  dt_bauhaus_widget_set_label(g->deep_blacks, NULL, N_("-6 EV"));
 
   g->blacks = dt_bauhaus_slider_from_params(self, "blacks");
   dt_bauhaus_slider_set_step(g->blacks, .05);
   dt_bauhaus_slider_set_format(g->blacks, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->blacks, NULL, _("-5 EV"));
+  dt_bauhaus_widget_set_label(g->blacks, NULL, N_("-5 EV"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
   dt_bauhaus_slider_set_step(g->shadows, .05);
   dt_bauhaus_slider_set_format(g->shadows, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->shadows, NULL, _("-4 EV"));
+  dt_bauhaus_widget_set_label(g->shadows, NULL, N_("-4 EV"));
 
   g->midtones = dt_bauhaus_slider_from_params(self, "midtones");
   dt_bauhaus_slider_set_step(g->midtones, .05);
   dt_bauhaus_slider_set_format(g->midtones, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->midtones, NULL, _("-3 EV"));
+  dt_bauhaus_widget_set_label(g->midtones, NULL, N_("-3 EV"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "highlights");
   dt_bauhaus_slider_set_step(g->highlights, .05);
   dt_bauhaus_slider_set_format(g->highlights, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->highlights, NULL, _("-2 EV"));
+  dt_bauhaus_widget_set_label(g->highlights, NULL, N_("-2 EV"));
 
   g->whites = dt_bauhaus_slider_from_params(self, "whites");
   dt_bauhaus_slider_set_step(g->whites, .05);
   dt_bauhaus_slider_set_format(g->whites, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->whites, NULL, _("-1 EV"));
+  dt_bauhaus_widget_set_label(g->whites, NULL, N_("-1 EV"));
 
   g->speculars = dt_bauhaus_slider_from_params(self, "speculars");
   dt_bauhaus_slider_set_step(g->speculars, .05);
   dt_bauhaus_slider_set_format(g->speculars, _("%+.2f EV"));
-  dt_bauhaus_widget_set_label(g->speculars, NULL, _("+0 EV"));
+  dt_bauhaus_widget_set_label(g->speculars, NULL, N_("+0 EV"));
 
   // Advanced view
 
@@ -3132,7 +3140,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->smoothing = dt_bauhaus_slider_new_with_range(self, -1.0f, +1.0f, 0.1, 0.0f, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->smoothing, -2.33f, 1.67f);
-  dt_bauhaus_widget_set_label(g->smoothing, NULL, _("curve smoothing"));
+  dt_bauhaus_widget_set_label(g->smoothing, NULL, N_("curve smoothing"));
   gtk_widget_set_tooltip_text(g->smoothing, _("positive values will produce more progressive tone transitions\n"
                                               "but the curve might become oscillatory in some settings.\n"
                                               "negative values will avoid oscillations and behave more robustly\n"
@@ -3150,7 +3158,7 @@ void gui_init(struct dt_iop_module_t *self)
                                            "higher contrast between areas to dodge and areas to burn"));
 
   g->details = dt_bauhaus_combobox_from_params(self, N_("details"));
-  dt_bauhaus_widget_set_label(g->details, NULL, _("preserve details"));
+  dt_bauhaus_widget_set_label(g->details, NULL, N_("preserve details"));
   gtk_widget_set_tooltip_text(g->details, _("'no' affects global and local contrast (safe if you only add contrast)\n"
                                             "'guided filter' only affects global contrast and tries to preserve local contrast\n"
                                             "'averaged guided filter' is a geometric mean of 'no' and 'guided filter' methods\n"
@@ -3223,7 +3231,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
 
   g->show_luminance_mask = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->show_luminance_mask, NULL, _("display exposure mask"));
+  dt_bauhaus_widget_set_label(g->show_luminance_mask, NULL, N_("display exposure mask"));
   dt_bauhaus_widget_set_quad_paint(g->show_luminance_mask, dtgtk_cairo_paint_showmask,
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->show_luminance_mask, TRUE);

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -90,20 +90,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast compression"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "spatial extent"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_tonemapping_gui_data_t *g = (dt_iop_tonemapping_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "contrast compression", GTK_WIDGET(g->contrast));
-  dt_accel_connect_slider_iop(self, "spatial extent", GTK_WIDGET(g->Fsize));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -503,7 +503,7 @@ void gui_init(dt_iop_module_t *self)
   // Any widgets that are _not_ directly linked to a field need to have a custom callback
   // function set up to respond to the "value-changed" signal.
   g->extra = dt_bauhaus_slider_new_with_range(self, -0.5, 0.5, .01, 0, 2);
-  dt_bauhaus_widget_set_label(g->extra, NULL, _("extra"));
+  dt_bauhaus_widget_set_label(g->extra, NULL, N_("extra"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->extra), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->extra), "value-changed", G_CALLBACK(extra_callback), self);
 }

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -99,22 +99,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mid-tones bias"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_velvia_gui_data_t *g = (dt_iop_velvia_gui_data_t*)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "strength",
-                              GTK_WIDGET(g->strength_scale));
-  dt_accel_connect_slider_iop(self, "mid-tones bias",
-                              GTK_WIDGET(g->bias_scale));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -80,19 +80,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vibrance"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_vibrance_gui_data_t *g = (dt_iop_vibrance_gui_data_t*)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "vibrance",
-                              GTK_WIDGET(g->amount_scale));
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -170,34 +170,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scale"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "fall-off strength"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "horizontal center"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vertical center"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shape"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "width-height ratio"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dithering"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_slider_iop(self, "scale", GTK_WIDGET(g->scale));
-  dt_accel_connect_slider_iop(self, "fall-off strength", GTK_WIDGET(g->falloff_scale));
-  dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->brightness));
-  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->saturation));
-  dt_accel_connect_slider_iop(self, "horizontal center", GTK_WIDGET(g->center_x));
-  dt_accel_connect_slider_iop(self, "vertical center", GTK_WIDGET(g->center_y));
-  dt_accel_connect_slider_iop(self, "shape", GTK_WIDGET(g->shape));
-  dt_accel_connect_slider_iop(self, "width-height ratio", GTK_WIDGET(g->whratio));
-  dt_accel_connect_slider_iop(self, "dithering", GTK_WIDGET(g->dithering));
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -304,32 +304,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_key_accels(dt_iop_module_so_t *self)
-{
-  dt_accel_register_iop(self, FALSE, NC_("accel", "refresh"), 0, 0);
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "opacity"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scale"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "rotation"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "x offset"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "y offset"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "marker"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "scale on"));
-}
-
-void connect_key_accels(dt_iop_module_t *self)
-{
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
-
-  dt_accel_connect_button_iop(self, "refresh", GTK_WIDGET(g->refresh));
-  dt_accel_connect_slider_iop(self, "opacity", GTK_WIDGET(g->opacity));
-  dt_accel_connect_slider_iop(self, "scale", GTK_WIDGET(g->scale));
-  dt_accel_connect_slider_iop(self, "rotation", GTK_WIDGET(g->rotate));
-  dt_accel_connect_slider_iop(self, "x offset", GTK_WIDGET(g->x_offset));
-  dt_accel_connect_slider_iop(self, "y offset", GTK_WIDGET(g->y_offset));
-  dt_accel_connect_combobox_iop(self, "marker", GTK_WIDGET(g->watermarks));
-  dt_accel_connect_combobox_iop(self, "scale on", GTK_WIDGET(g->sizeto));
-}
-
 static void _combo_box_set_active_text(dt_iop_watermark_gui_data_t *g, gchar *text)
 {
   int i = 0;

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -354,7 +354,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->discard_button, 3, line++, 3, 1);
 
   d->pastemode = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->pastemode, NULL, _("mode"));
+  dt_bauhaus_widget_set_label(d->pastemode, NULL, N_("mode"));
   dt_bauhaus_combobox_add(d->pastemode, _("append"));
   dt_bauhaus_combobox_add(d->pastemode, _("overwrite"));
   gtk_widget_set_tooltip_text(d->pastemode, _("how to handle existing history"));

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1084,7 +1084,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 
   d->storage = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->storage, NULL, _("target storage"));
+  dt_bauhaus_widget_set_label(d->storage, NULL, N_("target storage"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->storage, FALSE, TRUE, 0);
 
   // add all storage widgets to the stack widget
@@ -1112,7 +1112,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 
   d->format = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->format, NULL, _("file format"));
+  dt_bauhaus_widget_set_label(d->format, NULL, N_("file format"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->format, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(d->format), "value-changed", G_CALLBACK(_format_changed), (gpointer)d);
 
@@ -1135,7 +1135,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 
   d->dimensions_type = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->dimensions_type, NULL, _("set size"));
+  dt_bauhaus_widget_set_label(d->dimensions_type, NULL, N_("set size"));
   gtk_widget_set_tooltip_text(d->dimensions_type, _("choose a method for setting the output size"));
   dt_bauhaus_combobox_add(d->dimensions_type, _("in pixels (for file)"));
   dt_bauhaus_combobox_add(d->dimensions_type, _("in cm (for print)"));
@@ -1227,20 +1227,20 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(grid_outer), TRUE, TRUE, 0);
 
   d->upscale = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->upscale, NULL, _("allow upscaling"));
+  dt_bauhaus_widget_set_label(d->upscale, NULL, N_("allow upscaling"));
   dt_bauhaus_combobox_add(d->upscale, _("no"));
   dt_bauhaus_combobox_add(d->upscale, _("yes"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->upscale, FALSE, TRUE, 0);
 
   d->high_quality = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->high_quality, NULL, _("high quality resampling"));
+  dt_bauhaus_widget_set_label(d->high_quality, NULL, N_("high quality resampling"));
   dt_bauhaus_combobox_add(d->high_quality, _("no"));
   dt_bauhaus_combobox_add(d->high_quality, _("yes"));
   gtk_widget_set_tooltip_text(d->high_quality, _("do high quality resampling during export"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->high_quality, FALSE, TRUE, 0);
 
   d->export_masks = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->export_masks, NULL, _("store masks"));
+  dt_bauhaus_widget_set_label(d->export_masks, NULL, N_("store masks"));
   dt_bauhaus_combobox_add(d->export_masks, _("no"));
   dt_bauhaus_combobox_add(d->export_masks, _("yes"));
   gtk_widget_set_tooltip_text(d->export_masks, _("store masks as layers in exported images. only works for some formats."));
@@ -1254,7 +1254,7 @@ void gui_init(dt_lib_module_t *self)
   dt_loc_get_datadir(datadir, sizeof(datadir));
 
   d->profile = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->profile, NULL, _("profile"));
+  dt_bauhaus_widget_set_label(d->profile, NULL, N_("profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->profile, FALSE, TRUE, 0);
   dt_bauhaus_combobox_add(d->profile, _("image settings"));
   for(GList *l = darktable.color_profiles->profiles; l; l = g_list_next(l))
@@ -1276,7 +1276,7 @@ void gui_init(dt_lib_module_t *self)
   //  Add intent combo
 
   d->intent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->intent, NULL, _("intent"));
+  dt_bauhaus_widget_set_label(d->intent, NULL, N_("intent"));
   dt_bauhaus_combobox_add(d->intent, _("image settings"));
   dt_bauhaus_combobox_add(d->intent, _("perceptual"));
   dt_bauhaus_combobox_add(d->intent, _("relative colorimetric"));
@@ -1287,7 +1287,7 @@ void gui_init(dt_lib_module_t *self)
   //  Add style combo
 
   d->style = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->style, NULL, _("style"));
+  dt_bauhaus_widget_set_label(d->style, NULL, N_("style"));
   _lib_export_styles_changed_callback(NULL, self);
   gtk_box_pack_start(GTK_BOX(self->widget), d->style, FALSE, TRUE, 0);
   gtk_widget_set_tooltip_text(d->style, _("temporary style to use while exporting"));
@@ -1295,7 +1295,7 @@ void gui_init(dt_lib_module_t *self)
   //  Add check to control whether the style is to replace or append the current module
 
   d->style_mode = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->style_mode, NULL, _("mode"));
+  dt_bauhaus_widget_set_label(d->style_mode, NULL, N_("mode"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->style_mode, FALSE, TRUE, 0);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -419,9 +419,8 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
       dt_undo_iterate_internal(darktable.undo, DT_UNDO_HISTORY, mod, &_history_invalidate_cb);
 
       // we cleanup the module
-      dt_accel_disconnect_list(&mod->accel_closures);
-      dt_accel_cleanup_locals_iop(mod);
-      mod->accel_closures = NULL;
+      dt_accel_cleanup_closures_iop(mod);
+
       // don't delete the module, a pipe may still need it
       dev->alliop = g_list_append(dev->alliop, mod);
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -555,7 +555,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->clear_metadata_button), "clicked", G_CALLBACK(clear_metadata_callback), self);
 
   GtkWidget *pastemode = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(pastemode, NULL, _("mode"));
+  dt_bauhaus_widget_set_label(pastemode, NULL, N_("mode"));
   dt_bauhaus_combobox_add(pastemode, _("merge"));
   dt_bauhaus_combobox_add(pastemode, _("overwrite"));
   gtk_widget_set_tooltip_text(pastemode, _("how to handle existing metadata"));

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -185,9 +185,7 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_lib_pre
 
 
     // commit all the user input fields
-    char path[1024];
-    snprintf(path, sizeof(path), "preset/%s", g->original_name);
-    dt_accel_rename_preset_lib(g->module, path, name);
+    dt_accel_rename_preset_lib(g->module, g->original_name, name);
     DT_DEBUG_SQLITE3_PREPARE_V2
       (dt_database_get(darktable.db),
        "INSERT INTO data.presets (name, description, operation, op_version, op_params,"

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -335,7 +335,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Guides
   lib->guide_selector = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(lib->guide_selector, NULL, _("guides"));
+  dt_bauhaus_widget_set_label(lib->guide_selector, NULL, N_("guides"));
   gtk_box_pack_start(GTK_BOX(self->widget), lib->guide_selector, TRUE, TRUE, 0);
 
   lib->guides_widgets = gtk_stack_new();
@@ -366,7 +366,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(lib->guide_selector), "value-changed", G_CALLBACK(guides_presets_changed), lib);
 
   lib->flip_guides = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(lib->flip_guides, NULL, _("flip"));
+  dt_bauhaus_widget_set_label(lib->flip_guides, NULL, N_("flip"));
   dt_bauhaus_combobox_add(lib->flip_guides, _("none"));
   dt_bauhaus_combobox_add(lib->flip_guides, _("horizontally"));
   dt_bauhaus_combobox_add(lib->flip_guides, _("vertically"));
@@ -375,7 +375,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), lib->flip_guides, TRUE, TRUE, 0);
 
   lib->overlay = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(lib->overlay, NULL, _("overlay"));
+  dt_bauhaus_widget_set_label(lib->overlay, NULL, N_("overlay"));
   dt_bauhaus_combobox_add(lib->overlay, _("none"));
   dt_bauhaus_combobox_add(lib->overlay, _("selected image"));
   dt_bauhaus_combobox_add(lib->overlay, _("id"));
@@ -399,7 +399,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show(label);
 
   lib->overlay_mode = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(lib->overlay_mode, NULL, _("overlay mode"));
+  dt_bauhaus_widget_set_label(lib->overlay_mode, NULL, N_("overlay mode"));
   dt_bauhaus_combobox_add(lib->overlay_mode, C_("blendmode", "normal"));
   dt_bauhaus_combobox_add(lib->overlay_mode, C_("blendmode", "xor"));
   dt_bauhaus_combobox_add(lib->overlay_mode, C_("blendmode", "add"));
@@ -425,7 +425,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), lib->overlay_mode, TRUE, TRUE, 0);
 
   lib->overlay_splitline = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(lib->overlay_splitline, NULL, _("split line"));
+  dt_bauhaus_widget_set_label(lib->overlay_splitline, NULL, N_("split line"));
   dt_bauhaus_combobox_add(lib->overlay_splitline, _("off"));
   dt_bauhaus_combobox_add(lib->overlay_splitline, _("on"));
   gtk_widget_set_tooltip_text(lib->overlay_splitline, _("only draw part of the overlay"));

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1178,7 +1178,7 @@ gui_init (dt_lib_module_t *self)
 
   d->media = dt_bauhaus_combobox_new(NULL);
 
-  dt_bauhaus_widget_set_label(d->media, NULL, _("media"));
+  dt_bauhaus_widget_set_label(d->media, NULL, N_("media"));
 
   g_signal_connect(G_OBJECT(d->media), "value-changed", G_CALLBACK(_media_changed), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->media), TRUE, TRUE, 0);
@@ -1186,7 +1186,7 @@ gui_init (dt_lib_module_t *self)
   //  Add printer profile combo
 
   d->pprofile = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->pprofile, NULL, _("profile"));
+  dt_bauhaus_widget_set_label(d->pprofile, NULL, N_("profile"));
 
   int combo_idx, n;
   GList *l = d->profiles;
@@ -1241,7 +1241,7 @@ gui_init (dt_lib_module_t *self)
   //  Add printer intent combo
 
   d->pintent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->pintent, NULL, _("intent"));
+  dt_bauhaus_widget_set_label(d->pintent, NULL, N_("intent"));
   dt_bauhaus_combobox_add(d->pintent, _("perceptual"));
   dt_bauhaus_combobox_add(d->pintent, _("relative colorimetric"));
   dt_bauhaus_combobox_add(d->pintent, C_("rendering intent", "saturation"));
@@ -1274,7 +1274,7 @@ gui_init (dt_lib_module_t *self)
 
   //// papers
 
-  dt_bauhaus_widget_set_label(d->papers, NULL, _("paper size"));
+  dt_bauhaus_widget_set_label(d->papers, NULL, N_("paper size"));
 
   g_signal_connect(G_OBJECT(d->papers), "value-changed", G_CALLBACK(_paper_changed), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->papers), TRUE, TRUE, 0);
@@ -1282,7 +1282,7 @@ gui_init (dt_lib_module_t *self)
   //// portrait / landscape
 
   d->orientation = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->orientation, NULL, _("orientation"));
+  dt_bauhaus_widget_set_label(d->orientation, NULL, N_("orientation"));
   dt_bauhaus_combobox_add(d->orientation, _("portrait"));
   dt_bauhaus_combobox_add(d->orientation, _("landscape"));
 
@@ -1406,7 +1406,7 @@ gui_init (dt_lib_module_t *self)
   //  Add export profile combo
 
   d->profile = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->profile, NULL, _("profile"));
+  dt_bauhaus_widget_set_label(d->profile, NULL, N_("profile"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->profile), TRUE, TRUE, 0);
   dt_bauhaus_combobox_add(d->profile, _("image settings"));
@@ -1454,7 +1454,7 @@ gui_init (dt_lib_module_t *self)
   //  Add export intent combo
 
   d->intent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->intent, NULL, _("intent"));
+  dt_bauhaus_widget_set_label(d->intent, NULL, N_("intent"));
 
   dt_bauhaus_combobox_add(d->intent, _("image settings"));
   dt_bauhaus_combobox_add(d->intent, _("perceptual"));
@@ -1470,7 +1470,7 @@ gui_init (dt_lib_module_t *self)
   //  Add export style combo
 
   d->style = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->style, NULL, _("style"));
+  dt_bauhaus_widget_set_label(d->style, NULL, N_("style"));
 
   dt_bauhaus_combobox_add(d->style, _("none"));
 
@@ -1513,7 +1513,7 @@ gui_init (dt_lib_module_t *self)
   //  Whether to add/replace style items
 
   d->style_mode = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(d->style_mode, NULL, _("mode"));
+  dt_bauhaus_widget_set_label(d->style_mode, NULL, N_("mode"));
 
   dt_bauhaus_combobox_add(d->style_mode, _("replace history"));
   dt_bauhaus_combobox_add(d->style_mode, _("append history"));

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -559,7 +559,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->applymode = dt_bauhaus_combobox_new(NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->applymode), TRUE, FALSE, 0);
-  dt_bauhaus_widget_set_label(d->applymode, NULL, _("mode"));
+  dt_bauhaus_widget_set_label(d->applymode, NULL, N_("mode"));
   dt_bauhaus_combobox_add(d->applymode, _("append"));
   dt_bauhaus_combobox_add(d->applymode, _("overwrite"));
   gtk_widget_set_tooltip_text(d->applymode, _("how to handle existing history"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -745,6 +745,8 @@ int try_enter(dt_view_t *self)
 
 static void dt_dev_cleanup_module_accels(dt_iop_module_t *module)
 {
+
+  //FIXME
   dt_accel_disconnect_list(&module->accel_closures);
   dt_accel_cleanup_locals_iop(module);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -743,14 +743,6 @@ int try_enter(dt_view_t *self)
   return 0;
 }
 
-static void dt_dev_cleanup_module_accels(dt_iop_module_t *module)
-{
-
-  //FIXME
-  dt_accel_disconnect_list(&module->accel_closures);
-  dt_accel_cleanup_locals_iop(module);
-}
-
 static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
 {
   // stop crazy users from sleeping on key-repeat spacebar:
@@ -916,9 +908,8 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
       dev->iop = g_list_remove_link(dev->iop, g_list_nth(dev->iop, i));
 
       // we cleanup the module
-      dt_accel_disconnect_list(&module->accel_closures);
-      dt_accel_cleanup_locals_iop(module);
-      dt_iop_cleanup_module(module);
+      dt_accel_cleanup_closures_iop(module);
+
       free(module);
     }
   }
@@ -3092,7 +3083,7 @@ void leave(dt_view_t *self)
     dt_iop_module_t *module = (dt_iop_module_t *)(dev->iop->data);
     if(!dt_iop_is_hidden(module)) dt_iop_gui_cleanup_module(module);
 
-    dt_dev_cleanup_module_accels(module);
+    dt_accel_cleanup_closures_iop(module);
     module->accel_closures = NULL;
     dt_iop_cleanup_module(module);
     free(module);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2203,7 +2203,7 @@ void gui_init(dt_view_t *self)
     /** let's fill the encapsulating widgets */
     /* mode of operation */
     GtkWidget *mode = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(mode, NULL, _("mode"));
+    dt_bauhaus_widget_set_label(mode, NULL, N_("mode"));
     dt_bauhaus_combobox_add(mode, _("mark with CFA color"));
     dt_bauhaus_combobox_add(mode, _("mark with solid color"));
     dt_bauhaus_combobox_add(mode, _("false color"));
@@ -2215,7 +2215,7 @@ void gui_init(dt_view_t *self)
 
     /* color scheme */
     GtkWidget *colorscheme = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(colorscheme, NULL, _("color scheme"));
+    dt_bauhaus_widget_set_label(colorscheme, NULL, N_("color scheme"));
     dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "red"));
     dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "green"));
     dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "blue"));
@@ -2231,7 +2231,7 @@ void gui_init(dt_view_t *self)
     /* threshold */
     GtkWidget *threshold = dt_bauhaus_slider_new_with_range(NULL, 0.0, 2.0, 0.01, 1.0, 3);
     dt_bauhaus_slider_set(threshold, dev->rawoverexposed.threshold);
-    dt_bauhaus_widget_set_label(threshold, NULL, _("clipping threshold"));
+    dt_bauhaus_widget_set_label(threshold, NULL, N_("clipping threshold"));
     gtk_widget_set_tooltip_text(
         threshold, _("threshold of what shall be considered overexposed\n1.0 - white level\n0.0 - black level"));
     g_signal_connect(G_OBJECT(threshold), "value-changed", G_CALLBACK(rawoverexposed_threshold_callback), dev);
@@ -2267,7 +2267,7 @@ void gui_init(dt_view_t *self)
     /** let's fill the encapsulating widgets */
     /* preview mode */
     GtkWidget *mode = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(mode, NULL, _("clipping preview mode"));
+    dt_bauhaus_widget_set_label(mode, NULL, N_("clipping preview mode"));
     dt_bauhaus_combobox_add(mode, _("full gamut"));
     dt_bauhaus_combobox_add(mode, _("any RGB channel"));
     dt_bauhaus_combobox_add(mode, _("luminance only"));
@@ -2281,7 +2281,7 @@ void gui_init(dt_view_t *self)
 
     /* color scheme */
     GtkWidget *colorscheme = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(colorscheme, NULL, _("color scheme"));
+    dt_bauhaus_widget_set_label(colorscheme, NULL, N_("color scheme"));
     dt_bauhaus_combobox_add(colorscheme, _("black & white"));
     dt_bauhaus_combobox_add(colorscheme, _("red & blue"));
     dt_bauhaus_combobox_add(colorscheme, _("purple & green"));
@@ -2295,7 +2295,7 @@ void gui_init(dt_view_t *self)
     GtkWidget *lower = dt_bauhaus_slider_new_with_range(NULL, -32., -4., 1., -12.69, 2);
     dt_bauhaus_slider_set(lower, dev->overexposed.lower);
     dt_bauhaus_slider_set_format(lower, "%+.2f EV");
-    dt_bauhaus_widget_set_label(lower, NULL, _("lower threshold"));
+    dt_bauhaus_widget_set_label(lower, NULL, N_("lower threshold"));
     gtk_widget_set_tooltip_text(lower, _("clipping threshold for the black point,\n"
                                          "in EV, relatively to white (0 EV).\n"
                                          "8 bits sRGB clips blacks at -12.69 EV,\n"
@@ -2312,7 +2312,7 @@ void gui_init(dt_view_t *self)
     GtkWidget *upper = dt_bauhaus_slider_new_with_range(NULL, 0.0, 100.0, 0.1, 99.99, 2);
     dt_bauhaus_slider_set(upper, dev->overexposed.upper);
     dt_bauhaus_slider_set_format(upper, "%.2f%%");
-    dt_bauhaus_widget_set_label(upper, NULL, _("upper threshold"));
+    dt_bauhaus_widget_set_label(upper, NULL, N_("upper threshold"));
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(upper, _("clipping threshold for the white point.\n"
                                          "100% is peak medium luminance."));
@@ -2368,7 +2368,7 @@ void gui_init(dt_view_t *self)
     const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
 
     GtkWidget *display_intent = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(display_intent, NULL, _("display intent"));
+    dt_bauhaus_widget_set_label(display_intent, NULL, N_("display intent"));
     gtk_box_pack_start(GTK_BOX(vbox), display_intent, TRUE, TRUE, 0);
     dt_bauhaus_combobox_add(display_intent, _("perceptual"));
     dt_bauhaus_combobox_add(display_intent, _("relative colorimetric"));
@@ -2376,7 +2376,7 @@ void gui_init(dt_view_t *self)
     dt_bauhaus_combobox_add(display_intent, _("absolute colorimetric"));
 
     GtkWidget *display2_intent = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(display2_intent, NULL, _("preview display intent"));
+    dt_bauhaus_widget_set_label(display2_intent, NULL, N_("preview display intent"));
     gtk_box_pack_start(GTK_BOX(vbox), display2_intent, TRUE, TRUE, 0);
     dt_bauhaus_combobox_add(display2_intent, _("perceptual"));
     dt_bauhaus_combobox_add(display2_intent, _("relative colorimetric"));
@@ -2395,10 +2395,10 @@ void gui_init(dt_view_t *self)
     GtkWidget *display2_profile = dt_bauhaus_combobox_new(NULL);
     GtkWidget *softproof_profile = dt_bauhaus_combobox_new(NULL);
     GtkWidget *histogram_profile = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(softproof_profile, NULL, _("softproof profile"));
-    dt_bauhaus_widget_set_label(display_profile, NULL, _("display profile"));
-    dt_bauhaus_widget_set_label(display2_profile, NULL, _("preview display profile"));
-    dt_bauhaus_widget_set_label(histogram_profile, NULL, _("histogram profile"));
+    dt_bauhaus_widget_set_label(softproof_profile, NULL, N_("softproof profile"));
+    dt_bauhaus_widget_set_label(display_profile, NULL, N_("display profile"));
+    dt_bauhaus_widget_set_label(display2_profile, NULL, N_("preview display profile"));
+    dt_bauhaus_widget_set_label(histogram_profile, NULL, N_("histogram profile"));
     gtk_box_pack_start(GTK_BOX(vbox), softproof_profile, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(vbox), display_profile, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(vbox), display2_profile, TRUE, TRUE, 0);
@@ -2517,7 +2517,7 @@ void gui_init(dt_view_t *self)
 
     /** let's fill the encapsulating widget */
     GtkWidget *overlay_colors = dev->overlay_color.colors = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(overlay_colors, NULL, _("overlay color"));
+    dt_bauhaus_widget_set_label(overlay_colors, NULL, N_("overlay color"));
     dt_bauhaus_combobox_add(overlay_colors, _("gray"));
     dt_bauhaus_combobox_add(overlay_colors, _("red"));
     dt_bauhaus_combobox_add(overlay_colors, _("green"));

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1392,7 +1392,7 @@ void gui_init(dt_view_t *self)
   dt_loc_get_datadir(datadir, sizeof(datadir));
 
   GtkWidget *display_intent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(display_intent, NULL, _("display intent"));
+  dt_bauhaus_widget_set_label(display_intent, NULL, N_("display intent"));
   gtk_box_pack_start(GTK_BOX(vbox), display_intent, TRUE, TRUE, 0);
   dt_bauhaus_combobox_add(display_intent, _("perceptual"));
   dt_bauhaus_combobox_add(display_intent, _("relative colorimetric"));
@@ -1400,7 +1400,7 @@ void gui_init(dt_view_t *self)
   dt_bauhaus_combobox_add(display_intent, _("absolute colorimetric"));
 
   GtkWidget *display2_intent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(display2_intent, NULL, _("preview display intent"));
+  dt_bauhaus_widget_set_label(display2_intent, NULL, N_("preview display intent"));
   gtk_box_pack_start(GTK_BOX(vbox), display2_intent, TRUE, TRUE, 0);
   dt_bauhaus_combobox_add(display2_intent, _("perceptual"));
   dt_bauhaus_combobox_add(display2_intent, _("relative colorimetric"));
@@ -1408,11 +1408,11 @@ void gui_init(dt_view_t *self)
   dt_bauhaus_combobox_add(display2_intent, _("absolute colorimetric"));
 
   GtkWidget *display_profile = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(display_profile, NULL, _("display profile"));
+  dt_bauhaus_widget_set_label(display_profile, NULL, N_("display profile"));
   gtk_box_pack_start(GTK_BOX(vbox), display_profile, TRUE, TRUE, 0);
 
   GtkWidget *display2_profile = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(display2_profile, NULL, _("preview display profile"));
+  dt_bauhaus_widget_set_label(display2_profile, NULL, N_("preview display profile"));
   gtk_box_pack_start(GTK_BOX(vbox), display2_profile, TRUE, TRUE, 0);
 
   for(GList *profiles = darktable.color_profiles->profiles; profiles; profiles = g_list_next(profiles))


### PR DESCRIPTION
Using dt_bauhaus_widget_set_label and new functions to create different button types, automatically register accelerator shortcuts at start up and connect them at module gui creation, also for multi-instance. Maintain a list of connected widgets to switch quickly between instances (similar to what used to already happen for local accelerators).

(Mostly) does away with the need for separate init/connect_key_accels (for iop modules). These were generally boiler plate implementations using the same labels as the widget creation code, but with the risk that there were discrepancies that stopped the accelerator working (I found several of those as well as comboboxes registered as sliders etc). Now _all_ widgets can have shortcuts. For some large modules (colorbalance) they are grouped in sections. Some buttons that didn't have shortcuts before haven't been migrated yet; this can now be done more easily with new helper functions dt_iop_(toggle)button_new. For togglebuttons, click and ctrl-click shortcuts are supported (if a second label is provided); see for example the retouch and spot removal code. This could be easily extended to shift and ctrl-shift-click.

There is a rather large impact on translations in two ways:
- in order to have access to both the untranslated and the translated labels, the interface of dt_bauhaus_widget_set_label had to be changed to expect untranslated labels. It now is called with labels marked with N_() rather than _() as before. This obviously required changes throughout the code and would make backports harder if this was introduced after 3.4. @TurboGit for this reason, even if the entirety of this PR doesn't make it into 3.4, it would be good in that case if at least the first commit was cherry-picked.
- There used to be two separate translations for each label in the gui; one without context, used in gui_init, and another with context "accel" in the accelerator code. My analysis (see attached excel spreadsheet) shows that in almost all cases the translations are identical, unless the accel one is missing or likely incorrect. I think there is very little benefit to be had by forcing double work, even if that would make (for some languages maybe) the settings dialog "read" more naturally/grammatically correct or be somewhat shorter or otherwise tailored. Rather, imho it is more convenient/clear to have the shortcuts settings show _exactly_ the same string as the module gui, as enforced here.

The translation context is intended to be used to distinguish different meanings in different _contexts_. For example "highlight" might refer to something else in one module than in another and consequently have different translations. The gui and a shortcut to that gui share the _same_ context and therefore translations _should_ be identical. I haven't seen any instances where modules try to enforce a different translation for themselves (maybe because with the generic "accel" context this is not possible) but if there ever was a need to support this, the gettext Q_ approach could be introduced. This uses strings like "filmicrgb|exposure" and could be passed as a single string down the same function interfaces without forcing every single function call on the way to take a second (context) parameter alongside each label. Unfortunately by default xgettext doesn't define a NQ_ macro (which, similarly to NC_ would only mark the translation string but doesn't substitute it). It can be added easily though. Another utility function to just extract the untranslated string (after the "|") would be needed to achieve consistent (english) naming in keyboardrc.

@johnny-bit you seem to know most about presets; this area of the code still needs to be improved/fixed. The goal would be to have the keyboardrc be independent of translations, so the ui language can be changed and all shortcuts to presets still work. But somehow I'm only seeing translated preset names coming out of the queries (so the keyboardrc shows large diffs when switching languages). I don't think this is a regression; keyboardrc always showed a mixture of english and ui languages. At least now the "preset" bit is in english, but I need help accessing the english preset names.

@elstoc I cleaned up the code to determine the multi-instance to connect, based on user preferences, to fix memory leaks. I would much appreciate if you could confirm this still achieves the same effect. I used a different, one pass, approach that avoids the multiple lists (that are left dangling) of the original implementation.

A last functional change is that _all_ modules now have their accelerators initialiased, rather than just those that are marked "visible". I never saw the point in making that distinction; if a new user goes through the trouble of defining a shortcut, they want it to work without having to jump through hoops like editing the darktablerc file. It definitely has annoyed me many times in the past, especially on fresh test-installs where I hadn't selected "all modules" (and restarted) yet. More recently (maybe with the "re"group work?) I seem to have an unusual issue that I can't reenable (make visible) all modules in one go anymore. Just sharpen, rgblevels, bilat, colorbalance, colorin, hazeremoval, basecurve, toneequal, clipping, flip, lens, exposure, denoiseprofile, demosaic, highlights, temperature have visible=TRUE by default for me and this doesn't change when I select the "all modules" grouping. The root cause for this problem is unclear to me, but at least for this work it doesn't matter anymore.

This PR turned out to be more work than anticipated, but I'm quite happy with it now. Initially I just wanted to get the first commit in before xmas and leave the rest for 3.6. The much larger goal is still to more fundamentally overhaul the input system. But at least with this there is the beginning of a cleaner handover between ui definition and input methods (keyboard and vimkeys for now) that would form the basis of that work.

I have another PR in the works that slightly reduces the amount of work done in gui_init, as a result of further gui_init/reload_defaults/gui_update separation, which will help startup time. **Edit: This has now been submitted as #6673.** I've only introduced here the smallest fixes needed for correct functioning. Once this is merged, next steps are switching over more buttons, registering all color pickers and adding blending shortcuts for the active module.

[dt_po_messages.xlsx](https://github.com/darktable-org/darktable/files/5443737/dt_po_messages.xlsx)

