### PR TITLE
performance: parallelize circle-mask drawing

### DIFF
--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -894,6 +894,7 @@ static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
   const float pos_y = *posy;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(h, w) \
   dt_omp_sharedconst(points, pos_x, pos_y) \
   schedule(static) if(h*w > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
 #endif

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -21,6 +21,7 @@
 #include "develop/blend.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
+#include "develop/openmp_maths.h"
 
 static void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
                                    int *inside_border, int *near, int *inside_source)
@@ -733,7 +734,7 @@ static int dt_circle_get_points(dt_develop_t *dev, float x, float y, float radiu
   int l = MAX(100, (int)(2.0 * M_PI * r));
 
   // buffer allocations
-  *points = dt_alloc_align(64, 2 * (l + 1) * sizeof(float));
+  *points = dt_alloc_align_float(2 * (l + 1));
   if(*points == NULL)
   {
     *points_count = 0;
@@ -771,7 +772,7 @@ static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_i
   float r = (circle->radius + circle->border) * MIN(wd, ht);
   int l = (int)(2.0 * M_PI * r);
   // buffer allocations
-  float *points = dt_alloc_align(64, 2 * (l + 1) * sizeof(float));
+  float *const restrict points = dt_alloc_align_float(2 * (l + 1));
   if(points == NULL)
     return 0;
 
@@ -812,7 +813,9 @@ static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_i
   return 1;
 }
 
-static int dt_circle_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
+static int dt_circle_get_area(const dt_iop_module_t *const restrict module,
+                              const dt_dev_pixelpipe_iop_t *const restrict piece,
+                              dt_masks_form_t *const restrict form,
                               int *width, int *height, int *posx, int *posy)
 {
   // we get the circle values
@@ -822,7 +825,7 @@ static int dt_circle_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   float r = (circle->radius + circle->border) * MIN(wd, ht);
   int l = (int)(2.0 * M_PI * r);
   // buffer allocations
-  float *points = dt_alloc_align(64, 2 * (l + 1) * sizeof(float));
+  float *const restrict points = dt_alloc_align_float(2 * (l + 1));
   if(points == NULL)
     return 0;
 
@@ -864,7 +867,9 @@ static int dt_circle_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   return 1;
 }
 
-static int dt_circle_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
+/*static*/ int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
+                              const dt_dev_pixelpipe_iop_t *const restrict piece,
+                              dt_masks_form_t *const restrict form,
                               float **buffer, int *width, int *height, int *posx, int *posy)
 {
   double start2 = dt_get_wtime();
@@ -877,23 +882,37 @@ static int dt_circle_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   start2 = dt_get_wtime();
 
   // we get the circle values
-  dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
+  dt_masks_point_circle_t *const restrict circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
 
   // we create a buffer of points with all points in the area
-  int w = *width, h = *height;
-  float *points = dt_alloc_align(64, w * h * 2 * sizeof(float));
+  const int w = *width, h = *height;
+  float *const restrict points = dt_alloc_align_float(w * h * 2);
   if(points == NULL)
     return 0;
 
+  const float pos_x = *posx;
+  const float pos_y = *posy;
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_sharedconst(points, pos_x, pos_y) \
+  schedule(static) if(h*w > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
+#endif
   for(int i = 0; i < h; i++)
+  {
+    float *const restrict p = points + 2 * i * w;
+    const float y = i + pos_y;
+#ifdef _OPENMP
+#pragma omp simd aligned(points : 64)
+#endif
     for(int j = 0; j < w; j++)
     {
-      points[(i * w + j) * 2] = (j + (*posx));
-      points[(i * w + j) * 2 + 1] = (i + (*posy));
+      p[2*j] = pos_x + j;
+      p[2*j + 1] = y;
     }
-
+  }
   if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] circle draw took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+
   start2 = dt_get_wtime();
 
   // we back transform all this points
@@ -909,7 +928,7 @@ static int dt_circle_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   start2 = dt_get_wtime();
 
   // we allocate the buffer
-  *buffer = dt_alloc_align(64, w * h * sizeof(float));
+  *buffer = dt_alloc_align_float(w * h);
   if(*buffer == NULL)
   {
     dt_free_align(points);
@@ -917,39 +936,45 @@ static int dt_circle_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   }
 
   // we populate the buffer
-  int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
-  float center[2] = { circle->center[0] * wi, circle->center[1] * hi };
-  float radius2 = circle->radius * MIN(wi, hi) * circle->radius * MIN(wi, hi);
-  float total2 = (circle->radius + circle->border) * MIN(wi, hi) * (circle->radius + circle->border)
-                 * MIN(wi, hi);
-  for(int i = 0; i < h; i++)
-    for(int j = 0; j < w; j++)
-    {
-      float x = points[(i * w + j) * 2];
-      float y = points[(i * w + j) * 2 + 1];
-      float l2 = (x - center[0]) * (x - center[0]) + (y - center[1]) * (y - center[1]);
-      if(l2 < radius2)
-        (*buffer)[i * w + j] = 1.0f;
-      else if(l2 < total2)
-      {
-        float f = (total2 - l2) / (total2 - radius2);
-        (*buffer)[i * w + j] = f * f;
-      }
-      else
-        (*buffer)[i * w + j] = 0.0f;
-    }
+  float *const restrict ptbuffer = *buffer;
+  const int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
+  const int mindim = MIN(wi, hi);
+  const float centerx = circle->center[0] * wi;
+  const float centery = circle->center[1] * hi;
+  const float radius2 = circle->radius * mindim * circle->radius * mindim;
+  const float total2 = (circle->radius + circle->border) * mindim * (circle->radius + circle->border) * mindim;
+  const float border2 = total2 - radius2;
+  const float *const points_y = points + 1;
+#ifdef _OPENMP
+#pragma omp parallel for default(none)  \
+  dt_omp_firstprivate(h, w) \
+  dt_omp_sharedconst(border2, total2, centerx, centery, points, points_y, ptbuffer) \
+  schedule(simd:static) if(h*w > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
+#endif
+  for(int i = 0 ; i < h*w; i++)
+  {
+    // find the square of the distance from the center
+    const float l2 = sqf(points[2 * i] - centerx) + sqf(points_y[2 * i] - centery);
+    // quadratic falloff between the circle's radius and the radius of the outside of the feathering
+    const float ratio = (total2 - l2) / border2;
+    // enforce 1.0 inside the circle and 0.0 outside the feathering
+    const float f = CLAMP(ratio, 0.0f, 1.0f);
+    ptbuffer[i] = f * f;
+  }
+
   dt_free_align(points);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] circle fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
-//   start2 = dt_get_wtime();
 
   return 1;
 }
 
 
