### PR TITLE
Fix history hash computation.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1353,12 +1353,15 @@ static gsize _history_hash_compute_from_db(const int32_t imgid, guint8 **hash)
   }
   sqlite3_finalize(stmt);
 
-  // get history
+  // get history. the active history for an image are all the latest operations (MAX(num))
+  // which are enabled. this is important here as we want the hash to represent the actual
+  // developement of the image.
   gboolean history_on = FALSE;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT operation, op_params, blendop_params"
+                              "SELECT operation, op_params, blendop_params, enabled, MAX(num)"
                               " FROM main.history"
-                              " WHERE imgid = ?1 AND enabled = 1 AND num <= ?2"
+                              " WHERE imgid = ?1 AND num <= ?2"
+                              " GROUP BY operation, multi_priority"
                               " ORDER BY num",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
@@ -1366,18 +1369,22 @@ static gsize _history_hash_compute_from_db(const int32_t imgid, guint8 **hash)
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    // operation
-    char *buf = (char *)sqlite3_column_text(stmt, 0);
-    if(buf) g_checksum_update(checksum, (const guchar *)buf, -1);
-    // op_params
-    buf = (char *)sqlite3_column_blob(stmt, 1);
-    int params_len = sqlite3_column_bytes(stmt, 1);
-    if(buf) g_checksum_update(checksum, (const guchar *)buf, params_len);
-    // blendop_params
-    buf = (char *)sqlite3_column_blob(stmt, 2);
-    params_len = sqlite3_column_bytes(stmt, 2);
-    if(buf) g_checksum_update(checksum, (const guchar *)buf, params_len);
-    history_on = TRUE;
+    const int enabled = sqlite3_column_int(stmt, 3);
+    if(enabled)
+    {
+      // operation
+      char *buf = (char *)sqlite3_column_text(stmt, 0);
+      if(buf) g_checksum_update(checksum, (const guchar *)buf, -1);
+      // op_params
+      buf = (char *)sqlite3_column_blob(stmt, 1);
+      int params_len = sqlite3_column_bytes(stmt, 1);
+      if(buf) g_checksum_update(checksum, (const guchar *)buf, params_len);
+      // blendop_params
+      buf = (char *)sqlite3_column_blob(stmt, 2);
+      params_len = sqlite3_column_bytes(stmt, 2);
+      if(buf) g_checksum_update(checksum, (const guchar *)buf, params_len);
+      history_on = TRUE;
+    }
   }
   sqlite3_finalize(stmt);
 


### PR DESCRIPTION
The actual hash representing the current dev must be using only the
last active module for each operation. This also fixes the same kind
of issue when multiple instances of the same module is used.

Fixes #7159.