### PR TITLE
add a new colorbalancergb module

### DIFF
--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -32,18 +32,6 @@ typedef enum dt_adaptation_t
 } dt_adaptation_t;
 
 
-#ifdef _OPENMP
-#pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
-#endif
-static inline void dot_product(const float v_in[4], const float M[3][4], float v_out[4])
-{
-  // specialized 3×3 dot products of 4×1 RGB-alpha pixels
-  v_out[0] = M[0][0] * v_in[0] + M[0][1] * v_in[1] + M[0][2] * v_in[2];
-  v_out[1] = M[1][0] * v_in[0] + M[1][1] * v_in[1] + M[1][2] * v_in[2];
-  v_out[2] = M[2][0] * v_in[0] + M[2][1] * v_in[1] + M[2][2] * v_in[2];
-}
-
-
 // modified LMS cone response space for Bradford transform
 // explanation here : https://onlinelibrary.wiley.com/doi/pdf/10.1002/9781119021780.app3
 // but coeffs are wrong in the above, so they come from :

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -891,6 +891,208 @@ static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float 
   XYZ_D65[2] = XYZ[2];
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
+#endif
+static inline void dot_product(const float v_in[4], const float M[3][4], float v_out[4])
+{
+  // specialized 3×4 dot products of 4×1 RGB-alpha pixels
+  for(size_t i = 0; i < 3; ++i)
+  {
+    v_out[i] = 0.f;
+    for(size_t j = 0; j < 3; ++j)
+      v_out[i] += M[i][j] * v_in[j];
+  }
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(LMS, XYZ: 16)
+#endif
+static inline void XYZ_to_LMS(const float XYZ[4], float LMS[4])
+{
+  // Convert CIE 1931 2° XYZ D50 to CIE 2006 LMS D65
+  /* XYZ is white-balanced from D50 to D65 using CAT16 which results in the following matrix :
+  * CAT_to_XYZ * WB * XYZ_to_CAT =
+  * [[  9.80760485e-01,  -4.25541784e-17,  -7.61959005e-19],
+  *  [  4.82934624e-17,   1.01555271e+00,  -7.63213113e-18],
+  *  [ -6.47162968e-19,  -5.69389701e-19,   1.30191586e+00]]
+  *
+  * See chromatic_adaptation.h for the details of the algo and D65/D50 values.
+  *
+  * The XYZ 2° D65 is then converted to CIE 2006 LMS using the approximation by
+  * Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
+  * with even spacing of Munsell colours
+  * https://doi.org/10.2352/issn.2169-2629.2019.27.38
+  * resulting in the following matrix :
+  * XYZ_to_LMS =
+  * [[0.257085, 0.859943, -0.031061],
+  *  [-0.394427, 1.175800, 0.196423],
+  *  [0.064856, -0.076250, 0.559067]]
+  */
+  const float mat[3][4] = { { 0.25213881,  0.87331744, -0.04043881, 0.  },
+                            {-0.38683842,  1.19408687,  0.25572622, 0.  },
+                            { 0.0636082 , -0.07743589,  0.72785819, 0.f } };
+  dot_product(XYZ, mat, LMS);
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(XYZ, LMS: 16)
+#endif
+static inline void LMS_to_XYZ(const float LMS[4], float XYZ[4])
+{
+  // Convert CIE 2006 LMS D65 to CIE 1931 2° XYZ D50 in one step
+  // going through CIE 2006 LMS -> CIE 2° XYZ D65 -> CIE 2° XYZ D50
+
+  /* The following matrix is the inverse of the above*/
+  const float mat[3][4] = { { 1.82871912, -1.30123107,  0.55877659, 0. },
+                            { 0.61270075,  0.38283494, -0.10046468, 0. },
+                            {-0.09462902,  0.1544451 ,  1.31437368, 0. } };
+  dot_product(LMS, mat, XYZ);
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(LMS, RGB: 16)
+#endif
+static inline void gradingRGB_to_LMS(const float RGB[4], float LMS[4])
+{
+  const float mat[3][4] = { { 0.95f, 0.38f, 0.00f, 0.f },
+                            { 0.05f, 0.62f, 0.03f, 0.f },
+                            { 0.00f, 0.00f, 0.97f, 0.f } };
+  dot_product(RGB, mat, LMS);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(LMS, RGB: 16)
+#endif
+static inline void LMS_to_gradingRGB(const float LMS[4], float RGB[4])
+{
+  const float mat[3][4] = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
+                            { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
+                            {         0.f,          0.f,  1.03092784f, 0.f } };
+  dot_product(LMS, mat, RGB);
+}
+
+
+/*
+* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
+* with even spacing of Munsell colours
+* https://doi.org/10.2352/issn.2169-2629.2019.27.38
+* The following takes the paper's direct transform but fixes the reverse transform
+* which is wrong. D65 coordinates are taken from CIE 1931 XYZ 2° and converted to
+* RGB
+*/
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, LMS: 16)
+#endif
+static inline void LMS_to_Ych(const float LMS[4], float Ych[3])
+{
+  Ych[0] = fmaxf(0.68990272f * LMS[0] + 0.34832189f * LMS[1], 0.f);
+  const float a = LMS[0] + LMS[1] + LMS[2];
+
+  float lms[4];
+  for(size_t c = 0; c < 4; c++) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
+
+  float rgb[4] = { 0.f };
+  LMS_to_gradingRGB(lms, rgb);
+  rgb[0] -= 0.18662246f;
+  rgb[1] -= 0.5847461f;
+
+  Ych[1] = hypotf(rgb[1], rgb[0]);
+  Ych[2] = atan2f(rgb[1], rgb[0]);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, LMS: 16)
+#endif
+static inline void Ych_to_LMS(const float Ych[3], float LMS[4])
+{
+  // Ych is offset such that D65 point has c = 0
+  float rgb[4];
+  rgb[0] = fmaxf(Ych[1] * cosf(Ych[2]) + 0.18662246f, 0.f);
+  rgb[1] = fmaxf(Ych[1] * sinf(Ych[2]) + 0.5847461f, 0.f);
+
+  const float sum = rgb[0] + rgb[1];
+  if(fabsf(sum) > 1.f)
+  {
+    rgb[0] /= sum;
+    rgb[1] /= sum;
+  }
+
+  rgb[2] = 1.f - rgb[0] - rgb[1];
+  rgb[3] = 0.f;
+
+  float lms[4] = { 0.f };
+  gradingRGB_to_LMS(rgb, lms);
+  for(size_t c = 0; c < 4; c++) lms[c] = fmaxf(lms[c], 0.f);
+
+  const float a = Ych[0] / (0.68990272f * lms[0] + 0.34832189f * lms[1]);
+  for(size_t c = 0; c < 3; c++) LMS[c] = lms[c] * a;
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(XYZ, RGB: 16)
+#endif
+static inline void XYZ_to_gradingRGB(const float XYZ[4], float RGB[3])
+{
+  // fast path with collapsed matrices to go directly from CIE 1931 2° XYZ D50 to Filmlight grading RGB D65
+  // this should be numerically equivalent to XYZ_to_LMS() followed by LMS_to_gradingRGB()
+  // but saves one matrix product by collapsing the 2 matrices from the above functions
+  const float mat[3][4] = { { 0.53346004f,  0.15226970f , -0.19946283f, 0.f },
+                            {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
+                            { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
+  dot_product(XYZ, mat, RGB);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(XYZ, RGB: 16)
+#endif
+static inline void gradingRGB_to_XYZ(const float RGB[4], float XYZ[3])
+{
+  // inverse of the above
+  const float mat[3][4] = { { 1.67222161f, -0.11185000f,  0.50297636f, 0.f },
+                            { 0.60120746f,  0.47018395f, -0.08596569f, 0.f },
+                            {-0.08217531f,  0.05979694f,  1.27957582f, 0.f } };
+  dot_product(RGB, mat, XYZ);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, RGB: 16)
+#endif
+static inline void gradingRGB_to_Ych(float RGB[4], float Ych[3])
+{
+  Ych[0] = fmaxf(0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2], 0.f);
+  const float a = RGB[0] + RGB[1] + RGB[2];
+  for(size_t c = 0; c < 4; c++) RGB[c] = (a == 0.f) ? 0.f : RGB[c] / a;
+
+  RGB[0] -= 0.18662246f;
+  RGB[1] -= 0.5847461f;
+
+  Ych[1] = hypotf(RGB[1], RGB[0]);
+  Ych[2] = atan2f(RGB[1], RGB[0]);
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, RGB: 16)
+#endif
+static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[3])
+{
+  RGB[0] = Ych[1] * cosf(Ych[2]) + 0.18662246f;
+  RGB[1] = Ych[1] * sinf(Ych[2]) + 0.5847461f;
+  RGB[2] = fmaxf(1.f - RGB[0] - RGB[1], 0.f);
+
+  const float a = Ych[0] / (0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2]);
+  for(size_t c = 0; c < 3; ++c) RGB[c] *= a;
+}
+
+
+
 #undef DT_RESTRICT
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1029,8 +1029,8 @@ static inline void Ych_to_LMS(const float Ych[3], float LMS[4])
   gradingRGB_to_LMS(rgb, lms);
   for(size_t c = 0; c < 4; c++) lms[c] = fmaxf(lms[c], 0.f);
 
-  const float a = Ych[0] / (0.68990272f * lms[0] + 0.34832189f * lms[1]);
-  for(size_t c = 0; c < 3; c++) LMS[c] = lms[c] * a;
+  const float a = 0.68990272f * lms[0] + 0.34832189f * lms[1];
+  for(size_t c = 0; c < 3; c++) LMS[c] = (a == 0.f) ? 0.f : lms[c] * Ych[0] / a;
 }
 
 
@@ -1087,8 +1087,8 @@ static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[3])
   RGB[1] = Ych[1] * sinf(Ych[2]) + 0.5847461f;
   RGB[2] = fmaxf(1.f - RGB[0] - RGB[1], 0.f);
 
-  const float a = Ych[0] / (0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2]);
-  for(size_t c = 0; c < 3; ++c) RGB[c] *= a;
+  const float a = (0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2]);
+  for(size_t c = 0; c < 3; ++c) RGB[c] = (a == 0.f) ? 0.f : RGB[c] * Ych[0] / a;
 }
 
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -114,6 +114,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {31.0f }, "equalizer", 0},
   { {32.0f }, "vibrance", 0},
   { {33.0f }, "colorbalance", 0},
