### PR TITLE
Add debug strings for default params and history init

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1377,6 +1377,8 @@ void _dev_insert_module(dt_develop_t *dev, dt_iop_module_t *module, const int im
   DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 4, module->default_params, module->params_size, SQLITE_TRANSIENT);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
+
+  dt_print(DT_DEBUG_PARAMS, "[history] module %s inserted to history\n", module->op);
 }
 
 static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
@@ -1672,6 +1674,15 @@ void _dev_write_history(dt_develop_t *dev, const int imgid)
   }
 }
 
+// helper function for debug strings
+char * _print_validity(gboolean state)
+{
+  if(state)
+    return "ok";
+  else
+    return "WRONG";
+}
+
 void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_image)
 {
   if(imgid <= 0) return;
@@ -1696,6 +1707,8 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
     // cleanup
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.history", NULL, NULL, NULL);
 
+    dt_print(DT_DEBUG_PARAMS, "[history] temporary history deleted\n");
+
     // make sure all modules default params are loaded to init history
     _dt_dev_load_pipeline_defaults(dev);
 
@@ -1707,8 +1720,12 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
     first_run = _dev_auto_apply_presets(dev);
     auto_apply_modules = _dev_get_module_nb_records() - default_modules;
 
+    dt_print(DT_DEBUG_PARAMS, "[history] temporary history initialised with default params and presets\n");
+
     // now merge memory.history into main.history
     _dev_merge_history(dev, imgid);
+
+    dt_print(DT_DEBUG_PARAMS, "[history] temporary history merged with image history\n");
 
     //  first time we are loading the image, try to import lightroom .xmp if any
     if(dev->image_loading && first_run) dt_lightroom_import(dev->image_storage.id, dev, TRUE);
@@ -1836,6 +1853,13 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
     gboolean is_valid_blendop_size = (bl_length == sizeof(dt_develop_blend_params_t));
     gboolean is_valid_module_version = (modversion == hist->module->version());
     gboolean is_valid_params_size = (param_length == hist->module->params_size);
+
+    dt_print(DT_DEBUG_PARAMS, "[history] successfully loaded module %s from history\n"
+                              "\t\t\tblendop v. %i:\tversion %s\tparams %s\n"
+                              "\t\t\tparams v. %i:\tversion %s\tparams %s\n",
+                              module_name,
+                              blendop_version, _print_validity(is_valid_blendop_version), _print_validity(is_valid_blendop_size),
+                              modversion, _print_validity(is_valid_module_version), _print_validity(is_valid_params_size));
 
     // Init buffers and values
     hist->enabled = enabled;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1360,7 +1360,11 @@ void dt_iop_gui_init(dt_iop_module_t *module)
 void dt_iop_reload_defaults(dt_iop_module_t *module)
 {
   if(darktable.gui) ++darktable.gui->reset;
-  if(module->reload_defaults) module->reload_defaults(module);
+  if(module->reload_defaults)
+  {
+    module->reload_defaults(module);
+    dt_print(DT_DEBUG_PARAMS, "[params] defaults reloaded for %s\n", module->op);
+  }
   dt_iop_load_default_params(module);
   if(darktable.gui) --darktable.gui->reset;
 
@@ -1918,6 +1922,8 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
     piece->hash = hash;
 
     free(str);
+
+    dt_print(DT_DEBUG_PARAMS, "[params] commit for %s in pipe %i with hash %lu\n", module->op, pipe->type, (long unsigned int)piece->hash);
   }
   // printf("commit params hash += module %s: %lu, enabled = %d\n", piece->module->op, piece->hash,
   // piece->enabled);
@@ -2677,7 +2683,7 @@ static gboolean enable_module_callback(GtkAccelGroup *accel_group, GObject *acce
 
   //cannot toggle module if there's no enable button
   if(module->hide_enable_button) return TRUE;
-  
+
   gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(module->off));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), !active);
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -354,7 +354,10 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
 void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
-  // call reset_params on all pieces first.
+
+  dt_print(DT_DEBUG_PARAMS, "[pixelpipe] synch all modules with defaults_params for pipe %i\n", pipe->type);
+
+  // call reset_params on all pieces first. This is mandatory to init utility modules that don't have an history stack
   GList *nodes = pipe->nodes;
   while(nodes)
   {
@@ -365,6 +368,9 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
                          pipe, piece);
     nodes = g_list_next(nodes);
   }
+
+  dt_print(DT_DEBUG_PARAMS, "[pixelpipe] synch all modules with history for pipe %i\n", pipe->type);
+
   // go through all history items and adjust params
   GList *history = dev->history;
   for(int k = 0; k < dev->history_end && history; k++)
