### PR TITLE
Final part of init_gui/reload/update cleanup

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -583,7 +583,7 @@ void dt_bauhaus_init()
   darktable.bauhaus->key_val = NULL;
   memset(darktable.bauhaus->key_history, 0, sizeof(darktable.bauhaus->key_history));
 
-  darktable.bauhaus->skip_accel = 0;
+  darktable.bauhaus->skip_accel = 1;
 
   // this easily gets keyboard input:
   // darktable.bauhaus->popup_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2442,9 +2442,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_widget_set_name(GTK_WIDGET(iopw), "blending-wrapper");
 
     bd->blend_inited = 1;
-    gtk_widget_queue_draw(GTK_WIDGET(iopw));
-    dt_iop_gui_update_blending(module);
-
   }
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1077,15 +1077,14 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
     {
       if(!dt_iop_is_hidden(module) && !module->expander)
       {
-        ++darktable.gui->reset;
-        module->gui_init(module);
-        dt_iop_reload_defaults(module);
-        --darktable.gui->reset;
+        dt_iop_gui_init(module);
 
         /* add module to right panel */
         GtkWidget *expander = dt_iop_gui_get_expander(module);
         dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
         dt_iop_gui_set_expanded(module, TRUE, FALSE);
+
+        dt_iop_reload_defaults(module);
         dt_iop_gui_update_blending(module);
 
         // the pipe need to be reconstruct

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -914,10 +914,21 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
   if(!dt_iop_is_hidden(module))
   {
     // make sure gui_init and reload defaults is called safely
-    ++darktable.gui->reset;
-    module->gui_init(module);
+    dt_iop_gui_init(module);
+
+    /* add module to right panel */
+    GtkWidget *expander = dt_iop_gui_get_expander(module);
+    dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+    GValue gv = { 0, { { 0 } } };
+    g_value_init(&gv, G_TYPE_INT);
+    gtk_container_child_get_property(
+        GTK_CONTAINER(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER)),
+        base->expander, "position", &gv);
+    gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER),
+                          expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
+    dt_iop_gui_set_expanded(module, TRUE, FALSE);
+
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
-    --darktable.gui->reset;
 
     if(copy_params)
     {
@@ -936,17 +947,6 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
     // we save the new instance creation
     dt_dev_add_history_item(module->dev, module, TRUE);
 
-    /* add module to right panel */
-    GtkWidget *expander = dt_iop_gui_get_expander(module);
-    dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
-    GValue gv = { 0, { { 0 } } };
-    g_value_init(&gv, G_TYPE_INT);
-    gtk_container_child_get_property(
-        GTK_CONTAINER(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER)),
-        base->expander, "position", &gv);
-    gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER),
-                          expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
-    dt_iop_gui_set_expanded(module, TRUE, FALSE);
     dt_iop_gui_update_blending(module);
   }
 
@@ -1308,9 +1308,19 @@ static void _iop_gui_update_label(dt_iop_module_t *module)
   _iop_panel_label(lab, module);
 }
 