+  { {33.5f }, "colorbalancergb", 0},
   { {34.0f }, "colorize", 0},
   { {35.0f }, "colortransfer", 0},
   { {36.0f }, "colormapping", 0},
@@ -216,6 +217,7 @@ const dt_iop_order_entry_t v30_order[] = {
                                   //    very good in scene-referred workflow
   { {40.0f }, "basicadj", 0},        // module mixing view/model/control at once, usage should be discouraged
   { {41.0f }, "colorbalance", 0},    // scene-referred color manipulation
+  { {41.5f }, "colorbalancergb", 0},    // scene-referred color manipulation
   { {42.0f }, "rgbcurve", 0},        // really versatile way to edit colour in scene-referred and display-referred workflow
   { {43.0f }, "rgblevels", 0},       // same
   { {44.0f }, "basecurve", 0},       // conversion from scene-referred to display referred, reverse-engineered
@@ -660,6 +662,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "nlmeans", "negadoctor");
           _insert_before(iop_order_list, "negadoctor", "channelmixerrgb");
           _insert_before(iop_order_list, "negadoctor", "censorize");
+          _insert_before(iop_order_list, "rgbcurve", "colorbalancergb");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -144,6 +144,7 @@ add_iop(filmicrgb "filmicrgb.c")
 add_iop(negadoctor "negadoctor.c")
 add_iop(channelmixerrgb "channelmixerrgb.c")
 add_iop(censorize "censorize.c")
