### PR TITLE
[collect] fix edgecase where tag_id column might be null

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1300,7 +1300,8 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     GList *sorted_names = NULL;
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
-      char *name = g_strdup((const char *)sqlite3_column_text(stmt, 0));
+      const char* sqlite_name = (const char *)sqlite3_column_text(stmt, 0);
+      char *name = sqlite_name == NULL ? g_strdup("") : g_strdup(sqlite_name);
       char *name_folded = g_utf8_casefold(name, -1);
       gchar *collate_key = NULL;
 


### PR DESCRIPTION
fixes #7214

in rare cases `sqlite3_column_text` can be `NULL`, and calling `strlen` on NULL results in segfault. This fixes the problem by making NULL tag an empty string.

sidenote: this most likely means that the db is mangled, but at least the darktable won't segfault immediately.