### PR TITLE
Prevent drawing of selection triangle in zoomable thumbs

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -265,6 +265,8 @@ static gboolean _event_cursor_draw(GtkWidget *widget, cairo_t *cr, gpointer user
   if(!user_data || !widget) return TRUE;
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
 
+  if(thumb->zoomable) return TRUE;
+
   GtkStateFlags state = gtk_widget_get_state_flags(thumb->w_cursor);
   GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_cursor);
   GdkRGBA col;


### PR DESCRIPTION
The "selected thumb" marker should only be shown for filmstrip thumbs.

As we don't have information in `dt_thumbnail_t` who owns the thumb we
use the zoomable gboolean instead.

@AlicVB what do you think about this?

Hopefully fixes #6637