+add_iop(colorbalancergb "colorbalancergb.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -250,7 +250,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float max_saturation_h = (Y == 0.f) ? 0.f : atan2f(max_chroma_h, Y);
     float C = fminf(Ych[1], max_chroma_h);
     float S = (Y == 0.f) ? 0.f : atan2f(C, Y);
-    const float radius = hypotf(C, Y);
+    const float radius = (Y == 0.f) ? 0.f : hypotf(C, Y);
 
     // Opacities for luma masks
     const float alpha = expf(- Y * d->shadows_weight);         // opacity of shadows
@@ -258,7 +258,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float gamma = expf(-3.0f * (alpha - beta) * (alpha - beta)); // opacity of midtones
     const float alpha_comp = 1.f - alpha;
     const float beta_comp = 1.f - beta;
-    // const float sum_of_masks = alpha + beta + gamma;
+    //const float sum_of_masks = alpha + beta + gamma;
 
     // Saturation : mix of chroma and luminance
     const float boost_shadows_sat = alpha * d->saturation_shadows;
@@ -276,7 +276,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     chroma_boost = fmaxf(chroma_boost, 0.f);
 
     // Repack
-    Ych[0] = fmaxf(radius * cosf(S), 0.f);
+    Ych[0] = radius * fmaxf(cosf(S), 0.f);
     Ych[1] = fminf(chroma_boost * radius * sinf(S), max_chroma_h);
     Ych_to_gradingRGB(Ych, RGB);
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -258,13 +258,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float gamma = expf(-3.0f * (alpha - beta) * (alpha - beta)); // opacity of midtones
     const float alpha_comp = 1.f - alpha;
     const float beta_comp = 1.f - beta;
-    const float sum_of_masks = alpha + beta + gamma;
+    // const float sum_of_masks = alpha + beta + gamma;
 
     // Saturation : mix of chroma and luminance
     const float boost_shadows_sat = alpha * d->saturation_shadows;
     const float boost_highlights_sat = beta * d->saturation_highlights;
     const float boost_midtones_sat = gamma * d->saturation_midtones;
-    const float boost_sat = 1.f + Y * (boost_shadows_sat + boost_midtones_sat + boost_highlights_sat) / sum_of_masks;
+    const float boost_sat = 1.f + Y * (boost_shadows_sat + boost_midtones_sat + boost_highlights_sat);
     S = S * boost_sat + d->saturation_global;
     S = fminf(fmaxf(S, 0.f), max_saturation_h);
 
@@ -272,7 +272,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float boost_shadows_chroma = alpha * d->chroma_shadows;
     const float boost_highlights_chroma = beta * d->chroma_highlights;
     const float boost_midtones_chroma = gamma * d->chroma_midtones;
-    float chroma_boost = 1.f + d->chroma_global + (boost_shadows_chroma + boost_highlights_chroma + boost_midtones_chroma) * max_chroma_h / d->max_chroma / sum_of_masks;
+    float chroma_boost = 1.f + d->chroma_global + (boost_shadows_chroma + boost_highlights_chroma + boost_midtones_chroma) * max_chroma_h / d->max_chroma;
     chroma_boost = fmaxf(chroma_boost, 0.f);
 
     // Repack

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1,0 +1,852 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+// our includes go first:
+#include "bauhaus/bauhaus.h"
+#include "common/exif.h"
+#include "common/colorspaces_inline_conversions.h"
+#include "common/opencl.h"
+#include "develop/blend.h"
+#include "develop/imageop.h"
+#include "develop/imageop_math.h"
+#include "develop/imageop_gui.h"
+#include "dtgtk/gradientslider.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "gui/presets.h"
+#include "gui/color_picker_proxy.h"
+#include "iop/iop_api.h"
+
+//#include <gtk/gtk.h>
+#include <stdlib.h>
+#define LUT_ELEM 360 // gamut LUT number of elements: resolution of 1°
+#define STEPS 72     // so we test 72×72×72 combinations of RGB in [0; 1] to build the gamut LUT
+
+// Filmlight Yrg puts red at 330°, while usual HSL wheels put it at 360/0°
+// so shift in GUI only it to not confuse people. User params are always degrees,
+// pixel params are always radians.
+#define ANGLE_SHIFT -30.f
+#define DEG_TO_RAD(x) ((x + ANGLE_SHIFT) * M_PI / 180.f)
+#define RAD_TO_DEG(x) (x * 180.f / M_PI - ANGLE_SHIFT)
+
+DT_MODULE_INTROSPECTION(1, dt_iop_colorbalancergb_params_t)
+
+
+typedef struct dt_iop_colorbalancergb_params_t
+{
+  float shadows_Y;          // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float shadows_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float shadows_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float midtones_Y;           // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float midtones_C;           // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float midtones_H;           // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float highlights_Y;           // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float highlights_C;           // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float highlights_H;           // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float global_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float global_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float global_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float shadows_weight;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+  float midtones_weight;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+  float highlights_weight; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+  float chroma_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+  float chroma_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float chroma_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
+  float chroma_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+  float saturation_offset; // $MIN: -10.0 $MAX: 10.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation offset"
+  float saturation_factor; // $MIN: -0.5 $MAX: 0.5 $DEFAULT: 0.0 $DESCRIPTION: "saturation factor"
+  float hue_angle;         // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+} dt_iop_colorbalancergb_params_t;
+
+
+typedef struct dt_iop_colorbalancergb_gui_data_t
+{
+  GtkWidget *shadows_H, *midtones_H, *highlights_H, *global_H;
+  GtkWidget *shadows_C, *midtones_C, *highlights_C, *global_C;
+  GtkWidget *shadows_Y, *midtones_Y, *highlights_Y, *global_Y;
+  GtkWidget *shadows_weight, *midtones_weight, *highlights_weight;
+  GtkWidget *chroma_highlights, *chroma_global, *chroma_shadows, *chroma_midtones;
+  GtkWidget *saturation_offset, *saturation_factor, *hue_angle;
+  GtkNotebook *notebook;
+} dt_iop_colorbalancergb_gui_data_t;
+
+typedef struct dt_iop_colorbalancergb_data_t
+{
+  float global[4];
+  float shadows[4];
+  float highlights[4];
+  float midtones[4];
+  float midtones_Y;
+  float chroma_highlights, chroma_global, chroma_shadows, chroma_midtones;
+  float saturation_offset, saturation_factor, hue_angle;
+  float shadows_weight, midtones_weight, highlights_weight;
+  float *gamut_LUT;
+  float max_chroma;
+  gboolean lut_inited;
+  struct dt_iop_order_iccprofile_info_t *work_profile;
+} dt_iop_colorbalancergb_data_t;
+
+/*
+typedef struct dt_iop_colorbalance_global_data_t
+{
+  int kernel_colorbalance;
+  int kernel_colorbalance_cdl;
+  int kernel_colorbalance_lgg;
+} dt_iop_colorbalance_global_data_t;
+*/
+
+const char *name()
+{
+  return _("color balance rgb");
+}
+
+const char *aliases()
+{
+  return _("offset power slope|cdl|color grading|contrast|chroma_highlights|hue");
+}
+
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("affect color, brightness and contrast"),
+                                      _("corrective or creative"),
+                                      _("linear, Lab, scene-referred"),
+                                      _("non-linear, RGB"),
+                                      _("non-linear, Lab, scene-referred"));
+}
+
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+int default_group()
+{
+  return IOP_GROUP_COLOR | IOP_GROUP_GRADING;
+}
+
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_rgb;
+}
+
+/* Custom matrix handling for speed */
+static inline void repack_3x3_to_3xSSE(const float input[9], float output[3][4])
+{
+  // Repack a 3×3 array/matrice into a 3×1 SSE2 vector to enable SSE4/AVX/AVX2 dot products
+  output[0][0] = input[0];
+  output[0][1] = input[1];
+  output[0][2] = input[2];
+  output[0][3] = 0.0f;
+
+  output[1][0] = input[3];
+  output[1][1] = input[4];
+  output[1][2] = input[5];
+  output[1][3] = 0.0f;
+
+  output[2][0] = input[6];
+  output[2][1] = input[7];
+  output[2][2] = input[8];
+  output[2][3] = 0.0f;
+}
+
+
+static void mat3mul(float *dst, const float *const m1, const float *const m2)
+{
+  for(int k = 0; k < 3; ++k)
+  {
+    for(int i = 0; i < 3; ++i)
+    {
+      float x = 0.0f;
+      for(int j = 0; j < 3; j++) x += m1[4 * k + j] * m2[4 * j + i];
+      dst[4 * k + i] = x;
+    }
+  }
+}
+
+
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)piece->data;
+  const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  if(work_profile == NULL) return; // no point
+
+  float DT_ALIGNED_ARRAY RGB_to_XYZ[3][4];
+  float DT_ALIGNED_ARRAY XYZ_to_RGB[3][4];
+
+  // repack the matrices as flat AVX2-compliant matrice
+  if(work_profile)
+  {
+    // work profile can't be fetched in commit_params since it is not yet initialised
+    repack_3x3_to_3xSSE(work_profile->matrix_in, RGB_to_XYZ);
+    repack_3x3_to_3xSSE(work_profile->matrix_out, XYZ_to_RGB);
+  }
+
+  // Matrices from CIE 1931 2° XYZ D50 to Filmlight grading RGB D65 through CIE 2006 LMS
+  const float XYZ_to_gradRGB[3][4] = { { 0.53346004f,  0.15226970f , -0.19946283f, 0.f },
+                                          {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
+                                          { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
+  const float gradRGB_to_XYZ[3][4] = { { 1.67222161f, -0.11185000f,  0.50297636f, 0.f },
+                                          { 0.60120746f,  0.47018395f, -0.08596569f, 0.f },
+                                          {-0.08217531f,  0.05979694f,  1.27957582f, 0.f } };
+
+  // Premultiply the pipe RGB -> XYZ and XYZ -> grading RGB matrices to spare 2 matrix products per pixel
+  float DT_ALIGNED_ARRAY input_matrix[3][4];
+  float DT_ALIGNED_ARRAY output_matrix[3][4];
+  mat3mul((float *)input_matrix, (float *)XYZ_to_gradRGB, (float *)RGB_to_XYZ);
+  mat3mul((float *)output_matrix, (float *)XYZ_to_RGB, (float *)gradRGB_to_XYZ);
+
+  const float *const restrict in = __builtin_assume_aligned(((const float *const restrict)ivoid), 64);
+  float *const restrict out = __builtin_assume_aligned(((float *const restrict)ovoid), 64);
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) aligned(in, out: 64)\
+      dt_omp_firstprivate(in, out, roi_in, roi_out, d, input_matrix, output_matrix) schedule(static)
+#endif
+  for(size_t k = 0; k < (size_t)4 * roi_in->width * roi_out->height; k += 4)
+  {
+    const float *const restrict pix_in = __builtin_assume_aligned(in + k, 16);
+    float *const restrict pix_out = __builtin_assume_aligned(out + k, 16);
+
+    float Ych[4] = { 0.f };
+    float RGB[4] = { 0.f };
+
+    for(size_t c = 0; c < 4; ++c) Ych[c] = fmaxf(pix_in[c], 0.f);
+    dot_product(Ych, input_matrix, RGB);
+    for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c], 0.f);
+    gradingRGB_to_Ych(RGB, Ych);
+
+    // Sanitize input : no negative luminance
+    float Y = fmaxf(Ych[0], 0.000244140625f); // -12 EV
+
+    // Hue shift - do it now because we need the gamut limit at output hue right after
+    Ych[2] += d->hue_angle;
+
+    // Get max allowed chroma in working RGB gamut at current output hue
+    float max_chroma_h = d->gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
+    float C = fminf(Ych[1], max_chroma_h);
+
+    // Saturation : mix of chroma and luminance
+    const float radius = hypotf(C, Ych[0]);
+    float saturation = (Ych[0] <= 0.f ) ? 0.f : atan2f(C, Y);
+    saturation += saturation * d->saturation_factor * Y + d->saturation_offset;
+    saturation = fminf(fmaxf(saturation, 0.f), M_PI_2);
+
+    // Chroma : distance to white at constant luminance
+    const float boost_shadows = 0.25f * ((1.f / Y - 1.f / 1.1845f) * d->chroma_shadows + 1.f / 1.1845f - 1.f / Y);
+    const float boost_highlights = Y * d->chroma_highlights;
+    const float boost_midtones = 4.f * (powf(Y, d->chroma_midtones) - Y);
+    float chroma_boost = 1.f + d->chroma_global + (boost_shadows + boost_highlights + boost_midtones) * max_chroma_h / d->max_chroma;
+    chroma_boost = fmaxf(chroma_boost, 0.f);
+
+    // Repack
+    Ych[0] = fmaxf(radius * cosf(saturation), 0.f);
+    Ych[1] = fminf(chroma_boost * radius * sinf(saturation), max_chroma_h);
+    Y = Ych[0];
+    Ych_to_gradingRGB(Ych, RGB);
+
+    /* Color balance */
+
+    // global
+    const float *const restrict global = __builtin_assume_aligned(d->global, 16);
+    for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c] + global[c], 0.f);
+
+    // 3 ways : shadows, highlights, midtones
+    const float alpha = expf(- Y * d->shadows_weight);
+    const float beta = 1.f - expf(- Y * d->highlights_weight);
+    const float alpha_comp = 1.f - alpha;
+    const float beta_comp = 1.f - beta;
+
+    const float *const restrict highlights = __builtin_assume_aligned(d->highlights, 16);
+    const float *const restrict shadows = __builtin_assume_aligned(d->shadows, 16);
+    const float *const restrict midtones = __builtin_assume_aligned(d->midtones, 16);
+    for(size_t c = 0; c < 4; ++c)
+    {
+      RGB[c] *= beta_comp * (alpha_comp + alpha * shadows[c]) + beta * highlights[c];
+      // factorization of : (RGB[c] * (1.f - alpha) + RGB[c] * d->shadows[c] * alpha) * (1.f - beta)  + RGB[c] * d->highlights[c] * beta;
+      RGB[c] = powf(fmaxf(RGB[c] / d->midtones_weight, 0.f), midtones[c]) * d->midtones_weight;
+    }
+
+    // for the Y midtones power (gamma), we need to go in Ych again because RGB doesn't preserve color
+    gradingRGB_to_Ych(RGB, Ych);
+    Ych[0] = powf(fmaxf(Ych[0] / d->midtones_weight, 0.f), d->midtones_Y) * d->midtones_weight;
+
+    // Gamut mapping
+    max_chroma_h = d->gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
+    Ych[1] = fminf(Ych[1], max_chroma_h);
+
+    Ych_to_gradingRGB(Ych, RGB);
+    for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c], 0.f);
+    dot_product(RGB, output_matrix, pix_out);
+    for(size_t c = 0; c < 4; ++c) pix_out[c] = fmaxf(pix_out[c], 0.f);
+  }
+}
+
+/*
+void init_global(dt_iop_module_so_t *module)
+{
+  const int program = 8; // extended.cl, from programs.conf
+  dt_iop_colorbalance_global_data_t *gd
+      = (dt_iop_colorbalance_global_data_t *)malloc(sizeof(dt_iop_colorbalance_global_data_t));
+  module->data = gd;
+  gd->kernel_colorbalance = dt_opencl_create_kernel(program, "colorbalance");
+  gd->kernel_colorbalance_lgg = dt_opencl_create_kernel(program, "colorbalance_lgg");
+  gd->kernel_colorbalance_cdl = dt_opencl_create_kernel(program, "colorbalance_cdl");
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  dt_iop_colorbalance_global_data_t *gd = (dt_iop_colorbalance_global_data_t *)module->data;
+  dt_opencl_free_kernel(gd->kernel_colorbalance);
+  dt_opencl_free_kernel(gd->kernel_colorbalance_lgg);
+  dt_opencl_free_kernel(gd->kernel_colorbalance_cdl);
+  free(module->data);
+  module->data = NULL;
+}
+*/
+
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
+  dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)p1;
+
+  d->chroma_global = p->chroma_global;
+  d->chroma_highlights = p->chroma_highlights * 4.f;
+  d->chroma_midtones = fminf(1.f / (1.f + p->chroma_midtones), 8.f);
+  d->chroma_shadows = 1.f + p->chroma_shadows;
+
+  d->saturation_offset = M_PI * p->saturation_offset / 180.f;
+  d->saturation_factor = (p->saturation_factor);
+  d->hue_angle = M_PI * p->hue_angle / 180.f;
+
+  // measure the grading RGB of a pure white
+  const float Ych_norm[4] = { 1.f, 0.f, 0.f, 0.f };
+  float RGB_norm[4] = { 0.f };
+  Ych_to_gradingRGB(Ych_norm, RGB_norm);
+
+  // global
+  {
+    float Ych[4] = { 1.f, p->global_C, DEG_TO_RAD(p->global_H), 0.f };
+    Ych_to_gradingRGB(Ych, d->global);
+    for(size_t c = 0; c < 4; c++) d->global[c] = (d->global[c] - RGB_norm[c]) + RGB_norm[c] * p->global_Y;
+  }
+
+  // shadows
+  {
+    float Ych[4] = { 1.f, p->shadows_C, DEG_TO_RAD(p->shadows_H), 0.f };
+    Ych_to_gradingRGB(Ych, d->shadows);
+    for(size_t c = 0; c < 4; c++) d->shadows[c] = 1.f + (d->shadows[c] - RGB_norm[c]) + p->shadows_Y;
+    d->shadows_weight = 1.f - p->shadows_weight;
+  }
+
+  // highlights
+  {
+    float Ych[4] = { 1.f, p->highlights_C, DEG_TO_RAD(p->highlights_H), 0.f };
+    Ych_to_gradingRGB(Ych, d->highlights);
+    for(size_t c = 0; c < 4; c++) d->highlights[c] = 1.f + (d->highlights[c] - RGB_norm[c]) + p->highlights_Y;
+    d->highlights_weight = 1.f + p->highlights_weight;
+  }
+
+  // midtones
+  {
+    float Ych[4] = { 1.f, p->midtones_C, DEG_TO_RAD(p->midtones_H), 0.f };
+    Ych_to_gradingRGB(Ych, d->midtones);
+    for(size_t c = 0; c < 4; c++) d->midtones[c] = 1.f / (1.f + (d->midtones[c] - RGB_norm[c]));
+    d->midtones_Y = 1.f / (1.f + p->midtones_Y);
+    d->midtones_weight = fmaxf(1.f + p->midtones_weight, 0.0001f);
+  }
+
+  // Check if the RGB working profile has changed in pipe
+  struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  if(work_profile == NULL) return;
+  if(work_profile != d->work_profile)
+  {
+    d->lut_inited = FALSE;
+    d->work_profile = work_profile;
+  }
+
+  // find the maximum chroma allowed by the current working gamut in conjunction to hue
+  // this will be used to prevent users to mess up their images by pushing chroma out of gamut
+  if(!d->lut_inited && d->gamut_LUT)
+  {
+    float *const restrict LUT = d->gamut_LUT;
+
+    // init the LUT between -pi and pi by increments of 1°
+    for(size_t k = 0; k < LUT_ELEM; k++) LUT[k] = 0.f;
+
+    // Premultiply the matrix to speed-up
+    float DT_ALIGNED_ARRAY RGB_to_XYZ[3][4];
+    repack_3x3_to_3xSSE(work_profile->matrix_in, RGB_to_XYZ);
+    const float XYZ_to_gradingRGB[3][4] = { { 0.53346004f,  0.15226970f , -0.19946283f, 0.f },
+                                            {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
+                                            { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
+    float DT_ALIGNED_ARRAY input_matrix[3][4];
+    mat3mul((float *)input_matrix, (float *)XYZ_to_gradingRGB, (float *)RGB_to_XYZ);
+
+    // make RGB values vary between [0; 1] in working space, convert to Ych and get the max(c(h)))
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+      dt_omp_firstprivate(input_matrix) schedule(static) shared(LUT)
+#endif
+    for(size_t r = 0; r < STEPS; r++)
+      for(size_t g = 0; g < STEPS; g++)
+        for(size_t b = 0; b < STEPS; b++)
+        {
+          const float DT_ALIGNED_PIXEL rgb[4] = { (float)r / (float)(STEPS - 1),
+                                                  (float)g / (float)(STEPS - 1),
+                                                  (float)b / (float)(STEPS - 1),
+                                                  0.f };
+
+          float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
+          float DT_ALIGNED_PIXEL Ych[4] = { 0.f };
+          dot_product(rgb, input_matrix, RGB);
+          gradingRGB_to_Ych(RGB, Ych);
+          const size_t index = CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1);
+          if(LUT[index] < Ych[1]) LUT[index] = Ych[1];
+        }
+
+    d->lut_inited = TRUE;
+
+    d->max_chroma = 0.f;
+    for(size_t k = 0; k < LUT_ELEM; k++)
+      if(d->max_chroma < LUT[k]) d->max_chroma = LUT[k];
+  }
+}
+
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  piece->data = calloc(1, sizeof(dt_iop_colorbalancergb_data_t));
+  dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
+  d->gamut_LUT = NULL;
+  d->gamut_LUT = dt_alloc_sse_ps(LUT_ELEM);
+  d->lut_inited = FALSE;
+  d->work_profile = NULL;
+}
+
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
+  if(d->gamut_LUT) dt_free_align(d->gamut_LUT);
+  free(piece->data);
+  piece->data = NULL;
+}
+
+void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float RGB[4], float Ych[4])
+{
+  const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  if(work_profile == NULL) return; // no point
+
+  float XYZ[4] = { 0.f };
+  float LMS[4] = { 0.f };
+
+  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ, work_profile->matrix_in, work_profile->lut_in,
+                             work_profile->unbounded_coeffs_in, work_profile->lutsize,
+                             work_profile->nonlinearlut);
+  XYZ_to_gradingRGB(XYZ, LMS);
+  gradingRGB_to_Ych(LMS, Ych);
+
+  if(Ych[2] < 0.f)
+    Ych[2] = 2.f * M_PI + Ych[2];
+}
+
+
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
+
+  float Ych[4] = { 0.f };
+  pipe_RGB_to_Ych(self, piece, (const float *)self->picked_color, Ych);
+  float hue = RAD_TO_DEG(Ych[2]) + 180.f;   // take the opponent color
+  hue = (hue > 360.f) ? hue - 360.f : hue;  // normalize in [0 ; 360]°
+
+  ++darktable.gui->reset;
+  if(picker == g->global_H)
+  {
+    p->global_H = hue;
+    p->global_C = Ych[1] * Ych[0];
+    dt_bauhaus_slider_set_soft(g->global_H, p->global_H);
+    dt_bauhaus_slider_set_soft(g->global_C, p->global_C);
+  }
+  else if(picker == g->shadows_H)
+  {
+    p->shadows_H = hue;
+    p->shadows_C = Ych[1] * Ych[0];
+    dt_bauhaus_slider_set_soft(g->shadows_H, p->shadows_H);
+    dt_bauhaus_slider_set_soft(g->shadows_C, p->shadows_C);
+  }
+  else if(picker == g->midtones_H)
+  {
+    p->midtones_H = hue;
+    p->midtones_C = Ych[1] * Ych[0];
+    dt_bauhaus_slider_set_soft(g->midtones_H, p->midtones_H);
+    dt_bauhaus_slider_set_soft(g->midtones_C, p->midtones_C);
+  }
+  else if(picker == g->highlights_H)
+  {
+    p->highlights_H = hue;
+    p->highlights_C = Ych[1] * Ych[0];
+    dt_bauhaus_slider_set_soft(g->highlights_H, p->highlights_H);
+    dt_bauhaus_slider_set_soft(g->highlights_C, p->highlights_C);
+  }
+  else
+    fprintf(stderr, "[colorbalancergb] unknown color picker\n");
+  --darktable.gui->reset;
+
+  gui_changed(self, picker, NULL);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+
+static void paint_chroma_slider(GtkWidget *w, const float hue)
+{
+  const float x_min = DT_BAUHAUS_WIDGET(w)->data.slider.soft_min;
+  const float x_max = DT_BAUHAUS_WIDGET(w)->data.slider.soft_max;
+  const float x_range = x_max - x_min;
+
+  // Varies x in range around current y param
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
+    const float x = x_min + stop * x_range;
+    const float h = DEG_TO_RAD(hue);
+
+    float RGB[4] = { 0.f };
+    float Ych[4] = { 0.75f, x, h, 0.f };
+    float LMS[4] = { 0.f };
+    Ych_to_gradingRGB(Ych, LMS);
+    gradingRGB_to_XYZ(LMS, Ych);
+    dt_XYZ_to_Rec709_D65(Ych, RGB);
+    const float max_RGB = fmaxf(fmaxf(RGB[0], RGB[1]), RGB[2]);
+    for(size_t c = 0; c < 3; c++) RGB[c] = powf(RGB[c] / max_RGB, 1.f / 2.2f);
+    dt_bauhaus_slider_set_stop(w, stop, RGB[0], RGB[1], RGB[2]);
+  }
+
+  gtk_widget_queue_draw(w);
+}
+
+
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
+{
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
+
+   ++darktable.gui->reset;
+
+  if(!w || w == g->global_H)
+    paint_chroma_slider(g->global_C, p->global_H);
+
+  if(!w || w == g->shadows_H)
+    paint_chroma_slider(g->shadows_C, p->shadows_H);
+
+  if(!w || w == g->midtones_H)
+    paint_chroma_slider(g->midtones_C, p->midtones_H);
+
+  if(!w || w == g->highlights_H)
+    paint_chroma_slider(g->highlights_C, p->highlights_H);
+
+  --darktable.gui->reset;
+
+}
+
+void gui_update(dt_iop_module_t *self)
+{
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
+
+  dt_bauhaus_slider_set_soft(g->chroma_highlights, p->chroma_highlights);
+  dt_bauhaus_slider_set_soft(g->chroma_global, p->chroma_global);
+  dt_bauhaus_slider_set_soft(g->chroma_midtones, p->chroma_midtones);
+  dt_bauhaus_slider_set_soft(g->chroma_shadows, p->chroma_shadows);
+  dt_bauhaus_slider_set_soft(g->saturation_offset, p->saturation_offset);
+  dt_bauhaus_slider_set_soft(g->saturation_factor, p->saturation_factor);
+  dt_bauhaus_slider_set_soft(g->hue_angle, p->hue_angle);
+
+  dt_bauhaus_slider_set_soft(g->global_C, p->global_C);
+  dt_bauhaus_slider_set_soft(g->global_H, p->global_H);
+  dt_bauhaus_slider_set_soft(g->global_Y, p->global_Y);
+
+  dt_bauhaus_slider_set_soft(g->shadows_C, p->shadows_C);
+  dt_bauhaus_slider_set_soft(g->shadows_H, p->shadows_H);
+  dt_bauhaus_slider_set_soft(g->shadows_Y, p->shadows_Y);
+  dt_bauhaus_slider_set_soft(g->shadows_weight, p->shadows_weight);
+
+  dt_bauhaus_slider_set_soft(g->midtones_C, p->midtones_C);
+  dt_bauhaus_slider_set_soft(g->midtones_H, p->midtones_H);
+  dt_bauhaus_slider_set_soft(g->midtones_Y, p->midtones_Y);
+  dt_bauhaus_slider_set_soft(g->midtones_weight, p->midtones_weight);
+
+  dt_bauhaus_slider_set_soft(g->highlights_C, p->highlights_C);
+  dt_bauhaus_slider_set_soft(g->highlights_H, p->highlights_H);
+  dt_bauhaus_slider_set_soft(g->highlights_Y, p->highlights_Y);
+  dt_bauhaus_slider_set_soft(g->highlights_weight, p->highlights_weight);
+
+  gui_changed(self, NULL, NULL);
+  dt_iop_color_picker_reset(self, TRUE);
+}
+
+
+void gui_reset(dt_iop_module_t *self)
+{
+  //dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_color_picker_reset(self, TRUE);
+}
+
+
+void gui_init(dt_iop_module_t *self)
+{
+  dt_iop_colorbalancergb_gui_data_t *g = IOP_GUI_ALLOC(colorbalancergb);
+
+  // start building top level widget
+  g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
+
+  // Page CAT
+  self->widget = dt_ui_notebook_page(g->notebook, _("master"), _("global grading"));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("saturation and hue")), FALSE, FALSE, 0);
+
+  g->saturation_offset = dt_bauhaus_slider_from_params(self, "saturation_offset");
+  dt_bauhaus_slider_set_soft_range(g->saturation_offset, -5., 5.);
+  dt_bauhaus_slider_set_digits(g->saturation_offset, 4);
+  dt_bauhaus_slider_set_step(g->saturation_offset, .5);
+  dt_bauhaus_slider_set_format(g->saturation_offset, "%.2f °");
+  gtk_widget_set_tooltip_text(g->saturation_offset, _("add or remove saturation by an absolute amount"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_offset), TRUE, TRUE, 0);
+
+  g->saturation_factor = dt_bauhaus_slider_from_params(self, "saturation_factor");
+  dt_bauhaus_slider_set_digits(g->saturation_factor, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_factor, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_factor, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_factor, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_factor), TRUE, TRUE, 0);
+
+  g->hue_angle = dt_bauhaus_slider_from_params(self, "hue_angle");
+  dt_bauhaus_slider_set_digits(g->hue_angle, 4);
+  dt_bauhaus_slider_set_step(g->hue_angle, 1.);
+  dt_bauhaus_slider_set_format(g->hue_angle, "%.2f °");
+  gtk_widget_set_tooltip_text(g->hue_angle, _("rotate all hues by an angle, at the same luminance"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->hue_angle), TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("chroma grading")), FALSE, FALSE, 0);
+
+  g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
+  dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
+  dt_bauhaus_slider_set_digits(g->chroma_global, 4);
+  dt_bauhaus_slider_set_factor(g->chroma_global, 100.0f);
+  dt_bauhaus_slider_set_format(g->chroma_global, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->chroma_global, _("increase colorfulness at same luminance globally"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->chroma_global), TRUE, TRUE, 0);
+
+  g->chroma_shadows = dt_bauhaus_slider_from_params(self, "chroma_shadows");
+  dt_bauhaus_slider_set_digits(g->chroma_shadows, 4);
+  dt_bauhaus_slider_set_factor(g->chroma_shadows, 100.0f);
+  dt_bauhaus_slider_set_format(g->chroma_shadows, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->chroma_shadows, _("increase colorfulness at same luminance mostly in shadows"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->chroma_shadows), TRUE, TRUE, 0);
+
+  g->chroma_midtones = dt_bauhaus_slider_from_params(self, "chroma_midtones");
+  dt_bauhaus_slider_set_digits(g->chroma_midtones, 4);
+  dt_bauhaus_slider_set_factor(g->chroma_midtones, 100.0f);
+  dt_bauhaus_slider_set_format(g->chroma_midtones, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->chroma_midtones, _("increase colorfulness at same luminance mostly in midtones"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->chroma_midtones), TRUE, TRUE, 0);
+
+  g->chroma_highlights = dt_bauhaus_slider_from_params(self, "chroma_highlights");
+  dt_bauhaus_slider_set_digits(g->chroma_highlights, 4);
+  dt_bauhaus_slider_set_factor(g->chroma_highlights, 100.0f);
+  dt_bauhaus_slider_set_format(g->chroma_highlights, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->chroma_highlights, _("increase colorfulness at same luminance mostly in highlights"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->chroma_highlights), TRUE, TRUE, 0);
+
+
+  self->widget = dt_ui_notebook_page(g->notebook, _("4 ways"), _("selective color grading"));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("global")), FALSE, FALSE, 0);
+
+  g->global_Y = dt_bauhaus_slider_from_params(self, "global_Y");
+  dt_bauhaus_slider_set_soft_range(g->global_Y, -0.05, 0.05);
+  dt_bauhaus_slider_set_factor(g->global_Y, 100.0f);
+  dt_bauhaus_slider_set_digits(g->global_Y, 4);
+  dt_bauhaus_slider_set_format(g->global_Y, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->global_Y, _("global luminance offset"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->global_Y), TRUE, TRUE, 0);
+
+  g->global_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "global_H"));
+  dt_bauhaus_slider_set_feedback(g->global_H, 0);
+  dt_bauhaus_slider_set_step(g->global_H, 10.);
+  dt_bauhaus_slider_set_digits(g->global_H, 4);
+  dt_bauhaus_slider_set_format(g->global_H, "%.2f °");
+  gtk_widget_set_tooltip_text(g->global_H, _("hue of the global color offset"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->global_H), TRUE, TRUE, 0);
+
+  g->global_C = dt_bauhaus_slider_from_params(self, "global_C");
+  dt_bauhaus_slider_set_soft_range(g->global_C, 0., 0.02);
+  dt_bauhaus_slider_set_digits(g->global_C, 4);
+  dt_bauhaus_slider_set_factor(g->global_C, 100.0f);
+  dt_bauhaus_slider_set_format(g->global_C, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->global_C, _("chroma of the global color offset"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->global_C), TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("shadows")), FALSE, FALSE, 0);
+
+  g->shadows_Y = dt_bauhaus_slider_from_params(self, "shadows_Y");
+  dt_bauhaus_slider_set_soft_range(g->shadows_Y, -0.5, 0.5);
+  dt_bauhaus_slider_set_factor(g->shadows_Y, 100.0f);
+  dt_bauhaus_slider_set_digits(g->shadows_Y, 4);
+  dt_bauhaus_slider_set_format(g->shadows_Y, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->shadows_Y, _("luminance gain in shadows"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->shadows_Y), TRUE, TRUE, 0);
+
+  g->shadows_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "shadows_H"));
+  dt_bauhaus_slider_set_feedback(g->shadows_H, 0);
+  dt_bauhaus_slider_set_step(g->shadows_H, 10.);
+  dt_bauhaus_slider_set_digits(g->shadows_H, 4);
+  dt_bauhaus_slider_set_format(g->shadows_H, "%.2f °");
+  gtk_widget_set_tooltip_text(g->shadows_H, _("hue of the color gain in shadows"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->shadows_H), TRUE, TRUE, 0);
+
+  g->shadows_C = dt_bauhaus_slider_from_params(self, "shadows_C");
+  dt_bauhaus_slider_set_soft_range(g->shadows_C, 0., 0.2);
+  dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
+  dt_bauhaus_slider_set_digits(g->shadows_C, 4);
+  dt_bauhaus_slider_set_factor(g->shadows_C, 100.0f);
+  dt_bauhaus_slider_set_format(g->shadows_C, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->shadows_C, _("chroma of the color gain in shadows"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->shadows_C), TRUE, TRUE, 0);
+
+  g->shadows_weight = dt_bauhaus_slider_from_params(self, "shadows_weight");
+  dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
+  dt_bauhaus_slider_set_step(g->shadows_weight, 0.1);
+  dt_bauhaus_slider_set_format(g->shadows_weight, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->shadows_weight, 100.0f);
+  gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->shadows_weight), TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("midtones")), FALSE, FALSE, 0);
+
+  g->midtones_Y = dt_bauhaus_slider_from_params(self, "midtones_Y");
+  dt_bauhaus_slider_set_soft_range(g->midtones_Y, -0.5, 0.5);
+  dt_bauhaus_slider_set_factor(g->midtones_Y, 100.0f);
+  dt_bauhaus_slider_set_digits(g->midtones_Y, 4);
+  dt_bauhaus_slider_set_format(g->midtones_Y, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->midtones_Y, _("luminance exponent in midtones"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_Y), TRUE, TRUE, 0);
+
+  g->midtones_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "midtones_H"));
+  dt_bauhaus_slider_set_feedback(g->midtones_H, 0);
+  dt_bauhaus_slider_set_step(g->midtones_H, 10.);
+  dt_bauhaus_slider_set_digits(g->midtones_H, 4);
+  dt_bauhaus_slider_set_format(g->midtones_H, "%.2f °");
+  gtk_widget_set_tooltip_text(g->midtones_H, _("hue of the color exponent in midtones"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_H), TRUE, TRUE, 0);
+
+  g->midtones_C = dt_bauhaus_slider_from_params(self, "midtones_C");
+  dt_bauhaus_slider_set_soft_range(g->midtones_C, 0., 0.10);
+  dt_bauhaus_slider_set_step(g->midtones_C, 0.005);
+  dt_bauhaus_slider_set_digits(g->midtones_C, 4);
+  dt_bauhaus_slider_set_factor(g->midtones_C, 100.0f);
+  dt_bauhaus_slider_set_format(g->midtones_C, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->midtones_C, _("chroma of the color exponent in midtones"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_C), TRUE, TRUE, 0);
+
+  g->midtones_weight = dt_bauhaus_slider_from_params(self, "midtones_weight");
+  dt_bauhaus_slider_set_step(g->midtones_weight, 0.1);
+  dt_bauhaus_slider_set_digits(g->midtones_weight, 4);
+  dt_bauhaus_slider_set_format(g->midtones_weight, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->midtones_weight, 100.0f);
+  gtk_widget_set_tooltip_text(g->midtones_weight, _("weight of the midtones over the whole tonal range"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_weight), TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights")), FALSE, FALSE, 0);
+
+  g->highlights_Y = dt_bauhaus_slider_from_params(self, "highlights_Y");
+  dt_bauhaus_slider_set_soft_range(g->highlights_Y, -0.5, 0.5);
+  dt_bauhaus_slider_set_factor(g->highlights_Y, 100.0f);
+  dt_bauhaus_slider_set_digits(g->highlights_Y, 4);
+  dt_bauhaus_slider_set_format(g->highlights_Y, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->highlights_Y, _("luminance gain in highlights"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->highlights_Y), TRUE, TRUE, 0);
+
+  g->highlights_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "highlights_H"));
+  dt_bauhaus_slider_set_feedback(g->highlights_H, 0);
+  dt_bauhaus_slider_set_step(g->highlights_H, 10.);
+  dt_bauhaus_slider_set_digits(g->highlights_H, 4);
+  dt_bauhaus_slider_set_format(g->highlights_H, "%.2f °");
+  gtk_widget_set_tooltip_text(g->highlights_H, _("hue of the color gain in highlights"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->highlights_H), TRUE, TRUE, 0);
+
+  g->highlights_C = dt_bauhaus_slider_from_params(self, "highlights_C");
+  dt_bauhaus_slider_set_soft_range(g->highlights_C, 0., 0.2);
+  dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
+  dt_bauhaus_slider_set_digits(g->highlights_C, 4);
+  dt_bauhaus_slider_set_factor(g->highlights_C, 100.0f);
+  dt_bauhaus_slider_set_format(g->highlights_C, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->highlights_C, _("chroma of the color gain in highlights"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->highlights_C), TRUE, TRUE, 0);
+
+  g->highlights_weight = dt_bauhaus_slider_from_params(self, "highlights_weight");
+  dt_bauhaus_slider_set_step(g->highlights_weight, 0.1);
+  dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
+  dt_bauhaus_slider_set_format(g->highlights_weight, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->highlights_weight, 100.0f);
+  gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->highlights_weight), TRUE, TRUE, 0);
+
+  // paint backgrounds
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
+    const float h = DEG_TO_RAD(stop * (360.f));
+    float RGB[4] = { 0.f };
+    float Ych[4] = { 0.75f, 0.2f, h, 0.f };
+    float LMS[4] = { 0.f };
+    Ych_to_gradingRGB(Ych, LMS);
+    gradingRGB_to_XYZ(LMS, Ych);
+    dt_XYZ_to_Rec709_D65(Ych, RGB);
+    const float max_RGB = fmaxf(fmaxf(RGB[0], RGB[1]), RGB[2]);
+    for(size_t c = 0; c < 3; c++) RGB[c] = powf(RGB[c] / max_RGB, 1.f / 2.2f);
+    dt_bauhaus_slider_set_stop(g->global_H, stop, RGB[0], RGB[1], RGB[2]);
+    dt_bauhaus_slider_set_stop(g->shadows_H, stop, RGB[0], RGB[1], RGB[2]);
+    dt_bauhaus_slider_set_stop(g->highlights_H, stop, RGB[0], RGB[1], RGB[2]);
+    dt_bauhaus_slider_set_stop(g->midtones_H, stop, RGB[0], RGB[1], RGB[2]);
+
+    const float Y = 0.f + stop;
+    dt_bauhaus_slider_set_stop(g->global_Y, stop, Y, Y, Y);
+    dt_bauhaus_slider_set_stop(g->shadows_Y, stop, Y, Y, Y);
+    dt_bauhaus_slider_set_stop(g->highlights_Y, stop, Y, Y, Y);
+    dt_bauhaus_slider_set_stop(g->midtones_Y, stop, Y, Y, Y);
+  }
+
+  // pack the high-level widget
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+}
+
+
+void gui_cleanup(struct dt_iop_module_t *self)
+{
+  IOP_GUI_FREE;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -52,28 +52,30 @@ DT_MODULE_INTROSPECTION(1, dt_iop_colorbalancergb_params_t)
 
 typedef struct dt_iop_colorbalancergb_params_t
 {
-  float shadows_Y;          // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-  float shadows_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-  float shadows_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-  float midtones_Y;           // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-  float midtones_C;           // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-  float midtones_H;           // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-  float highlights_Y;           // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-  float highlights_C;           // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-  float highlights_H;           // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-  float global_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-  float global_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-  float global_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-  float shadows_weight;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
-  float midtones_weight;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
-  float highlights_weight; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
-  float chroma_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-  float chroma_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-  float chroma_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-  float chroma_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
-  float saturation_offset; // $MIN: -10.0 $MAX: 10.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation offset"
-  float saturation_factor; // $MIN: -1. $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation factor"
-  float hue_angle;         // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+  float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float midtones_Y;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float midtones_C;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float highlights_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float global_Y;              // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float shadows_weight;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+  float midtones_weight;       // $MIN: -6.0 $MAX:   6.0 $DEFAULT: 0.0 $DESCRIPTION: "fulcrum"
+  float highlights_weight;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+  float chroma_shadows;        // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+  float chroma_highlights;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float chroma_global;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
+  float chroma_midtones;       // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+  float saturation_global;     // $MIN: -10.0 $MAX: 10.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation global"
+  float saturation_highlights; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float saturation_midtones;   // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+  float saturation_shadows;    // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+  float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
 } dt_iop_colorbalancergb_params_t;
 
 
@@ -84,7 +86,8 @@ typedef struct dt_iop_colorbalancergb_gui_data_t
   GtkWidget *shadows_Y, *midtones_Y, *highlights_Y, *global_Y;
   GtkWidget *shadows_weight, *midtones_weight, *highlights_weight;
   GtkWidget *chroma_highlights, *chroma_global, *chroma_shadows, *chroma_midtones;
-  GtkWidget *saturation_offset, *saturation_factor, *hue_angle;
+  GtkWidget *saturation_global, *saturation_highlights, *saturation_midtones, *saturation_shadows;
+  GtkWidget *hue_angle;
   GtkNotebook *notebook;
 } dt_iop_colorbalancergb_gui_data_t;
 
