### PR TITLE
remove color picker queue_draw from idle after run

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -558,14 +558,19 @@ void dt_control_toast_redraw()
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
 }
 
+static int _widget_queue_draw(void *widget)
+{
+  gtk_widget_queue_draw((GtkWidget*)widget);
+  return FALSE;
+}
+
 void dt_control_queue_redraw_widget(GtkWidget *widget)
 {
   if(dt_control_running())
   {
-    g_idle_add((GSourceFunc)gtk_widget_queue_draw, (void*)widget);
+    g_idle_add(_widget_queue_draw, (void*)widget);
   }
 }
-
 
 int dt_control_key_pressed_override(guint key, guint state)
 {


### PR DESCRIPTION
This is the solution found by @ralfbrown to #7229. Fixes incorrect usage of g_idle_add. Thank you!

fixes #7229

Works just as well (sans the cpu usage) as #7215, but I now have managed, much less frequently, to still trigger a crash in gtk_widget_queue_draw when leaving darkroom. Not sure whether that is exactly the same issue. It could be that somewhere a redraw of a different widget than the main module->widget is queued. Or maybe there still is a race, within a much smaller window, between destroying the widget (after cleaning the queue) and queueing a fresh redraw. There's locking going on in the colorpicker that seems to prevent this (most of the time). Maybe not completely or maybe this comes from somewhere else. I don't think it is a _regression_, so @TurboGit I think you should merge this one.