### PR TITLE
Hide the output parametric mask channels by default

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -161,7 +161,8 @@ typedef enum dt_develop_blendif_channels_t
   DEVELOP_BLENDIF_SIZE = 16,
 
   DEVELOP_BLENDIF_Lab_MASK = 0x3377,
-  DEVELOP_BLENDIF_RGB_MASK = 0x77FF
+  DEVELOP_BLENDIF_RGB_MASK = 0x77FF,
+  DEVELOP_BLENDIF_OUTPUT_MASK = 0xF0F0
 } dt_develop_blendif_channels_t;
 
 
@@ -443,6 +444,7 @@ typedef struct dt_iop_gui_blendif_filter_t
   GtkLabel *label[4];
   GtkLabel *picker_label;
   GtkWidget *polarity;
+  GtkBox *box;
 } dt_iop_gui_blendif_filter_t;
 
 typedef struct dt_iop_blend_name_value_t
@@ -509,6 +511,7 @@ typedef struct dt_iop_gui_blend_data_t
   dt_dev_pixelpipe_display_mask_t save_for_leave;
   int timeout_handle;
   GtkNotebook *channel_tabs;
+  gboolean output_channels_shown;
 
   GtkWidget *channel_boost_factor_slider;
 
@@ -632,6 +635,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module);
 void dt_iop_gui_update_masks(dt_iop_module_t *module);
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
 void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
+void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module);
 
 gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -73,6 +73,7 @@ void dt_iop_load_default_params(dt_iop_module_t *module)
   dt_develop_blend_colorspace_t cst = dt_develop_blend_default_module_blend_colorspace(module);
   dt_develop_blend_init_blend_parameters(module->default_blendop_params, cst);
   dt_iop_commit_blend_params(module, module->default_blendop_params);
+  dt_iop_gui_blending_reload_defaults(module);
 }
 
 static void dt_iop_modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,


### PR DESCRIPTION
The output parametric masks are sensitive to the output of the module, which means that when the settings of the module are updated and the output changes, it may be needed to adapt the masks again.

In order to simplify the usage of the parametric masking (and prefer the use of the input parametric masks), the output parametric mask controls will be hidden by default except if the blending of the module uses some of the output parametric mask channels.

An additional option is shown in the blending menu to show or hide the output parametric mask controls.

When hiding the output parametric mask controls the settings of those channels will be reset to avoid impacting the mask with hidden information.

@aurelienpierre I hope this suits you ;)