### PR TITLE
switch notebook page to show accelerated widget

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -641,7 +641,14 @@ void dt_accel_widget_toast(GtkWidget *widget)
 
     g_free(text);
   }
-
+  else
+  {
+    GtkWidget *box = gtk_widget_get_parent(widget);
+    GtkWidget *notebook = gtk_widget_get_parent(box);
+    if(GTK_IS_NOTEBOOK(notebook))
+      gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook),
+                                    gtk_notebook_page_num(GTK_NOTEBOOK(notebook), box));
+  }
 }
 
 float dt_accel_get_slider_scale_multiplier()


### PR DESCRIPTION
When a bauhaus widget is changed using shortcuts/dynamic mouse scroll, a toast shows up with the new value if the widget isn't visible. However, if the module is expanded, but the widget is on a notebook tab that is not currently shown, it is still considered "visible" so the toast isn't shown. This PR switches (in most/all?) cases the notebook to show the changing widget.

Widgets are still treated as "visible" when they are scrolled out of sight or covered.