-static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                  dt_masks_form_t *form, const dt_iop_roi_t *roi, float *buffer)
+static int dt_circle_get_mask_roi(const dt_iop_module_t *const restrict module,
+                                  const dt_dev_pixelpipe_iop_t *const restrict piece,
+                                  dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
+                                  float *const restrict buffer)
 {
   double start1 = dt_get_wtime();
   double start2 = start1;
@@ -957,10 +982,13 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
   // we get the circle parameters
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
   const int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
-  const float center[2] = { circle->center[0] * wi, circle->center[1] * hi };
-  const float radius2 = circle->radius * MIN(wi, hi) * circle->radius * MIN(wi, hi);
-  const float total = (circle->radius + circle->border) * MIN(wi, hi);
+  const float centerx = circle->center[0] * wi;
+  const float centery = circle->center[1] * hi;
+  const int mindim = MIN(wi, hi);
+  const float radius2 = circle->radius * mindim * circle->radius * mindim;
+  const float total = (circle->radius + circle->border) * mindim;
   const float total2 = total * total;
+  const float border2 = total2 - radius2;
 
   // we create a buffer of grid points for later interpolation: higher speed and reduced memory footprint;
   // we match size of buffer to bounding box around the shape
@@ -983,25 +1011,25 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
   // we look at the outer circle of the shape - no effects outside of this circle;
   // we need many points as we do not know how the circle might get distorted in the pixelpipe
   const size_t circpts = dt_masks_roundup(MIN(360, 2 * M_PI * total2), 8);
-  float *circ = dt_alloc_align(64, circpts * 2 * sizeof(float));
+  float *const restrict circ = dt_alloc_align_float(circpts * 2);
   if(circ == NULL) return 0;
 
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(circpts, center, total) \
-  shared(circ)
+  dt_omp_firstprivate(circpts, centerx, centery, total) \
+  dt_omp_sharedconst(circ) schedule(static) if(circpts/8 > 1000)
 #else
-#pragma omp parallel for shared(points)
+#pragma omp parallel for shared(points) schedule(static)
 #endif
 #endif
   for(int n = 0; n < circpts / 8; n++)
   {
     const float phi = (2.0f * M_PI * n) / circpts;
-    const float x = total * cos(phi);
-    const float y = total * sin(phi);
-    const float cx = center[0];
-    const float cy = center[1];
+    const float x = total * cosf(phi);
+    const float y = total * sinf(phi);
+    const float cx = centerx;
+    const float cy = centery;
     const int index_x = 2 * n * 8;
     const int index_y = 2 * n * 8 + 1;
     // take advantage of symmetry
@@ -1079,7 +1107,7 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
     return 1;
 
 
-  float *points = dt_alloc_align(64, (size_t)bbw * bbh * 2 * sizeof(float));
+  float *const restrict points = dt_alloc_align_float((size_t)bbw * bbh * 2);
   if(points == NULL) return 0;
 
   // we populate the grid points in module coordinates
@@ -1087,7 +1115,8 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(iscale, bbxm, bbym, bbXM, bbYM, bbw, px, py, grid) \
-  shared(points) schedule(static) collapse(2)
+  dt_omp_sharedconst(points) \
+  schedule(static) collapse(2) if(bbw*bbh > 50000)
 #else
 #pragma omp parallel for shared(points)
 #endif
@@ -1123,8 +1152,9 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(bbh, bbw, center, radius2, total2) \
-  shared(points) schedule(static) collapse(2)
+  dt_omp_firstprivate(bbh, bbw, centerx, centery, border2, total2) \
+  dt_omp_sharedconst(points) \
+  schedule(static) collapse(2) if(bbh*bbw > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
 #else
 #pragma omp parallel for shared(points)
 #endif
@@ -1133,18 +1163,13 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
     for(int i = 0; i < bbw; i++)
     {
       const size_t index = (size_t)j * bbw + i;
-      const float x = points[index * 2];
-      const float y = points[index * 2 + 1];
-      const float l2 = (x - center[0]) * (x - center[0]) + (y - center[1]) * (y - center[1]);
-      if(l2 < radius2)
-        points[index * 2] = 1.0f;
-      else if(l2 < total2)
-      {
-        const float f = (total2 - l2) / (total2 - radius2);
-        points[index * 2] = f * f;
-      }
-      else
-        points[index * 2] = 0.0f;
+      // find the square of the distance from the center
+      const float l2 = sqf(points[2 * index] - centerx) + sqf(points[2 * index + 1] - centery);
+      // quadratic falloff between the circle's radius and the radius of the outside of the feathering
+      const float ratio = (total2 - l2) / border2;
+      // enforce 1.0 inside the circle and 0.0 outside the feathering
+      const float f = CLAMP(ratio, 0.0f, 1.0f);
+      points[2*index] = f * f;
     }
 
   if(darktable.unmuted & DT_DEBUG_PERF)
@@ -1160,7 +1185,7 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(grid, bbxm, bbym, bbw, endx, endy, w) \
-  shared(buffer, points) schedule(static)
+  dt_omp_sharedconst(buffer, points) schedule(static)
 #else
 #pragma omp parallel for shared(buffer)
 #endif

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -867,7 +867,7 @@ static int dt_circle_get_area(const dt_iop_module_t *const restrict module,
   return 1;
 }
 
-/*static*/ int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
+static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
                               const dt_dev_pixelpipe_iop_t *const restrict piece,
                               dt_masks_form_t *const restrict form,
                               float **buffer, int *width, int *height, int *posx, int *posy)


### PR DESCRIPTION
plus generalized cleanup of the code, including adding const and restrict qualifiers.

Verified against tests 0073, 0074, and 0075, which all use circle shapes.
