### PR TITLE
imageio_tiff: enable shortfile w/ masks, misc fixes

### DIFF
--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -426,14 +426,17 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
 #ifdef MASKS_USE_SAME_FORMAT
-        TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)3);
+        TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)layers);
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
-        TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+        if(layers == 3)
+          TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+        else
+          TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
         TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
         free(rowdata);
-        const size_t _rowsize = (w * 3) * d->bpp / 8;
+        const size_t _rowsize = (w * layers) * d->bpp / 8;
         rowdata = malloc(_rowsize);
 
         if(d->bpp == 32)
@@ -443,9 +446,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             const float *in = raster_mask + (size_t)y * w;
             float *out = (float *)rowdata;
 
-            for(int x = 0; x < w; x++, out += 3)
+            for(int x = 0; x < w; x++, out += layers)
             {
-              for(int c = 0; c < 3; c++)
+              for(int c = 0; c < layers; c++)
                 out[c] = in[x];
             }
 
@@ -463,9 +466,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             const float *in = raster_mask + (size_t)y * w;
             uint16_t *out = (uint16_t *)rowdata;
 
-            for(int x = 0; x < w; x++, out += 3)
+            for(int x = 0; x < w; x++, out += layers)
             {
-              for(int c = 0; c < 3; c++)
+              for(int c = 0; c < layers; c++)
                 out[c] = CLAMP_FLT(in[x]) * 65535;
             }
 
@@ -483,9 +486,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             const float *in = raster_mask + (size_t)y * w;
             uint8_t *out = (uint8_t *)rowdata;
 
-            for(int x = 0; x < w; x++, out += 3)
+            for(int x = 0; x < w; x++, out += layers)
             {
-              for(int c = 0; c < 3; c++)
+              for(int c = 0; c < layers; c++)
                 out[c] = CLAMP_FLT(in[x]) * 255;
             }
 

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -500,6 +500,8 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)1);
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)32);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)SAMPLEFORMAT_IEEEFP);
+        if(d->compress == 2) // override predictor set above assuming MASKS_USE_SAME_FORMAT
+            TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_FLOATINGPOINT);
         TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
         TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -140,10 +140,6 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
       TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_HORIZONTAL);
     TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
   }
-  else // (d->compress == 0)
-  {
-    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
-  }
 
   if(profile != NULL)
   {
@@ -236,14 +232,12 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
   TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
-  TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
   int resolution = dt_conf_get_int("metadata/resolution");
   if(resolution > 0)
   {
     TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
     TIFFSetField(tif, TIFFTAG_YRESOLUTION, (float)resolution);
-    TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
   }
 
   const size_t rowsize = (d->global.width * layers) * d->bpp / 8;
@@ -405,22 +399,16 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_HORIZONTAL);
           TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
         }
-        else // (d->compress == 0)
-        {
-          TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
-        }
 
         if(resolution > 0)
         {
           TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
           TIFFSetField(tif, TIFFTAG_YRESOLUTION, (float)resolution);
-          TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
         }
 
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);
         TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)h);
         TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
-        TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
 #ifdef MASKS_USE_SAME_FORMAT
         TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)layers);

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -145,7 +145,6 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
   }
 
-  TIFFSetField(tif, TIFFTAG_FILLORDER, (uint16_t)FILLORDER_MSB2LSB);
   if(profile != NULL)
   {
     TIFFSetField(tif, TIFFTAG_ICCPROFILE, (uint32_t)profile_len, profile);
@@ -231,11 +230,13 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)d->global.width);
   TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)d->global.height);
   if(layers == 3)
+  {
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
+  }
   else
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
 
-  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
   TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
@@ -411,8 +412,6 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
           TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
         }
 
-        TIFFSetField(tif, TIFFTAG_FILLORDER, (uint16_t)FILLORDER_MSB2LSB);
-
         if(resolution > 0)
         {
           TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
@@ -422,7 +421,6 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);
         TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)h);
-        TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
         TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
 #ifdef MASKS_USE_SAME_FORMAT
@@ -430,7 +428,10 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
         if(layers == 3)
