### PR TITLE
darkroom : show toast message on rating & colorlabels

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -486,13 +486,21 @@ void dt_control_log(const char *msg, ...)
   g_idle_add(_redraw_center, 0);
 }
 
-void dt_toast_log(const char *msg, ...)
+void dt_toast_log(const gboolean markup, const char *msg, ...)
 {
   dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  char tmp_msg[DT_CTL_TOAST_MSG_SIZE];
   va_list ap;
   va_start(ap, msg);
-  vsnprintf(darktable.control->toast_message[darktable.control->toast_pos], DT_CTL_TOAST_MSG_SIZE, msg, ap);
+  vsnprintf(tmp_msg, DT_CTL_TOAST_MSG_SIZE, msg, ap);
   va_end(ap);
+  // if we don't want markup, we escape <>&... so they are not interpreted later
+  if(markup)
+    snprintf(darktable.control->toast_message[darktable.control->toast_pos], DT_CTL_TOAST_MSG_SIZE, "%s", tmp_msg);
+  else
+    snprintf(darktable.control->toast_message[darktable.control->toast_pos], DT_CTL_TOAST_MSG_SIZE, "%s",
+             g_markup_escape_text(tmp_msg, DT_CTL_TOAST_MSG_SIZE));
+
   if(darktable.control->toast_message_timeout_id) g_source_remove(darktable.control->toast_message_timeout_id);
   darktable.control->toast_ack = darktable.control->toast_pos;
   darktable.control->toast_pos = (darktable.control->toast_pos + 1) % DT_CTL_TOAST_SIZE;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -57,7 +57,7 @@ int dt_control_key_released(guint key, guint state);
 int dt_control_key_pressed_override(guint key, guint state);
 gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer user_data);
 void dt_control_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
