### PR TITLE
chromatic aberration correction

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -91,6 +91,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {13.0f }, "spots", 0},
   { {14.0f }, "retouch", 0},
   { {15.0f }, "lens", 0},
+  { {15.5f }, "cacorrectrgb", 0},
   { {16.0f }, "ashift", 0},
   { {17.0f }, "liquify", 0},
   { {18.0f }, "rotatepixels", 0},
@@ -174,6 +175,8 @@ const dt_iop_order_entry_t v30_order[] = {
   { {11.0f }, "rotatepixels", 0},
   { {12.0f }, "scalepixels", 0},
   { {13.0f }, "lens", 0},
+  { {13.5f }, "cacorrectrgb", 0}, // correct chromatic aberrations after lens correction so that lensfun
+                                  // does not reintroduce chromatic aberrations when trying to correct them
   { {14.0f }, "hazeremoval", 0},
   { {15.0f }, "ashift", 0},
   { {16.0f }, "flip", 0},
@@ -654,6 +657,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "negadoctor", "channelmixerrgb");
           _insert_before(iop_order_list, "negadoctor", "censorize");
           _insert_before(iop_order_list, "rgbcurve", "colorbalancergb");
+          _insert_before(iop_order_list, "ashift", "cacorrectrgb");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -145,6 +145,7 @@ add_iop(negadoctor "negadoctor.c")
 add_iop(channelmixerrgb "channelmixerrgb.c" "../chart/common.c")
 add_iop(censorize "censorize.c")
 add_iop(colorbalancergb "colorbalancergb.c")
