### PR TITLE
Fix histogram.c compile error

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -527,7 +527,7 @@ static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(wf_width, wf_height, wf_linear, primaries_linear, ch) \
-  dt_omp_shared(wf_linear) aligned(wf_linear, wf_display, primaries_linear:64) \
+  dt_omp_shared(wf_display) aligned(wf_linear, wf_display, primaries_linear:64) \
   schedule(simd:static)
 #endif
   for(int p = 0; p < wf_height * wf_width * 4; p += 4)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -223,7 +223,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *d, const float *
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(input, width, height, wf_width, bin_width, _height, scale) \
-  shared(wf_linear) aligned(input, wf_linear:64) \
+  aligned(input, wf_linear:64) \
   schedule(simd:static, bin_width)
 #endif
   for(int x = 0; x < width; x++)
@@ -513,7 +513,7 @@ static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(wf_width, wf_height, wf_linear, primaries_linear, ch) \
-  shared(wf_display) aligned(wf_linear, wf_display, primaries_linear:64) \
+  aligned(wf_linear, wf_display, primaries_linear:64) \
   schedule(simd:static)
 #endif
   for(int p = 0; p < wf_height * wf_width * 4; p += 4)
@@ -532,7 +532,7 @@ static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(wf_display, wf_width, wf_height, wf_stride) \
-  shared(wf_8bit) aligned(wf_8bit, wf_display:64) \
+  aligned(wf_8bit, wf_display:64) \
   schedule(simd:static) collapse(2)
 #endif
   // FIXME: we could do this in place in wf_display, but it'd require care w/OpenMP

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -221,10 +221,21 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *d, const float *
   // FIXME: instead outer loop could be by bin
   // FIXME: could flip x/y axes here and when reading to make row-wise iteration?
 #ifdef _OPENMP
+#ifdef __GNUCC__
+#include <features.h>
+#if __GNUC_PREREQ(9,0)
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(input, width, height, wf_width, bin_width, _height, scale) \
+  shared(wf_linear) \
+  aligned(input, wf_linear:64) \
+  schedule(simd:static, bin_width)
+#else
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(input, width, height, wf_width, bin_width, _height, scale) \
   aligned(input, wf_linear:64) \
   schedule(simd:static, bin_width)
+#endif
+#endif
 #endif
   for(int x = 0; x < width; x++)
   {
@@ -511,10 +522,19 @@ static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t 
 
   // map linear waveform data to a display colorspace
 #ifdef _OPENMP
+#ifdef __GNUCC__
+#if __GNUC_PREREQ(9,0)
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(wf_width, wf_height, wf_linear, primaries_linear, ch) \
+  shared(wf_linear) aligned(wf_linear, wf_display, primaries_linear:64) \
+  schedule(simd:static)
+#else
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(wf_width, wf_height, wf_linear, primaries_linear, ch) \
   aligned(wf_linear, wf_display, primaries_linear:64) \
   schedule(simd:static)
+#endif
+#endif
 #endif
   for(int p = 0; p < wf_height * wf_width * 4; p += 4)
   {
@@ -530,10 +550,19 @@ static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t 
                                           d->profile_linear, d->profile_display, "waveform linear to display");
 
 #ifdef _OPENMP
+#ifdef __GNUCC__
+#if __GNUC_PREREQ(9,0)
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(wf_display, wf_width, wf_height, wf_stride) \
+  shared(wf_8bit) aligned(wf_8bit, wf_display:64) \
+  schedule(simd:static) collapse(2)
+#else
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(wf_display, wf_width, wf_height, wf_stride) \
   aligned(wf_8bit, wf_display:64) \
   schedule(simd:static) collapse(2)
+#endif
+#endif
 #endif
   // FIXME: we could do this in place in wf_display, but it'd require care w/OpenMP
   for(int y = 0; y < wf_height; y++)


### PR DESCRIPTION
declaring variables const implies sharing, so explicitly sharing in a pragma causes and error