### PR TITLE
presets menu: add preferences entry. applied to metadata_view and metadata plugins

### DIFF
--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -365,6 +365,7 @@ static inline GtkWidget *dt_ui_label_new(const gchar *str)
 {
   GtkWidget *label = gtk_label_new(str);
   gtk_widget_set_halign(label, GTK_ALIGN_START);
+  gtk_label_set_xalign (GTK_LABEL(label), 0.0f);
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   return label;
 };

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -65,7 +65,6 @@ typedef struct dt_lib_export_t
   GtkWidget *storage_extra_container, *format_extra_container;
   GtkWidget *high_quality;
   GtkWidget *export_masks;
-  GtkWidget *metadata_button;
   char *metadata_export;
 } dt_lib_export_t;
 
@@ -1078,11 +1077,19 @@ static void _lib_export_styles_changed_callback(gpointer instance, gpointer user
   g_list_free_full(styles, dt_style_free);
 }
 
-static void _metadata_export_clicked(GtkComboBox *widget, dt_lib_export_t *d)
+void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 {
+  dt_lib_export_t *d = (dt_lib_export_t *)self->data;
   const gchar *name = dt_bauhaus_combobox_get_text(d->storage);
   const gboolean ondisk = name && !g_strcmp0(name, _("file on disk")); // FIXME: NO!!!!!one!
   d->metadata_export = dt_lib_export_metadata_configuration_dialog(d->metadata_export, ondisk);
+}
+
+void set_preferences(void *menu, dt_lib_module_t *self)
+{
+  GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
+  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -1366,12 +1373,6 @@ void gui_init(dt_lib_module_t *self)
   d->export_button = GTK_BUTTON(dt_ui_button_new(_("export"), _("export with current settings"), NULL));
   gtk_box_pack_start(hbox, GTK_WIDGET(d->export_button), TRUE, TRUE, 0);
 
-  //  Add metadata exportation control
-  d->metadata_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_BOX, NULL);
-  gtk_widget_set_name(d->metadata_button, "non-flat");
-  gtk_widget_set_tooltip_text(d->metadata_button, _("edit metadata exportation details"));
-  gtk_box_pack_end(hbox, d->metadata_button, FALSE, TRUE, 0);
-
   g_signal_connect(G_OBJECT(d->dimensions_type), "value_changed", G_CALLBACK(_dimensions_type_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->export_button), "clicked", G_CALLBACK(_export_button_clicked), (gpointer)d);
   g_signal_connect(G_OBJECT(d->width), "changed", G_CALLBACK(_width_changed), (gpointer)d);
@@ -1380,7 +1381,6 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->print_height), "changed", G_CALLBACK(_print_height_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->print_dpi), "changed", G_CALLBACK(_print_dpi_changed), (gpointer)d);
 
-  g_signal_connect(G_OBJECT(d->metadata_button), "clicked", G_CALLBACK(_metadata_export_clicked), (gpointer)d);
   g_signal_connect(G_OBJECT(d->width), "changed", G_CALLBACK(_width_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->height), "changed", G_CALLBACK(_height_changed), (gpointer)d);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -32,6 +32,9 @@
 
 #include <gdk/gdkkeysyms.h>
 #include <sys/param.h>
+#ifdef GDK_WINDOWING_QUARTZ
+#include "osx/osx.h"
+#endif
 #ifdef USE_LUA
 #include "lua/call.h"
 #include "lua/image.h"
@@ -40,6 +43,34 @@
 #define SHOW_FLAGS 1
 
 DT_MODULE(1)
+
+typedef enum dt_metadata_pref_cols_t
+{
+  DT_METADATA_PREF_COL_INDEX = 0, // index
+  DT_METADATA_PREF_COL_NAME_L,    // displayed name
+  DT_METADATA_PREF_COL_VISIBLE,   // visibility
+  DT_METADATA_PREF_NUM_COLS
+} dt_metadata_pref_cols_t;
+
+typedef enum dt_metadata_cols_t
+{
+  DT_METADATA_COL_INDEX = 0,      // index
+  DT_METADATA_COL_NAME,           // metadata english name
+  DT_METADATA_COL_NAME_L,         // displayed name
+  DT_METADATA_COL_TOOLTIP,        // tooltip
+  DT_METADATA_COL_VALUE,          // metadata value
+  DT_METADATA_COL_VISIBLE,        // visibility
+  DT_METADATA_COL_ORDER,          // display order
+  DT_METADATA_NUM_COLS
+} dt_metadata_cols_t;
+
+typedef struct dt_lib_metadata_view_t
+{
+  GtkTreeModel *model;
+  GtkTreeModel *sort_model;
+  GtkTreeModel *filter_model;
+  GtkWidget *view;
+} dt_lib_metadata_view_t;
 
 enum
 {
@@ -93,67 +124,54 @@ enum
   md_size
 };
 
