### PR TITLE
reports status

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -4026,7 +4026,7 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
       else
       {
         fprintf(stderr, "cannot write xmp file '%s': '%s'\n", filename, strerror(errno));
-        dt_control_log(_("cannot read xmp file '%s': '%s'"), filename, strerror(errno));
+        dt_control_log(_("cannot write xmp file '%s': '%s'"), filename, strerror(errno));
       }
       
     }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -31,6 +31,8 @@ extern "C" {
 #include <time.h>
 #include <unistd.h>
 #include <zlib.h>
+
+#include "control/control.h"
 }
 
 #include <cassert>

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3972,6 +3972,7 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
       else
       {
         fprintf(stderr, "cannot read xmp file '%s': '%s'\n", filename, strerror(errno));
+        dt_control_log(_("cannot read xmp file '%s': '%s'"), filename, strerror(errno));
       }
 
       Exiv2::DataBuf buf = Exiv2::readFile(WIDEN(filename));
@@ -4023,6 +4024,7 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
       else
       {
         fprintf(stderr, "cannot write xmp file '%s': '%s'\n", filename, strerror(errno));
+        dt_control_log(_("cannot read xmp file '%s': '%s'"), filename, strerror(errno));
       }
       
     }


### PR DESCRIPTION
I was trying to make a duplicate from a raw that was one a NAS. The NAS was accessed via nfs and I had **no write permissions**. Thus the xmp generation failed. However, there was no feedback from dt and dt behaved as if it was successful.

This PR adds writing to the console the reason for failure of *g_fopen*, if any.