### PR TITLE
iop_profile: fix order of matrix multiplications

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -446,7 +446,7 @@ static inline void _transform_matrix_rgb(const float *const restrict image_in,
   // RGB -> XYZ -> RGB are 2 matrices products, they can be premultiplied globally ahead
   // and put in a new matrix. then we spare one matrix product per pixel.
   float matrix[9] DT_ALIGNED_ARRAY;
-  mat3mul(matrix, profile_info_from->matrix_in, profile_info_to->matrix_out);
+  mat3mul(matrix, profile_info_to->matrix_out, profile_info_from->matrix_in);
 
   if(profile_info_from->nonlinearlut || profile_info_to->nonlinearlut)
   {
@@ -1502,7 +1502,7 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
     lut_to_cl = dt_ioppr_get_trc_cl(profile_info_to);
 
     float matrix[9] DT_ALIGNED_PIXEL;
-    mat3mul(matrix, profile_info_from->matrix_in, profile_info_to->matrix_out);
+    mat3mul(matrix, profile_info_to->matrix_out, profile_info_from->matrix_in);
 
     if(in_place)
     {


### PR DESCRIPTION
PR https://github.com/darktable-org/darktable/pull/7597 changed the matrices to be the right ones, however the order of multiplication was still incorrect.