### PR TITLE
Remove `plugins/slideshow/high_quality` preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1690,13 +1690,6 @@
     <shortdescription>always use LittleCMS 2 to apply output color profile</shortdescription>
     <longdescription>this is slower than the default.</longdescription>
   </dtconfig>
-  <dtconfig prefs="otherviews" section="slideshow">
-    <name>plugins/slideshow/high_quality</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription>do high quality processing for slideshow</shortdescription>
-    <longdescription>same option as for export, but applies to slideshow.</longdescription>
-  </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/export/high_quality_processing</name>
     <type>bool</type>

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -207,7 +207,7 @@ static int process_image(dt_slideshow_t *d, dt_slideshow_slot_t slot)
   sqlite3_finalize(stmt);
 
   // this is a little slow, might be worth to do an option:
-  const gboolean high_quality = dt_conf_get_bool("plugins/slideshow/high_quality");
+  const gboolean high_quality = !dt_conf_get_bool("ui/performance");
 
   if(id)
   {


### PR DESCRIPTION
This pr is a suggestion and a step to reduce the overwhelming size of the preferences.

I think instead of the extra `plugins/slideshow/high_quality` we could be using the
`ui/performance` flag too.

Related #6707