### PR TITLE
prefs: remove import settings from pref dialog

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -664,42 +664,49 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
     <name>ui_last/import_ignore_jpegs</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>ignore JPEG images when importing film rolls</shortdescription>
     <longdescription>when having raw+JPEG images together in one directory it makes no sense to import both. with this flag one can ignore all JPEGs found.</longdescription>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
+    <name>ui_last/import_apply_metadata</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>apply metadata on import</shortdescription>
+    <longdescription>apply some metadata to all newly imported images.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>ui_last/import_recursive</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>recursive directory traversal when importing filmrolls</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
     <name>ui_last/import_last_creator</name>
     <type>string</type>
     <default/>
     <shortdescription>creator to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
     <name>ui_last/import_last_publisher</name>
     <type>string</type>
     <default/>
     <shortdescription>publisher to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
     <name>ui_last/import_last_rights</name>
     <type>string</type>
     <default/>
     <shortdescription>rights to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
     <name>ui_last/import_last_tags</name>
     <type>string</type>
     <default/>
@@ -713,7 +720,7 @@
     <shortdescription>last opened directory.</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="import" section="import">
+  <dtconfig>
     <name>ui_last/import_initial_rating</name>
     <type min="0" max="5">int</type>
     <default>1</default>
@@ -1539,7 +1546,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>always show thumbnail overlays</shortdescription>
-    <longdescription>show overlays (rating stars, "edited" mark, etc) for all thumbnails in file manager, not only hovered one</longdescription>
+    <longdescription>show overlays (rating stars, 'edited' mark, etc) for all thumbnails in file manager, not only hovered one</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>darkroom/ui/single_module</name>

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -587,6 +587,30 @@ const char *dt_confgen_get(const char *name, dt_confgen_value_kind_t kind)
   return "";
 }
 
+const char *dt_confgen_get_label(const char *name)
+{
+  const dt_confgen_value_t *item = g_hash_table_lookup(darktable.conf->x_confgen, name);
+
+  if(item)
+  {
+    return item->shortdesc;
+  }
+
+  return "";
+}
+
+const char *dt_confgen_get_tooltip(const char *name)
+{
+  const dt_confgen_value_t *item = g_hash_table_lookup(darktable.conf->x_confgen, name);
+
+  if(item)
+  {
+    return item->longdesc;
+  }
+
+  return "";
+}
+
 int dt_confgen_get_int(const char *name, dt_confgen_value_kind_t kind)
 {
   if(!dt_confgen_value_exists(name, kind))

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -44,6 +44,8 @@ typedef struct dt_confgen_value_t
   char *min;
   char *max;
   char *enum_values;
+  char *shortdesc;
+  char *longdesc;
 } dt_confgen_value_t;
 
 typedef struct dt_conf_t
@@ -106,6 +108,9 @@ int64_t dt_confgen_get_int64(const char *name, dt_confgen_value_kind_t kind);
 gboolean dt_confgen_get_bool(const char *name, dt_confgen_value_kind_t kind);
 float dt_confgen_get_float(const char *name, dt_confgen_value_kind_t kind);
 const char *dt_confgen_get(const char *name, dt_confgen_value_kind_t kind);
+
+const char *dt_confgen_get_label(const char *name);
+const char *dt_confgen_get_tooltip(const char *name);
 
 gboolean dt_conf_is_default(const char *name);
 

--- a/src/gui/camera_import_dialog.c
+++ b/src/gui/camera_import_dialog.c
@@ -19,6 +19,7 @@
 #include "gui/camera_import_dialog.h"
 #include "common/metadata.h"
 #include "gui/import_metadata.h"
+#include "gui/preferences.h"
 #include "common/camera_control.h"
 #include "common/darktable.h"
 #include "common/debug.h"
@@ -106,22 +107,12 @@ enum
   N_COLUMNS
 };
 
-static void _check_button_callback(GtkWidget *cb, gpointer user_data)
+static void _date_override_callback(GtkWidget *cb, gpointer user_data)
 {
-
   _camera_import_dialog_t *cid = (_camera_import_dialog_t *)user_data;
-
-  if(cb == cid->settings.general.ignore_jpeg)
-  {
-    dt_conf_set_bool("ui_last/import_ignore_jpegs",
-                     gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cid->settings.general.ignore_jpeg)));
-  }
-  else if(cb == cid->settings.general.date_override)
-  {
-    // Enable/disable the date entry widget
-    gtk_widget_set_sensitive(cid->settings.general.date_entry, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(
-                                                                   cid->settings.general.date_override)));
-  }
+  // Enable/disable the date entry widget
+  gtk_widget_set_sensitive(cid->settings.general.date_entry,
+                           gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb)));
 }
 
 static void _gcw_store_callback(GtkDarktableButton *button, gpointer user_data)