+void dt_iop_gui_init(dt_iop_module_t *module)
+{
+  ++darktable.gui->reset;
+  if(module->gui_init) module->gui_init(module);
+  --darktable.gui->reset;
+}
+
 void dt_iop_reload_defaults(dt_iop_module_t *module)
 {
+  ++darktable.gui->reset;
   if(module->reload_defaults) module->reload_defaults(module);
+  --darktable.gui->reset;
+
   dt_iop_load_default_params(module);
 
   if(module->header) _iop_gui_update_header(module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1311,7 +1311,9 @@ static void _iop_gui_update_label(dt_iop_module_t *module)
 void dt_iop_gui_init(dt_iop_module_t *module)
 {
   ++darktable.gui->reset;
+  --darktable.bauhaus->skip_accel;
   if(module->gui_init) module->gui_init(module);
+  ++darktable.bauhaus->skip_accel;
   --darktable.gui->reset;
 }
 
@@ -1565,13 +1567,11 @@ static void dt_iop_init_module_so(void *m)
     // create a gui and have the widgets register their accelerators
     dt_iop_module_t *module_instance = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
 
-    if(!dt_iop_load_module_by_so(module_instance, module, NULL) && module->gui_init)
+    if(module->gui_init && !dt_iop_load_module_by_so(module_instance, module, NULL))
     {
       darktable.control->accel_initialising = TRUE;
-      ++darktable.gui->reset;
-      module->gui_init(module_instance);
+      dt_iop_gui_init(module_instance);
       module->gui_cleanup(module_instance);
-      --darktable.gui->reset;
       darktable.control->accel_initialising = FALSE;
 
       dt_iop_cleanup_module(module_instance);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1581,7 +1581,7 @@ static void dt_iop_init_module_so(void *m)
 
     if(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
     {
-      dt_accel_register_slider_iop(module, FALSE, N_("fusion"));
+      dt_accel_register_slider_iop(module, FALSE, NC_("accel","fusion") ? "accel|fusion" : "");
     }
     if(!(module->flags() & IOP_FLAGS_DEPRECATED))
     {

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -616,6 +616,8 @@ void dt_iop_request_focus(dt_iop_module_t *module);
 void dt_iop_default_init(dt_iop_module_t *module);
 /** loads default settings from database. */
 void dt_iop_load_default_params(dt_iop_module_t *module);
+/** creates the module's gui widget */
+void dt_iop_gui_init(dt_iop_module_t *module);
 /** reloads certain gui/param defaults when the image was switched. */
 void dt_iop_reload_defaults(dt_iop_module_t *module);
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -57,6 +57,11 @@ void dt_accel_path_iop(char *s, size_t n, char *module, const char *path)
       g_free(split_paths[0]);
       split_paths[0] = g_strdup(_("preset"));
     }
+    for(gchar **cur_path = split_paths; *cur_path; cur_path++)
+    {
+      gchar *after_context = strchr(*cur_path,'|');
+      if(after_context) memmove(*cur_path, after_context + 1, strlen(after_context));
+    }
     gchar *joined_paths = g_strjoinv("/", split_paths);
     snprintf(s, n, "<Darktable>/%s/%s/%s", "image operations", module, joined_paths);
     g_free(joined_paths);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4463,9 +4463,9 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
-  dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)module->params;
+  dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
+
   dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
   dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
   dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1830,7 +1830,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, _("luma"), _("change lightness at each feature size"));
   dt_ui_notebook_page(c->channel_tabs, _("chroma"), _("change color saturation at each feature size"));
   dt_ui_notebook_page(c->channel_tabs, _("edges"), _("change edge halos at each feature size\nonly changes results of luma and chroma tabs"));
-  gtk_widget_show_all(GTK_WIDGET(c->channel_tabs));
+  gtk_widget_show(gtk_notebook_get_nth_page(c->channel_tabs, c->channel));
   gtk_notebook_set_current_page(c->channel_tabs, c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -366,10 +366,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   }
 }
 
-/** gui callbacks, these are needed. */
 void gui_update(dt_iop_module_t *self)
 {
-  // let gui slider match current parameters:
   dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
   dt_iop_bilat_params_t *p = (dt_iop_bilat_params_t *)self->params;
   dt_bauhaus_slider_set(g->detail, p->detail);

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -264,9 +264,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_bilateral_gui_data_t *g = (dt_iop_bilateral_gui_data_t *)self->gui_data;
-  dt_iop_bilateral_params_t *p = (dt_iop_bilateral_params_t *)module->params;
+  dt_iop_bilateral_params_t *p = (dt_iop_bilateral_params_t *)self->params;
   dt_bauhaus_slider_set_soft(g->radius, p->radius);
   // dt_bauhaus_slider_set(g->scale2, p->sigma[1]);
   dt_bauhaus_slider_set_soft(g->red, p->red);

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1500,6 +1500,20 @@ void reload_defaults(dt_iop_module_t *module)
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
+
+  if(module->widget)
+  {
+    if(dt_image_is_raw(&module->dev->image_storage))
+      if(module->dev->image_storage.buf_dsc.filters != 9u &&
+        !(dt_image_monochrome_flags(&module->dev->image_storage) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)))
+        gtk_label_set_text(GTK_LABEL(module->widget), _("automatic chromatic aberration correction"));
+      else
+        gtk_label_set_text(GTK_LABEL(module->widget),
+                          _("automatic chromatic aberration correction\ndisabled for non-Bayer sensors"));
+    else
+      gtk_label_set_text(GTK_LABEL(module->widget),
+                        _("automatic chromatic aberration correction\nonly works for raw images."));
+  }
 }
 
 /** commit is the synch point between core and gui, so it copies params to pipe data. */