+add_iop(cacorrectrgb "cacorrectrgb.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -83,7 +83,7 @@ typedef struct dt_iop_cacorrect_data_t
 const char *name()
 {
   // make sure you put all your translatable strings into _() !
-  return _("chromatic aberrations");
+  return _("raw chromatic aberrations");
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -322,7 +322,7 @@ dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
     const float low_guide = fmaxf(manifolds[k * 6 + 3 + guide], 1E-6);
     const float log_high = logf(high_guide);
     const float log_low = logf(low_guide);
-    const float pixelg = in[k * 4 + guide];
+    const float pixelg = fmaxf(in[k * 4 + guide], 0.0f);
     const float log_pixg = logf(fminf(fmaxf(pixelg, low_guide), high_guide));
     float dist = fabsf(log_high - log_pixg) / fmaxf(fabsf(log_high - log_low), 1E-6);
     dist = fminf(dist, 1.0f);
@@ -331,7 +331,7 @@ dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
     {
       const size_t c = (guide + kc + 1) % 3;
       //const size_t c2 = (guide + (kc ^ 1) + 1) % 3;
-      const float pixelc = in[k * 4 + c];
+      const float pixelc = fmaxf(in[k * 4 + c], 0.0f);
 
       const float xl = log2f(fmaxf(low_guide, 1E-6));
       const float yl = log2f(fmaxf(manifolds[k * 6 + 3 + c], 1E-6));
@@ -374,9 +374,7 @@ dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
       float dist_dr = 1.0f; //(pixelc - estimate_d) / (estimate_r - estimate_d);
       dist_dr = fminf(dist_dr, 1.0f);
       dist_dr = fmaxf(dist_dr, 0.0f);
-      const float outp = powf(fmaxf(pixelc, 0.99f * pixelc + 0.01f * estimate_r), fmaxf(1.0f - weight_corr, 0.0f)) * powf(estimate_d * fmaxf(1.0f - dist_dr, 0.0f) + estimate_r * dist_dr, weight_corr);
-
-      if(outp <= 0.0f) printf("problem, dist: %f, ratio_h: %f, ratio_l: %f, pixelg: %f, outp: %f, pixelc: %f\n", dist, ratio_high_manifolds, ratio_low_manifolds, pixelg, outp, pixelc);
+      const float outp = powf(pixelc, fmaxf(1.0f - weight_corr, 0.0f)) * powf(estimate_d * fmaxf(1.0f - dist_dr, 0.0f) + estimate_r * dist_dr, weight_corr);
 
       switch(mode)
       {

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -126,34 +126,8 @@ static void ca_correct_rgb(const float* const restrict in, const size_t width, c
   float *const restrict blurred_manifold_higher = dt_alloc_sse_ps(dt_round_size_sse(width * height * ch));
   float *const restrict blurred_manifold_lower = dt_alloc_sse_ps(dt_round_size_sse(width * height * ch));
 
-  float minr = 10000000.0f;
-  float maxr = 0.0f;
-  float ming = 10000000.0f;
-  float maxg = 0.0f;
-  float minb = 10000000.0f;
-  float maxb = 0.0f;
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, width, height) \
-  schedule(simd:static) aligned(in:64) \
-  reduction(max:maxr, maxg, maxb)\
-  reduction(min:minr, ming, minb)
-#endif
-  for(size_t k = 0; k < width * height; k++)
-  {
-    const float pixelr = in[k * 4];
-    if(pixelr < minr) minr = pixelr;
-    if(pixelr > maxr) maxr = pixelr;
-    const float pixelg = in[k * 4 + 1];
-    if(pixelg < ming) ming = pixelg;
-    if(pixelg > maxg) maxg = pixelg;
-    const float pixelb = in[k * 4 + 2];
-    if(pixelb < minb) minb = pixelb;
-    if(pixelb > maxb) maxb = pixelb;
-  }
-
-  float max[4] = {maxr, maxg, maxb, 1.0f};
-  float min[4] = {fminf(minr, 0.0f), fminf(ming, 0.0f), fminf(minb, 0.0f), 0.0f};
+  float max[4] = {INFINITY, INFINITY, INFINITY, 1.0f};
+  float min[4] = {0.0f, 0.0f, 0.0f, 0.0f};
   dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
   if(!g) return;
   dt_gaussian_blur_4c(g, in, blurred_in);

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -40,15 +40,24 @@ typedef enum dt_iop_cacorrectrgb_guide_channel_t
   DT_CACORRECT_RGB_B = 2     // $DESCRIPTION: "blue"
 } dt_iop_cacorrectrgb_guide_channel_t;
 
+typedef enum dt_iop_cacorrectrgb_mode_t
+{
+  DT_CACORRECT_MODE_STANDARD = 0,  // $DESCRIPTION: "standard"
+  DT_CACORRECT_MODE_DARKEN = 1,    // $DESCRIPTION: "darken only"
+  DT_CACORRECT_MODE_BRIGHTEN = 2   // $DESCRIPTION: "brighten only"
+} dt_iop_cacorrectrgb_mode_t;
+
+
 typedef struct dt_iop_cacorrectrgb_params_t
 {
   dt_iop_cacorrectrgb_guide_channel_t guide_channel; // $DEFAULT: DT_CACORRECT_RGB_G $DESCRIPTION: "guide"
-  float radius; // $MIN: 1 $MAX: 400 $DEFAULT: 1 $DESCRIPTION: "radius"
+  float radius; // $MIN: 1 $MAX: 400 $DEFAULT: 5 $DESCRIPTION: "radius"
+  dt_iop_cacorrectrgb_mode_t mode; // $DEFAULT: DT_CACORRECT_MODE_STANDARD $DESCRIPTION: "correction mode"
 } dt_iop_cacorrectrgb_params_t;
 
 typedef struct dt_iop_cacorrectrgb_gui_data_t
 {
-  GtkWidget *guide_channel, *radius;
+  GtkWidget *guide_channel, *radius, *mode;
 } dt_iop_cacorrectrgb_gui_data_t;
 
 // this returns a translatable name
@@ -295,12 +304,13 @@ static void apply_correction(const float* const restrict in,
                           const size_t width, const size_t height,
                           const size_t ch, const float sigma,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
+                          const dt_iop_cacorrectrgb_mode_t mode,
                           float* const restrict out)
 
 {
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma) \
+dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
   schedule(simd:static) aligned(in, manifolds, out)
 #endif
   for(size_t k = 0; k < width * height; k++)
@@ -321,7 +331,18 @@ dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma) \
       const float ratio_low_manifolds = manifolds[k * 6 + 3 + c] / low_guide;
 
       const float ratio = powf(ratio_low_manifolds, dist) * powf(ratio_high_manifolds, 1.0f - dist);
-      out[k * 4 + c] =  pixelg * ratio;
+      switch(mode)
+      {
+        case DT_CACORRECT_MODE_STANDARD:
+          out[k * 4 + c] = pixelg * ratio;
+          break;
+        case DT_CACORRECT_MODE_DARKEN:
+          out[k * 4 + c] = fminf(pixelg * ratio, in[k * 4 + c]);
+          break;
+        case DT_CACORRECT_MODE_BRIGHTEN:
+          out[k * 4 + c] = fmaxf(pixelg * ratio, in[k * 4 + c]);
+          break;
+      }
     }
 
     out[k * 4 + guide] = pixelg;
@@ -348,6 +369,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 
   const dt_iop_cacorrectrgb_guide_channel_t guide = d->guide_channel;
+  const dt_iop_cacorrectrgb_mode_t mode = d->mode;
 
   const float downsize = 3.0f;
   const size_t ds_width = width / downsize;
@@ -364,7 +386,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // upscale manifolds
   interpolate_bilinear(ds_manifolds, ds_width, ds_height, manifolds, width, height, 6);
   dt_free_align(ds_manifolds);
-  apply_correction(in, manifolds, width, height, ch, sigma, guide, out);
+  apply_correction(in, manifolds, width, height, ch, sigma, guide, mode, out);
   dt_free_align(manifolds);
 }
 
