### PR TITLE
dynamically add warning label to iop when needed

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1428,7 +1428,8 @@ margin: 0 2px;
 }
 
 #modulegroups-deprecated-msg,
-#iop-plugin-deprecated
+#iop-plugin-deprecated,
+#iop-plugin-warning
 {
   background-color: #852A2A;
   padding: 0.45em;

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2435,7 +2435,7 @@ void ask_for_upgrade(const gchar *dbname, const gboolean has_gui)
 
   char *label_text = g_markup_printf_escaped(_("the database schema has to be upgraded for\n"
                                                "\n"
-                                               "<span style=\"italic\">%s</span>\n"
+                                               "<span style='italic'>%s</span>\n"
                                                "\n"
                                                "do you want to proceed or quit now to do a backup\n"),
                                                dbname);
@@ -2782,7 +2782,7 @@ start:
 
       char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
                                                    "\n"
-                                                   "<span style=\"italic\">%s</span>\n"
+                                                   "<span style='italic'>%s</span>\n"
                                                    "\n"
                                                    "it seems that the database is corrupted.\n"
                                                    "%s"
@@ -2960,7 +2960,7 @@ start:
 
     char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
                                                  "\n"
-                                                 "<span style=\"italic\">%s</span>\n"
+                                                 "<span style='italic'>%s</span>\n"
                                                  "\n"
                                                  "it seems that the database is corrupted.\n"
                                                  "%s"
@@ -3294,7 +3294,7 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
 
   char *label_text = g_markup_printf_escaped(_("the database could use some maintenance\n"
                                                  "\n"
-                                                 "there's <span style=\"italic\">%s</span> to be freed"
+                                                 "there's <span style='italic'>%s</span> to be freed"
                                                  "\n\n"
                                                  "do you want to proceed now?\n\n"
                                                  "%s\n"

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -383,7 +383,9 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
         break;
     }
   }
-  else if(has_prefix(variable, "LABELS_ICONS") && g_strcmp0(params->jobcode, "infos") == 0)
+  else if((has_prefix(variable, "LABELS_ICONS") ||
+           has_prefix(variable, "LABELS_COLORICONS"))
+          && g_strcmp0(params->jobcode, "infos") == 0)
   {
     escape = FALSE;
     GList *res = dt_metadata_get(params->imgid, "Xmp.darktable.colorlabels", NULL);
@@ -392,82 +394,10 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     {
       do
       {
-        const char *lb = (char *)(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)));
-        if(g_strcmp0(lb, "red") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_RED];
-          result = dt_util_dstrcat(result,
-                                   "<span foreground=\"#%02x%02x%02x\">⬤ </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "yellow") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_YELLOW];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">⬤ </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "green") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_GREEN];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">⬤ </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "blue") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_BLUE];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">⬤ </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "purple") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_PURPLE];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">⬤ </span>",
-                                   R(c), G(c), B(c));
-        }
-      } while((res = g_list_next(res)) != NULL);
-    }
-    g_list_free(res);
-  }
-  else if(has_prefix(variable, "LABELS_COLORICONS") && g_strcmp0(params->jobcode, "infos") == 0)
-  {
-    escape = FALSE;
-    GList *res = dt_metadata_get(params->imgid, "Xmp.darktable.colorlabels", NULL);
-    res = g_list_first(res);
-    if(res != NULL)
-    {
-      do
-      {
-        const char *lb = (char *)(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)));
-        if(g_strcmp0(lb, "red") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_RED];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02x\">🔴 </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "yellow") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_YELLOW];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">🟡 </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "green") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_GREEN];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">🟢 </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "blue") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_BLUE];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">🔵 </span>",
-                                   R(c), G(c), B(c));
-        }
-        else if(g_strcmp0(lb, "purple") == 0)
-        {
-          const GdkRGBA c = darktable.bauhaus->colorlabels[DT_COLORLABELS_PURPLE];
-          result = dt_util_dstrcat(result, "<span foreground=\"#%02x%02x%02X\">🟣 </span>",
-                                   R(c), G(c), B(c));
-        }
+        const GdkRGBA c = darktable.bauhaus->colorlabels[GPOINTER_TO_INT(res->data)];
+        result = dt_util_dstrcat(result,
+                                  "<span foreground='#%02x%02x%02x'>⬤ </span>",
+                                  R(c), G(c), B(c));
       } while((res = g_list_next(res)) != NULL);
     }
     g_list_free(res);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -167,10 +167,6 @@ static inline gboolean has_prefix(char **str, const char *prefix)
 
 static char *get_base_value(dt_variables_params_t *params, char **variable)
 {
-#define R(c) ((guint)(c.red * 255))
-#define G(c) ((guint)(c.green * 255))
-#define B(c) ((guint)(c.blue * 255))
-
   char *result = NULL;
   gboolean escape = TRUE;
 
@@ -392,12 +388,16 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     res = g_list_first(res);
     if(res != NULL)
     {
+      gboolean color_dot = has_prefix(variable, "LABELS_COLORICONS");
+      const char *colored_dots[] = { "🔴", "🟡", "🟢", "🔵", "🟣" };
       do
       {
+        const char *dot = color_dot ? colored_dots[GPOINTER_TO_INT(res->data)] : "⬤";
         const GdkRGBA c = darktable.bauhaus->colorlabels[GPOINTER_TO_INT(res->data)];
         result = dt_util_dstrcat(result,
-                                  "<span foreground='#%02x%02x%02x'>⬤ </span>",
-                                  R(c), G(c), B(c));
+                                 "<span foreground='#%02x%02x%02x'>%s </span>",
+                                 (guint)(c.red*255), (guint)(c.green*255), (guint)(c.blue*255),
+                                 dot);
       } while((res = g_list_next(res)) != NULL);
     }
     g_list_free(res);
