### PR TITLE
slideshow : better handling of shortcuts

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -358,7 +358,12 @@ static gboolean _dt_ctl_switch_mode_to_by_view(gpointer user_data)
 void dt_ctl_switch_mode_to(const char *mode)
 {
   const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
-  if(current_view && !strcmp(mode, current_view->module_name)) return;
+  if(current_view && !strcmp(mode, current_view->module_name))
+  {
+    // if we are not in lighttable, we switch back to that view
+    if(strcmp(current_view->module_name, "lighttable")) dt_ctl_switch_mode_to("lighttable");
+    return;
+  }
 
   g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
 }

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -562,6 +562,11 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
 
 int key_released(dt_view_t *self, guint key, guint state)
 {
+  return 0;
+}
+
+int key_pressed(dt_view_t *self, guint key, guint state)
+{
   dt_slideshow_t *d = (dt_slideshow_t *)self->data;
   dt_control_accels_t *accels = &darktable.control->accels;
 
@@ -577,17 +582,6 @@ int key_released(dt_view_t *self, guint key, guint state)
       d->auto_advance = FALSE;
       dt_control_log(_("slideshow paused"));
     }
-    return 0;
-  }
-  else if(key == accels->global_collapsing_controls.accel_key
-          || (state && accels->global_collapsing_controls.accel_mods))
-  {
-    // do nothing for any combination of accel for showing the border controls
-    return 0;
-  }
-  else if(key == accels->slideshow_view.accel_key && state == accels->slideshow_view.accel_mods)
-  {
-    // do nothing : we don't want to exit slideshow
     return 0;
   }
   else if(key == GDK_KEY_Up || key == GDK_KEY_KP_Add || key == GDK_KEY_plus)
@@ -612,10 +606,6 @@ int key_released(dt_view_t *self, guint key, guint state)
     d->auto_advance = FALSE;
     _step_state(d, S_REQUEST_STEP);
   }
-  else if(key == GDK_KEY_F11)
-  {
-    // let F11 be passed through, this is to make dt full screen
-  }
   else
   {
     // go back to lt mode
@@ -623,11 +613,6 @@ int key_released(dt_view_t *self, guint key, guint state)
     dt_ctl_switch_mode_to("lighttable");
   }
 
-  return 0;
-}
-
-int key_pressed(dt_view_t *self, guint key, guint state)
-{
   return 0;
 }
 

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -570,7 +570,15 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   dt_slideshow_t *d = (dt_slideshow_t *)self->data;
   dt_control_accels_t *accels = &darktable.control->accels;
 
-  if(key == accels->slideshow_start.accel_key && state == accels->slideshow_start.accel_mods)
+  if(key == GDK_KEY_Shift_L || key == GDK_KEY_Shift_R || key == GDK_KEY_Shift_Lock || key == GDK_KEY_Control_L
+     || key == GDK_KEY_Control_R || key == GDK_KEY_Alt_L || key == GDK_KEY_Alt_R || key == GDK_KEY_Caps_Lock
+     || key == GDK_KEY_Num_Lock || key == GDK_KEY_ISO_Level3_Shift)
+  {
+    // we don't want to handle modifiers keys here. They will be handled by the state value when pressing the
+    // regular key
+    return 0;
+  }
+  else if(key == accels->slideshow_start.accel_key && state == accels->slideshow_start.accel_mods)
   {
     if(!d->auto_advance)
     {
@@ -594,13 +602,13 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     _set_delay(d, -1);
     dt_control_log(ngettext("slideshow delay set to %d second", "slideshow delay set to %d seconds", d->delay), d->delay);
   }
-  else if(key == GDK_KEY_Left || key == GDK_KEY_Shift_L)
+  else if(key == GDK_KEY_Left)
   {
     if (d->auto_advance) dt_control_log(_("slideshow paused"));
     d->auto_advance = FALSE;
     _step_state(d, S_REQUEST_STEP_BACK);
   }
-  else if(key == GDK_KEY_Right || key == GDK_KEY_Shift_R)
+  else if(key == GDK_KEY_Right)
   {
     if (d->auto_advance) dt_control_log(_("slideshow paused"));
     d->auto_advance = FALSE;


### PR DESCRIPTION
This should solve most part of recent shortcuts issues with slideshow.
What it does : 
1. use `key_pressed` instead of `key_released` inside the view, because key_pressed event are not triggered if a "global" shortcut is associated with the key.
So this avoid to make exception for all global shortcuts (borders, fullscreen, help window, ...)
Currently, if you press a global shortcut not handled by an exception in slideshow, this exit the slideshow AND apply the shortcut. Example, if you type `H`, you see the help window and exit slideshow, same with `ESC` : exit fullscreen AND the slideshow...
2. in order to make exit more discoverable, I've also implemented an exit by retyping the view shortcut (`S` here). I've done that for all view, as imho, it would be handy. But that can be discussed...