### PR TITLE
Map: better group of images based on cluster calculation (dbscan)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1508,6 +1508,20 @@
     <shortdescription>pretty print the image location</shortdescription>
     <longdescription>show a more readable representation of the location in the image information module</longdescription>
   </dtconfig>
+  <dtconfig prefs="otherviews" section="geoloc">
+    <name>plugins/map/epsilon_factor</name>
+    <type min="10" max="100">int</type>
+    <default>25</default>
+    <shortdescription>modify the spatial size of an images group on the map</shortdescription>
+    <longdescription>increase or decrease the spatial size of images groups on the map. can influence the calculation time</longdescription>
+  </dtconfig>
+  <dtconfig prefs="otherviews" section="geoloc">
+    <name>plugins/map/min_images_per_group</name>
+    <type min="1" max="10">int</type>
+    <default>1</default>
+    <shortdescription>minimum number of images to set up an images group</shortdescription>
+    <longdescription>the minimum number of images to set up an images group. can influence the calculation time.</longdescription>
+  </dtconfig>
   <dtconfig prefs="lighttable">
     <name>plugins/lighttable/draw_custom_metadata</name>
     <type>bool</type>

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "bauhaus/bauhaus.h"
 #include "common/collection.h"
 #include "common/darktable.h"
 #include "common/debug.h"
@@ -51,6 +52,7 @@ uint32_t container(dt_lib_module_t *self)
 typedef struct dt_lib_map_settings_t
 {
   GtkWidget *show_osd_checkbutton, *filtered_images_checkbutton, *map_source_dropdown;
+  GtkWidget *epsilon_factor, *min_images;
 } dt_lib_map_settings_t;
 
 int position()
@@ -91,6 +93,26 @@ static void _map_source_changed(GtkWidget *widget, gpointer data)
     map_source = g_value_get_int(&value);
     g_value_unset(&value);
     dt_view_map_set_map_source(darktable.view_manager, map_source);
+  }
+}
+
+static void _epsilon_factor_callback(GtkWidget *slider, gpointer data)
+{
+  const float epsilon = dt_bauhaus_slider_get(slider);
+  dt_conf_set_int("plugins/map/epsilon_factor", epsilon);
+  if(darktable.view_manager->proxy.map.view)
+  {
+    darktable.view_manager->proxy.map.redraw(darktable.view_manager->proxy.map.view);
+  }
+}
+
+static void _min_images_callback(GtkWidget *slider, gpointer data)
+{
+  const int min_images = dt_bauhaus_slider_get(slider);
+  dt_conf_set_int("plugins/map/min_images_per_group", min_images);
+  if(darktable.view_manager->proxy.map.view)
+  {
+    darktable.view_manager->proxy.map.redraw(darktable.view_manager->proxy.map.view);
   }
 }
 
@@ -153,6 +175,19 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->map_source_dropdown), "changed", G_CALLBACK(_map_source_changed), NULL);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
+
+  d->epsilon_factor = dt_bauhaus_slider_new_with_range(NULL, 10., 100., 5.,
+                            dt_conf_get_int("plugins/map/epsilon_factor"), 0);
+  gtk_widget_set_tooltip_text(d->epsilon_factor, _("modify the spatial size of an images group on the map"));
+  dt_bauhaus_widget_set_label(d->epsilon_factor, NULL, N_("group size factor"));
+  g_signal_connect(G_OBJECT(d->epsilon_factor), "value-changed", G_CALLBACK(_epsilon_factor_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->epsilon_factor), TRUE, TRUE, 0);
+  d->min_images = dt_bauhaus_slider_new_with_range(NULL, 1.0, 10.0, 1.0,
+                            dt_conf_get_int("plugins/map/min_images_per_group"), 0);
+  gtk_widget_set_tooltip_text(d->min_images, _("minimum of images to make a group"));
+  dt_bauhaus_widget_set_label(d->min_images, NULL, N_("min images per group"));
+  g_signal_connect(G_OBJECT(d->min_images), "value-changed", G_CALLBACK(_min_images_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->min_images), TRUE, TRUE, 0);
 
   g_object_unref(model);
   g_free(map_source);


### PR DESCRIPTION
The effect is really good as long as the number of images on the map don't exceed 2000.
You can shift the map, the images groups remain stable.
In map settings one can adjust the main parameters of dbscan (epsilon and min images)

But, as the calculation time is f(n^2), for 30.000 I wait 6 or 7 seconds to get the clusters calculated.

Not usable as is, unfortunately, but I post the PR hoping I'll get some suggestions to improve the performance, at least from the UI standpoint.
