### PR TITLE
[tags] fix missing check for null

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1689,8 +1689,8 @@ char *dt_tag_get_subtags(const gint imgid, const char *category, const int level
       // check we have not yet this subtag in the list
       if(tags && strlen(tags) >= strlen(subtag) + 1)
       {
-        char *found = g_strstr_len(tags, strlen(tags), subtag);
-        if(found[strlen(subtag)] == ',')
+        gchar *found = g_strstr_len(tags, strlen(tags), subtag);
+        if(found && found[strlen(subtag)] == ',')
           valid = FALSE;
       }
       if(valid)


### PR DESCRIPTION
in tags.c we've checked whether last char of found subtag was comma
but we didn't check if we actually found the subtag.

this adds missing non-null check.

This was mentioned by parafin here: https://github.com/darktable-org/darktable/pull/6769#issuecomment-744023860