### PR TITLE
imageio: round to nearest on export

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -953,9 +953,9 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
         for(size_t k = 0; k < (size_t)processed_width * processed_height; k++)
         {
           // convert in place, this is unfortunately very serial..
-          const uint8_t r = CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff) + 0.5f;
-          const uint8_t g = CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff) + 0.5f;
-          const uint8_t b = CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff) + 0.5f;
+          const uint8_t r = roundf(CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff));
+          const uint8_t g = roundf(CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff));
+          const uint8_t b = roundf(CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff));
           outbuf[4 * k + 0] = r;
           outbuf[4 * k + 1] = g;
           outbuf[4 * k + 2] = b;
@@ -972,9 +972,9 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
         for(size_t k = 0; k < (size_t)processed_width * processed_height; k++)
         {
           // convert in place, this is unfortunately very serial..
-          const uint8_t r = CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff) + 0.5f;
-          const uint8_t g = CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff) + 0.5f;
-          const uint8_t b = CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff) + 0.5f;
+          const uint8_t r = roundf(CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff));
+          const uint8_t g = roundf(CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff));
+          const uint8_t b = roundf(CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff));
           outbuf[4 * k + 0] = r;
           outbuf[4 * k + 1] = g;
           outbuf[4 * k + 2] = b;
@@ -1008,7 +1008,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
       {
         // convert in place
         const size_t k = (size_t)processed_width * y + x;
-        for(int i = 0; i < 3; i++) buf16[4 * k + i] = CLAMP(buff[4 * k + i] * 0xffff, 0, 0xffff) + 0.5f;
+        for(int i = 0; i < 3; i++) buf16[4 * k + i] = roundf(CLAMP(buff[4 * k + i] * 0xffff, 0, 0xffff));
       }
   }
   // else output float, no further harm done to the pixels :)

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -953,9 +953,9 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
         for(size_t k = 0; k < (size_t)processed_width * processed_height; k++)
         {
           // convert in place, this is unfortunately very serial..
-          const uint8_t r = CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff);
-          const uint8_t g = CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff);
-          const uint8_t b = CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff);
+          const uint8_t r = CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff) + 0.5f;
+          const uint8_t g = CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff) + 0.5f;
+          const uint8_t b = CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff) + 0.5f;
           outbuf[4 * k + 0] = r;
           outbuf[4 * k + 1] = g;
           outbuf[4 * k + 2] = b;
@@ -972,9 +972,9 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
         for(size_t k = 0; k < (size_t)processed_width * processed_height; k++)
         {
           // convert in place, this is unfortunately very serial..
-          const uint8_t r = CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff);
-          const uint8_t g = CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff);
-          const uint8_t b = CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff);
+          const uint8_t r = CLAMP(inbuf[4 * k + 0] * 0xff, 0, 0xff) + 0.5f;
+          const uint8_t g = CLAMP(inbuf[4 * k + 1] * 0xff, 0, 0xff) + 0.5f;
+          const uint8_t b = CLAMP(inbuf[4 * k + 2] * 0xff, 0, 0xff) + 0.5f;
           outbuf[4 * k + 0] = r;
           outbuf[4 * k + 1] = g;
           outbuf[4 * k + 2] = b;
@@ -1008,7 +1008,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
       {
         // convert in place
         const size_t k = (size_t)processed_width * y + x;
-        for(int i = 0; i < 3; i++) buf16[4 * k + i] = CLAMP(buff[4 * k + i] * 0x10000, 0, 0xffff);
+        for(int i = 0; i < 3; i++) buf16[4 * k + i] = CLAMP(buff[4 * k + i] * 0xffff, 0, 0xffff) + 0.5f;
       }
   }
   // else output float, no further harm done to the pixels :)

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -297,9 +297,9 @@ int write_image(struct dt_imageio_module_data_t *data,
           const float *in_pixel = &in_data[(size_t)4 * ((y * width) + x)];
           uint16_t *out_pixel = (uint16_t *)&out[(y * rowbytes) + (3 * sizeof(uint16_t) * x)];
 
-          out_pixel[0] = (uint16_t)(CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f) + 0.5f);
-          out_pixel[1] = (uint16_t)(CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f) + 0.5f);
-          out_pixel[2] = (uint16_t)(CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f) + 0.5f);
+          out_pixel[0] = (uint16_t)roundf(CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f));
+          out_pixel[1] = (uint16_t)roundf(CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f));
+          out_pixel[2] = (uint16_t)roundf(CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f));
       }
     }
     break;
