### PR TITLE
fix false positive warning for CAT applied twice

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1225,8 +1225,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // reference illuminant is hard-set D50 for darktable's pipeline
   // test illuminant is user params
   d->p = powf(0.818155f / d->illuminant[2], 0.0834f);
-
-  declare_cat_on_pipe(self, FALSE);
 }
 
 
@@ -2031,6 +2029,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     update_G_colors(self);
     update_B_colors(self);
   }
+
+  declare_cat_on_pipe(self, FALSE);
 
   if(self->enabled && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB))
   {

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1116,7 +1116,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       break;
     }
   }
-  declare_cat_on_pipe(self, FALSE);
 }
 
 static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -748,6 +748,12 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
   // stop crazy users from sleeping on key-repeat spacebar:
   if(dev->image_loading) return;
 
+  // Pipe reset needed when changing image
+  // FIXME: synch with dev_init() and dev_cleanup() instead of redoing it
+  dev->proxy.chroma_adaptation = NULL;
+  dev->proxy.wb_is_D65 = TRUE;
+  dev->proxy.wb_coeffs[0] = 0.f;
+
   // change active image
   g_slist_free(darktable.view_manager->active_images);
   darktable.view_manager->active_images = NULL;


### PR DESCRIPTION
reset the pipe flags when image is changed