@@ -1523,16 +1537,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  if(dt_image_is_raw(&self->dev->image_storage))
-    if(self->dev->image_storage.buf_dsc.filters != 9u &&
-       !(dt_image_monochrome_flags(&self->dev->image_storage) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)))
-      gtk_label_set_text(GTK_LABEL(self->widget), _("automatic chromatic aberration correction"));
-    else
-      gtk_label_set_text(GTK_LABEL(self->widget),
-                         _("automatic chromatic aberration correction\ndisabled for non-Bayer sensors"));
-  else
-    gtk_label_set_text(GTK_LABEL(self->widget),
-                       _("automatic chromatic aberration correction\nonly works for raw images."));
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -578,9 +578,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
-  dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)module->params;
+  dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
 
   const int output_channel_index = dt_bauhaus_combobox_get(g->output_channel);
   if(output_channel_index >= 0)

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -294,9 +294,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_rlce_gui_data_t *g = (dt_iop_rlce_gui_data_t *)self->gui_data;
-  dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)module->params;
+  dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)self->params;
   dt_bauhaus_slider_set(g->scale1, p->radius);
   dt_bauhaus_slider_set(g->scale2, p->slope);
 }

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -273,9 +273,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colisa_gui_data_t *g = (dt_iop_colisa_gui_data_t *)self->gui_data;
-  dt_iop_colisa_params_t *p = (dt_iop_colisa_params_t *)module->params;
+  dt_iop_colisa_params_t *p = (dt_iop_colisa_params_t *)self->params;
   dt_bauhaus_slider_set(g->contrast, p->contrast);
   dt_bauhaus_slider_set(g->brightness, p->brightness);
   dt_bauhaus_slider_set(g->saturation, p->saturation);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1771,7 +1771,6 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
       {
         GtkWidget *label = dt_ui_section_label_new(_(long_label[i]));
         gtk_container_add(GTK_CONTAINER(new_container), label);
-        gtk_widget_show(label);
       }
 
       gtk_container_add(GTK_CONTAINER(new_container), g->blocks[i]);
@@ -1803,7 +1802,6 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
         gtk_style_context_add_class(gtk_widget_get_style_context(label[i]), "section_label_top");
 
         gtk_container_add(GTK_CONTAINER(new_container), label[i]);
-        gtk_widget_show(label[i]);
         gtk_grid_attach_next_to(GTK_GRID(new_container), g->blocks[i], label[i], GTK_POS_BOTTOM, 1, 1);
       }
     }
@@ -1820,7 +1818,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
   for(int i=0; i<3; i++) g_object_unref(G_OBJECT(g->blocks[i]));
 
   gtk_container_add(GTK_CONTAINER(g->main_box), new_container);
-  gtk_widget_show(new_container);
+  if(old_container) gtk_widget_show_all(new_container);
 }
 
 static void _cycle_layout_callback(GtkWidget *label, GdkEventButton *event, dt_iop_module_t *self)

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -831,9 +831,8 @@ void gui_reset(struct dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
-  dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)module->params;
+  dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
   if(g->patch >= p->num_patches || g->patch < 0) return;
   if(dt_bauhaus_combobox_length(g->combobox_patch) != p->num_patches)
   {

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -210,9 +210,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
-  dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)module->params;
+  dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
   dt_bauhaus_slider_set(g->slider, p->saturation);
   gtk_widget_queue_draw(self->widget);
 }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1767,13 +1767,10 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
-  dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)module->params;
+  dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->clipping_combobox, p->normalize);
-
-  update_profile_list(self);
 
   // working profile
   int idx = -1;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1796,7 +1796,6 @@ void gui_update(struct dt_iop_module_t *self)
   }
   dt_bauhaus_combobox_set(g->work_combobox, idx);
 
