### PR TITLE
[brush/sharpen] fix memset size calculation after transition to align_float

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2698,7 +2698,7 @@ static int dt_brush_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
     dt_free_align(payload);
     return 0;
   }
-  memset(*buffer, 0, bufsize);
+  memset(*buffer, 0, sizeof(float) * bufsize);
 
   // now we fill the falloff
   int p0[2], p1[2];

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -307,7 +307,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const size_t mat_size = (size_t)4 * wd4;
   float *const mat = dt_alloc_align_float(mat_size);
-  memset(mat, 0, mat_size);
+  memset(mat, 0, sizeof(float) * mat_size);
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)
                        * (data->radius * roi_in->scale / piece->iscale);
@@ -501,7 +501,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   const size_t mat_size = (size_t)4 * wd4;
   float *const mat = dt_alloc_align_float(mat_size);
-  memset(mat, 0, mat_size);
+  memset(mat, 0, sizeof(float) * mat_size);
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)
                        * (data->radius * roi_in->scale / piece->iscale);


### PR DESCRIPTION
the size calculation for memset was missing multiplication by float

this hopefuly fixes #7496