### PR TITLE
Check if libavif offers encoder support

### DIFF
--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -69,6 +69,9 @@ static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, con
 {
   module->widget = NULL;
   module->parameter_lua_type = LUAA_INVALID_TYPE;
+  // Can by set by the module function to false if something went wrong.
+  module->ready = TRUE;
+
   g_strlcpy(module->plugin_name, plugin_name, sizeof(module->plugin_name));
   dt_print(DT_DEBUG_CONTROL, "[imageio_load_module] loading format module `%s' from %s\n", plugin_name, libname);
   module->module = g_module_open(libname, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
@@ -130,6 +133,11 @@ static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, con
     dt_lua_register_format_type(darktable.lua_state.state, module, my_type);
 #endif
     module->init(module);
+    if (!module->ready)
+    {
+      goto error;
+    }
+
 #ifdef USE_LUA
     lua_pushcfunction(darktable.lua_state.state, dt_lua_type_member_luaautoc);
     dt_lua_type_register_struct_type(darktable.lua_state.state, my_type);

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -131,6 +131,7 @@ typedef struct dt_imageio_module_format_t
   int (*read_image)(dt_imageio_module_data_t *data, uint8_t *out);
   luaA_Type parameter_lua_type;
 
+  gboolean ready;
 } dt_imageio_module_format_t;
 
 

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -135,6 +135,14 @@ static int flp2(int i)
 
 void init(dt_imageio_module_format_t *self)
 {
+  if (codecName == NULL)
+  {
+    dt_print(DT_DEBUG_IMAGEIO,
+             "libavif doesn't offer encoding support!\n");
+    self->ready = FALSE;
+    return;
+  }
+
 #ifdef USE_LUA
   /* bit depth */
   dt_lua_register_module_member(darktable.lua_state.state,

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -146,10 +146,12 @@ static int orientation_member(lua_State *L)
     return 0;
   }
 }
+#endif // USE_LUA
 
 
 void init(dt_imageio_module_format_t *self)
 {
+#ifdef USE_LUA
   lua_State* L = darktable.lua_state.state ;
 
   luaA_enum(L, _pdf_pages_t);
@@ -180,13 +182,8 @@ void init(dt_imageio_module_format_t *self)
 
   lua_pushcfunction(L, orientation_member);
   dt_lua_type_register_type(L, self->parameter_lua_type, "orientation");
-}
-#else // USE_LUA
-void init(dt_imageio_module_format_t *self)
-{
-  // we need an empty init, even when compiled without Lua
-}
 #endif // USE_LUA
+}
 
 void cleanup(dt_imageio_module_format_t *self)
 {


### PR DESCRIPTION
On Debian/Ubuntu libavif currently only provides decoder support. This checks for encoder support and if not supported doesn't provide AVIF as an option for export formats.