-  // TODO: merge this into update_profile_list()
   prof = g->image_profiles;
   while(prof)
   {
@@ -1928,11 +1927,15 @@ void reload_defaults(dt_iop_module_t *module)
     d->type = DT_COLORSPACE_ENHANCED_MATRIX;
 
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
+
+  update_profile_list(module);
 }
 
 static void update_profile_list(dt_iop_module_t *self)
 {
   dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+
+  if(!g) return;
 
   // clear and refill the image profile list
   g_list_free_full(g->image_profiles, free);
@@ -2076,9 +2079,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->work_combobox = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->work_combobox, NULL, N_("working profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->work_combobox, TRUE, TRUE, 0);
-
-  // now generate the list of profiles applicable to the current image and update the list
-//  update_profile_list(self);
 
   dt_bauhaus_combobox_set(g->profile_combobox, 0);
   {

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -312,9 +312,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
-  dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)module->params;
+  dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -789,9 +789,9 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colorout_gui_data_t *g = (dt_iop_colorout_gui_data_t *)self->gui_data;
-  dt_iop_colorout_params_t *p = (dt_iop_colorout_params_t *)module->params;
+  dt_iop_colorout_params_t *p = (dt_iop_colorout_params_t *)self->params;
+
   dt_bauhaus_combobox_set(g->output_intent, (int)p->intent);
 
   for(GList *iter = darktable.color_profiles->profiles; iter; iter = g_list_next(iter))

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1222,9 +1222,9 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
-  dt_iop_colorreconstruct_params_t *p = (dt_iop_colorreconstruct_params_t *)module->params;
+  dt_iop_colorreconstruct_params_t *p = (dt_iop_colorreconstruct_params_t *)self->params;
+
   dt_bauhaus_slider_set(g->threshold, p->threshold);
   dt_bauhaus_slider_set(g->spatial, p->spatial);
   dt_bauhaus_slider_set(g->range, p->range);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2346,8 +2346,8 @@ void gui_init(struct dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, _("saturation"), NULL);
   dt_ui_notebook_page(c->channel_tabs, _("hue"), NULL);
 
-  gtk_widget_show_all(GTK_WIDGET(c->channel_tabs));
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
+  gtk_widget_show(gtk_notebook_get_nth_page(c->channel_tabs, c->channel));
+  gtk_notebook_set_current_page(c->channel_tabs, c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(_channel_tabs_switch_callback), self);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new("   "), FALSE, FALSE, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3974,10 +3974,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->use_new_vst = dt_bauhaus_toggle_from_params(self, "use_new_vst");
 
-  gtk_widget_show_all(g->box_nlm);
-  gtk_widget_show_all(g->box_wavelets);
-  gtk_widget_show_all(g->box_variance);
-
   gtk_widget_set_tooltip_text(g->wb_adaptive_anscombe, _("adapt denoising according to the\n"
                                                          "white balance coefficients.\n"
                                                          "should be enabled on a first instance\n"

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3318,9 +3318,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(dt_iop_module_t *self)
 {
-  // let gui slider match current parameters:
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
+
   dt_bauhaus_slider_set_soft(g->radius, p->radius);
   dt_bauhaus_slider_set_soft(g->nbhood, p->nbhood);
   dt_bauhaus_slider_set_soft(g->strength, p->strength);

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -728,9 +728,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
-  dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)module->params;
+  dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)self->params;
   dt_bauhaus_combobox_set(g->dither_type, p->dither_type);
 #if 0
   dt_bauhaus_slider_set(g->radius, p->random.radius);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -570,9 +570,11 @@ void gui_update(struct dt_iop_module_t *self)
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias), p->compensate_exposure_bias);
   /* xgettext:no-c-format */
-  gtk_button_set_label(GTK_BUTTON(g->compensate_exposure_bias), g_strdup_printf(_("compensate camera exposure (%+.1f EV)"),
-                                                                                  get_exposure_bias(self)));
+  gchar *label = g_strdup_printf(_("compensate camera exposure (%+.1f EV)"), get_exposure_bias(self));
+  gtk_button_set_label(GTK_BUTTON(g->compensate_exposure_bias), label);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->compensate_exposure_bias))), PANGO_ELLIPSIZE_MIDDLE);
+  g_free(label);
+
   dt_bauhaus_slider_set_soft(g->black, p->black);
   dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2204,9 +2204,8 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
