### PR TITLE
fix buffer overflow

### DIFF
--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -487,8 +487,9 @@ static void _size_in_px_update(dt_lib_export_t *d)
   }
   else
   {
-    gchar size_in_px_txt[25];
-    sprintf(size_in_px_txt, "that is equal %s x %s px", gtk_entry_get_text(GTK_ENTRY(d->width)), gtk_entry_get_text(GTK_ENTRY(d->height)));
+    gchar size_in_px_txt[120];
+    snprintf(size_in_px_txt, sizeof(size_in_px_txt) / sizeof(size_in_px_txt[0]), _("which is equal to %s × %s px"),
+             gtk_entry_get_text(GTK_ENTRY(d->width)), gtk_entry_get_text(GTK_ENTRY(d->height)));
     gtk_label_set_text(GTK_LABEL(d->size_in_px), size_in_px_txt);
   }
 }


### PR DESCRIPTION
darktable crashes due to a buffer overflow when "in cm (for print)" is selected in the export dialog. This pull request fixes this by using `snprintf` and a larger buffer. The buffer size is chosen generously in order not to limit translators unnecessarily. Also revised the wording and enabled translation.