### PR TITLE
accelerators: always show toast message when adjusting controls

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -596,16 +596,13 @@ void dt_accel_widget_toast(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
 
-  if(!gtk_widget_is_visible(GTK_WIDGET(w)) && !darktable.gui->reset)
+  if(!darktable.gui->reset)
   {
     char *text = NULL;
-    int show = 1;
 
     switch(w->type){
       case DT_BAUHAUS_SLIDER:
       {
-        dt_bauhaus_slider_data_t *d = &w->data.slider;
-        show = !d->is_dragging;
         text = dt_bauhaus_slider_get_text(widget);
         break;
       }
@@ -617,26 +614,23 @@ void dt_accel_widget_toast(GtkWidget *widget)
         break;
     }
 
-    if (show)
-    {
-      if(w->label[0] != '\0')
-      { // label is not empty
-        if(w->module && w->module->multi_name[0] != '\0')
-          dt_toast_log(_("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, text);
-        else if(w->module && !strstr(w->module->name(), w->label))
-          dt_toast_log(_("%s / %s: %s"), w->module->name(), w->label, text);
-        else
-          dt_toast_log(_("%s: %s"), w->label, text);
-      }
+    if(w->label[0] != '\0')
+    { // label is not empty
+      if(w->module && w->module->multi_name[0] != '\0')
+        dt_toast_log(_("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, text);
+      else if(w->module && !strstr(w->module->name(), w->label))
+        dt_toast_log(_("%s / %s: %s"), w->module->name(), w->label, text);
       else
-      { //label is empty
-        if(w->module && w->module->multi_name[0] != '\0')
-          dt_toast_log(_("%s %s / %s"), w->module->name(), w->module->multi_name, text);
-        else if(w->module)
-          dt_toast_log(_("%s / %s"), w->module->name(), text);
-        else
-          dt_toast_log(_("%s"), text);
-      }
+        dt_toast_log(_("%s: %s"), w->label, text);
+    }
+    else
+    { //label is empty
+      if(w->module && w->module->multi_name[0] != '\0')
+        dt_toast_log(_("%s %s / %s"), w->module->name(), w->module->multi_name, text);
+      else if(w->module)
+        dt_toast_log(_("%s / %s"), w->module->name(), text);
+      else
+        dt_toast_log(_("%s"), text);
     }
 
     g_free(text);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -630,7 +630,7 @@ void dt_accel_widget_toast(GtkWidget *widget)
       else if(w->module)
         dt_toast_log(_("%s / %s"), w->module->name(), text);
       else
-        dt_toast_log(_("%s"), text);
+        dt_toast_log("%s", text);
     }
 
     g_free(text);


### PR DESCRIPTION
As discussed in #6688, this changes the keyboard accelerators so that slider and combobox adjustments always show a toast message regardless of whether the module being adjusted is visible.