+        {
           TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+          TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
+        }
         else
           TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
         TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -95,7 +95,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     }
   }
 
-  int n_pages = 1;
+  uint16_t n_pages = 1;
   // only when masks are to be stored we check for extra pages!
   if(export_masks && pipe)
   {
@@ -116,6 +116,15 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     goto exit;
   }
 
+  if(n_pages > 1)
+  {
+    TIFFSetField(tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
+    TIFFSetField(tif, TIFFTAG_PAGENAME, _("image"));
+    TIFFSetField(tif, TIFFTAG_PAGENUMBER, 0, n_pages);
+  }
+  else
+    TIFFSetField(tif, TIFFTAG_SUBFILETYPE, 0);
+
   TIFFSetField(tif, TIFFTAG_DOCUMENTNAME, filename);
 
   // http://partners.adobe.com/public/developer/en/tiff/TIFFphotoshop.pdf (dated 2002)
@@ -127,17 +136,17 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   // http://www.awaresystems.be/imaging/tiff/tifftags/predictor.html
   if(d->compress == 1)
   {
-    TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
-    TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_NONE);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_ADOBE_DEFLATE);
+    TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_NONE);
     TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
   }
   else if(d->compress == 2)
   {
-    TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_ADOBE_DEFLATE);
     if(d->bpp == 32)
-      TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_FLOATINGPOINT);
+      TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_FLOATINGPOINT);
     else
-      TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_HORIZONTAL);
+      TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_HORIZONTAL);
     TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
   }
 
@@ -152,15 +161,14 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
    it's safe to assume a grayscale.
    As there might be pipeline errors at the border we leave them alone.
    After these checks layers can be used later on.
-   Exporting using masks currently does not support grayscale images.
 */
-  int layers = 3;  // default are rgb images
+  uint16_t layers = 3;  // default are rgb images
 
   int shortmode = 0;
   if(dt_conf_key_exists("plugins/imageio/format/tiff/shortfile"))
     shortmode = dt_conf_get_int("plugins/imageio/format/tiff/shortfile");
 
-  if((d->global.height > 4) && (d->global.width > 4) && (n_pages == 1) && shortmode)
+  if((d->global.height > 4) && (d->global.width > 4) && shortmode)
   {
     layers = 1;    // let's now assume a grayscale
     if(d->bpp == 32)
@@ -220,17 +228,17 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   if(layers == 1)
     dt_control_log(_("will export as a grayscale image"));
 
-  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)layers);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, layers);
   TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
-  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
+  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (d->bpp == 32) ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT);
   TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)d->global.width);
   TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)d->global.height);
   if(layers == 3)
-    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
   else
-    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
 
-  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
   int resolution = dt_conf_get_int("metadata/resolution");
@@ -238,7 +246,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   {
     TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
     TIFFSetField(tif, TIFFTAG_YRESOLUTION, (float)resolution);
-    TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
+    TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
   }
 
   const size_t rowsize = (d->global.width * layers) * d->bpp / 8;
@@ -309,10 +317,6 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   rc = 0;
 
   // close the file before adding exif data
-  TIFFSetField(tif, TIFFTAG_PAGENAME, _("image"));
-  TIFFSetField(tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
-  TIFFSetField(tif, TIFFTAG_PAGENUMBER, 0, n_pages);
-
   if(tif)
   {
     TIFFClose(tif);
@@ -351,7 +355,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
                                          0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                                          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
     static const size_t missing_raster_mask_w = 8, missing_raster_mask_h = 8;
-    int page = 1;
+    uint16_t page = 1;
     for(GList *iter = pipe->nodes; iter; iter = g_list_next(iter))
     {
       dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)iter->data;
@@ -387,17 +391,17 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
         if(d->compress == 1)
         {
-          TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
-          TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_NONE);
+          TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_ADOBE_DEFLATE);
+          TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_NONE);
           TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
         }
         else if(d->compress == 2)
         {
-          TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
+          TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_ADOBE_DEFLATE);
           if(d->bpp == 32)
-            TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_FLOATINGPOINT);
+            TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_FLOATINGPOINT);
           else
