### PR TITLE
Add shortcuts for blending and group shapes

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -873,7 +873,7 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
 
   if(w->module)
   {
-    if(!darktable.bauhaus->skip_accel && (!section_orig || strcmp("blend", section_orig)))
+    if(!darktable.bauhaus->skip_accel)
     {
       gchar *combined_label = section_orig
                             ? g_strdup_printf("%s`%s", section_orig, label_orig)

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2760,6 +2760,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
   /* create and add blend mode if module supports it */
   if(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
   {
+    --darktable.bauhaus->skip_accel;
+
     module->blend_data = g_malloc0(sizeof(dt_iop_gui_blend_data_t));
     dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
@@ -2986,6 +2988,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_widget_set_name(GTK_WIDGET(iopw), "blending-wrapper");
 
     bd->blend_inited = 1;
+
+    ++darktable.bauhaus->skip_accel;
   }
 }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2182,22 +2182,22 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
     bd->masks_type[1] = DT_MASKS_PATH;
     bd->masks_shapes[1] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add path"), N_("add multiple paths"),
                                                   G_CALLBACK(_blendop_masks_add_shape_callback),
-                                                  TRUE, 0, 0, dtgtk_cairo_paint_masks_path, abox);
+                                                  FALSE, 0, 0, dtgtk_cairo_paint_masks_path, abox);
 
     bd->masks_type[2] = DT_MASKS_ELLIPSE;
     bd->masks_shapes[2] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add ellipse"), N_("add multiple ellipses"),
                                                   G_CALLBACK(_blendop_masks_add_shape_callback),
-                                                  TRUE, 0, 0, dtgtk_cairo_paint_masks_ellipse, abox);
+                                                  FALSE, 0, 0, dtgtk_cairo_paint_masks_ellipse, abox);
 
     bd->masks_type[3] = DT_MASKS_CIRCLE;
     bd->masks_shapes[3] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add circle"), N_("add multiple circles"),
                                                   G_CALLBACK(_blendop_masks_add_shape_callback),
-                                                  TRUE, 0, 0, dtgtk_cairo_paint_masks_circle, abox);
+                                                  FALSE, 0, 0, dtgtk_cairo_paint_masks_circle, abox);
 
     bd->masks_type[4] = DT_MASKS_BRUSH;
     bd->masks_shapes[4] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add brush"), N_("add multiple brush strokes"),
                                                   G_CALLBACK(_blendop_masks_add_shape_callback),
-                                                  TRUE, 0, 0, dtgtk_cairo_paint_masks_brush, abox);
+                                                  FALSE, 0, 0, dtgtk_cairo_paint_masks_brush, abox);
 
     gtk_box_pack_start(GTK_BOX(bd->masks_box), dt_ui_section_label_new(_("drawn mask")), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(hbox), TRUE, TRUE, 0);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1076,12 +1076,13 @@ static void _blendop_masks_modes_none_clicked(GtkWidget *button, GdkEventButton 
   }
 }
 
-static void _blendop_masks_modes_toggle(GtkToggleButton *button, dt_iop_module_t *module, const unsigned int mask_mode)
+static gboolean _blendop_masks_modes_toggle(GtkToggleButton *button, dt_iop_module_t *module, const unsigned int mask_mode)
 {
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return FALSE;
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
-  const gboolean was_toggled = gtk_toggle_button_get_active(button);
+  const gboolean was_toggled = !gtk_toggle_button_get_active(button);
+  gtk_toggle_button_set_active(button, was_toggled);
 
   // avoids trying to untoggle the cancel button
   if(data->selected_mask_mode
@@ -1103,31 +1104,33 @@ static void _blendop_masks_modes_toggle(GtkToggleButton *button, dt_iop_module_t
       g_list_nth_data(data->masks_modes_toggles,
                       g_list_index(data->masks_modes, (gconstpointer)DEVELOP_MASK_DISABLED)));
   }
+
+  return TRUE;
 }
 
-static void _blendop_masks_modes_uni_toggled(GtkToggleButton *button, dt_iop_module_t *module)
+static gboolean _blendop_masks_modes_uni_toggled(GtkToggleButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
-  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED);
+  return _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED);
 }
 
-static void _blendop_masks_modes_drawn_toggled(GtkToggleButton *button, dt_iop_module_t *module)
+static gboolean _blendop_masks_modes_drawn_toggled(GtkToggleButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
-  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK);
+  return _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK);
 }
 
-static void _blendop_masks_modes_param_toggled(GtkToggleButton *button, dt_iop_module_t *module)
+static gboolean _blendop_masks_modes_param_toggled(GtkToggleButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
-  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL);
+  return _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL);
 }
 
