### PR TITLE
src:common: Add missing string.h for strerror() in grealpath.h

### DIFF
--- a/src/common/grealpath.h
+++ b/src/common/grealpath.h
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <errno.h>
 #include <glib.h>
 


### PR DESCRIPTION
This is later used for printing errors.