### PR TITLE
[imageio] use dt_print more, make tiff io respect DT_DEBUG_IMAGEIO

### DIFF
--- a/src/common/imageio_gm.c
+++ b/src/common/imageio_gm.c
@@ -80,7 +80,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
     goto error;
   }
 
-  fprintf(stderr, "[GraphicsMagick_open] image `%s' loading\n", img->filename);
+  dt_print(DT_DEBUG_IMAGEIO, "[GraphicsMagick_open] image `%s' loading\n", img->filename);
 
   width = image->columns;
   height = image->rows;

--- a/src/common/imageio_im.c
+++ b/src/common/imageio_im.c
@@ -75,7 +75,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
     err = DT_IMAGEIO_FILE_NOT_FOUND;
     goto error;
   }
-  fprintf(stderr, "[ImageMagick_open] image `%s' loading\n", img->filename);
+  dt_print(DT_DEBUG_IMAGEIO, "[ImageMagick_open] image `%s' loading\n", img->filename);
 
   img->width = MagickGetImageWidth(image);
   img->height = MagickGetImageHeight(image);

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -299,9 +299,12 @@ failed:
 
 static void _warning_error_handler(const char *type, const char* module, const char* fmt, va_list ap)
 {
-  fprintf(stderr, "[tiff_open] %s: %s: ", type, module);
-  vfprintf(stderr, fmt, ap);
-  fprintf(stderr, "\n");
+  if(!g_strcmp0(type, "error") || ( !g_strcmp0(type, "warning") && (darktable.unmuted & DT_DEBUG_IMAGEIO)))
+  {
+    fprintf(stderr, "[tiff_open] %s: %s: ", type, module);
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+  }
 }
 
 static void _warning_handler(const char* module, const char* fmt, va_list ap)
@@ -356,7 +359,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
 
   t.scanlinesize = TIFFScanlineSize(t.tiff);
 
-  dt_print(DT_DEBUG_CAMERA_SUPPORT, "[tiff_open] %dx%d %dbpp, %d samples per pixel.\n", t.width, t.height, t.bpp, t.spp);
+  dt_print(DT_DEBUG_IMAGEIO, "[tiff_open] %dx%d %dbpp, %d samples per pixel.\n", t.width, t.height, t.bpp, t.spp);
 
   // we only support 8/16 and 32 bits per pixel formats.
   if(t.bpp != 8 && t.bpp != 16 && t.bpp != 32)

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -299,17 +299,17 @@ failed:
 
 static void _warning_error_handler(const char *type, const char* module, const char* fmt, va_list ap)
 {
-  if(!g_strcmp0(type, "error") || ( !g_strcmp0(type, "warning") && (darktable.unmuted & DT_DEBUG_IMAGEIO)))
-  {
-    fprintf(stderr, "[tiff_open] %s: %s: ", type, module);
-    vfprintf(stderr, fmt, ap);
-    fprintf(stderr, "\n");
-  }
+  fprintf(stderr, "[tiff_open] %s: %s: ", type, module);
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
 }
 
 static void _warning_handler(const char* module, const char* fmt, va_list ap)
 {
-  _warning_error_handler("warning", module, fmt, ap);
+  if(darktable.unmuted & DT_DEBUG_IMAGEIO)
+  {
+    _warning_error_handler("warning", module, fmt, ap);
+  }
 }
 
 static void _error_handler(const char* module, const char* fmt, va_list ap)


### PR DESCRIPTION
Graphics/image magick imageio backends used fprintf instead of dt_print for additional debuging output. Changed to use dt_print

TIFF backend used `DT_DEBUG_CAMERA_SUPPORT` instead of `DT_DEBUG_IMAGEIO`

TIFF backend printed both errors and warnings not respecting `DT_DEBUG_IMAGEIO`, now it should print only errors if no debugging is requested

This addresses pint 1 of #7040
Fixes #5580 :)