### PR TITLE
Introducing the rcd demosaicer (2nd attempt)

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2696,8 +2696,26 @@ static void rcd_demosaic(float *out, const float *cfa, dt_iop_roi_t *const roi_o
     {
       const int indx = row * width + col;
       const float cfai = cfa[indx];
-      const float V_Stat = fmaxf(epssq, -18.f * cfai * (cfa[indx - w1] + cfa[indx + w1] + 2.f * (cfa[indx - w2] + cfa[indx + w2]) - cfa[indx - w3] - cfa[indx + w3]) - 2.f * cfai * (cfa[indx - w4] + cfa[indx + w4] - 19.f * cfai) - cfa[indx - w1] * (70.f * cfa[indx + w1] + 12.f * cfa[indx - w2] - 24.f * cfa[indx + w2] + 38.f * cfa[indx - w3] - 16.f * cfa[indx + w3] - 12.f * cfa[indx - w4] + 6.f * cfa[indx + w4] - 46.f * cfa[indx - w1]) + cfa[indx + w1] * (24.f * cfa[indx - w2] - 12.f * cfa[indx + w2] + 16.f * cfa[indx - w3] - 38.f * cfa[indx + w3] - 6.f * cfa[indx - w4] + 12.f * cfa[indx + w4] + 46.f * cfa[indx + w1]) + cfa[indx - w2] * (14.f * cfa[indx + w2] - 12.f * cfa[indx + w3] - 2.f * cfa[indx - w4] + 2.f * cfa[indx + w4] + 11.f * cfa[indx - w2]) + cfa[indx + w2] * (-12.f * cfa[indx - w3] + 2.f * (cfa[indx - w4] - cfa[indx + w4]) + 11.f * cfa[indx + w2]) + cfa[indx - w3] * (2.f * cfa[indx + w3] - 6.f * cfa[indx - w4] + 10.f * cfa[indx - w3]) + cfa[indx + w3] * (-6.f * cfa[indx + w4] + 10.f * cfa[indx + w3]) + cfa[indx - w4] * cfa[indx - w4] + cfa[indx + w4] * cfa[indx + w4]);
-      const float H_Stat = fmaxf(epssq, -18.f * cfai * (cfa[indx -  1] + cfa[indx +  1] + 2.f * (cfa[indx -  2] + cfa[indx +  2]) - cfa[indx -  3] - cfa[indx +  3]) - 2.f * cfai * (cfa[indx -  4] + cfa[indx +  4] - 19.f * cfai) - cfa[indx -  1] * (70.f * cfa[indx +  1] + 12.f * cfa[indx -  2] - 24.f * cfa[indx +  2] + 38.f * cfa[indx -  3] - 16.f * cfa[indx +  3] - 12.f * cfa[indx -  4] + 6.f * cfa[indx +  4] - 46.f * cfa[indx -  1]) + cfa[indx +  1] * (24.f * cfa[indx -  2] - 12.f * cfa[indx +  2] + 16.f * cfa[indx -  3] - 38.f * cfa[indx +  3] - 6.f * cfa[indx -  4] + 12.f * cfa[indx +  4] + 46.f * cfa[indx +  1]) + cfa[indx -  2] * (14.f * cfa[indx +  2] - 12.f * cfa[indx +  3] - 2.f * cfa[indx -  4] + 2.f * cfa[indx +  4] + 11.f * cfa[indx -  2]) + cfa[indx +  2] * (-12.f * cfa[indx -  3] + 2.f * (cfa[indx -  4] - cfa[indx +  4]) + 11.f * cfa[indx +  2]) + cfa[indx -  3] * (2.f * cfa[indx +  3] - 6.f * cfa[indx -  4] + 10.f * cfa[indx -  3]) + cfa[indx +  3] * (-6.f * cfa[indx +  4] + 10.f * cfa[indx +  3]) + cfa[indx -  4] * cfa[indx -  4] + cfa[indx +  4] * cfa[indx +  4]);
+      const float V_Stat = fmaxf(epssq, -18.f * cfai * (cfa[indx - w1] + cfa[indx + w1] + 2.f * (cfa[indx - w2] + cfa[indx + w2]) - cfa[indx - w3] - cfa[indx + w3])
+                                        - 2.f * cfai * (cfa[indx - w4] + cfa[indx + w4] - 19.f * cfai)
+                                        - cfa[indx - w1] * ( 70.f * cfa[indx + w1] + 12.f * cfa[indx - w2] - 24.f * cfa[indx + w2] + 38.f * cfa[indx - w3] - 16.f * cfa[indx + w3] - 12.f * cfa[indx - w4] + 6.f * cfa[indx + w4] - 46.f * cfa[indx - w1])
+                                        + cfa[indx + w1] * ( 24.f * cfa[indx - w2] - 12.f * cfa[indx + w2] + 16.f * cfa[indx - w3] - 38.f * cfa[indx + w3] - 6.f * cfa[indx - w4] + 12.f * cfa[indx + w4] + 46.f * cfa[indx + w1])
+                                        + cfa[indx - w2] * ( 14.f * cfa[indx + w2] - 12.f * cfa[indx + w3] - 2.f * cfa[indx - w4] + 2.f * cfa[indx + w4] + 11.f * cfa[indx - w2])
+                                        + cfa[indx + w2] * (-12.f * cfa[indx - w3] +  2.f * (cfa[indx - w4] - cfa[indx + w4]) + 11.f * cfa[indx + w2])
+                                        + cfa[indx - w3] * (  2.f * cfa[indx + w3] -  6.f * cfa[indx - w4] + 10.f * cfa[indx - w3])
+                                        + cfa[indx + w3] * ( -6.f * cfa[indx + w4] + 10.f * cfa[indx + w3])
+                                        + cfa[indx - w4] * cfa[indx - w4]
+                                        + cfa[indx + w4] * cfa[indx + w4]);
+      const float H_Stat = fmaxf(epssq, -18.f * cfai * (cfa[indx - 1] + cfa[indx + 1] + 2.f * (cfa[indx - 2] + cfa[indx + 2]) - cfa[indx - 3] - cfa[indx + 3])
+                                        - 2.f * cfai * (cfa[indx - 4] + cfa[indx + 4] - 19.f * cfai)
+                                        - cfa[indx - 1] * (70.f * cfa[indx + 1] + 12.f * cfa[indx - 2] - 24.f * cfa[indx + 2] + 38.f * cfa[indx - 3] - 16.f * cfa[indx + 3] - 12.f * cfa[indx - 4] + 6.f * cfa[indx + 4] - 46.f * cfa[indx - 1])
+                                        + cfa[indx + 1] * (24.f * cfa[indx - 2] - 12.f * cfa[indx + 2] + 16.f * cfa[indx - 3] - 38.f * cfa[indx + 3] - 6.f * cfa[indx - 4] + 12.f * cfa[indx + 4] + 46.f * cfa[indx + 1])
+                                        + cfa[indx - 2] * (14.f * cfa[indx + 2] - 12.f * cfa[indx + 3] - 2.f * cfa[indx - 4] + 2.f * cfa[indx + 4] + 11.f * cfa[indx -  2])
+                                        + cfa[indx + 2] * (-12.f * cfa[indx - 3] + 2.f * (cfa[indx - 4] - cfa[indx + 4]) + 11.f * cfa[indx + 2])
+                                        + cfa[indx - 3] * (2.f * cfa[indx + 3] - 6.f * cfa[indx - 4] + 10.f * cfa[indx - 3])
+                                        + cfa[indx + 3] * (-6.f * cfa[indx + 4] + 10.f * cfa[indx + 3])
+                                       + cfa[indx - 4] * cfa[indx - 4]
+                                       + cfa[indx + 4] * cfa[indx + 4]);
       VH_Dir[indx] = V_Stat / (V_Stat + H_Stat);
     }
   }
