### PR TITLE
Improve modulegroups GUI

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -826,6 +826,28 @@ dialog .dialog-vbox notebook stack box box checkbutton label  /* fix a margin on
     padding: 2px;
 }
 
+/*--------------------------------------------------------
+  - Bauhaus controls (sliders and comboboxes in modules) -
+  --------------------------------------------------------*/
+
+#bauhaus-popup
+{
+  color: @bauhaus_fg;
+}
+
+#bauhaus-popup:selected
+{
+  color: @bauhaus_fg_selected;
+}
+
+#bauhaus-combobox,
+#bauhaus-slider
+{
+  min-height: 1em;
+  background-color: transparent;
+  color: @bauhaus_fg;
+}
+
 /*----------------------------------------
   - Context menu & tooltips & comboboxes -
   ----------------------------------------*/
@@ -867,8 +889,8 @@ tooltip,
 popover,
 combobox window,
 dialog combobox window,
-#modulegroups-iop-popup,
-#modulegroups-iop-popup viewport
+#bauhaus-popup,
+#modulegroups-iop-popup
 {
   opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
   background-color: @tooltip_bg_color;
@@ -878,6 +900,11 @@ dialog combobox window,
   min-height: 0.4em;
   min-width: 0.4em;
   padding: 0.2em 0;
+}
+
+#modulegroups-iop-popup viewport
+{
+  background-color: @tooltip_bg_color;
 }
 
 popover
@@ -1018,29 +1045,6 @@ notebook tab label /* disabled tabs */
 notebook header /* add space between notebook tabs and options below */
 {
   margin-bottom: 6px;
-}
-
-/*--------------------------------------------------------
-  - Bauhaus controls (sliders and comboboxes in modules) -
-  --------------------------------------------------------*/
-
-#bauhaus-popup
-{
-  background-color: @really_dark_bg_color;
-  color: @bauhaus_fg;
-}
-
-#bauhaus-popup:selected
-{
-  color: @bauhaus_fg_selected;
-}
-
-#bauhaus-combobox,
-#bauhaus-slider
-{
-  min-height: 1em;
-  background-color: transparent;
-  color: @bauhaus_fg;
 }
 
 /*--------------------------

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -867,7 +867,8 @@ tooltip,
 popover,
 combobox window,
 dialog combobox window,
-#modulegroups-iop-popup
+#modulegroups-iop-popup,
+#modulegroups-iop-popup viewport
 {
   opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
   background-color: @tooltip_bg_color;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -866,12 +866,13 @@ menuitem arrow,
 tooltip,
 popover,
 combobox window,
-dialog combobox window
+dialog combobox window,
+#modulegroups-iop-popup
 {
   opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
   background-color: @tooltip_bg_color;
   border-radius: 2px;
-  border: 0;
+  border: 1px solid @button_border;
   outline-style: none;
   min-height: 0.4em;
   min-width: 0.4em;
@@ -1265,7 +1266,7 @@ margin: 0 2px;
 {
   color: @fg_color;
   background-color: @plugin_bg_color;
-  padding-left: 0.5em;
+  padding: 0.5em 0.6em;
 }
 
 #modulegroups-presets-list
@@ -1280,6 +1281,8 @@ margin: 0 2px;
   color: @plugin_label_color;
   border-left: 2px solid @bg_color;
   padding: 7px 17px;
+  font-size: 1.1em;
+  min-width: 150px;
 }
 
 #modulegroups-iop-header,
@@ -1293,14 +1296,8 @@ margin: 0 2px;
 
 #modulegroups-header
 {
+  padding-top: 0.5em;
   margin-bottom: 0.4em;
-}
-
-#modulegroups-preset,
-#modulegroups-preset-activated
-{
-  font-size: 1.1em;
-  min-width: 150px;
 }
 
 #modulegroups-group-icon {
@@ -1317,6 +1314,12 @@ margin: 0 2px;
 #modulegroups-iop-popup-name
 {
   border: 0;
+}
+
+#modulegroups_iop_title,
+#modulegroups-iop-popup-name
+{
+   padding: 0.2em 0.5em;
 }
 
 #modulegroups-groups-title
@@ -1378,12 +1381,6 @@ margin: 0 2px;
   min-width: 1.6em;
   min-height: 1.6em;
   border: 0;
-}
-
-#modulegroups-iop-popup
-{
-  padding: 0.2em;
-  background-color: @grey_30;
 }
 
 #modulegroups_iop_title


### PR DESCRIPTION
This improves modulegroups GUI and also add a thin border on all popover menus (so presets, styles menu in darkroom, etc.) for consistency and better visibility as pointed by @TurboGit here: https://github.com/darktable-org/darktable/pull/6970#issuecomment-729970054

@AlicVB: as this is on top of your work, your review is welcomed!