### PR TITLE
Generate preferences dialog for in module preference support.

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -2,7 +2,9 @@
 <!ELEMENT dtconfig (name,type,default,capability?,shortdescription?,longdescription?)>
 <!ATTLIST dtconfig
 	prefs (import|lighttable|darkroom|otherviews|processing|security|cpugpu|storage|misc) #IMPLIED
-        section (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp|accel|general|modules|thumbs) #IMPLIED
+        section
+        (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp|accel|general|modules|thumbs) #IMPLIED
+        dialog (collect|import) #IMPLIED
         restart (true|false) #IMPLIED
         capability CDATA #IMPLIED
 >

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -320,14 +320,14 @@
     <shortdescription>disable the entry completion</shortdescription>
     <longdescription>the entry completion is useful for those who enter tags from keyboard only. for others the entry completion can be embarrassing. need to restart darktable.</longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="tags">
+  <dtconfig dialog="collect">
     <name>plugins/lighttable/tagging/no_uncategorized</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>in collect module, do not set the 'uncategorized' entry for tags</shortdescription>
-    <longdescription>in collect module, do not set the 'uncategorized' entry for tags which do not have children</longdescription>
+    <shortdescription>do not set the 'uncategorized' entry for tags</shortdescription>
+    <longdescription>do not set the 'uncategorized' entry for tags which do not have children</longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="tags">
+  <dtconfig dialog="collect">
     <name>plugins/lighttable/tagging/case_sensitivity</name>
     <type>
       <enum>
@@ -336,8 +336,8 @@
       </enum>
     </type>
     <default>insensitive</default>
-    <shortdescription>in collect module, tags case sensitivity</shortdescription>
-    <longdescription>in collect module, tags case sensitivity. without the Sqlite ICU extension, insensivity works only for the 26 latin letters</longdescription>
+    <shortdescription>tags case sensitivity</shortdescription>
+    <longdescription>tags case sensitivity. without the Sqlite ICU extension, insensivity works only for the 26 latin letters</longdescription>
   </dtconfig>
   <dtconfig prefs="cpugpu" capability="opencl">
     <name>opencl</name>
@@ -449,7 +449,7 @@
     <shortdescription>ask before removing empty folders</shortdescription>
     <longdescription>always ask the user before removing any empty folder. this can happen after moving or deleting images.</longdescription>
   </dtconfig>
-  <dtconfig prefs="lighttable" section="general">
+  <dtconfig dialog="collect">
     <name>show_folder_levels</name>
     <type min="1" max="5">int</type>
     <default>1</default>
@@ -559,7 +559,7 @@
     <shortdescription>sort film rolls by</shortdescription>
     <longdescription>sets the collections-list order for film rolls</longdescription>
   </dtconfig>
-  <dtconfig prefs="lighttable" section="general">
+  <dtconfig dialog="collect">
     <name>plugins/collect/descending</name>
     <type>bool</type>
     <default>true</default>

--- a/src/gui/preferences_dialogs.h
+++ b/src/gui/preferences_dialogs.h
@@ -1,0 +1,25 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+void dt_prefs_init_dialog_collect(GtkWidget *dialog);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -20,12 +20,29 @@
   gtk_viewport_set_shadow_type(GTK_VIEWPORT(viewport), GTK_SHADOW_NONE); // doesn't seem to work from gtkrc
   gtk_container_add(GTK_CONTAINER(scroll), viewport);
   gtk_container_add(GTK_CONTAINER(viewport), grid);
-
 </xsl:variable>
 
   <xsl:variable name="tab_end">
   gtk_widget_show_all(stack);
 }
+</xsl:variable>
+
+<xsl:variable name="dialog_start">(GtkWidget *dialog)
+{
+  GtkWidget *widget, *label, *labelev, *viewport, *box;
+  GtkWidget *grid = gtk_grid_new();
+  gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(3));
+  gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
+  gtk_widget_set_valign(grid, GTK_ALIGN_START);
+  int line = 0;
+  char tooltip[1024];
+  GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+  g_object_set_data(G_OBJECT(dialog), "local-dialog", GUINT_TO_POINTER(1));
+</xsl:variable>
+
+<xsl:variable name="dialog_end">
+  gtk_box_pack_start(GTK_BOX(area), grid, FALSE, FALSE, 0);
+  }
 </xsl:variable>
 
   <xsl:param name="HAVE_OPENCL">1</xsl:param>
