### PR TITLE
deprecate rawdenoise.c

### DIFF
--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -123,7 +123,7 @@ const char *name()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
 int default_group()


### PR DESCRIPTION
this module is vastly superceded by the denoiseprofile one, which has the same wavelets decomposition method with much better settings. I see no reason to keep it, it confuses users.