### PR TITLE
[performance] rewrite DWT in rawdenoise

### DIFF
--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -272,8 +272,8 @@ static void dwt_denoise_horiz_1ch(float *const restrict out, float *const restri
   const int hscale = MIN(1 << lev, width);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(height, width, hscale) \
-  dt_omp_sharedconst(in, out) \
+  dt_omp_firstprivate(height, width, hscale, thold, last) \
+  dt_omp_sharedconst(in, out, accum) \
   schedule(static)
 #endif
   for(int row = 0; row < height ; row++)


### PR DESCRIPTION
Yields a 3x performance gain for 1-2 threads, decreasing to ~10% at 32 threads (memory bandwith limits) for Bayer-filtered sensors.  I haven't touched the X-Trans version yet, as I'll need to set up correctness tests.

Use integration test 0049-rawdenoise from #7082 to verify correctness.

Once #7075 is merged, a good chunk of the code can be moved to src/common/dwt.c which will allow elimination of some code I needed to duplicate while that PR was still pending.