@@ -375,7 +397,8 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_cacorrectrgb_params_t *p = (dt_iop_cacorrectrgb_params_t *)self->params;
 
   dt_bauhaus_combobox_set_from_value(g->guide_channel, p->guide_channel);
-  dt_bauhaus_slider_set(g->radius, p->radius);
+  dt_bauhaus_slider_set_soft(g->radius, p->radius);
+  dt_bauhaus_combobox_set_from_value(g->mode, p->mode);
 }
 
 /** optional: if this exists, it will be called to init new defaults if a new image is
@@ -385,7 +408,8 @@ void reload_defaults(dt_iop_module_t *module)
   dt_iop_cacorrectrgb_params_t *d = (dt_iop_cacorrectrgb_params_t *)module->default_params;
 
   d->guide_channel = DT_CACORRECT_RGB_G;
-  d->radius = 1.0f;
+  d->radius = 5.0f;
+  d->mode = DT_CACORRECT_MODE_STANDARD;
 
   dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)module->gui_data;
   if(g)
@@ -393,6 +417,7 @@ void reload_defaults(dt_iop_module_t *module)
     dt_bauhaus_combobox_set_default(g->guide_channel, d->guide_channel);
     dt_bauhaus_slider_set_default(g->radius, d->radius);
     dt_bauhaus_slider_set_soft_range(g->radius, 1.0, 20.0);
+    dt_bauhaus_combobox_set_default(g->mode, d->mode);
   }
 }
 
@@ -409,4 +434,14 @@ void gui_init(dt_iop_module_t *self)
                                            "have artefacts."));
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   gtk_widget_set_tooltip_text(g->radius, _("increase for stronger correction\n"));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("advanced parameters:")), TRUE, TRUE, 0);
+  g->mode = dt_bauhaus_combobox_from_params(self, "mode");
+  gtk_widget_set_tooltip_text(g->mode, _("correction mode to use.\n"
+                                         "can help with multiple\n"
+                                         "instances for very damaged\n"
+                                         "images.\n"
+                                         "darken only is particularly\n"
+                                         "efficient to correct blue\n"
+                                         "chromatic aberration."));
 }

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -52,12 +52,13 @@ typedef struct dt_iop_cacorrectrgb_params_t
 {
   dt_iop_cacorrectrgb_guide_channel_t guide_channel; // $DEFAULT: DT_CACORRECT_RGB_G $DESCRIPTION: "guide"
   float radius; // $MIN: 1 $MAX: 400 $DEFAULT: 5 $DESCRIPTION: "radius"
+  float strength; // $MIN: 0 $MAX: 5 $DEFAULT: 3 $DESCRIPTION: "strength"
   dt_iop_cacorrectrgb_mode_t mode; // $DEFAULT: DT_CACORRECT_MODE_STANDARD $DESCRIPTION: "correction mode"
 } dt_iop_cacorrectrgb_params_t;
 
 typedef struct dt_iop_cacorrectrgb_gui_data_t
 {
-  GtkWidget *guide_channel, *radius, *mode;
+  GtkWidget *guide_channel, *radius, *strength, *mode;
 } dt_iop_cacorrectrgb_gui_data_t;
 
 // this returns a translatable name
@@ -182,7 +183,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
   // as it is the average of the values where the guide is higher than its
   // average, and the lower manifold of the guided channel is equal to 1.
 
-for(size_t p = 0; p < log2f(sigma)+1; p++)
+for(size_t p = 0; p < 3; p++)
 {
   // refine the manifolds
   // improve result especially on very degraded images
@@ -308,12 +309,13 @@ static void apply_correction(const float* const restrict in,
                           const size_t ch, const float sigma,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
                           const dt_iop_cacorrectrgb_mode_t mode,
+                          const float strength,
                           float* const restrict out)
 
 {
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
+dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode, strength) \
   schedule(simd:static) aligned(in, manifolds, out)
 #endif
   for(size_t k = 0; k < width * height; k++)
@@ -357,7 +359,7 @@ dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
       const float dist_to_good_2 = sqrtf((x - xh) * (x - xh) + (y - yh) * (y - yh));
       const float dist_to_good = fminf(dist_to_good_1, dist_to_good_2);
 
-      const float weight_corr = exp2f(-dist_to_bad / ((dist_to_good + 0.01f) * 10.0f));
+      const float weight_corr = exp2f(-dist_to_bad / ((dist_to_good + 0.01f) * strength));
 
       //const float weight_corr = exp2f(-fmaxf(dist_to_bad - strength, 0.0f) / fmaxf(40.0f * strength, 1E-6));
 
@@ -431,8 +433,58 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // upscale manifolds
   interpolate_bilinear(ds_manifolds, ds_width, ds_height, manifolds, width, height, 6);
   dt_free_align(ds_manifolds);
-  apply_correction(in, manifolds, width, height, ch, sigma, guide, mode, out);
+  apply_correction(in, manifolds, width, height, ch, sigma, guide, mode, 1000.0f/*powf(10.0f, d->strength - 2.0f)*/, out);
   dt_free_align(manifolds);