-static gchar *_md_labels[md_size];
-
-/* initialize the labels text */
-static void _lib_metatdata_view_init_labels()
-{
+static const char *_labels[] = {
   /* internal */
-  _md_labels[md_internal_filmroll] = _("filmroll");
-  _md_labels[md_internal_imgid] = _("image id");
-  _md_labels[md_internal_groupid] = _("group id");
-  _md_labels[md_internal_filename] = _("filename");
-  _md_labels[md_internal_version] = _("version");
-  _md_labels[md_internal_fullpath] = _("full path");
-  _md_labels[md_internal_local_copy] = _("local copy");
-  _md_labels[md_internal_import_timestamp] = _("import timestamp");
-  _md_labels[md_internal_change_timestamp] = _("change timestamp");
-  _md_labels[md_internal_export_timestamp] = _("export timestamp");
-  _md_labels[md_internal_print_timestamp] = _("print timestamp");
+  N_("filmroll"),
+  N_("image id"),
+  N_("group id"),
+  N_("filename"),
+  N_("version"),
+  N_("full path"),
+  N_("local copy"),
+  N_("import timestamp"),
+  N_("change timestamp"),
+  N_("export timestamp"),
+  N_("print timestamp"),
 #if SHOW_FLAGS
-  _md_labels[md_internal_flags] = _("flags");
+  N_("flags"),
 #endif
 
   /* exif */
-  _md_labels[md_exif_model] = _("model");
-  _md_labels[md_exif_maker] = _("maker");
-  _md_labels[md_exif_lens] = _("lens");
-  _md_labels[md_exif_aperture] = _("aperture");
-  _md_labels[md_exif_exposure] = _("exposure");
-  _md_labels[md_exif_exposure_bias] = _("exposure bias");
-  _md_labels[md_exif_focal_length] = _("focal length");
-  _md_labels[md_exif_focus_distance] = _("focus distance");
-  _md_labels[md_exif_iso] = _("ISO");
-  _md_labels[md_exif_datetime] = _("datetime");
-  _md_labels[md_exif_width] = _("width");
-  _md_labels[md_exif_height] = _("height");
-
-  _md_labels[md_width] = _("export width");
-  _md_labels[md_height] = _("export height");
+  N_("model"),
+  N_("maker"),
+  N_("lens"),
+  N_("aperture"),
+  N_("exposure"),
+  N_("exposure bias"),
+  N_("focal length"),
+  N_("focus distance"),
+  N_("ISO"),
+  N_("datetime"),
+  N_("width"),
+  N_("height"),
+  N_("export width"),
+  N_("export height"),
 
   /* xmp */
-  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
-  {
-    const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
-    const gchar *name = dt_metadata_get_name(keyid);
-    _md_labels[md_xmp_metadata+i] = _(name);
-  }
+  //FIXME: reserve DT_METADATA_NUMBER places
+  "","","","","","","",
 
   /* geotagging */
-  _md_labels[md_geotagging_lat] = _("latitude");
-  _md_labels[md_geotagging_lon] = _("longitude");
-  _md_labels[md_geotagging_ele] = _("elevation");
+  N_("latitude"),
+  N_("longitude"),
+  N_("elevation"),
 
   /* tags */
-  _md_labels[md_tag_names] = _("tags");
-  _md_labels[md_categories] = _("categories");
-}
+  N_("tags"),
+  N_("categories"),
+};
 
-typedef struct dt_lib_metadata_view_t
-{
-  GtkLabel *name[md_size];
-  GtkLabel *metadata[md_size];
-} dt_lib_metadata_view_t;
+static gboolean _dndactive = FALSE;
 
 const char *name(dt_lib_module_t *self)
 {
@@ -176,10 +194,49 @@ int position()
   return 299;
 }
 
-/* helper which eliminates non-printable characters from a string
+static gboolean _is_metadata_ui(const int i)
+{
+  // internal metadata ar not to be shown on the ui
+  if(i >= md_xmp_metadata && i < md_xmp_metadata + DT_METADATA_NUMBER)
+  {
+    const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
+    return !(dt_metadata_get_type(keyid) == DT_METADATA_TYPE_INTERNAL);
+  }
+  else return TRUE;
+}
 
-Strings which are already in valid UTF-8 are retained.
-*/
+static const char *_get_label(const int i)
+{
+  if(i >= md_xmp_metadata && i < md_xmp_metadata + DT_METADATA_NUMBER)
+  {
+    const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i - md_xmp_metadata);
+    return(dt_metadata_get_name(keyid));
+  }
+  else return _labels[i];
+}
+
+/* initialize the labels text */
+static void _lib_metadata_view_init_labels(GtkTreeModel *model)
+{
+  GtkListStore *store = GTK_LIST_STORE(model);
+  for(int i = 0; i < md_size; i++)
+  {
+    GtkTreeIter iter;
+    gtk_list_store_append(store, &iter);
+    const char *name = _get_label(i);
+    gtk_list_store_set(store, &iter,
+                       DT_METADATA_COL_INDEX, i,
+                       DT_METADATA_COL_NAME, name,
+                       DT_METADATA_COL_NAME_L, _(name),
+                       DT_METADATA_COL_VALUE, "-",
+                       DT_METADATA_COL_VISIBLE, _is_metadata_ui(i),
+                       DT_METADATA_COL_ORDER, i,
+                       -1);
+  }
+}
+
+// helper which eliminates non-printable characters from a string
+// strings which are already in valid UTF-8 are retained.
 static void _filter_non_printable(char *string, size_t length)
 {
   /* explicitly tell the validator to ignore the trailing nulls, otherwise this fails */
@@ -199,16 +256,33 @@ static void _filter_non_printable(char *string, size_t length)
 
 #define NODATA_STRING "-"
 
+static void _get_index_iter(const int i, GtkTreeModel *model, GtkTreeIter *iter)
+{
+  char path_str[4];
+  snprintf(path_str, sizeof(path_str), "%d", i);
+  GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+  gtk_tree_model_get_iter(GTK_TREE_MODEL(model), iter, path);
+  gtk_tree_path_free(path);
+}
+
 /* helper function for updating a metadata value */
-static void _metadata_update_value(GtkLabel *label, const char *value)
+static void _metadata_update_value(const int i, const char *value, GtkTreeModel *model)
 {
   gboolean validated = g_utf8_validate(value, -1, NULL);
   const gchar *str = validated ? value : NODATA_STRING;
-  gtk_label_set_text(GTK_LABEL(label), str);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(label), str);
+  GtkTreeIter iter;
+  _get_index_iter(i, model, &iter);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_METADATA_COL_VALUE, str, -1);
 }
 
-static void _metadata_update_timestamp(GtkLabel *label, const time_t *value)
+static void _metadata_update_tooltip(const int i, const char *tooltip, GtkTreeModel *model)
+{
+  GtkTreeIter iter;
+  _get_index_iter(i, model, &iter);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_METADATA_COL_TOOLTIP, tooltip, -1);
+}
+
+static void _metadata_update_timestamp(const int i, const time_t *value, GtkTreeModel *model)
 {
   char datetime[200];
   // just %c is too long and includes a time zone that we don't know from exif
@@ -218,7 +292,7 @@ static void _metadata_update_timestamp(GtkLabel *label, const time_t *value)
     const gboolean valid_utf = g_utf8_validate(datetime, datetime_len, NULL);
     if(valid_utf)
     {
-      _metadata_update_value(label, datetime);
+      _metadata_update_value(i, datetime, model);
     }
     else
     {
@@ -226,21 +300,20 @@ static void _metadata_update_timestamp(GtkLabel *label, const time_t *value)
       gchar *local_datetime = g_locale_to_utf8(datetime,datetime_len,NULL,NULL, &error);
       if(local_datetime)
       {
-        _metadata_update_value(label, local_datetime);
+        _metadata_update_value(i, local_datetime, model);
         g_free(local_datetime);
       }
       else
       {
-        _metadata_update_value(label, NODATA_STRING);
+        _metadata_update_value(i, NODATA_STRING, model);
         fprintf(stderr, "[metadata timestamp] could not convert '%s' to UTF-8: %s\n", datetime, error->message);
         g_error_free(error);
       }
     }
   }
   else
