### PR TITLE
ensure that mouse actions aren't performed if extraneous modifier keys held

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2154,11 +2154,11 @@ static gboolean dt_bauhaus_slider_add_delta_internal(GtkWidget *widget, float de
 
   float multiplier = 0.0f;
 
-  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2154,12 +2154,11 @@ static gboolean dt_bauhaus_slider_add_delta_internal(GtkWidget *widget, float de
 
   float multiplier = 0.0f;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -388,9 +388,6 @@ static inline void dt_unlock_image_pair(int32_t imgid1, int32_t imgid2) RELEASE(
   dt_pthread_mutex_unlock(&(darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)]));
 }
 
-// A mask to strip out the Ctrl, Shift, and Alt mod keys for shortcuts
-#define KEY_STATE_MASK (GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_MOD1_MASK)
-
 // check whether the specified mask of modifier keys exactly matches, among the set Shift+Control+(Alt/Meta).
 // ignores the state of any other shifting keys
 static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -397,6 +397,16 @@ static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModi
   return (state & modifiers) == desired_modifier_mask;
 }
 
+// check whether the given modifier state includes AT LEAST the specified mask of modifier keys
+static inline gboolean dt_modifiers_include(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
+{
+//TODO: on Macs, remap the GDK_CONTROL_MASK bit in desired_modifier_mask to be the bit for the Cmd key
+  const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  // check whether all modifier bits of interest are turned on
+  return (state & (modifiers & desired_modifier_mask)) == desired_modifier_mask;
+}
+
+
 static inline gboolean dt_is_aligned(const void *pointer, size_t byte_count)
 {
     return (uintptr_t)pointer % byte_count == 0;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -388,6 +388,23 @@ static inline void dt_unlock_image_pair(int32_t imgid1, int32_t imgid2) RELEASE(
   dt_pthread_mutex_unlock(&(darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)]));
 }
 
+// A mask to strip out the Ctrl, Shift, and Alt mod keys for shortcuts
+#define KEY_STATE_MASK (GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_MOD1_MASK)
+
+// check whether the specified mask of modifier keys exactly matches, among the set Shift+Control+(Alt/Meta).
+// ignores the state of any other shifting keys
+static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
+{
+  return (state & KEY_STATE_MASK) == desired_modifier_mask;
+}
+
+// check whether the specified mask of modifier keys exactly matches, among the full set of Gdk modifier keys
+static inline gboolean dt_gdk_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
+{
+  const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  return (state & modifiers) == desired_modifier_mask;
+}
+
 static inline gboolean dt_is_aligned(const void *pointer, size_t byte_count)
 {
     return (uintptr_t)pointer % byte_count == 0;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -395,13 +395,8 @@ static inline void dt_unlock_image_pair(int32_t imgid1, int32_t imgid2) RELEASE(
 // ignores the state of any other shifting keys
 static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
 {
-  return (state & KEY_STATE_MASK) == desired_modifier_mask;
-}
-
-// check whether the specified mask of modifier keys exactly matches, among the full set of Gdk modifier keys
-static inline gboolean dt_gdk_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
-{
   const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+//TODO: on Macs, remap the GDK_CONTROL_MASK bit in desired_modifier_mask to be the bit for the Cmd key
   return (state & modifiers) == desired_modifier_mask;
 }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -37,9 +37,6 @@
 #include <shobjidl.h>
 #endif
 
-// A mask to strip out the Ctrl, Shift, and Alt mod keys for shortcuts
-#define KEY_STATE_MASK (GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_MOD1_MASK)
-
 struct dt_lib_backgroundjob_element_t;
 
 typedef GdkCursorType dt_cursor_t;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1329,7 +1329,7 @@ static int _blendop_masks_add_shape_callback(GtkWidget *widget, GdkEventButton *
 {
   if(event->button ==1)
   {
-    return _blendop_masks_add_shape(widget, self, event->state & GDK_CONTROL_MASK);
+    return _blendop_masks_add_shape(widget, self, (event->state & KEY_STATE_MASK) == GDK_CONTROL_MASK);
   }
   return FALSE;
 }
@@ -1349,7 +1349,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
-      const int control_button_pressed = event->state & GDK_CONTROL_MASK;
+      const int control_button_pressed = (event->state & KEY_STATE_MASK) == GDK_CONTROL_MASK;
 
       switch(bd->masks_shown)
       {

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1104,12 +1104,11 @@ static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton 
 
     module->request_mask_display &= ~(DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL | DT_DEV_PIXELPIPE_DISPLAY_ANY);
 
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    if((event->state & modifiers) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+    if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK | GDK_SHIFT_MASK))
       module->request_mask_display |= (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
-    else if((event->state & modifiers) == GDK_SHIFT_MASK)
+    else if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK))
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_CHANNEL;
-    else if((event->state & modifiers) == GDK_CONTROL_MASK)
+    else if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK))
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_MASK;
     else
       module->request_mask_display |= (has_mask_display ? 0 : DT_DEV_PIXELPIPE_DISPLAY_MASK);
@@ -1327,9 +1326,9 @@ static int _blendop_masks_add_shape(GtkWidget *widget, dt_iop_module_t *self, gb
 
 static int _blendop_masks_add_shape_callback(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  if(event->button ==1)
+  if(event->button == 1)
   {
-    return _blendop_masks_add_shape(widget, self, (event->state & KEY_STATE_MASK) == GDK_CONTROL_MASK);
+    return _blendop_masks_add_shape(widget, self, dt_modifier_is(event->state, GDK_CONTROL_MASK));
   }
   return FALSE;
 }
@@ -1349,7 +1348,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
-      const int control_button_pressed = (event->state & KEY_STATE_MASK) == GDK_CONTROL_MASK;
+      const gboolean control_button_pressed = dt_modifier_is(event->state, GDK_CONTROL_MASK);
 
       switch(bd->masks_shown)
       {
@@ -1802,16 +1801,15 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget, GdkEventCrossing *even
   dt_dev_pixelpipe_display_mask_t mode = 0;
 
   // depending on shift modifiers we activate channel and/or mask display
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((event->state & modifiers) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+  if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
   {
     mode = (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
   }
-  else if((event->state & modifiers) == GDK_SHIFT_MASK)
+  else if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK))
   {
     mode = DT_DEV_PIXELPIPE_DISPLAY_CHANNEL;
   }
-  else if((event->state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     mode = DT_DEV_PIXELPIPE_DISPLAY_MASK;
   }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1104,11 +1104,11 @@ static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton 
 
     module->request_mask_display &= ~(DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL | DT_DEV_PIXELPIPE_DISPLAY_ANY);
 
-    if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+    if(dt_modifier_is(event->state, GDK_CONTROL_MASK | GDK_SHIFT_MASK))
       module->request_mask_display |= (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
-    else if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK))
+    else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_CHANNEL;
-    else if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK))
+    else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_MASK;
     else
       module->request_mask_display |= (has_mask_display ? 0 : DT_DEV_PIXELPIPE_DISPLAY_MASK);
@@ -1801,15 +1801,15 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget, GdkEventCrossing *even
   dt_dev_pixelpipe_display_mask_t mode = 0;
 
   // depending on shift modifiers we activate channel and/or mask display
-  if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
   {
     mode = (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
   }
-  else if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK))
+  else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
   {
     mode = DT_DEV_PIXELPIPE_DISPLAY_CHANNEL;
   }
