### PR TITLE
rename "denoise (bilateral filter)" to "surface blur"

### DIFF
--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -69,7 +69,7 @@ typedef struct dt_iop_bilateral_data_t
 
 const char *name()
 {
-  return _("denoise (bilateral filter)");
+  return _("surface blur");
 }
 
 int default_group()


### PR DESCRIPTION
The bilateral filter is one of the first edge-avoiding blurring filters. Its use as a denoising has been improved through the non-local means. It is a rather coarse way to denoise and it is known to overshoot.

However, as a creative filter, it produces interesting results that look like comics or can, if blended in chrominance, quickly even the color of a surface (say, to remove skin redness).

The purpose of the rename is to discourage users to use it to deblur, since we have better modules, but also advertise what it does rather than what it is (and suggest possible uses).

In the future, an RGB guided filter could be added as another options, since the goal is the same, minus the overshoot.