### PR TITLE
refactor: consolidate code for displaying module trouble messages

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1354,6 +1354,31 @@ void dt_iop_set_module_in_trouble(dt_iop_module_t *module, const gboolean state)
   _iop_gui_update_header(module);
 }
 
+void dt_iop_set_module_trouble_message(dt_iop_module_t *const module, GtkWidget *label_widget,
+                                       char* const trouble_msg, const char* const trouble_tooltip)
+{
+  if (trouble_msg && *trouble_msg)
+  {
+    // set the module's trouble flag
+    dt_iop_set_module_in_trouble(module, TRUE);
+    // set the warning message in the module's message area just below the header
+    char *msg = dt_iop_warning_message(trouble_msg);
+    gtk_label_set_text(GTK_LABEL(label_widget), msg);
+    g_free(msg);
+    gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), trouble_tooltip ? trouble_tooltip : "");
+    gtk_widget_set_visible(GTK_WIDGET(label_widget), TRUE);
+  }
+  else
+  {
+    // no trouble, so clear the trouble flag and hide the message area
+    dt_iop_set_module_in_trouble(module, FALSE);
+    gtk_label_set_text(GTK_LABEL(label_widget), "");
+    gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), "");
+    gtk_widget_set_visible(GTK_WIDGET(label_widget), FALSE);
+  }
+}
+
+
 static void _iop_gui_update_label(dt_iop_module_t *module)
 {
   if(!module->header) return;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -712,6 +712,12 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
 /** show in iop module header that the module is in trouble */
 void dt_iop_set_module_in_trouble(dt_iop_module_t *module, const gboolean);
 
+/** set the trouble message for the module.  If non-empty, also flag the module as being in trouble; if empty
+ ** or NULL, clear the trouble flag.  Because we don't necessarily know where to get the widget for the
+ ** message area, have the caller pass it in **/
+void dt_iop_set_module_trouble_message(dt_iop_module_t *module, GtkWidget *label_widget,
+                                       char *const trouble_msg, const char *const trouble_tooltip);
+
 // format modules description going in tooltips
 char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
                              const char *purpose, const char *input,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2017,45 +2017,29 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     if(!is_module_cat_on_pipe(self))
     {
       // our second biggest problem : another channelmixerrgb instance is doing CAT earlier in the pipe
-      dt_iop_set_module_in_trouble(self, TRUE);
-      char *wmes = dt_iop_warning_message(_("double CAT applied"));
-      gtk_label_set_text(GTK_LABEL(g->warning_label), wmes);
-      g_free(wmes);
-      gtk_widget_set_tooltip_text(GTK_WIDGET(g->warning_label),
-                                  _("you have 2 instances or more of color calibration,\n"
-                                    "all performing chromatic adaptation.\n"
-                                    "this can lead to inconsistencies, unless you\n"
-                                    "use them with masks or know what you are doing."));
-      gtk_widget_set_visible(GTK_WIDGET(g->warning_label), TRUE);
+      dt_iop_set_module_trouble_message(self, g->warning_label,_("double CAT applied"),
+                                        _("you have 2 instances or more of color calibration,\n"
+                                          "all performing chromatic adaptation.\n"
+                                          "this can lead to inconsistencies, unless you\n"
+                                          "use them with masks or know what you are doing."));
     }
     else if(!self->dev->proxy.wb_is_D65)
     {
       // our first and biggest problem : white balance module is being clever with WB coeffs
-      dt_iop_set_module_in_trouble(self, TRUE);
-      char *wmes = dt_iop_warning_message(_("white balance module error"));
-      gtk_label_set_text(GTK_LABEL(g->warning_label), wmes);
-      g_free(wmes);
-      gtk_widget_set_tooltip_text(GTK_WIDGET(g->warning_label),
-                                  _("the white balance module is not using the camera\n"
-                                    "reference illuminant, which will cause issues here\n"
-                                    "with chromatic adaptation. either set it to reference\n"
-                                    "or disable chromatic adaptation here."));
-      gtk_widget_set_visible(GTK_WIDGET(g->warning_label), TRUE);
+      dt_iop_set_module_trouble_message(self, g->warning_label,_("white balance module error"),
+                                        _("the white balance module is not using the camera\n"
+                                          "reference illuminant, which will cause issues here\n"
+                                          "with chromatic adaptation. either set it to reference\n"
+                                          "or disable chromatic adaptation here."));
     }
     else
     {
-      dt_iop_set_module_in_trouble(self, FALSE);
-      gtk_label_set_text(GTK_LABEL(g->warning_label), "");
-      gtk_widget_set_tooltip_text(GTK_WIDGET(g->warning_label), "");
-      gtk_widget_set_visible(GTK_WIDGET(g->warning_label), FALSE);
+      dt_iop_set_module_trouble_message(self, g->warning_label, NULL, NULL);
     }
   }
   else
   {
-    dt_iop_set_module_in_trouble(self, FALSE);
-    gtk_label_set_text(GTK_LABEL(g->warning_label), "");
-    gtk_widget_set_tooltip_text(GTK_WIDGET(g->warning_label), "");
-    gtk_widget_set_visible(GTK_WIDGET(g->warning_label), FALSE);
+    dt_iop_set_module_trouble_message(self, g->warning_label, NULL, NULL);
   }
 
   --darktable.gui->reset;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1159,25 +1159,17 @@ static void display_wb_error(struct dt_iop_module_t *self)
 
   if(self->dev->proxy.chroma_adaptation != NULL && !self->dev->proxy.wb_is_D65)
   {
-    // our second biggest problem : another channelmixerrgb instance is doing CAT
-    // earlier in the pipe
-    dt_iop_set_module_in_trouble(self, TRUE);
-    char *wmes = dt_iop_warning_message(_("white balance applied twice"));
-    gtk_label_set_text(GTK_LABEL(g->warning_label), wmes);
-    g_free(wmes);
-    gtk_widget_set_tooltip_text(GTK_WIDGET(g->warning_label),
-                                _("the color calibration module is enabled,\n"
-                                  "and performing chromatic adaptation.\n"
-                                  "set the white balance here to camera reference (D65)\n"
-                                  "or disable chromatic adaptation in color calibration."));
-    gtk_widget_set_visible(GTK_WIDGET(g->warning_label), TRUE);
+    // our second biggest problem : another module is doing CAT elsewhere in the pipe
+    dt_iop_set_module_trouble_message(self, g->warning_label, _("white balance applied twice"),
+                                      _("the color calibration module is enabled,\n"
+                                        "and performing chromatic adaptation.\n"
+                                        "set the white balance here to camera reference (D65)\n"
+                                        "or disable chromatic adaptation in color calibration."));
   }
   else
   {
-    dt_iop_set_module_in_trouble(self, FALSE);
-    gtk_label_set_text(GTK_LABEL(g->warning_label), "");
-    gtk_widget_set_tooltip_text(GTK_WIDGET(g->warning_label), "");
-    gtk_widget_set_visible(GTK_WIDGET(g->warning_label), FALSE);
+    // no longer in trouble
+    dt_iop_set_module_trouble_message(self, g->warning_label, NULL, NULL);
   }
 
   --darktable.gui->reset;


### PR DESCRIPTION
Thanks, Aurelien, for adding the infrastructure to have modules flag trouble to the user.

In addition to cutting down a bit on duplication right in the two modules which currently use the trouble messages, I'm planning on adding a couple of functions which will enable modules to report other trouble (e.g. skipped processing for lack of memory), and having one common function will make that easier to code.