@@ -545,11 +545,6 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     return e_res;
   }
   return result;
-
-#undef R
-#undef G
-#undef B
-
 }
 
 // bash style variable manipulation. all patterns are just simple string comparisons!

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1268,13 +1268,17 @@ static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module)
 {
   gtk_widget_set_name(lab, "iop-panel-label");
   char *module_name = dt_history_item_get_name_html(module);
-  gchar *label = g_strdup_printf("%s",
-                                 (module->has_trouble && module->enabled)
-                                 ? dt_iop_warning_message(module_name)
-                                 : module_name);
+
+  if((module->has_trouble && module->enabled))
+  {
+    char *saved_old_name = module_name;
+    module_name = dt_iop_warning_message(module_name);
+    g_free(saved_old_name);
+  }
+
+  gtk_label_set_markup(GTK_LABEL(lab), module_name);
   g_free(module_name);
 
-  gtk_label_set_markup(GTK_LABEL(lab), label);
   gtk_label_set_ellipsize(GTK_LABEL(lab), !module->multi_name[0] ? PANGO_ELLIPSIZE_END: PANGO_ELLIPSIZE_MIDDLE);
   g_object_set(G_OBJECT(lab), "xalign", 0.0, (gchar *)0);
   if((module->flags() & IOP_FLAGS_DEPRECATED) && module->deprecated_msg())
@@ -1285,8 +1289,6 @@ static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(lab, tooltip);
     g_free(tooltip);
   }
-
-  g_free(label);
 }
 
 static void _iop_gui_update_header(dt_iop_module_t *module)
