### PR TITLE
CMake/compilers : stop compiler on first error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -704,7 +704,7 @@ include_directories(SYSTEM ${Pugixml_INCLUDE_DIRS})
 list(APPEND LIBS ${Pugixml_LIBRARIES})
 
 if(NOT SOURCE_PACKAGE)
-  add_definitions(-Werror)
+  add_definitions(-Werror -Wfatal-errors )
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
This prevent the compiler to carry on after the first fatal error is encountered. It avoids developers to go through pages of errors to find the original one.