### PR TITLE
small refactor iop gui expander setup

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1105,8 +1105,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
         dt_iop_gui_init(module);
 
         /* add module to right panel */
-        GtkWidget *expander = dt_iop_gui_get_expander(module);
-        dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+        dt_iop_gui_get_expander(module);
         dt_iop_gui_set_expanded(module, TRUE, FALSE);
 
         dt_iop_reload_defaults(module);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1105,7 +1105,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
         dt_iop_gui_init(module);
 
         /* add module to right panel */
-        dt_iop_gui_get_expander(module);
+        dt_iop_gui_set_expander(module);
         dt_iop_gui_set_expanded(module, TRUE, FALSE);
 
         dt_iop_reload_defaults(module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -920,7 +920,7 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
     dt_iop_gui_init(module);
 
     /* add module to right panel */
-    dt_iop_gui_get_expander(module);
+    dt_iop_gui_set_expander(module);
     GValue gv = { 0, { { 0 } } };
     g_value_init(&gv, G_TYPE_INT);
     gtk_container_child_get_property(
@@ -2435,7 +2435,7 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
   return TRUE;
 }
 
-GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
+void dt_iop_gui_set_expander(dt_iop_module_t *module)
 {
   char tooltip[512];
 
@@ -2568,8 +2568,6 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
 
   dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
   dt_iop_show_hide_header_buttons(header, NULL, FALSE, FALSE);
-
-  return module->expander;
 }
 
 GtkWidget *dt_iop_gui_get_widget(dt_iop_module_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -920,15 +920,14 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
     dt_iop_gui_init(module);
 
     /* add module to right panel */
-    GtkWidget *expander = dt_iop_gui_get_expander(module);
-    dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+    dt_iop_gui_get_expander(module);
     GValue gv = { 0, { { 0 } } };
     g_value_init(&gv, G_TYPE_INT);
     gtk_container_child_get_property(
         GTK_CONTAINER(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER)),
         base->expander, "position", &gv);
     gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER),
-                          expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
+                          module->expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
     dt_iop_gui_set_expanded(module, TRUE, FALSE);
 
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
@@ -2403,7 +2402,6 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
       button && GTK_IS_BUTTON(button->data);
       button = g_list_previous(button))
   {
-    gtk_widget_set_no_show_all(GTK_WIDGET(button->data), TRUE);
     gtk_widget_set_visible(GTK_WIDGET(button->data), show_buttons && !always_hide);
     gtk_widget_set_opacity(GTK_WIDGET(button->data), opacity);
   }
@@ -2534,8 +2532,6 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   for(int i = IOP_MODULE_LAST - 1; i > IOP_MODULE_LABEL; i--)
     if(hw[i]) gtk_box_pack_end(GTK_BOX(header), hw[i], FALSE, FALSE, 0);
 
-  dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, FALSE);
-
   dt_gui_add_help_link(header, "interacting.html");
 
   gtk_widget_set_halign(hw[IOP_MODULE_LABEL], GTK_ALIGN_START);
@@ -2569,6 +2565,9 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   /* connect accelerators */
   dt_iop_connect_common_accels(module);
   if(module->connect_key_accels) module->connect_key_accels(module);
