### PR TITLE
fix OpenCL detection for Big Sur 

### DIFF
--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -31,7 +31,7 @@
 #if defined(WIN32)
 static const char *ocllib[] = { "OpenCL.dll", NULL };
 #elif defined(__APPLE__)
-static const char *ocllib[] = { "/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL", "/System/Library/Frameworks/OpenCL.framework/Versions/Current/Libraries/libcldcpuengine.dylib", "/System/Library/Frameworks/OpenCL.framework/Versions/Current/Libraries/libcl2module.dylib", NULL };
+static const char *ocllib[] = { "/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL", "/System/Library/Frameworks/OpenCL.framework/Versions/Current/Libraries/libcldcpuengine.dylib", NULL };
 #else
 static const char *ocllib[] = { "libOpenCL", "libOpenCL.so", "libOpenCL.so.1", NULL };
 #endif

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -31,7 +31,7 @@
 #if defined(WIN32)
 static const char *ocllib[] = { "OpenCL.dll", NULL };
 #elif defined(__APPLE__)
-static const char *ocllib[] = { "/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL", NULL };
+static const char *ocllib[] = { "/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL", "/System/Library/Frameworks/OpenCL.framework/Versions/Current/Libraries/libcldcpuengine.dylib", "/System/Library/Frameworks/OpenCL.framework/Versions/Current/Libraries/libcl2module.dylib", NULL };
 #else
 static const char *ocllib[] = { "libOpenCL", "libOpenCL.so", "libOpenCL.so.1", NULL };
 #endif


### PR DESCRIPTION
fixes #6918 (at least for Big Sur)

according to https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes:

> "New in macOS Big Sur 11.0.1, the system ships with a built-in dynamic linker cache of all system-provided libraries. As part of this change, copies of dynamic libraries are no longer present on the filesystem. Code that attempts to check for dynamic library presence by looking for a file at a path or enumerating a directory will fail. Instead, check for library presence by attempting to dlopen() the path, which will correctly check for the library in the cache. (62986286)"

Libraries are mentioned in /System/Library/dyld/dyld_shared_cache_x86_64.map  but not visible in /System/Library/Frameworks/OpenCL.framework/Versions/Current/Libraries/

requires a test with older osx versions