### PR TITLE
[performance] adjust OpenMP directives for better scaling

### DIFF
--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -920,15 +920,16 @@ static void build_round_stamp(float complex **pstamp,
   // hypotf only for PI / 32 = 0.098 of the stamp area.
   #ifdef _OPENMP
   #pragma omp parallel for schedule(static) default(none) \
-    dt_omp_firstprivate(iradius, strength, abs_strength, table_size)  \
-    dt_omp_sharedconst(center, warp, stamp_extent, lookup_table)
+    dt_omp_firstprivate(iradius, strength, abs_strength, table_size)   \
+    dt_omp_sharedconst(center, warp, stamp_extent, lookup_table, LOOKUP_OVERSAMPLE)
   #endif
 
   for(int y = 0; y <= iradius; y++)
   {
     for(int x = y; x <= iradius; x++)
     {
-      const float dist = hypotf(x, y);
+//      const float dist = hypotf(x, y);
+      const float dist = sqrtf(x*x + y*y); // faster than lib function, and we know we won't have overflow or denormals
       const int idist = round(dist * LOOKUP_OVERSAMPLE);
       if(idist >= table_size)
         // idist will only grow bigger in this row

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -844,8 +844,8 @@ static float *build_lookup_table(const int distance, const float control1, const
   return lookup;
 }
 
-static void compute_round_stamp_extent(cairo_rectangle_int_t *stamp_extent,
-                                        const dt_liquify_warp_t *warp)
+static void compute_round_stamp_extent(cairo_rectangle_int_t *const restrict stamp_extent,
+                                        const dt_liquify_warp_t *const restrict warp)
 {
 
   const int iradius = round(cabs(warp->radius - warp->point));
@@ -878,8 +878,8 @@ static void compute_round_stamp_extent(cairo_rectangle_int_t *stamp_extent,
 */
 
 static void build_round_stamp(float complex **pstamp,
-                               cairo_rectangle_int_t *stamp_extent,
-                               const dt_liquify_warp_t *warp)
+                               cairo_rectangle_int_t *const restrict stamp_extent,
+                               const dt_liquify_warp_t *const restrict warp)
 {
   const int iradius = round(cabs(warp->radius - warp->point));
   assert(iradius > 0);
@@ -894,8 +894,8 @@ static void build_round_stamp(float complex **pstamp,
     (strength * STAMP_RELOCATION) : strength;
   const float abs_strength = cabs(strength);
 
-  float complex *stamp = malloc(sizeof(float complex)
-                                 * stamp_extent->width * stamp_extent->height);
+  float complex *restrict stamp = malloc(sizeof(float complex)
+                                         * stamp_extent->width * stamp_extent->height);
 
   // clear memory
   #ifdef _OPENMP
@@ -910,16 +910,18 @@ static void build_round_stamp(float complex **pstamp,
 
   // lookup table: map of distance from center point => warp
   const int table_size = iradius * LOOKUP_OVERSAMPLE;
-  const float *lookup_table = build_lookup_table(table_size, warp->control1, warp->control2);
+  const float *const restrict lookup_table = build_lookup_table(table_size, warp->control1, warp->control2);
 
   // points into buffer at the center of the circle
-  float complex *center = stamp + 2 * iradius * iradius + 2 * iradius;
+  float complex *const center = stamp + 2 * iradius * iradius + 2 * iradius;
 
   // The expensive operation here is hypotf ().  By dividing the
   // circle in octants and doing only the inside we have to calculate
   // hypotf only for PI / 32 = 0.098 of the stamp area.
   #ifdef _OPENMP
-  #pragma omp parallel for schedule (dynamic, 1) default (shared)
+  #pragma omp parallel for schedule(static) default(none) \
+    dt_omp_firstprivate(iradius, strength, abs_strength, table_size)  \
+    dt_omp_sharedconst(center, warp, stamp_extent, lookup_table)
   #endif
 
   for(int y = 0; y <= iradius; y++)
@@ -930,18 +932,19 @@ static void build_round_stamp(float complex **pstamp,
       const int idist = round(dist * LOOKUP_OVERSAMPLE);
       if(idist >= table_size)
         // idist will only grow bigger in this row
-        goto next_row;
+        //goto next_row;
+        break;
 
       // pointers into the 8 octants of the circle
       // octant count is ccw from positive x-axis
-      float complex *o1 = center - y * stamp_extent->width + x;
-      float complex *o2 = center - x * stamp_extent->width + y;
-      float complex *o3 = center - x * stamp_extent->width - y;
-      float complex *o4 = center - y * stamp_extent->width - x;
-      float complex *o5 = center + y * stamp_extent->width - x;
-      float complex *o6 = center + x * stamp_extent->width - y;
-      float complex *o7 = center + x * stamp_extent->width + y;
-      float complex *o8 = center + y * stamp_extent->width + x;
+      float complex *const o1 = center - y * stamp_extent->width + x;
+      float complex *const o2 = center - x * stamp_extent->width + y;
+      float complex *const o3 = center - x * stamp_extent->width - y;
+      float complex *const o4 = center - y * stamp_extent->width - x;
+      float complex *const o5 = center + y * stamp_extent->width - x;
+      float complex *const o6 = center + x * stamp_extent->width - y;
+      float complex *const o7 = center + x * stamp_extent->width + y;
+      float complex *const o8 = center + y * stamp_extent->width + x;
 
       float abs_lookup = abs_strength * lookup_table[idist] / iradius;
 
@@ -975,7 +978,7 @@ static void build_round_stamp(float complex **pstamp,
            break;
       }
     }
-  next_row: ; // ";" makes compiler happy
+//  next_row: ; // ";" makes compiler happy
   }
 
   dt_free_align((void *) lookup_table);
@@ -993,9 +996,9 @@ static void build_round_stamp(float complex **pstamp,
 */
 
 static void add_to_global_distortion_map(float complex *global_map,
-                                          const cairo_rectangle_int_t *global_map_extent,
-                                          const dt_liquify_warp_t *warp,
-                                          const float complex *stamp,
+                                          const cairo_rectangle_int_t *const restrict global_map_extent,
+                                          const dt_liquify_warp_t *const restrict warp,
+                                          const float complex *const restrict stamp,
                                           const cairo_rectangle_int_t *stamp_extent)
 {
   cairo_rectangle_int_t mmext = *stamp_extent;
@@ -1013,10 +1016,8 @@ static void add_to_global_distortion_map(float complex *global_map,
 
   for(int y = cmmext.y; y < cmmext.y + cmmext.height; y++)
   {
-    const float complex *srcrow = stamp + ((y - mmext.y) * mmext.width);
-
-    float complex *destrow = global_map +
-      ((y - global_map_extent->y) * global_map_extent->width);
+    const float complex *const srcrow = stamp + ((y - mmext.y) * mmext.width);
+    float complex *const destrow = global_map + ((y - global_map_extent->y) * global_map_extent->width);
 
     for(int x = cmmext.x; x < cmmext.x + cmmext.width; x++)
     {
@@ -1034,11 +1035,11 @@ static void add_to_global_distortion_map(float complex *global_map,
 
 static void apply_global_distortion_map(struct dt_iop_module_t *module,
                                          dt_dev_pixelpipe_iop_t *piece,
-                                         const float *in,
-                                         float *out,
-                                         const dt_iop_roi_t *roi_in,
-                                         const dt_iop_roi_t *roi_out,
-                                         const float complex *map,
+                                         const float *const restrict in,
+                                         float *const restrict out,
+                                         const dt_iop_roi_t *const roi_in,
+                                         const dt_iop_roi_t *const roi_out,
+                                         const float complex *const map,
                                          const cairo_rectangle_int_t *extent)
 {
   const int ch = piece->colors;
@@ -1156,10 +1157,10 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 
     for(int y = 0; y <  map_extent->height; y++)
     {
-      const float complex *row = map + y * map_extent->width;
+      const float complex *const row = map + y * map_extent->width;
       for(int x = 0; x < map_extent->width; x++)
       {
-        const float complex d = * (row + x);
+        const float complex d = row[x];
         // compute new position (nx,ny) given the displacement d
         const int nx = x + (int)creal(d);
         const int ny = y + (int)cimag(d);
@@ -1182,7 +1183,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 
     for(int y = 0; y <  map_extent->height; y++)
     {
-      float complex *row = imap + y * map_extent->width;
+      float complex *const row = imap + y * map_extent->width;
       float complex last[2] = { 0, 0 };
       for(int x = 0; x < map_extent->width / 2 + 1; x++)
       {


### PR DESCRIPTION
This PR tweaks some of the OpenMP directives in liquify.c, as well as adding `const` and `restrict` qualifiers.
Verified pixel-identical output with test 0036.

build_round_stamp() performance is critical not just to liquify itself, but also any other iop following it in the pipeline using shapes, as distort_transform calls that function.  Unfortunately, it is also very much memory-bound since multiple threads write to common cache lines....

On darktable-bench-3.4.xmp with 32 threads, average of two runs:
before  after   iop
0.071   0.064   liquify
0.163   0.137   spot healing
0.211   0.191   retouch (heal)
0.470   0.443   retouch (wavelets with brush)

Single-threaded performance is unchanged within measurement error in all cases:
0.259  liquify
0.328  spot
0.383  retouch (heal)
0.825  retouch (wavelet)
