### PR TITLE
libs preset : reorder like iop

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1000,8 +1000,8 @@
     <shortdescription>draw borders around grouped images</shortdescription>
     <longdescription>draw borders around grouped images when grouping is turned off and the mouse hovers over one of the images of the group</longdescription>
   </dtconfig>
-  <dtconfig prefs="darkroom">
-    <name>plugins/darkroom/default_presets_first</name>
+  <dtconfig prefs="misc" section="interface">
+    <name>modules/default_presets_first</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>sort built-in presets first</shortdescription>
@@ -1011,10 +1011,16 @@
     <name>plugins/darkroom/hide_default_presets</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>hide built-in presets</shortdescription>
+    <shortdescription>hide built-in presets for image operations</shortdescription>
     <longdescription>hides built-in presets of modules in both presets and favourites menu.</longdescription>
   </dtconfig>
-
+  <dtconfig prefs="lighttable">
+    <name>plugins/lighttable/hide_default_presets</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>hide built-in presets for panels</shortdescription>
+    <longdescription>hides built-in presets of panels in presets menu.</longdescription>
+  </dtconfig>
   <dtconfig prefs="import" section="session">
     <name>session/base_directory_pattern</name>
     <type>string</type>

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1135,7 +1135,7 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
   darktable.gui->presets_popup_menu = GTK_MENU(gtk_menu_new());
   menu = darktable.gui->presets_popup_menu;
   const gboolean hide_default = dt_conf_get_bool("plugins/darkroom/hide_default_presets");
-  const gboolean default_first = dt_conf_get_bool("plugins/darkroom/default_presets_first");
+  const gboolean default_first = dt_conf_get_bool("modules/default_presets_first");
 
   gchar *query = NULL;
 


### PR DESCRIPTION
this fix #6990 
We still need to choose some things here which prefs to (re-)use and where to put them ?
currently with this PR : 
1. we re-use `plugins/darkroom/default_presets_first` pref for the order. Which make sense imho for consistency. Problem : this pref is exposed inside the darkroom panel, where to put it if it's used for libs and iops ? (we can also eventually change the name, but this will break old settings...)
2. we use a new `plugins/lighttable/hide_default_presets` setting, as hidding built-in prefs for libs can be way more problematic than for iops. For example, modulegroups can hardly work on first launch without them (well, it can, but result in bad ui experience imho) and same question as for 1 : do we want to expose it and where ?

what do you think ?

PS : once that sorted out, it's mainly a copy-paste of what happen for iops.