### PR TITLE
introduce macro for_each_channel to aid vectorization

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -493,6 +493,7 @@ static inline float *dt_alloc_perthread_float(const size_t n, size_t* padded_siz
   _DT_Pragma(omp simd __VA_ARGS__) \
   for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
 #else
+#define for_each_channel(_var, ...) \
   for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
 #endif
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -492,9 +492,14 @@ static inline float *dt_alloc_perthread_float(const size_t n, size_t* padded_siz
 #define for_each_channel(_var, ...) \
   _DT_Pragma(omp simd __VA_ARGS__) \
   for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
+#define for_four_channels(_var, ...) \
+  _DT_Pragma(omp simd __VA_ARGS__) \
+  for (size_t _var = 0; _var < 4; _var++)
 #else
 #define for_each_channel(_var, ...) \
   for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
+#define for_four_channels(_var, ...) \
+  for (size_t _var = 0; _var < 4; _var++)
 #endif
 
 // copy the RGB channels of a pixel; includes the 'alpha' channel as well if faster due to vectorization, but

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -457,6 +457,53 @@ static inline float *dt_alloc_perthread_float(const size_t n, size_t* padded_siz
 // return a pointer to the indicated thread's private buffer.
 #define dt_get_bythread(buf, padsize, tnum) ((buf) + ((padsize) * (tnum)))
 
+// Most code in dt assumes that the compiler is capable of auto-vectorization.  In some cases, this will yield
+// suboptimal code if the compiler in fact does NOT auto-vectorize.  Uncomment the following line for such a
+// compiler.
+//#define DT_NO_VECTORIZATION
+
+// For some combinations of compiler and architecture, the compiler may actually emit inferior code if given
+// a hint to vectorize a loop.  Uncomment the following line if such a combination is the compilation target.
+//#define DT_NO_SIMD_HINTS
+
+// To be able to vectorize per-pixel loops, we need to operate on all four channels, but if the compiler does
+// not auto-vectorize, doing so increases computation by 1/3 for a channel which typically is ignored anyway.
+// Select the appropriate number of channels over which to loop to produce the fastest code.
+#ifdef DT_NO_VECTORIZATION
+#define DT_PIXEL_SIMD_CHANNELS 3
+#else
+#define DT_PIXEL_SIMD_CHANNELS 4
+#endif
+
+// A macro which gives us a configurable shorthand to produce the optimal performance when processing all of the
+// channels in a pixel.  Its first argument is the name of the variable to be used inside the 'for' loop it creates,
+// while the optional second argument is a set of OpenMP directives, typically specifying variable alignment.
+// If indexing off of the begining of any buffer allocated with dt's image or aligned allocation functions, the
+// alignment to specify is 64; otherwise, use 16, as there may have been an odd number of pixels from the start.
+// Sample usage:
+//         for_each_channel(k,aligned(src,dest:16))
+//         {
+//           src[k] = dest[k] / 3.0f;
+//         }
+#if defined(_OPENMP) && defined(OPENMP_SIMD_) && !defined(DT_NO_SIMD_HINTS)
+//https://stackoverflow.com/questions/45762357/how-to-concatenate-strings-in-the-arguments-of-pragma
+#define _DT_Pragma_(x) _Pragma(#x)
+#define _DT_Pragma(x) _DT_Pragma_(x)
+#define for_each_channel(_var, ...) \
+  _DT_Pragma(omp simd __VA_ARGS__) \
+  for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
+#else
+  for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
+#endif
+
+// copy the RGB channels of a pixel; includes the 'alpha' channel as well if faster due to vectorization, but
+// subsequent code should ignore the value of the alpha unless explicitly set afterwards (since it might not have
+// been copied)
+static inline void copy_pixel(float *const __restrict__ out, const float *const __restrict__ in)
+{
+  for_each_channel(k,aligned(in,out:16)) out[k] = in[k];
+}
+
 static inline void dt_print_mem_usage()
 {
 #if defined(__linux__)

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -71,17 +71,6 @@ struct patch_t
 };
 typedef struct patch_t patch_t;
 
-// some shorthand to make code more legible
-// if we have OpenMP simd enabled, declare a vectorizable for loop;
-// otherwise, just leave it a plain for()
-#if defined(_OPENMP) && defined(OPENMP_SIMD_)
-#define SIMD_FOR \
-  _Pragma("omp simd") \
-  for
-#else
-#define SIMD_FOR for
-#endif
-
 // avoid cluttering the scalar codepath with #ifdefs by hiding the dependency on SSE2
 #ifndef __SSE2__
 # define _mm_prefetch(where,hint)
@@ -384,13 +373,13 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
 {
   // define the factors for applying blending between the original image and the denoised version
   // if running in RGB space, 'luma' should equal 'chroma'
-  const float weight[4] = { params->luma, params->chroma, params->chroma, 1.0f };
-  const float invert[4] = { 1.0f - params->luma, 1.0f - params->chroma, 1.0f - params->chroma, 0.0f };
+  const float DT_ALIGNED_PIXEL weight[4] = { params->luma, params->chroma, params->chroma, 1.0f };
+  const float DT_ALIGNED_PIXEL invert[4] = { 1.0f - params->luma, 1.0f - params->chroma, 1.0f - params->chroma, 0.0f };
   const bool skip_blend = (params->luma == 1.0 && params->chroma == 1.0);
 
   // define the normalization to convert central pixel differences into central pixel weights
   const float cp_norm = compute_center_pixel_norm(params->center_weight,params->patch_radius);
-  const float center_norm[4] = { cp_norm, cp_norm, cp_norm, 1.0f };
+  const float DT_ALIGNED_PIXEL center_norm[4] = { cp_norm, cp_norm, cp_norm, 1.0f };
 
   // define the patches to be compared when denoising a pixel
   const size_t stride = 4 * roi_in->width;
@@ -475,8 +464,8 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
               distortion += (col_sums[col+radius] - col_sums[col-radius-1]);
               const float wt = gh(distortion * sharpness);
               const float *const inpx = in+4*col;
-              const float pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
-              SIMD_FOR (size_t c = 0; c < 4; c++)
+              const float DT_ALIGNED_PIXEL pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
+              for_each_channel(c,aligned(pixel,out:16))
               {
                 out[4*col+c] += pixel[c] * wt;
               }
@@ -493,8 +482,8 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
                                            / (1.0f + params->center_weight);
               const float wt = gh(fmaxf(0.0f, dissimilarity * sharpness - 2.0f));
               const float *const inpx = in + 4*col;
-              const float pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
-              SIMD_FOR (size_t c = 0; c < 4; c++)
+              const float DT_ALIGNED_PIXEL pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
+              for_each_channel(c,aligned(pixel,out:16))
               {
                 out[4*col+c] += pixel[c] * wt;
               }
@@ -571,7 +560,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
           float *const out = outbuf + 4 * row * roi_out->width;
           for (int col = chunk_left; col < chunk_right; col++)
           {
-            SIMD_FOR(size_t c = 0; c < 4; c++)
+            for_each_channel(c,aligned(out:16))
             {
               out[4*col+c] /= out[4*col+3];
             }
@@ -587,7 +576,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
           float *out = outbuf + row * 4 * roi_out->width;
           for (int col = chunk_left; col < chunk_right; col++)
           {
-            SIMD_FOR(size_t c = 0; c < 4; c++)
+            for_each_channel(c,aligned(in,out,weight,invert:16))
             {
               out[4*col+c] = (in[4*col+c] * invert[c]) + (out[4*col+c] / out[4*col+3] * weight[c]);
             }
@@ -616,7 +605,7 @@ void nlmeans_denoise_sse2(const float *const inbuf, float *const outbuf,
 
   // define the normalization to convert central pixel differences into central pixel weights
   const float cp_norm = compute_center_pixel_norm(params->center_weight,params->patch_radius);
-  const float center_norm[4] = { cp_norm, cp_norm, cp_norm, 1.0f };
+  const float DT_ALIGNED_PIXEL center_norm[4] = { cp_norm, cp_norm, cp_norm, 1.0f };
 
   // define the patches to be compared when denoising a pixel
   const size_t stride = 4 * roi_in->width;

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -465,7 +465,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
               const float wt = gh(distortion * sharpness);
               const float *const inpx = in+4*col;
               const float DT_ALIGNED_PIXEL pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
-              for_each_channel(c,aligned(pixel,out:16))
+              for_four_channels(c,aligned(pixel,out:16))
               {
                 out[4*col+c] += pixel[c] * wt;
               }
@@ -483,7 +483,7 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
               const float wt = gh(fmaxf(0.0f, dissimilarity * sharpness - 2.0f));
               const float *const inpx = in + 4*col;
               const float DT_ALIGNED_PIXEL pixel[4] = { inpx[offset],  inpx[offset+1], inpx[offset+2], 1.0f };
-              for_each_channel(c,aligned(pixel,out:16))
+              for_four_channels(c,aligned(pixel,out:16))
               {
                 out[4*col+c] += pixel[c] * wt;
               }


### PR DESCRIPTION
Prompted by #7497, I've implemented a macro I had been thinking about anyway (to help vectorize and document all of the `for(c=0;c<3;c++)` loops).  Right now, I've only used it to replace the SIMD_FOR macro in common/nlmeans_core.h, but its use can gradually be rolled out throughout the codebase.


We want to process all 4 channels of a color pixel to get auto-vectorization, but doing so would add 33% extra computation with a non-vectorizing compiler.  In addition, for some systems it may be better to omit the simd hinting.

To address the above and reduce the amount of boilerplate code in the middle of a function, we introduce a preprocessor macro which hides the details of these variations through alternative expansions and documents the purpose of the short loop with its name:
``
     for_each_channel(VAR)
     {
        buffer[VAR] = 0.0f;
     }
``
or
``
     for_each_channel(VAR,openmp attribute)
     {
        buffer[VAR] = 0.0f;
     }
``
where "openmp attribute" will typically be "aligned(X,Y,Z:16)" or "aligned(A,B:64)".