@@ -96,7 +99,8 @@ typedef struct dt_iop_colorbalancergb_data_t
   float midtones[4];
   float midtones_Y;
   float chroma_highlights, chroma_global, chroma_shadows, chroma_midtones;
-  float saturation_offset, saturation_factor, hue_angle;
+  float saturation_global, saturation_highlights, saturation_midtones, saturation_shadows;
+  float hue_angle;
   float shadows_weight, midtones_weight, highlights_weight;
   float *gamut_LUT;
   float max_chroma;
@@ -216,10 +220,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const float *const restrict in = __builtin_assume_aligned(((const float *const restrict)ivoid), 64);
   float *const restrict out = __builtin_assume_aligned(((float *const restrict)ovoid), 64);
+  const float *const restrict gamut_LUT = __builtin_assume_aligned(((const float *const restrict)d->gamut_LUT), 64);
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) aligned(in, out: 64)\
-      dt_omp_firstprivate(in, out, roi_in, roi_out, d, input_matrix, output_matrix) schedule(static)
+      dt_omp_firstprivate(in, out, roi_in, roi_out, d, input_matrix, output_matrix, gamut_LUT) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)4 * roi_in->width * roi_out->height; k += 4)
   {
@@ -235,32 +240,44 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     gradingRGB_to_Ych(RGB, Ych);
 
     // Sanitize input : no negative luminance
-    float Y = fmaxf(Ych[0], 0.000244140625f); // -12 EV
+    float Y = fmaxf(Ych[0], 0.f);
 
     // Hue shift - do it now because we need the gamut limit at output hue right after
     Ych[2] += d->hue_angle;
 
     // Get max allowed chroma in working RGB gamut at current output hue
-    float max_chroma_h = d->gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
+    const float max_chroma_h = gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
+    const float max_saturation_h = (Y == 0.f) ? 0.f : atan2f(max_chroma_h, Y);
     float C = fminf(Ych[1], max_chroma_h);
+    float S = (Y == 0.f) ? 0.f : atan2f(C, Y);
+    const float radius = hypotf(C, Y);
+
+    // Opacities for luma masks
+    const float alpha = expf(- Y * d->shadows_weight);         // opacity of shadows
+    const float beta = 1.f - expf(- Y * d->highlights_weight); // opacity of highlights
+    const float gamma = expf(-3.0f * (alpha - beta) * (alpha - beta)); // opacity of midtones
+    const float alpha_comp = 1.f - alpha;
+    const float beta_comp = 1.f - beta;
+    const float sum_of_masks = alpha + beta + gamma;
 
     // Saturation : mix of chroma and luminance
-    const float radius = hypotf(C, Ych[0]);
-    float saturation = (Ych[0] <= 0.f ) ? 0.f : atan2f(C, Y);
-    saturation += saturation * d->saturation_factor * Y + d->saturation_offset;
-    saturation = fminf(fmaxf(saturation, 0.f), M_PI_2);
+    const float boost_shadows_sat = alpha * d->saturation_shadows;
+    const float boost_highlights_sat = beta * d->saturation_highlights;
+    const float boost_midtones_sat = gamma * d->saturation_midtones;
+    const float boost_sat = 1.f + Y * (boost_shadows_sat + boost_midtones_sat + boost_highlights_sat) / sum_of_masks;
+    S = S * boost_sat + d->saturation_global;
+    S = fminf(fmaxf(S, 0.f), max_saturation_h);
 
     // Chroma : distance to white at constant luminance
-    const float boost_shadows = 0.25f * ((1.f / Y - 1.f / 1.1845f) * d->chroma_shadows + 1.f / 1.1845f - 1.f / Y);
-    const float boost_highlights = Y * d->chroma_highlights;
-    const float boost_midtones = 4.f * (powf(Y, d->chroma_midtones) - Y);
-    float chroma_boost = 1.f + d->chroma_global + (boost_shadows + boost_highlights + boost_midtones) * max_chroma_h / d->max_chroma;
+    const float boost_shadows_chroma = alpha * d->chroma_shadows;
+    const float boost_highlights_chroma = beta * d->chroma_highlights;
+    const float boost_midtones_chroma = gamma * d->chroma_midtones;
+    float chroma_boost = 1.f + d->chroma_global + (boost_shadows_chroma + boost_highlights_chroma + boost_midtones_chroma) * max_chroma_h / d->max_chroma / sum_of_masks;
     chroma_boost = fmaxf(chroma_boost, 0.f);
 
     // Repack
-    Ych[0] = fmaxf(radius * cosf(saturation), 0.f);
-    Ych[1] = fminf(chroma_boost * radius * sinf(saturation), max_chroma_h);
-    Y = Ych[0];
+    Ych[0] = fmaxf(radius * cosf(S), 0.f);
+    Ych[1] = fminf(chroma_boost * radius * sinf(S), max_chroma_h);
     Ych_to_gradingRGB(Ych, RGB);
 
     /* Color balance */
@@ -270,11 +287,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c] + global[c], 0.f);
 
     // 3 ways : shadows, highlights, midtones
