### PR TITLE
add function to verify piece->colors and set module's trouble flag if…

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -21,6 +21,7 @@
 #include "common/debug.h"
 #include "common/exif.h"
 #include "common/dtpthread.h"
+#include "common/imagebuf.h"
 #include "common/imageio_rawspeed.h"
 #include "common/interpolation.h"
 #include "common/iop_group.h"
@@ -3288,6 +3289,31 @@ char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, con
 
 #undef P_TAB
 #undef TAB_SIZE
+}
+
+gboolean dt_iop_have_required_input_format(const int req_ch, struct dt_iop_module_t *const module,
+                                           const int ch, GtkWidget *warn_label,
+                                           const void *const restrict ivoid, void *const restrict ovoid,
+                                           const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  if (!module) return FALSE;
+  if (ch == req_ch)
+  {
+    dt_iop_set_module_trouble_message(module, warn_label, NULL, NULL);
+    return TRUE;
+  }
+  else
+  {
+    // copy the input buffer to the output
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    // set trouble message
+    dt_iop_set_module_trouble_message(module, warn_label, _("unsupported input"),
+                                      _("You have placed this module at\n"
+                                        "a position in the pipeline where\n"
+                                        "the data format does not match\n"
+                                        "its requirements."));
+    return FALSE;
+  }
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3307,11 +3307,15 @@ gboolean dt_iop_have_required_input_format(const int req_ch, struct dt_iop_modul
     // copy the input buffer to the output
     dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
     // set trouble message
-    dt_iop_set_module_trouble_message(module, warn_label, _("unsupported input"),
-                                      _("You have placed this module at\n"
-                                        "a position in the pipeline where\n"
-                                        "the data format does not match\n"
-                                        "its requirements."));
+    if (module)
+      dt_iop_set_module_trouble_message(module, warn_label, _("unsupported input"),
+                                        _("You have placed this module at\n"
+                                          "a position in the pipeline where\n"
+                                          "the data format does not match\n"
+                                          "its requirements."));
+    // and print an error message to the console
+    const char *name = module ? module->name() : "?";
+    fprintf(stderr,"[%s] unsupported data format\n",name);
     return FALSE;
   }
 }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -729,6 +729,13 @@ char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
 /* return a warning message, prefixed by the special character ⚠ */
 char *dt_iop_warning_message(char *message);
 
