### PR TITLE
[safe copy] mark deprecateed modules as unsafe too

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -489,11 +489,6 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest, dt_develop_t *d
   return module_added;
 }
 
-static inline gboolean _is_module_to_skip(const int flags)
-{
-  return flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN);
-}
-
 static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_imgid, GList *ops, const gboolean copy_full)
 {
   GList *modules_used = NULL;
@@ -566,7 +561,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
          && !(mod_src->default_enabled && mod_src->enabled
               && !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size) // it's not a enabled by default module with unmodified settings
               && !dt_iop_is_hidden(mod_src))
-         && (copy_full || !_is_module_to_skip(mod_src->flags()))
+         && (copy_full || !dt_history_module_skip_copy(mod_src->flags()))
         )
       {
         mod_list = g_list_append(mod_list, mod_src);
@@ -645,7 +640,7 @@ static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const
       {
         dt_iop_module_so_t *module = (dt_iop_module_so_t *)modules->data;
 
-        if(_is_module_to_skip(module->flags()))
+        if(dt_history_module_skip_copy(module->flags()))
         {
           if(skip_modules)
             skip_modules = dt_util_dstrcat(skip_modules, ",");

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -21,6 +21,7 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 #include <sqlite3.h>
+#include "develop/imageop.h"
 
 struct dt_develop_t;
 struct dt_iop_module_t;
@@ -77,6 +78,11 @@ gboolean dt_history_copy(int imgid);
 gboolean dt_history_copy_parts(int imgid);
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo);
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo);
+
+static inline gboolean dt_history_module_skip_copy(const int flags)
+{
+  return flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN);
+}
 
 /** load a dt file and applies to selected images */
 int dt_history_load_and_apply_on_list(gchar *filename, const GList *list);

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -254,7 +254,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
 
       if(!(flags & IOP_FLAGS_HIDDEN))
       {
-        const gboolean is_safe = ((flags & IOP_FLAGS_UNSAFE_COPY) == 0);
+        const gboolean is_safe = ((flags & IOP_FLAGS_UNSAFE_COPY) == 0) && ((flags & IOP_FLAGS_DEPRECATED) == 0);
 
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
         gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -254,7 +254,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
 
       if(!(flags & IOP_FLAGS_HIDDEN))
       {
-        const gboolean is_safe = ((flags & IOP_FLAGS_UNSAFE_COPY) == 0) && ((flags & IOP_FLAGS_DEPRECATED) == 0);
+        const gboolean is_safe = !dt_history_module_skip_copy(flags);
 
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
         gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,


### PR DESCRIPTION
copy parts dialog by default as unsafe module unchecked. However
it doesn't have deprecated modules unchecked.

This change marks deprecated modules as deprecated too.

Fixes #7249