### PR TITLE
Fix integer overflows in size_t calculations

### DIFF
--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -820,20 +820,20 @@ static void add_hdr_patches(int *N, double **target_L, double **target_a, double
 
   if(n_extra_patches > 0)
   {
-    *target_L = realloc(*target_L, (*N + n_extra_patches + 4) * sizeof(double));
-    *target_a = realloc(*target_a, (*N + n_extra_patches + 4) * sizeof(double));
-    *target_b = realloc(*target_b, (*N + n_extra_patches + 4) * sizeof(double));
-    *colorchecker_Lab = realloc(*colorchecker_Lab, 3 * (*N + n_extra_patches) * sizeof(double));
+    *target_L = realloc(*target_L, sizeof(double) * (*N + n_extra_patches + 4));
+    *target_a = realloc(*target_a, sizeof(double) * (*N + n_extra_patches + 4));
+    *target_b = realloc(*target_b, sizeof(double) * (*N + n_extra_patches + 4));
+    *colorchecker_Lab = realloc(*colorchecker_Lab, sizeof(double) * 3 * (*N + n_extra_patches));
 
-    memmove(&(*target_L)[n_extra_patches], *target_L, *N * sizeof(double));
-    memmove(&(*target_a)[n_extra_patches], *target_a, *N * sizeof(double));
-    memmove(&(*target_b)[n_extra_patches], *target_b, *N * sizeof(double));
-    memmove(&(*colorchecker_Lab)[3 * n_extra_patches], *colorchecker_Lab, 3 * *N * sizeof(double));
+    memmove(&(*target_L)[n_extra_patches], *target_L, sizeof(double) * *N);
+    memmove(&(*target_a)[n_extra_patches], *target_a, sizeof(double) * *N);
+    memmove(&(*target_b)[n_extra_patches], *target_b, sizeof(double) * *N);
+    memmove(&(*colorchecker_Lab)[3 * n_extra_patches], *colorchecker_Lab, sizeof(double) * 3 * *N);
 
-    memcpy(*target_L, extra_target_L, n_extra_patches * sizeof(double));
-    memcpy(*target_a, extra_target_a, n_extra_patches * sizeof(double));
-    memcpy(*target_b, extra_target_b, n_extra_patches * sizeof(double));
-    memcpy(*colorchecker_Lab, extra_colorchecker_Lab, 3 * n_extra_patches * sizeof(double));
+    memcpy(*target_L, extra_target_L, sizeof(double) * n_extra_patches);
+    memcpy(*target_a, extra_target_a, sizeof(double) * n_extra_patches);
+    memcpy(*target_b, extra_target_b, sizeof(double) * n_extra_patches);
+    memcpy(*colorchecker_Lab, extra_colorchecker_Lab, sizeof(double) * 3 * n_extra_patches);
 
     *N += n_extra_patches;
   }
@@ -1049,11 +1049,11 @@ static void process_data(dt_lut_t *self, double *target_L, double *target_a, dou
 #endif
 
   const double *target[3] = { target_L, target_a, target_b };
-  double *coeff_L = malloc((N + 4) * sizeof(double));
-  double *coeff_a = malloc((N + 4) * sizeof(double));
-  double *coeff_b = malloc((N + 4) * sizeof(double));
+  double *coeff_L = malloc(sizeof(double) * (N + 4) );
+  double *coeff_a = malloc(sizeof(double) * (N + 4) );
+  double *coeff_b = malloc(sizeof(double) * (N + 4) );
   double *coeff[] = { coeff_L, coeff_a, coeff_b };
-  int *perm = malloc((N + 4) * sizeof(int));
+  int *perm = malloc(sizeof(int) * (N + 4));
   double avgerr, maxerr;
   sparsity = thinplate_match(&tonecurve, 3, N, colorchecker_Lab, target, sparsity, perm, coeff, &avgerr, &maxerr);
 
@@ -1107,7 +1107,7 @@ static void process_button_clicked_callback(GtkButton *button, gpointer user_dat
   double *target_L = (double *)calloc(sizeof(double), (N + 4));
   double *target_a = (double *)calloc(sizeof(double), (N + 4));
   double *target_b = (double *)calloc(sizeof(double), (N + 4));
-  double *colorchecker_Lab = (double *)calloc(3 * sizeof(double), N);
+  double *colorchecker_Lab = (double *)calloc(sizeof(double) * 3, N);
 
   GHashTableIter table_iter;
   gpointer set_key, value;
@@ -1793,7 +1793,7 @@ static int parse_csv(dt_lut_t *self, const char *filename, double **target_L_ptr
   double *target_L = (double *)calloc(sizeof(double), (N + 4));
   double *target_a = (double *)calloc(sizeof(double), (N + 4));
   double *target_b = (double *)calloc(sizeof(double), (N + 4));
-  double *source_Lab = (double *)calloc(3 * sizeof(double), N);
+  double *source_Lab = (double *)calloc(sizeof(double) * 3, N);
   *target_L_ptr = target_L;
   *target_a_ptr = target_a;
   *target_b_ptr = target_b;

--- a/src/chart/pfm.c
+++ b/src/chart/pfm.c
@@ -141,9 +141,9 @@ void write_pfm(const char *filename, int width, int height, float *data)
       float *out = (float *)buf_line;
       for(int i = 0; i < width; i++, in += 3, out += 3)
       {
-        memcpy(out, in, 3 * sizeof(float));
+        memcpy(out, in, sizeof(float) * 3);
       }
-      int cnt = fwrite(buf_line, 3 * sizeof(float), width, f);
+      int cnt = fwrite(buf_line, sizeof(float) * 3, width, f);
       if(cnt != width) break;
     }
     dt_free_align(buf_line);

--- a/src/chart/pfm.c
+++ b/src/chart/pfm.c
@@ -58,7 +58,7 @@ float *read_pfm(const char *filename, int *wd, int *ht)
   float scale_factor = g_ascii_strtod(scale_factor_string, NULL);
   int swap_byte_order = (scale_factor >= 0.0) ^ (G_BYTE_ORDER == G_BIG_ENDIAN);
 
-  float *image = (float *)dt_alloc_align(64, sizeof(float) * width * height * 3);
+  float *image = (float *)dt_alloc_align_float((size_t)3 * width * height);
   if(!image)
   {
     fprintf(stderr, "error allocating memory\n");
@@ -132,7 +132,7 @@ void write_pfm(const char *filename, int width, int height, float *data)
   {
     // INFO: per-line fwrite call seems to perform best. LebedevRI, 18.04.2014
     (void)fprintf(f, "PF\n%d %d\n-1.0\n", width, height);
-    void *buf_line = dt_alloc_align(64, 3 * sizeof(float) * width);
+    void *buf_line = dt_alloc_align_float((size_t)3 * width);
     for(int j = 0; j < height; j++)
     {
       // NOTE: pfm has rows in reverse order

--- a/src/chart/pfm.c
+++ b/src/chart/pfm.c
@@ -113,9 +113,9 @@ float *read_pfm(const char *filename, int *wd, int *ht)
   float *line = (float *)calloc(3 * width, sizeof(float));
   for(size_t j = 0; j < height / 2; j++)
   {
-    memcpy(line, image + width * j * 3, 3 * sizeof(float) * width);
-    memcpy(image + width * j * 3, image + width * (height - 1 - j) * 3, 3 * sizeof(float) * width);
-    memcpy(image + width * (height - 1 - j) * 3, line, 3 * sizeof(float) * width);
+    memcpy(line, image + width * j * 3, sizeof(float) * width * 3);
+    memcpy(image + width * j * 3, image + width * (height - 1 - j) * 3, sizeof(float) * width * 3);
+    memcpy(image + width * (height - 1 - j) * 3, line, sizeof(float) * width * 3);
   }
   free(line);
   fclose(f);

--- a/src/chart/thinplate.c
+++ b/src/chart/thinplate.c
@@ -120,7 +120,7 @@ static inline int solve(double *As, double *w, double *v, const double *b, doubl
   dsvd(As, wd, s + 1, S, w, v); // As is wd x s+1 but row stride S.
   if(w[s] < 1e-3)               // if the smallest singular value becomes too small, we're done
     return 1;
-  double *tmp = malloc(S * sizeof(double));
+  double *tmp = malloc(sizeof(double) * S);
   for(int i = 0; i <= s; i++) // compute tmp = u^t * b
   {
     tmp[i] = 0.0;
@@ -157,7 +157,7 @@ int thinplate_match(const tonecurve_t *curve, // tonecurve to apply after this (
   if(maxerr) *maxerr = 0.0;
 
   const int wd = N + 4;
-  double *A = malloc(wd * wd * sizeof(double));
+  double *A = malloc(sizeof(double) * wd * wd);
   // construct system matrix A such that:
   // A c = f
   //
@@ -181,7 +181,7 @@ int thinplate_match(const tonecurve_t *curve, // tonecurve to apply after this (
     for(int i = N; i < wd; i++) A[j * wd + i] = 0.0f;
 
   // precompute normalisation factors for columns of A
-  double *norm = malloc(wd * sizeof(double));
+  double *norm = malloc(sizeof(double) * wd);
   for(int i = 0; i < wd; i++)
   {
     norm[i] = 0.0;
@@ -191,14 +191,14 @@ int thinplate_match(const tonecurve_t *curve, // tonecurve to apply after this (
 
   // XXX do we need these explicitly?
   // residual = target vector
-  double(*r)[wd] = malloc(dim * wd * sizeof(double));
-  const double **b = malloc(dim * sizeof(double *));
+  double(*r)[wd] = malloc(sizeof(double) * dim * wd);
+  const double **b = malloc(sizeof(double *) * dim);
   for(int k = 0; k < dim; k++) b[k] = target[k];
-  for(int k = 0; k < dim; k++) memcpy(r[k], b[k], wd * sizeof(double));
+  for(int k = 0; k < dim; k++) memcpy(r[k], b[k], sizeof(double) * wd);
 
-  double *w = malloc(S * sizeof(double));
-  double *v = malloc(S * S * sizeof(double));
-  double *As = calloc(wd * S, sizeof(double));
+  double *w = malloc(sizeof(double) * S);
+  double *v = malloc(sizeof(double) * S * S);
+  double *As = calloc((size_t)wd * S, sizeof(double));
 
   // for rank from 0 to sparsity level
   int s = 0, patches = 0;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -407,7 +407,7 @@ int main(int argc, char *arg[])
   }
 
   int m_argc = 0;
-  char **m_arg = malloc((5 + argc - k + 1) * sizeof(char *));
+  char **m_arg = malloc(sizeof(char *) * (5 + argc - k + 1));
   m_arg[m_argc++] = "darktable-cli";
   m_arg[m_argc++] = "--library";
   m_arg[m_argc++] = ":memory:";

--- a/src/cltest/main.c
+++ b/src/cltest/main.c
@@ -37,7 +37,7 @@ int main(int argc, char *arg[])
   // only used to force-init opencl, so we want these options:
   char *m_arg[] = { "-d", "opencl", "--library", ":memory:"};
   const int m_argc = sizeof(m_arg) / sizeof(m_arg[0]);
-  char **argv = malloc(argc * sizeof(arg[0]) + sizeof(m_arg));
+  char **argv = malloc(sizeof(arg[0]) * argc + sizeof(m_arg));
   if(!argv) goto end;
   for(int i = 0; i < argc; i++)
     argv[i] = arg[i];

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -151,7 +151,7 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   b->buf = dt_alloc_align_float(b->size_x * b->size_z * b->numslices * b->slicerows);
   if (b->buf)
   {
-    memset(b->buf, 0, b->size_x * b->size_z * b->numslices * b->slicerows * sizeof(float));
+    memset(b->buf, 0, sizeof(float) * b->size_x * b->size_z * b->numslices * b->slicerows);
   }
   else
   {

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -252,7 +252,7 @@ void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in)
       // clear elements in the part of the buffer which holds the final result now that we've read the partial result,
       // since we'll be adding to those locations later
       if (j < b->size_y)
-        memset(buf + j*oy, '\0', oy*sizeof(float));
+        memset(buf + j*oy, '\0', sizeof(float) * oy);
     }
   }
 }

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -148,7 +148,7 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   b->numslices = darktable.num_openmp_threads;
   b->sliceheight = (height + b->numslices - 1) / b->numslices;
   b->slicerows = (b->size_y + b->numslices - 1) / b->numslices + 2;
-  b->buf = dt_alloc_align(64, b->size_x * b->size_z * b->numslices * b->slicerows * sizeof(float));
+  b->buf = dt_alloc_align_float(b->size_x * b->size_z * b->numslices * b->slicerows);
   if (b->buf)
   {
     memset(b->buf, 0, b->size_x * b->size_z * b->numslices * b->slicerows * sizeof(float));

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -245,7 +245,7 @@ cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem o
   cl_int err = -666;
   cl_mem tmp = NULL;
 
-  tmp = dt_opencl_alloc_device(b->devid, b->width, b->height, 4 * sizeof(float));
+  tmp = dt_opencl_alloc_device(b->devid, b->width, b->height, sizeof(float) * 4);
   if(tmp == NULL) goto error;
 
   size_t origin[] = { 0, 0, 0 };

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -120,7 +120,7 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
 
   // alloc grid buffer:
   b->dev_grid
-      = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * sizeof(float));
+      = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid)
   {
     dt_bilateral_free_cl(b);
@@ -129,7 +129,7 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
 
   // alloc temporary grid buffer
   b->dev_grid_tmp
-      = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * sizeof(float));
+      = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid_tmp)
   {
     dt_bilateral_free_cl(b);

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -59,7 +59,7 @@ size_t dt_bilateral_memory_use2(const int width,
                                 const float sigma_s,
                                 const float sigma_r)
 {
-  return dt_bilateral_memory_use(width, height, sigma_s, sigma_r) + (size_t)width * height * 4 * sizeof(float);
+  return dt_bilateral_memory_use(width, height, sigma_s, sigma_r) + sizeof(float) * 4 * width * height;
 }
 
 // modules that want to use dt_bilateral_slice_to_output_cl() ought to take this one;
@@ -69,7 +69,7 @@ size_t dt_bilateral_singlebuffer_size2(const int width,
                                        const float sigma_s,
                                        const float sigma_r)
 {
-  return MAX(dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r), (size_t)width * height * 4 * sizeof(float));
+  return MAX(dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r), sizeof(float) * 4 * width * height);
 }
 
 

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -536,7 +536,7 @@ static void dt_box_mean_4ch_sse(float *const buf, const int height, const int wi
 {
   const int size = MAX(width,height);
 
-  __m128 *const scanline_buf = dt_alloc_align(64, dt_get_num_threads() * size * sizeof(__m128) * 4);
+  __m128 *const scanline_buf = dt_alloc_align(64, sizeof(__m128) * dt_get_num_threads() * size * 4);
 
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -493,7 +493,7 @@ static void dt_box_mean_1ch(float *const buf, const int height, const int width,
                             const int iterations)
 {
   const int size = MAX(width,height);
-  float *const restrict scanlines = dt_alloc_align_float((size_t)4 * size * dt_get_num_threads());
+  float *const restrict scanlines = dt_alloc_align_float(dt_get_num_threads() * size * 4);
 
   for(int iteration = 0; iteration < iterations; iteration++)
   {
@@ -508,7 +508,7 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
                             const int iterations)
 {
   const int size = MAX(width,height);
-  float *const restrict scanlines = dt_alloc_align_float((size_t)4 * size * dt_get_num_threads());
+  float *const restrict scanlines = dt_alloc_align_float(dt_get_num_threads() * size * 4);
 
   for(int iteration = 0; iteration < iterations; iteration++)
   {
@@ -536,7 +536,7 @@ static void dt_box_mean_4ch_sse(float *const buf, const int height, const int wi
 {
   const int size = MAX(width,height);
 
-  __m128 *const scanline_buf = dt_alloc_align(64, sizeof(__m128) * 4 * size * dt_get_num_threads());
+  __m128 *const scanline_buf = dt_alloc_align(64, dt_get_num_threads() * size * sizeof(__m128) * 4);
 
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {
@@ -598,7 +598,7 @@ static inline void box_mean_2ch(float *const restrict in, const size_t height, c
   // We make use of the separable nature of the filter kernel to speed-up the computation
   // by convolving along columns and rows separately (complexity O(2 × radius) instead of O(radius²)).
 
-  const size_t Ndim = 2 * 2 *MAX(width,height);
+  const size_t Ndim = MAX(width,height) * 2 * 2;
   float *const restrict temp = dt_alloc_align_float(Ndim * dt_get_num_threads());
   if (temp == NULL) return;
 
@@ -717,7 +717,7 @@ static inline void box_max_vert_16wide(const int N, const float *const restrict 
 // does the calculation in-place if input and output images are identical
 static void box_max_1ch(float *const buf, const int height, const int width, const int w)
 {
-  float *const restrict scratch_buffers = dt_alloc_align_float(MAX(width,16*height) * dt_get_num_threads());
+  float *const restrict scratch_buffers = dt_alloc_align_float(dt_get_num_threads() * MAX(width,16*height));
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(w, width, height, buf)    \
@@ -842,7 +842,7 @@ static inline void box_min_vert_16wide(const int N, const float *const restrict 
 // does the calculation in-place if input and output images are identical
 static void box_min_1ch(float *const buf, const int height, const int width, const int w)
 {
-  float *const restrict scratch_buffers = dt_alloc_align_float(MAX(width,16*height) * dt_get_num_threads());
+  float *const restrict scratch_buffers = dt_alloc_align_float(dt_get_num_threads() * MAX(width,16*height));
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(w, width, height, buf)    \

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -493,7 +493,7 @@ static void dt_box_mean_1ch(float *const buf, const int height, const int width,
                             const int iterations)
 {
   const int size = MAX(width,height);
-  float *const restrict scanlines = dt_alloc_align(64, 4 * size * sizeof(float) * dt_get_num_threads());
+  float *const restrict scanlines = dt_alloc_align_float((size_t)4 * size * dt_get_num_threads());
 
   for(int iteration = 0; iteration < iterations; iteration++)
   {
@@ -508,7 +508,7 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
                             const int iterations)
 {
   const int size = MAX(width,height);
-  float *const restrict scanlines = dt_alloc_align(64, 4 * size * sizeof(float) * dt_get_num_threads());
+  float *const restrict scanlines = dt_alloc_align_float((size_t)4 * size * dt_get_num_threads());
 
   for(int iteration = 0; iteration < iterations; iteration++)
   {
@@ -536,7 +536,7 @@ static void dt_box_mean_4ch_sse(float *const buf, const int height, const int wi
 {
   const int size = MAX(width,height);
 
-  __m128 *const scanline_buf = dt_alloc_align(64, size * dt_get_num_threads() * 4 * sizeof(__m128));
+  __m128 *const scanline_buf = dt_alloc_align(64, sizeof(__m128) * 4 * size * dt_get_num_threads());
 
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -340,7 +340,7 @@ static void _camera_process_job(const dt_camctl_t *c, const dt_camera_t *camera,
           // dt_colorspaces_color_profile_type_t color_space = dt_imageio_jpeg_read_color_space(&jpg);
           //if(color_space == DT_COLORSPACE_DISPLAY)
           //  color_space = DT_COLORSPACE_SRGB;            // no embedded colorspace, assume is sRGB
-          uint8_t *const buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * jpg.width * jpg.height * 4);
+          uint8_t *const buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * 4 * jpg.width * jpg.height);
           if(!buffer)
           {
             dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view could not allocate image buffer\n");

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -340,7 +340,7 @@ static void _camera_process_job(const dt_camctl_t *c, const dt_camera_t *camera,
           // dt_colorspaces_color_profile_type_t color_space = dt_imageio_jpeg_read_color_space(&jpg);
           //if(color_space == DT_COLORSPACE_DISPLAY)
           //  color_space = DT_COLORSPACE_SRGB;            // no embedded colorspace, assume is sRGB
-          uint8_t *const buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+          uint8_t *const buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
           if(!buffer)
           {
             dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view could not allocate image buffer\n");

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -105,7 +105,7 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const ds
 
   const float w = 1.0f / (float)size;
 
-  const int numthreads = dt_get_num_threads();
+  const size_t numthreads = dt_get_num_threads();
 
   size_t allocsize;
   float *const restrict mean = dt_alloc_perthread_float(3, &allocsize);
@@ -231,13 +231,13 @@ static void color_picker_helper_bayer_parallel(const dt_iop_buffer_dsc_t *const 
 
   uint32_t weights[4] = { 0u, 0u, 0u, 0u };
 
-  const int numthreads = dt_get_num_threads();
+  const size_t numthreads = dt_get_num_threads();
 
   //TODO: convert to use dt_alloc_perthread
-  float *const msum = malloc((size_t)4 * numthreads * sizeof(float));
-  float *const mmin = malloc((size_t)4 * numthreads * sizeof(float));
-  float *const mmax = malloc((size_t)4 * numthreads * sizeof(float));
-  uint32_t *const cnt = malloc((size_t)4 * numthreads * sizeof(uint32_t));
+  float *const msum = malloc(numthreads * sizeof(float) * 4);
+  float *const mmin = malloc(numthreads * sizeof(float) * 4);
+  float *const mmax = malloc(numthreads * sizeof(float) * 4);
+  uint32_t *const cnt = malloc(numthreads * sizeof(uint32_t) * 4);
 
   for(int n = 0; n < 4 * numthreads; n++)
   {
@@ -360,13 +360,13 @@ static void color_picker_helper_xtrans_parallel(const dt_iop_buffer_dsc_t *const
 
   uint32_t weights[3] = { 0u, 0u, 0u };
 
-  const int numthreads = dt_get_num_threads();
+  const size_t numthreads = dt_get_num_threads();
 
   //TODO: convert to use dt_alloc_perthread
-  float *const msum = malloc((size_t)3 * numthreads * sizeof(float));
-  float *const mmin = malloc((size_t)3 * numthreads * sizeof(float));
-  float *const mmax = malloc((size_t)3 * numthreads * sizeof(float));
-  uint32_t *const cnt = malloc((size_t)3 * numthreads * sizeof(uint32_t));
+  float *const mmin = malloc(numthreads * sizeof(float) * 3);
+  float *const msum = malloc(numthreads * sizeof(float) * 3);
+  float *const mmax = malloc(numthreads * sizeof(float) * 3);
+  uint32_t *const cnt = malloc(numthreads * sizeof(uint32_t) * 3);
 
   for(int n = 0; n < 3 * numthreads; n++)
   {

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -234,10 +234,10 @@ static void color_picker_helper_bayer_parallel(const dt_iop_buffer_dsc_t *const 
   const size_t numthreads = dt_get_num_threads();
 
   //TODO: convert to use dt_alloc_perthread
-  float *const msum = malloc(numthreads * sizeof(float) * 4);
-  float *const mmin = malloc(numthreads * sizeof(float) * 4);
-  float *const mmax = malloc(numthreads * sizeof(float) * 4);
-  uint32_t *const cnt = malloc(numthreads * sizeof(uint32_t) * 4);
+  float *const msum = malloc(sizeof(float) * numthreads * 4);
+  float *const mmin = malloc(sizeof(float) * numthreads * 4);
+  float *const mmax = malloc(sizeof(float) * numthreads * 4);
+  uint32_t *const cnt = malloc(sizeof(uint32_t) * numthreads * 4);
 
   for(int n = 0; n < 4 * numthreads; n++)
   {
@@ -363,10 +363,10 @@ static void color_picker_helper_xtrans_parallel(const dt_iop_buffer_dsc_t *const
   const size_t numthreads = dt_get_num_threads();
 
   //TODO: convert to use dt_alloc_perthread
-  float *const mmin = malloc(numthreads * sizeof(float) * 3);
-  float *const msum = malloc(numthreads * sizeof(float) * 3);
-  float *const mmax = malloc(numthreads * sizeof(float) * 3);
-  uint32_t *const cnt = malloc(numthreads * sizeof(uint32_t) * 3);
+  float *const mmin = malloc(sizeof(float) * numthreads * 3);
+  float *const msum = malloc(sizeof(float) * numthreads * 3);
+  float *const mmax = malloc(sizeof(float) * numthreads * 3);
+  uint32_t *const cnt = malloc(sizeof(uint32_t) * numthreads * 3);
 
   for(int n = 0; n < 3 * numthreads; n++)
   {

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -372,7 +372,7 @@ static double _HLG_fct(double x)
 
 static cmsToneCurve* _colorspaces_create_transfer(int32_t size, double (*fct)(double))
 {
-  float *values = g_malloc(size * sizeof(float));
+  float *values = g_malloc(sizeof(float) * size);
 
   for (int32_t i = 0; i < size; ++i)
   {

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1338,7 +1338,7 @@ static GList *load_profile_from_dir(const char *subdir)
         if(!icc_content) goto icc_loading_done;
 
         // TODO: add support for grayscale profiles, then remove _ensure_rgb_profile() from here
-        cmsHPROFILE tmpprof = _ensure_rgb_profile(cmsOpenProfileFromMem(icc_content, end * sizeof(char)));
+        cmsHPROFILE tmpprof = _ensure_rgb_profile(cmsOpenProfileFromMem(icc_content, sizeof(char) * end));
         if(tmpprof)
         {
           dt_colorspaces_color_profile_t *prof = (dt_colorspaces_color_profile_t *)calloc(1, sizeof(dt_colorspaces_color_profile_t));

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1445,12 +1445,12 @@ void dt_show_times_f(const dt_times_t *start, const char *prefix, const char *su
 void dt_configure_performance()
 {
   const int atom_cores = dt_get_num_atom_cores();
-  const int threads = dt_get_num_threads();
+  const size_t threads = dt_get_num_threads();
   const size_t mem = dt_get_total_memory();
   const size_t bits = CHAR_BIT * sizeof(void *);
   gchar *demosaic_quality = dt_conf_get_string("plugins/darkroom/demosaic/quality");
 
-  fprintf(stderr, "[defaults] found a %zu-bit system with %zu kb ram and %d cores (%d atom based)\n",
+  fprintf(stderr, "[defaults] found a %zu-bit system with %zu kb ram and %zu cores (%d atom based)\n",
           bits, mem, threads, atom_cores);
   if(mem >= (8lu << 20) && threads > 4 && atom_cores == 0)
   {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -415,10 +415,11 @@ void dt_show_times_f(const dt_times_t *start, const char *prefix, const char *su
 /** \brief check if file is a supported image */
 gboolean dt_supported_image(const gchar *filename);
 
-static inline int dt_get_num_threads()
+static inline size_t dt_get_num_threads()
 {
 #ifdef _OPENMP
-  return omp_get_num_procs();
+  // we can safely assume omp_get_num_procs is > 0
+  return (size_t)omp_get_num_procs();
 #else
   return 1;
 #endif

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -702,7 +702,7 @@ static cl_int dwt_wavelet_decompose_cl(cl_mem img, dwt_params_cl_t *const p, _dw
   /* image buffers */
   buffer[0] = img;
   /* temporary storage */
-  buffer[1] = dt_opencl_alloc_device_buffer(devid, (size_t)p->width * p->height * p->ch * sizeof(float));
+  buffer[1] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * p->ch * p->width * p->height);
   if(buffer[1] == NULL)
   {
     printf("not enough memory for wavelet decomposition");
@@ -711,7 +711,7 @@ static cl_int dwt_wavelet_decompose_cl(cl_mem img, dwt_params_cl_t *const p, _dw
   }
 
   // buffer to reconstruct the image
-  layers = dt_opencl_alloc_device_buffer(devid, (size_t)p->width * p->height * p->ch * sizeof(float));
+  layers = dt_opencl_alloc_device_buffer(devid, sizeof(float) * p->ch * p->width * p->height);
   if(layers == NULL)
   {
     printf("not enough memory for wavelet decomposition");
@@ -735,7 +735,7 @@ static cl_int dwt_wavelet_decompose_cl(cl_mem img, dwt_params_cl_t *const p, _dw
 
   if(p->merge_from_scale > 0)
   {
-    merged_layers = dt_opencl_alloc_device_buffer(devid, (size_t)p->width * p->height * p->ch * sizeof(float));
+    merged_layers = dt_opencl_alloc_device_buffer(devid, sizeof(float) * p->ch * p->width * p->height);
     if(merged_layers == NULL)
     {
       printf("not enough memory for wavelet decomposition");
@@ -767,7 +767,7 @@ static cl_int dwt_wavelet_decompose_cl(cl_mem img, dwt_params_cl_t *const p, _dw
 
     // when (*layer_func) uses too much memory I get a -4 error, so alloc and free for each scale
     // setup a temp buffer
-    temp = dt_opencl_alloc_device_buffer(devid, (size_t)p->width * p->height * p->ch * sizeof(float));
+    temp = dt_opencl_alloc_device_buffer(devid, sizeof(float) * p->ch * p->width * p->height);
     if(temp == NULL)
     {
       printf("not enough memory for wavelet decomposition");

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -128,7 +128,7 @@ static void dwt_add_layer(const float *const restrict img, float *const restrict
 
 static void dwt_get_image_layer(float *const layer, dwt_params_t *const p)
 {
-  if(p->image != layer) memcpy(p->image, layer, p->width * p->height * p->ch * sizeof(float));
+  if(p->image != layer) memcpy(p->image, layer, sizeof(float) * p->width * p->height * p->ch);
 }
 
 // first, "vertical" pass of wavelet decomposition
@@ -232,7 +232,7 @@ static void dwt_decompose_horiz(float *const restrict out, float *const restrict
     }
     // now that we're done with the row of pixels, we can overwrite the intermediate result from the
     // first pass with the final decomposition
-    memcpy(coarse, temprow, 4 * width * sizeof(float));
+    memcpy(coarse, temprow, sizeof(float) * 4 * width);
   }
 }
 

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -253,7 +253,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
   float *merged_layers = NULL;
   float *buffer[2] = { 0, 0 };
   int bcontinue = 1;
-  const int size = p->width * p->height * p->ch;
+  const size_t size = (size_t)p->width * p->height * p->ch;
 
   assert(p->ch == 4);
 
@@ -266,7 +266,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
   /* temporary storage */
   buffer[1] = dt_alloc_align_float(size);
   // buffer to reconstruct the image
-  layers = dt_alloc_align_float(4 * p->width * p->height);
+  layers = dt_alloc_align_float((size_t)4 * p->width * p->height);
   // scratch buffer for decomposition
   temp = dt_alloc_align_float(dt_get_num_threads() * 4 * p->width);
 

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -275,7 +275,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
     printf("not enough memory for wavelet decomposition");
     goto cleanup;
   }
-  memset(layers, 0, p->width * p->height * p->ch * sizeof(float));
+  memset(layers, 0, sizeof(float) * p->ch * p->width * p->height);
 
   if(p->merge_from_scale > 0)
   {
@@ -285,7 +285,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
       printf("not enough memory for wavelet decomposition");
       goto cleanup;
     }
-    memset(merged_layers, 0, p->width * p->height * p->ch * sizeof(float));
+    memset(merged_layers, 0, sizeof(float) * p->ch * p->width * p->height);
   }
 
   // iterate over wavelet scales
@@ -537,7 +537,7 @@ void dwt_denoise(float *const img, const int width, const int height, const int 
   float *const interm = details + width * height;	// temporary storage for use during each pass
 
   // zero the accumulator
-  memset(details, 0, width * height * sizeof(float));
+  memset(details, 0, sizeof(float) * width * height);
 
   for(int lev = 0; lev < bands; lev++)
   {

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -580,8 +580,8 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
   const int mult = 1u << scale;
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;
-  const int nthreads = dt_get_num_threads();
-  float *squared_sums = dt_alloc_align_float((size_t)3 * nthreads);
+  const size_t nthreads = dt_get_num_threads();
+  float *squared_sums = dt_alloc_align_float(nthreads * 3);
   for(int i = 0; i < 3*nthreads; i++)
     squared_sums[i] = 0.0f;
 
@@ -686,8 +686,8 @@ void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict
   const int mult = 1u << scale;
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;
-  const int nthreads = dt_get_num_threads();
-  __m128 *squared_sums = dt_alloc_align(64, sizeof(__m128) * nthreads);
+  const size_t nthreads = dt_get_num_threads();
+  __m128 *squared_sums = dt_alloc_align(64, nthreads * sizeof(__m128));
   for(int i = 0; i < nthreads; i++)
     squared_sums[i] = _mm_setzero_ps();
 

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -687,7 +687,7 @@ void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;
   const size_t nthreads = dt_get_num_threads();
-  __m128 *squared_sums = dt_alloc_align(64, nthreads * sizeof(__m128));
+  __m128 *squared_sums = dt_alloc_align(64, sizeof(__m128) * nthreads);
   for(int i = 0; i < nthreads; i++)
     squared_sums[i] = _mm_setzero_ps();
 

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -581,7 +581,7 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;
   const int nthreads = dt_get_num_threads();
-  float *squared_sums = dt_alloc_align(64,3*sizeof(float)*nthreads);
+  float *squared_sums = dt_alloc_align_float((size_t)3 * nthreads);
   for(int i = 0; i < 3*nthreads; i++)
     squared_sums[i] = 0.0f;
 
@@ -687,7 +687,7 @@ void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;
   const int nthreads = dt_get_num_threads();
-  __m128 *squared_sums = dt_alloc_align(64,sizeof(__m128)*nthreads);
+  __m128 *squared_sums = dt_alloc_align(64, sizeof(__m128) * nthreads);
   for(int i = 0; i < nthreads; i++)
     squared_sums[i] = _mm_setzero_ps();
 

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -82,7 +82,7 @@ static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
                                    const int buf_width, const int buf_height)
 {
   float *const restrict luma =  dt_alloc_sse_ps(buf_width * buf_height);
-  uint8_t *const restrict focus_peaking = dt_alloc_align(64, 4 * buf_width * buf_height * sizeof(uint8_t));
+  uint8_t *const restrict focus_peaking = dt_alloc_align(64, sizeof(uint8_t) * buf_width * buf_height * 4);
 
   // Create a luma buffer as the euclidian norm of RGB channels
 #ifdef _OPENMP

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -87,9 +87,9 @@ size_t dt_gaussian_memory_use(const int width,    // width of input image
 {
   size_t mem_use;
 #ifdef HAVE_OPENCL
-  mem_use = (size_t)(width + BLOCKSIZE) * (height + BLOCKSIZE) * channels * sizeof(float) * 2;
+  mem_use = sizeof(float) * channels * (width + BLOCKSIZE) * (height + BLOCKSIZE) * 2;
 #else
-  mem_use = (size_t)width * height * channels * sizeof(float);
+  mem_use = sizeof(float) * channels * width * height;
 #endif
   return mem_use;
 }
@@ -100,9 +100,9 @@ size_t dt_gaussian_singlebuffer_size(const int width,    // width of input image
 {
   size_t mem_use;
 #ifdef HAVE_OPENCL
-  mem_use = (size_t)(width + BLOCKSIZE) * (height + BLOCKSIZE) * channels * sizeof(float);
+  mem_use = sizeof(float) * channels * (width + BLOCKSIZE) * (height + BLOCKSIZE);
 #else
-  mem_use = (size_t)width * height * channels * sizeof(float);
+  mem_use = sizeof(float) * channels * width * height;
 #endif
   return mem_use;
 }

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -588,9 +588,9 @@ dt_gaussian_cl_t *dt_gaussian_init_cl(const int devid,
   g->bheight = bheight;
 
   // get intermediate vector buffers with read-write access
-  g->dev_temp1 = dt_opencl_alloc_device_buffer(devid, (size_t)bwidth * bheight * channels * sizeof(float));
+  g->dev_temp1 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * channels * bwidth * bheight);
   if(!g->dev_temp1) goto error;
-  g->dev_temp2 = dt_opencl_alloc_device_buffer(devid, (size_t)bwidth * bheight * channels * sizeof(float));
+  g->dev_temp2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * channels * bwidth * bheight);
   if(!g->dev_temp2) goto error;
 
   return g;

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -136,7 +136,7 @@ dt_gaussian_t *dt_gaussian_init(const int width,    // width of input image
     g->min[k] = min[k];
   }
 
-  g->buf = dt_alloc_align(64, (size_t)width * height * channels * sizeof(float));
+  g->buf = dt_alloc_align_float((size_t)channels * width * height);
   if(!g->buf) goto error;
 
   return g;

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -234,7 +234,7 @@ static inline void box_mean_1d_9ch(int N, const float *x, float *y, size_t strid
 static void box_mean_4ch(color_image img, int w)
 {
   const size_t size = 4 * max_i(img.width, img.height);
-  float *img_bak = dt_alloc_align_float((size_t)size * dt_get_num_threads());
+  float *img_bak = dt_alloc_align_float(dt_get_num_threads() * size);
   const size_t width = 4 * img.width;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) dt_omp_firstprivate(w, size, width, img_bak) shared(img)
@@ -316,7 +316,7 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
   color_image variance = new_color_image(width, height, 9);
   const size_t img_dimen = max_i(mean.width, mean.height);
   const size_t img_bak_sz = 13 * img_dimen;
-  float *img_bak = dt_alloc_align_float(img_bak_sz * dt_get_num_threads());
+  float *img_bak = dt_alloc_align_float(dt_get_num_threads() * img_bak_sz);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) shared(img, imgg, mean, variance, img_bak) \
   dt_omp_firstprivate(img_bak_sz, img_dimen, w, guide_weight) dt_omp_sharedconst(source)

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -71,7 +71,7 @@ typedef struct color_image
 // allocate space for n-component image of size width x height
 static inline color_image new_color_image(int width, int height, int ch)
 {
-  return (color_image){ dt_alloc_align(64, sizeof(float) * width * height * ch), width, height, ch };
+  return (color_image){ dt_alloc_align_float((size_t)width * height * ch), width, height, ch };
 }
 
 // free space for n-component image
@@ -234,7 +234,7 @@ static inline void box_mean_1d_9ch(int N, const float *x, float *y, size_t strid
 static void box_mean_4ch(color_image img, int w)
 {
   const size_t size = 4 * max_i(img.width, img.height);
-  float *img_bak = dt_alloc_align(64, dt_get_num_threads() * size * sizeof(float));
+  float *img_bak = dt_alloc_align_float((size_t)size * dt_get_num_threads());
   const size_t width = 4 * img.width;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) dt_omp_firstprivate(w, size, width, img_bak) shared(img)
@@ -316,7 +316,7 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
   color_image variance = new_color_image(width, height, 9);
   const size_t img_dimen = max_i(mean.width, mean.height);
   const size_t img_bak_sz = 13 * img_dimen;
-  float *img_bak = dt_alloc_align(64, dt_get_num_threads() * img_bak_sz * sizeof(float));
+  float *img_bak = dt_alloc_align_float(img_bak_sz * dt_get_num_threads());
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) shared(img, imgg, mean, variance, img_bak) \
   dt_omp_firstprivate(img_bak_sz, img_dimen, w, guide_weight) dt_omp_sharedconst(source)

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -196,7 +196,7 @@ static void dt_heal_laplace_loop(float *pixels, const int width, const int heigh
    * coefs can put them in a dummy column to be multiplied by an empty pixel.
    */
   const int zero = ch * width * height;
-  memset(pixels + zero, 0, ch * sizeof(float));
+  memset(pixels + zero, 0, sizeof(float) * ch);
 
   /* Construct the system of equations.
    * Arrange Aidx in checkerboard order, so that a single linear pass over that
@@ -269,7 +269,7 @@ cleanup:
 void dt_heal(const float *const src_buffer, float *dest_buffer, const float *const mask_buffer, const int width,
              const int height, const int ch, const int use_sse)
 {
-  float *diff_buffer = dt_alloc_align(64, width * (height + 1) * ch * sizeof(float));
+  float *diff_buffer = dt_alloc_align(64, sizeof(float) * width * (height + 1) * ch);
 
   if(diff_buffer == NULL)
   {
@@ -337,7 +337,7 @@ cl_int dt_heal_cl(heal_params_cl_t *p, cl_mem dev_src, cl_mem dev_dest, const fl
   float *src_buffer = NULL;
   float *dest_buffer = NULL;
 
-  src_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+  src_buffer = dt_alloc_align(64, sizeof(float) * width * height * ch);
   if(src_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
@@ -345,7 +345,7 @@ cl_int dt_heal_cl(heal_params_cl_t *p, cl_mem dev_src, cl_mem dev_dest, const fl
     goto cleanup;
   }
 
-  dest_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+  dest_buffer = dt_alloc_align(64, sizeof(float) * width * height * ch);
   if(dest_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
@@ -370,7 +370,7 @@ cl_int dt_heal_cl(heal_params_cl_t *p, cl_mem dev_src, cl_mem dev_dest, const fl
   // I couldn't make it run fast on opencl (the reduction takes forever), so just call the cpu version
   dt_heal(src_buffer, dest_buffer, mask_buffer, width, height, ch, 0);
 
-  err = dt_opencl_write_buffer_to_device(p->devid, dest_buffer, dev_dest, 0, width * height * ch * sizeof(float),
+  err = dt_opencl_write_buffer_to_device(p->devid, dest_buffer, dev_dest, 0, sizeof(float) * width * height * ch,
                                          TRUE);
   if(err != CL_SUCCESS)
   {

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -180,7 +180,7 @@ static void dt_heal_laplace_loop(float *pixels, const int width, const int heigh
   int nmask = 0;
   int nmask2 = 0;
 
-  float *Adiag = dt_alloc_align(64, sizeof(float) * width * height);
+  float *Adiag = dt_alloc_align_float((size_t)width * height);
   int *Aidx = dt_alloc_align(64, sizeof(int) * 5 * width * height);
 
   if((Adiag == NULL) || (Aidx == NULL))
@@ -269,7 +269,7 @@ cleanup:
 void dt_heal(const float *const src_buffer, float *dest_buffer, const float *const mask_buffer, const int width,
              const int height, const int ch, const int use_sse)
 {
-  float *diff_buffer = dt_alloc_align(64, sizeof(float) * width * (height + 1) * ch);
+  float *diff_buffer = dt_alloc_align_float((size_t)ch * width * (height + 1));
 
   if(diff_buffer == NULL)
   {
@@ -337,7 +337,7 @@ cl_int dt_heal_cl(heal_params_cl_t *p, cl_mem dev_src, cl_mem dev_dest, const fl
   float *src_buffer = NULL;
   float *dest_buffer = NULL;
 
-  src_buffer = dt_alloc_align(64, sizeof(float) * width * height * ch);
+  src_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(src_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
@@ -345,7 +345,7 @@ cl_int dt_heal_cl(heal_params_cl_t *p, cl_mem dev_src, cl_mem dev_dest, const fl
     goto cleanup;
   }
 
-  dest_buffer = dt_alloc_align(64, sizeof(float) * width * height * ch);
+  dest_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(dest_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -91,7 +91,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     // Decompress the JPG into our own memory format
     dt_imageio_jpeg_t jpg;
     if(dt_imageio_jpeg_decompress_header(buf, bufsize, &jpg)) goto error;
-    *buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+    *buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
     if(!*buffer) goto error;
 
     *width = jpg.width;

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -183,7 +183,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
       break;
     }
 
-    *buffer = malloc((*width) * (*height) * 4 * sizeof(uint8_t));
+    *buffer = malloc(sizeof(uint8_t) * (*width) * (*height) * 4);
     if (*buffer == NULL) goto error_im;
 
     mret = MagickExportImagePixels(image, 0, 0, *width, *height, "RGBP", CharPixel, *buffer);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -131,7 +131,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     *height = image->rows;
     *color_space = DT_COLORSPACE_SRGB; // FIXME: this assumes that embedded thumbnails are always srgb
 
-    *buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * 4 * image->columns * image->rows);
+    *buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * image->columns * image->rows);
     if(!*buffer) goto error_gm;
 
     for(uint32_t row = 0; row < image->rows; row++)

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -91,7 +91,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     // Decompress the JPG into our own memory format
     dt_imageio_jpeg_t jpg;
     if(dt_imageio_jpeg_decompress_header(buf, bufsize, &jpg)) goto error;
-    *buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * jpg.width * jpg.height * 4);
+    *buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * 4 * jpg.width * jpg.height);
     if(!*buffer) goto error;
 
     *width = jpg.width;
@@ -131,7 +131,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     *height = image->rows;
     *color_space = DT_COLORSPACE_SRGB; // FIXME: this assumes that embedded thumbnails are always srgb
 
-    *buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * image->columns * image->rows * 4);
+    *buffer = (uint8_t *)dt_alloc_align(64, (size_t)sizeof(uint8_t) * 4 * image->columns * image->rows);
     if(!*buffer) goto error_gm;
 
     for(uint32_t row = 0; row < image->rows; row++)

--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -221,7 +221,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       goto out;
     }
 
-    uint8_t *data = (uint8_t *)g_malloc0(icc.size * sizeof(uint8_t));
+    uint8_t *data = (uint8_t *)g_malloc0(sizeof(uint8_t) * icc.size);
     if (data == NULL) {
       dt_print(DT_DEBUG_IMAGEIO,
                "Failed to allocate ICC buffer for AVIF image [%s]\n",

--- a/src/common/imageio_exr.cc
+++ b/src/common/imageio_exr.cc
@@ -129,7 +129,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
   }
 
   // FIXME: is this really needed?
-  memset(buf, 0, (size_t)4 * img->width * img->height * sizeof(float));
+  memset(buf, 0, sizeof(float) * 4 * img->width * img->height);
 
   /* setup framebuffer */
   xstride = sizeof(float) * 4;

--- a/src/common/imageio_exr.cc
+++ b/src/common/imageio_exr.cc
@@ -129,7 +129,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
   }
 
   // FIXME: is this really needed?
-  memset(buf, 0, 4 * img->width * img->height * sizeof(float));
+  memset(buf, 0, (size_t)4 * img->width * img->height * sizeof(float));
 
   /* setup framebuffer */
   xstride = sizeof(float) * 4;

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -173,7 +173,7 @@ static int decompress_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
 static int decompress_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
 {
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {
@@ -613,7 +613,7 @@ static int read_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
 static int read_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
 {
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {
@@ -737,7 +737,7 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, 
   img->width = jpg.width;
   img->height = jpg.height;
 
-  uint8_t *tmp = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * jpg.width * jpg.height * 4);
+  uint8_t *tmp = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
   if(dt_imageio_jpeg_read(&jpg, tmp))
   {
     dt_free_align(tmp);

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -268,7 +268,7 @@ int dt_imageio_jpeg_compress(const uint8_t *in, uint8_t *out, const int width, c
   jpg.dest.empty_output_buffer = dt_imageio_jpeg_empty_output_buffer;
   jpg.dest.term_destination = dt_imageio_jpeg_term_destination;
   jpg.dest.next_output_byte = (JOCTET *)out;
-  jpg.dest.free_in_buffer = 4 * width * height * sizeof(uint8_t);
+  jpg.dest.free_in_buffer = sizeof(uint8_t) * 4 * width * height;
 
   jpg.cinfo.err = jpeg_std_error(&jerr.pub);
   jerr.pub.error_exit = dt_imageio_jpeg_error_exit;
@@ -303,7 +303,7 @@ int dt_imageio_jpeg_compress(const uint8_t *in, uint8_t *out, const int width, c
   jpeg_finish_compress(&(jpg.cinfo));
   dt_free_align(row);
   jpeg_destroy_compress(&(jpg.cinfo));
-  return 4 * width * height * sizeof(uint8_t) - jpg.dest.free_in_buffer;
+  return sizeof(uint8_t) * 4 * width * height - jpg.dest.free_in_buffer;
 }
 
 

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -289,7 +289,7 @@ int dt_imageio_jpeg_compress(const uint8_t *in, uint8_t *out, const int width, c
   if(quality > 90) jpg.cinfo.comp_info[0].v_samp_factor = 1;
   if(quality > 92) jpg.cinfo.comp_info[0].h_samp_factor = 1;
   jpeg_start_compress(&(jpg.cinfo), TRUE);
-  uint8_t *row = dt_alloc_align(64, (size_t)3 * width * sizeof(uint8_t));
+  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -529,7 +529,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename, const uint8_t *
     cmsSaveProfileToMem(out_profile, 0, &len);
     if(len > 0)
     {
-      unsigned char *buf = dt_alloc_align(64, (size_t)len * sizeof(unsigned char));
+      unsigned char *buf = dt_alloc_align(64, sizeof(unsigned char) * len);
       cmsSaveProfileToMem(out_profile, buf, &len);
       write_icc_profile(&(jpg.cinfo), buf, len);
       dt_free_align(buf);
@@ -538,7 +538,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename, const uint8_t *
 
   if(exif && exif_len > 0 && exif_len < 65534) jpeg_write_marker(&(jpg.cinfo), JPEG_APP0 + 1, exif, exif_len);
 
-  uint8_t *row = dt_alloc_align(64, (size_t)3 * width * sizeof(uint8_t));
+  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {

--- a/src/common/imageio_pfm.c
+++ b/src/common/imageio_pfm.c
@@ -86,10 +86,10 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
   float *line = (float *)calloc(4 * img->width, sizeof(float));
   for(size_t j = 0; j < img->height / 2; j++)
   {
-    memcpy(line, buf + img->width * j * 4, 4 * sizeof(float) * img->width);
+    memcpy(line, buf + img->width * j * 4, sizeof(float) * 4 * img->width);
     memcpy(buf + img->width * j * 4, buf + img->width * (img->height - 1 - j) * 4,
-           4 * sizeof(float) * img->width);
-    memcpy(buf + img->width * (img->height - 1 - j) * 4, line, 4 * sizeof(float) * img->width);
+           sizeof(float) * 4 * img->width);
+    memcpy(buf + img->width * (img->height - 1 - j) * 4, line, sizeof(float) * 4 * img->width);
   }
   free(line);
   fclose(f);

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -124,7 +124,7 @@ int read_image(dt_imageio_png_t *png, void *out)
     return 1;
   }
 
-  png_bytep *row_pointers = malloc((size_t)png->height * sizeof(png_bytep));
+  png_bytep *row_pointers = malloc(sizeof(png_bytep) * png->height);
 
   png_bytep row_pointer = (png_bytep)out;
   const size_t rowbytes = png_get_rowbytes(png->png_ptr, png->info_ptr);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1095,7 +1095,7 @@ void dt_ioppr_transform_image_colorspace_rgb(const float *const restrict image_i
      && strcmp(profile_info_from->filename, profile_info_to->filename) == 0)
   {
     if(image_in != image_out)
-      memcpy(image_out, image_in, width * height * 4 * sizeof(float));
+      memcpy(image_out, image_in, sizeof(float) * 4 * width * height);
 
     return;
   }
@@ -1394,7 +1394,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   else
   {
     // no matrix, call lcms2
-    src_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+    src_buffer = dt_alloc_align(64, sizeof(float) * width * height * ch);
     if(src_buffer == NULL)
     {
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] error allocating memory for color transformation 1\n");
@@ -1604,8 +1604,8 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
   else
   {
     // no matrix, call lcms2
-    src_buffer_in = dt_alloc_align(64, width * height * ch * sizeof(float));
-    src_buffer_out = dt_alloc_align(64, width * height * ch * sizeof(float));
+    src_buffer_in  = dt_alloc_align(64, sizeof(float) * width * height * ch);
+    src_buffer_out = dt_alloc_align(64, sizeof(float) * width * height * ch);
     if(src_buffer_in == NULL || src_buffer_out == NULL)
     {
       fprintf(stderr,

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1394,7 +1394,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   else
   {
     // no matrix, call lcms2
-    src_buffer = dt_alloc_align(64, sizeof(float) * width * height * ch);
+    src_buffer = dt_alloc_align_float((size_t) ch * width * height);
     if(src_buffer == NULL)
     {
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] error allocating memory for color transformation 1\n");
@@ -1604,8 +1604,8 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
   else
   {
     // no matrix, call lcms2
-    src_buffer_in  = dt_alloc_align(64, sizeof(float) * width * height * ch);
-    src_buffer_out = dt_alloc_align(64, sizeof(float) * width * height * ch);
+    src_buffer_in  = dt_alloc_align_float((size_t) ch * width * height);
+    src_buffer_out = dt_alloc_align_float((size_t) ch * width * height);
     if(src_buffer_in == NULL || src_buffer_out == NULL)
     {
       fprintf(stderr,

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1175,7 +1175,7 @@ void dt_ioppr_get_profile_info_cl(const dt_iop_order_iccprofile_info_t *const pr
 
 cl_float *dt_ioppr_get_trc_cl(const dt_iop_order_iccprofile_info_t *const profile_info)
 {
-  cl_float *trc = malloc(profile_info->lutsize * 6 * sizeof(cl_float));
+  cl_float *trc = malloc(sizeof(cl_float) * 6 * profile_info->lutsize);
   if(trc)
   {
     int x = 0;
@@ -1224,7 +1224,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
   }
   else
   {
-    profile_lut_cl = malloc(1 * 6 * sizeof(cl_float));
+    profile_lut_cl = malloc(sizeof(cl_float) * 1 * 6);
 
     dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 1, 1 * 6, sizeof(float));
     if(dev_profile_lut == NULL)
@@ -1330,7 +1330,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
 
     if(in_place)
     {
-      dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
       if(dev_tmp == NULL)
       {
         fprintf(stderr,
@@ -1506,7 +1506,7 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
 
     if(in_place)
     {
-      dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
       if(dev_tmp == NULL)
       {
         fprintf(

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1287,7 +1287,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     return FALSE;
   }
 
-  const int ch = 4;
+  const size_t ch = 4;
   float *src_buffer = NULL;
   int in_place = (dev_img_in == dev_img_out);
 
@@ -1394,7 +1394,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   else
   {
     // no matrix, call lcms2
-    src_buffer = dt_alloc_align_float((size_t) ch * width * height);
+    src_buffer = dt_alloc_align_float(ch * width * height);
     if(src_buffer == NULL)
     {
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] error allocating memory for color transformation 1\n");
@@ -1463,7 +1463,7 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
     return TRUE;
   }
 
-  const int ch = 4;
+  const size_t ch = 4;
   float *src_buffer_in = NULL;
   float *src_buffer_out = NULL;
   int in_place = (dev_img_in == dev_img_out);
@@ -1604,8 +1604,8 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
   else
   {
     // no matrix, call lcms2
-    src_buffer_in  = dt_alloc_align_float((size_t) ch * width * height);
-    src_buffer_out = dt_alloc_align_float((size_t) ch * width * height);
+    src_buffer_in  = dt_alloc_align_float(ch * width * height);
+    src_buffer_out = dt_alloc_align_float(ch * width * height);
     if(src_buffer_in == NULL || src_buffer_out == NULL)
     {
       fprintf(stderr,

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -283,7 +283,7 @@ static inline float *ll_pad_input(
   const int stride = 4;
   *wd2 = 2*max_supp + wd;
   *ht2 = 2*max_supp + ht;
-  float *const out = dt_alloc_align(64, *wd2**ht2*sizeof(*out));
+  float *const out = dt_alloc_align_float((size_t) *wd2 * *ht2);
 
   if(b && b->mode == 2)
   { // pad by preview buffer
@@ -589,12 +589,12 @@ void local_laplacian_internal(
 
   // allocate pyramid pointers for padded input
   for(int l=1;l<=last_level;l++)
-    padded[l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
+    padded[l] = dt_alloc_align_float((size_t)dl(w,l) * dl(h,l));
 
   // allocate pyramid pointers for output
   float *output[max_levels] = {0};
   for(int l=0;l<=last_level;l++)
-    output[l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
+    output[l] = dt_alloc_align_float((size_t)dl(w,l) * dl(h,l));
 
   // create gauss pyramid of padded input, write coarse directly to output
 #if defined(__SSE2__)
@@ -620,7 +620,7 @@ void local_laplacian_internal(
   // allocate memory for intermediate laplacian pyramids
   float *buf[num_gamma][max_levels] = {{0}};
   for(int k=0;k<num_gamma;k++) for(int l=0;l<=last_level;l++)
-    buf[k][l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
+    buf[k][l] = dt_alloc_align_float((size_t)dl(w,l)*dl(h,l));
 
   // the paper says remapping only level 3 not 0 does the trick, too
   // (but i really like the additional octave of sharpness we get,

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -777,7 +777,7 @@ size_t local_laplacian_memory_use(const int width,     // width of input image
   size_t memory_use = 0;
 
   for(int l=0;l<num_levels;l++)
-    memory_use += (size_t)(2 + num_gamma) * dl(paddwd, l) * dl(paddht, l) * sizeof(float);
+    memory_use += sizeof(float) * (2 + num_gamma) * dl(paddwd, l) * dl(paddht, l);
 
   return memory_use;
 }
@@ -790,5 +790,5 @@ size_t local_laplacian_singlebuffer_size(const int width,     // width of input 
   const int paddwd = width  + 2*max_supp;
   const int paddht = height + 2*max_supp;
 
-  return (size_t)dl(paddwd, 0) * dl(paddht, 0) * sizeof(float);
+  return sizeof(float) * dl(paddwd, 0) * dl(paddht, 0);
 }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1131,7 +1131,7 @@ static int _write_image(dt_imageio_module_data_t *data, const char *filename, co
                         const gboolean export_masks)
 {
   _dummy_data_t *d = (_dummy_data_t *)data;
-  memcpy(d->buf, in, data->width * data->height * sizeof(uint32_t));
+  memcpy(d->buf, in, sizeof(uint32_t) * data->width * data->height);
   return 0;
 }
 

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -931,7 +931,7 @@ int nlmeans_denoise_cl(const dt_nlmeans_param_t *const params, const int devid,
   unsigned int state = 0;
   for(int k = 0; k < NUM_BUCKETS; k++)
   {
-    buckets[k] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(float));
+    buckets[k] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
     if(buckets[k] == NULL) goto error;
   }
 
@@ -1027,7 +1027,7 @@ int nlmeans_denoiseprofile_cl(const dt_nlmeans_param_t *const params, const int 
   unsigned int state = 0;
   for(int k = 0; k < NUM_BUCKETS; k++)
   {
-    buckets[k] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(float));
+    buckets[k] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
     if(buckets[k] == NULL) goto error;
   }
 

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -123,7 +123,7 @@ define_patches(const dt_nlmeans_param_t *const params, const int stride, int *nu
     n_patches = (n_patches + 1) / 2;
   *num_patches = n_patches ;
   // allocate a cacheline-aligned buffer
-  struct patch_t* patches = dt_alloc_align(64,n_patches*sizeof(struct patch_t));
+  struct patch_t* patches = dt_alloc_align(64, sizeof(struct patch_t) * n_patches);
   // set up the patch offsets
   int patch_num = 0;
   int shift = 0;
@@ -406,7 +406,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
 #endif /* CACHE_PIXDIFFS */
   const int padded_scratch_size = 16*((scratch_size+15)/16); // round up to a full cache line
   const int numthreads = dt_get_num_threads() ;
-  float *scratch_buf = dt_alloc_align(64,numthreads * padded_scratch_size * sizeof(float));
+  float *scratch_buf = dt_alloc_align_float((size_t)numthreads * padded_scratch_size);
   const int chk_height = compute_slice_height(roi_out->height);
   const int chk_width = compute_slice_width(roi_out->width);
 #ifdef _OPENMP
@@ -632,7 +632,7 @@ void nlmeans_denoise_sse2(const float *const inbuf, float *const outbuf,
 #endif /* CACHE_PIXDIFFS_SSE */
   const int padded_scratch_size = 16*((scratch_size+15)/16); // round up to a full cache line
   const int numthreads = dt_get_num_threads() ;
-  float *scratch_buf = dt_alloc_align(64,numthreads * padded_scratch_size * sizeof(float));
+  float *scratch_buf = dt_alloc_align_float((size_t)numthreads * padded_scratch_size);
   const int chk_height = compute_slice_height(roi_out->height);
   const int chk_width = compute_slice_width(roi_out->width);
 #ifdef _OPENMP

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -400,13 +400,13 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
   // allocate scratch space, including an overrun area on each end so we don't need a boundary check on every access
   const int radius = params->patch_radius;
 #if defined(CACHE_PIXDIFFS)
-  const int scratch_size = (2*radius+3)*(SLICE_WIDTH + 2*radius + 1);
+  const size_t scratch_size = (2*radius+3)*(SLICE_WIDTH + 2*radius + 1);
 #else
-  const int scratch_size = SLICE_WIDTH + 2*radius + 1 + 48; // getting false sharing without the +48....
+  const size_t scratch_size = SLICE_WIDTH + 2*radius + 1 + 48; // getting false sharing without the +48....
 #endif /* CACHE_PIXDIFFS */
-  const int padded_scratch_size = 16*((scratch_size+15)/16); // round up to a full cache line
-  const int numthreads = dt_get_num_threads() ;
-  float *scratch_buf = dt_alloc_align_float((size_t)numthreads * padded_scratch_size);
+  const size_t padded_scratch_size = 16*((scratch_size+15)/16); // round up to a full cache line
+  const size_t numthreads = dt_get_num_threads() ;
+  float *scratch_buf = dt_alloc_align_float(numthreads * padded_scratch_size);
   const int chk_height = compute_slice_height(roi_out->height);
   const int chk_width = compute_slice_width(roi_out->width);
 #ifdef _OPENMP
@@ -626,12 +626,12 @@ void nlmeans_denoise_sse2(const float *const inbuf, float *const outbuf,
   // allocate scratch space, including an overrun area on each end so we don't need a boundary check on every access
   const int radius = params->patch_radius;
 #if defined(CACHE_PIXDIFFS_SSE)
-  const int scratch_size = (2*radius+3)*(SLICE_WIDTH + 2*radius + 1);
+  const size_t scratch_size = (2*radius+3)*(SLICE_WIDTH + 2*radius + 1);
 #else
-  const int scratch_size = SLICE_WIDTH + 2*radius + 1 + 48; // getting false sharing without the +48....
+  const size_t scratch_size = SLICE_WIDTH + 2*radius + 1 + 48; // getting false sharing without the +48....
 #endif /* CACHE_PIXDIFFS_SSE */
-  const int padded_scratch_size = 16*((scratch_size+15)/16); // round up to a full cache line
-  const int numthreads = dt_get_num_threads() ;
+  const size_t padded_scratch_size = 16*((scratch_size+15)/16); // round up to a full cache line
+  const size_t numthreads = dt_get_num_threads() ;
   float *scratch_buf = dt_alloc_align_float((size_t)numthreads * padded_scratch_size);
   const int chk_height = compute_slice_height(roi_out->height);
   const int chk_width = compute_slice_width(roi_out->width);

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -431,7 +431,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
       // we want to incrementally sum results (especially weights in col[3]), so clear the output buffer to zeros
       for (int i = chunk_top; i < chunk_bot; i++)
       {
-        memset(outbuf + 4*(i*roi_out->width+chunk_left), '\0', (chunk_right-chunk_left) * 4 * sizeof(float));
+        memset(outbuf + 4*(i*roi_out->width+chunk_left), '\0', sizeof(float) * 4 * (chunk_right-chunk_left));
       }
       // cycle through all of the patches over our slice of the image
       for (int p = 0; p < num_patches; p++)
@@ -657,7 +657,7 @@ void nlmeans_denoise_sse2(const float *const inbuf, float *const outbuf,
       // we want to incrementally sum results (especially weights in col[3]), so clear the output buffer to zeros
       for (int i = chunk_top; i < chunk_bot; i++)
       {
-        memset(outbuf + 4*(i*roi_out->width+chunk_left), '\0', (chunk_right-chunk_left) * 4 * sizeof(float));
+        memset(outbuf + 4*(i*roi_out->width+chunk_left), '\0', sizeof(float) * 4 * (chunk_right-chunk_left));
       }
       // cycle through all of the patches over our slice of the image
       for (int p = 0; p < num_patches; p++)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2680,8 +2680,8 @@ cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
       free(neweventtags);
       return NULL;
     }
-    memcpy(neweventlist, *eventlist, *maxevents * sizeof(cl_event));
-    memcpy(neweventtags, *eventtags, *maxevents * sizeof(dt_opencl_eventtag_t));
+    memcpy(neweventlist, *eventlist, sizeof(cl_event) * *maxevents);
+    memcpy(neweventtags, *eventtags, sizeof(dt_opencl_eventtag_t) * *maxevents);
     free(*eventlist);
     free(*eventtags);
     *eventlist = neweventlist;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2729,7 +2729,7 @@ void dt_opencl_events_reset(const int devid)
     (cl->dlocl->symbols->dt_clReleaseEvent)((*eventlist)[k]);
   }
 
-  memset(*eventtags, 0, *maxevents * sizeof(dt_opencl_eventtag_t));
+  memset(*eventtags, 0, sizeof(dt_opencl_eventtag_t) * *maxevents);
   *numevents = 0;
   *eventsconsolidated = 0;
   *lostevents = 0;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -633,8 +633,8 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   g_free(library);
 
   cl_int err;
-  all_platforms = malloc(DT_OPENCL_MAX_PLATFORMS * sizeof(cl_platform_id));
-  all_num_devices = malloc(DT_OPENCL_MAX_PLATFORMS * sizeof(cl_uint));
+  all_platforms = malloc(sizeof(cl_platform_id) * DT_OPENCL_MAX_PLATFORMS);
+  all_num_devices = malloc(sizeof(cl_uint) * DT_OPENCL_MAX_PLATFORMS);
   cl_uint num_platforms = DT_OPENCL_MAX_PLATFORMS;
   err = (cl->dlocl->symbols->dt_clGetPlatformIDs)(DT_OPENCL_MAX_PLATFORMS, all_platforms, &num_platforms);
   if(err != CL_SUCCESS)
@@ -1220,7 +1220,7 @@ static void dt_opencl_priority_parse(dt_opencl_t *cl, char *configstr, int *prio
 {
   int devs = cl->num_devs;
   int count = 0;
-  int *full = malloc((size_t)(devs + 1) * sizeof(int));
+  int *full = malloc(sizeof(int) * (devs + 1));
   int mnd = 0;
 
   // NULL or empty configstring?
@@ -1763,7 +1763,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
         return CL_SUCCESS;
       }
 
-      cl_device_id *devices = malloc(numdev * sizeof(cl_device_id));
+      cl_device_id *devices = malloc(sizeof(cl_device_id) * numdev);
       err = (cl->dlocl->symbols->dt_clGetProgramInfo)(program, CL_PROGRAM_DEVICES,
                                                       sizeof(cl_device_id) * numdev, devices, NULL);
       if(err != CL_SUCCESS)
@@ -1773,7 +1773,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
         return CL_SUCCESS;
       }
 
-      size_t *binary_sizes = malloc(numdev * sizeof(size_t));
+      size_t *binary_sizes = malloc(sizeof(size_t) * numdev);
       err = (cl->dlocl->symbols->dt_clGetProgramInfo)(program, CL_PROGRAM_BINARY_SIZES,
                                                       sizeof(size_t) * numdev, binary_sizes, NULL);
       if(err != CL_SUCCESS)
@@ -1784,7 +1784,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
         return CL_SUCCESS;
       }
 
-      unsigned char **binaries = malloc(numdev * sizeof(unsigned char *));
+      unsigned char **binaries = malloc(sizeof(unsigned char *) * numdev);
       for(int i = 0; i < numdev; i++) binaries[i] = (unsigned char *)malloc(binary_sizes[i]);
       err = (cl->dlocl->symbols->dt_clGetProgramInfo)(program, CL_PROGRAM_BINARIES,
                                                       sizeof(unsigned char *) * numdev, binaries, NULL);
@@ -2887,8 +2887,8 @@ void dt_opencl_events_profiling(const int devid, const int aggregated)
   if(*eventlist == NULL || *numevents == 0 || *eventtags == NULL || *eventsconsolidated == 0)
     return; // nothing to do
 
-  char **tags = malloc((*eventsconsolidated + 1) * sizeof(char *));
-  float *timings = malloc((*eventsconsolidated + 1) * sizeof(float));
+  char **tags = malloc(sizeof(char *) * (*eventsconsolidated + 1));
+  float *timings = malloc(sizeof(float) * (*eventsconsolidated + 1));
   int items = 1;
   tags[0] = "";
   timings[0] = 0.0f;

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -199,7 +199,7 @@ static void _pdf_set_offset(dt_pdf_t *pdf, int id, size_t offset)
   if(id >= pdf->n_offsets)
   {
     pdf->n_offsets = MAX(pdf->n_offsets * 2, id);
-    pdf->offsets = realloc(pdf->offsets, pdf->n_offsets * sizeof(size_t));
+    pdf->offsets = realloc(pdf->offsets, sizeof(size_t) * pdf->n_offsets);
   }
   pdf->offsets[id] = offset;
 }

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -417,7 +417,7 @@ dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf, const unsigned char *image, int 
   );
 
   // the stream
-  stream_size = _pdf_write_stream(pdf, pdf->default_encoder, image, width * height * 3 * (bpp / 8));
+  stream_size = _pdf_write_stream(pdf, pdf->default_encoder, image, (size_t)3 * (bpp / 8) * width * height);
   if(stream_size == 0)
   {
     free(pdf_image);
@@ -874,7 +874,7 @@ int main(int argc, char *argv[])
     int width, height;
     float *image = read_ppm(argv[i + 1], &width, &height);
     if(!image) exit(1);
-    uint16_t *data = (uint16_t *)malloc(width * height * 3 * sizeof(uint16_t));
+    uint16_t *data = (uint16_t *)malloc(sizeof(uint16_t) * 3 * width * height);
     if(!data)
     {
       free(image);

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -65,7 +65,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
     return 1;
   }
 
-  void *out = (void *)malloc(width*height*3);
+  void *out = (void *)malloc((size_t)3 * width * height);
 
   if (bpp == 8)
   {

--- a/src/common/tea.h
+++ b/src/common/tea.h
@@ -24,7 +24,7 @@
 // cutting throughput by a factor equal to the number of threads sharing a cache line (8 with a 64-byte cache
 // line and 32-bit ints)
 #define TEA_STATE_SIZE (MAX(64, 2*sizeof(unsigned int)))
-static inline unsigned int* alloc_tea_states(int numthreads)
+static inline unsigned int* alloc_tea_states(size_t numthreads)
 {
   unsigned int* states = dt_alloc_align(64, numthreads * TEA_STATE_SIZE);
   if (states) memset(states, 0, numthreads * TEA_STATE_SIZE);

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -774,7 +774,7 @@ char *dt_read_file(const char *const filename, size_t *filesize)
   size_t end = ftell(fd);
   rewind(fd);
 
-  char *content = (char *)malloc(end * sizeof(char));
+  char *content = (char *)malloc(sizeof(char) * end);
   if(!content) return NULL;
 
   size_t count = fread(content, sizeof(char), end, fd);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -280,7 +280,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
   const float opacity = fminf(fmaxf(0.0f, (d->opacity / 100.0f)), 1.0f);
 
   // allocate space for blend mask
-  float *const restrict _mask = dt_alloc_align(64, buffsize * sizeof(float));
+  float *const restrict _mask = dt_alloc_align_float(buffsize);
   if(!_mask)
   {
     dt_control_log(_("could not allocate buffer for blending"));
@@ -419,7 +419,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
         default:
           assert(0);
       }
-      float *const restrict mask_bak = dt_alloc_align(64, sizeof(*mask_bak) * buffsize);
+      float *const restrict mask_bak = dt_alloc_align_float(buffsize);
       if(mask_bak)
       {
         memcpy(mask_bak, mask, sizeof(*mask_bak) * buffsize);
@@ -427,7 +427,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
                                                                       : (float *const restrict)ovoid;
         if(!rois_equal && d->feathering_guide == DEVELOP_MASK_GUIDE_IN)
         {
-          float *const restrict guide_tmp = dt_alloc_align(64, sizeof(*guide_tmp) * buffsize * ch);
+          float *const restrict guide_tmp = dt_alloc_align_float(buffsize * ch);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(ch, guide_tmp, ivoid, iwidth, oheight, owidth, xoffs, yoffs)
@@ -601,7 +601,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   const float opacity = fminf(fmaxf(0.0f, (d->opacity / 100.0f)), 1.0f);
 
   // allocate space for blend mask
-  float *_mask = dt_alloc_align(64, buffsize * sizeof(float));
+  float *_mask = dt_alloc_align_float(buffsize);
   if(!_mask)
   {
     dt_control_log(_("could not allocate buffer for blending"));

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1177,7 +1177,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->opacity = o->opacity;
     n->mask_id = o->mask_id;
     n->blendif = o->blendif & ~(1u << DEVELOP_BLENDIF_active); // knock out old unused "active" flag
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
 
     return 0;
   }
@@ -1199,7 +1199,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->mask_id = o->mask_id;
     n->blur_radius = o->radius;
     n->blendif = o->blendif & ~(1u << DEVELOP_BLENDIF_active); // knock out old unused "active" flag
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
 
     return 0;
   }
@@ -1224,7 +1224,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     // bit no. 32 in blendif.
     n->blendif = (o->blendif & (1u << DEVELOP_BLENDIF_active) ? o->blendif | 31 : o->blendif)
                  & ~(1u << DEVELOP_BLENDIF_active);
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
 
     return 0;
   }
@@ -1244,7 +1244,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->mask_id = o->mask_id;
     n->blur_radius = o->radius;
     n->blendif = o->blendif;
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     return 0;
   }
 
@@ -1263,7 +1263,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->mask_id = o->mask_id;
     n->blur_radius = o->radius;
     n->blendif = o->blendif;
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     return 0;
   }
 
@@ -1286,7 +1286,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blur_radius = o->blur_radius;
     n->contrast = o->contrast;
     n->brightness = o->brightness;
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     return 0;
   }
 
@@ -1309,7 +1309,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blur_radius = o->blur_radius;
     n->contrast = o->contrast;
     n->brightness = o->brightness;
-    memcpy(n->blendif_parameters, o->blendif_parameters, 4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+    memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     memcpy(n->raster_mask_source, o->raster_mask_source, sizeof(n->raster_mask_source));
     n->raster_mask_instance = o->raster_mask_instance;
     n->raster_mask_id = o->raster_mask_id;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -838,7 +838,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       cl_mem guide = d->feathering_guide == DEVELOP_MASK_GUIDE_IN ? dev_in : dev_out;
       if(!rois_equal && d->feathering_guide == DEVELOP_MASK_GUIDE_IN)
       {
-        dev_guide = dt_opencl_alloc_device(devid, owidth, oheight, 4 * sizeof(float));
+        dev_guide = dt_opencl_alloc_device(devid, owidth, oheight, sizeof(float) * 4);
         if(dev_guide == NULL) goto error;
         guide = dev_guide;
         size_t origin_1[] = { xoffs, yoffs, 0 };
@@ -908,7 +908,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   }
 
   // get temporary buffer for output image to overcome readonly/writeonly limitation
-  dev_tmp = dt_opencl_alloc_device(devid, owidth, oheight, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, owidth, oheight, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -266,7 +266,7 @@ void dt_develop_blendif_lab_make_mask(struct dt_dev_pixelpipe_iop_t *piece, cons
     dt_develop_blendif_process_parameters(parameters, d);
 
     // allocate space for a temporary mask buffer to split the computation of every channel
-    float *const restrict temp_mask = dt_alloc_align(64, buffsize * sizeof(float));
+    float *const restrict temp_mask = dt_alloc_align_float(buffsize);
     if(!temp_mask)
     {
       return;

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -317,7 +317,7 @@ void dt_develop_blendif_rgb_hsl_make_mask(struct dt_dev_pixelpipe_iop_t *piece, 
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
 
     // allocate space for a temporary mask buffer to split the computation of every channel
-    float *const restrict temp_mask = dt_alloc_align(64, buffsize * sizeof(float));
+    float *const restrict temp_mask = dt_alloc_align_float(buffsize);
     if(!temp_mask)
     {
       return;

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -294,7 +294,7 @@ void dt_develop_blendif_rgb_jzczhz_make_mask(struct dt_dev_pixelpipe_iop_t *piec
     const dt_iop_order_iccprofile_info_t *profile = &blend_profile;
 
     // allocate space for a temporary mask buffer to split the computation of every channel
-    float *const restrict temp_mask = dt_alloc_align(64, buffsize * sizeof(float));
+    float *const restrict temp_mask = dt_alloc_align_float(buffsize);
     if(!temp_mask)
     {
       return;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -662,10 +662,10 @@ static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, co
       float pd[7] = { point3->corner[0] * wd - dx, point3->corner[1] * ht - dy, point3->ctrl1[0] * wd - dx,
                       point3->ctrl1[1] * ht - dy, point3->border[0] * MIN(wd, ht), point3->hardness,
                       point3->density };
-      memcpy(p1, pa, 7 * sizeof(float));
-      memcpy(p2, pb, 7 * sizeof(float));
-      memcpy(p3, pc, 7 * sizeof(float));
-      memcpy(p4, pd, 7 * sizeof(float));
+      memcpy(p1, pa, sizeof(float) * 7);
+      memcpy(p2, pb, sizeof(float) * 7);
+      memcpy(p3, pc, sizeof(float) * 7);
+      memcpy(p4, pd, sizeof(float) * 7);
     }
     else
     {
@@ -681,10 +681,10 @@ static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, co
       float pd[7] = { point3->corner[0] * wd - dx, point3->corner[1] * ht - dy, point3->ctrl2[0] * wd - dx,
                       point3->ctrl2[1] * ht - dy, point3->border[0] * MIN(wd, ht), point3->hardness,
                       point3->density };
-      memcpy(p1, pa, 7 * sizeof(float));
-      memcpy(p2, pb, 7 * sizeof(float));
-      memcpy(p3, pc, 7 * sizeof(float));
-      memcpy(p4, pd, 7 * sizeof(float));
+      memcpy(p1, pa, sizeof(float) * 7);
+      memcpy(p2, pb, sizeof(float) * 7);
+      memcpy(p3, pc, sizeof(float) * 7);
+      memcpy(p4, pd, sizeof(float) * 7);
     }
 
     // 1st. special case: render abrupt transitions between different opacity and/or hardness values
@@ -2799,7 +2799,7 @@ static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
   start = start2 = dt_get_wtime();
 
   // empty the output buffer
-  memset(buffer, 0, (size_t)width * height * sizeof(float));
+  memset(buffer, 0, sizeof(float) * width * height);
 
   const guint nb_corner = g_list_length(form->points);
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2689,8 +2689,8 @@ static int dt_brush_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
 //   start2 = dt_get_wtime();
 
   // we allocate the buffer
-  const size_t bufsize = (size_t)(*width) * (*height)  * sizeof(float);
-  *buffer = dt_alloc_align(64, bufsize);
+  const size_t bufsize = (size_t)(*width) * (*height);
+  *buffer = dt_alloc_align_float(bufsize);
   if(*buffer == NULL)
   {
     dt_free_align(points);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -731,10 +731,10 @@ static int dt_circle_get_points(dt_develop_t *dev, float x, float y, float radiu
 
   // how many points do we need ?
   float r = radius * MIN(wd, ht);
-  int l = MAX(100, (int)(2.0 * M_PI * r));
+  const size_t l = MAX(100, (size_t)(2.0 * M_PI * r));
 
   // buffer allocations
-  *points = dt_alloc_align_float(2 * (l + 1));
+  *points = dt_alloc_align_float((l + 1) * 2);
   if(*points == NULL)
   {
     *points_count = 0;
@@ -769,10 +769,10 @@ static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_i
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
   float wd = piece->pipe->iwidth, ht = piece->pipe->iheight;
 
-  float r = (circle->radius + circle->border) * MIN(wd, ht);
-  int l = (int)(2.0 * M_PI * r);
+  const float r = (circle->radius + circle->border) * MIN(wd, ht);
+  const size_t l = (size_t)(2.0 * M_PI * r);
   // buffer allocations
-  float *const restrict points = dt_alloc_align_float(2 * (l + 1));
+  float *const restrict points = dt_alloc_align_float((l + 1) * 2);
   if(points == NULL)
     return 0;
 
@@ -822,10 +822,10 @@ static int dt_circle_get_area(const dt_iop_module_t *const restrict module,
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
   float wd = piece->pipe->iwidth, ht = piece->pipe->iheight;
 
-  float r = (circle->radius + circle->border) * MIN(wd, ht);
-  int l = (int)(2.0 * M_PI * r);
+  const float r = (circle->radius + circle->border) * MIN(wd, ht);
+  const size_t l = (size_t)(2.0 * M_PI * r);
   // buffer allocations
-  float *const restrict points = dt_alloc_align_float(2 * (l + 1));
+  float *const restrict points = dt_alloc_align_float((l + 1) * 2);
   if(points == NULL)
     return 0;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1003,7 +1003,7 @@ static int dt_circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
   // initialize output buffer with zero
-  memset(buffer, 0, (size_t)w * h * sizeof(float));
+  memset(buffer, 0, sizeof(float) * w * h);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] circle init took %0.04f sec\n", form->name, dt_get_wtime() - start2);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1753,7 +1753,7 @@ static int dt_ellipse_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
   // initialize output buffer with zero
-  memset(buffer, 0, (size_t)w * h * sizeof(float));
+  memset(buffer, 0, sizeof(float) * w * h);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse init took %0.04f sec\n", form->name, dt_get_wtime() - start2);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -297,7 +297,7 @@ static int dt_ellipse_get_points(dt_develop_t *dev, float xx, float yy, float ra
                   * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda)))) / n));
 
   // buffer allocations
-  *points = dt_alloc_align(64, 2 * (l + 5) * sizeof(float));
+  *points = dt_alloc_align_float((size_t)2 * (l + 5));
   if(*points == NULL)
   {
     *points_count = 0;
@@ -1439,7 +1439,7 @@ static int dt_ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_
                       * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
 
   // buffer allocations
-  float *points = dt_alloc_align(64, 2 * (l + 5) * sizeof(float));
+  float *points = dt_alloc_align_float((size_t) 2 * (l + 5));
   if(points == NULL)
     return 0;
 
@@ -1525,7 +1525,7 @@ static int dt_ellipse_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
                       * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
 
   // buffer allocations
-  float *points = dt_alloc_align(64, 2 * (l + 5) * sizeof(float));
+  float *points = dt_alloc_align_float((size_t)2 * (l + 5));
   if(points == NULL)
     return 0;
 
@@ -1595,7 +1595,7 @@ static int dt_ellipse_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
 
   // we create a buffer of points with all points in the area
   int w = *width, h = *height;
-  float *points = dt_alloc_align(64, w * h * 2 * sizeof(float));
+  float *points = dt_alloc_align_float((size_t)2 * w * h);
   if(points == NULL)
     return 0;
 
@@ -1623,13 +1623,13 @@ static int dt_ellipse_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
   start2 = dt_get_wtime();
 
   // we allocate the buffer
-  *buffer = dt_alloc_align(64, w * h * sizeof(float));
+  *buffer = dt_alloc_align_float((size_t)w * h);
   if(*buffer == NULL)
   {
     dt_free_align(points);
     return 0;
   }
-  memset(*buffer, 0, w * h * sizeof(float));
+  memset(*buffer, 0, sizeof(float) * w * h);
 
   // we populate the buffer
   const int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
@@ -1764,7 +1764,7 @@ static int dt_ellipse_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop
   const float lambda = (ta - tb) / (ta + tb);
   const int l = (int)(M_PI * (ta + tb) * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
   const size_t ellpts = MIN(360, l);
-  float *ell = dt_alloc_align(64, ellpts * 2 * sizeof(float));
+  float *ell = dt_alloc_align_float(ellpts * 2);
   if(ell == NULL) return 0;
 
 #ifdef _OPENMP
@@ -1845,7 +1845,7 @@ static int dt_ellipse_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop
     return 1;
 
 
-  float *points = dt_alloc_align(64, (size_t)bbw * bbh * 2 * sizeof(float));
+  float *points = dt_alloc_align_float((size_t)2 * bbw * bbh);
   if(points == NULL) return 0;
 
   // we populate the grid points in module coordinates

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -884,9 +884,9 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
   const float sinv = sinf(v);
 
   const int count = sqrtf(wd * wd + ht * ht) + 3;
-  *points = dt_alloc_align(64, 2 * count * sizeof(float));
+  *points = dt_alloc_align_float((size_t)2 * count);
   if(*points == NULL) return 0;
-  memset(*points, 0, 2 * count * sizeof(float));
+  memset(*points, 0, (size_t)2 * count * sizeof(float));
 
 
   // we set the anchor point
@@ -980,7 +980,7 @@ static int dt_gradient_get_points_border(dt_develop_t *dev, float x, float y, fl
   if(r1 && r2 && points_count1 > 4 && points_count2 > 4)
   {
     int k = 0;
-    *points = dt_alloc_align(64, 2 * ((points_count1 - 3) + (points_count2 - 3) + 1) * sizeof(float));
+    *points = dt_alloc_align_float((size_t)2 * ((points_count1 - 3) + (points_count2 - 3) + 1));
     if(*points == NULL) goto end;
     *points_count = (points_count1 - 3) + (points_count2 - 3) + 1;
     for(int i = 3; i < points_count1; i++)
@@ -1003,7 +1003,7 @@ static int dt_gradient_get_points_border(dt_develop_t *dev, float x, float y, fl
   else if(r1 && points_count1 > 4)
   {
     int k = 0;
-    *points = dt_alloc_align(64, 2 * ((points_count1 - 3)) * sizeof(float));
+    *points = dt_alloc_align_float((size_t)2 * ((points_count1 - 3)));
     if(*points == NULL) goto end;
     *points_count = points_count1 - 3;
     for(int i = 3; i < points_count1; i++)
@@ -1018,7 +1018,7 @@ static int dt_gradient_get_points_border(dt_develop_t *dev, float x, float y, fl
   else if(r2 && points_count2 > 4)
   {
     int k = 0;
-    *points = dt_alloc_align(64, 2 * ((points_count2 - 3)) * sizeof(float));
+    *points = dt_alloc_align_float((size_t)2 * ((points_count2 - 3)));
     if(*points == NULL) goto end;
     *points_count = points_count2 - 3;
 
@@ -1103,7 +1103,7 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   const int gw = (w + grid - 1) / grid + 1;
   const int gh = (h + grid - 1) / grid + 1;
 
-  float *points = dt_alloc_align(64, gw * gh * 2 * sizeof(float));
+  float *points = dt_alloc_align_float((size_t)2 * gw * gh);
   if(points == NULL) return 0;
 
 #ifdef _OPENMP
@@ -1156,7 +1156,7 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
 
   const int lutmax = ceilf(4 * compression * ihwscale);
   const int lutsize = 2 * lutmax + 2;
-  float *lut = dt_alloc_align(64, lutsize * sizeof(float));
+  float *lut = dt_alloc_align_float((size_t)lutsize);
   if(lut == NULL)
   {
     dt_free_align(points);
@@ -1212,13 +1212,13 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   dt_free_align(lut);
 
   // we allocate the buffer
-  *buffer = dt_alloc_align(64, w * h * sizeof(float));
+  *buffer = dt_alloc_align_float((size_t)w * h);
   if(*buffer == NULL)
   {
     dt_free_align(points);
     return 0;
   }
-  memset(*buffer, 0, w * h * sizeof(float));
+  memset(*buffer, 0, (size_t)w * h * sizeof(float));
 
 // we fill the mask buffer by interpolation
 #ifdef _OPENMP
@@ -1274,7 +1274,7 @@ static int dt_gradient_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_io
   const int gw = (w + grid - 1) / grid + 1;
   const int gh = (h + grid - 1) / grid + 1;
 
-  float *points = dt_alloc_align(64, (size_t)gw * gh * 2 * sizeof(float));
+  float *points = dt_alloc_align_float((size_t)2 * gw * gh);
   if(points == NULL) return 0;
 
 #ifdef _OPENMP
@@ -1330,7 +1330,7 @@ static int dt_gradient_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_io
 
   const int lutmax = ceilf(4 * compression * ihwscale);
   const int lutsize = 2 * lutmax + 2;
-  float *lut = dt_alloc_align(64, lutsize * sizeof(float));
+  float *lut = dt_alloc_align_float((size_t)lutsize);
   if(lut == NULL)
   {
     dt_free_align(points);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -886,7 +886,7 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
   const int count = sqrtf(wd * wd + ht * ht) + 3;
   *points = dt_alloc_align_float((size_t)2 * count);
   if(*points == NULL) return 0;
-  memset(*points, 0, (size_t)2 * count * sizeof(float));
+  memset(*points, 0, sizeof(float) * 2 * count);
 
 
   // we set the anchor point
@@ -1218,7 +1218,7 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
     dt_free_align(points);
     return 0;
   }
-  memset(*buffer, 0, (size_t)w * h * sizeof(float));
+  memset(*buffer, 0, sizeof(float) * w * h);
 
 // we fill the mask buffer by interpolation
 #ifdef _OPENMP

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -252,7 +252,7 @@ static void _inverse_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece
   // we create a new buffer
   const int wt = piece->iwidth;
   const int ht = piece->iheight;
-  float *buf = dt_alloc_align(64, (size_t)ht * wt * sizeof(float));
+  float *buf = dt_alloc_align_float((size_t)ht * wt);
 
   // we fill this buffer
   for(int yy = 0; yy < MIN(*posy, ht); yy++)
@@ -340,7 +340,7 @@ static int dt_group_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   *height = b - t;
 
   // we allocate the buffer
-  *buffer = dt_alloc_align(64, sizeof(float) * (r - l) * (b - t));
+  *buffer = dt_alloc_align_float((size_t)(r - l) * (b - t));
 
   // and we copy each buffer inside, row by row
   for(int i = 0; i < nb; i++)
@@ -456,7 +456,7 @@ static int dt_group_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
   const int height = roi->height;
 
   // we need to allocate a temporary buffer for intermediate creation of individual shapes
-  float *bufs = dt_alloc_align(64, (size_t)width * height * sizeof(float));
+  float *bufs = dt_alloc_align_float((size_t)width * height);
   if(bufs == NULL) return 0;
 
   // empty the output buffer

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -290,13 +290,13 @@ static int dt_group_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   const guint nb = g_list_length(form->points);
   if(nb == 0) return 0;
   float **bufs = calloc(nb, sizeof(float *));
-  int *w = malloc(nb * sizeof(int));
-  int *h = malloc(nb * sizeof(int));
-  int *px = malloc(nb * sizeof(int));
-  int *py = malloc(nb * sizeof(int));
-  int *ok = malloc(nb * sizeof(int));
-  int *states = malloc(nb * sizeof(int));
-  float *op = malloc(nb * sizeof(float));
+  int *w = malloc(sizeof(int) * nb);
+  int *h = malloc(sizeof(int) * nb);
+  int *px = malloc(sizeof(int) * nb);
+  int *py = malloc(sizeof(int) * nb);
+  int *ok = malloc(sizeof(int) * nb);
+  int *states = malloc(sizeof(int) * nb);
+  float *op = malloc(sizeof(float) * nb);
 
   // and we get all masks
   GList *fpts = g_list_first(form->points);

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -460,7 +460,7 @@ static int dt_group_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
   if(bufs == NULL) return 0;
 
   // empty the output buffer
-  memset(buffer, 0, (size_t)width * height * sizeof(float));
+  memset(buffer, 0, sizeof(float) * width * height);
 
   // and we get all masks
   GList *fpts = g_list_first(form->points);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1404,7 +1404,7 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
     form->version = sqlite3_column_int(stmt, 4);
     form->points = NULL;
     const int nb_points = sqlite3_column_int(stmt, 6);
-    memcpy(form->source, sqlite3_column_blob(stmt, 7), 2 * sizeof(float));
+    memcpy(form->source, sqlite3_column_blob(stmt, 7), sizeof(float) * 2);
 
     // and now we "read" the blob
     if(form->type & DT_MASKS_CIRCLE)
@@ -2673,7 +2673,7 @@ char *dt_masks_group_get_hash_buffer(dt_masks_form_t *form, char *str)
   pos += sizeof(int);
   memcpy(str + pos, &form->version, sizeof(int));
   pos += sizeof(int);
-  memcpy(str + pos, &form->source, 2 * sizeof(float));
+  memcpy(str + pos, &form->source, sizeof(float) * 2);
   pos += 2 * sizeof(float);
 
   GList *forms = g_list_first(form->points);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2191,7 +2191,7 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
   // we determine a higher approx of the entry number
   guint nbe = 5 + g_list_length(darktable.develop->forms) + g_list_length(darktable.develop->iop);
   free(bd->masks_combo_ids);
-  bd->masks_combo_ids = malloc(nbe * sizeof(int));
+  bd->masks_combo_ids = malloc( sizeof(int) *nbe);
 
   int *cids = bd->masks_combo_ids;
   GtkWidget *combo = bd->masks_combo;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -385,9 +385,9 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
   const size_t ss = (size_t)hb * wb;
   if(ss < 10 || hb < 0 || wb < 0) return 0;
 
-  int *binter = dt_alloc_align(64, ss * sizeof(int));
+  int *binter = dt_alloc_align(64, sizeof(int) * ss);
   if(binter == NULL) return 0;
-  memset(binter, 0, ss * sizeof(int));
+  memset(binter, 0, sizeof(int) * ss);
 
   dt_masks_dynbuf_t *extra = dt_masks_dynbuf_init(100000, "path extra");
   if(extra == NULL)
@@ -2866,7 +2866,7 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   // deal with feather if it does not lie outside of roi
   if(!path_encircles_roi)
   {
-    int *dpoints = dt_alloc_align(64, 4 * border_count * sizeof(int));
+    int *dpoints = dt_alloc_align(64, sizeof(int) * 4 * border_count);
     if(dpoints == NULL)
     {
       dt_free_align(points);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2245,7 +2245,7 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
     dt_free_align(border);
     return 0;
   }
-  memset(*buffer, 0, bufsize * sizeof(float));
+  memset(*buffer, 0, sizeof(float) * bufsize);
 
   // we write all the point around the path into the buffer
   int nbp = border_count;
@@ -2625,7 +2625,7 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   start = start2 = dt_get_wtime();
 
   // empty the output buffer
-  memset(buffer, 0, (size_t)width * height * sizeof(float));
+  memset(buffer, 0, sizeof(float) * width * height);
 
   guint nb_corner = g_list_length(form->points);
 
@@ -2760,7 +2760,7 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
       dt_free_align(border);
       return 0;
     }
-    memcpy(cpoints, points, (size_t)2 * points_count * sizeof(float));
+    memcpy(cpoints, points, sizeof(float) * 2 * points_count);
 
     // now we clip cpoints to roi -> catch special case when roi lies completely within path.
     // dirty trick: we allow path to extend one pixel beyond height-1. this avoids need of special handling

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -572,7 +572,7 @@ static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, con
     }
   }
 
-  float *border_init = dt_alloc_align(64, (size_t)6 * nb * sizeof(float));
+  float *border_init = dt_alloc_align_float((size_t)6 * nb);
   int cw = _path_is_clockwise(form);
   if(cw == 0) cw = -1;
 
@@ -2238,7 +2238,7 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
-  *buffer = dt_alloc_align(64, bufsize * sizeof(float));
+  *buffer = dt_alloc_align_float(bufsize);
   if(*buffer == NULL)
   {
     dt_free_align(points);
@@ -2753,14 +2753,14 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   if(path_in_roi)
   {
     // second copy of path which we can modify when cropping to roi
-    float *cpoints = dt_alloc_align(64, 2 * points_count * sizeof(float));
+    float *cpoints = dt_alloc_align_float((size_t)2 * points_count);
     if(cpoints == NULL)
     {
       dt_free_align(points);
       dt_free_align(border);
       return 0;
     }
-    memcpy(cpoints, points, 2 * points_count * sizeof(float));
+    memcpy(cpoints, points, (size_t)2 * points_count * sizeof(float));
 
     // now we clip cpoints to roi -> catch special case when roi lies completely within path.
     // dirty trick: we allow path to extend one pixel beyond height-1. this avoids need of special handling

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -516,7 +516,7 @@ static void histogram_collect_cl(int devid, dt_dev_pixelpipe_iop_t *piece, cl_me
 
   if(!pixel) return;
 
-  cl_int err = dt_opencl_copy_device_to_host(devid, pixel, img, roi->width, roi->height, 4 * sizeof(float));
+  cl_int err = dt_opencl_copy_device_to_host(devid, pixel, img, roi->width, roi->height, sizeof(float) * 4);
   if(err != CL_SUCCESS)
   {
     if(tmpbuf) dt_free_align(tmpbuf);
@@ -2408,11 +2408,11 @@ restart:
       g_free(pipe->output_backbuf);
       pipe->output_backbuf_width = pipe->backbuf_width;
       pipe->output_backbuf_height = pipe->backbuf_height;
-      pipe->output_backbuf = g_malloc0((size_t)pipe->output_backbuf_width * pipe->output_backbuf_height * 4 * sizeof(uint8_t));
+      pipe->output_backbuf = g_malloc0(sizeof(uint8_t) * 4 * pipe->output_backbuf_width * pipe->output_backbuf_height);
     }
 
     if(pipe->output_backbuf)
-      memcpy(pipe->output_backbuf, pipe->backbuf, (size_t)pipe->output_backbuf_width * pipe->output_backbuf_height * 4 * sizeof(uint8_t));
+      memcpy(pipe->output_backbuf, pipe->backbuf, sizeof(uint8_t) * 4 * pipe->output_backbuf_width * pipe->output_backbuf_height);
     pipe->output_imgid = pipe->image.id;
   }
   dt_pthread_mutex_unlock(&pipe->backbuf_mutex);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -111,7 +111,7 @@ static char *_pipe_type_to_str(int pipe_type)
 int dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height, int levels,
                                  gboolean store_masks)
 {
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 4 * sizeof(float) * width * height, 2);
+  const int res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
@@ -120,14 +120,14 @@ int dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, int32_t width, int32_
 
 int dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height)
 {
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 4 * sizeof(float) * width * height, 2);
+  const int res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }
 
 int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height)
 {
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 4 * sizeof(float) * width * height, 0);
+  const int res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 0);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -512,7 +512,7 @@ static void histogram_collect_cl(int devid, dt_dev_pixelpipe_iop_t *piece, cl_me
   if(buffer && bufsize >= (size_t)roi->width * roi->height * 4 * sizeof(float))
     pixel = buffer;
   else
-    pixel = tmpbuf = dt_alloc_align(64, (size_t)roi->width * roi->height * 4 * sizeof(float));
+    pixel = tmpbuf = dt_alloc_align_float((size_t)4 * roi->width * roi->height);
 
   if(!pixel) return;
 
@@ -2160,7 +2160,7 @@ post_process_collect_info:
         // input may not be available, so we use the output from gamma
         // this may lead to some rounding errors
         // FIXME: under what circumstances would input not be available? when this iop's result is pulled in from cache?
-        float *const buf = dt_alloc_align(64, roi_out->width * roi_out->height * 4 * sizeof(float));
+        float *const buf = dt_alloc_align_float((size_t)4 * roi_out->width * roi_out->height);
         if(buf)
         {
           const uint8_t *in = (uint8_t *)(*output);
@@ -2504,9 +2504,8 @@ float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const dt_iop_modul
                     && module->processed_roi_in.width == 0
                     && module->processed_roi_in.height == 0))
             {
-              float *transformed_mask = dt_alloc_align(64, sizeof(float)
-                                                          * module->processed_roi_out.width
-                                                          * module->processed_roi_out.height);
+              float *transformed_mask = dt_alloc_align_float((size_t)module->processed_roi_out.width
+                                                              * module->processed_roi_out.height);
               module->module->distort_mask(module->module,
                                           module,
                                           raster_mask,

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -202,17 +202,17 @@ static int _simplex(double (*objfunc)(double[], void *[]), double start[], int n
   /* dynamically allocate arrays */
 
   /* allocate the rows of the arrays */
-  v = (double **)malloc((n + 1) * sizeof(double *));
-  f = (double *)malloc((n + 1) * sizeof(double));
-  vr = (double *)malloc(n * sizeof(double));
-  ve = (double *)malloc(n * sizeof(double));
-  vc = (double *)malloc(n * sizeof(double));
-  vm = (double *)malloc(n * sizeof(double));
+  v = (double **)malloc(sizeof(double *) * (n + 1));
+  f = (double *)malloc(sizeof(double) * (n + 1));
+  vr = (double *)malloc(sizeof(double) * n);
+  ve = (double *)malloc(sizeof(double) * n);
+  vc = (double *)malloc(sizeof(double) * n);
+  vm = (double *)malloc(sizeof(double) * n);
 
   /* allocate the columns of the arrays */
   for(i = 0; i <= n; i++)
   {
-    v[i] = (double *)malloc(n * sizeof(double));
+    v[i] = (double *)malloc(sizeof(double) * n);
   }
 
   /* create the initial simplex */

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -650,7 +650,7 @@ void _gradient_arc(cairo_t *cr, double lw, int nb_steps, double x_center, double
 {
   cairo_set_line_width(cr, lw);
 
-  double *portions = malloc((1 + nb_steps) * sizeof(double));
+  double *portions = malloc(sizeof(double) * (1 + nb_steps));
 
   // note: cairo angles seems to be shifted by M_PI relatively to the unit circle
   angle_from = angle_from + M_PI;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -406,11 +406,11 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       // get new surface with preview image
       const int buf_width = dev->preview_pipe->output_backbuf_width;
       const int buf_height = dev->preview_pipe->output_backbuf_height;
-      uint8_t *rgbbuf = g_malloc0((size_t)buf_width * buf_height * 4 * sizeof(unsigned char));
+      uint8_t *rgbbuf = g_malloc0(sizeof(unsigned char) * 4 * buf_width * buf_height);
 
       dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
       dt_pthread_mutex_lock(mutex);
-      memcpy(rgbbuf, dev->preview_pipe->output_backbuf, (size_t)buf_width * buf_height * 4 * sizeof(unsigned char));
+      memcpy(rgbbuf, dev->preview_pipe->output_backbuf, sizeof(unsigned char) * 4 * buf_width * buf_height);
       dt_pthread_mutex_unlock(mutex);
 
       const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, buf_width);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1422,7 +1422,7 @@ static void _event_dnd_get(GtkWidget *widget, GdkDragContext *context, GtkSelect
       const int imgs_nb = g_list_length(table->drag_list);
       if(imgs_nb)
       {
-        uint32_t *imgs = malloc(imgs_nb * sizeof(uint32_t));
+        uint32_t *imgs = malloc(sizeof(uint32_t) * imgs_nb);
         GList *l = table->drag_list;
         for(int i = 0; i < imgs_nb; i++)
         {

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -207,7 +207,7 @@ int main(int argc, char *arg[])
   }
 
   int m_argc = 0;
-  char **m_arg = malloc((3 + argc - k + 1) * sizeof(char *));
+  char **m_arg = malloc(sizeof(char *) * (3 + argc - k + 1));
   m_arg[m_argc++] = "darktable-generate-cache";
   m_arg[m_argc++] = "--conf";
   m_arg[m_argc++] = "write_sidecar_files=FALSE";

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -244,7 +244,7 @@ gchar *dt_gtkentry_build_completion_tooltip_text(const gchar *header,
 {
   size_t array_len = 0;
   for(dt_gtkentry_completion_spec const *p = compl_list; p->description != NULL; p++) array_len++;
-  const gchar **lines = malloc((array_len + 2) * sizeof(gchar *));
+  const gchar **lines = malloc(sizeof(gchar *) * (array_len + 2));
   const gchar **l = lines;
   *l++ = header;
 

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -523,7 +523,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 
       cmsSaveProfileToMem(out_profile, 0, &icc_profile_len);
       if (icc_profile_len > 0) {
-        icc_profile_data = malloc(icc_profile_len * sizeof(uint8_t));
+        icc_profile_data = malloc(sizeof(uint8_t) * icc_profile_len);
         if (icc_profile_data == NULL) {
           rc = 1;
           goto out;

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -367,7 +367,7 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
     const int w = j2k->global.width, h = j2k->global.height;
 
     opj_image_cmptparm_t cmptparm[4]; /* RGBA: max. 4 components */
-    memset(&cmptparm[0], 0, numcomps * sizeof(opj_image_cmptparm_t));
+    memset(&cmptparm[0], 0, sizeof(opj_image_cmptparm_t) * numcomps);
 
     for(int i = 0; i < numcomps; i++)
     {

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -370,14 +370,14 @@ int write_image(dt_imageio_module_data_t *jpg_tmp, const char *filename, const v
     cmsSaveProfileToMem(out_profile, 0, &len);
     if(len > 0)
     {
-      unsigned char *buf = malloc(len * sizeof(unsigned char));
+      unsigned char *buf = malloc(sizeof(unsigned char) * len);
       cmsSaveProfileToMem(out_profile, buf, &len);
       write_icc_profile(&(jpg->cinfo), buf, len);
       free(buf);
     }
   }
 
-  uint8_t *row = dt_alloc_align(64, (size_t)3 * jpg->global.width * sizeof(uint8_t));
+  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * jpg->global.width);
   const uint8_t *buf;
   while(jpg->cinfo.next_scanline < jpg->cinfo.image_height)
   {

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -309,7 +309,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
   {
     if(d->params.bpp == 8)
     {
-      image_data = dt_alloc_align(64, data->width * data->height * 3);
+      image_data = dt_alloc_align(64, (size_t)3 * data->width * data->height);
       const uint8_t *in_ptr = (const uint8_t *)in;
       uint8_t *out_ptr = (uint8_t *)image_data;
       for(int y = 0; y < data->height; y++)
@@ -320,7 +320,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     }
     else
     {
-      image_data = dt_alloc_align(64, data->width * data->height * 3 * sizeof(uint16_t));
+      image_data = dt_alloc_align(64, sizeof(uint16_t) * 3 * data->width * data->height);
       const uint16_t *in_ptr = (const uint16_t *)in;
       uint16_t *out_ptr = (uint16_t *)image_data;
       for(int y = 0; y < data->height; y++)

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -288,7 +288,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
       cmsSaveProfileToMem(profile->profile, 0, &len);
       if(len > 0)
       {
-        unsigned char *buf = malloc(len * sizeof(unsigned char));
+        unsigned char *buf = malloc(sizeof(unsigned char) * len);
         cmsSaveProfileToMem(profile->profile, buf, &len);
         icc_id = dt_pdf_add_icc_from_data(d->pdf, buf, len);
         free(buf);
@@ -345,7 +345,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
   if(num == total)
   {
     int n_images = g_list_length(d->images);
-    dt_pdf_page_t **pages = malloc(n_images * sizeof(dt_pdf_page_t *));
+    dt_pdf_page_t **pages = malloc(sizeof(dt_pdf_page_t *) * n_images);
 
     gboolean outline_mode = d->params.mode != MODE_NORMAL;
     gboolean show_bb = d->params.mode == MODE_DEBUG;

--- a/src/imageio/format/pfm.c
+++ b/src/imageio/format/pfm.c
@@ -46,7 +46,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     while((len + 1 + off) & 0xf) off++;
     while(off-- > 0) fprintf(f, "0");
     fprintf(f, "\n");
-    void *buf_line = dt_alloc_align(64, 3 * sizeof(float) * pfm->width);
+    void *buf_line = dt_alloc_align_float((size_t)3 * pfm->width);
     for(int j = 0; j < pfm->height; j++)
     {
       // NOTE: pfm has rows in reverse order
@@ -55,7 +55,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
       float *out = (float *)buf_line;
       for(int i = 0; i < pfm->width; i++, in += 4, out += 3)
       {
-        memcpy(out, in, 3 * sizeof(float));
+        memcpy(out, in, (size_t)3 * sizeof(float));
       }
       // INFO: per-line fwrite call seems to perform best. LebedevRI, 18.04.2014
       int cnt = fwrite(buf_line, 3 * sizeof(float), pfm->width, f);

--- a/src/imageio/format/pfm.c
+++ b/src/imageio/format/pfm.c
@@ -55,10 +55,10 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
       float *out = (float *)buf_line;
       for(int i = 0; i < pfm->width; i++, in += 4, out += 3)
       {
-        memcpy(out, in, (size_t)3 * sizeof(float));
+        memcpy(out, in, sizeof(float) * 3);
       }
       // INFO: per-line fwrite call seems to perform best. LebedevRI, 18.04.2014
-      int cnt = fwrite(buf_line, 3 * sizeof(float), pfm->width, f);
+      int cnt = fwrite(buf_line, sizeof(float) * 3, pfm->width, f);
       if(cnt != pfm->width)
         status = 1;
       else

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -174,7 +174,7 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
     cmsSaveProfileToMem(out_profile, 0, &len);
     if(len > 0)
     {
-      char *buf = malloc(len * sizeof(char));
+      char *buf = malloc(sizeof(char) * len);
       char name[512] = { 0 };
       cmsSaveProfileToMem(out_profile, buf, &len);
       dt_colorspaces_get_profile_name(out_profile, "en", "US", name, sizeof(name));
@@ -201,7 +201,7 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
    */
   png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
 
-  png_bytep *row_pointers = dt_alloc_align(64, (size_t)height * sizeof(png_bytep));
+  png_bytep *row_pointers = dt_alloc_align(64, sizeof(png_bytep) * height);
 
   if(p->bpp > 8)
   {

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -264,7 +264,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
       for(int x = 0; x < d->global.width; x++, in += 4, out += layers)
       {
-        memcpy(out, in, layers * sizeof(float));
+        memcpy(out, in, sizeof(float) * layers);
       }
 
       if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -283,7 +283,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
       for(int x = 0; x < d->global.width; x++, in += 4, out += layers)
       {
-        memcpy(out, in, layers * sizeof(uint16_t));
+        memcpy(out, in, sizeof(uint16_t) * layers);
       }
 
       if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -302,7 +302,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
 
       for(int x = 0; x < d->global.width; x++, in += 4, out += layers)
       {
-        memcpy(out, in, layers * sizeof(uint8_t));
+        memcpy(out, in, sizeof(uint8_t) * layers);
       }
 
       if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -184,14 +184,14 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
         gboolean free_channel_data = TRUE;
         if(d->bpp == 8)
         {
-          channel_data = malloc((size_t)d->global.width * d->global.height * sizeof(uint8_t));
+          channel_data = malloc(sizeof(uint8_t) * d->global.width * d->global.height);
           uint8_t *ch = (uint8_t *)channel_data;
           for(size_t i = 0; i < (size_t)d->global.width * d->global.height; i++)
             ch[i] = CLAMP((int)(raster_mask[i] * 255.0), 0, 255);
         }
         else if(d->bpp == 16)
         {
-          channel_data = malloc((size_t)d->global.width * d->global.height * sizeof(uint16_t));
+          channel_data = malloc(sizeof(uint16_t) * d->global.width * d->global.height);
           uint16_t *ch = (uint16_t *)channel_data;
           for(size_t i = 0; i < (size_t)d->global.width * d->global.height; i++)
             ch[i] = CLAMP((int)(raster_mask[i] * 65535.0), 0, 65535);

--- a/src/iop/amaze_demosaic_RT.cc
+++ b/src/iop/amaze_demosaic_RT.cc
@@ -414,7 +414,7 @@ void amaze_demosaic_RT(dt_dev_pixelpipe_iop_t *piece, const float *const in,
     constexpr int cldf = 2; // factor to multiply cache line distance. 1 = 64 bytes, 2 = 128 bytes ...
     // assign working space
     char *buffer
-        = (char *)calloc(14 * sizeof(float) * ts * ts + sizeof(char) * ts * tsh + 18 * cldf * 64 + 63, 1);
+        = (char *)calloc(sizeof(float) * 14 * ts * ts + sizeof(char) * ts * tsh + 18 * cldf * 64 + 63, 1);
     // aligned to 64 byte boundary
     char *data = (char *)((uintptr_t(buffer) + uintptr_t(63)) / 64 * 64);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -959,7 +959,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
   // if module is set to neutral parameters we just copy input->output and are done
   if(isneutral(data))
   {
-    memcpy(out, in, (size_t)roi_out->width * roi_out->height * sizeof(float));
+    memcpy(out, in, sizeof(float) * roi_out->width * roi_out->height);
     return;
   }
 
@@ -2918,7 +2918,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // if module is set to neutral parameters we just copy input->output and are done
   if(isneutral(data))
   {
-    memcpy(ovoid, ivoid, (size_t)roi_out->width * roi_out->height * ch * sizeof(float));
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1241,10 +1241,10 @@ static int edge_enhance(const double *in, double *out, const int width, const in
   double *Gx = NULL;
   double *Gy = NULL;
 
-  Gx = malloc((size_t)width * height * sizeof(double));
+  Gx = malloc(sizeof(double) * width * height);
   if(Gx == NULL) goto error;
 
-  Gy = malloc((size_t)width * height * sizeof(double));
+  Gy = malloc(sizeof(double) * width * height);
   if(Gy == NULL) goto error;
 
   // perform edge enhancement in both directions
@@ -1403,7 +1403,7 @@ static int line_detect(float *in, const int width, const int height, const int x
   }
 
   // allocate intermediate buffers
-  greyscale = malloc((size_t)width * height * sizeof(double));
+  greyscale = malloc(sizeof(double) * width * height);
   if(greyscale == NULL) goto error;
 
   // convert to greyscale image
@@ -1430,7 +1430,7 @@ static int line_detect(float *in, const int width, const int height, const int x
   if(lines_count > 0)
   {
     // aggregate lines data into our own structures
-    ashift_lines = (dt_iop_ashift_line_t *)malloc((size_t)lines_count * sizeof(dt_iop_ashift_line_t));
+    ashift_lines = (dt_iop_ashift_line_t *)malloc(sizeof(dt_iop_ashift_line_t) * lines_count);
     if(ashift_lines == NULL) goto error;
 
     for(int n = 0; n < lines_count; n++)
@@ -1573,9 +1573,9 @@ static int get_structure(dt_iop_module_t *module, dt_iop_ashift_enhance_t enhanc
     scale = g->buf_scale;
 
     // create a temporary buffer to hold image data
-    buffer = malloc((size_t)width * height * 4 * sizeof(float));
+    buffer = malloc(sizeof(float) * 4 * (size_t)width * height);
     if(buffer != NULL)
-      memcpy(buffer, g->buf, (size_t)width * height * 4 * sizeof(float));
+      memcpy(buffer, g->buf, sizeof(float) * 4 * width * height);
   }
   dt_pthread_mutex_unlock(&g->lock);
 
@@ -1708,7 +1708,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
   const int riter = (set_count > RANSAC_HURDLE) ? RANSAC_RUNS : fact(set_count);
 
   // some data needed for quickperm
-  int *perm = malloc((set_count + 1) * sizeof(int));
+  int *perm = malloc(sizeof(int) * (set_count + 1));
   for(int n = 0; n < set_count + 1; n++) perm[n] = n;
   int piter = 1;
 
@@ -1866,9 +1866,9 @@ static int remove_outliers(dt_iop_module_t *module)
   const int ymax = ymin + height;
 
   // holds the index set of lines we want to work on
-  int *lines_set = malloc(g->lines_count * sizeof(int));
+  int *lines_set = malloc(sizeof(int) * g->lines_count);
   // holds the result of ransac
-  int *inout_set = malloc(g->lines_count * sizeof(int));
+  int *inout_set = malloc(sizeof(int) * g->lines_count);
 
   // some accounting variables
   int vnb = 0, vcount = 0;
@@ -2896,13 +2896,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       // if needed allocate buffer
       free(g->buf); // a no-op if g->buf is NULL
       // only get new buffer if no old buffer available or old buffer does not fit in terms of size
-      g->buf = malloc((size_t)width * height * 4 * sizeof(float));
+      g->buf = malloc(sizeof(float) * 4 * width * height);
     }
 
     if(g->buf /* && hash != g->buf_hash */)
     {
       // copy data
-      memcpy(g->buf, ivoid, (size_t)width * height * ch * sizeof(float));
+      memcpy(g->buf, ivoid, sizeof(float) * ch * width * height);
 
       g->buf_width = width;
       g->buf_height = height;
@@ -3030,13 +3030,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       // if needed allocate buffer
       free(g->buf); // a no-op if g->buf is NULL
       // only get new buffer if no old buffer or old buffer does not fit in terms of size
-      g->buf = malloc((size_t)iwidth * iheight * 4 * sizeof(float));
+      g->buf = malloc(sizeof(float) * 4 * iwidth * iheight);
     }
 
     if(g->buf /* && hash != g->buf_hash */)
     {
       // copy data
-      err = dt_opencl_copy_device_to_host(devid, g->buf, dev_in, iwidth, iheight, 4 * sizeof(float));
+      err = dt_opencl_copy_device_to_host(devid, g->buf, dev_in, iwidth, iheight, sizeof(float) * 4);
 
       g->buf_width = iwidth;
       g->buf_height = iheight;
@@ -3285,7 +3285,7 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   const int isflipped = g->isflipped;
 
   // allocate new index array
-  my_points_idx = (dt_iop_ashift_points_idx_t *)malloc(lines_count * sizeof(dt_iop_ashift_points_idx_t));
+  my_points_idx = (dt_iop_ashift_points_idx_t *)malloc(sizeof(dt_iop_ashift_points_idx_t) * lines_count);
   if(my_points_idx == NULL) goto error;
 
   // account for total number of points
@@ -3321,7 +3321,7 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   }
 
   // now allocate new points buffer
-  my_points = (float *)malloc((size_t)2 * total_points * sizeof(float));
+  my_points = (float *)malloc(sizeof(float) * 2 * total_points);
   if(my_points == NULL) goto error;
 
   // second step: generate points for each line

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -690,14 +690,14 @@ static void homography(float *homograph, const float angle, const float shift_v,
   float (*moutput)[3] = m3;
 
   // Step 1: flip x and y coordinates (see above)
-  memset(minput, 0, 9 * sizeof(float));
+  memset(minput, 0, sizeof(float) * 9);
   minput[0][1] = 1.0f;
   minput[1][0] = 1.0f;
   minput[2][2] = 1.0f;
 
 
   // Step 2: rotation of image around its center
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = cosi;
   mwork[0][1] = -sini;
   mwork[1][0] = sini;
@@ -711,7 +711,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
 
 
   // Step 3: apply shearing
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = 1.0f;
   mwork[0][1] = shear;
   mwork[1][1] = 1.0f;
@@ -725,7 +725,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
 
 
   // Step 4: apply vertical lens shift effect
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = exppa_v;
   mwork[1][0] = 0.5f * ((exppa_v - 1.0f) * u) / v;
   mwork[1][1] = 2.0f * exppa_v / (exppa_v + 1.0f);
@@ -740,7 +740,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
 
 
   // Step 5: horizontal compression
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = 1.0f;
   mwork[1][1] = r_v;
   mwork[1][2] = 0.5f * u * (1.0f - r_v);
@@ -753,7 +753,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
 
 
   // Step 6: flip x and y back again
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][1] = 1.0f;
   mwork[1][0] = 1.0f;
   mwork[2][2] = 1.0f;
@@ -767,7 +767,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
   // from here output vectors would be in (x : y : 1) format
 
   // Step 7: now we can apply horizontal lens shift with the same matrix format as above
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = exppa_h;
   mwork[1][0] = 0.5f * ((exppa_h - 1.0f) * v) / u;
   mwork[1][1] = 2.0f * exppa_h / (exppa_h + 1.0f);
@@ -782,7 +782,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
 
 
   // Step 8: vertical compression
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = 1.0f;
   mwork[1][1] = r_h;
   mwork[1][2] = 0.5f * v * (1.0f - r_h);
@@ -795,7 +795,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
 
 
   // Step 9: apply aspect ratio scaling
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = 1.0f * ascale;
   mwork[1][1] = 1.0f / ascale;
   mwork[2][2] = 1.0f;
@@ -823,7 +823,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
       vmin = fmin(vmin, po[1] / po[2]);
     }
 
-  memset(mwork, 0, 9 * sizeof(float));
+  memset(mwork, 0, sizeof(float) * 9);
   mwork[0][0] = 1.0f;
   mwork[1][1] = 1.0f;
   mwork[2][2] = 1.0f;
@@ -841,7 +841,7 @@ static void homography(float *homograph, const float angle, const float shift_v,
   if(dir == ASHIFT_HOMOGRAPH_FORWARD)
   {
     // we have what we need -> copy it to the right place
-    memcpy(homograph, moutput, 9 * sizeof(float));
+    memcpy(homograph, moutput, sizeof(float) * 9);
   }
   else
   {
@@ -849,11 +849,11 @@ static void homography(float *homograph, const float angle, const float shift_v,
     if(mat3inv((float *)homograph, (float *)moutput))
     {
       // in case of error we set to unity matrix
-      memset(mwork, 0, 9 * sizeof(float));
+      memset(mwork, 0, sizeof(float) * 9);
       mwork[0][0] = 1.0f;
       mwork[1][1] = 1.0f;
       mwork[2][2] = 1.0f;
-      memcpy(homograph, mwork, 9 * sizeof(float));
+      memcpy(homograph, mwork, sizeof(float) * 9);
     }
   }
 }

--- a/src/iop/ashift_lsd.c
+++ b/src/iop/ashift_lsd.c
@@ -308,7 +308,7 @@ static ntuple_list new_ntuple_list(unsigned int dim)
   n_tuple->dim = dim;
 
   /* get memory for tuples */
-  n_tuple->values = (double *) malloc( dim*n_tuple->max_size * sizeof(double) );
+  n_tuple->values = (double *) malloc(sizeof(double) * dim * n_tuple->max_size);
   if( n_tuple->values == NULL ) error("not enough memory.");
 
   return n_tuple;

--- a/src/iop/ashift_nmsimplex.c
+++ b/src/iop/ashift_nmsimplex.c
@@ -106,17 +106,17 @@ static int simplex(double (*objfunc)(double[], void *params), double start[], in
   /* dynamically allocate arrays */
 
   /* allocate the rows of the arrays */
-  v = (double **)malloc((n + 1) * sizeof(double *));
-  f = (double *)malloc((n + 1) * sizeof(double));
-  vr = (double *)malloc(n * sizeof(double));
-  ve = (double *)malloc(n * sizeof(double));
-  vc = (double *)malloc(n * sizeof(double));
-  vm = (double *)malloc(n * sizeof(double));
+  v = (double **)malloc(sizeof(double *) * (n + 1));
+  f = (double *)malloc(sizeof(double) * (n + 1));
+  vr = (double *)malloc(sizeof(double) * n);
+  ve = (double *)malloc(sizeof(double) * n);
+  vc = (double *)malloc(sizeof(double) * n);
+  vm = (double *)malloc(sizeof(double) * n);
 
   /* allocate the columns of the arrays */
   for(i = 0; i <= n; i++)
   {
-    v[i] = (double *)malloc(n * sizeof(double));
+    v[i] = (double *)malloc(sizeof(double) * n);
   }
 
   /* create the initial simplex */

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -357,14 +357,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   /* allocate space for a temporary buffer. we don't want to use dev_in in the buffer ping-pong below, as we
      need to keep it for blendops */
-  dev_tmp = dt_opencl_alloc_device(devid, roi_out->width, roi_out->height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, roi_out->width, roi_out->height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   /* allocate space to store detail information. Requires a number of additional buffers, each with full image
    * size */
   for(int k = 0; k < max_scale; k++)
   {
-    dev_detail[k] = dt_opencl_alloc_device(devid, roi_out->width, roi_out->height, 4 * sizeof(float));
+    dev_detail[k] = dt_opencl_alloc_device(devid, roi_out->width, roi_out->height, sizeof(float) * 4);
     if(dev_detail[k] == NULL) goto error;
   }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -244,7 +244,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   // lead to out of bounds memory access
   if(width < 2 * max_mult || height < 2 * max_mult)
   {
-    memcpy(o, i, width * height * 4 * sizeof(float));
+    memcpy(o, i, sizeof(float) * 4 * width * height);
     return;
   }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -253,7 +253,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   float *buf2 = NULL;
   float *buf1 = NULL;
 
-  tmp = (float *)dt_alloc_align(64, (size_t)sizeof(float) * 4 * width * height);
+  tmp = (float *)dt_alloc_align_float((size_t)4 * width * height);
   if(tmp == NULL)
   {
     fprintf(stderr, "[atrous] failed to allocate coarse buffer!\n");
@@ -262,7 +262,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
 
   for(int k = 0; k < max_scale; k++)
   {
-    detail[k] = (float *)dt_alloc_align(64, (size_t)sizeof(float) * 4 * width * height);
+    detail[k] = (float *)dt_alloc_align_float((size_t)4 * width * height);
     if(detail[k] == NULL)
     {
       fprintf(stderr, "[atrous] failed to allocate one of the detail buffers!\n");

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1050,8 +1050,8 @@ static inline void gauss_blur(
     const size_t ht)
 {
   const float w[5] = { 1.f / 16.f, 4.f / 16.f, 6.f / 16.f, 4.f / 16.f, 1.f / 16.f };
-  float *tmp = dt_alloc_align(64, (size_t)wd*ht*4*sizeof(float));
-  memset(tmp, 0, 4*wd*ht*sizeof(float));
+  float *tmp = dt_alloc_align_float((size_t)4 * wd * ht);
+  memset(tmp, 0, (size_t)4 * wd * ht * sizeof(float));
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ht, input, w, wd) \
@@ -1133,7 +1133,7 @@ static inline void gauss_reduce(
   // blur, store only coarse res
   const size_t cw = (wd-1)/2+1, ch = (ht-1)/2+1;
 
-  float *blurred = dt_alloc_align(64, (size_t)wd*ht*4*sizeof(float));
+  float *blurred = dt_alloc_align_float((size_t)4 * wd * ht);
   gauss_blur(input, blurred, wd, ht);
   for(size_t j=0;j<ch;j++) for(size_t i=0;i<cw;i++)
     for(int c=0;c<4;c++) coarse[4*(j*cw+i)+c] = blurred[4*(2*j*wd+2*i)+c];
@@ -1168,8 +1168,8 @@ void process_fusion(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   for(int k = 0; k < num_levels; k++)
   {
     // coarsest step is some % of image width.
-    col[k] = dt_alloc_align(64, sizeof(float) * 4 * w * h);
-    comb[k] = dt_alloc_align(64, sizeof(float) * 4 * w * h);
+    col[k]  = dt_alloc_align_float((size_t)4 * w * h);
+    comb[k] = dt_alloc_align_float((size_t)4 * w * h);
     memset(comb[k], 0, sizeof(float) * 4 * w * h);
     w = (w - 1) / 2 + 1;
     h = (h - 1) / 2 + 1;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -547,20 +547,20 @@ int process_cl_fusion(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
 
   int num_levels = num_levels_max;
 
-  dev_tmp1 = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp1 = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp1 == NULL) goto error;
 
-  dev_tmp2 = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp2 = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp2 == NULL) goto error;
 
   // allocate buffers for wavelet transform and blending
   for(int k = 0, step = 1, w = width, h = height; k < num_levels; k++)
   {
     // coarsest step is some % of image width.
-    dev_col[k] = dt_opencl_alloc_device(devid, w, h, 4 * sizeof(float));
+    dev_col[k] = dt_opencl_alloc_device(devid, w, h, sizeof(float) * 4);
     if(dev_col[k] == NULL) goto error;
 
-    dev_comb[k] = dt_opencl_alloc_device(devid, w, h, 4 * sizeof(float));
+    dev_comb[k] = dt_opencl_alloc_device(devid, w, h, sizeof(float) * 4);
     if(dev_comb[k] == NULL) goto error;
 
     size_t sizes[] = { ROUNDUPWD(w), ROUNDUPHT(h), 1 };
@@ -1160,8 +1160,8 @@ void process_fusion(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   // allocate temporary buffer for wavelet transform + blending
   const int wd = roi_in->width, ht = roi_in->height;
   int num_levels = 8;
-  float **col = malloc(num_levels * sizeof(float *));
-  float **comb = malloc(num_levels * sizeof(float *));
+  float **col = malloc(sizeof(float *) * num_levels);
+  float **comb = malloc(sizeof(float *) * num_levels);
   int w = wd, h = ht;
   const int rad = MIN(wd, (int)ceilf(256 * roi_in->scale / piece->iscale));
   int step = 1;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1051,7 +1051,7 @@ static inline void gauss_blur(
 {
   const float w[5] = { 1.f / 16.f, 4.f / 16.f, 6.f / 16.f, 4.f / 16.f, 1.f / 16.f };
   float *tmp = dt_alloc_align_float((size_t)4 * wd * ht);
-  memset(tmp, 0, (size_t)4 * wd * ht * sizeof(float));
+  memset(tmp, 0, sizeof(float) * 4 * wd * ht);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ht, input, w, wd) \
@@ -1073,7 +1073,7 @@ static inline void gauss_blur(
       for(int ii=-2;ii<=2;ii++)
         tmp[4*(j*wd+i)+c] += input[4*(j*wd+MIN(i+ii, wd-(i+ii-wd+1) ))+c] * w[ii+2];
   }
-  memset(output, 0, 4*wd*ht*sizeof(float));
+  memset(output, 0, sizeof(float) * 4 * wd * ht);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ht, output, w, wd) \
@@ -1103,7 +1103,7 @@ static inline void gauss_expand(
 {
   const size_t cw = (wd-1)/2+1;
   // fill numbers in even pixels, zero odd ones
-  memset(fine, 0, 4*wd*ht*sizeof(float));
+  memset(fine, 0, sizeof(float) * 4 * wd * ht);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(cw, fine, ht, input, wd) \

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -763,10 +763,10 @@ static void _get_auto_exp_histogram(const float *const img, const int width, con
   uint32_t *histogram = NULL;
   const float mul = hist_size;
 
-  histogram = dt_alloc_align(64, hist_size * sizeof(uint32_t));
+  histogram = dt_alloc_align(64, sizeof(uint32_t) * hist_size);
   if(histogram == NULL) goto cleanup;
 
-  memset(histogram, 0, hist_size * sizeof(uint32_t));
+  memset(histogram, 0, sizeof(uint32_t) * hist_size);
 
   if(box_area[2] > box_area[0] && box_area[3] > box_area[1])
   {

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1307,7 +1307,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       dt_pthread_mutex_unlock(&g->lock);
 
       // get the image, this works only in C
-      src_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+      src_buffer = dt_alloc_align_float((size_t)ch * width * height);
       if(src_buffer == NULL)
       {
         fprintf(stderr, "[basicadj process_cl] error allocating memory for color transformation 1\n");

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -142,7 +142,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(int l = -rad; l <= rad; l++)
       for(int k = -rad; k <= rad; k++) m[l * wd + k] /= weight;
 
-    float *const weights_buf = (float *)malloc(dt_get_num_threads() * weights_size * sizeof(float));
+    float *const weights_buf = (float *)malloc(sizeof(float) * dt_get_num_threads() * weights_size);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -115,7 +115,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   sigma[4] = data->sigma[4];
   if(fmaxf(sigma[0], sigma[1]) < .1)
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -124,7 +124,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(rad <= 6 && ((piece->pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL) == DT_DEV_PIXELPIPE_THUMBNAIL))
   {
     // no use denoising the thumbnail. takes ages without permutohedral
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
   }
   else if(rad <= 6)
   {
@@ -142,7 +142,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(int l = -rad; l <= rad; l++)
       for(int k = -rad; k <= rad; k++) m[l * wd + k] /= weight;
 
-    float *const weights_buf = (float *)malloc(weights_size * dt_get_num_threads() * sizeof(float));
+    float *const weights_buf = (float *)malloc(dt_get_num_threads() * weights_size * sizeof(float));
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -110,7 +110,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
 
   /* gather light by threshold */
-  float *const restrict blurlightness = dt_alloc_align(64, npixels * sizeof(float));
+  float *const restrict blurlightness = dt_alloc_align_float(npixels);
 //  memcpy(out, in, npixels * 4 * sizeof(float));  //TODO: do we need this?
 
   const int rad = 256.0f * (fmin(100.0f, data->size + 1.0f) / 100.0f);

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -281,7 +281,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
   {
     float *outb = out + (size_t)(j + border_in_y) * roi_out->width + border_in_x;
     const float *inb = in + (size_t)j * roi_in->width;
-    memcpy(outb, inb, roi_in->width * sizeof(float));
+    memcpy(outb, inb, sizeof(float) * roi_in->width);
   }
 }
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -347,7 +347,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   float *Gtmp = (float(*))calloc((height) * (width), sizeof *Gtmp);
 
   // temporary array to avoid race conflicts, only every second pixel needs to be saved here
-  float *RawDataTmp = (float *)malloc(height * width * sizeof(float) / 2 + 4);
+  float *RawDataTmp = (float *)malloc(sizeof(float) * height * width / 2 + 4);
 
   float blockave[2][2] = { { 0, 0 }, { 0, 0 } }, blocksqave[2][2] = { { 0, 0 }, { 0, 0 } },
         blockdenom[2][2] = { { 0, 0 }, { 0, 0 } }, blockvar[2][2];
@@ -363,7 +363,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   const int vblsz = ceil((float)(height + border2) / (ts - border2) + 2 + vz1);
   const int hblsz = ceil((float)(width + border2) / (ts - border2) + 2 + hz1);
 
-  char *buffer1 = (char *)calloc(vblsz * hblsz * (2 * 2 + 1), sizeof(float));
+  char *buffer1 = (char *)calloc((size_t)vblsz * hblsz * (2 * 2 + 1), sizeof(float));
 
   // block CA shift values and weight assigned to block
   float *blockwt = (float *)buffer1;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -312,7 +312,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   const int width = roi_in->width;
   const int height = roi_in->height;
   const uint32_t filters = piece->pipe->dsc.filters;
-  memcpy(out, in2, width * height * sizeof(float));
+  memcpy(out, in2, sizeof(float) * width * height);
   const float *const in = out;
   const double cared = 0, cablue = 0;
   const double caautostrength = 4;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1011,7 +1011,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       }
 
       // passthrough pixels
-      dt_simd_memcpy(in, out, roi_in->width * roi_in->height * ch);
+      dt_simd_memcpy(in, out, ch * roi_in->width * roi_in->height);
 
       dt_control_log(_("auto-detection of white balance completed"));
       return;

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -185,7 +185,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
 
       /* clip histogram and redistribute clipped entries */
-      memcpy(clippedhist, hist, (BINS + 1) * sizeof(int));
+      memcpy(clippedhist, hist, sizeof(int) * (BINS + 1));
       int ce = 0, ceb = 0;
       do
       {

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -91,7 +91,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = piece->colors;
 
   // PASS1: Get a luminance map of image...
-  float *luminance = (float *)malloc(((size_t)roi_out->width * roi_out->height) * sizeof(float));
+  float *luminance = (float *)malloc(sizeof(float) * ((size_t)roi_out->width * roi_out->height));
 // double lsmax=0.0,lsmin=1.0;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -122,7 +122,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float slope = data->slope;
 
   const size_t destbuf_size = roi_out->width;
-  float *const dest_buf = malloc(destbuf_size * sizeof(float) * dt_get_num_threads());
+  float *const dest_buf = malloc(sizeof(float) * dt_get_num_threads() * destbuf_size);
 
 // CLAHE
 #ifdef _OPENMP

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -147,13 +147,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     float *dest = dest_buf + destbuf_size * dt_get_thread_num();
 
     /* initially fill histogram */
-    memset(hist, 0, (BINS + 1) * sizeof(int));
+    memset(hist, 0, sizeof(int) * (BINS + 1));
     for(int yi = yMin; yi < yMax; ++yi)
       for(int xi = xMin0; xi < xMax0; ++xi)
         ++hist[ROUND_POSISTIVE(luminance[(size_t)yi * roi_in->width + xi] * (float)BINS)];
 
     // Destination row
-    memset(dest, 0, roi_out->width * sizeof(float));
+    memset(dest, 0, sizeof(float) * roi_out->width);
     float *ld = dest;
 
     for(int i = 0; i < roi_out->width; i++)

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -770,8 +770,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   default:
   {
     // setup linear system of equations
-    double *A = malloc(N4 * N4 * sizeof(*A));
-    double *b = malloc(N4 * sizeof(*b));
+    double *A = malloc(sizeof(*A) * N4 * N4);
+    double *b = malloc(sizeof(*b) * N4);
     // coefficients from nonlinear radial kernel functions
     for(int j=0;j<N;j++)
       for(int i=j;i<N;i++)
@@ -786,7 +786,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       for(int i=N;i<N4;i++)
         A[j*N4+i] = 0;
     // make coefficient matrix triangular
-    int *pivot = malloc(N4 * sizeof(*pivot));
+    int *pivot = malloc(sizeof(*pivot) * N4);
     if (gauss_make_triangular(A, pivot, N4))
     {
       // calculate coefficients for L channel

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -455,12 +455,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_pthread_mutex_lock(&g->lock);
     if(g->buffer) free(g->buffer);
 
-    g->buffer = malloc((size_t)4 * width * height  * sizeof(float));
+    g->buffer = malloc(sizeof(float) * 4 * width * height);
     g->width = width;
     g->height = height;
     g->ch = 4;
 
-    if(g->buffer) memcpy(g->buffer, in, (size_t)4 * width * height * sizeof(float));
+    if(g->buffer) memcpy(g->buffer, in, sizeof(float) * 4 * width * height);
 
     dt_pthread_mutex_unlock(&g->lock);
   }
@@ -474,12 +474,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float equalization = data->equalization / 100.0f;
 
     // get mapping from input clusters to target clusters
-    int *const mapio = malloc(data->n * sizeof(int));
+    int *const mapio = malloc(sizeof(int) * data->n);
 
     get_cluster_mapping(data->n, data->target_mean, data->target_weight, data->source_mean,
                         data->source_weight, dominance, mapio);
 
-    float2 *const var_ratio = malloc(data->n * sizeof(float2));
+    float2 *const var_ratio = malloc(sizeof(float2) * data->n);
 
     for(int i = 0; i < data->n; i++)
     {
@@ -643,7 +643,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
           = (data->target_var[i][1] > 0.0f) ? data->source_var[mapio[i]][1] / data->target_var[i][1] : 0.0f;
     }
 
-    dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+    dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
     if(dev_tmp == NULL) goto error;
 
     dev_target_hist = dt_opencl_copy_host_to_device_constant(devid, sizeof(int) * HISTN, data->target_hist);

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -569,7 +569,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // incomplete parameter set -> do nothing
   else
   {
-    memcpy(out, in, (size_t)sizeof(float) * 4 * width * height);
+    memcpy(out, in, sizeof(float) * 4 * width * height);
   }
 }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -296,9 +296,9 @@ static void kmeans(const float *col, const int width, const int height, const in
   const int nit = 40;                       // number of iterations
   const int samples = width * height * 0.2; // samples: only a fraction of the buffer.
 
-  float2 *const mean = malloc(n * sizeof(float2));
-  float2 *const var = malloc(n * sizeof(float2));
-  int *const cnt = malloc(n * sizeof(int));
+  float2 *const mean = malloc(sizeof(float2) * n);
+  float2 *const var = malloc(sizeof(float2) * n);
+  int *const cnt = malloc(sizeof(int) * n);
   int count;
 
   float a_min = FLT_MAX, b_min = FLT_MAX, a_max = FLT_MIN, b_max = FLT_MIN;
@@ -612,7 +612,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_pthread_mutex_lock(&g->lock);
     free(g->buffer);
 
-    g->buffer = malloc(width * height * ch * sizeof(float));
+    g->buffer = malloc(sizeof(float) * ch * width * height);
     g->width = width;
     g->height = height;
     g->ch = ch;
@@ -964,13 +964,13 @@ static void process_clusters(gpointer instance, gpointer user_data)
   const int width = g->width;
   const int height = g->height;
   const int ch = g->ch;
-  float *buffer = malloc(width * height * ch * sizeof(float));
+  float *buffer = malloc(sizeof(float) * ch * width * height);
   if(!buffer)
   {
     dt_pthread_mutex_unlock(&g->lock);
     return;
   }
-  memcpy(buffer, g->buffer, width * height * ch * sizeof(float));
+  memcpy(buffer, g->buffer, sizeof(float) * ch * width * height);
   dt_pthread_mutex_unlock(&g->lock);
 
   if(p->flag & GET_SOURCE)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -173,7 +173,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 static void capture_histogram(const float *col, const int width, const int height, int *hist)
 {
   // build separate histogram
-  memset(hist, 0, HISTN * sizeof(int));
+  memset(hist, 0, sizeof(int) * HISTN);
   for(int k = 0; k < height; k++)
     for(int i = 0; i < width; i++)
     {

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -667,7 +667,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 error:
   dt_control_log(_("module `color reconstruction' failed"));
   dt_iop_colorreconstruct_bilateral_free(b);
-  memcpy(ovoid, ivoid, (size_t)sizeof(float) * piece->colors * roi_out->width * roi_out->height);
+  memcpy(ovoid, ivoid, sizeof(float) * piece->colors * roi_out->width * roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -265,7 +265,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   b->scale = iscale / roi->scale;
   b->sigma_s = MAX(roi->height / (b->size_y - 1.0f), roi->width / (b->size_x - 1.0f));
   b->sigma_r = 100.0f / (b->size_z - 1.0f);
-  b->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(!b->buf)
   {
     fprintf(stderr, "[color reconstruction] not able to allocate buffer (b)\n");
@@ -273,7 +273,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
     return NULL;
   }
 
-  memset(b->buf, 0, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  memset(b->buf, 0, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
 #if 0
   fprintf(stderr, "[bilateral] created grid [%d %d %d]"
           " with sigma (%f %f) (%f %f)\n", b->size_x, b->size_y, b->size_z,
@@ -303,10 +303,10 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->buf)
   {
-    memcpy(bf->buf, b->buf, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+    memcpy(bf->buf, b->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   }
   else
   {
@@ -339,10 +339,10 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   b->scale = bf->scale;
   b->sigma_s = bf->sigma_s;
   b->sigma_r = bf->sigma_r;
-  b->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(b->buf && bf->buf)
   {
-    memcpy(b->buf, bf->buf, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+    memcpy(b->buf, bf->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   }
   else
   {
@@ -817,12 +817,12 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->dev_grid)
   {
     // read bilateral grid from device memory to host buffer (blocking)
     cl_int err = dt_opencl_read_buffer_from_device(b->devid, bf->buf, b->dev_grid, 0,
-                                    b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t), TRUE);
+                                    sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z, TRUE);
     if(err != CL_SUCCESS)
     {
       dt_print(DT_DEBUG_OPENCL,

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -755,7 +755,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
 
   // alloc grid buffer:
   b->dev_grid
-      = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * 4 * sizeof(float));
+      = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (b)\n");
@@ -765,7 +765,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
 
   // alloc temporary grid buffer
   b->dev_grid_tmp
-      = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * 4 * sizeof(float));
+      = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid_tmp)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (c)\n");
@@ -896,7 +896,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
 
   // alloc grid buffer:
   b->dev_grid
-      = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * 4 * sizeof(float));
+      = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (g)\n");
@@ -906,7 +906,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
 
   // alloc temporary grid buffer
   b->dev_grid_tmp
-      = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * 4 * sizeof(float));
+      = dt_opencl_alloc_device_buffer(b->devid, sizeof(float) * 4 * b->size_x * b->size_y * b->size_z);
   if(!b->dev_grid_tmp)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] not able to allocate device buffer (h)\n");

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -142,7 +142,7 @@ void connect_key_accels(dt_iop_module_t *self)
 static void capture_histogram(const float *col, const dt_iop_roi_t *roi, int *hist)
 {
   // build separate histogram
-  memset(hist, 0, HISTN * sizeof(int));
+  memset(hist, 0, sizeof(int) * HISTN);
   for(int k = 0; k < roi->height; k++)
     for(int i = 0; i < roi->width; i++)
     {

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -386,13 +386,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
 
     // cluster input buffer
-    float2 *const mean = malloc(data->n * sizeof(float2));
-    float2 *const var = malloc(data->n * sizeof(float2));
+    float2 *const mean = malloc(sizeof(float2) * data->n);
+    float2 *const var = malloc(sizeof(float2) * data->n);
 
     kmeans(in, roi_in, data->n, mean, var);
 
     // get mapping from input clusters to target clusters
-    int *const mapio = malloc(data->n * sizeof(int));
+    int *const mapio = malloc(sizeof(int) * data->n);
 
     get_cluster_mapping(data->n, mean, data->mean, mapio);
 

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -251,9 +251,9 @@ static void kmeans(const float *col, const dt_iop_roi_t *const roi, const int n,
   const int nit = 10;                                 // number of iterations
   const int samples = roi->width * roi->height * 0.2; // samples: only a fraction of the buffer.
 
-  float2 *const mean = malloc(n * sizeof(float2));
-  float2 *const var = malloc(n * sizeof(float2));
-  int *const cnt = malloc(n * sizeof(int));
+  float2 *const mean = malloc(sizeof(float2) * n);
+  float2 *const var = malloc(sizeof(float2) * n);
+  int *const cnt = malloc(sizeof(int) * n);
 
   // init n clusters for a, b channels at random
   for(int k = 0; k < n; k++)

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -385,7 +385,7 @@ void process_display(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece
 
   const dt_iop_colorzones_channel_t display_channel = g->channel;
 
-  memcpy(ovoid, ivoid, roi_out->width * roi_out->height * ch * sizeof(float));
+  memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)                                                           \

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -231,7 +231,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
   // Pre-Compute Fibonacci Lattices
 
   // precompute all required fibonacci lattices:
-  if((xy_avg = malloc((size_t)2 * sizeof(int) * samples_avg)))
+  if((xy_avg = malloc(sizeof(int) * 2 * samples_avg)))
   {
     int *tmp = xy_avg;
     for(int u = 0; u < samples_avg; u++)
@@ -248,7 +248,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
     goto ERROR_EXIT;
   }
 
-  if((xy_small = malloc((size_t)2 * sizeof(int) * samples_small)))
+  if((xy_small = malloc(sizeof(int) * 2 * samples_small)))
   {
     int *tmp = xy_small;
     for(int u = 0; u < samples_small; u++)

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -397,7 +397,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
   goto FINISH_PROCESS;
 
 ERROR_EXIT:
-  memcpy(o, i, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+  memcpy(o, i, sizeof(float) * ch * roi_out->width * roi_out->height);
 
 FINISH_PROCESS:
   free(xy_artifact);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3125,7 +3125,7 @@ static int green_equilibration_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
 
     const int bufsize = (bwidth / flocopt.sizex) * (bheight / flocopt.sizey);
 
-    dev_m = dt_opencl_alloc_device_buffer(devid, (size_t)bufsize * 2 * sizeof(float));
+    dev_m = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 2 * bufsize);
     if(dev_m == NULL) goto error;
 
     size_t fsizes[3] = { bwidth, bheight, 1 };
@@ -3153,7 +3153,7 @@ static int green_equilibration_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
 
     const int reducesize = MIN(REDUCESIZE, ROUNDUP(bufsize, slocopt.sizex) / slocopt.sizex);
 
-    dev_r = dt_opencl_alloc_device_buffer(devid, (size_t)reducesize * 2 * sizeof(float));
+    dev_r = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 2 * reducesize);
     if(dev_r == NULL) goto error;
 
     size_t ssizes[3] = { reducesize * slocopt.sizex, 1, 1 };
@@ -3991,20 +3991,20 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
 
     for(int n = 0; n < ndir; n++)
     {
-      dev_rgbv[n] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 4 * sizeof(float));
+      dev_rgbv[n] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
       if(dev_rgbv[n] == NULL) goto error;
     }
 
-    dev_gminmax = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 2 * sizeof(float));
+    dev_gminmax = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 2 * width * height);
     if(dev_gminmax == NULL) goto error;
 
-    dev_aux = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 4 * sizeof(float));
+    dev_aux = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
     if(dev_aux == NULL) goto error;
 
     if(scaled)
     {
       // need to scale to right res
-      dev_tmp = dt_opencl_alloc_device(devid, (size_t)width, height, 4 * sizeof(float));
+      dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
       if(dev_tmp == NULL) goto error;
     }
     else
@@ -4246,7 +4246,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
     // prepare derivatives buffers
     for(int n = 0; n < ndir; n++)
     {
-      dev_drv[n] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(float));
+      dev_drv[n] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
       if(dev_drv[n] == NULL) goto error;
     }
 
@@ -4291,10 +4291,10 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
     // reserve buffers for homogeneity maps and sum maps
     for(int n = 0; n < ndir; n++)
     {
-      dev_homo[n] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(unsigned char));
+      dev_homo[n] = dt_opencl_alloc_device_buffer(devid, sizeof(unsigned char) * width * height);
       if(dev_homo[n] == NULL) goto error;
 
-      dev_homosum[n] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(unsigned char));
+      dev_homosum[n] = dt_opencl_alloc_device_buffer(devid, sizeof(unsigned char) * width * height);
       if(dev_homosum[n] == NULL) goto error;
     }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2276,14 +2276,14 @@ static void vng_interpolate(float *out, const float *const in,
   if(only_vng_linear) return;
 
   char *buffer
-      = (char *)dt_alloc_align(64, (size_t)sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
+      = (char *)dt_alloc_align(64, sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
   {
     fprintf(stderr, "[demosaic] not able to allocate VNG buffer\n");
     return;
   }
   for(int row = 0; row < 3; row++) brow[row] = (float(*)[4])buffer + row * width;
-  ip = (int *)(buffer + (size_t)sizeof(**brow) * width * 3);
+  ip = (int *)(buffer + sizeof(**brow) * width * 3);
 
   for(int row = 0; row < prow; row++) /* Precalculate for VNG */
     for(int col = 0; col < pcol; col++)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2534,7 +2534,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
   const float *input = in;
   if(median)
   {
-    float *med_in = (float *)dt_alloc_align(64, (size_t)roi_in->height * roi_in->width * sizeof(float));
+    float *med_in = (float *)dt_alloc_align_float((size_t)roi_in->height * roi_in->width);
     pre_median(med_in, in, roi_in, filters, 1, thrs);
     input = med_in;
   }
@@ -2901,7 +2901,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       roo.width = roi_in->width;
       roo.height = roi_in->height;
       roo.scale = 1.0f;
-      tmp = (float *)dt_alloc_align(64, (size_t)roo.width * roo.height * 4 * sizeof(float));
+      tmp = (float *)dt_alloc_align_float((size_t)4 * roo.width * roo.height);
     }
 
     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
@@ -2929,7 +2929,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
       if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO)
       {
-        in = (float *)dt_alloc_align(64, (size_t)roi_in->height * roi_in->width * sizeof(float));
+        in = (float *)dt_alloc_align_float((size_t)roi_in->height * roi_in->width);
         switch(data->green_eq)
         {
           case DT_IOP_GREEN_EQ_FULL:
@@ -2941,7 +2941,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                      roi_in->x, roi_in->y, threshold);
             break;
           case DT_IOP_GREEN_EQ_BOTH:
-            aux = dt_alloc_align(64, (size_t)roi_in->height * roi_in->width * sizeof(float));
+            aux = dt_alloc_align_float((size_t)roi_in->height * roi_in->width);
             green_equilibration_favg(aux, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
                                      roi_in->x, roi_in->y);
             green_equilibration_lavg(in, aux, roi_in->width, roi_in->height, piece->pipe->dsc.filters, roi_in->x,
@@ -3165,7 +3165,7 @@ static int green_equilibration_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
                                                  slocal);
     if(err != CL_SUCCESS) goto error;
 
-    sumsum = dt_alloc_align(64, (size_t)reducesize * 2 * sizeof(float));
+    sumsum = dt_alloc_align_float((size_t)2 * reducesize);
     if(sumsum == NULL) goto error;
     err = dt_opencl_read_buffer_from_device(devid, (void *)sumsum, dev_r, 0,
                                             (size_t)reducesize * 2 * sizeof(float), CL_TRUE);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2159,7 +2159,7 @@ static void lin_interpolate(float *out, const float *const in, const dt_iop_roi_
   // COLORB TOT_WEIGHT
   // COLORPIX                   # color of center pixel
 
-  int(*const lookup)[16][32] = malloc((size_t)16 * 16 * 32 * sizeof(int));
+  int(*const lookup)[16][32] = malloc(sizeof(int) * 16 * 16 * 32);
 
   const int size = (filters == 9) ? 6 : 16;
   for(int row = 0; row < size; row++)
@@ -2614,7 +2614,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
 
       // write using MOVNTPS (write combine omitting caches)
       // _mm_stream_ps(buf, col);
-      memcpy(buf, color, 4 * sizeof(float));
+      memcpy(buf, color, sizeof(float) * 4);
       buf += 4;
       buf_in++;
     }
@@ -2706,7 +2706,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
         }
       }
       // _mm_stream_ps(buf, col);
-      memcpy(buf, color, 4 * sizeof(float));
+      memcpy(buf, color, sizeof(float) * 4);
       buf += 4;
     }
   }
@@ -3008,7 +3008,7 @@ static int color_smoothing_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
   cl_int err = -999;
 
-  cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   dt_opencl_local_buffer_t locopt
@@ -3280,7 +3280,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
     // need to reserve scaled auxiliary buffer or use dev_out
     if(scaled)
     {
-      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, 4 * sizeof(float));
+      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
       if(dev_aux == NULL) goto error;
       width = roi_in->width;
       height = roi_in->height;
@@ -3326,7 +3326,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         dev_in = dev_aux;
       }
 
-      dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, 4 * sizeof(float));
+      dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
       if(dev_tmp == NULL) goto error;
 
       {
@@ -3671,7 +3671,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     // need to reserve scaled auxiliary buffer or use dev_out
     if(scaled)
     {
-      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, 4 * sizeof(float));
+      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
       if(dev_aux == NULL) goto error;
       width = roi_in->width;
       height = roi_in->height;
@@ -3679,7 +3679,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     else
       dev_aux = dev_out;
 
-    dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, 4 * sizeof(float));
+    dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
     if(dev_tmp == NULL) goto error;
 
     {
@@ -4420,7 +4420,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
     }
 
     // need to get another temp buffer for the output image (may use the space of dev_drv[] freed earlier)
-    dev_tmptmp = dt_opencl_alloc_device(devid, (size_t)width, height, 4 * sizeof(float));
+    dev_tmptmp = dt_opencl_alloc_device(devid, (size_t)width, height, sizeof(float) * 4);
     if(dev_tmptmp == NULL) goto error;
 
     cl_mem dev_t1 = dev_tmp;
@@ -4536,7 +4536,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       if(dev_edge_in == NULL) goto error;
 
       // reserve output buffer for VNG processing of edge
-      dev_edge_out = dt_opencl_alloc_device(devid, edges[n][2], edges[n][3], 4 * sizeof(float));
+      dev_edge_out = dt_opencl_alloc_device(devid, edges[n][2], edges[n][3], sizeof(float) * 4);
       if(dev_edge_out == NULL) goto error;
 
       // copy edge to input buffer

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -539,6 +539,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
   const int ndir = 4 << (passes > 1);
 
   const size_t buffer_size = (size_t)TS * TS * (ndir * 4 + 3) * sizeof(float);
+  //TODO: should this use dt_alloc_align_float or _perthread_float?
   char *const all_buffers = (char *)dt_alloc_align(64, dt_get_num_threads() * buffer_size);
   if(!all_buffers)
   {

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1138,7 +1138,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   // lead to out of bounds memory access
   if(width < 2 * max_mult || height < 2 * max_mult)
   {
-    memcpy(ovoid, ivoid, npixels * 4 * sizeof(float));
+    memcpy(ovoid, ivoid, sizeof(float) * 4 * npixels);
     return;
   }
 
@@ -1639,7 +1639,7 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   const int width = roi_in->width, height = roi_in->height;
   size_t npixels = (size_t)width * height;
 
-  memcpy(ovoid, ivoid, npixels * 4 * sizeof(float));
+  memcpy(ovoid, ivoid, sizeof(float) * 4 * npixels);
   if(((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW) || (g == NULL))
   {
     return;
@@ -1681,7 +1681,7 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   g->variance_G = var[1];
   g->variance_B = var[2];
 
-  memcpy(ovoid, ivoid, npixels * 4 * sizeof(float));
+  memcpy(ovoid, ivoid, sizeof(float) * 4 * npixels);
 }
 
 #if defined(HAVE_OPENCL) && !USE_NEW_IMPL_CL

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1724,7 +1724,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
   // allocate a buffer for a preconditioned copy of the image
   const int devid = piece->pipe->devid;
-  cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_denoiseprofile] couldn't allocate GPU buffer\n");
@@ -1845,7 +1845,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
                             (bb[2] / aa[2]) * (bb[2] / aa[2]), 0.0f };
 
   const int devid = piece->pipe->devid;
-  cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
@@ -2138,7 +2138,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   sumsum = dt_alloc_align_float((size_t)4 * reducesize);
   if(sumsum == NULL) goto error;
 
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   float m[] = { 0.0625f, 0.25f, 0.375f, 0.25f, 0.0625f }; // 1/16, 4/16, 6/16, 4/16, 1/16
@@ -2151,7 +2151,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   for(int k = 0; k < max_scale; k++)
   {
-    dev_detail[k] = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+    dev_detail[k] = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
     if(dev_detail[k] == NULL) goto error;
   }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1759,7 +1759,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   }
 
   // allocate a buffer to receive the denoised image
-  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 4 * sizeof(float));
+  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
   if(dev_U2 == NULL) err = -999;
 
   if (err == CL_SUCCESS)
@@ -1848,14 +1848,14 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   cl_mem dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
   if(dev_tmp == NULL) goto error;
 
-  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 4 * sizeof(float));
+  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
   if(dev_U2 == NULL) goto error;
 
   cl_mem buckets[NUM_BUCKETS] = { NULL };
   unsigned int state = 0;
   for(int k = 0; k < NUM_BUCKETS; k++)
   {
-    buckets[k] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(float));
+    buckets[k] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
     if(buckets[k] == NULL) goto error;
   }
 
@@ -2129,10 +2129,10 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   const int reducesize = MIN(REDUCESIZE, ROUNDUP(bufsize, slocopt.sizex) / slocopt.sizex);
 
-  dev_m = dt_opencl_alloc_device_buffer(devid, (size_t)bufsize * 4 * sizeof(float));
+  dev_m = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * bufsize);
   if(dev_m == NULL) goto error;
 
-  dev_r = dt_opencl_alloc_device_buffer(devid, (size_t)reducesize * 4 * sizeof(float));
+  dev_r = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * reducesize);
   if(dev_r == NULL) goto error;
 
   sumsum = dt_alloc_align_float((size_t)4 * reducesize);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1147,8 +1147,8 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   float *tmp = NULL;
   float *buf1 = NULL, *buf2 = NULL;
   for(int k = 0; k < max_scale; k++)
-    buf[k] = dt_alloc_align(64, (size_t)4 * sizeof(float) * npixels);
-  tmp = dt_alloc_align(64, (size_t)4 * sizeof(float) * npixels);
+    buf[k] = dt_alloc_align_float((size_t)4 * npixels);
+  tmp = dt_alloc_align_float((size_t)4 * npixels);
 
   float wb[3];
   const float wb_weights[3] = { 2.0f, 1.0f, 2.0f };
@@ -1525,7 +1525,7 @@ static void process_nlmeans_cpu(dt_dev_pixelpipe_iop_t *piece,
 
   // P == 0 : this will degenerate to a (fast) bilateral filter.
 
-  float *in = dt_alloc_align(64, (size_t)4 * sizeof(float) * roi_in->width * roi_in->height);
+  float *in = dt_alloc_align_float((size_t)4 * roi_in->width * roi_in->height);
 
   float wb[3];
   float p[3];
@@ -1645,7 +1645,7 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     return;
   }
 
-  float *in = dt_alloc_align(64, (size_t)4 * sizeof(float) * roi_in->width * roi_in->height);
+  float *in = dt_alloc_align_float((size_t)4 * roi_in->width * roi_in->height);
 
   float wb[3];
   const float wb_weights[3] = { 1.0f, 1.0f, 1.0f };
@@ -2135,7 +2135,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   dev_r = dt_opencl_alloc_device_buffer(devid, (size_t)reducesize * 4 * sizeof(float));
   if(dev_r == NULL) goto error;
 
-  sumsum = dt_alloc_align(64, (size_t)reducesize * 4 * sizeof(float));
+  sumsum = dt_alloc_align_float((size_t)4 * reducesize);
   if(sumsum == NULL) goto error;
 
   dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -116,7 +116,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int chs = piece->colors;
   const int width = roi_in->width, height = roi_in->height;
   const float scale = roi_in->scale;
-  memcpy(ovoid, ivoid, (size_t)chs * sizeof(float) * width * height);
+  memcpy(ovoid, ivoid, sizeof(float) * chs * width * height);
 #if 1
   // printf("thread %d starting equalizer", (int)pthread_self());
   // if(piece->iscale != 1.0) printf(" for preview\n");

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -140,7 +140,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   for(int k = 1; k < numl_cap; k++)
   {
     const int wd = (int)(1 + (width >> (k - 1))), ht = (int)(1 + (height >> (k - 1)));
-    tmp[k] = (float *)malloc((size_t)sizeof(float) * wd * ht);
+    tmp[k] = (float *)malloc(sizeof(float) * wd * ht);
   }
 
   for(int level = 1; level < numl_cap; level++) dt_iop_equalizer_wtf(ovoid, tmp, level, width, height);

--- a/src/iop/equalizer_eaw.h
+++ b/src/iop/equalizer_eaw.h
@@ -34,14 +34,16 @@ static void dt_iop_equalizer_wtf(float *buf, float **weight_a, const int l, cons
   const int wd = (int)(1 + (width >> (l - 1))), ht = (int)(1 + (height >> (l - 1)));
   int ch = 0;
   // store weights for luma channel only, chroma uses same basis.
-  memset(weight_a[l], 0, (size_t)sizeof(float) * wd * ht);
+  memset(weight_a[l], 0, sizeof(float) * wd * ht);
   for(int j = 0; j < ht - 1; j++)
     for(int i = 0; i < wd - 1; i++) weight_a[l][(size_t)j * wd + i] = gbuf(buf, i << (l - 1), j << (l - 1));
 
   const int step = 1 << l;
   const int st = step / 2;
 
-  float *const tmp_width_buf = (float *)malloc(width * dt_get_num_threads() * sizeof(float));
+  const size_t numthreads = dt_get_num_threads();
+
+  float *const tmp_width_buf = (float *)malloc(numthreads * sizeof(float) * width);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(height, l, st, step, tmp_width_buf, wd, width) \
@@ -75,7 +77,7 @@ static void dt_iop_equalizer_wtf(float *buf, float **weight_a, const int l, cons
 
   free((void *)tmp_width_buf);
 
-  float *const tmp_height_buf = (float *)malloc(height * dt_get_num_threads() * sizeof(float));
+  float *const tmp_height_buf = (float *)malloc(numthreads * sizeof(float) * height);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(height, l, st, step, tmp_height_buf, wd, width) \
@@ -116,7 +118,9 @@ static void dt_iop_equalizer_iwtf(float *buf, float **weight_a, const int l, con
   const int st = step / 2;
   const int wd = (int)(1 + (width >> (l - 1)));
 
-  float *const tmp_height_buf = (float *)malloc(height * dt_get_num_threads() * sizeof(float));
+  const size_t numthreads = dt_get_num_threads();
+
+  float *const tmp_height_buf = (float *)malloc(numthreads * sizeof(float) * height);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(height, l, st, step, tmp_height_buf, wd, width) \
@@ -148,7 +152,7 @@ static void dt_iop_equalizer_iwtf(float *buf, float **weight_a, const int l, con
 
   free((void *)tmp_height_buf);
 
-  float *const tmp_width_buf = (float *)malloc(width * dt_get_num_threads() * sizeof(float));
+  float *const tmp_width_buf = (float *)malloc(numthreads * sizeof(float) * width);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(height, l, st, step, tmp_width_buf, wd, width) \

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1562,13 +1562,13 @@ static inline cl_int reconstruct_highlights_cl(cl_mem in, cl_mem mask, cl_mem re
   const int scales = get_scales(roi_in, piece);
 
   // wavelets scales buffers
-  cl_mem LF_even = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float)); // low-frequencies RGB
-  cl_mem LF_odd = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float));  // low-frequencies RGB
-  cl_mem HF_RGB = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float));  // high-frequencies RGB
+  cl_mem LF_even = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4); // low-frequencies RGB
+  cl_mem LF_odd = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4);  // low-frequencies RGB
+  cl_mem HF_RGB = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4);  // high-frequencies RGB
   cl_mem HF_grey = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float)); // max(high-frequencies RGB) grey
 
   // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
-  cl_mem temp = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float));;
+  cl_mem temp = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4);;
 
   if(!LF_even || !LF_odd || !HF_RGB || !HF_grey || !temp)
   {
@@ -1790,7 +1790,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   {
     // Inpaint noise
     const float noise_level = d->noise_level / scale;
-    inpainted = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float));
+    inpainted = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4);
     dt_opencl_set_kernel_arg(devid, gd->kernel_filmic_inpaint_noise, 0, sizeof(cl_mem), (void *)&in);
     dt_opencl_set_kernel_arg(devid, gd->kernel_filmic_inpaint_noise, 1, sizeof(cl_mem), (void *)&mask);
     dt_opencl_set_kernel_arg(devid, gd->kernel_filmic_inpaint_noise, 2, sizeof(cl_mem), (void *)&inpainted);
@@ -1803,7 +1803,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(err != CL_SUCCESS) goto error;
 
     // first step of highlight reconstruction in RGB
-    reconstructed = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float));
+    reconstructed = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4);
     err = reconstruct_highlights_cl(inpainted, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RGB, gd, d, piece, roi_in);
     if(err != CL_SUCCESS) goto error;
     dt_opencl_release_mem_object(inpainted);
@@ -1811,7 +1811,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
     if(d->high_quality_reconstruction > 0)
     {
-      ratios = dt_opencl_alloc_device(devid, sizes[0], sizes[1], 4 * sizeof(float));
+      ratios = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float) * 4);
       norms = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float));
 
       if(norms && ratios)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1083,14 +1083,14 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
   const int scales = get_scales(roi_in, piece);
 
   // wavelets scales buffers
-  float *const restrict LF_even = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch); // low-frequencies RGB
-  float *const restrict LF_odd = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);  // low-frequencies RGB
-  float *const restrict HF_RGB = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);  // high-frequencies RGB
+  float *const restrict LF_even = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height); // low-frequencies RGB
+  float *const restrict LF_odd = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);  // low-frequencies RGB
+  float *const restrict HF_RGB = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);  // high-frequencies RGB
   float *const restrict HF_grey
-      = dt_alloc_sse_ps(roi_out->width * roi_out->height); // max(high-frequencies RGB) grey
+      = dt_alloc_sse_ps((size_t)roi_out->width * roi_out->height); // max(high-frequencies RGB) grey
 
   // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
-  float *const restrict temp = dt_alloc_sse_ps(roi_out->width * dt_get_num_threads() * ch);
+  float *const restrict temp = dt_alloc_sse_ps(dt_get_num_threads() * ch * roi_out->width);
 
   if(!LF_even || !LF_odd || !HF_RGB || !HF_grey || !temp)
   {

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -430,7 +430,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_pixelmax_second, sizes, local);
       if(err != CL_SUCCESS) goto error;
 
-      maximum = dt_alloc_align(64, reducesize * sizeof(float));
+      maximum = dt_alloc_align_float((size_t)reducesize);
       err = dt_opencl_read_buffer_from_device(devid, (void *)maximum, dev_r, 0,
                                             (size_t)reducesize * sizeof(float), CL_TRUE);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -397,10 +397,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       size_t sizes[3];
       size_t local[3];
 
-      dev_m = dt_opencl_alloc_device_buffer(devid, (size_t)bufsize * sizeof(float));
+      dev_m = dt_opencl_alloc_device_buffer(devid, sizeof(float) * bufsize);
       if(dev_m == NULL) goto error;
 
-      dev_r = dt_opencl_alloc_device_buffer(devid, (size_t)reducesize * sizeof(float));
+      dev_r = dt_opencl_alloc_device_buffer(devid, sizeof(float) * reducesize);
       if(dev_r == NULL) goto error;
 
       sizes[0] = bwidth;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -188,7 +188,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   size_t sizes[3];
   size_t local[3];
 
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   dev_m = dt_opencl_copy_host_to_device_constant(devid, mat_size, mat);

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -280,7 +280,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const dt_iop_hotpixels_data_t *data = (dt_iop_hotpixels_data_t *)piece->data;
 
   // The processing loop should output only a few pixels, so just copy everything first
-  memcpy(ovoid, ivoid, (size_t)roi_out->width * roi_out->height * sizeof(float));
+  memcpy(ovoid, ivoid, sizeof(float) * roi_out->width * roi_out->height);
 
   int fixed;
   if(piece->pipe->dsc.filters == 9u)

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -599,7 +599,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, 4 * sizeof(float)));
+  g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, sizeof(float) * 4));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);
 
   g->pickerbuttons = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -381,7 +381,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
   {
-    memcpy(ovoid, ivoid, (size_t)ch * sizeof(float) * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -459,7 +459,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     }
     else
     {
-      memcpy(ovoid, ivoid, (size_t)ch * sizeof(float) * roi_out->width * roi_out->height);
+      memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     }
 
     if(modflags & LF_MODIFY_VIGNETTING)
@@ -647,7 +647,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   tmpbuf = (float *)dt_alloc_align(64, tmpbuflen);
   if(tmpbuf == NULL) goto error;
 
-  dev_tmp = (cl_mem)dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = (cl_mem)dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   dev_tmpbuf = (cl_mem)dt_opencl_alloc_device_buffer(devid, tmpbuflen);
@@ -869,7 +869,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
 
   if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
   {
-    float *buf = (float *)malloc(2 * 3 * sizeof(float));
+    float *buf = (float *)malloc(sizeof(float) * 2 * 3);
     for(size_t i = 0; i < points_count * 2; i += 2)
     {
       float p1 = points[i];
@@ -909,7 +909,7 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
 
   if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
   {
-    float *buf = (float *)malloc(2 * 3 * sizeof(float));
+    float *buf = (float *)malloc(sizeof(float) * 2 * 3);
     for(size_t i = 0; i < points_count * 2; i += 2)
     {
       modifier->ApplySubpixelGeometryDistortion(points[i], points[i + 1], 1, 1, buf);
@@ -1020,7 +1020,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     float xm = FLT_MAX, xM = -FLT_MAX, ym = FLT_MAX, yM = -FLT_MAX;
     const size_t nbpoints = 2 * awidth + 2 * aheight;
 
-    float *const buf = (float *)dt_alloc_align(64, nbpoints * 2 * 3 * sizeof(float));
+    float *const buf = (float *)dt_alloc_align(64, sizeof(float) * nbpoints * 2 * 3);
 
 #ifdef _OPENMP
 #pragma omp parallel default(none) \
@@ -1471,7 +1471,7 @@ static int ptr_array_insert_sorted(GPtrArray *array, const void *item, GCompareF
   if(r == m) m++;
 
 done:
-  memmove(root + m + 1, root + m, (length - m) * sizeof(void *));
+  memmove(root + m + 1, root + m, sizeof(void *) * (length - m));
   root[m] = item;
   return m;
 }
@@ -1511,7 +1511,7 @@ static void ptr_array_insert_index(GPtrArray *array, const void *item, int index
   int length = array->len;
   g_ptr_array_set_size(array, length + 1);
   root = (const void **)array->pdata;
-  memmove(root + index + 1, root + index, (length - index) * sizeof(void *));
+  memmove(root + index + 1, root + index, sizeof(void *) * (length - index));
   root[index] = item;
 }
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -403,7 +403,9 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       // acquire temp memory for distorted pixel coords
       const size_t bufsize = (size_t)roi_out->width * 2 * 3;
-      void *buf = dt_alloc_align(64, bufsize * dt_get_num_threads() * sizeof(float));
+
+      // TODO: Should this be migrated to dt_alloc__perthread_float?
+      void *buf = dt_alloc_align_float(bufsize * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -507,7 +509,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       // acquire temp memory for distorted pixel coords
       const size_t buf2size = (size_t)roi_out->width * 2 * 3;
-      void *buf2 = dt_alloc_align(64, buf2size * sizeof(float) * dt_get_num_threads());
+      void *buf2 = dt_alloc_align_float(buf2size * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -951,7 +953,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 
   // acquire temp memory for distorted pixel coords
   const size_t bufsize = (size_t)roi_out->width * 2 * 3;
-  float *buf = (float *)dt_alloc_align(64, bufsize * sizeof(float) * dt_get_num_threads());
+  float *buf = (float *)dt_alloc_align_float(bufsize * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -816,12 +816,12 @@ static float complex point_at_arc_length(const float complex points[], const int
 
 static float *build_lookup_table(const int distance, const float control1, const float control2)
 {
-  float complex *clookup = dt_alloc_align(64, (distance + 2) * sizeof(float complex));
+  float complex *clookup = dt_alloc_align(64, sizeof(float complex) * (distance + 2));
 
   interpolate_cubic_bezier(I, control1 + I, control2, 1.0, clookup, distance + 2);
 
   // reparameterize bezier by x and keep only y values
-  float *lookup = dt_alloc_align(64, (distance + 2) * sizeof(float));
+  float *lookup = dt_alloc_align_float((size_t)(distance + 2));
   float *ptr = lookup;
   float complex *cptr = clookup + 1;
   const float complex *cptr_end = cptr + distance;
@@ -1105,7 +1105,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 {
   // allocate distortion map big enough to contain all paths
   const int mapsize = map_extent->width * map_extent->height;
-  float complex *map = dt_alloc_align(64, mapsize * sizeof(float complex));
+  float complex *map = dt_alloc_align(64, sizeof(float complex) * mapsize);
   memset(map, 0, mapsize * sizeof(float complex));
 
   // build map
@@ -1121,7 +1121,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 
   if(inverted)
   {
-    float complex * const imap = dt_alloc_align(64, mapsize * sizeof(float complex));
+    float complex * const imap = dt_alloc_align(64, sizeof(float complex) * mapsize);
     memset(imap, 0, mapsize * sizeof(float complex));
 
     // copy map into imap(inverted map).

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -557,7 +557,7 @@ static void _distort_paths(const struct dt_iop_module_t *module,
 
   // create buffer with all points
 
-  float *buffer = malloc(2 * sizeof(float) * len);
+  float *buffer = malloc(sizeof(float) * 2 * len);
   float *b = buffer;
 
   for(int k = 0; k < MAX_NODES; k++)
@@ -1483,25 +1483,25 @@ static cl_int_t apply_global_distortion_map_cl(struct dt_iop_module_t *module,
      case DT_INTERPOLATION_BILINEAR:
        kdesc.size = 1;
        kdesc.resolution = 1;
-       k = malloc(2 * sizeof(float));
+       k = malloc(sizeof(float) * 2);
        k[0] = 1.0f;
        k[1] = 0.0f;
        break;
      case DT_INTERPOLATION_BICUBIC:
        kdesc.size = 2;
-       k = malloc((kdesc.size * kdesc.resolution + 1) * sizeof(float));
+       k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1));
        for(int i = 0; i <= kdesc.size * kdesc.resolution; ++i)
          k[i] = bicubic(0.5f, (float) i / kdesc.resolution);
        break;
      case DT_INTERPOLATION_LANCZOS2:
        kdesc.size = 2;
-       k = malloc((kdesc.size * kdesc.resolution + 1) * sizeof(float));
+       k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1));
        for(int i = 0; i <= kdesc.size * kdesc.resolution; ++i)
          k[i] = lanczos(2, (float) i / kdesc.resolution);
        break;
      case DT_INTERPOLATION_LANCZOS3:
        kdesc.size = 3;
-       k = malloc((kdesc.size * kdesc.resolution + 1) * sizeof(float));
+       k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1));
        for(int i = 0; i <= kdesc.size * kdesc.resolution; ++i)
          k[i] = lanczos(3, (float) i / kdesc.resolution);
        break;
@@ -1783,7 +1783,7 @@ static GList *interpolate_paths(dt_iop_liquify_params_t *p)
 
     if(data->header.type == DT_LIQUIFY_PATH_CURVE_TO_V1)
     {
-      float complex *buffer = malloc(INTERPOLATION_POINTS * sizeof(float complex));
+      float complex *buffer = malloc(sizeof(float complex) * INTERPOLATION_POINTS);
       interpolate_cubic_bezier(*p1,
                                 data->node.ctrl1,
                                 data->node.ctrl2,
@@ -2335,10 +2335,10 @@ static void smooth_path_linsys(size_t n,
                                 const int *equation)
 {
   --n;
-  float *a = malloc(n * sizeof(float)); // subdiagonal
-  float *b = malloc(n * sizeof(float)); // main diagonal
-  float *c = malloc(n * sizeof(float)); // superdiagonal
-  float complex *d = malloc(n * sizeof(float complex)); // right hand side
+  float *a = malloc(sizeof(float) * n); // subdiagonal
+  float *b = malloc(sizeof(float) * n); // main diagonal
+  float *c = malloc(sizeof(float) * n); // superdiagonal
+  float complex *d = malloc(sizeof(float complex) * n); // right hand side
 
   // Build the tridiagonal matrix.
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1106,7 +1106,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   // allocate distortion map big enough to contain all paths
   const int mapsize = map_extent->width * map_extent->height;
   float complex *map = dt_alloc_align(64, sizeof(float complex) * mapsize);
-  memset(map, 0, mapsize * sizeof(float complex));
+  memset(map, 0, sizeof(float complex) * mapsize);
 
   // build map
   for(GList *i = interpolated; i != NULL; i = i->next)
@@ -1122,7 +1122,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   if(inverted)
   {
     float complex * const imap = dt_alloc_align(64, sizeof(float complex) * mapsize);
-    memset(imap, 0, mapsize * sizeof(float complex));
+    memset(imap, 0, sizeof(float complex) * mapsize);
 
     // copy map into imap(inverted map).
     // imap [ n + dx(map[n]) , n + dy(map[n]) ] = -map[n]

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -267,7 +267,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     b = NULL; // make sure we don't clean it up twice
   }
 
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -458,7 +458,7 @@ uint8_t calculate_clut_compressed(dt_iop_lut3d_params_t *const p, const char *co
 
   get_cache_filename(p->lutname, cache_filename);
   buf_size_lut = (size_t)(level * level * level * 3);
-  lclut = dt_alloc_align(16, buf_size_lut * sizeof(float));
+  lclut = dt_alloc_align(16, sizeof(float) * buf_size_lut);
   if(!lclut)
   {
     fprintf(stderr, "[lut3d] error allocating buffer for gmz lut\n");
@@ -558,7 +558,7 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   }
   const size_t buf_size_lut = (size_t)png.height * png.height * 3;
   dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu floats for png lut - level %d\n", buf_size_lut, level);
-  float *lclut = dt_alloc_align(16, buf_size_lut * sizeof(float));
+  float *lclut = dt_alloc_align(16, sizeof(float) * buf_size_lut);
   if(!lclut)
   {
     fprintf(stderr, "[lut3d] error - allocating buffer for png lut\n");
@@ -788,7 +788,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
         }
         buf_size = level * level * level * 3;
         dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube lut - level %d\n", buf_size, level);
-        lclut = dt_alloc_align(16, buf_size * sizeof(float));
+        lclut = dt_alloc_align(16, sizeof(float) * buf_size);
         if(!lclut)
         {
           fprintf(stderr, "[lut3d] error - allocating buffer for cube lut\n");
@@ -900,7 +900,7 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
             }
             buf_size = level * level * level * 3;
             dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube lut - level %d\n", buf_size, level);
-            lclut = dt_alloc_align(16, buf_size * sizeof(float));
+            lclut = dt_alloc_align(16, sizeof(float) * buf_size);
             if(!lclut)
             {
               fprintf(stderr, "[lut3d] error - allocating buffer for cube lut\n");

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1102,7 +1102,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else  // no clut
   {
-    memcpy(obuf, ibuf, width * height * ch * sizeof(float));
+    memcpy(obuf, ibuf, sizeof(float) * ch * width * height);
   }
 }
 

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -78,7 +78,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;
-  memcpy(o, i, (size_t)ch * roi_out->width * roi_out->height * sizeof(float));
+  memcpy(o, i, sizeof(float) * ch * roi_out->width * roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -242,7 +242,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float detail = -1.0f; // bilateral base layer
 
   cl_mem dev_tmp = NULL;
-  dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
 
   dt_bilateral_cl_t *b = dt_bilateral_init_cl(devid, roi_in->width, roi_in->height, sigma_s, sigma_r);
   if(!b) goto error;

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -165,7 +165,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   // allocate a buffer to receive the denoised image
   const int devid = piece->pipe->devid;
-  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 4 * sizeof(float));
+  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
   if(dev_U2 == NULL)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_nlmeans] couldn't allocate GPU buffer\n");
@@ -230,14 +230,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float weight[4] = { d->luma, d->chroma, d->chroma, 1.0f };
 
   const int devid = piece->pipe->devid;
-  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * 4 * sizeof(float));
+  cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);
   if(dev_U2 == NULL) goto error;
 
   cl_mem buckets[NUM_BUCKETS] = { NULL };
   unsigned int state = 0;
   for(int k = 0; k < NUM_BUCKETS; k++)
   {
-    buckets[k] = dt_opencl_alloc_device_buffer(devid, (size_t)width * height * sizeof(float));
+    buckets[k] = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
     if(buckets[k] == NULL) goto error;
   }
 

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -165,7 +165,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = 4;
   assert(piece->colors == ch);
 
-  float *const img_tmp = dt_alloc_align(64, sizeof(float) * ch * roi_out->width * roi_out->height);
+  float *const img_tmp = dt_alloc_align_float((size_t) ch * roi_out->width * roi_out->height);
   if(img_tmp == NULL)
   {
     fprintf(stderr, "[overexposed process] can't alloc temp image\n");

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -456,7 +456,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int height = roi_out->height;
 
   // display mask using histogram profile as output
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, ch * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * ch);
   if(dev_tmp == NULL)
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -165,7 +165,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = 4;
   assert(piece->colors == ch);
 
-  float *const img_tmp = dt_alloc_align(64, ch * roi_out->width * roi_out->height * sizeof(float));
+  float *const img_tmp = dt_alloc_align(64, sizeof(float) * ch * roi_out->width * roi_out->height);
   if(img_tmp == NULL)
   {
     fprintf(stderr, "[overexposed process] can't alloc temp image\n");

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -480,7 +480,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(!(d->threshold > 0.0f))
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float)*width*height);
+    memcpy(ovoid, ivoid, sizeof(float)*width*height);
   }
   else
   {

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -308,7 +308,7 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
   if (!img)
   {
     // we ran out of memory, so just pass through the image without denoising
-    memcpy(out, in, size * sizeof(float));
+    memcpy(out, in, sizeof(float) * size);
     return;
   }
   float *const fimg = img + width;	// point at the actual color channel contents in the buffer

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -243,10 +243,10 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       switch(mode)
       {
         case DT_DEV_RAWOVEREXPOSED_MODE_MARK_CFA:
-          memcpy(out + pout, dt_iop_rawoverexposed_colors[c], 4 * sizeof(float));
+          memcpy(out + pout, dt_iop_rawoverexposed_colors[c], sizeof(float) * 4);
           break;
         case DT_DEV_RAWOVEREXPOSED_MODE_MARK_SOLID:
-          memcpy(out + pout, color, 4 * sizeof(float));
+          memcpy(out + pout, color, sizeof(float) * 4);
           break;
         case DT_DEV_RAWOVEREXPOSED_MODE_FALSECOLOR:
           out[pout + c] = 0.0;

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -163,7 +163,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const int colorscheme = dev->rawoverexposed.colorscheme;
   const float *const color = dt_iop_rawoverexposed_colors[colorscheme];
 
-  memcpy(ovoid, ivoid, (size_t)ch * roi_out->width * roi_out->height * sizeof(float));
+  memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
 
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, image->id, DT_MIPMAP_FULL, DT_MIPMAP_BLOCKING, 'r');

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -190,7 +190,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   // acquire temp memory for distorted pixel coords
   const size_t coordbufsize = (size_t)roi_out->width * 2;
-  float *coordbuf = dt_alloc_align(64, coordbufsize * sizeof(float) * dt_get_num_threads());
+  float *coordbuf = dt_alloc_align_float(coordbufsize * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3927,7 +3927,7 @@ static cl_int retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
   const int ch = 4;
 
   const cl_mem dev_dest =
-    dt_opencl_alloc_device(devid, roi_mask_scaled->width, roi_mask_scaled->height, ch * sizeof(float));
+    dt_opencl_alloc_device(devid, roi_mask_scaled->width, roi_mask_scaled->height, sizeof(float) * ch);
   if(dev_dest == NULL)
   {
     fprintf(stderr, "retouch_blur_cl error 2\n");

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2937,7 +2937,7 @@ static void rt_build_scaled_mask(float *const mask, dt_iop_roi_t *const roi_mask
   const int x_to = roi_mask_scaled->width + roi_mask_scaled->x;
   const int y_to = roi_mask_scaled->height + roi_mask_scaled->y;
 
-  mask_tmp = dt_alloc_align(64, sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
+  mask_tmp = dt_alloc_align_float((size_t)roi_mask_scaled->width * roi_mask_scaled->height);
   if(mask_tmp == NULL)
   {
     fprintf(stderr, "rt_build_scaled_mask: error allocating memory\n");
@@ -3151,7 +3151,7 @@ static void retouch_clone(float *const in, dt_iop_roi_t *const roi_in, const int
                           const int use_sse)
 {
   // alloc temp image to avoid issues when areas self-intersects
-  float *img_src = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
+  float *img_src = dt_alloc_align_float((size_t)ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_src == NULL)
   {
     fprintf(stderr, "retouch_clone: error allocating memory for cloning\n");
@@ -3179,7 +3179,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
   float *img_dest = NULL;
 
   // alloc temp image to blur
-  img_dest = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
+  img_dest = dt_alloc_align_float((size_t)ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_dest == NULL)
   {
     fprintf(stderr, "retouch_blur: error allocating memory for blurring\n");
@@ -3253,8 +3253,8 @@ static void retouch_heal(float *const in, dt_iop_roi_t *const roi_in, const int 
   float *img_dest = NULL;
 
   // alloc temp images for source and destination
-  img_src = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
-  img_dest = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
+  img_src  = dt_alloc_align_float((size_t)ch * roi_mask_scaled->width * roi_mask_scaled->height);
+  img_dest = dt_alloc_align_float((size_t)ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if((img_src == NULL) || (img_dest == NULL))
   {
     fprintf(stderr, "retouch_heal: error allocating memory for healing\n");
@@ -3477,7 +3477,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 
   // we will do all the clone, heal, etc on the input image,
   // this way the source for one algorithm can be the destination from a previous one
-  in_retouch = dt_alloc_align(64, sizeof(float) * ch * roi_rt->width * roi_rt->height);
+  in_retouch = dt_alloc_align_float((size_t)ch * roi_rt->width * roi_rt->height);
   if(in_retouch == NULL) goto cleanup;
 
   memcpy(in_retouch, ivoid, sizeof(float) * ch * roi_rt->width * roi_rt->height);
@@ -3612,7 +3612,7 @@ cl_int rt_process_stats_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
 
   float *src_buffer = NULL;
 
-  src_buffer = dt_alloc_align(64, sizeof(float) * ch * width * height);
+  src_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(src_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
@@ -3651,7 +3651,7 @@ cl_int rt_adjust_levels_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
 
   float *src_buffer = NULL;
 
-  src_buffer = dt_alloc_align(64, sizeof(float) * ch * width * height);
+  src_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(src_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2937,13 +2937,13 @@ static void rt_build_scaled_mask(float *const mask, dt_iop_roi_t *const roi_mask
   const int x_to = roi_mask_scaled->width + roi_mask_scaled->x;
   const int y_to = roi_mask_scaled->height + roi_mask_scaled->y;
 
-  mask_tmp = dt_alloc_align(64, roi_mask_scaled->width * roi_mask_scaled->height * sizeof(float));
+  mask_tmp = dt_alloc_align(64, sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
   if(mask_tmp == NULL)
   {
     fprintf(stderr, "rt_build_scaled_mask: error allocating memory\n");
     goto cleanup;
   }
-  memset(mask_tmp, 0, roi_mask_scaled->width * roi_mask_scaled->height * sizeof(float));
+  memset(mask_tmp, 0, sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -3151,7 +3151,7 @@ static void retouch_clone(float *const in, dt_iop_roi_t *const roi_in, const int
                           const int use_sse)
 {
   // alloc temp image to avoid issues when areas self-intersects
-  float *img_src = dt_alloc_align(64, roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
+  float *img_src = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_src == NULL)
   {
     fprintf(stderr, "retouch_clone: error allocating memory for cloning\n");
@@ -3179,7 +3179,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
   float *img_dest = NULL;
 
   // alloc temp image to blur
-  img_dest = dt_alloc_align(64, roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
+  img_dest = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_dest == NULL)
   {
     fprintf(stderr, "retouch_blur: error allocating memory for blurring\n");
@@ -3253,8 +3253,8 @@ static void retouch_heal(float *const in, dt_iop_roi_t *const roi_in, const int 
   float *img_dest = NULL;
 
   // alloc temp images for source and destination
-  img_src = dt_alloc_align(64, roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
-  img_dest = dt_alloc_align(64, roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
+  img_src = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
+  img_dest = dt_alloc_align(64, sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if((img_src == NULL) || (img_dest == NULL))
   {
     fprintf(stderr, "retouch_heal: error allocating memory for healing\n");
@@ -3477,10 +3477,10 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 
   // we will do all the clone, heal, etc on the input image,
   // this way the source for one algorithm can be the destination from a previous one
-  in_retouch = dt_alloc_align(64, roi_rt->width * roi_rt->height * ch * sizeof(float));
+  in_retouch = dt_alloc_align(64, sizeof(float) * ch * roi_rt->width * roi_rt->height);
   if(in_retouch == NULL) goto cleanup;
 
-  memcpy(in_retouch, ivoid, roi_rt->width * roi_rt->height * ch * sizeof(float));
+  memcpy(in_retouch, ivoid, sizeof(float) * ch * roi_rt->width * roi_rt->height);
 
   // user data passed from the decompose routine to the one that process each scale
   usr_data.self = self;
@@ -3612,7 +3612,7 @@ cl_int rt_process_stats_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
 
   float *src_buffer = NULL;
 
-  src_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+  src_buffer = dt_alloc_align(64, sizeof(float) * ch * width * height);
   if(src_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
@@ -3630,7 +3630,7 @@ cl_int rt_process_stats_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
   // just call the CPU version for now
   rt_process_stats(self, piece, src_buffer, width, height, ch, levels, 1);
 
-  err = dt_opencl_write_buffer_to_device(devid, src_buffer, dev_img, 0, width * height * ch * sizeof(float), TRUE);
+  err = dt_opencl_write_buffer_to_device(devid, src_buffer, dev_img, 0, sizeof(float) * ch * width * height, TRUE);
   if(err != CL_SUCCESS)
   {
     goto cleanup;
@@ -3651,7 +3651,7 @@ cl_int rt_adjust_levels_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
 
   float *src_buffer = NULL;
 
-  src_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+  src_buffer = dt_alloc_align(64, sizeof(float) * ch * width * height);
   if(src_buffer == NULL)
   {
     fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
@@ -3669,7 +3669,7 @@ cl_int rt_adjust_levels_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
   // just call the CPU version for now
   rt_adjust_levels(self, piece, src_buffer, width, height, ch, levels, 1);
 
-  err = dt_opencl_write_buffer_to_device(devid, src_buffer, dev_img, 0, width * height * ch * sizeof(float), TRUE);
+  err = dt_opencl_write_buffer_to_device(devid, src_buffer, dev_img, 0, sizeof(float) * ch * width * height, TRUE);
   if(err != CL_SUCCESS)
   {
     goto cleanup;
@@ -3739,7 +3739,7 @@ static cl_int rt_build_scaled_mask_cl(const int devid, float *const mask, dt_iop
   }
 
   const cl_mem dev_mask_scaled
-      = dt_opencl_alloc_device_buffer(devid, roi_mask_scaled->width * roi_mask_scaled->height * sizeof(float));
+      = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_mask_scaled == NULL)
   {
     fprintf(stderr, "rt_build_scaled_mask_cl error 2\n");
@@ -3748,7 +3748,7 @@ static cl_int rt_build_scaled_mask_cl(const int devid, float *const mask, dt_iop
   }
 
   err = dt_opencl_write_buffer_to_device(devid, *mask_scaled, dev_mask_scaled, 0,
-                                         roi_mask_scaled->width * roi_mask_scaled->height * sizeof(float), TRUE);
+                                         sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height, TRUE);
   if(err != CL_SUCCESS)
   {
     fprintf(stderr, "rt_build_scaled_mask_cl error 4\n");
@@ -3844,7 +3844,7 @@ static cl_int retouch_clone_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
 
   // alloc source temp image to avoid issues when areas self-intersects
   const cl_mem dev_src = dt_opencl_alloc_device_buffer(devid,
-                                          roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
+                                          sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_src == NULL)
   {
     fprintf(stderr, "retouch_clone_cl error 2\n");
@@ -4024,7 +4024,7 @@ static cl_int retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
 
   cl_mem dev_dest = NULL;
   cl_mem dev_src = dt_opencl_alloc_device_buffer(devid,
-                                          roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
+                                          sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_src == NULL)
   {
     fprintf(stderr, "retouch_heal_cl: error allocating memory for healing\n");
@@ -4033,7 +4033,7 @@ static cl_int retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
   }
 
   dev_dest = dt_opencl_alloc_device_buffer(devid,
-                                           roi_mask_scaled->width * roi_mask_scaled->height * ch * sizeof(float));
+                                           sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_dest == NULL)
   {
     fprintf(stderr, "retouch_heal_cl: error allocating memory for healing\n");
@@ -4311,7 +4311,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   // we will do all the clone, heal, etc on the input image,
   // this way the source for one algorithm can be the destination from a previous one
-  const cl_mem in_retouch = dt_opencl_alloc_device_buffer(devid, roi_rt->width * roi_rt->height * ch * sizeof(float));
+  const cl_mem in_retouch = dt_opencl_alloc_device_buffer(devid, sizeof(float) * ch * roi_rt->width * roi_rt->height);
   if(in_retouch == NULL)
   {
     fprintf(stderr, "process_internal: error allocating memory for wavelet decompose\n");

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1578,7 +1578,7 @@ static void _generate_curve_lut(dt_dev_pixelpipe_t *pipe, dt_iop_rgbcurve_data_t
   {
     for(int ch = 0; ch < DT_IOP_RGBCURVE_MAX_CHANNELS; ch++)
     {
-      memcpy(curve_nodes[ch], d->params.curve_nodes[ch], DT_IOP_RGBCURVE_MAXNODES * sizeof(dt_iop_rgbcurve_node_t));
+      memcpy(curve_nodes[ch], d->params.curve_nodes[ch], sizeof(dt_iop_rgbcurve_node_t) * DT_IOP_RGBCURVE_MAXNODES);
     }
   }
 

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1315,7 +1315,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       dt_pthread_mutex_unlock(&g->lock);
 
       // get the image, this works only in C
-      src_buffer = dt_alloc_align(64, sizeof(float) * ch * width * height);
+      src_buffer = dt_alloc_align_float((size_t)ch * width * height);
       if(src_buffer == NULL)
       {
         fprintf(stderr, "[rgblevels process_cl] error allocating memory for temp table 1\n");

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1315,7 +1315,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       dt_pthread_mutex_unlock(&g->lock);
 
       // get the image, this works only in C
-      src_buffer = dt_alloc_align(64, width * height * ch * sizeof(float));
+      src_buffer = dt_alloc_align(64, sizeof(float) * ch * width * height);
       if(src_buffer == NULL)
       {
         fprintf(stderr, "[rgblevels process_cl] error allocating memory for temp table 1\n");

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -535,7 +535,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     b = NULL; // make sure we don't clean it up twice
   }
 
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   size_t origin[] = { 0, 0, 0 };

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -148,7 +148,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     return TRUE;
   }
 
-  mat = malloc(wd * sizeof(float));
+  mat = malloc(sizeof(float) * wd);
 
   // init gaussian kernel
   float *m = mat + rad;
@@ -187,7 +187,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   size_t sizes[3];
   size_t local[3];
 
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   dev_m = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * wd, mat);

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -294,7 +294,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     return;
   }
 
-  float *const tmp = dt_alloc_align(64, (size_t)sizeof(float) * roi_out->width * roi_out->height);
+  float *const tmp = dt_alloc_align_float((size_t)roi_out->width * roi_out->height);
   if(tmp == NULL)
   {
     fprintf(stderr, "[sharpen] failed to allocate temporary buffer\n");
@@ -304,8 +304,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int wd = 2 * rad + 1;
   const int wd4 = (wd & 3) ? (wd >> 2) + 1 : wd >> 2;
 
-  const size_t mat_size = wd4 * 4 * sizeof(float);
-  float *const mat = dt_alloc_align(64, mat_size);
+  const size_t mat_size = (size_t)4 * wd4;
+  float *const mat = dt_alloc_align_float(mat_size);
   memset(mat, 0, mat_size);
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)
@@ -488,7 +488,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     return;
   }
 
-  float *const tmp = dt_alloc_align(64, (size_t)sizeof(float) * roi_out->width * roi_out->height);
+  float *const tmp = dt_alloc_align_float((size_t)roi_out->width * roi_out->height);
   if(tmp == NULL)
   {
     fprintf(stderr, "[sharpen] failed to allocate temporary buffer\n");
@@ -498,8 +498,8 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int wd = 2 * rad + 1;
   const int wd4 = (wd & 3) ? (wd >> 2) + 1 : wd >> 2;
 
-  const size_t mat_size = wd4 * 4 * sizeof(float);
-  float *const mat = dt_alloc_align(64, mat_size);
+  const size_t mat_size = (size_t)4 * wd4;
+  float *const mat = dt_alloc_align_float(mat_size);
   memset(mat, 0, mat_size);
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -282,7 +282,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int rad = MIN(MAXR, ceilf(data->radius * roi_in->scale / piece->iscale));
   if(rad == 0)
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -290,7 +290,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // avoids handling of all kinds of border cases below
   if(roi_out->width < 2 * rad + 1 || roi_out->height < 2 * rad + 1)
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -476,7 +476,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int rad = MIN(MAXR, ceilf(data->radius * roi_in->scale / piece->iscale));
   if(rad == 0)
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -484,7 +484,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   // avoids handling of all kinds of border cases below
   if(roi_out->width < 2 * rad + 1 || roi_out->height < 2 * rad + 1)
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -288,7 +288,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   size_t sizes[3];
   size_t local[3];
 
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 
   dev_m = dt_opencl_copy_host_to_device_constant(devid, mat_size, mat);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -566,7 +566,7 @@ void _process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
         const int dy = posy - posy_source;
         const int fw = 2 * rad, fh = 2 * rad;
 
-        float *filter = malloc((2 * rad + 1) * sizeof(float));
+        float *filter = malloc(sizeof(float) * (2 * rad + 1));
 
         if(rad > 0)
         {

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -272,7 +272,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *mask = NULL;
   if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(piece->module, mask_id))
   {
-    mask = (float *)dt_alloc_align(64, (size_t)roi_out->width * roi_out->height * sizeof(float));
+    mask = (float *)dt_alloc_align_float((size_t)roi_out->width * roi_out->height);
     memset(mask, 0, sizeof(float) * roi_out->width * roi_out->height);
   }
   else

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -134,7 +134,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   // Apply velvia saturation
   if(strength <= 0.0)
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
   else
   {
 #ifdef _OPENMP
@@ -182,7 +182,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   // Apply velvia saturation
   if(strength <= 0.0)
-    memcpy(out, in, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(out, in, sizeof(float) * ch * roi_out->width * roi_out->height);
   else
   {
 #ifdef _OPENMP

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -877,7 +877,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   gchar *svgdoc = _watermark_get_svgdoc(self, data, &piece->pipe->image);
   if(!svgdoc)
   {
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -892,7 +892,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     fprintf(stderr,"[watermark] Cairo surface error: %s\n",cairo_status_to_string(cairo_surface_status(surface)));
     g_free(image);
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     return;
   }
 
@@ -907,7 +907,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     cairo_surface_destroy(surface);
     g_free(image);
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
     fprintf(stderr, "[watermark] error processing svg file: %s\n", error->message);
     g_error_free(error);
@@ -1022,7 +1022,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     g_object_unref(svg);
     g_free(image);
     g_free(image_two);
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * ch * roi_out->width * roi_out->height);
+    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
     return;
   }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1063,7 +1063,7 @@ static char **split_path(const char *path)
   // there are size + 1 elements in tokens -- the final NULL! we want to ignore it.
   const unsigned int size = g_strv_length(tokens);
 
-  result = malloc(size * sizeof(char *));
+  result = malloc(sizeof(char *) * size);
   for(unsigned int i = 0; i < size; i++)
     result[i] = tokens[i + 1];
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1664,7 +1664,7 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     memcpy(new_params + first_half, &fversion, sizeof(int32_t));
     memcpy(new_params + first_half + sizeof(int32_t), &sversion, sizeof(int32_t));
     // copy the rest of the old params over
-    memcpy(new_params + first_half + 2 * sizeof(int32_t), buf, old_params_size - first_half);
+    memcpy(new_params + first_half + sizeof(int32_t) * 2, buf, old_params_size - first_half);
 
     *new_size = new_params_size;
     *new_version = 2;
@@ -1676,8 +1676,8 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     size_t new_params_size = old_params_size + sizeof(int32_t);
     void *new_params = calloc(1, new_params_size);
 
-    memcpy(new_params, old_params, 2 * sizeof(int32_t));
-    memcpy(new_params + 3 * sizeof(int32_t), old_params + 2 * sizeof(int32_t), old_params_size - 2 * sizeof(int32_t));
+    memcpy(new_params, old_params, sizeof(int32_t) * 2);
+    memcpy(new_params + sizeof(int32_t) * 3, old_params + sizeof(int32_t) * 2, old_params_size - sizeof(int32_t) * 2);
 
     *new_size = new_params_size;
     *new_version = 3;
@@ -1723,7 +1723,7 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
 
     void *new_params = calloc(1, new_params_size);
     size_t pos = 0;
-    memcpy(new_params, old_params, 4 * sizeof(int32_t));
+    memcpy(new_params, old_params, sizeof(int32_t) * 4);
     pos += 4 * sizeof(int32_t);
     memcpy(new_params + pos, &icctype, sizeof(int32_t));
     pos += sizeof(int32_t);
@@ -1753,9 +1753,9 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     void *new_params = calloc(1, new_params_size);
 
     size_t pos = 0;
-    memcpy(new_params, old_params, 3 * sizeof(int32_t));
+    memcpy(new_params, old_params, sizeof(int32_t) * 3);
     pos += 4 * sizeof(int32_t);
-    memcpy(new_params + pos, old_params + pos - sizeof(int32_t), old_params_size - 3 * sizeof(int32_t));
+    memcpy(new_params + pos, old_params + pos - sizeof(int32_t), old_params_size - sizeof(int32_t) * 3);
 
     *new_size = new_params_size;
     *new_version = 5;
@@ -1781,11 +1781,11 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     size_t new_params_size = old_params_size + flags_size;
     void *new_params = calloc(1, new_params_size);
     size_t pos = 0;
-    memcpy(new_params, old_params, 6 * sizeof(int32_t));
+    memcpy(new_params, old_params, sizeof(int32_t) * 6);
     pos += 6 * sizeof(int32_t);
     memcpy(new_params + pos, flags, flags_size);
     pos += flags_size;
-    memcpy(new_params + pos, old_params + pos - flags_size, old_params_size - 6 * sizeof(int32_t));
+    memcpy(new_params + pos, old_params + pos - flags_size, old_params_size - sizeof(int32_t) * 6);
 
     g_free(flags);
     *new_size = new_params_size;
@@ -1807,9 +1807,9 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     void *new_params = calloc(1, new_params_size);
 
     size_t pos = 0;
-    memcpy(new_params, old_params, 4 * sizeof(int32_t));
+    memcpy(new_params, old_params, sizeof(int32_t) * 4);
     pos += 5 * sizeof(int32_t);
-    memcpy(new_params + pos, old_params + pos - sizeof(int32_t), old_params_size - 4 * sizeof(int32_t));
+    memcpy(new_params + pos, old_params + pos - sizeof(int32_t), old_params_size - sizeof(int32_t) * 4);
 
     *new_size = new_params_size;
     *new_version = 7;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -703,7 +703,7 @@ static GList *_lib_geotagging_get_timezones(void)
                        NULL,
                        NULL) == ERROR_SUCCESS)
     {
-      wchar_t *subkeyname = (wchar_t *)malloc((max_subkey_len + 1) * sizeof(wchar_t));
+      wchar_t *subkeyname = (wchar_t *)malloc(sizeof(wchar_t) * (max_subkey_len + 1));
 
       for(DWORD i = 1; i < n_subkeys; i++)
       {

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -280,7 +280,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     {
       const dt_iop_order_iccprofile_info_t *const profile_info_to =
         dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
-      img_display = dt_alloc_align(64, width * height * 4 * sizeof(float));
+      img_display = dt_alloc_align(64, sizeof(float) * 4 * width * height);
       if(!img_display) return;
       dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,
                                               profile_info_to, "final histogram");

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -280,7 +280,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     {
       const dt_iop_order_iccprofile_info_t *const profile_info_to =
         dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
-      img_display = dt_alloc_align(64, sizeof(float) * 4 * width * height);
+      img_display = dt_alloc_align_float((size_t)4 * width * height);
       if(!img_display) return;
       dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,
                                               profile_info_to, "final histogram");
@@ -1235,10 +1235,10 @@ void gui_init(dt_lib_module_t *self)
   // be scaled. 175 rows is reasonable CPU usage and represents plenty
   // of tonal gradation. 256 would match the # of bins in a regular
   // histogram.
-  d->waveform_height = 175;
-  d->waveform_linear = dt_alloc_align(64, sizeof(float) * d->waveform_height * d->waveform_max_width * 4);
-  d->waveform_display = dt_alloc_align(64, sizeof(float) * d->waveform_height * d->waveform_max_width * 4);
-  d->waveform_8bit = dt_alloc_align(64, sizeof(uint8_t) * d->waveform_height * d->waveform_max_width * 4);
+  d->waveform_height  = 175;
+  d->waveform_linear  = dt_alloc_align_float((size_t)4 * d->waveform_height * d->waveform_max_width);
+  d->waveform_display = dt_alloc_align_float((size_t)4 * d->waveform_height * d->waveform_max_width);
+  d->waveform_8bit    = dt_alloc_align(64, sizeof(uint8_t) * 4 * d->waveform_height * d->waveform_max_width);
 
   // proxy functions and data so that pixelpipe or tether can
   // provide data for a histogram

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -942,7 +942,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
         const float oboost = exp2f(old_blend->blendif_boost_factors[ch]);
         const float nboost = exp2f(hitem->blend_params->blendif_boost_factors[ch]);
 
-        if((oactive || nactive) && (memcmp(of, nf, 4 * sizeof(float)) || opolarity != npolarity))
+        if((oactive || nactive) && (memcmp(of, nf, sizeof(float) * 4) || opolarity != npolarity))
         {
           if(first)
           {

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -152,7 +152,7 @@ static int write_image(dt_imageio_module_data_t *data, const char *filename, con
 {
   dt_print_format_t *d = (dt_print_format_t *)data;
 
-  d->params->buf = (uint16_t *)malloc(d->head.width * d->head.height * 3 * (d->bpp == 8?1:2));
+  d->params->buf = (uint16_t *)malloc((size_t)3 * (d->bpp == 8?1:2) * d->head.width * d->head.height);
 
   if (d->bpp == 8)
   {

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -204,7 +204,7 @@ static int load_from_lua(lua_State *L)
   int argc = lua_gettop(L);
 
   char **argv = calloc(argc + 1, sizeof(char *));
-  char **argv_copy = malloc((argc + 1) * sizeof(char *));
+  char **argv_copy = malloc(sizeof(char *) * (argc + 1));
   argv[0] = strdup("lua");
   argv_copy[0] = argv[0];
   for(int i = 1; i < argc; i++)

--- a/src/tests/unittests/util/testimg.c
+++ b/src/tests/unittests/util/testimg.c
@@ -33,7 +33,7 @@ Testimg *testimg_alloc(const int width, const int height)
   Testimg *ti = calloc(sizeof(Testimg), 1);
   ti->width = width;
   ti->height = height;
-  ti->pixels = calloc(width * height * 4, sizeof(float));
+  ti->pixels = calloc((size_t)4 * width * height, sizeof(float));
   ti->name = "";
   return ti;
 }

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -438,7 +438,7 @@ void init(dt_view_t *self)
     d->bunker_buf[i] = (uint8_t *)g_list_last(d->bufs)->data;
   }
   // font
-  d->letters = (cairo_pattern_t **)malloc(n_letters * sizeof(cairo_pattern_t *));
+  d->letters = (cairo_pattern_t **)malloc(sizeof(cairo_pattern_t *) * n_letters);
   for(int i = 0; i < n_letters; i++)
     d->letters[i]
         = _new_sprite(font[i], FONT_WIDTH, FONT_HEIGHT, NULL, &(d->bufs), &(d->surfaces), &(d->patterns));

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -350,7 +350,7 @@ static inline cairo_pattern_t *_new_sprite(const uint8_t *data, const int width,
 {
   const int32_t stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, width);
   uint8_t *buf = (uint8_t *)malloc(stride * height);
-  for(int y = 0; y < height; y++) memcpy(&buf[y * stride], &(data[y * width]), width * sizeof(uint8_t));
+  for(int y = 0; y < height; y++) memcpy(&buf[y * stride], &(data[y * width]), sizeof(uint8_t) * width);
   cairo_surface_t *surface = cairo_image_surface_create_for_data(buf, CAIRO_FORMAT_A8, width, height, stride);
   cairo_pattern_t *pattern = cairo_pattern_create_for_surface(surface);
   cairo_pattern_set_filter(pattern, CAIRO_FILTER_NEAREST);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2283,10 +2283,10 @@ static void _view_map_dnd_get_callback(GtkWidget *widget, GdkDragContext *contex
         if(lib->selected_images)
         {
           // drag & drop of images
-          const int imgs_nb = g_list_length(lib->selected_images);
+          const guint imgs_nb = g_list_length(lib->selected_images);
           if(imgs_nb)
           {
-            uint32_t *imgs = malloc(imgs_nb * sizeof(uint32_t));
+            uint32_t *imgs = malloc(sizeof(uint32_t) * imgs_nb);
             GList *l = lib->selected_images;
             for(int i = 0; i < imgs_nb; i++)
             {

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -271,7 +271,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
       }
 
       // process live view histogram
-      float *const tmp_f = dt_alloc_align(64, sizeof(float) * pw * ph * 4);
+      float *const tmp_f = dt_alloc_align_float((size_t)4 * pw * ph);
       if(tmp_f)
       {
         dt_develop_t *dev = darktable.develop;

--- a/tools/basecurve/darktable-curve-tool.c
+++ b/tools/basecurve/darktable-curve-tool.c
@@ -832,7 +832,7 @@ main(int argc, char** argv)
     }
   }
 
-  raw_buff_f = calloc(1, 3*raw_width*raw_height*sizeof(float));
+  raw_buff_f = calloc(1, sizeof(float)*3*raw_width*raw_height);
   if (!raw_buff_f) {
     fprintf(stderr, "error: failed allocating raw file float buffer\n");
     goto exit;
@@ -845,7 +845,7 @@ main(int argc, char** argv)
   free(raw_buff);
   raw_buff = NULL;
 
-  jpeg_buff_f = calloc(1, 3*jpeg_width*jpeg_height*sizeof(float));
+  jpeg_buff_f = calloc(1, sizeof(float)*3*jpeg_width*jpeg_height);
   if (!jpeg_buff_f) {
     fprintf(stderr, "error: failed allocating JPEG file float buffer\n");
     goto exit;

--- a/tools/basecurve/darktable-curve-tool.c
+++ b/tools/basecurve/darktable-curve-tool.c
@@ -662,22 +662,22 @@ read_curveset(
   float* curve,
   uint32_t* hist)
 {
-  int r = fread(curve, 1, 3*CURVE_RESOLUTION*sizeof(float), f);
-  if (r != 3*CURVE_RESOLUTION*sizeof(float))
+  size_t r = fread(curve, 1, sizeof(float) * 3 * CURVE_RESOLUTION, f);
+  if (r != sizeof(float) * 3 * CURVE_RESOLUTION)
   {
     /* could not read save state, either missing stats in that save file or
      * corrupt data. both cases need to clean state */
-    memset(curve, 0, 3*CURVE_RESOLUTION*sizeof(float));
+    memset(curve, 0, sizeof(float) * 3 * CURVE_RESOLUTION);
   }
   else
   {
-    r = fread(hist, 1, 3*CURVE_RESOLUTION*sizeof(uint32_t), f);
-    if (r != 3*CURVE_RESOLUTION*sizeof(uint32_t))
+    r = fread(hist, 1, sizeof(uint32_t) * 3 * CURVE_RESOLUTION, f);
+    if (r != sizeof(uint32_t) * 3 * CURVE_RESOLUTION)
     {
       /* could not read save state, either missing stats in that save file or
        * corrupt data. both cases need to clean state */
-      memset(curve, 0, 3*CURVE_RESOLUTION*sizeof(float));
-      memset(hist, 0, 3*CURVE_RESOLUTION*sizeof(uint32_t));
+      memset(curve, 0, sizeof(float) * 3 * CURVE_RESOLUTION);
+      memset(hist, 0, sizeof(uint32_t) * 3 * CURVE_RESOLUTION);
     }
   }
 }

--- a/tools/basecurve/darktable-curve-tool.c
+++ b/tools/basecurve/darktable-curve-tool.c
@@ -765,7 +765,7 @@ main(int argc, char** argv)
     opt.num_nodes = 20;
   }
 
-  curve = calloc(1, CURVE_RESOLUTION*sizeof(float)*6);
+  curve = calloc(1, sizeof(float) * 6 * CURVE_RESOLUTION);
   if (!curve) {
     fprintf(stderr, "error: failed allocating curve\n");
     ret = -1;
@@ -774,7 +774,7 @@ main(int argc, char** argv)
   curve_base = curve;
   curve_tone = curve + 3*CURVE_RESOLUTION;
 
-  hist = calloc(1, CURVE_RESOLUTION*sizeof(uint32_t)*6);
+  hist = calloc(1, sizeof(uint32_t) * 6 * CURVE_RESOLUTION);
   if (!hist) {
     fprintf(stderr, "error: failed allocating histogram\n");
     ret = -1;

--- a/tools/noise/noiseprofile.c
+++ b/tools/noise/noiseprofile.c
@@ -82,7 +82,7 @@ read_histogram(const char *filename, int *bins)
   }
   fseek(f, 0, SEEK_SET);
   // second round, alloc and read
-  float *hist = (float *)malloc(3*sizeof(float)*(*bins));
+  float *hist = (float *)malloc(sizeof(float) * 3 * (*bins));
   int k=0;
   while(!feof(f))
   {
@@ -202,7 +202,7 @@ int main(int argc, char *arg[])
   {
     int bins = 0;
     float *hist = read_histogram(arg[3], &bins);
-    float *inv_hist = (float *)malloc(3*sizeof(float)*bins);
+    float *inv_hist = (float *)malloc(sizeof(float) * 3 * bins);
     invert_histogram(hist, inv_hist, bins);
 #if 1
     // output curves and their inverse:


### PR DESCRIPTION
This is 2-parter:

1. fixes incorrect assumption about data size, now forces calculation using platform dependent size_t

Fixes #3298

2. in many places in code we've had things like `malloc(3*width*height*sizeof(float))` which would turn whole operation into signed int based, causing wraparound effect for large enough width & height.

this changeset should allow for processing of gigantic images on 64-bit systems (over 135 MPix) where otherwise mem allocations could fail due to size calculation wrapping around.

for reference see #3298

There still might be places where allocations are wrongly calculated. This might be a suggestion for future reference ;)

//EDIT:

Might be linked to #2607 problems...