-  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)module->params;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -611,9 +611,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
-  dt_iop_global_tonemap_params_t *p = (dt_iop_global_tonemap_params_t *)module->params;
+  dt_iop_global_tonemap_params_t *p = (dt_iop_global_tonemap_params_t *)self->params;
+
   dt_bauhaus_combobox_set(g->operator, p->operator);
   dt_bauhaus_slider_set(g->drago.bias, p->drago.bias);
   dt_bauhaus_slider_set(g->drago.max_light, p->drago.max_light);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1112,9 +1112,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
-  dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)module->params;
+  dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1008,9 +1008,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)module->params;
+  dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
   dt_bauhaus_slider_set(g->clip, p->clip);
   dt_bauhaus_combobox_set(g->mode, p->mode);
 }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1513,8 +1513,7 @@ static void camera_set(dt_iop_module_t *self, const lfCamera *cam)
 
   if(!cam)
   {
-    gtk_button_set_label(GTK_BUTTON(g->camera_model), "");
-    gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), PANGO_ELLIPSIZE_END);
+    gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), "");
     gtk_widget_set_tooltip_text(GTK_WIDGET(g->camera_model), "");
     return;
   }
@@ -1533,8 +1532,7 @@ static void camera_set(dt_iop_module_t *self, const lfCamera *cam)
       fm = g_strdup_printf("%s, %s", maker, model);
     else
       fm = g_strdup_printf("%s", model);
-    gtk_button_set_label(GTK_BUTTON(g->camera_model), fm);
-    gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), PANGO_ELLIPSIZE_END);
+    gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), fm);
     g_free(fm);
   }
 
@@ -1789,8 +1787,7 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
       fm = g_strdup_printf("%s, %s", maker, model);
     else
       fm = g_strdup_printf("%s", model);
-    gtk_button_set_label(GTK_BUTTON(g->lens_model), fm);
-    gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), PANGO_ELLIPSIZE_END);
+    gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), fm);
     g_free(fm);
   }
 
@@ -2404,10 +2401,8 @@ void gui_update(struct dt_iop_module_t *self)
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
   // these are the wrong (untranslated) strings in general but that's ok, they will be overwritten further
   // down
-  gtk_button_set_label(GTK_BUTTON(g->camera_model), p->camera);
-  gtk_button_set_label(GTK_BUTTON(g->lens_model), p->lens);
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), PANGO_ELLIPSIZE_END);
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), PANGO_ELLIPSIZE_END);
+  gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), p->camera);
+  gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), p->lens);
   gtk_widget_set_tooltip_text(g->camera_model, "");
   gtk_widget_set_tooltip_text(g->lens_model, "");
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -533,9 +533,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_lowpass_gui_data_t *g = (dt_iop_lowpass_gui_data_t *)self->gui_data;
-  dt_iop_lowpass_params_t *p = (dt_iop_lowpass_params_t *)module->params;
+  dt_iop_lowpass_params_t *p = (dt_iop_lowpass_params_t *)self->params;
   dt_bauhaus_slider_set(g->radius, p->radius);
   dt_bauhaus_combobox_set(g->lowpass_algo, p->lowpass_algo);
   dt_bauhaus_slider_set(g->contrast, p->contrast);

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1677,7 +1677,7 @@ void gui_init(dt_iop_module_t *self)
 #else
   gtk_widget_set_tooltip_text(button, _("select a png (haldclut)"
       ", a cube or a 3dl file "
-      "CAUTION: 3D lut folder must be set in preferences/core options/miscellaneous before choosing the lut file"));
+      "CAUTION: 3D lut folder must be set in preferences/processing before choosing the lut file"));
 #endif // HAVE_GMIC
   gtk_box_pack_start(GTK_BOX(g->hbox), button, FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), self);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -673,7 +673,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->gamma, 4);
   gtk_widget_set_tooltip_text(g->gamma, _("gamma exponential factor"));
 
