### PR TITLE
split tiling->factor into CPU and GPU requirements

### DIFF
--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1233,10 +1233,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
   headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
   const float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  float factor = fmax(tiling.factor + pinned_buffer_overhead, 1.0f);
+  float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
                                   pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
-  float maxbuf = fmax(tiling.maxbuf, 1.0f);
+  float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
   int width = _min(roi_in->width, darktable.opencl->dev[devid].max_image_width);
   int height = _min(roi_in->height, darktable.opencl->dev[devid].max_image_height);
 
@@ -1600,10 +1600,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
   headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
   const float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  float factor = fmax(tiling.factor + pinned_buffer_overhead, 1.0f);
+  float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
                                   pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
-  float maxbuf = fmax(tiling.maxbuf, 1.0f);
+  float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
 
   int width = _min(_max(roi_in->width, roi_out->width), darktable.opencl->dev[devid].max_image_width);
   int height = _min(_max(roi_in->height, roi_out->height), darktable.opencl->dev[devid].max_image_height);
@@ -2023,7 +2023,9 @@ void default_tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpi
       = ((float)roi_out->width * (float)roi_out->height) / ((float)roi_in->width * (float)roi_in->height);
 
   tiling->factor = 1.0f + ioratio;
+  tiling->factor_cl = tiling->factor;  // by default, we need the same memory on host or GPU
   tiling->maxbuf = 1.0f;
+  tiling->maxbuf_cl = tiling->maxbuf;
   tiling->overhead = 0;
   tiling->overlap = 0;
   tiling->xalign = 1;

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -24,10 +24,14 @@
 
 typedef struct dt_develop_tiling_t
 {
-  /** memory requirement as a multiple of image buffer size */
+  /** memory requirement as a multiple of image buffer size (on host/CPU) */
   float factor;
-  /** maximum requirement for temporary buffers as a multiple of image buffer size */
+  /** memory requirement as a multiple of image buffer size (on GPU) */
+  float factor_cl;
+  /** maximum requirement for temporary buffers as a multiple of image buffer size (on host) */
   float maxbuf;
+  /** maximum requirement for temporary buffers as a multiple of image buffer size (on GPU) */
+  float maxbuf_cl;
   /** on-top memory requirement, with a size independent of input buffer */
   unsigned overhead;
   /** overlap needed between tiles (in pixels) */

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -473,8 +473,10 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
   const int max_filter_radius = 2 * (1 << max_scale); // 2 * 2^max_scale
 
-  tiling->factor = 3.0f + max_scale; // in + out + tmp + scale buffers
+  tiling->factor = 3.0f + max_scale; //TODO: reduce to 5.0f after merging PR7485
+  tiling->factor_cl = 3.0f + max_scale; // in + out + tmp + scale buffers
   tiling->maxbuf = 1.0f;
+  tiling->maxbuf_cl = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = max_filter_radius;
   tiling->xalign = 1;

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -320,7 +320,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const float _r = ceilf(rad * roi_in->scale / piece->iscale);
   const int radius = MIN(256.0f, _r);
 
-  tiling->factor = 2.0f + NUM_BUCKETS * 0.25f; // in + out + NUM_BUCKETS * 0.25 tmp
+  tiling->factor = 2.0f + 0.25f + 0.05f; // in + out + blurlightness + slice for dt_box_mean
+  tiling->factor_cl = 2.0f + NUM_BUCKETS * 0.25f; // in + out + NUM_BUCKETS * 0.25 tmp
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 5 * radius; // This is a guess. TODO: check if that's sufficiently large

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -672,7 +672,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     const int K = ceilf(d->nbhood * fminf(roi_in->scale, 2.0f) / fmaxf(piece->iscale, 1.0f)); // nbhood
     const int K_scattered = ceilf(d->scattering * (K * K * K + 7.0 * K * sqrt(K)) / 6.0) + K;
 
-    tiling->factor = 4.0f + 0.25f * NUM_BUCKETS; // in + out + (2 + NUM_BUCKETS * 0.25) tmp
+    tiling->factor = 2.0f + 0.25f; // in + out + tmp
+    tiling->factor_cl = 4.0f + 0.25f * NUM_BUCKETS; // in + out + (2 + NUM_BUCKETS * 0.25) tmp
     tiling->maxbuf = 1.0f;
     tiling->overhead = 0;
     tiling->overlap = P + K_scattered;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -111,7 +111,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const float sigma = sqrtf((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
   const int wdh = ceilf(3.0f * sigma);
 
-  tiling->factor = 3.0f; // in + out + tmp
+  tiling->factor = 2.1f; // in + out + small slice for box_mean
+  tiling->factor_cl = 3.0f; // in + out + tmp
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = wdh;

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -398,7 +398,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const float sigma = sqrtf((radius * (radius + 1) * BOX_ITERATIONS + 2) / 3.0f);
   const int wdh = ceilf(3.0f * sigma);
 
-  tiling->factor = 3.0f; // in + out + tmp
+  tiling->factor = 2.1f; // in + out + small slice for box_mean
+  tiling->factor_cl = 3.0f; // in + out + tmp
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = wdh;

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -115,6 +115,7 @@ const char *name()
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+  // optionally add IOP_FLAGS_ALLOW_TILING and implement tiling_callback
 }
 
 // where does it appear in the gui?
@@ -199,6 +200,23 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   g_hash_table_remove_all(self->raster_mask.source.masks);
   g_hash_table_insert(self->raster_mask.source.masks, GINT_TO_POINTER(mask_id), g_strdup(mask_name));
 }
+
+#if 0
+/** optional, only needed if tiling is permitted by setting IOP_FLAGS_ALLOW_TILING */
+void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
+                     struct dt_develop_tiling_t *tiling)
+{
+  tiling->factor = 2.0f;    // input buffer + output buffer; increase if additional memory allocated
+  tiling->factor_cl = 2.0f; // same, but for OpenCL code path running on GPU
+  tiling->maxbuf = 1.0f;    // largest buffer needed regardless of how tiling splits up the processing
+  tiling->maxbuf_cl = 1.0f; // same, but for running on GPU
+  tiling->overhead = 0;     // number of bytes of fixed overhead
+  tiling->overlap = 0;      // how many pixels do we need to access from the neighboring tile?
+  tiling->xalign = 1;
+  tiling->yalign = 1;
+}
+#endif
 
 /** modify regions of interest (optional, per pixel ops don't need this) */
 // void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t


### PR DESCRIPTION
For multiple of the tiling-enabled iops, the CPU and GPU code paths require different amounts of memory.  Until now, tiling_callback() has had to report the larger of the two, which results in a larger number of smaller-than-necessary tiles being used when memory is restricted.  The pending #7485 will show very little improvement unless the tiling code gets access to the much smaller CPU memory requirements of the modified code.

Set up the call to tiling_callback such that existing code in iops will result in a report of the same value for CPU and GPU.

Added a sample tiling_callback to useless.c documenting the new split value return.

Also adjusted the reported tiling factors for several iops which already have different memory requirements (though not as dramatically as atrous will have), including bloom, highpass, monochrome, soften.

[And while I was at it, cleaned up two parallel  loops in monochrome.c]
