### PR TITLE
[gtk] protect against nulls

### DIFF
--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -154,6 +154,7 @@ GType dtgtk_button_get_type()
 
 void dtgtk_button_set_paint(GtkDarktableButton *button, DTGTKCairoPaintIconFunc paint, gint paintflags, void *paintdata)
 {
+  g_return_if_fail(button != NULL);
   button->icon = paint;
   button->icon_flags = paintflags;
   button->icon_data = paintdata;
@@ -161,6 +162,7 @@ void dtgtk_button_set_paint(GtkDarktableButton *button, DTGTKCairoPaintIconFunc 
 
 void dtgtk_button_set_active(GtkDarktableButton *button, gboolean active)
 {
+  g_return_if_fail(button != NULL);
   if(active)
     button->icon_flags |= CPF_ACTIVE;
   else
@@ -169,6 +171,7 @@ void dtgtk_button_set_active(GtkDarktableButton *button, gboolean active)
 
 void dtgtk_button_override_color(GtkDarktableButton *button, GdkRGBA *color)
 {
+  g_return_if_fail(button != NULL);
   if(color)
   {
     button->fg = *color;
@@ -180,6 +183,7 @@ void dtgtk_button_override_color(GtkDarktableButton *button, GdkRGBA *color)
 
 void dtgtk_button_override_background_color(GtkDarktableButton *button, GdkRGBA *color)
 {
+  g_return_if_fail(button != NULL);
   if(color)
   {
     button->bg = *color;

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -126,6 +126,8 @@ static inline gint _get_active_marker(GtkDarktableGradientSlider *gslider)
 
 static inline void _clamp_marker(GtkDarktableGradientSlider *gslider, const gint selected)
 {
+  g_return_if_fail(gslider != NULL);
+
   const gdouble min = (selected == 0) ? 0.0f : gslider->position[selected - 1];
   const gdouble max = (selected == gslider->positions - 1) ? 1.0f : gslider->position[selected + 1];
   gslider->position[selected] = CLAMP(gslider->position[selected], min, max);
@@ -166,6 +168,9 @@ static gint _get_active_marker_from_screen(GtkWidget *widget, const gdouble x, c
 
 static gdouble _slider_move(GtkWidget *widget, gint k, gdouble value, gint direction)
 {
+  g_return_val_if_fail(widget != NULL, value);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), value);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   gdouble newvalue = value;
@@ -217,6 +222,9 @@ static gdouble _slider_move(GtkWidget *widget, gint k, gdouble value, gint direc
 
 static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble delta, guint state, const gint selected)
 {
+  g_return_val_if_fail(widget != NULL, TRUE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), TRUE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   if(selected == -1) return TRUE;
@@ -256,6 +264,9 @@ static float _default_linear_scale_callback(GtkWidget *self, float value, int di
 
 static gboolean _gradient_slider_enter_notify_event(GtkWidget *widget, GdkEventCrossing *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
   gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_PRELIGHT, TRUE);
   gslider->is_entered = TRUE;
@@ -265,6 +276,9 @@ static gboolean _gradient_slider_enter_notify_event(GtkWidget *widget, GdkEventC
 
 static gboolean _gradient_slider_leave_notify_event(GtkWidget *widget, GdkEventCrossing *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
   if(!(gslider->is_dragging))
   {
@@ -278,6 +292,9 @@ static gboolean _gradient_slider_leave_notify_event(GtkWidget *widget, GdkEventC
 
 static gboolean _gradient_slider_button_press(GtkWidget *widget, GdkEventButton *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   // reset slider
@@ -335,6 +352,9 @@ static gboolean _gradient_slider_button_press(GtkWidget *widget, GdkEventButton 
 
 static gboolean _gradient_slider_motion_notify(GtkWidget *widget, GdkEventMotion *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   if(gslider->is_dragging == TRUE && gslider->selected != -1 && gslider->do_reset == FALSE)
@@ -362,6 +382,9 @@ static gboolean _gradient_slider_motion_notify(GtkWidget *widget, GdkEventMotion
 
 static gboolean _gradient_slider_button_release(GtkWidget *widget, GdkEventButton *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
   const gint selected = _get_active_marker(gslider);
 
@@ -386,6 +409,9 @@ static gboolean _gradient_slider_button_release(GtkWidget *widget, GdkEventButto
 
 static gboolean _gradient_slider_scroll_event(GtkWidget *widget, GdkEventScroll *event)
 {
+  g_return_val_if_fail(widget != NULL, TRUE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), TRUE);
+
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -406,6 +432,9 @@ static gboolean _gradient_slider_scroll_event(GtkWidget *widget, GdkEventScroll 
 
 static gboolean _gradient_slider_key_press_event(GtkWidget *widget, GdkEventKey *event)
 {
+  g_return_val_if_fail(widget != NULL, TRUE);
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), TRUE);
+
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   const gint selected = _get_active_marker(gslider);
@@ -455,6 +484,8 @@ static void _gradient_slider_class_init(GtkDarktableGradientSliderClass *klass)
 
 static void _gradient_slider_init(GtkDarktableGradientSlider *gslider)
 {
+  g_return_if_fail(gslider != NULL);
+
   GtkWidget *widget = GTK_WIDGET(gslider);
   gtk_widget_add_events(widget,
                         GDK_EXPOSURE_MASK |
@@ -473,6 +504,9 @@ static void _gradient_slider_init(GtkDarktableGradientSlider *gslider)
 
 static void _gradient_slider_get_preferred_height(GtkWidget *widget, gint *min_height, gint *nat_height)
 {
+  g_return_if_fail(widget != NULL);
+  g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget));
+
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
 
@@ -487,6 +521,9 @@ static void _gradient_slider_get_preferred_height(GtkWidget *widget, gint *min_h
 
 static void _gradient_slider_get_preferred_width(GtkWidget *widget, gint *min_width, gint *nat_width)
 {
+  g_return_if_fail(widget != NULL);
+  g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget));
+
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
 
@@ -653,6 +690,8 @@ gint _list_find_by_position(gconstpointer a, gconstpointer b)
 
 static void _gradient_slider_set_defaults(GtkDarktableGradientSlider *gslider)
 {
+  g_return_if_fail(gslider != NULL);
+
   gslider->is_dragging = gslider->is_changed = gslider->do_reset = gslider->is_entered = 0;
   gslider->timeout_handle = 0;
   gslider->selected = gslider->positions == 1 ? 0 : -1;
@@ -737,6 +776,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new_with_color_and_name(GdkRGBA star
 void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslider, gfloat position,
                                                GdkRGBA color)
 {
+  g_return_if_fail(gslider != NULL);
   const gfloat rawposition = gslider->scale_callback((GtkWidget *)gslider, position, GRADIENT_SLIDER_SET);
   // First find color at position, if exists update color, otherwise create a new stop at position.
   GList *current = g_list_find_custom(gslider->colors, (gpointer)&rawposition, _list_find_by_position);
@@ -756,6 +796,7 @@ void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslid
 
 void dtgtk_gradient_slider_multivalue_clear_stops(GtkDarktableGradientSlider *gslider)
 {
+  g_return_if_fail(gslider != NULL);
   g_list_free_full(gslider->colors, g_free);
   gslider->colors = NULL;
 }
@@ -774,12 +815,14 @@ gdouble dtgtk_gradient_slider_multivalue_get_value(GtkDarktableGradientSlider *g
 
 void dtgtk_gradient_slider_multivalue_get_values(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
+  g_return_if_fail(gslider != NULL);
   for(int k = 0; k < gslider->positions; k++)
     values[k] = gslider->scale_callback((GtkWidget *)gslider, gslider->position[k], GRADIENT_SLIDER_GET);
 }
 
 void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint pos)
 {
+  g_return_if_fail(gslider != NULL);
   assert(pos <= gslider->positions);
 
   gslider->position[pos] = CLAMP(gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET), 0.0, 1.0);
@@ -790,6 +833,8 @@ void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gsli
 
 void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
+  g_return_if_fail(gslider != NULL);
+  g_return_if_fail(values != NULL);
   for(int k = 0; k < gslider->positions; k++)
     gslider->position[k] = CLAMP(gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
@@ -799,6 +844,7 @@ void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gsl
 
 void dtgtk_gradient_slider_multivalue_set_marker(GtkDarktableGradientSlider *gslider, gint mark, gint pos)
 {
+  g_return_if_fail(gslider != NULL);
   assert(pos <= gslider->positions);
 
   gslider->marker[pos] = mark;
@@ -807,6 +853,7 @@ void dtgtk_gradient_slider_multivalue_set_marker(GtkDarktableGradientSlider *gsl
 
 void dtgtk_gradient_slider_multivalue_set_markers(GtkDarktableGradientSlider *gslider, gint *markers)
 {
+  g_return_if_fail(gslider != NULL);
   for(int k = 0; k < gslider->positions; k++) gslider->marker[k] = markers[k];
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
@@ -814,6 +861,7 @@ void dtgtk_gradient_slider_multivalue_set_markers(GtkDarktableGradientSlider *gs
 void dtgtk_gradient_slider_multivalue_set_resetvalue(GtkDarktableGradientSlider *gslider, gdouble value,
                                                      gint pos)
 {
+  g_return_if_fail(gslider != NULL);
   assert(pos <= gslider->positions);
 
   gslider->resetvalue[pos] = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
@@ -829,6 +877,7 @@ gdouble dtgtk_gradient_slider_multivalue_get_resetvalue(GtkDarktableGradientSlid
 
 void dtgtk_gradient_slider_multivalue_set_resetvalues(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
+  g_return_if_fail(gslider != NULL);
   for(int k = 0; k < gslider->positions; k++)
     gslider->resetvalue[k] = gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET);
   gslider->is_resettable = TRUE;
@@ -836,6 +885,7 @@ void dtgtk_gradient_slider_multivalue_set_resetvalues(GtkDarktableGradientSlider
 
 void dtgtk_gradient_slider_multivalue_set_picker(GtkDarktableGradientSlider *gslider, gdouble value)
 {
+  g_return_if_fail(gslider != NULL);
   gslider->picker[0] = gslider->picker[1] = gslider->picker[2]
     = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
@@ -844,6 +894,7 @@ void dtgtk_gradient_slider_multivalue_set_picker(GtkDarktableGradientSlider *gsl
 void dtgtk_gradient_slider_multivalue_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean,
                                                             gdouble min, gdouble max)
 {
+  g_return_if_fail(gslider != NULL);
   gslider->picker[0] = gslider->scale_callback((GtkWidget *)gslider, mean, GRADIENT_SLIDER_SET);
   gslider->picker[1] = gslider->scale_callback((GtkWidget *)gslider, min, GRADIENT_SLIDER_SET);
   gslider->picker[2] = gslider->scale_callback((GtkWidget *)gslider, max, GRADIENT_SLIDER_SET);
@@ -852,11 +903,13 @@ void dtgtk_gradient_slider_multivalue_set_picker_meanminmax(GtkDarktableGradient
 
 gboolean dtgtk_gradient_slider_multivalue_is_dragging(GtkDarktableGradientSlider *gslider)
 {
+  g_return_val_if_fail(gslider != NULL, FALSE);
   return gslider->is_dragging;
 }
 
 void dtgtk_gradient_slider_multivalue_set_increment(GtkDarktableGradientSlider *gslider, gdouble value)
 {
+  g_return_if_fail(gslider != NULL);
   gslider->increment = value;
 }
 
@@ -968,6 +1021,7 @@ gdouble dtgtk_gradient_slider_get_resetvalue(GtkDarktableGradientSlider *gslider
 
 void dtgtk_gradient_slider_set_picker(GtkDarktableGradientSlider *gslider, gdouble value)
 {
+  g_return_if_fail(gslider != NULL);
   gslider->picker[0] = gslider->picker[1] = gslider->picker[2]
     = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
@@ -976,6 +1030,7 @@ void dtgtk_gradient_slider_set_picker(GtkDarktableGradientSlider *gslider, gdoub
 void dtgtk_gradient_slider_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean,
                                                  gdouble min, gdouble max)
 {
+  g_return_if_fail(gslider != NULL);
   gslider->picker[0] = gslider->scale_callback((GtkWidget *)gslider, mean, GRADIENT_SLIDER_SET);
   gslider->picker[1] = gslider->scale_callback((GtkWidget *)gslider, min, GRADIENT_SLIDER_SET);
   gslider->picker[2] = gslider->scale_callback((GtkWidget *)gslider, max, GRADIENT_SLIDER_SET);
@@ -984,11 +1039,13 @@ void dtgtk_gradient_slider_set_picker_meanminmax(GtkDarktableGradientSlider *gsl
 
 gboolean dtgtk_gradient_slider_is_dragging(GtkDarktableGradientSlider *gslider)
 {
+  g_return_val_if_fail(gslider != NULL, FALSE);
   return gslider->is_dragging;
 }
 
 void dtgtk_gradient_slider_set_increment(GtkDarktableGradientSlider *gslider, gdouble value)
 {
+  g_return_if_fail(gslider != NULL);
   gslider->increment = value;
 }
 

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -168,7 +168,6 @@ static gint _get_active_marker_from_screen(GtkWidget *widget, const gdouble x, c
 
 static gdouble _slider_move(GtkWidget *widget, gint k, gdouble value, gint direction)
 {
-  g_return_val_if_fail(widget != NULL, value);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), value);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -222,7 +221,6 @@ static gdouble _slider_move(GtkWidget *widget, gint k, gdouble value, gint direc
 
 static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble delta, guint state, const gint selected)
 {
-  g_return_val_if_fail(widget != NULL, TRUE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), TRUE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -264,7 +262,6 @@ static float _default_linear_scale_callback(GtkWidget *self, float value, int di
 
 static gboolean _gradient_slider_enter_notify_event(GtkWidget *widget, GdkEventCrossing *event)
 {
-  g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -276,7 +273,6 @@ static gboolean _gradient_slider_enter_notify_event(GtkWidget *widget, GdkEventC
 
 static gboolean _gradient_slider_leave_notify_event(GtkWidget *widget, GdkEventCrossing *event)
 {
-  g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -292,7 +288,6 @@ static gboolean _gradient_slider_leave_notify_event(GtkWidget *widget, GdkEventC
 
 static gboolean _gradient_slider_button_press(GtkWidget *widget, GdkEventButton *event)
 {
-  g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -352,7 +347,6 @@ static gboolean _gradient_slider_button_press(GtkWidget *widget, GdkEventButton 
 
 static gboolean _gradient_slider_motion_notify(GtkWidget *widget, GdkEventMotion *event)
 {
-  g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -382,7 +376,6 @@ static gboolean _gradient_slider_motion_notify(GtkWidget *widget, GdkEventMotion
 
 static gboolean _gradient_slider_button_release(GtkWidget *widget, GdkEventButton *event)
 {
-  g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -409,7 +402,6 @@ static gboolean _gradient_slider_button_release(GtkWidget *widget, GdkEventButto
 
 static gboolean _gradient_slider_scroll_event(GtkWidget *widget, GdkEventScroll *event)
 {
-  g_return_val_if_fail(widget != NULL, TRUE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), TRUE);
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
@@ -432,7 +424,6 @@ static gboolean _gradient_slider_scroll_event(GtkWidget *widget, GdkEventScroll 
 
 static gboolean _gradient_slider_key_press_event(GtkWidget *widget, GdkEventKey *event)
 {
-  g_return_val_if_fail(widget != NULL, TRUE);
   g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), TRUE);
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -505,7 +496,6 @@ static void _gradient_slider_init(GtkDarktableGradientSlider *gslider)
 static void _gradient_slider_get_preferred_height(GtkWidget *widget, gint *min_height, gint *nat_height)
 {
   g_return_if_fail(widget != NULL);
-  g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget));
 
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
@@ -521,7 +511,6 @@ static void _gradient_slider_get_preferred_height(GtkWidget *widget, gint *min_h
 
 static void _gradient_slider_get_preferred_width(GtkWidget *widget, gint *min_width, gint *nat_width)
 {
-  g_return_if_fail(widget != NULL);
   g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget));
 
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
@@ -541,7 +530,6 @@ static void _gradient_slider_get_preferred_width(GtkWidget *widget, gint *min_wi
 
 static void _gradient_slider_destroy(GtkWidget *widget)
 {
-  g_return_if_fail(widget != NULL);
   g_return_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget));
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -561,12 +549,10 @@ static void _gradient_slider_destroy(GtkWidget *widget)
 
 static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr)
 {
+  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
   assert(gslider->position > 0);
-
-  g_return_val_if_fail(widget != NULL, FALSE);
-  g_return_val_if_fail(DTGTK_IS_GRADIENT_SLIDER(widget), FALSE);
 
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
   GtkStateFlags state = gtk_widget_get_state_flags(widget);

--- a/src/dtgtk/icon.c
+++ b/src/dtgtk/icon.c
@@ -91,6 +91,7 @@ GType dtgtk_icon_get_type()
 
 void dtgtk_icon_set_paint(GtkWidget *icon, DTGTKCairoPaintIconFunc paint, gint paintflags, void *paintdata)
 {
+  g_return_if_fail(icon != NULL);
   DTGTK_ICON(icon)->icon = paint;
   DTGTK_ICON(icon)->icon_flags = paintflags;
   DTGTK_ICON(icon)->icon_data = paintdata;

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -104,6 +104,9 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
 
 static gboolean _thumbnail_btn_enter_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), FALSE);
+
   int flags = gtk_widget_get_state_flags(widget);
   flags |= GTK_STATE_FLAG_PRELIGHT;
 
@@ -113,6 +116,9 @@ static gboolean _thumbnail_btn_enter_notify_callback(GtkWidget *widget, GdkEvent
 }
 static gboolean _thumbnail_btn_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
 {
+  g_return_val_if_fail(widget != NULL, FALSE);
+  g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), FALSE);
+
   int flags = gtk_widget_get_state_flags(widget);
   flags &= ~GTK_STATE_FLAG_PRELIGHT;
 
@@ -164,6 +170,9 @@ GType dtgtk_thumbnail_btn_get_type()
 
 gboolean dtgtk_thumbnail_btn_is_hidden(GtkWidget *widget)
 {
+  g_return_val_if_fail(widget != NULL, TRUE);
+  g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), TRUE);
+
   return DTGTK_THUMBNAIL_BTN(widget)->hidden;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -40,7 +40,6 @@ static void _thumbnail_btn_init(GtkDarktableThumbnailBtn *button)
 
 static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
 {
-  g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), FALSE);
 
   if(gtk_widget_get_allocated_height(widget) < 2 || gtk_widget_get_allocated_height(widget) < 2) return TRUE;
@@ -105,7 +104,6 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
 static gboolean _thumbnail_btn_enter_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
 {
   g_return_val_if_fail(widget != NULL, FALSE);
-  g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), FALSE);
 
   int flags = gtk_widget_get_state_flags(widget);
   flags |= GTK_STATE_FLAG_PRELIGHT;
@@ -117,7 +115,6 @@ static gboolean _thumbnail_btn_enter_notify_callback(GtkWidget *widget, GdkEvent
 static gboolean _thumbnail_btn_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
 {
   g_return_val_if_fail(widget != NULL, FALSE);
-  g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), FALSE);
 
   int flags = gtk_widget_get_state_flags(widget);
   flags &= ~GTK_STATE_FLAG_PRELIGHT;
@@ -170,7 +167,6 @@ GType dtgtk_thumbnail_btn_get_type()
 
 gboolean dtgtk_thumbnail_btn_is_hidden(GtkWidget *widget)
 {
-  g_return_val_if_fail(widget != NULL, TRUE);
   g_return_val_if_fail(DTGTK_IS_THUMBNAIL_BTN(widget), TRUE);
 
   return DTGTK_THUMBNAIL_BTN(widget)->hidden;

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -188,6 +188,7 @@ GType dtgtk_togglebutton_get_type()
 void dtgtk_togglebutton_set_paint(GtkDarktableToggleButton *button, DTGTKCairoPaintIconFunc paint,
                                   gint paintflags, void *paintdata)
 {
+  g_return_if_fail(button != NULL);
   button->icon = paint;
   button->icon_flags = paintflags;
   button->icon_data = paintdata;
@@ -195,6 +196,7 @@ void dtgtk_togglebutton_set_paint(GtkDarktableToggleButton *button, DTGTKCairoPa
 
 void dtgtk_togglebutton_override_color(GtkDarktableToggleButton *button, GdkRGBA *color)
 {
+  g_return_if_fail(button != NULL);
   if(color)
   {
     button->fg = *color;
@@ -206,6 +208,7 @@ void dtgtk_togglebutton_override_color(GtkDarktableToggleButton *button, GdkRGBA
 
 void dtgtk_togglebutton_override_background_color(GtkDarktableToggleButton *button, GdkRGBA *color)
 {
+  g_return_if_fail(button != NULL);
   if(color)
   {
     button->bg = *color;


### PR DESCRIPTION
fixes #7592 - it however does not address the root cause. maybe it's an unchecked memory issue when allocation fails?

however it's better to have gtk yell at the console rather than outright crash