-            TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_HORIZONTAL);
+            TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_HORIZONTAL);
           TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
         }
 
@@ -405,26 +409,29 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         {
           TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
           TIFFSetField(tif, TIFFTAG_YRESOLUTION, (float)resolution);
-          TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
+          TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
         }
 
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);
         TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)h);
-        TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
+        TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
 
 #ifdef MASKS_USE_SAME_FORMAT
-        TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)layers);
+        TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, layers);
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
-        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
+        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (d->bpp == 32) ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT);
         if(layers == 3)
-          TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+          TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
         else
-          TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
+          TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
         TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
-        free(rowdata);
-        const size_t _rowsize = (w * layers) * d->bpp / 8;
-        rowdata = malloc(_rowsize);
+        if(w != d->global.width)
+        {
+          free(rowdata);
+          const size_t _rowsize = (w * layers) * d->bpp / 8;
+          rowdata = malloc(_rowsize);
+        }
 
         if(d->bpp == 32)
         {
@@ -456,7 +463,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             for(int x = 0; x < w; x++, out += layers)
             {
               for(int c = 0; c < layers; c++)
-                out[c] = CLAMP_FLT(in[x]) * 65535;
+                out[c] = CLAMP_FLT(in[x]) * 65535.0f + 0.5f;
             }
 
             if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -476,7 +483,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             for(int x = 0; x < w; x++, out += layers)
             {
               for(int c = 0; c < layers; c++)
-                out[c] = CLAMP_FLT(in[x]) * 255;
+                out[c] = CLAMP_FLT(in[x]) * 255.0f + 0.5f;
             }
 
             if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -487,12 +494,12 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
           }
         }
 #else // MASKS_USE_SAME_FORMAT
-        TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)1);
-        TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)32);
-        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)SAMPLEFORMAT_IEEEFP);
+        TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+        TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 32);
+        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
         if(d->compress == 2) // override predictor set above assuming MASKS_USE_SAME_FORMAT
-            TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_FLOATINGPOINT);
-        TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
+            TIFFSetField(tif, TIFFTAG_PREDICTOR, PREDICTOR_FLOATINGPOINT);
+        TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
         TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
         for(int y = 0; y < h; y++)
@@ -515,14 +522,16 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
       } // for all raster masks
     } // for all pipe nodes
 
-    TIFFClose(tif);
-    tif = NULL;
+    // success
+    rc = 0;
   } // if more than 1 page, i.e., there are masks
 
-  // success
-  rc = 0;
-
 exit:
+  if(tif)
+  {
+    TIFFClose(tif);
+    tif = NULL;
+  }
   free(profile);
   profile = NULL;
   free(rowdata);

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -230,13 +230,11 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)d->global.width);
   TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)d->global.height);
   if(layers == 3)
-  {
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
-    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
-  }
   else
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
 
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
   TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
@@ -421,6 +419,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);
         TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)h);
+        TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
         TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
 #ifdef MASKS_USE_SAME_FORMAT
@@ -428,10 +427,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
         if(layers == 3)
-        {
           TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
-          TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
-        }
         else
           TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
         TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -238,6 +238,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   {
     TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
     TIFFSetField(tif, TIFFTAG_YRESOLUTION, (float)resolution);
+    TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
   }
 
   const size_t rowsize = (d->global.width * layers) * d->bpp / 8;
@@ -404,6 +405,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         {
           TIFFSetField(tif, TIFFTAG_XRESOLUTION, (float)resolution);
           TIFFSetField(tif, TIFFTAG_YRESOLUTION, (float)resolution);
+          TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
         }
 
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);


### PR DESCRIPTION
Fixes a rare potential bug: MASKS_USE_SAME_FORMAT currently hard-codes 3 channels being stored for the mask, but a new "shortmode" was introduced to store grayscale image data as a single channel in 3.2.1; this keeps the image and mask channels in sync.

This PR also fixes a potential bug when MASKS_USE_SAME_FORMAT is not defined for some reason, ensuring the compression predictor matches the hard-coded floating point mask data format instead of the predictor set based on image data format.