### PR TITLE
Fix picker leave

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -560,14 +560,25 @@ void dt_control_toast_redraw()
 
 static gboolean _gtk_widget_queue_draw(gpointer user_data)
 {
-  gtk_widget_queue_draw(GTK_WIDGET(user_data));
+  GtkWidget **widget_pointer = (GtkWidget **)user_data;
+  if(*widget_pointer)
+  {
+    g_signal_handlers_disconnect_by_func(G_OBJECT(*widget_pointer), gtk_widget_destroyed, widget_pointer);
+    gtk_widget_queue_draw(GTK_WIDGET(*widget_pointer));
+  }
   return FALSE;
 }
 
 void dt_control_queue_redraw_widget(GtkWidget *widget)
 {
   if(dt_control_running())
-    g_main_context_invoke(NULL, _gtk_widget_queue_draw, widget);
+  {
+    GtkWidget **widget_pointer = malloc(sizeof (GtkWidget *));
+    *widget_pointer = widget;
+    g_signal_connect(G_OBJECT(widget), "destroy", G_CALLBACK(gtk_widget_destroyed), widget_pointer);
+
+    g_main_context_invoke_full(NULL, G_PRIORITY_DEFAULT, _gtk_widget_queue_draw, widget_pointer, g_free);
+  }
 }
 
 

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -558,26 +558,11 @@ void dt_control_toast_redraw()
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
 }
 
-static gboolean _gtk_widget_queue_draw(gpointer user_data)
-{
-  GtkWidget **widget_pointer = (GtkWidget **)user_data;
-  if(*widget_pointer)
-  {
-    g_signal_handlers_disconnect_by_func(G_OBJECT(*widget_pointer), gtk_widget_destroyed, widget_pointer);
-    gtk_widget_queue_draw(GTK_WIDGET(*widget_pointer));
-  }
-  return FALSE;
-}
-
 void dt_control_queue_redraw_widget(GtkWidget *widget)
 {
   if(dt_control_running())
   {
-    GtkWidget **widget_pointer = malloc(sizeof (GtkWidget *));
-    *widget_pointer = widget;
-    g_signal_connect(G_OBJECT(widget), "destroy", G_CALLBACK(gtk_widget_destroyed), widget_pointer);
-
-    g_main_context_invoke_full(NULL, G_PRIORITY_DEFAULT, _gtk_widget_queue_draw, widget_pointer, g_free);
+    g_idle_add((GSourceFunc)gtk_widget_queue_draw, (void*)widget);
   }
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1947,6 +1947,8 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
 
 void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
 {
+  while(g_idle_remove_by_data(module->widget))
+    ; // remove multiple delayed gtk_widget_queue_draw triggers
   module->gui_cleanup(module);
   dt_iop_gui_cleanup_blending(module);
 }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -242,6 +242,8 @@ static void _iop_color_picker_signal_callback(gpointer instance, dt_iop_module_t
   // to work properly. This will force colorin to be run and it
   // will set the work_profile if needed.
 
+  if(!dev) return;
+
   dev->preview_pipe->changed |= DT_DEV_PIPE_REMOVE;
   dev->preview_pipe->cache_obsolete = 1;
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1518,8 +1518,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // for some reason this is needed on some systems to pick up the correctly themed cursor
   dt_control_change_cursor(GDK_LEFT_PTR);
 
-  dt_iop_color_picker_init();
-
   // create focus-peaking button
   darktable.gui->focus_peaking_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_focus_peaking, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(darktable.gui->focus_peaking_button, _("enable focus-peaking mode"));
@@ -3159,7 +3157,7 @@ static gboolean _scroll_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event
   if(event->state & GDK_CONTROL_MASK)
   {
     int delta_y=0;
-    
+
     dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y);
 
     dt_conf_set_int(config_str, dt_conf_get_int(config_str) + increment*delta_y);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3013,10 +3013,14 @@ void enter(dt_view_t *self)
   // connect to preference change for module header button hiding
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                                   G_CALLBACK(_preference_changed_button_hide), dev);
+
+  dt_iop_color_picker_init();
 }
 
 void leave(dt_view_t *self)
 {
+  dt_iop_color_picker_cleanup();
+
   _unregister_modules_drag_n_drop(self);
 
   /* disconnect from filmstrip image activate */


### PR DESCRIPTION
fixes #7153

@ralfbrown as you have done a lot of work on pipes/locks/threads, maybe you've got a better solution to avoiding the case where gtk_widget_queue_draw gets called on a widget that has just been deleted? The solution implemented here involves connecting and disconnected a signal every time dt_control_queue_redraw_widget gets called and it is used in 42 locations. Probably many of those could directly use gtk_widget_queue_draw because it is clear that they are in the same gui thread. But using dt_control_queue_redraw_widget everywhere has the appeal that one doesn't need to worry about that. Until something like this introduces a penalty for the extra robustness.
