### PR TITLE
gradudatednd: cleanup parallel loops, deduplicate fast_exp2f code

### DIFF
--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -726,6 +726,41 @@ int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state)
   return 0;
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd simdlen(4)
+#endif
+static inline float density_times_length(const float dens, const float length)
+{
+//  return (dens * CLIP(0.5f + length) / 8.0f);
+  return (dens * CLAMP(0.5f + length, 0.0f, 1.0f) / 8.0f);
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd simdlen(4)
+#endif
+static inline float compute_density(const float dens, const float length)
+{
+#if 1
+  // !!! approximation is ok only when highest density is 8
+  // for input x = (data->density * CLIP( 0.5+length ), calculate 2^x as (e^(ln2*x/8))^8
+  // use exp2f approximation to calculate e^(ln2*x/8)
+  // in worst case - density==8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
+  const float t = DT_M_LN2f * density_times_length(dens,length);
+  const float d1 = t * t * 0.5f;
+  const float d2 = d1 * t * 0.333333333f;
+  const float d3 = d2 * t * 0.25f;
+  const float d = 1 + t + d1 + d2 + d3; /* taylor series for e^x till x^4 */
+  // printf("%d %d  %f\n",y,x,d);
+  float density = d * d;
+  density = density * density;
+  density = density * density;
+#else
+  // use fair exp2f
+  const float density = exp2f(dens * CLIP(0.5f + length));
+#endif
+  return density;
+}
+
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -744,63 +779,41 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float sinv = sinf(v);
   const float cosv = cosf(v);
   const float filter_radie = sqrtf((hh * hh) + (hw * hw)) / hh;
-  const float offset = data->offset / 100.0f * 2.0f;
+  const float offset = data->offset / 100.0f * 2;
 
-#if 1
-  const float filter_hardness
-      = 1.0 / filter_radie / (1.0 - (0.5 + (data->hardness / 100.0) * 0.9 / 2.0)) * 0.5;
-#else
-  const float hardness = data->hardness / 100.0f;
-  const float t = 1.0f - .8f / (.8f + hardness);
-  const float c = 1.0f + 1000.0f * powf(4.0, hardness);
-#endif
+  const float filter_hardness = 1.0 / filter_radie / (1.0 - (0.5 + (data->hardness / 100.0) * 0.9 / 2.0)) * 0.5;
 
-
+  const int width = roi_out->width;
+  const int height = roi_out->height;
   if(data->density > 0)
   {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(ch, cosv, data, filter_hardness, hh_inv, hw_inv, \
-                        ivoid, ix, iy, offset, ovoid, roi_out, sinv) \
+                        ivoid, ix, iy, offset, ovoid, height, width, sinv) \
     schedule(static)
 #endif
-    for(int y = 0; y < roi_out->height; y++)
+    for(int y = 0; y < height; y++)
     {
-      const size_t k = (size_t)roi_out->width * y * ch;
-      const float *in = (float *)ivoid + k;
-      float *out = (float *)ovoid + k;
+      const size_t k = (size_t)width * y * ch;
+      const float *const restrict in = (float *)ivoid + k;
+      float *const restrict out = (float *)ovoid + k;
 
       float length = (sinv * (-1.0 + ix * hw_inv) - cosv * (-1.0 + (iy + y) * hh_inv) - 1.0 + offset)
                      * filter_hardness;
       const float length_inc = sinv * hw_inv * filter_hardness;
 
-      for(int x = 0; x < roi_out->width; x++, in += ch, out += ch)
+      for(int x = 0; x < width; x++)
       {
-#if 1
-        // !!! approximation is ok only when highest density is 8
-        // for input x = (data->density * CLIP( 0.5+length ), calculate 2^x as (e^(ln2*x/8))^8
-        // use exp2f approximation to calculate e^(ln2*x/8)
-        // in worst case - density==8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = DT_M_LN2f * (data->density * CLIP(0.5f + length) / 8.0f);
-        const float d1 = t * t * 0.5f;
-        const float d2 = d1 * t * 0.333333333f;
-        const float d3 = d2 * t * 0.25f;
-        const float d = 1 + t + d1 + d2 + d3; /* taylor series for e^x till x^4 */
-        // printf("%d %d  %f\n",y,x,d);
-        float density = d;
-        density = density * density;
-        density = density * density;
-        density = density * density;
-#else
-        // use fair exp2f
-        const float density = exp2f(data->density * CLIP(0.5f + length));
-#endif
+        const float density = compute_density(data->density, length);
 
-        for(int l = 0; l < 3; l++)
+        #ifdef _OPENMP
+        #pragma omp simd aligned(in, out : 16)
+        #endif
+        for(int l = 0; l < 4; l++)
         {
-          out[l] = MAX(0.0f, (in[l] / (data->color[l] + data->color1[l] * density)));
+          out[ch*x+l] = MAX(0.0f, (in[ch*x+l] / (data->color[l] + data->color1[l] * density)));
         }
-
         length += length_inc;
       }
     }
@@ -810,50 +823,37 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(ch, cosv, data, filter_hardness, hh_inv, hw_inv, \
-                        ivoid, ix, iy, offset, ovoid, roi_out, sinv) \
+                        ivoid, ix, iy, offset, ovoid, height, width, sinv)    \
     schedule(static)
 #endif
