### PR TITLE
add a censorization module

### DIFF
--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -24,9 +24,9 @@
 
 typedef enum dt_gaussian_order_t
 {
-  DT_IOP_GAUSSIAN_ZERO = 0,
-  DT_IOP_GAUSSIAN_ONE = 1,
-  DT_IOP_GAUSSIAN_TWO = 2
+  DT_IOP_GAUSSIAN_ZERO = 0, // $DESCRIPTION: "order 0"
+  DT_IOP_GAUSSIAN_ONE = 1,  // $DESCRIPTION: "order 1"
+  DT_IOP_GAUSSIAN_TWO = 2   // $DESCRIPTION: "order 2"
 } dt_gaussian_order_t;
 
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -105,6 +105,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {26.0f }, "hazeremoval", 0},
   { {27.0f }, "colorin", 0},
   { {27.5f }, "channelmixerrgb", 0},
+  { {27.5f }, "censorize", 0},
   { {27.5f }, "negadoctor", 0},
   { {27.5f }, "basicadj", 0},
   { {28.0f }, "colorreconstruct", 0},
@@ -188,6 +189,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { {27.0f }, "equalizer", 0},
   { {28.0f }, "colorin", 0},
   { {28.5f }, "channelmixerrgb", 0},
+  { {28.5f }, "censorize", 0},
   { {28.5f }, "negadoctor", 0},      // Cineon film encoding comes after scanner input color profile
   { {29.0f }, "nlmeans", 0},         // signal processing (denoising)
                                   //    -> needs a signal as scene-referred as possible (even if it works in Lab)
@@ -636,6 +638,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           //                The insertion can be done depending on the current iop-order list kind.
           _insert_before(iop_order_list, "nlmeans", "negadoctor");
           _insert_before(iop_order_list, "negadoctor", "channelmixerrgb");
+          _insert_before(iop_order_list, "negadoctor", "censorize");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -143,6 +143,7 @@ add_iop(toneequal "toneequal.c" DEFAULT_VISIBLE)
 add_iop(filmicrgb "filmicrgb.c")
 add_iop(negadoctor "negadoctor.c")
 add_iop(channelmixerrgb "channelmixerrgb.c")
