### PR TITLE
make channelmixerrgb compatible with non-D65 illuminant

### DIFF
--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -224,11 +224,12 @@ static inline void illuminant_CCT_to_RGB(const float t, float RGB[4])
 
 
 // Fetch image from pipeline and read EXIF for camera RAW WB coeffs
-static inline int find_temperature_from_raw_coeffs(const dt_image_t *img, float *chroma_x, float *chroma_y);
+static inline int find_temperature_from_raw_coeffs(const dt_image_t *img, const float custom_wb[4], float *chroma_x, float *chroma_y);
 
 
 static int illuminant_to_xy(const dt_illuminant_t illuminant, // primary type of illuminant
                             const dt_image_t *img,            // image container
+                            const float custom_wb[4],         // optional user-set WB coeffs
                             float *x_out, float *y_out,       // chromaticity output
                             const float t,                    // temperature in K, if needed
                             const dt_illuminant_fluo_t fluo,  // sub-type of fluorescent illuminant, if needed
@@ -305,7 +306,7 @@ static int illuminant_to_xy(const dt_illuminant_t illuminant, // primary type of
     {
       // Detect WB from RAW EXIF
       if(img)
-        if(find_temperature_from_raw_coeffs(img, &x, &y)) break;
+        if(find_temperature_from_raw_coeffs(img, custom_wb, &x, &y)) break;
     }
     case DT_ILLUMINANT_CUSTOM: // leave x and y as-is
     case DT_ILLUMINANT_DETECT_EDGES:
@@ -391,71 +392,71 @@ static inline void matrice_pseudoinverse(float (*in)[3], float (*out)[3], int si
 }
 
 
-static int find_temperature_from_raw_coeffs(const dt_image_t *img, float *chroma_x, float *chroma_y)
+static int find_temperature_from_raw_coeffs(const dt_image_t *img, const float custom_wb[4], float *chroma_x, float *chroma_y)
 {
   if(img == NULL) return FALSE;
-  const int is_raw = dt_image_is_matrix_correction_supported(img);
+  if(!dt_image_is_matrix_correction_supported(img)) return FALSE;
 
-  if(is_raw)
+  int has_valid_coeffs = TRUE;
+  const int num_coeffs = (img->flags & DT_IMAGE_4BAYER) ? 4 : 3;
+
+  // Check coeffs
+  for(int k = 0; has_valid_coeffs && k < num_coeffs; k++)
+    if(!isnormal(img->wb_coeffs[k]) || img->wb_coeffs[k] == 0.0f) has_valid_coeffs = FALSE;
+
+  if(!has_valid_coeffs) return FALSE;
+
+  // Get white balance camera factors
+  float WB[4] = { img->wb_coeffs[0],
+                  img->wb_coeffs[1],
+                  img->wb_coeffs[2],
+                  img->wb_coeffs[3] };
+
+  // Adapt the camera coeffs with custom white balance if provided
+  // this can deal with WB coeffs that don't use the input matrix reference
+  if(custom_wb)
+    for(size_t k = 0; k < 4; k++) WB[k] *= custom_wb[k];
+
+  // Get the camera input profile (matrice of primaries)
+  float XYZ_to_CAM[4][3];
+  XYZ_to_CAM[0][0] = NAN;
+
+  if(!isnan(img->d65_color_matrix[0]))
   {
-    int has_valid_coeffs = TRUE;
-    const int num_coeffs = (img->flags & DT_IMAGE_4BAYER) ? 4 : 3;
+    // keep in sync with reload_defaults from colorin.c
+    // embedded matrix is used with higher priority than standard one
+    XYZ_to_CAM[0][0] = img->d65_color_matrix[0];
+    XYZ_to_CAM[0][1] = img->d65_color_matrix[1];
+    XYZ_to_CAM[0][2] = img->d65_color_matrix[2];
 
-    // Check coeffs
-    for(int k = 0; has_valid_coeffs && k < num_coeffs; k++)
-      if(!isnormal(img->wb_coeffs[k]) || img->wb_coeffs[k] == 0.0f) has_valid_coeffs = FALSE;
+    XYZ_to_CAM[1][0] = img->d65_color_matrix[3];
+    XYZ_to_CAM[1][1] = img->d65_color_matrix[4];
+    XYZ_to_CAM[1][2] = img->d65_color_matrix[5];
 
-    if(has_valid_coeffs)
-    {
-      // Get white balance camera factors
-      float WB[4] = { img->wb_coeffs[0],
-                      img->wb_coeffs[1],
-                      img->wb_coeffs[2],
-                      img->wb_coeffs[3] };
-
-      // Get the camera input profile (matrice of primaries)
-      float XYZ_to_CAM[4][3];
-      XYZ_to_CAM[0][0] = NAN;
-
-      if(!isnan(img->d65_color_matrix[0]))
-      {
-        // keep in sync with reload_defaults from colorin.c
-        // embedded matrix is used with higher priority than standard one
-        XYZ_to_CAM[0][0] = img->d65_color_matrix[0];
-        XYZ_to_CAM[0][1] = img->d65_color_matrix[1];
-        XYZ_to_CAM[0][2] = img->d65_color_matrix[2];
-
-        XYZ_to_CAM[1][0] = img->d65_color_matrix[3];
-        XYZ_to_CAM[1][1] = img->d65_color_matrix[4];
-        XYZ_to_CAM[1][2] = img->d65_color_matrix[5];
-
-        XYZ_to_CAM[2][0] = img->d65_color_matrix[6];
-        XYZ_to_CAM[2][1] = img->d65_color_matrix[7];
-        XYZ_to_CAM[2][2] = img->d65_color_matrix[8];
-      }
-      else
-      {
-        dt_dcraw_adobe_coeff(img->camera_makermodel, (float(*)[12])XYZ_to_CAM);
-      }
-
-      if(isnan(XYZ_to_CAM[0][0])) return FALSE;
-
-      // Bloody input matrices define XYZ -> CAM transform, as if we often needed camera profiles to output
-      // So we need to invert them. Here go your CPU cycles again.
-      float CAM_to_XYZ[4][3];
-      CAM_to_XYZ[0][0] = NAN;
-      matrice_pseudoinverse(XYZ_to_CAM, CAM_to_XYZ, 3);
-      if(isnan(CAM_to_XYZ[0][0])) return FALSE;
-
-      float x, y;
-      WB_coeffs_to_illuminant_xy(CAM_to_XYZ, WB, &x, &y);
-      *chroma_x = x;
-      *chroma_y = y;
-
-      return TRUE;
-    }
+    XYZ_to_CAM[2][0] = img->d65_color_matrix[6];
+    XYZ_to_CAM[2][1] = img->d65_color_matrix[7];
+    XYZ_to_CAM[2][2] = img->d65_color_matrix[8];
   }
-  return FALSE;
+  else
+  {
+    dt_dcraw_adobe_coeff(img->camera_makermodel, (float(*)[12])XYZ_to_CAM);
+  }
+
+  if(isnan(XYZ_to_CAM[0][0])) return FALSE;
+
+  // Bloody input matrices define XYZ -> CAM transform, as if we often needed camera profiles to output
+  // So we need to invert them. Here go your CPU cycles again.
+  float CAM_to_XYZ[4][3];
+  CAM_to_XYZ[0][0] = NAN;
+  matrice_pseudoinverse(XYZ_to_CAM, CAM_to_XYZ, 3);
+  if(isnan(CAM_to_XYZ[0][0])) return FALSE;
+
+  float x, y;
+  WB_coeffs_to_illuminant_xy(CAM_to_XYZ, WB, &x, &y);
+  *chroma_x = x;
+  *chroma_y = y;
+
+  return TRUE;
 }
 
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -111,7 +111,8 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 
   dev->proxy.exposure.module = NULL;
   dev->proxy.chroma_adaptation = NULL;
-  dev->proxy.wb_is_D65 = FALSE;
+  dev->proxy.wb_is_D65 = TRUE; // don't display error messages until we know for sure it's FALSE
+  dev->proxy.wb_coeffs[0] = 0.f;
 
   dev->rawoverexposed.enabled = FALSE;
   dev->rawoverexposed.mode = dt_conf_get_int("darkroom/ui/rawoverexposed/mode");

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -268,6 +268,7 @@ typedef struct dt_develop_t
 
     // is the WB module using D65 illuminant and not doing full chromatic adaptation ?
     gboolean wb_is_D65;
+    float wb_coeffs[4];
 
   } proxy;
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -185,7 +185,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.illum_fluo = DT_ILLUMINANT_FLUO_F3;
   p.illum_led = DT_ILLUMINANT_LED_B5;
   p.temperature = 5003.f;
-  illuminant_to_xy(DT_ILLUMINANT_PIPE, NULL, &p.x, &p.y, p.temperature, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
+  illuminant_to_xy(DT_ILLUMINANT_PIPE, NULL, NULL, &p.x, &p.y, p.temperature, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
 
   p.red[0] = 1.f;
   p.red[1] = 0.f;
@@ -342,6 +342,56 @@ void init_presets(dt_iop_module_so_t *self)
   p.blue[2] = 0.f;
   dt_gui_presets_add_generic(_("swap R and B"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+}
+
+
+static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
+{
+  // keep this in synch with temperature.c !
+  // predicts the bogus D65 that temperature.c will compute for the camera input matrix
+  if(!dt_image_is_matrix_correction_supported(&module->dev->image_storage))
+  {
+    bwb[0] = 1.0;
+    bwb[2] = 1.0;
+    bwb[1] = 1.0;
+    bwb[3] = 1.0;
+
+    return 0;
+  }
+
+  double mul[4];
+  if(dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.camera_makermodel, NULL, NULL, module->dev->image_storage.d65_color_matrix, mul))
+  {
+    // normalize green:
+    bwb[0] = mul[0] / mul[1];
+    bwb[2] = mul[2] / mul[1];
+    bwb[1] = 1.0;
+    bwb[3] = mul[3] / mul[1];
+
+    return 0;
+  }
+
+  return 1;
+}
+
+
+static int get_white_balance_coeff(struct dt_iop_module_t *self, float custom_wb[4])
+{
+  // Init output with a no-op
+  for(size_t k = 0; k < 4; k++) custom_wb[k] = 1.f;
+
+  // First, get the D65-ish coeffs from the input matrix
+  double bwb[4];
+  if(calculate_bogus_daylight_wb(self, bwb)) return 1;
+
+  // Second, if the temperature module is not using these, for example because they are wrong
+  // and user made a correct preset, find the WB adaptation ratio
+  if(self->dev->proxy.wb_coeffs[0] != 0.f)
+  {
+    for(size_t k = 0; k < 4; k++) custom_wb[k] = bwb[k] / self->dev->proxy.wb_coeffs[k];
+  }
+
+  return 0;
 }
 
 
@@ -937,14 +987,14 @@ static void check_if_close_to_daylight(const float x, const float y, float *temp
   float uv_test[2];
 
   // Compute the test chromaticity from the daylight model
-  illuminant_to_xy(DT_ILLUMINANT_D, NULL, &xy_test[0], &xy_test[1], t, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
+  illuminant_to_xy(DT_ILLUMINANT_D, NULL, NULL, &xy_test[0], &xy_test[1], t, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
   xy_to_uv(xy_test, uv_test);
 
   // Compute the error between the reference illuminant and the test illuminant derivated from the CCT with daylight model
   const float delta_daylight = hypotf((uv_test[0] - uv_ref[0]), (uv_test[1] - uv_ref[1]));
 
   // Compute the test chromaticity from the blackbody model
-  illuminant_to_xy(DT_ILLUMINANT_BB, NULL, &xy_test[0], &xy_test[1], t, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
+  illuminant_to_xy(DT_ILLUMINANT_BB, NULL, NULL, &xy_test[0], &xy_test[1], t, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
   xy_to_uv(xy_test, uv_test);
 
   // Compute the error between the reference illuminant and the test illuminant derivated from the CCT with black body model
@@ -1163,7 +1213,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // find x y coordinates of illuminant for CIE 1931 2° observer
   float x = p->x;
   float y = p->y;
-  illuminant_to_xy(p->illuminant, &(self->dev->image_storage), &x, &y, p->temperature, p->illum_fluo, p->illum_led);
+  float custom_wb[4];
+  get_white_balance_coeff(self, custom_wb);
+  illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb, &x, &y, p->temperature, p->illum_fluo,
+                   p->illum_led);
 
   // if illuminant is set as camera, x and y are set on-the-fly at commit time, so we need to set adaptation too
   if(p->illuminant == DT_ILLUMINANT_CAMERA)
@@ -1230,7 +1283,7 @@ static void update_illuminants(dt_iop_module_t *self)
   float x = p->x;
   float y = p->y;
 
-  const int changed = illuminant_to_xy(p->illuminant, NULL, &x, &y, p->temperature, p->illum_fluo, p->illum_led);
+  const int changed = illuminant_to_xy(p->illuminant, NULL, NULL, &x, &y, p->temperature, p->illum_fluo, p->illum_led);
 
   if(changed)
   {
@@ -1656,7 +1709,10 @@ static gboolean illuminant_color_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   float x = p->x;
   float y = p->y;
   float RGB[4] = { 0 };
-  illuminant_to_xy(p->illuminant, &(self->dev->image_storage), &x, &y, p->temperature, p->illum_fluo, p->illum_led);
+  float custom_wb[4];
+  get_white_balance_coeff(self, custom_wb);
+  illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb,
+                   &x, &y, p->temperature, p->illum_fluo, p->illum_led);
   illuminant_xy_to_RGB(x, y, RGB);
   cairo_set_source_rgb(cr, RGB[0], RGB[1], RGB[2]);
   cairo_rectangle(cr, INNER_PADDING, margin, width, height);
@@ -1678,7 +1734,9 @@ static void update_approx_cct(dt_iop_module_t *self)
 
   float x = p->x;
   float y = p->y;
-  illuminant_to_xy(p->illuminant, &(self->dev->image_storage), &x, &y, p->temperature, p->illum_fluo, p->illum_led);
+  float custom_wb[4];
+  get_white_balance_coeff(self, custom_wb);
+  illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb, &x, &y, p->temperature, p->illum_fluo, p->illum_led);
 
   dt_illuminant_t test_illuminant;
   float t = 5000.f;
@@ -1771,34 +1829,6 @@ void gui_reset(dt_iop_module_t *self)
   dt_iop_color_picker_reset(self, TRUE);
   gui_changed(self, NULL, NULL);
 }
-
-static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
-{
-  if(!dt_image_is_matrix_correction_supported(&module->dev->image_storage))
-  {
-    bwb[0] = 1.0;
-    bwb[2] = 1.0;
-    bwb[1] = 1.0;
-    bwb[3] = 1.0;
-
-    return 0;
-  }
-
-  double mul[4];
-  if(dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.camera_makermodel, NULL, NULL, module->dev->image_storage.d65_color_matrix, mul))
-  {
-    // normalize green:
-    bwb[0] = mul[0] / mul[1];
-    bwb[2] = mul[2] / mul[1];
-    bwb[1] = 1.0;
-    bwb[3] = mul[3] / mul[1];
-
-    return 0;
-  }
-
-  return 1;
-}
-
 
 void gui_update(struct dt_iop_module_t *self)
 {
@@ -1912,13 +1942,13 @@ void reload_defaults(dt_iop_module_t *module)
 
   const dt_image_t *img = &module->dev->image_storage;
 
-  double bwb[4] = { 0. };
+  float custom_wb[4];
   if(!CAT_already_applied
      && is_modern
-     && !(calculate_bogus_daylight_wb(module, bwb)))
+     && !get_white_balance_coeff(module, custom_wb))
   {
     // if workflow = modern and we find WB coeffs, take care of white balance here
-    if(find_temperature_from_raw_coeffs(img, &(d->x), &(d->y)))
+    if(find_temperature_from_raw_coeffs(img, custom_wb, &(d->x), &(d->y)))
       d->illuminant = DT_ILLUMINANT_CAMERA;
 
     check_if_close_to_daylight(d->x, d->y, &(d->temperature), &(d->illuminant), &(d->adaptation));
@@ -1965,13 +1995,13 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     if(p->illuminant == DT_ILLUMINANT_CAMERA)
     {
       // Get camera WB and update illuminant
-      const int found = find_temperature_from_raw_coeffs(&(self->dev->image_storage), &(p->x), &(p->y));
+      float custom_wb[4];
+      get_white_balance_coeff(self, custom_wb);
+      const int found = find_temperature_from_raw_coeffs(&(self->dev->image_storage), custom_wb, &(p->x), &(p->y));
+      check_if_close_to_daylight(p->x, p->y, &(p->temperature), NULL, &(p->adaptation));
 
       if(found)
-      {
         dt_control_log(_("white balance successfuly extracted from raw image"));
-        check_if_close_to_daylight(p->x, p->y, &(p->temperature), NULL, &(p->adaptation));
-      }
     }
     else if(p->illuminant == DT_ILLUMINANT_DETECT_EDGES
             || p->illuminant == DT_ILLUMINANT_DETECT_SURFACES)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -774,6 +774,11 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
     self->dev->proxy.wb_is_D65 = is_D65;
   }
+
+  for(int k = 0; k < 4; k++)
+  {
+    self->dev->proxy.wb_coeffs[k] = d->coeffs[k];
+  }
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
It has been brought to my attention (here : https://discuss.pixls.us/t/introducing-color-calibration-module-formerly-known-as-channel-mixer-rgb/21227/84?u=aurelienpierre) that some cameras have D65 white balance coefficients that don't actually make a D65 light source neutral. 

These will be a challenge to color-correct later. So users should create personal presets for temperature.c with the proper D65 WB coeffs. But then the color calibration module can't use them to set the camera WB defaults.

This PR:
1. makes the white balance module advertise its WB coeff on the global dev structure at commit_params time,
2. makes the color calibration module compute its "as shot in camera" coeffs using the actual WB coeffs from white balance module,
3. makes the "as shot in camera" coeffs computed at run time (instead of commit time), to keep track of later changes in temperature and to avoid inconsistent cache states (because color calibration does not recommit if white balance is changed, it simply re-runs).

Notice that, when the pipeline is initialized, the defaults params of modules are loaded before the user presets, and the WB coeffs are posted on the pipe only at commit params time. So, color calibration will only have the D65 camera defaults available when it initializes its own defaults. To make the color calibration account for user presets in white balance, it should be used only in "as shot in camera" mode, possibly auto-applied from a preset.

The "as shot in camera" mode will always fetch the updated params. If manual adjustments needs to be done over the camera defaults, switching to another illuminant will preserve the current parameters.

To test, load a grey image in darkroom, set color calibration illuminant to "as shot in camera", change the temperature in white balance module, and ensure that the resulting image is still grey (it will be brighter or darker, but that's expected).