### PR TITLE
[camera_jobs] finetune delay behaviour for bracketed shots

### DIFF
--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -126,7 +126,8 @@ static int32_t dt_camera_capture_job_run(dt_job_t *job)
   for(uint32_t i = 0; i < params->count; i++)
   {
     // Delay if active
-    if(params->delay) g_usleep(params->delay * G_USEC_PER_SEC);
+    if(params->delay && !params->brackets) // delay between brackets
+      g_usleep(params->delay * G_USEC_PER_SEC);
 
     for(uint32_t b = 0; b < (params->brackets * 2) + 1; b++)
     {
@@ -143,6 +144,9 @@ static int32_t dt_camera_capture_job_run(dt_job_t *job)
         }
         else
         {
+          if(params->delay) // delay after previous bracket (no delay for 1st bracket)
+            g_usleep(params->delay * G_USEC_PER_SEC);
+
           // Step up with (steps)
           for(uint32_t s = 0; s < params->steps; s++)
             if(g_list_previous(current_value)) current_value = g_list_previous(current_value);
@@ -163,6 +167,9 @@ static int32_t dt_camera_capture_job_run(dt_job_t *job)
     // lets reset to original value before continue
     if(params->brackets)
     {
+      if(params->delay) // delay after final bracket
+        g_usleep(params->delay * G_USEC_PER_SEC);
+
       current_value = g_list_find(values, original_value);
       dt_camctl_camera_set_property_string(darktable.camctl, NULL, "shutterspeed", current_value->data);
     }


### PR DESCRIPTION
As discussed on IRC with r00t_ (mikeeusa) the delay behaviour for bracketed shots on nikon DSLRs might result in getting corrupted shots.

This change is supposed to alleviate this problem while enhancing overall delay behaviour.

Change was originally co-authored by houz.

mikeeusa also developed 32-bit compatible version of 3.0.1 branch, available here: https://files.fm/u/vg6vh765v