### PR TITLE
refactor: dedup file-copying code

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3959,20 +3959,12 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
       // from different computers. sample use case: images on NAS, several computers using them NOT AT THE SAME TIME and
       // the xmp crawler is used to find changed sidecars.
       errno = 0;
-      FILE *fd = g_fopen(filename, "rb");
-      if(fd)
+      size_t end;
+      unsigned char *content = (unsigned char*)dt_read_file(filename, &end);
+      if(content)
       {
-        fseek(fd, 0, SEEK_END);
-        size_t end = ftell(fd);
-        rewind(fd);
-        unsigned char *content = (unsigned char *)malloc(end * sizeof(char));
-        if(content)
-        {
-          if(fread(content, sizeof(unsigned char), end, fd) == end)
-            checksum_old = g_compute_checksum_for_data(G_CHECKSUM_MD5, content, end);
-          free(content);
-        }
-        fclose(fd);
+        checksum_old = g_compute_checksum_for_data(G_CHECKSUM_MD5, content, end);
+        free(content);
       }
       else
       {

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -764,6 +764,54 @@ char *dt_util_format_exposure(const float exposuretime)
   return result;
 }
 
+char *dt_read_file(const char *const filename, size_t *filesize)
+{
+  if (filesize) *filesize = 0;
+  FILE *fd = g_fopen(filename, "rb");
+  if(!fd) return NULL;
+
+  fseek(fd, 0, SEEK_END);
+  size_t end = ftell(fd);
+  rewind(fd);
+
+  char *content = (char *)malloc(end * sizeof(char));
+  if(!content) return NULL;
+
+  size_t count = fread(content, sizeof(char), end, fd);
+  fclose(fd);
+  if (count == end)
+  {
+    if (filesize) *filesize = end;
+    return content;
+  }
+  free(content);
+  return NULL;
+}
+
+void dt_copy_file(const char *const sourcefile, const char *dst)
+{
+  char *content = NULL;
+  FILE *fin = g_fopen(sourcefile, "rb");
+  FILE *fout = g_fopen(dst, "wb");
+
+  if(fin && fout)
+  {
+    fseek(fin, 0, SEEK_END);
+    size_t end = ftell(fin);
+    rewind(fin);
+    content = (char *)g_malloc_n(end, sizeof(char));
+    if(content == NULL) goto END;
+    if(fread(content, sizeof(char), end, fin) != end) goto END;
+    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
+  }
+
+END:
+  if(fout != NULL) fclose(fout);
+  if(fin != NULL) fclose(fin);
+
+  g_free(content);
+}
+
 void dt_copy_resource_file(const char *src, const char *dst)
 {
   char share[PATH_MAX] = { 0 };

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -817,26 +817,7 @@ void dt_copy_resource_file(const char *src, const char *dst)
   char share[PATH_MAX] = { 0 };
   dt_loc_get_datadir(share, sizeof(share));
   gchar *sourcefile = g_build_filename(share, src, NULL);
-  char *content = NULL;
-  FILE *fin = g_fopen(sourcefile, "rb");
-  FILE *fout = g_fopen(dst, "wb");
-
-  if(fin && fout)
-  {
-    fseek(fin, 0, SEEK_END);
-    size_t end = ftell(fin);
-    rewind(fin);
-    content = (char *)g_malloc_n(end, sizeof(char));
-    if(content == NULL) goto END;
-    if(fread(content, sizeof(char), end, fin) != end) goto END;
-    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
-  }
-
-END:
-  if(fout != NULL) fclose(fout);
-  if(fin != NULL) fclose(fin);
-
-  g_free(content);
+  dt_copy_file(sourcefile, dst);
   g_free(sourcefile);
 }
 

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -764,6 +764,34 @@ char *dt_util_format_exposure(const float exposuretime)
   return result;
 }
 
+void dt_copy_resource_file(const char *src, const char *dst)
+{
+  char share[PATH_MAX] = { 0 };
+  dt_loc_get_datadir(share, sizeof(share));
+  gchar *sourcefile = g_build_filename(share, src, NULL);
+  char *content = NULL;
+  FILE *fin = g_fopen(sourcefile, "rb");
+  FILE *fout = g_fopen(dst, "wb");
+
+  if(fin && fout)
+  {
+    fseek(fin, 0, SEEK_END);
+    size_t end = ftell(fin);
+    rewind(fin);
+    content = (char *)g_malloc_n(end, sizeof(char));
+    if(content == NULL) goto END;
+    if(fread(content, sizeof(char), end, fin) != end) goto END;
+    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
+  }
+
+END:
+  if(fout != NULL) fclose(fout);
+  if(fin != NULL) fclose(fin);
+
+  g_free(content);
+  g_free(sourcefile);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -75,6 +75,13 @@ gchar *dt_util_normalize_path(const gchar *input);
 // format exposure time string
 gchar *dt_util_format_exposure(const float exposuretime);
 
+// read the contents of the given file into a malloc'ed buffer
+// returns NULL if unable to read file or alloc memory; sets filesize to the number of bytes returned
+char *dt_read_file(const char *filename, size_t *filesize);
+
+// copy the contents of the given file to a new file
+void dt_copy_file(const char *src, const char *dst);
+
 // copy the contents of a file in dt's data directory to a new file
 void dt_copy_resource_file(const char *src, const char *dst);
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -75,6 +75,9 @@ gchar *dt_util_normalize_path(const gchar *input);
 // format exposure time string
 gchar *dt_util_format_exposure(const float exposuretime);
 
+// copy the contents of a file in dt's data directory to a new file
+void dt_copy_resource_file(const char *src, const char *dst);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -402,34 +402,6 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   return 0;
 }
 
