### PR TITLE
[gtk] Fix scroll resize behaviour

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3155,7 +3155,11 @@ static gboolean _scroll_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event
 
   if(event->state & GDK_CONTROL_MASK)
   {
-    dt_conf_set_int(config_str, dt_conf_get_int(config_str) + increment*event->delta_y);
+    int delta_y=0;
+    
+    dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y);
+
+    dt_conf_set_int(config_str, dt_conf_get_int(config_str) + increment*delta_y);
 
     _scroll_wrap_resize(w, NULL, config_str);
   }


### PR DESCRIPTION
Depending on gtk backend a scroll event might send scroll_up/down (whit no delta) or smooth scroll event (with delta). This may cause issue like described in #6641 

The code here is taken almost verbatim now from Gdk manual for scroll event handling to make sure both directional and smooth scrolls are handled.

fixes #6641 