### PR TITLE
retouch.c : fix preview refreshing issue

### DIFF
--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1417,7 +1417,7 @@ static gboolean rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton,
   }
   dt_pthread_mutex_unlock(&g->lock);
 
-  dt_iop_refresh_center(self);
+  dt_dev_reprocess_center(self->dev);
 
   gtk_toggle_button_set_active(togglebutton, g->display_wavelet_scale);
   return TRUE;


### PR DESCRIPTION
When toggling on/off the scale preview, the cache is not properly invalidated and recomputed. One needs to disable/enable the module to force cache update.

See example of the bug in there : https://youtu.be/gH1gRQ3Und0?t=3787

Ping @ralfbrown for review, this is a change you made.