+
+
+  // reduce artifacts
+
+  // contains 2 guided channels of in, and of out
+  float *const restrict in_out = dt_alloc_sse_ps(dt_round_size_sse(width * height * ch));
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+dt_omp_firstprivate(in, out, in_out, width, height, guide, ch) \
+  schedule(simd:static) aligned(in, out, in_out:64)
+#endif
+  for(size_t k = 0; k < width * height; k++)
+  {
+    for(size_t kc = 0; kc <= 1; kc++)
+    {
+      size_t c = (guide + kc + 1) % 3;
+      in_out[k * ch + kc * 2 + 0] = log2f(fmaxf(in[k * 4 + c], 0.000016f)) + 16.0f;
+      in_out[k * ch + kc * 2 + 1] = log2f(fmaxf(out[k * 4 + c], 0.000016f)) + 16.0f;
+    }
+  }
+
+  float *const restrict blurred_in_out = dt_alloc_sse_ps(dt_round_size_sse(width * height * ch));
+  float max[4] = {INFINITY, INFINITY, INFINITY, INFINITY};
+  float min[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+  dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
+  if(!g) return;
+  dt_gaussian_blur_4c(g, in_out, blurred_in_out);
+  dt_gaussian_free(g);
+  dt_free_align(in_out);
+
+  const float stren = powf(20.0f, 2.0f - d->strength);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, stren, ch) \
+  schedule(simd:static) aligned(in, out, blurred_in_out:64)
+#endif
+  for(size_t k = 0; k < width * height; k++)
+  {
+    for(size_t kc = 0; kc <= 1; kc++)
+    {
+      size_t c = (guide + kc + 1) % 3;
+      const float avg_in = blurred_in_out[k * ch + kc * 2 + 0];
+      const float avg_out = blurred_in_out[k * ch + kc * 2 + 1];
+      const float w = expf(-fmaxf(fabsf(avg_out - avg_in), 0.01f) * stren);
+      out[k * ch + c] = fmaxf(1.0f - w, 0.0f) * fmaxf(in[k * ch + c], 0.0f) + w * fmaxf(out[k * ch + c], 0.0f);
+    }
+  }
+
+
+
 }
 
 /** gui setup and update, these are needed. */
@@ -443,6 +495,7 @@ void gui_update(dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set_from_value(g->guide_channel, p->guide_channel);
   dt_bauhaus_slider_set_soft(g->radius, p->radius);
+  dt_bauhaus_slider_set_soft(g->strength, p->strength);
   dt_bauhaus_combobox_set_from_value(g->mode, p->mode);
 }
 
@@ -454,6 +507,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   d->guide_channel = DT_CACORRECT_RGB_G;
   d->radius = 5.0f;
+  d->strength = 3.0f;
   d->mode = DT_CACORRECT_MODE_STANDARD;
 
   dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)module->gui_data;
