### PR TITLE
[presets] fixes import xml parser call not checking for null

### DIFF
--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -194,6 +194,9 @@ static int get_preset_element_float(xmlDocPtr doc, gchar *name)
 int dt_presets_import_from_file(const char *preset_path)
 {
   xmlDocPtr doc = xmlParseFile(preset_path);
+  if(!doc)
+    return FALSE;
+  
   gchar *name = get_preset_element(doc, "name");
   gchar *description = get_preset_element(doc, "description");
   gchar *operation = get_preset_element(doc, "operation");


### PR DESCRIPTION
`dt_prest_import_from_file` did not check for null, and could crash
darktable when importing malformed file.

Fixes #5967