### PR TITLE
Profile list: clarify which system display profile is preview

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1403,7 +1403,7 @@ dt_colorspaces_t *dt_colorspaces_init()
                                      _("system display profile"), -1, -1, ++display_pos, ++category_pos, -1, -1));
   res->profiles = g_list_append(
       res->profiles, _create_profile(DT_COLORSPACE_DISPLAY2, dt_colorspaces_create_srgb_profile(),
-                                     _("system display profile"), -1, -1, -1, ++category_pos, -1, ++display2_pos));
+                                     _("system display profile (second window)"), -1, -1, -1, ++category_pos, -1, ++display2_pos));
   // we want a v4 with parametric curve for input and a v2 with point trc for output
   // see http://ninedegreesbelow.com/photography/lcms-make-icc-profiles.html#profile-variants-and-versions
   // TODO: what about display?
@@ -1661,7 +1661,7 @@ const char *dt_colorspaces_get_name(dt_colorspaces_color_profile_type_t type,
      case DT_COLORSPACE_WORK:
        return _("work profile");
      case DT_COLORSPACE_DISPLAY2:
-       return _("system display profile");
+       return _("system display profile (second window)");
      case DT_COLORSPACE_REC709:
        return _("gamma22 Rec709");
      case DT_COLORSPACE_PROPHOTO_RGB:


### PR DESCRIPTION
This prevents having a duplicate "system display profile" entry in the histogram profile combobox and clearly indicates which profile is which.

Note that this also renames "system display profile" to "system display profile (preview)" in the "preview display profile" combobox. I think this is beneficial since it may be different from the "system display profile" in the "display profile" combobox (if the preview window is on a different display).