### PR TITLE
Improve display of parametric mask channels

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -177,12 +177,12 @@ blendif_factor_Lab(const float4 input, const float4 output,
   if(!(mask_mode & DEVELOP_MASK_CONDITIONAL)) return (mask_combine & DEVELOP_COMBINE_INCL) ? 0.0f : 1.0f;
 
   scaled[DEVELOP_BLENDIF_L_in] = input.x / 100.0f,			// L scaled to 0..1
-  scaled[DEVELOP_BLENDIF_A_in] = input.y / 128.0f;		// a scaled to -0.5..0.5
-  scaled[DEVELOP_BLENDIF_B_in] = input.z / 128.0f;		// b scaled to -0.5..0.5
+  scaled[DEVELOP_BLENDIF_A_in] = input.y / 256.0f;		// a scaled to -0.5..0.5
+  scaled[DEVELOP_BLENDIF_B_in] = input.z / 256.0f;		// b scaled to -0.5..0.5
 
   scaled[DEVELOP_BLENDIF_L_out] = output.x / 100.0f;			// L scaled to 0..1
-  scaled[DEVELOP_BLENDIF_A_out] = output.y / 128.0f;		// a scaled to -0.5..0.5
-  scaled[DEVELOP_BLENDIF_B_out] = output.z / 128.0f;		// b scaled to -0.5..0.5
+  scaled[DEVELOP_BLENDIF_A_out] = output.y / 256.0f;		// a scaled to -0.5..0.5
+  scaled[DEVELOP_BLENDIF_B_out] = output.z / 256.0f;		// b scaled to -0.5..0.5
 
 
   if((blendif & 0x7f00) != 0)  // do we need to consider LCh ?

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -440,6 +440,25 @@ static inline void dt_XYZ_to_sRGB_clipped(const float *const XYZ, float *const s
 #undef CLIP
 }
 
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(sRGB, XYZ_D50: 16)
+#endif
+static inline void dt_Rec709_to_XYZ_D50(const float *const DT_RESTRICT sRGB, float *const DT_RESTRICT XYZ_D50)
+{
+  // Conversion matrix from http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html
+  const float M[3][4] DT_ALIGNED_PIXEL = {
+      { 0.4360747f, 0.3850649f, 0.1430804f, 0.0f },
+      { 0.2225045f, 0.7168786f, 0.0606169f, 0.0f },
+      { 0.0139322f, 0.0971045f, 0.7141733f, 0.0f },
+  };
+
+  // sRGB -> XYZ
+  for(size_t x = 0; x < 3; x++)
+      XYZ_D50[x] = M[x][0] * sRGB[0] + M[x][1] * sRGB[1] + M[x][2] * sRGB[2];
+}
+
+
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -161,12 +161,12 @@ void dt_develop_blendif_process_parameters(float *const restrict parameters,
       parameters[j + 4] = 1.0f / fmaxf(0.001f, parameters[j + 1] - parameters[j + 0]);
       parameters[j + 5] = 1.0f / fmaxf(0.001f, parameters[j + 3] - parameters[j + 2]);
       // handle the case when one end is open to avoid clipping input/output values
-      if(blendif_parameters[i * 4 + 0] <= -offset && blendif_parameters[i * 4 + 1] <= -offset)
+      if(blendif_parameters[i * 4 + 0] <= 0.0f && blendif_parameters[i * 4 + 1] <= 0.0f)
       {
         parameters[j + 0] = -INFINITY;
         parameters[j + 1] = -INFINITY;
       }
-      if(blendif_parameters[i * 4 + 2] >= 1.0f - offset && blendif_parameters[i * 4 + 3] >= 1.0f - offset)
+      if(blendif_parameters[i * 4 + 2] >= 1.0f && blendif_parameters[i * 4 + 3] >= 1.0f)
       {
         parameters[j + 2] = INFINITY;
         parameters[j + 3] = INFINITY;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -130,23 +130,29 @@ const dt_iop_gui_blendif_colorstop_t _gradient_L[]
         { 0.5f,   { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
         { 1.0f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
 
-const dt_iop_gui_blendif_colorstop_t _gradient_a[]
-    = { { 0.0f,   { 0, 0.34 * NEUTRAL_GRAY * 2, 0.27 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.25f,  { 0.25 * NEUTRAL_GRAY * 2, 0.34 * NEUTRAL_GRAY * 2, 0.39 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.375f, { 0.375 * NEUTRAL_GRAY * 2, 0.46 * NEUTRAL_GRAY * 2, 0.45 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.5f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 0.625f, { 0.51 * NEUTRAL_GRAY * 2, 0.4 * NEUTRAL_GRAY * 2, 0.45 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.75f,  { 0.52 * NEUTRAL_GRAY * 2, 0.29 * NEUTRAL_GRAY * 2, 0.39 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 1.0f,   { 0.53 * NEUTRAL_GRAY * 2, 0.08 * NEUTRAL_GRAY * 2, 0.28 * NEUTRAL_GRAY * 2, 1.0 } } };
+// The values for "a" are generated in the following way:
+//   Lab (with L=[90 to 68], b=0, and a=[-56 to 56] -> sRGB (D65 linear) -> normalize with MAX(R,G,B) = 0.75
+const dt_iop_gui_blendif_colorstop_t _gradient_a[] = {
+    { 0.000f, { 0.0112790f, 0.7500000f, 0.5609999f, 1.0f } },
+    { 0.250f, { 0.2888855f, 0.7500000f, 0.6318934f, 1.0f } },
+    { 0.375f, { 0.4872486f, 0.7500000f, 0.6825501f, 1.0f } },
+    { 0.500f, { 0.7500000f, 0.7499399f, 0.7496052f, 1.0f } },
+    { 0.625f, { 0.7500000f, 0.5054633f, 0.5676756f, 1.0f } },
+    { 0.750f, { 0.7500000f, 0.3423850f, 0.4463195f, 1.0f } },
+    { 1.000f, { 0.7500000f, 0.1399815f, 0.2956989f, 1.0f } },
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_b[]
-    = { { 0.0f,   { 0, 0.27 * NEUTRAL_GRAY * 2, 0.58 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.25f,  { 0.25 * NEUTRAL_GRAY * 2, 0.39 * NEUTRAL_GRAY * 2, 0.54 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.375f, { 0.38 * NEUTRAL_GRAY * 2, 0.45 * NEUTRAL_GRAY * 2, 0.52 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.5f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 0.625f, { 0.58 * NEUTRAL_GRAY * 2, 0.55 * NEUTRAL_GRAY * 2, 0.38 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.75f,  { 0.66 * NEUTRAL_GRAY * 2, 0.59 * NEUTRAL_GRAY * 2, 0.25 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 1.0f,   { 0.81 * NEUTRAL_GRAY * 2, 0.66 * NEUTRAL_GRAY * 2, 0, 1.0 } } };
+// The values for "b" are generated in the following way:
+//   Lab (with L=[58 to 62], a=0, and b=[-65 to 65] -> sRGB (D65 linear) -> normalize with MAX(R,G,B) = 0.75
+const dt_iop_gui_blendif_colorstop_t _gradient_b[] = {
+    { 0.000f, { 0.0162050f, 0.1968228f, 0.7500000f, 1.0f } },
+    { 0.250f, { 0.2027354f, 0.3168822f, 0.7500000f, 1.0f } },
+    { 0.375f, { 0.3645722f, 0.4210476f, 0.7500000f, 1.0f } },
+    { 0.500f, { 0.6167146f, 0.5833379f, 0.7500000f, 1.0f } },
+    { 0.625f, { 0.7500000f, 0.6172369f, 0.5412091f, 1.0f } },
+    { 0.750f, { 0.7500000f, 0.5590797f, 0.3071980f, 1.0f } },
+    { 1.000f, { 0.7500000f, 0.4963975f, 0.0549797f, 1.0f } },
+};
 
 const dt_iop_gui_blendif_colorstop_t _gradient_gray[]
     = { { 0.0f,   { 0, 0, 0, 1.0 } },
@@ -155,60 +161,83 @@ const dt_iop_gui_blendif_colorstop_t _gradient_gray[]
         { 0.5f,   { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
         { 1.0f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
 
-const dt_iop_gui_blendif_colorstop_t _gradient_red[]
-    = { { 0.0f,   { 0, 0, 0, 1.0 } },
-        { 0.125f, { NEUTRAL_GRAY / 8, 0, 0, 1.0 } },
-        { 0.25f,  { NEUTRAL_GRAY / 4, 0, 0, 1.0 } },
-        { 0.5f,   { NEUTRAL_GRAY / 2, 0, 0, 1.0 } },
-        { 1.0f,   { NEUTRAL_GRAY, 0, 0, 1.0 } } };
+const dt_iop_gui_blendif_colorstop_t _gradient_red[] = {
+    { 0.000f, { 0.0000000f, 0.0000000f, 0.0000000f, 1.0f } },
+    { 0.125f, { 0.0937500f, 0.0000000f, 0.0000000f, 1.0f } },
+    { 0.250f, { 0.1875000f, 0.0000000f, 0.0000000f, 1.0f } },
+    { 0.500f, { 0.3750000f, 0.0000000f, 0.0000000f, 1.0f } },
+    { 1.000f, { 0.7500000f, 0.0000000f, 0.0000000f, 1.0f } }
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_green[]
-    = { { 0.0f,   { 0, 0, 0, 1.0 } },
-        { 0.125f, { 0, NEUTRAL_GRAY / 8, 0, 1.0 } },
-        { 0.25f,  { 0, NEUTRAL_GRAY / 8, 0, 1.0 } },
-        { 0.5f,   { 0, NEUTRAL_GRAY / 2, 0, 1.0 } },
-        { 1.0f,   { 0, NEUTRAL_GRAY, 0, 1.0 } } };
+const dt_iop_gui_blendif_colorstop_t _gradient_green[] = {
+    { 0.000f, { 0.0000000f, 0.0000000f, 0.0000000f, 1.0f } },
+    { 0.125f, { 0.0000000f, 0.0937500f, 0.0000000f, 1.0f } },
+    { 0.250f, { 0.0000000f, 0.1875000f, 0.0000000f, 1.0f } },
+    { 0.500f, { 0.0000000f, 0.3750000f, 0.0000000f, 1.0f } },
+    { 1.000f, { 0.0000000f, 0.7500000f, 0.0000000f, 1.0f } }
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_blue[]
-    = { { 0.0f,   { 0, 0, 0, 1.0 } },
-        { 0.125f, { 0, 0, NEUTRAL_GRAY / 8, 1.0 } },
-        { 0.25f,  { 0, 0, NEUTRAL_GRAY / 4, 1.0 } },
-        { 0.5f,   { 0, 0, NEUTRAL_GRAY / 2, 1.0 } },
-        { 1.0f,   { 0, 0, NEUTRAL_GRAY, 1.0 } } };
+const dt_iop_gui_blendif_colorstop_t _gradient_blue[] = {
+    { 0.000f, { 0.0000000f, 0.0000000f, 0.0000000f, 1.0f } },
+    { 0.125f, { 0.0000000f, 0.0000000f, 0.0937500f, 1.0f } },
+    { 0.250f, { 0.0000000f, 0.0000000f, 0.1875000f, 1.0f } },
+    { 0.500f, { 0.0000000f, 0.0000000f, 0.3750000f, 1.0f } },
+    { 1.000f, { 0.0000000f, 0.0000000f, 0.7500000f, 1.0f } }
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_chroma[]
-    = { { 0.0f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 0.125f, { NEUTRAL_GRAY, NEUTRAL_GRAY * 0.875, NEUTRAL_GRAY, 1.0 } },
-        { 0.25f,  { NEUTRAL_GRAY, NEUTRAL_GRAY * 0.75, NEUTRAL_GRAY, 1.0 } },
-        { 0.5f,   { NEUTRAL_GRAY, NEUTRAL_GRAY * 0.5, NEUTRAL_GRAY, 1.0 } },
-        { 1.0f,   { NEUTRAL_GRAY, 0, NEUTRAL_GRAY, 1.0 } } };
+// The chroma values are displayed in a gradient from {0.5,0.5,0.5} to {0.5,0.0,0.5} (pink)
+const dt_iop_gui_blendif_colorstop_t _gradient_chroma[] = {
+    { 0.000f, { 0.5000000f, 0.5000000f, 0.5000000f, 1.0f } },
+    { 0.125f, { 0.5000000f, 0.4375000f, 0.5000000f, 1.0f } },
+    { 0.250f, { 0.5000000f, 0.3750000f, 0.5000000f, 1.0f } },
+    { 0.500f, { 0.5000000f, 0.2500000f, 0.5000000f, 1.0f } },
+    { 1.000f, { 0.5000000f, 0.0000000f, 0.5000000f, 1.0f } }
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_hue[]
-    = { { 0.0f,   { 1.00f * 1.5f * NEUTRAL_GRAY, 0.68f * 1.5f * NEUTRAL_GRAY, 0.78f * 1.5f * NEUTRAL_GRAY, 1.0 } },
-        { 0.166f, { 0.95f * 1.5f * NEUTRAL_GRAY, 0.73f * 1.5f * NEUTRAL_GRAY, 0.56f * 1.5f * NEUTRAL_GRAY, 1.0 } },
-        { 0.333f, { 0.71f * 1.5f * NEUTRAL_GRAY, 0.81f * 1.5f * NEUTRAL_GRAY, 0.55f * 1.5f * NEUTRAL_GRAY, 1.0 } },
-        { 0.500f, { 0.45f * 1.5f * NEUTRAL_GRAY, 0.85f * 1.5f * NEUTRAL_GRAY, 0.77f * 1.5f * NEUTRAL_GRAY, 1.0 } },
-        { 0.666f, { 0.49f * 1.5f * NEUTRAL_GRAY, 0.82f * 1.5f * NEUTRAL_GRAY, 1.00f * 1.5f * NEUTRAL_GRAY, 1.0 } },
-        { 0.833f, { 0.82f * 1.5f * NEUTRAL_GRAY, 0.74f * 1.5f * NEUTRAL_GRAY, 1.00f * 1.5f * NEUTRAL_GRAY, 1.0 } },
-        { 1.0f,   { 1.00f * 1.5f * NEUTRAL_GRAY, 0.68f * 1.5f * NEUTRAL_GRAY, 0.78f * 1.5f * NEUTRAL_GRAY, 1.0 } } };
+// The hue values for LCh are generated in the following way:
+//   LCh (with L=65 and C=37) -> sRGB (D65 linear) -> normalize with MAX(R,G,B) = 0.75
+// Please keep in sync with the display in the gamma module
+const dt_iop_gui_blendif_colorstop_t _gradient_LCh_hue[] = {
+    { 0.000f, { 0.7500000f, 0.2200405f, 0.4480174f, 1.0f } },
+    { 0.104f, { 0.7500000f, 0.2475123f, 0.2488547f, 1.0f } },
+    { 0.200f, { 0.7500000f, 0.3921083f, 0.2017670f, 1.0f } },
+    { 0.295f, { 0.7500000f, 0.7440329f, 0.3011876f, 1.0f } },
+    { 0.377f, { 0.3813996f, 0.7500000f, 0.3799668f, 1.0f } },
+    { 0.503f, { 0.0747526f, 0.7500000f, 0.7489037f, 1.0f } },
+    { 0.650f, { 0.0282981f, 0.3736209f, 0.7500000f, 1.0f } },
+    { 0.803f, { 0.2583821f, 0.2591069f, 0.7500000f, 1.0f } },
+    { 0.928f, { 0.7500000f, 0.2788102f, 0.7492077f, 1.0f } },
+    { 1.000f, { 0.7500000f, 0.2200405f, 0.4480174f, 1.0f } },
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_HUE[]
-    = { { 0.0f,   { NEUTRAL_GRAY, 0, 0, 1.0 } },
-        { 0.166f, { NEUTRAL_GRAY, NEUTRAL_GRAY, 0, 1.0 } },
-        { 0.332f, { 0, NEUTRAL_GRAY, 0, 1.0 } },
-        { 0.498f, { 0, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 0.664f, { 0, 0, NEUTRAL_GRAY, 1.0 } },
-        { 0.830f, { NEUTRAL_GRAY, 0, NEUTRAL_GRAY, 1.0 } },
-        { 1.0f,   { NEUTRAL_GRAY, 0, 0, 1.0 } } };
+// The hue values for HSL are generated in the following way:
+//   HSL (with S=0.5 and L=0.5) -> any RGB(linear) -> (normalize with MAX(R,G,B) = 0.75)
+// Please keep in sync with the display in the gamma module
+const dt_iop_gui_blendif_colorstop_t _gradient_HSL_hue[] = {
+    { 0.000f, { 0.7500000f, 0.2500000f, 0.2500000f, 1.0f } },
+    { 0.167f, { 0.7500000f, 0.7500000f, 0.2500000f, 1.0f } },
+    { 0.333f, { 0.2500000f, 0.7500000f, 0.2500000f, 1.0f } },
+    { 0.500f, { 0.2500000f, 0.7500000f, 0.7500000f, 1.0f } },
+    { 0.667f, { 0.2500000f, 0.2500000f, 0.7500000f, 1.0f } },
+    { 0.833f, { 0.7500000f, 0.2500000f, 0.7500000f, 1.0f } },
+    { 1.000f, { 0.7500000f, 0.2500000f, 0.2500000f, 1.0f } },
+};
 
-const dt_iop_gui_blendif_colorstop_t _gradient_jhue[]
-    = { { 0.0f,   { 0.7500000f, 0.3884988f, 0.5190513f, 1.0f } },
-        { 0.166f, { 0.7500000f, 0.5681609f, 0.0076022f, 1.0f } },
-        { 0.333f, { 0.4671101f, 0.7500000f, 0.0513506f, 1.0f } },
-        { 0.500f, { 0.3124952f, 0.7500000f, 0.7078146f, 1.0f } },
-        { 0.666f, { 0.2260024f, 0.2816575f, 0.7500000f, 1.0f } },
-        { 0.833f, { 0.3612153f, 0.2183850f, 0.7500000f, 1.0f } },
-        { 1.0f,   { 0.7500000f, 0.3884988f, 0.5190513f, 1.0f } } };
+// The hue values for JzCzhz are generated in the following way:
+//   JzCzhz (with Jz=0.011 and Cz=0.01) -> sRGB(D65 linear) -> normalize with MAX(R,G,B) = 0.75
+// Please keep in sync with the display in the gamma module
+const dt_iop_gui_blendif_colorstop_t _gradient_JzCzhz_hue[] = {
+    { 0.000f, { 0.7500000f, 0.1946971f, 0.3697612f, 1.0f } },
+    { 0.082f, { 0.7500000f, 0.2278141f, 0.2291548f, 1.0f } },
+    { 0.150f, { 0.7500000f, 0.3132381f, 0.1653960f, 1.0f } },
+    { 0.275f, { 0.7483232f, 0.7500000f, 0.1939316f, 1.0f } },
+    { 0.378f, { 0.2642865f, 0.7500000f, 0.2642768f, 1.0f } },
+    { 0.570f, { 0.0233180f, 0.7493543f, 0.7500000f, 1.0f } },
+    { 0.650f, { 0.1119025f, 0.5116763f, 0.7500000f, 1.0f } },
+    { 0.762f, { 0.3331225f, 0.3337235f, 0.7500000f, 1.0f } },
+    { 0.883f, { 0.7464700f, 0.2754816f, 0.7500000f, 1.0f } },
+    { 1.000f, { 0.7500000f, 0.1946971f, 0.3697612f, 1.0f } },
+};
 
 
 static inline dt_iop_colorspace_type_t _blendif_colorpicker_cst(dt_iop_gui_blend_data_t *data)
@@ -1789,7 +1818,7 @@ const dt_iop_gui_blendif_channel_t Lab_channels[]
           TRUE, 0.0f,
           { DEVELOP_BLENDIF_C_in, DEVELOP_BLENDIF_C_out }, DT_DEV_PIXELPIPE_DISPLAY_LCH_C,
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("saturation") },
-        { N_("h"), N_("sliders for hue channel (of LCh)"), 1.0f / 360.0f, COLORSTOPS(_gradient_hue),
+        { N_("h"), N_("sliders for hue channel (of LCh)"), 1.0f / 360.0f, COLORSTOPS(_gradient_LCh_hue),
           FALSE, 0.0f,
           { DEVELOP_BLENDIF_h_in, DEVELOP_BLENDIF_h_out }, DT_DEV_PIXELPIPE_DISPLAY_LCH_h,
           _blendif_scale_print_hue, NULL, N_("hue") },
@@ -1808,7 +1837,7 @@ const dt_iop_gui_blendif_channel_t rgb_channels[]
         { N_("B"), N_("sliders for blue channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_blue), TRUE, 0.0f,
           { DEVELOP_BLENDIF_BLUE_in, DEVELOP_BLENDIF_BLUE_out }, DT_DEV_PIXELPIPE_DISPLAY_B,
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("blue") },
-        { N_("H"), N_("sliders for hue channel (of HSL)"), 1.0f / 360.0f, COLORSTOPS(_gradient_HUE),
+        { N_("H"), N_("sliders for hue channel (of HSL)"), 1.0f / 360.0f, COLORSTOPS(_gradient_HSL_hue),
           FALSE, 0.0f,
           { DEVELOP_BLENDIF_H_in, DEVELOP_BLENDIF_H_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_H,
           _blendif_scale_print_hue, NULL, N_("hue") },
@@ -1843,7 +1872,7 @@ const dt_iop_gui_blendif_channel_t rgbj_channels[]
           TRUE, -6.64385619f, // cf. _blend_init_blendif_boost_parameters
           { DEVELOP_BLENDIF_Cz_in, DEVELOP_BLENDIF_Cz_out }, DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz,
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("chroma") },
-        { N_("hz"), N_("sliders for hue channel (of JzCzhz)"), 1.0f / 360.0f, COLORSTOPS(_gradient_jhue),
+        { N_("hz"), N_("sliders for hue channel (of JzCzhz)"), 1.0f / 360.0f, COLORSTOPS(_gradient_JzCzhz_hue),
           FALSE, 0.0f,
           { DEVELOP_BLENDIF_hz_in, DEVELOP_BLENDIF_hz_out }, DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz,
           _blendif_scale_print_hue, NULL, N_("hue") },

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -122,7 +122,7 @@ static inline void _blendif_lab_a(const float *const restrict pixels, float *con
 {
   for(size_t x = 0, j = 0; x < stride; x++, j += DT_BLENDIF_LAB_CH)
   {
-    mask[x] *= _blendif_compute_factor(pixels[j + 1] / 128.0f, invert_mask, parameters);
+    mask[x] *= _blendif_compute_factor(pixels[j + 1] / 256.0f, invert_mask, parameters);
   }
 }
 
@@ -135,7 +135,7 @@ static inline void _blendif_lab_b(const float *const restrict pixels, float *con
 {
   for(size_t x = 0, j = 0; x < stride; x++, j += DT_BLENDIF_LAB_CH)
   {
-    mask[x] *= _blendif_compute_factor(pixels[j + 2] / 128.0f, invert_mask, parameters);
+    mask[x] *= _blendif_compute_factor(pixels[j + 2] / 256.0f, invert_mask, parameters);
   }
 }
 

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -1170,75 +1170,101 @@ static inline float _rgb_luminance(const float *const restrict rgb,
 #endif
 static void _display_channel(const float *const restrict a, float *const restrict b,
                              const float *const restrict mask, const size_t stride, const int channel,
+                             const float *const restrict boost_factors,
                              const dt_iop_order_iccprofile_info_t *const profile)
 {
   switch(channel)
   {
     case DT_DEV_PIXELPIPE_DISPLAY_R:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_RED_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(a[j + 0]);
+        const float c = clamp_simd(a[j + 0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_RED_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(b[j + 0]);
+        const float c = clamp_simd(b[j + 0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_G:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GREEN_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(a[j + 1]);
+        const float c = clamp_simd(a[j + 1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GREEN_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(b[j + 1]);
+        const float c = clamp_simd(b[j + 1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_B:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_BLUE_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(a[j + 2]);
+        const float c = clamp_simd(a[j + 2] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_BLUE_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(b[j + 2]);
+        const float c = clamp_simd(b[j + 2] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GRAY_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(_rgb_luminance(a + j, profile));
+        const float c = clamp_simd(_rgb_luminance(a + j, profile) * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GRAY_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(_rgb_luminance(b + j, profile));
+        const float c = clamp_simd(_rgb_luminance(b + j, profile) * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_H:
+      // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float HSL[3] DT_ALIGNED_PIXEL;
@@ -1249,6 +1275,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_H | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+      // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float HSL[3] DT_ALIGNED_PIXEL;
@@ -1259,6 +1286,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_S:
+      // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float HSL[3] DT_ALIGNED_PIXEL;
@@ -1269,6 +1297,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_S | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+      // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float HSL[3] DT_ALIGNED_PIXEL;
@@ -1279,6 +1308,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_l:
+      // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float HSL[3] DT_ALIGNED_PIXEL;
@@ -1289,6 +1319,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_l | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+      // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float HSL[3] DT_ALIGNED_PIXEL;
@@ -1347,18 +1378,19 @@ void dt_develop_blendif_rgb_hsl_blend(struct dt_dev_pixelpipe_iop_t *piece,
     const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_DISPLAY);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
-
+    const float *const restrict boost_factors = d->blendif_boost_factors;
     const dt_dev_pixelpipe_display_mask_t channel = request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY;
+
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) \
-  dt_omp_firstprivate(a, b, mask, channel, oheight, owidth, iwidth, xoffs, yoffs, profile)
+  dt_omp_firstprivate(a, b, mask, channel, oheight, owidth, iwidth, xoffs, yoffs, boost_factors, profile)
 #endif
     for(size_t y = 0; y < oheight; y++)
     {
       const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_RGB_CH;
       const size_t b_start = y * owidth * DT_BLENDIF_RGB_CH;
       const size_t m_start = y * owidth;
-      _display_channel(a + a_start, b + b_start, mask + m_start, owidth, channel, profile);
+      _display_channel(a + a_start, b + b_start, mask + m_start, owidth, channel, boost_factors, profile);
     }
   }
   else

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -840,120 +840,159 @@ static inline void _rgb_to_JzCzhz(const float *const restrict rgb, float *const 
   dt_JzAzBz_2_JzCzhz(JzAzBz, JzCzhz);
 }
 
+
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b:16) uniform(channel, profile, stride)
 #endif
 static void _display_channel(const float *const restrict a, float *const restrict b,
-                             const float* const restrict mask, const size_t stride, const int channel,
+                             const float *const restrict mask, const size_t stride, const int channel,
+                             const float *const restrict boost_factors,
                              const dt_iop_order_iccprofile_info_t *const profile)
 {
   switch(channel)
   {
     case DT_DEV_PIXELPIPE_DISPLAY_R:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_RED_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(a[j + 0]);
+        const float c = clamp_simd(a[j + 0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_RED_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(b[j + 0]);
+        const float c = clamp_simd(b[j + 0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_G:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GREEN_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(a[j + 1]);
+        const float c = clamp_simd(a[j + 1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GREEN_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(b[j + 1]);
+        const float c = clamp_simd(b[j + 1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_B:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_BLUE_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(a[j + 2]);
+        const float c = clamp_simd(a[j + 2] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_BLUE_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(b[j + 2]);
+        const float c = clamp_simd(b[j + 2] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GRAY_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(_rgb_luminance(a + j, profile));
+        const float c = clamp_simd(_rgb_luminance(a + j, profile) * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_GRAY_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        const float c = clamp_simd(_rgb_luminance(b + j, profile));
+        const float c = clamp_simd(_rgb_luminance(b + j, profile) * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Jz_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
         _rgb_to_JzCzhz(a + j, JzCzhz, profile);
-        const float c = clamp_simd(JzCzhz[0]);
+        const float c = clamp_simd(JzCzhz[0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Jz_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
         _rgb_to_JzCzhz(b + j, JzCzhz, profile);
-        const float c = clamp_simd(JzCzhz[0]);
+        const float c = clamp_simd(JzCzhz[0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Cz_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
         _rgb_to_JzCzhz(a + j, JzCzhz, profile);
-        const float c = clamp_simd(JzCzhz[1]);
+        const float c = clamp_simd(JzCzhz[1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+    {
+      const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Cz_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
         _rgb_to_JzCzhz(b + j, JzCzhz, profile);
-        const float c = clamp_simd(JzCzhz[1]);
+        const float c = clamp_simd(JzCzhz[1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
         b[j + DT_BLENDIF_RGB_BCH] = mask[i];
       }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz:
+      // no boost factor for hues
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
@@ -964,6 +1003,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT:
+      // no boost factor for hues
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
@@ -1020,18 +1060,19 @@ void dt_develop_blendif_rgb_jzczhz_blend(struct dt_dev_pixelpipe_iop_t *piece, c
     const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_SCENE);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
-
+    const float *const restrict boost_factors = d->blendif_boost_factors;
     const dt_dev_pixelpipe_display_mask_t channel = request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY;
+
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) \
-  dt_omp_firstprivate(a, b, mask, channel, oheight, owidth, iwidth, xoffs, yoffs, profile)
+  dt_omp_firstprivate(a, b, mask, channel, oheight, owidth, iwidth, xoffs, yoffs, boost_factors, profile)
 #endif
     for(size_t y = 0; y < oheight; y++)
     {
       const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_RGB_CH;
       const size_t b_start = y * owidth * DT_BLENDIF_RGB_CH;
       const size_t m_start = y * owidth;
-      _display_channel(a + a_start, b + b_start, mask + m_start, owidth, channel, profile);
+      _display_channel(a + a_start, b + b_start, mask + m_start, owidth, channel, boost_factors, profile);
     }
   }
   else

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -58,263 +58,322 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-static inline float Hue_2_RGB(float v1, float v2, float vH)
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out, mask_color: 16) uniform(mask_color, alpha)
+#endif
+static inline void _write_pixel(const float *const restrict in, uint8_t *const restrict out,
+                                const float *const restrict mask_color, const float alpha)
 {
-  if(vH < 0.0f) vH += 1.0f;
-  if(vH > 1.0f) vH -= 1.0f;
-  if((6.0f * vH) < 1.0f) return (v1 + (v2 - v1) * 6.0f * vH);
-  if((2.0f * vH) < 1.0f) return (v2);
-  if((3.0f * vH) < 2.0f) return (v1 + (v2 - v1) * ((2.0f / 3.0f) - vH) * 6.0f);
-  return v1;
-}
+  // takes a linear RGB pixel as input
+  float pixel[3] DT_ALIGNED_PIXEL;
 
-static inline void HSL_2_RGB(const float *HSL, float *RGB)
-{
-  float H = HSL[0];
-  float S = HSL[1];
-  float L = HSL[2];
+  // linear sRGB (REC 709) -> gamma corrected sRGB
+  for(size_t c = 0; c < 3; c++)
+    pixel[c] = in[c] <= 0.0031308 ? 12.92 * in[c] : (1.0 + 0.055) * powf(in[c], 1.0 / 2.4) - 0.055;
 
-  float var_1, var_2;
-
-  if(S < 1e-6f)
+  // it seems that the output of this module is BGR(A) instead of RGBA
+  for(size_t c = 0; c < 3; c++)
   {
-    RGB[0] = RGB[1] = RGB[2] = L;
-  }
-  else
-  {
-    if(L < 0.5f)
-      var_2 = L * (1.0f + S);
-    else
-      var_2 = (L + S) - (S * L);
-
-    var_1 = 2.0f * L - var_2;
-
-    RGB[0] = Hue_2_RGB(var_1, var_2, H + (1.0f / 3.0f));
-    RGB[1] = Hue_2_RGB(var_1, var_2, H);
-    RGB[2] = Hue_2_RGB(var_1, var_2, H - (1.0f / 3.0f));
+    const float value = roundf(255.0f * (pixel[c] * (1.0f - alpha) + mask_color[c] * alpha));
+    out[2 - c] = (uint8_t)(fminf(fmaxf(value, 0.0f), 255.0f));
   }
 }
 
-static inline void LCH_2_Lab(const float *LCH, float *Lab)
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(pixel: 16) uniform(norm)
+#endif
+static void _normalize_color(float *const restrict pixel, const float norm)
 {
-  Lab[0] = LCH[0];
-  Lab[1] = cosf(2.0f * M_PI * LCH[2]) * LCH[1];
-  Lab[2] = sinf(2.0f * M_PI * LCH[2]) * LCH[1];
+  // color may not be black!
+  const float factor = norm / fmaxf(pixel[0], fmaxf(pixel[1], pixel[2]));
+  for(size_t x = 0; x < 3; x++) pixel[x] = pixel[x] * factor;
 }
 
-static inline void LCH_2_RGB(const float *LCH, float *RGB)
+#ifdef _OPENMP
+#pragma omp declare simd aligned(XYZ, sRGB: 16) uniform(norm)
+#endif
+static inline void _XYZ_to_REC_709_normalized(const float *const restrict XYZ, float *const restrict sRGB,
+                                                  const float norm)
 {
-  float Lab[3], XYZ[3];
-  LCH_2_Lab(LCH, Lab);
-  dt_Lab_to_XYZ(Lab, XYZ);
-  dt_XYZ_to_sRGB_clipped(XYZ, RGB);
+  dt_XYZ_to_Rec709_D50(XYZ, sRGB);
+  _normalize_color(sRGB, norm);
 }
 
-static inline void Lab_2_RGB(const float *Lab, float *RGB)
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out: 64) uniform(buffsize, alpha)
+#endif
+static void _channel_display_monochrome(const float *const restrict in, uint8_t *const restrict out,
+                                        const size_t buffsize, const float alpha)
 {
-  float XYZ[3];
-  dt_Lab_to_XYZ(Lab, XYZ);
-  dt_XYZ_to_sRGB_clipped(XYZ, RGB);
-}
+  const float mask_color[3] DT_ALIGNED_PIXEL = { 1.0f, 1.0f, 0.0f }; // yellow
 
-static inline void JzCzhz_2_RGB(const float *const JzCzhz, float *const rgb)
-{
-  float JzAzBz[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
-  float XYZ[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
-  dt_JzCzhz_2_JzAzBz(JzCzhz, JzAzBz);
-  dt_JzAzBz_2_XYZ(JzAzBz, XYZ);
-  dt_XYZ_to_sRGB_clipped(XYZ, rgb);
-}
-
-static inline void false_color(float val, dt_dev_pixelpipe_display_mask_t channel, float *out)
-{
-  float in[3];
-
-  switch((channel & DT_DEV_PIXELPIPE_DISPLAY_ANY) & ~DT_DEV_PIXELPIPE_DISPLAY_OUTPUT)
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in,out, buffsize, alpha, mask_color)
+#endif
+  for(size_t j = 0; j < buffsize; j += 4)
   {
-    case DT_DEV_PIXELPIPE_DISPLAY_L:
-      in[0] = val * 100.0f;
-      in[1] = 0.0f;
-      in[2] = 0.0f;
-      Lab_2_RGB(in, out);
-      break;
+    float pixel[3] DT_ALIGNED_PIXEL;
+    pixel[0] = in[j + 1];
+    pixel[1] = in[j + 1];
+    pixel[2] = in[j + 1];
+    _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+  }
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out: 64) uniform(buffsize, alpha, channel)
+#endif
+static void _channel_display_false_color(const float *const restrict in, uint8_t *const restrict out,
+                                         const size_t buffsize, const float alpha,
+                                         dt_dev_pixelpipe_display_mask_t channel)
+{
+  const float mask_color[3] DT_ALIGNED_PIXEL = { 1.0f, 1.0f, 0.0f }; // yellow
+
+  switch(channel & DT_DEV_PIXELPIPE_DISPLAY_ANY & ~DT_DEV_PIXELPIPE_DISPLAY_OUTPUT)
+  {
     case DT_DEV_PIXELPIPE_DISPLAY_a:
-      in[0] = 80.0f;
-      in[1] = val * 256.0f - 128.0f;
-      in[2] = 0.0f;
-      Lab_2_RGB(in, out);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float lab[3] DT_ALIGNED_PIXEL;
+        float xyz[3] DT_ALIGNED_PIXEL;
+        float pixel[3] DT_ALIGNED_PIXEL;
+        lab[0] = 80.0f;
+        lab[1] = in[j + 1] * 256.0f - 128.0f;
+        lab[2] = 0.0f;
+        dt_Lab_to_XYZ(lab, xyz);
+        _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_b:
-      in[0] = 80.0f;
-      in[1] = 0.0f;
-      in[2] = val * 256.0f - 128.0f;
-      Lab_2_RGB(in, out);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float lab[3] DT_ALIGNED_PIXEL;
+        float xyz[3] DT_ALIGNED_PIXEL;
+        float pixel[3] DT_ALIGNED_PIXEL;
+        lab[0] = 80.0f;
+        lab[1] = 0.0f;
+        lab[2] = in[j + 1] * 256.0f - 128.0f;
+        dt_Lab_to_XYZ(lab, xyz);
+        _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_R:
-      out[0] = val;
-      out[1] = out[2] = 0.0f;
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float pixel[3] DT_ALIGNED_PIXEL;
+        pixel[0] = in[j + 1];
+        pixel[1] = 0.0f;
+        pixel[2] = 0.0f;
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_G:
-      out[1] = val;
-      out[0] = out[2] = 0.0f;
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float pixel[3] DT_ALIGNED_PIXEL;
+        pixel[0] = 0.0f;
+        pixel[1] = in[j + 1];
+        pixel[2] = 0.0f;
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_B:
-      out[2] = val;
-      out[0] = out[1] = 0.0f;
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float pixel[3] DT_ALIGNED_PIXEL;
+        pixel[0] = 0.0f;
+        pixel[1] = 0.0f;
+        pixel[2] = in[j + 1];
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_LCH_C:
-      in[0] = 80.0f;
-      in[1] = val * 128.0f * sqrtf(2.0f);
-      in[2] = 0.9111f;
-      LCH_2_RGB(in, out);
+    case DT_DEV_PIXELPIPE_DISPLAY_HSL_S:
+    case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz:
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float pixel[3] DT_ALIGNED_PIXEL;
+        pixel[0] = 0.50f;
+        pixel[1] = 0.50 * (1.0f - in[j + 1]);
+        pixel[2] = 0.50f;
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_LCH_h:
-      in[0] = 50.0f;
-      in[1] = 0.25f * 128.0f * sqrtf(2.0f);
-      in[2] = val;
-      LCH_2_RGB(in, out);
+    {
+      const float chroma = 0.25f * 128.0f * sqrtf(2.0f);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color, chroma)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float lch[3] DT_ALIGNED_PIXEL;
+        float lab[3] DT_ALIGNED_PIXEL;
+        float xyz[3] DT_ALIGNED_PIXEL;
+        float pixel[3] DT_ALIGNED_PIXEL;
+        lch[0] = 50.0f;
+        lch[1] = chroma;
+        lch[2] = in[j + 1];
+        dt_LCH_2_Lab(lch, lab);
+        dt_Lab_to_XYZ(lab, xyz);
+        _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
+    }
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_H:
-      in[0] = val;
-      in[1] = 1.0f;
-      in[2] = 0.5f;
-      HSL_2_RGB(in, out);
-      break;
-    case DT_DEV_PIXELPIPE_DISPLAY_HSL_S:
-      in[0] = 0.8333f;
-      in[1] = val;
-      in[2] = 0.5f;
-      HSL_2_RGB(in, out);
-      break;
-    case DT_DEV_PIXELPIPE_DISPLAY_HSL_l:
-      in[0] = 0.0f;
-      in[1] = 0.0f;
-      in[2] = val;
-      HSL_2_RGB(in, out);
-      break;
-    case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz:
-      in[0] = val;
-      in[1] = 0.0f;
-      in[2] = 0.0f;
-      JzCzhz_2_RGB(in, out);
-      break;
-    case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz:
-      in[0] = 0.0115f;
-      in[1] = val;
-      in[2] = 0.8333f;
-      JzCzhz_2_RGB(in, out);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float hsl[3] DT_ALIGNED_PIXEL;
+        float pixel[3] DT_ALIGNED_PIXEL;
+        hsl[0] = in[j + 1];
+        hsl[1] = 0.75f;
+        hsl[2] = 0.5f;
+        dt_HSL_2_RGB(hsl, pixel);
+        _normalize_color(pixel, 0.75f);
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz:
-      in[0] = 0.01f;
-      in[1] = 0.02f;
-      in[2] = val;
-      JzCzhz_2_RGB(in, out);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+#endif
+      for(size_t j = 0; j < buffsize; j += 4)
+      {
+        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        float JzAzBz[3] DT_ALIGNED_PIXEL;
+        float xyz[3] DT_ALIGNED_PIXEL;
+        float pixel[3] DT_ALIGNED_PIXEL;
+        JzCzhz[0] = 0.01f;
+        JzCzhz[1] = 0.015f;
+        JzCzhz[2] = in[j + 1];
+        dt_JzCzhz_2_JzAzBz(JzCzhz, JzAzBz);
+        dt_JzAzBz_2_XYZ(JzAzBz, xyz);
+        _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
+        _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+      }
       break;
+    case DT_DEV_PIXELPIPE_DISPLAY_L:
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
+    case DT_DEV_PIXELPIPE_DISPLAY_HSL_l:
+    case DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz:
     default:
-      out[0] = out[1] = out[2] = val;
+      _channel_display_monochrome(in, out, buffsize, alpha);
       break;
   }
 }
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out: 64) uniform(buffsize, alpha)
+#endif
+static void _mask_display(const float *const restrict in, uint8_t *const restrict out, const size_t buffsize,
+                          const float alpha)
+{
+  const float mask_color[3] DT_ALIGNED_PIXEL = { 1.0f, 1.0f, 0.0f }; // yellow
+
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+      dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+  #endif
+    for(size_t j = 0; j < buffsize; j+= 4)
+    {
+      const float gray = 0.3f * in[j + 0] + 0.59f * in[j + 1] + 0.11f * in[j + 2];
+      float pixel[3] DT_ALIGNED_PIXEL = { gray, gray, gray };
+      _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
+    }
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out: 64) uniform(buffsize)
+#endif
+static void _copy_output(const float *const restrict in, uint8_t *const restrict out, const size_t buffsize)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) \
+    dt_omp_firstprivate(in, out, buffsize)
+#endif
+  for(size_t j = 0; j < buffsize; j += 4)
+  {
+    // it seems that the output of this module is BGR(A) instead of RGBA
+    for(size_t c = 0; c < 3; c++)
+    {
+      out[j + 2 - c] = (uint8_t)(fminf(fmaxf(roundf(255.0f * in[j + c]), 0.0f), 255.0f));
+    }
+  }
+}
+
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  const int ch = piece->colors;
+  if(piece->colors != 4) return; // this module seems to handle only RGBA pixels
+
+  // this module also expects the same size of input image as the output image
+  if(roi_in->width != roi_out->width || roi_in->height != roi_out->height)
+    return;
 
   const dt_dev_pixelpipe_display_mask_t mask_display = piece->pipe->mask_display;
   char *str = dt_conf_get_string("channel_display");
   const int fcolor = !strcmp(str, "false color");
   g_free(str);
 
-  if((mask_display & DT_DEV_PIXELPIPE_DISPLAY_CHANNEL) && (mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY) && fcolor)
+  const size_t buffsize = (size_t)roi_out->width * roi_out->height * 4;
+  const float alpha = (mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) ? 1.0f : 0.0f;
+
+  if((mask_display & DT_DEV_PIXELPIPE_DISPLAY_CHANNEL) && (mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY))
   {
-    const float yellow[3] = { 1.0f, 1.0f, 0.0f };
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, i, mask_display, o, roi_out, yellow) \
-    schedule(static)
-#endif
-    for(int k = 0; k < roi_out->height; k++)
+    if(fcolor)
     {
-      const float *in = ((float *)i) + (size_t)ch * k * roi_out->width;
-      uint8_t *out = ((uint8_t *)o) + (size_t)ch * k * roi_out->width;
-      for(int j = 0; j < roi_out->width; j++, in += ch, out += ch)
-      {
-        const float alpha = (mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) ? in[3] : 0.0f;
-        float colors[3];
-        false_color(in[1], mask_display, colors);
-        for(int c = 0; c < 3; c++)
-        {
-          const float value = colors[c] * (1.0f - alpha) + yellow[c] * alpha;
-          out[2 - c] = ((uint8_t)(CLAMP(round(255.0f * value), 0x0, 0xff)));
-        }
-      }
+      _channel_display_false_color((const float *const restrict)i, (uint8_t *const restrict)o, buffsize, alpha,
+                                   mask_display);
     }
-  }
-  else if((mask_display & DT_DEV_PIXELPIPE_DISPLAY_CHANNEL) && (mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY))
-  {
-    const float yellow[3] = { 1.0f, 1.0f, 0.0f };
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, i, mask_display, o, roi_out, yellow) \
-    schedule(static)
-#endif
-    for(int k = 0; k < roi_out->height; k++)
+    else
     {
-      const float *in = ((float *)i) + (size_t)ch * k * roi_out->width;
-      uint8_t *out = ((uint8_t *)o) + (size_t)ch * k * roi_out->width;
-      for(int j = 0; j < roi_out->width; j++, in += ch, out += ch)
-      {
-        float alpha = (mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) ? in[3] : 0.0f;
-        for(int c = 0; c < 3; c++)
-        {
-          const float value = in[1] * (1.0f - alpha) + yellow[c] * alpha;
-          out[2 - c] = ((uint8_t)(CLAMP(round(255.0f * value), 0x0, 0xff)));
-        }
-      }
+      _channel_display_monochrome((const float *const restrict)i, (uint8_t *const restrict)o, buffsize, alpha);
     }
   }
   else if(mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
   {
-    const float yellow[3] = { 1.0f, 1.0f, 0.0f };
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, i, o, roi_out, yellow) \
-    schedule(static)
-#endif
-    for(int k = 0; k < roi_out->height; k++)
-    {
-      const float *in = ((float *)i) + (size_t)ch * k * roi_out->width;
-      uint8_t *out = ((uint8_t *)o) + (size_t)ch * k * roi_out->width;
-      for(int j = 0; j < roi_out->width; j++, in += ch, out += ch)
-      {
-        const float gray = 0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2];
-        const float alpha = in[3];
-        for(int c = 0; c < 3; c++)
-        {
-          const float value = gray * (1.0f - alpha) + yellow[c] * alpha;
-          out[2 - c] = ((uint8_t)(CLAMP(round(255.0f * value), 0x0, 0xff)));
-        }
-      }
-    }
+    _mask_display((const float *const restrict)i, (uint8_t *const restrict)o, buffsize, 1.0f);
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, i, o, roi_out) \
-    schedule(static)
-#endif
-    for(int k = 0; k < roi_out->height; k++)
-    {
-      const float *in = ((float *)i) + (size_t)ch * k * roi_out->width;
-      uint8_t *out = ((uint8_t *)o) + (size_t)ch * k * roi_out->width;
-      for(int j = 0; j < roi_out->width; j++, in += ch, out += ch)
-      {
-        for(int c = 0; c < 3; c++) out[2 - c] = ((uint8_t)(CLAMP(round(255.0f * in[c]), 0x0, 0xff)));
-      }
-    }
+    _copy_output((const float *const restrict)i, (uint8_t *const restrict)o, buffsize);
   }
 }
 


### PR DESCRIPTION
The display of the individual parametric mask channels has currently several small issues. To improve the situation this pull request contains the following changes:

- Include the boost factor in the computation of the display value for the channel, e.g. to see if the channel is clipped. This is something that was overlooked in #4688 

- Display the lab parametric channel masks correctly. The values should be converted from RGB to Lab using the same profile as will be used by the pipeline to convert the output of the module (in Lab) to RGB (used for gamma). Before #4688 the Lab masks were not working at all, and it seems that the fix in #4688 is not correct.

- Try to have more similar colors between the three blending implementations where it is meaningful (luminance, chroma and hue).