### PR TITLE
[masks/imageio] track module name changes in mask manager

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1050,7 +1050,7 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
     gtk_widget_destroy(entry);
     dt_iop_show_hide_header_buttons(module->header, NULL, TRUE, FALSE); // after removing entry
     dt_iop_gui_update_header(module);
-
+    dt_masks_group_update_name(module);
     return TRUE;
   }
 

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "common/darktable.h"
 #include "common/opencl.h"
 #include "develop/pixelpipe.h"
 #include "dtgtk/button.h"
@@ -328,6 +329,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *g
 void dt_masks_gui_form_save_creation(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *form,
                                      dt_masks_form_gui_t *gui);
 void dt_masks_group_ungroup(dt_masks_form_t *dest_grp, dt_masks_form_t *grp);
+void dt_masks_group_update_name(dt_iop_module_t *module);
 dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_form_t *form);
 
 void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton, struct dt_iop_module_t *module);


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/7640

Track module name changes in mask manager.
Currently shapes in the mask manager get the name of module which created it, however once the module name is changed the change it not propagated to the mask manger, the old module name still is associated with the shape in the mask manager.

Additionally some refactoring in `masks.c` was done to reduce code duplication.
