### PR TITLE
[highpass] add missing xmmintrin.h

### DIFF
--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -35,6 +35,9 @@
 #include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
+#if defined(__SSE__)
+#include <xmmintrin.h>
+#endif
 
 #define MAX_RADIUS 16
 #define BOX_ITERATIONS 8


### PR DESCRIPTION
Does what ralfbrown said in https://github.com/darktable-org/darktable/pull/6698#issuecomment-720124400 :+1: 