### PR TITLE
nlmeans_core: replace SIMD_FOR with for to improve performance

### DIFF
--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -476,7 +476,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
               const float wt = gh(distortion * sharpness);
               const float *const inpx = in+4*col;
               const float pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
-              SIMD_FOR (size_t c = 0; c < 4; c++)
+              for (size_t c = 0; c < 4; c++)
               {
                 out[4*col+c] += pixel[c] * wt;
               }

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -494,7 +494,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
               const float wt = gh(fmaxf(0.0f, dissimilarity * sharpness - 2.0f));
               const float *const inpx = in + 4*col;
               const float pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
-              SIMD_FOR (size_t c = 0; c < 4; c++)
+              for (size_t c = 0; c < 4; c++)
               {
                 out[4*col+c] += pixel[c] * wt;
               }


### PR DESCRIPTION
CPU: Intel(R) Core(TM) i7-6700
Threads: 4
Build: Release, SSE2-optimized codepaths disabled
Compiler: `gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0`

Test: `0020-denoise-nlmeans`

**pixel pipeline** processing took:
`SIMD_FOR`: 7.9s (7.927; 7.889; 7.897)
`for`: 5.3s (5.285; 5.337; 5.272)

**CPU time** for [Loop at line 473 in nlmeans_denoise._omp_fn.0]
_Measured by Intel VTune Profiler_
`SIMD_FOR`: 19.010s
`for`: 7.424s

Test: `0035-multiple-modules`

**pixel pipeline** processing took:
`SIMD_FOR`: 11.514s (11.494; 11.536; 11.512)
`for`: 10.118s (10.135; 10.118; 10.101)

**CPU time** for [Loop at line 489 in nlmeans_denoise._omp_fn.0]:
`SIMD_FOR`: 24.540s
`for`: 18.068s