### PR TITLE
[Issue #6668] Film roll by folder sorted depending on pref-setting

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -544,8 +544,8 @@
     <name>plugins/collect/descending</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>sort collection recent to older</shortdescription>
-    <longdescription>changes the default collections-list order for folders, times and dates to run from recent to older</longdescription>
+    <shortdescription>sort collection in descending order</shortdescription>
+    <longdescription>changes the collections-list order for folders, film-rolls by folder, times and dates to descending</longdescription>
   </dtconfig>
   <dtconfig>
     <name>ui_last/colorpicker_mean</name>

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1725,7 +1725,12 @@ static void list_view(dt_lib_collect_rule_t *dr)
           if(strcmp(dt_conf_get_string("plugins/collect/filmroll_sort"), "id") == 0)
             order_by = g_strdup("ORDER BY film_rolls_id DESC");
           else
-            order_by = g_strdup("ORDER BY folder");
+          {
+            if(dt_conf_get_bool("plugins/collect/descending"))
+              order_by = g_strdup("ORDER BY folder DESC");
+            else
+              order_by = g_strdup("ORDER BY folder");
+          }
 
           // filmroll
           g_snprintf(query, sizeof(query),


### PR DESCRIPTION
Second suggestion how to fix #6668
As folders and dates are already sorted depending on the checkbox 'sort collection recent to older', it makes sense to also include film-rolls.