@@ -462,6 +516,7 @@ void reload_defaults(dt_iop_module_t *module)
     dt_bauhaus_combobox_set_default(g->guide_channel, d->guide_channel);
     dt_bauhaus_slider_set_default(g->radius, d->radius);
     dt_bauhaus_slider_set_soft_range(g->radius, 1.0, 20.0);
+    dt_bauhaus_slider_set_default(g->strength, d->strength);
     dt_bauhaus_combobox_set_default(g->mode, d->mode);
   }
 }
@@ -479,6 +534,8 @@ void gui_init(dt_iop_module_t *self)
                                            "have artefacts."));
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   gtk_widget_set_tooltip_text(g->radius, _("increase for stronger correction\n"));
+  g->strength = dt_bauhaus_slider_from_params(self, "strength");
+  gtk_widget_set_tooltip_text(g->strength, _("increase for stronger correction\n"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("advanced parameters:")), TRUE, TRUE, 0);
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -143,6 +143,9 @@ static void get_manifolds(const float* const restrict in, const size_t width, co
   dt_gaussian_blur_4c(g, in, blurred_in);
 
   // construct the manifolds
+  // higher manifold is the blur of all pixels that are above average,
+  // lower manifold is the blur of all pixels that are below average
+  // we use the guide channel to categorize the pixels as above or below average
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
 dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, height, guide) \

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -61,20 +61,25 @@ typedef struct dt_iop_cacorrectrgb_gui_data_t
   GtkWidget *guide_channel, *radius, *strength, *mode;
 } dt_iop_cacorrectrgb_gui_data_t;
 
-// this returns a translatable name
 const char *name()
 {
-  // make sure you put all your translatable strings into _() !
   return _("chromatic aberrations rgb");
 }
 
-// some additional flags (self explanatory i think):
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("correct chromatic aberrations"),
+                                      _("corrective"),
+                                      _("linear, raw, scene-referred"),
+                                      _("linear, raw"),
+                                      _("linear, raw, scene-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
 }
 