-    _metadata_update_value(label, NODATA_STRING);
+    _metadata_update_value(i, NODATA_STRING, model);
 }
-
 
 #ifdef USE_LUA
 static int lua_update_metadata(lua_State*L);
@@ -249,6 +322,7 @@ static int lua_update_metadata(lua_State*L);
 static void _metadata_view_update_values(dt_lib_module_t *self)
 {
   dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
+  GtkTreeModel *model = GTK_TREE_MODEL(d->model);
   int32_t mouse_over_id = dt_control_get_mouse_over_id();
 
   if(mouse_over_id == -1)
@@ -284,49 +358,48 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     /* update all metadata */
 
     dt_image_film_roll(img, value, sizeof(value));
-    _metadata_update_value(d->metadata[md_internal_filmroll], value);
-
+    _metadata_update_value(md_internal_filmroll, value, model);
     char tooltip[512];
     snprintf(tooltip, sizeof(tooltip), _("double click to jump to film roll\n%s"), value);
-    gtk_widget_set_tooltip_text(GTK_WIDGET(d->metadata[md_internal_filmroll]), tooltip);
+    _metadata_update_tooltip(md_internal_filmroll, tooltip, model);
 
     snprintf(value, sizeof(value), "%d", img->id);
-    _metadata_update_value(d->metadata[md_internal_imgid], value);
+    _metadata_update_value(md_internal_imgid, value, model);
 
     snprintf(value, sizeof(value), "%d", img->group_id);
-    _metadata_update_value(d->metadata[md_internal_groupid], value);
+    _metadata_update_value(md_internal_groupid, value, model);
 
-    _metadata_update_value(d->metadata[md_internal_filename], img->filename);
+    _metadata_update_value(md_internal_filename, img->filename, model);
 
     snprintf(value, sizeof(value), "%d", img->version);
-    _metadata_update_value(d->metadata[md_internal_version], value);
+    _metadata_update_value(md_internal_version, value, model);
 
     gboolean from_cache = FALSE;
     dt_image_full_path(img->id, pathname, sizeof(pathname), &from_cache);
-    _metadata_update_value(d->metadata[md_internal_fullpath], pathname);
+    _metadata_update_value(md_internal_fullpath, pathname, model);
 
     g_strlcpy(value, (img->flags & DT_IMAGE_LOCAL_COPY) ? _("yes") : _("no"), sizeof(value));
-    _metadata_update_value(d->metadata[md_internal_local_copy], value);
+    _metadata_update_value(md_internal_local_copy, value, model);
 
     if (img->import_timestamp >=0)
-      _metadata_update_timestamp(d->metadata[md_internal_import_timestamp], &img->import_timestamp);
+      _metadata_update_timestamp(md_internal_import_timestamp, &img->import_timestamp, model);
     else
-      _metadata_update_value(d->metadata[md_internal_import_timestamp], NODATA_STRING);
+      _metadata_update_value(md_internal_import_timestamp, NODATA_STRING, model);
 
     if (img->change_timestamp >=0)
-      _metadata_update_timestamp(d->metadata[md_internal_change_timestamp], &img->change_timestamp);
+      _metadata_update_timestamp(md_internal_change_timestamp, &img->change_timestamp, model);
     else
-      _metadata_update_value(d->metadata[md_internal_change_timestamp], NODATA_STRING);
+      _metadata_update_value(md_internal_change_timestamp, NODATA_STRING, model);
 
     if (img->export_timestamp >=0)
-      _metadata_update_timestamp(d->metadata[md_internal_export_timestamp], &img->export_timestamp);
+      _metadata_update_timestamp(md_internal_export_timestamp, &img->export_timestamp, model);
     else
-      _metadata_update_value(d->metadata[md_internal_export_timestamp], NODATA_STRING);
+      _metadata_update_value(md_internal_export_timestamp, NODATA_STRING, model);
 
     if (img->print_timestamp >=0)
-      _metadata_update_timestamp(d->metadata[md_internal_print_timestamp], &img->print_timestamp);
+      _metadata_update_timestamp(md_internal_print_timestamp, &img->print_timestamp, model);
     else
-      _metadata_update_value(d->metadata[md_internal_print_timestamp], NODATA_STRING);
+      _metadata_update_value(md_internal_print_timestamp, NODATA_STRING, model);
 
     // TODO: decide if this should be removed for a release. maybe #ifdef'ing to only add it to git compiles?
 
@@ -476,8 +549,8 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       flags_tooltip = g_strjoinv("\n", tooltip_parts);
       g_free(loader_tooltip);
 
-      _metadata_update_value(d->metadata[md_internal_flags], value);
-      gtk_widget_set_tooltip_text(GTK_WIDGET(d->metadata[md_internal_flags]), flags_tooltip);
+      _metadata_update_value(md_internal_flags, value, model);
+      _metadata_update_tooltip(md_internal_flags, flags_tooltip, model);
 
       g_free(star_string);
       g_free(flags_tooltip);
@@ -489,42 +562,42 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 #endif // SHOW_FLAGS
 
     /* EXIF */
-    _metadata_update_value(d->metadata[md_exif_model], img->camera_alias);
-    _metadata_update_value(d->metadata[md_exif_lens], img->exif_lens);
-    _metadata_update_value(d->metadata[md_exif_maker], img->camera_maker);
+    _metadata_update_value(md_exif_model, img->camera_alias, model);
+    _metadata_update_value(md_exif_lens, img->exif_lens, model);
+    _metadata_update_value(md_exif_maker, img->camera_maker, model);
 
     snprintf(value, sizeof(value), "f/%.1f", img->exif_aperture);
-    _metadata_update_value(d->metadata[md_exif_aperture], value);
+    _metadata_update_value(md_exif_aperture, value, model);
 
     char *exposure_str = dt_util_format_exposure(img->exif_exposure);
-    _metadata_update_value(d->metadata[md_exif_exposure], exposure_str);
+    _metadata_update_value(md_exif_exposure, exposure_str, model);
     g_free(exposure_str);
 
     if(isnan(img->exif_exposure_bias))
     {
-      _metadata_update_value(d->metadata[md_exif_exposure_bias], NODATA_STRING);
+      _metadata_update_value(md_exif_exposure_bias, NODATA_STRING, model);
     }
     else
     {
       snprintf(value, sizeof(value), _("%+.2f EV"), img->exif_exposure_bias);
-      _metadata_update_value(d->metadata[md_exif_exposure_bias], value);
+      _metadata_update_value(md_exif_exposure_bias, value, model);
     }
 
     snprintf(value, sizeof(value), "%.0f mm", img->exif_focal_length);
-    _metadata_update_value(d->metadata[md_exif_focal_length], value);
+    _metadata_update_value(md_exif_focal_length, value, model);
 
     if(isnan(img->exif_focus_distance) || fpclassify(img->exif_focus_distance) == FP_ZERO)
     {
-      _metadata_update_value(d->metadata[md_exif_focus_distance], NODATA_STRING);
+      _metadata_update_value(md_exif_focus_distance, NODATA_STRING, model);
     }
     else
     {
       snprintf(value, sizeof(value), "%.2f m", img->exif_focus_distance);
-      _metadata_update_value(d->metadata[md_exif_focus_distance], value);
+      _metadata_update_value(md_exif_focus_distance, value, model);
     }
 
     snprintf(value, sizeof(value), "%.0f", img->exif_iso);
-    _metadata_update_value(d->metadata[md_exif_iso], value);
+    _metadata_update_value(md_exif_iso, value, model);
 
     struct tm tt_exif = { 0 };
     if(sscanf(img->exif_datetime_taken, "%d:%d:%d %d:%d:%d", &tt_exif.tm_year, &tt_exif.tm_mon,
@@ -534,58 +607,50 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       tt_exif.tm_mon--;
       tt_exif.tm_isdst = -1;
       const time_t exif_timestamp = mktime(&tt_exif);
-      _metadata_update_timestamp(d->metadata[md_exif_datetime], &exif_timestamp);
+      _metadata_update_timestamp(md_exif_datetime, &exif_timestamp, model);
     }
     else
-      _metadata_update_value(d->metadata[md_exif_datetime], img->exif_datetime_taken);
+      _metadata_update_value(md_exif_datetime, img->exif_datetime_taken, model);
 
     if(((img->p_width != img->width) || (img->p_height != img->height))  &&
        (img->p_width || img->p_height))
     {
       snprintf(value, sizeof(value), "%d (%d)", img->p_height, img->height);
-      _metadata_update_value(d->metadata[md_exif_height], value);
+      _metadata_update_value(md_exif_height, value, model);
       snprintf(value, sizeof(value), "%d (%d) ",img->p_width, img->width);
-      _metadata_update_value(d->metadata[md_exif_width], value);
+      _metadata_update_value(md_exif_width, value, model);
     }
     else {
     snprintf(value, sizeof(value), "%d", img->height);
-    _metadata_update_value(d->metadata[md_exif_height], value);
+    _metadata_update_value(md_exif_height, value, model);
     snprintf(value, sizeof(value), "%d", img->width);
-    _metadata_update_value(d->metadata[md_exif_width], value);
+    _metadata_update_value(md_exif_width, value, model);
     }
 
     if(img->verified_size)
     {
       snprintf(value, sizeof(value), "%d", img->final_height);
-    _metadata_update_value(d->metadata[md_height], value);
+    _metadata_update_value(md_height, value, model);
       snprintf(value, sizeof(value), "%d", img->final_width);
-    _metadata_update_value(d->metadata[md_width], value);
+    _metadata_update_value(md_width, value, model);
     }
     else
     {
-      _metadata_update_value(d->metadata[md_height], "-");
-      _metadata_update_value(d->metadata[md_width], "-");
+      _metadata_update_value(md_height, "-", model);
+      _metadata_update_value(md_width, "-", model);
     }
     /* XMP */
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
     {
       const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
       const gchar *key = dt_metadata_get_key(keyid);
-      const gchar *name = dt_metadata_get_name(keyid);
-      gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
-      const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
-      g_free(setting);
-      const int meta_type = dt_metadata_get_type(keyid);
-      if(meta_type == DT_METADATA_TYPE_INTERNAL || hidden)
+      const gboolean hidden = dt_metadata_get_type(keyid) == DT_METADATA_TYPE_INTERNAL;
+      if(hidden)
       {
-        gtk_widget_hide(GTK_WIDGET(d->name[md_xmp_metadata+i]));
-        gtk_widget_hide(GTK_WIDGET(d->metadata[md_xmp_metadata+i]));
         g_strlcpy(value, NODATA_STRING, sizeof(value));
       }
       else
       {
-        gtk_widget_show(GTK_WIDGET(d->name[md_xmp_metadata+i]));
-        gtk_widget_show(GTK_WIDGET(d->metadata[md_xmp_metadata+i]));
         GList *res = dt_metadata_get(img->id, key, NULL);
         if(res)
         {
@@ -596,67 +661,67 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
         else
           g_strlcpy(value, NODATA_STRING, sizeof(value));
       }
-      _metadata_update_value(d->metadata[md_xmp_metadata+i], value);
+      _metadata_update_value(md_xmp_metadata+i, value, model);
     }
 
     /* geotagging */
     /* latitude */
     if(isnan(img->geoloc.latitude))
     {
-      _metadata_update_value(d->metadata[md_geotagging_lat], NODATA_STRING);
+      _metadata_update_value(md_geotagging_lat, NODATA_STRING, model);
     }
     else
     {
       if(dt_conf_get_bool("plugins/lighttable/metadata_view/pretty_location"))
       {
         gchar *latitude = dt_util_latitude_str(img->geoloc.latitude);
-        _metadata_update_value(d->metadata[md_geotagging_lat], latitude);
+        _metadata_update_value(md_geotagging_lat, latitude, model);
         g_free(latitude);
       }
       else
       {
         const gchar NS = img->geoloc.latitude < 0 ? 'S' : 'N';
         snprintf(value, sizeof(value), "%c %09.6f", NS, fabs(img->geoloc.latitude));
-        _metadata_update_value(d->metadata[md_geotagging_lat], value);
+        _metadata_update_value(md_geotagging_lat, value, model);
       }
     }
     /* longitude */
     if(isnan(img->geoloc.longitude))
     {
-      _metadata_update_value(d->metadata[md_geotagging_lon], NODATA_STRING);
+      _metadata_update_value(md_geotagging_lon, NODATA_STRING, model);
     }
     else
     {
       if(dt_conf_get_bool("plugins/lighttable/metadata_view/pretty_location"))
       {
         gchar *longitude = dt_util_longitude_str(img->geoloc.longitude);
-        _metadata_update_value(d->metadata[md_geotagging_lon], longitude);
+        _metadata_update_value(md_geotagging_lon, longitude, model);
         g_free(longitude);
       }
       else
       {
         const gchar EW = img->geoloc.longitude < 0 ? 'W' : 'E';
         snprintf(value, sizeof(value), "%c %010.6f", EW, fabs(img->geoloc.longitude));
-        _metadata_update_value(d->metadata[md_geotagging_lon], value);
+        _metadata_update_value(md_geotagging_lon, value, model);
       }
     }
     /* elevation */
     if(isnan(img->geoloc.elevation))
     {
-      _metadata_update_value(d->metadata[md_geotagging_ele], NODATA_STRING);
+      _metadata_update_value(md_geotagging_ele, NODATA_STRING, model);
     }
     else
     {
       if(dt_conf_get_bool("plugins/lighttable/metadata_view/pretty_location"))
       {
         gchar *elevation = dt_util_elevation_str(img->geoloc.elevation);
-        _metadata_update_value(d->metadata[md_geotagging_ele], elevation);
+        _metadata_update_value(md_geotagging_ele, elevation, model);
         g_free(elevation);
       }
       else
       {
         snprintf(value, sizeof(value), "%.2f %s", img->geoloc.elevation, _("m"));
-        _metadata_update_value(d->metadata[md_geotagging_ele], value);
+        _metadata_update_value(md_geotagging_ele, value, model);
       }
     }
 
@@ -703,8 +768,8 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       }
       if(tagstring) tagstring[strlen(tagstring)-2] = '\0';
     }
-    _metadata_update_value(d->metadata[md_tag_names], tagstring ? tagstring : NODATA_STRING);
-    _metadata_update_value(d->metadata[md_categories], categoriesstring ? categoriesstring : NODATA_STRING);
+    _metadata_update_value(md_tag_names, tagstring ? tagstring : NODATA_STRING, model);
+    _metadata_update_value(md_categories, categoriesstring ? categoriesstring : NODATA_STRING, model);
 
     g_free(tagstring);
     g_free(categoriesstring);
@@ -725,7 +790,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
 /* reset */
 fill_minuses:
-  for(int k = 0; k < md_size; k++) _metadata_update_value(d->metadata[k], NODATA_STRING);
+  for(int k = 0; k < md_size; k++) _metadata_update_value(k, NODATA_STRING, model);
 #ifdef USE_LUA
   dt_lua_async_call_alien(lua_update_metadata,
       0,NULL,NULL,
@@ -759,11 +824,76 @@ static void _jump_to()
   }
 }
 
