### PR TITLE
Link to dtdocs repository in release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,8 @@ you are strongly advised to take a backup first.
   release. Note that this user manual is also the last version as a
   new project has taken over the lead on this. The goal is to have
   an up-to-date user manual by using a simpler format
-  to write text for contributors.
+  to write text for contributors. Feedback or contributions for the 
+  new format are welcome at https://github.com/darktable-org/dtdocs.
 
   Current manual (multilingual):
 


### PR DESCRIPTION
Since the documentation was overhauled significantly, with one of the goals making it easier to keep updated, I think it is a good idea to link to the new repository in the release notes. It is already on the docs main page, but adding it here may help making people aware that their input is appreciated.