### PR TITLE
add a chroma adaptation workflow

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2380,6 +2380,18 @@
     <shortdescription>auto-apply pixel workflow defaults</shortdescription>
     <longdescription>scene-referred workflow is based on linear modules and will auto-apply filmic and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve and the legacy module pipe order.</longdescription>
   </dtconfig>
+  <dtconfig prefs="processing">
+    <name>plugins/darkroom/chromatic-adaptation</name>
+    <type>
+      <enum>
+        <option>modern</option>
+        <option>legacy</option>
+      </enum>
+    </type>
+    <default>legacy</default>
+    <shortdescription>auto-apply chromatic adaptation defaults</shortdescription>
+    <longdescription>legacy performs a basic chromatic adaptation using only the white balance module\nmodern uses a combination of white balance module and color calibration module, with improved color science for chromatic adaptation.</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" restart="true">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>
     <type>bool</type>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1377,6 +1377,10 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
+
+  workflow = dt_conf_get_string("plugins/darkroom/chromatic-adaptation");
+  const gboolean is_modern_chroma = strcmp(workflow, "modern") == 0;
+
   g_free(workflow);
 
   //  Add scene-referred workflow
@@ -1387,16 +1391,18 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);
 
   const gboolean auto_apply_filmic = has_matrix && is_scene_referred;
+  const gboolean auto_apply_cat = has_matrix && is_modern_chroma;
   const gboolean auto_apply_sharpen = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
 
-  if(auto_apply_filmic || auto_apply_sharpen)
+  if(auto_apply_filmic || auto_apply_sharpen || auto_apply_cat)
   {
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
       if(((auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0)
-          || (auto_apply_sharpen && strcmp(module->op, "sharpen") == 0))
+          || (auto_apply_sharpen && strcmp(module->op, "sharpen") == 0)
+          || (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
          && !dt_history_check_module_exists(imgid, module->op)
          && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
       {

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1287,7 +1287,7 @@ void gui_update(struct dt_iop_module_t *self)
   const gboolean is_modern = strcmp(workflow, "modern") == 0;
   g_free(workflow);
 
-  if(is_modern)
+  if(is_modern && tempK > 6500.f && tempK <= 6504.f)
   {
     // if we use modern chroma adatation, white balance is handled by channelmixerrgb
     // so we hide most of the controls here to not confuse users


### PR DESCRIPTION
fix #6803

Similar in logic to display-referred/scene-referred workflow. Offers 2 worflows : 
* modern
* legacy
![Screenshot_20201110_024018](https://user-images.githubusercontent.com/2779157/98616939-230ca180-22fe-11eb-8390-afd02d60fc50.png)

Legacy is the current one. It will set channelmixerrgb defaults to be a simple channel mixer, disabled by default, and will rely on current white balance module to apply the raw WB from EXIF coeffs.

Modern will set channelmixer enabled by default with chromatic adaptation adjusted from raw WB EXIF coeffs and will set the white balance to camera default (D65) only to help demosaicing. Since white balance is handled in channelmixerrgb, the white balance module is stripped from most of its options, only the actual RGB coeff are accessible but toggled off by default.
![Screenshot_20201110_023637](https://user-images.githubusercontent.com/2779157/98617121-9ca48f80-22fe-11eb-9138-dcc50aa93c4a.png)
