### PR TITLE
Avoid gcc-11 stringop-overflow error

### DIFF
--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -511,7 +511,7 @@ static inline float get_tint_from_tinted_xy(const float x, const float y, const 
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void xy_to_uv(const float xy[2], float uv[4])
+static inline void xy_to_uv(const float xy[2], float uv[2])
 {
   // Convert to CIE1960 Yuv color space, usefull to compute CCT
   // https://en.wikipedia.org/wiki/CIE_1960_color_space

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1787,7 +1787,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     if(find_temperature_from_raw_coeffs(&(self->dev->image_storage), custom_wb, &(x), &(y)))
     {
       // Convert illuminant from xyY to XYZ
-      float XYZ[3];
+      float XYZ[4];
       illuminant_xy_to_XYZ(x, y, XYZ);
 
       // Convert illuminant from XYZ to Bradford modified LMS
@@ -2506,7 +2506,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->illuminant_type = p->illuminant;
 
   // Convert illuminant from xyY to XYZ
-  float XYZ[3];
+  float XYZ[4];
   illuminant_xy_to_XYZ(x, y, XYZ);
 
   // Convert illuminant from XYZ to Bradford modified LMS


### PR DESCRIPTION
I tried to compile Darktable on Fedora rawhide (I have a copr repo with a custom Darktable build).
The future Fedora 34 uses GCC 11 and I got some errors like:

```
[ 66%] Building C object lib64/darktable/plugins/CMakeFiles/filmicrgb.dir/introspection_filmicrgb.c.o
cd /builddir/build/BUILD/darktable-3.4.0/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu/lib64/darktable/plugins && /usr/bin/gcc -DDT_HAVE_SIGNAL_TRACE -DGDK_DISABLE_DEPRECATED -DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_22 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_MIN_REQUIRED -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES -DHAVE_BUILTIN_CPU_SUPPORTS -DHAVE_CONFIG_H -DHAVE_GAME -DHAVE_GMIC -DHAVE_GPHOTO2 -DHAVE_GPHOTO_25_OR_NEWER -DHAVE_GRAPHICSMAGICK -DHAVE_HTTP_SERVER -DHAVE_KWALLET -DHAVE_LENSFUN -DHAVE_LIBSECRET -DHAVE_MAP -DHAVE_OPENCL -DHAVE_OPENEXR -DHAVE_OPENJPEG -DHAVE_OSMGPSMAP_110_OR_NEWER -DHAVE_PRINT -DHAVE_SQLITE_324_OR_NEWER -DUSE_COLORDGTK -DUSE_LUA -D_XOPEN_SOURCE=700 -D__GDK_KEYSYMS_COMPAT_H__ -Dfilmicrgb_EXPORTS -I/builddir/build/BUILD/darktable-3.4.0/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu/lib64/darktable/plugins -I/builddir/build/BUILD/darktable-3.4.0/src/iop -I/builddir/build/BUILD/darktable-3.4.0/src -I/builddir/build/BUILD/darktable-3.4.0/src/external/lua/src -I/builddir/build/BUILD/darktable-3.4.0/src/external/LuaAutoC -I/builddir/build/BUILD/darktable-3.4.0/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu/bin -isystem /builddir/build/BUILD/darktable-3.4.0/src/external -isystem /builddir/build/BUILD/darktable-3.4.0/src/external/OpenCL -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem /usr/include/gtk-3.0 -isystem /usr/include/pango-1.0 -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/fribidi -isystem /usr/include/libxml2 -isystem /usr/include/cairo -isystem /usr/include/pixman-1 -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/gio-unix-2.0 -isystem /usr/include/atk-1.0 -isystem /usr/include/at-spi2-atk/2.0 -isystem /usr/include/dbus-1.0 -isystem /usr/lib64/dbus-1.0/include -isystem /usr/include/at-spi-2.0 -isystem /usr/include/libsoup-2.4 -isystem /usr/include/OpenEXR -isystem /usr/include/lensfun -isystem /usr/include/librsvg-2.0 -isystem /usr/include/json-glib-1.0 -isystem /usr/include/openjpeg-2.3 -isystem /usr/include/libsecret-1 -isystem /usr/include/GraphicsMagick -isystem /usr/include/osmgpsmap-1.0 -isystem /usr/include/colord-1 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wall -Wformat -Wformat-security -Wshadow -Wtype-limits -Wvla -Wold-style-declaration -Wno-unknown-pragmas -Wno-error=varargs -Wno-format-truncation -Wno-error=address-of-packed-member -std=c99 -fopenmp -mtune=generic -msse2 -g -mfpmath=sse -DNDEBUG -O3 -fexpensive-optimizations -fPIC -fvisibility=hidden   -Werror -Wfatal-errors -include common/module_api.h -include iop/iop_api.h -o CMakeFiles/filmicrgb.dir/introspection_filmicrgb.c.o -c /builddir/build/BUILD/darktable-3.4.0/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu/lib64/darktable/plugins/introspection_filmicrgb.c
In file included from /builddir/build/BUILD/darktable-3.4.0/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu/lib64/darktable/plugins/introspection_channelmixerrgb.c:157:
/builddir/build/BUILD/darktable-3.4.0/src/iop/channelmixerrgb.c: In function 'check_if_close_to_daylight':
/builddir/build/BUILD/darktable-3.4.0/src/iop/channelmixerrgb.c:948:3: error: 'xy_to_uv' accessing 16 bytes in a region of size 8 [-Werror=stringop-overflow=]
  948 |   xy_to_uv(xy_ref, uv_ref);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
gmake[2]: *** [lib64/darktable/plugins/CMakeFiles/channelmixerrgb.dir/build.make:91: lib64/darktable/plugins/CMakeFiles/channelmixerrgb.dir/introspection_channelmixerrgb.c.o] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/darktable-3.4.0/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu'
gmake[1]: *** [CMakeFiles/Makefile2:3905: lib64/darktable/plugins/CMakeFiles/channelmixerrgb.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```

I had a look at the code around that failure, and it seems that the warning is valid, `src/common/illuminants.h` declares various functions that takes array inputs like `float uv[4]`, but then on the calling site, it's used with shorter arrays like `float uv_ref[2];`.
In the current form, the code does not crash as only the first 2 floats are updated in `illuminants.h`, but if the functions are updated in the future, this could lead to unexpected crashes.
So, I corrected this in 2 ways:
- for `xy_to_uv`, I just changed the functions signature, as his seemed to be a simple helper, and only used in one way.
- for `convert_any_XYZ_to_LMS` calls, I simply made sure that the temporary array on the calling side is large enough for the called function.