### PR TITLE
Slideshow shortcut fix

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -131,7 +131,8 @@ typedef struct dt_control_accels_t
     lighttable_center, lighttable_preview, lighttable_preview_display_focus,
     lighttable_timeline, lighttable_preview_zoom_100, lighttable_preview_zoom_fit,
     global_focus_peaking, global_sideborders, global_accels_window,
-    darkroom_preview, slideshow_start, darkroom_skip_mouse_events, global_collapsing_controls;
+    darkroom_preview, slideshow_start, darkroom_skip_mouse_events, global_collapsing_controls,
+    slideshow_view;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -232,6 +232,9 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   dt_accel_path_global(path, sizeof(path), "toggle panels collapsing controls");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_collapsing_controls);
 
+  dt_accel_path_global(path, sizeof(path), "slideshow view");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.slideshow_view);
+
   dt_accel_path_global(path, sizeof(path), "show accels window");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_accels_window);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1413,7 +1413,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // Side-border hide/show
   dt_accel_register_global(NC_("accel", "toggle side borders"), GDK_KEY_Tab, 0);
 
-  dt_accel_register_global(NC_("accel", "toggle panels collapsing controls"), GDK_KEY_B, 0);
+  dt_accel_register_global(NC_("accel", "toggle panels collapsing controls"), GDK_KEY_b, 0);
   dt_accel_connect_global("toggle panels collapsing controls",
                           g_cclosure_new(G_CALLBACK(_panels_controls_accel_callback), NULL, NULL));
 

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -585,6 +585,11 @@ int key_released(dt_view_t *self, guint key, guint state)
     // do nothing for any combination of accel for showing the border controls
     return 0;
   }
+  else if(key == accels->slideshow_view.accel_key && state == accels->slideshow_view.accel_mods)
+  {
+    // do nothing : we don't want to exit slideshow
+    return 0;
+  }
   else if(key == GDK_KEY_Up || key == GDK_KEY_KP_Add)
   {
     _set_delay(d, 1);


### PR DESCRIPTION
this fix #7113 
this also fix the border shortcut which by default exit slideshow. This was due to the fact that the default shortcut for this was `B` (in upper case) So when we test it with global shortcut, we have problem as what is typed is `b` in lower case.
I've changed default shortcut to `b` in lower case. but :
- "old" user will need to either redefine the shortcut or to reset shortcuts to defaults
- there's lot of other default shortcuts in upper case

So to have something cleaner, I think we need :
1. to change all default shortcuts to lower case
2. to add some magic routine somewhere to convert every shortcut key to lower case

Not sure about point 2...