### PR TITLE
colorpicker: convert color patch to display profile

### DIFF
--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -351,6 +351,27 @@ static inline void dt_ioppr_rgb_matrix_to_xyz(const float rgb[3], float xyz[3],
     _ioppr_linear_rgb_matrix_to_xyz(rgb, xyz, matrix_in);
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd \
+  aligned(rgb, xyz, matrix_out, unbounded_coeffs_out:16) \
+  aligned(lut_out:64) \
+  uniform(rgb, xyz, matrix_out, lut_out, unbounded_coeffs_out)
+#endif
+static inline void dt_ioppr_xyz_to_rgb_matrix(const float xyz[3], float rgb[3],
+                                              const float matrix_out[9], float *const lut_out[3],
+                                              const float unbounded_coeffs_out[3][3],
+                                              const int lutsize, const int nonlinearlut)
+{
+  if(nonlinearlut)
+  {
+    float linear_rgb[3] DT_ALIGNED_PIXEL;
+    _ioppr_xyz_to_linear_rgb_matrix(xyz, linear_rgb, matrix_out);
+    _apply_trc_out(linear_rgb, rgb, lut_out, unbounded_coeffs_out, lutsize);
+  }
+  else
+    _ioppr_xyz_to_linear_rgb_matrix(xyz, rgb, matrix_out);
+}
+
 
 #ifdef _OPENMP
 #pragma omp declare simd \

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -113,9 +113,11 @@ static inline gboolean _convert_color_space(const GdkRGBA *restrict sample, GdkR
                              display_profile->unbounded_coeffs_out, display_profile->lutsize,
                              display_profile->nonlinearlut);
 
-  color->red = RGB[0];
-  color->green = RGB[1];
-  color->blue = RGB[2];
+  // Sanitize values and ensure gamut-fitting
+  // we reproduce the default behaviour of colorout, which is harsh gamut clipping
+  color->red = CLAMP(RGB[0], 0.f, 1.f);
+  color->green = CLAMP(RGB[1], 0.f, 1.f);
+  color->blue = CLAMP(RGB[2], 0.f, 1.f);
 
   return FALSE;
 }
@@ -184,9 +186,9 @@ static void _update_sample_label(dt_colorpicker_sample_t *sample)
   }
 
   // Setting the output button
-  sample->rgb.red   = CLAMP(rgb[0], 0.f, 1.f);
-  sample->rgb.green = CLAMP(rgb[1], 0.f, 1.f);
-  sample->rgb.blue  = CLAMP(rgb[2], 0.f, 1.f);
+  sample->rgb.red   = rgb[0];
+  sample->rgb.green = rgb[1];
+  sample->rgb.blue  = rgb[2];
 
   // Setting the output label
   char text[128] = { 0 };

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -19,6 +19,7 @@
 #include "bauhaus/bauhaus.h"
 #include "libs/colorpicker.h"
 #include "common/darktable.h"
+#include "common/iop_profile.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -87,13 +88,56 @@ void connect_key_accels(dt_lib_module_t *self)
 
 // GUI callbacks
 
