### PR TITLE
colorout: cleanup parallel loops

### DIFF
--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -472,7 +472,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void Xprocess_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -442,7 +442,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 // fprintf(stderr,"Using xform codepath\n");
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, d, gamutcheck, ivoid, ovoid, roi_out) \
+    dt_omp_firstprivate(ch, d, gamutcheck, ivoid, out, roi_out) \
     schedule(static)
 #endif
     for(int k = 0; k < roi_out->height; k++)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -348,22 +348,23 @@ static void process_fastpath_apply_tonecurves(struct dt_iop_module_t *self, dt_d
                                               const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
-  const int ch = piece->colors;
-
+  
   if(!isnan(d->cmatrix[0]))
   {
+    assert(piece->colors == 4);
+    const size_t npixels = (size_t)roi_out->width * roi_out->height;
+    float *const restrict out = (float *const)ovoid;
     // out is already converted to RGB from Lab.
 
     // do we have any lut to apply, or is this a linear profile?
     if((d->lut[0][0] >= 0.0f) && (d->lut[1][0] >= 0.0f) && (d->lut[2][0] >= 0.0f))
     { // apply profile
-      float *const out = (float *const)ovoid;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-      dt_omp_firstprivate(ch, d, out, roi_out) \
+      dt_omp_firstprivate(d, out, npixels) \
       schedule(static)
 #endif
-      for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
+      for(size_t k = 0; k < 4 * npixels; k += 4)
       {
         for(int c = 0; c < 3; c++)
         {
@@ -374,13 +375,12 @@ static void process_fastpath_apply_tonecurves(struct dt_iop_module_t *self, dt_d
     }
     else if((d->lut[0][0] >= 0.0f) || (d->lut[1][0] >= 0.0f) || (d->lut[2][0] >= 0.0f))
     { // apply profile
-      float *const out = (float *const)ovoid;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-      dt_omp_firstprivate(ch, d, out, roi_out) \
+      dt_omp_firstprivate(d, out, npixels) \
       schedule(static)
 #endif
-      for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
+      for(size_t k = 0; k < 4 * npixels; k += 4)
       {
         for(int c = 0; c < 3; c++)
         {
@@ -401,6 +401,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
   const int ch = piece->colors;
   const int gamutcheck = (d->mode == DT_PROFILE_GAMUTCHECK);
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
+  float *const restrict out = (float *)ovoid;
 
   if(d->type == DT_COLORSPACE_LAB)
   {
@@ -408,32 +410,32 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else if(!isnan(d->cmatrix[0]))
   {
+    const float *const restrict in = (const float *const)ivoid;
+    const float *const restrict cmatrix = d->cmatrix; 
 // fprintf(stderr,"Using cmatrix codepath\n");
 // convert to rgb using matrix
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(d, ch, ivoid, ovoid, roi_out) \
+    dt_omp_firstprivate(cmatrix, ch, in, out, npixels) \
     schedule(static)
 #endif
-    for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
+    for(size_t k = 0; k < (size_t)ch * npixels; k += ch)
     {
-      const float *const in = (const float *const)ivoid + (size_t)k;
-      float *out = (float *)ovoid + (size_t)k;
-
       float xyz[3];
-      dt_Lab_to_XYZ(in, xyz);
+      dt_Lab_to_XYZ(in + k, xyz);
 
       for(int c = 0; c < 3; c++)
       {
-        out[c] = 0.0f;
+        float sum = 0.0f;
         for(int i = 0; i < 3; i++)
         {
-          out[c] += d->cmatrix[3 * c + i] * xyz[i];
+          sum += cmatrix[3 * c + i] * xyz[i];
         }
+        out[k+c] = sum;
       }
     }
 
-    process_fastpath_apply_tonecurves(self, piece, ivoid, ovoid, roi_in, roi_out);
+    process_fastpath_apply_tonecurves(self, piece, in, out, roi_in, roi_out);
   }
   else
   {
@@ -446,35 +448,38 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(int k = 0; k < roi_out->height; k++)
     {
       const float *in = ((float *)ivoid) + (size_t)ch * k * roi_out->width;
-      float *out = ((float *)ovoid) + (size_t)ch * k * roi_out->width;
+      float *const restrict outp = out + (size_t)ch * k * roi_out->width;
 
-      cmsDoTransform(d->xform, in, out, roi_out->width);
+      cmsDoTransform(d->xform, in, outp, roi_out->width);
 
       if(gamutcheck)
       {
-        for(int j = 0; j < roi_out->width; j++, out += 4)
+        for(int j = 0; j < roi_out->width; j++)
         {
-          if(out[0] < 0.0f || out[1] < 0.0f || out[2] < 0.0f)
+          if(outp[ch*j+0] < 0.0f || outp[ch*j+1] < 0.0f || out[ch*j+2] < 0.0f)
           {
-            out[0] = 0.0f;
-            out[1] = 1.0f;
-            out[2] = 1.0f;
+            outp[ch*j+0] = 0.0f;
+            outp[ch*j+1] = 1.0f;
+            outp[ch*j+2] = 1.0f;
           }
         }
       }
     }
   }
 
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
+    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+void Xprocess_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
   const int ch = piece->colors;
   const int gamutcheck = (d->mode == DT_PROFILE_GAMUTCHECK);
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
+  float *const restrict out = (float *)ovoid;
 
   if(d->type == DT_COLORSPACE_LAB)
   {
@@ -482,32 +487,25 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   }
   else if(!isnan(d->cmatrix[0]))
   {
-// fprintf(stderr,"Using cmatrix codepath\n");
+    const float *const restrict in = (const float *const)ivoid;
+    const float *const restrict cmatrix = d->cmatrix; 
+    const __m128 m0 = _mm_set_ps(0.0f, cmatrix[6], cmatrix[3], cmatrix[0]);
+    const __m128 m1 = _mm_set_ps(0.0f, cmatrix[7], cmatrix[4], cmatrix[1]);
+    const __m128 m2 = _mm_set_ps(0.0f, cmatrix[8], cmatrix[5], cmatrix[2]);
+ fprintf(stderr,"Using cmatrix codepath\n");
 // convert to rgb using matrix
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, d, ivoid, ovoid, roi_in, roi_out) \
+    dt_omp_firstprivate(ch, npixels, m0, m1, m2, in, out)    \
     schedule(static)
 #endif
-    for(int j = 0; j < roi_out->height; j++)
+    for(int j = 0; j < ch * npixels; j += ch)
     {
-
-      float *in = (float *)ivoid + (size_t)ch * roi_in->width * j;
-      float *out = (float *)ovoid + (size_t)ch * roi_out->width * j;
-      const __m128 m0 = _mm_set_ps(0.0f, d->cmatrix[6], d->cmatrix[3], d->cmatrix[0]);
-      const __m128 m1 = _mm_set_ps(0.0f, d->cmatrix[7], d->cmatrix[4], d->cmatrix[1]);
-      const __m128 m2 = _mm_set_ps(0.0f, d->cmatrix[8], d->cmatrix[5], d->cmatrix[2]);
-
-      for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
-      {
-        const __m128 xyz = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-        const __m128 t
-            = _mm_add_ps(_mm_mul_ps(m0, _mm_shuffle_ps(xyz, xyz, _MM_SHUFFLE(0, 0, 0, 0))),
-                         _mm_add_ps(_mm_mul_ps(m1, _mm_shuffle_ps(xyz, xyz, _MM_SHUFFLE(1, 1, 1, 1))),
-                                    _mm_mul_ps(m2, _mm_shuffle_ps(xyz, xyz, _MM_SHUFFLE(2, 2, 2, 2)))));
-
-        _mm_stream_ps(out, t);
-      }
+      const __m128 xyz = dt_Lab_to_XYZ_sse2(_mm_load_ps(in + j));
+      const __m128 t = ((m0 * _mm_shuffle_ps(xyz, xyz, _MM_SHUFFLE(0, 0, 0, 0))) +
+                        ((m1 * _mm_shuffle_ps(xyz, xyz, _MM_SHUFFLE(1, 1, 1, 1))) +
+                         (m2 * _mm_shuffle_ps(xyz, xyz, _MM_SHUFFLE(2, 2, 2, 2)))));
+      _mm_stream_ps(out + j, t);
     }
     _mm_sfence();
 
@@ -519,21 +517,21 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     const __m128 outofgamutpixel = _mm_set_ps(0.0f, 1.0f, 1.0f, 0.0f);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, d, ivoid, gamutcheck, outofgamutpixel, ovoid, roi_out) \
+    dt_omp_firstprivate(ch, d, ivoid, gamutcheck, outofgamutpixel, out, roi_out) \
     schedule(static)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {
       const float *in = ((float *)ivoid) + (size_t)ch * k * roi_out->width;
-      float *out = ((float *)ovoid) + (size_t)ch * k * roi_out->width;
+      float *outp = out + (size_t)ch * k * roi_out->width;
 
-      cmsDoTransform(d->xform, in, out, roi_out->width);
+      cmsDoTransform(d->xform, in, outp, roi_out->width);
 
       if(gamutcheck)
       {
-        for(int j = 0; j < roi_out->width; j++, out += 4)
+        for(int j = 0; j < roi_out->width; j++)
         {
-          const __m128 pixel = _mm_load_ps(out);
+          const __m128 pixel = _mm_load_ps(outp + 4*j);
           __m128 ingamut = _mm_cmplt_ps(pixel, _mm_set_ps(-FLT_MAX, 0.0f, 0.0f, 0.0f));
 
           ingamut = _mm_or_ps(_mm_unpacklo_ps(ingamut, ingamut), _mm_unpackhi_ps(ingamut, ingamut));
@@ -541,7 +539,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
           const __m128 result
               = _mm_or_ps(_mm_and_ps(ingamut, outofgamutpixel), _mm_andnot_ps(ingamut, pixel));
-          _mm_stream_ps(out, result);
+          _mm_stream_ps(outp + 4*j, result);
         }
       }
     }


### PR DESCRIPTION
Verified to produce the same output as before, but note that the plain-C path's output differs slightly from the default SSE path even without this PR (e.g. max dE = 1.0337 on test 0001).  I haven't investigated that yet.

