### PR TITLE
rework modules descriptions

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3053,15 +3053,15 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module)
 char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, const char *purpose, const char *input, const char *process,
                              const char *output)
 {
-  char *str_purpose = g_strdup(_("purpose"));
-  char *str_input = g_strdup(_("input"));
-  char *str_process = g_strdup(_("process"));
-  char *str_output = g_strdup(_("output"));
+  char *str_purpose = _("purpose");
+  char *str_input = _("input");
+  char *str_process = _("process");
+  char *str_output = _("output");
 
-  char *icon_purpose = g_strdup("🖌");
-  char *icon_input = g_strdup("⇥");
-  char *icon_process = g_strdup("⟴");
-  char *icon_output = g_strdup("↦");
+  char *icon_purpose = "🖌";
+  char *icon_input = "⇥";
+  char *icon_process = "⟴";
+  char *icon_output = "↦";
 
 
   /* if the font can't display icons, default to nothing
@@ -3069,7 +3069,7 @@ char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, con
   * into Gtk useless docs without examples. Good luck.
   PangoFontDescription *desc = darktable.bauhaus->pango_font_desc;
   if(!pango_font_has_char(desc->get_font(), g_utf8_to_ucs4(icon_purpose, 1)))
-    icon_purpose = icon_input = icon_process = icon_output = g_strdup("");
+    icon_purpose = icon_input = icon_process = icon_output = "";
   */
 
   char *str_out = g_strdup_printf("%s.\n\n"
@@ -3082,14 +3082,6 @@ char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, con
                                   icon_input, str_input, input,
                                   icon_process, str_process, process,
                                   icon_output, str_output, output);
-  g_free(str_purpose);
-  g_free(str_input);
-  g_free(str_process);
-  g_free(str_output);
-  g_free(icon_purpose);
-  g_free(icon_input);
-  g_free(icon_process);
-  g_free(icon_output);
 
   return str_out;
 }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -176,7 +176,7 @@ typedef struct dt_iop_module_so_t
   int (*default_group)(void);
   int (*flags)(void);
 
-  const char *(*description)(void);
+  const char *(*description)(struct dt_iop_module_t *self);
   /* should return a string with 5 lines:
      line 1 : summary of what it does
      line 2 : oriented creative or corrective ?
@@ -414,7 +414,7 @@ typedef struct dt_iop_module_t
   int (*flags)(void);
 
   /** get a descriptive text used for example in a tooltip in more modules */
-  const char *(*description)(void);
+  const char *(*description)(struct dt_iop_module_t *self);
 
   int (*operation_tags)(void);
 
@@ -696,6 +696,10 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module);
 
 /** (un)hide iop module header right side buttons */
 gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
