### PR TITLE
Detect module name edit Entry after buttons pressed

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2534,7 +2534,7 @@
     <shortdescription>colorbalance slider block layout</shortdescription>
     <longdescription>choose how to organise the slider blocks for lift, gamma and gain:\nlist - all sliders are shown in one long list (with headers),\ntabs - use tabs to switch between the blocks of sliders,\ncolumns - the blocks of sliders are shown next to each other (in narrow columns)</longdescription>
   </dtconfig>
-  <dtconfig prefs="darkroom" section="general">
+  <dtconfig prefs="darkroom" section="modules">
     <name>darkroom/ui/hide_header_buttons</name>
     <type>
       <enum>

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1073,7 +1073,8 @@ static gboolean _rename_module_resize(GtkWidget *entry, GdkEventKey *event, dt_i
 
 static void _iop_gui_rename_module(dt_iop_module_t *module)
 {
-  if(gtk_container_get_focus_child(GTK_CONTAINER(module->header))) return;
+  GtkWidget *focused = gtk_container_get_focus_child(GTK_CONTAINER(module->header));
+  if(focused && GTK_IS_ENTRY(focused)) return;
 
   GtkWidget *entry = gtk_entry_new();
 
@@ -2448,7 +2449,8 @@ static void header_size_callback(GtkWidget *widget, GdkRectangle *allocation, Gt
 gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide)
 {
   // check if Entry widget for module name edit exists
-  if(gtk_container_get_focus_child(GTK_CONTAINER(header))) return TRUE;
+  GtkWidget *focused = gtk_container_get_focus_child(GTK_CONTAINER(header));
+  if(focused && GTK_IS_ENTRY(focused)) return TRUE;
 
   if(event && (darktable.develop->darkroom_skip_mouse_events ||
      event->detail == GDK_NOTIFY_INFERIOR ||


### PR DESCRIPTION
Normally none of the widgets in module headers are focusable, except when an Entry widget has been temporarily added to change the instance name. But it turns out that after a button has been clicked, Gtk considers it focused/focusable and returns it with gtk_container_get_focus_child. So now an explicit test that the focus child is indeed an Entry is added.

Fixes #7622 and also an issue that clicking on a button and then ctrl-clicking on the header to edit the instance name did not work either.

Also moved the preference setting for hiding the module header buttons to the "modules" section.

