### PR TITLE
exif: use Exiv2 accessors that check multiple IFDs

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -768,14 +768,14 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       // dt_strlcpy_to_utf8(uf->conf->shutterText, max_name, pos, exifData);
       img->exif_exposure = pos->toFloat();
     }
-    else if(FIND_EXIF_TAG("Exif.Photo.ShutterSpeedValue"))
+    else if(FIND_EXIF_TAG("Exif.Photo.ShutterSpeedValue") || FIND_EXIF_TAG("Exif.Image.ShutterSpeedValue"))
     {
       // uf_strlcpy_to_utf8(uf->conf->shutterText, max_name, pos, exifData);
       img->exif_exposure = 1.0 / pos->toFloat();
     }
 
     // Read exposure bias
-    if(FIND_EXIF_TAG("Exif.Photo.ExposureBiasValue"))
+    if(FIND_EXIF_TAG("Exif.Photo.ExposureBiasValue") || FIND_EXIF_TAG("Exif.Image.ExposureBiasValue"))
     {
       img->exif_exposure_bias = pos->toFloat();
     }
@@ -785,7 +785,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     {
       img->exif_aperture = pos->toFloat();
     }
-    else if(FIND_EXIF_TAG("Exif.Photo.ApertureValue"))
+    else if(FIND_EXIF_TAG("Exif.Photo.ApertureValue") || FIND_EXIF_TAG("Exif.Image.ApertureValue"))
     {
       img->exif_aperture = pos->toFloat();
     }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -763,7 +763,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     dt_image_refresh_makermodel(img);
 
     /* Read shutter time */
-    if(FIND_EXIF_TAG("Exif.Photo.ExposureTime"))
+    if((pos = Exiv2::exposureTime(exifData)) != exifData.end() && pos->size())
     {
       // dt_strlcpy_to_utf8(uf->conf->shutterText, max_name, pos, exifData);
       img->exif_exposure = pos->toFloat();
@@ -781,7 +781,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     }
 
     /* Read aperture */
-    if(FIND_EXIF_TAG("Exif.Photo.FNumber"))
+    if((pos = Exiv2::fNumber(exifData)) != exifData.end() && pos->size())
     {
       img->exif_aperture = pos->toFloat();
     }
@@ -928,7 +928,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     /*
      * Read image orientation
      */
-    if(FIND_EXIF_TAG("Exif.Image.Orientation"))
+    if((pos = Exiv2::orientation(exifData)) != exifData.end() && pos->size())
     {
       img->orientation = dt_image_orientation_to_flip_bits(pos->toLong());
     }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -928,7 +928,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     /*
      * Read image orientation
      */
-    if((pos = Exiv2::orientation(exifData)) != exifData.end() && pos->size())
+    if(FIND_EXIF_TAG("Exif.Image.Orientation"))
     {
       img->orientation = dt_image_orientation_to_flip_bits(pos->toLong());
     }


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/6686
Fixes #6817 
Fixes #6886 

There are potentially a few more to be covered like `ShutterSpeedValue` and `ApertureValue` that do not have an Exiv2 accessor, so we could either walk down the options here now, or request accessors in Exiv2 and cover later...