### PR TITLE
[Issue #6668] Define sorting order in collect module instead of prefs

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -540,13 +540,6 @@
     <shortdescription>sort film rolls by</shortdescription>
     <longdescription>sets the collections-list order for film rolls</longdescription>
   </dtconfig>
-  <dtconfig prefs="lighttable">
-    <name>plugins/collect/descending</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription>sort collection recent to older</shortdescription>
-    <longdescription>changes the default collections-list order for folders, times and dates to run from recent to older</longdescription>
-  </dtconfig>
   <dtconfig>
     <name>ui_last/colorpicker_mean</name>
     <type>int</type>

--- a/doc/usermanual/preferences/lighttable_options.xml
+++ b/doc/usermanual/preferences/lighttable_options.xml
@@ -36,12 +36,6 @@
       Set the collection list order for film rolls.
     </para>
 
-    <bridgehead renderas="sect5">sort collection recent to older</bridgehead>
-
-    <para>
-      Changes the default collections list for folders, times and dates to run from recent to older.
-    </para>
-
     <bridgehead renderas="sect5">high quality thumb processing from size</bridgehead>
 
     <para>


### PR DESCRIPTION
As suggested in #6668 I've moved the definition of the sorting order from preferences to the collect module.

At the moment it uses the same pref-setting as before and therefor only affects folder, film-roll sorted by folder and dates

![sort-popup-committed](https://user-images.githubusercontent.com/5677563/98476887-827f8a00-21f6-11eb-8d83-5fd88428b571.png)