@@ -270,24 +261,21 @@ static void _camera_import_dialog_new(_camera_import_dialog_t *data)
 
   gtk_box_pack_start(GTK_BOX(data->import.page), data->import.treeview, TRUE, TRUE, 0);
 
+  dt_import_metadata_t *metadata = data->settings.general.metadata;
 
   // SETTINGS PAGE
   data->settings.page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  // ignoring of jpegs. hack while we don't handle raw+jpeg in the same directories.
-  data->settings.general.ignore_jpeg = gtk_check_button_new_with_label(_("ignore JPEG files"));
-  gtk_widget_set_tooltip_text(data->settings.general.ignore_jpeg,
-               _("do not load files with an extension of .jpg or .jpeg. this can be useful when there are "
-                 "raw+JPEG in a directory."));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->settings.general.ignore_jpeg),
-                               dt_conf_get_bool("ui_last/import_ignore_jpegs"));
-  gtk_box_pack_start(GTK_BOX(data->settings.page), data->settings.general.ignore_jpeg, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(data->settings.general.ignore_jpeg), "clicked",
-                   G_CALLBACK(_check_button_callback), data);
+  GtkWidget *grid = gtk_grid_new();
+  // ignoring of jpegs
+  dt_preferences_dialog_bool(grid, "ui_last/import_ignore_jpegs");
+  // initial rating
+  dt_preferences_dialog_int(grid, "ui_last/import_initial_rating");
+  // apply metadata
+  metadata->apply_metadata = dt_preferences_dialog_bool(grid, "ui_last/import_apply_metadata");
+  gtk_box_pack_start(GTK_BOX(data->settings.page), grid, FALSE, FALSE, 0);
 
   // metadata
-
-  dt_import_metadata_t *metadata = data->settings.general.metadata;
   metadata->box = data->settings.page;
   dt_import_metadata_dialog_new(metadata);
 
@@ -306,7 +294,7 @@ static void _camera_import_dialog_new(_camera_import_dialog_t *data)
   gtk_box_pack_start(GTK_BOX(hbox), data->settings.general.date_entry, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->settings.general.date_override), "clicked",
-                   G_CALLBACK(_check_button_callback), data);
+                   G_CALLBACK(_date_override_callback), data);
 
   gtk_box_pack_start(GTK_BOX(data->settings.page), hbox, FALSE, FALSE, 0);
 

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -95,20 +95,7 @@ static void _metadata_presets_changed(GtkWidget *widget, dt_import_metadata_t *m
 void dt_import_metadata_dialog_new(dt_import_metadata_t *metadata)
 {
   // default metadata
-  GtkWidget *apply_metadata = gtk_check_button_new_with_label(_("apply metadata on import"));
-  gtk_widget_set_tooltip_text(apply_metadata, _("apply some metadata to all newly imported images."));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(apply_metadata),
-                               dt_conf_get_bool("ui_last/import_apply_metadata"));
-  gtk_box_pack_start(GTK_BOX(metadata->box), apply_metadata, FALSE, FALSE, 0);
-  metadata->apply_metadata = apply_metadata;
-  GValue value = {
-    0,
-  };
-  g_value_init(&value, G_TYPE_INT);
-  gtk_widget_style_get_property(apply_metadata, "indicator-size", &value);
-  gtk_widget_style_get_property(apply_metadata, "indicator-spacing", &value);
-  g_value_unset(&value);
-
+  GtkWidget *apply_metadata = metadata->apply_metadata;
   GtkWidget *grid = gtk_grid_new();
   gtk_box_pack_start(GTK_BOX(metadata->box), grid, FALSE, FALSE, 0);
 
@@ -257,8 +244,6 @@ void dt_import_metadata_dialog_new(dt_import_metadata_t *metadata)
 
 void dt_import_metadata_evaluate(dt_import_metadata_t *metadata)
 {
-  dt_conf_set_bool("ui_last/import_apply_metadata",
-                   gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(metadata->apply_metadata)));
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
     if(metadata->metadata[i])

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -26,6 +26,7 @@
 #include "common/l10n.h"
 #include "common/presets.h"
 #include "control/control.h"
+#include "control/conf.h"
 #include "develop/imageop.h"
 #include "gui/accelerators.h"
 #include "gui/draw.h"
@@ -2186,6 +2187,148 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
   gtk_widget_destroy(GTK_WIDGET(dialog));
   free(g);
 }
