### PR TITLE
thumbs : show busy msg if loading delay

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -62,6 +62,7 @@ void dt_control_log_busy_enter();
 void dt_control_toast_busy_enter();
 void dt_control_log_busy_leave();
 void dt_control_toast_busy_leave();
+void dt_control_draw_busy_msg(cairo_t *cr, int width, int height);
 // disable the possibility to change the cursor shape with dt_control_change_cursor
 void dt_control_forbid_change_cursor();
 // enable the possibility to change the cursor shape with dt_control_change_cursor

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -133,6 +133,8 @@ typedef struct
   float zoom_100; // max zoom value (image 100%)
 
   gboolean display_focus; // do we display rectangles to show focused part of the image
+
+  gboolean busy; // should we show the busy message ?
 } dt_thumbnail_t;
 
 dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over,


### PR DESCRIPTION
this is esp. useful when zooming in culling or preview where nothing seems to happen when ctrl-scroll if the image take some time to load in cache.
I've reused the same code as for darkroom with same msg at same position on the thumbnail.