### PR TITLE
borders (framing): fix unaligned-load SSE crash

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -363,7 +363,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 static void set_outer_border_sse(float *buf, const float col[4], const int height, const int width,
                                  const int border_height, const int border_width)
 {
-  const __m128 color = _mm_load_ps(col);
+  const __m128 color = _mm_loadu_ps(col);  // use unalignd load since 'col' is not necessarily 16-byte aligned
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(buf, col, border_height, height, width, color)  \


### PR DESCRIPTION
On some systems, unaligned SSE loads segfault.  The color to be
written to the image border is passed in an unaligned array, so use
_mm_loadu_ps instead of _mm_load_ps.  (Since we do the load exactly
once per image, the speed difference doesn't matter.)

Hopefully fixes #6805 (_mm_load_ps does not crash here).