### PR TITLE
histogram: handle manually selected display profile

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1495,10 +1495,24 @@ dt_colorspaces_t *dt_colorspaces_init()
   for(GList *iter = temp_profiles; iter; iter = g_list_next(iter))
   {
     dt_colorspaces_color_profile_t *prof = (dt_colorspaces_color_profile_t *)iter->data;
+    // FIXME: do want to filter out non-RGB profiles for cases besides histogram profile? colorin is OK with RGB or XYZ, print is OK with anything which LCMS likes, otherwise things are more choosey
+    const cmsColorSpaceSignature color_space = cmsGetColorSpace(prof->profile);
     prof->out_pos = ++out_pos;
     prof->display_pos = ++display_pos;
     prof->display2_pos = ++display2_pos;
-    prof->category_pos = ++category_pos;
+    if(color_space == cmsSigRgbData)
+    {
+      prof->category_pos = ++category_pos;
+    }
+    else
+    {
+      fprintf(stderr, "output profile `%s' color space `%c%c%c%c' not supported for histogram profile\n",
+              prof->name,
+              (char)(color_space>>24),
+              (char)(color_space>>16),
+              (char)(color_space>>8),
+              (char)(color_space));
+    }
     prof->work_pos = ++work_pos;
   }
   res->profiles = g_list_concat(res->profiles, temp_profiles);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2172,7 +2172,7 @@ post_process_collect_info:
           }
           darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, buf,
                                                  roi_out->width, roi_out->height,
-                                                 DT_COLORSPACE_DISPLAY, "");
+                                                 darktable.color_profiles->display_type, darktable.color_profiles->display_filename);
           dt_free_align(buf);
         }
       }
@@ -2180,7 +2180,7 @@ post_process_collect_info:
       {
         darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, input,
                                                roi_in.width, roi_in.height,
-                                               DT_COLORSPACE_DISPLAY, "");
+                                               darktable.color_profiles->display_type, darktable.color_profiles->display_filename);
       }
     }
   }

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -117,6 +117,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *out_type, const gchar **out_filename)
 {
   // if in gamut check use soft proof
+  // FIXME: This isn't actually true -- we only use soft proof profile if it is chosen by the user as a histogram profile. Otherwise, if in gamut check, we still use the histogram profile.
   if(darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
   {
     *out_type = darktable.color_profiles->softproof_type;
@@ -151,6 +152,7 @@ static void _transform_image_colorspace(dt_iop_module_t *self, const float *cons
   const dt_iop_order_iccprofile_info_t *const profile_info_to
       = dt_ioppr_add_profile_info_to_list(self->dev, histogram_type, histogram_filename, INTENT_RELATIVE_COLORIMETRIC);
 
+  // FIXME: the histogram already does this work -- use that data instead?
   if(profile_info_from && profile_info_to)
     dt_ioppr_transform_image_colorspace_rgb(img_in, img_out, roi_in->width, roi_in->height, profile_info_from,
                                             profile_info_to, self->op);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -279,17 +279,8 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     dt_ioppr_get_histogram_profile_type(&out_profile_type, &out_profile_filename);
     if(out_profile_type != DT_COLORSPACE_NONE)
     {
-      const dt_iop_order_iccprofile_info_t *profile_info_to =
+      const dt_iop_order_iccprofile_info_t *const profile_info_to =
         dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
-      // FIXME: guard against unsupported profiles earlier, e.g. histogram_profile_callback() in darkroom.c?
-      if(profile_info_to == NULL || isnan(profile_info_to->matrix_in[0]) || isnan(profile_info_to->matrix_out[0]))
-      {
-        dt_control_log(_("unsupported histogram profile has been replaced by sRGB!"));
-        fprintf(stderr, "unsupported histogram profile `%s' has been replaced by sRGB!\n",
-                dt_colorspaces_get_name(out_profile_type, out_profile_filename));
-        profile_info_to = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL);
-      }
-
       img_display = dt_alloc_align_float((size_t)4 * width * height);
       if(!img_display) return;
       dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -271,16 +271,25 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
   // then the image is already converted by the caller.
   if(in_profile_type != DT_COLORSPACE_NONE)
   {
-    dt_colorspaces_color_profile_type_t out_profile_type;
-    const char *out_profile_filename;
     const dt_iop_order_iccprofile_info_t *const profile_info_from
       = dt_ioppr_add_profile_info_to_list(dev, in_profile_type, in_profile_filename, INTENT_PERCEPTUAL);
-    dt_ioppr_get_histogram_profile_type(&out_profile_type, &out_profile_filename);
 
+    dt_colorspaces_color_profile_type_t out_profile_type;
+    const char *out_profile_filename;
+    dt_ioppr_get_histogram_profile_type(&out_profile_type, &out_profile_filename);
     if(out_profile_type != DT_COLORSPACE_NONE)
     {
-      const dt_iop_order_iccprofile_info_t *const profile_info_to =
+      const dt_iop_order_iccprofile_info_t *profile_info_to =
         dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
+      // FIXME: guard against unsupported profiles earlier, e.g. histogram_profile_callback() in darkroom.c?
+      if(profile_info_to == NULL || isnan(profile_info_to->matrix_in[0]) || isnan(profile_info_to->matrix_out[0]))
+      {
+        dt_control_log(_("unsupported histogram profile has been replaced by sRGB!"));
+        fprintf(stderr, "unsupported histogram profile `%s' has been replaced by sRGB!\n",
+                dt_colorspaces_get_name(out_profile_type, out_profile_filename));
+        profile_info_to = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL);
+      }
+
       img_display = dt_alloc_align_float((size_t)4 * width * height);
       if(!img_display) return;
       dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,


### PR DESCRIPTION
If the user manually selected a display profile, it was ignored when generating the histogram. Code always defaulted to using `DT_COLORSPACE_DISPLAY`.

Histogram colorspace process:
- the histogram is calculated just before the "gamma" iop
- pixelpipe data is in the display profile as selected by user
- the data is converted to histogram profile then processed

Before this commit, the conversion to histogram profile would be wrong anytime the user selected a display profile which was not the one found by dt_colorspaces_set_display_profile(). The histogram would change erratically as the user selected different display profiles.

Note that the histogram still will change subtly as certain display profiles are chosen. This is particularly noticeable if using a
device-specific output profile. This is because the transformation from work profile to such a display profile may lose data. See #3271.