### PR TITLE
histogram: brighten primaries

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1171,9 +1171,9 @@ static void _lib_histogram_update_color(dt_lib_histogram_t *d)
   // red, green, blue in Lab selected for visual legibility and to
   // combine to reasonable-looking secondaries and a neutral "white"
   const double Lab_primaries[3][3] = {
-    {50.0, 70.0, 55.0},
-    {45.0, -64.0, 45.0},
-    {35.0, 8.0, -73.0}
+    {56.0, 85.0, 74.0},
+    {70.0, -100.0, 62.0},
+    {30.0, 42.0, -99.0}
   };
 
   if(xform_Lab_to_display)


### PR DESCRIPTION
These colors are closer in saturation to the appearance prior to #6135. This is as suggested by @Nilvus, see https://github.com/darktable-org/darktable/pull/6135#issuecomment-727248993.

Before #6135:

![image](https://user-images.githubusercontent.com/2311860/99177763-af420e80-26da-11eb-9a69-a51adb13e339.png)

With this PR:

![image](https://user-images.githubusercontent.com/2311860/99177796-c8e35600-26da-11eb-80fd-22b792a20117.png)

After #6135:

![image](https://user-images.githubusercontent.com/2311860/99177766-b8cb7680-26da-11eb-8214-c6a7a2b5d081.png)


