### PR TITLE
Add function to atomically allocate multiple buffers

### DIFF
--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -94,7 +94,7 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
       if (size & DT_IMGSZ_CLEARBUF)
         memset(*bufptr, 0, nfloats * sizeof(float));
     }
-    if (!bufptr)
+    if (!*bufptr)
     {
       success = FALSE;
       break;
@@ -128,6 +128,9 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
                                         "all of the memory required to process\n"
                                         "the image.  Some or all processing\n"
                                         "has been skipped."));
+    // and print an error message to the console
+    const char *name = module ? module->name() : "?";
+    fprintf(stderr,"[%s] unable to allocate working memory\n",name);
   }
   return success;
 }

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -105,7 +105,8 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
   // finally, check whether successful and clean up if something went wrong
   if (success)
   {
-    dt_iop_set_module_trouble_message(module, warn_label, NULL, NULL);
+    if (module)
+      dt_iop_set_module_trouble_message(module, warn_label, NULL, NULL);
   }
   else
   {
@@ -123,11 +124,12 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
     }
     va_end(args);
     // set the module's trouble flag
-    dt_iop_set_module_trouble_message(module, warn_label, _("insufficient memory"),
-                                      _("This module was unable to allocate\n"
-                                        "all of the memory required to process\n"
-                                        "the image.  Some or all processing\n"
-                                        "has been skipped."));
+    if (module)
+      dt_iop_set_module_trouble_message(module, warn_label, _("insufficient memory"),
+                                        _("This module was unable to allocate\n"
+                                          "all of the memory required to process\n"
+                                          "the image.  Some or all processing\n"
+                                          "has been skipped."));
     // and print an error message to the console
     const char *name = module ? module->name() : "?";
     fprintf(stderr,"[%s] unable to allocate working memory\n",name);

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -31,7 +31,7 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
   va_start(args,roi_out);
   while (TRUE)
   {
-    int size = va_arg(args,int);
+    const int size = va_arg(args,int);
     float **bufptr = va_arg(args,float**);
     if (size & DT_IMGSZ_PERTHREAD)
       (void)va_arg(args,size_t*);    // skip the extra pointer for per-thread allocations
@@ -45,7 +45,7 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
   va_start(args,roi_out);
   while (success)
   {
-    int size = va_arg(args,int);
+    const int size = va_arg(args,int);
     float **bufptr = va_arg(args,float**);
     size_t *paddedsize = (size & DT_IMGSZ_PERTHREAD) ? va_arg(args,size_t*) : NULL;
     if (size == 0 || !bufptr)
@@ -113,7 +113,7 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWid
     va_start(args,roi_out);
     while (TRUE)
     {
-      int size = va_arg(args,int);
+      const int size = va_arg(args,int);
       float **bufptr = va_arg(args,float**);
       if (size & DT_IMGSZ_PERTHREAD)
         (void)va_arg(args,size_t*);  // skip the extra pointer for per-thread allocations

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -16,7 +16,122 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdarg.h>
 #include "common/imagebuf.h"
+
+// Allocate one or more buffers as detailed in the given parameters.  If any allocation fails, free all of them,
+// set the module's trouble flag, and return FALSE.
+gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module, GtkWidget *warn_label,
+                                    const struct dt_iop_roi_t *const roi_in,
+                                    const struct dt_iop_roi_t *const roi_out, ...)
+{
+  gboolean success = TRUE;
+  va_list args;
+  // first pass: zero out all of the given buffer pointers
+  va_start(args,roi_out);
+  while (TRUE)
+  {
+    int size = va_arg(args,int);
+    float **bufptr = va_arg(args,float**);
+    if (size & DT_IMGSZ_PERTHREAD)
+      (void)va_arg(args,size_t*);    // skip the extra pointer for per-thread allocations
+    if (size == 0 || !bufptr)        // end of arg list?
+      break; 
+    *bufptr = NULL;
+  }
+  va_end(args);
+
+  // second pass: attempt to allocate the requested buffers
+  va_start(args,roi_out);
+  while (success)
+  {
+    int size = va_arg(args,int);
+    float **bufptr = va_arg(args,float**);
+    size_t *paddedsize = (size & DT_IMGSZ_PERTHREAD) ? va_arg(args,size_t*) : NULL;
+    if (size == 0 || !bufptr)
+      break;
+    const size_t channels = size & DT_IMGSZ_CH_MASK;
+    size_t nfloats;
+    switch (size & (DT_IMGSZ_ROI_MASK | DT_IMGSZ_DIM_MASK))
+    {
+    case DT_IMGSZ_OUTPUT | DT_IMGSZ_FULL:
+      nfloats = channels * roi_out->width * roi_out->height;
+      break;
+    case DT_IMGSZ_OUTPUT | DT_IMGSZ_HEIGHT:
+      nfloats = channels * roi_out->height;
+      break;
+    case DT_IMGSZ_OUTPUT | DT_IMGSZ_WIDTH:
+      nfloats = channels * roi_out->width;
+      break;
+    case DT_IMGSZ_OUTPUT | DT_IMGSZ_LONGEST:
+      nfloats = channels * MAX(roi_out->width, roi_out->height);
+      break;
+    case DT_IMGSZ_INPUT | DT_IMGSZ_FULL:
+      nfloats = channels * roi_in->width * roi_in->height;
+      break;
+    case DT_IMGSZ_INPUT | DT_IMGSZ_HEIGHT:
+      nfloats = channels * roi_in->height;
+      break;
+    case DT_IMGSZ_INPUT | DT_IMGSZ_WIDTH:
+      nfloats = channels * roi_in->width;
+      break;
+    case DT_IMGSZ_INPUT | DT_IMGSZ_LONGEST:
+      nfloats = channels * MAX(roi_in->width, roi_in->height);
+      break;
+    default:
+      nfloats = 0;
+      break;
+    }
+    if (size & DT_IMGSZ_PERTHREAD)
+    {
+      *bufptr = dt_alloc_perthread_float(nfloats,paddedsize);
+      if (size & DT_IMGSZ_CLEARBUF)
+        memset(*bufptr, 0, *paddedsize * dt_get_num_threads() * sizeof(float));
+    }
+    else
+    {
+      *bufptr = dt_alloc_align_float(nfloats);
+      if (size & DT_IMGSZ_CLEARBUF)
+        memset(*bufptr, 0, nfloats * sizeof(float));
+    }
+    if (!bufptr)
+    {
+      success = FALSE;
+      break;
+    }
+  }
+  va_end(args);
+
+  // finally, check whether successful and clean up if something went wrong
+  if (success)
+  {
+    dt_iop_set_module_trouble_message(module, warn_label, NULL, NULL);
+  }
+  else
+  {
+    va_start(args,roi_out);
+    while (TRUE)
+    {
+      int size = va_arg(args,int);
+      float **bufptr = va_arg(args,float**);
+      if (size & DT_IMGSZ_PERTHREAD)
+        (void)va_arg(args,size_t*);  // skip the extra pointer for per-thread allocations
+      if (size == 0 || !bufptr || !*bufptr)
+        break;  // end of arg list or this attempted allocation failed
+      dt_free_align(*bufptr);
+      *bufptr = NULL;
+    }
+    va_end(args);
+    // set the module's trouble flag
+    dt_iop_set_module_trouble_message(module, warn_label, _("insufficient memory"),
+                                      _("This module was unable to allocate\n"
+                                        "all of the memory required to process\n"
+                                        "the image.  Some or all processing\n"
+                                        "has been skipped."));
+  }
+  return success;
+}
+
 
 // Copy an image buffer, specifying the number of floats it contains.  Use of this function is to be preferred
 // over a bare memcpy both because it helps document the purpose of the code and because it gives us a single

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1289,6 +1289,8 @@ static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module)
 
 static void _iop_gui_update_header(dt_iop_module_t *module)
 {
+  if (!module->header)                  /* some modules such as overexposed don't actually have a header */
+    return;
   GList *childs = gtk_container_get_children(GTK_CONTAINER(module->header));
 
   /* get the enable button and button */
@@ -1361,20 +1363,26 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module, GtkWidget 
   {
     // set the module's trouble flag
     dt_iop_set_module_in_trouble(module, TRUE);
-    // set the warning message in the module's message area just below the header
-    char *msg = dt_iop_warning_message(trouble_msg);
-    gtk_label_set_text(GTK_LABEL(label_widget), msg);
-    g_free(msg);
-    gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), trouble_tooltip ? trouble_tooltip : "");
-    gtk_widget_set_visible(GTK_WIDGET(label_widget), TRUE);
+    if (label_widget)
+    {
+      // set the warning message in the module's message area just below the header
+      char *msg = dt_iop_warning_message(trouble_msg);
+      gtk_label_set_text(GTK_LABEL(label_widget), msg);
+      g_free(msg);
+      gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), trouble_tooltip ? trouble_tooltip : "");
+      gtk_widget_set_visible(GTK_WIDGET(label_widget), TRUE);
+    }
   }
   else
   {
     // no trouble, so clear the trouble flag and hide the message area
     dt_iop_set_module_in_trouble(module, FALSE);
-    gtk_label_set_text(GTK_LABEL(label_widget), "");
-    gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), "");
-    gtk_widget_set_visible(GTK_WIDGET(label_widget), FALSE);
+    if (label_widget)
+    {
+      gtk_label_set_text(GTK_LABEL(label_widget), "");
+      gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), "");
+      gtk_widget_set_visible(GTK_WIDGET(label_widget), FALSE);
+    }
   }
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1517,7 +1517,7 @@ static void process_nlmeans_cpu(dt_dev_pixelpipe_iop_t *piece,
   assert(piece->colors == 4);
 
   float *restrict in;
-  if (!dt_iop_alloc_image_buffers(NULL, NULL, roi_in, roi_out, 4 | DT_IMGSZ_INPUT, &in, 0))
+  if (!dt_iop_alloc_image_buffers(piece->module, NULL, roi_in, roi_out, 4 | DT_IMGSZ_INPUT, &in, 0))
     return;
 
   // adjust to zoom size:

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/eaw.h"
 #include "common/exif.h"
+#include "common/imagebuf.h"
 #include "common/nlmeans_core.h"
 #include "common/noiseprofiles.h"
 #include "common/opencl.h"
@@ -1515,6 +1516,10 @@ static void process_nlmeans_cpu(dt_dev_pixelpipe_iop_t *piece,
   const dt_iop_denoiseprofile_data_t *const d = (dt_iop_denoiseprofile_data_t *)piece->data;
   assert(piece->colors == 4);
 
+  float *restrict in;
+  if (!dt_iop_alloc_image_buffers(NULL, NULL, roi_in, roi_out, 4 | DT_IMGSZ_INPUT, &in, 0))
+    return;
+
   // adjust to zoom size:
   const float scale = fminf(roi_in->scale, 2.0f) / fmaxf(piece->iscale, 1.0f);
   const int P = ceilf(d->radius * scale); // pixel filter size
@@ -1524,8 +1529,6 @@ static void process_nlmeans_cpu(dt_dev_pixelpipe_iop_t *piece,
   const float central_pixel_weight = d->central_pixel_weight * scale;
 
   // P == 0 : this will degenerate to a (fast) bilateral filter.
-
-  float *in = dt_alloc_align_float((size_t)4 * roi_in->width * roi_in->height);
 
   float wb[3];
   float p[3];
@@ -1645,7 +1648,9 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     return;
   }
 
-  float *in = dt_alloc_align_float((size_t)4 * roi_in->width * roi_in->height);
+  float *restrict in;
+  if (!dt_iop_alloc_image_buffers(self, NULL, roi_in, roi_out, 4 | DT_IMGSZ_INPUT, &in, 0))
+    return;
 
   float wb[3];
   const float wb_weights[3] = { 1.0f, 1.0f, 1.0f };

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -190,6 +190,8 @@ static void wavelet_denoise(const float *const restrict in, float *const restric
 {
   const size_t size = (size_t)(roi->width / 2 + 1) * (roi->height / 2 + 1);
   float *const restrict fimg = dt_alloc_align_float(size);
+  if (!fimg)
+    return;
 
   const int nc = 4;
   for(int c = 0; c < nc; c++) /* denoise R,G1,B,G3 individually */


### PR DESCRIPTION
...and free any which have already been allocated if an allocation fails.  On failure, a message is printed to stderr and the module's trouble flag is set.

I need help in actually putting a warning message with tooltip under the module header like whitebalance and color calibration do.  For about a day when Aurelien first implemented the double-CAT warnings, all modules showed a (blank) warning-label box, so I thought that there was a general mechanism in place.  But it seems I was mistaken, and only wb and cc currently implement this....

There are more iops which could be switched over to the new allocation function, but those can be handled in a separate PR or as other updates are made to them.