### PR TITLE
move conditional definition of M_LN10 into a common header

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -21,6 +21,18 @@
 #include <math.h>
 #include <stdint.h>
 
+// work around missing standard math.h symbols
+/** ln(10) */
+#ifndef M_LN10
+#define M_LN10 2.30258509299404568402
+#endif /* !M_LN10 */
+
+/** PI */
+#ifndef M_PI
+#define M_PI   3.14159265358979323846
+#endif /* !M_PI */
+
+
 #define DT_M_PI_F (3.14159265358979324f)
 #define DT_M_PI (3.14159265358979324)
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -19,6 +19,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/dtpthread.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "common/iop_profile.h"
 #include "control/control.h"
@@ -35,7 +36,6 @@
 
 #include <assert.h>
 #include <gmodule.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/src/iop/ashift_lsd.c
+++ b/src/iop/ashift_lsd.c
@@ -140,20 +140,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <limits.h>
 #include <float.h>
-//#include "lsd.h"
-
-/** ln(10) */
-#ifndef M_LN10
-#define M_LN10 2.30258509299404568402
-#endif /* !M_LN10 */
-
-/** PI */
-#ifndef M_PI
-#define M_PI   3.14159265358979323846
-#endif /* !M_PI */
+#include "common/math.h"
 
 #ifndef FALSE
 #define FALSE 0


### PR DESCRIPTION
This should fix #7378, #7357.  It appears that the missing M_LN10 has come up in the past.

Also moved M_PI to be thorough.
