### PR TITLE
Update white balance spot picker to work with TIFF files

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -259,7 +259,8 @@ void dt_iop_color_picker_cleanup(void)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_iop_color_picker_signal_callback), NULL);
 }
 
-GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w)
+static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
+                                    const gboolean init_cst, const dt_iop_colorspace_type_t cst)
 {
   dt_iop_color_picker_t *color_picker = (dt_iop_color_picker_t *)g_malloc(sizeof(dt_iop_color_picker_t));
 
@@ -267,6 +268,8 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
     _iop_init_picker(color_picker, module, kind, button);
+    if(init_cst)
+      color_picker->picker_cst = cst;
     g_signal_connect_data(G_OBJECT(button), "button-press-event",
                           G_CALLBACK(_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
     if (w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
@@ -278,11 +281,24 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
     _iop_init_picker(color_picker, module, kind, w);
+    if(init_cst)
+      color_picker->picker_cst = cst;
     g_signal_connect_data(G_OBJECT(w), "quad-pressed",
                           G_CALLBACK(_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
 
     return w;
   }
+}
+
+GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w)
+{
+  return _color_picker_new(module, kind, w, FALSE, iop_cs_NONE);
+}
+
+GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
+                                        const dt_iop_colorspace_type_t cst)
+{
+  return _color_picker_new(module, kind, w, TRUE, cst);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -55,6 +55,10 @@ void dt_iop_color_picker_cleanup();
 /* link color picker to widget */
 GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w);
 
+/* link color picker to widget and initialize color picker color space with given value */
+GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
+                                        const dt_iop_colorspace_type_t cst);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -217,6 +217,10 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  // This module may work in RAW or RGB (e.g. for TIFF files) depending on the input
+  // The module does not change the color space between the input and output, therefore implement it here
+  if(piece)
+    return piece->dsc_in.cst;
   return iop_cs_RAW;
 }
 
@@ -2050,8 +2054,11 @@ void gui_init(struct dt_iop_module_t *self)
                                           dtgtk_cairo_paint_camera, NULL);
   gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance to as shot"));
 
-  // create color picker to be able to send its signal when spot selected
-  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
+  // create color picker to be able to send its signal when spot selected,
+  // this module may expect data in RAW or RGB, setting the color picker CST to iop_cs_NONE will make the color
+  // picker to depend on the number of color channels of the pixels. It is done like this as we may not know the
+  // actual kind of data we are using in the GUI (it is part of the pipeline).
+  g->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, NULL, iop_cs_NONE);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
 


### PR DESCRIPTION
Should fix #7133 

The issue seems related to the fact that the white balance module is defined as a RAW module, but that it may also work with RGB pixels.

Made the following changes:

- update `temperature.c` to acknowledge the fact that it may work with RGB pixels
- update `temperature.c` to use a color picker with `iop_cs_NONE` color space to make it work both with RAW and RGB pixels
- update the pipeline picker transform to avoid converting pixels when having a `iop_cs_NONE` color picker active

I'm not 100% convinced it is the best way to implement it, but I tried to limit the changes.
Tested it with a tiff file and a raw file. Let's hope that it doesn't introduce any regressions :anguished: 