-static void _blendop_masks_modes_both_toggled(GtkToggleButton *button, dt_iop_module_t *module)
+static gboolean _blendop_masks_modes_both_toggled(GtkToggleButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
-  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL);
+  return _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL);
 }
 
-static void _blendop_masks_modes_raster_toggled(GtkToggleButton *button, dt_iop_module_t *module)
+static gboolean _blendop_masks_modes_raster_toggled(GtkToggleButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
-  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER);
+  return _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER);
 }
 
 static void _blendop_blendif_suppress_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *module)
@@ -2788,58 +2791,49 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     GtkWidget *but = NULL;
 
     // DEVELOP_MASK_DISABLED
-    but = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-    gtk_widget_set_tooltip_text(but, _("off"));
-    gtk_widget_set_name(GTK_WIDGET(but), "dt-toggle-button");
+    but = dt_iop_togglebutton_new(module, "blend", N_("off"), NULL, G_CALLBACK(_blendop_masks_modes_none_clicked),
+                                  FALSE, 0, 0, dtgtk_cairo_paint_cancel, NULL);
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED));
     bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
-    g_signal_connect(G_OBJECT(but), "button-press-event", G_CALLBACK(_blendop_masks_modes_none_clicked), module);
 
     // DEVELOP_MASK_ENABLED
-    but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_uniform, CPF_STYLE_FLAT, NULL);
-    gtk_widget_set_tooltip_text(but, _("uniformly"));
+    but = dt_iop_togglebutton_new(module, "blend", N_("uniformly"), NULL, G_CALLBACK(_blendop_masks_modes_uni_toggled),
+                                  FALSE, 0, 0, dtgtk_cairo_paint_masks_uniform, NULL);
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED));
     bd->masks_modes_toggles  = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
-    g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_uni_toggled), module);
 
     if(bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT, NULL);
-      gtk_widget_set_tooltip_text(but, _("drawn mask"));
+      but = dt_iop_togglebutton_new(module, "blend", N_("drawn mask"), NULL, G_CALLBACK(_blendop_masks_modes_drawn_toggled),
+                                    FALSE, 0, 0, dtgtk_cairo_paint_masks_drawn, NULL);
       bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_drawn_toggled), module);
     }
     if(bd->blendif_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_parametric, CPF_STYLE_FLAT,
-                                   NULL);
-      gtk_widget_set_tooltip_text(but, _("parametric mask"));
+      but = dt_iop_togglebutton_new(module, "blend", N_("parametric mask"), NULL, G_CALLBACK(_blendop_masks_modes_param_toggled),
+                                    FALSE, 0, 0, dtgtk_cairo_paint_masks_parametric, NULL);
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_param_toggled), module);
     }
 
     if(bd->blendif_support && bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn_and_parametric,
-                                   CPF_STYLE_FLAT, NULL); // overlays and
-      gtk_widget_set_tooltip_text(but, _("drawn & parametric mask"));
+      but = dt_iop_togglebutton_new(module, "blend", N_("drawn & parametric mask"), NULL, G_CALLBACK(_blendop_masks_modes_both_toggled),
+                                    FALSE, 0, 0, dtgtk_cairo_paint_masks_drawn_and_parametric, NULL);
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_both_toggled), module);
     }
 
     if(bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_raster, CPF_STYLE_FLAT, NULL);
-      gtk_widget_set_tooltip_text(but, _("raster mask"));
+      but = dt_iop_togglebutton_new(module, "blend", N_("raster mask"), NULL, G_CALLBACK(_blendop_masks_modes_raster_toggled),
+                                    FALSE, 0, 0, dtgtk_cairo_paint_masks_raster, NULL);
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_raster_toggled), module);
     }
 
     GtkWidget *presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1231,11 +1231,8 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
   gtk_widget_set_tooltip_text(GTK_WIDGET(togglebutton), tooltip);
   gtk_widget_queue_draw(GTK_WIDGET(togglebutton));
 
-  if(dt_conf_get_bool("accel/prefer_enabled"))
-  {
-    // rebuild the accelerators
-    dt_iop_connect_accels_multi(module->so);
-  }
+  // rebuild the accelerators
+  dt_iop_connect_accels_multi(module->so);
 
   if(module->enabled && !gtk_widget_is_visible(module->header))
     dt_dev_modulegroups_update_visibility(darktable.develop);
