### PR TITLE
[performance] filmicrgb reconstruction speedup, part 2

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1048,15 +1048,15 @@ static inline void wavelets_detail_level(const float *const restrict detail, con
                                              const size_t width, const size_t height, const size_t ch)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture)       \
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, HF, LF, detail, texture)           \
     schedule(simd                                                                                                 \
              : static) aligned(HF, LF, detail, texture : 64)
 #endif
-  for(size_t k = 0; k < height * width * ch; k += ch)
+  for(size_t k = 0; k < 4 * height * width; k += 4)
   {
-    for(size_t c = 0; c < 3; ++c) HF[k + c] = detail[k + c] - LF[k + c];
+    for(size_t c = 0; c < 4; ++c) HF[k + c] = detail[k + c] - LF[k + c];
 
-    texture[k / ch] = fminabsf(fminabsf(HF[k], HF[k + 1]), HF[k + 2]);
+    texture[k / 4] = fminabsf(fminabsf(HF[k], HF[k + 1]), HF[k + 2]);
   }
 }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -828,7 +828,7 @@ inline static void sparse_scalar_product(const float *const buf, const size_t in
 }
 
 //TODO: consolidate with the copy of this code in src/common/dwt.c
-static inline int rowid_to_row(const int rowid, const int height, const int scale)
+static inline int dwt_interleave_rows(const int rowid, const int height, const int scale)
 {
   // to make this algorithm as cache-friendly as possible, we want to interleave the actual processing of rows
   // such that the next iteration processes the row 'scale' pixels below the current one, which will already
@@ -845,46 +845,53 @@ static inline int rowid_to_row(const int rowid, const int height, const int scal
   return long_passes + (rowid2 / (per_pass-1)) + scale * (rowid2 % (per_pass-1));
 }
 
-inline static void blur_2D_Bspline(const float *const in, float *const out, float *const tempbuf,
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out:64) aligned(tempbuf:16)
+#endif
+inline static void blur_2D_Bspline(const float *const restrict in, float *const restrict out,
+                                   float *const restrict tempbuf,
                                    const size_t width, const size_t height, const size_t mult)
 {
   // À-trous B-spline interpolation/blur shifted by mult
   #ifdef _OPENMP
   #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(out, in, width, height, mult) \
+    dt_omp_firstprivate(width, height, mult)  \
+    dt_omp_sharedconst(out, in, tempbuf) \
     schedule(simd:static)
   #endif
   for(size_t row = 0; row < height; row++)
   {
-    size_t i = rowid_to_row(row, height, mult);
+    // get a thread-private one-row temporary buffer
     float *const temp = tempbuf + 4 * width * dt_get_thread_num();
-    // Convolve B-spline filter over columns
-    for(size_t j = 0; j < width; j++)
+    // interleave the order in which we process the rows so that we minimize cache misses
+    const size_t i = dwt_interleave_rows(row, height, mult);
+    // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
+    size_t DT_ALIGNED_ARRAY indices[FSIZE] = { 0 };
+    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
+    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
+    // over the row
+    for(size_t ii = 0; ii < FSIZE; ++ii)
     {
-      // Compute the array indices of the pixels of interest
-      size_t DT_ALIGNED_ARRAY indices[FSIZE] = { 0 };
-
-      for(size_t ii = 0; ii < FSIZE; ++ii)
-      {
-        size_t r = CLAMP(mult * (ii - (FSIZE - 1) / 2) + i, 0, height - 1);
-        indices[ii] = 4 * (r * width + j);
-      }
-      // Compute the blur
-      sparse_scalar_product(in, indices, temp + j * 4);
+      const size_t r = CLAMP(mult * (ii - (FSIZE - 1) / 2) + i, 0, height - 1);
+      indices[ii] = 4 * r * width;
     }
-    // Convolve B-spline filter over current row
     for(size_t j = 0; j < width; j++)
     {
-      // Compute the array indices of the pixels of interest
-      size_t DT_ALIGNED_ARRAY indices[FSIZE] = { 0 };
-
+      // Compute the vertical blur of the current pixel and store it in the temp buffer for the row
+      sparse_scalar_product(in + j * 4, indices, temp + j * 4);
+    }
+    // Convolve B-spline filter horizontally over current row
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the array indices of the pixels of interest; since the offsets will change near the ends of
+      // the row, we need to recompute for each pixel
       for(size_t jj = 0; jj < FSIZE; ++jj)
       {
-        size_t col = CLAMP(mult * (jj - (FSIZE - 1) / 2) + j, 0, width - 1);
+        const size_t col = CLAMP(mult * (jj - (FSIZE - 1) / 2) + j, 0, width - 1);
         indices[jj] = 4 * col;
       }
-
-      // Compute the blur
+      // Compute the horizonal blur of the already vertically-blurred pixel and store the result at the proper
+      //  row/column location in the output buffer
       sparse_scalar_product(temp, indices, out + (i * width + j) * 4);
     }
   }
@@ -1128,24 +1135,28 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
   // with a vertical and horizontal blur, wich is 10 multiply-add instead of 25 by pixel.
   for(int s = 0; s < scales; ++s)
   {
-    const float *restrict detail;
-    float *restrict LF;
+    const float *restrict detail;       // buffer containing this scale's input
+    float *restrict LF;                 // output buffer for the current scale
+    float *restrict HF_RGB_temp;        // temp buffer for HF_RBG terms before blurring
 
     // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
     if(s == 0)
     {
       detail = in;
       LF = LF_odd;
+      HF_RGB_temp = LF_even;
     }
     else if(s % 2 != 0)
     {
       detail = LF_odd;
       LF = LF_even;
+      HF_RGB_temp = LF_odd;
     }
     else
     {
       detail = LF_even;
       LF = LF_odd;
+      HF_RGB_temp = LF_even;
     }
 
     const int mult = 1 << s; // fancy-pants C notation for 2^s with integer type, don't be afraid
@@ -1155,10 +1166,10 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
 
     // Compute wavelets high-frequency scales and save the mininum of texture over the RGB channels
     // Note : HF_RGB = detail - LF, HF_grey = max(HF_RGB)
-    wavelets_detail_level(detail, LF, HF_RGB, HF_grey, roi_out->width, roi_out->height, ch);
+    wavelets_detail_level(detail, LF, HF_RGB_temp, HF_grey, roi_out->width, roi_out->height, ch);
 
     // interpolate/blur/inpaint (same thing) the RGB high-frequency to fill holes
-    blur_2D_Bspline(HF_RGB, HF_RGB, temp, roi_out->width, roi_out->height, mult);
+    blur_2D_Bspline(HF_RGB_temp, HF_RGB, temp, roi_out->width, roi_out->height, mult);
 
     // Reconstruct clipped parts
     if(variant == DT_FILMIC_RECONSTRUCT_RGB)


### PR DESCRIPTION
Didn't push this on Sunday because "part 1" was still pending, then forgot.  This PR reorders the passes of the blur operation to permit interleaving of the passes, substantially cutting cache misses because the second pass over a row immediately follows the first, instead  of having the entire rest of the image in between.  It also reduces memory requirements since it no longer requires an intermediate buffer as large as the entire image.

10% reduction in wall time single-threaded and 25% at 12+ threads (compared to the already sped-up code), but it **does slightly change** the output due to the reordered arithmetic.  Swapping the two pairs of calls to `kernel_filmic_bspline_vertical` and `kernel_filmic_bspline_horizontal` in the OpenCL code path should make the CPU and GPU outputs agree again, but I'll have to leave that to e.g. @aurelienpierre because I can't test such changes.

Arguments for merging now:
- fewer images with edits that might change in the future (even though only slightly) if only 3.2.1 produces the "old" output
- enabling reconstruction becomes less onerous

Arguments against merging now:
- the 3.4 release is rushing up on us
- someone else needs to update the OpenCL code path

BTW, I think another 5-10% speedup is possible, but that would require taking a sledge hammer to Aurelien's beautifully-structured code.