@@ -385,6 +391,8 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 
 void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev)
 {
+  dt_print(DT_DEBUG_PARAMS, "[pixelpipe] pipeline state changed for pipe %i\n", pipe->type);
+
   dt_pthread_mutex_lock(&dev->history_mutex);
   // case DT_DEV_PIPE_UNCHANGED: case DT_DEV_PIPE_ZOOMED:
   if(pipe->changed & DT_DEV_PIPE_TOP_CHANGED)


### PR DESCRIPTION
Many users have reported weird issues with default modules and default params, with basecurve and filmic being both applied, for example. We have no way to follow the path of initialization to collect data on these unreproduceable bugs. This PR adds debug strings that can output the params state in the reading sequence:

```
$ /opt/darktable/bin/darktable -d params
7.678549 [history] temporary history deleted
7.678618 [params] defaults reloaded for filmicrgb
7.678632 [params] defaults reloaded for colormapping
7.678659 [params] defaults reloaded for channelmixerrgb
7.678966 [params] defaults reloaded for colorin
7.678987 [params] defaults reloaded for clipping
7.678992 [params] defaults reloaded for flip
7.678996 [params] defaults reloaded for ashift
7.679007 [params] defaults reloaded for lens
7.679012 [params] defaults reloaded for scalepixels
7.679016 [params] defaults reloaded for rotatepixels
7.679021 [params] defaults reloaded for denoiseprofile
7.679027 [params] defaults reloaded for demosaic
7.679032 [params] defaults reloaded for rawdenoise
7.679038 [params] defaults reloaded for hotpixels
7.679043 [params] defaults reloaded for cacorrect
7.679048 [params] defaults reloaded for highlights
7.679054 [params] defaults reloaded for temperature
7.679058 [params] defaults reloaded for invert
7.679063 [params] defaults reloaded for rawprepare
7.681843 [history] temporary history initialised with default params and presets
7.681942 [history] temporary history merged with image history
7.682007 [history] successfully loaded module colorin from history
                        blendop v. 10:  version ok      params ok
                        params v. 6:    version ok      params ok
7.682024 [history] successfully loaded module colorout from history
                        blendop v. 10:  version ok      params ok
                        params v. 5:    version ok      params ok
7.682038 [history] successfully loaded module gamma from history
                        blendop v. 10:  version ok      params ok
                        params v. 1:    version ok      params ok
7.682052 [history] successfully loaded module flip from history
                        blendop v. 10:  version ok      params ok
                        params v. 2:    version ok      params ok
7.682064 [history] successfully loaded module atrous from history
                        blendop v. 10:  version ok      params ok
                        params v. 1:    version ok      params ok
7.682076 [history] successfully loaded module highlights from history
                        blendop v. 10:  version ok      params ok
                        params v. 2:    version ok      params ok
7.871414 [params] defaults reloaded for filmicrgb
7.936990 [params] defaults reloaded for colormapping
8.049469 [params] defaults reloaded for channelmixerrgb
8.052413 [params] defaults reloaded for colorin
8.135181 [params] defaults reloaded for clipping
8.136906 [params] defaults reloaded for flip
8.141109 [params] defaults reloaded for ashift
8.151836 [params] defaults reloaded for lens
8.153500 [params] defaults reloaded for scalepixels
8.155075 [params] defaults reloaded for rotatepixels
8.183925 [params] defaults reloaded for denoiseprofile
8.186024 [params] defaults reloaded for demosaic
8.195344 [params] defaults reloaded for rawdenoise
8.201318 [params] defaults reloaded for hotpixels
8.202821 [params] defaults reloaded for cacorrect
8.210524 [params] defaults reloaded for highlights
8.216644 [params] defaults reloaded for temperature
8.219228 [params] defaults reloaded for invert
8.224462 [params] defaults reloaded for rawprepare
8.619278 [pixelpipe] pipeline state changed for pipe 2
8.619326 [pixelpipe] synch all modules with defaults_params for pipe 2
8.619382 [params] commit for flip in pipe 2 with hash 6381475781
8.623825 [params] commit for colorin in pipe 2 with hash 14533593663578724808
8.653171 [params] commit for colorout in pipe 2 with hash 17550375832207479573
8.653276 [params] commit for finalscale in pipe 2 with hash 6381440901
8.653288 [params] commit for overexposed in pipe 2 with hash 6381440901
8.653299 [params] commit for rawoverexposed in pipe 2 with hash 6381440901
8.653308 [params] commit for gamma in pipe 2 with hash 7567884774754821
8.653313 [pixelpipe] synch all modules with history for pipe 2
8.656893 [params] commit for colorin in pipe 2 with hash 14533593663578724808
8.669550 [params] commit for colorout in pipe 2 with hash 17550375832207479573
8.669664 [params] commit for gamma in pipe 2 with hash 7567884774754821
8.669722 [params] commit for flip in pipe 2 with hash 6381475781
8.669740 [params] commit for atrous in pipe 2 with hash 1483058877408221954
9.351467 [pixelpipe] pipeline state changed for pipe 4
9.351506 [pixelpipe] synch all modules with defaults_params for pipe 4
9.351562 [params] commit for flip in pipe 4 with hash 6381475781
9.354377 [params] commit for colorin in pipe 4 with hash 14533593663578724808
9.368433 [params] commit for colorout in pipe 4 with hash 17550375832207479573
9.368479 [params] commit for finalscale in pipe 4 with hash 6381440901
9.368489 [params] commit for overexposed in pipe 4 with hash 6381440901
9.368497 [params] commit for rawoverexposed in pipe 4 with hash 6381440901
9.368504 [params] commit for gamma in pipe 4 with hash 7567884774754821
9.368510 [pixelpipe] synch all modules with history for pipe 4
9.370992 [params] commit for colorin in pipe 4 with hash 14533593663578724808
9.385100 [params] commit for colorout in pipe 4 with hash 17550375832207479573
9.385159 [params] commit for gamma in pipe 4 with hash 7567884774754821
9.385168 [params] commit for flip in pipe 4 with hash 6381475781
9.385179 [params] commit for atrous in pipe 4 with hash 1483058877408221954
```

It also helps tracking the redundant calls to `reload_defaults` and `commit_params`, which take quite a lot of time at startup, as you see.

This PR applies on top of #7029 