### PR TITLE
never show filmstrip "cursors" on other modes

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2309,7 +2309,7 @@ spinbutton>button
 {
   color: transparent;
 }
-#thumb_main:active #thumb_cursor
+#thumbtable_filmstrip #thumb_main:active #thumb_cursor
 {
   color: @border_color;
 }


### PR DESCRIPTION
this can happen if overlay mode for culling is set to something else than "block".
Found in @pahl34 video in #7445 