+
+// format modules description going in tooltips
+char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, const char *purpose, const char *input, const char *process,
+                             const char *output);
 
 #define IOP_GUI_ALLOC(module) (dt_iop_##module##_gui_data_t *)(self->gui_data = calloc(1, sizeof(dt_iop_##module##_gui_data_t)))
 #define IOP_GUI_FREE free(self->gui_data); self->gui_data = NULL

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -113,13 +113,13 @@ const char *name()
   return _("perspective correction");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("distort perspective automatically,\n"
-           "for corrective and creative purposes.\n"
-           "works in RGB,\n"
-           "takes preferably a linear RGB input,\n"
-           "outputs linear RGB.");
+  return dt_iop_set_description(self, _("distort perspective automatically"),
+                                      _("corrective"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("geometric, RGB"),
+                                      _("linear, RGB, scene-referred"));
 }
 
 int flags()

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -118,13 +118,13 @@ const char *name()
   return _("contrast equalizer");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("add or remove local contrast,\n"
-           "for corrective and creative purposes.\n"
-           "works in Lab,\n"
-           "takes preferably a linear RGB input,\n"
-           "outputs almost linear RGB.");
+  return dt_iop_set_description(self, _("add or remove local contrast, sharpness, acutance"),
+                                      _("corrective and creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("frequential, RGB"),
+                                      _("linear, Lab, scene-referred"));
 }
 
 int default_group()

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -332,13 +332,14 @@ const char *name()
   return _("base curve");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("apply a view transform based on personal or camera manufacturer look,\n"
-           "for corrective purposes, to prepare images for display.\n"
-           "works in RGB,\n"
-           "takes preferably a linear RGB input,\n"
-           "outputs non-linear RGB.");
+  return dt_iop_set_description(self, _("apply a view transform based on personal or camera manufacturer look,\n"
+                                        "for corrective purposes, to prepare images for display"),
+                                      _("corrective"),
+                                      _("linear, RGB, display-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
 }
 
 int default_group()

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -135,13 +135,13 @@ const char *name()
   return _("basic adjustments");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("apply usual adjustments,\n"
-           "for corrective and creative purposes.\n"
-           "works in RGB,\n"
-           "takes preferably a linear RGB input,\n"
-           "outputs non-linear RGB.");
+  return dt_iop_set_description(self, _("apply usual image adjustments"),
+                                      _("creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, scene-referred"));
 }
 
 int default_group()

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -93,13 +93,13 @@ const char *name()
   return _("local contrast");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("manipulate local and global contrast separately,\n"
-           "for corrective and creative purposes.\n"
-           "works in Lab,\n"
-           "takes any RGB input,\n"
-           "outputs non-linear RGB.");
+  return dt_iop_set_description(self, _("manipulate local and global contrast separately"),
+                                      _("creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
 }
 
 // some additional flags (self explanatory i think):

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -76,14 +76,15 @@ const char *name()
   return _("bloom");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("apply Orton effect for a dreamy aetherical look,\n"
-           "for creative purposes.\n"
-           "works in Lab,\n"
-           "takes preferably a linear RGB input,\n"
-           "outputs non-linear RGB.");
+  return dt_iop_set_description(self, _("apply Orton effect for a dreamy aetherical look"),
+                                      _("creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
 }
+
 
 int flags()
 {

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -180,6 +180,16 @@ const char *name()
   return _("framing");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("add solid borders or margins around the picture"),
+                                      _("creative"),
+                                      _("linear or non-linear, RGB, display-referred"),
+                                      _("geometric, RGB"),
+                                      _("linear or non-linear, RGB, display-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_EFFECT | IOP_GROUP_EFFECTS;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -53,6 +53,16 @@ const char *name()
   return _("chromatic aberrations");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("correct chromatic aberrations for Bayer sensors"),
+                                      _("corrective"),
+                                      _("linear, raw, scene-referred"),
+                                      _("linear, raw"),
+                                      _("linear, raw, scene-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -125,6 +125,18 @@ const char *name()
   return _("channel mixer");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("perform color space corrections\n"
+                                        "such as white balance, channels mixing\n"
+                                        "and conversions to monochrome emulating film"),
+                                      _("corrective or creative"),
+                                      _("linear, RGB, display-referred"),
+                                      _("linear, RGB"),
+                                      _("linear, RGB, display-referred"));
+}
+
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -128,6 +128,17 @@ const char *name()
   return _("color calibration");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("perform color space corrections\n"
+                                        "such as white balance, channels mixing\n"
+                                        "and conversions to monochrome emulating film"),
+                                      _("corrective or creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("linear, RGB or XYZ"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -316,6 +316,15 @@ const char *name()
   return _("crop and rotate");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("change the framing and correct the perspective"),
+                                      _("corrective or creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("geometric, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_TECHNICAL;

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -79,6 +79,15 @@ const char *name()
   return _("contrast brightness saturation");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("adjust the look of the image"),
+                                      _("creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -149,13 +149,13 @@ const char *name()
   return _("color balance");
 }
 
-const char *description()
+const char *description(struct dt_iop_module_t *self)
 {
-  return _("affect color, brightness and contrast\n"
-           "for corrective and creative purposes.\n"
-           "works in RGB\n"
-           "takes preferably a linear RGB input,\n"
-           "outputs possibly non-linear RGB, depending on settings.");
+  return dt_iop_set_description(self, _("affect color, brightness and contrast"),
+                                      _("corrective or creative"),
+                                      _("linear, Lab, scene-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, Lab, scene-referred"));
 }
 
 int flags()

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -114,6 +114,17 @@ const char *name()
   return _("color look up table");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("perform color space corrections\n"
+                                        "and apply looks"),
+                                      _("corrective or creative"),
+                                      _("linear or non-linear, Lab, display-referred"),
+                                      _("defined by profile, Lab"),
+                                      _("linear or non-linear, Lab, display-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_COLOR | IOP_GROUP_TECHNICAL;

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -88,6 +88,16 @@ const char *name()
   return _("color contrast");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("increase saturation and separation between\n"
+                                        "opposite colors"),
+                                      _("creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -71,6 +71,15 @@ const char *name()
   return _("color correction");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("correct white balance selectively for blacks and whites"),
+                                      _("corrective or creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -126,6 +126,16 @@ const char *name()
   return _("input color profile");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("convert any RGB input to pipeline reference RGB\n"
+                                        "using color profiles to remap RGB values"),
+                                      _("mandatory"),
+                                      _("linear or non-linear, RGB, scene-referred"),
+                                      _("defined by profile"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_COLOR | IOP_GROUP_TECHNICAL;

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -146,6 +146,15 @@ const char *name()
   return _("color mapping");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("transfer a color palette and tonal repartition from one image to another"),
+                                      _("creative"),
+                                      _("linear or non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_EFFECT | IOP_GROUP_EFFECTS;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -81,6 +81,18 @@ const char *name()
   return _("output color profile");
 }
 
+
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("convert pipeline reference RGB to any display RGB\n"
+                                        "using color profiles to remap RGB values"),
+                                      _("mandatory"),
+                                      _("linear or non-linear, RGB or Lab, display-referred"),
+                                      _("defined by profile"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_COLOR | IOP_GROUP_TECHNICAL;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -129,6 +129,15 @@ const char *name()
   return _("color reconstruction");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("recover clipped highlights by propagating surrounding colors"),
+                                      _("corrective"),
+                                      _("linear or non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   // we do not allow tiling. reason: this module needs to see the full surrounding of highlights.

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -138,6 +138,15 @@ const char *name()
   return _("color zones");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("selectively shift hues, saturation and brightness of pixels"),
+                                      _("creative"),
+                                      _("linear or non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -69,6 +69,15 @@ const char *name()
   return _("defringe");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("attenuate chromatic aberration by desaturating edges"),
+                                      _("corrective"),
+                                      _("linear or non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -170,6 +170,15 @@ const char *name()
   return _("demosaic");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("reconstruct full RGB pixels from a sensor color filter array reading"),
+                                      _("mandatory"),
+                                      _("linear, raw, scene-referred"),
+                                      _("linear, raw"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_TECHNICAL;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -627,6 +627,15 @@ const char *name()
   return _("denoise (profiled)");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("denoise using noise statistics profiled on sensors"),
+                                      _("corrective"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("linear, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -104,6 +104,15 @@ const char *name()
   return _("dithering");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("reduce banding and posterization effects in output JPEGs by adding random noise"),
+                                      _("corrective"),
+                                      _("non-linear, RGB, display-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -108,6 +108,16 @@ const char *name()
   return _("exposure");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("redo the exposure of the shot as if you were still in-camera\n"
+                                        "using a color-safe brightening similar to increasing ISO setting"),
+                                      _("corrective and creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("linear, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_TECHNICAL;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -307,6 +307,17 @@ const char *name()
   return _("filmic rgb");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("apply a view transform to prepare the scene-referred pipeline\n"
+                                        "for display on SDR screens and paper prints\n"
+                                        "while preventing clipping in non-destructive ways"),
+                                      _("corrective and creative"),
+                                      _("linear or non-linear, RGB, scene-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_TONE | IOP_GROUP_TECHNICAL;

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -147,6 +147,15 @@ const char *name()
   return _("graduated density");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("simulate an optical graduated neutral density filter"),
+                                      _("corrective and creative"),
+                                      _("linear, linear or non-linear, RGB, scene-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -420,6 +420,15 @@ const char *name()
   return _("grain");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("simulate silver grains from film"),
+                                      _("creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -99,6 +99,14 @@ const char *name()
   return _("haze removal");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("remove fog and atmospheric hazing from pictures"),
+                                      _("corrective"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("frequential, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
 
 int flags()
 {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -81,6 +81,15 @@ const char *name()
   return _("highlight reconstruction");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("avoid magenta highlights and try to recover highlights colors"),
+                                      _("corrective"),
+                                      _("linear, raw, scene-referred"),
+                                      _("reconstruction, raw"),
+                                      _("linear, raw, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_TECHNICAL;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -90,6 +90,15 @@ const char *name()
   return _("highpass");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("isolate high frequencies in the image"),
+                                      _("creative"),
+                                      _("linear or non-linear, Lab, scene-referred"),
+                                      _("frequential, Lab"),
+                                      _("special, Lab, scene-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
@@ -453,7 +462,7 @@ static void blur_vertical_4ch(float *buf, const int height, const int width, con
     scanline[4*y+2] = L[2] / hits;
     scanline[4*y+3] = L[3] / hits;
   }
-  
+
   // copy blurred values back to original location in buffer
   for (size_t y = 0; y < height; y++)
   {

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -66,6 +66,16 @@ const char *name()
   return _("hot pixels");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("remove abnormally bright pixels by dampening them with neighbours"),
+                                      _("corrective"),
+                                      _("linear, raw, scene-referred"),
+                                      _("reconstruction, raw"),
+                                      _("linear, raw, scene-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -110,6 +110,16 @@ const char *name()
   return _("invert");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("invert film negatives"),
+                                      _("corrective"),
+                                      _("linear, raw, display-referred"),
+                                      _("linear, raw"),
+                                      _("linear, raw, display-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_TECHNICAL;

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -74,7 +74,7 @@ int default_group(void);
 int flags(void);
 
 /** get a descriptive text used for example in a tooltip in more modules */
-const char *description(void);
+const char *description(struct dt_iop_module_t *self);
 
 int operation_tags(void);
 int operation_tags_filter(void);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -148,6 +148,16 @@ const char *name()
   return _("lens correction");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("correct lenses optical flaws"),
+                                      _("corrective"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("geometric and reconstruction, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -292,6 +292,16 @@ const char *name()
   return _("liquify");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("distort parts of the image"),
+                                      _("creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("geometric, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_EFFECTS;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -86,6 +86,15 @@ const char *name()
   return _("lowlight vision");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("simulate human night vision"),
+                                      _("creative"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("linear, XYZ"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -129,6 +129,15 @@ const char *name()
   return _("lowpass");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("isolate low frequencies in the image"),
+                                      _("creative"),
+                                      _("linear or non-linear, Lab, scene-referred"),
+                                      _("frequential, Lab"),
+                                      _("special, Lab, scene-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -132,6 +132,15 @@ const char *name()
   return _("lut 3D");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("perform color space corrections and apply look"),
+                                      _("corrective or creative"),
+                                      _("linear, RGB, display-referred"),
+                                      _("defined by profile, RGB"),
+                                      _("linear or non-linear, RGB, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -201,6 +201,14 @@ const char *name()
   return _("negadoctor");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("invert film negative scans and simulate printing on paper"),
+                                      _("corrective and creative"),
+                                      _("linear, RGB, display-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
 
 int flags()
 {

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -88,6 +88,15 @@ const char *name()
   return _("denoise (non-local means)");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("apply a poisson noise removal best suited for astrophotography"),
+                                      _("corrective"),
+                                      _("non-linear, Lab, display-referred"),
+                                      _("non-linear, Lab"),
+                                      _("non-linear, Lab, display-referred"));
+}
+
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -94,6 +94,15 @@ const char *name()
   return _("unbreak input profile");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("correct input color profiles meant to be applied on non-linear RGB."),
+                                      _("corrective"),
+                                      _("linear, RGB, display-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_COLOR | IOP_GROUP_TECHNICAL;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -121,6 +121,15 @@ const char *name()
   return _("raw denoise");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("denoise the raw picture early in the pipeline"),
+                                      _("corrective"),
+                                      _("linear, raw, scene-referred"),
+                                      _("linear, raw"),
+                                      _("linear, raw, scene-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_SUPPORTS_BLENDING;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -195,6 +195,15 @@ const char *name()
   return _("retouch");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("remove and clone spots, perform split-frequency skin editing"),
+                                      _("corrective"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("geometric and frequential, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_EFFECTS;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -56,6 +56,15 @@ const char *name()
   return _("spot removal");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("remove sensor dust spots"),
+                                      _("corrective"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("geometric, raw"),
+                                      _("linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_EFFECTS;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -194,6 +194,15 @@ const char *name()
   return C_("modulename", "white balance");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("scale raw RGB channels to balance white and help demosaicing"),
+                                      _("corrective"),
+                                      _("linear, raw, scene-referred"),
+                                      _("linear, raw"),
+                                      _("linear, raw, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_GRADING;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -308,6 +308,15 @@ const char *name()
   return _("tone equalizer");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("relight the scene as if the lighting was done directly on the scene"),
+                                      _("corrective and creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("quasi-linear, RGB"),
+                                      _("quasi-linear, RGB, scene-referred"));
+}
+
 int default_group()
 {
   return IOP_GROUP_BASIC | IOP_GROUP_GRADING;

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -154,6 +154,15 @@ const char *name()
   return _("vignetting");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("simulate a lens fall-off close to edges"),
+                                      _("creative"),
+                                      _("non-linear, RGB, display-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -284,6 +284,15 @@ const char *name()
   return _("watermark");
 }
 
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("overlay an SVG watermark like a signature on the picture"),
+                                      _("creative"),
+                                      _("non-linear, RGB, display-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, RGB, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;


### PR DESCRIPTION
Add and normalize module descriptions which appear in tooltip when hovering the labels in darkroom.

Not all modules are done, this is proof of concept for validation (can be merged already if accepted).
![Screenshot_20201111_185410](https://user-images.githubusercontent.com/2779157/98846552-6aef0e00-244f-11eb-8420-c9b10f954668.png)

The form is uniform:

> description
>
> purpose of the module : corrective, creative or both,
> input expected by the module: linear or not, color space, display or scene referred,
> kind of processing: linear or not or geometrical or frequential, color space,
> output returned by the module: linear or not, color space, display or scene referred.

display-referred means the RGB has to be bounded in [0; 1] but can still be linearly encoded.
scene-referred means the RGB is unbounded in [0; + infinity[ but can be non-linearly encoded.
non-linear display-referred means the RGB is bounded to [0; 1] AND grey is expected at 18% or 50%, depending on encoding.
geometrical processing means the module does not affect pixel intensity but its only position
frequential processing means the module does high-pass, band-pass and low-pass manipulations.