+
+  dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+  dt_iop_show_hide_header_buttons(header, NULL, FALSE, FALSE);
 
   return module->expander;
 }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2403,6 +2403,7 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
       button && GTK_IS_BUTTON(button->data);
       button = g_list_previous(button))
   {
+    gtk_widget_set_no_show_all(GTK_WIDGET(button->data), TRUE);
     gtk_widget_set_visible(GTK_WIDGET(button->data), show_buttons && !always_hide);
     gtk_widget_set_opacity(GTK_WIDGET(button->data), opacity);
   }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -614,7 +614,7 @@ void dt_iop_commit_blend_params(dt_iop_module_t *module, const struct dt_develop
 /** make sure the raster mask is advertised if available */
 void dt_iop_set_mask_mode(dt_iop_module_t *module, int mask_mode);
 /** creates a label widget for the expander, with callback to enable/disable this module. */
-GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module);
+void dt_iop_gui_set_expander(dt_iop_module_t *module);
 /** get the widget of plugin ui in expander */
 GtkWidget *dt_iop_gui_get_widget(dt_iop_module_t *module);
 /** get the eventbox of plugin ui in expander */

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -297,8 +297,7 @@ static void _add_module_expander(GList *iop_list, dt_iop_module_t *module)
   if(!dt_iop_is_hidden(module) && !module->expander)
   {
       /* add module to right panel */
-      GtkWidget *expander = dt_iop_gui_get_expander(module);
-      dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+      dt_iop_gui_get_expander(module);
       dt_iop_gui_set_expanded(module, TRUE, FALSE);
       dt_iop_gui_update_blending(module);
   }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -297,7 +297,7 @@ static void _add_module_expander(GList *iop_list, dt_iop_module_t *module)
   if(!dt_iop_is_hidden(module) && !module->expander)
   {
       /* add module to right panel */
-      dt_iop_gui_get_expander(module);
+      dt_iop_gui_set_expander(module);
       dt_iop_gui_set_expanded(module, TRUE, FALSE);
       dt_iop_gui_update_blending(module);
   }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -946,7 +946,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
         module->gui_init(module);
 
         /* add module to right panel */
-        dt_iop_gui_get_expander(module);
+        dt_iop_gui_set_expander(module);
         dt_iop_gui_set_expanded(module, FALSE, dt_conf_get_bool("darkroom/ui/single_module"));
         dt_iop_gui_update_blending(module);
       }
@@ -2932,7 +2932,7 @@ void enter(dt_view_t *self)
       dt_iop_gui_init(module);
 
       /* add module to right panel */
-      dt_iop_gui_get_expander(module);
+      dt_iop_gui_set_expander(module);
 
       snprintf(option, sizeof(option), "plugins/darkroom/%s/expanded", module->op);
       if(dt_conf_get_bool(option))

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -946,8 +946,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
         module->gui_init(module);
 
         /* add module to right panel */
-        GtkWidget *expander = dt_iop_gui_get_expander(module);
-        dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+        dt_iop_gui_get_expander(module);
         dt_iop_gui_set_expanded(module, FALSE, dt_conf_get_bool("darkroom/ui/single_module"));
         dt_iop_gui_update_blending(module);
       }
@@ -2933,8 +2932,7 @@ void enter(dt_view_t *self)
       dt_iop_gui_init(module);
 
       /* add module to right panel */
-      GtkWidget *expander = dt_iop_gui_get_expander(module);
-      dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
+      dt_iop_gui_get_expander(module);
 
       snprintf(option, sizeof(option), "plugins/darkroom/%s/expanded", module->op);
       if(dt_conf_get_bool(option))


### PR DESCRIPTION
Edit: #7190 was fixed by cherry picking the first commit in this PR. The rest is just cleanup/minor refactor.

Prevents all right-hand buttons on processing module header being shown on entering the darkroom (when the header is being added to the expander). The buttons that were hidden by the "active" mode should stay hidden. All other modes have a callback when the panel is first shown and resized that rehides buttons when needed, but "active" doesn't, because it doesn't depend on column width.

The same result could be achieved by moving the call to 
` dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
`
inside `dt_iop_gui_get_expander`, before the initial `dt_iop_show_hide_header_buttons`. This would also clean up a (little) bit of code duplication, but is probably too large a change at this point in the release cycle, due to possible side effects.

A more complete refactor would rename `dt_iop_gui_get_expander` to `dt_iop_gui_set_expander` (or create_expander) and change the `GtkWidget *` return value to `void`, since it is not used anymore (except in `dt_iop_gui_duplicate` where it can be easily picked up from module->expander). And for consistency do the same to `dt_lib_gui_get_expander`.

@TurboGit let me know if you'd like me to submit that refactor for 3.4.1.