### PR TITLE
fix memory leaks

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -652,9 +652,13 @@ void dt_bauhaus_init()
 void dt_bauhaus_cleanup()
 {
   // TODO: destroy popup window and resources
-  // TODO: destroy keymap hash table!
   g_list_free_full(darktable.bauhaus->key_mod, (GDestroyNotify)g_free);
   g_list_free_full(darktable.bauhaus->key_val, (GDestroyNotify)g_free);
+  if(darktable.bauhaus->keymap)
+  {
+    g_hash_table_destroy(darktable.bauhaus->keymap);
+    darktable.bauhaus->keymap = NULL;
+  }
 }
 
 // fwd declare a few callbacks
@@ -925,6 +929,8 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, co
         darktable.bauhaus->key_val
             = g_list_insert_sorted(darktable.bauhaus->key_val, g_strdup(path), (GCompareFunc)strcmp);
       }
+      else
+        g_free(mod);
     }
     // might free an old path
     g_hash_table_replace(darktable.bauhaus->keymap, path, w);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1327,6 +1327,12 @@ void dt_cleanup()
     dt_bauhaus_cleanup();
   }
 
+  if (darktable.noiseprofile_parser)
+  {
+    g_object_unref(darktable.noiseprofile_parser);
+    darktable.noiseprofile_parser = NULL;
+  }
+
   dt_capabilities_cleanup();
 
   for (int k=0; k<DT_IMAGE_DBLOCKS; k++)


### PR DESCRIPTION
bauhaus.c: free duplicated string if not actually used
improved cleanup on exit: free keymap and noiseprofile_parser

These were the low-hanging fruit in a lengthy list of leaks produced by Valgrind.