### PR TITLE
Module aliases

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -173,6 +173,7 @@ typedef struct dt_iop_module_so_t
   /** callbacks, loaded once, referenced by the instances. */
   int (*version)(void);
   const char *(*name)(void);
+  const char *(*aliases)(void);
   int (*default_group)(void);
   int (*flags)(void);
 
@@ -411,6 +412,8 @@ typedef struct dt_iop_module_t
   int (*version)(void);
   /** get name of the module, to be translated. */
   const char *(*name)(void);
+  /** get aliases names of the module, to be translated. */
+  const char *(*aliases)(void);
   /** get the default group this module belongs to. */
   int (*default_group)(void);
   /** get the iop module flags. */
@@ -655,6 +658,7 @@ int get_module_flags(const char *op);
 
 /** returns the localized plugin name for a given op name. must not be freed. */
 gchar *dt_iop_get_localized_name(const gchar *op);
+gchar *dt_iop_get_localized_aliases(const gchar *op);
 
 /** Connects common accelerators to an iop module */
 void dt_iop_connect_common_accels(dt_iop_module_t *module);

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -72,6 +72,11 @@ const char *name()
   return _("denoise (bilateral filter)");
 }
 
+const char *aliases()
+{
+  return _("denoise (bilateral filter)");
+}
+
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -99,6 +99,12 @@ const char *name()
   return _("haze removal");
 }
 
+
+const char *aliases()
+{
+  return _("dehaze|defog|smoke|smog");
+}
+
 const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("remove fog and atmospheric hazing from pictures"),

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -68,7 +68,7 @@ void cleanup_global(struct dt_iop_module_so_t *self);
 int version(void);
 /** get name of the module, to be translated. */
 const char *name(void);
-/** get the alternative names of the module, to be translated. */
+/** get the alternative names or keywords of the module, to be translated. Separate variants by a pipe | */
 const char *aliases(void);
 /** get the default group this module belongs to. */
 int default_group(void);

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -68,6 +68,8 @@ void cleanup_global(struct dt_iop_module_so_t *self);
 int version(void);
 /** get name of the module, to be translated. */
 const char *name(void);
+/** get the alternative names of the module, to be translated. */
+const char *aliases(void);
 /** get the default group this module belongs to. */
 int default_group(void);
 /** get the iop module flags. */

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -509,9 +509,13 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
         }
         else
         {
-          const int is_match = (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_name(module->op), -1), -1,
-                                             g_utf8_casefold(text_entered, -1))
-                                != NULL);
+           const int is_match = (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_name(module->op), -1), -1,
+                                              g_utf8_casefold(text_entered, -1))
+                                 != NULL) ||
+                                 (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_aliases(module->op), -1), -1,
+                                               g_utf8_casefold(text_entered, -1))
+                                 != NULL);
+
 
           if(is_match)
             gtk_widget_show(w);


### PR DESCRIPTION
1. add the ability to add aliases (alternative names or keywords) to modules, that can be translated
2. add examples aliases in denoise (bilateral) to address concerns in #6885 
3. allow the module search bar to lookup modules by their aliases too.