### PR TITLE
generate-prefs: fix spacing of miscellaneous tab

### DIFF
--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -288,7 +288,6 @@ gboolean restart_required = FALSE;
       GtkWidget *seclabel = gtk_label_new(_("keyboard shortcuts with multiple instances"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
       g_object_set(lbox,  "tooltip-text", _("where multiple module instances are present, these preferences control rules that are applied (in order) to decide which module instance keyboard shortcuts will be applied to"), (gchar *)0);


### PR DESCRIPTION
Makes misc tab consistent with other tabs

Before 

![Screenshot_2020-10-27_12-20-28](https://user-images.githubusercontent.com/9555491/97300862-e4cba880-184e-11eb-85a1-4aed6d77090e.png)

After

![Screenshot_2020-10-27_12-20-54](https://user-images.githubusercontent.com/9555491/97300914-f8770f00-184e-11eb-936a-c3c216883fb9.png)
