### PR TITLE
rename "denoise (non-local means)" to "astrophoto denoise"

### DIFF
--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -85,7 +85,7 @@ typedef struct dt_iop_nlmeans_global_data_t
 
 const char *name()
 {
-  return _("denoise (non-local means)");
+  return _("astrophoto denoise");
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -88,6 +88,11 @@ const char *name()
   return _("astrophoto denoise");
 }
 
+const char *aliases()
+{
+  return _("denoise (non-local means)");
+}
+
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;


### PR DESCRIPTION
The name of the denoising method is not informative for most users and is a duplicate of the non-local means in denoiseprofile.c. As a result, users get prompted with 4 different modules to denoise and are lost.

This module denoise in Lab, which has a cubic root built-in, which makes it better suited to remove Poisson noise that is typical in astrophotography. Hence the rename, which should make it clearer.