### PR TITLE
two "monochromes" bugs in fr.po

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -4937,7 +4937,7 @@ msgstr "retourner les images"
 
 #: ../src/control/jobs/control_jobs.c:1476
 msgid "set monochrome images"
-msgstr "indique comme images monochromes"
+msgstr "définit comme images monochromes"
 
 #. get all selected images now, to avoid the set changing during ui interaction
 #: ../src/control/jobs/control_jobs.c:1483

--- a/po/fr.po
+++ b/po/fr.po
@@ -4937,7 +4937,7 @@ msgstr "retourner les images"
 
 #: ../src/control/jobs/control_jobs.c:1476
 msgid "set monochrome images"
-msgstr "indique comme images monchromes"
+msgstr "indique comme images monochromes"
 
 #. get all selected images now, to avoid the set changing during ui interaction
 #: ../src/control/jobs/control_jobs.c:1483
@@ -16405,7 +16405,7 @@ msgstr ""
 
 #: ../src/libs/image.c:574
 msgid "set selection as color images"
-msgstr "indique la sélection comme images monochromes"
+msgstr "enregistre la sélection comme images couleur"
 
 #: ../src/libs/image.c:617
 msgctxt "accel"

--- a/po/fr.po
+++ b/po/fr.po
@@ -16400,12 +16400,11 @@ msgstr "mise à jour des informations de l'image depuis le fichier"
 
 #: ../src/libs/image.c:570
 msgid "set selection as monochrome images and activate monochrome workflow"
-msgstr ""
-"enregistre la sélection comme images monochromes et active le flux monochrome"
+msgstr "définit la sélection comme images monochromes et active le flux monochrome"
 
 #: ../src/libs/image.c:574
 msgid "set selection as color images"
-msgstr "enregistre la sélection comme images couleur"
+msgstr "définit la sélection comme images couleur"
 
 #: ../src/libs/image.c:617
 msgctxt "accel"


### PR DESCRIPTION
Typo  : monchromes -> monochromes
Corrected : images monochromes -> images couleur (en : color images) + consitency with translation of message for monochromes images