### PR TITLE
surface blur: refine tiling factor

### DIFF
--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -295,7 +295,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   sigma[0] = data->sigma[0] * roi_in->scale / piece->iscale;
   sigma[1] = data->sigma[1] * roi_in->scale / piece->iscale;
   const int rad = (int)(3.0 * fmaxf(sigma[0], sigma[1]) + 1.0);
-  tiling->factor = 2 + 50;
+  tiling->factor = 2.0 /*input+output*/ + 80.0/16/*worst-case hashtable*/ + 52.0/16/*replay buffer*/;
   tiling->overhead = 0;
   tiling->overlap = rad;
   tiling->xalign = 1;


### PR DESCRIPTION
The tiling factor for surface blur (aka denoise bilateral) had been set to 2.0 + 50, which is considerably larger than necessary.  After a review of the code, it turns out that even in the worst case, a factor of 10.25 suffices.  This lets it run without tiling on far more computers (the integration test just barely misses out on triggering tiling with the original 52 factor -- changing the specified host memory limit from 8192 to 8000 is enough to cause tiling).  It's particularly important to avoid unnecessary tiling as the output changes everywhere except in the first, top-left tile.
