### PR TITLE
[framing] add missing xmmintrin.h

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -42,6 +42,9 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__SSE__)
+#include <xmmintrin.h>
+#endif
 
 DT_MODULE_INTROSPECTION(3, dt_iop_borders_params_t)
 


### PR DESCRIPTION
Does what ralfbrown said in https://github.com/darktable-org/darktable/pull/6698#issuecomment-720124400 :+1: but this time for framing module changed in pr #6701