+static inline gboolean _convert_color_space(const GdkRGBA *restrict sample, GdkRGBA *restrict color)
+{
+  // RGB values are relative to the histogram color profile
+  // we need to adapt them to display profile so color look right
+  // Note : dt_ioppr_set_pipe_output_profile_info sets a non-handled output profile to sRGB by default
+  // meaning that this conversion is wrong for fancy-pants LUT-based display profiles.
+
+  dt_iop_order_iccprofile_info_t *histogram_profile = dt_ioppr_get_histogram_profile_info(darktable.develop);
+  dt_iop_order_iccprofile_info_t *display_profile = dt_ioppr_get_pipe_output_profile_info(darktable.develop->pipe);
+
+  float RGB[3] = { sample->red, sample->green, sample->blue };
+  float XYZ[3];
+
+  if(!(histogram_profile && display_profile)) return TRUE; // no need to paint, color will be wrong
+
+  // convert from histogram RGB to XYZ
+  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ, histogram_profile->matrix_in, histogram_profile->lut_in,
+                             histogram_profile->unbounded_coeffs_in, histogram_profile->lutsize,
+                             histogram_profile->nonlinearlut);
+
+  // convert from XYZ to display RGB
+  dt_ioppr_xyz_to_rgb_matrix(XYZ, RGB, display_profile->matrix_out, display_profile->lut_out,
+                             display_profile->unbounded_coeffs_out, display_profile->lutsize,
+                             display_profile->nonlinearlut);
+
+  color->red = RGB[0];
+  color->green = RGB[1];
+  color->blue = RGB[2];
+
+  return FALSE;
+}
+
 static gboolean _sample_draw_callback(GtkWidget *widget, cairo_t *cr, dt_colorpicker_sample_t *sample)
 {
   const guint width = gtk_widget_get_allocated_width(widget);
   const guint height = gtk_widget_get_allocated_height(widget);
-  gdk_cairo_set_source_rgba(cr, &sample->rgb);
+
+  GdkRGBA *color = gdk_rgba_copy(&sample->rgb);
+  if(_convert_color_space(&sample->rgb, color))
+  {
+    // function failed, profiles are not set, color will be wrong, exit.
+    gdk_rgba_free(color);
+    return TRUE;
+  }
+
+  gdk_cairo_set_source_rgba(cr, color);
   cairo_rectangle(cr, 0, 0, width, height);
   cairo_fill (cr);
+
+  gdk_rgba_free(color);
 
   // if the sample is locked we want to add a lock
   if(sample->locked)
@@ -251,9 +295,31 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
 
   for(int i = 0; i < 3; i++)
   {
-    const float *rgb = i == 0 ? sample->picked_color_rgb_mean :
-                       i == 1 ? sample->picked_color_rgb_min :
-                                sample->picked_color_rgb_max;
+    const float *picked_rgb = (i == 0) ? sample->picked_color_rgb_mean :
+                             (i == 1) ? sample->picked_color_rgb_min
+                                      : sample->picked_color_rgb_max;
+    float rgb[3];
+    for(size_t c = 0; c < 3; c++) rgb[c] = picked_rgb[c];
+
+    GdkRGBA color_in;
+    color_in.red = rgb[0];
+    color_in.green = rgb[1];
+    color_in.blue = rgb[2];
+    color_in.alpha = 1.f;
+
+    GdkRGBA *color_out = gdk_rgba_copy(&color_in);
+
+    if(_convert_color_space(&color_in, color_out))
+    {
+      // function failed, profiles are not set, color will be wrong, exit.
+      gdk_rgba_free(color_out);
+      return FALSE;
+    }
+
+    rgb[0] = color_out->red;
+    rgb[1] = color_out->green;
+    rgb[2] = color_out->blue;
+    gdk_rgba_free(color_out);
 
     sample_parts[i] = g_strdup_printf("<span background='#%02X%02X%02X'>%32s</span>",
                                       (int)round(CLAMP(rgb[0], 0.f, 1.f) * 255.f),
@@ -263,9 +329,9 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
     sample_parts[i + 4] = g_strdup_printf("<span foreground='#FF7F7F'>%6d</span>  "
                                           "<span foreground='#7FFF7F'>%6d</span>  "
                                           "<span foreground='#7F7FFF'>%6d</span>  %s",
-                                          (int)round(rgb[0] * 255.f),
-                                          (int)round(rgb[1] * 255.f),
-                                          (int)round(rgb[2] * 255.f), _(name[i]));
+                                          (int)round(picked_rgb[0] * 255.f),
+                                          (int)round(picked_rgb[1] * 255.f),
+                                          (int)round(picked_rgb[2] * 255.f), _(name[i]));
 
     const float *lab = i == 0 ? sample->picked_color_lab_mean :
                        i == 1 ? sample->picked_color_lab_min :


### PR DESCRIPTION
fix #2106

Now the color is consistent with the image no matter what histogram profile is used. Before, it was completely off, the color used the numbers expressed in histogram space to paint in display space.

Notice the tooltip color is not fixed, I don't know where it is coded. Buuuut… it's our first ever color-managed GUI bit.

Hi @moy by the way !

![Screenshot_20201125_034434](https://user-images.githubusercontent.com/2779157/100176441-9272bb80-2ed0-11eb-8918-ac448d739d7d.png)
