### PR TITLE
Soft deprecated

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1403,7 +1403,8 @@ margin: 0 2px;
   color: @button_hover_fg;
 }
 
-#modulegroups-deprecated-msg
+#modulegroups-deprecated-msg,
+#iop-plugin-deprecated
 {
   background-color: @grey_10;
   padding-top: 0.45em;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1403,6 +1403,13 @@ margin: 0 2px;
   color: @button_hover_fg;
 }
 
+#modulegroups-deprecated-msg
+{
+  background-color: @grey_10;
+  padding-top: 0.45em;
+  padding-bottom: 0.45em;
+}
+
 /*---------------------------------------------------------------
   - Set sidebars settings on preferences window and filechooser -
   ---------------------------------------------------------------*/

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -122,6 +122,11 @@ static const char *default_aliases(void)
   return "";
 }
 
+static const char *default_deprecated_msg(void)
+{
+  return NULL;
+}
+
 static void default_commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params,
                                   dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
@@ -297,6 +302,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
   if(!g_module_symbol(module->module, "default_group", (gpointer) & (module->default_group)))
     module->default_group = default_group;
   if(!g_module_symbol(module->module, "flags", (gpointer) & (module->flags))) module->flags = default_flags;
+  if(!g_module_symbol(module->module, "deprecated_msg", (gpointer) & (module->deprecated_msg)))
+    module->deprecated_msg = default_deprecated_msg;
   if(!g_module_symbol(module->module, "description", (gpointer) & (module->description))) module->description = default_description;
   if(!g_module_symbol(module->module, "operation_tags", (gpointer) & (module->operation_tags)))
     module->operation_tags = default_operation_tags;
@@ -489,6 +496,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->aliases = so->aliases;
   module->default_group = so->default_group;
   module->flags = so->flags;
+  module->deprecated_msg = so->deprecated_msg;
   module->description = so->description;
   module->operation_tags = so->operation_tags;
   module->operation_tags_filter = so->operation_tags_filter;
@@ -2505,6 +2513,16 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
 
   gtk_widget_set_halign(hw[IOP_MODULE_LABEL], GTK_ALIGN_START);
   gtk_widget_set_halign(hw[IOP_MODULE_INSTANCE], GTK_ALIGN_END);
+
+  // show deprected message if any
+  if(module->deprecated_msg())
+  {
+    GtkWidget *lb = gtk_label_new(g_strdup(module->deprecated_msg()));
+    gtk_label_set_line_wrap(GTK_LABEL(lb), TRUE);
+    gtk_widget_set_name(lb, "iop-plugin-deprecated");
+    gtk_box_pack_start(GTK_BOX(iopw), lb, TRUE, TRUE, 0);
+    gtk_widget_show(lb);
+  }
 
   /* add the blending ui if supported */
   gtk_box_pack_start(GTK_BOX(iopw), module->widget, TRUE, TRUE, 0);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -176,6 +176,7 @@ typedef struct dt_iop_module_so_t
   const char *(*aliases)(void);
   int (*default_group)(void);
   int (*flags)(void);
+  const char *(*deprecated_msg)(void);
 
   char *(*description)(struct dt_iop_module_t *self);
   /* should return a string with 5 lines:
@@ -418,6 +419,8 @@ typedef struct dt_iop_module_t
   int (*default_group)(void);
   /** get the iop module flags. */
   int (*flags)(void);
+  /** get deprecated message if needed */
+  const char *(*deprecated_msg)(void);
 
   /** get a descriptive text used for example in a tooltip in more modules */
   char *(*description)(struct dt_iop_module_t *self);

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -125,6 +125,11 @@ const char *name()
   return _("channel mixer");
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use color calibration module instead...");
+}
+
 const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("perform color space corrections\n"

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -71,6 +71,11 @@ int default_group()
   return IOP_GROUP_EFFECT | IOP_GROUP_EFFECTS;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use new local contrast module instead...");
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_DEPRECATED;

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -112,6 +112,11 @@ int flags()
   return IOP_FLAGS_DEPRECATED | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_PREVIEW_NON_OPENCL;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated.");
+}
+
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -104,6 +104,10 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use cotrast equalizer module instead...");
+}
 
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -173,6 +173,11 @@ int flags()
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use filmic rgb module instead...");
+}
+
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -103,6 +103,11 @@ const char *name()
   return _("global tonemap");
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use filmic rgb module instead...");
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_DEPRECATED;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -110,6 +110,11 @@ const char *name()
   return _("invert");
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use negadoctor module instead...");
+}
+
 const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("invert film negatives"),

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -74,6 +74,8 @@ const char *aliases(void);
 int default_group(void);
 /** get the iop module flags. */
 int flags(void);
