### PR TITLE
overexposed: fix and clean up color profile handling

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -851,29 +851,13 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
   return profile_info;
 }
 
-static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *profile_type,
-                                        const char **profile_filename,
-                                        const gboolean force_normal_mode);
-
-static dt_iop_order_iccprofile_info_t *_get_histogram_profile_info(struct dt_develop_t *dev,
-                                                                   const int intent,
-                                                                   const gboolean force_normal_mode)
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev)
 {
   dt_colorspaces_color_profile_type_t histogram_profile_type;
   const char *histogram_profile_filename;
-  _get_histogram_profile_type(&histogram_profile_type, &histogram_profile_filename, force_normal_mode);
+  dt_ioppr_get_histogram_profile_type(&histogram_profile_type, &histogram_profile_filename);
   return dt_ioppr_add_profile_info_to_list(dev, histogram_profile_type, histogram_profile_filename,
-                                           intent);
-}
-
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev)
-{
-  return _get_histogram_profile_info(dev, INTENT_PERCEPTUAL, FALSE);
-}
-
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info_for_overexposed(struct dt_develop_t *dev)
-{
-  return _get_histogram_profile_info(dev, INTENT_RELATIVE_COLORIMETRIC, TRUE);
+                                           DT_INTENT_RELATIVE_COLORIMETRIC);
 }
 
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe)
@@ -1013,12 +997,10 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
     fprintf(stderr, "[dt_ioppr_get_export_profile_type] can't find colorout iop\n");
 }
 
