### PR TITLE
filmicrgb: change scaling of loop variable

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1059,11 +1059,11 @@ static inline void wavelets_detail_level(const float *const restrict detail, con
     schedule(simd                                                                                                 \
              : static) aligned(HF, LF, detail, texture : 64)
 #endif
-  for(size_t k = 0; k < 4 * height * width; k += 4)
+  for(size_t k = 0; k < height * width; k++)
   {
-    for(size_t c = 0; c < 4; ++c) HF[k + c] = detail[k + c] - LF[k + c];
+    for(size_t c = 0; c < 4; ++c) HF[4*k + c] = detail[4*k + c] - LF[4*k + c];
 
-    texture[k / 4] = fminabsf(fminabsf(HF[k], HF[k + 1]), HF[k + 2]);
+    texture[k] = fminabsf(fminabsf(HF[4*k], HF[4*k + 1]), HF[4*k + 2]);
   }
 }
 


### PR DESCRIPTION
Attempt to fix #7273, which appears to be a compiler code-generation bug.