### PR TITLE
modulegroup: force display tab reodering options to appear

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1109,18 +1109,16 @@ void init_presets(dt_lib_module_t *self)
   g_free(tx);
 
   // if needed, we add a new preset, based on last user config
-  if(!dt_conf_key_exists("plugins/darkroom/modulegroups_preset"))
-  {
-    tx = _preset_retrieve_old_layout(NULL, NULL);
-    dt_lib_presets_add(_("previous config"), self->plugin_name, self->version(), tx, strlen(tx), FALSE);
-    dt_conf_set_string("plugins/darkroom/modulegroups_preset", _("previous layout"));
-    g_free(tx);
+  tx = _preset_retrieve_old_layout(NULL, NULL);
+  dt_lib_presets_add(_("previous config"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
+  dt_conf_set_string("plugins/darkroom/modulegroups_preset", _("previous layout"));
+  g_free(tx);
 
-    tx = _preset_retrieve_old_layout_updated();
-    dt_lib_presets_add(_("previous config with new layout"), self->plugin_name, self->version(), tx,
-                       strlen(tx), FALSE);
-    g_free(tx);
-  }
+  tx = _preset_retrieve_old_layout_updated();
+  dt_lib_presets_add(_("previous config with new layout"), self->plugin_name, self->version(), tx,
+                      strlen(tx), TRUE);
+  g_free(tx);
+
   // if they exists, we retrieve old user presets from old modulelist lib
   _preset_retrieve_old_presets(self);
 }


### PR DESCRIPTION
This started because I accidentally removed the presets allowing to change the layout. Fact is the presets are not read-only, but also they are stored in database. Once removed, they can't be restored.

I'm not sure the layout reordering should be a preset. I think it would be more robust to have it in a function that stays in the program and dynamically re-allocate the tabs. Also, it's confusing to mix layouts and lists of modules in presets, as layouts are views while lists of modules are content.