### PR TITLE
gui_cleanup before destroying multi-instance widget

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -900,8 +900,8 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
     {
       if(!dt_iop_is_hidden(module))
       {
-        gtk_widget_destroy(module->expander);
         dt_iop_gui_cleanup_module(module);
+        gtk_widget_destroy(module->expander);
       }
 
       // we remove the module from the list


### PR DESCRIPTION
similar to #4096

Tone equaliser and color calibration save notebook page in gui_cleanup. When changing images a multi-instance would already have been destroyed by then.