### PR TITLE
[styles] introduce easy way to remove all styles

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -978,7 +978,6 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
   }
 }
 
-
 void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
 {
   int id = 0;
@@ -1006,6 +1005,11 @@ void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
     if(raise)
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
   }
+}
+
+void dt_styles_delete_by_name(const char *name)
+{
+  dt_styles_delete_by_name_adv(name, TRUE);
 }
 
 GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -978,7 +978,8 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
   }
 }
 
-void dt_styles_delete_by_name(const char *name)
+
+void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
 {
   int id = 0;
   if((id = dt_styles_get_id_by_name(name)) != 0)
@@ -1001,7 +1002,9 @@ void dt_styles_delete_by_name(const char *name)
     char tmp_accel[1024];
     snprintf(tmp_accel, sizeof(tmp_accel), C_("accel", "styles/apply %s"), name);
     dt_accel_deregister_global(tmp_accel);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+
+    if(raise)
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
   }
 }
 

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -89,7 +89,13 @@ void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, 
 void dt_styles_apply_to_image(const char *name, const gboolean dulpicate, const int32_t imgid);
 
 /** delete a style by name */
-void dt_styles_delete_by_name(const char *name);
+void dt_styles_delete_by_name_adv(const char *name, const gboolean raise);
+
+/** delete a style by name, raise signal */
+inline void dt_styles_delete_by_name(const char *name)
+{
+  dt_styles_delete_by_name_adv(name, TRUE);
+}
 
 /** get a style object by name, the object needs to be freed by the caller */
 dt_style_t *dt_styles_get_by_name(const char *name);

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -92,10 +92,7 @@ void dt_styles_apply_to_image(const char *name, const gboolean dulpicate, const 
 void dt_styles_delete_by_name_adv(const char *name, const gboolean raise);
 
 /** delete a style by name, raise signal */
-inline void dt_styles_delete_by_name(const char *name)
-{
-  dt_styles_delete_by_name_adv(name, TRUE);
-}
+void dt_styles_delete_by_name(const char *name);
 
 /** get a style object by name, the object needs to be freed by the caller */
 dt_style_t *dt_styles_get_by_name(const char *name);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -299,6 +299,29 @@ static void edit_clicked(GtkWidget *w, gpointer user_data)
   g_list_free_full (styles, (GDestroyNotify) gtk_tree_path_free);
 }
 
+gboolean _ask_before_delete_style(const gint style_cnt)
+{
+  gint res = GTK_RESPONSE_YES;
+
+  if(dt_conf_get_bool("plugins/lighttable/style/ask_before_delete_style"))
+  {
+    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+    GtkWidget *dialog = gtk_message_dialog_new
+      (GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+       ngettext("do you really want to remove %d style?", "do you really want to remove %d styles?", style_cnt),
+       style_cnt);
+#ifdef GDK_WINDOWING_QUARTZ
+    dt_osx_disallow_fullscreen(dialog);
+#endif
+
+    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("remove style?", "remove styles?", style_cnt));
+    res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+  }
+
+  return res == GTK_RESPONSE_YES;
+}
+
 static void delete_clicked(GtkWidget *w, gpointer user_data)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
@@ -315,34 +338,25 @@ static void delete_clicked(GtkWidget *w, gpointer user_data)
   if(style_names == NULL) return;
 
   const gint select_cnt = g_list_length(style_names);
+  const gboolean single_raise = (select_cnt == 1);
 
-  gint res = GTK_RESPONSE_YES;
+  const gboolean can_delete = _ask_before_delete_style(select_cnt);
 
-  if(dt_conf_get_bool("plugins/lighttable/style/ask_before_delete_style"))
+  if(can_delete)
   {
-    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog = gtk_message_dialog_new
-      (GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-       ngettext("do you really want to remove %d style?", "do you really want to remove %d styles?", select_cnt),
-       select_cnt);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("remove style?", "remove styles?", select_cnt));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
-  {
+    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
     for (GList *style = style_names; style != NULL; style = style->next)
     {
-      dt_styles_delete_by_name((char*)style->data);
+      dt_styles_delete_by_name_adv((char*)style->data, single_raise);
     }
-    _gui_styles_update_view(d);
-  }
 
+    if(!single_raise) {
+      // raise signal at the end of processing all styles if we have more than 1 to delete
+      // this also calls _gui_styles_update_view
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+    }
+    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT TRANSACTION", NULL, NULL, NULL);
+  }
   g_list_free_full(style_names, g_free);
 }
 
@@ -751,6 +765,27 @@ void gui_cleanup(dt_lib_module_t *self)
   dt_gui_key_accel_block_on_focus_disconnect(GTK_WIDGET(d->entry));
   free(self->data);
   self->data = NULL;
+}
+
+void gui_reset(dt_lib_module_t *self)
+{
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+  GList *all_styles = dt_styles_get_list("");
+  const gint styles_cnt = g_list_length(all_styles);
+  const gboolean can_delete = _ask_before_delete_style(styles_cnt);
+
+  if(can_delete)
+  {
+    for (GList *result = all_styles; result != NULL; result = result->next)
+    {
+      dt_style_t *style = (dt_style_t *)result->data;
+      dt_styles_delete_by_name_adv((char*)style->name, FALSE);
+    }
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+  }
+  g_list_free_full(all_styles, dt_style_free);
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT TRANSACTION", NULL, NULL, NULL);
+  _update(self);
 }
 
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -771,6 +771,13 @@ void gui_reset(dt_lib_module_t *self)
 {
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
   GList *all_styles = dt_styles_get_list("");
+
+  if(all_styles == NULL)
+  {
+    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "END TRANSACTION", NULL, NULL, NULL);
+    return;
+  }
+
   const gint styles_cnt = g_list_length(all_styles);
   const gboolean can_delete = _ask_before_delete_style(styles_cnt);
 


### PR DESCRIPTION
fixes #7247 by using reset button which removes all styles

additionally makes it so that signal isn't called for every style removal, just after all removals are done
and uses transactions for removal so that whole operation might be a tad bit faster and theoretically safer.