### PR TITLE
darkoom: hidpi fix for iop drag icon

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2088,13 +2088,11 @@ scale contents trough slider:hover
 
 .iop_drop_before
 {
-   border: 2px solid @plugin_bg_color;
    border-bottom: 2.4em solid @plugin_bg_color;
 }
 
 .iop_drop_after
 {
-   border: 2px solid @plugin_bg_color;
    border-top: 2.4em solid @plugin_bg_color;
 }
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2080,16 +2080,22 @@ scale contents trough slider:hover
   background-color: @scroll_bar_active;
 }
 
+.iop_drag_icon
+{
+  border: 1px solid @plugin_bg_color;
+  background-color: @bg_color;
+}
+
 .iop_drop_before
 {
    border: 2px solid @plugin_bg_color;
-   border-bottom: 2.8em solid @plugin_bg_color;
+   border-bottom: 2.4em solid @plugin_bg_color;
 }
 
 .iop_drop_after
 {
    border: 2px solid @plugin_bg_color;
-   border-top: 2.8em solid @plugin_bg_color;
+   border-top: 2.4em solid @plugin_bg_color;
 }
 
 /*** --- Thumbtable css part ---

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2607,10 +2607,22 @@ static void _on_drag_begin(GtkWidget *widget, GdkDragContext *context, gpointer 
     {
       GtkAllocation allocation_w = {0};
       gtk_widget_get_allocation(module_src->header, &allocation_w);
+      // method from https://blog.gtk.org/2017/04/23/drag-and-drop-in-lists/
+      cairo_surface_t *surface = dt_cairo_image_surface_create(CAIRO_FORMAT_RGB24, allocation_w.width, allocation_w.height);
+      cairo_t *cr = cairo_create(surface);
 
-      GdkPixbuf *pixbuf = gdk_pixbuf_get_from_window(window, allocation_w.x, allocation_w.y,
-                                                     allocation_w.width, allocation_w.height);
-      gtk_drag_set_icon_pixbuf(context, pixbuf, allocation_w.width / 2, allocation_w.height / 2);
+      // hack to render not transparent
+      GtkStyleContext *style_context = gtk_widget_get_style_context(module_src->header);
+      gtk_style_context_add_class(style_context, "iop_drag_icon");
+      gtk_widget_draw(module_src->header, cr);
+      gtk_style_context_remove_class(style_context, "iop_drag_icon");
+
+      // FIXME: this centers the icon on the mouse -- instead translate such that the label doesn't jump when mouse down?
+      cairo_surface_set_device_offset(surface, -allocation_w.width * darktable.gui->ppd / 2, -allocation_w.height * darktable.gui->ppd / 2);
+      gtk_drag_set_icon_surface(context, surface);
+
+      cairo_destroy(cr);
+      cairo_surface_destroy(surface);
     }
   }
 }


### PR DESCRIPTION
The icon made from the iop header previously rendered extra large when re-ordering iops on hidpi displays. This is because it was rendered via a GdkPixbuf, which is not aware of device vs. logical pixels. Instead, use Cairo -- which is hidpi aware -- to draw the icon.

This also fixes the mouse being 1/4 rather than 1/2-way along the icon on hipdi.

This PR also makes the gap which appears between iops be slightly smaller -- about the size of an iop header.

**Before**

![image](https://user-images.githubusercontent.com/2311860/100187957-2fc0f600-2eb7-11eb-990b-cc4d9b1da84f.png)

**After**

![image](https://user-images.githubusercontent.com/2311860/100188970-5e3fd080-2eb9-11eb-9e8a-188931bbebec.png)

There is now a class `iop_drop_icon` which can be used to style the dragging-iop image.