### PR TITLE
modulegroup search options refactor

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -986,19 +986,6 @@
     <shortdescription>position of the image information line</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="darkroom" restart="true">
-    <name>plugins/darkroom/search_iop_by_text</name>
-    <type>
-      <enum>
-        <option>show search text</option>
-        <option>show groups</option>
-        <option>show both</option>
-      </enum>
-    </type>
-    <default>show both</default>
-    <shortdescription>show module groups and/or search text entry</shortdescription>
-    <longdescription>show module groups and/or search text entry. (needs a restart)</longdescription>
-  </dtconfig>
   <dtconfig>
     <name>database_cache_quality</name>
     <type>int</type>

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2232,8 +2232,11 @@ static void _ui_panel_size_changed(GtkAdjustment *adjustment, GParamSpec *pspec,
 
   if(!darktable.gui->scroll_to[side]) return;
 
-  gtk_widget_get_allocation(darktable.gui->scroll_to[side], &allocation);
-  gtk_adjustment_set_value(adjustment, allocation.y);
+  if(GTK_IS_WIDGET(darktable.gui->scroll_to[side]))
+  {
+    gtk_widget_get_allocation(darktable.gui->scroll_to[side], &allocation);
+    gtk_adjustment_set_value(adjustment, allocation.y);
+  }
 
   darktable.gui->scroll_to[side] = NULL;
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -34,7 +34,7 @@
 
 DT_MODULE(1)
 
-#define FALLBACK_PRESET_NAME "default"
+#define FALLBACK_PRESET_NAME "modules: default"
 #define DEPRECATED_PRESET_NAME "modules: deprecated"
 // if a preset cannot be loaded or the current preset deleted, this is the fallabck preset
 
@@ -1144,7 +1144,7 @@ void init_presets(dt_lib_module_t *self)
                        "atrous|bilat|bloom|borders|clahe|colormapping"
                        "|grain|highpass|liquify|lowlight|lowpass|monochrome|retouch|sharpen"
                        "|soften|spots|vignette|watermark");
-  dt_lib_presets_add(_("modules: default"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
+  dt_lib_presets_add(_(FALLBACK_PRESET_NAME), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
   g_free(tx);
 
   // search only (only active modules visibles)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -74,6 +74,7 @@ typedef struct dt_lib_modulegroups_t
   GtkWidget *dialog;
   GtkWidget *presets_list, *preset_box;
   GtkWidget *preset_name, *preset_groups_box;
+  GtkWidget *edit_search_cb;
 } dt_lib_modulegroups_t;
 
 /* toggle button callback */
@@ -1231,6 +1232,7 @@ static void _manage_editor_save(dt_lib_module_t *self)
   if(!d->edit_groups || !d->edit_preset) return;
 
   // get all the values
+  d->edit_show_search = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->edit_search_cb));
   gchar *params = _preset_to_string(self, TRUE);
   gchar *newname = g_strdup(gtk_entry_get_text(GTK_ENTRY(d->preset_name)));
 
@@ -1843,6 +1845,12 @@ static void _manage_editor_load(const char *preset, dt_lib_module_t *self)
   if(ro) gtk_widget_set_sensitive(d->preset_name, FALSE);
   gtk_box_pack_start(GTK_BOX(hb1), d->preset_name, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(vb), hb1, FALSE, TRUE, 0);
+
+  // show search checkbox
+  d->edit_search_cb = gtk_check_button_new_with_label(_("show search line"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->edit_search_cb), d->edit_show_search);
+  if(ro) gtk_widget_set_sensitive(d->edit_search_cb, FALSE);
+  gtk_box_pack_start(GTK_BOX(vb), d->edit_search_cb, FALSE, TRUE, 0);
 
   hb1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   d->preset_groups_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1679,6 +1679,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   btn = dtgtk_button_new(_buttons_get_icon_fct(gr->icon), CPF_DO_NOT_USE_BORDER, NULL);
   gtk_widget_set_name(btn, "modulegroups-group-icon");
   gtk_widget_set_tooltip_text(btn, _("group icon"));
+  if(ro) gtk_widget_set_sensitive(btn, FALSE);
   g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_group_icon_popup), self);
   g_object_set_data(G_OBJECT(btn), "group", gr);
   gtk_box_pack_start(GTK_BOX(hb3), btn, FALSE, TRUE, 0);
@@ -1686,6 +1687,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   GtkWidget *tb = gtk_entry_new();
   gtk_widget_set_tooltip_text(tb, _("group name"));
   g_object_set_data(G_OBJECT(tb), "group", gr);
+  if(ro) gtk_widget_set_sensitive(tb, FALSE);
   g_signal_connect(G_OBJECT(tb), "changed", G_CALLBACK(_manage_editor_group_name_changed), self);
   gtk_entry_set_text(GTK_ENTRY(tb), gr->name);
   gtk_box_pack_start(GTK_BOX(hb3), tb, TRUE, TRUE, 0);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -479,6 +479,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
     }
   }
 
