### PR TITLE
[CI] add fuller GCC7 tests - make sure build target is built as well as all Release targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,22 @@ jobs:
           - nofeatures
           - nofeatures_nosse
         include:
+          - os: { label: ubuntu-18.04, code: bionic }
+            btype: RelWithDebInfo
+            compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
+            target: build
+          - os: { label: ubuntu-18.04, code: bionic }
+            btype: Release
+            compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
+            target: build
+          - os: { label: ubuntu-18.04, code: bionic }
+            btype: Release
+            compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
+            target: nofeatures
+          - os: { label: ubuntu-18.04, code: bionic }
+            btype: Release
+            compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
+            target: nofeatures_nosse
           - os: { label: ubuntu-latest, code: latest }
             btype: Debug
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,14 +194,6 @@ jobs:
             btype: Release
             compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
             target: build
-          - os: { label: ubuntu-18.04, code: bionic }
-            btype: Release
-            compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
-            target: nofeatures
-          - os: { label: ubuntu-18.04, code: bionic }
-            btype: Release
-            compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
-            target: nofeatures_nosse
           - os: { label: ubuntu-latest, code: latest }
             btype: Debug
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -400,7 +400,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
           blockdenomthr[2][2] = { { 0, 0 }, { 0, 0 } };
 
     // assign working space
-    const int buffersize = 3 * sizeof(float) * ts * ts + 6 * sizeof(float) * ts * tsh + 8 * 64 + 63;
+    const size_t buffersize = sizeof(float) * 3 * ts * ts + 6 * sizeof(float) * ts * tsh + 8 * 64 + 63;
     char *buffer = (char *)malloc(buffersize);
     char *data = (char *)(((uintptr_t)buffer + (uintptr_t)63) / 64 * 64);
 


### PR DESCRIPTION
#7605 was possilble because CI for GCC7 had only nofeatures/nofeatures_nosse targets and thus no OpenMP targets.

This PR adds those to CI in hopes of catching issues with GCC7 builds before they become problems :)