### PR TITLE
refactor: dedup clamping macros

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -434,11 +434,7 @@ static inline void dt_XYZ_to_sRGB_clipped(const float *const XYZ, float *const s
 {
   dt_XYZ_to_sRGB(XYZ, sRGB);
 
-#define CLIP(a) ((a) < 0 ? 0 : (a) > 1 ? 1 : (a))
-
   for(int i = 0; i < 3; i++) sRGB[i] = CLIP(sRGB[i]);
-
-#undef CLIP
 }
 
 

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -23,13 +23,8 @@
 #include <xmmintrin.h>
 #endif
 #include "common/gaussian.h"
+#include "common/math.h"
 #include "common/opencl.h"
-
-#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
-
-#if defined(__SSE__)
-#define MMCLAMPPS(a, mn, mx) (_mm_min_ps((mx), _mm_max_ps((a), (mn))))
-#endif
 
 #define BLOCKSIZE (1 << 6)
 

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -68,7 +68,7 @@ static inline float Log2(float x)
 
 static inline float Log2Thres(float x, float Thres)
 {
-  return logf(MAX(x,Thres)) / DT_M_LN2f;
+  return logf(x > Thres ? x : Thres) / DT_M_LN2f;
 }
 
 // ensure that any changes here are synchronized with data/kernels/extended.cl

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -38,6 +38,24 @@
 
 #define DT_M_LN2f (0.6931471805599453f)
 
+// clip channel value to be between 0 and 1
+// NaN-safe: NaN compares false and will result in 0.0
+// also does not force promotion of floats to doubles, but will use the type of its argument
+#define CLIP(x) (((x) >= 0) ? ((x) <= 1 ? (x) : 1) : 0)
+#define MM_CLIP_PS(X) (_mm_min_ps(_mm_max_ps((X), _mm_setzero_ps()), _mm_set1_ps(1.0)))
+
+// clip luminance values to be between 0 and 100
+#define LCLIP(x) ((x < 0) ? 0.0 : (x > 100.0) ? 100.0 : x)
+
+// clamp value to lie between mn and mx
+// Nan-safe: NaN compares false and will result in mn
+#define CLAMPF(a, mn, mx) ((a) >= (mn) ? ((a) <= (mx) ? (a) : (mx)) : (mn))
+//#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
+
+#if defined(__SSE__)
+#define MMCLAMPPS(a, mn, mx) (_mm_min_ps((mx), _mm_max_ps((a), (mn))))
+#endif
+
 static inline float clamp_range_f(const float x, const float low, const float high)
 {
   return x > high ? high : (x < low ? low : x);
@@ -45,26 +63,12 @@ static inline float clamp_range_f(const float x, const float low, const float hi
 
 static inline float Log2(float x)
 {
-  if(x > 0.0f)
-  {
-    return logf(x) / logf(2.0f);
-  }
-  else
-  {
-    return x;
-  }
+  return (x > 0.0f) ? (logf(x) / DT_M_LN2f) : x;
 }
 
 static inline float Log2Thres(float x, float Thres)
 {
-  if(x > Thres)
-  {
-    return logf(x) / logf(2.0f);
-  }
-  else
-  {
-    return logf(Thres) / logf(2.0f);
-  }
+  return logf(MAX(x,Thres)) / DT_M_LN2f;
 }
 
 // ensure that any changes here are synchronized with data/kernels/extended.cl
@@ -86,7 +90,7 @@ static inline float fastlog2(float x)
 static inline float
 fastlog (float x)
 {
-  return 0.69314718f * fastlog2 (x);
+  return DT_M_LN2f * fastlog2(x);
 }
 
 // multiply 3x3 matrix with 3x1 vector

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -32,7 +32,6 @@
 
 #define _XOPEN_SOURCE 700
 #include <errno.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,9 +48,8 @@
 #endif
 
 #include "pdf.h"
+#include "common/math.h"
 #include "common/utility.h"
-
-#define CLAMP_FLT(A) ((A) > (0.0f) ? ((A) < (1.0f) ? (A) : (1.0f)) : (0.0f))
 
 #define SKIP_SPACES(s)  {while(*(s) == ' ')(s)++;}
 
@@ -887,7 +885,7 @@ int main(int argc, char *argv[])
   #pragma omp parallel for schedule(static) default(none) shared(image, data, width, height)
 #endif
     for(int i = 0; i < width * height * 3; i++)
-      data[i] = CLAMP_FLT(image[i]) * 65535;
+      data[i] = CLIP(image[i]) * 65535;
 
     images[i] = dt_pdf_add_image(pdf, (unsigned char *)data, width, height, 16, icc_id, border);
     free(image);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -40,7 +40,6 @@
 #include <string.h>
 #include <strings.h>
 
-#define CLAMP_RANGE(x, y, z) (CLAMP(x, y, z))
 #define NEUTRAL_GRAY 0.5
 
 const dt_develop_name_value_t dt_develop_blend_mode_names[]
@@ -297,9 +296,9 @@ static void _blendif_scale(dt_iop_gui_blend_data_t *data, dt_iop_colorspace_type
   switch(cst)
   {
     case iop_cs_Lab:
-      out[0] = CLAMP_RANGE((in[0] / _get_boost_factor(data, 0, in_out)) / 100.0f, 0.0f, 1.0f);
-      out[1] = CLAMP_RANGE(((in[1] / _get_boost_factor(data, 1, in_out)) + 128.0f) / 256.0f, 0.0f, 1.0f);
-      out[2] = CLAMP_RANGE(((in[2] / _get_boost_factor(data, 2, in_out)) + 128.0f) / 256.0f, 0.0f, 1.0f);
+      out[0] = CLAMP((in[0] / _get_boost_factor(data, 0, in_out)) / 100.0f, 0.0f, 1.0f);
+      out[1] = CLAMP(((in[1] / _get_boost_factor(data, 1, in_out)) + 128.0f) / 256.0f, 0.0f, 1.0f);
+      out[2] = CLAMP(((in[2] / _get_boost_factor(data, 2, in_out)) + 128.0f) / 256.0f, 0.0f, 1.0f);
       break;
     case iop_cs_rgb:
       if(work_profile == NULL)
@@ -310,24 +309,24 @@ static void _blendif_scale(dt_iop_gui_blend_data_t *data, dt_iop_colorspace_type
                                                        work_profile->unbounded_coeffs_in,
                                                        work_profile->lutsize,
                                                        work_profile->nonlinearlut);
-      out[0] = CLAMP_RANGE((out[0] / _get_boost_factor(data, 0, in_out)), 0.0f, 1.0f);
-      out[1] = CLAMP_RANGE((in[0] / _get_boost_factor(data, 1, in_out)), 0.0f, 1.0f);
-      out[2] = CLAMP_RANGE((in[1] / _get_boost_factor(data, 2, in_out)), 0.0f, 1.0f);
-      out[3] = CLAMP_RANGE((in[2] / _get_boost_factor(data, 3, in_out)), 0.0f, 1.0f);
+      out[0] = CLAMP((out[0] / _get_boost_factor(data, 0, in_out)), 0.0f, 1.0f);
+      out[1] = CLAMP((in[0] / _get_boost_factor(data, 1, in_out)), 0.0f, 1.0f);
+      out[2] = CLAMP((in[1] / _get_boost_factor(data, 2, in_out)), 0.0f, 1.0f);
+      out[3] = CLAMP((in[2] / _get_boost_factor(data, 3, in_out)), 0.0f, 1.0f);
       break;
     case iop_cs_LCh:
-      out[3] = CLAMP_RANGE((in[1] / _get_boost_factor(data, 3, in_out)) / (128.0f * sqrtf(2.0f)), 0.0f, 1.0f);
-      out[4] = CLAMP_RANGE((in[2] / _get_boost_factor(data, 4, in_out)), 0.0f, 1.0f);
+      out[3] = CLAMP((in[1] / _get_boost_factor(data, 3, in_out)) / (128.0f * sqrtf(2.0f)), 0.0f, 1.0f);
+      out[4] = CLAMP((in[2] / _get_boost_factor(data, 4, in_out)), 0.0f, 1.0f);
       break;
     case iop_cs_HSL:
-      out[4] = CLAMP_RANGE((in[0] / _get_boost_factor(data, 4, in_out)), 0.0f, 1.0f);
-      out[5] = CLAMP_RANGE((in[1] / _get_boost_factor(data, 5, in_out)), 0.0f, 1.0f);
-      out[6] = CLAMP_RANGE((in[2] / _get_boost_factor(data, 6, in_out)), 0.0f, 1.0f);
+      out[4] = CLAMP((in[0] / _get_boost_factor(data, 4, in_out)), 0.0f, 1.0f);
+      out[5] = CLAMP((in[1] / _get_boost_factor(data, 5, in_out)), 0.0f, 1.0f);
+      out[6] = CLAMP((in[2] / _get_boost_factor(data, 6, in_out)), 0.0f, 1.0f);
       break;
     case iop_cs_JzCzhz:
-      out[4] = CLAMP_RANGE((in[0] / _get_boost_factor(data, 4, in_out)), 0.0f, 1.0f);
-      out[5] = CLAMP_RANGE((in[1] / _get_boost_factor(data, 5, in_out)), 0.0f, 1.0f);
-      out[6] = CLAMP_RANGE((in[2] / _get_boost_factor(data, 6, in_out)), 0.0f, 1.0f);
+      out[4] = CLAMP((in[0] / _get_boost_factor(data, 4, in_out)), 0.0f, 1.0f);
+      out[5] = CLAMP((in[1] / _get_boost_factor(data, 5, in_out)), 0.0f, 1.0f);
+      out[6] = CLAMP((in[2] / _get_boost_factor(data, 6, in_out)), 0.0f, 1.0f);
       break;
     default:
       out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
@@ -710,10 +709,10 @@ static float log10_scale_callback(GtkWidget *self, float inval, int dir)
   switch(dir)
   {
     case GRADIENT_SLIDER_SET:
-      outval = (log10(CLAMP_RANGE(inval, 0.0001f, 1.0f)) + 4.0f) / 4.0f;
+      outval = (log10(CLAMP(inval, 0.0001f, 1.0f)) + 4.0f) / 4.0f;
       break;
     case GRADIENT_SLIDER_GET:
-      outval = CLAMP_RANGE(exp(M_LN10 * (4.0f * inval - 4.0f)), 0.0f, 1.0f);
+      outval = CLAMP(exp(M_LN10 * (4.0f * inval - 4.0f)), 0.0f, 1.0f);
       if(outval <= tiny) outval = 0.0f;
       if(outval >= 1.0f - tiny) outval = 1.0f;
       break;
@@ -736,12 +735,12 @@ static float magnifier_scale_callback(GtkWidget *self, float inval, int dir)
   switch(dir)
   {
     case GRADIENT_SLIDER_SET:
-      outval = (invscale * tanh(range * (CLAMP_RANGE(inval, 0.0f, 1.0f) - 0.5f)) + 1.0f) * 0.5f;
+      outval = (invscale * tanh(range * (CLAMP(inval, 0.0f, 1.0f) - 0.5f)) + 1.0f) * 0.5f;
       if(outval <= tiny) outval = 0.0f;
       if(outval >= 1.0f - tiny) outval = 1.0f;
       break;
     case GRADIENT_SLIDER_GET:
-      outval = invrange * atanh((2.0f * CLAMP_RANGE(inval, eps, 1.0f - eps) - 1.0f) * scale) + 0.5f;
+      outval = invrange * atanh((2.0f * CLAMP(inval, eps, 1.0f - eps) - 1.0f) * scale) + 0.5f;
       if(outval <= tiny) outval = 0.0f;
       if(outval >= 1.0f - tiny) outval = 1.0f;
       break;

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -17,16 +17,14 @@
 */
 
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "common/darktable.h"
+#include "common/math.h"
 #include "develop/develop.h"
 #include "gradientslider.h"
 #include "gui/gtk.h"
-
-#define CLAMP_RANGE(x, y, z) (CLAMP(x, y, z))
 
 #define DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MAX 50
 #define DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MIN 10
@@ -71,7 +69,7 @@ static gboolean _gradient_slider_postponed_value_change(gpointer data)
   if(!DTGTK_GRADIENT_SLIDER(data)->is_dragging) DTGTK_GRADIENT_SLIDER(data)->timeout_handle = 0;
   else
   {
-    int delay = CLAMP_RANGE(darktable.develop->average_delay * 3 / 2,
+    int delay = CLAMP(darktable.develop->average_delay * 3 / 2,
                             DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MIN,
                             DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MAX);
     DTGTK_GRADIENT_SLIDER(data)->timeout_handle = g_timeout_add(delay, _gradient_slider_postponed_value_change, data);
@@ -118,7 +116,7 @@ static inline gdouble _get_position_from_screen(GtkWidget *widget, const gdouble
 {
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
   gdouble position = roundf(_screen_to_scale(widget, x) / gslider->increment) * gslider->increment;
-  return CLAMP_RANGE(position, 0., 1.);
+  return CLAMP(position, 0., 1.);
 }
 
 static inline gint _get_active_marker(GtkDarktableGradientSlider *gslider)
@@ -199,7 +197,7 @@ static gdouble _slider_move(GtkWidget *widget, gint k, gdouble value, gint direc
       const double vmin = ((k == 0) ? 0.0f : gslider->position[0]);
       const double vmax = ((k == gslider->positions - 1) ? 1.0f : gslider->position[gslider->positions - 1]);
 
-      newvalue = CLAMP_RANGE(value, vmin + ms * k, vmax - ms * (gslider->positions - 1 - k));
+      newvalue = CLAMP(value, vmin + ms * k, vmax - ms * (gslider->positions - 1 - k));
       const double rl = (newvalue - gslider->position[0]) / (gslider->position[k] - gslider->position[0]);
       const double rh = (gslider->position[gslider->positions - 1] - newvalue) /
                         (gslider->position[gslider->positions - 1] - gslider->position[k]);
@@ -312,7 +310,7 @@ static gboolean _gradient_slider_button_press(GtkWidget *widget, GdkEventButton 
       gslider->is_changed = TRUE;
       gslider->is_dragging = TRUE;
       // timeout_handle should always be zero here, but check just in case
-      int delay = CLAMP_RANGE(darktable.develop->average_delay * 3 / 2,
+      int delay = CLAMP(darktable.develop->average_delay * 3 / 2,
                               DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MIN,
                               DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MAX);
       if(!gslider->timeout_handle)
@@ -595,9 +593,9 @@ static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr)
   // do we have a picker value to draw?
   if(!isnan(gslider->picker[0]))
   {
-    int vx_min = _scale_to_screen(widget, CLAMP_RANGE(gslider->picker[1], 0.0, 1.0));
-    int vx_max = _scale_to_screen(widget, CLAMP_RANGE(gslider->picker[2], 0.0, 1.0));
-    int vx_avg = _scale_to_screen(widget, CLAMP_RANGE(gslider->picker[0], 0.0, 1.0));
+    int vx_min = _scale_to_screen(widget, CLAMP(gslider->picker[1], 0.0, 1.0));
+    int vx_max = _scale_to_screen(widget, CLAMP(gslider->picker[2], 0.0, 1.0));
+    int vx_avg = _scale_to_screen(widget, CLAMP(gslider->picker[0], 0.0, 1.0));
 
     cairo_set_source_rgba(cr, color.red, color.green, color.blue, 0.33);
 
@@ -784,7 +782,7 @@ void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gsli
 {
   assert(pos <= gslider->positions);
 
-  gslider->position[pos] = CLAMP_RANGE(gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET), 0.0, 1.0);
+  gslider->position[pos] = CLAMP(gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
   if(!darktable.gui->reset) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
@@ -793,7 +791,7 @@ void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gsli
 void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
   for(int k = 0; k < gslider->positions; k++)
-    gslider->position[k] = CLAMP_RANGE(gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET), 0.0, 1.0);
+    gslider->position[k] = CLAMP(gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
   if(!darktable.gui->reset) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -21,6 +21,7 @@
 #include "common/exif.h"
 #include "common/imageio.h"
 #include "common/imageio_module.h"
+#include "common/math.h"
 #include "control/conf.h"
 #include "imageio/format/imageio_format_api.h"
 #include "develop/pixelpipe_hb.h"
@@ -30,8 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <tiffio.h>
-
-#define CLAMP_FLT(A) ((A) > (0.0f) ? ((A) < (1.0f) ? (A) : (1.0f)) : (0.0f))
 
 // it would be nice to save space by storing the masks as single channel float data,
 // but at least GIMP can't open TIFF files where not all layers have the same format.
@@ -463,7 +462,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             for(int x = 0; x < w; x++, out += layers)
             {
               for(int c = 0; c < layers; c++)
-                out[c] = CLAMP_FLT(in[x]) * 65535.0f + 0.5f;
+                out[c] = CLIP(in[x]) * 65535.0f + 0.5f;
             }
 
             if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -483,7 +482,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             for(int x = 0; x < w; x++, out += layers)
             {
               for(int c = 0; c < layers; c++)
-                out[c] = CLAMP_FLT(in[x]) * 255.0f + 0.5f;
+                out[c] = CLIP(in[x]) * 255.0f + 0.5f;
             }
 
             if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -20,6 +20,7 @@
 #endif
 #include "bauhaus/bauhaus.h"
 #include "common/box_filters.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -34,14 +35,11 @@
 #include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define NUM_BUCKETS 4 /* OpenCL bucket chain size for tmp buffers; minimum 2 */
 
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
-#define LCLIP(x) ((x < 0) ? 0.0 : (x > 100.0) ? 100.0 : x)
 DT_MODULE_INTROSPECTION(1, dt_iop_bloom_params_t)
 
 typedef struct dt_iop_bloom_params_t

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
+#include "common/math.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -31,11 +32,8 @@
 #include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
-
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 
 #define ROUND_POSISTIVE(f) ((unsigned int)((f)+0.5))
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -45,8 +45,6 @@
 
 DT_MODULE_INTROSPECTION(5, dt_iop_clipping_params_t)
 
-#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
-
 /** flip H/V, rotate an image, then clip the buffer. */
 typedef enum dt_iop_clipping_flags_t
 {

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -99,9 +99,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-// try without clipping for now, usually it should be fine
-//#define CLIP(x,y,z)  if (x < y) x = y; if (x > z) x = z;
-
 // Verify before actually using this
 /*
 void tiling_callback  (dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *roi_in,

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -20,6 +20,7 @@
 #endif
 #include "bauhaus/bauhaus.h"
 #include "common/imageio.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "common/tea.h"
 #include "control/control.h"
@@ -34,7 +35,6 @@
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -43,8 +43,6 @@
 #if defined(__SSE__)
 #include <xmmintrin.h>
 #endif
-
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 
 DT_MODULE_INTROSPECTION(1, dt_iop_dither_params_t)
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -32,7 +33,6 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -41,8 +41,6 @@
 
 #define REDUCESIZE 64
 
-// NaN-safe clip: NaN compares false and will result in 0.0
-#define CLIP(x) (((x) >= 0.0) ? ((x) <= 1.0 ? (x) : 1.0) : 0.0)
 DT_MODULE_INTROSPECTION(3, dt_iop_global_tonemap_params_t)
 
 typedef enum _iop_operator_t

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -26,6 +26,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/debug.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -43,8 +44,6 @@
 #if defined(__SSE__)
 #include <xmmintrin.h>
 #endif
-
-#define CLIP(x) ((x < 0.0f) ? 0.0f : (x > 1.0f) ? 1.0f : x)
 
 DT_MODULE_INTROSPECTION(1, dt_iop_graduatednd_params_t)
 
@@ -782,7 +781,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         // for input x = (data->density * CLIP( 0.5+length ), calculate 2^x as (e^(ln2*x/8))^8
         // use exp2f approximation to calculate e^(ln2*x/8)
         // in worst case - density==8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = 0.693147181f /* ln2 */ * (data->density * CLIP(0.5f + length) / 8.0f);
+        const float t = DT_M_LN2f * (data->density * CLIP(0.5f + length) / 8.0f);
         const float d1 = t * t * 0.5f;
         const float d2 = d1 * t * 0.333333333f;
         const float d3 = d2 * t * 0.25f;
@@ -831,7 +830,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         // for input x = (-data->density * CLIP( 0.5-length ), calculate 2^x as (e^(ln2*x/8))^8
         // use exp2f approximation to calculate e^(ln2*x/8)
         // in worst case - density==-8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = 0.693147181f /* ln2 */ * (-data->density * CLIP(0.5f - length) / 8.0f);
+        const float t = DT_M_LN2f * (-data->density * CLIP(0.5f - length) / 8.0f);
         const float d1 = t * t * 0.5f;
         const float d2 = d1 * t * 0.333333333f;
         const float d3 = d2 * t * 0.25f;
@@ -916,7 +915,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
         // for input x = (data->density * CLIP( 0.5+length ), calculate 2^x as (e^(ln2*x/8))^8
         // use exp2f approximation to calculate e^(ln2*x/8)
         // in worst case - density==8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = 0.693147181f /* ln2 */ * (data->density * CLIP(0.5f + length) / 8.0f);
+        const float t = DT_M_LN2f * (data->density * CLIP(0.5f + length) / 8.0f);
         const float d1 = t * t * 0.5f;
         const float d2 = d1 * t * 0.333333333f;
         const float d3 = d2 * t * 0.25f;
@@ -967,7 +966,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
         // for input x = (-data->density * CLIP( 0.5-length ), calculate 2^x as (e^(ln2*x/8))^8
         // use exp2f approximation to calculate e^(ln2*x/8)
         // in worst case - density==-8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = 0.693147181f /* ln2 */ * (-data->density * CLIP(0.5f - length) / 8.0f);
+        const float t = DT_M_LN2f * (-data->density * CLIP(0.5f - length) / 8.0f);
         const float d1 = t * t * 0.5f;
         const float d2 = d1 * t * 0.333333333f;
         const float d3 = d2 * t * 0.25f;

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -19,11 +19,11 @@
 #include "config.h"
 #endif
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "common/math.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -48,7 +48,6 @@
 #define GRAIN_LUT_DELTA_MIN 0.0001
 #define GRAIN_LUT_PAPER_GAMMA 1.0
 
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 DT_MODULE_INTROSPECTION(2, dt_iop_grain_params_t)
 
 

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -19,12 +19,12 @@
 #include "config.h"
 #endif
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
 #include "common/box_filters.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -41,9 +41,6 @@
 #endif
 
 #define MAX_RADIUS 16
-
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
-#define LCLIP(x) ((x < 0) ? 0.0 : (x > 100.0) ? 100.0 : x)
 
 DT_MODULE_INTROSPECTION(1, dt_iop_highpass_params_t)
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -24,6 +24,7 @@
 #include "common/bilateralcl.h"
 #include "common/debug.h"
 #include "common/gaussian.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -37,13 +38,10 @@
 #include "iop/iop_api.h"
 #include <assert.h>
 #include <gtk/gtk.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <inttypes.h>
-
-#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
 
 DT_MODULE_INTROSPECTION(4, dt_iop_lowpass_params_t)
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -19,12 +19,12 @@
 #include "config.h"
 #endif
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -37,8 +37,6 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
-
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 
 DT_MODULE_INTROSPECTION(1, dt_iop_relight_params_t)
 

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -58,9 +58,6 @@
   (UNBOUND_SHADOWS_L | UNBOUND_SHADOWS_A | UNBOUND_SHADOWS_B | UNBOUND_HIGHLIGHTS_L | UNBOUND_HIGHLIGHTS_A   \
    | UNBOUND_HIGHLIGHTS_B | UNBOUND_GAUSSIAN)
 
-#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
-#define CLAMP_RANGE(x, y, z) (CLAMP(x, y, z))
-
 DT_MODULE_INTROSPECTION(5, dt_iop_shadhi_params_t)
 
 typedef enum dt_iop_shadhi_algo_t
@@ -394,13 +391,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     // overlay highlights
     float highlights2 = highlights * highlights;
-    const float highlights_xform = CLAMP_RANGE(1.0f - tb[0] / (1.0f - compress), 0.0f, 1.0f);
+    const float highlights_xform = CLAMP(1.0f - tb[0] / (1.0f - compress), 0.0f, 1.0f);
 
     while(highlights2 > 0.0f)
     {
-      const float la = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
+      const float la = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP(ta[0], lmin, lmax);
       float lb = (tb[0] - halfmax) * sign(-highlights) * sign(lmax - la) + halfmax;
-      lb = unbound_mask ? lb : CLAMP_RANGE(lb, lmin, lmax);
+      lb = unbound_mask ? lb : CLAMP(lb, lmin, lmax);
       const float lref = copysignf(fabs(la) > low_approximation ? 1.0f / fabs(la) : 1.0f / low_approximation, la);
       const float href = copysignf(
           fabs(1.0f - la) > low_approximation ? 1.0f / fabs(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
@@ -413,26 +410,26 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
               + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb) : doublemax * la
                                                                                            * lb) * optrans;
 
-      ta[0] = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
+      ta[0] = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP(ta[0], lmin, lmax);
 
       const float chroma_factor = (ta[0] * lref * (1.0f - highlights_ccorrect)
                                    + (1.0f - ta[0]) * href * highlights_ccorrect);
       ta[1] = ta[1] * (1.0f - optrans) + (ta[1] + tb[1]) * chroma_factor * optrans;
-      ta[1] = (flags & UNBOUND_HIGHLIGHTS_A) ? ta[1] : CLAMP_RANGE(ta[1], min[1], max[1]);
+      ta[1] = (flags & UNBOUND_HIGHLIGHTS_A) ? ta[1] : CLAMP(ta[1], min[1], max[1]);
 
       ta[2] = ta[2] * (1.0f - optrans) + (ta[2] + tb[2]) * chroma_factor * optrans;
-      ta[2] = (flags & UNBOUND_HIGHLIGHTS_B) ? ta[2] : CLAMP_RANGE(ta[2], min[2], max[2]);
+      ta[2] = (flags & UNBOUND_HIGHLIGHTS_B) ? ta[2] : CLAMP(ta[2], min[2], max[2]);
     }
 
     // overlay shadows
     float shadows2 = shadows * shadows;
-    const float shadows_xform = CLAMP_RANGE(tb[0] / (1.0f - compress) - compress / (1.0f - compress), 0.0f, 1.0f);
+    const float shadows_xform = CLAMP(tb[0] / (1.0f - compress) - compress / (1.0f - compress), 0.0f, 1.0f);
 
     while(shadows2 > 0.0f)
     {
-      const float la = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
+      const float la = (flags & UNBOUND_HIGHLIGHTS_L) ? ta[0] : CLAMP(ta[0], lmin, lmax);
       float lb = (tb[0] - halfmax) * sign(shadows) * sign(lmax - la) + halfmax;
-      lb = unbound_mask ? lb : CLAMP_RANGE(lb, lmin, lmax);
+      lb = unbound_mask ? lb : CLAMP(lb, lmin, lmax);
       const float lref = copysignf(fabs(la) > low_approximation ? 1.0f / fabs(la) : 1.0f / low_approximation, la);
       const float href = copysignf(
           fabs(1.0f - la) > low_approximation ? 1.0f / fabs(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
@@ -446,15 +443,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
               + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb) : doublemax * la
                                                                                            * lb) * optrans;
 
-      ta[0] = (flags & UNBOUND_SHADOWS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
+      ta[0] = (flags & UNBOUND_SHADOWS_L) ? ta[0] : CLAMP(ta[0], lmin, lmax);
 
       const float chroma_factor = (ta[0] * lref * shadows_ccorrect
                                    + (1.0f - ta[0]) * href * (1.0f - shadows_ccorrect));
       ta[1] = ta[1] * (1.0f - optrans) + (ta[1] + tb[1]) * chroma_factor * optrans;
-      ta[1] = (flags & UNBOUND_SHADOWS_A) ? ta[1] : CLAMP_RANGE(ta[1], min[1], max[1]);
+      ta[1] = (flags & UNBOUND_SHADOWS_A) ? ta[1] : CLAMP(ta[1], min[1], max[1]);
 
       ta[2] = ta[2] * (1.0f - optrans) + (ta[2] + tb[2]) * chroma_factor * optrans;
-      ta[2] = (flags & UNBOUND_SHADOWS_B) ? ta[2] : CLAMP_RANGE(ta[2], min[2], max[2]);
+      ta[2] = (flags & UNBOUND_SHADOWS_B) ? ta[2] : CLAMP(ta[2], min[2], max[2]);
     }
 
     _Lab_rescale(ta, &out[j]);

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -26,6 +26,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/box_filters.h"
 #include "common/colorspaces.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -44,9 +45,6 @@
 #endif
 
 #define MAX_RADIUS 32
-
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
-#define MM_CLIP_PS(X) (_mm_min_ps(_mm_max_ps((X), _mm_setzero_ps()), _mm_set1_ps(1.0)))
 
 DT_MODULE_INTROSPECTION(1, dt_iop_soften_params_t)
 

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/debug.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -37,11 +38,9 @@
 #include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 DT_MODULE_INTROSPECTION(1, dt_iop_splittoning_params_t)
 
 typedef struct dt_iop_splittoning_params_t

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -40,9 +40,6 @@
 #include <xmmintrin.h>
 #endif
 
-// NaN-safe clip: NaN compares false and will result in 0.0
-#define CLIP(x) (((x) >= 0.0) ? ((x) <= 1.0 ? (x) : 1.0) : 0.0)
-
 DT_MODULE_INTROSPECTION(2, dt_iop_velvia_params_t)
 
 typedef struct dt_iop_velvia_params_t

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -35,8 +35,6 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
-// NaN-safe clip: NaN compares false and will result in 0.0
-#define CLIP(x) (((x) >= 0.0) ? ((x) <= 1.0 ? (x) : 1.0) : 0.0)
 DT_MODULE_INTROSPECTION(2, dt_iop_vibrance_params_t)
 
 typedef struct dt_iop_vibrance_params_t

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -19,11 +19,11 @@
 #include "config.h"
 #endif
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "common/tea.h"
 #include "control/control.h"
@@ -40,8 +40,6 @@
 #include <inttypes.h>
 
 DT_MODULE_INTROSPECTION(4, dt_iop_vignette_params_t)
-
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 
 typedef enum dt_iop_dither_t
 {
@@ -751,7 +749,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       if(weight > 0)
       {
         // Then apply falloff vignette
-        float falloff = (data->brightness < 0) ? (1.0 + (weight * data->brightness))
+        float falloff = (data->brightness < 0) ? (1.0f + (weight * data->brightness))
                                                : (weight * data->brightness);
         col0 = data->brightness < 0 ? col0 * falloff + dith : col0 + falloff + dith;
         col1 = data->brightness < 0 ? col1 * falloff + dith : col1 + falloff + dith;
@@ -762,7 +760,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         col2 = unbound ? col2 : CLIP(col2);
 
         // apply saturation
-        float mv = (col0 + col1 + col2) / 3.0;
+        float mv = (col0 + col1 + col2) / 3.0f;
         float wss = weight * data->saturation;
         col0 = col0 - ((mv - col0) * wss);
         col1 = col1 - ((mv - col1) * wss);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -47,7 +47,6 @@
 #include "common/metadata.h"
 #include "common/utility.h"
 
-#define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 DT_MODULE_INTROSPECTION(5, dt_iop_watermark_params_t)
 
 // gchar *checksum = g_compute_checksum_for_data(G_CHECKSUM_MD5,data,length);

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -19,12 +19,12 @@
 #include "config.h"
 #endif
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "common/darktable.h"
 #include "common/gaussian.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include "control/conf.h"
 #include "control/control.h"
@@ -49,7 +49,6 @@
 #endif
 
 
-#define CLIP(x) (((x) >= 0) ? ((x) <= 1.0 ? (x) : 1.0) : 0.0)
 DT_MODULE_INTROSPECTION(1, dt_iop_zonesystem_params_t)
 #define MAX_ZONE_SYSTEM_SIZE 24
 


### PR DESCRIPTION
* consolidate all of the definitions of CLIP and CLAMPF in common/math.h
* change CLAMP_RANGE to CLAMP since that's how it's defined anyway
* change CLAMP_FLT to CLIP since it's the same
* remove unused CLAMPF from iop/shadhi.c

* bonus: change some instances of log(2) and magic constant for log(2) to symbolic DT_M_LN2f

Verified that all integration tests still pass.
