### PR TITLE
Enable always-on module when history disabled it

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -344,7 +344,13 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
     piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
     if(piece->module == hist->module)
     {
-      piece->enabled = hist->enabled;
+      const gboolean mustbe_enabled = piece->module->default_enabled && piece->module->hide_enable_button;
+      piece->enabled = hist->enabled || mustbe_enabled;
+      if((hist->enabled == 0) && mustbe_enabled)
+      {
+        fprintf(stderr,"[dt_dev_pixelpipe_synch] alway-on module `%s' found as disabled in history\n", piece->module->op);
+        // FIXME can we also repair history from here?
+      }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
     }
     nodes = g_list_next(nodes);


### PR DESCRIPTION
We might have corrupt history with a disabled module even when it needs to be enabled.
Gives some debugging output in case of such an error condition.

Fixes #6992

This is sort-of safety fix. We might also want to
1. repair history here (in another pr)
