### PR TITLE
deprecate zonesystem.c / zones

### DIFF
--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -120,7 +120,7 @@ const char *name()
 int flags()
 {
   return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_ALLOW_TILING
-         | IOP_FLAGS_PREVIEW_NON_OPENCL;
+         | IOP_FLAGS_PREVIEW_NON_OPENCL | IOP_FLAGS_DEPRECATED;
 }
 
 int default_group()


### PR DESCRIPTION
this module is not HDR-able, has a fiddly GUI, and since tone equalizer has been improved with EIGF and speed-up, there is no reason to keep it.