### PR TITLE
escape dt_control_log message so it is correct markup

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -474,7 +474,9 @@ void dt_control_log(const char *msg, ...)
   dt_pthread_mutex_lock(&darktable.control->log_mutex);
   va_list ap;
   va_start(ap, msg);
-  vsnprintf(darktable.control->log_message[darktable.control->log_pos], DT_CTL_LOG_MSG_SIZE, msg, ap);
+  char *escaped_msg = g_markup_vprintf_escaped(msg, ap);
+  g_strlcpy(darktable.control->log_message[darktable.control->log_pos], escaped_msg, DT_CTL_LOG_MSG_SIZE);
+  g_free(escaped_msg);
   va_end(ap);
   if(darktable.control->log_message_timeout_id) g_source_remove(darktable.control->log_message_timeout_id);
   darktable.control->log_ack = darktable.control->log_pos;


### PR DESCRIPTION
Should fix #7412. Haven't reproduced the original warning message, so can't positively confirm it is indeed gone.

This is the most minimalist fix. Alternatively, a dt_control_markup_log could be introduced along the lines of dt_toast_markup_log, but since there are no current uses it would not get tested. So I'll leave it as an exercise for later.