### PR TITLE
collect + tagging: fix tags case issues + uncategorized entry

### DIFF
--- a/src/common/map_locations.c
+++ b/src/common/map_locations.c
@@ -200,7 +200,7 @@ static gint _sort_by_path(gconstpointer a, gconstpointer b)
   const dt_map_location_t *tuple_a = (const dt_map_location_t *)a;
   const dt_map_location_t *tuple_b = (const dt_map_location_t *)b;
 
-  return g_ascii_strcasecmp(tuple_a->tag, tuple_b->tag);
+  return g_strcmp0(tuple_a->tag, tuple_b->tag);
 }
 
 // sort the tag list considering the '|' character

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -728,7 +728,7 @@ static gint sort_tag_by_path(gconstpointer a, gconstpointer b)
   const dt_tag_t *tuple_a = (const dt_tag_t *)a;
   const dt_tag_t *tuple_b = (const dt_tag_t *)b;
 
-  return g_ascii_strcasecmp(tuple_a->tag, tuple_b->tag);
+  return g_strcmp0(tuple_a->tag, tuple_b->tag);
 }
 
 static gint sort_tag_by_leave(gconstpointer a, gconstpointer b)
@@ -736,7 +736,7 @@ static gint sort_tag_by_leave(gconstpointer a, gconstpointer b)
   const dt_tag_t *tuple_a = (const dt_tag_t *)a;
   const dt_tag_t *tuple_b = (const dt_tag_t *)b;
 
-  return g_ascii_strcasecmp(tuple_a->leave, tuple_b->leave);
+  return g_strcmp0(tuple_a->leave, tuple_b->leave);
 }
 
 static gint sort_tag_by_count(gconstpointer a, gconstpointer b)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1278,7 +1278,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
         g_free(name_folded_slash);
       }
       else
-        collate_key = tag_collate_key(name_folded);
+        collate_key = tag_collate_key(name);
 
       g_free(name_folded);
       name_key_tuple_t *tuple = (name_key_tuple_t *)malloc(sizeof(name_key_tuple_t));
@@ -1302,8 +1302,13 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       char *name = tuple->name;
       const int count = tuple->count;
       if(name == NULL) continue; // safeguard against degenerated db entries
-
-      if(property == DT_COLLECTION_PROP_TAG && strchr(name, '|') == 0 && (last_tokens_length == 0 || strcmp(name, *last_tokens)))
+      // this is just for tags
+      char *next_name = g_strdup(names->next ? ((name_key_tuple_t *)names->next->data)->name : "");
+      if(strlen(next_name) >= strlen(name) + 1 && next_name[strlen(name)] == '|')
+        next_name[strlen(name)] = '\0';
+        
+      if(property == DT_COLLECTION_PROP_TAG && strchr(name, '|') == NULL
+        && (g_strcmp0(next_name, name)))
       {
         /* add uncategorized root iter if not exists */
         if(!uncategorized.stamp)
@@ -1412,6 +1417,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
           last_tokens_length = tokens_length;
         }
       }
+      g_free(next_name);
     }
     g_list_free_full(sorted_names, free_tuple);
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2423,7 +2423,7 @@ static gint _sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter
   gtk_tree_model_get(model, b, DT_LIB_TAGGING_COL_TAG, &tag_b, -1);
   if(tag_a == NULL) tag_a = g_strdup("");
   if(tag_b == NULL) tag_b = g_strdup("");
-  const gboolean sort = g_ascii_strcasecmp(tag_a, tag_b);
+  const gboolean sort = g_strcmp0(tag_a, tag_b);
   g_free(tag_a);
   g_free(tag_b);
   return sort;
@@ -2451,7 +2451,7 @@ static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
   else
     tag_b = g_strdup("");
 
-  const gboolean sort = g_ascii_strcasecmp(tag_a, tag_b);
+  const gboolean sort = g_strcmp0(tag_a, tag_b);
   g_free(tag_a);
   g_free(tag_b);
   return sort;


### PR DESCRIPTION
Fixes #7155

- does~~n't~~ consider different case strings as different tags (display)
- fixes the uncategorized tags issue (regression because the code was assuming a reverse order for tags). ~~However I guess the fix will not work if the user select reverse order.~~

~~BTW, where does the user set reverse order ? ~~

~~Another weakness of this fix: usage of deprecated g_strcasecmp().~~ Nope, g_ascii_strcasecmp is used, sorry.

@chill could you check if that fixes your issues ?
note: completion will show you the first option (in case of multiple cases). If you want to cleanup the case, you can easily see the differences in tag listview and then fix them with rename path in treeview (or edit tag if it's a leave).

~~If that works I can pursue with g_strcasecmp() replacement.~~
Thanks in advance
