### PR TITLE
modulegroups: set current group when entering darkroom

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -220,6 +220,9 @@ void view_enter(dt_lib_module_t *self, dt_view_t *old_view, dt_view_t *new_view)
     if(!dt_lib_presets_apply(preset, self->plugin_name, self->version()))
       dt_lib_presets_apply(_(FALLBACK_PRESET_NAME), self->plugin_name, self->version());
     g_free(preset);
+
+    //and set the current group
+    d->current = dt_conf_get_int("plugins/darkroom/groups");
   }
 }
 


### PR DESCRIPTION
resolves issue whereby, when exiting darkroom with "active" group selected, reentering darkroom changed the group to "none" (i.e. show all)