@@ -1728,6 +1725,25 @@ static void dt_iop_init_module_so(void *m)
     {
       darktable.control->accel_initialising = TRUE;
       dt_iop_gui_init(module_instance);
+
+      static gboolean blending_accels_initialized = FALSE;
+      if(!blending_accels_initialized)
+      {
+        dt_iop_colorspace_type_t cst = module->blend_colorspace(module_instance, NULL, NULL);
+
+        if((module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) &&
+           !(module->flags() & IOP_FLAGS_NO_MASKS) &&
+           (cst == iop_cs_Lab || cst == iop_cs_rgb))
+        {
+          GtkWidget *iopw = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+          dt_iop_gui_init_blending(iopw, module_instance);
+          dt_iop_gui_cleanup_blending(module_instance);
+          gtk_widget_destroy(iopw);
+
+          blending_accels_initialized = TRUE;
+        }
+      }
+
       module->gui_cleanup(module_instance);
       darktable.control->accel_initialising = FALSE;
 
@@ -2107,11 +2123,8 @@ static void dt_iop_gui_reset_callback(GtkButton *button, GdkEventButton *event, 
     dt_dev_add_history_item(module->dev, module, TRUE);
   }
 
-  if(dt_conf_get_bool("accel/prefer_expanded") || dt_conf_get_bool("accel/prefer_enabled") || dt_conf_get_bool("accel/prefer_unmasked"))
-  {
-    // rebuild the accelerators
-    dt_iop_connect_accels_multi(module->so);
-  }
+  // rebuild the accelerators
+  dt_iop_connect_accels_multi(module->so);
 }
 
 #if !GTK_CHECK_VERSION(3, 22, 0)
@@ -2352,11 +2365,8 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
       const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != !(e->state & GDK_SHIFT_MASK);
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 
-      if (dt_conf_get_bool("accel/prefer_expanded"))
-      {
-        // rebuild the accelerators
-        dt_iop_connect_accels_multi(module->so);
-      }
+      // rebuild the accelerators
+      dt_iop_connect_accels_multi(module->so);
 
       //used to take focus away from module search text input box when module selected
       gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
@@ -2780,11 +2790,7 @@ static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *accele
     dt_iop_request_focus(module);
   }
 
-  if(dt_conf_get_bool("accel/prefer_expanded"))
-  {
-    // rebuild the accelerators
-    dt_iop_connect_accels_multi(module->so);
-  }
+  dt_iop_connect_accels_multi(module->so);
 
   return TRUE;
 }
@@ -2818,11 +2824,8 @@ static gboolean enable_module_callback(GtkAccelGroup *accel_group, GObject *acce
 
   dt_iop_request_focus(module);
 
-  if(dt_conf_get_bool("accel/prefer_enabled"))
-  {
-    // rebuild the accelerators
-    dt_iop_connect_accels_multi(module->so);
-  }
+  // rebuild the accelerators
+  dt_iop_connect_accels_multi(module->so);
 
   return TRUE;
 }

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -402,17 +402,27 @@ static void _send_button_press_event(GtkWidget *w, guint state)
   gdk_event_free(event);
 }
 
+static gboolean _widget_visible(GtkWidget *w)
+{
+  GtkWidget *parent = gtk_widget_get_parent(w);
+  return gtk_widget_get_visible(w) &&
+         gtk_widget_get_visible(parent) &&
+         gtk_widget_get_visible(gtk_widget_get_parent(parent));
+}
+
 static gboolean _press_button_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                        GdkModifierType modifier, gpointer widget)
 {
-  _send_button_press_event(widget, 0);
+  if(_widget_visible(widget))
+    _send_button_press_event(widget, 0);
   return TRUE;
 }
 
 static gboolean _ctrl_press_button_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                              GdkModifierType modifier, gpointer widget)
 {
-  _send_button_press_event(widget, GDK_CONTROL_MASK);
+  if(_widget_visible(widget))
+    _send_button_press_event(widget, GDK_CONTROL_MASK);
   return TRUE;
 }
 

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -416,7 +416,7 @@ static gboolean _ctrl_press_button_callback(GtkAccelGroup *accel_group, GObject 
   return TRUE;
 }
 
-GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const gchar *label, const gchar *ctrl_label,
+GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, const gchar *label, const gchar *ctrl_label,
                                    GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
                                    DTGTKCairoPaintIconFunc paint, GtkWidget *box)
 {
@@ -435,23 +435,31 @@ GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const gchar *label, co
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), FALSE);
   if(GTK_IS_BOX(box)) gtk_box_pack_end(GTK_BOX(box), w, FALSE, FALSE, 0);
 