-  gtk_widget_show_all(vbox_gamma);
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_gamma, "gamma");
 
   /**** LOG MODE ****/
@@ -710,7 +709,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->auto_button, _("make an optimization with some guessing"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->auto_button, TRUE, TRUE, 0);
 
-  gtk_widget_show_all(vbox_log);
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_log, "log");
 
   // start building top level widget

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -612,9 +612,8 @@ void gui_reset(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)module->params;
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
 
   self->color_picker_box[0] = self->color_picker_box[1] = .25f;
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -923,7 +923,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, _("G"), NULL);
   dt_ui_notebook_page(c->channel_tabs, _("B"), NULL);
 
-  gtk_widget_show_all(GTK_WIDGET(c->channel_tabs));
+  gtk_widget_show(gtk_notebook_get_nth_page(c->channel_tabs, c->channel));
   gtk_notebook_set_current_page(c->channel_tabs, c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(rawdenoise_tab_switch), self);
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -526,10 +526,12 @@ void init(dt_iop_module_t *module)
 void reload_defaults(dt_iop_module_t *module)
 {
   // can't be switched on for non-raw images:
-  if(dt_image_is_raw(&module->dev->image_storage))
-    module->hide_enable_button = 0;
-  else
-    module->hide_enable_button = 1;
+  module->hide_enable_button = !dt_image_is_raw(&module->dev->image_storage);
+
+  if(module->widget)
+  {
+    gtk_stack_set_visible_child_name(GTK_STACK(module->widget), module->hide_enable_button ? "non_raw" : "raw");
+  }
 
   module->default_enabled = 0;
 }
@@ -585,7 +587,6 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
   dt_iop_cancel_history_update(self);
   dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
   gtk_widget_queue_draw(self->widget);
 }
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -689,6 +689,9 @@ void reload_defaults(dt_iop_module_t *self)
 
   self->hide_enable_button = 1;
   self->default_enabled = dt_image_is_rawprepare_supported(image) && !image_is_normalized(image);
+
+  if(self->widget)
+    gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
 void init_global(dt_iop_module_so_t *self)
@@ -731,8 +734,6 @@ void gui_update(dt_iop_module_t *self)
     dt_bauhaus_slider_set_soft(g->width, p->width);
     dt_bauhaus_slider_set_soft(g->height, p->height);
   }
-
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
 const gchar *black_label[]

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -232,10 +232,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
-
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
-  dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)module->params;
+  dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)self->params;
   dt_bauhaus_slider_set(g->exposure, p->ev);
   dt_bauhaus_slider_set(g->width, p->width);
   dtgtk_gradient_slider_set_value(g->center, p->center);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2271,15 +2271,6 @@ void gui_init(dt_iop_module_t *self)
   /* add signal handler for preview pipe finish to redraw the preview */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
                             G_CALLBACK(rt_develop_ui_pipe_finished_callback), self);
-
-  gtk_widget_show_all(g->vbox_blur);
-  gtk_widget_set_no_show_all(g->vbox_blur, TRUE);
-
-  gtk_widget_show_all(g->vbox_fill);
-  gtk_widget_set_no_show_all(g->vbox_fill, TRUE);
-
-  gtk_widget_show_all(g->vbox_preview_scale);
-  gtk_widget_set_no_show_all(g->vbox_preview_scale, TRUE);
 }
 
 void gui_reset(struct dt_iop_module_t *self)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -341,18 +341,16 @@ void reload_defaults(dt_iop_module_t *self)
 
   // FIXME: does not work.
   self->hide_enable_button = !self->default_enabled;
+
+  if(self->widget)
+    gtk_label_set_text(GTK_LABEL(self->widget), self->default_enabled
+                       ? _("automatic pixel rotation")
+                       : _("automatic pixel rotation\nonly works for the sensors that need it."));
 }
 
 void gui_update(dt_iop_module_t *self)
 {
-  if(!self->widget) return;
-  if(self->default_enabled)
-    gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel rotation"));
-  else
-    gtk_label_set_text(GTK_LABEL(self->widget),
-                       _("automatic pixel rotation\nonly works for the sensors that need it."));
 }