-static gboolean _filmroll_clicked(GtkWidget *widget, GdkEventButton *event, gpointer null)
+static gboolean _row_tooltip_setup(GtkWidget *view, gint x, gint y, gboolean kb_mode,
+      GtkTooltip* tooltip, dt_lib_module_t *self)
+{
+  gboolean res = FALSE;
+  GtkTreePath *path = NULL;
+  GtkTreeViewColumn *column = NULL;
+  // Get view path mouse position
+  if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), x, y, &path, &column, NULL, NULL))
+  {
+    gint x_offset = gtk_tree_view_column_get_x_offset(column);
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
+    GtkTreeIter iter;
+    if (gtk_tree_model_get_iter(model, &iter, path))
+    {
+      char *value = NULL;
+      if(x_offset > 0)
+      {
+        char *text = NULL;
+        gtk_tree_model_get(model, &iter, DT_METADATA_COL_VALUE, &value,
+                                         DT_METADATA_COL_TOOLTIP, &text, -1);
+        if(text)
+        {
+          g_free(value);
+          value = text;
+        }
+        if(value && value[0] != '-')
+        {
+          gtk_tooltip_set_text(tooltip, value);
+          res = TRUE;
+        }
+      }
+      else
+      {
+        gtk_tree_model_get(model, &iter, DT_METADATA_COL_NAME_L, &value, -1);
+        gtk_tooltip_set_text(tooltip, value);
+        res = TRUE;
+      }
+      g_free(value);
+    }
+  }
+  gtk_tree_path_free(path);
+
+  return res;
+}
+
+static gboolean _filmroll_clicked(GtkWidget *view, GdkEventButton *event, gpointer null)
 {
   if(event->type != GDK_2BUTTON_PRESS) return FALSE;
-  _jump_to();
-  return TRUE;
+  GtkTreePath *path = NULL;
+  // Get view path for row that was clicked
+  if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), (gint)event->x, (gint)event->y,
+                                   &path, NULL, NULL, NULL))
+  {
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
+    GtkTreeIter iter;
+    if(gtk_tree_model_get_iter(model, &iter, path))
+    {
+      char *name = NULL;
+      gtk_tree_model_get(model, &iter,
+                         DT_METADATA_COL_NAME, &name, -1);
+      if(name && !g_strcmp0(name, _get_label(md_internal_filmroll)))
+      {
+        g_free(name);
+        _jump_to();
+        return TRUE;
+      }
+      g_free(name);
+    }
+  }
+  return FALSE;
 }
 
 static gboolean _jump_to_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -791,46 +921,320 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_lib(self, "jump to film roll", closure);
 }
 