+
+static int _get_grid_nb_lines(GtkGrid *grid)
+{
+  int line = 0;
+  gboolean not_empty = TRUE;
+  while(not_empty)
+  {
+    for(int i = 0; i < 3; i++)
+    {
+      not_empty = gtk_grid_get_child_at(grid, i, line) != NULL;
+      if(not_empty) break;
+    }
+    if(not_empty) line++;
+  }
+  return line;
+}
+
+static GtkWidget *_set_labdef(const char *setting)
+{
+  const gboolean is_default = dt_conf_is_default(setting);
+  GtkWidget *labdef;
+  if(is_default)
+  {
+     labdef = gtk_label_new("");
+  }
+  else
+  {
+     labdef = gtk_label_new(NON_DEF_CHAR);
+     g_object_set(labdef, "tooltip-text", _("this setting has been modified"), (gchar *)0);
+  }
+  gtk_widget_set_name(labdef, "preference_non_default");
+  return labdef;
+}
+
+static void
+_dialog_bool_changed_callback(GtkWidget *widget, gpointer user_data)
+{
+  const char *name = gtk_widget_get_name(widget);
+  set_widget_label_default(widget, name, GTK_WIDGET(user_data));
+  dt_conf_set_bool(name, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+}
+
+static gboolean
+_dialog_bool_reset(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
+{
+  if(event->type == GDK_2BUTTON_PRESS)
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+GtkWidget *dt_preferences_dialog_bool(GtkWidget *grid, const char *setting)
+{
+  GtkWidget *widget, *label, *labelev, *box;
+  char tooltip[1024];
+  int line = _get_grid_nb_lines(GTK_GRID(grid));
+  GtkWidget *labdef = _set_labdef(setting);
+  label = gtk_label_new(_(dt_confgen_get_label(setting)));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  widget = gtk_check_button_new();
+  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), dt_conf_get_bool(setting));
+  gtk_widget_set_name(widget, setting);
+  g_signal_connect(G_OBJECT(widget), "toggled", G_CALLBACK(_dialog_bool_changed_callback), labdef);
+  snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "FALSE"));
+  g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
+  gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);
+  g_object_set(widget, "tooltip-text", _(dt_confgen_get_tooltip(setting)), (gchar *)0);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labdef, 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), box, 2, line++, 1, 1);
+  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_dialog_bool_reset), (gpointer)widget);
+  return widget;
+}
+
+static void
+_dialog_int_changed_callback(GtkWidget *widget, gpointer user_data)
+{
+  const char *name = gtk_widget_get_name(widget);
+  set_widget_label_default(widget, name, GTK_WIDGET(user_data));
+  const float factor = 1.0f;
+  dt_conf_set_int(name, gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);
+}
+
+static gboolean
+_dialog_int_reset(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
+{
+  if(event->type == GDK_2BUTTON_PRESS)
+  {
+    const char *name = gtk_widget_get_name(widget);
+    const int default_value = dt_confgen_get_int(name, DT_DEFAULT);
+    const float factor = 1.0f;
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), 1 * factor);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+GtkWidget *dt_preferences_dialog_int(GtkWidget *grid, const char *setting)
+{
+  GtkWidget *widget, *label, *labelev, *box;
+  char tooltip[1024];
+  int line = _get_grid_nb_lines(GTK_GRID(grid));
+  GtkWidget *labdef = _set_labdef(setting);
+  label = gtk_label_new(_(dt_confgen_get_label(setting)));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gint min = G_MININT;
+  gint max = G_MAXINT;
+  min = 0;
+  max = 5;
+  float factor = 1.0f;
+  double tmp;
+  tmp = min * (double)factor; min = tmp;
+  tmp = max * (double)factor; max = tmp;
+  widget = gtk_spin_button_new_with_range(min, max, 1);
+  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
+  gtk_widget_set_hexpand(widget, FALSE);
+  gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int("ui_last/import_initial_rating") * factor);
+  gtk_widget_set_name(widget, setting);
+  g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(_dialog_int_changed_callback), labdef);
+  snprintf(tooltip, 1024, _("double click to reset to `%d'"), (int)(1 * factor));
+  g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
+  gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);
+  g_object_set(widget, "tooltip-text", _(dt_confgen_get_tooltip(setting)), (gchar *)0);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labdef, 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), box, 2, line++, 1, 1);
+  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_dialog_int_reset), (gpointer)widget);
+  return widget;
+}
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/preferences.h
+++ b/src/gui/preferences.h
@@ -21,6 +21,11 @@
 /** shows the preferences dialog and blocks until it's closed. */
 void dt_gui_preferences_show();
 
