### PR TITLE
guard call to gui_update against missing implementation

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1895,7 +1895,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
     ++darktable.gui->reset;
     if(!dt_iop_is_hidden(module))
     {
-      if(module->params) module->gui_update(module);
+      if(module->params && module->gui_update) module->gui_update(module);
       dt_iop_gui_update_blending(module);
       dt_iop_gui_update_expanded(module);
       _iop_gui_update_label(module);


### PR DESCRIPTION
Prevents crash if an iop module is missing a gui_update implementation (15bef3b)