### PR TITLE
collect: shift-double click to switch from filmroll to corresponding folder

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2186,6 +2186,16 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
         else dt_collection_set_tag_id((dt_collection_t *)darktable.collection, 0);
       }
     }
+    else if(item == DT_COLLECTION_PROP_FILMROLL && event->state & GDK_SHIFT_MASK)
+    {
+      // go to corresponding folder collection
+      _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FOLDERS);
+    }
+    else if(item == DT_COLLECTION_PROP_FOLDERS && event->state & GDK_SHIFT_MASK)
+    {
+      // go to corresponding filmroll collection
+      _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FILMROLL);
+    }
   }
 
   g_signal_handlers_block_matched(d->rule[active].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);


### PR DESCRIPTION
After folder import, the filmroll collection is activated. For those who prefer the folder collection, shift-double click to go quickly to the corresponding folder.

Would there be any use case for which this wouldn't work ?