### PR TITLE
Add advanced tethering for Nikon

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1482,7 +1482,7 @@ void dt_camctl_camera_set_property_float(const dt_camctl_t *c, const dt_camera_t
                                          const char *property_name, const float value)
 {
   dt_camctl_t *camctl = (dt_camctl_t *)c;
-  if(!get_or_set_cam(c, cam))
+  if(!cam && (cam = camctl->active_camera) == NULL && (cam = camctl->wanted_camera) == NULL)
   {
     dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to set property from camera, camera==NULL\n");
     return;

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1541,6 +1541,33 @@ int dt_camctl_camera_property_exists(const dt_camctl_t *c, const dt_camera_t *ca
   return exists;
 }
 
+const CameraWidgetType *dt_camctl_camera_get_property_type(const dt_camera_t *cam, const char *property_name)
+{
+  if(!cam)
+  {
+    dt_print(DT_DEBUG_CAMCTL, "[camera_control] can't get property type because camera==NULL\n");
+    return NULL;
+  }
+  dt_camera_t *camera = (dt_camera_t *)cam;
+  CameraWidgetType * widgetType = NULL;
+
+  dt_pthread_mutex_lock(&camera->config_lock);
+  CameraWidget *widget;
+  int retrieved_property = gp_widget_get_child_by_name(camera->configuration, property_name, &widget);
+  if(!retrieved_property){
+    dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to get property %s from camera config. Error Code: %d\n", property_name, retrieved_property);
+  } else {
+    int retrieved_widget_type = gp_widget_get_type(widget, widgetType);
+    if(!retrieved_widget_type)
+    {
+      dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to get property type for %s from camera config. Error Code: %d\n", property_name, retrieved_property);
+    }
+  }
+  dt_pthread_mutex_unlock(&camera->config_lock);
+
+  return widgetType;
+}
+
 const char *dt_camctl_camera_property_get_first_choice(const dt_camctl_t *c, const dt_camera_t *cam,
                                                        const char *property_name)
 {

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -271,6 +271,14 @@ const char *dt_camctl_camera_get_property(const dt_camctl_t *c, const dt_camera_
                                           const char *property_name);
 /** Check if property exists. */
 int dt_camctl_camera_property_exists(const dt_camctl_t *c, const dt_camera_t *cam, const char *property_name);
+
+/**
+ * @param cam the camera to check property type for
+ * @param property_name the property check type for
+ * @return the type of camera widget, NULL on failure
+ */
+const CameraWidgetType *dt_camctl_camera_get_property_type(const dt_camera_t *cam, const char *property_name);
+
 /** Get first choice available for named property. */
 const char *dt_camctl_camera_property_get_first_choice(const dt_camctl_t *c, const dt_camera_t *cam,
                                                        const char *property_name);

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -277,7 +277,7 @@ int dt_camctl_camera_property_exists(const dt_camctl_t *c, const dt_camera_t *ca
  * @param property_name the property check type for
  * @return the type of camera widget, NULL on failure
  */
-const CameraWidgetType *dt_camctl_camera_get_property_type(const dt_camera_t *cam, const char *property_name);
+int dt_camctl_camera_get_property_type(const dt_camctl_t *c, const dt_camera_t *cam, const char *property_name, CameraWidgetType *widget_type);
 
 /** Get first choice available for named property. */
 const char *dt_camctl_camera_property_get_first_choice(const dt_camctl_t *c, const dt_camera_t *cam,

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -259,6 +259,8 @@ const char *dt_camctl_camera_get_model(const dt_camctl_t *c, const dt_camera_t *
 /** Set a property value \param cam Pointer to dt_camera_t if NULL the camctl->active_camera is used. */
 void dt_camctl_camera_set_property_string(const dt_camctl_t *c, const dt_camera_t *cam,
                                           const char *property_name, const char *value);
+void dt_camctl_camera_set_property_toggle(const dt_camctl_t *c, const dt_camera_t *cam,
+                                          const char *property_name);
 void dt_camctl_camera_set_property_choice(const dt_camctl_t *c, const dt_camera_t *cam,
                                           const char *property_name, const int value);
 void dt_camctl_camera_set_property_int(const dt_camctl_t *c, const dt_camera_t *cam,

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -263,6 +263,8 @@ void dt_camctl_camera_set_property_choice(const dt_camctl_t *c, const dt_camera_
                                           const char *property_name, const int value);
 void dt_camctl_camera_set_property_int(const dt_camctl_t *c, const dt_camera_t *cam,
                                        const char *property_name, const int value);
+void dt_camctl_camera_set_property_float(const dt_camctl_t *c, const dt_camera_t *cam,
+                                       const char *property_name, const float value);
 /** Get a property value from cached configuration. \param cam Pointer to dt_camera_t if NULL the
  * camctl->active_camera is used. */
 const char *dt_camctl_camera_get_property(const dt_camctl_t *c, const dt_camera_t *cam,

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -380,7 +380,7 @@ void gui_init(dt_lib_module_t *self)
   lib->focus_in_small
       = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_STYLE_FLAT
                                                   | CPF_DIRECTION_LEFT, NULL); // TODO icon not centered
-  lib->auto_focus = dtgtk_button_new(dtgtk_cairo_paint_zoom, CPF_STYLE_FLAT, NULL);
+  lib->auto_focus = dtgtk_button_new(dtgtk_cairo_paint_lock, CPF_STYLE_FLAT, NULL);
   lib->focus_out_small = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_STYLE_FLAT
                                                                    | CPF_DIRECTION_RIGHT, NULL); // TODO same here
   lib->focus_out_big = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle,

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -237,9 +237,8 @@ static void _zoom_live_view_clicked(GtkWidget *widget, gpointer user_data)
 static void _focus_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   int focus = GPOINTER_TO_INT(user_data);
-  dt_camera_t *cam = (dt_camera_t *)darktable.camctl->active_camera;
-  const CameraWidgetType *property_type = dt_camctl_camera_get_property_type(cam, "manualfocusdrive");
-  if(!property_type)
+  CameraWidgetType property_type;
+  if(dt_camctl_camera_get_property_type(darktable.camctl, NULL, "manualfocusdrive", &property_type))
   {
     // default to avoid breaking backwards compatibility
     // note that this might not work on non-Canon EOS cameras
@@ -250,7 +249,7 @@ static void _focus_button_clicked(GtkWidget *widget, gpointer user_data)
     // we need to check the property type here because of a peculiar difference between the property type that gphoto2
     // supports for Canon EOS and Nikon systems. In particular, if you have a Canon, expect a TOGGLE or RADIO.
     // If you have a Nikon, expect a RANGE.
-    switch(*property_type)
+    switch(property_type)
     {
       case GP_WIDGET_RANGE:
       {
@@ -280,7 +279,7 @@ static void _focus_button_clicked(GtkWidget *widget, gpointer user_data)
         break;
       default:
         // TODO evaluate if this is the right thing to do in default scenario
-        dt_print(DT_DEBUG_CAMCTL, "[camera control] unable to set manualfocusdrive for property type %d", *property_type);
+        dt_print(DT_DEBUG_CAMCTL, "[camera control] unable to set manualfocusdrive for property type %d", property_type);
         break;
     }
   }

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -33,10 +33,10 @@
 
 typedef enum dt_lib_live_view_focus_control_t
 {
-  NEAR = 0,
-  NEARER = 2,
-  FAR = 4,
-  FARTHER = 6
+  DT_FOCUS_NEAR = 0,
+  DT_FOCUS_NEARER = 2,
+  DT_FOCUS_FAR = 4,
+  DT_FOCUS_FARTHER = 6
 } dt_lib_live_view_focus_control_t;
 
 typedef enum dt_lib_live_view_flip_t
@@ -278,16 +278,16 @@ static void _focus_button_clicked(GtkWidget *widget, gpointer user_data)
         float focus_amount;
         switch(focus)
         {
-          case NEARER:
+          case DT_FOCUS_NEARER:
             focus_amount = 250;
             break;
-          case NEAR:
+          case DT_FOCUS_NEAR:
             focus_amount = 50;
             break;
-          case FAR:
+          case DT_FOCUS_FAR:
             focus_amount = -50;
             break;
-          case FARTHER:
+          case DT_FOCUS_FARTHER:
             focus_amount = -250;
             break;
           default:
@@ -400,15 +400,15 @@ void gui_init(dt_lib_module_t *self)
 
 
   g_signal_connect(G_OBJECT(lib->focus_in_big), "clicked",
-                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(NEARER));
+                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(DT_FOCUS_NEARER));
   g_signal_connect(G_OBJECT(lib->focus_in_small), "clicked",
-                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(NEAR));
+                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(DT_FOCUS_NEAR));
   g_signal_connect(G_OBJECT(lib->auto_focus), "clicked",
                    G_CALLBACK(_auto_focus_button_clicked), GINT_TO_POINTER(1));
   g_signal_connect(G_OBJECT(lib->focus_out_small), "clicked",
-                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(FAR));
+                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(DT_FOCUS_FAR));
   g_signal_connect(G_OBJECT(lib->focus_out_big), "clicked",
-                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(FARTHER));
+                   G_CALLBACK(_focus_button_clicked), GINT_TO_POINTER(DT_FOCUS_FARTHER));
 
   // Guides
   lib->guide_selector = dt_bauhaus_combobox_new(NULL);


### PR DESCRIPTION
### High Level
An attempt at implementing manual focus for Nikon cameras and auto focus for all cameras.

@Baranowski describes the missing feature is described in more detail in #3899

There's an alternate proposal using focus highlighting in #3976. While focus highlighting seems more robust, I'd be out of my depth in computing the in focus portion of the image and rendering the relevant overlay onto the live view.

### Details
- as per gphoto2 documentation, widgets of type RANGE require a float when setting param (see `set_property_float` in `camera_control.h`) [add set_property_float](https://github.com/darktable-org/darktable/commit/8781e767a0e97e012b62324ca9c112c3dc825d3f?branch=8781e767a0e97e012b62324ca9c112c3dc825d3f&diff=unified)
- Canon and Nikon have different widget types for `manualfocusdrive`... instead of hardcoding on manufacturer, might as well read the property type (requires [add get_property_type](https://github.com/darktable-org/darktable/commit/addb1e46cf717e28a9e6cd0be6b48a426726da3e)) and then set float for RANGE and choice for non-RANGE widget (the current default)
- `autofocusdrive` seems to be a TOGGLE widget for Nikon D800. 
** Not sure what it might be for other manufacturers/models, so have only implemented logic to trigger the toggle.
** logic is extensible to easily handle other widget types if a new behavior is discovered

### Testing
I only have a Nikon D800, so am unable to test if this breaks the feature for Canon EOS or if this works for other Nikon cameras.
- [x] start DT and attempt tethering w/ Nikon D800 connected (both before and after app startup)
- [x] start live view using the eye button 
- [x] focus in/out using small and large increments
- [x] trigger autofocus using the new autofocus button