### PR TITLE
flip: fix default enabled when importing image.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1885,6 +1885,12 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
     hist->params = malloc(hist->module->params_size);
     hist->blend_params = malloc(sizeof(dt_develop_blend_params_t));
 
+    if(hist->module->default_enabled)
+    {
+      hist->module->enabled = enabled;
+      dt_iop_gui_update_header(hist->module);
+    }
+
     // update module iop_order only on active history entries
     if(history_end_current > dev->history_end) hist->module->iop_order = hist->iop_order;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1341,7 +1341,7 @@ void dt_iop_gui_set_enable_button(dt_iop_module_t *module)
 
 void dt_iop_gui_update_header(dt_iop_module_t *module)
 {
-  _iop_gui_update_header(module);
+  if(module->header) _iop_gui_update_header(module);
 }
 
 void dt_iop_set_module_in_trouble(dt_iop_module_t *module, const gboolean state)


### PR DESCRIPTION
At the time the image is imported the auto apply preset is used
but we do not reload default first and so fail to set the
default_enabled flag. For this to happen we create the init()
routine on this module and explicity set default_enabled to 1
as it is done in reload_defaults.

Fixes #7213.