### PR TITLE
don't compute random number for dither when dithering is disabled

### DIFF
--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -757,6 +757,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           weight = 1.0;
         else if(weight <= 0.0)
           weight = 0.0;
+        else if(dither == 0.0f)
+        {
+          // don't bother computing the random number if dithering is disabled
+          dith = 0.0f;
+        }
         else
         {
           weight = 0.5 - cosf(M_PI * weight) / 2.0;


### PR DESCRIPTION
This is a companion to #7069, but can be merged independently.  Yields a substantial speedup by skipping the work of computing a random number and then multiplying it by zero.