+static char *_get_current_configuration(dt_lib_module_t *self)
+{
+  dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
+  char *pref = NULL;
+  GtkTreeIter iter;
+  gboolean valid = gtk_tree_model_get_iter_first(d->sort_model, &iter);
+  while(valid)
+  {
+    int index = 0;
+    char *name = NULL;
+    gboolean visible = TRUE;
+    gtk_tree_model_get(d->sort_model, &iter,
+                       DT_METADATA_COL_INDEX, &index,
+                       DT_METADATA_COL_NAME_L, &name,
+                       DT_METADATA_COL_VISIBLE, &visible,
+                       -1);
+    if(_is_metadata_ui(index))
+      pref = dt_util_dstrcat(pref, "%s%s,", visible ? "" : "|", name);
+    g_free(name);
+    valid = gtk_tree_model_iter_next(d->sort_model, &iter);
+  }
+  if(pref)
+  {
+    pref[strlen(pref) - 1] = '\0';
+  }
+  return pref;
+}
+
+static void _apply_preferences(const char *pref, dt_lib_module_t *self)
+{
+  if(!pref || !pref[0]) return;
+  dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
+  g_object_ref(d->filter_model);
+  gtk_tree_view_set_model(GTK_TREE_VIEW(d->view), NULL);
+  GList *prefs = dt_util_str_to_glist(",", pref);
+  int k = 0;
+  for(GList *meta = prefs; meta; meta = g_list_next(meta))
+  {
+    const char *name = (char *)meta->data;
+    gboolean visible = TRUE;
+    if(name)
+    {
+      if(name[0] == '|')
+      {
+        name++;
+        visible = FALSE;
+      }
+      GtkTreeIter iter;
+      gboolean valid = gtk_tree_model_get_iter_first(d->model, &iter);
+      while(valid)
+      {
+        char *text = NULL;
+        gtk_tree_model_get(d->model, &iter, DT_METADATA_COL_NAME, &text, -1);
+        if(name && !g_strcmp0(name, text))
+        {
+          gtk_list_store_set(GTK_LIST_STORE(d->model), &iter,
+                                            DT_METADATA_COL_ORDER, k,
+                                            DT_METADATA_COL_VISIBLE, visible,
+                                            -1);
+          g_free(text);
+          break;
+        }
+        g_free(text);
+        valid = gtk_tree_model_iter_next(d->model, &iter);
+      }
+    }
+    else continue;
+    k++;
+  }
+  g_list_free_full(prefs, g_free);
+  gtk_tree_view_set_model(GTK_TREE_VIEW(d->view), d->filter_model);
+  g_object_unref(d->filter_model);
+}
+
+static void _save_preferences(dt_lib_module_t *self)
+{
+  char *pref = _get_current_configuration(self);
+  dt_conf_set_string("plugins/lighttable/metadata_view/visible", pref);
+  g_free(pref);
+}
+
+static void _select_toggled_callback(GtkCellRendererToggle *cell_renderer, gchar *path_str, gpointer user_data)
+{
+  GtkListStore *store = (GtkListStore *)user_data;
+  GtkTreeIter iter;
+  GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+  gboolean selected;
+
+  gtk_tree_model_get_iter(GTK_TREE_MODEL(store), &iter, path);
+  gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, DT_METADATA_PREF_COL_VISIBLE, &selected, -1);
+  gtk_list_store_set(store, &iter, DT_METADATA_PREF_COL_VISIBLE, !selected, -1);
+
+  gtk_tree_path_free(path);
+}
+
+static void _drag_data_inserted(GtkTreeModel *tree_model, GtkTreePath *path, GtkTreeIter *iter, gpointer user_data)
+{
+  _dndactive = TRUE;
+}
+
+void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
+{
+  dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
+
+  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("metadata settings"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
+                                       _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_YES, NULL);
+  GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+
+  GtkWidget *w = gtk_scrolled_window_new(NULL, NULL);
+  gtk_widget_set_size_request(w, -1, DT_PIXEL_APPLY_DPI(300));
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(w), GTK_POLICY_NEVER, GTK_POLICY_ALWAYS);
+  gtk_scrolled_window_set_overlay_scrolling(GTK_SCROLLED_WINDOW(w), FALSE);
+  gtk_box_pack_start(GTK_BOX(area), w, TRUE, TRUE, 0);
+
+  GtkListStore *store = gtk_list_store_new(DT_METADATA_PREF_NUM_COLS,
+                                           G_TYPE_INT, G_TYPE_STRING, G_TYPE_BOOLEAN);
+  GtkTreeModel *model = GTK_TREE_MODEL(store);
+
+  {
+    GtkTreeIter sort_iter;
+    gboolean valid = gtk_tree_model_get_iter_first(d->sort_model, &sort_iter);
+    while(valid)
+    {
+      GtkTreeIter iter;
+      int index;
+      gboolean visible;
+      char *name = NULL;
+      gtk_tree_model_get(d->sort_model, &sort_iter,
+                         DT_METADATA_COL_INDEX, &index,
+                         DT_METADATA_COL_NAME_L, &name,
+                         DT_METADATA_COL_VISIBLE, &visible,
+                         -1);
+      if(!_is_metadata_ui(index))
+        continue;
+      gtk_list_store_append(store, &iter);
+      gtk_list_store_set(store, &iter,
+                         DT_METADATA_PREF_COL_INDEX, index,
+                         DT_METADATA_PREF_COL_NAME_L, name,
+                         DT_METADATA_PREF_COL_VISIBLE, visible,
+                         -1);
+      g_free(name);
+      valid = gtk_tree_model_iter_next(d->sort_model, &sort_iter);
+    }
+  }
+
+  GtkWidget *view = gtk_tree_view_new_with_model(model);
+  g_object_unref(model);
+  GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("metadata"), renderer,
+                                                    "text", DT_METADATA_PREF_COL_NAME_L, NULL);
+  gtk_tree_view_column_set_expand(column, TRUE);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
+  GtkWidget *header = gtk_tree_view_column_get_button(column);
+  gtk_widget_set_tooltip_text(header,
+                _("drag and drop one row at a time until you get the desired order"
+                "\nuntick to hide metadata which are not of interest for you"
+                "\nif different settings are needed, use presets"));
+  renderer = gtk_cell_renderer_toggle_new();
+  g_signal_connect(renderer, "toggled", G_CALLBACK(_select_toggled_callback), store);
+  column = gtk_tree_view_column_new_with_attributes(_("visible"), renderer,
+                                                    "active", DT_METADATA_PREF_COL_VISIBLE, NULL);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
+
+  // drag & drop
+  gtk_tree_view_set_reorderable(GTK_TREE_VIEW(view), TRUE);
+  g_signal_connect(G_OBJECT(model), "row-inserted", G_CALLBACK(_drag_data_inserted), NULL);
+
+  gtk_container_add(GTK_CONTAINER(w), view);
+
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(dialog);
+#endif
+  gtk_widget_show_all(dialog);
+
+  int i = 0;
+  if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_YES)
+  {
+    g_object_ref(d->filter_model);
+    gtk_tree_view_set_model(GTK_TREE_VIEW(d->view), NULL);
+    GtkTreeIter iter;
+    gboolean valid = gtk_tree_model_get_iter_first(model, &iter);
+    while(valid)
+    {
+      gboolean visible;
+      uint32_t index;
+      gtk_tree_model_get(model, &iter,
+                         DT_METADATA_PREF_COL_INDEX, &index,
+                         DT_METADATA_PREF_COL_VISIBLE, &visible,
+                         -1);
+      GtkTreeIter mv_iter;
+      _get_index_iter(index , d->model, &mv_iter);
+
+      gtk_list_store_set(GTK_LIST_STORE(d->model), &mv_iter,
+                         DT_METADATA_COL_ORDER, i,
+                         DT_METADATA_COL_VISIBLE, visible,
+                         -1);
+      valid = gtk_tree_model_iter_next(model, &iter);
+      i++;
+    }
+    gtk_tree_view_set_model(GTK_TREE_VIEW(d->view), d->filter_model);
+    g_object_unref(d->filter_model);
+    _save_preferences(self);
+  }
+  gtk_widget_destroy(dialog);
+}
+
+void set_preferences(void *menu, dt_lib_module_t *self)
+{
+  GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
+  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
+}
+
+void init_presets(dt_lib_module_t *self)
+{
+}
+
+void *get_params(dt_lib_module_t *self, int *size)
+{
+  *size = 0;
+  char *params = _get_current_configuration(self);
+  if(params)
+    *size =strlen(params) + 1;
+  return params;
+}
+
+int set_params(dt_lib_module_t *self, const void *params, int size)
+{
+  if(!params) return 1;
+
+  _apply_preferences(params, self);
+  _save_preferences(self);
+  return 0;
+}
+
+static void _set_ellipsize(GtkTreeViewColumn *col, GtkCellRenderer *renderer,
+                           GtkTreeModel *model, GtkTreeIter *iter, gpointer data)
+{
+  int i;
+  gtk_tree_model_get(model, iter, DT_METADATA_COL_INDEX, &i, -1);
+  const int ellipsize = i == md_exif_model || i == md_exif_lens || i == md_exif_maker
+                        ? PANGO_ELLIPSIZE_END
+                        : PANGO_ELLIPSIZE_MIDDLE;
+  g_object_set(renderer, "ellipsize", ellipsize, NULL);
+}
+
 void gui_init(dt_lib_module_t *self)
 {
-  /* initialize ui widgets */
+  /* initialize ui */
   dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)g_malloc0(sizeof(dt_lib_metadata_view_t));
   self->data = (void *)d;
