### PR TITLE
exif: copyright is mandatory, empty is ok

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1788,6 +1788,9 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
         exifData["Exif.Image.Copyright"] = (char *)res->data;
         g_list_free_full(res, &g_free);
       }
+      else
+        // mandatory tag for TIFF/EP, empty is ok (unknown)
+        exifData["Exif.Image.Copyright"] = "";
 
       res = dt_metadata_get(imgid, "Xmp.xmp.Rating", NULL);
       if(res != NULL)


### PR DESCRIPTION
See [TIFF/EP spec](http://www.barrypearson.co.uk/top2009/downloads/TAG2000-22_DIS12234-2.pdf).

It is however optional in [Exif spec](http://www.cipa.jp/std/documents/download_e.html?DC-008-Translation-2019-E), but empty is also ok by Exif and also means "unknown".