+// include the bool pref widget in grid and return the widget for potential action
+GtkWidget *dt_preferences_dialog_bool(GtkWidget *grid, const char *setting);
+// include the int pref widget in grid and return the widget for potential action
+GtkWidget *dt_preferences_dialog_int(GtkWidget *grid, const char *setting);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/tools/generate_darktablerc_conf.xsl
+++ b/tools/generate_darktablerc_conf.xsl
@@ -98,6 +98,38 @@ static void _insert_type(const char *name, const char *value)
   else                              item->type = DT_STRING;
 }
 
+static void _insert_shortdescription(const char *name, const char *value)
+{
+  dt_confgen_value_t *item = (dt_confgen_value_t *)g_hash_table_lookup(darktable.conf->x_confgen, name);
+
+  if(item)
+  {
+     g_free(item->shortdesc);
+  }
+  else
+  {
+     item = (dt_confgen_value_t *)g_malloc0(sizeof(dt_confgen_value_t));
+     g_hash_table_insert(darktable.conf->x_confgen, g_strdup(name), item);
+  }
+  item->shortdesc = g_strdup(value);
+}
+
+static void _insert_longdescription(const char *name, const char *value)
+{
+  dt_confgen_value_t *item = (dt_confgen_value_t *)g_hash_table_lookup(darktable.conf->x_confgen, name);
+
+  if(item)
+  {
+     g_free(item->longdesc);
+  }
+  else
+  {
+     item = (dt_confgen_value_t *)g_malloc0(sizeof(dt_confgen_value_t));
+     g_hash_table_insert(darktable.conf->x_confgen, g_strdup(name), item);
+  }
+  item->longdesc = g_strdup(value);
+}
+
 void dt_confgen_init()
 {
 ]]></xsl:text>
@@ -106,6 +138,8 @@ void dt_confgen_init()
     <xsl:variable name="default" select="default"/>
     <xsl:variable name="name" select="name"/>
     <xsl:variable name="type" select="type"/>
+		<xsl:variable name="shortdescription" select="shortdescription"/>
+		<xsl:variable name="longdescription" select="longdescription"/>
 
     <xsl:text>   // </xsl:text><xsl:value-of select="$name" />
     <xsl:text>&#xA;</xsl:text>
@@ -115,6 +149,10 @@ void dt_confgen_init()
     <xsl:text>&#xA;</xsl:text>
 
     <xsl:apply-templates select="type"/>
+
+		<xsl:apply-templates select="shortdescription"/>
+
+		<xsl:apply-templates select="longdescription"/>
 
     <xsl:text>&#xA;</xsl:text>
   </xsl:for-each>
@@ -157,6 +195,20 @@ void dt_confgen_init()
     <xsl:text>");</xsl:text>
     <xsl:text>&#xA;</xsl:text>
   </xsl:if>
+</xsl:template>
+
+<xsl:template match="shortdescription">
+	<xsl:text>   _insert_shortdescription("</xsl:text><xsl:value-of select="../name" />
+	<xsl:text>", "</xsl:text><xsl:value-of select="."/>
+	<xsl:text>");</xsl:text>
+	<xsl:text>&#xA;</xsl:text>
+</xsl:template>
+
+<xsl:template match="longdescription">
+	<xsl:text>   _insert_longdescription("</xsl:text><xsl:value-of select="../name" />
+	<xsl:text>", "</xsl:text><xsl:value-of select="."/>
+	<xsl:text>");</xsl:text>
+	<xsl:text>&#xA;</xsl:text>
 </xsl:template>
 
 <xsl:template match="default">

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -374,15 +374,6 @@ gboolean restart_required = FALSE;
         <!-- import -->
 
   <xsl:text>&#xA;static void&#xA;init_tab_import</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("import"), _("import"));&#xA;</xsl:text>
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("import"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
 
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='import' and @section='import']">
           <xsl:apply-templates select="." mode="tab_block"/>


### PR DESCRIPTION
related to #7050

details:
- import: add initial rating pref to have the import settings on the import dialog
- preferences: add int & bool routines to use prefs locally using the the global preferences darktableconfig.xml.in

![image](https://user-images.githubusercontent.com/23012047/103105858-3e621080-460f-11eb-928c-c0e135e5fd05.png)

![image](https://user-images.githubusercontent.com/23012047/103105896-9bf65d00-460f-11eb-8145-ed26bbb27905.png)