-static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *profile_type,
-                                        const char **profile_filename,
-                                        const gboolean force_normal_mode)
+void dt_ioppr_get_histogram_profile_type(dt_colorspaces_color_profile_type_t *profile_type,
+                                         const char **profile_filename)
 {
-  const dt_colorspaces_color_mode_t mode = force_normal_mode
-      ? DT_PROFILE_NORMAL : darktable.color_profiles->mode;
+  const dt_colorspaces_color_mode_t mode = darktable.color_profiles->mode;
 
   // if in gamut check use soft proof
   if(mode != DT_PROFILE_NORMAL || darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
@@ -1039,12 +1021,6 @@ static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *pro
     *profile_type = darktable.color_profiles->histogram_type;
     *profile_filename = darktable.color_profiles->histogram_filename;
   }
-}
-
-void dt_ioppr_get_histogram_profile_type(dt_colorspaces_color_profile_type_t *profile_type,
-                                         const char **profile_filename)
-{
-  return _get_histogram_profile_type(profile_type, profile_filename, FALSE);
 }
 
 

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -113,12 +113,6 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
  * histogram profile must not be cleanup()
  */
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev);
-/** returns a reference to the histogram profile info for use in overexposed iop
- * the rendering intent is set to relative colorimetric
- * the returned profile info doesn't depend on whether softproof mode / gamut check is enabled,
- * i.e. the chosen "histogram profile" is always used.
- */
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info_for_overexposed(struct dt_develop_t *dev);
 
 /** returns the active work/input/output profile on the pipe */
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe);

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -113,6 +113,12 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
  * histogram profile must not be cleanup()
  */
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev);
+/** returns a reference to the histogram profile info for use in overexposed iop
+ * the rendering intent is set to relative colorimetric
+ * the returned profile info doesn't depend on whether softproof mode / gamut check is enabled,
+ * i.e. the chosen "histogram profile" is always used.
+ */
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info_for_overexposed(struct dt_develop_t *dev);
 
 /** returns the active work/input/output profile on the pipe */
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -890,7 +890,7 @@ static void _pixelpipe_pick_live_samples(const float *const input, const dt_iop_
 
   // display rgb --> histogram rgb
   if(display_profile && histogram_profile)
-    xform_rgb2rgb = cmsCreateTransform(display_profile, TYPE_RGB_FLT, histogram_profile, TYPE_RGB_FLT, INTENT_PERCEPTUAL, 0);
+    xform_rgb2rgb = cmsCreateTransform(display_profile, TYPE_RGB_FLT, histogram_profile, TYPE_RGB_FLT, INTENT_RELATIVE_COLORIMETRIC, 0);
 
   if(darktable.color_profiles->display_type == DT_COLORSPACE_DISPLAY || histogram_type == DT_COLORSPACE_DISPLAY)
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
@@ -960,7 +960,7 @@ static void _pixelpipe_pick_primary_colorpicker(dt_develop_t *dev, const float *
 
   // display rgb --> histogram rgb
   if(display_profile && histogram_profile)
-    xform_rgb2rgb = cmsCreateTransform(display_profile, TYPE_RGB_FLT, histogram_profile, TYPE_RGB_FLT, INTENT_PERCEPTUAL, 0);
+    xform_rgb2rgb = cmsCreateTransform(display_profile, TYPE_RGB_FLT, histogram_profile, TYPE_RGB_FLT, INTENT_RELATIVE_COLORIMETRIC, 0);
 
   if(darktable.color_profiles->display_type == DT_COLORSPACE_DISPLAY || histogram_type == DT_COLORSPACE_DISPLAY)
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -125,7 +125,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if (!dt_iop_alloc_image_buffers(self, roi_in, roi_out, ch, &img_tmp, 0))
   {
     dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
-    return;
+    dt_control_log(_("module overexposed failed in buffer allocation"));
+    goto process_finish;
   }
 
   const float lower = exp2f(fminf(dev->overexposed.lower, -4.f));   // in EV
@@ -412,6 +413,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     fprintf(stderr, "[overexposed process_cl] error allocating memory for color transformation\n");
+    dt_control_log(_("module overexposed failed in buffer allocation"));
     goto error;
   }
 

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -113,53 +113,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 //   dt_accel_connect_slider_iop(self, "color scheme", GTK_WIDGET(g->colorscheme));
 // }
 
-// FIXME: this is pretty much a duplicate of dt_ioppr_get_histogram_profile_type() excepting that it doesn't check darktable.color_profiles->mode
-static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *out_type, const gchar **out_filename)
-{
-  // if in gamut check use soft proof
-  // FIXME: This isn't actually true -- we only use soft proof profile if it is chosen by the user as a histogram profile. Otherwise, if in gamut check, we still use the histogram profile.
-  if(darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
-  {
-    *out_type = darktable.color_profiles->softproof_type;
-    *out_filename = darktable.color_profiles->softproof_filename;
-  }
-  else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_WORK)
-  {
-    dt_ioppr_get_work_profile_type(darktable.develop, out_type, out_filename);
-  }
-  else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_EXPORT)
-  {
-    dt_ioppr_get_export_profile_type(darktable.develop, out_type, out_filename);
-  }
-  else
-  {
-    *out_type = darktable.color_profiles->histogram_type;
-    *out_filename = darktable.color_profiles->histogram_filename;
-  }
-}
-
-static void _transform_image_colorspace(dt_iop_module_t *self, const float *const img_in, float *const img_out,
-                                        const dt_iop_roi_t *const roi_in)
-{
-  dt_colorspaces_color_profile_type_t histogram_type = DT_COLORSPACE_SRGB;
-  const gchar *histogram_filename = NULL;
-
-  _get_histogram_profile_type(&histogram_type, &histogram_filename);
-
-  const dt_iop_order_iccprofile_info_t *const profile_info_from
-      = dt_ioppr_add_profile_info_to_list(self->dev, darktable.color_profiles->display_type,
-                                          darktable.color_profiles->display_filename, INTENT_PERCEPTUAL);
-  const dt_iop_order_iccprofile_info_t *const profile_info_to
-      = dt_ioppr_add_profile_info_to_list(self->dev, histogram_type, histogram_filename, INTENT_RELATIVE_COLORIMETRIC);
-
-  // FIXME: the histogram already does this work -- use that data instead?
-  if(profile_info_from && profile_info_to)
-    dt_ioppr_transform_image_colorspace_rgb(img_in, img_out, roi_in->width, roi_in->height, profile_info_from,
-                                            profile_info_to, self->op);
-  else
-    fprintf(stderr, "[_transform_image_colorspace] can't create transform profile\n");
-}
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -168,7 +121,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = 4;
   assert(piece->colors == ch);
 
-  float *restrict img_tmp;
+  float *restrict img_tmp = NULL;
   if (!dt_iop_alloc_image_buffers(self, roi_in, roi_out, ch, &img_tmp, 0))
   {
     dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
@@ -185,10 +138,22 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float *const restrict in = __builtin_assume_aligned((const float *const restrict)ivoid, 64);
   float *const restrict out = __builtin_assume_aligned((float *const restrict)ovoid, 64);
 
-  // display mask using histogram profile as output
-  _transform_image_colorspace(self, in, img_tmp, roi_out);
+  const dt_iop_order_iccprofile_info_t *const current_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info_for_overexposed(dev);
 
-  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);
+  // display mask using histogram profile as output
+  // FIXME: the histogram already does this work -- use that data instead?
+  if(current_profile && work_profile)
+    dt_ioppr_transform_image_colorspace_rgb(in, img_tmp, roi_out->width, roi_out->height, current_profile,
+                                            work_profile, self->op);
+  else
+  {
+    fprintf(stderr, "[overexposed process] can't create transform profile\n");
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    dt_control_log(_("module overexposed failed in color conversion"));
+    goto process_finish;
+  }
+
 
   #ifdef __SSE2__
     // flush denormals to zero to avoid performance penalty if there are a lot of near-zero values
