### PR TITLE
Optimize colorspaces conversions

### DIFF
--- a/data/kernels/colorspace.cl
+++ b/data/kernels/colorspace.cl
@@ -72,13 +72,11 @@ inline float4 lab_f_inv(float4 x)
 inline float4 Lab_to_XYZ(float4 Lab)
 {
   const float4 d50 = (float4)(0.9642f, 1.0f, 0.8249f, 0.0f);
-  float4 f, XYZ;
+  float4 f;
   f.y = (Lab.x + 16.0f)/116.0f;
   f.x = Lab.y/500.0f + f.y;
   f.z = f.y - Lab.z/200.0f;
-  XYZ = d50 * lab_f_inv(f);
-
-  return XYZ;
+  return d50 * lab_f_inv(f);
 }
 
 inline float4 prophotorgb_to_XYZ(float4 rgb)

--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -29,12 +29,11 @@ colorspaces_transform_lab_to_rgb_matrix(read_only image2d_t in, write_only image
   if(x >= width || y >= height) return;
 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  pixel.xyz = Lab_to_XYZ(pixel).xyz;
+  pixel = matrix_product(pixel, profile_info->matrix_out);
 
-  float4 xyz, RGB;
-
-  xyz = Lab_to_XYZ(pixel);
-  RGB = matrix_product(xyz, profile_info->matrix_out);
-  pixel.xyz = apply_trc_out(RGB, profile_info, lut).xyz;
+  if(profile_info->nonlinearlut)
+    pixel = apply_trc_out(pixel, profile_info, lut);
 
   write_imagef(out, (int2)(x, y), pixel);
 }
@@ -50,11 +49,11 @@ colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in, write_only image
 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
 
-  float4 xyz, RGB;
+  if(profile_info->nonlinearlut)
+    pixel = apply_trc_in(pixel, profile_info, lut);
 
-  RGB = apply_trc_in(pixel, profile_info, lut);
-  xyz = matrix_product(RGB, profile_info->matrix_in);
-  pixel.xyz = XYZ_to_Lab(xyz).xyz;
+  pixel = matrix_product(pixel, profile_info->matrix_in);
+  pixel.xyz = XYZ_to_Lab(pixel).xyz;
 
   write_imagef(out, (int2)(x, y), pixel);
 }
@@ -62,7 +61,7 @@ colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in, write_only image
 kernel void
 colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
     constant dt_colorspaces_iccprofile_info_cl_t *profile_info_from, read_only image2d_t lut_from,
-    constant dt_colorspaces_iccprofile_info_cl_t *profile_info_to, read_only image2d_t lut_to)
+    constant dt_colorspaces_iccprofile_info_cl_t *profile_info_to, read_only image2d_t lut_to, constant float *matrix)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -71,12 +70,13 @@ colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image
 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
 
-  float4 xyz, linear_rgb;
+  if(profile_info_from->nonlinearlut)
+    pixel = apply_trc_in(pixel, profile_info_from, lut_from);
 
-  linear_rgb = apply_trc_in(pixel, profile_info_from, lut_from);
-  xyz = matrix_product(linear_rgb, profile_info_from->matrix_in);
-  linear_rgb = matrix_product(xyz, profile_info_to->matrix_out);
-  pixel.xyz = apply_trc_out(linear_rgb, profile_info_to, lut_to).xyz;
+  pixel = matrix_product(pixel, matrix);
+
+  if(profile_info_to->nonlinearlut)
+    pixel = apply_trc_out(pixel, profile_info_to, lut_to);
 
   write_imagef(out, (int2)(x, y), pixel);
 }

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -280,10 +280,10 @@ static inline void _apply_trc_out(const float rgb_in[3], float rgb_out[3],
 static inline void _ioppr_linear_rgb_matrix_to_xyz(const float rgb[3], float xyz[3],
                                                    const float matrix[9])
 {
-  for(int c = 0; c < 3; c++) xyz[c] = 0.0f;
+  for(size_t c = 0; c < 3; c++) xyz[c] = 0.0f;
 
-  for(int c = 0; c < 3; c++)
-    for(int i = 0; i < 3; i++)
+  for(size_t c = 0; c < 3; c++)
+    for(size_t i = 0; i < 3; i++)
       xyz[c] += matrix[3 * c + i] * rgb[i];
 }
 
@@ -296,10 +296,10 @@ static inline void _ioppr_linear_rgb_matrix_to_xyz(const float rgb[3], float xyz
 static inline void _ioppr_xyz_to_linear_rgb_matrix(const float xyz[3], float rgb[3],
                                                    const float matrix[9])
 {
-  for(int c = 0; c < 3; c++) rgb[c] = 0.0f;
+  for(size_t c = 0; c < 3; c++) rgb[c] = 0.0f;
 
-  for(int c = 0; c < 3; c++)
-    for(int i = 0; i < 3; i++)
+  for(size_t c = 0; c < 3; c++)
+    for(size_t i = 0; i < 3; i++)
       rgb[c] += matrix[3 * c + i] * xyz[i];
 }
 
@@ -363,7 +363,7 @@ static inline void dt_ioppr_lab_to_rgb_matrix(const float lab[3], float rgb[3],
                                               const float unbounded_coeffs_out[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
-  float xyz[3] DT_ALIGNED_PIXEL;
+  float xyz[3] DT_ALIGNED_PIXEL = { 0.f };
   dt_Lab_to_XYZ(lab, xyz);
 
   if(nonlinearlut)
@@ -389,7 +389,7 @@ static inline void dt_ioppr_rgb_matrix_to_lab(const float rgb[3], float lab[3],
                                               const float unbounded_coeffs_in[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
-  float xyz[3] DT_ALIGNED_PIXEL;
+  float xyz[3] DT_ALIGNED_PIXEL = { 0.f };
   dt_ioppr_rgb_matrix_to_xyz(rgb, xyz, matrix_in, lut_in, unbounded_coeffs_in, lutsize, nonlinearlut);
   dt_XYZ_to_Lab(xyz, lab);
 }


### PR DESCRIPTION
Since colorspaces conversion in-pipe are done a lot more now that we use custom blending spaces, this ensures they are as fast as possible.

On CPU, this drops typical runtimes from 12-20 ms to 8-12 ms.
On GPU, from 8-12 ms to 4-9 ms.
The histogram conversion (from non-linear RGB to non-linear RGB, with 2 LUTs searches) drops from 22-24 ms on both CPU and GPU to 11 ms on CPU and 15-16 ms on GPU.

I have removed entirely the SSE2 code that was commented, since even after optimization, it was at least twice as slow as the pure C optimized by GCC10. For future reference, colorin and colorout use the same code, it might be good to remove the SSE2 function for them as well. 

I have also factorized the RGB -> XYZ -> RGB conversions by premultiplying the RGB -> XYZ and XYZ -> RGB matrices before the pixel loop. That saves 1 matrix multiplication per pixel.