### PR TITLE
bauhaus: fix _(NULL) call.

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -866,7 +866,7 @@ void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min,
 
 void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section_orig, const char *label_orig)
 {
-  const char *section = _(section_orig);
+  const char *section = section_orig ? _(section_orig) : NULL;
   const char *label = _(label_orig);
 
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);


### PR DESCRIPTION
dt_bauhaus_widget_set_label is called in multiple places with
section_orig=NULL, which, when passed to gettext-like functions,
generates undefined behavior. On musl libc, this segfaults the
application.

I'm not 100% sure this is the correct fix, since most of the `dt_bauhaus_widget_set_label` callers already call some gettext like function on their own. Maybe the localization should be removed from the function completely, instead?