### PR TITLE
Integrate low_quality_thumbnails preference into ui/performance

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -876,13 +876,6 @@
     <shortdescription>last timeline zoom.</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig> <!-- this option is not exposed in the gui because there might be crashy synchronisation issues when it's updated on the fly -->
-    <name>plugins/lighttable/low_quality_thumbnails</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>low quality thumbnails</shortdescription>
-    <longdescription>if set to true, thumbnails will be processed by first downscaling rather than demosaicing the full image. this can result in much faster processing times and blurrier images, especially when you cropped a lot.</longdescription>
-  </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/thumbnail_hq_min_level</name>
     <type>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1458,7 +1458,6 @@ void dt_configure_performance()
     dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL || !strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
-    dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
     dt_conf_set_bool("ui/performance", FALSE);
   }
   else if(mem > (2lu << 20) && threads >= 4 && atom_cores == 0)
@@ -1472,7 +1471,6 @@ void dt_configure_performance()
     dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL ||!strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
-    dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
     dt_conf_set_bool("ui/performance", FALSE);
   }
   else if(mem < (1lu << 20) || threads <= 2 || atom_cores > 0)
@@ -1484,7 +1482,6 @@ void dt_configure_performance()
     dt_conf_set_int("host_memory_limit", 500);
     dt_conf_set_int("singlebuffer_limit", 8);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "always bilinear (fast)");
-    dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", TRUE);
     dt_conf_set_bool("ui/performance", TRUE);
   }
   else
@@ -1496,7 +1493,6 @@ void dt_configure_performance()
     dt_conf_set_int("host_memory_limit", 1500);
     dt_conf_set_int("singlebuffer_limit", 16);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
-    dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
     dt_conf_set_bool("ui/performance", FALSE);
   }
 

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -661,9 +661,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
   dt_dev_init(&dev, 0);
   dt_dev_load_image(&dev, imgid);
 
-  const int buf_is_downscaled
-      = (thumbnail_export && dt_conf_get_bool("plugins/lighttable/low_quality_thumbnails"));
-
+  const gboolean buf_is_downscaled = (thumbnail_export && dt_conf_get_bool("ui/performance"));
   dt_mipmap_buffer_t buf;
   if(buf_is_downscaled)
     dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, DT_MIPMAP_F, DT_MIPMAP_BLOCKING, 'r');


### PR DESCRIPTION
As described in #7158 there is the hidden preference setting 'low_quality_thumbnails'
which has been set by 'dt_configure_performance' while installing dt.

It visually changes the output of thumbnails (&previews) for slow machines but the
reason for the decreased quality is not obvious for the user.

As we already have the option 'performance versus quality' (the tooltip tells the user
what the implication is) i think we can remove that preference and use the 'ui/performance'
setting to change the behaviour of 'dt_imageio_export_with_flags' instead.

Fixes #7158