### PR TITLE
defringe: cleanup and improve vectorizability

### DIFF
--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -298,7 +298,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
   dt_omp_sharedconst(d, width, height) \
   shared(xy_small, xy_avg) \
   firstprivate(thresh, avg_edge_chroma) \
-  schedule(dynamic)
+  schedule(dynamic,3)
 #endif
   for(int v = 0; v < height; v++)
   {


### PR DESCRIPTION
Verified identical output on test 0058.
```
Test 0058 sidecar on mire1-xtrans.raf
Thr  Old   New
1  20.767 18.894   -9.1%
4   5.214  4.831   -7.4%
8   2.664  2.465   -7.5%
16  1.517  1.235  -18.6%
32  1.208  0.693  -42.6%
```