-  _lib_metatdata_view_init_labels();
 
-  GtkWidget *child_grid_window = gtk_grid_new();
+  GtkListStore *store = gtk_list_store_new(DT_METADATA_NUM_COLS,
+                                           G_TYPE_INT,      // index
+                                           G_TYPE_STRING,  // name
+                                           G_TYPE_STRING,  // displayed name
+                                           G_TYPE_STRING,  // tooltip
+                                           G_TYPE_STRING,  // value
+                                           G_TYPE_BOOLEAN, // visibility
+                                           G_TYPE_INT      // order
+                                           );
+  d->model = GTK_TREE_MODEL(store);
 
-  self->widget = dt_ui_scroll_wrap(child_grid_window, 200, "plugins/lighttable/metadata_view/windowheight");
+  _lib_metadata_view_init_labels(d->model);
+
+  GtkTreeModel *sort_model = gtk_tree_model_sort_new_with_model(d->model);
+  d->sort_model = sort_model;
+
+  gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(sort_model),
+                                      DT_METADATA_COL_ORDER,
+                                      GTK_SORT_ASCENDING);
+  GtkTreeModel *filter_model = gtk_tree_model_filter_new(sort_model, NULL);
+  d->filter_model = filter_model;
+  gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(filter_model),
+                                           DT_METADATA_COL_VISIBLE);
+
+  GtkWidget *view = gtk_tree_view_new_with_model(GTK_TREE_MODEL(filter_model));
+  d->view = view;
+  gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(view), FALSE);
+  g_object_unref(filter_model);
+
+  // metadata column
+  GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("name"), renderer,
+                                        "text", DT_METADATA_COL_NAME_L, NULL);
+  g_object_set(renderer, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
+  gtk_tree_view_column_set_expand(column, TRUE);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
+
+  // value column
+  renderer = gtk_cell_renderer_text_new();
+  g_object_set(renderer, "xalign", 0.0, NULL);
+  // FIXME
+  //  gtk_widget_set_name(GTK_WIDGET(d->metadata[k]), "brightbg");
+  column = gtk_tree_view_column_new_with_attributes(_("value"), renderer,
+                                        "text", DT_METADATA_COL_VALUE, NULL);
+  gtk_tree_view_column_set_expand(column, TRUE);
+  gtk_tree_view_column_set_cell_data_func(column, renderer, _set_ellipsize, self, NULL);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
+
+  // film roll jump to:
+  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(_filmroll_clicked), NULL);
+
+  g_object_set(G_OBJECT(view), "has-tooltip", TRUE, NULL);
+  g_signal_connect(G_OBJECT(view), "query-tooltip", G_CALLBACK(_row_tooltip_setup), self);
+
+  self->widget = dt_ui_scroll_wrap(view, 100, "plugins/lighttable/metadata_view/windowheight");
 
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
-  gtk_grid_set_column_spacing(GTK_GRID(child_grid_window), DT_PIXEL_APPLY_DPI(5));
 