-  else if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     mode = DT_DEV_PIXELPIPE_DISPLAY_MASK;
   }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -988,7 +988,7 @@ static void dt_iop_gui_multiinstance_callback(GtkButton *button, GdkEventButton 
 static gboolean dt_iop_gui_off_button_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
-  if(!darktable.gui->reset && (e->state & KEY_STATE_MASK) == GDK_CONTROL_MASK)
+  if(!darktable.gui->reset && dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
     dt_iop_request_focus(darktable.develop->gui_module == module ? NULL : module);
     return TRUE;
@@ -1832,7 +1832,7 @@ static void dt_iop_gui_reset_callback(GtkButton *button, GdkEventButton *event, 
 {
   //Ctrl is used to apply any auto-presets to the current module
   //If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
-  if(((event->state & KEY_STATE_MASK) != GDK_CONTROL_MASK) || !dt_gui_presets_autoapply_for_module(module))
+  if(!dt_modifier_is(event->state, GDK_CONTROL_MASK) || !dt_gui_presets_autoapply_for_module(module))
   {
     // if a drawn mask is set, remove it from the list
     if(module->blend_params->mask_id > 0)
@@ -2080,13 +2080,13 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
 
   if(e->button == 1)
   {
-    if((e->state & KEY_STATE_MASK) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+    if(dt_modifier_is(e->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       GtkBox *container = dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER);
       g_object_set_data(G_OBJECT(container), "source_data", user_data);
       return FALSE;
     }
-    else if((e->state & KEY_STATE_MASK) == GDK_CONTROL_MASK)
+    else if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
       _iop_gui_rename_module(module);
       return TRUE;
@@ -2097,7 +2097,7 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
       if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
         darktable.gui->scroll_to[1] = module->expander;
 
-      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != ((e->state & KEY_STATE_MASK) != GDK_SHIFT_MASK);
+      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != (!dt_modifier_is(e->state, GDK_SHIFT_MASK));
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 
       // rebuild the accelerators

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2097,7 +2097,7 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
       if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
         darktable.gui->scroll_to[1] = module->expander;
 
-      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != ((e->state & KEY_STATE_MASK) != GDK_SHIFT_MASK));
+      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != ((e->state & KEY_STATE_MASK) != GDK_SHIFT_MASK);
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 
       // rebuild the accelerators

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -988,7 +988,7 @@ static void dt_iop_gui_multiinstance_callback(GtkButton *button, GdkEventButton 
 static gboolean dt_iop_gui_off_button_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
-  if(!darktable.gui->reset && e->state & GDK_CONTROL_MASK)
+  if(!darktable.gui->reset && (e->state & KEY_STATE_MASK) == GDK_CONTROL_MASK)
   {
     dt_iop_request_focus(darktable.develop->gui_module == module ? NULL : module);
     return TRUE;
@@ -1832,7 +1832,7 @@ static void dt_iop_gui_reset_callback(GtkButton *button, GdkEventButton *event, 
 {
   //Ctrl is used to apply any auto-presets to the current module
   //If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
-  if(!(event->state & GDK_CONTROL_MASK) || !dt_gui_presets_autoapply_for_module(module))
+  if(((event->state & KEY_STATE_MASK) != GDK_CONTROL_MASK) || !dt_gui_presets_autoapply_for_module(module))
   {
     // if a drawn mask is set, remove it from the list
     if(module->blend_params->mask_id > 0)
@@ -2080,13 +2080,13 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
 
   if(e->button == 1)
   {
-    if((e->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+    if((e->state & KEY_STATE_MASK) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       GtkBox *container = dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER);
       g_object_set_data(G_OBJECT(container), "source_data", user_data);
       return FALSE;
     }
-    else if(e->state & GDK_CONTROL_MASK)
+    else if((e->state & KEY_STATE_MASK) == GDK_CONTROL_MASK)
     {
       _iop_gui_rename_module(module);
       return TRUE;
@@ -2097,7 +2097,7 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
       if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
         darktable.gui->scroll_to[1] = module->expander;
 
-      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != !(e->state & GDK_SHIFT_MASK);
+      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != ((e->state & KEY_STATE_MASK) != GDK_SHIFT_MASK));
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 
       // rebuild the accelerators

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1506,8 +1506,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
   else
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
 
-  //TODO: allows Shift, Ctrl, or Shift+Ctrl; is this what we want here?
-  if(gui->creation && which == 1 && (state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
+  if(gui->creation && which == 1 &&
+     (dt_modifier_is(state, GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
   {
     // user just set the source position, so just return
     return 1;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1035,7 +1035,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
 {
   if(gui->creation)
   {
-    if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       const float amount = up ? 0.97f : 1.03f;
       float masks_hardness;
@@ -1095,7 +1095,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
       gui->scrollx = pzx;
       gui->scrolly = pzy;
     }
-    if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       // we try to change the opacity
       dt_masks_form_change_opacity(form, parentid, up);
@@ -1103,7 +1103,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
     else
     {
       // resize don't care where the mouse is inside a shape
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      if(dt_modifier_is(state, GDK_SHIFT_MASK))
       {
         const float amount = up ? 0.97f : 1.03f;
         // do not exceed upper limit of 1.0 and lower limit of 0.004
@@ -1196,8 +1196,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
   const float masks_density = 1.0f;
 
   if(gui->creation && which == 1
-     && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
-         || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
+     && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
@@ -1273,7 +1272,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
     else if(gui->point_selected >= 0)
     {
       // if ctrl is pressed, we change the type of point
-      if(gui->point_edited == gui->point_selected && ((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK))
+      if(gui->point_edited == gui->point_selected && dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         dt_masks_point_brush_t *point
             = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->point_edited);
@@ -1324,7 +1323,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
     {
       const guint nb = g_list_length(form->points);
       gui->point_edited = -1;
-      if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+      if(dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         // we add a new point to the brush
         dt_masks_point_brush_t *bzpt = (dt_masks_point_brush_t *)(malloc(sizeof(dt_masks_point_brush_t)));
@@ -1507,6 +1506,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
   else
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
 
+  //TODO: allows Shift, Ctrl, or Shift+Ctrl; is this what we want here?
   if(gui->creation && which == 1 && (state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
   {
     // user just set the source position, so just return

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -76,7 +76,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
     else
       masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
 
-    if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       float masks_border = 0.0f;
 
@@ -120,7 +120,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
       gui->scrollx = pzx;
       gui->scrolly = pzy;
     }
-    if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       // we try to change the opacity
       dt_masks_form_change_opacity(form, parentid, up);
@@ -129,7 +129,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
     {
       dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
       // resize don't care where the mouse is inside a shape
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      if(dt_modifier_is(state, GDK_SHIFT_MASK))
       {
         if(up && circle->border > 0.0005f)
           circle->border *= 0.97f;
@@ -209,8 +209,7 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
     return 1;
   }
   else if(gui->creation && which == 1
-          && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
-              || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
+          && ((dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)) || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -532,7 +532,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
           dt_conf_set_float("plugins/darkroom/masks/ellipse/border", ellipse->border);
         dt_toast_log(_("feather size: %3.2f%%"), ellipse->border*100.0f);
       }
-      else if(gui->edit_mode == DT_MASKS_EDIT_FULL && ((state & KEY_STATE_MASK) == 0))
+      else if(gui->edit_mode == DT_MASKS_EDIT_FULL && dt_modifier_is(state, 0))
       {
         const float oldradius = ellipse->radius[0];
 
@@ -562,7 +562,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         }
         dt_toast_log(_("size: %3.2f%%"), fmaxf(ellipse->radius[0], ellipse->radius[1])*100);
       }
-      else if ((state & KEY_STATE_MASK) != 0)
+      else if (!dt_modifier_is(state, 0))
       {
         // user is holding down a modifier key, but we didn't handle that particular combination
         // say we've processed the scroll event so that the image is not zoomed instead

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -389,7 +389,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
     }
 
-    if((state & KEY_STATE_MASK) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+    if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       float rotation;
 
@@ -411,7 +411,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
 
       dt_toast_log(_("rotation: %3.f°"), rotation);
     }
-    else if((state & KEY_STATE_MASK) == GDK_SHIFT_MASK)
+    else if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       float masks_border = 0.0f;
       int flags = 0;
@@ -486,7 +486,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       gui->scrollx = pzx;
       gui->scrolly = pzy;
     }
-    if((state & KEY_STATE_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       // we try to change the opacity
       dt_masks_form_change_opacity(form, parentid, up);
@@ -494,7 +494,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else
     {
       dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
-      if((state & KEY_STATE_MASK) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK)
+      if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK)
          && gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
         // we try to change the rotation
@@ -514,7 +514,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         dt_toast_log(_("rotation: %3.f°"), ellipse->rotation);
       }
       // resize don't care where the mouse is inside a shape
-      if((state & KEY_STATE_MASK) == GDK_SHIFT_MASK)
+      if(dt_modifier_is(state, GDK_SHIFT_MASK))
       {
         const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
         if(up && ellipse->border > 0.001f * reference)
@@ -596,7 +596,7 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     return 1;
   }
   else if(gui->point_selected >= 1 && !gui->creation && gui->edit_mode == DT_MASKS_EDIT_FULL
-          && !((state & KEY_STATE_MASK) == GDK_CONTROL_MASK))
+          && !dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
@@ -606,12 +606,12 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     return 1;
   }
   else if(gui->form_selected && !gui->creation && gui->edit_mode == DT_MASKS_EDIT_FULL
-          && !((state & KEY_STATE_MASK) == GDK_SHIFT_MASK))
+          && !dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     // we start the form dragging or rotating
-    if((state & KEY_STATE_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
@@ -619,7 +619,7 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
   }
-  else if(gui->form_selected && !gui->creation && ((state & KEY_STATE_MASK) == GDK_SHIFT_MASK))
+  else if(gui->form_selected && !gui->creation && dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
@@ -638,8 +638,7 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     return 1;
   }
   else if(gui->creation && which == 1
-          && (((state & KEY_STATE_MASK) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
-              || ((state & KEY_STATE_MASK) == GDK_SHIFT_MASK)))
+          && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -87,7 +87,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
 {
   if(gui->creation)
   {
-    if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
       if(up)
@@ -108,12 +108,12 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       gui->scrollx = pzx;
       gui->scrolly = pzy;
     }
-    if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       // we try to change the opacity
       dt_masks_form_change_opacity(form, parentid, up);
     }
-    else if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    else if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
       if(up)
@@ -166,7 +166,7 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
 
     return 1;
   }
-  else if(!gui->creation && ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK))
+  else if(!gui->creation && dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1125,7 +1125,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
   if(gui)
   {
     // for brush, the opacity is the density of the masks, do not update opacity here for the brush.
-    if(gui->creation && (state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == GDK_CONTROL_MASK)
+    if(gui->creation && dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
       float amount = 0.05f;
@@ -2218,9 +2218,9 @@ void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const f
 void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
                                            const float pzy)
 {
-  if((state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
+  if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     gui->source_pos_type = DT_MASKS_SOURCE_POS_ABSOLUTE;
-  else if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+  else if(dt_modifier_is(state, GDK_SHIFT_MASK))
     gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
   else
     fprintf(stderr, "[dt_masks_set_source_pos_initial_state] unknown state for setting masks position type\n");

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -915,7 +915,7 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
       gui->scrollx = pzx;
       gui->scrolly = pzy;
     }
-    if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       // we try to change the opacity
       dt_masks_form_change_opacity(form, parentid, up);
@@ -924,7 +924,7 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
     {
       const float amount = up ? 0.97f : 1.03f;
       // resize don't care where the mouse is inside a shape
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      if(dt_modifier_is(state, GDK_SHIFT_MASK))
       {
         float masks_size = 1.0f, feather_size = 0.0f;
         _path_get_sizes(module, form, gui, index, &masks_size, &feather_size);
@@ -1046,8 +1046,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/path/border"), 0.5f);
 
   if(gui->creation && which == 1 && form->points == NULL
-     && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
-         || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
+     && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
@@ -1197,7 +1196,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       form->points = g_list_append(form->points, bzpt);
 
       // if this is a ctrl click, the last created point is a sharp one
-      if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+      if(dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         dt_masks_point_path_t *bzpt3 = g_list_nth_data(form->points, nb - 1);
         bzpt3->ctrl1[0] = bzpt3->ctrl2[0] = bzpt3->corner[0];
@@ -1236,7 +1235,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     else if(gui->point_selected >= 0)
     {
       // if ctrl is pressed, we change the type of point
-      if(gui->point_edited == gui->point_selected && ((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK))
+      if(gui->point_edited == gui->point_selected && dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         dt_masks_point_path_t *point
             = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->point_edited);
@@ -1293,7 +1292,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     else if(gui->seg_selected >= 0)
     {
       gui->point_edited = -1;
-      if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+      if(dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         // we add a new point to the path
         dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -411,7 +411,7 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table, const float zoom_delta, co
   {
     // CULLING with multiple images
     // if shift+ctrl, we only change the current image
-    if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       const int mouseid = dt_control_get_mouse_over_id();
       for(GList *l = table->list; l; l = g_list_next(l))
@@ -525,7 +525,7 @@ static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_
 
   if(dt_gui_get_scroll_unit_delta(e, &delta))
   {
-    if((e->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
       // zooming
       const float zoom_delta = delta < 0 ? 0.5f : -0.5f;
@@ -590,7 +590,7 @@ static gboolean _event_button_press(GtkWidget *widget, GdkEventButton *event, gp
   if(event->button == 2)
   {
     // if shift is pressed, we work only with image hovered
-    if(event->state & GDK_SHIFT_MASK)
+    if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
       _toggle_zoom_current(table, event->x_root, event->y_root);
     else
       _toggle_zoom_all(table, event->x_root, event->y_root);
@@ -642,7 +642,7 @@ static gboolean _event_motion_notify(GtkWidget *widget, GdkEventMotion *event, g
     const float valx = (x - table->pan_x) * scale;
     const float valy = (y - table->pan_y) * scale;
 
-    if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
     {
       int mouseid = dt_control_get_mouse_over_id();
       for(GList *l = table->list; l; l = g_list_next(l))

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -230,11 +230,11 @@ static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble d
 
   float multiplier;
 
-  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -230,12 +230,11 @@ static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble d
 
   float multiplier;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -812,8 +812,7 @@ static gboolean _event_main_press(GtkWidget *widget, GdkEventButton *event, gpoi
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(event->button == 1
      && ((event->type == GDK_2BUTTON_PRESS && !thumb->single_click)
-         || (event->type == GDK_BUTTON_PRESS
-             && (event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK | GDK_MOD1_MASK)) == 0 && thumb->single_click)))
+         || (event->type == GDK_BUTTON_PRESS && (event->state & KEY_STATE_MASK) == 0 && thumb->single_click)))
   {
     dt_control_set_mouse_over_id(thumb->imgid); // to ensure we haven't lost imgid during double-click
   }
@@ -825,14 +824,13 @@ static gboolean _event_main_release(GtkWidget *widget, GdkEventButton *event, gp
 
   if(event->button == 1 && !thumb->moved && thumb->sel_mode != DT_THUMBNAIL_SEL_MODE_DISABLED)
   {
-    if((event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK | GDK_MOD1_MASK)) == 0
-       && thumb->sel_mode != DT_THUMBNAIL_SEL_MODE_MOD_ONLY)
+    if((event->state & KEY_STATE_MASK) == 0 && thumb->sel_mode != DT_THUMBNAIL_SEL_MODE_MOD_ONLY)
       dt_selection_select_single(darktable.selection, thumb->imgid);
-    else if((event->state & (GDK_MOD1_MASK)) == GDK_MOD1_MASK)
+    else if(dt_modifier_is(event->state, GDK_MOD1_MASK))
       dt_selection_select_single(darktable.selection, thumb->imgid);
-    else if((event->state & (GDK_CONTROL_MASK)) == GDK_CONTROL_MASK)
+    else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
       dt_selection_toggle(darktable.selection, thumb->imgid);
-    else if((event->state & (GDK_SHIFT_MASK)) == GDK_SHIFT_MASK)
+    else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
       dt_selection_select_range(darktable.selection, thumb->imgid);
   }
   return FALSE;
@@ -882,6 +880,7 @@ static gboolean _event_grouping_release(GtkWidget *widget, GdkEventButton *event
 
   if(event->button == 1 && !thumb->moved)
   {
+    //TODO: will succeed if either or *both* of Shift and Control are pressed.  Do we want this?
     if(event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) // just add the whole group to the selection. TODO:
                                                            // make this also work for collapsed groups.
     {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -812,7 +812,7 @@ static gboolean _event_main_press(GtkWidget *widget, GdkEventButton *event, gpoi
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(event->button == 1
      && ((event->type == GDK_2BUTTON_PRESS && !thumb->single_click)
-         || (event->type == GDK_BUTTON_PRESS && (event->state & KEY_STATE_MASK) == 0 && thumb->single_click)))
+         || (event->type == GDK_BUTTON_PRESS && dt_modifier_is(event->state, 0) && thumb->single_click)))
   {
     dt_control_set_mouse_over_id(thumb->imgid); // to ensure we haven't lost imgid during double-click
   }
@@ -824,7 +824,7 @@ static gboolean _event_main_release(GtkWidget *widget, GdkEventButton *event, gp
 
   if(event->button == 1 && !thumb->moved && thumb->sel_mode != DT_THUMBNAIL_SEL_MODE_DISABLED)
   {
-    if((event->state & KEY_STATE_MASK) == 0 && thumb->sel_mode != DT_THUMBNAIL_SEL_MODE_MOD_ONLY)
+    if(dt_modifier_is(event->state, 0) && thumb->sel_mode != DT_THUMBNAIL_SEL_MODE_MOD_ONLY)
       dt_selection_select_single(darktable.selection, thumb->imgid);
     else if(dt_modifier_is(event->state, GDK_MOD1_MASK))
       dt_selection_select_single(darktable.selection, thumb->imgid);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -898,7 +898,7 @@ static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_
 
   if(dt_gui_get_scroll_unit_delta(e, &delta))
   {
-    if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER && (e->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER && dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
       const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
       int new = old;
@@ -1001,7 +1001,7 @@ static gboolean _event_button_press(GtkWidget *widget, GdkEventButton *event, gp
   }
   else if(id > 0 && event->button == 1 && table->mode == DT_THUMBTABLE_MODE_FILMSTRIP
           && event->type == GDK_BUTTON_PRESS && strcmp(view->module_name, "map")
-          && (event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK | GDK_MOD1_MASK)) == 0)
+          && (event->state & KEY_STATE_MASK) == 0)
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
   }
@@ -1073,7 +1073,7 @@ static gboolean _event_button_release(GtkWidget *widget, GdkEventButton *event, 
     const int id = dt_control_get_mouse_over_id();
     if(id > 0 && event->button == 1 && table->mode == DT_THUMBTABLE_MODE_FILMSTRIP
             && event->type == GDK_BUTTON_RELEASE && !strcmp(view->module_name, "map")
-            && (event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK | GDK_MOD1_MASK)) == 0)
+            && (event->state & KEY_STATE_MASK) == 0)
     {
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
       return TRUE;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1001,7 +1001,7 @@ static gboolean _event_button_press(GtkWidget *widget, GdkEventButton *event, gp
   }
   else if(id > 0 && event->button == 1 && table->mode == DT_THUMBTABLE_MODE_FILMSTRIP
           && event->type == GDK_BUTTON_PRESS && strcmp(view->module_name, "map")
-          && (event->state & KEY_STATE_MASK) == 0)
+          && dt_modifier_is(event->state, 0))
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
   }
@@ -1072,8 +1072,8 @@ static gboolean _event_button_release(GtkWidget *widget, GdkEventButton *event, 
     dt_view_t *view = vm->current_view;
     const int id = dt_control_get_mouse_over_id();
     if(id > 0 && event->button == 1 && table->mode == DT_THUMBTABLE_MODE_FILMSTRIP
-            && event->type == GDK_BUTTON_RELEASE && !strcmp(view->module_name, "map")
-            && (event->state & KEY_STATE_MASK) == 0)
+       && event->type == GDK_BUTTON_RELEASE && !strcmp(view->module_name, "map")
+       && dt_modifier_is(event->state, 0))
     {
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
       return TRUE;

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -155,8 +155,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   // set module active if not yet the case
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
-  const GdkModifierType state
-      = e != NULL ? e->state & gtk_accelerator_get_default_mod_mask() : dt_key_modifier_state();
+  const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
   const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK);
   dt_iop_color_picker_kind_t kind = self->kind;
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -157,7 +157,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
 
   const GdkModifierType state
       = e != NULL ? e->state & gtk_accelerator_get_default_mod_mask() : dt_key_modifier_state();
-  const gboolean ctrl_key_pressed = (state == GDK_CONTROL_MASK);
+  const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK);
   dt_iop_color_picker_kind_t kind = self->kind;
 
   _iop_color_picker_reset(module->picker);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1129,10 +1129,10 @@ guint dt_gui_translated_key_state(GdkEventKey *event)
     //find any modifiers consumed to produce keyval
     guint consumed;
     gdk_keymap_translate_keyboard_state(gdk_keymap_get_for_display(gdk_display_get_default()), event->hardware_keycode, event->state, event->group, NULL, NULL, NULL, &consumed);
-    return event->state & ~consumed & KEY_STATE_MASK;
+    return event->state & ~consumed & gtk_accelerator_get_default_mod_mask();
   }
   else
-    return event->state & KEY_STATE_MASK;
+    return event->state & gtk_accelerator_get_default_mod_mask();
 }
 
 static gboolean key_pressed_override(GtkWidget *w, GdkEventKey *event, gpointer user_data)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3169,7 +3169,7 @@ static gboolean _scroll_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event
 
   const gint increment = _get_container_row_heigth(w);
 
-  if(event->state & GDK_CONTROL_MASK)
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     int delta_y=0;
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3002,7 +3002,7 @@ GdkModifierType dt_key_modifier_state()
   guint state = 0;
   GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
   gdk_device_get_state(gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_window_get_display(window))), window, NULL, &state);
-  return state & gtk_accelerator_get_default_mod_mask();
+  return state;
 }
 
 static void notebook_size_callback(GtkNotebook *notebook, GdkRectangle *allocation, gpointer *data)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4112,8 +4112,8 @@ static int fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
     dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
 
-    const int control = (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK;
-    const int shift = (event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK;
+    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
 
@@ -4164,8 +4164,8 @@ static int fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
     dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
 
-    const int control = (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK;
-    const int shift = (event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK;
+    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
 
@@ -4216,8 +4216,8 @@ static int fit_both_button_clicked(GtkWidget *widget, GdkEventButton *event, gpo
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
     dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
 
-    const int control = (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK;
-    const int shift = (event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK;
+    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
 
@@ -4270,8 +4270,8 @@ static int structure_button_clicked(GtkWidget *widget, GdkEventButton *event, gp
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
     dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
 
-    const int control = (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK;
-    const int shift = (event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK;
+    const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
+    const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
 
     dt_iop_ashift_enhance_t enhance;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3864,7 +3864,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
   // if shift button is pressed go into bounding mode (selecting or deselecting
   // in a rectangle area)
-  if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     g->lastx = pzx;
     g->lasty = pzy;
@@ -3944,7 +3944,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
 
   // finalize the isbounding mode
   // if user has released the shift button in-between -> do nothing
-  if(g->isbounding != ASHIFT_BOUNDING_OFF && (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+  if(g->isbounding != ASHIFT_BOUNDING_OFF && dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     int handled = 0;
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1835,7 +1835,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
 
   if(event->button == 1)
   {
-    if(event->type == GDK_BUTTON_PRESS && (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK
+    if(event->type == GDK_BUTTON_PRESS && dt_modifier_is(event->state, GDK_CONTROL_MASK)
       && nodes < MAXNODES && c->selected == -1)
     {
       // if we are not on a node -> add a new node at the current x of the pointer and y of the curve at that x
@@ -1957,12 +1957,11 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   float multiplier;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1957,11 +1957,11 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   float multiplier;
 
-  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3421,8 +3421,8 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
       g->prev_clip_h = g->clip_h;
 
       /* if shift is pressed, then lock crop on center */
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) g->shift_hold = TRUE;
-      if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK) g->ctrl_hold = TRUE;
+      if(dt_modifiers_include(state, GDK_SHIFT_MASK)) g->shift_hold = TRUE;
+      if(dt_modifiers_include(state, GDK_CONTROL_MASK)) g->ctrl_hold = TRUE;
     }
 
     return 1;

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1249,7 +1249,7 @@ static gboolean checker_button_press(GtkWidget *widget, GdkEventButton *event,
     return TRUE;
   }
   else if((event->button == 1) &&
-          ((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) &&
+          dt_modifier_is(event->state, GDK_SHIFT_MASK) &&
           (self->request_color_pick == DT_REQUEST_COLORPICK_MODULE))
   {
     // shift-left while colour picking: replace source colour

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -510,11 +510,11 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
   float multiplier;
 
-  if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK))
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -510,12 +510,11 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
   float multiplier;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((event->state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_gdk_modifier_is(event->state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((event->state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_gdk_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1565,12 +1565,11 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   float multiplier;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }
@@ -1901,12 +1900,12 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 
   if(event->button == 1)
   {
-    if(c->edit_by_area && event->type != GDK_2BUTTON_PRESS && (event->state & GDK_CONTROL_MASK) != GDK_CONTROL_MASK)
+    if(c->edit_by_area && event->type != GDK_2BUTTON_PRESS && !dt_modifier_is(event->state, GDK_CONTROL_MASK))
     {
       c->dragging = 1;
       return TRUE;
     }
-    else if(event->type == GDK_BUTTON_PRESS && (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK
+    else if(event->type == GDK_BUTTON_PRESS && dt_modifier_is(event->state, GDK_CONTROL_MASK)
             && nodes < DT_IOP_COLORZONES_MAXNODES && (c->selected == -1 || c->edit_by_area))
     {
       // if we are not on a node -> add a new node at the current x of the pointer and y of the curve at that x
@@ -2006,7 +2005,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
     }
 
     // ctrl+right click reset the node to y-zero
-    if((event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
     {
       curve[c->selected].y = 0.5f;
     }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2240,9 +2240,9 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
     const GdkModifierType state = dt_key_modifier_state();
     int picker_set_upper_lower; // flat=0, lower=-1, upper=1
-    if(state == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
       picker_set_upper_lower = 1;
-    else if(state == GDK_SHIFT_MASK)
+    else if(dt_modifier_is(state, GDK_SHIFT_MASK))
       picker_set_upper_lower = -1;
     else
       picker_set_upper_lower = 0;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1565,11 +1565,11 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   float multiplier;
 
-  if(dt_gdk_modifier_is(state, GDK_SHIFT_MASK))
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if(dt_gdk_modifier_is(state, GDK_CONTROL_MASK))
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -697,7 +697,7 @@ int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state)
 {
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
-  if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+  if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     float dens;
     if(up)
@@ -710,7 +710,7 @@ int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state)
     }
     return 1;
   }
-  if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     float comp;
     if(up)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3080,7 +3080,7 @@ int scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_
       dt_conf_set_float(CONF_STRENGTH, r);
       return 1;
     }
-    else if(state & GDK_CONTROL_MASK)
+    else if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       //  change the strength direction
       float phi = cargf(strength_v);
@@ -3096,7 +3096,7 @@ int scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_
       dt_conf_set_float(CONF_ANGLE, phi);
       return 1;
     }
-    else if(state & GDK_SHIFT_MASK)
+    else if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       //  change the strength
       const float phi = cargf(strength_v);
@@ -3198,7 +3198,7 @@ int button_pressed(struct dt_iop_module_t *module,
 
   if(gtk_toggle_button_get_active(g->btn_node_tool))
   {
-    if(which == 1 && (g->last_mouse_mods == GDK_CONTROL_MASK) &&
+    if(which == 1 && dt_modifier_is(g->last_mouse_mods, GDK_CONTROL_MASK) &&
         (g->last_hit.layer == DT_LIQUIFY_LAYER_CENTERPOINT))
     {
       // cycle node type: smooth -> cusp etc.
@@ -3207,7 +3207,7 @@ int button_pressed(struct dt_iop_module_t *module,
       handled = 1;
       goto done;
     }
-    if(which == 1 && (g->last_mouse_mods == GDK_CONTROL_MASK) &&
+    if(which == 1 && dt_modifier_is(g->last_mouse_mods, GDK_CONTROL_MASK) &&
         (g->last_hit.layer == DT_LIQUIFY_LAYER_STRENGTHPOINT))
     {
       // cycle warp type: linear -> radial etc.
@@ -3380,7 +3380,7 @@ int button_released(struct dt_iop_module_t *module,
 
   if(gtk_toggle_button_get_active(g->btn_node_tool))
   {
-    if(which == 1 && g->last_mouse_mods == 0 && !dragged)
+    if(which == 1 && dt_modifier_is(g->last_mouse_mods, 0) && !dragged)
     {
       // select/unselect start/endpoint and clear previous selections
       if(g->last_hit.layer == DT_LIQUIFY_LAYER_CENTERPOINT)
@@ -3399,7 +3399,7 @@ int button_released(struct dt_iop_module_t *module,
         goto done;
       }
     }
-    if(which == 1 && g->last_mouse_mods == GDK_SHIFT_MASK && !dragged)
+    if(which == 1 && dt_modifier_is(g->last_mouse_mods, GDK_SHIFT_MASK) && !dragged)
     {
       // select/unselect start/endpoint and keep previous selections
       if(g->last_hit.layer == DT_LIQUIFY_LAYER_CENTERPOINT)
@@ -3410,7 +3410,7 @@ int button_released(struct dt_iop_module_t *module,
         goto done;
       }
     }
-    if(which == 1 && (g->last_mouse_mods == GDK_CONTROL_MASK) && !dragged)
+    if(which == 1 && dt_modifier_is(g->last_mouse_mods, GDK_CONTROL_MASK) && !dragged)
     {
       // add node
       if(g->last_hit.layer == DT_LIQUIFY_LAYER_PATH)
@@ -3469,7 +3469,7 @@ int button_released(struct dt_iop_module_t *module,
       }
     }
     if(which == 1
-        && (g->last_mouse_mods == (GDK_MOD1_MASK | GDK_CONTROL_MASK))
+        && dt_modifier_is(g->last_mouse_mods, GDK_MOD1_MASK | GDK_CONTROL_MASK)
         && !dragged)
     {
       if(g->last_hit.layer == DT_LIQUIFY_LAYER_PATH)
@@ -3541,8 +3541,7 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn, GdkEventButton *ev
     return TRUE;
   }
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  g->creation_continuous = event != NULL && (event->state & modifiers) == GDK_CONTROL_MASK;
+  g->creation_continuous = event != NULL && dt_modifier_is(event->state, GDK_CONTROL_MASK);
 
   dt_control_hinter_message(darktable.control, "");
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3135,7 +3135,7 @@ int button_pressed(struct dt_iop_module_t *module,
   dt_iop_gui_enter_critical_section(module);
 
   g->last_mouse_pos = pt;
-  g->last_mouse_mods = state & gtk_accelerator_get_default_mod_mask();
+  g->last_mouse_mods = state;
   if(which == 1)
     g->last_button1_pressed_pos = pt;
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1558,7 +1558,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
-      const int control_button_pressed = event->state & GDK_CONTROL_MASK;
+      const gboolean control_button_pressed = dt_modifier_is(event->state, GDK_CONTROL_MASK);
 
       switch(bd->masks_shown)
       {
@@ -1598,8 +1598,7 @@ static gboolean rt_add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_i
 
   if(darktable.gui->reset) return FALSE;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  const int creation_continuous = ((e->state & modifiers) == GDK_CONTROL_MASK);
+  const int creation_continuous = dt_modifier_is(e->state, GDK_CONTROL_MASK);
 
   rt_add_shape(widget, creation_continuous, self);
 
@@ -1636,8 +1635,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
   gboolean accept = TRUE;
 
   const int index = rt_get_selected_shape_index(p);
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if(index >= 0 && ((e->state & modifiers) == GDK_CONTROL_MASK))
+  if(index >= 0 && dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
     if(new_algo != p->rt_forms[index].algorithm)
     {
@@ -1667,7 +1665,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
     return FALSE;
   }
 
-  if(index >= 0 && ((e->state & modifiers) == GDK_CONTROL_MASK))
+  if(index >= 0 && dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
     if(p->algorithm != p->rt_forms[index].algorithm)
     {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -515,9 +515,9 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
     const GdkModifierType state = dt_key_modifier_state();
     int picker_set_upper_lower; // flat=0, lower=-1, upper=1
-    if(state == GDK_CONTROL_MASK)
+    if(dt_modifier_is(state, GDK_CONTROL_MASK))
       picker_set_upper_lower = 1;
-    else if(state == GDK_SHIFT_MASK)
+    else if(dt_modifier_is(state, GDK_SHIFT_MASK))
       picker_set_upper_lower = -1;
     else
       picker_set_upper_lower = 0;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -571,12 +571,11 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   float multiplier;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }
@@ -1208,7 +1207,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 
   if(event->button == 1)
   {
-    if(event->type == GDK_BUTTON_PRESS && (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK
+    if(event->type == GDK_BUTTON_PRESS && dt_modifier_is(event->state, GDK_CONTROL_MASK)
        && nodes < DT_IOP_RGBCURVE_MAXNODES && g->selected == -1)
     {
       // if we are not on a node -> add a new node at the current x of the pointer and y of the curve at that x

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -312,8 +312,7 @@ static gboolean _add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_iop
 
   const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) self->gui_data;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  const int creation_continuous = ((e->state & modifiers) == GDK_CONTROL_MASK);
+  const gboolean creation_continuous = dt_modifier_is(e->state, GDK_CONTROL_MASK);
 
   _add_shape(widget, creation_continuous, self);
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1043,12 +1043,11 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   float multiplier;
 
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((state & modifiers) == GDK_SHIFT_MASK)
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
-  else if((state & modifiers) == GDK_CONTROL_MASK)
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
   {
     multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
   }
@@ -1720,7 +1719,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
 
   if(event->button == 1)
   {
-    if(event->type == GDK_BUTTON_PRESS && (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK
+    if(event->type == GDK_BUTTON_PRESS && dt_modifier_is(event->state, GDK_CONTROL_MASK)
        && nodes < DT_IOP_TONECURVE_MAXNODES && c->selected == -1)
     {
       // if we are not on a node -> add a new node at the current x of the pointer and y of the curve at that x

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2112,9 +2112,9 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
   const float increment = (up) ? +1.0f : -1.0f;
 
   float step;
-  if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+  if(dt_modifier_is(state, GDK_SHIFT_MASK))
     step = 1.0f;  // coarse
-  else if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
     step = 0.1f;  // fine
   else
     step = 0.25f; // standard

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -524,7 +524,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       //        I guess we have to split the computation.
       if(ratio <= 1.0)
       {
-        if(which == GDK_CONTROL_MASK)
+        if(dt_modifier_is(which, GDK_CONTROL_MASK))
         {
           dt_bauhaus_slider_set(g->scale, new_scale);
         }
@@ -554,7 +554,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       //        I guess we have to split the computation.
       if(ratio <= 1.0)
       {
-        if(which == GDK_CONTROL_MASK)
+        if(dt_modifier_is(which, GDK_CONTROL_MASK))
         {
           const float new_scale = 100.0 * new_vignette_h / max;
           dt_bauhaus_slider_set(g->scale, new_scale);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -597,9 +597,8 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
      || (!d->singleclick && event->type == GDK_2BUTTON_PRESS && event->button == 1)
      || (d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == 1)
      || ((d->view_rule == DT_COLLECTION_PROP_FOLDERS || d->view_rule == DT_COLLECTION_PROP_FILMROLL)
-         && (event->type == GDK_BUTTON_PRESS
-             && event->button == 1
-             && (event->state & GDK_SHIFT_MASK || event->state & GDK_CONTROL_MASK))))
+          && (event->type == GDK_BUTTON_PRESS && event->button == 1 && 
+              (dt_modifier_is(event->state, GDK_SHIFT_MASK) || dt_modifier_is(event->state, GDK_CONTROL_MASK)))))
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
     GtkTreePath *path = NULL;
@@ -608,8 +607,7 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &path, NULL, NULL,
                                      NULL))
     {
-      if(d->singleclick
-         && (event->state & GDK_SHIFT_MASK)
+      if(d->singleclick && dt_modifier_is(event->state, GDK_SHIFT_MASK)
          && gtk_tree_selection_count_selected_rows(selection) > 0
          && (d->view_rule == DT_COLLECTION_PROP_DAY
              || is_time_property(d->view_rule)
@@ -641,7 +639,7 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
     if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS)
         || (d->view_rule == DT_COLLECTION_PROP_FILMROLL))
        && (event->type == GDK_BUTTON_PRESS && event->button == 3)
-       && !(event->state & GDK_SHIFT_MASK || event->state & GDK_CONTROL_MASK))
+       && !(dt_modifier_is(event->state, GDK_SHIFT_MASK) || dt_modifier_is(event->state, GDK_CONTROL_MASK)))
     {
       row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
       view_popup_menu(treeview, event, d);
@@ -657,8 +655,9 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
         || is_time_property(d->view_rule)
         || d->view_rule == DT_COLLECTION_PROP_FOLDERS
         || d->view_rule == DT_COLLECTION_PROP_TAG
-        || d->view_rule == DT_COLLECTION_PROP_GEOTAGGING)
-       && !(event->state & GDK_SHIFT_MASK)
+        || d->view_rule == DT_COLLECTION_PROP_GEOTAGGING
+       )
+       && !dt_modifier_is(event->state, GDK_SHIFT_MASK)
       )
       return FALSE; /* we allow propagation (expand/collapse row) */
     else
@@ -2219,7 +2218,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
 
   if(text && strlen(text) > 0)
   {
-    if(event->state & GDK_SHIFT_MASK && event->state & GDK_CONTROL_MASK)
+    if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       if(item == DT_COLLECTION_PROP_FILMROLL)
       {
@@ -2267,7 +2266,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
       if(gtk_tree_model_iter_has_child(model, &iter))
       {
         /* if a tag has children, ctrl-clicking on a parent node should display all images under this hierarchy. */
-        if(event->state & GDK_CONTROL_MASK)
+        if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
         {
           gchar *n_text = g_strconcat(text, "|%", NULL);
           g_free(text);
@@ -2275,7 +2274,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
         }
         /* if a tag has children, shift-clicking on a parent node should display all images in and under this
          * hierarchy. */
-        else if(event->state & GDK_SHIFT_MASK)
+        else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
         {
           gchar *n_text = g_strconcat(text, "*", NULL);
           g_free(text);

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1436,7 +1436,7 @@ static gboolean _datetime_scroll_over(GtkWidget *w, GdkEventScroll *event, dt_li
     if(w == d->dt.widget[i]) break;
 
   int increment = event->direction == GDK_SCROLL_DOWN ? -1 : 1;
-  if(event->state & GDK_SHIFT_MASK)
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
     increment *= 10;
   value += increment;
   value = MAX(MIN(value, max[i]), min[i]);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -640,7 +640,7 @@ static gboolean _drawable_button_press_callback(GtkWidget *widget, GdkEventButto
 
 static gboolean _drawable_scroll_callback(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
-  if(event->state & GDK_CONTROL_MASK)
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     // bubble to adjusting the overall widget size
     return FALSE;
@@ -876,7 +876,7 @@ static gboolean _lib_histogram_scroll_callback(GtkWidget *widget, GdkEventScroll
 {
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y) &&
-     event->state & GDK_CONTROL_MASK && !darktable.gui->reset)
+     dt_modifier_is(event->state, GDK_CONTROL_MASK) && !darktable.gui->reset)
   {
     /* set size of navigation draw area */
     const float histheight = clamp_range_f(dt_conf_get_int("plugins/darkroom/histogram/height") * 1.0f + 10 * delta_y, 100.0f, 200.0f);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1173,7 +1173,7 @@ static gboolean _lib_truncate_stack_accel(GtkAccelGroup *accel_group, GObject *a
 
 static void _lib_history_compress_clicked_callback(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
 {
-  const gboolean compress = !(e->state & GDK_CONTROL_MASK);
+  const gboolean compress = !dt_modifier_is(e->state, GDK_CONTROL_MASK);
   _lib_history_truncate(compress);
 }
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1057,7 +1057,7 @@ static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
     }
 
     /* handle shiftclick on expander, hide all except this */
-    if(!dt_conf_get_bool("lighttable/ui/single_module") != !(e->state & GDK_SHIFT_MASK))
+    if(!dt_conf_get_bool("lighttable/ui/single_module") != !dt_modifier_is(e->state, GDK_SHIFT_MASK))
     {
       GList *it = g_list_first(darktable.lib->plugins);
       const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -92,7 +92,7 @@ static gboolean _mouse_scroll(GtkWidget *treeview, GdkEventScroll *event,
                               dt_lib_module_t *self)
 {
   dt_lib_map_locations_t *d = (dt_lib_map_locations_t *)self->data;
-  if (event->state & GDK_CONTROL_MASK)
+  if (dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     const gint increment = DT_PIXEL_APPLY_DPI(10.0);
     const gint min_height = DT_PIXEL_APPLY_DPI(100.0);
@@ -859,9 +859,11 @@ static gboolean _click_on_view(GtkWidget *view, GdkEventButton *event, dt_lib_mo
     return TRUE;
   }
 
-  if((event->type == GDK_BUTTON_PRESS && event->button == 3)
-    || (event->type == GDK_BUTTON_PRESS && event->button == 1 && !(event->state & GDK_CONTROL_MASK))
-    || (event->type == GDK_BUTTON_PRESS && event->button == 1 && event->state & GDK_CONTROL_MASK)
+  const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
+  const gboolean ctrl_pressed = dt_modifier_is(event->state, GDK_CONTROL_MASK);
+  if((button_pressed == 3)
+     || (button_pressed == 1 && !ctrl_pressed)
+     || (button_pressed == 1 && ctrl_pressed)
     )
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
@@ -870,7 +872,7 @@ static gboolean _click_on_view(GtkWidget *view, GdkEventButton *event, dt_lib_mo
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), (gint)event->x,
                                      (gint)event->y, &path, NULL, NULL, NULL))
     {
-      if(event->type == GDK_BUTTON_PRESS && event->button == 3)
+      if(button_pressed == 3)
       {
         gtk_tree_selection_select_path(selection, path);
         _pop_menu_view(view, event, self);
@@ -878,14 +880,14 @@ static gboolean _click_on_view(GtkWidget *view, GdkEventButton *event, dt_lib_mo
         _display_buttons(self);
         return TRUE;
       }
-      else if(event->type == GDK_BUTTON_PRESS && event->button == 1 && !(event->state & GDK_CONTROL_MASK))
+      else if(button_pressed == 1 && !ctrl_pressed)
       {
         if(gtk_tree_selection_path_is_selected(selection, path))
           g_timeout_add(100, _force_selection_changed, self);
         gtk_tree_path_free(path);
         return FALSE;
       }
-      else if(event->type == GDK_BUTTON_PRESS && event->button == 1 && event->state & GDK_CONTROL_MASK)
+      else if(button_pressed == 1 && ctrl_pressed)
       {
         gtk_tree_selection_select_path(selection, path);
         g_object_set(G_OBJECT(d->renderer), "editable", TRUE, NULL);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -969,7 +969,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
     // if we are already inside the selection, no change
     if(on_row && !gtk_tree_selection_path_is_selected(selection, mouse_path))
     {
-      if(!(event->state & GDK_CONTROL_MASK)) gtk_tree_selection_unselect_all(selection);
+      if(!dt_modifier_is(event->state, GDK_CONTROL_MASK)) gtk_tree_selection_unselect_all(selection);
       gtk_tree_selection_select_path(selection, mouse_path);
       gtk_tree_path_free(mouse_path);
     }

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -261,7 +261,7 @@ static gboolean _key_pressed(GtkWidget *textview, GdkEventKey *event, dt_lib_mod
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
 
-  if(event->state & GDK_CONTROL_MASK)
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
     switch(event->keyval)
     {

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -268,7 +268,7 @@ static gboolean _key_pressed(GtkWidget *textview, GdkEventKey *event, dt_lib_mod
       case GDK_KEY_Return:
       case GDK_KEY_KP_Enter:
         // insert new line
-        event->state &= ~GDK_CONTROL_MASK;
+        event->state &= ~GDK_CONTROL_MASK;  //TODO: on Mac, remap Ctrl to Cmd key
       default:
         d->editing = TRUE;
     }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2189,17 +2189,19 @@ static gboolean _click_on_view_dictionary(GtkWidget *view, GdkEventButton *event
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
-  if((event->type == GDK_BUTTON_PRESS && event->button == 3)
-    || (d->tree_flag && event->type == GDK_BUTTON_PRESS && event->button == 1 && event->state & GDK_SHIFT_MASK)
+  const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
+  const gboolean shift_pressed = dt_modifier_is(event->state, GDK_SHIFT_MASK);
+  if((button_pressed == 3)
+     || (d->tree_flag && button_pressed == 1 && shift_pressed)
     || (event->type == GDK_2BUTTON_PRESS && event->button == 1)
-    || (event->type == GDK_BUTTON_PRESS && event->button == 1))
+    || (button_pressed == 1))
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
     GtkTreePath *path = NULL;
     // Get tree path for row that was clicked
     if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), (gint)event->x, (gint)event->y, &path, NULL, NULL, NULL))
     {
-      if(event->type == GDK_BUTTON_PRESS && event->button == 1)
+      if(button_pressed == 1)
       {
         GtkTreeModel *model = gtk_tree_view_get_model(d->dictionary_view);
         GtkTreeIter iter;
@@ -2218,13 +2220,13 @@ static gboolean _click_on_view_dictionary(GtkWidget *view, GdkEventButton *event
       {
         gtk_tree_selection_select_path(selection, path);
         _update_atdetach_buttons(self);
-        if(event->type == GDK_BUTTON_PRESS && event->button == 3)
+        if(button_pressed == 3)
         {
           _pop_menu_dictionary(view, event, self);
           gtk_tree_path_free(path);
           return TRUE;
         }
-        else if(d->tree_flag && event->type == GDK_BUTTON_PRESS && event->button == 1 && event->state & GDK_SHIFT_MASK)
+        else if(d->tree_flag && button_pressed == 1 && shift_pressed)
         {
           gtk_tree_view_expand_row(GTK_TREE_VIEW(view), path, TRUE);
           return TRUE;

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -202,7 +202,7 @@ static gboolean _lib_lighttable_layout_btn_release(GtkWidget *w, GdkEventButton 
     // that means we want to activate the button
     if(w == d->layout_preview)
     {
-      d->fullpreview_focus = ((event->state & (GDK_CONTROL_MASK)) == GDK_CONTROL_MASK);
+      d->fullpreview_focus = dt_modifier_is(event->state, GDK_CONTROL_MASK);
       new_layout = DT_LIGHTTABLE_LAYOUT_PREVIEW;
     }
     else if(w == d->layout_culling_fix)

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1220,7 +1220,7 @@ static gboolean _lib_timeline_button_release_callback(GtkWidget *w, GdkEventButt
     }
     strip->selecting = FALSE;
 
-    if(!strip->move_edge && (e->state & GDK_SHIFT_MASK))
+    if(!strip->move_edge && dt_modifier_is(e->state, GDK_SHIFT_MASK))
       _selection_collect(strip, DT_LIB_TIMELINE_MODE_RESET);
     else
       _selection_collect(strip, DT_LIB_TIMELINE_MODE_AND);
@@ -1375,7 +1375,7 @@ static gboolean _lib_timeline_scroll_callback(GtkWidget *w, GdkEventScroll *e, g
   dt_lib_timeline_t *strip = (dt_lib_timeline_t *)self->data;
 
   // zoom change (with Ctrl key)
-  if(e->state & GDK_CONTROL_MASK)
+  if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
     int z = strip->zoom;
     if(e->direction == GDK_SCROLL_UP)
@@ -1409,7 +1409,7 @@ static gboolean _lib_timeline_scroll_callback(GtkWidget *w, GdkEventScroll *e, g
     if(dt_gui_get_scroll_unit_delta(e, &delta))
     {
       int move = -delta;
-      if(e->state & GDK_SHIFT_MASK) move *= 2;
+      if(dt_modifier_is(e->state, GDK_SHIFT_MASK)) move *= 2;
 
       _time_add(&(strip->time_pos), move, strip->zoom);
       // we ensure that the fimlstrip stay in the bounds

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4713,7 +4713,7 @@ static gboolean _second_window_key_pressed_callback(GtkWidget *widget, GdkEventK
   gtk_accel_map_lookup_entry(path_on, &key_on);
   gtk_accel_map_lookup_entry(path_off, &key_off);
 
-  if(event->keyval == key_on.accel_key && (event->state & KEY_STATE_MASK) == key_on.accel_mods)
+  if(event->keyval == key_on.accel_key && dt_modifier_is(event->state, key_on.accel_mods))
   {
     fullscreen = gdk_window_get_state(gtk_widget_get_window(widget)) & GDK_WINDOW_STATE_FULLSCREEN;
     if(fullscreen)
@@ -4721,7 +4721,7 @@ static gboolean _second_window_key_pressed_callback(GtkWidget *widget, GdkEventK
     else
       gtk_window_fullscreen(GTK_WINDOW(widget));
   }
-  else if(event->keyval == key_off.accel_key && (event->state & KEY_STATE_MASK) == key_off.accel_mods)
+  else if(event->keyval == key_off.accel_key && dt_modifier_is(event->state, key_off.accel_mods))
   {
     gtk_window_unfullscreen(GTK_WINDOW(widget));
   }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3598,7 +3598,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   zoom = DT_ZOOM_FREE;
   closeup = 0;
 
-  const gboolean constrained = !((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK);
+  const gboolean constrained = !dt_modifier_is(state, GDK_CONTROL_MASK);
   if(up)
   {
     if(fitscale <= 1.0f && (scale == 1.0f || scale == 2.0f) && constrained) return; // for large image size
@@ -3779,16 +3779,13 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     int procw, proch;
     dt_dev_get_processed_size(dev, &procw, &proch);
 
-    GdkModifierType modifiers;
-    modifiers = gtk_accelerator_get_default_mod_mask();
-
     // For each cursor press, move one screen by default
     float step_changex = dev->width / (procw * scale);
     float step_changey = dev->height / (proch * scale);
     float factor = 0.2f;
 
-    if((state & modifiers) == GDK_MOD1_MASK) factor = 0.02f;
-    if((state & modifiers) == GDK_CONTROL_MASK) factor = 1.0f;
+    if(dt_modifier_is(state, GDK_MOD1_MASK)) factor = 0.02f;
+    if(dt_modifier_is(state, GDK_CONTROL_MASK)) factor = 1.0f;
 
     float old_zoom_x, old_zoom_y;
 
@@ -4242,7 +4239,7 @@ static void second_window_scrolled(GtkWidget *widget, dt_develop_t *dev, double 
   closeup = 0;
   if(up)
   {
-    if((scale == 1.0f || scale == 2.0f) && !((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)) return;
+    if((scale == 1.0f || scale == 2.0f) && !dt_modifier_is(state, GDK_CONTROL_MASK)) return;
     if(scale >= 16.0f)
       return;
     else if(scale >= 8.0f)
@@ -4258,7 +4255,7 @@ static void second_window_scrolled(GtkWidget *widget, dt_develop_t *dev, double 
   }
   else
   {
-    if(scale == fitscale && !((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK))
+    if(scale == fitscale && !dt_modifier_is(state, GDK_CONTROL_MASK))
       return;
     else if(scale < 0.5 * fitscale)
       return;

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1738,14 +1738,14 @@ static gboolean _view_map_scroll_event(GtkWidget *w, GdkEventScroll *event, dt_v
   {
     if(dt_map_location_included(lon, lat, &lib->loc.main.data))
     {
-      if(event->state & GDK_SHIFT_MASK)
+      if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
       {
         if(event->direction == GDK_SCROLL_DOWN)
           lib->loc.main.data.delta1 *= 1.1;
         else
           lib->loc.main.data.delta1 /= 1.1;
       }
-      else if(event->state & GDK_CONTROL_MASK)
+      else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
       {
         if(event->direction == GDK_SCROLL_DOWN)
           lib->loc.main.data.delta2 *= 1.1;
@@ -1795,7 +1795,7 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
   if(e->button == 1)
   {
     // check if the click was in a location form - crtl gives priority to images
-    if(lib->loc.main.id > 0 && !(e->state & GDK_CONTROL_MASK))
+    if(lib->loc.main.id > 0 && !dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
 
       OsmGpsMapPoint *p = osm_gps_map_get_event_location(lib->map, e);
@@ -1803,7 +1803,7 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
       osm_gps_map_point_get_degrees(p, &lat, &lon);
       if(dt_map_location_included(lon, lat, &lib->loc.main.data))
       {
-        if(!(e->state & GDK_SHIFT_MASK))
+        if(!dt_modifier_is(e->state, GDK_SHIFT_MASK))
         {
           lib->start_drag_x = ceil(e->x_root);
           lib->start_drag_y = ceil(e->y_root);
@@ -1813,7 +1813,7 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
       }
     }
     // check if another location is clicked - ctrl gives priority to images
-    if (!(e->state & GDK_CONTROL_MASK))
+    if (!dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
       OsmGpsMapPoint *p = osm_gps_map_get_event_location(lib->map, e);
       float lat, lon;
@@ -1834,7 +1834,7 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
     }
     // check if the click was on image(s) or just some random position
     lib->selected_images = _view_map_get_imgs_at_pos(self, e->x, e->y,
-                                                     !(e->state & GDK_SHIFT_MASK));
+                                                     !dt_modifier_is(e->state, GDK_SHIFT_MASK));
     if(e->type == GDK_BUTTON_PRESS)
     {
       if(lib->selected_images)


### PR DESCRIPTION
A start at the additional changes mentioned in #7288.

Implemented `dt_modifier_is` as suggested by @dterrahe, as well as a companion `dt_gdk_modifier_is` as there are places in the code which get the set of shifting-key masks from Gdk instead of the hardcoded three keys used in most places.

