### PR TITLE
po/fix virgin paste history

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -773,7 +773,7 @@ int dt_history_copy_and_paste_on_image(const int32_t imgid, const int32_t dest_i
     return 1;
   }
 
-  dt_lock_image_pair(imgid,dest_imgid);
+  dt_lock_image_pair(imgid, dest_imgid);
 
   // be sure the current history is written before pasting some other history data
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
@@ -831,7 +831,7 @@ int dt_history_copy_and_paste_on_image(const int32_t imgid, const int32_t dest_i
   // signal that the mipmap need to be updated
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, dest_imgid);
 
-  dt_unlock_image_pair(imgid,dest_imgid);
+  dt_unlock_image_pair(imgid, dest_imgid);
 
   return ret_val;
 }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -596,6 +596,27 @@ GList *dt_ioppr_get_iop_order_list_version(dt_iop_order_t version)
   return iop_order_list;
 }
 
+gboolean dt_ioppr_has_iop_order_list(int32_t imgid)
+{
+  gboolean result = FALSE;
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT version, iop_list"
+                              " FROM main.module_order"
+                              " WHERE imgid=?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    result = (sqlite3_column_type(stmt, 1) != SQLITE_NULL);
+  }
+
+  sqlite3_finalize(stmt);
+
+  return result;
+}
+
 GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
 {
   GList *iop_order_list = NULL;

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -164,6 +164,9 @@ dt_iop_order_t dt_ioppr_get_iop_order_version(const int32_t imgid);
     or a customr order  */
 dt_iop_order_t dt_ioppr_get_iop_order_list_kind(GList *iop_order_list);
 
+/** returns true if imgid has an iop-order set */
+gboolean dt_ioppr_has_iop_order_list(int32_t imgid);
+
 /** returns a list of dt_iop_order_entry_t and updates *_version */
 GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted);
 /** return the iop-order list for the given version, this is used to get the built-in lists */

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1492,57 +1492,61 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  // now we want to auto-apply the iop-order list if one corresponds
+  // now we want to auto-apply the iop-order list if one corresponds and none are
+  // still applied. Note that we can already have an iop-order list set when
+  // copying an history or applying a style to a not yet developed image.
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT op_params"
-                              " FROM data.presets"
-                              " WHERE autoapply=1"
-                              "       AND ((?2 LIKE model AND ?3 LIKE maker) OR (?4 LIKE model AND ?5 LIKE maker))"
-                              "       AND ?6 LIKE lens AND ?7 BETWEEN iso_min AND iso_max"
-                              "       AND ?8 BETWEEN exposure_min AND exposure_max"
-                              "       AND ?9 BETWEEN aperture_min AND aperture_max"
-                              "       AND ?10 BETWEEN focal_length_min AND focal_length_max"
-                              "       AND (format = 0 OR (format&?11 != 0 AND ~format&?12 != 0))"
-                              "       AND operation = 'ioporder'"
-                              " ORDER BY writeprotect DESC, LENGTH(model), LENGTH(maker), LENGTH(lens)",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, image->exif_model, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, image->exif_maker, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, image->camera_alias, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, image->camera_maker, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, image->exif_lens, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, fmaxf(0.0f, fminf(FLT_MAX, image->exif_iso)));
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, fmaxf(0.0f, fminf(1000000, image->exif_exposure)));
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, fmaxf(0.0f, fminf(1000000, image->exif_aperture)));
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, fmaxf(0.0f, fminf(1000000, image->exif_focal_length)));
-  // 0: dontcare, 1: ldr, 2: raw plus monochrome & color
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 11, iformat);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 12, excluded);
-  if(sqlite3_step(stmt) == SQLITE_ROW)
+  if(!dt_ioppr_has_iop_order_list(imgid))
   {
-    const char *params = (char *)sqlite3_column_blob(stmt, 0);
-    const int32_t params_len = sqlite3_column_bytes(stmt, 0);
-    GList *iop_list = dt_ioppr_deserialize_iop_order_list(params, params_len);
-    dt_ioppr_write_iop_order_list(iop_list, imgid);
-    g_list_free_full(iop_list, free);
-    dt_ioppr_set_default_iop_order(dev, imgid);
-  }
-  else
-  {
-    // we have no auto-apply order, so apply iop order, depending of the worflow
-    GList *iop_list;
-    if(is_scene_referred || is_workflow_none)
-      iop_list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT op_params"
+                                " FROM data.presets"
+                                " WHERE autoapply=1"
+                                "       AND ((?2 LIKE model AND ?3 LIKE maker) OR (?4 LIKE model AND ?5 LIKE maker))"
+                                "       AND ?6 LIKE lens AND ?7 BETWEEN iso_min AND iso_max"
+                                "       AND ?8 BETWEEN exposure_min AND exposure_max"
+                                "       AND ?9 BETWEEN aperture_min AND aperture_max"
+                                "       AND ?10 BETWEEN focal_length_min AND focal_length_max"
+                                "       AND (format = 0 OR (format&?11 != 0 AND ~format&?12 != 0))"
+                                "       AND operation = 'ioporder'"
+                                " ORDER BY writeprotect DESC, LENGTH(model), LENGTH(maker), LENGTH(lens)",
+                                -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, image->exif_model, -1, SQLITE_TRANSIENT);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, image->exif_maker, -1, SQLITE_TRANSIENT);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, image->camera_alias, -1, SQLITE_TRANSIENT);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, image->camera_maker, -1, SQLITE_TRANSIENT);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, image->exif_lens, -1, SQLITE_TRANSIENT);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, fmaxf(0.0f, fminf(FLT_MAX, image->exif_iso)));
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, fmaxf(0.0f, fminf(1000000, image->exif_exposure)));
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, fmaxf(0.0f, fminf(1000000, image->exif_aperture)));
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, fmaxf(0.0f, fminf(1000000, image->exif_focal_length)));
+    // 0: dontcare, 1: ldr, 2: raw plus monochrome & color
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 11, iformat);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 12, excluded);
+    if(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      const char *params = (char *)sqlite3_column_blob(stmt, 0);
+      const int32_t params_len = sqlite3_column_bytes(stmt, 0);
+      GList *iop_list = dt_ioppr_deserialize_iop_order_list(params, params_len);
+      dt_ioppr_write_iop_order_list(iop_list, imgid);
+      g_list_free_full(iop_list, free);
+      dt_ioppr_set_default_iop_order(dev, imgid);
+    }
     else
-      iop_list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_LEGACY);
-    dt_ioppr_write_iop_order_list(iop_list, imgid);
-    g_list_free_full(iop_list, free);
-    dt_ioppr_set_default_iop_order(dev, imgid);
+    {
+      // we have no auto-apply order, so apply iop order, depending of the worflow
+      GList *iop_list;
+      if(is_scene_referred || is_workflow_none)
+        iop_list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30);
+      else
+        iop_list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_LEGACY);
+      dt_ioppr_write_iop_order_list(iop_list, imgid);
+      g_list_free_full(iop_list, free);
+      dt_ioppr_set_default_iop_order(dev, imgid);
+    }
+    sqlite3_finalize(stmt);
   }
-
-  sqlite3_finalize(stmt);
 
   image->flags |= DT_IMAGE_AUTO_PRESETS_APPLIED | DT_IMAGE_NO_LEGACY_PRESETS;
 


### PR DESCRIPTION
A long standing bug, I finally found the root cause. The iop-order list was properly set when pasting history but was reset later as part of auto applying presets/history for first dev of image.