### PR TITLE
[extract_wb] fix handling of exif models with aliases

### DIFF
--- a/tools/extract_wb.py
+++ b/tools/extract_wb.py
@@ -87,7 +87,7 @@ for camera in xml_doc.getroot().findall('Camera'):
         maker = cid.get('make')
         model = cid.get('model')
     exif_name_map[exif_id] = maker,model
-    for alias in camera.findall('Alias'):
+    for alias in camera.findall('Aliases/Alias'):
         exif_model = alias.text
         exif_id = exif_maker, exif_model
         exif_name_map[exif_id] = maker,model


### PR DESCRIPTION
it looks like original code wrongly searched for aliases in camera models. 
now all cameras with aliases are properly recognized thanks to power of friendship and this python documentation i read.