### PR TITLE
enhancement of thumb resizing (lt/culling/preview)

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -411,8 +411,12 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table, float val, double posx, do
       // we center the zoom around cursor position
       if(posx >= 0.0f && posy >= 0.0f)
       {
-        const int iw = gtk_widget_get_allocated_width(th->w_image_box);
-        const int ih = gtk_widget_get_allocated_height(th->w_image_box);
+        const int iw = gtk_widget_get_allocated_width(th->w_image);
+        const int ih = gtk_widget_get_allocated_height(th->w_image);
+        // we take in account that the image may be smaller that the imagebox
+        posx -= (gtk_widget_get_allocated_width(th->w_image_box) - iw) / 2;
+        posy -= (gtk_widget_get_allocated_height(th->w_image_box) - ih) / 2;
+        // we change the value and samitize them
         th->zoomx = fmaxf(iw - th->img_width * z_ratio, fminf(0.0f, posx - (posx - th->zoomx) * z_ratio));
         th->zoomy = fmaxf(ih - th->img_height * z_ratio, fminf(0.0f, posy - (posy - th->zoomy) * z_ratio));
       }
@@ -619,7 +623,7 @@ static gboolean _event_motion_notify(GtkWidget *widget, GdkEventMotion *event, g
       dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
       int iw = 0;
       int ih = 0;
-      gtk_widget_get_size_request(th->w_image_box, &iw, &ih);
+      gtk_widget_get_size_request(th->w_image, &iw, &ih);
       const int mindx = iw * darktable.gui->ppd_thb - th->img_width;
       const int mindy = ih * darktable.gui->ppd_thb - th->img_height;
       if(th->zoomx > 0) th->zoomx = 0;
@@ -1131,7 +1135,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     else
     {
       // we create a completly new thumb
-      dt_thumbnail_t *thumb = dt_thumbnail_new(10, 10, nid, nrow, table->overlays, TRUE, table->show_tooltips);
+      dt_thumbnail_t *thumb = dt_thumbnail_new(40, 40, nid, nrow, table->overlays, TRUE, table->show_tooltips);
       thumb->display_focus = table->focus;
       thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
       double aspect_ratio = sqlite3_column_double(stmt, 2);

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -61,8 +61,8 @@ typedef struct dt_culling_t
   gboolean select_desactivate;
 
   gboolean panning;      // are we moving zoomed images ?
-  int pan_x;             // last position during panning
-  int pan_y;             //
+  double pan_x;          // last position during panning
+  double pan_y;          //
   gboolean mouse_inside; // is the mouse inside culling center view ?
 
   gboolean focus; // do we show focus rectangles on images ?

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -125,10 +125,8 @@ typedef struct
 
   // difference between the global zoom values and the value to apply to this specific thumbnail
   float zoom;     // zoom value. 1.0 is "image to fit" (the initial value)
-  int zoomx;      // zoom panning of the image
-  int zoomy;      //
-  int current_zx; // zoom panning currently applied on the image
-  int current_zy; // can differ from zoomx if image is not loaded on first try
+  double zoomx;   // zoom panning of the image
+  double zoomy;   //
 
   float zoom_100; // max zoom value (image 100%)
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -262,7 +262,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
   }
 
   // if not cached, load or reload a mipmap
-  int res = 0;
+  dt_view_surface_value_t res = DT_VIEW_SURFACE_OK;
   if(d->preview_id != d->imgid || d->preview_zoom != nz * zoom_ratio || !d->preview_surf
      || d->preview_width != width || d->preview_height != height)
   {
@@ -271,7 +271,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
 
     res = dt_view_image_get_surface(d->imgid, img_wd * nz, img_ht * nz, &d->preview_surf, TRUE);
 
-    if(!res)
+    if(res == DT_VIEW_SURFACE_OK)
     {
       d->preview_id = d->imgid;
       d->preview_zoom = nz * zoom_ratio; //  only to check validity of mipmap cache size
@@ -342,7 +342,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     cairo_restore(cri);
   }
 
-  if(res)
+  if(res != DT_VIEW_SURFACE_OK)
   {
     if(!d->busy)
     {

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -234,8 +234,8 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr, int32_t width, int32
   cairo_fill (cr);
 
   cairo_surface_t *surf = NULL;
-  const int res = dt_view_image_get_surface(prt->image_id, iwidth, iheight, &surf, TRUE);
-  if(res)
+  const dt_view_surface_value_t res = dt_view_image_get_surface(prt->image_id, iwidth, iheight, &surf, TRUE);
+  if(res != DT_VIEW_SURFACE_OK)
   {
     // if the image is missing, we reload it again
     g_timeout_add(250, _expose_again, NULL);

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -334,9 +334,9 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
   {
     // FIXME: every time the mouse moves over the center view this redraws, which isn't necessary
     cairo_surface_t *surf = NULL;
-    const int res = dt_view_image_get_surface(lib->image_id, width - (MARGIN * 2.0f), height - (MARGIN * 2.0f),
-                                              &surf, FALSE);
-    if(res)
+    const dt_view_surface_value_t res = dt_view_image_get_surface(lib->image_id, width - (MARGIN * 2.0f),
+                                                                  height - (MARGIN * 2.0f), &surf, FALSE);
+    if(res != DT_VIEW_SURFACE_OK)
     {
       // if the image is missing, we reload it again
       g_timeout_add(250, _expose_again, NULL);

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -102,6 +102,14 @@ typedef enum dt_mouse_action_type_t
   DT_MOUSE_ACTION_RIGHT_DRAG
 } dt_mouse_action_type_t;
 
+// flags that a view can set in flags()
+typedef enum dt_view_surface_value_t
+{
+  DT_VIEW_SURFACE_OK = 0,
+  DT_VIEW_SURFACE_KO,
+  DT_VIEW_SURFACE_SMALLER
+} dt_view_surface_value_t;
+
 typedef struct dt_mouse_action_t
 {
   GtkAccelKey key;
@@ -196,8 +204,9 @@ int dt_view_get_image_to_act_on();
 
 /** returns an uppercase string of file extension **plus** some flag information **/
 char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const gboolean is_bw, const gboolean is_bw_flow);
-/** expose an image and return a cairi_surface. return != 0 if thumbnail wasn't loaded yet. */
-int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface, const gboolean quality);
+/** expose an image and return a cair0_surface. */
+dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface,
+                                                  const gboolean quality);
 
 
 /** Set the selection bit to a given value for the specified image */


### PR DESCRIPTION
This provide a nicer user experience with thumb (re) loading : 
- on first load, the thumb is not moved anymore from top-left corner, but appear at the right place directly
- when changing the thumb size, if needed, the previous thumb is shown scaled until the "right" size is loaded. This for "regular" thumbs as well as for zoomable ones (culling/preview) This avoid lot of flickering effect and avoid the impression of "stuck" resizing, esp. when zooming in preview or culling. Entering culling or preview also show immediately something (a rescaled image, but something anyway)
- when panning slowly on a zoomed preview or culling image, the image now follow exactly the mouse pointer.
- fix problem on centering zoom in preview if the image originally doesn't fill all of the area
- some refactoring, cleanup and comments in the code

This is a lot in 'almost' one simple commits, but all this things where nested together...
I've done quite some test, but considering the amount of cases, it wouldn't surprise me if some small glitches appears...