### PR TITLE
ctrl+click iop reset button to apply auto-presets

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1890,28 +1890,33 @@ void dt_iop_gui_reset(dt_iop_module_t *module)
   --darktable.gui->reset;
 }
 
-static void dt_iop_gui_reset_callback(GtkButton *button, dt_iop_module_t *module)
+static void dt_iop_gui_reset_callback(GtkButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
-  // if a drawn mask is set, remove it from the list
-  if(module->blend_params->mask_id > 0)
+  //Ctrl is used to apply any auto-presets to the current module
+  //If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
+  if(!(event->state & GDK_CONTROL_MASK) || !dt_gui_presets_autoapply_for_module(module))
   {
-    dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, module->blend_params->mask_id);
-    if(grp) dt_masks_form_remove(module, NULL, grp);
+    // if a drawn mask is set, remove it from the list
+    if(module->blend_params->mask_id > 0)
+    {
+      dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, module->blend_params->mask_id);
+      if(grp) dt_masks_form_remove(module, NULL, grp);
+    }
+    /* reset to default params */
+    memcpy(module->params, module->default_params, module->params_size);
+    dt_iop_commit_blend_params(module, module->default_blendop_params);
+
+    /* reset ui to its defaults */
+    dt_iop_gui_reset(module);
+
+    /* update ui to default params*/
+    dt_iop_gui_update(module);
+
+    /* and give focus to the module*/
+    dt_iop_request_focus(module);
+
+    dt_dev_add_history_item(module->dev, module, TRUE);
   }
-  /* reset to default params */
-  memcpy(module->params, module->default_params, module->params_size);
-  dt_iop_commit_blend_params(module, module->default_blendop_params);
-
-  /* reset ui to its defaults */
-  dt_iop_gui_reset(module);
-
-  /* update ui to default params*/
-  dt_iop_gui_update(module);
-
-  /* and give focus to the module*/
-  dt_iop_request_focus(module);
-
-  dt_dev_add_history_item(module->dev, module, TRUE);
 
   if(dt_conf_get_bool("accel/prefer_expanded") || dt_conf_get_bool("accel/prefer_enabled") || dt_conf_get_bool("accel/prefer_unmasked"))
   {
@@ -2408,7 +2413,7 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   hw[IOP_MODULE_RESET] = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT, NULL);
   module->reset_button = GTK_WIDGET(hw[IOP_MODULE_RESET]);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_RESET]), _("reset parameters"));
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "clicked", G_CALLBACK(dt_iop_gui_reset_callback), module);
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event", G_CALLBACK(dt_iop_gui_reset_callback), module);
   gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_RESET]), "module-reset-button");
 
   /* add preset button if module has implementation */

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -718,9 +718,8 @@ static void menuitem_new_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
   edit_preset(_("new preset"), module);
 }
 
-static void menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
+static void apply_preset(const gchar* name, dt_iop_module_t *module)
 {
-  gchar *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2
     (dt_database_get(darktable.db),
@@ -775,6 +774,82 @@ static void menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
     // rebuild the accelerators
     dt_iop_connect_accels_multi(module->so);
   }
+}
+
+static void menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
+{
+  gchar *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");
+  apply_preset(name, module);
+}
+
+gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
+{
+  dt_image_t *image = &module->dev->image_storage;
+
+  gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
+  const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
+  const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
+  const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);
+
+  char query[2024];
+  snprintf(query, sizeof(query),
+     "SELECT name"
+     " FROM data.presets"
+     " WHERE operation = ?1"
+     "        AND ((autoapply=1"
+     "           AND ((?2 LIKE model AND ?3 LIKE maker) OR (?4 LIKE model AND ?5 LIKE maker))"
+     "           AND ?6 LIKE lens AND ?7 BETWEEN iso_min AND iso_max"
+     "           AND ?8 BETWEEN exposure_min AND exposure_max"
+     "           AND ?9 BETWEEN aperture_min AND aperture_max"
+     "           AND ?10 BETWEEN focal_length_min AND focal_length_max"
+     "           AND (format = 0 OR (format&?11 != 0 AND ~format&?12 != 0))"
+     "           AND operation NOT IN"
+     "               ('ioporder', 'metadata', 'export', 'tagging', 'collect', '%s'))"
+     "  OR (name = ?13)) AND op_version = ?14",
+     is_display_referred?"":"basecurve");
+
+  sqlite3_stmt *stmt;
+  const char *workflow_preset = has_matrix && is_display_referred
+                                ? _("display-referred default")
+                                : (has_matrix && is_scene_referred
+                                   ?_("scene-referred default")
+                                   :"\t\n");
+  int iformat = 0;
+  if(dt_image_is_rawprepare_supported(image)) iformat |= FOR_RAW;
+  else iformat |= FOR_LDR;
+  if(dt_image_is_hdr(image)) iformat |= FOR_HDR;
+
+  int excluded = 0;
+  if(dt_image_monochrome_flags(image)) excluded |= FOR_NOT_MONO;
+  else excluded |= FOR_NOT_COLOR;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, module->op, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, image->exif_model, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, image->exif_maker, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, image->camera_alias, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, image->camera_maker, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, image->exif_lens, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, fmaxf(0.0f, fminf(FLT_MAX, image->exif_iso)));
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, fmaxf(0.0f, fminf(1000000, image->exif_exposure)));
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, fmaxf(0.0f, fminf(1000000, image->exif_aperture)));
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, fmaxf(0.0f, fminf(1000000, image->exif_focal_length)));
+  // 0: dontcare, 1: ldr, 2: raw plus monochrome & color
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 11, iformat);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 12, excluded);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 13, workflow_preset, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 14, module->version());
+
+  gboolean applied = FALSE;
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const char *name = (const char *)sqlite3_column_text(stmt, 0);
+    apply_preset(name, module);
+    applied = TRUE;
+  }
+  sqlite3_finalize(stmt);
+
+  return applied;
 }
 
 static gboolean menuitem_button_released_preset(GtkMenuItem *menuitem, GdkEventButton *event, dt_iop_module_t *module)

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -790,6 +790,7 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);
+  g_free(workflow);
 
   char query[2024];
   snprintf(query, sizeof(query),

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -60,6 +60,9 @@ void dt_gui_presets_popup_menu_show_for_module(dt_iop_module_t *module);
 /** show popupmenu for favorite modules */
 void dt_gui_favorite_presets_menu_show();
 
+/** apply any auto presets that are appropriate for the current module **/
+gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
`Ctrl+click` on an iop module reset button will reapply any automatic presets to that module. If no automatic presets are found, the module parameters will be reset to their default values (i.e. same as left-clicking on the reset button).

Resolves #6682