@@ -318,9 +318,9 @@ int write_image(struct dt_imageio_module_data_t *data,
           const float *in_pixel = &in_data[(size_t)4 * ((y * width) + x)];
           uint8_t *out_pixel = (uint8_t *)&out[(y * rowbytes) + (3 * sizeof(uint8_t) * x)];
 
-          out_pixel[0] = (uint8_t)(CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f) + 0.5f);
-          out_pixel[1] = (uint8_t)(CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f) + 0.5f);
-          out_pixel[2] = (uint8_t)(CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f) + 0.5f);
+          out_pixel[0] = (uint8_t)roundf(CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f));
+          out_pixel[1] = (uint8_t)roundf(CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f));
+          out_pixel[2] = (uint8_t)roundf(CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f));
       }
     }
     break;

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -297,9 +297,9 @@ int write_image(struct dt_imageio_module_data_t *data,
           const float *in_pixel = &in_data[(size_t)4 * ((y * width) + x)];
           uint16_t *out_pixel = (uint16_t *)&out[(y * rowbytes) + (3 * sizeof(uint16_t) * x)];
 
-          out_pixel[0] = (uint16_t)CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f);
-          out_pixel[1] = (uint16_t)CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f);
-          out_pixel[2] = (uint16_t)CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f);
+          out_pixel[0] = (uint16_t)(CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f) + 0.5f);
+          out_pixel[1] = (uint16_t)(CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f) + 0.5f);
+          out_pixel[2] = (uint16_t)(CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f) + 0.5f);
       }
     }
     break;
@@ -318,9 +318,9 @@ int write_image(struct dt_imageio_module_data_t *data,
           const float *in_pixel = &in_data[(size_t)4 * ((y * width) + x)];
           uint8_t *out_pixel = (uint8_t *)&out[(y * rowbytes) + (3 * sizeof(uint8_t) * x)];
 
-          out_pixel[0] = (uint8_t)CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f);
-          out_pixel[1] = (uint8_t)CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f);
-          out_pixel[2] = (uint8_t)CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f);
+          out_pixel[0] = (uint8_t)(CLAMP(in_pixel[0] * max_channel_f, 0, max_channel_f) + 0.5f);
+          out_pixel[1] = (uint8_t)(CLAMP(in_pixel[1] * max_channel_f, 0, max_channel_f) + 0.5f);
+          out_pixel[2] = (uint8_t)(CLAMP(in_pixel[2] * max_channel_f, 0, max_channel_f) + 0.5f);
       }
     }
     break;

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -69,10 +69,10 @@ typedef enum
 } dt_imageio_j2k_format_t;
 
 // borrowed from blender
-#define DOWNSAMPLE_FLOAT_TO_8BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 255 : (int)(255.0f * (_val)))
-#define DOWNSAMPLE_FLOAT_TO_12BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 4095 : (int)(4095.0f * (_val)))
+#define DOWNSAMPLE_FLOAT_TO_8BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 255 : (int)(255.0f * (_val) + 0.5f))
+#define DOWNSAMPLE_FLOAT_TO_12BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 4095 : (int)(4095.0f * (_val) + 0.5f))
 #define DOWNSAMPLE_FLOAT_TO_16BIT(_val)                                                                      \
-  (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 65535 : (int)(65535.0f * (_val)))
+  (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 65535 : (int)(65535.0f * (_val) + 0.5f))
 
 DT_MODULE(2)
 

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -69,10 +69,10 @@ typedef enum
 } dt_imageio_j2k_format_t;
 
 // borrowed from blender
-#define DOWNSAMPLE_FLOAT_TO_8BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 255 : (int)(255.0f * (_val) + 0.5f))
-#define DOWNSAMPLE_FLOAT_TO_12BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 4095 : (int)(4095.0f * (_val) + 0.5f))
+#define DOWNSAMPLE_FLOAT_TO_8BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 255 : (int)roundf(255.0f * (_val)))
+#define DOWNSAMPLE_FLOAT_TO_12BIT(_val) (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 4095 : (int)roundf(4095.0f * (_val)))
 #define DOWNSAMPLE_FLOAT_TO_16BIT(_val)                                                                      \
-  (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 65535 : (int)(65535.0f * (_val) + 0.5f))
+  (_val) <= 0.0f ? 0 : ((_val) >= 1.0f ? 65535 : (int)roundf(65535.0f * (_val)))
 
 DT_MODULE(2)
 


### PR DESCRIPTION
It is more traditional/correct to round than to simply truncate.