@@ -1361,10 +1363,26 @@ void dt_iop_set_module_in_trouble(dt_iop_module_t *module, const gboolean state)
 static void _set_trouble_message(dt_iop_module_t *const module, const char* const trouble_msg,
                                  const char* const trouble_tooltip, const char *const stderr_message)
 {
-  GtkWidget *label_widget = module ? module->warning_label : NULL;
-  //TODO: write function to create the label widget on the module's header
-  //if (!label_widget)
-  //  label_widget = module->warning_label = create_warning_label(module);
+  GtkWidget *label_widget = NULL;
+
+  if(module && module->widget)
+  {
+    GtkWidget *iopw = gtk_widget_get_parent(module->widget);
+    GList *children = gtk_container_get_children(GTK_CONTAINER(iopw));
+    label_widget = g_list_nth_data(children, 0);
+    g_list_free(children);
+    if(strcmp(gtk_widget_get_name(label_widget), "iop-plugin-warning"))
+    {
+      label_widget = gtk_label_new("");;
+      gtk_label_set_line_wrap(GTK_LABEL(label_widget), TRUE);
+      gtk_label_set_xalign(GTK_LABEL(label_widget), 0.0);
+      gtk_widget_set_name(label_widget, "iop-plugin-warning");
+      gtk_box_pack_start(GTK_BOX(iopw), label_widget, TRUE, TRUE, 0);
+      gtk_box_reorder_child(GTK_BOX(iopw), label_widget, 0);
+      gtk_widget_show(label_widget);
+    }
+  }
+
   if (trouble_msg && *trouble_msg)
   {
     if ((!module || !module->has_trouble) && (stderr_message || !label_widget))
@@ -1381,7 +1399,6 @@ static void _set_trouble_message(dt_iop_module_t *const module, const char* cons
         gtk_label_set_text(GTK_LABEL(label_widget), msg);
         g_free(msg);
         gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), trouble_tooltip ? trouble_tooltip : "");
-        gtk_widget_set_visible(GTK_WIDGET(label_widget), TRUE);
       }
       // set the module's trouble flag
       dt_iop_set_module_in_trouble(module, TRUE);
@@ -1393,15 +1410,13 @@ static void _set_trouble_message(dt_iop_module_t *const module, const char* cons
     dt_iop_set_module_in_trouble(module, FALSE);
     if (label_widget)
     {
-      gtk_label_set_text(GTK_LABEL(label_widget), "");
-      gtk_widget_set_tooltip_text(GTK_WIDGET(label_widget), "");
-      gtk_widget_set_visible(GTK_WIDGET(label_widget), FALSE);
+      gtk_widget_destroy(label_widget);
     }
   }
   else if (label_widget)
   {
     // hide the warning label; needed if the caller relies on this function to manage the visibility
-    gtk_widget_set_visible(GTK_WIDGET(label_widget), FALSE);
+    gtk_widget_destroy(label_widget);
   }
 }
 
@@ -2623,8 +2638,9 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   // show deprected message if any
   if(module->deprecated_msg())
   {
-    GtkWidget *lb = gtk_label_new(g_strdup(module->deprecated_msg()));
+    GtkWidget *lb = gtk_label_new(module->deprecated_msg());
     gtk_label_set_line_wrap(GTK_LABEL(lb), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(lb), 0.0);
     gtk_widget_set_name(lb, "iop-plugin-deprecated");
     gtk_box_pack_start(GTK_BOX(iopw), lb, TRUE, TRUE, 0);
     gtk_widget_show(lb);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -384,7 +384,6 @@ typedef struct dt_iop_module_t
   GtkDarktableToggleButton *off;
   /** this is the module header, contains label and buttons */
   GtkWidget *header;
-  GtkWidget *warning_label;
 
   /** expander containing the widget and flag to store expanded state */
   GtkWidget *expander;
@@ -733,7 +732,7 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
 void dt_iop_set_module_in_trouble(dt_iop_module_t *module, const gboolean);
 
 /** Set the trouble message for the module.  If non-empty, also flag the module as being in trouble; if empty
- ** or NULL, clear the trouble flag.  If 'toast_message' is non-NULL/non-empty, pop up a toast with that 
+ ** or NULL, clear the trouble flag.  If 'toast_message' is non-NULL/non-empty, pop up a toast with that
  ** message when the module does not have a warning-label widget (use %s for the module's name).  **/
 void dt_iop_set_module_trouble_message(dt_iop_module_t *module, char *const trouble_msg,
                                        const char *const trouble_tooltip, const char *stderr_message);
@@ -751,7 +750,7 @@ static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t 
 }
 #define IOP_GUI_ALLOC(module) \
   (dt_iop_##module##_gui_data_t *)_iop_gui_alloc(self,sizeof(dt_iop_##module##_gui_data_t))
-  
+
 #define IOP_GUI_FREE \
   dt_pthread_mutex_destroy(&self->gui_lock);if(self->gui_data){free(self->gui_data);} self->gui_data = NULL
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -728,9 +728,6 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module);
 /** (un)hide iop module header right side buttons */
 gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
 