+  // hide deprectade message. it will be shown after if needed
+  gtk_widget_set_visible(d->deprecated, FALSE);
+
   GList *modules = darktable.develop->iop;
   if(modules)
   {
@@ -551,7 +554,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
       }
 
       /* lets show/hide modules dependent on current group*/
-      gtk_widget_set_visible(d->deprecated, FALSE);
       switch(d->current)
       {
         case DT_MODULEGROUP_ACTIVE_PIPE:

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -265,6 +265,7 @@ static void _buttons_update(dt_lib_module_t *self)
     }
     gtk_widget_hide(d->hbox_buttons);
     d->current = DT_MODULEGROUP_ACTIVE_PIPE;
+    _lib_modulegroups_update_iop_visibility(self);
     return;
   }
   else

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -77,6 +77,13 @@ typedef struct dt_lib_modulegroups_t
   GtkWidget *edit_search_cb;
 } dt_lib_modulegroups_t;
 
+typedef enum dt_lib_modulegroup_iop_visibility_type_t
+{
+  DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE,
+  DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE,
+  DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE
+} dt_lib_modulegroup_iop_visibility_type_t;
+
 /* toggle button callback */
 static void _lib_modulegroups_toggle(GtkWidget *button, gpointer data);
 /* helper function to update iop module view depending on group */
@@ -738,6 +745,34 @@ static uint32_t _lib_modulegroups_get(dt_lib_module_t *self)
   return d->current;
 }
 
+static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref(gchar **ret)
+{
+  // show the search box ?
+  gchar *show_text_entry = dt_conf_get_string("plugins/darkroom/search_iop_by_text");
+  dt_lib_modulegroup_iop_visibility_type_t val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
+
+  if(strcmp(show_text_entry, "show search text") == 0)
+  {
+    // we only show the search box. no groups
+    *ret = dt_util_dstrcat(*ret, "1ꬹ1");
+    val = DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE;
+  }
+  else if(strcmp(show_text_entry, "show groups") == 0)
+  {
+    // we don't show the search box
+    *ret = dt_util_dstrcat(*ret, "0");
+    val = DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE;
+  }
+  else
+  {
+    // we show both
+    *ret = dt_util_dstrcat(*ret, "1");
+    val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
+  }
+  g_free(show_text_entry);
+  return val;
+}
+
 /* presets syntax :
   Layout presets are saved as string consisting of blocs separated by ꬹ
   OPTIONSꬹBLOC_0ꬹBLOC_1ꬹBLOC_2....
@@ -752,23 +787,7 @@ static gchar *_preset_retrieve_old_layout_updated()
   gchar *ret = NULL;
 
   // show the search box ?
-  const gchar *show_text_entry = dt_conf_get_string("plugins/darkroom/search_iop_by_text");
-  if(strcmp(show_text_entry, "show search text") == 0)
-  {
-    // we only show the search box. no groups
-    ret = dt_util_dstrcat(ret, "1ꬹ1");
-    return ret;
-  }
-  else if(strcmp(show_text_entry, "show groups") == 0)
-  {
-    // we don't show the search box
-    ret = dt_util_dstrcat(ret, "0");
-  }
-  else
-  {
-    // we show both
-    ret = dt_util_dstrcat(ret, "1");
-  }
+  if(_preset_retrieve_old_search_pref(&ret) == DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE) return ret;
 
   // layout with "new" 3 groups
   for(int i = 0; i < 4; i++)
@@ -817,23 +836,7 @@ static gchar *_preset_retrieve_old_layout(char *list, char *list_fav)
   gchar *ret = NULL;
 
   // show the search box ?
-  const gchar *show_text_entry = dt_conf_get_string("plugins/darkroom/search_iop_by_text");
-  if(strcmp(show_text_entry, "show search text") == 0)
-  {
-    // we only show the search box. no groups
-    ret = dt_util_dstrcat(ret, "1ꬹ1");
-    return ret;
-  }
-  else if(strcmp(show_text_entry, "show groups") == 0)
-  {
-    // we don't show the search box
-    ret = dt_util_dstrcat(ret, "0");
-  }
-  else
-  {
-    // we show both
-    ret = dt_util_dstrcat(ret, "1");
-  }
+  if(_preset_retrieve_old_search_pref(&ret) == DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE) return ret;
 
   // layout with "old" 5 groups
   for(int i = 0; i < 6; i++)


### PR DESCRIPTION
this PR : 
- fix some glitch with new modulegroups and searchbox
- move the search box visibility from pref to presets : you can now choose for each preset if you want to show the searchbox or not
- add a new preset to show only the searchbox + active modules (same as old pref "show only search")