### PR TITLE
Keep parametric mask settings on colorspace change

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -353,6 +353,7 @@ void dt_dev_reload_image(dt_develop_t *dev, const uint32_t imgid);
 int dt_dev_is_current_image(dt_develop_t *dev, uint32_t imgid);
 void dt_dev_add_history_item_ext(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable, gboolean no_image);
 void dt_dev_add_history_item(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable);
+void dt_dev_add_new_history_item(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable);
 void dt_dev_add_masks_history_item_ext(dt_develop_t *dev, struct dt_iop_module_t *_module, gboolean _enable, gboolean no_image);
 void dt_dev_add_masks_history_item(dt_develop_t *dev, struct dt_iop_module_t *_module, gboolean enable);
 void dt_dev_reload_history_items(dt_develop_t *dev);


### PR DESCRIPTION
When the color space of the blending module is changed, the parametric mask settings would be lost because they need to be reinitialized.

Improve the situation by looking up in the history the last edit of the blending parametric masks with the selected color space and copying them instead of starting with a fresh setting.

When changing the color space of the blending module, a new history item is now forced on top of the history.

Fixes #6843