### PR TITLE
bugfix: colorpicker crash on freeing aligned memory allocation

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -178,9 +178,9 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const ds
     }
   }
 
-  free(mmax);
-  free(mmin);
-  free(mean);
+  dt_free_align(mmax);
+  dt_free_align(mmin);
+  dt_free_align(mean);
 }
 
 static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,


### PR DESCRIPTION
Fixes #7431.