-    const float alpha = expf(- Y * d->shadows_weight);
-    const float beta = 1.f - expf(- Y * d->highlights_weight);
-    const float alpha_comp = 1.f - alpha;
-    const float beta_comp = 1.f - beta;
-
     const float *const restrict highlights = __builtin_assume_aligned(d->highlights, 16);
     const float *const restrict shadows = __builtin_assume_aligned(d->shadows, 16);
     const float *const restrict midtones = __builtin_assume_aligned(d->midtones, 16);
@@ -290,8 +302,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     Ych[0] = powf(fmaxf(Ych[0] / d->midtones_weight, 0.f), d->midtones_Y) * d->midtones_weight;
 
     // Gamut mapping
-    max_chroma_h = d->gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
-    Ych[1] = fminf(Ych[1], max_chroma_h);
+    const float out_max_chroma_h = gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
+    Ych[1] = fminf(Ych[1], out_max_chroma_h);
 
     Ych_to_gradingRGB(Ych, RGB);
     for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c], 0.f);
@@ -330,12 +342,16 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)p1;
 
   d->chroma_global = p->chroma_global;
-  d->chroma_highlights = p->chroma_highlights * 4.f;
-  d->chroma_midtones = fminf(1.f / (1.f + p->chroma_midtones), 8.f);
-  d->chroma_shadows = 1.f + p->chroma_shadows;
+  d->chroma_highlights = p->chroma_highlights;
+  d->chroma_midtones = p->chroma_midtones;
+  d->chroma_shadows = p->chroma_shadows;
 
