### PR TITLE
bugfix: unitialized values in rawdenoise X-Trans code path

### DIFF
--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -351,7 +351,7 @@ static void dwt_denoise_horiz_1ch(float *const restrict out, float *const restri
 static void dwt_denoise(float *const img, const int width, const int height,
                         const int bands, const float *const noise)
 {
-  float *const details = dt_alloc_sse_ps(2 * width * height);
+  float *const details = dt_alloc_align_float(2 * width * height);
   float *const interm = details + width * height;	// temporary storage for use during each pass
 
   // zero the accumulator
@@ -375,7 +375,7 @@ static void dwt_denoise(float *const img, const int width, const int height,
                             const dt_iop_rawdenoise_data_t * const data, const uint32_t filters)
 {
   const size_t size = (size_t)(roi->width / 2 + 1) * (roi->height / 2 + 1);
-  float *const restrict fimg = dt_alloc_sse_ps(size);
+  float *const restrict fimg = dt_alloc_align_float(size);
 
   const int nc = 4;
   for(int c = 0; c < nc; c++) /* denoise R,G1,B,G3 individually */

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -478,6 +478,11 @@ static void dwt_denoise(float *const img, const int width, const int height,
   dt_free_align(fimg);
 }
 
+static inline float vstransform(const float value)
+{
+  return sqrtf(MAX(0.0f, value));
+}
+
 static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_iop_roi_t *const roi,
                                    dt_iop_rawdenoise_data_t *data, const uint8_t (*const xtrans)[6])
 {
@@ -523,34 +528,133 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
       threshold_exp_4 *= threshold_exp_4;
       noise[i] = noise_all[i] * threshold_exp_4 * 16.0;
     }
-    memset(fimg, 0, size * sizeof(float));
 
+    const size_t nthreads = darktable.num_openmp_threads; // go direct, dt_get_num_threads() always returns numprocs
+    const size_t chunksize = (height + nthreads - 1) / nthreads;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(fimg, height, in, roi, size, width, xtrans) \
-    shared(c) \
+    shared(c) num_threads(nthreads) \
     schedule(static)
 #endif
-    for(int row = (c != 1); row < height - 1; row++)
+    for(size_t chunk = 0; chunk < nthreads; chunk++)
     {
-      int col = (c != 1);
-      const float *inp = in + (size_t)row * width + col;
-      float *fimgp = fimg + size + (size_t)row * width + col;
-      for(; col < width - 1; col++, inp++, fimgp++)
-        if(FCxtrans(row, col, roi, xtrans) == c)
+      const size_t start = chunk * chunksize;
+      const size_t pastend = MIN(start + chunksize,height);
+      for(size_t row = start; row < pastend; row++)
+      {
+        const float *const restrict inp = in + row * width;
+        float *const restrict fimgp = fimg + row * width + size;
+        // handle red/blue pixel in first column
+        if (c != 1 && FCxtrans(row, 0, roi, xtrans) == c)
         {
-          float d = sqrt(MAX(0, *inp));
-          *fimgp = d;
-          // cheap nearest-neighbor interpolate
-          if(c == 1)
-            fimgp[1] = fimgp[width] = d;
-          else
+          // copy to neighbors above and right
+          const float d = vstransform(inp[0]);
+          fimgp[0] = fimgp[-width] = fimgp[-width+1] = d;
+        }
+        for(size_t col = (c != 1); col < width-1; col++)
+        {
+          if (FCxtrans(row, col, roi, xtrans) == c)
           {
-            fimgp[-width - 1] = fimgp[-width] = fimgp[-width + 1] = fimgp[-1] = fimgp[1] = fimgp[width - 1]
-                = fimgp[width] = fimgp[width + 1] = d;
+            // the pixel at the current location has the desired color, so apply sqrt() as a variance-stablizing
+            // transform, and then do cheap nearest-neighbor interpolation by copying it to appropriate neighbors
+            const float d = vstransform(inp[col]);
+            fimgp[col] = d;
+            if (c == 1) // green pixel
+            {
+              // Copy to the right and down.  The X-Trans color layout is such that copying to those two neighbors
+              // results in all positions being filled except in the left-most and right-most columns and sometimes
+              // the topmost and bottom-most rows (depending on how the ROI aligns with the CFA).
+              fimgp[col+1] = fimgp[col+width] = d;
+            }
+            else // red or blue pixel
+            {
+              // Copy value to all eight neighbors; it's OK to copy to the row above even when we're in row 0 (or
+              // the row below when in the last row) because the destination is sandwiched between other buffers
+              // that will be overwritten afterwards anyway.  We need to copy to all adjacent positions because
+              // there may be two green pixels between nearest red/red or blue/blue, so each will cover one of the
+              // greens.
+              fimgp[col-width-1] = fimgp[col-width] = fimgp[col-width+1] = d; // row above
+              fimgp[col-1] = fimgp[col+1] = d;                                // left and right
+              if (row < pastend-1)
+                fimgp[col+width-1] = fimgp[col+width] = fimgp[col+width+1] = d; // row below
+            }
           }
         }
+        // leftmost and rightmost pixel in the row may still need to be filled in from a neighbor
+        if (FCxtrans(row, 0, roi, xtrans) != c)
+        {
+          int src = 0;
+          if (row > 1 && FCxtrans(row-1, 0, roi, xtrans) == c)
+            src = -width;
+          else if (FCxtrans(row, 1, roi, xtrans) == c)
+            src = 1;
+          else if (row > 1 && FCxtrans(row-1, 1, roi, xtrans) == c)
+            src = -width + 1;
+          else
+          {
+            //TODO: find pixel of correct color
+          }
+          fimgp[0] = vstransform(inp[src]);
+        }
+        // check the right-most pixel; if it's the desired color and not green, copy it to the neighbors
+        if (c != 1 && FCxtrans(row, width-1, roi, xtrans) == c)
+        {
+          // copy to neighbors above and left
+          const float d = vstransform(inp[width-1]);
+          fimgp[width-2] = fimgp[width-1] = fimgp[-1] = d;
+        }
+        else if (FCxtrans(row, width-1, roi, xtrans) != c)
+        {
+          int src = width-1;
+          if (FCxtrans(row, width-2, roi, xtrans) == c)
+            src = width-2;
+          else if (row > 1 && FCxtrans(row-1, width-1, roi, xtrans) == c)
+            src = -1;
+          else if (row > 1 && FCxtrans(row-1, width-2, roi, xtrans) == c)
+            src = -2;
+          else
+          {
+            //TODO: find pixel of correct color
+          }
+          fimgp[width-1] = vstransform(inp[src]);
+        }
+      }
+      if (pastend < height)
+      {
+        // Another slice follows us, and by updating the last row of our slice, we've clobbered values that
+        // were previously written by the other thread.  Restore them.
+        const float *const restrict inp = in + pastend * width;
+        float *const restrict fimgp = fimg + pastend * width + size;
+        for (size_t col = 0; col < width-1; col++)
+        {
+          if (FCxtrans(pastend, col, roi, xtrans) == c)
+          {
+            const float d = vstransform(inp[col]);
+            if (c == 1) // green pixel
+            {
+              if (FCxtrans(pastend, col+1, roi, xtrans) != c)
+                fimgp[col] = fimgp[col+1] = d;  // copy to the right
+            }
+            else // red/blue pixel
+            {
+              // copy the pixel's adjusted value to the prior row and left and right (if not at edge)
+              //fimgp[col] = fimgp[col+1] = d;
+              fimgp[col-width] = fimgp[col-width+1] = d;
+              if (col > 0) /*fimgp[col-1] =*/ fimgp[col-width-1] = d;
+            }
+          }
+          // some red and blue values may need to be restored from the row TWO past the end of our slice
+          if (c != 1 && pastend+1 < height && FCxtrans(pastend+1, col, roi, xtrans) == c)
+          {
+            const float d = vstransform(inp[col+width]);
+            fimgp[col] = fimgp[col+1] = d;
+            if (col > 0) fimgp[col-1] = d;
+          }
+        }
+      }
     }
+    memset(fimg, 0, size * sizeof(float));
 
     int lastpass;
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -541,7 +541,7 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
     const size_t chunksize = (height + nthreads - 1) / nthreads;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(fimg, height, in, roi, size, width, xtrans) \
+  dt_omp_firstprivate(fimg, height, in, roi, size, width, xtrans, nthreads, chunksize) \
     shared(c) num_threads(nthreads) \
     schedule(static)
 #endif


### PR DESCRIPTION
Current master leaves 1/3 to 2/3 of the pixels in the top-most and bottom-most rows, as well as left-most and right-most columns uninitialized.  The integration test is repeatable because it just happens to perform a memory allocation large enough that it goes direct to the OS, which provides new, freshly-zeroed pages for the Red pass (and then it re-uses left-over values for the Green and Blue passes).  An attempted switch to the faster code already in use for the Bayer code path brought this to light with a band of changed pixels on all four edges.

This PR ensures proper initialization for all edge pixels, and also addresss the discontinuity at per-thread slices which changes output depending on the number of threads.  While I have not been able to entirely eliminate differences, for the particular situation encountered in #7087, the number of changed pixels drops by a factor of 12 and the max dE is less than half when changing the number of threads from 4 to 16.

This fix necessarily **changes the output**, so if merged we'll need a new expected.png for test 0068.
