### PR TITLE
interpolation: switch from M_PI to M_PI_F in lanczos to avoid DP FLOPs

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -349,8 +349,8 @@ static inline float lanczos(float width, float t)
   } sign;
   sign.i = ((a & 1) << 31) | 0x3f800000;
 
-  return (DT_LANCZOS_EPSILON + width * sign.f * sinf_fast(M_PI * r) * sinf_fast(M_PI * t / width))
-         / (DT_LANCZOS_EPSILON + M_PI * M_PI * t * t);
+  return (DT_LANCZOS_EPSILON + width * sign.f * sinf_fast(M_PI_F * r) * sinf_fast(M_PI_F * t / width))
+         / (DT_LANCZOS_EPSILON + M_PI_F * M_PI_F * t * t);
 }
 
 #if defined(__SSE2__)


### PR DESCRIPTION
CPU: `Intel(R) Core(TM) i7-6700`
Threads: 4
Build: Release, SSE2-optimized codepaths disabled
Compiler: `gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0`

pixel pipeline processing took:

Test, native-no-sse2, native-no-sse2-lanczos_M_PI_F:
```
0018-perspective-corr: 1.00 -> 0.89 (1.11x)
0077-croprotate-keystone: 0.90 -> 0.81 (1.12x)
0009-flip-v: 0.86 -> 0.77 (1.12x)
0008-flip-h: 0.86 -> 0.77 (1.12x)
0010-flip-hv: 0.86 -> 0.77 (1.12x)
```

`lanczos` function CPU time in `0010-flip-hv` test:
```
lanczos_M_PI    0.794s
lanczos_M_PI_F	0.448s (1.77x)
```