### PR TITLE
mask-manager: fix cleanup unused shapes

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2829,7 +2829,7 @@ void dt_masks_cleanup_unused_from_list(GList *history_list)
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
-    if(hist->forms && strcmp(hist->op_name, "mask_manager") != 0)
+    if(hist->forms && strcmp(hist->op_name, "mask_manager") == 0)
     {
       _masks_cleanup_unused(&hist->forms, history_list, history_end);
       history_end = num - 1;


### PR DESCRIPTION
now cleans up shapes that are *only* used by the mask manager module instead of those that are *not* used by the mask manager module