### PR TITLE
Refactor: add common image-copy function

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ FILE(GLOB SOURCE_FILES
   "common/image.c"
   "common/image_cache.c"
   "common/image_compression.c"
+  "common/imagebuf.c"
   "common/imageio.c"
   "common/imageio_jpeg.c"
   "common/imageio_png.c"

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -324,9 +324,9 @@ void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 
 void *dt_alloc_align(size_t alignment, size_t size);
-static inline void * dt_alloc_align_float(size_t pixels)
+static inline float *dt_alloc_align_float(size_t pixels)
 {
-  return __builtin_assume_aligned(dt_alloc_align(64, pixels * sizeof(float)), 64);
+  return (float*)__builtin_assume_aligned(dt_alloc_align(64, pixels * sizeof(float)), 64);
 }
 size_t dt_round_size(const size_t size, const size_t alignment);
 size_t dt_round_size_sse(const size_t size);

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -41,16 +41,6 @@ void dt_iop_image_copy(float *const __restrict__ out, const float *const __restr
   memcpy(out, in, nfloats * sizeof(float));
 }
 
-// Copy an image buffer, specifying its dimensions and number of channels.  Use of this function is to be
-// preferred over a bare memcpy both because it helps document the purpose of the code and because it gives us
-// a single point where we can optimize performance on different architectures.
-void dt_iop_image_copy_by_size(float *const __restrict__ out, const float *const __restrict__ in,
-                               const size_t width, const size_t height, const size_t ch)
-{
-  const size_t nfloats = ch * width * height; 
-  dt_iop_image_copy(out, in, nfloats);
-}
-
 // Copy an image buffer, specifying the regions of interest.  The output RoI may be larger than the input RoI,
 // in which case the result is optionally padded with zeros.  If the output RoI is smaller than the input RoI,
 // only a portion of the input buffer will be copied.

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -1,0 +1,88 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2016-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/imagebuf.h"
+
+// Copy an image buffer, specifying the number of floats it contains.  Use of this function is to be preferred
+// over a bare memcpy both because it helps document the purpose of the code and because it gives us a single
+// point where we can optimize performance on different architectures.
+void dt_iop_image_copy(float *const __restrict__ out, const float *const __restrict__ in, const size_t nfloats)
+{
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(in, out, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      out[k] = in[k];
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+  memcpy(out, in, nfloats * sizeof(float));
+}
+
+// Copy an image buffer, specifying its dimensions and number of channels.  Use of this function is to be
+// preferred over a bare memcpy both because it helps document the purpose of the code and because it gives us
+// a single point where we can optimize performance on different architectures.
+void dt_iop_image_copy_by_size(float *const __restrict__ out, const float *const __restrict__ in,
+                               const size_t width, const size_t height, const size_t ch)
+{
+  const size_t nfloats = ch * width * height; 
+  dt_iop_image_copy(out, in, nfloats);
+}
+
+// Copy an image buffer, specifying the regions of interest.  The output RoI may be larger than the input RoI,
+// in which case the result is optionally padded with zeros.  If the output RoI is smaller than the input RoI,
+// only a portion of the input buffer will be copied.
+void dt_iop_copy_image_roi(float *const __restrict__ out, const float *const __restrict__ in, const size_t ch,
+                           const dt_iop_roi_t *const __restrict__ roi_in,
+                           const dt_iop_roi_t *const __restrict__ roi_out, const int zero_pad)
+{
+  if (roi_in->width == roi_out->width && roi_in->height == roi_out->height)
+  {
+    // fast path, just copy the entire contents of the buffer
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, ch);
+  }
+  else if (roi_in->width <= roi_out->width && roi_in->height <= roi_out->height)
+  {
+    // output needs padding
+    fprintf(stderr,"copy_image_roi with larger output not yet implemented\n");
+    //TODO
+  }
+  else if (roi_in->width >= roi_out->width && roi_in->height >= roi_out->height)
+  {
+    // copy only a portion of the input
+    fprintf(stderr,"copy_image_roi with smaller output not yet implemented\n");
+    //TODO
+  }
+  else
+  {
+    // inconsistent RoIs!!
+    fprintf(stderr,"copy_image_roi called with inconsistent RoI!\n");
+    //TODO
+  }
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -1,0 +1,68 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2016-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "develop/imageop.h" // for dt_iop_roi_t
+
+__DT_CLONE_TARGETS__
+static inline void dt_simd_memcpy(const float *const __restrict__ in,
+                                  float *const __restrict__ out,
+                                  const size_t num_elem)
+{
+  // Perform a parallel vectorized memcpy on 64-bits aligned
+  // contiguous buffers. This is several times faster than the original memcpy
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+dt_omp_firstprivate(in, out, num_elem) \
+schedule(simd:static) aligned(in, out:64)
+#endif
+  for(size_t k = 0; k < num_elem; k++)
+    out[k] = in[k];
+}
+
+static inline float *__restrict__ dt_iop_image_alloc(const size_t width, const size_t height, const size_t ch)
+{
+  return dt_alloc_align_float(width * height * ch);
+}
+
+// Copy an image buffer, specifying the number of floats it contains.  Use of this function is to be preferred
+// over a bare memcpy both because it helps document the purpose of the code and because it gives us a single
+// point where we can optimize performance on different architectures.
+void dt_iop_image_copy(float *const __restrict__ out, const float *const __restrict__ in, const size_t nfloats);
+
+// Copy an image buffer, specifying its dimensions and number of channels.  Use of this function is to be
+// preferred over a bare memcpy both because it helps document the purpose of the code and because it gives us
+// a single point where we can optimize performance on different architectures.
+void dt_iop_image_copy_by_size(float *const __restrict__ out, const float *const __restrict__ in,
+                               const size_t width, const size_t height, const size_t ch);
+
+// Copy an image buffer, specifying the region of interest.  The output RoI may be larger than the input RoI,
+// in which case the result is optionally padded with zeros.  If the output RoI is smaller than the input RoI,
+// only a portion of the input buffer will be copied.
+void dt_iop_copy_image_roi(float *const __restrict__ out, const float *const __restrict__ in, const size_t ch,
+                           const dt_iop_roi_t *const __restrict__ roi_in,
+                           const dt_iop_roi_t *const __restrict__ roi_out, const int zero_pad);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -40,6 +40,8 @@ schedule(simd:static) aligned(in, out:64)
     out[k] = in[k];
 }
 
+// Allocate a 64-byte aligned buffer for an image of the given dimensions and channels.
+// The return value must be freed with dt_free_align().
 static inline float *__restrict__ dt_iop_image_alloc(const size_t width, const size_t height, const size_t ch)
 {
   return dt_alloc_align_float(width * height * ch);
@@ -53,8 +55,11 @@ void dt_iop_image_copy(float *const __restrict__ out, const float *const __restr
 // Copy an image buffer, specifying its dimensions and number of channels.  Use of this function is to be
 // preferred over a bare memcpy both because it helps document the purpose of the code and because it gives us
 // a single point where we can optimize performance on different architectures.
-void dt_iop_image_copy_by_size(float *const __restrict__ out, const float *const __restrict__ in,
-                               const size_t width, const size_t height, const size_t ch);
+static inline void dt_iop_image_copy_by_size(float *const __restrict__ out, const float *const __restrict__ in,
+                                             const size_t width, const size_t height, const size_t ch)
+{
+  dt_iop_image_copy(out, in, width * height * ch);
+}
 
 // Copy an image buffer, specifying the region of interest.  The output RoI may be larger than the input RoI,
 // in which case the result is optionally padded with zeros.  If the output RoI is smaller than the input RoI,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -149,24 +149,6 @@ static inline void dt_iop_estimate_exp(const float *const x, const float *const 
 }
 
 
-__DT_CLONE_TARGETS__
-static inline void dt_simd_memcpy(const float *const __restrict__ in,
-                                  float *const __restrict__ out,
-                                  const size_t num_elem)
-{
-  // Perform a parallel vectorized memcpy on 64-bits aligned
-  // contiguous buffers. This is several times faster than the original memcpy
-
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, out, num_elem) \
-schedule(simd:static) aligned(in, out:64)
-#endif
-  for(size_t k = 0; k < num_elem; k++)
-    out[k] = in[k];
-}
-
-
 /** evaluates the exp fit. */
 #ifdef _OPENMP
 #pragma omp declare simd

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -23,6 +23,7 @@
 #include "common/bilateral.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/debug.h"
+#include "common/imagebuf.h"
 #include "common/interpolation.h"
 #include "common/math.h"
 #include "common/opencl.h"
@@ -959,7 +960,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
   // if module is set to neutral parameters we just copy input->output and are done
   if(isneutral(data))
   {
-    memcpy(out, in, sizeof(float) * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, 1);
     return;
   }
 
@@ -1575,7 +1576,7 @@ static int get_structure(dt_iop_module_t *module, dt_iop_ashift_enhance_t enhanc
     // create a temporary buffer to hold image data
     buffer = malloc(sizeof(float) * 4 * (size_t)width * height);
     if(buffer != NULL)
-      memcpy(buffer, g->buf, sizeof(float) * 4 * width * height);
+      dt_iop_image_copy_by_size(buffer, g->buf, width, height, 4);
   }
   dt_pthread_mutex_unlock(&g->lock);
 
@@ -2902,7 +2903,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     if(g->buf /* && hash != g->buf_hash */)
     {
       // copy data
-      memcpy(g->buf, ivoid, sizeof(float) * ch * width * height);
+      dt_iop_image_copy_by_size(g->buf, ivoid, width, height, ch);
 
       g->buf_width = width;
       g->buf_height = height;
@@ -2918,7 +2919,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // if module is set to neutral parameters we just copy input->output and are done
   if(isneutral(data))
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -18,6 +18,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/eaw.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "control/conf.h"
 #include "control/control.h"
@@ -244,7 +245,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   // lead to out of bounds memory access
   if(width < 2 * max_mult || height < 2 * max_mult)
   {
-    memcpy(o, i, sizeof(float) * 4 * width * height);
+    dt_iop_image_copy_by_size(o, i, width, height, 4);
     return;
   }
 

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -23,6 +23,7 @@ extern "C" {
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -115,7 +116,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   sigma[4] = data->sigma[4];
   if(fmaxf(sigma[0], sigma[1]) < .1)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size((float*)ovoid, (float*)ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -124,7 +125,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(rad <= 6 && ((piece->pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL) == DT_DEV_PIXELPIPE_THUMBNAIL))
   {
     // no use denoising the thumbnail. takes ages without permutohedral
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size((float*)ovoid, (float*)ivoid, roi_out->width, roi_out->height, ch);
   }
   else if(rad <= 6)
   {

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -19,6 +19,7 @@
 #include "config.h"
 #endif
 #include "common/darktable.h"
+#include "common/imagebuf.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/gtk.h"
@@ -312,7 +313,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   const int width = roi_in->width;
   const int height = roi_in->height;
   const uint32_t filters = piece->pipe->dsc.filters;
-  memcpy(out, in2, sizeof(float) * width * height);
+  dt_iop_image_copy_by_size(out, in2, width, height, 1);
   const float *const in = out;
   const double cared = 0, cablue = 0;
   const double caautostrength = 4;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -26,6 +26,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "common/opencl.h"
 #include "common/illuminants.h"
+#include "common/imagebuf.h"
 #include "common/iop_profile.h"
 #include "develop/imageop_math.h"
 #include "develop/openmp_maths.h"
@@ -1011,7 +1012,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       }
 
       // passthrough pixels
-      dt_simd_memcpy(in, out, ch * roi_in->width * roi_in->height);
+      dt_iop_image_copy_by_size(out, in, roi_in->width, roi_in->height, ch);
 
       dt_control_log(_("auto-detection of white balance completed"));
       return;

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -23,6 +23,7 @@
 #include <time.h>
 
 #include "common/darktable.h"
+#include "common/imagebuf.h"
 #include "develop/imageop_math.h"
 
 /** Note :

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -19,6 +19,7 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "common/iop_profile.h"
 #include "common/colormatrices.c"
 #include "common/colorspaces.h"
@@ -1025,7 +1026,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * 4 * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, piece->colors);
   }
   else if(!isnan(d->cmatrix[0]))
   {
@@ -1421,7 +1422,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * 4 * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, piece->colors);
   }
   else if(!isnan(d->cmatrix[0]))
   {

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -22,6 +22,7 @@
 #include "common/colorspaces.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/file_location.h"
+#include "common/imagebuf.h"
 #include "common/iop_profile.h"
 #include "common/opencl.h"
 #include "control/conf.h"
@@ -403,7 +404,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    memcpy(ovoid, ivoid, sizeof(float)*4*roi_out->width*roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
   }
   else if(!isnan(d->cmatrix[0]))
   {
@@ -477,7 +478,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   if(d->type == DT_COLORSPACE_LAB)
   {
-    memcpy(ovoid, ivoid, sizeof(float)*4*roi_out->width*roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
   }
   else if(!isnan(d->cmatrix[0]))
   {

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -22,6 +22,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/debug.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -667,7 +668,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 error:
   dt_control_log(_("module `color reconstruction' failed"));
   dt_iop_colorreconstruct_bilateral_free(b);
-  memcpy(ovoid, ivoid, sizeof(float) * piece->colors * roi_out->width * roi_out->height);
+  dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, piece->colors);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -19,6 +19,7 @@
 #include "config.h"
 #endif
 #include "common/colorspaces.h"
+#include "common/imagebuf.h"
 #include "common/points.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -360,7 +361,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       dt_iop_colortransfer_params_t *p = (dt_iop_colortransfer_params_t *)self->params;
       p->flag = ACQUIRE2;
     }
-    memcpy(out, in, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, ch);
   }
   else if(data->flag == APPLY)
   {
@@ -438,7 +439,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else
   {
-    memcpy(out, in, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, ch);
   }
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -23,6 +23,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/iop_profile.h"
 #include "common/colorspaces_inline_conversions.h"
+#include "common/imagebuf.h"
 #include "common/math.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
@@ -385,7 +386,7 @@ void process_display(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece
 
   const dt_iop_colorzones_channel_t display_channel = g->channel;
 
-  memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+  dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)                                                           \

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
 #include "common/gaussian.h"
+#include "common/imagebuf.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
@@ -397,7 +398,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
   goto FINISH_PROCESS;
 
 ERROR_EXIT:
-  memcpy(o, i, sizeof(float) * ch * roi_out->width * roi_out->height);
+  dt_iop_image_copy_by_size(o, i, roi_out->width, roi_out->height, ch);
 
 FINISH_PROCESS:
   free(xy_artifact);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -22,6 +22,7 @@
 #include "common/interpolation.h"
 #include "common/opencl.h"
 #include "common/image_cache.h"
+#include "common/imagebuf.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -280,7 +281,7 @@ static const char* method2string(dt_iop_demosaic_method_t method)
 static void pre_median_b(float *out, const float *const in, const dt_iop_roi_t *const roi, const uint32_t filters,
                          const int num_passes, const float threshold)
 {
-  memcpy(out, in, sizeof(float) * roi->width * roi->height);
+  dt_iop_image_copy_by_size(out, in, roi->width, roi->height, 1);
 
   // now green:
   const int lim[5] = { 0, 1, 2, 1, 0 };
@@ -405,7 +406,7 @@ static void green_equilibration_lavg(float *out, const float *const in, const in
   if(FC(oj + y, oi + x, filters) != 1) oi++;
   if(FC(oj + y, oi + x, filters) != 1) oj--;
 
-  memcpy(out, in, sizeof(float) * height * width);
+  dt_iop_image_copy_by_size(out, in, width, height, 1);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -455,7 +456,7 @@ static void green_equilibration_favg(float *out, const float *const in, const in
 
   if((FC(oj + y, oi + x, filters) & 1) != 1) oi++;
   const int g2_offset = oi ? -1 : 1;
-  memcpy(out, in, sizeof(float) * height * width);
+  dt_iop_image_copy_by_size(out, in, width, height, 1);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(g2_offset, height, in, width) \

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -20,6 +20,7 @@
 #endif
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "common/imagebuf.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -116,7 +117,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int chs = piece->colors;
   const int width = roi_in->width, height = roi_in->height;
   const float scale = roi_in->scale;
-  memcpy(ovoid, ivoid, sizeof(float) * chs * width * height);
+  dt_iop_image_copy_by_size(ovoid, ivoid, width, height, chs);
 #if 1
   // printf("thread %d starting equalizer", (int)pthread_self());
   // if(piece->iscale != 1.0) printf(" for preview\n");

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "control/control.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
@@ -280,7 +281,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const dt_iop_hotpixels_data_t *data = (dt_iop_hotpixels_data_t *)piece->data;
 
   // The processing loop should output only a few pixels, so just copy everything first
-  memcpy(ovoid, ivoid, sizeof(float) * roi_out->width * roi_out->height);
+  dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, 1);
 
   int fixed;
   if(piece->pipe->dsc.filters == 9u)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -382,7 +382,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
   {
-    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
+    dt_iop_image_copy_by_size((float*)ovoid, (float*)ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -460,11 +460,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     }
     else
     {
-<<<<<<< HEAD
-      memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
-=======
-      dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
->>>>>>> switch memcpy to dt_iop_image_copy_by_size
+      dt_iop_image_copy_by_size((float*)ovoid, (float*)ivoid, roi_out->width, roi_out->height, ch);
     }
 
     if(modflags & LF_MODIFY_VIGNETTING)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -24,6 +24,7 @@ extern "C" {
 #include "bauhaus/bauhaus.h"
 #include "common/interpolation.h"
 #include "common/file_location.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -381,7 +382,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -459,7 +460,11 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     }
     else
     {
+<<<<<<< HEAD
       memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+=======
+      dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
+>>>>>>> switch memcpy to dt_iop_image_copy_by_size
     }
 
     if(modflags & LF_MODIFY_VIGNETTING)
@@ -931,7 +936,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
   {
-    memcpy(out, in, sizeof(float) * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, 1);
     return;
   }
 
@@ -944,7 +949,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 
   if(!(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE)))
   {
-    memcpy(out, in, sizeof(float) * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, 1);
     delete modifier;
     return;
   }

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -21,6 +21,7 @@
 
 #include "bauhaus/bauhaus.h"
 #include "common/imageio_png.h"
+#include "common/imagebuf.h"
 #include "common/colorspaces.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/file_location.h"
@@ -1102,7 +1103,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else  // no clut
   {
-    memcpy(obuf, ibuf, sizeof(float) * ch * width * height);
+    dt_iop_image_copy_by_size(obuf, ibuf, width, height, ch);
   }
 }
 

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -29,6 +29,7 @@
 #include "config.h"
 #endif
 
+#include "common/imagebuf.h"
 #include "develop/develop.h"
 
 DT_MODULE_INTROSPECTION(2, dt_iop_mask_manager_params_t)
@@ -78,7 +79,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;
-  memcpy(o, i, sizeof(float) * ch * roi_out->width * roi_out->height);
+  dt_iop_image_copy_by_size(o, i, roi_out->width, roi_out->height, ch);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -21,6 +21,7 @@
 #endif
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
+#include "common/imagebuf.h"
 #include "common/dwt.h"
 #include "control/control.h"
 #include "develop/imageop.h"
@@ -473,14 +474,11 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_rawdenoise_data_t *d = (dt_iop_rawdenoise_data_t *)piece->data;
-
-  const int width = roi_in->width;
-  const int height = roi_in->height;
+  const dt_iop_rawdenoise_data_t *const restrict d = (dt_iop_rawdenoise_data_t *)piece->data;
 
   if(!(d->threshold > 0.0f))
   {
-    memcpy(ovoid, ivoid, sizeof(float)*width*height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_in->width, roi_in->height, piece->colors);
   }
   else
   {

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -297,8 +297,9 @@ static inline float vstransform(const float value)
   return sqrtf(MAX(0.0f, value));
 }
 
-static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_iop_roi_t *const roi,
-                                   dt_iop_rawdenoise_data_t *data, const uint8_t (*const xtrans)[6])
+static void wavelet_denoise_xtrans(const float *const restrict in, float *const restrict out,
+                                   const dt_iop_roi_t *const restrict roi,
+                                   const dt_iop_rawdenoise_data_t *const data, const uint8_t (*const xtrans)[6])
 {
   const int width = roi->width;
   const int height = roi->height;
@@ -451,8 +452,8 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
     // undo the original transform
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(height, fimg, roi, width, xtrans) \
-    shared(c, out) \
+    dt_omp_firstprivate(height, fimg, roi, width, xtrans, c) \
+    dt_omp_sharedconst(out) \
     schedule(static)
 #endif
     for(int row = 0; row < height; row++)

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -22,6 +22,7 @@
 
 #include "common/darktable.h"    // for darktable, darktable_t, dt_alloc_a...
 #include "common/image.h"        // for dt_image_t, ::DT_IMAGE_4BAYER
+#include "common/imagebuf.h"     // for dt_iop_image_copy_by_size
 #include "common/mipmap_cache.h" // for dt_mipmap_buffer_t, dt_mipmap_cach...
 #include "common/opencl.h"
 #include "control/control.h"      // for dt_control_log
@@ -163,7 +164,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const int colorscheme = dev->rawoverexposed.colorscheme;
   const float *const color = dt_iop_rawoverexposed_colors[colorscheme];
 
-  memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+  dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
 
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, image->id, DT_MIPMAP_FULL, DT_MIPMAP_BLOCKING, 'r');

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -26,6 +26,7 @@
 #include "common/dwt.h"
 #include "common/gaussian.h"
 #include "common/heal.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "develop/blend.h"
 #include "develop/imageop_math.h"
@@ -3480,7 +3481,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   in_retouch = dt_alloc_align_float((size_t)ch * roi_rt->width * roi_rt->height);
   if(in_retouch == NULL) goto cleanup;
 
-  memcpy(in_retouch, ivoid, sizeof(float) * ch * roi_rt->width * roi_rt->height);
+  dt_iop_image_copy_by_size(in_retouch, ivoid, roi_rt->width, roi_rt->height, ch);
 
   // user data passed from the decompose routine to the one that process each scale
   usr_data.self = self;

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -22,6 +22,7 @@
 #include <xmmintrin.h>
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -282,7 +283,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int rad = MIN(MAXR, ceilf(data->radius * roi_in->scale / piece->iscale));
   if(rad == 0)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -290,7 +291,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // avoids handling of all kinds of border cases below
   if(roi_out->width < 2 * rad + 1 || roi_out->height < 2 * rad + 1)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -476,7 +477,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int rad = MIN(MAXR, ceilf(data->radius * roi_in->scale / piece->iscale));
   if(rad == 0)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -484,7 +485,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   // avoids handling of all kinds of border cases below
   if(roi_out->width < 2 * rad + 1 || roi_out->height < 2 * rad + 1)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -134,7 +135,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   // Apply velvia saturation
   if(strength <= 0.0)
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
   else
   {
 #ifdef _OPENMP
@@ -182,7 +183,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   // Apply velvia saturation
   if(strength <= 0.0)
-    memcpy(out, in, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(out, in, roi_out->width, roi_out->height, ch);
   else
   {
 #ifdef _OPENMP

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -17,6 +17,7 @@
 */
 
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "common/tags.h"
 #include "common/variables.h"
 #include "control/control.h"
@@ -877,7 +878,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   gchar *svgdoc = _watermark_get_svgdoc(self, data, &piece->pipe->image);
   if(!svgdoc)
   {
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -892,7 +893,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     fprintf(stderr,"[watermark] Cairo surface error: %s\n",cairo_status_to_string(cairo_surface_status(surface)));
     g_free(image);
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     return;
   }
 
@@ -907,7 +908,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     cairo_surface_destroy(surface);
     g_free(image);
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
     fprintf(stderr, "[watermark] error processing svg file: %s\n", error->message);
     g_error_free(error);
@@ -1022,7 +1023,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     g_object_unref(svg);
     g_free(image);
     g_free(image_two);
-    memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->width * roi_out->height);
+    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
     return;
   }


### PR DESCRIPTION
This PR replaces lots of calls to memcpy() with a new function whose name documents the purpose of the call (dt_iop_image_copy_by_size), avoids the int vs. size_t problems and associated overflows being addressed in #7419, and opens the door to implementing performance optimizations on the image copy.

There's also a stub of a function to copy ROIs from the image buffer, which is something that's done in various places throughout the code.  Consolidating all of those is now on my to-do list.

Finally, a function to allocate a buffer for an image, to replace various bare calls to malloc().


@johnny-bit I hope you don't mind that I went ahead and dealt with most of the memcpy calls related to #7419 :-).