-  /* initialize the metadata name/value labels */
-  for(int k = 0; k < md_size; k++)
-  {
-    d->name[k] = GTK_LABEL(gtk_label_new(_md_labels[k]));;
-    gtk_widget_set_halign(GTK_WIDGET(d->name[k]), GTK_ALIGN_START);
-    gtk_label_set_xalign (d->name[k], 0.0f);
-    gtk_label_set_ellipsize(d->name[k], PANGO_ELLIPSIZE_END);
-    gtk_widget_set_tooltip_text(GTK_WIDGET(d->name[k]), _md_labels[k]);
-
-    d->metadata[k] = GTK_LABEL(gtk_label_new("-"));
-    gtk_widget_set_name(GTK_WIDGET(d->metadata[k]), "brightbg");
-    gtk_label_set_selectable(d->metadata[k], TRUE);
-    gtk_widget_set_halign(GTK_WIDGET(d->metadata[k]), GTK_ALIGN_FILL);
-    gtk_label_set_xalign (d->metadata[k], 0.0f);
-    gtk_label_set_ellipsize(GTK_LABEL(d->metadata[k]),
-                            k == md_exif_model || k == md_exif_lens || k == md_exif_maker
-                            ? PANGO_ELLIPSIZE_END : PANGO_ELLIPSIZE_MIDDLE);
-    if(k == md_internal_filmroll)
-    {
-      // film roll jump to:
-      g_signal_connect(G_OBJECT(GTK_WIDGET(d->metadata[k])), "button-press-event", G_CALLBACK(_filmroll_clicked), NULL);
-    }
-
-    gtk_grid_attach(GTK_GRID(child_grid_window), GTK_WIDGET(d->name[k]), 0, k, 1, 1);
-    gtk_grid_attach(GTK_GRID(child_grid_window), GTK_WIDGET(d->metadata[k]), 1, k, 1, 1);
-  }
+  char *pref = dt_conf_get_string("plugins/lighttable/metadata_view/visible");
+  _apply_preferences(pref, self);
+  g_free(pref);
 
   /* lets signup for mouse over image change signals */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