-  gchar *label_first_line = g_strdelimit(g_strdup(label), "\n", '\0');
+  gchar *combined_label = section
+                        ? g_strdup_printf("%s`%s", section, label)
+                        : g_strdup(label);
+  gchar *combined_ctrl_label = ctrl_label && section
+                        ? g_strdup_printf("%s`%s", section, ctrl_label)
+                        : g_strdup(ctrl_label);
+
   if(darktable.control->accel_initialising)
   {
-    dt_accel_register_iop(self->so, local, label_first_line, accel_key, mods);
-    if(ctrl_label) dt_accel_register_iop(self->so, local, ctrl_label, 0, 0);
+    dt_accel_register_iop(self->so, local, combined_label, accel_key, mods);
+    if(ctrl_label) dt_accel_register_iop(self->so, local, combined_ctrl_label, 0, 0);
   }
   else
   {
     GClosure *closure = g_cclosure_new(G_CALLBACK(_press_button_callback), (gpointer)w, NULL);
-    dt_accel_connect_iop(self, label_first_line, closure);
+    dt_accel_connect_iop(self, combined_label, closure);
     if(ctrl_label)
     {
       closure = g_cclosure_new(G_CALLBACK(_ctrl_press_button_callback), (gpointer)w, NULL);
-      dt_accel_connect_iop(self, ctrl_label, closure);
+      dt_accel_connect_iop(self, combined_ctrl_label, closure);
     }
   }
-  g_free(label_first_line);
+
+  g_free(combined_ctrl_label);
+  g_free(combined_label);
 
   return w;
 }

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -26,7 +26,7 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param);
 
-GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const gchar *label, const gchar *ctrl_label,
+GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, const gchar *label, const gchar *ctrl_label,
                                    GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
                                    DTGTKCairoPaintIconFunc paint, GtkWidget *box);
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3615,15 +3615,15 @@ void gui_init(dt_iop_module_t *self)
                                        G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                        _liquify_cairo_paint_node_tool, hbox));
 
-  g->btn_curve_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("draw curves"), N_("draw multiple curves"),
+  g->btn_curve_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("shapes"), N_("draw curves"), N_("draw multiple curves"),
                                         G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                         _liquify_cairo_paint_curve_tool, hbox));
 
-  g->btn_line_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("draw lines"), N_("draw multiple lines"),
+  g->btn_line_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("shapes"), N_("draw lines"), N_("draw multiple lines"),
                                        G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                        _liquify_cairo_paint_line_tool, hbox));
 
-  g->btn_point_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("draw points"), N_("draw multiple points"),
+  g->btn_point_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("shapes"), N_("draw points"), N_("draw multiple points"),
                                          G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                          _liquify_cairo_paint_point_tool, hbox));
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3569,7 +3569,7 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn, GdkEventButton *ev
   }
 
   sync_pipe(module, FALSE);
-  dt_iop_request_focus(module);
+//  dt_iop_request_focus(module);
 
   return TRUE;
 }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3611,19 +3611,19 @@ void gui_init(dt_iop_module_t *self)
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
-  g->btn_node_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("edit, add and delete nodes"), NULL,
+  g->btn_node_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("edit, add and delete nodes"), NULL,
                                        G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                        _liquify_cairo_paint_node_tool, hbox));
 
-  g->btn_curve_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("draw curves"), N_("draw multiple curves"),
+  g->btn_curve_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("draw curves"), N_("draw multiple curves"),
                                         G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                         _liquify_cairo_paint_curve_tool, hbox));
 
-  g->btn_line_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("draw lines"), N_("draw multiple lines"),
+  g->btn_line_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("draw lines"), N_("draw multiple lines"),
                                        G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                        _liquify_cairo_paint_line_tool, hbox));
 
-  g->btn_point_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, N_("draw points"), N_("draw multiple points"),
+  g->btn_point_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("draw points"), N_("draw multiple points"),
                                          G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
                                          _liquify_cairo_paint_point_tool, hbox));
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2038,24 +2038,24 @@ void gui_init(dt_iop_module_t *self)
                _("to add a shape select an algorithm and a shape type and click on the image.\n"
                  "shapes are added to the current scale"));
 
