### PR TITLE
color_picker_proxy: force a full preview-pipe recompute.

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -234,6 +234,16 @@ dt_iop_colorspace_type_t dt_iop_color_picker_get_active_cst(dt_iop_module_t *mod
 static void _iop_color_picker_signal_callback(gpointer instance, dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
                                               gpointer user_data)
 {
+  dt_develop_t *dev = module->dev;
+
+  // Invalidate the cache to ensure it will be fully recomputed.
+  // modules between colorin & colorout may need the work_profile
+  // to work properly. This will force colorin to be run and it
+  // will set the work_profile if needed.
+
+  dev->preview_pipe->changed |= DT_DEV_PIPE_REMOVE;
+  dev->preview_pipe->cache_obsolete = 1;
+
   _iop_color_picker_apply(module, piece);
 }
 


### PR DESCRIPTION
We may need that for modules between colorin & colorout.

Fixes issue discussed in #4940.
Fixes #6360.