-
 void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(rotatepixels);

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -257,16 +257,15 @@ void reload_defaults(dt_iop_module_t *self)
 
   // FIXME: does not work.
   self->hide_enable_button = !self->default_enabled;
+
+  if(self->widget)
+    gtk_label_set_text(GTK_LABEL(self->widget), self->default_enabled
+                       ? _("automatic pixel scaling")
+                       :_("automatic pixel scaling\nonly works for the sensors that need it."));
 }
 
 void gui_update(dt_iop_module_t *self)
 {
-  if(!self->widget) return;
-  if(self->default_enabled)
-    gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel scaling"));
-  else
-    gtk_label_set_text(GTK_LABEL(self->widget),
-                       _("automatic pixel scaling\nonly works for the sensors that need it."));
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -665,9 +665,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_shadhi_gui_data_t *g = (dt_iop_shadhi_gui_data_t *)self->gui_data;
-  dt_iop_shadhi_params_t *p = (dt_iop_shadhi_params_t *)module->params;
+  dt_iop_shadhi_params_t *p = (dt_iop_shadhi_params_t *)self->params;
   dt_bauhaus_slider_set(g->shadows, p->shadows);
   dt_bauhaus_slider_set(g->highlights, p->highlights);
   dt_bauhaus_slider_set(g->whitepoint, p->whitepoint);

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -682,9 +682,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_sharpen_gui_data_t *g = (dt_iop_sharpen_gui_data_t *)self->gui_data;
-  dt_iop_sharpen_params_t *p = (dt_iop_sharpen_params_t *)module->params;
+  dt_iop_sharpen_params_t *p = (dt_iop_sharpen_params_t *)self->params;
   dt_bauhaus_slider_set_soft(g->radius, p->radius);
   dt_bauhaus_slider_set(g->amount, p->amount);
   dt_bauhaus_slider_set(g->threshold, p->threshold);

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -637,9 +637,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_soften_gui_data_t *g = (dt_iop_soften_gui_data_t *)self->gui_data;
-  dt_iop_soften_params_t *p = (dt_iop_soften_params_t *)module->params;
+  dt_iop_soften_params_t *p = (dt_iop_soften_params_t *)self->params;
   dt_bauhaus_slider_set(g->size, p->size);
   dt_bauhaus_slider_set(g->saturation, p->saturation);
   dt_bauhaus_slider_set(g->brightness, p->brightness);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -432,9 +432,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
-  dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)module->params;
+  dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
 
   dt_bauhaus_slider_set(g->shadow_hue_gslider, p->shadow_hue);
   dt_bauhaus_slider_set(g->shadow_sat_gslider, p->shadow_saturation);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1123,8 +1123,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
   dt_iop_temperature_params_t *fp = (dt_iop_temperature_params_t *)self->default_params;
 
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "disabled" : "enabled");
-
   if(self->hide_enable_button) return;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -1448,6 +1446,8 @@ void reload_defaults(dt_iop_module_t *module)
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)module->gui_data;
   if(g)
   {
+    gtk_stack_set_visible_child_name(GTK_STACK(module->widget), module->hide_enable_button ? "disabled" : "enabled");
+
     dt_bauhaus_slider_set_default(g->scale_r, d->red);
     dt_bauhaus_slider_set_default(g->scale_g, d->green);
     dt_bauhaus_slider_set_default(g->scale_b, d->blue);
@@ -1959,8 +1959,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->colorpicker, TRUE, TRUE, 0);
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_asshot, TRUE, TRUE, 0);
   gtk_box_pack_start(box_enabled, g->buttonbar, TRUE, TRUE, 0);
-
-  gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
 
   g->presets = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->presets, NULL, N_("settings")); // relabel to settings to remove confusion between module presets and white balance settings

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3205,8 +3205,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
                             G_CALLBACK(_develop_ui_pipe_started_callback), self);
