### PR TITLE
colormapping: cleanup parallel loops

### DIFF
--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -447,14 +447,14 @@ static void kmeans(const float *col, const int width, const int height, const in
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_colormapping_data_t *data = (dt_iop_colormapping_data_t *)piece->data;
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
-  float *in = (float *)ivoid;
-  float *out = (float *)ovoid;
+  dt_iop_colormapping_data_t *const restrict data = (dt_iop_colormapping_data_t *)piece->data;
+  dt_iop_colormapping_gui_data_t *const restrict g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  float *const restrict in = (float *)ivoid;
+  float *const restrict out = (float *)ovoid;
 
   const int width = roi_in->width;
   const int height = roi_in->height;
-  const int ch = piece->colors;
+  assert(piece->colors == 4);
 
   const float scale = piece->iscale / roi_in->scale;
   const float sigma_s = 50.0f / scale;
@@ -466,12 +466,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_pthread_mutex_lock(&g->lock);
     if(g->buffer) free(g->buffer);
 
-    g->buffer = malloc((size_t)width * height * ch * sizeof(float));
+    g->buffer = malloc((size_t)4 * width * height  * sizeof(float));
     g->width = width;
     g->height = height;
-    g->ch = ch;
+    g->ch = 4;
 
-    if(g->buffer) memcpy(g->buffer, in, (size_t)width * height * ch * sizeof(float));
+    if(g->buffer) memcpy(g->buffer, in, (size_t)4 * width * height * sizeof(float));
 
     dt_pthread_mutex_unlock(&g->lock);
   }
@@ -481,8 +481,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     // for all pixels: find input cluster, transfer to mapped target cluster and apply histogram
 
-    float dominance = data->dominance / 100.0f;
-    float equalization = data->equalization / 100.0f;
+    const float dominance = data->dominance / 100.0f;
+    const float equalization = data->equalization / 100.0f;
 
     // get mapping from input clusters to target clusters
     int *const mapio = malloc(data->n * sizeof(int));
@@ -500,25 +500,21 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           = (data->target_var[i][1] > 0.0f) ? data->source_var[mapio[i]][1] / data->target_var[i][1] : 0.0f;
     }
 
+    const size_t npixels = height * width;
 // first get delta L of equalized L minus original image L, scaled to fit into [0 .. 100]
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, height, width) \
-    shared(data, in, out, equalization) \
+    dt_omp_firstprivate(npixels) \
+    dt_omp_sharedconst(in, out, data, equalization)        \
     schedule(static)
 #endif
-    for(int k = 0; k < height; k++)
+    for(size_t k = 0; k < 4*npixels; k += 4)
     {
-      size_t j = (size_t)ch * width * k;
-      for(int i = 0; i < width; i++)
-      {
-        const float L = in[j];
-        out[j] = 0.5f * ((L * (1.0f - equalization)
-                          + data->source_ihist[data->target_hist[(int)CLAMP(
-                                HISTN * L / 100.0f, 0.0f, (float)HISTN - 1.0f)]] * equalization) - L) + 50.0f;
-        out[j] = CLAMP(out[j], 0.0f, 100.0f);
-        j += ch;
-      }
+      const float L = in[k];
+      out[k] = 0.5f * ((L * (1.0f - equalization)
+                        + data->source_ihist[data->target_hist[(int)CLAMP(
+                              HISTN * L / 100.0f, 0.0f, (float)HISTN - 1.0f)]] * equalization) - L) + 50.0f;
+      out[k] = CLAMP(out[k], 0.0f, 100.0f);
     }
 
     if(equalization > 0.001f)
@@ -541,16 +537,18 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     float *const weight_buf = dt_alloc_perthread(data->n, sizeof(float), &allocsize);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, height, mapio, var_ratio, weight_buf, width, allocsize) \
-    shared(data, in, out, equalization) \
-    schedule(static)
+#pragma omp parallel default(none) \
+    dt_omp_firstprivate(npixels, mapio, var_ratio, weight_buf, allocsize) \
+    dt_omp_sharedconst(data, in, out, equalization)
 #endif
-    for(int k = 0; k < height; k++)
     {
-      float *weight = dt_get_perthread(weight_buf,allocsize);
-      size_t j = (size_t)ch * width * k;
-      for(int i = 0; i < width; i++)
+      // get a thread-private scratch buffer; do this before the actual loop so we don't have to look it up for
+      // every single pixel
+      float *const restrict weight = dt_get_perthread(weight_buf,allocsize);
+#ifdef _OPENMP
+#pragma omp for schedule(static)
+#endif
+      for(size_t j = 0; j < 4*npixels; j += 4)
       {
         const float L = in[j];
         const float Lab[3] = { L, in[j + 1], in[j + 2] };
@@ -560,7 +558,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         out[j] = CLAMP(out[j], 0.0f, 100.0f);
 
         get_clusters(in + j, data->n, data->target_mean, weight);
+        // zero the 'a' and 'b' channels
         out[j + 1] = out[j + 2] = 0.0f;
+        // then accumulate a weighted average for a and b
         for(int c = 0; c < data->n; c++)
         {
           out[j + 1] += weight[c] * ((Lab[1] - data->target_mean[c][0]) * var_ratio[c][0]
@@ -568,8 +568,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           out[j + 2] += weight[c] * ((Lab[2] - data->target_mean[c][1]) * var_ratio[c][1]
                                      + data->source_mean[mapio[c]][1]);
         }
+        // pass through the alpha channel
         out[j + 3] = in[j + 3];
-        j += ch;
       }
     }
 
@@ -580,7 +580,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // incomplete parameter set -> do nothing
   else
   {
-    memcpy(out, in, (size_t)sizeof(float) * ch * width * height);
+    memcpy(out, in, (size_t)sizeof(float) * 4 * width * height);
   }
 }
 


### PR DESCRIPTION
Produces identical output.  Speed with GCC8 is the same within measurement error, but other compilers might now be able to apply more optimizations.
