### PR TITLE
deprecate invert.c

### DIFF
--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -117,7 +117,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ONE_INSTANCE;
+  return IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_DEPRECATED;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
There is a fundamental mistake in the color science here, that does not allow to correct sensors and undo scanner gamma if any, before doing the inversion. As such, we invert sRGB for scanners or linear non-profiled and possibly non color-balanced sensor RGB otherwise. So far, people seem happy with negadoctor.