-    for(int y = 0; y < roi_out->height; y++)
+    for(int y = 0; y < height; y++)
     {
-      const size_t k = (size_t)roi_out->width * y * ch;
-      const float *in = (float *)ivoid + k;
-      float *out = (float *)ovoid + k;
+      const size_t k = (size_t)width * y * ch;
+      const float *const restrict in = (float *)ivoid + k;
+      float *const restrict out = (float *)ovoid + k;
 
       float length = (sinv * (-1.0f + ix * hw_inv) - cosv * (-1.0f + (iy + y) * hh_inv) - 1.0f + offset)
                      * filter_hardness;
       const float length_inc = sinv * hw_inv * filter_hardness;
 
-      for(int x = 0; x < roi_out->width; x++, in += ch, out += ch)
+      for(int x = 0; x < width; x++)
       {
-#if 1
-        // !!! approximation is ok only when lowest density is -8
-        // for input x = (-data->density * CLIP( 0.5-length ), calculate 2^x as (e^(ln2*x/8))^8
-        // use exp2f approximation to calculate e^(ln2*x/8)
-        // in worst case - density==-8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = DT_M_LN2f * (-data->density * CLIP(0.5f - length) / 8.0f);
-        const float d1 = t * t * 0.5f;
-        const float d2 = d1 * t * 0.333333333f;
-        const float d3 = d2 * t * 0.25f;
-        const float d = 1 + t + d1 + d2 + d3; /* taylor series for e^x till x^4 */
-        float density = d;
-        density = density * density;
-        density = density * density;
-        density = density * density;
-#else
-        const float density = exp2f(-data->density * CLIP(0.5f - length));
-#endif
+        const float density = compute_density(-data->density, -length);
 
-        for(int l = 0; l < 3; l++)
+        #ifdef _OPENMP
+        #pragma omp simd aligned(in, out : 16)
+        #endif
+        for(int l = 0; l < 4; l++)
         {
-          out[l] = MAX(0.0f, (in[l] * (data->color[l] + data->color1[l] * density)));
+          out[ch*x+l] = MAX(0.0f, (in[ch*x+l] * (data->color[l] + data->color1[l] * density)));
         }
-
         length += length_inc;
       }
     }
   }
 
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
+    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)
@@ -877,63 +877,37 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const float filter_radie = sqrtf((hh * hh) + (hw * hw)) / hh;
   const float offset = data->offset / 100.0f * 2;
 
-#if 1
-  const float filter_hardness = 1.0 / filter_radie
-                                   / (1.0 - (0.5 + (data->hardness / 100.0) * 0.9 / 2.0)) * 0.5;
-#else
-  const float hardness = data->hardness / 100.0f;
-  const float t = 1.0f - .8f / (.8f + hardness);
-  const float c = 1.0f + 1000.0f * powf(4.0, hardness);
-#endif
+  const float filter_hardness = 1.0 / filter_radie / (1.0 - (0.5 + (data->hardness / 100.0) * 0.9 / 2.0)) * 0.5;
 
-
+  const int width = roi_out->width;
+  const int height = roi_out->height;
   if(data->density > 0)
   {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(ch, cosv, data, filter_hardness, hh_inv, hw_inv, \
-                        ivoid, ix, iy, offset, ovoid, roi_out, sinv) \
+                        ivoid, ix, iy, offset, ovoid, height, width, sinv)    \
     schedule(static)
 #endif
