### PR TITLE
duplicate : disable preview for zoom >= 200%

### DIFF
--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -258,6 +258,12 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     const float min_scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1 << closeup, 0);
     const float cur_scale = dt_dev_get_zoom_scale(dev, zoom, 1 << closeup, 0);
+    // if cur_scale is >=2.0f (200%) we disable preview as it can hit cairo size limits without warnings
+    if(cur_scale >= 2.0f)
+    {
+      dt_control_log(_("preview is only possible for zoom lower than 200%%..."));
+      return;
+    }
     nz = cur_scale / min_scale;
   }
 


### PR DESCRIPTION
this fix #7340

Not the ideal fix as it disable preview completely, but I think we are hitting here cairo limitations : 
if you replace the lines in duplicate.c around line 300
```
wd = dev->pipe->output_backbuf_width / darktable.gui->ppd;
ht = dev->pipe->output_backbuf_height / darktable.gui->ppd;
```

by something like : 
```
if (cur_scale <= 2.0f)
{
  wd = dev->pipe->output_backbuf_width / darktable.gui->ppd;
  ht = dev->pipe->output_backbuf_height / darktable.gui->ppd;
}
else
{
  wd = dev->pipe->output_backbuf_width * cur_scale / darktable.gui->ppd;
  ht = dev->pipe->output_backbuf_height * cur_scale / darktable.gui->ppd;
}
```
it *seems* to work well... until you hit a size limit :( here, with a regular image, I hit limit at 800%, but if I try with pano, even at 200%, I get a grey screen, without any suspect cpu or RAM usage...
I *think* that cairo silently fail after a certain size, and I've not found in the docs any data about this limits, so I've preferred to avoid other weird issues and disable it for zoom >= 2.0 (before, there's not such scaling needed, so it's safer)