-  d->saturation_offset = M_PI * p->saturation_offset / 180.f;
-  d->saturation_factor = (p->saturation_factor);
+  d->saturation_global = M_PI * p->saturation_global / 180.f;
+
+  d->saturation_highlights = p->saturation_highlights;
+  d->saturation_midtones = p->saturation_midtones;
+  d->saturation_shadows = p->saturation_shadows;
+
   d->hue_angle = M_PI * p->hue_angle / 180.f;
 
   // measure the grading RGB of a pure white
@@ -372,7 +388,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     Ych_to_gradingRGB(Ych, d->midtones);
     for(size_t c = 0; c < 4; c++) d->midtones[c] = 1.f / (1.f + (d->midtones[c] - RGB_norm[c]));
     d->midtones_Y = 1.f / (1.f + p->midtones_Y);
-    d->midtones_weight = fmaxf(1.f + p->midtones_weight, 0.0001f);
+    d->midtones_weight = exp2f(p->midtones_weight);
   }
 
   // Check if the RGB working profile has changed in pipe
@@ -573,13 +589,17 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
 
-  dt_bauhaus_slider_set_soft(g->chroma_highlights, p->chroma_highlights);
+  dt_bauhaus_slider_set_soft(g->hue_angle, p->hue_angle);
+
   dt_bauhaus_slider_set_soft(g->chroma_global, p->chroma_global);