@@ -2770,8 +2788,87 @@ static void rcd_demosaic(float *out, const float *cfa, dt_iop_roi_t *const roi_o
     {
       const int indx = row * width + col;
 
-      const float P_Stat = fmaxf( -18.f * cfa[indx] * cfa[indx - w1 - 1] - 18.f * cfa[indx] * cfa[indx + w1 + 1] - 36.f * cfa[indx] * cfa[indx - w2 - 2] - 36.f * cfa[indx] * cfa[indx + w2 + 2] + 18.f * cfa[indx] * cfa[indx - w3 - 3] + 18.f * cfa[indx] * cfa[indx + w3 + 3] - 2.f * cfa[indx] * cfa[indx - w4 - 4] - 2.f * cfa[indx] * cfa[indx + w4 + 4] + 38.f * cfa[indx] * cfa[indx] - 70.f * cfa[indx - w1 - 1] * cfa[indx + w1 + 1] - 12.f * cfa[indx - w1 - 1] * cfa[indx - w2 - 2] + 24.f * cfa[indx - w1 - 1] * cfa[indx + w2 + 2] - 38.f * cfa[indx - w1 - 1] * cfa[indx - w3 - 3] + 16.f * cfa[indx - w1 - 1] * cfa[indx + w3 + 3] + 12.f * cfa[indx - w1 - 1] * cfa[indx - w4 - 4] - 6.f * cfa[indx - w1 - 1] * cfa[indx + w4 + 4] + 46.f * cfa[indx - w1 - 1] * cfa[indx - w1 - 1] + 24.f * cfa[indx + w1 + 1] * cfa[indx - w2 - 2] - 12.f * cfa[indx + w1 + 1] * cfa[indx + w2 + 2] + 16.f * cfa[indx + w1 + 1] * cfa[indx - w3 - 3] - 38.f * cfa[indx + w1 + 1] * cfa[indx + w3 + 3] - 6.f * cfa[indx + w1 + 1] * cfa[indx - w4 - 4] + 12.f * cfa[indx + w1 + 1] * cfa[indx + w4 + 4] + 46.f * cfa[indx + w1 + 1] * cfa[indx + w1 + 1] + 14.f * cfa[indx - w2 - 2] * cfa[indx + w2 + 2] - 12.f * cfa[indx - w2 - 2] * cfa[indx + w3 + 3] - 2.f * cfa[indx - w2 - 2] * cfa[indx - w4 - 4] + 2.f * cfa[indx - w2 - 2] * cfa[indx + w4 + 4] + 11.f * cfa[indx - w2 - 2] * cfa[indx - w2 - 2] - 12.f * cfa[indx + w2 + 2] * cfa[indx - w3 - 3] + 2 * cfa[indx + w2 + 2] * cfa[indx - w4 - 4] - 2.f * cfa[indx + w2 + 2] * cfa[indx + w4 + 4] + 11.f * cfa[indx + w2 + 2] * cfa[indx + w2 + 2] + 2.f * cfa[indx - w3 - 3] * cfa[indx + w3 + 3] - 6.f * cfa[indx - w3 - 3] * cfa[indx - w4 - 4] + 10.f * cfa[indx - w3 - 3] * cfa[indx - w3 - 3] - 6.f * cfa[indx + w3 + 3] * cfa[indx + w4 + 4] + 10.f * cfa[indx + w3 + 3] * cfa[indx + w3 + 3] + 1.f * cfa[indx - w4 - 4] * cfa[indx - w4 - 4] + 1.f * cfa[indx + w4 + 4] * cfa[indx + w4 + 4], epssq );
-      const float Q_Stat = fmaxf( -18.f * cfa[indx] * cfa[indx + w1 - 1] - 18.f * cfa[indx] * cfa[indx - w1 + 1] - 36.f * cfa[indx] * cfa[indx + w2 - 2] - 36.f * cfa[indx] * cfa[indx - w2 + 2] + 18.f * cfa[indx] * cfa[indx + w3 - 3] + 18.f * cfa[indx] * cfa[indx - w3 + 3] - 2.f * cfa[indx] * cfa[indx + w4 - 4] - 2.f * cfa[indx] * cfa[indx - w4 + 4] + 38.f * cfa[indx] * cfa[indx] - 70.f * cfa[indx + w1 - 1] * cfa[indx - w1 + 1] - 12.f * cfa[indx + w1 - 1] * cfa[indx + w2 - 2] + 24.f * cfa[indx + w1 - 1] * cfa[indx - w2 + 2] - 38.f * cfa[indx + w1 - 1] * cfa[indx + w3 - 3] + 16.f * cfa[indx + w1 - 1] * cfa[indx - w3 + 3] + 12.f * cfa[indx + w1 - 1] * cfa[indx + w4 - 4] - 6.f * cfa[indx + w1 - 1] * cfa[indx - w4 + 4] + 46.f * cfa[indx + w1 - 1] * cfa[indx + w1 - 1] + 24.f * cfa[indx - w1 + 1] * cfa[indx + w2 - 2] - 12.f * cfa[indx - w1 + 1] * cfa[indx - w2 + 2] + 16.f * cfa[indx - w1 + 1] * cfa[indx + w3 - 3] - 38.f * cfa[indx - w1 + 1] * cfa[indx - w3 + 3] - 6.f * cfa[indx - w1 + 1] * cfa[indx + w4 - 4] + 12.f * cfa[indx - w1 + 1] * cfa[indx - w4 + 4] + 46.f * cfa[indx - w1 + 1] * cfa[indx - w1 + 1] + 14.f * cfa[indx + w2 - 2] * cfa[indx - w2 + 2] - 12.f * cfa[indx + w2 - 2] * cfa[indx - w3 + 3] - 2.f * cfa[indx + w2 - 2] * cfa[indx + w4 - 4] + 2.f * cfa[indx + w2 - 2] * cfa[indx - w4 + 4] + 11.f * cfa[indx + w2 - 2] * cfa[indx + w2 - 2] - 12.f * cfa[indx - w2 + 2] * cfa[indx + w3 - 3] + 2 * cfa[indx - w2 + 2] * cfa[indx + w4 - 4] - 2.f * cfa[indx - w2 + 2] * cfa[indx - w4 + 4] + 11.f * cfa[indx - w2 + 2] * cfa[indx - w2 + 2] + 2.f * cfa[indx + w3 - 3] * cfa[indx - w3 + 3] - 6.f * cfa[indx + w3 - 3] * cfa[indx + w4 - 4] + 10.f * cfa[indx + w3 - 3] * cfa[indx + w3 - 3] - 6.f * cfa[indx - w3 + 3] * cfa[indx - w4 + 4] + 10.f * cfa[indx - w3 + 3] * cfa[indx - w3 + 3] + 1.f * cfa[indx + w4 - 4] * cfa[indx + w4 - 4] + 1.f * cfa[indx - w4 + 4] * cfa[indx - w4 + 4], epssq );
+      const float P_Stat = fmaxf( -18.f * cfa[indx]          * cfa[indx - w1 - 1]
+                                 - 18.f * cfa[indx]          * cfa[indx + w1 + 1]
+                                 - 36.f * cfa[indx]          * cfa[indx - w2 - 2]
+                                 - 36.f * cfa[indx]          * cfa[indx + w2 + 2]
+                                 + 18.f * cfa[indx]          * cfa[indx - w3 - 3]
+                                 + 18.f * cfa[indx]          * cfa[indx + w3 + 3]
+                                  - 2.f * cfa[indx]          * cfa[indx - w4 - 4]
+                                  - 2.f * cfa[indx]          * cfa[indx + w4 + 4]
+                                 + 38.f * cfa[indx]          * cfa[indx]
+                                 - 70.f * cfa[indx - w1 - 1] * cfa[indx + w1 + 1]
+                                 - 12.f * cfa[indx - w1 - 1] * cfa[indx - w2 - 2]
+                                 + 24.f * cfa[indx - w1 - 1] * cfa[indx + w2 + 2]
+                                 - 38.f * cfa[indx - w1 - 1] * cfa[indx - w3 - 3]
+                                 + 16.f * cfa[indx - w1 - 1] * cfa[indx + w3 + 3]
+                                 + 12.f * cfa[indx - w1 - 1] * cfa[indx - w4 - 4]
+                                  - 6.f * cfa[indx - w1 - 1] * cfa[indx + w4 + 4]
+                                 + 46.f * cfa[indx - w1 - 1] * cfa[indx - w1 - 1]
+                                 + 24.f * cfa[indx + w1 + 1] * cfa[indx - w2 - 2]
+                                 - 12.f * cfa[indx + w1 + 1] * cfa[indx + w2 + 2]
+                                 + 16.f * cfa[indx + w1 + 1] * cfa[indx - w3 - 3]
+                                 - 38.f * cfa[indx + w1 + 1] * cfa[indx + w3 + 3]
+                                  - 6.f * cfa[indx + w1 + 1] * cfa[indx - w4 - 4]
+                                 + 12.f * cfa[indx + w1 + 1] * cfa[indx + w4 + 4]
+                                 + 46.f * cfa[indx + w1 + 1] * cfa[indx + w1 + 1]
+                                 + 14.f * cfa[indx - w2 - 2] * cfa[indx + w2 + 2]
+                                 - 12.f * cfa[indx - w2 - 2] * cfa[indx + w3 + 3]
+                                  - 2.f * cfa[indx - w2 - 2] * cfa[indx - w4 - 4]
+                                  + 2.f * cfa[indx - w2 - 2] * cfa[indx + w4 + 4]
+                                 + 11.f * cfa[indx - w2 - 2] * cfa[indx - w2 - 2]
+                                 - 12.f * cfa[indx + w2 + 2] * cfa[indx - w3 - 3]
+                                 +  2.f * cfa[indx + w2 + 2] * cfa[indx - w4 - 4]
+                                  - 2.f * cfa[indx + w2 + 2] * cfa[indx + w4 + 4]
+                                 + 11.f * cfa[indx + w2 + 2] * cfa[indx + w2 + 2]
+                                  + 2.f * cfa[indx - w3 - 3] * cfa[indx + w3 + 3]
+                                  - 6.f * cfa[indx - w3 - 3] * cfa[indx - w4 - 4]
+                                 + 10.f * cfa[indx - w3 - 3] * cfa[indx - w3 - 3]
+                                  - 6.f * cfa[indx + w3 + 3] * cfa[indx + w4 + 4]
+                                 + 10.f * cfa[indx + w3 + 3] * cfa[indx + w3 + 3]
+                                  + 1.f * cfa[indx - w4 - 4] * cfa[indx - w4 - 4]
+                                  + 1.f * cfa[indx + w4 + 4] * cfa[indx + w4 + 4], epssq );
+
+      const float Q_Stat = fmaxf( -18.f * cfa[indx]          * cfa[indx + w1 - 1]
+                                 - 18.f * cfa[indx]          * cfa[indx - w1 + 1]
+                                 - 36.f * cfa[indx]          * cfa[indx + w2 - 2]
+                                 - 36.f * cfa[indx]          * cfa[indx - w2 + 2]
+                                 + 18.f * cfa[indx]          * cfa[indx + w3 - 3]
+                                 + 18.f * cfa[indx]          * cfa[indx - w3 + 3]
+                                  - 2.f * cfa[indx]          * cfa[indx + w4 - 4]
+                                  - 2.f * cfa[indx]          * cfa[indx - w4 + 4]
+                                 + 38.f * cfa[indx]          * cfa[indx]
+                                 - 70.f * cfa[indx + w1 - 1] * cfa[indx - w1 + 1]
+                                 - 12.f * cfa[indx + w1 - 1] * cfa[indx + w2 - 2]
+                                 + 24.f * cfa[indx + w1 - 1] * cfa[indx - w2 + 2]
+                                 - 38.f * cfa[indx + w1 - 1] * cfa[indx + w3 - 3]
+                                 + 16.f * cfa[indx + w1 - 1] * cfa[indx - w3 + 3]
+                                 + 12.f * cfa[indx + w1 - 1] * cfa[indx + w4 - 4]
+                                  - 6.f * cfa[indx + w1 - 1] * cfa[indx - w4 + 4]
+                                 + 46.f * cfa[indx + w1 - 1] * cfa[indx + w1 - 1]
+                                 + 24.f * cfa[indx - w1 + 1] * cfa[indx + w2 - 2]
+                                 - 12.f * cfa[indx - w1 + 1] * cfa[indx - w2 + 2]
+                                 + 16.f * cfa[indx - w1 + 1] * cfa[indx + w3 - 3]
+                                 - 38.f * cfa[indx - w1 + 1] * cfa[indx - w3 + 3]
+                                  - 6.f * cfa[indx - w1 + 1] * cfa[indx + w4 - 4]
+                                 + 12.f * cfa[indx - w1 + 1] * cfa[indx - w4 + 4]
+                                 + 46.f * cfa[indx - w1 + 1] * cfa[indx - w1 + 1]
+                                 + 14.f * cfa[indx + w2 - 2] * cfa[indx - w2 + 2]
+                                 - 12.f * cfa[indx + w2 - 2] * cfa[indx - w3 + 3]
+                                  - 2.f * cfa[indx + w2 - 2] * cfa[indx + w4 - 4]
+                                  + 2.f * cfa[indx + w2 - 2] * cfa[indx - w4 + 4]
+                                 + 11.f * cfa[indx + w2 - 2] * cfa[indx + w2 - 2]
+                                 - 12.f * cfa[indx - w2 + 2] * cfa[indx + w3 - 3]
+                                  + 2.f * cfa[indx - w2 + 2] * cfa[indx + w4 - 4]
+                                  - 2.f * cfa[indx - w2 + 2] * cfa[indx - w4 + 4]
+                                 + 11.f * cfa[indx - w2 + 2] * cfa[indx - w2 + 2]
+                                  + 2.f * cfa[indx + w3 - 3] * cfa[indx - w3 + 3]
+                                  - 6.f * cfa[indx + w3 - 3] * cfa[indx + w4 - 4]
+                                 + 10.f * cfa[indx + w3 - 3] * cfa[indx + w3 - 3]
+                                  - 6.f * cfa[indx - w3 + 3] * cfa[indx - w4 + 4]
+                                 + 10.f * cfa[indx - w3 + 3] * cfa[indx - w3 + 3]
+                                  + 1.f * cfa[indx + w4 - 4] * cfa[indx + w4 - 4]
+                                  + 1.f * cfa[indx - w4 + 4] * cfa[indx - w4 + 4], epssq );
       PQ_Dir[indx] = P_Stat / (P_Stat + Q_Stat);
     }
   }


### PR DESCRIPTION
The rcd demosaicer developed by Luis Sanz Rodríguez is publically available at
https://github.com/LuisSR/RCD-Demosaicing and is licenced under the GNU GPL version 3.

I came across this demosaicer via the rt issue tracker https://github.com/Beep6581/RawTherapee/issues/5908 and have been using it in dt for a month or so.

The results are pretty good, quality en-par with Amaze, in some situations amaze is better, in others it's rcd having better results.

The biggest pro argument is less color overshoot, the penalty is minimally increased blur.

The algo has been directly taken from the original source, adopted to dt style and performance tuned via omp.

Right now the performance is just about that of amaze. (the first attempt had a number of issues leading to sometimes wrong colors and access on out-of-buffer crashes in the border interpolation code.)

The border interpolation used the dcraw algo in the original code, i chose the code used by rt as it has less artefacts.