### PR TITLE
common: Fix DT_FMA macro

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -196,7 +196,7 @@ static inline int dt_version()
 #ifdef FP_FAST_FMAF
   #define DT_FMA(x, y, z) fmaf(x, y, z)
 #else
-  #define DT_FMA(x, y, z)  x * y + z;
+  #define DT_FMA(x, y, z) ((x) * (y) + (z))
 #endif
 
 struct dt_gui_gtk_t;


### PR DESCRIPTION
Build error:
```
    src/common/darktable.h:199:37: error: expected ')' before ';' token
        #define DT_FMA(x, y, z)  x * y + z;
                                         ^
```