-    for(int y = 0; y < roi_out->height; y++)
+    for(int y = 0; y < height; y++)
     {
-      const size_t k = (size_t)roi_out->width * y * ch;
-      const float *in = (float *)ivoid + k;
-      float *out = (float *)ovoid + k;
+      const size_t k = (size_t)width * y * ch;
+      const float *const restrict in = (float *)ivoid + k;
+      float *const restrict out = (float *)ovoid + k;
 
       float length = (sinv * (-1.0 + ix * hw_inv) - cosv * (-1.0 + (iy + y) * hh_inv) - 1.0 + offset)
                      * filter_hardness;
       const float length_inc = sinv * hw_inv * filter_hardness;
 
       const __m128 c = _mm_set_ps(0, data->color[2], data->color[1], data->color[0]);
-      const __m128 c1 = _mm_sub_ps(_mm_set1_ps(1.0f), c);
+      const __m128 c1 = _mm_set1_ps(1.0f) - c;
 
-      for(int x = 0; x < roi_out->width; x++, in += ch, out += ch)
+      for(int x = 0; x < width; x++)
       {
-#if 1
-        // !!! approximation is ok only when highest density is 8
-        // for input x = (data->density * CLIP( 0.5+length ), calculate 2^x as (e^(ln2*x/8))^8
-        // use exp2f approximation to calculate e^(ln2*x/8)
-        // in worst case - density==8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = DT_M_LN2f * (data->density * CLIP(0.5f + length) / 8.0f);
-        const float d1 = t * t * 0.5f;
-        const float d2 = d1 * t * 0.333333333f;
-        const float d3 = d2 * t * 0.25f;
-        const float d = 1 + t + d1 + d2 + d3; /* taylor series for e^x till x^4 */
-        // printf("%d %d  %f\n",y,x,d);
-        __m128 density = _mm_set1_ps(d);
-        density = _mm_mul_ps(density, density);
-        density = _mm_mul_ps(density, density);
-        density = _mm_mul_ps(density, density);
-#else
-        // use fair exp2f
-        const __m128 density = _mm_set1_ps(exp2f(data->density * CLIP(0.5f + length)));
-#endif
+        const __m128 density = _mm_set1_ps(compute_density(data->density, length));
 
         /* max(0,in / (c + (1-c)*density)) */
-        _mm_stream_ps(out, _mm_max_ps(_mm_set1_ps(0.0f),
-                                      _mm_div_ps(_mm_load_ps(in), _mm_add_ps(c, _mm_mul_ps(c1, density)))));
-
+        _mm_stream_ps(out + ch*x, _mm_max_ps(_mm_set1_ps(0.0f), (_mm_load_ps(in + ch*x) / (c + (c1 * density)))));
         length += length_inc;
       }
     }
@@ -943,46 +917,28 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(ch, cosv, data, filter_hardness, hh_inv, hw_inv, \
-                        ivoid, ix, iy, offset, ovoid, roi_out, sinv) \
+                        ivoid, ix, iy, offset, ovoid, height, width, sinv)    \
     schedule(static)
 #endif
-    for(int y = 0; y < roi_out->height; y++)
+    for(int y = 0; y < height; y++)
     {
-      const size_t k = (size_t)roi_out->width * y * ch;
-      const float *in = (float *)ivoid + k;
-      float *out = (float *)ovoid + k;
+      const size_t k = (size_t)width * y * ch;
+      const float *const restrict in = (float *)ivoid + k;
+      float *const restrict out = (float *)ovoid + k;
 
       float length = (sinv * (-1.0f + ix * hw_inv) - cosv * (-1.0f + (iy + y) * hh_inv) - 1.0f + offset)
                       * filter_hardness;
       const float length_inc = sinv * hw_inv * filter_hardness;
 
       const __m128 c = _mm_set_ps(0, data->color[2], data->color[1], data->color[0]);
-      const __m128 c1 = _mm_sub_ps(_mm_set1_ps(1.0f), c);
+      const __m128 c1 = _mm_set1_ps(1.0f) - c;
 
-      for(int x = 0; x < roi_out->width; x++, in += ch, out += ch)
+      for(int x = 0; x < width; x++)
       {
-#if 1
-        // !!! approximation is ok only when lowest density is -8
-        // for input x = (-data->density * CLIP( 0.5-length ), calculate 2^x as (e^(ln2*x/8))^8
-        // use exp2f approximation to calculate e^(ln2*x/8)
-        // in worst case - density==-8,CLIP(0.5-length) == 1.0 it gives 0.6% of error
-        const float t = DT_M_LN2f * (-data->density * CLIP(0.5f - length) / 8.0f);
-        const float d1 = t * t * 0.5f;
-        const float d2 = d1 * t * 0.333333333f;
-        const float d3 = d2 * t * 0.25f;
-        const float d = 1 + t + d1 + d2 + d3; /* taylor series for e^x till x^4 */
-        __m128 density = _mm_set1_ps(d);
-        density = _mm_mul_ps(density, density);
-        density = _mm_mul_ps(density, density);
-        density = _mm_mul_ps(density, density);
-#else
-        const __m128 density = _mm_set1_ps(exp2f(-data->density * CLIP(0.5f - length)));
-#endif
+        const __m128 density = _mm_set1_ps(compute_density(-data->density, -length));
 
         /* max(0,in * (c + (1-c)*density)) */
-        _mm_stream_ps(out, _mm_max_ps(_mm_set1_ps(0.0f),
-                                      _mm_mul_ps(_mm_load_ps(in), _mm_add_ps(c, _mm_mul_ps(c1, density)))));
-
+        _mm_stream_ps(out + ch*x, _mm_max_ps(_mm_set1_ps(0.0f), (_mm_load_ps(in + ch*x) * (c + (c1 * density)))));
         length += length_inc;
       }
     }


### PR DESCRIPTION
Verified identical output on tests 0011 and 0012.

Further cleanup/optimization would be possible, but will slightly
change the output due to changed rounding.  This commit also makes the
plain C and SSE code paths agree with each other by changing float
literals in the plain C path to double literals as in the default SSE
path.