### PR TITLE
Color zones: Make the colors in the interface background less saturated to prevent visual illusions

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2488,6 +2488,13 @@
     <shortdescription>arange buttons as bar below temp/tint sliders</shortdescription>
     <longdescription>if enabled, the buttons in white balance module will be aranged below temp/tint sliders, otherwise they'll be shown in a grid to the right of temp/tint sliders</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/colorzones/bg_sat_factor</name>
+    <type min="0.1" max="1.0">float</type>
+    <default>0.5</default>
+    <shortdescription>saturation factor of the background</shortdescription>
+    <longdescription>higher value means more saturated backgrounds in color zones</longdescription>
+  </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>plugins/darkroom/colorbalance/layout</name>
     <type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2492,7 +2492,7 @@
     <name>plugins/darkroom/colorzones/bg_sat_factor</name>
     <type min="0.1" max="1.0">float</type>
     <default>0.5</default>
-    <shortdescription>saturation factor of the background</shortdescription>
+    <shortdescription>saturation factor of the color zones background</shortdescription>
     <longdescription>higher value means more saturated backgrounds in color zones</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="modules">

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -984,12 +984,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
                              const int select_by_picker, const int width, const int height,
                              const float *picked_color)
 {
-  float bg_sat_factor = dt_conf_get_float("plugins/darkroom/colorzones/bg_sat_factor");
-  if (bg_sat_factor == 0) {
-    bg_sat_factor = 0.5;
-    dt_conf_set_float("plugins/darkroom/colorzones/bg_sat_factor", bg_sat_factor);
-  }
-  
+  const float bg_sat_factor = dt_conf_get_float("plugins/darkroom/colorzones/bg_sat_factor");
   const float normalize_C = (128.f * bg_sat_factor * sqrtf(2.f));
 
   const int cellsi = DT_COLORZONES_CELLSI;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -984,7 +984,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
                              const int select_by_picker, const int width, const int height,
                              const float *picked_color)
 {
-  const float normalize_C = (16.f * sqrtf(2.f));
+  const float normalize_C = (64.f * sqrtf(2.f));
 
   const int cellsi = DT_COLORZONES_CELLSI;
   const int cellsj = DT_COLORZONES_CELLSJ;
@@ -1012,7 +1012,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
           break;
         case DT_IOP_COLORZONES_C:
           LCh[0] = 50.0f;
-          LCh[1] = picked_color[1] * 0.25f * ii;
+          LCh[1] = picked_color[1] * ii;
           LCh[2] = picked_color[2];
           break;
         default: // DT_IOP_COLORZONES_h

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -984,7 +984,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
                              const int select_by_picker, const int width, const int height,
                              const float *picked_color)
 {
-  const float normalize_C = (128.f * sqrtf(2.f));
+  const float normalize_C = (16.f * sqrtf(2.f));
 
   const int cellsi = DT_COLORZONES_CELLSI;
   const int cellsj = DT_COLORZONES_CELLSJ;
@@ -1012,7 +1012,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
           break;
         case DT_IOP_COLORZONES_C:
           LCh[0] = 50.0f;
-          LCh[1] = picked_color[1] * 2.f * ii;
+          LCh[1] = picked_color[1] * 0.25f * ii;
           LCh[2] = picked_color[2];
           break;
         default: // DT_IOP_COLORZONES_h

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -984,7 +984,13 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
                              const int select_by_picker, const int width, const int height,
                              const float *picked_color)
 {
-  const float normalize_C = (64.f * sqrtf(2.f));
+  float bg_sat_factor = dt_conf_get_float("plugins/darkroom/colorzones/bg_sat_factor");
+  if (bg_sat_factor == 0) {
+    bg_sat_factor = 0.5;
+    dt_conf_set_float("plugins/darkroom/colorzones/bg_sat_factor", bg_sat_factor);
+  }
+  
+  const float normalize_C = (128.f * bg_sat_factor * sqrtf(2.f));
 
   const int cellsi = DT_COLORZONES_CELLSI;
   const int cellsj = DT_COLORZONES_CELLSJ;
@@ -1012,7 +1018,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
           break;
         case DT_IOP_COLORZONES_C:
           LCh[0] = 50.0f;
-          LCh[1] = picked_color[1] * ii;
+          LCh[1] = picked_color[1] * 2.f * bg_sat_factor * ii;
           LCh[2] = picked_color[2];
           break;
         default: // DT_IOP_COLORZONES_h


### PR DESCRIPTION
Fixes #4630