### PR TITLE
cleanup: avoid float->double->float by using float version of math functions

### DIFF
--- a/src/common/curve_tools.c
+++ b/src/common/curve_tools.c
@@ -438,7 +438,7 @@ float *monotone_hermite_set(int n, float x[], float y[])
   }
   for(i = 0; i < n; i++)
   {
-    if(fabs(delta[i]) < EPSILON)
+    if(fabsf(delta[i]) < EPSILON)
     {
       m[i] = 0.0f;
       m[i + 1] = 0.0f;

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -37,8 +37,8 @@ static void compute_gauss_params(const float sigma, dt_gaussian_order_t order, f
                                  float *a2, float *a3, float *b1, float *b2, float *coefp, float *coefn)
 {
   const float alpha = 1.695f / sigma;
-  const float ema = exp(-alpha);
-  const float ema2 = exp(-2.0f * alpha);
+  const float ema = expf(-alpha);
+  const float ema2 = expf(-2.0f * alpha);
   *b1 = -2.0f * ema;
   *b2 = ema2;
   *a0 = 0.0f;

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -475,7 +475,7 @@ gchar *dt_util_latitude_str(float latitude)
 
   if(latitude < 0)
   {
-    latitude = fabs(latitude);
+    latitude = fabsf(latitude);
     c = OSD_COORDINATES_CHR_S;
   }
 
@@ -493,7 +493,7 @@ gchar *dt_util_longitude_str(float longitude)
 
   if(longitude < 0)
   {
-    longitude = fabs(longitude);
+    longitude = fabsf(longitude);
     c = OSD_COORDINATES_CHR_W;
   }
 
@@ -510,7 +510,7 @@ gchar *dt_util_elevation_str(float elevation)
 
   if(elevation < 0)
   {
-    elevation = fabs(elevation);
+    elevation = fabsf(elevation);
     c = OSD_ELEVATION_BSL;
   }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -392,7 +392,7 @@ static inline int _blendif_print_digits_default(float value)
 static inline int _blendif_print_digits_ab(float value)
 {
   int digits;
-  if(fabs(value) < 10.0f) digits = 1;
+  if(fabsf(value) < 10.0f) digits = 1;
   else digits = 0;
 
   return digits;

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -121,7 +121,7 @@ static inline void dt_iop_estimate_exp(const float *const x, const float *const 
   // map every thing to y = y0*(x/x0)^g
   // and fix (x0,y0) as the last point.
   // assume (x,y) pairs are ordered by ascending x, so this is the last point:
-  float x0 = x[num - 1], y0 = y[num - 1];
+  const float x0 = x[num - 1], y0 = y[num - 1];
 
   float g = 0.0f;
   int cnt = 0;
@@ -134,7 +134,7 @@ static inline void dt_iop_estimate_exp(const float *const x, const float *const 
     const float yy = y[k] / y0, xx = x[k] / x0;
     if(yy > 0.0f && xx > 0.0f)
     {
-      const float gg = logf(y[k] / y0) / log(x[k] / x0);
+      const float gg = logf(y[k] / y0) / logf(x[k] / x0);
       g += gg;
       cnt++;
     }

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -688,7 +688,7 @@ static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, co
     }
 
     // 1st. special case: render abrupt transitions between different opacity and/or hardness values
-    if((fabs(p1[5] - p2[5]) > 0.05f || fabs(p1[6] - p2[6]) > 0.05f) || (start_stamp && n == 2 * nb - 1))
+    if((fabsf(p1[5] - p2[5]) > 0.05f || fabsf(p1[6] - p2[6]) > 0.05f) || (start_stamp && n == 2 * nb - 1))
     {
       if(n == 0)
       {
@@ -714,7 +714,7 @@ static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, co
     }
 
     // 2nd. special case: render transition point between different brush sizes
-    if(fabs(p1[4] - p2[4]) > 0.0001f && n > 0)
+    if(fabsf(p1[4] - p2[4]) > 0.0001f && n > 0)
     {
       if(dborder)
       {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -331,8 +331,8 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
                                              gboolean clockwise)
 {
   // we want to find the start and end angles
-  float a1 = atan2(bmin[1] - cmax[1], bmin[0] - cmax[0]);
-  float a2 = atan2(bmax[1] - cmax[1], bmax[0] - cmax[0]);
+  float a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
+  float a2 = atan2f(bmax[1] - cmax[1], bmax[0] - cmax[0]);
 
   if(a1 == a2) return;
 
@@ -380,8 +380,8 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
                                                    dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder)
 {
   // we want to find the start and end angles
-  float a1 = fmodf(atan2(bmin[1] - cmax[1], bmin[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
-  float a2 = fmodf(atan2(bmax[1] - cmax[1], bmax[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
+  float a1 = fmodf(atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
+  float a2 = fmodf(atan2f(bmax[1] - cmax[1], bmax[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
 
   if(a1 == a2) return;
 
@@ -419,7 +419,7 @@ static void _brush_points_stamp(float *cmax, float *bmin, dt_masks_dynbuf_t *dpo
                                 gboolean clockwise)
 {
   // we want to find the start angle
-  float a1 = atan2(bmin[1] - cmax[1], bmin[0] - cmax[0]);
+  float a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
 
   // we determine the radius too
   float rad = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -662,7 +662,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
     if(cdx != 0.0 && cdy != 0.0)
     {
       cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-      float cangle = atan(cdx / cdy);
+      float cangle = atanf(cdx / cdy);
 
       if(cdy > 0)
         cangle = (M_PI / 2) - cangle;
@@ -671,18 +671,18 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
 
       // (arrowx,arrowy) is the point of intersection, we move it (factor 1.11) a bit farther than the
       // inner circle to avoid superposition.
-      const float arrowx = gpt->points[0] + 1.11 * radius * cos(cangle) + dx;
-      const float arrowy = gpt->points[1] + 1.11 * radius * sin(cangle) + dy;
+      const float arrowx = gpt->points[0] + 1.11 * radius * cosf(cangle) + dx;
+      const float arrowy = gpt->points[1] + 1.11 * radius * sinf(cangle) + dy;
 
       cairo_move_to(cr, gpt->source[0] + dxs, gpt->source[1] + dys); // source center
       cairo_line_to(cr, arrowx, arrowy);                             // dest border
       // then draw to line for the arrow itself
-      const float arrow_scale = 6.0 * pr_d;
-      cairo_move_to(cr, arrowx + arrow_scale * cos(cangle + (0.4)),
-                    arrowy + arrow_scale * sin(cangle + (0.4)));
+      const float arrow_scale = 6.0f * pr_d;
+      cairo_move_to(cr, arrowx + arrow_scale * cosf(cangle + (0.4f)),
+                    arrowy + arrow_scale * sinf(cangle + (0.4f)));
       cairo_line_to(cr, arrowx, arrowy);
-      cairo_line_to(cr, arrowx + arrow_scale * cos(cangle - (0.4)),
-                    arrowy + arrow_scale * sin(cangle - (0.4)));
+      cairo_line_to(cr, arrowx + arrow_scale * cosf(cangle - (0.4f)),
+                    arrowy + arrow_scale * sinf(cangle - (0.4f)));
 
       cairo_set_dash(cr, dashed, 0, 0);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
@@ -998,8 +998,8 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
   for(int n = 0; n < circpts / 8; n++)
   {
     const float phi = (2.0f * M_PI * n) / circpts;
-    const float x = total * cos(phi);
-    const float y = total * sin(phi);
+    const float x = total * cosf(phi);
+    const float y = total * sinf(phi);
     const float cx = center[0];
     const float cy = center[1];
     const int index_x = 2 * n * 8;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -183,9 +183,9 @@ static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selecte
 {
   if(points_count <= 10) return;
 
-  const float r = atan2(points[3] - points[1], points[2] - points[0]);
-  const float sinr = sin(r);
-  const float cosr = cos(r);
+  const float r = atan2f(points[3] - points[1], points[2] - points[0]);
+  const float sinr = sinf(r);
+  const float cosr = cosf(r);
 
   float x = 0.0f;
   float y = 0.0f;
@@ -225,9 +225,9 @@ static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len,
 {
   if(border_count <= 10) return;
 
-  const float r = atan2(border[3] - border[1], border[2] - border[0]);
-  const float sinr = sin(r);
-  const float cosr = cos(r);
+  const float r = atan2f(border[3] - border[1], border[2] - border[0]);
+  const float sinr = sinf(r);
+  const float cosr = cosf(r);
 
   float x = 0.0f;
   float y = 0.0f;
@@ -309,15 +309,15 @@ static int dt_ellipse_get_points(dt_develop_t *dev, float xx, float yy, float ra
   const float x = (*points)[0] = xx * wd;
   const float y = (*points)[1] = yy * ht;
 
-  (*points)[2] = x + a * cos(v);
-  (*points)[3] = y + a * sin(v);
-  (*points)[4] = x - a * cos(v);
-  (*points)[5] = y - a * sin(v);
+  (*points)[2] = x + a * cosf(v);
+  (*points)[3] = y + a * sinf(v);
+  (*points)[4] = x - a * cosf(v);
+  (*points)[5] = y - a * sinf(v);
 
-  (*points)[6] = x + b * cos(v - M_PI / 2.0f);
-  (*points)[7] = y + b * sin(v - M_PI / 2.0f);
-  (*points)[8] = x - b * cos(v - M_PI / 2.0f);
-  (*points)[9] = y - b * sin(v - M_PI / 2.0f);
+  (*points)[6] = x + b * cosf(v - M_PI / 2.0f);
+  (*points)[7] = y + b * sinf(v - M_PI / 2.0f);
+  (*points)[8] = x - b * cosf(v - M_PI / 2.0f);
+  (*points)[9] = y - b * sinf(v - M_PI / 2.0f);
 
 
   for(int i = 5; i < l + 5; i++)
@@ -865,7 +865,7 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 4);
 
-    const float dv = atan2(pts[3] - pts[1], pts[2] - pts[0]) - atan2(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
 
     ellipse->rotation += dv / M_PI * 180.0f;
     ellipse->rotation = fmodf(ellipse->rotation, 360.0f);
@@ -1172,9 +1172,9 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
 
   if(!gpt) return;
 
-  const float r = atan2(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
-  const float sinr = sin(r);
-  const float cosr = cos(r);
+  const float r = atan2f(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
+  const float sinr = sinf(r);
+  const float cosr = cosf(r);
 
   xref = gpt->points[0];
   yref = gpt->points[1];
@@ -1197,9 +1197,9 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
   }
   else if((gui->group_selected == index) && gui->form_rotating)
   {
-    const float v = atan2(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
-    sinv = sin(v);
-    cosv = cos(v);
+    const float v = atan2f(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
+    sinv = sinf(v);
+    cosv = cosf(v);
   }
   else if((gui->group_selected == index) && (gui->point_dragging >= 1))
   {
@@ -1284,7 +1284,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
     if(cdx != 0.0 && cdy != 0.0)
     {
       cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-      float cangle = atan(cdx / cdy);
+      float cangle = atanf(cdx / cdy);
 
       if(cdy > 0)
         cangle = (M_PI / 2) - cangle;
@@ -1317,8 +1317,8 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       // is not recorded anywhere. Let's use a stupid search to find the closest
       // point on the border where to attach the arrow.
 
-      const float cosc = cos(cangle);
-      const float sinc = sin(cangle);
+      const float cosc = cosf(cangle);
+      const float sinc = sinf(cangle);
       const float step = r / 259.f;
 
       float dist = FLT_MAX;
@@ -1354,11 +1354,11 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       // then draw to line for the arrow itself
       const float arrow_scale = 6.0 * pr_d;
 
-      cairo_move_to(cr, arrowx + arrow_scale * cos(cangle + (0.4)),
-                    arrowy + arrow_scale * sin(cangle + (0.4)));
+      cairo_move_to(cr, arrowx + arrow_scale * cosf(cangle + (0.4)),
+                    arrowy + arrow_scale * sinf(cangle + (0.4)));
       cairo_line_to(cr, arrowx, arrowy);
-      cairo_line_to(cr, arrowx + arrow_scale * cos(cangle - (0.4)),
-                    arrowy + arrow_scale * sin(cangle - (0.4)));
+      cairo_line_to(cr, arrowx + arrow_scale * cosf(cangle - (0.4)),
+                    arrowy + arrow_scale * sinf(cangle - (0.4)));
 
       cairo_set_dash(cr, dashed, 0, 0);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
@@ -1447,15 +1447,15 @@ static int dt_ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_
   const float x = points[0] = ellipse->center[0] * wd;
   const float y = points[1] = ellipse->center[1] * ht;
 
-  points[2] = x + a * cos(v);
-  points[3] = y + a * sin(v);
-  points[4] = x - a * cos(v);
-  points[5] = y - a * sin(v);
+  points[2] = x + a * cosf(v);
+  points[3] = y + a * sinf(v);
+  points[4] = x - a * cosf(v);
+  points[5] = y - a * sinf(v);
 
-  points[6] = x + b * cos(v - M_PI / 2.0f);
-  points[7] = y + b * sin(v - M_PI / 2.0f);
-  points[8] = x - b * cos(v - M_PI / 2.0f);
-  points[9] = y - b * sin(v - M_PI / 2.0f);
+  points[6] = x + b * cosf(v - M_PI / 2.0f);
+  points[7] = y + b * sinf(v - M_PI / 2.0f);
+  points[8] = x - b * cosf(v - M_PI / 2.0f);
+  points[9] = y - b * sinf(v - M_PI / 2.0f);
 
   for(int i = 1; i < l + 5; i++)
   {
@@ -1533,15 +1533,15 @@ static int dt_ellipse_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
   const float x = points[0] = ellipse->center[0] * wd;
   const float y = points[1] = ellipse->center[1] * ht;
 
-  points[2] = x + a * cos(v);
-  points[3] = y + a * sin(v);
-  points[4] = x - a * cos(v);
-  points[5] = y - a * sin(v);
+  points[2] = x + a * cosf(v);
+  points[3] = y + a * sinf(v);
+  points[4] = x - a * cosf(v);
+  points[5] = y - a * sinf(v);
 
-  points[6] = x + b * cos(v - M_PI / 2.0f);
-  points[7] = y + b * sin(v - M_PI / 2.0f);
-  points[8] = x - b * cos(v - M_PI / 2.0f);
-  points[9] = y - b * sin(v - M_PI / 2.0f);
+  points[6] = x + b * cosf(v - M_PI / 2.0f);
+  points[7] = y + b * sinf(v - M_PI / 2.0f);
+  points[8] = x - b * cosf(v - M_PI / 2.0f);
+  points[9] = y - b * sinf(v - M_PI / 2.0f);
 
   for(int i = 5; i < l + 5; i++)
   {
@@ -1662,9 +1662,9 @@ static int dt_ellipse_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
     {
       float x = points[(i * w + j) * 2] - center[0];
       float y = points[(i * w + j) * 2 + 1] - center[1];
-      float v = atan2(y, x) - alpha;
-      float cosv = cos(v);
-      float sinv = sin(v);
+      float v = atan2f(y, x) - alpha;
+      float cosv = cosf(v);
+      float sinv = sinf(v);
       float radius2 = a * a * b * b / (a * a * sinv * sinv + b * b * cosv * cosv);
       float total2 = ta * ta * tb * tb / (ta * ta * sinv * sinv + tb * tb * cosv * cosv);
       float l2 = x * x + y * y;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -282,8 +282,7 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 4);
 
-    const float dv = atan2(pts[3] - pts[1], pts[2] - pts[0])
-      - atan2(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
 
     gradient->rotation -= dv / M_PI * 180.0f;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
@@ -371,16 +370,16 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     gradient->anchor[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
 
-    float rotation = atan2(pts[3] - pts[1], pts[2] - pts[0]);
+    float rotation = atan2f(pts[3] - pts[1], pts[2] - pts[0]);
     // If the transform has flipped the image about one axis, then the
     // 'handedness' of the coordinate system is changed. In this case the
     // rotation angle must be offset by 180 degrees so that the gradient points
     // in the correct direction as dragged. We test for this by checking the
     // angle between two vectors that should be 90 degrees apart. If the angle
     // is -90 degrees, then the image is flipped.
-    float check_angle = atan2(pts[7] - pts[1], pts[6] - pts[0]) - atan2(pts[5] - pts[1], pts[4] - pts[0]);
+    float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2(pts[5] - pts[1], pts[4] - pts[0]);
     // Normalize to the range -180 to 180 degrees
-    check_angle = atan2(sin(check_angle), cos(check_angle));
+    check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if (check_angle < 0)
       rotation -= M_PI;
 
@@ -609,17 +608,17 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     // draw arrow on the end of the gradient to clearly display the direction
 
     // size & width of the arrow
-    const float arrow_angle = 0.25;
-    const float arrow_length = 15.0 / zoom_scale;
+    const float arrow_angle = 0.25f;
+    const float arrow_length = 15.0f / zoom_scale;
 
     const float a_dx = anchor_x - pivot_end_x;
     const float a_dy = pivot_end_y - anchor_y;
-    const float angle = atan2(a_dx, a_dy) - M_PI / 2.0;
+    const float angle = atan2f(a_dx, a_dy) - M_PI / 2.0f;
 
-    const float arrow_x1 = pivot_end_x + (arrow_length * cos(angle + arrow_angle));
-    const float arrow_x2 = pivot_end_x + (arrow_length * cos(angle - arrow_angle));
-    const float arrow_y1 = pivot_end_y + (arrow_length * sin(angle + arrow_angle));
-    const float arrow_y2 = pivot_end_y + (arrow_length * sin(angle - arrow_angle));
+    const float arrow_x1 = pivot_end_x + (arrow_length * cosf(angle + arrow_angle));
+    const float arrow_x2 = pivot_end_x + (arrow_length * cosf(angle - arrow_angle));
+    const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
+    const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
 
     dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_move_to(cr, pivot_end_x, pivot_end_y);
@@ -670,9 +669,9 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
   }
   else if((gui->group_selected == index) && gui->form_rotating)
   {
-    const float v = atan2(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
-    sinv = sin(v);
-    cosv = cos(v);
+    const float v = atan2f(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
+    sinv = sinf(v);
+    cosv = cosf(v);
   }
 
   // draw line
@@ -845,17 +844,17 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     // draw arrow on the end of the gradient to clearly display the direction
 
     // size & width of the arrow
-    const float arrow_angle = 0.25;
-    const float arrow_length = 15.0 / zoom_scale;
+    const float arrow_angle = 0.25f;
+    const float arrow_length = 15.0f / zoom_scale;
 
     const float a_dx = anchor_x - pivot_end_x;
     const float a_dy = pivot_end_y - anchor_y;
-    const float angle = atan2(a_dx, a_dy) - M_PI/2.0;
+    const float angle = atan2f(a_dx, a_dy) - M_PI/2.0f;
 
-    const float arrow_x1 = pivot_end_x + (arrow_length * cos(angle + arrow_angle));
-    const float arrow_x2 = pivot_end_x + (arrow_length * cos(angle - arrow_angle));
-    const float arrow_y1 = pivot_end_y + (arrow_length * sin(angle + arrow_angle));
-    const float arrow_y2 = pivot_end_y + (arrow_length * sin(angle - arrow_angle));
+    const float arrow_x1 = pivot_end_x + (arrow_length * cosf(angle + arrow_angle));
+    const float arrow_x2 = pivot_end_x + (arrow_length * cosf(angle - arrow_angle));
+    const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
+    const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
 
     dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_move_to(cr, pivot_end_x, pivot_end_y);
@@ -881,8 +880,8 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
   const float distance = 0.1f * fminf(wd, ht);
 
   const float v = (-rotation / 180.0f) * M_PI;
-  const float cosv = cos(v);
-  const float sinv = sin(v);
+  const float cosv = cosf(v);
+  const float sinv = sinf(v);
 
   const int count = sqrtf(wd * wd + ht * ht) + 3;
   *points = dt_alloc_align(64, 2 * count * sizeof(float));
@@ -896,13 +895,13 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
 
   // we set the pivot points
   const float v1 = (-(rotation - 90.0f) / 180.0f) * M_PI;
-  const float x1 = x * wd + distance * cos(v1);
-  const float y1 = y * ht + distance * sin(v1);
+  const float x1 = x * wd + distance * cosf(v1);
+  const float y1 = y * ht + distance * sinf(v1);
   (*points)[2] = x1;
   (*points)[3] = y1;
   const float v2 = (-(rotation + 90.0f) / 180.0f) * M_PI;
-  const float x2 = x * wd + distance * cos(v2);
-  const float y2 = y * ht + distance * sin(v2);
+  const float x2 = x * wd + distance * cosf(v2);
+  const float y2 = y * ht + distance * sinf(v2);
   (*points)[4] = x2;
   (*points)[5] = y2;
 
@@ -964,15 +963,15 @@ static int dt_gradient_get_points_border(dt_develop_t *dev, float x, float y, fl
 
   const float v1 = (-(rotation - 90.0f) / 180.0f) * M_PI;
 
-  const float x1 = (x * wd + distance * scale * cos(v1)) / wd;
-  const float y1 = (y * ht + distance * scale * sin(v1)) / ht;
+  const float x1 = (x * wd + distance * scale * cosf(v1)) / wd;
+  const float y1 = (y * ht + distance * scale * sinf(v1)) / ht;
 
   const int r1 = dt_gradient_get_points(dev, x1, y1, rotation, curvature, &points1, &points_count1);
 
   const float v2 = (-(rotation + 90.0f) / 180.0f) * M_PI;
 
-  const float x2 = (x * wd + distance * scale * cos(v2)) / wd;
-  const float y2 = (y * ht + distance * scale * sin(v2)) / ht;
+  const float x2 = (x * wd + distance * scale * cosf(v2)) / wd;
+  const float y2 = (y * ht + distance * scale * sinf(v2)) / ht;
 
   const int r2 = dt_gradient_get_points(dev, x2, y2, rotation, curvature, &points2, &points_count2);
 
@@ -1146,8 +1145,8 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   const float hwscale = 1.0f / sqrtf(wd * wd + ht * ht);
   const float ihwscale = 1.0f / hwscale;
   const float v = (-gradient->rotation / 180.0f) * M_PI;
-  const float sinv = sin(v);
-  const float cosv = cos(v);
+  const float sinv = sinf(v);
+  const float cosv = cosf(v);
   const float xoffset = cosv * gradient->anchor[0] * wd + sinv * gradient->anchor[1] * ht;
   const float yoffset = sinv * gradient->anchor[0] * wd - cosv * gradient->anchor[1] * ht;
   const float compression = fmaxf(gradient->compression, 0.001f);
@@ -1320,8 +1319,8 @@ static int dt_gradient_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_io
   const float hwscale = 1.0f / sqrtf(wd * wd + ht * ht);
   const float ihwscale = 1.0f / hwscale;
   const float v = (-gradient->rotation / 180.0f) * M_PI;
-  const float sinv = sin(v);
-  const float cosv = cos(v);
+  const float sinv = sinf(v);
+  const float cosv = cosf(v);
   const float xoffset = cosv * gradient->anchor[0] * wd + sinv * gradient->anchor[1] * ht;
   const float yoffset = sinv * gradient->anchor[0] * wd - cosv * gradient->anchor[1] * ht;
   const float compression = fmaxf(gradient->compression, 0.001f);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -908,7 +908,7 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
   *points_count = 3;
 
   // we set the line point
-  const float xstart = fabs(curvature) > 1.0f ? -sqrtf(1.0f / fabsf(curvature)) : -1.0f;
+  const float xstart = fabsf(curvature) > 1.0f ? -sqrtf(1.0f / fabsf(curvature)) : -1.0f;
   const float xdelta = -2.0f * xstart / (count - 3);
 
   int in_frame = FALSE;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -246,8 +246,8 @@ static void _path_points_recurs_border_gaps(float *cmax, float *bmin, float *bmi
                                             dt_masks_dynbuf_t *dborder, gboolean clockwise)
 {
   // we want to find the start and end angles
-  double a1 = atan2(bmin[1] - cmax[1], bmin[0] - cmax[0]);
-  double a2 = atan2(bmax[1] - cmax[1], bmax[0] - cmax[0]);
+  double a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
+  double a2 = atan2f(bmax[1] - cmax[1], bmax[0] - cmax[0]);
   if(a1 == a2) return;
 
   // we have to be sure that we turn in the correct direction

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -645,8 +645,8 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
     }
     else
     {
-      width = floorf(width * sqrt(scale));
-      height = floorf(height * sqrt(scale));
+      width = floorf(width * sqrtf(scale));
+      height = floorf(height * sqrtf(scale));
     }
   }
 
@@ -853,7 +853,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   const int opitch = roi_out->width * out_bpp;
   const int max_bpp = _max(in_bpp, out_bpp);
 
-  float fullscale = fmax(roi_in->scale / roi_out->scale, sqrt(((float)roi_in->width * roi_in->height)
+  float fullscale = fmax(roi_in->scale / roi_out->scale, sqrtf(((float)roi_in->width * roi_in->height)
                                                               / ((float)roi_out->width * roi_out->height)));
 
   /* inaccuracy for roi_in elements in roi_out -> roi_in calculations */
@@ -912,8 +912,8 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
     }
     else
     {
-      width = floorf(width * sqrt(scale));
-      height = floorf(height * sqrt(scale));
+      width = floorf(width * sqrtf(scale));
+      height = floorf(height * sqrtf(scale));
     }
   }
 
@@ -1255,8 +1255,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     }
     else
     {
-      width = floorf(width * sqrt(scale));
-      height = floorf(height * sqrt(scale));
+      width = floorf(width * sqrtf(scale));
+      height = floorf(height * sqrtf(scale));
     }
   }
 
@@ -1573,7 +1573,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   const int opitch = roi_out->width * out_bpp;
   const int max_bpp = _max(in_bpp, out_bpp);
 
-  float fullscale = fmax(roi_in->scale / roi_out->scale, sqrt(((float)roi_in->width * roi_in->height)
+  float fullscale = fmax(roi_in->scale / roi_out->scale, sqrtf(((float)roi_in->width * roi_in->height)
                                                               / ((float)roi_out->width * roi_out->height)));
 
   /* inaccuracy for roi_in elements in roi_out -> roi_in calculations */
@@ -1623,8 +1623,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
     }
     else
     {
-      width = floorf(width * sqrt(scale));
-      height = floorf(height * sqrt(scale));
+      width = floorf(width * sqrtf(scale));
+      height = floorf(height * sqrtf(scale));
     }
   }
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -82,9 +82,9 @@ void dtgtk_cairo_paint_triangle(cairo_t *cr, gint x, int y, gint w, gint h, gint
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
 
-  double C = cos(-(M_PI / 2.0)), S = sin(-(M_PI / 2.0)); // -90 degrees
-  C = flags & CPF_DIRECTION_DOWN ? cos(-(M_PI * 1.5)) : C;
-  S = flags & CPF_DIRECTION_DOWN ? sin(-(M_PI * 1.5)) : S;
+  double C = cosf(-(M_PI / 2.0f)), S = sinf(-(M_PI / 2.0f)); // -90 degrees
+  C = flags & CPF_DIRECTION_DOWN ? cosf(-(M_PI * 1.5f)) : C;
+  S = flags & CPF_DIRECTION_DOWN ? sinf(-(M_PI * 1.5f)) : S;
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
@@ -112,9 +112,9 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
 
-  double C = cos(-(M_PI / 2.0)), S = sin(-(M_PI / 2.0)); // -90 degrees
-  C = flags & CPF_DIRECTION_DOWN ? cos(-(M_PI * 1.5)) : C;
-  S = flags & CPF_DIRECTION_DOWN ? sin(-(M_PI * 1.5)) : S;
+  double C = cosf(-(M_PI / 2.0f)), S = sinf(-(M_PI / 2.0f)); // -90 degrees
+  C = flags & CPF_DIRECTION_DOWN ? cosf(-(M_PI * 1.5f)) : C;
+  S = flags & CPF_DIRECTION_DOWN ? sinf(-(M_PI * 1.5f)) : S;
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
@@ -143,9 +143,9 @@ void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
 
-  double C = cos(-(M_PI / 2.0)), S = sin(-(M_PI / 2.0)); // -90 degrees
-  C = flags & CPF_DIRECTION_UP ? cos(-(M_PI * 1.5)) : C;
-  S = flags & CPF_DIRECTION_UP ? sin(-(M_PI * 1.5)) : S;
+  double C = cosf(-(M_PI / 2.0)), S = sinf(-(M_PI / 2.0)); // -90 degrees
+  C = flags & CPF_DIRECTION_UP ? cosf(-(M_PI * 1.5f)) : C;
+  S = flags & CPF_DIRECTION_UP ? sinf(-(M_PI * 1.5f)) : S;
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
@@ -170,9 +170,9 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
 
-  double C = cos(-(M_PI / 2.0)), S = sin(-(M_PI / 2.0)); // -90 degrees
-  C = flags & CPF_DIRECTION_DOWN ? cos(-(M_PI * 1.5)) : C;
-  S = flags & CPF_DIRECTION_DOWN ? sin(-(M_PI * 1.5)) : S;
+  double C = cosf(-(M_PI / 2.0f)), S = sinf(-(M_PI / 2.0f)); // -90 degrees
+  C = flags & CPF_DIRECTION_DOWN ? cosf(-(M_PI * 1.5f)) : C;
+  S = flags & CPF_DIRECTION_DOWN ? sinf(-(M_PI * 1.5f)) : S;
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
@@ -194,7 +194,7 @@ void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 {
   PREAMBLE(1, 0, 0)
 
-  double C = cos(-1.570796327), S = sin(-1.570796327);
+  double C = cosf(-1.570796327f), S = sinf(-1.570796327f);
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -404,7 +404,7 @@ static inline void dt_draw_histogram_8_zoomed(cairo_t *cr, const uint32_t *hist,
   {
     const float value = ((float)hist[channels * k + channel] - zoom_offset_y) * zoom_factor;
     const float hist_value = value < 0 ? 0.f : value;
-    cairo_line_to(cr, ((float)k - zoom_offset_x) * zoom_factor, linear ? hist_value : log(1.0f + hist_value));
+    cairo_line_to(cr, ((float)k - zoom_offset_x) * zoom_factor, linear ? hist_value : logf(1.0f + hist_value));
   }
   cairo_line_to(cr, (255.f - zoom_offset_x), -zoom_offset_y * zoom_factor);
   cairo_close_path(cr);

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -163,7 +163,7 @@ static void dt_guides_draw_rules_of_thirds(cairo_t *cr, const float left, const 
 static void dt_guides_draw_harmonious_triangles(cairo_t *cr, const float left, const float top, const float width,
                                                 const float height/*, const float dst*/)
 {
-  int dst = (int)((height * cos(atan(width / height)) / (cos(atan(height / width)))));
+  int dst = (int)((height * cosf(atanf(width / height)) / (cosf(atanf(height / width)))));
 
   dt_draw_line(cr, -width / 2, -height / 2, width / 2, height / 2);
   dt_draw_line(cr, -width / 2 + dst, -height / 2, -width / 2, height / 2);

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -178,9 +178,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         float *in = (float *)in_void + (size_t)4 * y * d->global.width;
         for(int x = 1; x < d->global.width-1; x++, in += 4)
         {
-          if((fabs(fmax(in[0], 0.001f) / fmax(in[1], 0.001f)) > 1.01f) ||
-             (fabs(fmax(in[0], 0.001f) / fmax(in[2], 0.001f)) > 1.01f) ||
-             (fabs(fmax(in[1], 0.001f) / fmax(in[2], 0.001f)) > 1.01f))
+          if((fabsf(fmaxf(in[0], 0.001f) / fmaxf(in[1], 0.001f)) > 1.01f) ||
+             (fabsf(fmaxf(in[0], 0.001f) / fmaxf(in[2], 0.001f)) > 1.01f) ||
+             (fabsf(fmaxf(in[1], 0.001f) / fmaxf(in[2], 0.001f)) > 1.01f))
           {
             layers = 3;
             goto checkdone;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -544,7 +544,7 @@ static inline void vec3prodn(float *dst, const float *const v1, const float *con
   const float l3 = v1[0] * v2[1] - v1[1] * v2[0];
 
   // normalize so that l1^2 + l2^2 + l3^3 = 1
-  const float sq = sqrt(l1 * l1 + l2 * l2 + l3 * l3);
+  const float sq = sqrtf(l1 * l1 + l2 * l2 + l3 * l3);
 
   const float f = sq > 0.0f ? 1.0f / sq : 1.0f;
 
@@ -557,7 +557,7 @@ static inline void vec3prodn(float *dst, const float *const v1, const float *con
 // dst and v may be the same
 static inline void vec3norm(float *dst, const float *const v)
 {
-  const float sq = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+  const float sq = sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
 
   // special handling for an all-zero vector
   const float f = sq > 0.0f ? 1.0f / sq : 1.0f;
@@ -572,7 +572,7 @@ static inline void vec3norm(float *dst, const float *const v)
 // dst and v may be the same
 static inline void vec3lnorm(float *dst, const float *const v)
 {
-  const float sq = sqrt(v[0] * v[0] + v[1] * v[1]);
+  const float sq = sqrtf(v[0] * v[0] + v[1] * v[1]);
 
   // special handling for a point vector of the image center
   const float f = sq > 0.0f ? 1.0f / sq : 1.0f;
@@ -658,27 +658,27 @@ static void homography(float *homograph, const float angle, const float shift_v,
   const float v = height;
 
   const float phi = M_PI * angle / 180.0f;
-  const float cosi = cos(phi);
-  const float sini = sin(phi);
-  const float ascale = sqrt(aspect);
+  const float cosi = cosf(phi);
+  const float sini = sinf(phi);
+  const float ascale = sqrtf(aspect);
 
   // most of this comes from ShiftN
   const float f_global = f_length_kb;
   const float horifac = 1.0f - orthocorr / 100.0f;
-  const float exppa_v = exp(shift_v);
+  const float exppa_v = expf(shift_v);
   const float fdb_v = f_global / (14.4f + (v / u - 1) * 7.2f);
   const float rad_v = fdb_v * (exppa_v - 1.0f) / (exppa_v + 1.0f);
-  const float alpha_v = CLAMP(atan(rad_v), -1.5f, 1.5f);
-  const float rt_v = sin(0.5f * alpha_v);
-  const float r_v = fmax(0.1f, 2.0f * (horifac - 1.0f) * rt_v * rt_v + 1.0f);
+  const float alpha_v = CLAMP(atanf(rad_v), -1.5f, 1.5f);
+  const float rt_v = sinf(0.5f * alpha_v);
+  const float r_v = fmaxf(0.1f, 2.0f * (horifac - 1.0f) * rt_v * rt_v + 1.0f);
 
   const float vertifac = 1.0f - orthocorr / 100.0f;
-  const float exppa_h = exp(shift_h);
+  const float exppa_h = expf(shift_h);
   const float fdb_h = f_global / (14.4f + (u / v - 1) * 7.2f);
   const float rad_h = fdb_h * (exppa_h - 1.0f) / (exppa_h + 1.0f);
-  const float alpha_h = CLAMP(atan(rad_h), -1.5f, 1.5f);
-  const float rt_h = sin(0.5f * alpha_h);
-  const float r_h = fmax(0.1f, 2.0f * (vertifac - 1.0f) * rt_h * rt_h + 1.0f);
+  const float alpha_h = CLAMP(atanf(rad_h), -1.5f, 1.5f);
+  const float rt_h = sinf(0.5f * alpha_h);
+  const float r_h = fmaxf(0.1f, 2.0f * (vertifac - 1.0f) * rt_h * rt_h + 1.0f);
 
 
   // three intermediate buffers for matrix calculation ...
@@ -1485,7 +1485,7 @@ static int line_detect(float *in, const int width, const int height, const int x
       ashift_lines[lct].weight = weight;
 
 
-      const float angle = atan2(py2 - py1, px2 - px1) / M_PI * 180.0f;
+      const float angle = atan2f(py2 - py1, px2 - px1) / M_PI * 180.0f;
       const int vertical = fabs(fabs(angle) - 90.0f) < MAX_TANGENTIAL_DEVIATION ? 1 : 0;
       const int horizontal = fabs(fabs(fabs(angle) - 90.0f) - 90.0f) < MAX_TANGENTIAL_DEVIATION ? 1 : 0;
 
@@ -1696,7 +1696,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
 
   // hurdle value epsilon for rejecting a line as an outlier will be self-tuning
   // in a number of dry runs
-  float epsilon = pow(10.0f, -RANSAC_EPSILON);
+  float epsilon = powf(10.0f, -RANSAC_EPSILON);
   float epsilon_step = RANSAC_EPSILON_STEP;
   // some accounting variables for self-tuning
   int lines_eliminated = 0;
@@ -1808,9 +1808,9 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
         float ratio = 100.0f * (float)lines_eliminated / ((float)set_count * valid_runs);
         // adjust epsilon accordingly
         if(ratio < RANSAC_ELIMINATION_RATIO)
-          epsilon = pow(10.0f, log10(epsilon) - epsilon_step);
+          epsilon = powf(10.0f, log10(epsilon) - epsilon_step);
         else if(ratio > RANSAC_ELIMINATION_RATIO)
-          epsilon = pow(10.0f, log10(epsilon) + epsilon_step);
+          epsilon = powf(10.0f, log10(epsilon) + epsilon_step);
 #ifdef ASHIFT_DEBUG
         printf(" (elimination ratio %f) -> %f\n", ratio, epsilon);
 #endif
@@ -2404,8 +2404,8 @@ static double crop_fitness(double *params, void *data)
   P[2] = 1.0f;
 
   // two auxiliary points (some arbitrary distance away from P) to construct the diagonals
-  const float Pa[2][3] = { { P[0] + 10.0f * cos(alpha), P[1] + 10.0f * sin(alpha), 1.0f },
-                           { P[0] + 10.0f * cos(alpha), P[1] - 10.0f * sin(alpha), 1.0f } };
+  const float Pa[2][3] = { { P[0] + 10.0f * cosf(alpha), P[1] + 10.0f * sinf(alpha), 1.0f },
+                           { P[0] + 10.0f * cosf(alpha), P[1] - 10.0f * sinf(alpha), 1.0f } };
 
   // the two diagonals: D = P x Pa
   float D[2][3];
@@ -2446,7 +2446,7 @@ static double crop_fitness(double *params, void *data)
     }
 
   // calculate the area of the rectangle
-  const float A = 2.0f * d2min * sin(2.0f * alpha);
+  const float A = 2.0f * d2min * sinf(2.0f * alpha);
 
 #ifdef ASHIFT_DEBUG
   printf("crop fitness with x %f, y %f, angle %f -> distance %f, area %f\n",
@@ -2536,7 +2536,7 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
   {
     params[0] = 0.5;
     params[1] = 0.5;
-    params[2] = atan2((float)cropfit.height, (float)cropfit.width);
+    params[2] = atan2f((float)cropfit.height, (float)cropfit.width);
     cropfit.x = NAN;
     cropfit.y = NAN;
     cropfit.alpha = NAN;
@@ -2548,7 +2548,7 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
     params[1] = 0.5;
     cropfit.x = NAN;
     cropfit.y = NAN;
-    cropfit.alpha = atan2((float)cropfit.height, (float)cropfit.width);
+    cropfit.alpha = atan2f((float)cropfit.height, (float)cropfit.width);
     pcount = 2;
   }
 
@@ -2571,7 +2571,7 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
 
   // we need the half diagonal of that rectangle (this is in output image dimensions);
   // no need to check for division by zero here as this case implies A == 0.0f, caught above
-  const float d = sqrt(A / (2.0f * sin(2.0f * cropfit.alpha)));
+  const float d = sqrtf(A / (2.0f * sinf(2.0f * cropfit.alpha)));
 
   // the rectangle's center in input image (homogeneous) coordinates
   const float Pc[3] = { cropfit.x * wd, cropfit.y * ht, 1.0f };
@@ -2583,10 +2583,10 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
   P[1] /= P[2];
 
   // calculate clipping margins relative to output image dimensions
-  g->cl = CLAMP((P[0] - d * cos(cropfit.alpha)) / owd, 0.0f, 1.0f);
-  g->cr = CLAMP((P[0] + d * cos(cropfit.alpha)) / owd, 0.0f, 1.0f);
-  g->ct = CLAMP((P[1] - d * sin(cropfit.alpha)) / oht, 0.0f, 1.0f);
-  g->cb = CLAMP((P[1] + d * sin(cropfit.alpha)) / oht, 0.0f, 1.0f);
+  g->cl = CLAMP((P[0] - d * cosf(cropfit.alpha)) / owd, 0.0f, 1.0f);
+  g->cr = CLAMP((P[0] + d * cosf(cropfit.alpha)) / owd, 0.0f, 1.0f);
+  g->ct = CLAMP((P[1] - d * sinf(cropfit.alpha)) / oht, 0.0f, 1.0f);
+  g->cb = CLAMP((P[1] + d * sinf(cropfit.alpha)) / oht, 0.0f, 1.0f);
 
   // final sanity check
   if(g->cr - g->cl <= 0.0f || g->cb - g->ct <= 0.0f) goto failed;
@@ -2632,7 +2632,7 @@ static void crop_adjust(dt_iop_module_t *module, const dt_iop_ashift_params_t *c
   const float wd = g->buf_width;
   const float ht = g->buf_height;
 
-  const float alpha = atan2(ht, wd);
+  const float alpha = atan2f(ht, wd);
 
   float homograph[3][3];
   homography((float *)homograph, rotation, lensshift_v, lensshift_h, shear, f_length_kb,
@@ -2674,8 +2674,8 @@ static void crop_adjust(dt_iop_module_t *module, const dt_iop_ashift_params_t *c
   const float P[3] = { newx * owd, newy * oht, 1.0f };
 
   // two auxiliary points (some arbitrary distance away from P) to construct the diagonals
-  const float Pa[2][3] = { { P[0] + 10.0f * cos(alpha), P[1] + 10.0f * sin(alpha), 1.0f },
-                           { P[0] + 10.0f * cos(alpha), P[1] - 10.0f * sin(alpha), 1.0f } };
+  const float Pa[2][3] = { { P[0] + 10.0f * cosf(alpha), P[1] + 10.0f * sinf(alpha), 1.0f },
+                           { P[0] + 10.0f * cosf(alpha), P[1] - 10.0f * sinf(alpha), 1.0f } };
 
   // the two diagonals: D = P x Pa
   float D[2][3];
@@ -2715,17 +2715,17 @@ static void crop_adjust(dt_iop_module_t *module, const dt_iop_ashift_params_t *c
       d2min = MIN(d2min, d2);
     }
 
-  const float d = sqrt(d2min);
+  const float d = sqrtf(d2min);
 
   // do not allow crop area to drop below 1% of input image area
-  const float A = 2.0f * d * d * sin(2.0f * alpha);
+  const float A = 2.0f * d * d * sinf(2.0f * alpha);
   if(A < 0.01f * wd * ht) return;
 
   // calculate clipping margins relative to output image dimensions
-  g->cl = CLAMP((P[0] - d * cos(alpha)) / owd, 0.0f, 1.0f);
-  g->cr = CLAMP((P[0] + d * cos(alpha)) / owd, 0.0f, 1.0f);
-  g->ct = CLAMP((P[1] - d * sin(alpha)) / oht, 0.0f, 1.0f);
-  g->cb = CLAMP((P[1] + d * sin(alpha)) / oht, 0.0f, 1.0f);
+  g->cl = CLAMP((P[0] - d * cosf(alpha)) / owd, 0.0f, 1.0f);
+  g->cr = CLAMP((P[0] + d * cosf(alpha)) / owd, 0.0f, 1.0f);
+  g->ct = CLAMP((P[1] - d * sinf(alpha)) / oht, 0.0f, 1.0f);
+  g->cb = CLAMP((P[1] + d * sinf(alpha)) / oht, 0.0f, 1.0f);
 
 #ifdef ASHIFT_DEBUG
   printf("margins after crop adjustment: x %f, y %f, angle %f, crop area (%f %f %f %f), width %f, height %f\n",
@@ -2869,14 +2869,14 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // origin of image and opposite corner as reference points
     float points[4] = { 0.0f, 0.0f, (float)piece->buf_in.width, (float)piece->buf_in.height };
     float ivec[2] = { points[2] - points[0], points[3] - points[1] };
-    float ivecl = sqrt(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
+    float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
     // where do they go?
     dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2);
 
     float ovec[2] = { points[2] - points[0], points[3] - points[1] };
-    float ovecl = sqrt(ovec[0] * ovec[0] + ovec[1] * ovec[1]);
+    float ovecl = sqrtf(ovec[0] * ovec[0] + ovec[1] * ovec[1]);
 
     // angle between input vector and output vector
     float alpha = acos(CLAMP((ivec[0] * ovec[0] + ivec[1] * ovec[1]) / (ivecl * ovecl), -1.0f, 1.0f));
@@ -3003,14 +3003,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     // origin of image and opposite corner as reference points
     float points[4] = { 0.0f, 0.0f, (float)piece->buf_in.width, (float)piece->buf_in.height };
     float ivec[2] = { points[2] - points[0], points[3] - points[1] };
-    float ivecl = sqrt(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
+    float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
     // where do they go?
     dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2);
 
     float ovec[2] = { points[2] - points[0], points[3] - points[1] };
-    float ovecl = sqrt(ovec[0] * ovec[0] + ovec[1] * ovec[1]);
+    float ovecl = sqrtf(ovec[0] * ovec[0] + ovec[1] * ovec[1]);
 
     // angle between input vector and output vector
     float alpha = acos(CLAMP((ivec[0] * ovec[0] + ivec[1] * ovec[1]) / (ivecl * ovecl), -1.0f, 1.0f));

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -593,7 +593,7 @@ static inline float vec3scalar(const float *const v1, const float *const v2)
 static inline int vec3isnull(const float *const v)
 {
   const float eps = 1e-10f;
-  return (fabs(v[0]) < eps && fabs(v[1]) < eps && fabs(v[2]) < eps);
+  return (fabsf(v[0]) < eps && fabsf(v[1]) < eps && fabsf(v[2]) < eps);
 }
 
 #ifdef ASHIFT_DEBUG
@@ -1443,10 +1443,10 @@ static int line_detect(float *in, const int width, const int height, const int x
       // check for lines running along image borders and skip them.
       // these would likely be false-positives which could result
       // from any kind of processing artifacts
-      if((fabs(x1 - x2) < 1 && fmax(x1, x2) < 2) ||
-         (fabs(x1 - x2) < 1 && fmin(x1, x2) > width - 3) ||
-         (fabs(y1 - y2) < 1 && fmax(y1, y2) < 2) ||
-         (fabs(y1 - y2) < 1 && fmin(y1, y2) > height - 3))
+      if((fabsf(x1 - x2) < 1 && fmaxf(x1, x2) < 2) ||
+         (fabsf(x1 - x2) < 1 && fminf(x1, x2) > width - 3) ||
+         (fabsf(y1 - y2) < 1 && fmaxf(y1, y2) < 2) ||
+         (fabsf(y1 - y2) < 1 && fminf(y1, y2) > height - 3))
         continue;
 
       // line position in absolute coordinates
@@ -1486,8 +1486,8 @@ static int line_detect(float *in, const int width, const int height, const int x
 
 
       const float angle = atan2f(py2 - py1, px2 - px1) / M_PI * 180.0f;
-      const int vertical = fabs(fabs(angle) - 90.0f) < MAX_TANGENTIAL_DEVIATION ? 1 : 0;
-      const int horizontal = fabs(fabs(fabs(angle) - 90.0f) - 90.0f) < MAX_TANGENTIAL_DEVIATION ? 1 : 0;
+      const int vertical = fabsf(fabsf(angle) - 90.0f) < MAX_TANGENTIAL_DEVIATION ? 1 : 0;
+      const int horizontal = fabsf(fabsf(fabsf(angle) - 90.0f) - 90.0f) < MAX_TANGENTIAL_DEVIATION ? 1 : 0;
 
       const int relevant = ashift_lines[lct].length > MIN_LINE_LENGTH ? 1 : 0;
 
@@ -1738,7 +1738,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
     // a) L1 and L2 are identical -> V is NULL -> no valid vantage point
     // b) vantage point lies inside image frame (no chance to correct for this case)
     if(vec3isnull(V) ||
-       (fabs(V[2]) > 0.0f &&
+       (fabsf(V[2]) > 0.0f &&
         V[0]/V[2] >= xmin &&
         V[1]/V[2] >= ymin &&
         V[0]/V[2] <= xmax &&
@@ -1770,7 +1770,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
         // of the "distance" between point and line. Note that this is not the real euclidean
         // distance but - with the given normalization - just a pragmatically selected number
         // that goes to zero if V lies on L and increases the more V and L are apart
-        const float d = fabs(vec3scalar(V, L3));
+        const float d = fabsf(vec3scalar(V, L3));
 
         // depending on d we either include or exclude the point from the set
         inout[n] = (d < epsilon) ? 1 : 0;

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1081,9 +1081,9 @@ static void _get_auto_exp(const uint32_t *const histogram, const unsigned int hi
     expcomp = 0.5 * (double)expcomp1 + 0.5 * (double)expcomp2; // for small expcomp
   }
 
-  const float gain = exp((float)expcomp * log(2.f));
+  const float gain = expf((float)expcomp * log(2.f));
 
-  const float corr = sqrt(gain * scale / rawmax);
+  const float corr = sqrtf(gain * scale / rawmax);
   black = shc * corr;
 
   // now tune hlcompr to bring back rawmax to 65535
@@ -1096,7 +1096,7 @@ static void _get_auto_exp(const uint32_t *const histogram, const unsigned int hi
 
   // now find brightness if gain didn't bring ave to midgray using
   // the envelope of the actual 'control cage' brightness curve for simplicity
-  const float midtmp = gain * sqrt(median * ave) / scale;
+  const float midtmp = gain * sqrtf(median * ave) / scale;
 
   if(midtmp < 0.1f)
   {
@@ -1580,7 +1580,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     if(process_saturation_vibrance)
     {
       const float average = (out[k] + out[k+1] + out[k+2]) / 3;
-      const float delta = sqrt( (average-out[k])*(average-out[k])+(average-out[k+1])*(average-out[k+1])+(average-out[k+2])*(average-out[k+2]));
+      const float delta = sqrtf( (average-out[k])*(average-out[k])+(average-out[k+1])*(average-out[k+1])+(average-out[k+2])*(average-out[k+2]));
       const float P = vibrance * (1 - powf(delta, fabsf(vibrance)));
 
       for(size_t c = 0; c < 3; c++)

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -220,7 +220,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // sigmoidal curve for d->contrast above 1
     const float boost = 20.0f;
     const float contrastm1sq = boost * (d->contrast - 1.0f) * (d->contrast - 1.0f);
-    const float contrastscale = sqrt(1.0f + contrastm1sq);
+    const float contrastscale = sqrtf(1.0f + contrastm1sq);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(contrastm1sq, contrastscale) \

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -206,7 +206,7 @@ static inline float hue_conversion(const float HSL_Hue)
   dt_XYZ_to_Lab(XYZ, Lab);
 
   // Hue from LCH color space in [-pi, +pi] interval
-  float LCH_hue = atan2(Lab[2], Lab[1]);
+  float LCH_hue = atan2f(Lab[2], Lab[1]);
 
   return LCH_hue;
 }
@@ -381,14 +381,14 @@ static void dt_iop_colorreconstruct_bilateral_splat(dt_iop_colorreconstruct_bila
       switch(precedence)
       {
         case COLORRECONSTRUCT_PRECEDENCE_CHROMA:
-          weight = sqrt(ain * ain + bin * bin);
+          weight = sqrtf(ain * ain + bin * bin);
           break;
 
         case COLORRECONSTRUCT_PRECEDENCE_HUE:
-          m = atan2(bin, ain) - params[0];
+          m = atan2f(bin, ain) - params[0];
           // readjust m into [-pi, +pi] interval
           m = m > M_PI ? m - 2*M_PI : (m < -M_PI ? m + 2*M_PI : m);
-          weight = exp(-m*m/params[1]);
+          weight = expf(-m*m/params[1]);
           break;
 
         case COLORRECONSTRUCT_PRECEDENCE_NONE:

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -903,8 +903,8 @@ static inline void backtransform_v2(float *const buf, const int wd, const int ht
       {
         const float x = MAX(buf2[c], 0.0f);
         const float delta = x * x + bias;
-        const float denominator = 4.0f / (sqrt(a) * (2.0f - p[c]));
-        const float z1 = (x + sqrt(MAX(delta, 0.0f))) / denominator;
+        const float denominator = 4.0f / (sqrtf(a) * (2.0f - p[c]));
+        const float z1 = (x + sqrtf(MAX(delta, 0.0f))) / denominator;
         buf2[c] = powf(z1, 1.0f / (1.0f - p[c] / 2.0f)) - b;
         buf2[c] *= wb[c];
       }
@@ -917,9 +917,9 @@ static inline void precondition_Y0U0V0(const float *const in, float *const buf, 
                                        const float a, const float p[3], const float b, const float toY0U0V0[9])
 {
   const float expon[3] = { -p[0] / 2 + 1, -p[1] / 2 + 1, -p[2] / 2 + 1 };
-  const float scale[3] = { 2.0f / ((-p[0] + 2) * sqrt(a)),
-                           2.0f / ((-p[1] + 2) * sqrt(a)),
-                           2.0f / ((-p[2] + 2) * sqrt(a)) };
+  const float scale[3] = { 2.0f / ((-p[0] + 2) * sqrtf(a)),
+                           2.0f / ((-p[1] + 2) * sqrtf(a)),
+                           2.0f / ((-p[2] + 2) * sqrtf(a)) };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(buf, ht, in, wd, b, toY0U0V0, expon, scale)       \
@@ -951,9 +951,9 @@ static inline void backtransform_Y0U0V0(float *const buf, const int wd, const in
 {
   const float bias_wb[3] = { bias * wb[0], bias * wb[1], bias * wb[2] };
   const float expon[3] = {  1.0f / (1.0f - p[0] / 2.0f),  1.0f / (1.0f - p[1] / 2.0f),  1.0f / (1.0f - p[2] / 2.0f) };
-  const float scale[3] = { (sqrt(a) * (2.0f - p[0])) / 4.0f,
-                           (sqrt(a) * (2.0f - p[1])) / 4.0f,
-                           (sqrt(a) * (2.0f - p[2])) / 4.0f };
+  const float scale[3] = { (sqrtf(a) * (2.0f - p[0])) / 4.0f,
+                           (sqrtf(a) * (2.0f - p[1])) / 4.0f,
+                           (sqrtf(a) * (2.0f - p[2])) / 4.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(buf, ht, wd, b, bias_wb, toRGB, expon, scale)  \
@@ -975,7 +975,7 @@ static inline void backtransform_Y0U0V0(float *const buf, const int wd, const in
     {
       const float x = MAX(rgb[c], 0.0f);
       const float delta = x * x + bias_wb[c];
-      const float z1 = (x + sqrt(MAX(delta, 0.0f))) * scale[c];
+      const float z1 = (x + sqrtf(MAX(delta, 0.0f))) * scale[c];
       buf2[c] = powf(z1, expon[c]) - b;
     }
   }
@@ -1071,7 +1071,7 @@ static void set_up_conversion_matrices(float toY0U0V0[9], float toRGB[9], float 
   // we then normalize the line so that variance becomes equal to 1:
   // var(Y0) = 1/9 * (var(R) + var(G) + var(B)) = 1/3
   // var(sqrt(3)Y0) = 1
-  sum_invwb *= sqrt(3);
+  sum_invwb *= sqrtf(3);
   toY0U0V0[0] = sum_invwb / wb[0];
   toY0U0V0[1] = sum_invwb / wb[1];
   toY0U0V0[2] = sum_invwb / wb[2];
@@ -1081,8 +1081,8 @@ static void set_up_conversion_matrices(float toY0U0V0[9], float toRGB[9], float 
   // apart of the normalization: these coefficients do differences of RGB channels
   // to try to reduce or cancel the signal. If we change these depending on white
   // balance, we will not reduce/cancel the signal anymore.
-  const float stddevU0 = sqrt(0.5f * 0.5f * wb[0] * wb[0] + 0.5f * 0.5f * wb[2] * wb[2]);
-  const float stddevV0 = sqrt(0.25f * 0.25f * wb[0] * wb[0] + 0.5f * 0.5f * wb[1] * wb[1] + 0.25f * 0.25f * wb[2] * wb[2]);
+  const float stddevU0 = sqrtf(0.5f * 0.5f * wb[0] * wb[0] + 0.5f * 0.5f * wb[2] * wb[2]);
+  const float stddevV0 = sqrtf(0.25f * 0.25f * wb[0] * wb[0] + 0.5f * 0.5f * wb[1] * wb[1] + 0.25f * 0.25f * wb[2] * wb[2]);
   toY0U0V0[3] /= stddevU0;
   toY0U0V0[4] /= stddevU0;
   toY0U0V0[5] /= stddevU0;
@@ -1093,7 +1093,7 @@ static void set_up_conversion_matrices(float toY0U0V0[9], float toRGB[9], float 
   if(!is_invertible)
   {
     // use standard form if whitebalance adapted matrix is not invertible
-    float stddevY0 = sqrt(1.0f / 9.0f * (wb[0] * wb[0] + wb[1] * wb[1] + wb[2] * wb[2]));
+    float stddevY0 = sqrtf(1.0f / 9.0f * (wb[0] * wb[0] + wb[1] * wb[1] + wb[2] * wb[2]));
     toY0U0V0[0] = 1.0f / (3.0f * stddevY0);
     toY0U0V0[1] = 1.0f / (3.0f * stddevY0);
     toY0U0V0[2] = 1.0f / (3.0f * stddevY0);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1533,7 +1533,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
      * Use double precision locally to avoid cancellation effect on
      * the "+ d" operation.
      */
-    const float x = (rescale) ? pow(2.0, (double)a * nodes_data->x[k] + b) + d : nodes_data->x[k];
+    const float x = (rescale) ? powf(2.0f, (double)a * nodes_data->x[k] + b) + d : nodes_data->x[k];
     const float y = powf(nodes_data->y[k], 1.0f / gamma);
 
     cairo_arc(cr, x * width, (1.0 - y) * (double)height, DT_PIXEL_APPLY_DPI(3), 0, 2. * M_PI);
@@ -1555,7 +1555,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
      * Use double precision locally to avoid cancellation effect on
      * the "+ d" operation.
      */
-    const float x = (rescale) ? pow(2.0, (double)a * k / 255.0 + b) + d : k / 255.0;
+    const float x = (rescale) ? powf(2.0f, (double)a * k / 255.0f + b) + d : k / 255.0f;
     const float y = powf(c->table[k], 1.0f / gamma);
     cairo_line_to(cr, x * width, (double)height * (1.0 - y));
   }

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -304,7 +304,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
 {
   // we get the extremities of the line
   const float v = (-rotation / 180) * M_PI;
-  const float sinv = sin(v);
+  const float sinv = sinf(v);
   float pts[4];
 
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
@@ -346,7 +346,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
   else
   {
     // otherwise we determine the extremities
-    const float cosv = cos(v);
+    const float cosv = cosf(v);
     float xx1 = (sinv - cosv + 1.0f - offset / 50.0f) * wp * 0.5f / sinv;
     float xx2 = (sinv + cosv + 1.0f - offset / 50.0f) * wp * 0.5f / sinv;
     float yy1 = 0.0f;
@@ -519,7 +519,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
   // the extremities
   float x1, y1, x2, y2;
-  const float l = sqrt((xb - xa) * (xb - xa) + (yb - ya) * (yb - ya));
+  const float l = sqrtf((xb - xa) * (xb - xa) + (yb - ya) * (yb - ya));
   const float ext = wd * 0.01f / zoom_scale;
   x1 = xa + (xb - xa) * ext / l;
   y1 = ya + (yb - ya) * ext / l;
@@ -737,15 +737,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int iy = (roi_in->y);
   const float iw = piece->buf_in.width * roi_out->scale;
   const float ih = piece->buf_in.height * roi_out->scale;
-  const float hw = iw / 2.0;
-  const float hh = ih / 2.0;
-  const float hw_inv = 1.0 / hw;
-  const float hh_inv = 1.0 / hh;
+  const float hw = iw / 2.0f;
+  const float hh = ih / 2.0f;
+  const float hw_inv = 1.0f / hw;
+  const float hh_inv = 1.0f / hh;
   const float v = (-data->rotation / 180) * M_PI;
-  const float sinv = sin(v);
-  const float cosv = cos(v);
-  const float filter_radie = sqrt((hh * hh) + (hw * hw)) / hh;
-  const float offset = data->offset / 100.0 * 2;
+  const float sinv = sinf(v);
+  const float cosv = cosf(v);
+  const float filter_radie = sqrtf((hh * hh) + (hw * hw)) / hh;
+  const float offset = data->offset / 100.0f * 2.0f;
 
 #if 1
   const float filter_hardness
@@ -868,15 +868,15 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int iy = (roi_in->y);
   const float iw = piece->buf_in.width * roi_out->scale;
   const float ih = piece->buf_in.height * roi_out->scale;
-  const float hw = iw / 2.0;
-  const float hh = ih / 2.0;
-  const float hw_inv = 1.0 / hw;
-  const float hh_inv = 1.0 / hh;
+  const float hw = iw / 2.0f;
+  const float hh = ih / 2.0f;
+  const float hw_inv = 1.0f / hw;
+  const float hh_inv = 1.0f / hh;
   const float v = (-data->rotation / 180) * M_PI;
-  const float sinv = sin(v);
-  const float cosv = cos(v);
-  const float filter_radie = sqrt((hh * hh) + (hw * hw)) / hh;
-  const float offset = data->offset / 100.0 * 2;
+  const float sinv = sinf(v);
+  const float cosv = cosf(v);
+  const float filter_radie = sqrtf((hh * hh) + (hw * hw)) / hh;
+  const float offset = data->offset / 100.0f * 2;
 
 #if 1
   const float filter_hardness = 1.0 / filter_radie
@@ -1011,15 +1011,15 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int iy = (roi_in->y);
   const float iw = piece->buf_in.width * roi_out->scale;
   const float ih = piece->buf_in.height * roi_out->scale;
-  const float hw = iw / 2.0;
-  const float hh = ih / 2.0;
-  const float hw_inv = 1.0 / hw;
-  const float hh_inv = 1.0 / hh;
+  const float hw = iw / 2.0f;
+  const float hh = ih / 2.0f;
+  const float hw_inv = 1.0f / hw;
+  const float hh_inv = 1.0f / hh;
   const float v = (-data->rotation / 180) * M_PI;
-  const float sinv = sin(v);
-  const float cosv = cos(v);
-  const float filter_radie = sqrt((hh * hh) + (hw * hw)) / hh;
-  const float offset = data->offset / 100.0 * 2;
+  const float sinv = sinf(v);
+  const float cosv = cosf(v);
+  const float filter_radie = sqrtf((hh * hh) + (hw * hw)) / hh;
+  const float offset = data->offset / 100.0f * 2;
   const float density = data->density;
 
 #if 1

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -111,7 +111,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int rad = MAX_RADIUS * (fmin(100.0f, d->sharpness + 1) / 100.0f);
   const int radius = MIN(MAX_RADIUS, ceilf(rad * roi_in->scale / piece->iscale));
 
-  const float sigma = sqrt((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
+  const float sigma = sqrtf((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
   const int wdh = ceilf(3.0f * sigma);
 
   tiling->factor = 3.0f; // in + out + tmp
@@ -145,7 +145,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   /* sigma-radius correlation to match opencl vs. non-opencl. identified by numerical experiments but
    * unproven. ask me if you need details. ulrich */
-  const float sigma = sqrt((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
+  const float sigma = sqrtf((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
   const int wdh = ceilf(3.0f * sigma);
   const int wd = 2 * wdh + 1;
   const size_t mat_size = (size_t)wd * sizeof(float);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -879,7 +879,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
         modifier->ApplySubpixelGeometryDistortion(p1, p2, 1, 1, buf);
         const float dist1 = points[i]     - buf[0];
         const float dist2 = points[i + 1] - buf[3];
-        if(fabs(dist1) < .5f && fabs(dist2) < .5f) break; // we have converged
+        if(fabsf(dist1) < .5f && fabsf(dist2) < .5f) break; // we have converged
         p1 += dist1;
         p2 += dist2;
       }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -237,7 +237,7 @@ static void compute_lut(dt_dev_pixelpipe_iop_t *piece)
   for(unsigned int i = 0; i < 0x10000; i++)
   {
     float percentage = (float)i / (float)0x10000ul;
-    d->lut[i] = 100.0f * pow(percentage, d->in_inv_gamma);
+    d->lut[i] = 100.0f * powf(percentage, d->in_inv_gamma);
   }
 }
 
@@ -395,7 +395,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       const float percentage = (L_in - d->levels[0]) / (d->levels[2] - d->levels[0]);
       // Within the expected input range we can use the lookup table, else we need to compute from scratch
-      L_out = percentage < 1.0f ? d->lut[(int)(percentage * 0x10000ul)] : 100.0f * pow(percentage, d->in_inv_gamma);
+      L_out = percentage < 1.0f ? d->lut[(int)(percentage * 0x10000ul)] : 100.0f * powf(percentage, d->in_inv_gamma);
     }
 
     // Preserving contrast

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -480,7 +480,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // going from (0,0) to (1,100) or (0,100) to (1,0), respectively
     const float boost = 5.0f;
     const float contrastm1sq = boost * (fabs(d->contrast) - 1.0f) * (fabs(d->contrast) - 1.0f);
-    const float contrastscale = copysign(sqrt(1.0f + contrastm1sq), d->contrast);
+    const float contrastscale = copysign(sqrtf(1.0f + contrastm1sq), d->contrast);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(contrastm1sq, contrastscale) \

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -278,8 +278,8 @@ static void wavelet_denoise(const float *const restrict in, float *const restric
         float avg = ( window[0][col-1] + window[0][col+1] +
                       window[2][col-1] + window[2][col+1] - blk[~row & 1]*4 )
                     * mul[row & 1] + (window[1][col] + blk[row & 1]) * 0.5;
-        avg = avg < 0 ? 0 : sqrt(avg);
-        float diff = sqrt(BAYER(row,col)) - avg;
+        avg = avg > 0 ? sqrtf(avg) : 0;
+        float diff = sqrtf(BAYER(row,col)) - avg;
         if      (diff < -thold) diff += thold;
         else if (diff >  thold) diff -= thold;
         else diff = 0;

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -109,7 +109,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-#define GAUSS(a, b, c, x) (a * pow(2.718281828, (-pow((x - b), 2) / (pow(c, 2)))))
+#define GAUSS(a, b, c, x) (a * powf(2.718281828f, (-powf((x - b), 2) / (powf(c, 2)))))
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2809,7 +2809,7 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
   const float delta = (right - left) / 2.0f;
   const float mid = left + delta;
   const float tmp = (middle - mid) / delta;
-  const float in_inv_gamma = pow(10, tmp);
+  const float in_inv_gamma = powf(10, tmp);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3172,7 +3172,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
                          dt_iop_roi_t *const roi_mask_scaled, const float opacity, const int blur_type,
                          const float blur_radius, dt_dev_pixelpipe_iop_t *piece, const int use_sse)
 {
-  if(fabs(blur_radius) <= 0.1f) return;
+  if(fabsf(blur_radius) <= 0.1f) return;
 
   const float sigma = blur_radius * roi_in->scale / piece->iscale;
 
@@ -3189,7 +3189,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
   // copy source image so we blur just the mask area (at least the smallest rect that covers it)
   rt_copy_in_to_out(in, roi_in, img_dest, roi_mask_scaled, ch, 0, 0);
 
-  if(blur_type == DT_IOP_RETOUCH_BLUR_GAUSSIAN && fabs(blur_radius) > 0.1f)
+  if(blur_type == DT_IOP_RETOUCH_BLUR_GAUSSIAN && fabsf(blur_radius) > 0.1f)
   {
     float Labmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
     float Labmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
@@ -3205,7 +3205,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
       dt_gaussian_free(g);
     }
   }
-  else if(blur_type == DT_IOP_RETOUCH_BLUR_BILATERAL && fabs(blur_radius) > 0.1f)
+  else if(blur_type == DT_IOP_RETOUCH_BLUR_BILATERAL && fabsf(blur_radius) > 0.1f)
   {
     const float sigma_r = 100.0f; // does not depend on scale
     const float sigma_s = sigma;
@@ -3921,7 +3921,7 @@ static cl_int retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
 {
   cl_int err = CL_SUCCESS;
 
-  if(fabs(blur_radius) <= 0.1f) return err;
+  if(fabsf(blur_radius) <= 0.1f) return err;
 
   const float sigma = blur_radius * roi_layer->scale / piece->iscale;
   const int ch = 4;
@@ -3955,7 +3955,7 @@ static cl_int retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
     goto cleanup;
   }
 
-  if(blur_type == DT_IOP_RETOUCH_BLUR_GAUSSIAN && fabs(blur_radius) > 0.1f)
+  if(blur_type == DT_IOP_RETOUCH_BLUR_GAUSSIAN && fabsf(blur_radius) > 0.1f)
   {
     float Labmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
     float Labmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
@@ -3969,7 +3969,7 @@ static cl_int retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
       if(err != CL_SUCCESS) goto cleanup;
     }
   }
-  else if(blur_type == DT_IOP_RETOUCH_BLUR_BILATERAL && fabs(blur_radius) > 0.1f)
+  else if(blur_type == DT_IOP_RETOUCH_BLUR_BILATERAL && fabsf(blur_radius) > 0.1f)
   {
     const float sigma_r = 100.0f; // does not depend on scale
     const float sigma_s = sigma;

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1220,7 +1220,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
           else if(L_in >= d->params.levels[c][2])
           {
             const float percentage = (L_in - d->params.levels[c][0]) * mult[c];
-            out[c] = pow(percentage, d->inv_gamma[c]);
+            out[c] = powf(percentage, d->inv_gamma[c]);
           }
           else
           {
@@ -1242,7 +1242,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
           if(lum >= d->params.levels[ch_levels][2])
           {
             const float percentage = (lum - d->params.levels[ch_levels][0]) * mult[ch_levels];
-            curve_lum = pow(percentage, d->inv_gamma[ch_levels]);
+            curve_lum = powf(percentage, d->inv_gamma[ch_levels]);
           }
           else
           {

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -365,7 +365,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float max[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
   const float min[4] = { 0.0f, -1.0f, -1.0f, 0.0f };
   const float lmin = 0.0f;
-  const float lmax = max[0] + fabs(min[0]);
+  const float lmax = max[0] + fabsf(min[0]);
   const float halfmax = lmax / 2.0;
   const float doublemax = lmax * 2.0;
 
@@ -401,9 +401,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       const float la = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
       float lb = (tb[0] - halfmax) * sign(-highlights) * sign(lmax - la) + halfmax;
       lb = unbound_mask ? lb : CLAMP_RANGE(lb, lmin, lmax);
-      const float lref = copysignf(fabs(la) > low_approximation ? 1.0f / fabs(la) : 1.0f / low_approximation, la);
+      const float lref = copysignf(fabsf(la) > low_approximation ? 1.0f / fabsf(la) : 1.0f / low_approximation, la);
       const float href = copysignf(
-          fabs(1.0f - la) > low_approximation ? 1.0f / fabs(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
+          fabsf(1.0f - la) > low_approximation ? 1.0f / fabsf(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
 
       const float chunk = highlights2 > 1.0f ? 1.0f : highlights2;
       const float optrans = chunk * highlights_xform;
@@ -433,9 +433,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       const float la = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
       float lb = (tb[0] - halfmax) * sign(shadows) * sign(lmax - la) + halfmax;
       lb = unbound_mask ? lb : CLAMP_RANGE(lb, lmin, lmax);
-      const float lref = copysignf(fabs(la) > low_approximation ? 1.0f / fabs(la) : 1.0f / low_approximation, la);
+      const float lref = copysignf(fabsf(la) > low_approximation ? 1.0f / fabsf(la) : 1.0f / low_approximation, la);
       const float href = copysignf(
-          fabs(1.0f - la) > low_approximation ? 1.0f / fabs(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
+          fabsf(1.0f - la) > low_approximation ? 1.0f / fabsf(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
 
 
       const float chunk = shadows2 > 1.0f ? 1.0f : shadows2;

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -246,7 +246,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   /* sigma-radius correlation to match opencl vs. non-opencl. identified by numerical experiments but
    * unproven. ask me if you need details. ulrich */
-  const float sigma = sqrt((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
+  const float sigma = sqrtf((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
   const int wdh = ceilf(3.0f * sigma);
   const int wd = 2 * wdh + 1;
   const size_t mat_size = sizeof(float) * wd;
@@ -393,7 +393,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
   /* sigma-radius correlation to match opencl vs. non-opencl. identified by numerical experiments but
    * unproven. ask me if you need details. ulrich */
-  const float sigma = sqrt((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
+  const float sigma = sqrtf((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
   const int wdh = ceilf(3.0f * sigma);
 
   tiling->factor = 3.0f; // in + out + tmp

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -313,8 +313,8 @@ static float deg2rad(float deg)
 
 static int latlon2zoom(int pix_height, int pix_width, float lat1, float lat2, float lon1, float lon2)
 {
-  float lat1_m = atanh(sin(lat1));
-  float lat2_m = atanh(sin(lat2));
+  float lat1_m = atanh(sinf(lat1));
+  float lat2_m = atanh(sinf(lat2));
   int zoom_lon = LOG2((double)(2 * pix_width * M_PI) / (TILESIZE * (lon2 - lon1)));
   int zoom_lat = LOG2((double)(2 * pix_height * M_PI) / (TILESIZE * (lat2_m - lat1_m)));
   return MIN(zoom_lon, zoom_lat);


### PR DESCRIPTION
This saves a conversion instruction before and after the function call or inline instruction, but more importantly several of the functions are substantially faster in their float form than double form.  Q&D benchmarking shows that:
   sinf/cosf run in about 1/2 the time of sin/cos
   powf runs in about 3/5 the time of pow
   expf runs in about 3/4 the time of exp

Square root compiles to a single instruction, so sqrt and sqrtf take the same amount of time, but we still save the two conversions.