@@ -108,7 +125,7 @@ gboolean restart_required = FALSE;
 
   <!-- reset callbacks -->
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs]">
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs or @dialog]">
     <xsl:if test="name != 'opencl' or $HAVE_OPENCL=1">
       <xsl:text>static gboolean&#xA;reset_widget_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *label, GdkEventButton *event, GtkWidget *widget)&#xA;{&#xA;  if(event->type == GDK_2BUTTON_PRESS)&#xA;  {&#xA;</xsl:text>
       <xsl:apply-templates select="." mode="reset"/>
@@ -118,9 +135,21 @@ gboolean restart_required = FALSE;
 
   <!-- response callbacks (on dialog close) -->
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs]">
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs or @dialog]">
     <xsl:if test="name != 'opencl' or $HAVE_OPENCL=1">
-      <xsl:text>static void&#xA;preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkDialog *dialog, gint response_id, GtkWidget *widget)&#xA;{&#xA;  if(response_id != GTK_RESPONSE_DELETE_EVENT) return;&#xA;</xsl:text>
+      <xsl:text>static void&#xA;preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/>
+      <xsl:text> (GtkDialog *dialog, gint response_id, GtkWidget *widget)&#xA;</xsl:text>
+      <xsl:text>{&#xA;</xsl:text>
+      <xsl:text>  const gint dkind = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(dialog), "local-dialog"));&#xA;</xsl:text>
+      <xsl:text>  if(dkind)&#xA;</xsl:text>
+      <xsl:text>  {&#xA;</xsl:text>
+      <xsl:text>    if(response_id == GTK_RESPONSE_NONE) return;&#xA;</xsl:text>
+      <xsl:text>    if(response_id == GTK_RESPONSE_DELETE_EVENT) return;&#xA;</xsl:text>
+      <xsl:text>  }&#xA;</xsl:text>
+      <xsl:text>  else&#xA;</xsl:text>
+      <xsl:text>  {&#xA;</xsl:text>
+      <xsl:text>    if(response_id != GTK_RESPONSE_DELETE_EVENT) return;&#xA;</xsl:text>
+      <xsl:text>  }&#xA;</xsl:text>
       <xsl:text>  gtk_widget_set_can_focus(GTK_WIDGET(dialog), TRUE);&#xA;</xsl:text>
       <xsl:text>  gtk_widget_grab_focus(GTK_WIDGET(dialog));&#xA;</xsl:text>
       <xsl:apply-templates select="." mode="change"/>
@@ -130,7 +159,7 @@ gboolean restart_required = FALSE;
 
   <!-- restart callbacks (on change) -->
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs]">
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs or @dialog]">
     <xsl:text>static void&#xA;preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *widget, gpointer user_data)&#xA;{&#xA;</xsl:text>
     <xsl:if test="@restart">
       <xsl:text>  restart_required = TRUE;&#xA;</xsl:text>
@@ -392,6 +421,14 @@ gboolean restart_required = FALSE;
           <xsl:apply-templates select="." mode="tab_block"/>
   </xsl:for-each>
   <xsl:value-of select="$tab_end" />
+
+  <!-- dialog: collect -->
+
+  <xsl:text>&#xA;void dt_prefs_init_dialog_collect</xsl:text><xsl:value-of select="$dialog_start"/>
+  <xsl:for-each select="./dtconfiglist/dtconfig[@dialog='collect']">
+      <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+  <xsl:value-of select="$dialog_end" />
 
   <!-- closing credits -->
   <xsl:text>&#xA;#endif&#xA;</xsl:text>


### PR DESCRIPTION
This adds a new attribute dialog which can be set to generate the needed
preference dialog for a specific module.

The current version supports dialog="collect" and generate the routine:

   static void
   init_dialog_collect (GtkWidget *dialog);

The user has to create a dialog and call this routine to populate
the dialog with all corresponding options.

Part of #7530.