### PR TITLE
rename channel mixer RGB to color calibration

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -124,7 +124,7 @@ typedef struct dt_iop_channelmixer_rbg_data_t
 
 const char *name()
 {
-  return _("channel mixer rgb");
+  return _("color calibration");
 }
 
 int flags()


### PR DESCRIPTION
People are starting to get confused about a chromatic adaptation transform (CAT) in the channel mixer.

Well…

Your input color profile is nothing but a channel mixer in which the coefficients are already preset (aka it's a 3×3 matrice).

Your white balance is nothing but a channel mixer in which you only set the red/red, green/green and blue/blue coefficients (aka the diagonal of the 3×3 matrice). What any fancy temperature + tint does is precomputing these 3 coeffs from 2 parameters.

So if you think about it from a broader perspective, channel mixer lets you correct your input profile and white balance, by scaling and rotating the primaries in 3D.

That is color calibration. So I propose to name it that way, because people care more about the label than the action.