-static void copy_res(const char *src, const char *dst)
-{
-  char share[PATH_MAX] = { 0 };
-  dt_loc_get_datadir(share, sizeof(share));
-  gchar *sourcefile = g_build_filename(share, src, NULL);
-  char *content = NULL;
-  FILE *fin = g_fopen(sourcefile, "rb");
-  FILE *fout = g_fopen(dst, "wb");
-
-  if(fin && fout)
-  {
-    fseek(fin, 0, SEEK_END);
-    size_t end = ftell(fin);
-    rewind(fin);
-    content = (char *)g_malloc_n(end, sizeof(char));
-    if(content == NULL) goto END;
-    if(fread(content, sizeof(char), end, fin) != end) goto END;
-    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
-  }
-
-END:
-  if(fout != NULL) fclose(fout);
-  if(fin != NULL) fclose(fin);
-
-  g_free(content);
-  g_free(sourcefile);
-}
-
 void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *dd)
 {
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)dd;
@@ -441,31 +413,31 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
   sprintf(c, "/style");
   g_mkdir_with_parents(filename, 0755);
   sprintf(c, "/style/style.css");
-  copy_res("/style/style.css", filename);
+  dt_copy_resource_file("/style/style.css", filename);
   sprintf(c, "/style/favicon.ico");
-  copy_res("/style/favicon.ico", filename);
+  dt_copy_resource_file("/style/favicon.ico", filename);
 
   // create subdir pswp for photoswipe scripts
   sprintf(c, "/pswp/default-skin/");
   g_mkdir_with_parents(filename, 0755);
   sprintf(c, "/pswp/photoswipe.js");
-  copy_res("/pswp/photoswipe.js", filename);
+  dt_copy_resource_file("/pswp/photoswipe.js", filename);
   sprintf(c, "/pswp/photoswipe.min.js");
-  copy_res("/pswp/photoswipe.min.js", filename);
+  dt_copy_resource_file("/pswp/photoswipe.min.js", filename);
   sprintf(c, "/pswp/photoswipe-ui-default.js");
-  copy_res("/pswp/photoswipe-ui-default.js", filename);
+  dt_copy_resource_file("/pswp/photoswipe-ui-default.js", filename);
   sprintf(c, "/pswp/photoswipe.css");
-  copy_res("/pswp/photoswipe.css", filename);
+  dt_copy_resource_file("/pswp/photoswipe.css", filename);
   sprintf(c, "/pswp/photoswipe-ui-default.min.js");
-  copy_res("/pswp/photoswipe-ui-default.min.js", filename);
+  dt_copy_resource_file("/pswp/photoswipe-ui-default.min.js", filename);
   sprintf(c, "/pswp/default-skin/default-skin.css");
-  copy_res("/pswp/default-skin/default-skin.css", filename);
+  dt_copy_resource_file("/pswp/default-skin/default-skin.css", filename);
   sprintf(c, "/pswp/default-skin/default-skin.png");
-  copy_res("/pswp/default-skin/default-skin.png", filename);
+  dt_copy_resource_file("/pswp/default-skin/default-skin.png", filename);
   sprintf(c, "/pswp/default-skin/default-skin.svg");
-  copy_res("/pswp/default-skin/default-skin.svg", filename);
+  dt_copy_resource_file("/pswp/default-skin/default-skin.svg", filename);
   sprintf(c, "/pswp/default-skin/preloader.gif");
-  copy_res("/pswp/default-skin/preloader.gif", filename);
+  dt_copy_resource_file("/pswp/default-skin/preloader.gif", filename);
 
   sprintf(c, "/index.html");
 

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -366,34 +366,6 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   return 0;
 }
 
-static void copy_res(const char *src, const char *dst)
-{
-  char share[PATH_MAX] = { 0 };
-  dt_loc_get_datadir(share, sizeof(share));
-  gchar *sourcefile = g_build_filename(share, src, NULL);
-  char *content = NULL;
-  FILE *fin = g_fopen(sourcefile, "rb");
-  FILE *fout = g_fopen(dst, "wb");
-
-  if(fin && fout)
-  {
-    fseek(fin, 0, SEEK_END);
-    size_t end = ftell(fin);
-    rewind(fin);
-    content = (char *)g_malloc_n(end, sizeof(char));
-    if(content == NULL) goto END;
-    if(fread(content, sizeof(char), end, fin) != end) goto END;
-    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
-  }
-
-END:
-  if(fout != NULL) fclose(fout);
-  if(fin != NULL) fclose(fin);
-
-  g_free(content);
-  g_free(sourcefile);
-}
-
 void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *dd)
 {
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)dd;
@@ -402,7 +374,7 @@ void finalize_store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t 
   char *c = filename + strlen(filename);
 
   sprintf(c, "/photobook.cls");
-  copy_res("/latex/photobook.cls", filename);
+  dt_copy_resource_file("/latex/photobook.cls", filename);
 
   sprintf(c, "/main.tex");
 


### PR DESCRIPTION
This PR eliminates duplicate code to copy the contents of a file.

The first commit is safe to cherry-pick, as it just moves an existing function and elides the clone of that function from another file.

The second commit should get some testing before merge, as it involves actual refactoring of code and I haven't yet figured out what user actions are needed to trigger those four file-copy instances.