-/** show in iop module header that the module is in trouble */
-void dt_iop_set_module_in_trouble(dt_iop_module_t *module, const gboolean);
-
 /** Set the trouble message for the module.  If non-empty, also flag the module as being in trouble; if empty
  ** or NULL, clear the trouble flag.  If 'toast_message' is non-NULL/non-empty, pop up a toast with that
  ** message when the module does not have a warning-label widget (use %s for the module's name).  **/

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -39,6 +39,14 @@
 #define FINISH { cairo_identity_matrix(cr); \
                  cairo_restore(cr); }
 
+const GdkRGBA _colorlabels[]
+  = { {.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 }, // red
+      {.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 }, // yellow
+      {.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 }, // green
+      {.red = 0.0, .green = 0.0, .blue = 0.9, .alpha = 1.0 }, // blue
+      {.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 }, // purple
+    };
+
 void dtgtk_cairo_paint_empty(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 0, 0)
@@ -1207,19 +1215,8 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
   if(color < DT_COLORLABELS_LAST)
   {
-    GdkRGBA colorlabels[DT_COLORLABELS_LAST];
-    if(data != NULL)
-    {
-      memcpy(&colorlabels, data, sizeof(GdkRGBA) * DT_COLORLABELS_LAST);
-    }
-    else
-    {
-      colorlabels[DT_COLORLABELS_RED]    = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 };
-      colorlabels[DT_COLORLABELS_YELLOW] = (GdkRGBA){.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
-      colorlabels[DT_COLORLABELS_GREEN]  = (GdkRGBA){.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
-      colorlabels[DT_COLORLABELS_BLUE]   = (GdkRGBA){.red = 0.0, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
-      colorlabels[DT_COLORLABELS_PURPLE] = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
-    }
+    const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
+
     set_color(cr, colorlabels[color]);
   }
   else if(color == 7)
@@ -1359,19 +1356,7 @@ void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h,
 {
   PREAMBLE(1, 0, 0)
 
-  GdkRGBA colorlabels[DT_COLORLABELS_LAST];
-  if(data != NULL)
-  {
-    memcpy(&colorlabels, data, sizeof(GdkRGBA) * DT_COLORLABELS_LAST);
-  }
-  else
-  {
-    colorlabels[DT_COLORLABELS_RED]    = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 };
-    colorlabels[DT_COLORLABELS_YELLOW] = (GdkRGBA){.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
-    colorlabels[DT_COLORLABELS_GREEN]  = (GdkRGBA){.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
-    colorlabels[DT_COLORLABELS_BLUE]   = (GdkRGBA){.red = 0.0, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
-    colorlabels[DT_COLORLABELS_PURPLE] = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
-  }
+  const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
 
   const float r = 0.18;
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2118,23 +2118,23 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
           const char *lb = (char *)(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)));
           if(g_strcmp0(lb, "red") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#ee0000\">⬤ </span>");
+            result = dt_util_dstrcat(result, "<span foreground='#ee0000'>⬤ </span>");
           }
           else if(g_strcmp0(lb, "yellow") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#eeee00\">⬤ </span>");
+            result = dt_util_dstrcat(result, "<span foreground='#eeee00'>⬤ </span>");
           }
           else if(g_strcmp0(lb, "green") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#00ee00\">⬤ </span>");
+            result = dt_util_dstrcat(result, "<span foreground='#00ee00'>⬤ </span>");
           }
           else if(g_strcmp0(lb, "blue") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#0000ee\">⬤ </span>");
+            result = dt_util_dstrcat(result, "<span foreground='#0000ee'>⬤ </span>");
           }
           else if(g_strcmp0(lb, "purple") == 0)
           {
-            result = dt_util_dstrcat(result, "<span foreground=\"#ee00ee\">⬤ </span>");
+            result = dt_util_dstrcat(result, "<span foreground='#ee00ee'>⬤ </span>");
           }
         } while((res = g_list_next(res)) != NULL);
       }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -28,6 +28,7 @@
 #include "gui/accelerators.h"
 #include "gui/drag_and_drop.h"
 #include "views/view.h"
+#include "bauhaus/bauhaus.h"
 
 // specials functions for GList globals actions
 static gint _list_compare_by_imgid(gconstpointer a, gconstpointer b)
@@ -2115,27 +2116,10 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
       {
         do
         {
-          const char *lb = (char *)(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)));
-          if(g_strcmp0(lb, "red") == 0)
-          {
-            result = dt_util_dstrcat(result, "<span foreground='#ee0000'>⬤ </span>");
-          }
-          else if(g_strcmp0(lb, "yellow") == 0)
-          {
-            result = dt_util_dstrcat(result, "<span foreground='#eeee00'>⬤ </span>");
-          }
-          else if(g_strcmp0(lb, "green") == 0)
-          {
-            result = dt_util_dstrcat(result, "<span foreground='#00ee00'>⬤ </span>");
-          }
-          else if(g_strcmp0(lb, "blue") == 0)
-          {
-            result = dt_util_dstrcat(result, "<span foreground='#0000ee'>⬤ </span>");
-          }
-          else if(g_strcmp0(lb, "purple") == 0)
-          {
-            result = dt_util_dstrcat(result, "<span foreground='#ee00ee'>⬤ </span>");
-          }
+          const GdkRGBA c = darktable.bauhaus->colorlabels[GPOINTER_TO_INT(res->data)];
+          result = dt_util_dstrcat(result,
+                                   "<span foreground='#%02x%02x%02x'>⬤ </span>",
+                                   (guint)(c.red*255), (guint)(c.green*255), (guint)(c.blue*255));
         } while((res = g_list_next(res)) != NULL);
       }
       g_list_free(res);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1302,7 +1302,7 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
 
       if(darktable.gui->last_preset && found)
       {
-        char *markup = g_markup_printf_escaped("%s <span weight=\"bold\">%s</span>", _("update preset"),
+        char *markup = g_markup_printf_escaped("%s <span weight='bold'>%s</span>", _("update preset"),
                                                darktable.gui->last_preset);
         mi = gtk_menu_item_new_with_label("");
         gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1969,10 +1969,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkBox *box_enabled = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
 
-  self->warning_label = dt_ui_label_new("");
-  gtk_label_set_line_wrap(GTK_LABEL(self->warning_label), TRUE);
-  gtk_box_pack_start(GTK_BOX(box_enabled), self->warning_label, FALSE, FALSE, 4);
-
   g->mod_temp = NAN;
   for(int k = 0; k < 4; k++)
   {

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -591,14 +591,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->extra, NULL, N_("extra"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->extra), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->extra), "value-changed", G_CALLBACK(extra_callback), self);
-
-  // set up a box for the warnings from dt_iop_have_required_input_format and the like
-  GtkBox *box_enabled = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-
-  self->warning_label = dt_ui_label_new("");
-  gtk_label_set_line_wrap(GTK_LABEL(self->warning_label), TRUE);
-  gtk_box_pack_start(GTK_BOX(box_enabled), self->warning_label, FALSE, FALSE, 4);
-  
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -633,7 +633,7 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo)
       writeprotect = sqlite3_column_int(stmt, 2);
       char *markup;
       mi = gtk_menu_item_new_with_label("");
-      markup = g_markup_printf_escaped("<span weight=\"bold\">%s</span>", name);
+      markup = g_markup_printf_escaped("<span weight='bold'>%s</span>", name);
       gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
       g_free(markup);
     }


### PR DESCRIPTION
This will allow dt_iop_set_module_trouble_message to be used in any iop, without explicitly needing to set up a widget for it in gui_init.

I haven't tested it with dt_iop_have_required_input_format because I don't know how to trigger a warning there.

The logic in _set_trouble_message was not changed, even though it seems that only the first error will get written to stderr. Which makes sense if we want to avoid repeating identical messages, but also means that if the message changes, it will get swallowed as well.

Also fixes a couple of semi-unrelated g_strdup leaks.