-// where does it appear in the gui?
 int default_group()
 {
   return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -158,7 +158,7 @@ typedef struct dt_iop_cacorrectrgb_gui_data_t
 
 const char *name()
 {
-  return _("chromatic aberrations rgb");
+  return _("chromatic aberrations");
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -1,0 +1,153 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+// our includes go first:
+#include "bauhaus/bauhaus.h"
+#include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "gui/color_picker_proxy.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+
+#include <gtk/gtk.h>
+#include <stdlib.h>
+
+// This is an example implementation of an image operation module that does nothing useful.
+// It demonstrates how the different functions work together. To build your own module,
+// take all of the functions that are mandatory, stripping them of comments.
+// Then add only the optional functions that are required to implement the functionality
+// you need. Don't copy default implementations (hint: if you don't need to change or add
+// anything, you probably don't need the copy). Make sure you choose descriptive names
+// for your fields and variables. The ones given here are just examples; rename them.
+//
+// To have your module compile and appear in darkroom, add it to CMakeLists.txt, with
+//  add_iop(useless "useless.c")
+// and to iop_order.c, in the initialisation of legacy_order & v30_order with:
+//  { {XX.0f }, "useless", 0},
+
+// This is the version of the module's parameters,
+// and includes version information about compile-time dt.
+// The first released version should be 1.
+DT_MODULE_INTROSPECTION(1, dt_iop_cacorrectrgb_params_t)
+
+// TODO: some build system to support dt-less compilation and translation!
+
+// Enums used in params_t can have $DESCRIPTIONs that will be used to
+// automatically populate a combobox with dt_bauhaus_combobox_from_params.
+// They are also used in the history changes tooltip.
+// Combobox options will be presented in the same order as defined here.
+// These numbers must not be changed when a new version is introduced.
+typedef enum dt_iop_cacorrectrgb_guide_channel_t
+{
+  DT_CACORRECT_RGB_R = 0,    // $DESCRIPTION: "red"
+  DT_CACORRECT_RGB_G = 1,    // $DESCRIPTION: "green"
+  DT_CACORRECT_RGB_B = 2     // $DESCRIPTION: "blue"
+} dt_iop_cacorrectrgb_guide_channel_t;
+
+typedef struct dt_iop_cacorrectrgb_params_t
+{
+  dt_iop_cacorrectrgb_guide_channel_t guide_channel; // $DEFAULT: DT_CACORRECT_RGB_G $DESCRIPTION: "guide"
+  int radius; // $MIN: 1 $MAX: 20 $DEFAULT: 1 $DESCRIPTION: "radius"
+} dt_iop_cacorrectrgb_params_t;
+
+typedef struct dt_iop_cacorrectrgb_gui_data_t
+{
+  GtkWidget *guide_channel, *radius;
+} dt_iop_cacorrectrgb_gui_data_t;
+
+// this returns a translatable name
+const char *name()
+{
+  // make sure you put all your translatable strings into _() !
+  return _("chromatic aberrations rgb");
+}
+
+// some additional flags (self explanatory i think):
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+// where does it appear in the gui?
+int default_group()
+{
+  return IOP_GROUP_CORRECT | IOP_GROUP_TECHNICAL;
+}
+
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_rgb;
+}
+
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  memcpy(piece->data, p1, self->params_size);
+}
+
+/** process, all real work is done here. */
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  // this is called for preview and full pipe separately, each with its own pixelpipe piece.
+  // get our data struct:
+  //dt_iop_cacorrectrgb_params_t *d = (dt_iop_cacorrectrgb_params_t *)piece->data;
+  // the total scale is composed of scale before input to the pipeline (iscale),
+  // and the scale of the roi.
+  //const float scale = piece->iscale / roi_in->scale;
+  // how many colors in our buffer?
+  const int ch = piece->colors;
+
+  memcpy(ovoid, ivoid, sizeof(float) * ch * roi_out->height * roi_in->width);
+}
+
+/** gui setup and update, these are needed. */
+void gui_update(dt_iop_module_t *self)
+{
+  dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)self->gui_data;
+  dt_iop_cacorrectrgb_params_t *p = (dt_iop_cacorrectrgb_params_t *)self->params;
+
+  dt_bauhaus_combobox_set_from_value(g->guide_channel, p->guide_channel);
+  dt_bauhaus_slider_set(g->radius, p->radius);
+}
+
+/** optional: if this exists, it will be called to init new defaults if a new image is
+ * loaded from film strip mode. */
+void reload_defaults(dt_iop_module_t *module)
+{
+  dt_iop_cacorrectrgb_params_t *d = (dt_iop_cacorrectrgb_params_t *)module->default_params;
+
+  d->guide_channel = DT_CACORRECT_RGB_G;
+  d->radius = 1;
+
+  dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)module->gui_data;
+  if(g)
+  {
+    dt_bauhaus_combobox_set_default(g->guide_channel, d->guide_channel);
+    dt_bauhaus_slider_set_default(g->radius, d->radius);
+  }
+}
+
+void gui_init(dt_iop_module_t *self)
+{
+  dt_iop_cacorrectrgb_gui_data_t *g = IOP_GUI_ALLOC(cacorrectrgb);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  g->guide_channel = dt_bauhaus_combobox_from_params(self, "guide_channel");
+  g->radius = dt_bauhaus_slider_from_params(self, "radius");
+}

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2021 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -203,8 +203,8 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
     const float weightl = fmaxf(blurred_manifold_lower[k * 4 + 3], 1E-2);
 
     // normalize guide
-    float highg = blurred_manifold_higher[k * 4 + guide] / weighth;
-    float lowg = blurred_manifold_lower[k * 4 + guide] / weightl;
+    const float highg = blurred_manifold_higher[k * 4 + guide] / weighth;
+    const float lowg = blurred_manifold_lower[k * 4 + guide] / weightl;
 
     blurred_manifold_higher[k * 4 + guide] = highg;
     blurred_manifold_lower[k * 4 + guide] = lowg;
@@ -212,9 +212,9 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
     // normalize and unlog other channels
     for(size_t kc = 0; kc <= 1; kc++)
     {
-      size_t c = (kc + guide + 1) % 3;
-      float highc = blurred_manifold_higher[k * 4 + c] / weighth;
-      float lowc = blurred_manifold_lower[k * 4 + c] / weightl;
+      const size_t c = (kc + guide + 1) % 3;
+      const float highc = blurred_manifold_higher[k * 4 + c] / weighth;
+      const float lowc = blurred_manifold_lower[k * 4 + c] / weightl;
       blurred_manifold_higher[k * 4 + c] = exp2f(highc) * highg;
       blurred_manifold_lower[k * 4 + c] = exp2f(lowc) * lowg;
     }
