### PR TITLE
zero out node past end of curve on delete

### DIFF
--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1938,6 +1938,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
       basecurve[k].x = basecurve[k + 1].x;
       basecurve[k].y = basecurve[k + 1].y;
     }
+    basecurve[nodes - 1].x = basecurve[nodes - 1].y = 0;
     c->selected = -2; // avoid re-insertion of that point immediately after this
     p->basecurve_nodes[ch]--;
     gtk_widget_queue_draw(self->widget);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2024,6 +2024,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
           curve[k].x = curve[k + 1].x;
           curve[k].y = curve[k + 1].y;
         }
+        curve[nodes - 1].x = curve[nodes - 1].y = 0;
         p->curve_num_nodes[ch]--;
       }
       else

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1323,6 +1323,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       curve_nodes[k].x = curve_nodes[k + 1].x;
       curve_nodes[k].y = curve_nodes[k + 1].y;
     }
+    curve_nodes[nodes - 1].x = curve_nodes[nodes - 1].y = 0;
     g->selected = -2; // avoid re-insertion of that point immediately after this
     p->curve_num_nodes[ch]--;
     dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1832,6 +1832,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
       tonecurve[k].x = tonecurve[k + 1].x;
       tonecurve[k].y = tonecurve[k + 1].y;
     }
+    tonecurve[nodes - 1].x = tonecurve[nodes - 1].y = 0;
     c->selected = -2; // avoid re-insertion of that point immediately after this
     p->tonecurve_nodes[ch]--;
     gtk_widget_queue_draw(self->widget);


### PR DESCRIPTION
When shortening a curve, the leftover rubbish shows up in the history diff and incorrectly causes identical presets not to be recognised. For example, in _basecurve_ apply the first preset. The preset menu will indicate in bold that it is active. Now "accidentally" add a node by clicking and dragging on the curve. Correct the mistake by right-clicking on the new node. Result is identical to the preset but is no longer matched.