-
-  show_guiding_controls(self);
 }
 
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1585,9 +1585,8 @@ void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g, dt_iop_toneequa
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
-  dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)module->params;
+  dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
   update_exposure_sliders(g, p);
 

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -220,9 +220,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_tonemapping_gui_data_t *g = (dt_iop_tonemapping_gui_data_t *)self->gui_data;
-  dt_iop_tonemapping_params_t *p = (dt_iop_tonemapping_params_t *)module->params;
+  dt_iop_tonemapping_params_t *p = (dt_iop_tonemapping_params_t *)self->params;
   dt_bauhaus_slider_set(g->contrast, p->contrast);
   dt_bauhaus_slider_set(g->Fsize, p->Fsize);
 }

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -313,9 +313,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_velvia_gui_data_t *g = (dt_iop_velvia_gui_data_t *)self->gui_data;
-  dt_iop_velvia_params_t *p = (dt_iop_velvia_params_t *)module->params;
+  dt_iop_velvia_params_t *p = (dt_iop_velvia_params_t *)self->params;
   dt_bauhaus_slider_set(g->strength_scale, p->strength);
   dt_bauhaus_slider_set(g->bias_scale, p->bias);
 }

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -188,11 +188,11 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_vibrance_gui_data_t *g = (dt_iop_vibrance_gui_data_t *)self->gui_data;
-  dt_iop_vibrance_params_t *p = (dt_iop_vibrance_params_t *)module->params;
+  dt_iop_vibrance_params_t *p = (dt_iop_vibrance_params_t *)self->params;
   dt_bauhaus_slider_set(g->amount_scale, p->amount);
 }
+
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_vibrance_gui_data_t *g = IOP_GUI_ALLOC(vibrance);

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -978,9 +978,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
-  dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)module->params;
+  dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
   dt_bauhaus_slider_set(g->scale, p->scale);
   dt_bauhaus_slider_set(g->falloff_scale, p->falloff_scale);
   dt_bauhaus_slider_set(g->brightness, p->brightness);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -944,13 +944,14 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
       if(!dt_iop_is_hidden(module))
       {
         module->gui_init(module);
-        dt_iop_reload_defaults(module);
 
         /* add module to right panel */
         GtkWidget *expander = dt_iop_gui_get_expander(module);
         dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
         dt_iop_gui_set_expanded(module, FALSE, dt_conf_get_bool("darkroom/ui/single_module"));
         dt_iop_gui_update_blending(module);
+
+        dt_iop_reload_defaults(module);
       }
     }
     else
@@ -2895,8 +2896,6 @@ void enter(dt_view_t *self)
   /*
    * add IOP modules to plugin list
    */
-  // avoid triggering of events before plugin is ready:
-  ++darktable.gui->reset;
   char option[1024];
   GList *modules = g_list_last(dev->iop);
   while(modules)
@@ -2906,8 +2905,7 @@ void enter(dt_view_t *self)
     /* initialize gui if iop have one defined */
     if(!dt_iop_is_hidden(module))
     {
-      module->gui_init(module);
-      dt_iop_reload_defaults(module);
+      dt_iop_gui_init(module);
 
       /* add module to right panel */
       GtkWidget *expander = dt_iop_gui_get_expander(module);
@@ -2918,13 +2916,12 @@ void enter(dt_view_t *self)
         dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
       else
         dt_iop_gui_set_expanded(module, FALSE, FALSE);
+
+      dt_iop_reload_defaults(module);
     }
 
     modules = g_list_previous(modules);
   }
-
-  // make signals work again:
-  --darktable.gui->reset;
 
   /* signal that darktable.develop is initialized and ready to be used */
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE);


### PR DESCRIPTION
This finishes off #6240 

The biggest change is to make sure the iop gui->widget is added to the side panel _before_ reload_defaults is called. This means reload_defaults can always count on all widgets having been shown/realised (by a call to show_all). So the behavior is now predictable; no longer are workarounds required to make things that work after an image change also work the 1st time. So I've been able to remove some duplicated calls that were just put in "to make sure".

gui_init is now more light weight. It tries to avoid showing/realising widgets if not necessary; the show_all when the complete widget is added to the panel takes care of that. This makes #6648 more efficient.

There are also other random fixes/cleanups that I came across while I did this work.

The commits are grouped by theme, but I haven't tested them separately for subtly dependencies, so I wouldn't recommend cherry-picking.