-  g->bt_edit_masks = dt_iop_togglebutton_new(self, NULL, N_("show and edit shapes on the current scale"),
-                                                         N_("show and edit shapes in restricted mode"),
+  g->bt_edit_masks = dt_iop_togglebutton_new(self, N_("editing"), N_("show and edit shapes on the current scale"),
+                                                                  N_("show and edit shapes in restricted mode"),
                                              G_CALLBACK(rt_edit_masks_callback), TRUE, 0, 0,
                                              dtgtk_cairo_paint_masks_eye, hbox_shapes);
 
-  g->bt_brush = dt_iop_togglebutton_new(self, NULL, N_("add brush"), N_("add multiple brush strokes"),
+  g->bt_brush = dt_iop_togglebutton_new(self, N_("shapes"), N_("add brush"), N_("add multiple brush strokes"),
                                         G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                         dtgtk_cairo_paint_masks_brush, hbox_shapes);
 
-  g->bt_path = dt_iop_togglebutton_new(self, NULL, N_("add path"), N_("add multiple paths"),
+  g->bt_path = dt_iop_togglebutton_new(self, N_("shapes"), N_("add path"), N_("add multiple paths"),
                                        G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_masks_path, hbox_shapes);
 
-  g->bt_ellipse = dt_iop_togglebutton_new(self, NULL, N_("add ellipse"), N_("add multiple ellipses"),
+  g->bt_ellipse = dt_iop_togglebutton_new(self, N_("shapes"), N_("add ellipse"), N_("add multiple ellipses"),
                                           G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                           dtgtk_cairo_paint_masks_ellipse, hbox_shapes);
 
-  g->bt_circle = dt_iop_togglebutton_new(self, NULL, N_("add circle"), N_("add multiple circles"),
+  g->bt_circle = dt_iop_togglebutton_new(self, N_("shapes"), N_("add circle"), N_("add multiple circles"),
                                          G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                          dtgtk_cairo_paint_masks_circle, hbox_shapes);
 
@@ -2064,19 +2064,19 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(hbox_algo), dt_ui_label_new(_("algorithms:")), FALSE, TRUE, 0);
 
-  g->bt_blur = dt_iop_togglebutton_new(self, NULL, N_("activate blur tool"), NULL,
+  g->bt_blur = dt_iop_togglebutton_new(self, N_("tools"), N_("activate blur tool"), NULL,
                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_tool_blur, hbox_algo);
 
-  g->bt_fill = dt_iop_togglebutton_new(self, NULL, N_("activate fill tool"), NULL,
+  g->bt_fill = dt_iop_togglebutton_new(self, N_("tools"), N_("activate fill tool"), NULL,
                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_tool_fill, hbox_algo);
 
-  g->bt_clone = dt_iop_togglebutton_new(self, NULL, N_("activate cloning tool"), NULL,
+  g->bt_clone = dt_iop_togglebutton_new(self, N_("tools"), N_("activate cloning tool"), NULL,
                                         G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                         dtgtk_cairo_paint_tool_clone, hbox_algo);
 
-  g->bt_heal = dt_iop_togglebutton_new(self, NULL, N_("activate healing tool"), NULL,
+  g->bt_heal = dt_iop_togglebutton_new(self, N_("tools"), N_("activate healing tool"), NULL,
                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_tool_heal, hbox_algo);
 
@@ -2123,29 +2123,29 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *hbox_scale = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
   // display & suppress masks
-  g->bt_showmask = dt_iop_togglebutton_new(self, NULL, N_("display masks"), NULL,
+  g->bt_showmask = dt_iop_togglebutton_new(self, N_("editing"), N_("display masks"), NULL,
                                            G_CALLBACK(rt_showmask_callback), TRUE, 0, 0,
                                            dtgtk_cairo_paint_showmask, hbox_scale);
 
-  g->bt_suppress = dt_iop_togglebutton_new(self, NULL, N_("temporarily switch off shapes"), NULL,
+  g->bt_suppress = dt_iop_togglebutton_new(self, N_("editing"), N_("temporarily switch off shapes"), NULL,
                                            G_CALLBACK(rt_suppress_callback), TRUE, 0, 0,
                                            dtgtk_cairo_paint_eye_toggle, hbox_scale);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   // copy/paste shapes
-  g->bt_paste_scale = dt_iop_togglebutton_new(self, NULL, N_("paste cut shapes to current scale"), NULL,
+  g->bt_paste_scale = dt_iop_togglebutton_new(self, N_("editing"), N_("paste cut shapes to current scale"), NULL,
                                               G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
                                               dtgtk_cairo_paint_paste_forms, hbox_scale);
 
-  g->bt_copy_scale = dt_iop_togglebutton_new(self, NULL, N_("cut shapes from current scale"), NULL,
+  g->bt_copy_scale = dt_iop_togglebutton_new(self, N_("editing"), N_("cut shapes from current scale"), NULL,
                                              G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
                                              dtgtk_cairo_paint_cut_forms, hbox_scale);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   // display final image/current scale
-  g->bt_display_wavelet_scale = dt_iop_togglebutton_new(self, NULL, N_("display wavelet scale"), NULL,
+  g->bt_display_wavelet_scale = dt_iop_togglebutton_new(self, N_("editing"), N_("display wavelet scale"), NULL,
                                                         G_CALLBACK(rt_display_wavelet_scale_callback), TRUE, 0, 0,
                                                         dtgtk_cairo_paint_display_wavelet_scale, hbox_scale);
 
@@ -2178,7 +2178,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(prev_lvl), GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 0);
 
   // auto-levels button
-  g->bt_auto_levels = dt_iop_togglebutton_new(self, NULL, N_("auto levels"), NULL,
+  g->bt_auto_levels = dt_iop_togglebutton_new(self, N_("editing"), N_("auto levels"), NULL,
                                               G_CALLBACK(rt_auto_levels_callback), TRUE, 0, 0,
                                               dtgtk_cairo_paint_auto_levels, prev_lvl);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2038,24 +2038,24 @@ void gui_init(dt_iop_module_t *self)
                _("to add a shape select an algorithm and a shape type and click on the image.\n"
                  "shapes are added to the current scale"));
 
-  g->bt_edit_masks = dt_iop_togglebutton_new(self, N_("show and edit shapes on the current scale"),
-                                                   N_("show and edit shapes in restricted mode"),
+  g->bt_edit_masks = dt_iop_togglebutton_new(self, NULL, N_("show and edit shapes on the current scale"),
+                                                         N_("show and edit shapes in restricted mode"),
                                              G_CALLBACK(rt_edit_masks_callback), TRUE, 0, 0,
                                              dtgtk_cairo_paint_masks_eye, hbox_shapes);
 
-  g->bt_brush = dt_iop_togglebutton_new(self, N_("add brush"), N_("add multiple brush strokes"),
+  g->bt_brush = dt_iop_togglebutton_new(self, NULL, N_("add brush"), N_("add multiple brush strokes"),
                                         G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                         dtgtk_cairo_paint_masks_brush, hbox_shapes);
 
-  g->bt_path = dt_iop_togglebutton_new(self, N_("add path"), N_("add multiple paths"),
+  g->bt_path = dt_iop_togglebutton_new(self, NULL, N_("add path"), N_("add multiple paths"),
                                        G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_masks_path, hbox_shapes);
 
-  g->bt_ellipse = dt_iop_togglebutton_new(self, N_("add ellipse"), N_("add multiple ellipses"),
+  g->bt_ellipse = dt_iop_togglebutton_new(self, NULL, N_("add ellipse"), N_("add multiple ellipses"),
                                           G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                           dtgtk_cairo_paint_masks_ellipse, hbox_shapes);
 
-  g->bt_circle = dt_iop_togglebutton_new(self, N_("add circle"), N_("add multiple circles"),
+  g->bt_circle = dt_iop_togglebutton_new(self, NULL, N_("add circle"), N_("add multiple circles"),
                                          G_CALLBACK(rt_add_shape_callback), TRUE, 0, 0,
                                          dtgtk_cairo_paint_masks_circle, hbox_shapes);
 
@@ -2064,19 +2064,19 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(hbox_algo), dt_ui_label_new(_("algorithms:")), FALSE, TRUE, 0);
 
-  g->bt_blur = dt_iop_togglebutton_new(self, N_("activate blur tool"), NULL,
+  g->bt_blur = dt_iop_togglebutton_new(self, NULL, N_("activate blur tool"), NULL,
                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_tool_blur, hbox_algo);
 
-  g->bt_fill = dt_iop_togglebutton_new(self, N_("activate fill tool"), NULL,
+  g->bt_fill = dt_iop_togglebutton_new(self, NULL, N_("activate fill tool"), NULL,
                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_tool_fill, hbox_algo);
 
-  g->bt_clone = dt_iop_togglebutton_new(self, N_("activate cloning tool"), NULL,
+  g->bt_clone = dt_iop_togglebutton_new(self, NULL, N_("activate cloning tool"), NULL,
                                         G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                         dtgtk_cairo_paint_tool_clone, hbox_algo);
 
-  g->bt_heal = dt_iop_togglebutton_new(self, N_("activate healing tool"), NULL,
+  g->bt_heal = dt_iop_togglebutton_new(self, NULL, N_("activate healing tool"), NULL,
                                        G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_tool_heal, hbox_algo);
 
@@ -2123,29 +2123,29 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *hbox_scale = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
   // display & suppress masks
-  g->bt_showmask = dt_iop_togglebutton_new(self, N_("display masks"), NULL,
+  g->bt_showmask = dt_iop_togglebutton_new(self, NULL, N_("display masks"), NULL,
                                            G_CALLBACK(rt_showmask_callback), TRUE, 0, 0,
                                            dtgtk_cairo_paint_showmask, hbox_scale);
 
-  g->bt_suppress = dt_iop_togglebutton_new(self, N_("temporarily switch off shapes"), NULL,
+  g->bt_suppress = dt_iop_togglebutton_new(self, NULL, N_("temporarily switch off shapes"), NULL,
                                            G_CALLBACK(rt_suppress_callback), TRUE, 0, 0,
                                            dtgtk_cairo_paint_eye_toggle, hbox_scale);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   // copy/paste shapes
-  g->bt_paste_scale = dt_iop_togglebutton_new(self, N_("paste cut shapes to current scale"), NULL,
+  g->bt_paste_scale = dt_iop_togglebutton_new(self, NULL, N_("paste cut shapes to current scale"), NULL,
                                               G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
                                               dtgtk_cairo_paint_paste_forms, hbox_scale);
 
-  g->bt_copy_scale = dt_iop_togglebutton_new(self, N_("cut shapes from current scale"), NULL,
+  g->bt_copy_scale = dt_iop_togglebutton_new(self, NULL, N_("cut shapes from current scale"), NULL,
                                              G_CALLBACK(rt_copypaste_scale_callback), TRUE, 0, 0,
                                              dtgtk_cairo_paint_cut_forms, hbox_scale);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   // display final image/current scale
-  g->bt_display_wavelet_scale = dt_iop_togglebutton_new(self, N_("display wavelet scale"), NULL,
+  g->bt_display_wavelet_scale = dt_iop_togglebutton_new(self, NULL, N_("display wavelet scale"), NULL,
                                                         G_CALLBACK(rt_display_wavelet_scale_callback), TRUE, 0, 0,
                                                         dtgtk_cairo_paint_display_wavelet_scale, hbox_scale);
 
@@ -2178,7 +2178,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(prev_lvl), GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 0);
 
   // auto-levels button
-  g->bt_auto_levels = dt_iop_togglebutton_new(self, N_("auto levels"), NULL,
+  g->bt_auto_levels = dt_iop_togglebutton_new(self, NULL, N_("auto levels"), NULL,
                                               G_CALLBACK(rt_auto_levels_callback), TRUE, 0, 0,
                                               dtgtk_cairo_paint_auto_levels, prev_lvl);
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -802,17 +802,17 @@ void gui_init(dt_iop_module_t *self)
                                              G_CALLBACK(_edit_masks), TRUE, 0, 0,
                                              dtgtk_cairo_paint_masks_eye, hbox);
 
-  g->bt_path = dt_iop_togglebutton_new(self, NULL, N_("add path"), N_("add multiple paths"),
+  g->bt_path = dt_iop_togglebutton_new(self, N_("shapes"), N_("add path"), N_("add multiple paths"),
                                        G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_masks_path, hbox);
 
-  g->bt_ellipse = dt_iop_togglebutton_new(self, NULL, N_("add ellipse"), N_("add multiple ellipses"),
-                                       G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
-                                       dtgtk_cairo_paint_masks_ellipse, hbox);
+  g->bt_ellipse = dt_iop_togglebutton_new(self, N_("shapes"), N_("add ellipse"), N_("add multiple ellipses"),
+                                          G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
+                                          dtgtk_cairo_paint_masks_ellipse, hbox);
 
-  g->bt_circle = dt_iop_togglebutton_new(self, NULL, N_("add circle"), N_("add multiple circles"),
-                                       G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
-                                       dtgtk_cairo_paint_masks_circle, hbox);
+  g->bt_circle = dt_iop_togglebutton_new(self, N_("shapes"), N_("add circle"), N_("add multiple circles"),
+                                         G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
+                                         dtgtk_cairo_paint_masks_circle, hbox);
 
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -798,19 +798,19 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(hbox, _("click on a shape and drag on canvas.\nuse the mouse wheel "
                                       "to adjust size.\nright click to remove a shape."));
 
-  g->bt_edit_masks = dt_iop_togglebutton_new(self, N_("show and edit shapes"), NULL,
+  g->bt_edit_masks = dt_iop_togglebutton_new(self, NULL, N_("show and edit shapes"), NULL,
                                              G_CALLBACK(_edit_masks), TRUE, 0, 0,
                                              dtgtk_cairo_paint_masks_eye, hbox);
 
-  g->bt_path = dt_iop_togglebutton_new(self, N_("add path"), N_("add multiple paths"),
+  g->bt_path = dt_iop_togglebutton_new(self, NULL, N_("add path"), N_("add multiple paths"),
                                        G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_masks_path, hbox);
 
-  g->bt_ellipse = dt_iop_togglebutton_new(self, N_("add ellipse"), N_("add multiple ellipses"),
+  g->bt_ellipse = dt_iop_togglebutton_new(self, NULL, N_("add ellipse"), N_("add multiple ellipses"),
                                        G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_masks_ellipse, hbox);
 
-  g->bt_circle = dt_iop_togglebutton_new(self, N_("add circle"), N_("add multiple circles"),
+  g->bt_circle = dt_iop_togglebutton_new(self, NULL, N_("add circle"), N_("add multiple circles"),
                                        G_CALLBACK(_add_shape_callback), TRUE, 0, 0,
                                        dtgtk_cairo_paint_masks_circle, hbox);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2044,7 +2044,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->balance_label = dt_ui_section_label_new(_("white balance settings"));
   gtk_box_pack_start(box_enabled, g->balance_label, TRUE, TRUE, 0);
 
-  g->btn_asshot = dt_iop_togglebutton_new(self, N_("settings") "`" N_("as shot"), NULL,
+  g->btn_asshot = dt_iop_togglebutton_new(self, N_("settings"), N_("as shot"), NULL,
                                           G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                           dtgtk_cairo_paint_camera, NULL);
   gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance to as shot"));
@@ -2057,13 +2057,13 @@ void gui_init(struct dt_iop_module_t *self)
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
 
-  g->btn_user = dt_iop_togglebutton_new(self, N_("settings") "`" N_("user modified"), NULL,
+  g->btn_user = dt_iop_togglebutton_new(self, N_("settings"), N_("user modified"), NULL,
                                         G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                         dtgtk_cairo_paint_masks_drawn, NULL);
   gtk_widget_set_tooltip_text(g->btn_user, _("set white balance to user modified"));
 
 
-  g->btn_d65 = dt_iop_togglebutton_new(self, N_("settings") "`" N_("camera reference"), NULL,
+  g->btn_d65 = dt_iop_togglebutton_new(self, N_("settings"), N_("camera reference"), NULL,
                                        G_CALLBACK(btn_toggled), FALSE, 0, 0,
                                        dtgtk_cairo_paint_bulb, NULL);
   gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance to camera reference point\nin most cases it should be D65"));

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3117,17 +3117,15 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->speculars, .05);
   dt_bauhaus_slider_set_format(g->speculars, _("%+.2f EV"));
 
-  ++darktable.bauhaus->skip_accel;
-  dt_bauhaus_widget_set_label(g->noise, NULL, N_("-8 EV"));
-  dt_bauhaus_widget_set_label(g->ultra_deep_blacks, NULL, N_("-7 EV"));
-  dt_bauhaus_widget_set_label(g->deep_blacks, NULL, N_("-6 EV"));
-  dt_bauhaus_widget_set_label(g->blacks, NULL, N_("-5 EV"));
-  dt_bauhaus_widget_set_label(g->shadows, NULL, N_("-4 EV"));
-  dt_bauhaus_widget_set_label(g->midtones, NULL, N_("-3 EV"));
-  dt_bauhaus_widget_set_label(g->highlights, NULL, N_("-2 EV"));
-  dt_bauhaus_widget_set_label(g->whites, NULL, N_("-1 EV"));
-  dt_bauhaus_widget_set_label(g->speculars, NULL, N_("+0 EV"));
-  --darktable.bauhaus->skip_accel;
+  dt_bauhaus_widget_set_label(g->noise, N_("simple"), N_("-8 EV"));
+  dt_bauhaus_widget_set_label(g->ultra_deep_blacks, N_("simple"), N_("-7 EV"));
+  dt_bauhaus_widget_set_label(g->deep_blacks, N_("simple"), N_("-6 EV"));
+  dt_bauhaus_widget_set_label(g->blacks, N_("simple"), N_("-5 EV"));
+  dt_bauhaus_widget_set_label(g->shadows, N_("simple"), N_("-4 EV"));
+  dt_bauhaus_widget_set_label(g->midtones, N_("simple"), N_("-3 EV"));
+  dt_bauhaus_widget_set_label(g->highlights, N_("simple"), N_("-2 EV"));
+  dt_bauhaus_widget_set_label(g->whites, N_("simple"), N_("-1 EV"));
+  dt_bauhaus_widget_set_label(g->speculars, N_("simple"), N_("+0 EV"));
 
   // Advanced view
 


### PR DESCRIPTION
Creates a separate "pseudo" module called "blending" in the shortcuts list. Shortcuts defined here will be applicable to the currently  active module (subject to multi-instance prioritisation).

There are sub-groups for tools and shapes (and these have also been introduced in retouch/liquify/spots).

Edit 2: removed shortcuts for colorpickers as those do not get grouped correctly when translated.

Edit: Tone equaliser shortcuts are called "dark highlights", "light shadows", "speculars" etc so it is hard to for example assign keys 1/2/3 etc in the correct order. Now a new section "simple" is created with duplicates of the slider shortcuts called +0 EV, -1 EV, -2 EV etc.