### PR TITLE
dithering: remove thread number from random seed

### DIFF
--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -606,7 +606,7 @@ static void process_random(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
     const float *const in = (const float *)ivoid + k;
     float *const out = (float *)ovoid + k;
     unsigned int *tea_state = get_tea_state(tea_states,dt_get_thread_num());
-    tea_state[0] = j * height + dt_get_thread_num();
+    tea_state[0] = j * height; /* + dt_get_thread_num() -- do not include, makes results unreproducible */
     for(int i = 0; i < width; i++)
     {
       encrypt_tea(tea_state);

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -714,7 +714,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float *in = (const float *)ivoid + k;
     float *out = (float *)ovoid + k;
     unsigned int *tea_state = get_tea_state(tea_states,dt_get_thread_num());
-    tea_state[0] = j * roi_out->height + dt_get_thread_num();
+    tea_state[0] = j * roi_out->height; /* + dt_get_thread_num() -- do not include, makes results unreproducible */
     for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
     {
       // current pixel coord translated to local coord


### PR DESCRIPTION
... since it makes results unreproducible

As mentioned in #7069.