@@ -282,7 +282,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
     const float weightl = (pixelg <= avg);
     for(size_t kc = 0; kc <= 1; kc++)
     {
-      size_t c = (kc + guide + 1) % 3;
+      const size_t c = (kc + guide + 1) % 3;
       const float pixel = fmaxf(in[k * 4 + c], 1E-6);
       const float log_diff = log2f(pixel / pixelg);
       manifold_higher[k * 4 + c] = log_diff * weighth;
@@ -331,7 +331,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
     for(size_t k = 0; k < width * height; k++)
     {
       // in order to refine the manifolds, we will compute weights
-      // for which all channel will have a contribution.
+      // for which all channels will have a contribution.
       // this will allow to avoid taking too much into account pixels
       // that have wrong values due to the chromatic aberration
       //
@@ -360,7 +360,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
       float w = 1.0f;
       for(size_t kc = 0; kc <= 1; kc++)
       {
-        size_t c = (guide + kc + 1) % 3;
+        const size_t c = (guide + kc + 1) % 3;
         // weight by considering how close pixel is for a manifold,
         // and how close the log difference between the channels is
         // close to the wrong log difference between the channels.
@@ -397,7 +397,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
       {
         for(size_t kc = 0; kc <= 1; kc++)
         {
-          size_t c = (guide + kc + 1) % 3;
+          const size_t c = (guide + kc + 1) % 3;
           const float pixel = fmaxf(in[k * 4 + c], 1E-6);
           const float log_diff = logf(pixel) - pixelg;
           manifold_higher[k * 4 + c] = log_diff * w;
@@ -409,7 +409,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
       {
         for(size_t kc = 0; kc <= 1; kc++)
         {
-          size_t c = (guide + kc + 1) % 3;
+          const size_t c = (guide + kc + 1) % 3;
           const float pixel = fmaxf(in[k * 4 + c], 1E-6);
           const float log_diff = logf(pixel) - pixelg;
           manifold_lower[k * 4 + c] = log_diff * w;
@@ -541,7 +541,7 @@ dt_omp_firstprivate(in, out, in_out, width, height, guide, ch) \
   {
     for(size_t kc = 0; kc <= 1; kc++)
     {
-      size_t c = (guide + kc + 1) % 3;
+      const size_t c = (guide + kc + 1) % 3;
       in_out[k * ch + kc * 2 + 0] = in[k * 4 + c];
       in_out[k * ch + kc * 2 + 1] = out[k * 4 + c];
     }
@@ -581,7 +581,7 @@ dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety, ch) \
     }
     for(size_t kc = 0; kc <= 1; kc++)
     {
-      size_t c = (guide + kc + 1) % 3;
+      const size_t c = (guide + kc + 1) % 3;
       out[k * ch + c] = fmaxf(1.0f - w, 0.0f) * fmaxf(in[k * ch + c], 0.0f) + w * fmaxf(out[k * ch + c], 0.0f);
     }
   }
@@ -692,16 +692,16 @@ void gui_init(dt_iop_module_t *self)
                                            "use sharpest channel if some\n"
                                            "channels are blurry.\n"
                                            "try changing guide channel if you\n"
-                                           "have artefacts."));
+                                           "have artifacts."));
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
-  gtk_widget_set_tooltip_text(g->radius, _("increase for stronger correction\n"));
+  gtk_widget_set_tooltip_text(g->radius, _("increase for stronger correction"));
   g->strength = dt_bauhaus_slider_from_params(self, "strength");
   gtk_widget_set_tooltip_text(g->strength, _("balance between smoothing colors\n"
                                              "and preserving them.\n"
                                              "high values can lead to overshooting\n"
                                              "and edge bleeding."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("advanced parameters:")), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("advanced parameters")), TRUE, TRUE, 0);
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->mode, _("correction mode to use.\n"
                                          "can help with multiple\n"
@@ -712,7 +712,7 @@ void gui_init(dt_iop_module_t *self)
                                          "chromatic aberration."));
   g->refine_manifolds = dt_bauhaus_toggle_from_params(self, "refine_manifolds");
   gtk_widget_set_tooltip_text(g->refine_manifolds, _("runs an iterative approach\n"
-                                                    "with several radiuses.\n"
+                                                    "with several radius.\n"
                                                     "improves result on images\n"
                                                     "with very large chromatic\n"
                                                     "aberrations, but can smooth\n"

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -313,8 +313,8 @@ dt_omp_firstprivate(in, out, in_out, width, height, guide, ch) \
     for(size_t kc = 0; kc <= 1; kc++)
     {
       size_t c = (guide + kc + 1) % 3;
-      in_out[k * ch + kc * 2 + 0] = /*log2f*/(fmaxf(in[k * 4 + c], 0.000016f))/* + 16.0f*/;
-      in_out[k * ch + kc * 2 + 1] = /*log2f*/(fmaxf(out[k * 4 + c], 0.000016f))/* + 16.0f*/;
+      in_out[k * ch + kc * 2 + 0] = in[k * 4 + c];
+      in_out[k * ch + kc * 2 + 1] = out[k * 4 + c];
     }
   }
 
@@ -337,8 +337,8 @@ dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety, ch) \
     float w = 1.0f;
     for(size_t kc = 0; kc <= 1; kc++)
     {
-      const float avg_in = log2(blurred_in_out[k * ch + kc * 2 + 0]);
-      const float avg_out = log2(blurred_in_out[k * ch + kc * 2 + 1]);
+      const float avg_in = log2f(fmaxf(blurred_in_out[k * ch + kc * 2 + 0], 1E-6));
+      const float avg_out = log2f(fmaxf(blurred_in_out[k * ch + kc * 2 + 1], 1E-6));
       w *= expf(-fmaxf(fabsf(avg_out - avg_in), 0.01f) * safety);
     }
     for(size_t kc = 0; kc <= 1; kc++)


