### PR TITLE
module order: purge cache one step below

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -823,19 +823,19 @@ static void dt_iop_gui_movedown_callback(GtkButton *button, dt_iop_module_t *mod
   dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_movedown_callback end");
 
   // we rebuild the pipe
-  prev->dev->pipe->changed |= DT_DEV_PIPE_REMOVE;
-  prev->dev->preview_pipe->changed |= DT_DEV_PIPE_REMOVE;
-  prev->dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
-  prev->dev->pipe->cache_obsolete = 1;
-  prev->dev->preview_pipe->cache_obsolete = 1;
-  prev->dev->preview2_pipe->cache_obsolete = 1;
+  module->dev->pipe->changed |= DT_DEV_PIPE_REMOVE;
+  module->dev->preview_pipe->changed |= DT_DEV_PIPE_REMOVE;
+  module->dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
+  module->dev->pipe->cache_obsolete = 1;
+  module->dev->preview_pipe->cache_obsolete = 1;
+  module->dev->preview2_pipe->cache_obsolete = 1;
 
   // rebuild the accelerators
   dt_iop_connect_accels_multi(module->so);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED);
 
   // invalidate buffers and force redraw of darkroom
-  dt_dev_invalidate_all(prev->dev);
+  dt_dev_invalidate_all(module->dev);
 }
 
 static void dt_iop_gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)


### PR DESCRIPTION
I'm not sure I fully understand how this part of the code works, but I might have find a minor issue. @TurboGit, can you check ?

When moving a module down the pipe, the function finds the "previous" module and insert the current module before this. But then the pipe gets invalidated from the "previous" module, which is one step too late. This could lead to the current module being not flushed from cache properly, and preview updates inconsistencies. So this commit ensures we flush caches from the current module, which is one step before what is done as of today. It is even possible that we must flush even before current module.

Note the `insert_after` works properly, the cache is flushed from under the current module.