+/** get the deprecated message if needed, to be translated. */
+const char *deprecated_msg(void);
 
 /** get a descriptive text used for example in a tooltip in more modules */
 const char *description(struct dt_iop_module_t *self);

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -94,6 +94,11 @@ int flags()
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_DEPRECATED;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use tone equalizer module instead...");
+}
+
 int default_group()
 {
   return IOP_GROUP_TONE | IOP_GROUP_GRADING;

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -85,6 +85,11 @@ int flags()
   return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use local contrast or tone equalizer modules instead...");
+}
+
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_rgb;

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -123,6 +123,11 @@ int flags()
          | IOP_FLAGS_PREVIEW_NON_OPENCL | IOP_FLAGS_DEPRECATED;
 }
 
+const char *deprecated_msg()
+{
+  return _("This module is deprecated. Better use tone equalizer module instead...");
+}
+
 int default_group()
 {
   return IOP_GROUP_TONE | IOP_GROUP_GRADING;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -573,8 +573,14 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
 
         default:
         {
+          // show deprecated module in specific group deprecated
+          dt_lib_modulegroups_group_t *gr =
+            (dt_lib_modulegroups_group_t *)g_list_nth_data(d->groups, d->current - 1);
+
           if(_lib_modulegroups_test_internal(self, d->current, module)
-             && (!(module->flags() & IOP_FLAGS_DEPRECATED) || module->enabled))
+            && (!(module->flags() & IOP_FLAGS_DEPRECATED)
+                || module->enabled
+                || !strcmp(gr->name, _("deprecated"))))
           {
             if(w) gtk_widget_show(w);
           }
@@ -1080,6 +1086,12 @@ void init_presets(dt_lib_module_t *self)
                        "|grain|highpass|liquify|lowlight|lowpass|monochrome|retouch|sharpen"
                        "|soften|spots|vignette|watermark");
   dt_lib_presets_add(_("modules: default"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
+  g_free(tx);
+
+  tx = NULL;
+  tx = dt_util_dstrcat(tx, "ꬹ1ꬹ%s|%s||%s", C_("modulegroup", "deprecated"), "basic",
+                       "zonesystem|invert");
+  dt_lib_presets_add(_("modules: deprecated"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
   g_free(tx);
 
   // if needed, we add a new preset, based on last user config

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -60,6 +60,7 @@ typedef struct dt_lib_modulegroups_t
   GtkWidget *active_btn;
   GtkWidget *hbox_groups;
   GtkWidget *hbox_search_box;
+  GtkWidget *deprecated;
 
   GList *groups;
 
@@ -341,6 +342,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->hbox_buttons, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), d->hbox_search_box, TRUE, TRUE, 0);
 
+  // deprecated message
+  d->deprecated = gtk_label_new(
+      _("Following modules are deprecated because they have internal design mistakes that can't be solved AND "
+        "alternatives that solve them.\nThey will be removed for new edits in next release."));
+  gtk_widget_set_name(d->deprecated, "modulegroups-deprecated-msg");
+  gtk_label_set_line_wrap(GTK_LABEL(d->deprecated), TRUE);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->deprecated, TRUE, TRUE, 0);
+
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->active_btn), TRUE);
   d->current = dt_conf_get_int("plugins/darkroom/groups");
   if(d->current == DT_MODULEGROUP_NONE) _lib_modulegroups_update_iop_visibility(self);
@@ -576,6 +585,7 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
           // show deprecated module in specific group deprecated
           dt_lib_modulegroups_group_t *gr =
             (dt_lib_modulegroups_group_t *)g_list_nth_data(d->groups, d->current - 1);