-void dt_toast_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
+void dt_toast_log(const gboolean markup, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 void dt_control_log_busy_enter();
 void dt_control_toast_busy_enter();
 void dt_control_log_busy_leave();

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -140,7 +140,7 @@ typedef struct dt_control_accels_t
 #define DT_CTL_LOG_MSG_SIZE 200
 #define DT_CTL_LOG_TIMEOUT 5000
 #define DT_CTL_TOAST_SIZE 10
-#define DT_CTL_TOAST_MSG_SIZE 200
+#define DT_CTL_TOAST_MSG_SIZE 300
 #define DT_CTL_TOAST_TIMEOUT 1500
 /**
  * this manages everything time-consuming.

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1799,7 +1799,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
       opacity = CLAMP(opacity + amount, 0.05f, 1.0f);
       dt_conf_set_float("plugins/darkroom/masks/opacity", opacity);
       const int opacitypercent = opacity * 100;
-      dt_toast_log(_("opacity: %d%%"), opacitypercent);
+      dt_toast_log(FALSE, _("opacity: %d%%"), opacitypercent);
       ret = 1;
     }
 
@@ -2483,7 +2483,7 @@ void dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up)
       const float opacity = CLAMP(fpt->opacity + amount, 0.05f, 1.0f);
       fpt->opacity = opacity;
       const int opacitypercent = opacity * 100;
-      dt_toast_log(_("opacity: %d%%"), opacitypercent);
+      dt_toast_log(FALSE, _("opacity: %d%%"), opacitypercent);
       dt_dev_add_masks_history_item(darktable.develop, NULL, TRUE);
       dt_masks_update_image(darktable.develop);
       break;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2027,9 +2027,19 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
 
         // translate in human readable value
         if(r == DT_VIEW_REJECT)
-          dt_toast_log(_("image rejected"));
-        else
-          dt_toast_log(ngettext("image rated to %d star", "image rated to %d stars", r), r);
+          dt_toast_log(FALSE, _("image rejected"));
+        else if(r == 1)
+          dt_toast_log(FALSE, _("image rated to %s"), "★");
+        else if(r == 2)
+          dt_toast_log(FALSE, _("image rated to %s"), "★★");
+        else if(r == 3)
+          dt_toast_log(FALSE, _("image rated to %s"), "★★★");
+        else if(r == 4)
+          dt_toast_log(FALSE, _("image rated to %s"), "★★★★");
+        else if(r == 5)
+          dt_toast_log(FALSE, _("image rated to %s"), "★★★★★");
+        else if(r == 0)
+          dt_toast_log(FALSE, _("image rated to 0 star"));
       }
     }
   }
@@ -2061,31 +2071,31 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
           const char *lb = (char *)(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)));
           if(g_strcmp0(lb, "red") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#ee0000\">⚫ </span>");
+            result = dt_util_dstrcat(result, "<span foreground=\"#ee0000\">⬤ </span>");
           }
           else if(g_strcmp0(lb, "yellow") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#eeee00\">⚫ </span>");
+            result = dt_util_dstrcat(result, "<span foreground=\"#eeee00\">⬤ </span>");
           }
           else if(g_strcmp0(lb, "green") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#00ee00\">⚫ </span>");
+            result = dt_util_dstrcat(result, "<span foreground=\"#00ee00\">⬤ </span>");
           }
           else if(g_strcmp0(lb, "blue") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#0000ee\">⚫ </span>");
+            result = dt_util_dstrcat(result, "<span foreground=\"#0000ee\">⬤ </span>");
           }
           else if(g_strcmp0(lb, "purple") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#ee00ee\">⚫ </span>");
+            result = dt_util_dstrcat(result, "<span foreground=\"#ee00ee\">⬤ </span>");
           }
         } while((res = g_list_next(res)) != NULL);
       }
       g_list_free(res);
       if(result)
-        dt_toast_log(_("colorlabels set to : %s"), result);
+        dt_toast_log(TRUE, _("colorlabels set to : %s"), result);
       else
-        dt_toast_log(_("all colorlabels removed"));
+        dt_toast_log(FALSE, _("all colorlabels removed"));
       g_free(result);
     }
   }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -21,6 +21,7 @@
 #include "common/colorlabels.h"
 #include "common/debug.h"
 #include "common/history.h"
+#include "common/image_cache.h"
 #include "common/ratings.h"
 #include "common/selection.h"
 #include "control/control.h"
@@ -2009,6 +2010,30 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
 {
   GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE));
   dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
+
+  // if we are in darkroom we show a message as there might be no other indication
+  const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
+  if(v->view(v) == DT_VIEW_DARKROOM && g_list_length(imgs) == 1 && darktable.develop->preview_pipe)
+  {
+    // we verify that the image is the active one
+    const int id = GPOINTER_TO_INT(g_list_nth_data(imgs, 0));
+    if(id == darktable.develop->preview_pipe->output_imgid)
+    {
+      const dt_image_t *img = dt_image_cache_get(darktable.image_cache, id, 'r');
+      if(img)
+      {
+        const int r = img->flags & DT_IMAGE_REJECTED ? DT_VIEW_REJECT : (img->flags & DT_VIEW_RATINGS_MASK);
+        dt_image_cache_read_release(darktable.image_cache, img);
+
+        // translate in human readable value
+        if(r == DT_VIEW_REJECT)
+          dt_toast_log(_("image rejected"));
+        else
+          dt_toast_log(ngettext("image rated to %d star", "image rated to %d stars", r), r);
+      }
+    }
+  }
+
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
 }
@@ -2017,6 +2042,54 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
 {
   GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE));
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
+
+  // if we are in darkroom we show a message as there might be no other indication
+  const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
+  if(v->view(v) == DT_VIEW_DARKROOM && g_list_length(imgs) == 1 && darktable.develop->preview_pipe)
+  {
+    // we verify that the image is the active one
+    const int id = GPOINTER_TO_INT(g_list_nth_data(imgs, 0));
+    if(id == darktable.develop->preview_pipe->output_imgid)
+    {
+      GList *res = dt_metadata_get(id, "Xmp.darktable.colorlabels", NULL);
+      res = g_list_first(res);
+      gchar *result = NULL;
+      if(res != NULL)
+      {
+        do
+        {
+          const char *lb = (char *)(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)));
+          if(g_strcmp0(lb, "red") == 0)
+          {
+            result = dt_util_dstrcat(result, "<span foreground=\"#ee0000\">⚫ </span>");
+          }
+          else if(g_strcmp0(lb, "yellow") == 0)
+          {
+            result = dt_util_dstrcat(result, "<span foreground=\"#eeee00\">⚫ </span>");
+          }
+          else if(g_strcmp0(lb, "green") == 0)
+          {
+            result = dt_util_dstrcat(result, "<span foreground=\"#00ee00\">⚫ </span>");
+          }
+          else if(g_strcmp0(lb, "blue") == 0)
+          {
+            result = dt_util_dstrcat(result, "<span foreground=\"#0000ee\">⚫ </span>");
+          }
+          else if(g_strcmp0(lb, "purple") == 0)
+          {
+            result = dt_util_dstrcat(result, "<span foreground=\"#ee00ee\">⚫ </span>");
+          }
+        } while((res = g_list_next(res)) != NULL);
+      }
+      g_list_free(res);
+      if(result)
+        dt_toast_log(_("colorlabels set to : %s"), result);
+      else
+        dt_toast_log(_("all colorlabels removed"));
+      g_free(result);
+    }
+  }
+
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -590,20 +590,20 @@ void dt_accel_widget_toast(GtkWidget *widget)
     if(w->label[0] != '\0')
     { // label is not empty
       if(w->module && w->module->multi_name[0] != '\0')
-        dt_toast_log(_("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, text);
+        dt_toast_log(FALSE, _("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, text);
       else if(w->module && !strstr(w->module->name(), w->label))
-        dt_toast_log(_("%s / %s: %s"), w->module->name(), w->label, text);
+        dt_toast_log(FALSE, _("%s / %s: %s"), w->module->name(), w->label, text);
       else
-        dt_toast_log(_("%s: %s"), w->label, text);
+        dt_toast_log(FALSE, _("%s: %s"), w->label, text);
     }
     else
     { //label is empty
       if(w->module && w->module->multi_name[0] != '\0')
-        dt_toast_log(_("%s %s / %s"), w->module->name(), w->module->multi_name, text);
+        dt_toast_log(FALSE, _("%s %s / %s"), w->module->name(), w->module->multi_name, text);
       else if(w->module)
-        dt_toast_log(_("%s / %s"), w->module->name(), text);
+        dt_toast_log(FALSE, _("%s / %s"), w->module->name(), text);
       else
-        dt_toast_log("%s", text);
+        dt_toast_log(FALSE, "%s", text);
     }
 
     g_free(text);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -290,9 +290,9 @@ static gboolean toggle_tooltip_visibility(GtkAccelGroup *accel_group, GObject *a
     gboolean tooltip_hidden = !dt_conf_get_bool("ui/hide_tooltips");
     dt_conf_set_bool("ui/hide_tooltips", tooltip_hidden);
     if(tooltip_hidden)
-      dt_toast_log(_("tooltips off"));
+      dt_toast_log(FALSE, _("tooltips off"));
     else
-      dt_toast_log(_("tooltips on"));
+      dt_toast_log(FALSE, _("tooltips on"));
   }
   else
   {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2621,7 +2621,7 @@ static void _ui_log_redraw_callback(gpointer instance, GtkWidget *widget)
   if(darktable.control->log_ack != darktable.control->log_pos)
   {
     if(strcmp(darktable.control->log_message[darktable.control->log_ack], gtk_label_get_text(GTK_LABEL(widget))))
-      gtk_label_set_text(GTK_LABEL(widget), darktable.control->log_message[darktable.control->log_ack]);
+      gtk_label_set_markup(GTK_LABEL(widget), darktable.control->log_message[darktable.control->log_ack]);
     if(!gtk_widget_get_visible(widget))
     {
       const int h = gtk_widget_get_allocated_height(dt_ui_center_base(darktable.gui->ui));
@@ -2643,7 +2643,7 @@ static void _ui_toast_redraw_callback(gpointer instance, GtkWidget *widget)
   if(darktable.control->toast_ack != darktable.control->toast_pos)
   {
     if(strcmp(darktable.control->toast_message[darktable.control->toast_ack], gtk_label_get_text(GTK_LABEL(widget))))
-      gtk_label_set_text(GTK_LABEL(widget), darktable.control->toast_message[darktable.control->toast_ack]);
+      gtk_label_set_markup(GTK_LABEL(widget), darktable.control->toast_message[darktable.control->toast_ack]);
     if(!gtk_widget_get_visible(widget))
     {
       const int h = gtk_widget_get_allocated_height(dt_ui_center_base(darktable.gui->ui));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3787,11 +3787,11 @@ static gboolean change_slider_accel_precision(GtkAccelGroup *accel_group, GObjec
   dt_conf_set_int("accel/slider_precision", new_precision);
 
   if(new_precision == DT_IOP_PRECISION_FINE)
-    dt_toast_log(_("keyboard shortcut slider precision: fine"));
+    dt_toast_log(FALSE, _("keyboard shortcut slider precision: fine"));
   else if(new_precision == DT_IOP_PRECISION_NORMAL)
-    dt_toast_log(_("keyboard shortcut slider precision: normal"));
+    dt_toast_log(FALSE, _("keyboard shortcut slider precision: normal"));
   else
-    dt_toast_log(_("keyboard shortcut slider precision: coarse"));
+    dt_toast_log(FALSE, _("keyboard shortcut slider precision: coarse"));
 
   return TRUE;
 }


### PR DESCRIPTION
this fix #6037

toast msg appears only in darkroom if the impacted image is the current one (this doesn't affect filmstrip)
This is needed because otherwise we have no indication of rating/colorlabels change

To be able to show colorlabels in... colors, I've updated toast msg to allow markup. This shouldn't change "normal" text