@@ -861,20 +1265,39 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
+void gui_reset(dt_lib_module_t *self)
+{
+  dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
+  GtkTreeIter iter;
+  gboolean valid = gtk_tree_model_get_iter_first(d->model, &iter);
+  int i = 0;
+  while(valid)
+  {
+    gtk_list_store_set(GTK_LIST_STORE(d->model), &iter,
+                       DT_METADATA_COL_ORDER, i,
+                       DT_METADATA_COL_VISIBLE, TRUE,
+                       -1);
+    valid = gtk_tree_model_iter_next(d->model, &iter);
+    i++;
+  }
+  _save_preferences(self);
+}
+
 #ifdef USE_LUA
-static int lua_update_widgets(lua_State*L)
+static int lua_update_values(lua_State*L)
 {
   dt_lib_module_t *self = lua_touserdata(L, 1);
+  dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
   dt_lua_module_entry_push(L,"lib",self->plugin_name);
   lua_getuservalue(L,2);
   lua_getfield(L,3,"values");
-  lua_getfield(L,3,"widgets");
+  lua_getfield(L,3,"indexes");
   lua_pushnil(L);
   while(lua_next(L, 4) != 0)
   {
     lua_getfield(L,5,lua_tostring(L,-2));
-    GtkLabel *widget = lua_touserdata(L,-1);
-    _metadata_update_value(widget,luaL_checkstring(L,7));
+    int index = lua_tointeger(L,-1);
+    _metadata_update_value(index,luaL_checkstring(L,7),d->model);
     lua_pop(L,2);
   }
   return 0;
@@ -898,7 +1321,7 @@ static int lua_update_metadata(lua_State*L)
     lua_settable(L,6);
     lua_pop(L, 2);
   }
-  lua_pushcfunction(L,lua_update_widgets);
+  lua_pushcfunction(L,lua_update_values);
   dt_lua_gtk_wrap(L);
   lua_pushlightuserdata(L,self);
   lua_call(L,1,0);
@@ -927,30 +1350,39 @@ static int lua_register_info(lua_State *L)
     lua_pop(L,1);
   }
   {
-    GtkLabel *name = GTK_LABEL(gtk_label_new(key));
-    GtkLabel *value = GTK_LABEL(gtk_label_new("-"));
-    gtk_widget_set_name(GTK_WIDGET(value), "brightbg");
-    gtk_label_set_selectable(value, TRUE);
-    gtk_widget_set_halign(GTK_WIDGET(name), GTK_ALIGN_START);
-    gtk_widget_set_halign(GTK_WIDGET(value), GTK_ALIGN_FILL);
-    gtk_label_set_xalign (value, 0.0f);
-    gtk_grid_attach_next_to(GTK_GRID(self->widget), GTK_WIDGET(name), NULL, GTK_POS_BOTTOM, 1, 1);
-    gtk_grid_attach_next_to(GTK_GRID(self->widget), GTK_WIDGET(value), GTK_WIDGET(name), GTK_POS_RIGHT, 1, 1);
-    gtk_widget_show_all(self->widget);
+    GtkTreeIter iter;
+    dt_lib_metadata_view_t *d = (dt_lib_metadata_view_t *)self->data;
+    gtk_list_store_append(GTK_LIST_STORE(d->model), &iter);
+    // get the row index
+    GtkTreePath *path = gtk_tree_model_get_path(d->model, &iter);
+    gint *i = gtk_tree_path_get_indices(path);
+    const int index = i[0];
+    gtk_tree_path_free(path);
+    gtk_list_store_set(GTK_LIST_STORE(d->model), &iter,
+                       DT_METADATA_COL_INDEX, index,
+                       DT_METADATA_COL_NAME, key,
+                       DT_METADATA_COL_NAME_L, key,
+                       DT_METADATA_COL_VALUE, "-",
+                       DT_METADATA_COL_VISIBLE, TRUE,
+                       DT_METADATA_COL_ORDER, index,
+                       -1);
     {
-      lua_getfield(L,-1,"widgets");
+      lua_getfield(L,-1,"indexes");
       lua_pushstring(L,key);
-      lua_pushlightuserdata(L,value);
+      lua_pushinteger(L,index);
       lua_settable(L,5);
       lua_pop(L,1);
     }
+    // apply again preferences because it's already done
+    char *pref = dt_conf_get_string("plugins/lighttable/metadata_view/visible");
+    _apply_preferences(pref, self);
+    g_free(pref);
   }
   return 0;
 }
 
 void init(struct dt_lib_module_t *self)
 {
-
   lua_State *L = darktable.lua_state.state;
   int my_type = dt_lua_module_entry_get_type(L, "lib", self->plugin_name);
   lua_pushlightuserdata(L, self);
@@ -966,7 +1398,7 @@ void init(struct dt_lib_module_t *self)
   lua_newtable(L);
   lua_setfield(L,-2,"values");
   lua_newtable(L);
-  lua_setfield(L,-2,"widgets");
+  lua_setfield(L,-2,"indexes");
   lua_pop(L,2);
 }
 #endif


### PR DESCRIPTION
Do not solve #7050 but could contribute as suggested [here](https://github.com/darktable-org/darktable/issues/7050#issuecomment-743407679)

Fixes #5609

Introduce the set_preferences() routine for plugin. When exists add an entry at the bottom of the presets menu.
Apply this to metadata editor.
![image](https://user-images.githubusercontent.com/23012047/101995471-d0315b80-3ca8-11eb-87e6-37139ee83c93.png)


Use it to select and hide the metadata_view information one is not interested in.
![image](https://user-images.githubusercontent.com/23012047/101995699-db858680-3caa-11eb-9710-a57c38f87924.png)


@Nilvus. You may want to give advices / instructions to ensure a consistent look / behavior for these popups. 
