### PR TITLE
[Issue #6663] Fix tag-sub-hierarchy

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1441,6 +1441,7 @@ gchar *dt_collection_get_makermodel(const char *exif_maker, const char *exif_mod
 static gchar *get_query_string(const dt_collection_properties_t property, const gchar *text)
 {
   char *escaped_text = sqlite3_mprintf("%q", text);
+  unsigned int escaped_length = strlen(escaped_text);
   gchar *query = NULL;
 
   switch(property)
@@ -1582,9 +1583,9 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     case DT_COLLECTION_PROP_TAG: // tag
     
       /* shift-click adds an asterix * to include items in and under this hierarchy without using a wildcard % which also would include similar named items */
-      if (!strcmp(strrchr(escaped_text, '\0') - 1, "*"))
+      if ((escaped_length > 0) && (escaped_text[escaped_length-1] == '*')) 
       {
-        escaped_text[strlen(escaped_text)-1] = 0;        
+        escaped_text[escaped_length-1] = '\0';
         query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
                                      "data.tags AS b ON a.tagid = b.id WHERE name LIKE '%s' OR name LIKE '%s|%%'))",
                               escaped_text, escaped_text);

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1509,7 +1509,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         const gboolean not_tagged = strcmp(escaped_text, _("not tagged")) == 0;
         const gboolean no_location = strcmp(escaped_text, _("tagged")) == 0;
-        const gboolean all_tagged = strcmp(escaped_text, _("tagged%")) == 0;
+        const gboolean all_tagged = strcmp(escaped_text, _("tagged*")) == 0;
         char *escaped_text2 = g_strstr_len(escaped_text, -1, "|");
         if(not_tagged || all_tagged)
           query = dt_util_dstrcat(query, "(id %s IN (SELECT id AS imgid FROM main.images "

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1580,9 +1580,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       query = dt_util_dstrcat(query, ")");
       break;
     case DT_COLLECTION_PROP_TAG: // tag
-      query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
+    
+      /* shift-click adds an asterix * to include items in and under this hierarchy without using a wildcard % which also would include similar named items */
+      if (!strcmp(strrchr(escaped_text, '\0') - 1, "*"))
+      {
+        escaped_text[strlen(escaped_text)-1] = 0;        
+        query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
+                                     "data.tags AS b ON a.tagid = b.id WHERE name LIKE '%s' OR name LIKE '%s|%%'))",
+                              escaped_text, escaped_text);
+      /* default */
+      } else
+      {
+        query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
                                      "data.tags AS b ON a.tagid = b.id WHERE name LIKE '%s'))",
                               escaped_text);
+      }
+
       break;
 
     case DT_COLLECTION_PROP_LENS: // lens

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2106,7 +2106,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
          * hierarchy. */
         else if(event->state & GDK_SHIFT_MASK)
         {
-          gchar *n_text = g_strconcat(text, "%", NULL);
+          gchar *n_text = g_strconcat(text, "*", NULL);
           g_free(text);
           text = n_text;
         }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2003,6 +2003,16 @@ static void combo_changed(GtkWidget *combo, dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(d->text, _("type your query, use `%' as wildcard and `,' to separate values"));
   }
+  else if(property == DT_COLLECTION_PROP_TAG)
+  {
+    /* xgettext:no-c-format */
+    gtk_widget_set_tooltip_text(d->text, _("type your query, use `%' as wildcard\nShift-Click on the tag / add *: include sub-hierarchy, Ctrl-Click: only show sub-hierarchy"));
+  }
+  else if(property == DT_COLLECTION_PROP_GEOTAGGING)
+  {
+    /* xgettext:no-c-format */
+    gtk_widget_set_tooltip_text(d->text, _("type your query, use `%' as wildcard\nShift-Click on tagged / add *: include locations, Ctrl-Click: only show locations"));
+  }
   else
   {
     /* xgettext:no-c-format */


### PR DESCRIPTION
Fix for #6663: only include items in and under the selected hierarchy without using a wildcard % which also would include similar named items