### PR TITLE
export metadata: consider repeatable Iptc like Iptc.Application2.Keywords

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1320,15 +1320,7 @@ static gchar *dt_cleanup_synonyms(gchar *synonyms_entry)
     gchar **entry = tokens;
     while (*entry)
     {
-      // remove leading and trailing spaces
-      char *e = *entry + strlen(*entry) - 1;
-      while(*e == ' ' && e > *entry)
-      {
-        *e = '\0';
-        e--;
-      }
-      e = *entry;
-      while(*e == ' ') e++;
+      char *e = g_strstrip(*entry);
       if(*e)
       {
         synonyms = dt_util_dstrcat(synonyms, "%s, ", e);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -554,7 +554,7 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
   else if (has_prefix(variable, "TAGS"))
   {
     GList *tags_list = dt_tag_get_list_export(params->imgid, params->data->tags_flags);
-    char *tags = dt_util_glist_to_str(",", tags_list);
+    char *tags = dt_util_glist_to_str(", ", tags_list);
     g_list_free_full(tags_list, g_free);
     result = g_strdup(tags);
     g_free(tags);


### PR DESCRIPTION
fixes #7345

However doesn't cover the case where the (or one of the) metadata contains a comma. In that case this metadata won't be correctly exported (as the comma is used a internal list separator).
