### PR TITLE
use embedded preview even if only auto history applied

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1154,7 +1154,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
     return;
   }
 
-  const gboolean altered = !dt_image_basic(imgid);
+  const gboolean altered = dt_image_altered(imgid);
   int res = 1;
 
   const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, imgid, 'r');


### PR DESCRIPTION
this fix #7162

I think the only drawback is if one has some crop auto applied (does lensfun crop ?) but anyway in this case thumbnails will be completely off too...