### PR TITLE
add missing thread-safety-analysis annotations to permit Debug build …

### DIFF
--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -41,7 +41,7 @@ static inline double dt_pthread_get_wtime()
 
 
 #define TOPN 3
-typedef struct dt_pthread_mutex_t
+typedef struct CAPABILITY("mutex") dt_pthread_mutex_t
 {
   pthread_mutex_t mutex;
   char name[256];
@@ -52,7 +52,7 @@ typedef struct dt_pthread_mutex_t
   double top_locked_sum[TOPN];
   char top_wait_name[TOPN][256];
   double top_wait_sum[TOPN];
-} dt_pthread_mutex_t;
+} CAPABILITY("mutex") dt_pthread_mutex_t;
 
 typedef struct dt_pthread_rwlock_t
 {
@@ -108,6 +108,7 @@ static inline int dt_pthread_mutex_init_with_caller(dt_pthread_mutex_t *mutex,
 #define dt_pthread_mutex_lock(A) dt_pthread_mutex_lock_with_caller(A, __FILE__, __LINE__, __FUNCTION__)
 static inline int dt_pthread_mutex_lock_with_caller(dt_pthread_mutex_t *mutex, const char *file,
                                                     const int line, const char *function)
+  ACQUIRE(mutex) NO_THREAD_SAFETY_ANALYSIS
 {
   const double t0 = dt_pthread_get_wtime();
   const int ret = pthread_mutex_lock(&(mutex->mutex));
@@ -135,6 +136,7 @@ static inline int dt_pthread_mutex_lock_with_caller(dt_pthread_mutex_t *mutex, c
 #define dt_pthread_mutex_trylock(A) dt_pthread_mutex_trylock_with_caller(A, __FILE__, __LINE__, __FUNCTION__)
 static inline int dt_pthread_mutex_trylock_with_caller(dt_pthread_mutex_t *mutex, const char *file,
                                                        const int line, const char *function)
+  TRY_ACQUIRE(0, mutex)
 {
   const double t0 = dt_pthread_get_wtime();
   const int ret = pthread_mutex_trylock(&(mutex->mutex));
@@ -163,6 +165,7 @@ static inline int dt_pthread_mutex_trylock_with_caller(dt_pthread_mutex_t *mutex
 #define dt_pthread_mutex_unlock(A) dt_pthread_mutex_unlock_with_caller(A, __FILE__, __LINE__, __FUNCTION__)
 static inline int dt_pthread_mutex_unlock_with_caller(dt_pthread_mutex_t *mutex, const char *file,
                                                       const int line, const char *function)
+  RELEASE(mutex) NO_THREAD_SAFETY_ANALYSIS
 {
   const double t0 = dt_pthread_get_wtime();
   const double locked = t0 - mutex->time_locked;

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -112,10 +112,7 @@ static inline int dt_pthread_mutex_lock_with_caller(dt_pthread_mutex_t *mutex, c
 {
   const double t0 = dt_pthread_get_wtime();
   const int ret = pthread_mutex_lock(&(mutex->mutex));
-#ifndef __APPLE__
-  //FIXME: figure out why some Macs get an error return
   assert(!ret);
-#endif
   mutex->time_locked = dt_pthread_get_wtime();
   double wait = mutex->time_locked - t0;
   mutex->time_sum_wait += wait;
@@ -195,10 +192,7 @@ static inline int dt_pthread_mutex_unlock_with_caller(dt_pthread_mutex_t *mutex,
 
   // need to unlock last, to shield our internal data.
   const int ret = pthread_mutex_unlock(&(mutex->mutex));
-#ifndef __APPLE__
-  //FIXME: figure out why some Macs get an error return
   assert(!ret);
-#endif
   return ret;
 }
 

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -112,7 +112,10 @@ static inline int dt_pthread_mutex_lock_with_caller(dt_pthread_mutex_t *mutex, c
 {
   const double t0 = dt_pthread_get_wtime();
   const int ret = pthread_mutex_lock(&(mutex->mutex));
+#ifndef __APPLE__
+  //FIXME: figure out why some Macs get an error return
   assert(!ret);
+#endif
   mutex->time_locked = dt_pthread_get_wtime();
   double wait = mutex->time_locked - t0;
   mutex->time_sum_wait += wait;
@@ -192,7 +195,10 @@ static inline int dt_pthread_mutex_unlock_with_caller(dt_pthread_mutex_t *mutex,
 
   // need to unlock last, to shield our internal data.
   const int ret = pthread_mutex_unlock(&(mutex->mutex));
+#ifndef __APPLE__
+  //FIXME: figure out why some Macs get an error return
   assert(!ret);
+#endif
   return ret;
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -141,7 +141,6 @@ void dt_dev_cleanup(dt_develop_t *dev)
   if(!dev) return;
   // image_cache does not have to be unref'd, this is done outside develop module.
   dt_pthread_mutex_destroy(&dev->pipe_mutex);
-  dt_pthread_mutex_destroy(&dev->pipe_mutex);
   dt_pthread_mutex_destroy(&dev->preview_pipe_mutex);
   dt_pthread_mutex_destroy(&dev->preview2_pipe_mutex);
   dev->proxy.chroma_adaptation = NULL;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1222,6 +1222,8 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   /* lets zero mem */
   memset(gui, 0, sizeof(dt_gui_gtk_t));
 
+  dt_pthread_mutex_init(&gui->mutex, NULL);
+
   // force gtk3 to use normal scroll bars instead of the popup thing. they get in the way of controls
   // the alternative would be to gtk_scrolled_window_set_overlay_scrolling(..., FALSE); every single widget
   // that might have scroll bars


### PR DESCRIPTION
…with llvm/clang

Compiler annotations for thread safety analysis were only present on the non-debug code in common/dtpthread.h, which caused `./build.sh --build-type Debug` to fail for llvm/clang.

Fixes the issue mentioned by @MStraeten in a comment on #7349.