### PR DESCRIPTION
Fixes #6965

## Why another chromatic aberration correction module
Chromatic aberration can currently be corrected using several ways in darktable:
- lens correction module (cannot correct all chromatic aberrations)
- chromatic aberration module (it is too early in pipeline, due to that lens correction may add new aberration instead of correcting the existing one. Also, it does not work for xtrans sensors)
- defringe (it is too late in pipeline: strong blue CA give black edges due to colorin, and gives color halos around edges)

## Main characteristics
This PR adds a new module (after lens correction and before colorin in pipeline) to correct chromatic aberration.
It works on any kind of chromatic aberration whatever the physical cause (unaligned channels, some channels out of focus, ...).
It gives way lower color halos than defringe.
It is also quite fast, execution time is independent from the radius (relies on gaussian blur, execution time is approximately 5x the execution time of a gaussian blur with 4 channels, as the algorithm uses 5 gaussian blurs).

## The algorithm
The algorithm is inspired by adaptive manifolds: https://www.inf.ufrgs.br/~eslgastal/AdaptiveManifolds/

The main idea is to locally find a function to approximate the channel to correct from the guide channel.
Let's say our guide channel is the green channel.
We could use a very simple function based on the ratio of local averages:
`R = local_average_R * G / local_average_G`
This works quite well but produces color halos.

We use adaptive manifolds to make the function more complex, while still keeping its formula very simple (we don't want overfitting, or we would not correct anything).
We construct 2 local averages per channels, one average of the pixels that are higher of the local average, and one average of the pixels that are lower than the local average.
See in this graph, the green line is the average of dots that are higher than average, and the red line is the average of dots that are lower than average:

![manifolds](https://user-images.githubusercontent.com/34063828/103461857-adcbb480-4d21-11eb-8f19-a99000e42c84.png)

We compute the manifolds based only on the guide average, this way we split the pixels in a consistent way across channels.

Then, we compute the ratio of the higher manifolds and lower manifolds, and approximate the result based on the distance of the input pixel of the guide channel to the 2 manifolds.

It is basically a refinement of the ratio of local averages that can handle edges.

## Some results
original image (lens correction is powerless for the CA of this image):
![Capture d’écran du 2021-01-02 17-51-15](https://user-images.githubusercontent.com/34063828/103462117-680feb80-4d23-11eb-9cc8-466167935637.png)

defringe (CA are removed but halos are very visible with the saturated blue sky):
![Capture d’écran du 2021-01-02 17-52-10](https://user-images.githubusercontent.com/34063828/103462115-66debe80-4d23-11eb-8df3-c89a274c62b0.png)

this PR (only some small artefacts in the sky close to the bird beak and the yellow area, due to the fact that our function is too sparse to accurately model this area that has 3 very different colors in a small area)
![Capture d’écran du 2021-01-02 17-51-19](https://user-images.githubusercontent.com/34063828/103462116-67775500-4d23-11eb-90f9-24c818dabc91.png)

## TODO
rebase on master, code cleanup, git cleanup...