### PR TITLE
Tweak white balance default color space

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -219,8 +219,8 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 {
   // This module may work in RAW or RGB (e.g. for TIFF files) depending on the input
   // The module does not change the color space between the input and output, therefore implement it here
-  if(piece)
-    return piece->dsc_in.cst;
+  if(piece && piece->dsc_in.cst != iop_cs_RAW)
+    return iop_cs_rgb;
   return iop_cs_RAW;
 }
 


### PR DESCRIPTION
Little tweak to the white balance module on top of #7143 to make it clear that the module only supports RAW or RGB pixels as input.

This should not change anything in behavior as we cannot move Lab modules before demosaic and we cannot move the white balance module at all.

@TurboGit Feel free to include it or close this PR, it's only minor to make things more clear and I don't expect any change in behavior (except if someone knows a way to move a Lab module before the white balance module...).