### PR TITLE
highpass: fix unaligned-load SSE crash

### DIFF
--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -344,7 +344,7 @@ static void blur_vertical_sse(float *buf, const int height, const int width, con
   for (size_t y = 0; y < radius && y < height; y++)
   {
     size_t index = y * width;
-    L += _mm_load_ps(buf + index);
+    L += _mm_loadu_ps(buf + index);	// use unaligned load since width is not necessarily a multiple of 4
     hits += one;
   }
   // process the blur up to the point where we start removing values
@@ -353,7 +353,7 @@ static void blur_vertical_sse(float *buf, const int height, const int width, con
     const int np = y + radius;
     if(np < height)
     {
-      L += _mm_load_ps(buf+np*width);
+      L += _mm_loadu_ps(buf+np*width);
       hits += one;
     }
     _mm_store_ps(scanline+4*y, L / hits);
@@ -363,11 +363,11 @@ static void blur_vertical_sse(float *buf, const int height, const int width, con
   {
     const int op = y - radius - 1;
     const int np = y + radius;
-    L -= _mm_load_ps(buf+op*width);
+    L -= _mm_loadu_ps(buf+op*width);
     hits -= one;
     if(np < height)
     {
-      L += _mm_load_ps(buf+np*width);
+      L += _mm_loadu_ps(buf+np*width);
       hits += one;
     }
     _mm_store_ps(scanline+4*y, L / hits);
@@ -377,6 +377,7 @@ static void blur_vertical_sse(float *buf, const int height, const int width, con
   for (size_t y = 0; y < height; y++)
   {
     // use unaligned store since width is not necessarily a multiple of four
+    // use the faster aligned load since we've ensured that scanline is aligned
     _mm_storeu_ps(buf + y*width, _mm_load_ps(scanline + 4*y));
   }
   return;


### PR DESCRIPTION
When the image width is not a multiple of four, we need to access
locations which are not 16-byte aligned.  On some systems, _mm_load_ps
segfaults for unaligned loads, so use _mm_loadu_ps instead, even
though it is slower.

Fixes #6801.