### PR TITLE
basics : disable on canvas controls

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2122,6 +2122,7 @@ static void popup_callback(GtkButton *button, dt_iop_module_t *module)
 void dt_iop_request_focus(dt_iop_module_t *module)
 {
   if(darktable.gui->reset || (darktable.develop->gui_module == module)) return;
+  if(module && dt_dev_modulegroups_get(darktable.develop) == DT_MODULEGROUP_BASICS) return;
 
   if(darktable.develop->gui_module != module) darktable.develop->focus_hash++;
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -659,7 +659,8 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     }
     else
     {
-      gchar *txt = dt_util_dstrcat(NULL, "%s (%s)\n\n%s", item->widget_name, item->module->name(), item->tooltip);
+      gchar *txt = dt_util_dstrcat(NULL, "%s (%s)\n\n%s\n\n%s", item->widget_name, item->module->name(),
+                                   item->tooltip, _("(some features may only be available in the full module)"));
       gtk_widget_set_tooltip_text(item->widget, txt);
       g_free(txt);
     }


### PR DESCRIPTION
this fix #7647 
- this don't put focus on modules when using basics widgets and so avoid the use of on canvas controls, which will result sooner or later to weird issues as we don't have the full module open...
- this also add a warning in widgets tooltips to say that some features may only be available inside the full module.