### PR TITLE
denoiseprofiled(wavelets): cut memory use in half

### DIFF
--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -24,7 +24,7 @@
 typedef void((*eaw_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
                                 const int scale, const float sharpen, const int32_t width, const int32_t height));
 
-typedef void((*eaw_synthesize_t)(float *const restrict out, const float *const restrict in, const float *const restrict detail,
+typedef void((*eaw_synthesize_t)(float *const out, const float *const in, const float *const restrict detail,
                                  const float *const restrict thrsf, const float *const restrict boostf,
                                  const int32_t width, const int32_t height));
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -755,7 +755,8 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(ht, in_bpp, ipitch, ivoid, wd) \
-      shared(input, width, ioffs) \
+      dt_omp_sharedconst(ioffs) \
+      shared(input, width) \
       schedule(static)
 #endif
       for(size_t j = 0; j < ht; j++)
@@ -1104,7 +1105,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(in_bpp, ipitch, ivoid) \
-      shared(input, ioffs, iroi_full) \
+      dt_omp_sharedconst(ioffs) shared(input, iroi_full) \
       schedule(static)
 #endif
       for(size_t j = 0; j < iroi_full.height; j++)
@@ -1422,7 +1423,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(in_bpp, ipitch, ivoid) \
-        shared(input_buffer, width, ioffs, wd, ht) \
+        dt_omp_sharedconst(ioffs, wd, ht) shared(input_buffer, width) \
         schedule(static)
 #endif
         for(size_t j = 0; j < ht; j++)
@@ -1880,7 +1881,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(in_bpp, ipitch, ivoid) \
-        shared(input_buffer, width, ioffs, iroi_full) schedule(static)
+        dt_omp_sharedconst(ioffs) shared(input_buffer, width, iroi_full) schedule(static)
 #endif
         for(size_t j = 0; j < iroi_full.height; j++)
           memcpy((char *)input_buffer + j * iroi_full.width * in_bpp, (char *)ivoid + ioffs + j * ipitch,
@@ -1929,7 +1930,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(ipitch, opitch, ovoid, out_bpp) \
-        shared(ooffs, output_buffer, oroi_full, oorigin, oregion) \
+        dt_omp_sharedconst(ooffs) shared(output_buffer, oroi_full, oorigin, oregion) \
         schedule(static)
 #endif
         for(size_t j = 0; j < oregion[1]; j++)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -727,13 +727,10 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
     const int max_filter_radius = (1u << max_scale); // 2 * 2^max_scale
 
-#ifdef PR7575_MERGED
     tiling->factor = 5.0f; // in + out + precond + tmp + reducebuffer
     tiling->factor_cl = 3.5f + max_scale; // in + out + tmp + reducebuffer + scale buffers
-#else
-    tiling->factor = 3.5f + max_scale; // in + out + tmp + reducebuffer + scale buffers
-#endif
     tiling->maxbuf = 1.0f;
+    tiling->maxbuf_cl = 1.0f;
     tiling->overhead = 0;
     tiling->overlap = max_filter_radius;
     tiling->xalign = 1;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -327,8 +327,8 @@ static void debug_dump_PFM(const dt_dev_pixelpipe_iop_t *const piece, const char
     {
       fprintf(f, "PF\n%d %d\n-1.0\n", width, height);
       const size_t n = (size_t)width * height;
-      for(int k=0; k<n; k++)
-        fwrite(buf+4*k, sizeof(float), 3, f);
+      for(size_t k=0; k<n; k++)
+        fwrite(buf+4U*k, sizeof(float), 3, f);
       fclose(f);
     }
   }
@@ -1325,7 +1325,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 #ifdef _OPENMP
 #pragma omp simd aligned(buf1, out : 64)
 #endif
-  for (size_t k = 0; k < 4 * npixels; k++)
+  for (size_t k = 0; k < 4U * npixels; k++)
     out[k] += buf1[k];
 
   if(!d->use_new_vst)
@@ -1565,17 +1565,17 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
 }
 #endif
 
-static void sum_rec(const unsigned npixels, const float *in, float *out)
+static void sum_rec(const size_t npixels, const float *in, float *out)
 {
   if(npixels <= 3)
   {
-    for(int c = 0; c < 3; c++)
+    for(size_t c = 0; c < 3; c++)
     {
       out[c] = 0.0;
     }
-    for(int i = 0; i < npixels; i++)
+    for(size_t i = 0; i < npixels; i++)
     {
-      for(int c = 0; c < 3; c++)
+      for(size_t c = 0; c < 3; c++)
       {
         out[c] += in[i * 4 + c];
       }
@@ -1583,43 +1583,43 @@ static void sum_rec(const unsigned npixels, const float *in, float *out)
     return;
   }
 
-  unsigned npixels_first_half = npixels >> 1;
-  unsigned npixels_second_half = npixels - npixels_first_half;
+  const size_t npixels_first_half = npixels >> 1;
+  const size_t npixels_second_half = npixels - npixels_first_half;
   sum_rec(npixels_first_half, in, out);
-  sum_rec(npixels_second_half, in + 4 * npixels_first_half, out + 4 * npixels_first_half);
+  sum_rec(npixels_second_half, in + 4U * npixels_first_half, out + 4U * npixels_first_half);
   for(int c = 0; c < 3; c++)
   {
-    out[c] += out[4 * npixels_first_half + c];
+    out[c] += out[4U * npixels_first_half + c];
   }
 }
 
 /* this gives (npixels-1)*V[X] */
-static void variance_rec(const unsigned npixels, const float *in, float *out, const float mean[3])
+static void variance_rec(const size_t npixels, const float *in, float *out, const float mean[3])
 {
   if(npixels <= 3)
   {
-    for(int c = 0; c < 3; c++)
+    for(size_t c = 0; c < 3; c++)
     {
       out[c] = 0.0;
     }
-    for(int i = 0; i < npixels; i++)
+    for(size_t i = 0; i < npixels; i++)
     {
-      for(int c = 0; c < 3; c++)
+      for(size_t c = 0; c < 3; c++)
       {
-        float diff = in[i * 4 + c] - mean[c];
+        const float diff = in[i * 4 + c] - mean[c];
         out[c] += diff * diff;
       }
     }
     return;
   }
 
-  unsigned npixels_first_half = npixels >> 1;
-  unsigned npixels_second_half = npixels - npixels_first_half;
+  const size_t npixels_first_half = npixels >> 1;
+  const size_t npixels_second_half = npixels - npixels_first_half;
   variance_rec(npixels_first_half, in, out, mean);
-  variance_rec(npixels_second_half, in + 4 * npixels_first_half, out + 4 * npixels_first_half, mean);
+  variance_rec(npixels_second_half, in + 4U * npixels_first_half, out + 4U * npixels_first_half, mean);
   for(int c = 0; c < 3; c++)
   {
-    out[c] += out[4 * npixels_first_half + c];
+    out[c] += out[4U * npixels_first_half + c];
   }
 }
 


### PR DESCRIPTION
Analogous to the changes in #7485, reverse the order in which the wavelets scales are recombined to eliminate the need to store all  of them.
