### PR TITLE
connect histogram scroll to right exposure instance

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -218,7 +218,7 @@ typedef struct dt_develop_t
   {
     // list of exposure iop instances, with plugin hooks, used by histogram dragging functions
     // each element is dt_dev_proxy_exposure_t
-    GList *exposure;
+    dt_dev_proxy_exposure_t exposure;
 
     // modulegroups plugin hooks
     struct
@@ -388,8 +388,6 @@ void dt_dev_invalidate_from_gui(dt_develop_t *dev);
  * exposure plugin hook, set the exposure and the black level
  */
 
-/** a function used to sort the list */
-gint dt_dev_exposure_hooks_sort(gconstpointer a, gconstpointer b);
 /** check if exposure iop hooks are available */
 gboolean dt_dev_exposure_hooks_available(dt_develop_t *dev);
 /** reset exposure to defaults */

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2893,7 +2893,13 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
     }
 
     // switch accelerators to new module
-    if(accel_mod_new) dt_accel_connect_instance_iop(accel_mod_new);
+    if(accel_mod_new)
+    {
+      dt_accel_connect_instance_iop(accel_mod_new);
+
+      if(!strcmp(accel_mod_new->op, "exposure"))
+        darktable.develop->proxy.exposure.module = accel_mod_new;
+    }
   }
 }
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -133,14 +133,12 @@ void connect_key_accels(dt_iop_module_t *self)
   /* register hooks with current dev so that  histogram
      can interact with this module.
   */
-  dt_dev_proxy_exposure_t *instance = g_malloc0(sizeof(dt_dev_proxy_exposure_t));
+  dt_dev_proxy_exposure_t *instance = &darktable.develop->proxy.exposure;
   instance->module = self;
   instance->set_exposure = dt_iop_exposure_set_exposure;
   instance->get_exposure = dt_iop_exposure_get_exposure;
   instance->set_black = dt_iop_exposure_set_black;
   instance->get_black = dt_iop_exposure_get_black;
-  darktable.develop->proxy.exposure
-      = g_list_prepend(darktable.develop->proxy.exposure, instance);
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
@@ -914,18 +912,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  GList *instances = darktable.develop->proxy.exposure;
-  while(instances != NULL)
-  {
-    GList *next = g_list_next(instances);
-    dt_dev_proxy_exposure_t *instance = (dt_dev_proxy_exposure_t *)instances->data;
-    if(instance->module == self)
-    {
-      g_free(instance);
-      darktable.develop->proxy.exposure = g_list_delete_link(darktable.develop->proxy.exposure, instances);
-    }
-    instances = next;
-  }
+  if(darktable.develop->proxy.exposure.module == self)
+    darktable.develop->proxy.exposure.module = NULL;
 
   free(g->deflicker_histogram);
   g->deflicker_histogram = NULL;


### PR DESCRIPTION
fixes #6806

removed list of exposure module proxies used by histogram to respond to mouse wheel scroll. The list-of-modules approach was orthogonal to the active multi-instance module scoring approach and got broken by #6648.

I've left the find_last_exposure_instance in place, just in case in future different modules are able to respond to exposure change requests, but at the moment it just returns the one instance of the proxy. Also to limit the size of this bug-fix patch.

