### PR TITLE
tagging & metadata : use dt_gui_get_scroll_unit_deltas() to resize widgets

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -530,16 +530,20 @@ static gboolean _mouse_scroll(GtkWidget *swindow, GdkEventScroll *event, dt_lib_
       const gint max_height = DT_PIXEL_APPLY_DPI(20*d->line_height + d->line_height / 5);
       gint height;
       gtk_widget_get_size_request(GTK_WIDGET(swindow), NULL, &height);
-      height = height + increment * event->delta_y;
-      height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
-      gtk_widget_set_size_request(GTK_WIDGET(swindow), -1, (gint)height);
+      int delta_y;
+      if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+      {
+        height = height + increment * delta_y;
+        height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
+        gtk_widget_set_size_request(GTK_WIDGET(swindow), -1, (gint)height);
 
-      const gchar *name = dt_metadata_get_name_by_display_order(i);
-      gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_text_height", name);
-      dt_conf_set_int(setting, height);
-      g_free(setting);
+        const gchar *name = dt_metadata_get_name_by_display_order(i);
+        gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_text_height", name);
+        dt_conf_set_int(setting, height);
+        g_free(setting);
 
-      return TRUE;
+        return TRUE;
+      }
     }
   }
   return FALSE;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2152,11 +2152,15 @@ static gboolean _mouse_scroll_attached(GtkWidget *treeview, GdkEventScroll *even
     const gint max_height = DT_PIXEL_APPLY_DPI(500.0);
     gint width, height;
     gtk_widget_get_size_request (GTK_WIDGET(d->attached_window), &width, &height);
-    height = height + increment * event->delta_y;
-    height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
-    gtk_widget_set_size_request(GTK_WIDGET(d->attached_window), -1, (gint)height);
-    dt_conf_set_int("plugins/lighttable/tagging/heightattachedwindow", (gint)height);
-    return TRUE;
+    int delta_y;
+    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+    {
+      height = height + increment * delta_y;
+      height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
+      gtk_widget_set_size_request(GTK_WIDGET(d->attached_window), -1, (gint)height);
+      dt_conf_set_int("plugins/lighttable/tagging/heightattachedwindow", (gint)height);
+      return TRUE;
+    }
   }
   return FALSE;
 }
@@ -2171,11 +2175,15 @@ static gboolean _mouse_scroll_dictionary(GtkWidget *treeview, GdkEventScroll *ev
     const gint max_height = DT_PIXEL_APPLY_DPI(1000.0);
     gint width, height;
     gtk_widget_get_size_request (GTK_WIDGET(d->dictionary_window), &width, &height);
-    height = height + increment * event->delta_y;
-    height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
-    gtk_widget_set_size_request(GTK_WIDGET(d->dictionary_window), -1, (gint)height);
-    dt_conf_set_int("plugins/lighttable/tagging/heightdictionarywindow", (gint)height);
-    return TRUE;
+    int delta_y;
+    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+    {
+      height = height + increment * delta_y;
+      height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
+      gtk_widget_set_size_request(GTK_WIDGET(d->dictionary_window), -1, (gint)height);
+      dt_conf_set_int("plugins/lighttable/tagging/heightdictionarywindow", (gint)height);
+      return TRUE;
+    }
   }
   return FALSE;
 }


### PR DESCRIPTION
Apply same fix as #7108 for tagging and metadata plugins.
