### PR TITLE
atrous: cut memory use in half

### DIFF
--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -417,7 +417,7 @@ void eaw_decompose_sse2(float *const restrict out, const float *const restrict i
 #undef SUM_PIXEL_EPILOGUE_SSE
 #endif
 
-void eaw_synthesize(float *const restrict out, const float *const restrict in, const float *const restrict detail,
+void eaw_synthesize(float *const out, const float *const in, const float *const restrict detail,
                     const float *const restrict threshold, const float *const restrict boost,
                     const int32_t width, const int32_t height)
 {
@@ -445,7 +445,7 @@ void eaw_synthesize(float *const restrict out, const float *const restrict in, c
 }
 
 #if defined(__SSE2__)
-void eaw_synthesize_sse2(float *const restrict out, const float *const restrict in, const float *const restrict detail,
+void eaw_synthesize_sse2(float *const out, const float *const in, const float *const restrict detail,
                          const float *const restrict thrsf, const float *const restrict boostf,
                          const int32_t width, const int32_t height)
 {

--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -24,7 +24,7 @@
 typedef void((*eaw_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
                                 const int scale, const float sharpen, const int32_t width, const int32_t height));
 
-typedef void((*eaw_synthesize_t)(float *const restrict out, const float *const restrict in, const float *const restrict detail,
+typedef void((*eaw_synthesize_t)(float *const out, const float *const in, const float *const restrict detail,
                                  const float *const restrict thrsf, const float *const restrict boostf,
                                  const int32_t width, const int32_t height));
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -258,8 +258,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   float *restrict tmp = NULL;
   float *restrict tmp2 = NULL;
 
-  if (!dt_iop_alloc_image_buffers(self, NULL, roi_in, roi_out,
-                                  4, &tmp, 4, &tmp2, 4, &detail, 0))
+  if (!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &tmp, 4, &tmp2, 4, &detail, 0))
   {
     dt_iop_copy_image_roi(out, i, piece->colors, roi_in, roi_out, TRUE);
     return;


### PR DESCRIPTION
Instead of collecting all of the detail scales produced during the wavelet decomposition and then synthesizing them together in a separate pass, reversing the order of synthesis allows us to reuse the same buffer for each detail scale.  This means that the number of buffers needed drops from one scratch buffer plus 8 scale buffers (for images >= 1024px on the short side) to just two scratch buffers plus the single scale buffer.  In the terms used by tiling_callback(), tiling->factor decreases from 11 to 5.

This can dramatically speed up processing under low-memory conditions.  Using mire1-xtrans.raf and the old default host_memory_limit of 1500, wall time with 32 threads decreases from 2.7 seconds to 1.2 second as the number of tiles drops from 35 to 5.

Even with enough memory to avoid tiling, there is still a slight performance improvement (measured ~3.5% speedup using 4, 8, and 32 threads).

The altered order of execution does change the output slightly (max dE 1.5779, 159 pixels changed, PAE the smallest representable difference).

**Someone who knows OpenCL should apply the same reordering to the GPU code path to let the contrast equalizer run on cards with less RAM.**