+          gtk_widget_set_visible(d->deprecated, !strcmp(gr->name, _("deprecated")));
 
           if(_lib_modulegroups_test_internal(self, d->current, module)
             && (!(module->flags() & IOP_FLAGS_DEPRECATED)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2028,12 +2028,16 @@ static void _manage_preset_update_list(dt_lib_module_t *self)
     gtk_container_add(GTK_CONTAINER(evt), lbl);
     gtk_box_pack_start(GTK_BOX(hb), evt, TRUE, TRUE, 0);
 
-    // duplicate button
-    GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT, NULL);
-    gtk_widget_set_tooltip_text(btn, _("duplicate this preset"));
-    g_object_set_data(G_OBJECT(btn), "preset_name", g_strdup(name));
-    g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_preset_duplicate), self);
-    gtk_box_pack_end(GTK_BOX(hb), btn, FALSE, FALSE, 0);
+    // duplicate button (not for deprecate preset)
+    GtkWidget *btn;
+    if(g_strcmp0(name, _("modules: deprecated")))
+    {
+      btn = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT, NULL);
+      gtk_widget_set_tooltip_text(btn, _("duplicate this preset"));
+      g_object_set_data(G_OBJECT(btn), "preset_name", g_strdup(name));
+      g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_preset_duplicate), self);
+      gtk_box_pack_end(GTK_BOX(hb), btn, FALSE, FALSE, 0);
+    }
 
     // remove button (not for read-lony presets)
     if(!ro)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1098,9 +1098,12 @@ void init_presets(dt_lib_module_t *self)
   dt_lib_presets_add(_("modules: default"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
   g_free(tx);
 
+  // this is a special preset for all newly deprecated modules
+  // so users still have a chance to access them until next release (with warning messages)
+  // this modules are deprecated in 3.4 and should be removed from this group in 3.6
   tx = NULL;
   tx = dt_util_dstrcat(tx, "ꬹ1ꬹ%s|%s||%s", C_("modulegroup", "deprecated"), "basic",
-                       "zonesystem|invert");
+                       "zonesystem|invert|channelmixer|globaltonemap|relight|tonemap");
   dt_lib_presets_add(_("modules: deprecated"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
   g_free(tx);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1004,7 +1004,7 @@ void init_presets(dt_lib_module_t *self)
                        "|shadhi|temperature|toneequal");
   tx = dt_util_dstrcat(tx, "ꬹ%s|%s||%s", C_("modulegroup", "tone"),
                        "tone", "bilat|filmicrgb|globaltonemap|levels"
-                       "|relight|rgbcurve|rgblevels|tonecurve|tonemap|zonesystem");
+                       "|rgbcurve|rgblevels|tonecurve|tonemap");
   tx = dt_util_dstrcat(tx, "ꬹ%s|%s||%s", C_("modulegroup", "color"), "color",
                        "channelmixer|channelmixerrgb|colorbalance|colorchecker|colorcontrast"
                        "|colorcorrection|colorin|colorout|colorzones|lut3d|monochrome"
@@ -1072,9 +1072,9 @@ void init_presets(dt_lib_module_t *self)
   tx = dt_util_dstrcat(tx, "ꬹ%s|%s||%s", C_("modulegroup", "grading"), "grading",
                        "basicadj|channelmixer|channelmixerrgb|colisa|colorbalance"
                        "|colorcontrast|colorcorrection|colorize|colorzones|globaltonemap"
-                       "|graduatednd|levels|relight|rgbcurve|rgblevels|shadhi|splittoning"
+                       "|graduatednd|levels|rgbcurve|rgblevels|shadhi|splittoning"
                        "|tonecurve|toneequal|tonemap"
-                       "|velvia|vibrance|zonesystem");
+                       "|velvia|vibrance");
   tx = dt_util_dstrcat(tx, "ꬹ%s|%s||%s", C_("modulegroup", "effects"), "effect",
                        "atrous|bilat|bloom|borders|clahe|colormapping"
                        "|grain|highpass|liquify|lowlight|lowpass|monochrome|retouch|sharpen"


### PR DESCRIPTION
this close #6912 , this fix #6907 
Here is some refinement on top of @TurboGit PR #6912 

it create a special modulegroups preset with all recently deprecated modules.
So this modules are still accessible until next release when they will disappear from modules groups, except for old edit using them.
That way, it let  some time to users to adapt their workflow accordingly.

Warning messages are show on top of each modules, with a proposal of replacement modules.

@aurelienpierre : can I ask you to review all the deprecated message inside modules ? Most are just copy-paste of some of your comments around... eventually we can even add the reason of deprecation but I'm not sure it's worth the pain...
@TurboGit : thanks for the base implementation