### PR TITLE
Lua password storage and retrieval

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -668,6 +668,7 @@ if(USE_LUA)
       "lua/lualib.c"
       "lua/luastorage.c"
       "lua/modules.c"
+      "lua/password.c"
       "lua/preferences.c"
       "lua/print.c"
       "lua/storage.c"

--- a/src/common/pwstorage/pwstorage.c
+++ b/src/common/pwstorage/pwstorage.c
@@ -98,7 +98,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
       break;
     case PW_STORAGE_BACKEND_LIBSECRET:
 #ifdef HAVE_LIBSECRET
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using libsecret backend for username/password storage");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using libsecret backend for username/password storage.\n");
       pwstorage->backend_context = (void *)dt_pwstorage_libsecret_new();
       if(pwstorage->backend_context == NULL)
       {
@@ -119,7 +119,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 #endif
     case PW_STORAGE_BACKEND_KWALLET:
 #ifdef HAVE_KWALLET
-      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using kwallet backend for username/password storage");
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] using kwallet backend for username/password storage.\n");
       pwstorage->backend_context = (void *)dt_pwstorage_kwallet_new();
       if(pwstorage->backend_context == NULL)
       {

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -36,6 +36,7 @@
 #include "lua/lualib.h"
 #include "lua/luastorage.h"
 #include "lua/modules.h"
+#include "lua/password.h"
 #include "lua/preferences.h"
 #include "lua/print.h"
 #include "lua/storage.h"
@@ -136,7 +137,7 @@ static lua_CFunction init_funcs[]
         dt_lua_init_luastorages,   dt_lua_init_tags,        dt_lua_init_film,     dt_lua_init_call,
         dt_lua_init_view,          dt_lua_init_events,      dt_lua_init_init,     dt_lua_init_widget,
         dt_lua_init_lualib,        dt_lua_init_gettext,     dt_lua_init_guides,   dt_lua_init_cairo,
-        NULL };
+        dt_lua_init_password,      NULL };
 
 
 void dt_lua_init(lua_State *L, const char *lua_command)

--- a/src/lua/password.c
+++ b/src/lua/password.c
@@ -1,0 +1,74 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2013-2020 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "lua/preferences.h"
+#include "common/pwstorage/pwstorage.h"
+#include "control/conf.h"
+#include "gui/gtk.h"
+#include "lua/call.h"
+#include "lua/widget/widget.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int get_password(lua_State *L)
+{
+  const char *application = luaL_checkstring(L, 1);
+  const char *username = luaL_checkstring(L, 2);
+  GHashTable *table = dt_pwstorage_get(application);
+  gchar *password = g_strdup(g_hash_table_lookup(table, username));
+  g_hash_table_destroy(table);
+  lua_pushstring(L, password);
+  return 1;
+}
+
+static int save_password(lua_State *L)
+{
+  const char *application = luaL_checkstring(L, 1);
+  const char *username = luaL_checkstring(L, 2);
+  const char *password = luaL_checkstring(L, 3);
+  gboolean result = TRUE;
+
+  GHashTable *table = g_hash_table_new(g_str_hash, g_str_equal);
+  
+  g_hash_table_insert(table, (gchar *)username, (gchar *)password);
+
+  if(!dt_pwstorage_set(application, table))
+  {
+    dt_print(DT_DEBUG_PWSTORAGE, "[%s] cannot store username/token\n", application);
+    result = FALSE;
+  }
+
+  g_hash_table_destroy(table);
+  lua_pushboolean(L, result);
+  return 1;
+}
+
+int dt_lua_init_password(lua_State *L)
+{
+  dt_lua_push_darktable_lib(L);
+  dt_lua_goto_subtable(L, "password");
+
+  lua_pushcfunction(L, get_password);
+  lua_setfield(L, -2, "get");
+
+  lua_pushcfunction(L, save_password);
+  lua_setfield(L, -2, "save");
+
+  lua_pop(L, 1);
+  return 0;
+}

--- a/src/lua/password.h
+++ b/src/lua/password.h
@@ -18,33 +18,7 @@
 
 #pragma once
 
-#include <lua/lua.h>
-
-/*
- * LUA API VERSIONING
- * This API versioning follows semantic versioning as defined in
- * http://semver.org
- * only stable releases are considered "released"
- *   => no need to increase API version with every commit,
- *   however, beware of stable releases and API changes
- */
-// 1.6 was 2.0.1
-// 1.6.1 was 2.0.2
-// 2.0.0 was 3.0.0
-// 2.2.0 was 4.0.0 ( removed the ugly yield functions make scripts incompatible)
-// 2.4.0 was 5.0.0 (going to lua 5.3 is a major API bump)
-// 3.2.0 was 6.0.0 (removed facebook, flickr, and picasa from types.dt_imageio_storage_module_t)
-/* incompatible API change */
-#define LUA_API_VERSION_MAJOR 6
-/* backward compatible API change */
-#define LUA_API_VERSION_MINOR 2
-/* bugfixes that should not change anything to the API */
-#define LUA_API_VERSION_PATCH 0
-/* suffix for unstable version */
-#define LUA_API_VERSION_SUFFIX ""
-
-/** initialize lua stuff at DT start time */
-int dt_lua_init_configuration(lua_State *L);
+int dt_lua_init_password(lua_State *L);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Added darktable.password.save(app, username, password) and darktable.password.get(app, username) to the Lua API for storage and retrieval of passwords.

I've included a simple script to demonstrate and test the API.  Run darktable with -d lua -d pwstorage 

[password.zip](https://github.com/darktable-org/darktable/files/5745497/password.zip)
