### PR TITLE
Dedup image-buffer operations

### DIFF
--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "common/imagebuf.h"
 #include "control/control.h"
 #include "develop/imageop.h"
 #include "dwt.h"
@@ -275,7 +276,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
     printf("not enough memory for wavelet decomposition");
     goto cleanup;
   }
-  memset(layers, 0, sizeof(float) * p->ch * p->width * p->height);
+  dt_iop_image_fill(layers,0.0f,p->width,p->height,p->ch);
 
   if(p->merge_from_scale > 0)
   {
@@ -285,7 +286,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
       printf("not enough memory for wavelet decomposition");
       goto cleanup;
     }
-    memset(merged_layers, 0, sizeof(float) * p->ch * p->width * p->height);
+    dt_iop_image_fill(merged_layers,0.0f,p->width,p->height,p->ch);
   }
 
   // iterate over wavelet scales
@@ -537,7 +538,7 @@ void dwt_denoise(float *const img, const int width, const int height, const int 
   float *const interm = details + width * height;	// temporary storage for use during each pass
 
   // zero the accumulator
-  memset(details, 0, sizeof(float) * width * height);
+  dt_iop_image_fill(details, 0.0f, width, height, 1);
 
   for(int lev = 0; lev < bands; lev++)
   {

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -191,6 +191,32 @@ void dt_iop_copy_image_roi(float *const __restrict__ out, const float *const __r
   }
 }
 
+void dt_iop_image_scaled_copy(float *const restrict buf, const float *const restrict src, const float scale,
+                              const size_t width, const size_t height, const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf, src : 16) default(none) \
+  dt_omp_firstprivate(buf, src, scale, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] = scale * src[k];
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf, src : 16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] = scale * src[k];
+}
+
 void dt_iop_image_fill(float *const buf, const float fill_value, const size_t width, const size_t height,
                        const size_t ch)
 {

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -148,7 +148,7 @@ void dt_iop_image_copy(float *const __restrict__ out, const float *const __restr
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
     const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for simd aligned(in, out : 16) default(none) \
     dt_omp_firstprivate(in, out, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
       out[k] = in[k];
@@ -189,6 +189,196 @@ void dt_iop_copy_image_roi(float *const __restrict__ out, const float *const __r
     fprintf(stderr,"copy_image_roi called with inconsistent RoI!\n");
     //TODO
   }
+}
+
+void dt_iop_image_fill(float *const buf, const float fill_value, const size_t width, const size_t height,
+                       const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf:16) default(none) \
+  dt_omp_firstprivate(buf, fill_value, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] = fill_value;
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+  if (fill_value == 0.0f)
+  {
+    // take advantage of compiler intrinsic which is hopefully highly optimized
+    memset(buf, 0, sizeof(float) * nfloats);
+  }
+  else
+  {
+#ifdef _OPENMP
+#pragma simd aligned(buf:16)
+#endif
+    for (size_t k = 0; k < nfloats; k++)
+      buf[k] = fill_value;
+  }
+}
+
+void dt_iop_image_add_const(float *const buf, const float add_value, const size_t width, const size_t height,
+                            const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf:16) default(none) \
+  dt_omp_firstprivate(buf, add_value, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] += add_value;
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf:16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] += add_value;
+}
+
+void dt_iop_image_add_image(float *const buf, const float* const other_image,
+                            const size_t width, const size_t height, const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf, other_image : 16) default(none) \
+  dt_omp_firstprivate(buf, other_image, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] += other_image[k];
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf, other_image : 16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] += other_image[k];
+}
+
+void dt_iop_image_sub_image(float *const buf, const float* const other_image,
+                            const size_t width, const size_t height, const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf, other_image : 16) default(none) \
+  dt_omp_firstprivate(buf, other_image, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] -= other_image[k];
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf, other_image : 16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] -= other_image[k];
+}
+
+void dt_iop_image_invert(float *const buf, const float max_value, const size_t width, const size_t height,
+                         const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf:16) default(none) \
+  dt_omp_firstprivate(buf, max_value, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] = max_value - buf[k];
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf:16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] = max_value - buf[k];
+}
+
+void dt_iop_image_mul_const(float *const buf, const float mul_value, const size_t width, const size_t height,
+                            const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf:16) default(none) \
+  dt_omp_firstprivate(buf, mul_value, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] *= mul_value;
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf:16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] *= mul_value;
+}
+
+void dt_iop_image_div_const(float *const buf, const float div_value, const size_t width, const size_t height,
+                            const size_t ch)
+{
+  const size_t nfloats = width * height * ch;
+#ifdef _OPENMP
+  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  {
+    // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
+    // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
+    // memory won't be able to take advantage of more than four cores).
+    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+#pragma omp parallel for simd aligned(buf:16) default(none) \
+  dt_omp_firstprivate(buf, div_value, nfloats) schedule(simd:static) num_threads(nthreads)
+    for(size_t k = 0; k < nfloats; k++)
+      buf[k] /= div_value;
+    return;
+  }
+#endif // _OPENMP
+  // no OpenMP, or image too small to bother parallelizing
+#ifdef _OPENMP
+#pragma simd aligned(buf:16)
+#endif
+  for (size_t k = 0; k < nfloats; k++)
+    buf[k] /= div_value;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -19,6 +19,9 @@
 #include <stdarg.h>
 #include "common/imagebuf.h"
 
+static size_t parallel_imgop_minimum = 500000;
+static size_t parallel_imgop_maxthreads = 4;
+
 // Allocate one or more buffers as detailed in the given parameters.  If any allocation fails, free all of them,
 // set the module's trouble flag, and return FALSE.
 gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module,
@@ -142,12 +145,12 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module,
 void dt_iop_image_copy(float *const __restrict__ out, const float *const __restrict__ in, const size_t nfloats)
 {
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(in, out : 16) default(none) \
     dt_omp_firstprivate(in, out, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -196,12 +199,12 @@ void dt_iop_image_scaled_copy(float *const restrict buf, const float *const rest
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf, src : 16) default(none) \
   dt_omp_firstprivate(buf, src, scale, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -222,12 +225,12 @@ void dt_iop_image_fill(float *const buf, const float fill_value, const size_t wi
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, fill_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -256,12 +259,12 @@ void dt_iop_image_add_const(float *const buf, const float add_value, const size_
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, add_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -282,12 +285,12 @@ void dt_iop_image_add_image(float *const buf, const float* const other_image,
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf, other_image : 16) default(none) \
   dt_omp_firstprivate(buf, other_image, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -308,12 +311,12 @@ void dt_iop_image_sub_image(float *const buf, const float* const other_image,
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf, other_image : 16) default(none) \
   dt_omp_firstprivate(buf, other_image, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -334,12 +337,12 @@ void dt_iop_image_invert(float *const buf, const float max_value, const size_t w
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, max_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -360,12 +363,12 @@ void dt_iop_image_mul_const(float *const buf, const float mul_value, const size_
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, mul_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -386,12 +389,12 @@ void dt_iop_image_div_const(float *const buf, const float div_value, const size_
 {
   const size_t nfloats = width * height * ch;
 #ifdef _OPENMP
-  if (nfloats > 500000)	// is the copy big enough to outweigh threading overhead?
+  if (nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = darktable.num_openmp_threads < 4 ? darktable.num_openmp_threads : 4;
+    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, div_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -405,6 +408,23 @@ void dt_iop_image_div_const(float *const buf, const float div_value, const size_
 #endif
   for (size_t k = 0; k < nfloats; k++)
     buf[k] /= div_value;
+}
+
+// perform timings to determine the optimal threshold for switching to parallel operations, as well as the
+// maximal number of threads before saturating the memory bus
+void dt_iop_image_copy_benchmark()
+{
+  ///TODO
+}
+
+void dt_iop_image_copy_configure()
+{
+  int thresh = dt_conf_get_int("memcpy_parallel_threshold");
+  if (thresh > 0)
+    parallel_imgop_minimum = thresh;
+  int threads = dt_conf_get_int("memcpy_parallel_maxthreads");
+  if (threads > 0)
+    parallel_imgop_maxthreads = threads;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -94,6 +94,34 @@ void dt_iop_copy_image_roi(float *const __restrict__ out, const float *const __r
                            const dt_iop_roi_t *const __restrict__ roi_in,
                            const dt_iop_roi_t *const __restrict__ roi_out, const int zero_pad);
 
+// Fill an image buffer with a specified value.
+void dt_iop_image_fill(float *const buf, const float fill_value, const size_t width, const size_t height,
+                       const size_t ch);
+
+// Add a specified constant value to every element of the image buffer
+void dt_iop_image_add_const(float *const buf, const float add_value, const size_t width, const size_t height,
+                            const size_t ch);
+
+// Add the contents of another image buffer to the given buffer, element-wise
+void dt_iop_image_add_image(float *const buf, const float *const other_buf, const size_t width, const size_t height,
+                            const size_t ch);
+
+// Subtract the contents of another image buffer from the given buffer, element-wise
+void dt_iop_image_sub_image(float *const buf, const float *const other_buf, const size_t width, const size_t height,
+                            const size_t ch);
+
+// Subtract each element of the image buffer from the given constant value 
+void dt_iop_image_invert(float *const buf, const float max_value, const size_t width, const size_t height,
+                         const size_t ch);
+
+// Multiply every element of the image buffer by a specified constant value
+void dt_iop_image_mul_const(float *const buf, const float mul_value, const size_t width, const size_t height,
+                            const size_t ch);
+
+// Divide every element of the image buffer by a specified constant value
+void dt_iop_image_div_const(float *const buf, const float div_value, const size_t width, const size_t height,
+                            const size_t ch);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -94,6 +94,10 @@ void dt_iop_copy_image_roi(float *const __restrict__ out, const float *const __r
                            const dt_iop_roi_t *const __restrict__ roi_in,
                            const dt_iop_roi_t *const __restrict__ roi_out, const int zero_pad);
 
+// Copy one image buffer to another, multiplying each element by the specified scale factor
+void dt_iop_image_scaled_copy(float *const __restrict__ buf, const float *const __restrict__ src, const float scale,
+                              const size_t width, const size_t height, const size_t ch);
+
 // Fill an image buffer with a specified value.
 void dt_iop_image_fill(float *const buf, const float fill_value, const size_t width, const size_t height,
                        const size_t ch);

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -126,6 +126,13 @@ void dt_iop_image_mul_const(float *const buf, const float mul_value, const size_
 void dt_iop_image_div_const(float *const buf, const float div_value, const size_t width, const size_t height,
                             const size_t ch);
 
+// perform timings to determine the optimal threshold for switching to parallel operations, as well as the
+// maximal number of threads before saturating the memory bus
+void dt_iop_image_copy_benchmark();
+
+// load configurable settings from darktablerc
+void dt_iop_image_copy_configure();
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -26,6 +26,7 @@
 #endif
 
 #include "common/colorspaces_inline_conversions.h"
+#include "common/imagebuf.h"
 #include "common/math.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
@@ -231,10 +232,7 @@ void dt_develop_blendif_lab_make_mask(struct dt_dev_pixelpipe_iop_t *piece, cons
     }
     else
     {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(mask, buffsize, global_opacity) schedule(static)
-#endif
-      for(size_t x = 0; x < buffsize; x++) mask[x] = global_opacity * mask[x];
+      dt_iop_image_mul_const(mask,global_opacity,owidth,oheight,1); //mask[k] *= global_opacity;
     }
   }
   else if(canceling_channel || !any_channel_active)
@@ -244,17 +242,11 @@ void dt_develop_blendif_lab_make_mask(struct dt_dev_pixelpipe_iop_t *piece, cons
     // and depends on whether the mask combination is inclusive and whether the mask is inverted
     if((mask_inversed == 0) ^ (mask_inclusive == 0))
     {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(mask, buffsize, global_opacity) schedule(static)
-#endif
-      for(size_t x = 0; x < buffsize; x++) mask[x] = global_opacity;
+      dt_iop_image_fill(mask,global_opacity,owidth,oheight,1); //mask[k] = global_opacity;
     }
     else
     {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(mask, buffsize) schedule(static)
-#endif
-      for(size_t x = 0; x < buffsize; x++) mask[x] = 0.0f;
+      dt_iop_image_fill(mask,0.0f,owidth,oheight,1); //mask[k] = 0.0f;
     }
   }
   else

--- a/src/develop/blends/blendif_raw.c
+++ b/src/develop/blends/blendif_raw.c
@@ -25,6 +25,7 @@
                      "fast-math", "no-math-errno")
 #endif
 
+#include "common/imagebuf.h"
 #include "common/math.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
@@ -62,11 +63,7 @@ void dt_develop_blendif_raw_make_mask(struct dt_dev_pixelpipe_iop_t *piece, cons
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for simd schedule(static) default(none) aligned(mask: 64) \
-    dt_omp_firstprivate(mask, buffsize, global_opacity)
-#endif
-    for(size_t x = 0; x < buffsize; x++) mask[x] = global_opacity * mask[x];
+    dt_iop_image_mul_const(mask,global_opacity,owidth,oheight,1); // mask[k] *= global_opacity;
   }
 }
 
@@ -431,12 +428,7 @@ void dt_develop_blendif_raw_blend(struct dt_dev_pixelpipe_iop_t *piece,
 
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
-    const size_t buffsize = (size_t)owidth * oheight;
-#ifdef _OPENMP
-#pragma omp parallel for simd schedule(static) default(none) aligned(b: 64) \
-  dt_omp_firstprivate(b, buffsize)
-#endif
-    for(size_t x = 0; x < buffsize; x++) b[x] = 0.0f;
+    dt_iop_image_fill(b,0.0f,owidth,oheight,1); //b[k] = 0.0f;
   }
   else
   {

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -26,6 +26,7 @@
 #endif
 
 #include "common/colorspaces_inline_conversions.h"
+#include "common/imagebuf.h"
 #include "common/math.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
@@ -277,10 +278,7 @@ void dt_develop_blendif_rgb_hsl_make_mask(struct dt_dev_pixelpipe_iop_t *piece, 
     }
     else
     {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(mask, buffsize, global_opacity) schedule(static)
-#endif
-      for(size_t x = 0; x < buffsize; x++) mask[x] = global_opacity * mask[x];
+      dt_iop_image_mul_const(mask,global_opacity,owidth,oheight,1); // mask[k] *= global_opacity;
     }
   }
   else if(canceling_channel || !any_channel_active)
@@ -288,20 +286,8 @@ void dt_develop_blendif_rgb_hsl_make_mask(struct dt_dev_pixelpipe_iop_t *piece, 
     // one of the conditional channel selects nothing
     // this means that the conditional opacity of all pixels is the same
     // and depends on whether the mask combination is inclusive and whether the mask is inverted
-    if((mask_inversed == 0) ^ (mask_inclusive == 0))
-    {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(mask, buffsize, global_opacity) schedule(static)
-#endif
-      for(size_t x = 0; x < buffsize; x++) mask[x] = global_opacity;
-    }
-    else
-    {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(mask, buffsize) schedule(static)
-#endif
-      for(size_t x = 0; x < buffsize; x++) mask[x] = 0.0f;
-    }
+    const float opac = ((mask_inversed == 0) ^ (mask_inclusive == 0)) ? global_opacity : 0.0f;
+    dt_iop_image_fill(mask,opac,owidth,oheight,1); // mask[k] = opac;
   }
   else
   {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "common/debug.h"
+#include "common/imagebuf.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/blend.h"
@@ -2799,7 +2800,7 @@ static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
   start = start2 = dt_get_wtime();
 
   // empty the output buffer
-  memset(buffer, 0, sizeof(float) * width * height);
+  dt_iop_image_fill(buffer, 0.0f, width, height, 1);
 
   const guint nb_corner = g_list_length(form->points);
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "common/debug.h"
+#include "common/imagebuf.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/blend.h"
@@ -2625,7 +2626,7 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   start = start2 = dt_get_wtime();
 
   // empty the output buffer
-  memset(buffer, 0, sizeof(float) * width * height);
+  dt_iop_image_fill(buffer, 0.0f, width, height, 1);
 
   guint nb_corner = g_list_length(form->points);
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -20,6 +20,7 @@
 #endif
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
+#include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "control/conf.h"
 #include "control/control.h"
@@ -269,7 +270,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
   const int border_in_y = MAX(border_size_t - roi_out->y, 0);
 
   // fill the image with 0 so that the added border isn't part of the mask
-  memset(out, 0, sizeof(float) * roi_out->width * roi_out->height);
+  dt_iop_image_fill(out, 0.0f, roi_out->width, roi_out->height, 1);
 
   // blit image inside border and fill the output with previous processed out
 #ifdef _OPENMP

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2933,7 +2933,7 @@ static void rt_build_scaled_mask(float *const mask, dt_iop_roi_t *const roi_mask
     fprintf(stderr, "rt_build_scaled_mask: error allocating memory\n");
     goto cleanup;
   }
-  memset(mask_tmp, 0, sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
+  dt_iop_image_fill(mask_tmp, 0.0f, roi_mask_scaled->width, roi_mask_scaled->height, 1);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -22,6 +22,7 @@
 #include "common/debug.h"
 #include "common/histogram.h"
 #include "common/iop_profile.h"
+#include "common/imagebuf.h"
 #include "common/image_cache.h"
 #include "common/math.h"
 #include "control/conf.h"
@@ -203,7 +204,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *d, const float *
   const int wf_width = ceilf(width / (float)bin_width);
   d->waveform_width = wf_width;
 
-  memset(wf_linear, 0, sizeof(float) * wf_width * wf_height * 4);
+  dt_iop_image_fill(wf_linear, 0.0f, wf_width, wf_height, 4);
 
   // Every bin_width x height portion of the image is being described
   // in a 1 pixel x wf_height portion of the histogram.


### PR DESCRIPTION
Add functions for various simple image manipulations such as incrementing every element by a constant to common/imagebuf, then replace the equivalent code snippets in other files with calls to those functions.  Since these were all parallelized loops, but with such simple bodies that the memory bus is the limiting factor on most machines, we now have them all in one place where parameters such as maximum number of threads and threshold size for even using OpenMP (since there is considerable overhead in starting a parallel section) can be tuned.