### PR TITLE
refactor: remove duplicate definitions of clamp_simd() and sqf()

### DIFF
--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -29,6 +29,7 @@
 #include "common/math.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "develop/openmp_maths.h"
 #include <math.h>
 
 #define DT_BLENDIF_LAB_CH 4
@@ -39,14 +40,6 @@ typedef void(_blend_row_func)(const float *const restrict a, float *const restri
                               const float *const restrict mask, const size_t stride,
                               const float *const restrict min, const float *const restrict max);
 
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float clamp_simd(const float x)
-{
-  return fminf(fmaxf(x, 0.0f), 1.0f);
-}
 
 #ifdef _OPENMP
 #pragma omp declare simd

--- a/src/develop/blends/blendif_raw.c
+++ b/src/develop/blends/blendif_raw.c
@@ -28,20 +28,13 @@
 #include "common/math.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "develop/openmp_maths.h"
 #include <math.h>
 
 
 typedef void(_blend_row_func)(const float *const restrict a, float *const restrict b,
                               const float *const restrict mask, const size_t stride);
 
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float clamp_simd(const float x)
-{
-  return fminf(fmaxf(x, 0.0f), 1.0f);
-}
 
 void dt_develop_blendif_raw_make_mask(struct dt_dev_pixelpipe_iop_t *piece, const float *const restrict a,
                                       const float *const restrict b, const struct dt_iop_roi_t *const roi_in,

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -29,6 +29,7 @@
 #include "common/math.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "develop/openmp_maths.h"
 #include <math.h>
 
 #define DT_BLENDIF_RGB_CH 4
@@ -38,14 +39,6 @@
 typedef void(_blend_row_func)(const float *const restrict a, float *const restrict b,
                               const float *const restrict mask, const size_t stride);
 
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float clamp_simd(const float x)
-{
-  return fminf(fmaxf(x, 0.0f), 1.0f);
-}
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ: 16)

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -28,6 +28,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "develop/openmp_maths.h"
 #include <math.h>
 
 #define DT_BLENDIF_RGB_CH 4
@@ -36,23 +37,6 @@
 
 typedef void(_blend_row_func)(const float *const restrict a, float *const restrict b, const float p,
                               const float *const restrict mask, const size_t stride);
-
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float clamp_simd(const float x)
-{
-  return fminf(fmaxf(x, 0.0f), 1.0f);
-}
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float sqf(const float x)
-{
-  return x * x;
-}
 
 
 #ifdef _OPENMP

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -27,6 +27,7 @@
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
+#include "develop/openmp_maths.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
@@ -202,14 +203,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     return 0;
   }
   return 1;
-}
-
-#ifdef _OPENMT
-#pragma omp declare simd
-#endif
-static inline float clamp_simd(const float value)
-{
-  return fmaxf(0.0f, fminf(1.0f, value));
 }
 
 static void process_hsl_v1(dt_dev_pixelpipe_iop_t *piece, const float *const restrict in,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -28,6 +28,7 @@
 #include "common/illuminants.h"
 #include "common/iop_profile.h"
 #include "develop/imageop_math.h"
+#include "develop/openmp_maths.h"
 #include "gui/accelerators.h"
 #include "gui/color_picker_proxy.h"
 #include "gui/gtk.h"
@@ -392,24 +393,6 @@ static inline float scalar_product(const float v_1[4], const float v_2[4])
   float DT_ALIGNED_PIXEL premul[4] = { 0.f };
   for(size_t c = 0; c < 3; c++) premul[c] = v_1[c] * v_2[c];
   return premul[0] + premul[1] + premul[2];
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float sqf(const float x)
-{
-  return x * x;
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float clamp_simd(const float x)
-{
-  return fminf(fmaxf(x, 0.0f), 1.0f);
 }
 
 


### PR DESCRIPTION
Since these functions are defined in openmp_maths.h, we can remove them from the multiple .c files they got copied into and just include the header.