@@ -415,6 +380,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     _MM_SET_FLUSH_ZERO_MODE(oldMode);
   #endif
 
+process_finish:
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
     dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 
@@ -422,27 +388,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #ifdef HAVE_OPENCL
-static void _transform_image_colorspace_cl(dt_iop_module_t *self, const int devid, cl_mem dev_img_in,
-                                           cl_mem dev_img_out, const dt_iop_roi_t *const roi_in)
-{
-  dt_colorspaces_color_profile_type_t histogram_type = DT_COLORSPACE_SRGB;
-  const gchar *histogram_filename = NULL;
-
-  _get_histogram_profile_type(&histogram_type, &histogram_filename);
-
-  const dt_iop_order_iccprofile_info_t *const profile_info_from
-      = dt_ioppr_add_profile_info_to_list(self->dev, darktable.color_profiles->display_type,
-                                          darktable.color_profiles->display_filename, INTENT_PERCEPTUAL);
-  const dt_iop_order_iccprofile_info_t *const profile_info_to
-      = dt_ioppr_add_profile_info_to_list(self->dev, histogram_type, histogram_filename, INTENT_PERCEPTUAL);
-
-  if(profile_info_from && profile_info_to)
-    dt_ioppr_transform_image_colorspace_rgb_cl(devid, dev_img_in, dev_img_out, roi_in->width, roi_in->height,
-                                               profile_info_from, profile_info_to, self->op);
-  else
-    fprintf(stderr, "[_transform_image_colorspace_cl] can't create transform profile\n");
-}
-
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -458,6 +403,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_out->width;
   const int height = roi_out->height;
 
+  const dt_iop_order_iccprofile_info_t *const current_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info_for_overexposed(dev);
+
   // display mask using histogram profile as output
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * ch);
   if(dev_tmp == NULL)
@@ -467,9 +415,16 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     goto error;
   }
 
-  _transform_image_colorspace_cl(self, devid, dev_in, dev_tmp, roi_out);
+  if(current_profile && work_profile)
+    dt_ioppr_transform_image_colorspace_rgb_cl(devid, dev_in, dev_tmp, roi_out->width, roi_out->height,
+                                               current_profile, work_profile, self->op);
+  else
+  {
+    fprintf(stderr, "[overexposed process_cl] can't create transform profile\n");
+    dt_control_log(_("module overexposed failed in color conversion"));
+    goto error;
+  }
 
-  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);
   const int use_work_profile = (work_profile == NULL) ? 0 : 1;
   cl_mem dev_profile_info = NULL;
   cl_mem dev_profile_lut = NULL;

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -139,7 +139,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *const restrict out = __builtin_assume_aligned((float *const restrict)ovoid, 64);
 
   const dt_iop_order_iccprofile_info_t *const current_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
-  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info_for_overexposed(dev);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);
 
   // display mask using histogram profile as output
   // FIXME: the histogram already does this work -- use that data instead?
@@ -404,7 +404,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int height = roi_out->height;
 
   const dt_iop_order_iccprofile_info_t *const current_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
-  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info_for_overexposed(dev);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);
 
   // display mask using histogram profile as output
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * ch);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -281,7 +281,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     if(out_profile_type != DT_COLORSPACE_NONE)
     {
       const dt_iop_order_iccprofile_info_t *const profile_info_to =
-        dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
+        dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_RELATIVE_COLORIMETRIC);
       img_display = dt_alloc_align_float((size_t)4 * width * height);
       if(!img_display) return;
       dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -301,7 +301,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
           // the histogram will have some relationship to a captured
           // image's profile, go with the standard work profile.
           // FIXME: can figure out the current default work colorspace via checking presets?
-          profile_to = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", DT_INTENT_PERCEPTUAL);
+          profile_to = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", DT_INTENT_RELATIVE_COLORIMETRIC);
         }
         else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_EXPORT)
         {


### PR DESCRIPTION
The rendering intent of the conversion from source (display) profile to histogram profile was changed from perceptual to relative colorimetric in 532a1c5191ee64f0ba60386b34191dd591885202. However, there was duplicated code doing the same task in the OpenCL path which wasn't changed accordingly.

Also use the same histogram profile info for the luminance calculation inside `process()` for consistency. Remove duplication of code that already exists in `iop_profile.c`.

Instead of hardcoded display profile, use whichever profile is used in the current part of the pixelpipe. This prepares for the possibility to move `overexposed` to an earlier position in the pixelpipe, right before `colorout`.

One possible issue that was noticed so far: with this PR, if OpenCL is not used, with a certain device-specific display profile I couldn't get luminance upper clipping indicator to show at all with the default upper limit. This may be related to differences between CPU and OpenCL implementations in the details of how clipping and LUTs are handled.