### PR TITLE
colorspaces: ICC v2.4 is more appropriate for profile content

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -315,7 +315,7 @@ static cmsHPROFILE _create_lcms_profile(const char *desc, const char *dmdd,
   cmsToneCurve *out_curves[3] = { trc, trc, trc };
   cmsHPROFILE profile = cmsCreateRGBProfile(whitepoint, primaries, out_curves);
 
-  if(v2) cmsSetProfileVersion(profile, 2.1);
+  if(v2) cmsSetProfileVersion(profile, 2.4);
 
   cmsSetHeaderFlags(profile, cmsEmbeddedProfileTrue);
 


### PR DESCRIPTION
ExifTool output on dt exported image

Before (xyY used directly, bug):

```
---- ICC_Profile2 ----
ProfileDescription              : sRGB
ProfileCopyright                : Public Domain
MediaWhitePoint                 : 0.3127 0.32899 1
ChromaticAdaptation             : 1.04788 0.02292 -0.05022 0.02959 0.99048 -0.01707 -0.00925 0.01508 0.75168
RedMatrixColumn                 : 0.43604 0.22249 0.01392
BlueMatrixColumn                : 0.14305 0.06061 0.71391
GreenMatrixColumn               : 0.38512 0.7169 0.09706
RedTRC                          : (Binary data 8204 bytes, use -b option to extract)
GreenTRC                        : (Binary data 8204 bytes, use -b option to extract)
BlueTRC                         : (Binary data 8204 bytes, use -b option to extract)
MediaBlackPoint                 : 0 0 0
DeviceModelDesc                 : sRGB
DeviceMfgDesc                   : darktable
```

After (correct):

```
---- ICC_Profile2 ----
ProfileDescription              : sRGB
ProfileCopyright                : Public Domain
MediaWhitePoint                 : 0.95045 1 1.08905
ChromaticAdaptation             : 1.04788 0.02292 -0.05022 0.02959 0.99048 -0.01707 -0.00925 0.01508 0.75168
RedMatrixColumn                 : 0.43604 0.22249 0.01392
BlueMatrixColumn                : 0.14305 0.06061 0.71391
GreenMatrixColumn               : 0.38512 0.7169 0.09706
RedTRC                          : (Binary data 8204 bytes, use -b option to extract)
GreenTRC                        : (Binary data 8204 bytes, use -b option to extract)
BlueTRC                         : (Binary data 8204 bytes, use -b option to extract)
MediaBlackPoint                 : 0 0 0
DeviceModelDesc                 : sRGB
DeviceMfgDesc                   : darktable
```