+  dt_bauhaus_slider_set_soft(g->chroma_highlights, p->chroma_highlights);
   dt_bauhaus_slider_set_soft(g->chroma_midtones, p->chroma_midtones);
   dt_bauhaus_slider_set_soft(g->chroma_shadows, p->chroma_shadows);
-  dt_bauhaus_slider_set_soft(g->saturation_offset, p->saturation_offset);
-  dt_bauhaus_slider_set_soft(g->saturation_factor, p->saturation_factor);
-  dt_bauhaus_slider_set_soft(g->hue_angle, p->hue_angle);
+
+  dt_bauhaus_slider_set_soft(g->saturation_global, p->saturation_global);
+  dt_bauhaus_slider_set_soft(g->saturation_highlights, p->saturation_highlights);
+  dt_bauhaus_slider_set_soft(g->saturation_midtones, p->saturation_midtones);
+  dt_bauhaus_slider_set_soft(g->saturation_shadows, p->saturation_shadows);
 
   dt_bauhaus_slider_set_soft(g->global_C, p->global_C);
   dt_bauhaus_slider_set_soft(g->global_H, p->global_H);
@@ -622,23 +642,6 @@ void gui_init(dt_iop_module_t *self)
   // Page CAT
   self->widget = dt_ui_notebook_page(g->notebook, _("master"), _("global grading"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("saturation and hue")), FALSE, FALSE, 0);
-
-  g->saturation_offset = dt_bauhaus_slider_from_params(self, "saturation_offset");
-  dt_bauhaus_slider_set_soft_range(g->saturation_offset, -5., 5.);
-  dt_bauhaus_slider_set_digits(g->saturation_offset, 4);
-  dt_bauhaus_slider_set_step(g->saturation_offset, .5);
-  dt_bauhaus_slider_set_format(g->saturation_offset, "%.2f °");
-  gtk_widget_set_tooltip_text(g->saturation_offset, _("add or remove saturation by an absolute amount"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_offset), TRUE, TRUE, 0);
-
-  g->saturation_factor = dt_bauhaus_slider_from_params(self, "saturation_factor");
-  dt_bauhaus_slider_set_digits(g->saturation_factor, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_factor, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_factor, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->saturation_factor, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_factor), TRUE, TRUE, 0);
-
   g->hue_angle = dt_bauhaus_slider_from_params(self, "hue_angle");
   dt_bauhaus_slider_set_digits(g->hue_angle, 4);
   dt_bauhaus_slider_set_step(g->hue_angle, 1.);
@@ -646,10 +649,41 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue_angle, _("rotate all hues by an angle, at the same luminance"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->hue_angle), TRUE, TRUE, 0);
 
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("saturation grading")), FALSE, FALSE, 0);
+
+  g->saturation_global = dt_bauhaus_slider_from_params(self, "saturation_global");
+  dt_bauhaus_slider_set_soft_range(g->saturation_global, -5., 5.);
+  dt_bauhaus_slider_set_digits(g->saturation_global, 4);
+  dt_bauhaus_slider_set_step(g->saturation_global, .5);
+  dt_bauhaus_slider_set_format(g->saturation_global, "%.2f °");
+  gtk_widget_set_tooltip_text(g->saturation_global, _("add or remove saturation by an absolute amount"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_global), TRUE, TRUE, 0);
+
+  g->saturation_shadows = dt_bauhaus_slider_from_params(self, "saturation_shadows");
+  dt_bauhaus_slider_set_digits(g->saturation_shadows, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_shadows, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_shadows, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_shadows, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_shadows), TRUE, TRUE, 0);
+
+  g->saturation_midtones= dt_bauhaus_slider_from_params(self, "saturation_midtones");
+  dt_bauhaus_slider_set_digits(g->saturation_midtones, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_midtones, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_midtones, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_midtones, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_midtones), TRUE, TRUE, 0);
+
+  g->saturation_highlights = dt_bauhaus_slider_from_params(self, "saturation_highlights");
+  dt_bauhaus_slider_set_digits(g->saturation_highlights, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_highlights, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_highlights, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_highlights, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->saturation_highlights), TRUE, TRUE, 0);
+
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("chroma grading")), FALSE, FALSE, 0);
 
   g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
-  dt_bauhaus_slider_set_soft_range(g->chroma_global, 0., 0.005);
+  dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
   dt_bauhaus_slider_set_digits(g->chroma_global, 4);
   dt_bauhaus_slider_set_factor(g->chroma_global, 100.0f);
   dt_bauhaus_slider_set_format(g->chroma_global, "%.2f %%");
@@ -769,11 +803,11 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_C), TRUE, TRUE, 0);
 
   g->midtones_weight = dt_bauhaus_slider_from_params(self, "midtones_weight");
+  dt_bauhaus_slider_set_soft_range(g->midtones_weight, -2., +2.);
   dt_bauhaus_slider_set_step(g->midtones_weight, 0.1);
   dt_bauhaus_slider_set_digits(g->midtones_weight, 4);
-  dt_bauhaus_slider_set_format(g->midtones_weight, "%.2f %%");
-  dt_bauhaus_slider_set_factor(g->midtones_weight, 100.0f);
-  gtk_widget_set_tooltip_text(g->midtones_weight, _("weight of the midtones over the whole tonal range"));
+  dt_bauhaus_slider_set_format(g->midtones_weight, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->midtones_weight, _("peak white luminance value used to normalize the power function"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_weight), TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights")), FALSE, FALSE, 0);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -72,7 +72,7 @@ typedef struct dt_iop_colorbalancergb_params_t
   float chroma_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
   float chroma_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
   float saturation_offset; // $MIN: -10.0 $MAX: 10.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation offset"
-  float saturation_factor; // $MIN: -0.5 $MAX: 0.5 $DEFAULT: 0.0 $DESCRIPTION: "saturation factor"
+  float saturation_factor; // $MIN: -1. $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation factor"
   float hue_angle;         // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
 } dt_iop_colorbalancergb_params_t;
 
