### PR TITLE
ppd corrected dragging distance in culling/preview mode

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -581,8 +581,9 @@ static gboolean _event_motion_notify(GtkWidget *widget, GdkEventMotion *event, g
     const double x = event->x_root;
     const double y = event->y_root;
     // we want the images to stay in the screen
-    const float valx = x - table->pan_x;
-    const float valy = y - table->pan_y;
+    const float scale = darktable.gui->ppd_thb / darktable.gui->ppd;
+    const float valx = (x - table->pan_x) * scale;
+    const float valy = (y - table->pan_y) * scale;
 
     if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     {


### PR DESCRIPTION
While dragging image content in preview or culling mode the amount of shift
in both directions wants to be corrected for ppd_thb for a more pleasant user interface.