### PR TITLE
deprecate tonemap.cc / local tonemapping

### DIFF
--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -82,7 +82,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
Local tonemapping uses a gaussian blur to mask highlights out of shadows. This is guaranteed to produce halos where both masks meet. The only way to get around that is to basically dial down the settings up to the point where the whole module becomes almost useless.

In e5bad645351196de4b3b0b5a867afbebeda1c203 I have added an "HDR local tonemapping" preset for local contrast module that achieves the same purpose minus the halos. Also tone equalizer with EIGF allows the same feature with more controls over the masking vs. the tone mapping separately, while this module hides it. 

Alternatively, shadows/highlights module can still be used for the same purpose, with minimal headache.

[![](https://api.gh-polls.com/poll/01EQ11E5EC0TJ0195GY34BVKXF/deprecate%20local%20tonemapping%2C%20I%20don't%20use%20it%2C%20it's%20ugly)](https://api.gh-polls.com/poll/01EQ11E5EC0TJ0195GY34BVKXF/deprecate%20local%20tonemapping%2C%20I%20don't%20use%20it%2C%20it's%20ugly/vote)
[![](https://api.gh-polls.com/poll/01EQ11E5EC0TJ0195GY34BVKXF/I%20don't%20care%20either%20ways%2C%20no%20opinion%2C%20doesn't%20matter)](https://api.gh-polls.com/poll/01EQ11E5EC0TJ0195GY34BVKXF/I%20don't%20care%20either%20ways%2C%20no%20opinion%2C%20doesn't%20matter/vote)
[![](https://api.gh-polls.com/poll/01EQ11E5EC0TJ0195GY34BVKXF/keep%20local%20tonemapping%2C%20I%C2%A0need%20it)](https://api.gh-polls.com/poll/01EQ11E5EC0TJ0195GY34BVKXF/keep%20local%20tonemapping%2C%20I%C2%A0need%20it/vote)