### PR TITLE
Correct channel display of JzCzhz hue

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -803,7 +803,7 @@ static inline void dt_XYZ_2_JzAzBz(const float *const DT_RESTRICT XYZ_D65, float
   for(int i = 0; i < 3; i++)
   {
     LMS[i] = M[i][0] * XYZ[0] + M[i][1] * XYZ[1] + M[i][2] * XYZ[2];
-    LMS[i] = powf(fmax(LMS[i] / 10000.f, 0.0f), n);
+    LMS[i] = powf(fmaxf(LMS[i] / 10000.f, 0.0f), n);
     LMS[i] = powf((c1 + c2 * LMS[i]) / (1.0f + c3 * LMS[i]), p);
   }
 
@@ -852,9 +852,9 @@ static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float 
   const float d = -0.56f;
   const float d0 = 1.6295499532821566e-11f;
   const float MI[3][4] DT_ALIGNED_ARRAY = {
-      {  1.9242264357876067, -1.0047923125953657,  0.0376514040306180f, 0.0f },
-      {  0.3503167620949991,  0.7264811939316552, -0.0653844229480850f, 0.0f },
-      { -0.0909828109828475, -0.3127282905230739,  1.5227665613052603f, 0.0f },
+      {  1.9242264357876067f, -1.0047923125953657f,  0.0376514040306180f, 0.0f },
+      {  0.3503167620949991f,  0.7264811939316552f, -0.0653844229480850f, 0.0f },
+      { -0.0909828109828475f, -0.3127282905230739f,  1.5227665613052603f, 0.0f },
   };
   const float AI[3][4] DT_ALIGNED_ARRAY = {
       {  1.0f,  0.1386050432715393f,  0.0580473161561189f, 0.0f },
@@ -878,7 +878,7 @@ static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float 
   for(int i = 0; i < 3; i++)
   {
     LMS[i] = AI[i][0] * IzAzBz[0] + AI[i][1] * IzAzBz[1] + AI[i][2] * IzAzBz[2];
-    LMS[i] = powf(fmax(LMS[i], 0.0f), p_inv);
+    LMS[i] = powf(fmaxf(LMS[i], 0.0f), p_inv);
     LMS[i] = 10000.f * powf(fmaxf((c1 - LMS[i]) / (c3 * LMS[i] - c2), 0.0f), n_inv);
   }
 
@@ -890,7 +890,7 @@ static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float 
 
   // X'Y'Z -> XYZ_D65
   XYZ_D65[0] = (XYZ[0] + (b - 1.0f) * XYZ[2]) / b;
-  XYZ_D65[1] = (XYZ[1] + (g - 1.0f) * XYZ[0]) / g;
+  XYZ_D65[1] = (XYZ[1] + (g - 1.0f) * XYZ_D65[0]) / g;
   XYZ_D65[2] = XYZ[2];
 }
 

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -278,14 +278,15 @@ static void _channel_display_false_color(const float *const restrict in, uint8_t
       {
         float JzCzhz[3] DT_ALIGNED_PIXEL;
         float JzAzBz[3] DT_ALIGNED_PIXEL;
-        float xyz[3] DT_ALIGNED_PIXEL;
+        float XYZ_D65[3] DT_ALIGNED_PIXEL;
         float pixel[3] DT_ALIGNED_PIXEL;
         JzCzhz[0] = 0.011f;
         JzCzhz[1] = 0.01f;
         JzCzhz[2] = in[j + 1];
         dt_JzCzhz_2_JzAzBz(JzCzhz, JzAzBz);
-        dt_JzAzBz_2_XYZ(JzAzBz, xyz);
-        _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
+        dt_JzAzBz_2_XYZ(JzAzBz, XYZ_D65);
+        dt_XYZ_to_Rec709_D65(XYZ_D65, pixel);
+        _normalize_color(pixel, 0.75f);
         _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
       }
       break;


### PR DESCRIPTION
Tried the magic trick of @aurelienpierre on the conversions in the gamma module, and it failed for the JzCzhz hue... This PR tries to fix those issues:

- Fixes a small error in the computation of JzAzBz to XYZ D65
- Use a direct XYZ D65 to sRGB conversion

There is a still a slight difference for the display of a “neutral” color that is probably due to the use of floats instead of doubles for the JzAzBz to XYZ conversion.

@TurboGit I hope this is the last one on this subject!