### PR TITLE
refactor: more consolidation of box filters

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -406,6 +406,101 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
   dt_free_align(scanlines);
 }
 
+// moved here from common/fast_guided_filter.h   TODO: optimize like the other N-channel versions
+__DT_CLONE_TARGETS__
+static inline void box_average(float *const restrict in,
+                               const size_t width, const size_t height, const size_t ch,
+                               const int radius)
+{
+  // Compute in-place a box average (filter) on a multi-channel image over a window of size 2*radius + 1
+  // We make use of the separable nature of the filter kernel to speed-up the computation
+  // by convolving along columns and rows separately (complexity O(2 × radius) instead of O(radius²)).
+
+  assert(ch <= 4);
+
+  const size_t Ndim = width * height * ch;
+  float *const restrict temp = dt_alloc_sse_ps(Ndim);
+
+  // Convolve box average along columns
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(in, temp, width, height, ch, radius) \
+  schedule(simd:static) collapse(2)
+#endif
+  for(size_t j = 0; j < width; j++)
+  {
+    for(size_t i = 0; i < height; i++)
+    {
+      const size_t begin_convol = (i < radius) ? 0 : i - radius;
+      size_t end_convol = i + radius;
+      end_convol = (end_convol < height) ? end_convol : height - 1;
+      const float num_elem = (float)end_convol - (float)begin_convol + 1.0f;
+      const size_t index = (i * width + j) * ch;
+
+      float w[4] DT_ALIGNED_PIXEL = { 0.0f };
+
+      // Convolve
+      for(size_t c = begin_convol; c <= end_convol; c++)
+      {
+        const size_t index_c = (c * width + j) * ch;
+#ifdef _OPENMP
+#pragma omp simd aligned(in:64) aligned(w:16) reduction(+:w)
+#endif
+        for(size_t k = 0; k < ch; ++k)
+          w[k] += in[index_c + k];
+      }
+
+    // Normalize and Save
+#ifdef _OPENMP
+#pragma omp simd aligned(temp:64) aligned(w:16)
+#endif
+      for(size_t k = 0; k < ch; ++k)
+        temp[index + k] = w[k] / num_elem;
+    }
+  }
+
+  // Convolve box average along rows and output result
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(in, temp, width, height, ch, radius) \
+  schedule(simd:static) collapse(2)
+#endif
+  for(size_t i = 0; i < height; i++)
+  {
+    for(size_t j = 0; j < width; j++)
+    {
+      const size_t begin_convol = (j < radius) ? 0 : j - radius;
+      size_t end_convol = j + radius;
+      end_convol = (end_convol < width) ? end_convol : width - 1;
+      const float num_elem = (float)end_convol - (float)begin_convol + 1.0f;
+      const size_t stride = i * width;
+      const size_t index = (stride + j) * ch;
+
+      float w[4] DT_ALIGNED_PIXEL = { 0.0f };
+
+      // Convolve
+      for(size_t c = begin_convol; c <= end_convol; c++)
+      {
+        const size_t index_c = (stride + c) * ch;
+#ifdef _OPENMP
+#pragma omp simd aligned(temp:64) aligned(w:16) reduction(+:w)
+#endif
+        for(size_t k = 0; k < ch; ++k)
+          w[k] += temp[index_c + k];
+      }
+
+      // Normalize and Save
+#ifdef _OPENMP
+#pragma omp simd aligned(w:16) aligned(in:64)
+#endif
+      for(size_t k = 0; k < ch; ++k)
+        in[index + k] = w[k] / num_elem;
+    }
+  }
+
+  if(temp != NULL) dt_free_align(temp);
+}
+
 void dt_box_mean(float *const buf, const int height, const int width, const int ch,
                  const int radius, const int iterations)
 {
@@ -417,8 +512,11 @@ void dt_box_mean(float *const buf, const int height, const int width, const int 
   {
     dt_box_mean_4ch(buf,height,width,radius,iterations);
   }
+  else if (ch == 2) // used by fast_guided_filter.h
+  {
+    box_average(buf, width, height, ch, radius);
+  }
 }
-
 
 
 // calculate the one-dimensional moving maximum over a window of size 2*w+1

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -522,7 +522,6 @@ static void box_max_1ch(float *const buf, const int height, const int width, con
   dt_omp_sharedconst(scratch_buffers) \
   schedule(static)
 #endif
-#if 1
   for(int col = 0; col < (width & ~15); col += 16)
   {
     float *const restrict scratch = scratch_buffers + 16 * height * dt_get_thread_num();
@@ -532,9 +531,6 @@ static void box_max_1ch(float *const buf, const int height, const int width, con
     box_max_vert_16wide(height, scratch, buf + col, width, w);
   }
   for (size_t col = width & ~15 ; col < width; col++)
-#else
-  for (size_t col = 0 ; col < width; col++)
-#endif
   {
     float *const restrict scratch = scratch_buffers;
     for(size_t row = 0; row < height; row++)
@@ -651,7 +647,6 @@ static void box_min_1ch(float *const buf, const int height, const int width, con
   dt_omp_sharedconst(scratch_buffers) \
   schedule(static)
 #endif
-#if 1
   for(int col = 0; col < (width & ~15); col += 16)
   {
     float *const restrict scratch = scratch_buffers + 16 * height * dt_get_thread_num();
@@ -661,9 +656,6 @@ static void box_min_1ch(float *const buf, const int height, const int width, con
     box_min_vert_16wide(height, scratch, buf + col, width, w);
   }
   for (size_t col = width & ~15 ; col < width; col++)
-#else
-  for (size_t col = 0 ; col < width; col++)
-#endif
   {
     float *const restrict scratch = scratch_buffers;
     for(size_t row = 0; row < height; row++)

--- a/src/common/box_filters.h
+++ b/src/common/box_filters.h
@@ -21,6 +21,7 @@
 // default number of iterations to run for dt_box_mean
 #define BOX_ITERATIONS 8
 
+// ch = number of channels per pixel.  Supported values: 1 and 4
 void dt_box_mean(float *const buf, const int height, const int width, const int ch,
                  const int radius, const int interations);
 

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <time.h>
 
+#include "common/box_filters.h"
 #include "common/darktable.h"
 
 /** Note :
@@ -303,101 +304,6 @@ static inline void variance_analyse(const float *const restrict guide, // I
 
 
 __DT_CLONE_TARGETS__
-static inline void box_average(float *const restrict in,
-                               const size_t width, const size_t height, const size_t ch,
-                               const int radius)
-{
-  // Compute in-place a box average (filter) on a multi-channel image over a window of size 2*radius + 1
-  // We make use of the separable nature of the filter kernel to speed-up the computation
-  // by convolving along columns and rows separately (complexity O(2 × radius) instead of O(radius²)).
-
-  assert(ch <= 4);
-
-  const size_t Ndim = width * height * ch;
-  float *const restrict temp = dt_alloc_sse_ps(Ndim);
-
-  // Convolve box average along columns
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, temp, width, height, ch, radius) \
-  schedule(simd:static) collapse(2)
-#endif
-  for(size_t j = 0; j < width; j++)
-  {
-    for(size_t i = 0; i < height; i++)
-    {
-      const size_t begin_convol = (i < radius) ? 0 : i - radius;
-      size_t end_convol = i + radius;
-      end_convol = (end_convol < height) ? end_convol : height - 1;
-      const float num_elem = (float)end_convol - (float)begin_convol + 1.0f;
-      const size_t index = (i * width + j) * ch;
-
-      float w[4] DT_ALIGNED_PIXEL = { 0.0f };
-
-      // Convolve
-      for(size_t c = begin_convol; c <= end_convol; c++)
-      {
-        const size_t index_c = (c * width + j) * ch;
-#ifdef _OPENMP
-#pragma omp simd aligned(in:64) aligned(w:16) reduction(+:w)
-#endif
-        for(size_t k = 0; k < ch; ++k)
-          w[k] += in[index_c + k];
-      }
-
-    // Normalize and Save
-#ifdef _OPENMP
-#pragma omp simd aligned(temp:64) aligned(w:16)
-#endif
-      for(size_t k = 0; k < ch; ++k)
-        temp[index + k] = w[k] / num_elem;
-    }
-  }
-
-  // Convolve box average along rows and output result
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, temp, width, height, ch, radius) \
-  schedule(simd:static) collapse(2)
-#endif
-  for(size_t i = 0; i < height; i++)
-  {
-    for(size_t j = 0; j < width; j++)
-    {
-      const size_t begin_convol = (j < radius) ? 0 : j - radius;
-      size_t end_convol = j + radius;
-      end_convol = (end_convol < width) ? end_convol : width - 1;
-      const float num_elem = (float)end_convol - (float)begin_convol + 1.0f;
-      const size_t stride = i * width;
-      const size_t index = (stride + j) * ch;
-
-      float w[4] DT_ALIGNED_PIXEL = { 0.0f };
-
-      // Convolve
-      for(size_t c = begin_convol; c <= end_convol; c++)
-      {
-        const size_t index_c = (stride + c) * ch;
-#ifdef _OPENMP
-#pragma omp simd aligned(temp:64) aligned(w:16) reduction(+:w)
-#endif
-        for(size_t k = 0; k < ch; ++k)
-          w[k] += temp[index_c + k];
-      }
-
-      // Normalize and Save
-#ifdef _OPENMP
-#pragma omp simd aligned(w:16) aligned(in:64)
-#endif
-      for(size_t k = 0; k < ch; ++k)
-        in[index + k] = w[k] / num_elem;
-    }
-  }
-
-  if(temp != NULL) dt_free_align(temp);
-}
-
-
-__DT_CLONE_TARGETS__
 static inline void apply_linear_blending(float *const restrict image,
                                          const float *const restrict ab,
                                          const size_t num_elem)
@@ -523,7 +429,7 @@ static inline void fast_surface_blur(float *const restrict image,
     variance_analyse(ds_mask, ds_image, ds_ab, ds_width, ds_height, ds_radius, feathering);
 
     // Compute the patch-wise average of parameters a and b
-    box_average(ds_ab, ds_width, ds_height, 2, ds_radius);
+    dt_box_mean(ds_ab, ds_height, ds_width, 2, ds_radius, 1);
 
     if(i != iterations - 1)
     {

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "common/box_filters.h"
 #include "common/fast_guided_filter.h"
 #include "develop/openmp_maths.h"
 
@@ -132,7 +133,8 @@ schedule(static) collapse(2) aligned(luma_ds, luma:64)
     }
 
   // Anti-aliasing
-  box_average(luma_ds, buf_width, buf_height, 1, 2);
+//  box_average(luma_ds, buf_width, buf_height, 1, 2);
+  dt_box_mean(luma_ds, buf_height, buf_width, 1, 2, 1);
 
   // Compute the gradient mean over the picture
   float TV_sum = 0.0f;

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -126,7 +126,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 /* create overexpose image and then blur */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(brightness, in, out, npixels, saturation) \
+  dt_omp_firstprivate(brightness, npixels, saturation) \
+  dt_omp_sharedconst(in, out) \
   schedule(static)
 #endif
   for(size_t k = 0; k < 4 * npixels; k += 4)
@@ -152,7 +153,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(amount, amount_1, in, out, npixels) \
-  schedule(static) aligned(in, out) \
+  schedule(simd:static) aligned(in, out : 64) \
   collapse(2)
 #endif
   for(size_t k = 0; k < 4 * npixels; k += 4)
@@ -168,28 +169,30 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_soften_data_t *data = (dt_iop_soften_data_t *)piece->data;
-  float *in = (float *)ivoid;
-  float *out = (float *)ovoid;
-  const int ch = piece->colors;
+  dt_iop_soften_data_t *const data = (dt_iop_soften_data_t *)piece->data;
+  assert(piece->colors == 4);
 
   const float brightness = 1.0 / exp2f(-data->brightness);
   const float saturation = data->saturation / 100.0;
+
+  const float *const restrict in = (const float *const)ivoid;
+  float *const restrict out = (float *const)ovoid;
+
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
 /* create overexpose image and then blur */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, brightness, roi_out, saturation) \
-  shared(in, out) \
+  dt_omp_firstprivate(npixels, brightness, saturation) \
+  dt_omp_sharedconst(in, out) \
   schedule(static)
 #endif
-  for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
+  for(size_t k = 0; k < 4 * npixels; k += 4)
   {
-    size_t index = ch * k;
     float h, s, l;
-    rgb2hsl(&in[index], &h, &s, &l);
+    rgb2hsl(&in[k], &h, &s, &l);
     s *= saturation;
     l *= brightness;
-    hsl2rgb(&out[index], h, CLIP(s), CLIP(l));
+    hsl2rgb(&out[k], h, CLIP(s), CLIP(l));
   }
 
   const float w = piece->iwidth * piece->iscale;
@@ -198,99 +201,19 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   int rad = mrad * (fmin(100.0, data->size + 1) / 100.0);
   const int radius = MIN(mrad, ceilf(rad * roi_in->scale / piece->iscale));
 
-  const int size = roi_out->width > roi_out->height ? roi_out->width : roi_out->height;
-
-  __m128 *const scanline_buf = dt_alloc_align(64, size * dt_get_num_threads() * sizeof(__m128));
-
-  for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
-  {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, radius, roi_out, scanline_buf, size) \
-    shared(out) \
-    schedule(static)
-#endif
-    /* horizontal blur out into out */
-    for(int y = 0; y < roi_out->height; y++)
-    {
-      __m128 *scanline = scanline_buf + size * dt_get_thread_num();
-      size_t index = (size_t)y * roi_out->width;
-      __m128 L = _mm_setzero_ps();
-      int hits = 0;
-      for(int x = -radius; x < roi_out->width; x++)
-      {
-        int op = x - radius - 1;
-        int np = x + radius;
-        if(op >= 0)
-        {
-          L = _mm_sub_ps(L, _mm_load_ps(&out[(index + op) * ch]));
-          hits--;
-        }
-        if(np < roi_out->width)
-        {
-          L = _mm_add_ps(L, _mm_load_ps(&out[(index + np) * ch]));
-          hits++;
-        }
-        if(x >= 0) scanline[x] = _mm_div_ps(L, _mm_set_ps1(hits));
-      }
-
-      for(int x = 0; x < roi_out->width; x++) _mm_store_ps(&out[(index + x) * ch], scanline[x]);
-    }
-
-    /* vertical pass on blurlightness */
-    const int opoffs = -(radius + 1) * roi_out->width;
-    const int npoffs = (radius)*roi_out->width;
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, npoffs, opoffs, radius, roi_out, scanline_buf, size) \
-    shared(out) \
-    schedule(static)
-#endif
-    for(int x = 0; x < roi_out->width; x++)
-    {
-      __m128 *scanline = scanline_buf + size * dt_get_thread_num();
-      __m128 L = _mm_setzero_ps();
-      int hits = 0;
-      size_t index = (size_t)x - radius * roi_out->width;
-      for(int y = -radius; y < roi_out->height; y++)
-      {
-        int op = y - radius - 1;
-        int np = y + radius;
-
-        if(op >= 0)
-        {
-          L = _mm_sub_ps(L, _mm_load_ps(&out[(index + opoffs) * ch]));
-          hits--;
-        }
-        if(np < roi_out->height)
-        {
-          L = _mm_add_ps(L, _mm_load_ps(&out[(index + npoffs) * ch]));
-          hits++;
-        }
-        if(y >= 0) scanline[y] = _mm_div_ps(L, _mm_set_ps1(hits));
-        index += roi_out->width;
-      }
-
-      for(int y = 0; y < roi_out->height; y++)
-        _mm_store_ps(&out[((size_t)y * roi_out->width + x) * ch], scanline[y]);
-    }
-  }
-
-  dt_free_align(scanline_buf);
+  dt_box_mean(out, roi_out->height, roi_out->width, 4, radius, BOX_ITERATIONS);
 
   const __m128 amount = _mm_set1_ps(data->amount / 100.0);
   const __m128 amount_1 = _mm_set1_ps(1 - (data->amount) / 100.0);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, amount, amount_1, roi_out) \
-  shared(in, out, data) \
+  dt_omp_firstprivate(npixels, amount, amount_1, roi_out) \
+  dt_omp_sharedconst(in, out, data) \
   schedule(static)
 #endif
-  for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
+  for(size_t k = 0; k < 4 * npixels; k += 4)
   {
-    int index = ch * k;
-    _mm_store_ps(&out[index], _mm_add_ps(_mm_mul_ps(_mm_load_ps(&in[index]), amount_1),
-                                         _mm_mul_ps(MM_CLIP_PS(_mm_load_ps(&out[index])), amount)));
+    _mm_store_ps(&out[k], ((_mm_load_ps(&in[k]) * amount_1) + (MM_CLIP_PS(_mm_load_ps(&out[k])) * amount)));
   }
 }
 #endif


### PR DESCRIPTION
This PR continues the process of consolidating all implementations of box filters in one source file by moving the box_average function from fast_guided_filters.h (used by tone equalizer with the old guided filter and focus peaking) as well as the previously-missed SSE codepath in soften.c.  It also optimizes some of the moved code.

The optimzation causes a different order of evaluation, which very slightly changes the output of test 0079 from the pending #7370 (304 total pixels changed, max dE = 1.0918, PAE equal to the minimum representable difference).

Benchmark results, using mire1-xtrans.raf to get longer runtimes than with mire1.cr2:
```
Soften (test 0051 sidecar)         ToneEq (GF) (test 0079 sidecar)
Thr   Old    New                        Thr   Old    New
1     3.799   2.378  (-36.4%)      1      1.436  1.048  (-27%)
4     0.987   0.640  (-35.1%)      4      0.398  0.297  (-25%)
8     0.540   0.389  (-28.0%)      8      0.220  0.164  (-25%)
16   0.329   0.282  (-14.3%)      16    0.123  0.096  (-22%)
32   0.260   0.256  (-1.5%)        32    0.084  0.079  (-6%)
```