+add_iop(censorize "censorize.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -1,0 +1,414 @@
+/*
+  This file is part of darktable,
+  Copyright (C) 2011-2020 darktable developers.
+
+  darktable is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  darktable is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "bauhaus/bauhaus.h"
+#include "common/debug.h"
+#include "common/gaussian.h"
+#include "common/opencl.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "develop/imageop_math.h"
+#include "develop/imageop_gui.h"
+#include "develop/tiling.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "gui/presets.h"
+#include "iop/iop_api.h"
+#include <assert.h>
+#include <gtk/gtk.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <inttypes.h>
+
+#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
+
+DT_MODULE_INTROSPECTION(1, dt_iop_censorize_params_t)
+
+typedef struct dt_iop_censorize_params_t
+{
+  float radius_1;              // $MIN: 0.0 $MAX: 500.0 $DEFAULT: 10.0 $DESCRIPTION: "input blur radius"
+  float pixelate;              // $MIN: 0.0 $MAX: 5.0   $DEFAULT: 1.0  $DESCRIPTION: "pixellation radius"
+  float radius_2;              // $MIN: 0.0 $MAX: 500.0 $DEFAULT: 10.0 $DESCRIPTION: "output blur radius"
+} dt_iop_censorize_params_t;
+
+
+typedef struct dt_iop_censorize_gui_data_t
+{
+  GtkWidget *radius_1, *pixelate, *radius_2;
+} dt_iop_censorize_gui_data_t;
+
+typedef dt_iop_censorize_params_t dt_iop_censorize_data_t;
+
+typedef struct dt_iop_censorize_global_data_t
+{
+  int kernel_lowpass_mix;
+} dt_iop_censorize_global_data_t;
+
+typedef struct point_t
+{
+  size_t x, y;
+} point_t;
+
+const char *
+name()
+{
+  return _("censorize");
+}
+
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("censorize license plates and body parts for privacy"),
+                                      _("creative"),
+                                      _("linear or non-linear, RGB, scene-referred"),
+                                      _("frequential, RGB"),
+                                      _("special, RGB, scene-referred"));
+}
+
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
+}
+
+int default_group()
+{
+  return IOP_GROUP_EFFECT | IOP_GROUP_EFFECTS;
+}
+
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_rgb;
+}
+
+#if FALSE
+int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_censorize_data_t *d = (dt_iop_censorize_data_t *)piece->data;
+  dt_iop_censorize_global_data_t *gd = (dt_iop_censorize_global_data_t *)self->global_data;
+
+  cl_int err = -999;
+  const int devid = piece->pipe->devid;
+
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  const int channels = piece->colors;
+
+  const float radius_1 = fmax(0.1f, d->radius_1);
+  const float sigma = radius_1 * roi_in->scale / piece->iscale;
+  const float saturation = d->saturation;
+  const int order = d->order;
+  const int unbound = d->unbound;
+
+  size_t sizes[3];
+
+  cl_mem dev_cm = NULL;
+  cl_mem dev_ccoeffs = NULL;
+  cl_mem dev_lm = NULL;
+  cl_mem dev_lcoeffs = NULL;
+  cl_mem dev_tmp = NULL;
+
+  dt_gaussian_cl_t *g = NULL;
+  dt_bilateral_cl_t *b = NULL;
+
+  float RGBmax[] = { 100.0f, 128.0f, 128.0f, 1.0f };
+  float RGBmin[] = { 0.0f, -128.0f, -128.0f, 0.0f };
+
+  if(unbound)
+  {
+    for(int k = 0; k < 4; k++) RGBmax[k] = INFINITY;
+    for(int k = 0; k < 4; k++) RGBmin[k] = -INFINITY;
+  }
+
+  if(d->lowpass_algo == LOWPASS_ALGO_GAUSSIAN)
+  {
+    g = dt_gaussian_init_cl(devid, width, height, channels, RGBmax, RGBmin, sigma, order);
+    if(!g) goto error;
+    err = dt_gaussian_blur_cl(g, dev_in, dev_out);
+    if(err != CL_SUCCESS) goto error;
+    dt_gaussian_free_cl(g);
+    g = NULL;
+  }
+  else
+  {
+    const float sigma_r = 100.0f; // does not depend on scale
+    const float sigma_s = sigma;
+    const float detail = -1.0f; // we want the bilateral base layer
+
+    b = dt_bilateral_init_cl(devid, width, height, sigma_s, sigma_r);
+    if(!b) goto error;
+    err = dt_bilateral_splat_cl(b, dev_in);
+    if(err != CL_SUCCESS) goto error;
+    err = dt_bilateral_blur_cl(b);
+    if(err != CL_SUCCESS) goto error;
+    err = dt_bilateral_slice_cl(b, dev_in, dev_out, detail);
+    if(err != CL_SUCCESS) goto error;
+    dt_bilateral_free_cl(b);
+    b = NULL; // make sure we don't clean it up twice
+  }
+
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  if(dev_tmp == NULL) goto error;
+
+  dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
+  if(dev_cm == NULL) goto error;
+
+  dev_ccoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->cunbounded_coeffs);
+  if(dev_ccoeffs == NULL) goto error;
+
+  dev_lm = dt_opencl_copy_host_to_device(devid, d->ltable, 256, 256, sizeof(float));
+  if(dev_lm == NULL) goto error;
+
+  dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);
+  if(dev_lcoeffs == NULL) goto error;
+
+  size_t origin[] = { 0, 0, 0 };
+  size_t region[] = { width, height, 1 };
+  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
+  if(err != CL_SUCCESS) goto error;
+
+  sizes[0] = ROUNDUPWD(width);
+  sizes[1] = ROUNDUPWD(height);
+  sizes[2] = 1;
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 0, sizeof(cl_mem), (void *)&dev_tmp);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 1, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 2, sizeof(int), (void *)&width);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 3, sizeof(int), (void *)&height);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 4, sizeof(float), (void *)&saturation);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 5, sizeof(cl_mem), (void *)&dev_cm);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 6, sizeof(cl_mem), (void *)&dev_ccoeffs);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 7, sizeof(cl_mem), (void *)&dev_lm);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 8, sizeof(cl_mem), (void *)&dev_lcoeffs);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 9, sizeof(int), (void *)&unbound);
+
+  err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_lowpass_mix, sizes);
+  if(err != CL_SUCCESS) goto error;
+
+  dt_opencl_release_mem_object(dev_tmp);
+  dt_opencl_release_mem_object(dev_lcoeffs);
+  dt_opencl_release_mem_object(dev_lm);
+  dt_opencl_release_mem_object(dev_ccoeffs);
+  dt_opencl_release_mem_object(dev_cm);
+
+  return TRUE;
+
+error:
+  if(g) dt_gaussian_free_cl(g);
+  if(b) dt_bilateral_free_cl(b);
+
+  dt_opencl_release_mem_object(dev_tmp);
+  dt_opencl_release_mem_object(dev_lcoeffs);
+  dt_opencl_release_mem_object(dev_lm);
+  dt_opencl_release_mem_object(dev_ccoeffs);
+  dt_opencl_release_mem_object(dev_cm);
+  dt_print(DT_DEBUG_OPENCL, "[opencl_lowpass] couldn't enqueue kernel! %d\n", err);
+  return FALSE;
+}
+#endif
+
+void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
+                     struct dt_develop_tiling_t *tiling)
+{
+  dt_iop_censorize_data_t *d = (dt_iop_censorize_data_t *)piece->data;
+
+  const float radius_1 = fmax(0.1f, d->radius_1);
+  const float sigma = radius_1 * roi_in->scale / piece->iscale;
+
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  const int channels = piece->colors;
+
+  const size_t basebuffer = width * height * channels * sizeof(float);
+  tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+  tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
+  tiling->overhead = 0;
+  tiling->overlap = ceilf(4 * sigma);
+  tiling->xalign = 1;
+  tiling->yalign = 1;
+  return;
+}
+
+
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_censorize_data_t *data = (dt_iop_censorize_data_t *)piece->data;
+  const float *const restrict in = (const float *const restrict)ivoid;
+  float *const restrict out = (float *const restrict)ovoid;
+
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  const int ch = 4;
+  assert(piece->colors == ch);
+
+  float *const restrict temp = dt_alloc_sse_ps(width * height * ch);
+
+  const float sigma_1 = data->radius_1 * roi_in->scale / piece->iscale;
+  const float sigma_2 = data->radius_2 * roi_in->scale / piece->iscale;
+  const size_t pixel_radius = data->pixelate / 100.f * hypotf(width, height);
+  const size_t pixels_x = width / (2 * pixel_radius);
+  const size_t pixels_y = height / (2 * pixel_radius);
+
+  float RGBmax[4], RGBmin[4];
+  for(int k = 0; k < 4; k++)
+  {
+    RGBmax[k] = INFINITY;
+    RGBmin[k] = 0.f;
+  }
+
+  const float *restrict input = in;
+  float *restrict output = out;
+
+  // first blurring step
+  if(sigma_1 != 0.f)
+  {
+    dt_gaussian_t *g = dt_gaussian_init(width, height, ch, RGBmax, RGBmin, sigma_1, 0);
+    if(!g) return;
+    dt_gaussian_blur_4c(g, input, output);
+    dt_gaussian_free(g);
+
+    input = output;
+  }
+
+  output = temp;
+
+  // pixelate
+  if(pixel_radius != 0)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(width, height, ch, input, output, pixel_radius, pixels_y, pixels_x) \
+  aligned(input, output:64) \
+  schedule(simd:static) collapse(2)
+#endif
+    for(size_t j = 0; j < pixels_y + 1; j++)
+      for(size_t i = 0; i < pixels_x + 1; i++)
+      {
+        // get the top left coordinate of the big pixel
+        const point_t tl = { CLAMP(2 * pixel_radius * i, 0, width - 1),
+                             CLAMP(2 * pixel_radius * j, 0, height - 1) };
+        // get the center of the big pixel
+        const point_t cc = { CLAMP(tl.x + pixel_radius, 0, width - 1),
+                             CLAMP(tl.y + pixel_radius, 0, height - 1) };
+        // get the bottom right coordinate of the big pixel
+        const point_t br = { CLAMP(cc.x + pixel_radius, 0, width - 1),
+                             CLAMP(cc.y + pixel_radius, 0, height - 1) };
+
+        // get the bounding box + center point coordinates
+        const point_t box[5] = { tl, { br.x, tl.y }, cc, { tl.x, br.y }, br };
+
+        // find the average color over the big pixel
+        float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
+
+        #ifdef _OPENMP
+        #pragma omp reduction(+:RGB) aligned(RGB:16) aligned(input:64) collapse(2)
+        #endif
+        for(size_t k = 0; k < 5; k++)
+          for(size_t c = 0; c < 4; c++)
+            RGB[c] += input[(width * box[k].y + box[k].x) * 4 + c] / 5.f;
+
+        // paint the big pixel with solid color == average
+        #ifdef _OPENMP
+        #pragma omp collapse(3)
+        #endif
+        for(size_t jj = tl.y; jj < br.y; jj++)
+          for(size_t ii = tl.x; ii < br.x; ii++)
+            for(size_t c = 0; c < 4; c++)
+              output[(jj * width + ii) * 4 + c] = RGB[c];
+      }
+
+    input = output;
+  }
+
+  output = out;
+
+  // second blurring step
+  if(sigma_2 != 0.f)
+  {
+    dt_gaussian_t *g = dt_gaussian_init(width, height, ch, RGBmax, RGBmin, sigma_2, 0);
+    if(!g) return;
+    dt_gaussian_blur_4c(g, input, output);
+    dt_gaussian_free(g);
+  }
+  else
+  {
+    dt_simd_memcpy(input, output, width * height * ch);
+  }
+
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
+    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+
+  dt_free_align(temp);
+}
+
+void gui_update(struct dt_iop_module_t *self)
+{
+  dt_iop_censorize_gui_data_t *g = (dt_iop_censorize_gui_data_t *)self->gui_data;
+  dt_iop_censorize_params_t *p = (dt_iop_censorize_params_t *)self->params;
+  dt_bauhaus_slider_set(g->radius_1, p->radius_1);
+  dt_bauhaus_slider_set(g->pixelate, p->pixelate);
+  dt_bauhaus_slider_set(g->radius_2, p->radius_2);
+}
+
+/*
+void init_global(dt_iop_module_so_t *module)
+{
+  const int program = 6; // gaussian.cl, from programs.conf
+  dt_iop_censorize_global_data_t *gd
+      = (dt_iop_censorize_global_data_t *)malloc(sizeof(dt_iop_censorize_global_data_t));
+  module->data = gd;
+  gd->kernel_lowpass_mix = dt_opencl_create_kernel(program, "lowpass_mix");
+}
+*/
+
+/*
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  dt_iop_censorize_global_data_t *gd = (dt_iop_censorize_global_data_t *)module->data;
+  dt_opencl_free_kernel(gd->kernel_lowpass_mix);
+  free(module->data);
+  module->data = NULL;
+}
+*/
+void gui_init(struct dt_iop_module_t *self)
+{
+  dt_iop_censorize_gui_data_t *g = IOP_GUI_ALLOC(censorize);
+
+  g->radius_1 = dt_bauhaus_slider_from_params(self, N_("radius_1"));
+  dt_bauhaus_slider_set_step(g->radius_1, 0.1);
+
+  g->pixelate = dt_bauhaus_slider_from_params(self, N_("pixelate"));
+  dt_bauhaus_slider_set_step(g->pixelate, 0.1);
+
+  g->radius_2 = dt_bauhaus_slider_from_params(self, N_("radius_2"));
+  dt_bauhaus_slider_set_step(g->radius_2, 0.1);
+
+  gtk_widget_set_tooltip_text(g->radius_1, _("radius of gaussian blur before pixellation"));
+  gtk_widget_set_tooltip_text(g->radius_2, _("radius of gaussian blur after pixellation"));
+  gtk_widget_set_tooltip_text(g->pixelate, _("radius of the intermediate pixellation"));
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
This adds a module that allows to censorize license plates, faces or… nipples for social media publishing and privacy. 

It's a quick repurposing of the lowpass filter, in RGB, and aims at giving a "not-too-ugly" censorization, with one gaussian blur, one pixellation, and another gaussian blur. The credit for the algo actually goes to my wife. The usual masking API is to be used there, there is no internal masking.

Pixellation only:
![Screenshot_20201205_020208](https://user-images.githubusercontent.com/2779157/101229094-e9ca1600-369e-11eb-87f1-239feeb23b68.png)

Pixellation + input blur:
![Screenshot_20201205_020305](https://user-images.githubusercontent.com/2779157/101229104-f2bae780-369e-11eb-937a-ffc6903b197f.png)

Pixellation + input blur + output blur:
![Screenshot_20201205_020340](https://user-images.githubusercontent.com/2779157/101229116-fe0e1300-369e-11eb-99c2-8ea7aa91b8e2.png)

The algo runs below 50 ms s at 4K on my CPU using all the features without masking and in about 180 ms with masking. The gaussian blur is the general gaussian from dt, the pixellation only runs in about 24 ms. OpenCL is not provided yet but easy to code since the gaussian stuff is already coded. The blurs are disabled with a radius = 0.0 and discarded from the processing in that case.

Possible results:
![_DSC0003_05](https://user-images.githubusercontent.com/2779157/101233338-746b3f00-36b8-11eb-963a-954d54e76a60.jpg)
![_DSC0003_04](https://user-images.githubusercontent.com/2779157/101233339-759c6c00-36b8-11eb-9aaa-d06b4f6c7785.jpg)

Also, setting the pixellation to 0 disables it, and the module becomes a scene-referred gaussian blur that can be used for physically-accurate blooming.

Lowpass gaussian blur (in Lab), radius = 50:
![_DSC0003_01](https://user-images.githubusercontent.com/2779157/101230661-f9e5f380-36a6-11eb-8e0f-2d0d5b66e13b.jpg)

Censorization gaussian blur (in linear RGB), radius = 50:
![_DSC0003_02](https://user-images.githubusercontent.com/2779157/101230685-16822b80-36a7-11eb-83ef-be2568d454fe.jpg)

(remember gaussian blur simulates diffusion, aka fog or frosten glass).

Note for later: masking is really slow.