+/** check whether we have the required number of channels in the input data; if not, copy the input buffer to the
+ ** output buffer, set the module's trouble message, and return FALSE */
+gboolean dt_iop_have_required_input_format(const int required_ch, struct dt_iop_module_t *const module,
+                                           const int actual_pipe_ch, GtkWidget *warnlabel,
+                                           const void *const __restrict__ ivoid, void *const __restrict__ ovoid,
+                                           const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -103,7 +103,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_bloom_data_t *const data = (dt_iop_bloom_data_t *)piece->data;
-  assert(piece->colors == 4);	//final blend code requires at least three channels
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const float *const restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -981,6 +981,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
 
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
+                                         g ? g->warning_label : NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
+
   float DT_ALIGNED_ARRAY RGB_to_XYZ[3][4];
   float DT_ALIGNED_ARRAY XYZ_to_RGB[3][4];
 

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -145,7 +145,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const dt_iop_colorcontrast_params_t *const d = (dt_iop_colorcontrast_params_t *)piece->data;
 
   // how many colors in our buffer?
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const float *const restrict in = (const float *const)ivoid;
   float *const restrict out = (float *const)ovoid;
@@ -197,7 +199,9 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const dt_iop_colorcontrast_params_t *const d = (dt_iop_colorcontrast_params_t *)piece->data;
 
   // how many colors in our buffer?
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const __m128 scale = _mm_set_ps(1.0f, d->b_steepness, d->a_steepness, 1.0f);
   const __m128 offset = _mm_set_ps(0.0f, d->b_offset, d->a_offset, 0.0f);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -130,7 +130,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const dt_iop_colorcorrection_data_t *const d = (dt_iop_colorcorrection_data_t *)piece->data;
   const float *const restrict in = (float *)i;
   float *const restrict out = (float *)o;
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         in, out, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
+
   // unpack the structure so that the compiler can keep the individual elements in registers instead of dereferencing
   // 'd' every time
   const float saturation = d->saturation;

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -445,7 +445,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const int width = roi_in->width;
   const int height = roi_in->height;
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         in, out, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const float scale = piece->iscale / roi_in->scale;
   const float sigma_s = 50.0f / scale;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -28,6 +28,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
@@ -348,10 +349,12 @@ static void process_fastpath_apply_tonecurves(struct dt_iop_module_t *self, dt_d
                                               const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
   
   if(!isnan(d->cmatrix[0]))
   {
-    assert(piece->colors == 4);
     const size_t npixels = (size_t)roi_out->width * roi_out->height;
     float *const restrict out = (float *const)ovoid;
     // out is already converted to RGB from Lab.

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -161,14 +161,15 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
              void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_defringe_data_t *const d = (dt_iop_defringe_data_t *)piece->data;
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, module, piece->colors, NULL,
+                                         i, o, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const int order = 1; // 0,1,2
   const float sigma = fmax(0.1f, fabs(d->radius)) * roi_in->scale / piece->iscale;
   const float Labmax[] = { 100.0f, 128.0f, 128.0f, 1.0f };
   const float Labmin[] = { 0.0f, -128.0f, -128.0f, 0.0f };
   const int ch = 4;
-  assert(piece->colors == 4);
-
   const int radius = ceil(2.0 * ceilf(sigma));
 
   // save the fibonacci lattices in them later

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1514,7 +1514,9 @@ static void process_nlmeans_cpu(dt_dev_pixelpipe_iop_t *piece,
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
   const dt_iop_denoiseprofile_data_t *const d = (dt_iop_denoiseprofile_data_t *)piece->data;
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, piece->module, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   float *restrict in;
   if (!dt_iop_alloc_image_buffers(piece->module, NULL, roi_in, roi_out, 4 | DT_IMGSZ_INPUT, &in, 0))

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -405,7 +405,9 @@ static void process_cpu(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
   const dt_iop_nlmeans_params_t *const d = (dt_iop_nlmeans_params_t *)piece->data;
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, piece->module, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   // adjust to zoom size:
   const float scale = fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1766,7 +1766,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const float *const restrict in = (float*)ivoid;
   float *const restrict out = (float*)ovoid;
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         in, out, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   dt_iop_rgbcurve_data_t *const restrict d = (dt_iop_rgbcurve_data_t *)(piece->data);
 

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -112,7 +112,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 {
   const dt_iop_soften_data_t *const d = (const dt_iop_soften_data_t *const)piece->data;
 
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const float brightness = 1.0 / exp2f(-d->brightness);
   const float saturation = d->saturation / 100.0;
@@ -168,7 +170,9 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_soften_data_t *const data = (dt_iop_soften_data_t *)piece->data;
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
 
   const float brightness = 1.0 / exp2f(-data->brightness);
   const float saturation = data->saturation / 100.0;

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -152,7 +152,10 @@ void init_presets(dt_iop_module_so_t *self)
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
+
   const dt_iop_splittoning_data_t *const data = (dt_iop_splittoning_data_t *)piece->data;
   const float compress = (data->compress / 110.0) / 2.0; // Don't allow 100% compression..
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -370,7 +370,10 @@ static inline float dt_prophoto_rgb_luminance(const float *const rgb)
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         i, o, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
+
   const dt_iop_tonecurve_data_t *const restrict d = (dt_iop_tonecurve_data_t *)(piece->data);
   const dt_iop_order_iccprofile_info_t *const work_profile
     = dt_ioppr_add_profile_info_to_list(self->dev, DT_COLORSPACE_PROPHOTO_RGB, "", INTENT_PERCEPTUAL);

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -272,7 +272,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // most modules only support a single type of input data, so we can check whether that format has been supplied
   // and simply pass along the data if not (setting a trouble flag to inform the user)
   dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;
-  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece,
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
                                          g ? g->warning_label : NULL,
                                          ivoid, ovoid, roi_in, roi_out))
     return;

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -96,7 +96,10 @@ const char *description(struct dt_iop_module_t *self)
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  assert(piece->colors == 4);
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, NULL,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // image has been copied through to output and module's trouble flag has been updated
+
   const dt_iop_vibrance_data_t *const d = (dt_iop_vibrance_data_t *)piece->data;
   const float *const restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;


### PR DESCRIPTION
… incorrect

This replaces existing `assert(piece->colors == 4)` statements with a function that checks for the required number of color channels, and if not the case, sets the module's trouble flag, prints a message on stderr, and copies the input buffer to the output buffer.  This permits dt to continue running with the module effectively disabled (instead of aborting) and notification of the user.