@@ -649,7 +649,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("chroma grading")), FALSE, FALSE, 0);
 
   g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
-  dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
+  dt_bauhaus_slider_set_soft_range(g->chroma_global, 0., 0.005);
   dt_bauhaus_slider_set_digits(g->chroma_global, 4);
   dt_bauhaus_slider_set_factor(g->chroma_global, 100.0f);
   dt_bauhaus_slider_set_format(g->chroma_global, "%.2f %%");
@@ -699,7 +699,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->global_H), TRUE, TRUE, 0);
 
   g->global_C = dt_bauhaus_slider_from_params(self, "global_C");
-  dt_bauhaus_slider_set_soft_range(g->global_C, 0., 0.02);
+  dt_bauhaus_slider_set_soft_range(g->global_C, 0., 0.005);
   dt_bauhaus_slider_set_digits(g->global_C, 4);
   dt_bauhaus_slider_set_factor(g->global_C, 100.0f);
   dt_bauhaus_slider_set_format(g->global_C, "%.2f %%");
@@ -725,7 +725,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->shadows_H), TRUE, TRUE, 0);
 
   g->shadows_C = dt_bauhaus_slider_from_params(self, "shadows_C");
-  dt_bauhaus_slider_set_soft_range(g->shadows_C, 0., 0.2);
+  dt_bauhaus_slider_set_soft_range(g->shadows_C, 0., 0.1);
   dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
   dt_bauhaus_slider_set_digits(g->shadows_C, 4);
   dt_bauhaus_slider_set_factor(g->shadows_C, 100.0f);
@@ -744,7 +744,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("midtones")), FALSE, FALSE, 0);
 
   g->midtones_Y = dt_bauhaus_slider_from_params(self, "midtones_Y");
-  dt_bauhaus_slider_set_soft_range(g->midtones_Y, -0.5, 0.5);
+  dt_bauhaus_slider_set_soft_range(g->midtones_Y, -0.25, 0.25);
   dt_bauhaus_slider_set_factor(g->midtones_Y, 100.0f);
   dt_bauhaus_slider_set_digits(g->midtones_Y, 4);
   dt_bauhaus_slider_set_format(g->midtones_Y, "%.2f %%");
@@ -760,7 +760,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->midtones_H), TRUE, TRUE, 0);
 
   g->midtones_C = dt_bauhaus_slider_from_params(self, "midtones_C");
-  dt_bauhaus_slider_set_soft_range(g->midtones_C, 0., 0.10);
+  dt_bauhaus_slider_set_soft_range(g->midtones_C, 0., 0.02);
   dt_bauhaus_slider_set_step(g->midtones_C, 0.005);
   dt_bauhaus_slider_set_digits(g->midtones_C, 4);
   dt_bauhaus_slider_set_factor(g->midtones_C, 100.0f);
@@ -795,7 +795,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->highlights_H), TRUE, TRUE, 0);
 
   g->highlights_C = dt_bauhaus_slider_from_params(self, "highlights_C");
-  dt_bauhaus_slider_set_soft_range(g->highlights_C, 0., 0.2);
+  dt_bauhaus_slider_set_soft_range(g->highlights_C, 0., 0.05);
   dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
   dt_bauhaus_slider_set_digits(g->highlights_C, 4);
   dt_bauhaus_slider_set_factor(g->highlights_C, 100.0f);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -110,7 +110,7 @@ typedef struct dt_iop_colorbalancergb_data_t
 
 const char *name()
 {
-  return _("color balance pro");
+  return _("color balance rgb");
 }
 
 const char *aliases()

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -118,6 +118,11 @@ const char *aliases()
   return _("offset power slope|cdl|color grading|contrast|chroma_highlights|hue");
 }
 
+const char *deprecated_msg()
+{
+  return _("this module is experimental and the internal algo may slightly change before darktable 3.6. don't use it for serious work yet.");
+}
+
 const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("affect color, brightness and contrast"),

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -249,7 +249,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float max_chroma_h = gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
     const float max_saturation_h = (Y == 0.f) ? 0.f : atan2f(max_chroma_h, Y);
     float C = fminf(Ych[1], max_chroma_h);
-    float S = (Y == 0.f) ? 0.f : atan2f(C, Y);
+    float S = fminf(atan2f(C, Y), max_saturation_h);
     const float radius = (Y == 0.f) ? 0.f : hypotf(C, Y);
 
     // Opacities for luma masks


### PR DESCRIPTION
## Why ?

The current color balance works internally in RGB but needs Lab input and output, so it triggers up to 4 useless RGB -> Lab -> RGB conversions. Plus, as an Lab module, blending and masking happen in Lab too.

## So ?

1. We take this opportunity to use a special purpose RGB space, and its connected Yrg space, designed by Filmlight for artistic color grading : https://doi.org/10.2352/issn.2169-2629.2019.27.38 But I had to fix some mistakes (the color conversion in the paper doesn't roundtrip) and optimize the code for performance (linear operations reordered to allow factorization and spare 4 useless matrix products). 
2. Input and output of the module are gamut-mapped. We compute a LUT of the gamut boundaries of the working RGB space (Rec2020 by default) projected in Ych (luminance, chroma, hue) derivated from Yrg, and scale the chroma setting with the maximum chroma allowed at current hue, plus clip the chroma at the maximum allowed at the end. For example:
![image](https://user-images.githubusercontent.com/2779157/102569215-556fa280-40e5-11eb-933e-1152168a93c7.png)
![image](https://user-images.githubusercontent.com/2779157/102569582-00805c00-40e6-11eb-8933-4019c36e9622.png)
We see on these graphs that the usual way of uniformingly pushing chroma is going to make cyan and magenta escape gamut much quicker than green or red. So we need a correction that takes the boundaries into account, and that's what is done here.

## Prerequisite

Before going any further, reading of https://munsell.com/color-blog/difference-chroma-saturation/ is advised to catch the difference between chroma and saturation. Chroma is colorfulness at same luminance, saturation is colorfulness + luminance. That's confusing because 99% of image processing applications call "saturation" a chroma adjustment (as did the previous color balance). Saturation actually helps getting deeper colours because they don't wash to grey but to white, which is more like painting.

## How to use

As usualy, a lot of info is hidden in tooltips.

First tab is the master/general correction:
![Screenshot_20201218_040307](https://user-images.githubusercontent.com/2779157/102569547-f52d3080-40e5-11eb-8c4c-5e93fcd2e7fb.png)

Saturation can be corrected through a combination of an offset (that is, an absolute correction that doesn't care about the original saturation) and a factor (a relative correction that is proportional to the input saturation). The saturation adjustment gives deeper and more natural color than the chroma.

Hues can be rotated to practice despilling (removing a parasite light casting wrong hue on some object or subject) : https://learn.foundry.com/nuke/12.1/content/comp_environment/keying_with_chromakeyer/despill_controls.html

Then, the chroma can be adjusted depending on luminance. It's the same logic as the current color balance in slope-offset-power mode. People who are used to RGB tone curves applied on decorrelated channels can reproduce a highlights desaturation without the hue shift as a side effect. The midtones chroma is close to what usually is called vibrance in many pieces of software.

The second tab deals with the actual balancing:
![Screenshot_20201218_041105](https://user-images.githubusercontent.com/2779157/102570140-15112400-40e7-11eb-9321-0cebaee2c972.png)

The global adjustment is the exact equivalent of today's offset: it raises the whole range by some offset. The highlights adjustment with the weight pushed to 100% is the exact equivalent of today's slope: it raises values proportionaly to their input values. The midtones adjustment is the exact equivalent to today's power or gamma: it applies a power function.

The shadows adjustment is sort-of similar in logic to today's lift, feature-wise, although the algo is tuned for scene-referred editing while the lift assumes bounded signals.

Remember all the settings have an impact on the whole tonal range, but each one has more weight on some part of that range. For this reason, this color balance introduces a weighting factor, that let users choose how wide or narrow they want to define their shadows/midtones/highlights.

## Some notes

With so many parameters, you need to dive into that module with some color science knowledge and have a theoritical understanding of what you are doing. Don't expect to just fiddle with the sliders and grasp what's going on. For resources, I can only recommend https://play.google.com/books/reader?id=kDcdAgAAQBAJ (672 pages of just color balancing), or https://www.youtube.com/watch?v=CaKhcCgazP0 for a basic intro. This module is designed to allow great control with minimal side effects provided you know what you are doing. Colorist is a full-time job in the cinema industry, some people get their income only from using that kind of module.

## Samples

(Before/After)
![P1010263_01](https://user-images.githubusercontent.com/2779157/102570858-90bfa080-40e8-11eb-9561-01b1295805f4.jpg)
![P1010263](https://user-images.githubusercontent.com/2779157/102570909-a765f780-40e8-11eb-80c8-1aacfa0db62a.jpg)

![Demi-marathon Hadrien-0044-_DSC0487_03](https://user-images.githubusercontent.com/2779157/102570955-bf3d7b80-40e8-11eb-952a-4580f43995e1.jpg)
![Demi-marathon Hadrien-0044-_DSC0487_02](https://user-images.githubusercontent.com/2779157/102570944-b8af0400-40e8-11eb-8a54-302c7f942a27.jpg)

![Demi-marathon Hadrien-0018-_DSC0461_04](https://user-images.githubusercontent.com/2779157/102571368-a08bb480-40e9-11eb-89e4-d7e55b75c308.jpg)
![Demi-marathon Hadrien-0018-_DSC0461_03](https://user-images.githubusercontent.com/2779157/102571251-61f5fa00-40e9-11eb-9a3e-14fca4bfe9b9.jpg)


