### PR TITLE
enable translation

### DIFF
--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -590,8 +590,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
 
-  dt_bauhaus_widget_set_label(g->brightness, NULL, NC_("lowpass", "brightness"));
-
   gtk_widget_set_tooltip_text(g->radius, _("radius of gaussian/bilateral blur"));
   gtk_widget_set_tooltip_text(g->contrast, _("contrast of lowpass filter"));
   gtk_widget_set_tooltip_text(g->brightness, _("brightness adjustment of lowpass filter"));

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -128,7 +128,7 @@ static void _draw_sym(cairo_t *cr, float x, float y, gboolean vertical, gboolean
   pango_font_description_set_absolute_size(desc, DT_PIXEL_APPLY_DPI(12) * PANGO_SCALE);
   PangoLayout *layout = pango_cairo_create_layout(cr);
   pango_layout_set_font_description(layout, desc);
-  pango_layout_set_text(layout, NC_("snapshot sign", "S"), -1);
+  pango_layout_set_text(layout, C_("snapshot sign", "S"), -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
 
   if(vertical)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -452,7 +452,7 @@ void expose(
     else
     {
       fontsize = DT_PIXEL_APPLY_DPI(14);
-      load_txt = dt_util_dstrcat(NULL, NC_("darkroom", "loading `%s' ..."), dev->image_storage.filename);
+      load_txt = dt_util_dstrcat(NULL, C_("darkroom", "loading `%s' ..."), dev->image_storage.filename);
     }
 
     pango_font_description_set_absolute_size(desc, fontsize * PANGO_SCALE);


### PR DESCRIPTION
Some strings are not translated because the wrong macro is used, see https://developer.gnome.org/glib/stable/glib-I18N.html#C-:CAPS vs https://developer.gnome.org/glib/stable/glib-I18N.html#NC-:CAPS 

There are many other places where `NC_` is employed instead of `C_`. I am not sure if this these represent bugs or features.