### PR TITLE
RCD fixing (1)

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -60,7 +60,7 @@ typedef enum dt_iop_demosaic_method_t
   DT_IOP_DEMOSAIC_VNG4 = 2,  // $DESCRIPTION: "VNG4"
   DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME = 3, // $DESCRIPTION: "passthrough (monochrome) (experimental)"
   DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR = 4, // $DESCRIPTION: "photosite color (debug)"
-  DT_IOP_DEMOSAIC_RCD = 5, // // $DESCRIPTION: "RCD"
+  DT_IOP_DEMOSAIC_RCD = 5,   // $DESCRIPTION: "RCD"
   // methods for x-trans images
   DT_IOP_DEMOSAIC_VNG = DEMOSAIC_XTRANS | 0,           // $DESCRIPTION: "VNG"
   DT_IOP_DEMOSAIC_MARKESTEIJN = DEMOSAIC_XTRANS | 1,   // $DESCRIPTION: "Markesteijn 1-pass"
@@ -2921,10 +2921,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     {
       passthrough_color(tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans);
     }
-    else if(demosaicing_method == DT_IOP_DEMOSAIC_RCD)
-    {
-      rcd_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters);
-    }
     else if(piece->pipe->dsc.filters == 9u)
     {
       if(demosaicing_method == DT_IOP_DEMOSAIC_FDC && (qual_flags & DEMOSAIC_XTRANS_FULL))
@@ -2972,6 +2968,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, data->CAM_to_RGB);
           dt_colorspaces_cygm_to_rgb(piece->pipe->dsc.processed_maximum, 1, data->CAM_to_RGB);
         }
+      }
+      else if(demosaicing_method == DT_IOP_DEMOSAIC_RCD)
+      {
+        rcd_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters);
       }
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
         demosaic_ppg(tmp, in, &roo, &roi, piece->pipe->dsc.filters,
@@ -4991,7 +4991,6 @@ void gui_update(struct dt_iop_module_t *self)
 
   const gboolean bayer = (self->dev->image_storage.buf_dsc.filters != 9u);
   const gboolean isppg = (p->demosaicing_method == DT_IOP_DEMOSAIC_PPG);
-  const gboolean isrcd = (p->demosaicing_method == DT_IOP_DEMOSAIC_RCD);
   const gboolean passing = ((p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
@@ -5005,7 +5004,7 @@ void gui_update(struct dt_iop_module_t *self)
     dt_bauhaus_combobox_set_from_value(g->demosaic_method_xtrans, p->demosaicing_method);
 
   gtk_widget_set_visible(g->median_thrs, bayer && isppg);
-  gtk_widget_set_visible(g->greeneq, !passing && !isrcd);
+  gtk_widget_set_visible(g->greeneq, !passing);
   gtk_widget_set_visible(g->color_smoothing, !passing);
 
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, self->dev->image_storage.id, 'w');
@@ -5052,7 +5051,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   const gboolean bayer = (self->dev->image_storage.buf_dsc.filters != 9u);
   const gboolean isppg = (p->demosaicing_method == DT_IOP_DEMOSAIC_PPG);
-  const gboolean isrcd = (p->demosaicing_method == DT_IOP_DEMOSAIC_RCD);
   const gboolean passing = ((p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
@@ -5066,7 +5064,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     dt_bauhaus_combobox_set_from_value(g->demosaic_method_xtrans, p->demosaicing_method);
 
   gtk_widget_set_visible(g->median_thrs, bayer && isppg);
-  gtk_widget_set_visible(g->greeneq, !passing && !isrcd);
+  gtk_widget_set_visible(g->greeneq, !passing);
   gtk_widget_set_visible(g->color_smoothing, !passing);
 
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, self->dev->image_storage.id, 'w');

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -323,8 +323,11 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
 #endif
   { 
     float *const VH_Dir = dt_alloc_align_float((size_t) RCD_TILESIZE * RCD_TILESIZE);
+    memset(VH_Dir, 0, sizeof(*VH_Dir) * RCD_TILESIZE * RCD_TILESIZE);
     float *const PQ_Dir = dt_alloc_align_float((size_t) RCD_TILESIZE * RCD_TILESIZE / 2);
+    memset(PQ_Dir, 0, sizeof(*PQ_Dir) * (RCD_TILESIZE * RCD_TILESIZE / 2));
     float *const cfa =    dt_alloc_align_float((size_t) RCD_TILESIZE * RCD_TILESIZE);
+    memset(cfa, 0, sizeof(*cfa) * RCD_TILESIZE * RCD_TILESIZE);
     float (*const rgb)[RCD_TILESIZE * RCD_TILESIZE] = (void *)dt_alloc_align_float((size_t)3 * RCD_TILESIZE * RCD_TILESIZE);
 
     // No overlapping use so re-use same buffer; also note we use divide-by-2 index for lower mem pressure

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -205,6 +205,7 @@ static INLINE void approxit(float *out, const float *cfa, const float *sum, cons
       rgb[idx][2] = fmaxf(0.0f, cfa[idx]);
     }
   }
+  rgb[idx][3] = 0.0f;
 }
 
 static void rcd_border_interpolate(float *out, const float *cfa, const int *cfarray, const int width, const int height, int border, float scaler)


### PR DESCRIPTION
This collective PR

1. does some slightly faster processing avoiding CLIP and using normalised input data in a safe range
2. Always writes 0.0f to the alpha channel too
3. Allows the green matching for rcd demosaicer too
4. Likely fixes #7558 by clearing allocated buffers as hinted by @heckflosse. Probably this is a fix, if not it won't hurt and will set data in a safe way...