### PR TITLE
thumb generation prefs rework

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -167,7 +167,7 @@
     <shortdescription>enable disk backend for full preview cache</shortdescription>
     <longdescription>if enabled, write full preview to disk (.cache/darktable/) when evicted from the memory cache. note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again. it's safe though to delete these manually, if you want. light table performance will be increased greatly when zooming image in full preview mode.</longdescription>
   </dtconfig>
-  <dtconfig prefs="lighttable" section="thumbs">
+  <dtconfig>
     <name>cache_color_managed</name>
     <type>bool</type>
     <default>true</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -279,13 +279,6 @@
     <shortdescription>timeout period of pixelpipe synchronization</shortdescription>
     <longdescription>time period (in units of 5ms) after which synchronization of preview and full pixelpipe is assumed to have failed. set to zero to omit pixelpipe synchronization. defaults to 200.</longdescription>
   </dtconfig>
-  <dtconfig prefs="lighttable" section="thumbs">
-    <name>never_use_embedded_thumb</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>don't use embedded preview JPEG but half-size raw</shortdescription>
-    <longdescription>check this option to not use the embedded JPEG from the raw file but process the raw data. this is slower but gives you color managed thumbnails.</longdescription>
-  </dtconfig>
   <dtconfig prefs="storage" section="xmp">
     <name>write_sidecar_files</name>
     <type>bool</type>
@@ -901,6 +894,25 @@
     <default>0</default>
     <shortdescription>last timeline zoom.</shortdescription>
     <longdescription/>
+  </dtconfig>
+  <dtconfig prefs="lighttable" section="thumbs">
+    <name>plugins/lighttable/thumbnail_raw_min_level</name>
+   <type>
+      <enum>
+        <option>always</option>
+        <option>small</option>
+        <option>VGA</option>
+        <option>720p</option>
+        <option>1080p</option>
+        <option>WQXGA</option>
+        <option>4K</option>
+        <option>5K</option>
+        <option>never</option>
+      </enum>
+    </type>
+    <default>never</default>
+    <shortdescription>thumb use raw file instead of embedded JPEG from size</shortdescription>
+    <longdescription>if the thumbnail size is greater than this value, it will be processed using raw datas instead of the embedded preview JPEG (better but slower).</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/thumbnail_hq_min_level</name>

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -581,8 +581,11 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
   // the orientation for this camera is not read correctly from exiv2, so we need
   // to go the full path (as the thumbnail will be flipped the wrong way round)
   const int incompatible = !strncmp(img.exif_maker, "Phase One", 9);
-  if(!img.verified_size && !dt_image_altered(imgid) && !dt_conf_get_bool("never_use_embedded_thumb")
-     && !incompatible)
+  char *min = dt_conf_get_string("plugins/lighttable/thumbnail_raw_min_level");
+  const gboolean use_raw = g_strcmp0(min, "never");
+  g_free(min);
+
+  if(!img.verified_size && !dt_image_altered(imgid) && !use_raw && !incompatible)
   {
     // we want to be sure to have the real image size.
     // some raw files need a pass via rawspeed to get it.

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -969,6 +969,19 @@ dt_mipmap_size_t dt_mipmap_cache_get_matching_size(const dt_mipmap_cache_t *cach
   return best;
 }
 
+dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(char *value)
+{
+  if(strcmp(value, "always") == 0) return DT_MIPMAP_0;
+  if(strcmp(value, "small") == 0) return DT_MIPMAP_1;
+  if(strcmp(value, "VGA") == 0) return DT_MIPMAP_2;
+  if(strcmp(value, "720p") == 0) return DT_MIPMAP_3;
+  if(strcmp(value, "1080p") == 0) return DT_MIPMAP_4;
+  if(strcmp(value, "WQXGA") == 0) return DT_MIPMAP_5;
+  if(strcmp(value, "4k") == 0) return DT_MIPMAP_6;
+  if(strcmp(value, "5K") == 0) return DT_MIPMAP_7;
+  return DT_MIPMAP_NONE;
+}
+
 void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid)
 {
   // get rid of all ldr thumbnails:
@@ -1163,7 +1176,12 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
   const int incompatible = !strncmp(cimg->exif_maker, "Phase One", 9);
   dt_image_cache_read_release(darktable.image_cache, cimg);
 
-  if(!altered && !dt_conf_get_bool("never_use_embedded_thumb") && !incompatible)
+  char *min = dt_conf_get_string("plugins/lighttable/thumbnail_raw_min_level");
+  const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
+  g_free(min);
+  const gboolean use_embedded = (size <= min_s);
+
+  if(!altered && use_embedded && !incompatible)
   {
     const dt_image_orientation_t orientation = dt_image_get_orientation(imgid);
 

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -164,6 +164,8 @@ dt_colorspaces_color_profile_type_t dt_mipmap_cache_get_colorspace();
 // only copies over the jpg backend on disk, doesn't directly affect the in-memory cache.
 void dt_mipmap_cache_copy_thumbnails(const dt_mipmap_cache_t *cache, const uint32_t dst_imgid, const uint32_t src_imgid);
 
+// return the mipmap corresponding to text value saved in prefs
+dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(char *value);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2791,19 +2791,11 @@ static int get_thumb_quality(int width, int height)
   // we check if we need ultra-high quality thumbnail for this size
   char *min = dt_conf_get_string("plugins/lighttable/thumbnail_hq_min_level");
 
-  int level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
-  int res = 0;
-  if (strcmp(min, "always")==0) res = 1;
-  else if (strcmp(min, "small")==0) res = ( level >= 1 );
-  else if (strcmp(min, "VGA")==0) res = ( level >= 2 );
-  else if (strcmp(min, "720p")==0) res = ( level >= 3 );
-  else if (strcmp(min, "1080p")==0) res = ( level >= 4 );
-  else if (strcmp(min, "WQXGA")==0) res = ( level >= 5 );
-  else if (strcmp(min, "4k")==0) res = ( level >= 6 );
-  else if (strcmp(min, "5K")==0) res = ( level >= 7 );
-
+  const int level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
+  const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
   g_free(min);
-  return res;
+
+  return (level >= min_s);
 }
 
 // set flags for demosaic quality based on factors besides demosaic
@@ -4996,7 +4988,7 @@ void gui_update(struct dt_iop_module_t *self)
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_COLORX));
 
