### PR TITLE
Prevent crash when pressing edit shortcut for hidden slider

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -88,7 +88,6 @@ static inline float inner_height(GtkAllocation allocation)
   return allocation.height - 2.0f * darktable.bauhaus->widget_space;
 }
 
-
 static GdkRGBA * default_color_assign()
 {
   // helper to initialize a color pointer with red color as a default
@@ -99,7 +98,6 @@ static GdkRGBA * default_color_assign()
   color.alpha = 1.0f;
   return gdk_rgba_copy(&color);
 }
-
 
 static int show_pango_text(dt_bauhaus_widget_t *w, GtkStyleContext *context, cairo_t *cr,
                            char *text, float x_pos, float y_pos, float max_width,
@@ -2047,6 +2045,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
   int offset = 0;
   GtkAllocation tmp;
   gtk_widget_get_allocation(GTK_WIDGET(w), &tmp);
+  if(tmp.width == 1) return;
 
   gtk_widget_realize(darktable.bauhaus->popup_window);
   switch(darktable.bauhaus->current->type)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -560,7 +560,6 @@ static gboolean bauhaus_slider_edit_callback(GtkAccelGroup *accel_group, GObject
 {
   GtkWidget *slider = GTK_WIDGET(data);
 
-  // FIXME: crashes when slider hidden
   dt_bauhaus_show_popup(DT_BAUHAUS_WIDGET(slider));
 
   return TRUE;


### PR DESCRIPTION
Assign a shortcut key to the edit action of an iop slider in a module that is not in your active group. Press that key just after entering darkroom. Watch dt crash.

This change doesn't check if the slider is visible; it just catches the case where it has not been allocated an area yet, which caused dt to crash. If the slider has been shown once, but then hidden, the edit area may pop up in unexpected places (or with unexpected size if the panel has been resized) but at least it doesn't crash (as much?)