### PR TITLE
ioporder : apply the right order for non-develop images

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1402,6 +1402,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
+  const gboolean is_workflow_none = strcmp(workflow, "none") == 0;
 
   workflow = dt_conf_get_string("plugins/darkroom/chromatic-adaptation");
   const gboolean is_modern_chroma = strcmp(workflow, "modern") == 0;
@@ -1527,6 +1528,18 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     const char *params = (char *)sqlite3_column_blob(stmt, 0);
     const int32_t params_len = sqlite3_column_bytes(stmt, 0);
     GList *iop_list = dt_ioppr_deserialize_iop_order_list(params, params_len);
+    dt_ioppr_write_iop_order_list(iop_list, imgid);
+    g_list_free_full(iop_list, free);
+    dt_ioppr_set_default_iop_order(dev, imgid);
+  }
+  else
+  {
+    // we have no auto-apply order, so apply iop order, depending of the worflow
+    GList *iop_list;
+    if(is_scene_referred || is_workflow_none)
+      iop_list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30);
+    else
+      iop_list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_LEGACY);
     dt_ioppr_write_iop_order_list(iop_list, imgid);
     g_list_free_full(iop_list, free);
     dt_ioppr_set_default_iop_order(dev, imgid);


### PR DESCRIPTION
this is a fix for the following "problem" :
(Note that if it's intended, I'll close this PR, as I can live with that and a automatic preset or such...)
- open dt in `display-referred` workflow and use embedded previews
- import some images without xmps
- open one image in darkroom and see order = legacy => normal
- change workflow to `scene-referred`
- open anther image. The order is legacy (should be v3.0 imo)

Now just for the record : 
- set dt on `scene-referred`
- import some images without xmps
- open an image in darkroom : order = v3.0 => ok

So the result is that for all our "old" images (non-edited) imported with the "old" display-reffered workflow we have to change manually the order in darkroom to get the right order we need for the workflow... Not the best imo...

What I've done is to use the auto-apply preset routine : here, we already check for auto-apply order. So if no order is auto-applied, we applied the order corresponding to the wanted workflow.
I think it's safe, because this function is only called for images without any history...