-  gtk_widget_set_visible(g->demosaic_method_bayer, bayer); 
+  gtk_widget_set_visible(g->demosaic_method_bayer, bayer);
   gtk_widget_set_visible(g->demosaic_method_xtrans, !bayer);
   if(bayer)
     dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayer, p->demosaicing_method);
@@ -5056,7 +5048,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_COLORX));
 
-  gtk_widget_set_visible(g->demosaic_method_bayer, bayer); 
+  gtk_widget_set_visible(g->demosaic_method_bayer, bayer);
   gtk_widget_set_visible(g->demosaic_method_xtrans, !bayer);
   if(bayer)
     dt_bauhaus_combobox_set_from_value(g->demosaic_method_bayer, p->demosaicing_method);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -934,6 +934,8 @@ int dt_view_get_image_to_act_on()
 dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface,
                                                   const gboolean quality)
 {
+  const double tt = dt_get_wtime();
+
   dt_view_surface_value_t ret = DT_VIEW_SURFACE_KO;
   // if surface not null, clean it up
   if(*surface && cairo_surface_get_reference_count(*surface) > 0) cairo_surface_destroy(*surface);
@@ -961,8 +963,6 @@ dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int heig
   const int img_width = buf_wd * scale;
   const int img_height = buf_ht * scale;
   *surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_width, img_height);
-
-  dt_print(DT_DEBUG_LIGHTTABLE, "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i\n", imgid, width, height, buf_wd, buf_ht, img_width, img_height);
 
   // we transfer cached image on a cairo_surface (with colorspace transform if needed)
   cairo_surface_t *tmp_surface = NULL;
@@ -1078,6 +1078,10 @@ dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int heig
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
   if(rgbbuf) free(rgbbuf);
+
+  dt_print(DT_DEBUG_LIGHTTABLE,
+           "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i created in %0.04f sec\n", imgid,
+           width, height, buf_wd, buf_ht, img_width, img_height, dt_get_wtime() - tt);
 
   // we consider skull as ok as the image hasn't to be reload
   return ret;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -934,7 +934,9 @@ int dt_view_get_image_to_act_on()
 dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface,
                                                   const gboolean quality)
 {
-  const double tt = dt_get_wtime();
+  double tt = 0;
+  if((darktable.unmuted & (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF)) == (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF))
+    tt = dt_get_wtime();
 
   dt_view_surface_value_t ret = DT_VIEW_SURFACE_KO;
   // if surface not null, clean it up
@@ -1079,9 +1081,18 @@ dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int heig
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
   if(rgbbuf) free(rgbbuf);
 
-  dt_print(DT_DEBUG_LIGHTTABLE,
-           "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i created in %0.04f sec\n", imgid,
-           width, height, buf_wd, buf_ht, img_width, img_height, dt_get_wtime() - tt);
+  // logs
+  if((darktable.unmuted & (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF)) == (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF))
+  {
+    dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF,
+             "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i created in %0.04f sec\n",
+             imgid, width, height, buf_wd, buf_ht, img_width, img_height, dt_get_wtime() - tt);
+  }
+  else if(darktable.unmuted & DT_DEBUG_LIGHTTABLE)
+  {
+    dt_print(DT_DEBUG_LIGHTTABLE, "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i\n", imgid,
+             width, height, buf_wd, buf_ht, img_width, img_height);
+  }
 
   // we consider skull as ok as the image hasn't to be reload
   return ret;


### PR DESCRIPTION
this PR add following changes : 
1. make thumb color management pref hidden (true by default) as it *seems* to cost about nothing in time (use `-d lighttable` to check).
2. make embedded preview usage size dependent (default = always use preview) This allow to use embedded preview only for small thumbs, where accuracy is less useful but timer is, and use raw for culling or full preview, where one would want more accurate images.
3. refactor a little bit

For point 1, observations have been done on my machine only, so it would be great if some other people can check their timings too. In the code the colormanagement is done each time the thumb needs to be shown. That means this is not the "thumb creation" timings that differ, but only the "image surface" creation from the cache. Here timmings are < 0.04 s even with colormanagement...
To check, use `-d lighttable` with this PR (I've added the timmings)