### PR TITLE
DNG: fix white balance coeffs and embedded matrices

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -2091,13 +2091,38 @@ int dt_colorspaces_conversion_matrices_xyz(const char *name, float in_XYZ_to_CAM
 }
 
 // Converted from dcraw's cam_xyz_coeff()
-int dt_colorspaces_conversion_matrices_rgb(const char *name, double out_RGB_to_CAM[4][3], double out_CAM_to_RGB[3][4], double mul[4])
+int dt_colorspaces_conversion_matrices_rgb(const char *name,
+                                           double out_RGB_to_CAM[4][3], double out_CAM_to_RGB[3][4],
+                                           const float *embedded_matrix,
+                                           double mul[4])
 {
   double RGB_to_CAM[4][3];
 
   float XYZ_to_CAM[4][3];
   XYZ_to_CAM[0][0] = NAN;
-  dt_dcraw_adobe_coeff(name, (float(*)[12])XYZ_to_CAM);
+
+  if(embedded_matrix == NULL || isnan(embedded_matrix[0]))
+  {
+    dt_dcraw_adobe_coeff(name, (float(*)[12])XYZ_to_CAM);
+  }
+  else
+  {
+    // keep in sync with reload_defaults from colorin.c
+    // embedded matrix is used with higher priority than standard one
+    XYZ_to_CAM[0][0] = embedded_matrix[0];
+    XYZ_to_CAM[0][1] = embedded_matrix[1];
+    XYZ_to_CAM[0][2] = embedded_matrix[2];
+
+    XYZ_to_CAM[1][0] = embedded_matrix[3];
+    XYZ_to_CAM[1][1] = embedded_matrix[4];
+    XYZ_to_CAM[1][2] = embedded_matrix[5];
+
+    XYZ_to_CAM[2][0] = embedded_matrix[6];
+    XYZ_to_CAM[2][1] = embedded_matrix[7];
+    XYZ_to_CAM[2][2] = embedded_matrix[8];
+  }
+
+
   if(isnan(XYZ_to_CAM[0][0]))
     return FALSE;
 

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -232,7 +232,7 @@ void dt_colorspaces_update_display2_transforms();
 int dt_colorspaces_conversion_matrices_xyz(const char *name, float in_XYZ_to_CAM[9], double XYZ_to_CAM[4][3], double CAM_to_XYZ[3][4]);
 
 /** Calculate CAM->RGB, RGB->CAM matrices and default WB multipliers */
-int dt_colorspaces_conversion_matrices_rgb(const char *name, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], double mul[4]);
+int dt_colorspaces_conversion_matrices_rgb(const char *name, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], const float *embedded_matrix, double mul[4]);
 
 /** Applies CYGM WB coeffs to an image that's already been converted to RGB by dt_colorspaces_cygm_to_rgb */
 void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int num, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], float coeffs[4]);

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -416,7 +416,27 @@ static int find_temperature_from_raw_coeffs(const dt_image_t *img, float *chroma
       // Get the camera input profile (matrice of primaries)
       float XYZ_to_CAM[4][3];
       XYZ_to_CAM[0][0] = NAN;
-      dt_dcraw_adobe_coeff(img->camera_makermodel, (float(*)[12])XYZ_to_CAM);
+
+      if(!isnan(img->d65_color_matrix[0]))
+      {
+        // keep in sync with reload_defaults from colorin.c
+        // embedded matrix is used with higher priority than standard one
+        XYZ_to_CAM[0][0] = img->d65_color_matrix[0];
+        XYZ_to_CAM[0][1] = img->d65_color_matrix[1];
+        XYZ_to_CAM[0][2] = img->d65_color_matrix[2];
+
+        XYZ_to_CAM[1][0] = img->d65_color_matrix[3];
+        XYZ_to_CAM[1][1] = img->d65_color_matrix[4];
+        XYZ_to_CAM[1][2] = img->d65_color_matrix[5];
+
+        XYZ_to_CAM[2][0] = img->d65_color_matrix[6];
+        XYZ_to_CAM[2][1] = img->d65_color_matrix[7];
+        XYZ_to_CAM[2][2] = img->d65_color_matrix[8];
+      }
+      else
+      {
+        dt_dcraw_adobe_coeff(img->camera_makermodel, (float(*)[12])XYZ_to_CAM);
+      }
 
       if(isnan(XYZ_to_CAM[0][0])) return FALSE;
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1774,7 +1774,7 @@ void gui_reset(dt_iop_module_t *self)
 
 static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
 {
-  if(!dt_image_is_raw(&module->dev->image_storage))
+  if(!dt_image_is_matrix_correction_supported(&module->dev->image_storage))
   {
     bwb[0] = 1.0;
     bwb[2] = 1.0;
@@ -1785,7 +1785,7 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
   }
 
   double mul[4];
-  if (dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.camera_makermodel, NULL, NULL, mul))
+  if(dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.camera_makermodel, NULL, NULL, module->dev->image_storage.d65_color_matrix, mul))
   {
     // normalize green:
     bwb[0] = mul[0] / mul[1];

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -4926,7 +4926,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 
     // Get and store the matrix to go from camera to RGB for 4Bayer images
     char *camera = self->dev->image_storage.camera_makermodel;
-    if (!dt_colorspaces_conversion_matrices_rgb(camera, NULL, d->CAM_to_RGB, NULL))
+    if (!dt_colorspaces_conversion_matrices_rgb(camera, NULL, d->CAM_to_RGB, self->dev->image_storage.d65_color_matrix, NULL))
     {
       fprintf(stderr, "[colorspaces] `%s' color matrix not found for 4bayer image!\n", camera);
       dt_control_log(_("`%s' color matrix not found for 4bayer image!"), camera);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -88,7 +88,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       double RGB_to_CAM[4][3];
 
       // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
-      if(!dt_colorspaces_conversion_matrices_rgb(camera, RGB_to_CAM, NULL, NULL))
+      if(!dt_colorspaces_conversion_matrices_rgb(camera, RGB_to_CAM, NULL, self->dev->image_storage.d65_color_matrix, NULL))
       {
         fprintf(stderr, "[invert] `%s' color matrix not found for 4bayer image\n", camera);
         dt_control_log(_("`%s' color matrix not found for 4bayer image"), camera);
@@ -531,7 +531,7 @@ void reload_defaults(dt_iop_module_t *self)
         const char *camera = self->dev->image_storage.camera_makermodel;
 
         // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
-        if(!dt_colorspaces_conversion_matrices_rgb(camera, g->RGB_to_CAM, g->CAM_to_RGB, NULL))
+        if(!dt_colorspaces_conversion_matrices_rgb(camera, g->RGB_to_CAM, g->CAM_to_RGB, self->dev->image_storage.d65_color_matrix, NULL))
         {
           fprintf(stderr, "[invert] `%s' color matrix not found for 4bayer image\n", camera);
           dt_control_log(_("`%s' color matrix not found for 4bayer image"), camera);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1355,7 +1355,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
 {
-  if(!dt_image_is_raw(&module->dev->image_storage))
+  if(!dt_image_is_matrix_correction_supported(&module->dev->image_storage))
   {
     bwb[0] = 1.0;
     bwb[2] = 1.0;
@@ -1366,7 +1366,7 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
   }
 
   double mul[4];
-  if (dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.camera_makermodel, NULL, NULL, mul))
+  if(dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.camera_makermodel, NULL, NULL, module->dev->image_storage.d65_color_matrix, mul))
   {
     // normalize green:
     bwb[0] = mul[0] / mul[1];


### PR DESCRIPTION
For DNG files from known cameras, colorin defaults to the embedded matrix which is good. However, the D65 WB coeffs are computed using the standard Adobe matrice, which is inconsistent. A set of WB coeff is tied to a particular matrice.

For DNG files from unknown cameras, colorin defaults to the embedded profile too. But the D65 WB coeffs cannot be computed at all, since there is no Adobe standard matrix.

This changes the D65 WB computation behaviour to always use the embedded DNG matrix if any, then try standard Adobe matrices, then default to WB coeff = 1. It makes white balance and color calibration modules support properly DNG files for default_params.