### PR TITLE
add a diffusion module

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -190,14 +190,14 @@ inline void compute_kern(const float4 c2,
     }
     case(DT_ISOTROPY_ISOPHOTE):
     {
-      float4 a[2][2] = { { 0.f } };
+      float4 a[2][2] = { { (float4)0.f } };
       rotation_matrix_isophote(c2, cos_theta, sin_theta, cos_theta2, sin_theta2, a);
       build_matrix(a, kern);
       break;
     }
     case(DT_ISOTROPY_GRADIENT):
     {
-      float4 a[2][2] = { { 0.f } };
+      float4 a[2][2] = { { (float4)0.f } };
       rotation_matrix_gradient(c2, cos_theta, sin_theta, cos_theta2, sin_theta2, a);
       build_matrix(a, kern);
       break;

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2018-2020 darktable developers.
+    copyright (c) 2021 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,15 +19,345 @@
 #include "common.h"
 #include "noise_generator.h"
 
+// use our own coordinate sampler
+const sampler_t samplerA = CLK_NORMALIZED_COORDS_FALSE |
+                           CLK_ADDRESS_NONE            |
+                           CLK_FILTER_NEAREST;
+
+typedef enum dt_isotropy_t
+{
+  DT_ISOTROPY_ISOTROPE = 0, // diffuse in all directions with same intensity
+  DT_ISOTROPY_ISOPHOTE = 1, // diffuse more in the isophote direction (orthogonal to gradient)
+  DT_ISOTROPY_GRADIENT = 2  // diffuse more in the gradient direction
+} dt_isotropy_t;
+
+
 kernel void
-diffuse(read_only image2d_t in, write_only image2d_t out,
-        const int width, const int height)
+diffuse_init(read_only image2d_t in, write_only image2d_t out,
+             const int width, const int height)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  float4 i = read_imagef(in, sampleri, (int2)(x, y));
-  write_imagef(out, (int2)(x, y), i);
+  write_imagef(out, (int2)(x, y), (float4)0.f);
+}
+
+#define FSIZE 5
+
+kernel void
+diffuse_blur_bspline(read_only image2d_t in,
+                     write_only image2d_t HF, write_only image2d_t LF,
+                     const int mult, const int width, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 acc = 0.f;
+
+  for(int ii = 0; ii < FSIZE; ++ii)
+    for(int jj = 0; jj < FSIZE; ++jj)
+    {
+      const int row = clamp(y + mult * (int)(ii - (FSIZE - 1) / 2), 0, height - 1);
+      const int col = clamp(x + mult * (int)(jj - (FSIZE - 1) / 2), 0, width - 1);
+      const int k_index = (row * width + col);
+
+      const float filter[FSIZE]
+          = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+      const float filters = filter[ii] * filter[jj];
+
+      acc += filters * read_imagef(in, samplerA, (int2)(col, row));
+    }
+
+  write_imagef(LF, (int2)(x, y), acc);
+  write_imagef(HF, (int2)(x, y), read_imagef(in, samplerA, (int2)(x, y)) - acc);
+}
+
+// Discretization parameters for the Partial Derivative Equation solver
+#define H 1         // spatial step
+#define KAPPA 0.25f // 0.25 if h = 1, 1 if h = 2
+
+
+inline void find_gradient(const float4 pixels[9], float4 xy[2])
+{
+  // Compute the gradient with centered finite differences in a 3×3 stencil
+  // warning : x is vertical, y is horizontal
+  xy[0] = (pixels[7] - pixels[1]) / 2.f;
+  xy[1] = (pixels[5] - pixels[3]) / 2.f;
+}
+
+inline void find_laplacian(const float4 pixels[9], float4 xy[2])
+{
+  // Compute the laplacian with centered finite differences in a 3×3 stencil
+  // warning : x is vertical, y is horizontal
+  xy[0] = (pixels[7] + pixels[1]) - 2.f * pixels[4];
+  xy[1] = (pixels[5] + pixels[3]) - 2.f * pixels[4];
+}
+
+inline float4 sqf(const float4 in)
+{
+  return in * in;
+}
+
+inline void rotation_matrix_isophote(const float4 c2,
+                                     const float4 cos_theta, const float4 sin_theta,
+                                     const float4 cos_theta2, const float4 sin_theta2,
+                                     float4 a[2][2])
+{
+  // Write the coefficients of a square symmetrical matrice of rotation of the gradient :
+  // [[ a11, a12 ],
+  //  [ a12, a22 ]]
+  // taken from https://www.researchgate.net/publication/220663968
+  // c dampens the gradient direction
+  a[0][0] = clamp(cos_theta2 + c2 * sin_theta2, 0.f, 1.f);
+  a[1][1] = clamp(c2 * cos_theta2 + sin_theta2, 0.f, 1.f);
+  a[0][1] = a[1][0] = clamp((c2 - 1.0f) * cos_theta * sin_theta, 0.f, 1.f);
+}
+
+inline void rotation_matrix_gradient(const float4 c2,
+                                     const float4 cos_theta, const float4 sin_theta,
+                                     const float4 cos_theta2, const float4 sin_theta2,
+                                     float4 a[2][2])
+{
+  // Write the coefficients of a square symmetrical matrice of rotation of the gradient :
+  // [[ a11, a12 ],
+  //  [ a12, a22 ]]
+  // based on https://www.researchgate.net/publication/220663968 and inverted
+  // c dampens the isophote direction
+  a[0][0] = clamp(c2 * cos_theta2 + sin_theta2, 0.f, 1.f);
+  a[1][1] = clamp(cos_theta2 + c2 * sin_theta2, 0.f, 1.f);
+  a[0][1] = a[1][0] = clamp((1.0f - c2) * cos_theta * sin_theta, 0.f, 1.f);
+}
+
+
+inline void build_matrix(const float4 a[2][2], float4 kern[9])
+{
+  const float4 b13 = a[0][1] / 2.0f;
+  const float4 b11 = -b13;
+  const float4 b22 = -2.0f * (a[0][0] + a[1][1]);
+
+  // build the kernel of rotated anisotropic laplacian
+  // from https://www.researchgate.net/publication/220663968 :
+  // [ [ -a12 / 2,  a22,           a12 / 2  ],
+  //   [ a11,      -2 (a11 + a22), a11      ],
+  //   [ a12 / 2,   a22,          -a12 / 2  ] ]
+  kern[0] = b11;
+  kern[1] = a[1][1];
+  kern[2] = b13;
+  kern[3] = a[0][0];
+  kern[4] = b22;
+  kern[5] = a[0][0];
+  kern[6] = b13;
+  kern[7] = a[1][1];
+  kern[8] = b11;
+}
+
+
+inline void isotrope_laplacian(float4 kern[9])
+{
+  // see in https://eng.aurelienpierre.com/2021/03/rotation-invariant-laplacian-for-2d-grids/#Second-order-isotropic-finite-differences
+  // for references (Oono & Puri)
+  kern[0] = 0.25f;
+  kern[1] = 0.5f;
+  kern[2] = 0.25f;
+  kern[3] = 0.5f;
+  kern[4] = -3.f;
+  kern[5] = 0.5f;
+  kern[6] = 0.25f;
+  kern[7] = 0.5f;
+  kern[8] = 0.25f;
+}
+
+
+inline void compute_kern(const float4 c2,
+                           const float4 cos_theta, const float4 sin_theta,
+                           const float4 cos_theta2, const float4 sin_theta2,
+                           const dt_isotropy_t isotropy_type,
+                           float4 kern[9])
+{
+  // Build the matrix of rotation with anisotropy
+
+  switch(isotropy_type)
+  {
+    case(DT_ISOTROPY_ISOTROPE):
+    default:
+    {
+      isotrope_laplacian(kern);
+      break;
+    }
+    case(DT_ISOTROPY_ISOPHOTE):
+    {
+      float4 a[2][2] = { { 0.f } };
+      rotation_matrix_isophote(c2, cos_theta, sin_theta, cos_theta2, sin_theta2, a);
+      build_matrix(a, kern);
+      break;
+    }
+    case(DT_ISOTROPY_GRADIENT):
+    {
+      float4 a[2][2] = { { 0.f } };
+      rotation_matrix_gradient(c2, cos_theta, sin_theta, cos_theta2, sin_theta2, a);
+      build_matrix(a, kern);
+      break;
+    }
+  }
+}
+
+
+kernel void
+diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
+            read_only image2d_t mask, const int has_mask,
+            write_only image2d_t output,
+            const int width, const int height,
+            const float4 anisotropy, const int4 isotropy_type,
+            const float regularization, const float variance_threshold,
+            const float current_radius_square, const int mult,
+            const float4 ABCD, const float strength)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  const char opacity = (has_mask) ? read_imageui(mask, sampleri, (int2)(x, y)).x : 1;
+
+  float4 out;
+
+  if(opacity)
+  {
+    // non-local neighbours coordinates
+    const int j_neighbours[3] = {
+      clamp((x - mult * H), 0, width - 1),
+      x,
+      clamp((x + mult * H), 0, width - 1) };
+    const int i_neighbours[3] = {
+      clamp((y - mult * H), 0, height - 1),
+      y,
+      clamp((y + mult * H), 0, height - 1) };
+
+    // fetch non-local pixels and store them locally and contiguously
+    float4 neighbour_pixel_HF[9];
+    float4 neighbour_pixel_LF[9];
+
+    for(int ii = 0; ii < 3; ii++)
+      for(int jj = 0; jj < 3; jj++)
+      {
+        neighbour_pixel_HF[3 * ii + jj] = read_imagef(HF, samplerA, (int2)(j_neighbours[ii], i_neighbours[jj]));
+        neighbour_pixel_LF[3 * ii + jj] = read_imagef(LF, samplerA, (int2)(j_neighbours[ii], i_neighbours[jj]));
+      }
+
+    // build the local anisotropic convolution filters for gradients and laplacians
+    // we use the low freq layer all the type as it is less likely to be nosy
+    float4 gradient[2], laplacian[2];
+    find_gradient(neighbour_pixel_LF, gradient);
+    find_laplacian(neighbour_pixel_LF, laplacian);
+
+    const float4 magnitude_grad = hypot(gradient[0], gradient[1]);
+    const float4 magnitude_lapl = hypot(laplacian[0], laplacian[1]);
+
+    const float4 theta_grad = atan2(gradient[1], gradient[0]);
+    const float4 theta_lapl = atan2(laplacian[1], laplacian[0]);
+
+    const float4 cos_theta_grad = native_cos(theta_grad);
+    const float4 cos_theta_lapl = native_cos(theta_lapl);
+    const float4 sin_theta_grad = native_sin(theta_grad);
+    const float4 sin_theta_lapl = native_sin(theta_lapl);
+
+    const float4 cos_theta_grad_sq = sqf(cos_theta_grad);
+    const float4 sin_theta_grad_sq = sqf(sin_theta_grad);
+    const float4 cos_theta_lapl_sq = sqf(cos_theta_lapl);
+    const float4 sin_theta_lapl_sq = sqf(sin_theta_lapl);
+
+    // c² in https://www.researchgate.net/publication/220663968
+    // warning : in c2[s], s is the order of the derivative
+    const float4 c2[4] = { native_exp(-magnitude_grad / anisotropy.x),
+                           native_exp(-magnitude_lapl / anisotropy.y),
+                           native_exp(-magnitude_grad / anisotropy.z),
+                           native_exp(-magnitude_lapl / anisotropy.w) };
+
+    float4 kern_first[9], kern_second[9], kern_third[9], kern_fourth[9];
+    compute_kern(c2[0], cos_theta_grad, sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.x, kern_first);
+    compute_kern(c2[1], cos_theta_lapl, sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.y, kern_second);
+    compute_kern(c2[2], cos_theta_grad, sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.z, kern_third);
+    compute_kern(c2[3], cos_theta_lapl, sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.w, kern_fourth);
+
+    // convolve filters and compute the variance and the regularization term
+    float4 derivatives[4] = { (float4)0.f };
+    float4 variance = (float4)0.f;
+
+    #pragma unroll
+    for(int k = 0; k < 9; k++)
+    {
+      derivatives[0] += kern_first[k] * neighbour_pixel_LF[k];
+      derivatives[1] += kern_second[k] * neighbour_pixel_LF[k];
+      derivatives[2] += kern_third[k] * neighbour_pixel_HF[k];
+      derivatives[3] += kern_fourth[k] * neighbour_pixel_HF[k];
+      variance += sqf(neighbour_pixel_HF[k]);
+    }
+
+    // Regularize the variance taking into account the blurring scale.
+    // This allows to keep the scene-referred variance roughly constant
+    // regardless of the wavelet scale where we compute it.
+    // Prevents large scale halos when deblurring.
+    variance /= 9.f / current_radius_square;
+    variance = variance_threshold + variance * regularization;
+
+    // compute the update
+    float4 acc = (float4)0.f;
+    for(int k = 0; k < 4; k++) acc += derivatives[k] * ((float *)&ABCD)[k];
+    float4 hf = read_imagef(HF, samplerA, (int2)(x, y));
+    acc = (hf + acc / variance) * strength;
+
+    // update the solution
+    float4 lf = read_imagef(LF, samplerA, (int2)(x, y));
+    out = fmax(acc + lf, 0.f);
+  }
+  else
+  {
+    float4 hf = read_imagef(HF, samplerA, (int2)(x, y));
+    float4 lf = read_imagef(LF, samplerA, (int2)(x, y));
+    out = hf + lf;
+  }
+
+  write_imagef(output, (int2)(x, y), out);
+}
+
+kernel void
+build_mask(read_only image2d_t in, write_only image2d_t mask,
+           const float threshold, const int width, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+  float4 pix_in = read_imagef(in, samplerA, (int2)(x, y));
+  float m = (pix_in.x > threshold || pix_in.y > threshold || pix_in.z > threshold);
+  write_imageui(mask, (int2)(x, y), m);
+}
+
+kernel void
+inpaint_mask(write_only image2d_t inpainted, read_only image2d_t original,
+              read_only image2d_t mask, const int width, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+  float4 pix_in = read_imagef(original, samplerA, (int2)(x, y));
+  char m = read_imageui(mask, samplerA, (int2)(x, y)).x;
+  float4 pix_out = pix_in;
+
+  if(m)
+  {
+    unsigned int state[4] = { splitmix32(x + 1), splitmix32((x + 1) * (y + 3)), splitmix32(1337), splitmix32(666) };
+    xoshiro128plus(state);
+    xoshiro128plus(state);
+    xoshiro128plus(state);
+    xoshiro128plus(state);
+    pix_out = fabs(gaussian_noise_simd(pix_in, pix_in, state));
+  }
+
+  write_imagef(inpainted, (int2)(x, y), pix_out);
 }

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -1,0 +1,33 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2018-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+#include "noise_generator.h"
+
+kernel void
+diffuse(read_only image2d_t in, write_only image2d_t out,
+        const int width, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 i = read_imagef(in, sampleri, (int2)(x, y));
+  write_imagef(out, (int2)(x, y), i);
+}

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -302,7 +302,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     // regardless of the wavelet scale where we compute it.
     // Prevents large scale halos when deblurring.
     variance /= 9.f / current_radius_square;
-    variance = variance_threshold + variance * regularization;
+    variance = variance_threshold + native_sqrt(variance * regularization);
 
     // compute the update
     float4 acc = (float4)0.f;

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -252,7 +252,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     // we use the low freq layer all the type as it is less likely to be nosy
     float4 gradient[2], laplacian[2];
     find_gradient(neighbour_pixel_LF, gradient);
-    find_laplacian(neighbour_pixel_LF, laplacian);
+    find_gradient(neighbour_pixel_HF, laplacian);
 
     const float4 magnitude_grad = hypot(gradient[0], gradient[1]);
     const float4 magnitude_lapl = hypot(laplacian[0], laplacian[1]);
@@ -308,7 +308,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     float4 acc = (float4)0.f;
     for(int k = 0; k < 4; k++) acc += derivatives[k] * ((float *)&ABCD)[k];
     float4 hf = read_imagef(HF, samplerA, (int2)(x, y));
-    acc = (hf + acc / variance) * strength;
+    acc = (hf * strength + acc / variance);
 
     // update the solution
     float4 lf = read_imagef(LF, samplerA, (int2)(x, y));

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -33,3 +33,4 @@ rgblevels.cl            29
 negadoctor.cl           30
 demosaic_rcd.cl         31
 channelmixer.cl         32
+diffuse.cl              33

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -32,6 +32,7 @@ build/lib/darktable/plugins/introspection_crop.c
 build/lib/darktable/plugins/introspection_defringe.c
 build/lib/darktable/plugins/introspection_demosaic.c
 build/lib/darktable/plugins/introspection_denoiseprofile.c
+build/lib/darktable/plugins/introspection_diffuse.c
 build/lib/darktable/plugins/introspection_dither.c
 build/lib/darktable/plugins/introspection_equalizer.c
 build/lib/darktable/plugins/introspection_exposure.c

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -106,6 +106,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {25.0f }, "profile_gamma", 0},
   { {26.0f }, "hazeremoval", 0},
   { {27.0f }, "colorin", 0},
+  { {27.5f }, "diffuse", 0},
   { {27.5f }, "channelmixerrgb", 0},
   { {27.5f }, "censorize", 0},
   { {27.5f }, "negadoctor", 0},
@@ -129,7 +130,6 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {43.0f }, "colorzones", 0},
   { {44.0f }, "lowlight", 0},
   { {45.0f }, "monochrome", 0},
-  { {45.5f }, "diffuse", 0},
   { {46.0f }, "filmic", 0},
   { {46.5f }, "filmicrgb", 0},
   { {47.0f }, "colisa", 0},
@@ -195,6 +195,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { {26.0f }, "profile_gamma", 0},
   { {27.0f }, "equalizer", 0},
   { {28.0f }, "colorin", 0},
+  { {28.5f }, "diffuse", 0},
   { {28.5f }, "channelmixerrgb", 0},
   { {28.5f }, "censorize", 0},
   { {28.5f }, "negadoctor", 0},      // Cineon film encoding comes after scanner input color profile
@@ -228,7 +229,6 @@ const dt_iop_order_entry_t v30_order[] = {
   { {43.0f }, "rgblevels", 0},       // same
   { {44.0f }, "basecurve", 0},       // conversion from scene-referred to display referred, reverse-engineered
                                   //    on camera JPEG default look
-  { {44.5f }, "diffuse", 0},
   { {45.0f }, "filmic", 0},          // same, but different (parametric) approach
   { {46.0f }, "filmicrgb", 0},       // same, upgraded
   { {47.0f }, "colisa", 0},          // edit contrast while damaging colour
@@ -663,7 +663,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "rgbcurve", "colorbalancergb");
           _insert_before(iop_order_list, "ashift", "cacorrectrgb");
           _insert_before(iop_order_list, "graduatednd", "crop");
-          _insert_before(iop_order_list, "filmicrgb", "diffuse");
+          _insert_before(iop_order_list, "channelmixerrgb", "diffuse");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -129,6 +129,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {43.0f }, "colorzones", 0},
   { {44.0f }, "lowlight", 0},
   { {45.0f }, "monochrome", 0},
+  { {45.5f }, "diffuse", 0},
   { {46.0f }, "filmic", 0},
   { {46.5f }, "filmicrgb", 0},
   { {47.0f }, "colisa", 0},
@@ -227,6 +228,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { {43.0f }, "rgblevels", 0},       // same
   { {44.0f }, "basecurve", 0},       // conversion from scene-referred to display referred, reverse-engineered
                                   //    on camera JPEG default look
+  { {44.5f }, "diffuse", 0},
   { {45.0f }, "filmic", 0},          // same, but different (parametric) approach
   { {46.0f }, "filmicrgb", 0},       // same, upgraded
   { {47.0f }, "colisa", 0},          // edit contrast while damaging colour
@@ -661,6 +663,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "rgbcurve", "colorbalancergb");
           _insert_before(iop_order_list, "ashift", "cacorrectrgb");
           _insert_before(iop_order_list, "graduatednd", "crop");
+          _insert_before(iop_order_list, "filmicrgb", "diffuse");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2250,6 +2250,8 @@ void *dt_opencl_alloc_device(const int devid, const int width, const int height,
     fmt = (cl_image_format){ CL_R, CL_FLOAT };
   else if(bpp == sizeof(uint16_t))
     fmt = (cl_image_format){ CL_R, CL_UNSIGNED_INT16 };
+  else if(bpp == sizeof(uint8_t))
+    fmt = (cl_image_format){ CL_R, CL_UNSIGNED_INT8 };
   else
     return NULL;
 

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -147,6 +147,7 @@ add_iop(channelmixerrgb "channelmixerrgb.c" "../chart/common.c")
 add_iop(censorize "censorize.c")
 add_iop(colorbalancergb "colorbalancergb.c")
 add_iop(cacorrectrgb "cacorrectrgb.c")
+add_iop(diffuse "diffuse.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -42,61 +42,37 @@
 DT_MODULE_INTROSPECTION(1, dt_iop_diffuse_params_t)
 
 #define MAX_NUM_SCALES 12
-
-typedef enum dt_iop_diffuse_model_t
-{
-  DT_DIFFUSE_GAUSSIAN    = 0,   // $DESCRIPTION: "gaussian (natural)"
-  DT_DIFFUSE_CONSTANT    = 1,   // $DESCRIPTION: "constant"
-  DT_DIFFUSE_LINEAR      = 2,   // $DESCRIPTION: "linear"
-  DT_DIFFUSE_QUADRATIC   = 3    // $DESCRIPTION: "quadratic"
-} dt_iop_diffuse_model_t;
-
-
-typedef enum dt_iop_diffuse_bokeh_t
-{
-  DT_DIFFUSE_BOKEH_NONE = 0,    // $DESCRIPTION: "ignore blur"
-  DT_DIFFUSE_BOKEH_EXCLUDE = 1, // $DESCRIPTION: "exclude all bokeh regions"
-  DT_DIFFUSE_BOKEH_INCLUDE = 2  // $DESCRIPTION: "include only bokeh regions"
-} dt_iop_diffuse_bokeh_t;
-
-
 typedef struct dt_iop_diffuse_params_t
 {
   // global parameters
-  int iterations;                 // $MIN: 1   $MAX: 20   $DEFAULT: 1  $DESCRIPTION: "iterations of diffusion"
-  float update;                   // $MIN: 0.  $MAX: 4.   $DEFAULT: 1. $DESCRIPTION: "speed of diffusion"
-  int radius;                     // $MIN: 1   $MAX: 1024 $DEFAULT: 8  $DESCRIPTION: "radius of diffusion"
-  dt_iop_diffuse_model_t model;
+  int iterations;       // $MIN: 1   $MAX: 12   $DEFAULT: 1  $DESCRIPTION: "iterations"
+  float sharpness;         // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "sharpness"
+  int radius;           // $MIN: 1   $MAX: 1024   $DEFAULT: 8  $DESCRIPTION: "radius"
+  float regularization; // $MIN: 0. $MAX: 6.   $DEFAULT: 0. $DESCRIPTION: "edge and noise avoiding"
+  float noise_threshold;// $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "edge/surface threshold"
+  float anisotropy;          // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "anisotropy"
 
   // masking
-  float threshold;                // $MIN: 0.  $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
-  dt_iop_diffuse_bokeh_t respect_bokeh; // $DEFAULT: 0 $DESCRIPTION: "lens blur"
+  float threshold; // $MIN: 0.  $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
 
   // first order derivative, anisotropic, aka first order integral of wavelets details scales
-  float base;                // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "strength"
-  float edges_base;          // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge directivity"
-  float regularization_base; // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge regularization"
+  float first;       // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "1st order (gradient)"
 
   // second order deritavite, isotropic, aka wavelets details scales
-  float zeroth;                   // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "strength"
-  float regularization_zeroth;    // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge regularization"
+  float second; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "2nd order (laplacian)"
 
   // third order derivative, anisotropic, aka first order derivative of wavelets details scales
-  float structure;                // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "strength"
-  float edges_structure;          // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge directivity"
-  float regularization_structure; // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge regularization"
+  float third;       // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "3rd order (gradient of laplacian)"
 
   // fourth order derivative, anisotropic, aka second order derivative of wavelets details scales
-  float texture;                  // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "strength"
-  float edges_texture;            // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge directivity"
-  float regularization_texture;   // $MIN: -8. $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "edge regularization"
+  float fourth;       // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "4th order (laplacian of laplacian)"
 } dt_iop_diffuse_params_t;
 
 
 typedef struct dt_iop_diffuse_gui_data_t
 {
-  GtkWidget *iterations, *texture, *structure, *zeroth, *edges_texture, *edges_structure, *radius, *update, *model, *threshold,
-      *regularization_texture, *regularization_structure, *respect_bokeh, *regularization_zeroth, *base, *edges_base, *regularization_base;
+  GtkWidget *iterations, *fourth, *third, *second, *radius, *sharpness, *threshold, *regularization, *first,
+      *anisotropy, *regularization_first, *noise_threshold;
 } dt_iop_diffuse_gui_data_t;
 
 
@@ -115,14 +91,13 @@ const char *aliases()
 
 const char *description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("simulate directional diffusion of light with heat transfer model\n"
-                                        "to apply an iterative edge-oriented blur, \n"
-                                        "inpaint damaged parts of the image,\n"
-                                        "or to remove blur with blind deconvolution."),
-                                      _("corrective and creative"),
-                                      _("linear, RGB, scene-referred"),
-                                      _("linear, RGB"),
-                                      _("linear, RGB, scene-referred"));
+  return dt_iop_set_description(self,
+                                _("simulate directional diffusion of light with heat transfer model\n"
+                                  "to apply an iterative edge-oriented blur, \n"
+                                  "inpaint damaged parts of the image,\n"
+                                  "or to remove blur with blind deconvolution."),
+                                _("corrective and creative"), _("linear, RGB, scene-referred"), _("linear, RGB"),
+                                _("linear, RGB, scene-referred"));
 }
 
 int default_group()
@@ -140,230 +115,162 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-
 void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_diffuse_params_t p;
   memset(&p, 0, sizeof(p));
 
-  p.iterations = 4;
+  p.iterations = 8;
   p.radius = 8;
-  p.update = 2.5f;
-  p.threshold = 0.f;
-  p.model = DT_DIFFUSE_GAUSSIAN;
-  p.respect_bokeh = TRUE;
+  p.sharpness = 0.01f;
+  p.threshold = 0.0f;
+  p.noise_threshold = -0.1f;
+  p.regularization = 4.5f;
+  p.anisotropy = 3.5f;
 
-  // first order
-  p.base = -0.15f;
-  p.edges_base = 3.5f;
-  p.regularization_base = 6.f;
-
-  // second order
-  p.zeroth = -0.5f;
-  p.regularization_zeroth = 3.5f;
-
-  // third order
-  p.structure = -0.75f;
-  p.edges_structure = 4.f;
-  p.regularization_structure = 3.5f;
-
-  // fourth order
-  p.texture = -1.f;
-  p.edges_texture = 3.f;
-  p.regularization_texture = 2.5f;
-
-  dt_gui_presets_add_generic(_("sharpen"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  p.first = +0.15f;
+  p.second = -0.15f;
+  p.third = 0.30f;
+  p.fourth = -0.30f;
+  dt_gui_presets_add_generic(_("remove medium lens blur"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.iterations = 4;
-  p.radius = 8;
-  p.update = 3.f;
-  p.threshold = 0.f;
-  p.model = DT_DIFFUSE_GAUSSIAN;
-  p.respect_bokeh = TRUE;
+  p.regularization = 4.f;
+  dt_gui_presets_add_generic(_("remove soft lens blur"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 
-  // first order
-  p.base = -0.25f;
-  p.edges_base = 3.5f;
-  p.regularization_base = 6.f;
-
-  // second order
-  p.zeroth = -0.75f;
-  p.regularization_zeroth = 3.5f;
-
-  // third order
-  p.structure = 1.f;
-  p.edges_structure = 4.f;
-  p.regularization_structure = 4.f;
-
-  // fourth order
-  p.texture = -1.f;
-  p.edges_texture = 3.f;
-  p.regularization_texture = 2.5f;
-
-  dt_gui_presets_add_generic(_("sharpen and denoise"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  p.iterations = 12;
+  p.regularization = 5.f;
+  dt_gui_presets_add_generic(_("remove heavy lens blur"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.iterations = 4;
-  p.texture = 0.5f;
-  p.structure = 1.f;
-  p.edges_texture = 0.f;
-  p.radius = 128;
-  p.update = 1.f;
-  p.threshold = 0.f;
-  p.regularization_texture = 0.f;
-  p.model = DT_DIFFUSE_GAUSSIAN;
+  p.radius = 4;
+  p.sharpness = 0.0f;
+  p.threshold = 0.2f;
+  p.noise_threshold = -0.1f;
+  p.regularization = 0.f;
+  p.anisotropy = 3.f;
+
+  p.first = +0.5f;
+  p.second = -0.5f;
+  p.third = +0.5f;
+  p.fourth = +0.5f;
+  dt_gui_presets_add_generic(_("denoise"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.iterations = 2;
+  p.radius = 16;
+  p.sharpness = 0.0f;
+  p.threshold = 0.0f;
+  p.noise_threshold = 0.f;
+  p.regularization = 0.f;
+  p.anisotropy = 3.f;
+
+  p.first = +0.25f;
+  p.second = +0.25f;
+  p.third = +0.25f;
+  p.fourth = +0.25f;
   dt_gui_presets_add_generic(_("diffuse"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
-  p.iterations = 10;
-  p.radius = 32;
-  p.update = 2.f;
-  p.threshold = 0.99f;
-  p.model = DT_DIFFUSE_GAUSSIAN;
-  p.respect_bokeh = FALSE;
+  p.iterations = 1;
+  p.radius = 6;
+  p.sharpness = 0.5f;
+  p.threshold = 0.0f;
+  p.noise_threshold = 6.f;
+  p.regularization = 0.f;
+  p.anisotropy = 0.f;
 
-  // first order
-  p.base = 1.f;
-  p.edges_base = 3.f;
-  p.regularization_base = -8.f;
-
-  // second order
-  p.zeroth = 1.f;
-  p.regularization_zeroth = -8.f;
-
-  // third order
-  p.structure = 1.f;
-  p.edges_structure = 3.f;
-  p.regularization_structure = -8.f;
-
-  // fourth order
-  p.texture = 1.f;
-  p.edges_texture = 3.f;
-  p.regularization_texture = -8.f;
-
-  dt_gui_presets_add_generic(_("inpaint highlights"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
-
-  p.iterations = 4;
-  p.radius = 32;
-  p.update = 1.f;
-  p.threshold = 0.f;
-  p.model = DT_DIFFUSE_GAUSSIAN;
-  p.respect_bokeh = FALSE;
-
-  // first order
-  p.base = 1.f;
-  p.edges_base = 3.f;
-  p.regularization_base = -8.f;
-
-  // second order
-  p.zeroth = 1.f;
-  p.regularization_zeroth = -8.f;
-
-  // third order
-  p.structure = 1.f;
-  p.edges_structure = 3.f;
-  p.regularization_structure = -8.f;
-
-  // fourth order
-  p.texture = 1.f;
-  p.edges_texture = 3.f;
-  p.regularization_texture = -8.f;
-
-  dt_gui_presets_add_generic(_("diffuse"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  p.first = +0.1f;
+  p.second = +0.1f;
+  p.third = +0.1f;
+  p.fourth = +0.1f;
+  dt_gui_presets_add_generic(_("increase perceptual acutance"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
 // B spline filter
 #define FSIZE 5
 
+// The B spline best approximate a Gaussian of standard deviation :
+// see https://eng.aurelienpierre.com/2021/03/rotation-invariant-laplacian-for-2d-grids/
+#define B_SPLINE_SIGMA 1.0553651328015339f
 
-#ifdef _OPENMP
-#pragma omp declare simd aligned(buf, indices, result:64)
-#endif
-inline static void sparse_scalar_product(const float *const buf, const size_t indices[FSIZE], float result[4])
+static inline float normalize_laplacian(const float sigma)
 {
-  // scalar product of 2 3×5 vectors stored as RGB planes and B-spline filter,
-  // e.g. RRRRR - GGGGG - BBBBB
+  // Normalize the wavelet scale to approximate a laplacian
+  // see https://eng.aurelienpierre.com/2021/03/rotation-invariant-laplacian-for-2d-grids/#Scaling-coefficient
+  return 2.f * M_PI_F / (sqrtf(M_PI_F) * sqf(sigma));
+}
 
-  const float DT_ALIGNED_ARRAY filter[FSIZE] =
-                        { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+static inline float equivalent_sigma_at_step(const float sigma, const unsigned int s)
+{
+  // If we stack several gaussian blurs of standard deviation sigma on top of each other,
+  // this is the equivalent standard deviation we get at the end (after s steps)
+  // First step is s = 0
+  // see
+  // https://eng.aurelienpierre.com/2021/03/rotation-invariant-laplacian-for-2d-grids/#Multi-scale-iterative-scheme
+  if(s == 0) return sigma;
+  else return sqrtf(sqf(equivalent_sigma_at_step(sigma, s - 1)) + sqf(exp2f((float)s) * sigma));
+}
 
-  #ifdef _OPENMP
-  #pragma omp simd aligned(buf, filter:64) aligned(result:16)
-  #endif
-  for(size_t c = 0; c < 4; ++c)
+static inline unsigned int num_steps_to_reach_equivalent_sigma(const float sigma_filter, const float sigma_final)
+{
+  // The inverse of the above : compute the number of scales needed to reach the desired equivalent sigma_final
+  // after sequential blurs of constant sigma_filter
+  unsigned int s = 0;
+  float radius = sigma_filter;
+  while(radius < sigma_final)
   {
-    float acc = 0.0f;
-    for(size_t k = 0; k < FSIZE; ++k)
-      acc += filter[k] * buf[indices[k] + c];
-    result[c] = acc;
+    fprintf(stdout, "computed radius : %f\n", radius);
+    ++s;
+    radius = sqrtf(sqf(radius) + sqf((float)(1 << s) * sigma_filter));
   }
+  fprintf(stdout, "computed radius : %f\n", radius);
+  return s + 1;
 }
 
-//TODO: consolidate with the copy of this code in src/common/dwt.c
-static inline int dwt_interleave_rows(const size_t rowid, const size_t height, const size_t scale)
+inline static void blur_2D_Bspline(const float *const restrict in, float *const restrict HF,
+                                   float *const restrict LF, const int mult, const size_t width, const size_t height)
 {
-  // to make this algorithm as cache-friendly as possible, we want to interleave the actual processing of rows
-  // such that the next iteration processes the row 'scale' pixels below the current one, which will already
-  // be in L2 cache (if not L1) from having been accessed on this iteration so if vscale is 16, we want to
-  // process rows 0, 16, 32, ..., then 1, 17, 33, ..., 2, 18, 34, ..., etc.
-  if (height <= scale)
-    return rowid;
-  const size_t per_pass = ((height + scale - 1) / scale);
-  const size_t long_passes = height % scale;
-  // adjust for the fact that we have some passes with one fewer iteration when height is not a multiple of scale
-  if (long_passes == 0 || rowid < long_passes * per_pass)
-    return (rowid / per_pass) + scale * (rowid % per_pass);
-  const size_t rowid2 = rowid - long_passes * per_pass;
-  return long_passes + (rowid2 / (per_pass-1)) + scale * (rowid2 % (per_pass-1));
-}
+  // see https://arxiv.org/pdf/1711.09791.pdf
+#ifdef _OPENMP
+#pragma omp parallel for default(none) dt_omp_firstprivate(width, height, in, LF, HF, mult) schedule(simd               \
+                                                                                               : static)          \
+    collapse(2)
+#endif
+  for(size_t i = 0; i < height; i++)
+  {
+    for(size_t j = 0; j < width; j++)
+    {
+      const size_t index = (i * width + j) * 4;
+      float DT_ALIGNED_PIXEL acc[4] = { 0.f };
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) aligned(tempbuf:16)
+#pragma omp simd aligned(in : 64) aligned(acc:16)
 #endif
-inline static void blur_2D_Bspline(const float *const restrict in, float *const restrict out,
-                                   float *const restrict tempbuf,
-                                   const size_t width, const size_t height, const int mult)
-{
-  // À-trous B-spline interpolation/blur shifted by mult
-  #ifdef _OPENMP
-  #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(width, height, mult)  \
-    dt_omp_sharedconst(out, in, tempbuf) \
-    schedule(simd:static)
-  #endif
-  for(size_t row = 0; row < height; row++)
-  {
-    // get a thread-private one-row temporary buffer
-    float *const temp = tempbuf + 4 * width * dt_get_thread_num();
-    // interleave the order in which we process the rows so that we minimize cache misses
-    const size_t i = dwt_interleave_rows(row, height, mult);
-    // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
-    size_t DT_ALIGNED_ARRAY indices[FSIZE] = { 0 };
-    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
-    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
-    // over the row
-    for(size_t ii = 0; ii < FSIZE; ++ii)
-    {
-      const size_t r = CLAMP((int)i + mult * (int)(ii - (FSIZE - 1) / 2), (int)0, (int)height - 1);
-      indices[ii] = 4 * r * width;
-    }
-    for(size_t j = 0; j < width; j++)
-    {
-      // Compute the vertical blur of the current pixel and store it in the temp buffer for the row
-      sparse_scalar_product(in + j * 4, indices, temp + j * 4);
-    }
-    // Convolve B-spline filter horizontally over current row
-    for(size_t j = 0; j < width; j++)
-    {
-      // Compute the array indices of the pixels of interest; since the offsets will change near the ends of
-      // the row, we need to recompute for each pixel
-      for(size_t jj = 0; jj < FSIZE; ++jj)
+      for(size_t ii = 0; ii < FSIZE; ++ii)
+        for(size_t jj = 0; jj < FSIZE; ++jj)
+        {
+          const size_t row = CLAMP((int)i + mult * (int)(ii - (FSIZE - 1) / 2), (int)0, (int)height - 1);
+          const size_t col = CLAMP((int)j + mult * (int)(jj - (FSIZE - 1) / 2), (int)0, (int)width - 1);
+          const size_t k_index = (row * width + col) * 4;
+
+          const float DT_ALIGNED_ARRAY filter[FSIZE]
+              = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+
+          const float filters = filter[ii] * filter[jj];
+
+          for(size_t c = 0; c < 4; c++) acc[c] += filters * in[k_index + c];
+        }
+
+      for_four_channels(c, aligned(in, HF, LF : 64) aligned(acc : 16))
       {
-        const size_t col = CLAMP((int)j + mult * (int)(jj - (FSIZE - 1) / 2), (int)0, (int)width - 1);
-        indices[jj] = 4 * col;
+        LF[index + c] = acc[c];
+        HF[index + c] = in[index + c] - acc[c];
       }
-      // Compute the horizonal blur of the already vertically-blurred pixel and store the result at the proper
-      //  row/column location in the output buffer
-      sparse_scalar_product(temp, indices, out + (i * width + j) * 4);
     }
   }
 }
@@ -374,8 +281,9 @@ static inline void init_reconstruct(float *const restrict reconstructed, const s
 // init the reconstructed buffer with non-clipped and partially clipped pixels
 // Note : it's a simple multiplied alpha blending where mask = alpha weight
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(reconstructed, width, height, ch)       \
-    schedule(simd : static) aligned(reconstructed : 64)
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(reconstructed, width, height, ch)                 \
+    schedule(simd                                                                                                 \
+             : static) aligned(reconstructed : 64)
 #endif
   for(size_t k = 0; k < height * width * ch; k++)
   {
@@ -383,181 +291,115 @@ static inline void init_reconstruct(float *const restrict reconstructed, const s
   }
 }
 
-
-static inline void wavelets_detail_level(const float *const restrict detail, const float *const restrict LF,
-                                         float *const restrict HF,
-                                         const size_t width, const size_t height, const size_t ch)
-{
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, HF, LF, detail)           \
-    schedule(simd : static) aligned(HF, LF, detail : 64)
-#endif
-  for(size_t k = 0; k < height * width * 4; k++) HF[k] = detail[k] - LF[k];
-}
-
-static int get_scales(const dt_iop_roi_t *roi_in, const dt_dev_pixelpipe_iop_t *const piece)
-{
-  /* How many wavelets scales do we need to compute at current zoom level ?
-   * 0. To get the same preview no matter the zoom scale, the relative image coverage ratio of the filter at
-   * the coarsest wavelet level should always stay constant.
-   * 1. The image coverage of each B spline filter of size `FSIZE` is `2^(level) * (FSIZE - 1) / 2 + 1` pixels
-   * 2. The coarsest level filter at full resolution should cover `1/FSIZE` of the largest image dimension.
-   * 3. The coarsest level filter at current zoom level should cover `scale/FSIZE` of the largest image dimension.
-   *
-   * So we compute the level that solves 1. subject to 3. Of course, integer rounding doesn't make that 1:1
-   * accurate.
-   */
-  const float scale = fmaxf(roi_in->scale / piece->iscale, 1.f);
-  const size_t size = MAX(piece->buf_in.height * piece->iscale, piece->buf_in.width * piece->iscale);
-  const int scales = floorf(log2f((2.0f * size * scale / ((FSIZE - 1) * FSIZE)) - 1.0f));
-  return CLAMP(scales, 1, MAX_NUM_SCALES);
-}
-
-
-inline static void wavelets_reconstruct_RGB(const float *const restrict HF, const float *const restrict LF,
-                                            float *const restrict reconstructed, const size_t width,
-                                            const size_t height, const size_t ch, const size_t s, const size_t scales)
-{
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none)                                                          \
-    dt_omp_firstprivate(width, height, ch, HF, LF, reconstructed, s, scales) schedule(simd : static) \
-    aligned(reconstructed, HF, LF:64)
-#endif
-  for(size_t k = 0; k < height * width * 4; ++k)
-  {
-    reconstructed[k] += (s == scales - 1) ? HF[k] + LF[k] : HF[k];
-  }
-}
-
 // Discretization parameters for the Partial Derivative Equation solver
-#define H 1              // spatial step
-#define KAPPA 0.25f    // 0.25 if h = 1, 1 if h = 2
+#define H 1         // spatial step
+#define KAPPA 0.25f // 0.25 if h = 1, 1 if h = 2
 
-static inline void heat_PDE_inpanting(const float *const restrict input,
-                                      float *const restrict output, const uint8_t *const restrict mask,
-                                      const size_t width, const size_t height, const size_t ch, const int mult,
-                                      const float texture, const float structure, const float zeroth, const float base_layer,
-                                      const float edges_texture, const float regularization_texture,
-                                      const float edges_structure, const float regularization_structure,
-                                      const float regularization_zeroth,
-                                      const float edges_base, const float regularization_base,
-                                      const dt_iop_diffuse_bokeh_t respect_bokeh, const int radius)
+static inline void heat_PDE_inpanting(const float *const restrict high_freq, const float *const restrict low_freq,
+                                      const uint8_t *const restrict mask, float *const restrict output,
+                                      const size_t width, const size_t height, const size_t ch,
+                                      const float fourth, const float third, const float second,
+                                      const float first_layer, const float anisotropy,
+                                      const float regularization, const float noise_threshold, const float final_radius, const float factor,
+                                      const int current_step, const int scales, const float zoom)
 {
-  // Simultaneous inpainting for image structure and texture using anisotropic heat transfer model
+  // Simultaneous inpainting for image structure and fourth using anisotropic heat transfer model
   // https://www.researchgate.net/publication/220663968
+  // modified for a multi-scale wavelet setup
 
-  const float DT_ALIGNED_ARRAY ABCD[4] = { texture * KAPPA,
-                                           structure * KAPPA,
-                                           zeroth,
-                                           base_layer * KAPPA };
 
-  const int compute_base = (base_layer != 0.f);
-  const int compute_zero = (zeroth != 0.f);
-  const int compute_structure = (structure != 0.f);
-  const int compute_texture = (texture != 0.f);
-
-  const float bokeh_factor = sqf((float)radius / (float)mult);
+  const int compute_fourth = TRUE;
+  //(fourth != 0.f);
 
   const int has_mask = (mask != NULL);
+  const int last_step = (scales - 1) == current_step;
 
-  const float *const restrict in = DT_IS_ALIGNED(input);
   float *const restrict out = DT_IS_ALIGNED(output);
+  const float *const restrict LF = DT_IS_ALIGNED(low_freq);
+  const float *const restrict HF = DT_IS_ALIGNED(high_freq);
 
-  #ifdef _OPENMP
-  #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, out, mask, height, width, ch, ABCD, \
-    has_mask, mult, compute_base, compute_zero, compute_structure, compute_texture, \
-    edges_texture, edges_structure, edges_base, regularization_texture, regularization_structure, regularization_zeroth, regularization_base, \
-    respect_bokeh, radius, bokeh_factor) \
-  schedule(dynamic) collapse(2)
-  #endif
+  const int current_radius = equivalent_sigma_at_step(B_SPLINE_SIGMA, current_step);
+  const float real_radius = equivalent_sigma_at_step(B_SPLINE_SIGMA, current_step) * zoom;
+
+  const float norm_lapl = expf(-sqf(real_radius) / sqf(final_radius));
+  const float DT_ALIGNED_ARRAY ABCD[4] = { fourth * KAPPA * norm_lapl, third * KAPPA * norm_lapl,
+                                           second * norm_lapl, first_layer * KAPPA * norm_lapl };
+
+  const float strength = factor * norm_lapl + 1.f;
+
+  fprintf(stdout, "current radius : %i, real radius : %f, final radius : %f, norm : %f, sharpness : %f\n", current_radius,
+          real_radius, final_radius, norm_lapl, strength);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) dt_omp_firstprivate(                                                       \
+    out, mask, HF, LF, height, width, ch, ABCD, has_mask, current_radius, compute_fourth, noise_threshold, \
+    anisotropy, regularization, real_radius, last_step, strength) schedule(dynamic) collapse(2)
+#endif
   for(size_t i = 0; i < height; ++i)
     for(size_t j = 0; j < width; ++j)
     {
       const size_t idx = (i * width + j);
-      const size_t index = idx * ch;
+      const size_t index = idx * 4;
       uint8_t opacity = (has_mask) ? mask[idx] : 1;
 
       if(opacity)
       {
         // build arrays of pointers to the pixels we will need here,
         // to be super clear with compiler about cache management
-        const float DT_ALIGNED_ARRAY *restrict grad_pixel[9] = { NULL };
-        const float DT_ALIGNED_ARRAY *restrict lapl_pixel[9] = { NULL };
+        const float *restrict neighbour_pixel_HF[9];
+        const float *restrict neighbour_pixel_LF[9];
 
-        if(compute_base || compute_structure || compute_texture)
-        {
-          // local neighbours
-          const size_t j_grad[3] = { CLAMP((int)(j - H), (int)0, (int)width - 1),    // y - 1
-                                                                              j,     // y
-                                    CLAMP((int)(j + H), (int)0, (int)width - 1) };   // y + 1
+        // non-local neighbours
+        const size_t j_neighbours[3] = { CLAMP((int)(j - current_radius * H), (int)0, (int)width - 1),   // y - mult
+                                         j,                                                              // y
+                                         CLAMP((int)(j + current_radius * H), (int)0, (int)width - 1) }; // y + mult
 
-          const size_t i_grad[3] = { CLAMP((int)(i - H), (int)0, (int)height - 1),   // x - 1
-                                                                                i,   // x
-                                    CLAMP((int)(i + H), (int)0, (int)height - 1) };  // x + 1
+        const size_t i_neighbours[3] = { CLAMP((int)(i - current_radius * H), (int)0, (int)height - 1),   // x - mult
+                                         i,                                                               // x
+                                         CLAMP((int)(i + current_radius * H), (int)0, (int)height - 1) }; // x + mult
 
-          // non-local neighbours
-          const size_t j_lapl[3] = { CLAMP((int)(j - mult * H), (int)0, (int)width - 1),   // y - mult
-                                                                              j,           // y
-                                    CLAMP((int)(j + mult * H), (int)0, (int)width - 1) };  // y + mult
-
-          const size_t i_lapl[3] = { CLAMP((int)(i - mult * H), (int)0, (int)height - 1),  // x - mult
-                                                                                i,         // x
-                                    CLAMP((int)(i + mult * H), (int)0, (int)height - 1) }; // x + mult
-
-          for(size_t ii = 0; ii < 3; ii++)
-            for(size_t jj = 0; jj < 3; jj++)
-            {
-              if(compute_base || compute_structure)
-                grad_pixel[3 * ii + jj] = (const float *const restrict)__builtin_assume_aligned(in + (i_grad[ii] * width + j_grad[jj]) * ch, 16);
-
-              if(compute_texture)
-                lapl_pixel[3 * ii + jj] = (const float *const restrict)__builtin_assume_aligned(in + (i_lapl[ii] * width + j_lapl[jj]) * ch, 16);
-            }
-        }
+        for(size_t ii = 0; ii < 3; ii++)
+          for(size_t jj = 0; jj < 3; jj++)
+          {
+            neighbour_pixel_HF[3 * ii + jj] = __builtin_assume_aligned(HF + (i_neighbours[ii] * width + j_neighbours[jj]) * 4, 16);
+            neighbour_pixel_LF[3 * ii + jj] = __builtin_assume_aligned(LF + (i_neighbours[ii] * width + j_neighbours[jj]) * 4, 16);
+          }
 
         // assert(grad_pixel[4] == lapl_pixel[4] == center)
-        const float *const restrict center = (const float *const restrict)__builtin_assume_aligned(in + index, 16);
+        const float *const restrict center_HF = neighbour_pixel_HF[4];
+        const float *const restrict center_LF = neighbour_pixel_LF[4];
 
-        const float *const restrict north  = grad_pixel[1];
-        const float *const restrict south  = grad_pixel[7];
-        const float *const restrict east   = grad_pixel[5];
-        const float *const restrict west   = grad_pixel[3];
+        const float *const restrict north = neighbour_pixel_LF[1];
+        const float *const restrict south = neighbour_pixel_LF[7];
+        const float *const restrict east = neighbour_pixel_LF[5];
+        const float *const restrict west = neighbour_pixel_LF[3];
 
-        const float *const restrict north_far = lapl_pixel[1];
-        const float *const restrict south_far = lapl_pixel[7];
-        const float *const restrict east_far  = lapl_pixel[5];
-        const float *const restrict west_far  = lapl_pixel[3];
+        const float *const restrict north_far = neighbour_pixel_LF[1];
+        const float *const restrict south_far = neighbour_pixel_LF[7];
+        const float *const restrict east_far = neighbour_pixel_LF[5];
+        const float *const restrict west_far = neighbour_pixel_LF[3];
 
         float DT_ALIGNED_ARRAY kern_grad[9][4];
         float DT_ALIGNED_ARRAY kern_lap[9][4];
-        float DT_ALIGNED_ARRAY kern_base[9][4];
-        float DT_ALIGNED_ARRAY TV[4][4] = { { 0.f } };
+        float DT_ALIGNED_ARRAY kern_first[9][4];
 
-        // build the local anisotropic convolution filters
-        #ifdef _OPENMP
-        #pragma omp simd aligned(north, south, west, east, north_far, south_far, east_far, west_far, center : 16) \
-          aligned(kern_grad, kern_lap, kern_base, TV : 64)
-        #endif
+// build the local anisotropic convolution filters
+#ifdef _OPENMP
+#pragma omp simd aligned(north, south, west, east, north_far, south_far, east_far, west_far, center_LF : 16)      \
+    aligned(kern_grad, kern_lap, kern_first : 64)
+#endif
         for(size_t c = 0; c < 4; c++)
         {
-          // Compute the zeroth-order term
-          if(compute_zero)
+          // Compute the gradient with centered finite differences - warning : x is vertical, y is horizontal
           {
-            TV[c][2] = fabsf(center[c]) + regularization_zeroth;
-          }
-
-          if(compute_structure || compute_base)
-          {
-            // Compute the gradient with centered finite differences - warning : x is vertical, y is horizontal
-            const float grad_x = (south[c] - north[c]) / 2.0f; // du(i, j) / dx
-            const float grad_y = (east[c] - west[c]) / 2.0f;   // du(i, j) / dy
+            const float grad_x_LF = (south[c] - north[c]) / 2.0f; // du(i, j) / dx
+            const float grad_y_LF = (east[c] - west[c]) / 2.0f;   // du(i, j) / dy
 
             // Find the dampening factor
-            const float tv = hypotf(grad_x, grad_y);
+            const float tv_LF = hypotf(grad_x_LF, grad_y_LF);
 
             // Find the direction of the gradient
-            const float theta = atan2f(grad_y, grad_x);
+            const float theta = atan2f(grad_y_LF, grad_x_LF);
 
             // Find the gradient rotation coefficients for the matrix
             const float sin_theta = sinf(theta);
@@ -565,16 +407,14 @@ static inline void heat_PDE_inpanting(const float *const restrict input,
             const float sin_theta2 = sqf(sin_theta);
             const float cos_theta2 = sqf(cos_theta);
 
-            // Build the convolution kernel for the structure extraction
-            if(compute_structure)
+            const float c2 = expf(-tv_LF / anisotropy);
+            const float a11 = cos_theta2 + c2 * sin_theta2;
+            const float a12 = (c2 - 1.0f) * cos_theta * sin_theta;
+            const float a22 = c2 * cos_theta2 + sin_theta2;
+
+            // Build the convolution kernel for the third extraction
+            // gradient of laplacian
             {
-              const float c2 = expf(-tv / edges_structure);
-              TV[c][1] = tv + regularization_structure;
-
-              const float a11 = cos_theta2 + c2 * sin_theta2;
-              const float a12 = (c2 - 1.0f) * cos_theta * sin_theta;
-              const float a22 = c2 * cos_theta2 + sin_theta2;
-
               const float b11 = -a12 / 2.0f;
               const float b13 = -b11;
               const float b22 = -2.0f * (a11 + a22);
@@ -590,45 +430,39 @@ static inline void heat_PDE_inpanting(const float *const restrict input,
               kern_grad[8][c] = b11;
             }
 
-            // Build the convolution kernel for the base
-            if(compute_base)
+            // Build the convolution kernel for the first
+            // integral of laplacian (== divergence of the gradient)
             {
-              const float c2 = expf(-tv / edges_base);
-              TV[c][3] = tv + regularization_base;
-
-              const float a11 = cos_theta2 + c2 * sin_theta2;
-              const float a12 = (c2 - 1.0f) * cos_theta * sin_theta;
-              const float a22 = c2 * cos_theta2 + sin_theta2;
-
               const float b11 = a12 / 2.0f;
               const float b22 = a11 + a22;
 
-              kern_base[0][c] = b11 / b22;
-              kern_base[1][c] = a22 / b22;
-              kern_base[2][c] = b11 / b22;
-              kern_base[3][c] = a11 / b22;
-              kern_base[4][c] = b22 / b22;
-              kern_base[5][c] = a11 / b22;
-              kern_base[6][c] = b11 / b22;
-              kern_base[7][c] = a22 / b22;
-              kern_base[8][c] = b11 / b22;
+              kern_first[0][c] = b11 / b22;
+              kern_first[1][c] = a22 / b22;
+              kern_first[2][c] = b11 / b22;
+              kern_first[3][c] = a11 / b22;
+              kern_first[4][c] = b22 / b22;
+              kern_first[5][c] = a11 / b22;
+              kern_first[6][c] = b11 / b22;
+              kern_first[7][c] = a22 / b22;
+              kern_first[8][c] = b11 / b22;
             }
           }
 
           // Compute the non-local laplacian
-          if(compute_texture)
+          if(compute_fourth)
           {
             // Compute the laplacian with centered finite differences - warning : x is vertical, y is horizontal
-            const float grad_x = south_far[c] + north_far[c] - 2.f * center[c]; // du(i, j) / dx
-            const float grad_y = east_far[c] + west_far[c] - 2.f * center[c];   // du(i, j) / dy
+            const float grad_x_LF
+                = (south_far[c] + north_far[c] - 2.f * center_LF[c]); // du(i, j) / dx
+            const float grad_y_LF
+                = (east_far[c] + west_far[c] - 2.f * center_LF[c]); // du(i, j) / dy
 
             // Find the dampening factor
-            const float tv = hypotf(grad_x, grad_y);
-            const float c2 = expf(-tv / edges_texture);
-            TV[c][0] = tv + regularization_texture;
+            const float tv_LF = hypotf(grad_x_LF, grad_y_LF);
+            const float c2 = expf(-tv_LF / anisotropy);
 
             // Find the direction of the gradient
-            const float theta = atan2f(grad_y, grad_x);
+            const float theta = atan2f(grad_y_LF, grad_x_LF);
 
             // Find the gradient rotation coefficients for the matrix
             const float sin_theta = sinf(theta);
@@ -636,13 +470,13 @@ static inline void heat_PDE_inpanting(const float *const restrict input,
             const float sin_theta2 = sqf(sin_theta);
             const float cos_theta2 = sqf(cos_theta);
 
-            // Build the convolution kernel for the texture extraction
+            // Build the convolution kernel for the fourth extraction
             const float a11 = cos_theta2 + c2 * sin_theta2;
             const float a12 = (c2 - 1.0f) * cos_theta * sin_theta;
             const float a22 = c2 * cos_theta2 + sin_theta2;
 
             const float b11 = a12 / sqrtf(2.f);
-            const float b22 = -2.f * (a11 + a22 ) - 4.f * a12 / sqrtf(2.f);
+            const float b22 = -2.f * (a11 + a22) - 4.f * a12 / sqrtf(2.f);
 
             kern_lap[0][c] = b11;
             kern_lap[1][c] = a22;
@@ -656,150 +490,97 @@ static inline void heat_PDE_inpanting(const float *const restrict input,
           }
         }
 
-        // Get the difference of gaussians as a metric of bokeh and a generalized gaussian to find the fall-of
-        // This assumes we diffuse a wavelet high-pass details layer that is roughly equivalent to a second order derivative
-        const float bokeh = (respect_bokeh == DT_DIFFUSE_BOKEH_EXCLUDE) ? 1.f - expf(- bokeh_factor * (sqf(center[0]) + sqf(center[1]) + sqf(center[2])))
-                              : (respect_bokeh == DT_DIFFUSE_BOKEH_INCLUDE) ? expf(- bokeh_factor * (sqf(center[0]) + sqf(center[1]) + sqf(center[2])))
-                                : 1.f;
-
-        // Use a collaborative regularization
-        float DT_ALIGNED_ARRAY TV_RGB[4];
-        #ifdef _OPENMP
-        #pragma omp simd aligned(TV, TV_RGB, ABCD: 64)
-        #endif
-        for(size_t k = 0; k < 4; k++)
-          TV_RGB[k] = ABCD[k] / fmaxf(fmaxf(TV[0][k], TV[1][k]), TV[2][k]);
-
         // Convolve anisotropic filters at current pixel for directional derivatives
         float DT_ALIGNED_ARRAY derivatives[4][4];
-        #ifdef _OPENMP
-        #pragma omp simd aligned(kern_grad, kern_base, kern_lap, in, derivatives, grad_pixel, lapl_pixel: 64)
-        #endif
+        float DT_ALIGNED_PIXEL TV[4] = { 0.f };
+
+#ifdef _OPENMP
+#pragma omp simd aligned(kern_grad, kern_first, kern_lap, derivatives, neighbour_pixel_HF : 64)          \
+    aligned(center_HF, TV : 16)
+#endif
         for(size_t c = 0; c < 4; c++)
         {
           float acc1 = 0.f;
           float acc2 = 0.f;
           float acc3 = 0.f;
+          float acc4 = 0.f;
 
-          if(compute_base || compute_structure)
+          for(size_t k = 0; k < 9; k++)
           {
-            for(size_t k = 0; k < 9; k++)
-            {
-              // Convolve the base term
-              acc1 += kern_base[k][c] * grad_pixel[k][c];
+            // Convolve the first term
+            acc1 += kern_first[k][c] * neighbour_pixel_HF[k][c];
 
-              // Convolve first-order term (gradient)
-              acc2 += kern_grad[k][c] * grad_pixel[k][c];
-            }
+            // Convolve first-order term (gradient)
+            acc2 += kern_grad[k][c] * neighbour_pixel_HF[k][c];
+
+            // Convolve second-order term (laplacian)
+            acc3 += kern_lap[k][c] * neighbour_pixel_HF[k][c];
+
+            // Compute "Total Variation" (it's not a real TV)
+            acc4 += neighbour_pixel_HF[k][c] * neighbour_pixel_HF[k][c];
           }
 
-          if(compute_texture)
-          {
-            for(size_t k = 0; k < 9; k++)
-            {
-              // Convolve second-order term (laplacian)
-              acc3 += kern_lap[k][c] * lapl_pixel[k][c];
-            }
-          }
+          TV[c] = noise_threshold + acc4 / 9.f * regularization;
 
           derivatives[c][0] = acc3;
           derivatives[c][1] = acc2;
-          derivatives[c][2] = -center[c];
+          derivatives[c][2] = -center_HF[c];
           derivatives[c][3] = -acc1;
         }
 
-        // Update the solution
-        #ifdef _OPENMP
-        #pragma omp simd aligned(in, out, derivatives, TV_RGB: 64)
-        #endif
+// Update the solution
+#ifdef _OPENMP
+#pragma omp simd aligned(out, derivatives, LF, HF : 64) aligned(TV, ABCD : 16)
+#endif
         for(size_t c = 0; c < 4; c++)
         {
           float acc = 0.f;
-          for(size_t k = 0; k < 4; k++) acc += derivatives[c][k] * TV_RGB[k];
-          out[index + c] = center[c] + bokeh * acc;
+          for(size_t k = 0; k < 4; k++) acc += derivatives[c][k] * ABCD[k];
+          acc = (HF[index + c] + acc / TV[c]) * strength;
+
+          out[index + c] += (last_step) ? acc + LF[index + c] : acc;
         }
       }
       else
       {
-        #ifdef _OPENMP
-        #pragma omp simd aligned(in, out: 64)
-        #endif
-        for(size_t c = 0; c < 4; c++) out[index + c] = in[index + c];
+#ifdef _OPENMP
+#pragma omp simd aligned(out, HF, LF : 64)
+#endif
+        for(size_t c = 0; c < 4; c++)
+          out[index + c] += (last_step) ? HF[index + c] + LF[index + c] : HF[index + c];
       }
     }
 }
 
-
-static float diffusion_scale_factor(const float current_radius, const float final_radius, const float zoom, const dt_iop_diffuse_model_t model)
-{
-  float factor;
-  const float scaled_radius = final_radius * zoom;
-
-  if(model == DT_DIFFUSE_GAUSSIAN)
-  {
-    factor = expf(-current_radius / scaled_radius);
-  }
-  else if(model == DT_DIFFUSE_CONSTANT)
-  {
-    factor = (current_radius <= scaled_radius) ? 1.f : 0.f;
-  }
-  else if(model == DT_DIFFUSE_LINEAR)
-  {
-    factor = fmaxf(1.f - current_radius / scaled_radius, 0.f);
-  }
-  else if(model == DT_DIFFUSE_QUADRATIC)
-  {
-    factor = fmaxf(sqrtf(1.f - current_radius / scaled_radius), 0.f);
-  }
-  else
-  {
-    return 1.f;
-  }
-
-  return factor * zoom;
-}
-
-
 static inline gint reconstruct_highlights(const float *const restrict in, float *const restrict reconstructed,
-                                          const uint8_t *const restrict mask,
-                                          const size_t ch,
+                                          const uint8_t *const restrict mask, const size_t ch,
                                           const dt_iop_diffuse_data_t *const data, dt_dev_pixelpipe_iop_t *piece,
                                           const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   gint success = TRUE;
 
-  // wavelets scales - either the max kernel size at current resolution or 4 times the blur radius
-  const float zoom = fmaxf(roi_in->scale / piece->iscale, 1.f);
-  const int current_zoom_scales = get_scales(roi_in, piece);
-  int diffusion_scales;
-  if(data->model == DT_DIFFUSE_GAUSSIAN)
-    diffusion_scales = ceilf(log2f(data->radius * zoom * 4));
-  else
-    diffusion_scales = ceilf(log2f(data->radius * zoom));
+  const float zoom = fmaxf(piece->iscale / roi_in->scale, 1.0f);
+  const float final_radius = data->radius * 3.0f / zoom;
+  const int diffusion_scales = num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
+  const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
+  fprintf(stdout, "scales : %i\n", scales);
 
-  const int scales = MIN(diffusion_scales, current_zoom_scales);
-
-  float structure = data->structure;
-  float texture = data->texture;
-  float zeroth = data->zeroth;
-  float base = data->base;
-  float edges_texture = expf(-data->edges_texture);
-  float edges_structure = expf(-data->edges_structure);
-  float edges_base = expf(-data->edges_base);
-  float regularization_texture = expf(data->regularization_texture);
-  float regularization_structure = expf(data->regularization_structure);
-  float regularization_zeroth = expf(data->regularization_zeroth);
-  float regularization_base = expf(data->regularization_base);
+  float third = data->third;
+  float fourth = data->fourth;
+  float second = data->second;
+  float first = data->first;
+  float anisotropy = expf(-data->anisotropy);
+  float regularization = powf(10.f, data->regularization) - 1.f;
+  float noise_threshold = powf(10.f, data->noise_threshold);
 
   // wavelets scales buffers
-  float *const restrict LF_even = dt_alloc_align_float(roi_out->width * roi_out->height * ch); // low-frequencies RGB
-  float *const restrict LF_odd = dt_alloc_align_float(roi_out->width * roi_out->height * ch);  // low-frequencies RGB
-  float *const restrict HF_RGB = dt_alloc_align_float(roi_out->width * roi_out->height * ch);  // high-frequencies RGB
+  float *const restrict LF_even
+      = dt_alloc_align_float(roi_out->width * roi_out->height * ch); // low-frequencies RGB
+  float *const restrict LF_odd
+      = dt_alloc_align_float(roi_out->width * roi_out->height * ch);                      // low-frequencies RGB
+  float *const restrict HF = dt_alloc_align_float(roi_out->width * roi_out->height * ch); // high-frequencies RGB
 
-  // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
-  float *const restrict temp1 = dt_alloc_align_float(roi_out->width * roi_out->height * ch);
-
-  if(!LF_even || !LF_odd || !HF_RGB || !temp1)
+  if(!LF_even || !LF_odd || !HF)
   {
     dt_control_log(_("filmic highlights reconstruction failed to allocate memory, check your RAM settings"));
     success = FALSE;
@@ -816,92 +597,49 @@ static inline gint reconstruct_highlights(const float *const restrict in, float 
   // with a vertical and horizontal blur, wich is 10 multiply-add instead of 25 by pixel.
   for(int s = 0; s < scales; ++s)
   {
-    const float *restrict detail;       // buffer containing this scale's input
-    float *restrict LF;                 // output buffer for the current scale
-    float *restrict HF_RGB_temp;        // temp buffer for HF_RBG terms before blurring
+    const float *restrict detail; // buffer containing this scale's input
+    float *restrict LF;           // output buffer for the current scale
 
     // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
     if(s == 0)
     {
       detail = in;
       LF = LF_odd;
-      HF_RGB_temp = LF_even;
     }
     else if(s % 2 != 0)
     {
       detail = LF_odd;
       LF = LF_even;
-      HF_RGB_temp = LF_odd;
     }
     else
     {
       detail = LF_even;
       LF = LF_odd;
-      HF_RGB_temp = LF_even;
     }
-
-    const int mult = 1 << s; // fancy-pants C notation for 2^s with integer type, don't be afraid
 
     // Compute wavelets low-frequency scales
-    blur_2D_Bspline(detail, LF, temp1, roi_out->width, roi_out->height, mult);
+    blur_2D_Bspline(detail, HF, LF, 1 << s, roi_out->width, roi_out->height);
+    fprintf(stdout, "mult : %i\n", 1 << s);
 
-    // Compute wavelets high-frequency scales and save the mininum of texture over the RGB channels
-    // Note : HF_RGB = detail - LF, HF_grey = max(HF_RGB)
-    wavelets_detail_level(detail, LF, HF_RGB_temp, roi_out->width, roi_out->height, ch);
-
-    // diffuse particles
-    float *HF_in = NULL;
-    float *HF_out = NULL;
-
-    const float factor = data->update * diffusion_scale_factor((float)mult, data->radius, zoom, data->model);
-
-    for(size_t it = 0; it < data->iterations; it++)
-    {
-      if(it == 0)
-      {
-        HF_in = HF_RGB_temp;
-        HF_out = temp1;
-      }
-      else if(it % 2 != 0)
-      {
-        HF_in = temp1;
-        HF_out = HF_RGB_temp;
-      }
-      else
-      {
-        HF_in = HF_RGB_temp;
-        HF_out = temp1;
-      }
-
-      heat_PDE_inpanting(HF_in, HF_out, mask, roi_out->width, roi_out->height, ch, mult,
-                         factor * texture, factor * structure, factor * zeroth, factor * base,
-                         edges_texture, regularization_texture, edges_structure, regularization_structure,
-                         regularization_zeroth, edges_base, regularization_base,
-                         data->respect_bokeh, data->radius);
-    }
-
-    HF_RGB_temp = HF_out;
-
-    // Collapse wavelets
-    wavelets_reconstruct_RGB(HF_RGB_temp, LF, reconstructed, roi_out->width, roi_out->height, ch, s, scales);
+    heat_PDE_inpanting(HF, LF, mask, reconstructed, roi_out->width, roi_out->height, ch, fourth, third,
+                       second, first, anisotropy, regularization, noise_threshold, data->radius,
+                       data->sharpness, s, scales, zoom);
   }
 
 error:
-  if(temp1) dt_free_align(temp1);
+  if(HF) dt_free_align(HF);
   if(LF_even) dt_free_align(LF_even);
   if(LF_odd) dt_free_align(LF_odd);
-  if(HF_RGB) dt_free_align(HF_RGB);
   return success;
 }
 
 
-static inline void build_mask(const float *const restrict input, uint8_t *const restrict mask, const float threshold,
-                              const size_t width, const size_t height, const size_t ch)
+static inline void build_mask(const float *const restrict input, uint8_t *const restrict mask,
+                              const float threshold, const size_t width, const size_t height, const size_t ch)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(input, mask, height, width, ch, threshold) \
-schedule(dynamic) aligned(mask, input:64)
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(input, mask, height, width, ch, threshold)        \
+    schedule(dynamic) aligned(mask, input : 64)
 #endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
@@ -924,21 +662,20 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const size_t ch = 4;
   float *restrict in = DT_IS_ALIGNED((float *const restrict)ivoid);
   float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);
-  float *restrict temp = NULL;
+  float *const restrict temp1 = dt_alloc_align_float(roi_out->width * roi_out->height * ch);
+  float *const restrict temp2 = dt_alloc_align_float(roi_out->width * roi_out->height * ch);
   uint8_t *restrict mask = NULL;
+  const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
 
   if(data->threshold > 0.f)
   {
-    const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
     const float blur = (float)data->radius / scale;
 
     // build a boolean mask, TRUE where image is above threshold
-    mask = dt_alloc_align(64,roi_out->width * roi_out->height * sizeof(uint8_t));
+    mask = dt_alloc_align(64, roi_out->width * roi_out->height * sizeof(uint8_t));
     build_mask(in, mask, data->threshold, roi_out->width, roi_out->height, ch);
 
     // init the inpainting area with blur
-    temp = dt_alloc_align_float(roi_out->width * roi_out->height * ch);
-
     float RGBmax[4], RGBmin[4];
     for(int k = 0; k < 4; k++)
     {
@@ -948,44 +685,68 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
     dt_gaussian_t *g = dt_gaussian_init(roi_out->width, roi_out->height, ch, RGBmax, RGBmin, blur, 0);
     if(!g) return;
-    dt_gaussian_blur_4c(g, in, temp);
+    dt_gaussian_blur_4c(g, in, temp1);
     dt_gaussian_free(g);
 
     // add noise and restore valid parts where mask = FALSE
     const float noise = 0.2;
 
-    #ifdef _OPENMP
-    #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(in, temp, mask, roi_out, ch, noise) \
-    schedule(dynamic)
-    #endif
+#ifdef _OPENMP
+#pragma omp parallel for default(none) dt_omp_firstprivate(in, temp1, mask, roi_out, ch, noise) schedule(dynamic)
+#endif
     for(size_t k = 0; k < roi_out->height * roi_out->width * ch; k += ch)
     {
       if(mask[k / ch])
       {
         const uint32_t i = k / roi_out->width;
         const uint32_t j = k - i;
-        uint32_t DT_ALIGNED_ARRAY state[4] = { splitmix32(j + 1), splitmix32((j + 1) * (i + 3)), splitmix32(1337), splitmix32(666) };
+        uint32_t DT_ALIGNED_ARRAY state[4]
+            = { splitmix32(j + 1), splitmix32((j + 1) * (i + 3)), splitmix32(1337), splitmix32(666) };
         xoshiro128plus(state);
         xoshiro128plus(state);
         xoshiro128plus(state);
         xoshiro128plus(state);
 
-        for(size_t c = 0; c < 4; c++) temp[k + c] = gaussian_noise(temp[k + c], noise, i % 2 || j % 2, state);
+        for(size_t c = 0; c < 4; c++) temp1[k + c] = gaussian_noise(temp1[k + c], noise, i % 2 || j % 2, state);
       }
       else
       {
-        for(size_t c = 0; c < 4; c++) temp[k + c] = in[k + c];
+        for(size_t c = 0; c < 4; c++) temp1[k + c] = in[k + c];
       }
     }
 
-    in = temp;
+    in = temp1;
   }
 
-  reconstruct_highlights(in, out, mask, ch, data, piece, roi_in, roi_out);
+  float *restrict temp_in = NULL;
+  float *restrict temp_out = NULL;
+  const int iterations = CLAMP(ceilf((float)data->iterations / scale), 1, MAX_NUM_SCALES);
+
+  for(int it = 0; it < iterations; it++)
+  {
+    if(it == 0)
+    {
+      temp_in = in;
+      temp_out = temp2;
+    }
+    else if(it % 2 == 0)
+    {
+      temp_in = temp1;
+      temp_out = temp2;
+    }
+    else
+    {
+      temp_in = temp2;
+      temp_out = temp1;
+    }
+
+    if(it == (int)iterations - 1) temp_out = out;
+    reconstruct_highlights(temp_in, temp_out, mask, ch, data, piece, roi_in, roi_out);
+  }
 
   if(mask) dt_free_align(mask);
-  if(temp) dt_free_align(temp);
+  if(temp1) dt_free_align(temp1);
+  if(temp2) dt_free_align(temp2);
 }
 
 
@@ -994,23 +755,17 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_diffuse_gui_data_t *g = (dt_iop_diffuse_gui_data_t *)self->gui_data;
   dt_iop_diffuse_params_t *p = (dt_iop_diffuse_params_t *)self->params;
   dt_bauhaus_slider_set_soft(g->iterations, p->iterations);
-  dt_bauhaus_slider_set_soft(g->texture, p->texture);
-  dt_bauhaus_slider_set_soft(g->structure, p->structure);
-  dt_bauhaus_slider_set_soft(g->zeroth, p->zeroth);
-  dt_bauhaus_slider_set_soft(g->base, p->base);
+  dt_bauhaus_slider_set_soft(g->fourth, p->fourth);
+  dt_bauhaus_slider_set_soft(g->third, p->third);
+  dt_bauhaus_slider_set_soft(g->second, p->second);
+  dt_bauhaus_slider_set_soft(g->first, p->first);
 
-  dt_bauhaus_slider_set_soft(g->edges_texture, p->edges_texture);
-  dt_bauhaus_slider_set_soft(g->regularization_texture, p->regularization_texture);
-  dt_bauhaus_slider_set_soft(g->edges_structure, p->edges_structure);
-  dt_bauhaus_slider_set_soft(g->regularization_structure, p->regularization_structure);
-  dt_bauhaus_slider_set_soft(g->regularization_zeroth, p->regularization_zeroth);
-  dt_bauhaus_slider_set_soft(g->edges_base, p->edges_base);
-  dt_bauhaus_slider_set_soft(g->regularization_base, p->regularization_base);
+  dt_bauhaus_slider_set_soft(g->noise_threshold, p->noise_threshold);
+  dt_bauhaus_slider_set_soft(g->regularization, p->regularization);
+  dt_bauhaus_slider_set_soft(g->anisotropy, p->anisotropy);
   dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  dt_bauhaus_slider_set_soft(g->update, p->update);
+  dt_bauhaus_slider_set_soft(g->sharpness, p->sharpness);
   dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
-  dt_bauhaus_combobox_set(g->model, p->model);
-  dt_bauhaus_combobox_set(g->respect_bokeh, p->respect_bokeh);
 }
 
 void gui_init(struct dt_iop_module_t *self)
@@ -1018,111 +773,86 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_diffuse_gui_data_t *g = IOP_GUI_ALLOC(diffuse);
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion intensity")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion properties")), FALSE, FALSE, 0);
 
   g->iterations = dt_bauhaus_slider_from_params(self, "iterations");
-  gtk_widget_set_tooltip_text(g->iterations, _("more iterations make the effect stronger but the module slower.\n"
-                                               "this is analogous to giving more time to the diffusion reaction.\n"
-                                               "if you plan on sharpening or inpainting, more iterations help reconstruction."));
+  gtk_widget_set_tooltip_text(g->iterations,
+                              _("more iterations make the effect stronger but the module slower.\n"
+                                "this is analogous to giving more time to the diffusion reaction.\n"
+                                "if you plan on sharpening or inpainting, more iterations help reconstruction."));
 
-  g->update = dt_bauhaus_slider_from_params(self, "update");
-  dt_bauhaus_slider_set_factor(g->update, 100.0f);
-  dt_bauhaus_slider_set_format(g->update, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->update, _("weight of each iterations update.\n"
-                                           "100 % is suitable for diffusion, inpainting and blurring.\n"
-                                           "lower if noise, halos or any artifact appear as you add more iterations."));
+  g->radius = dt_bauhaus_slider_from_params(self, "radius");
+  dt_bauhaus_slider_set_format(g->radius, "%.0f px");
+  gtk_widget_set_tooltip_text(
+      g->radius, _("scale of the diffusion.\n"
+                   "high values diffuse farther, at the expense of computation time.\n"
+                   "low values diffuse closer.\n"
+                   "if you plan on denoising, the radius should be around the width of your lens blur."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("first order diffusion (gradients)")), FALSE, FALSE, 0);
+  g->anisotropy = dt_bauhaus_slider_from_params(self, "anisotropy");
+  dt_bauhaus_slider_set_digits(g->anisotropy, 4);
+  gtk_widget_set_tooltip_text(g->anisotropy,
+                              _("anisotropy of the diffusion.\n"
+                                "high values force the diffusion to be 1D and perpendicular to edges.\n"
+                                "low values allow the diffusion to be 2D and uniform, like a classic blur."));
 
-  g->base = dt_bauhaus_slider_from_params(self, "base");
-  dt_bauhaus_slider_set_factor(g->base, 100.0f);
-  dt_bauhaus_slider_set_format(g->base, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->base, _("smoothing or sharpening of smooth details (gradients).\n"
-                                        "positive values diffuse and blur.\n"
-                                        "negative values sharpen.\n"
-                                        "zero does nothing."));
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("edges management")), FALSE,
+                     FALSE, 0);
 
-  g->edges_base = dt_bauhaus_slider_from_params(self, "edges_base");
-  gtk_widget_set_tooltip_text(g->edges_base, _("anisotropy of the diffusion.\n"
-                                              "high values force the diffusion to be 1D and perpendicular to edges.\n"
-                                              "low values allow the diffusion to be 2D and uniform, like a classic blur."));
+  g->sharpness = dt_bauhaus_slider_from_params(self, "sharpness");
+  dt_bauhaus_slider_set_factor(g->sharpness, 100.0f);
+  dt_bauhaus_slider_set_format(g->sharpness, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->sharpness,
+                              _("weight of each iterations sharpness.\n"
+                                "100 % is suitable for diffusion, inpainting and blurring.\n"
+                                "lower if noise, halos or any artifact appear as you add more iterations."));
 
-  g->regularization_base = dt_bauhaus_slider_from_params(self, "regularization_base");
-  gtk_widget_set_tooltip_text(g->regularization_base, _("normalization of the diffusion.\n"
-                                                        "high values dampen high-magnitude gradients to avoid overshooting at sharp edges.\n"
-                                                        "low values relay the dampening and allow more and more overshooting."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("second order diffusion (wavelets details)")), FALSE, FALSE, 0);
+  g->regularization = dt_bauhaus_slider_from_params(self, "regularization");
+  g->noise_threshold = dt_bauhaus_slider_from_params(self, "noise_threshold");
 
-  g->zeroth = dt_bauhaus_slider_from_params(self, "zeroth");
-  dt_bauhaus_slider_set_factor(g->zeroth, 100.0f);
-  dt_bauhaus_slider_set_format(g->zeroth, "%.2f %%");
 
-  g->regularization_zeroth = dt_bauhaus_slider_from_params(self, "regularization_zeroth");
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion typology")), FALSE,
+                     FALSE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("third order diffusion (smoothness)")), FALSE, FALSE, 0);
+  g->first = dt_bauhaus_slider_from_params(self, "first");
+  dt_bauhaus_slider_set_factor(g->first, 100.0f);
+  dt_bauhaus_slider_set_digits(g->first, 4);
+  dt_bauhaus_slider_set_format(g->first, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->first, _("smoothing or sharpening of smooth details (gradients).\n"
+                                         "positive values diffuse and blur.\n"
+                                         "negative values sharpen.\n"
+                                         "zero does nothing."));
 
-  g->structure = dt_bauhaus_slider_from_params(self, "structure");
-  dt_bauhaus_slider_set_factor(g->structure, 100.0f);
-  dt_bauhaus_slider_set_format(g->structure, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->structure, _("smoothing or sharpening of sharp details.\n"
+  g->second = dt_bauhaus_slider_from_params(self, "second");
+  dt_bauhaus_slider_set_digits(g->second, 4);
+  dt_bauhaus_slider_set_factor(g->second, 100.0f);
+  dt_bauhaus_slider_set_format(g->second, "%.2f %%");
+
+  g->third = dt_bauhaus_slider_from_params(self, "third");
+  dt_bauhaus_slider_set_digits(g->third, 4);
+  dt_bauhaus_slider_set_factor(g->third, 100.0f);
+  dt_bauhaus_slider_set_format(g->third, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->third, _("smoothing or sharpening of sharp details.\n"
                                               "positive values diffuse and blur.\n"
                                               "negative values sharpen.\n"
                                               "zero does nothing."));
 
-  g->edges_structure = dt_bauhaus_slider_from_params(self, "edges_structure");
-  gtk_widget_set_tooltip_text(g->edges_structure, _("anisotropy of the diffusion.\n"
-                                                    "high values force the diffusion to be 1D and perpendicular to edges.\n"
-                                                    "low values allow the diffusion to be 2D and uniform, like a classic blur."));
-
-  g->regularization_structure = dt_bauhaus_slider_from_params(self, "regularization_structure");
-  gtk_widget_set_tooltip_text(g->regularization_structure, _("normalization of the diffusion.\n"
-                                                             "high values dampen high-magnitude gradients to avoid overshooting at sharp edges.\n"
-                                                             "low values relay the dampening and allow more and more overshooting."));
-
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("non-local fourth order diffusion")), FALSE, FALSE, 0);
-
-  g->texture = dt_bauhaus_slider_from_params(self, "texture");
-  dt_bauhaus_slider_set_factor(g->texture, 100.0f);
-  dt_bauhaus_slider_set_format(g->texture, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->texture, _("smoothing or sharpening of sharp details (gradients).\n"
+  g->fourth = dt_bauhaus_slider_from_params(self, "fourth");
+  dt_bauhaus_slider_set_digits(g->fourth, 4);
+  dt_bauhaus_slider_set_factor(g->fourth, 100.0f);
+  dt_bauhaus_slider_set_format(g->fourth, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->fourth, _("smoothing or sharpening of sharp details (gradients).\n"
                                             "positive values diffuse and blur.\n"
                                             "negative values sharpen.\n"
                                             "zero does nothing."));
 
-  g->edges_texture = dt_bauhaus_slider_from_params(self, "edges_texture");
-  gtk_widget_set_tooltip_text(g->edges_texture, _("anisotropy of the diffusion.\n"
-                                                  "high values force the diffusion to be 1D and perpendicular to edges.\n"
-                                                  "low values allow the diffusion to be 2D and uniform, like a classic blur."));
-
-  g->regularization_texture = dt_bauhaus_slider_from_params(self, "regularization_texture");
-  gtk_widget_set_tooltip_text(g->regularization_texture, _("normalization of the diffusion.\n"
-                                                          "high values dampen high-magnitude gradients to avoid overshooting at sharp edges.\n"
-                                                          "low values relay the dampening and allow more and more overshooting."));
-
-
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion spatiality")), FALSE, FALSE, 0);
 
-  g->model = dt_bauhaus_combobox_from_params(self, "model");
-  gtk_widget_set_tooltip_text(g->threshold, _("defines how the diffusion blends as radius increases.\n"
-                                              "gaussian mimics natural diffusion, with large radii barely affected.\n"
-                                              "constant is a regular wavelets blending and affect each radius the same.\n"
-                                              "linear or quadratic define different rates of spatial diffusion."));
-
-  g->radius = dt_bauhaus_slider_from_params(self, "radius");
-  dt_bauhaus_slider_set_format(g->radius, "%.0f px");
-  gtk_widget_set_tooltip_text(g->radius, _("scale of the diffusion.\n"
-                                           "high values diffuse farther, at the expense of computation time.\n"
-                                           "low values diffuse closer.\n"
-                                           "if you plan on denoising, the radius should be around the width of your lens blur."));
-
   g->threshold = dt_bauhaus_slider_from_params(self, "threshold");
-  gtk_widget_set_tooltip_text(g->threshold, _("luminance threshold for the mask.\n"
-                                              "0. disables the luminance masking and applies the module on the whole image.\n"
-                                              "any higher value will exclude pixels whith luminance lower than the threshold.\n"
-                                              "this can be used to inpaint highlights."));
-
-  g->respect_bokeh = dt_bauhaus_combobox_from_params(self, "respect_bokeh");
-  gtk_widget_set_tooltip_text(g->respect_bokeh, _("exclude the blurry area from the module.\n"
-                                                  "this is useful if you plan on sharpening but want to preserve the bokeh.\n"));
+  gtk_widget_set_tooltip_text(g->threshold,
+                              _("luminance threshold for the mask.\n"
+                                "0. disables the luminance masking and applies the module on the whole image.\n"
+                                "any higher value will exclude pixels whith luminance lower than the threshold.\n"
+                                "this can be used to inpaint highlights."));
 }

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1,0 +1,900 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2019-2020 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "bauhaus/bauhaus.h"
+#include "common/darktable.h"
+#include "common/gaussian.h"
+#include "common/image.h"
+#include "common/iop_profile.h"
+#include "common/opencl.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop_gui.h"
+#include "develop/imageop_math.h"
+#include "develop/noise_generator.h"
+#include "develop/openmp_maths.h"
+#include "dtgtk/button.h"
+#include "dtgtk/drawingarea.h"
+#include "dtgtk/expander.h"
+#include "dtgtk/paint.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "gui/presets.h"
+#include "iop/iop_api.h"
+
+DT_MODULE_INTROSPECTION(1, dt_iop_diffuse_params_t)
+
+#define MAX_NUM_SCALES 12
+
+typedef enum dt_iop_diffuse_model_t
+{
+  DT_DIFFUSE_GAUSSIAN    = 0,   // $DESCRIPTION: "gaussian (natural)"
+  DT_DIFFUSE_CONSTANT    = 1,   // $DESCRIPTION: "constant"
+  DT_DIFFUSE_LINEAR      = 2,   // $DESCRIPTION: "linear"
+  DT_DIFFUSE_QUADRATIC   = 3    // $DESCRIPTION: "quadratic"
+} dt_iop_diffuse_model_t;
+
+
+typedef struct dt_iop_diffuse_params_t
+{
+  int iterations;       // $MIN: 1   $MAX: 20   $DEFAULT: 1  $DESCRIPTION: "iterations of diffusion"
+  float texture;        // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "texture"
+  float structure;      // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "structure"
+  float edges;          // $MIN: -12. $MAX: 12.   $DEFAULT: 0. $DESCRIPTION: "edge directivity"
+  int radius;           // $MIN: 1   $MAX: 1024 $DEFAULT: 8  $DESCRIPTION: "radius of diffusion"
+  float update;         // $MIN: 0.  $MAX: 1.   $DEFAULT: 1. $DESCRIPTION: "speed of diffusion"
+  float threshold;      // $MIN: 0.  $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
+  float regularization; // $MIN: -12. $MAX: 12.   $DEFAULT: 0. $DESCRIPTION: "edge regularization"
+  dt_iop_diffuse_model_t model;
+} dt_iop_diffuse_params_t;
+
+
+typedef struct dt_iop_diffuse_gui_data_t
+{
+  GtkWidget *iterations, *texture, *structure, *fine, *coarse, *edges, *radius, *update, *model, *threshold,
+      *regularization;
+} dt_iop_diffuse_gui_data_t;
+
+
+// only copy params struct to avoid a commit_params()
+typedef struct dt_iop_diffuse_params_t dt_iop_diffuse_data_t;
+
+const char *name()
+{
+  return _("diffuse or sharpen");
+}
+
+const char *aliases()
+{
+  return _("diffusion|deconvolution|blur|sharpening");
+}
+
+const char *description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("simulate directional diffusion of light with heat transfer model\n"
+                                        "to apply an iterative edge-oriented blur, \n"
+                                        "inpaint damaged parts of the image,\n"
+                                        "or to remove blur with blind deconvolution."),
+                                      _("corrective and creative"),
+                                      _("linear, RGB, scene-referred"),
+                                      _("linear, RGB"),
+                                      _("linear, RGB, scene-referred"));
+}
+
+int default_group()
+{
+  return IOP_GROUP_EFFECTS;
+}
+
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_rgb;
+}
+
+
+void init_presets(dt_iop_module_so_t *self)
+{
+  dt_iop_diffuse_params_t p;
+  memset(&p, 0, sizeof(p));
+
+  p.iterations = 4;
+  p.texture = -0.25f;
+  p.structure = -1.f;
+  p.edges = 4.f;
+  p.radius = 16;
+  p.update = 1.f;
+  p.threshold = 0.f;
+  p.regularization = 4.f;
+  p.model = DT_DIFFUSE_GAUSSIAN;
+  dt_gui_presets_add_generic(_("sharpen"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.iterations = 4;
+  p.texture = 0.25f;
+  p.structure = -1.f;
+  p.edges = 4.f;
+  p.radius = 16;
+  p.update = 1.f;
+  p.threshold = 0.f;
+  p.regularization = 4.f;
+  p.model = DT_DIFFUSE_GAUSSIAN;
+  dt_gui_presets_add_generic(_("sharpen and denoise"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.iterations = 4;
+  p.texture = 0.5f;
+  p.structure = 1.f;
+  p.edges = 0.f;
+  p.radius = 128;
+  p.update = 1.f;
+  p.threshold = 0.f;
+  p.regularization = 0.f;
+  p.model = DT_DIFFUSE_GAUSSIAN;
+  dt_gui_presets_add_generic(_("diffuse"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.iterations = 20;
+  p.texture = 0.25f;
+  p.structure = 1.f;
+  p.edges = 4.f;
+  p.radius = 1024;
+  p.update = 1.f;
+  p.threshold = 0.99f;
+  p.regularization = -12.f;
+  p.model = DT_DIFFUSE_CONSTANT;
+  dt_gui_presets_add_generic(_("inpaint highlights"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
+}
+
+// B spline filter
+#define FSIZE 5
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(buf, indices, result:64)
+#endif
+inline static void sparse_scalar_product(const float *const buf, const size_t indices[FSIZE], float result[4])
+{
+  // scalar product of 2 3×5 vectors stored as RGB planes and B-spline filter,
+  // e.g. RRRRR - GGGGG - BBBBB
+
+  const float DT_ALIGNED_ARRAY filter[FSIZE] =
+                        { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+
+  #ifdef _OPENMP
+  #pragma omp simd aligned(buf, filter:64) aligned(result:16)
+  #endif
+  for(int c = 0; c < 4; ++c)
+  {
+    float acc = 0.0f;
+    for(size_t k = 0; k < FSIZE; ++k)
+      acc += filter[k] * buf[indices[k] + c];
+    result[c] = acc;
+  }
+}
+
+//TODO: consolidate with the copy of this code in src/common/dwt.c
+static inline int dwt_interleave_rows(const size_t rowid, const size_t height, const size_t scale)
+{
+  // to make this algorithm as cache-friendly as possible, we want to interleave the actual processing of rows
+  // such that the next iteration processes the row 'scale' pixels below the current one, which will already
+  // be in L2 cache (if not L1) from having been accessed on this iteration so if vscale is 16, we want to
+  // process rows 0, 16, 32, ..., then 1, 17, 33, ..., 2, 18, 34, ..., etc.
+  if (height <= scale)
+    return rowid;
+  const size_t per_pass = ((height + scale - 1) / scale);
+  const size_t long_passes = height % scale;
+  // adjust for the fact that we have some passes with one fewer iteration when height is not a multiple of scale
+  if (long_passes == 0 || rowid < long_passes * per_pass)
+    return (rowid / per_pass) + scale * (rowid % per_pass);
+  const size_t rowid2 = rowid - long_passes * per_pass;
+  return long_passes + (rowid2 / (per_pass-1)) + scale * (rowid2 % (per_pass-1));
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out:64) aligned(tempbuf:16)
+#endif
+inline static void blur_2D_Bspline(const float *const restrict in, float *const restrict out,
+                                   float *const restrict tempbuf,
+                                   const size_t width, const size_t height, const int mult)
+{
+  // À-trous B-spline interpolation/blur shifted by mult
+  #ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+    dt_omp_firstprivate(width, height, mult)  \
+    dt_omp_sharedconst(out, in, tempbuf) \
+    schedule(simd:static)
+  #endif
+  for(size_t row = 0; row < height; row++)
+  {
+    // get a thread-private one-row temporary buffer
+    float *const temp = tempbuf + 4 * width * dt_get_thread_num();
+    // interleave the order in which we process the rows so that we minimize cache misses
+    const size_t i = dwt_interleave_rows(row, height, mult);
+    // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
+    size_t DT_ALIGNED_ARRAY indices[FSIZE] = { 0 };
+    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
+    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
+    // over the row
+    for(size_t ii = 0; ii < FSIZE; ++ii)
+    {
+      const size_t r = CLAMP((int)i + mult * (int)(ii - (FSIZE - 1) / 2), (int)0, (int)height - 1);
+      indices[ii] = 4 * r * width;
+    }
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the vertical blur of the current pixel and store it in the temp buffer for the row
+      sparse_scalar_product(in + j * 4, indices, temp + j * 4);
+    }
+    // Convolve B-spline filter horizontally over current row
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the array indices of the pixels of interest; since the offsets will change near the ends of
+      // the row, we need to recompute for each pixel
+      for(size_t jj = 0; jj < FSIZE; ++jj)
+      {
+        const size_t col = CLAMP((int)j + mult * (int)(jj - (FSIZE - 1) / 2), (int)0, (int)width - 1);
+        indices[jj] = 4 * col;
+      }
+      // Compute the horizonal blur of the already vertically-blurred pixel and store the result at the proper
+      //  row/column location in the output buffer
+      sparse_scalar_product(temp, indices, out + (i * width + j) * 4);
+    }
+  }
+}
+
+static inline void init_reconstruct(float *const restrict reconstructed, const size_t width, const size_t height,
+                                    const size_t ch)
+{
+// init the reconstructed buffer with non-clipped and partially clipped pixels
+// Note : it's a simple multiplied alpha blending where mask = alpha weight
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(reconstructed, width, height, ch)       \
+    schedule(simd : static) aligned(reconstructed : 64)
+#endif
+  for(size_t k = 0; k < height * width * ch; k++)
+  {
+    reconstructed[k] = 0.f;
+  }
+}
+
+
+static inline void wavelets_detail_level(const float *const restrict detail, const float *const restrict LF,
+                                         float *const restrict HF,
+                                         const size_t width, const size_t height, const size_t ch)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, HF, LF, detail)           \
+    schedule(simd                                                                                                 \
+             : static) aligned(HF, LF, detail : 64)
+#endif
+  for(size_t k = 0; k < height * width; k++)
+    for(size_t c = 0; c < 4; ++c) HF[4*k + c] = detail[4*k + c] - LF[4*k + c];
+}
+
+static int get_scales(const dt_iop_roi_t *roi_in, const dt_dev_pixelpipe_iop_t *const piece)
+{
+  /* How many wavelets scales do we need to compute at current zoom level ?
+   * 0. To get the same preview no matter the zoom scale, the relative image coverage ratio of the filter at
+   * the coarsest wavelet level should always stay constant.
+   * 1. The image coverage of each B spline filter of size `FSIZE` is `2^(level) * (FSIZE - 1) / 2 + 1` pixels
+   * 2. The coarsest level filter at full resolution should cover `1/FSIZE` of the largest image dimension.
+   * 3. The coarsest level filter at current zoom level should cover `scale/FSIZE` of the largest image dimension.
+   *
+   * So we compute the level that solves 1. subject to 3. Of course, integer rounding doesn't make that 1:1
+   * accurate.
+   */
+  const float scale = roi_in->scale / piece->iscale;
+  const size_t size = MAX(piece->buf_in.height * piece->iscale, piece->buf_in.width * piece->iscale);
+  const int scales = floorf(log2f((2.0f * size * scale / ((FSIZE - 1) * FSIZE)) - 1.0f));
+  return CLAMP(scales, 1, MAX_NUM_SCALES);
+}
+
+
+inline static void wavelets_reconstruct_RGB(const float *const restrict HF, const float *const restrict LF,
+                                            float *const restrict reconstructed, const size_t width,
+                                            const size_t height, const size_t ch, const size_t s, const size_t scales)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none)                                                          \
+    dt_omp_firstprivate(width, height, ch, HF, LF, reconstructed, s, scales) schedule(simd : static) \
+    aligned(reconstructed, HF:64)
+#endif
+  for(size_t k = 0; k < height * width * ch; ++k)
+  {
+    reconstructed[k] += (s == scales - 1) ? HF[k] + LF[k] : HF[k];
+  }
+}
+
+static void heat_PDE_inpanting(const float *const restrict input,
+                               float *const restrict output, const uint8_t *const restrict mask,
+                               const size_t width, const size_t height, const size_t ch, const int mult,
+                               const float texture, const float structure, const float edges, const float regularization)
+{
+  // Simultaneous inpainting for image structure and texture using anisotropic heat transfer model
+  // https://www.researchgate.net/publication/220663968
+
+  // Discretization parameters for the Partial Derivative Equation solver
+  const int h = 1;              // spatial step
+  const float kappa = 0.25f;    // 0.25 if h = 1, 1 if h = 2
+
+  const float A = texture * kappa;
+  const float B = structure * kappa;
+  const float K = edges;
+  const float L = regularization;
+
+  const int compute_texture = (A != 0.f);
+  const int compute_structure = (B != 0.f);
+
+  const int has_mask = (mask != NULL);
+
+  #ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(input, output, mask, height, width, ch, K, L, A, B, h, compute_structure, compute_texture, has_mask, mult) \
+  schedule(dynamic) collapse(2)
+  #endif
+  for(size_t i = 0; i < height; ++i)
+    for(size_t j = 0; j < width; ++j)
+    {
+      const size_t idx = (i * width + j);
+      const size_t index = idx * ch;
+      uint8_t opacity = (has_mask) ? mask[idx] : 1;
+
+      if(opacity)
+      {
+        // neighbours
+        const size_t j_prev = CLAMP((int)(j - h), (int)0, (int)width - 1); // y
+        const size_t j_next = CLAMP((int)(j + h), (int)0, (int)width - 1); // y
+        const size_t i_prev = CLAMP((int)(i - h), (int)0, (int)height - 1); // x
+        const size_t i_next = CLAMP((int)(i + h), (int)0, (int)height - 1); // x
+
+        const size_t j_far_prev = CLAMP((int)(j - mult * h), (int)0, (int)width - 1); // y
+        const size_t j_far_next = CLAMP((int)(j + mult * h), (int)0, (int)width - 1); // y
+        const size_t i_far_prev = CLAMP((int)(i - mult * h), (int)0, (int)height - 1); // x
+        const size_t i_far_next = CLAMP((int)(i + mult * h), (int)0, (int)height - 1); // x
+
+        const size_t DT_ALIGNED_ARRAY idx_grad[9]
+            = { (i_prev * width + j_prev) * ch, (i_prev * width + j) * ch, (i_prev * width + j_next) * ch,
+                (i * width + j_prev) * ch,      (i * width + j) * ch,      (i* width + j_next) * ch,
+                (i_next * width + j_prev) * ch, (i_next * width + j) * ch, (i_next * width + j_next) * ch };
+
+        const size_t DT_ALIGNED_ARRAY idx_lapl[9]
+            = { (i_far_prev * width + j_far_prev) * ch, (i_far_prev * width + j) * ch, (i_far_prev * width + j_far_next) * ch,
+                (i * width + j_far_prev) * ch,      (i * width + j) * ch,      (i* width + j_far_next) * ch,
+                (i_far_next * width + j_far_prev) * ch, (i_far_next * width + j) * ch, (i_far_next * width + j_far_next) * ch };
+
+        float DT_ALIGNED_ARRAY kern_grad[9][4] = { { 0.f } };
+        float DT_ALIGNED_ARRAY kern_lap[9][4] = { { 0.f } };
+        float DT_ALIGNED_PIXEL TV_grad[4] = { 1.f };
+        float DT_ALIGNED_PIXEL TV_lap[4] = { 1.f };
+
+        const float *const restrict north = __builtin_assume_aligned(input + idx_grad[1], 16);
+        const float *const restrict south = __builtin_assume_aligned(input + idx_grad[7], 16);
+        const float *const restrict east  = __builtin_assume_aligned(input + idx_grad[5], 16);
+        const float *const restrict west  = __builtin_assume_aligned(input + idx_grad[3], 16);
+
+        const float *const restrict north_far = __builtin_assume_aligned(input + idx_lapl[1], 16);
+        const float *const restrict south_far = __builtin_assume_aligned(input + idx_lapl[7], 16);
+        const float *const restrict east_far  = __builtin_assume_aligned(input + idx_lapl[5], 16);
+        const float *const restrict west_far  = __builtin_assume_aligned(input + idx_lapl[3], 16);
+
+        // build the local anisotropic convolution filters
+        #ifdef _OPENMP
+        #pragma omp simd aligned(north, south, west, east, TV_grad, TV_lap, north_far, south_far, east_far, west_far : 16) \
+          aligned(idx_grad, idx_lapl, kern_grad, kern_lap : 64)
+        #endif
+        for(size_t c = 0; c < 4; c++)
+        {
+          if(compute_structure)
+          {
+            // Compute the gradient with centered finite differences - warning : x is vertical, y is horizontal
+            const float grad_x = (south[c] - north[c]) / 2.0f; // du(i, j) / dx
+            const float grad_y = (east[c] - west[c]) / 2.0f;   // du(i, j) / dy
+
+            // Find the dampening factor
+            const float TV = hypotf(grad_x, grad_y);
+            const float c2 = expf(-TV / K);
+            TV_grad[c] = expf(-TV / L);
+
+            // Find the direction of the gradient
+            const float theta = atan2f(grad_y, grad_x);
+
+            // Find the gradient rotation coefficients for the matrix
+            float sin_theta = sinf(theta);
+            float cos_theta = cosf(theta);
+            const float sin_theta2 = sqf(sin_theta);
+            const float cos_theta2 = sqf(cos_theta);
+
+            // Build the convolution kernel for the structure extraction
+            const float a11 = cos_theta2 + c2 * sin_theta2;
+            const float a12 = (c2 - 1.0f) * cos_theta * sin_theta;
+            const float a22 = c2 * cos_theta2 + sin_theta2;
+
+            const float b11 = -a12 / 2.0f;
+            const float b13 = -b11;
+            const float b22 = -2.0f * (a11 + a22);
+
+            kern_grad[0][c] = b11;
+            kern_grad[1][c] = a22;
+            kern_grad[2][c] = b13;
+            kern_grad[3][c] = a11;
+            kern_grad[4][c] = b22;
+            kern_grad[5][c] = a11;
+            kern_grad[6][c] = b13;
+            kern_grad[7][c] = a22;
+            kern_grad[8][c] = b11;
+          }
+
+          if(compute_texture)
+          {
+            // Compute the laplacian with centered finite differences - warning : x is vertical, y is horizontal
+            const float grad_x = south_far[c] + north_far[c] - 2.f * input[index + c]; // du(i, j) / dx
+            const float grad_y = east_far[c] + west_far[c] - 2.f * input[index + c];   // du(i, j) / dy
+
+            // Find the dampening factor
+            const float TV = hypotf(grad_x, grad_y);
+            const float c2 = expf(-TV / K);
+            TV_lap[c] = expf(-TV / L);
+
+            // Find the direction of the gradient
+            const float theta = atan2f(grad_y, grad_x);
+
+            // Find the gradient rotation coefficients for the matrix
+            float sin_theta = sinf(theta);
+            float cos_theta = cosf(theta);
+            const float sin_theta2 = sqf(sin_theta);
+            const float cos_theta2 = sqf(cos_theta);
+
+            // Build the convolution kernel for the texture extraction
+            const float a11 = cos_theta2 + c2 * sin_theta2;
+            const float a12 = (c2 - 1.0f) * cos_theta * sin_theta;
+            const float a22 = c2 * cos_theta2 + sin_theta2;
+
+            const float b11 = a12 / sqrtf(2.f);
+            const float b22 = -2.f * (a11 + a22 ) - 4.f * a12 / sqrtf(2.f);
+
+            kern_lap[0][c] = b11;
+            kern_lap[1][c] = a22;
+            kern_lap[2][c] = b11;
+            kern_lap[3][c] = a11;
+            kern_lap[4][c] = b22;
+            kern_lap[5][c] = a11;
+            kern_lap[6][c] = b11;
+            kern_lap[7][c] = a22;
+            kern_lap[8][c] = b11;
+          }
+        }
+
+        float DT_ALIGNED_PIXEL grad[4] = { 0.f };
+        float DT_ALIGNED_PIXEL lapl[4] = { 0.f };
+
+        // Convolve anisotropic filters at current pixel
+        #ifdef _OPENMP
+        #pragma omp simd aligned(kern_grad, kern_lap, input, output, idx_grad: 64) aligned(TV_grad, TV_lap, grad, lapl : 16)
+        #endif
+        for(size_t c = 0; c < 4; c++)
+        {
+          float acc1 = 0.f;
+          float acc2 = 0.f;
+
+          for(size_t k = 0; k < 9; k++)
+          {
+            // Convolve first-order term (gradient)
+            acc1 += kern_grad[k][c] * input[idx_grad[k] + c];
+
+            // Convolve second-order term (laplacian)
+            acc2 += kern_lap[k][c] * input[idx_lapl[k] + c];
+          }
+
+          grad[c] = acc1;
+          lapl[c] = acc2;
+        }
+
+        // Use a collaborative regularization
+        const float TV_lap_min = fminf(fminf(TV_lap[0], TV_lap[1]), TV_lap[2]);
+        const float TV_grad_min = fminf(fminf(TV_grad[0], TV_grad[1]), TV_grad[2]);
+
+        // Update the solution
+        #ifdef _OPENMP
+        #pragma omp simd aligned(input, output: 64) aligned(grad, lapl : 16)
+        #endif
+        for(size_t c = 0; c < 4; c++)
+        {
+          output[index + c] = input[index + c] + A * lapl[c] * TV_lap_min + B * grad[c] * TV_grad_min;
+        }
+      }
+      else
+      {
+        #ifdef _OPENMP
+        #pragma omp simd aligned(input, output: 64)
+        #endif
+        for(size_t c = 0; c < 4; c++) output[index + c] = input[index + c];
+      }
+    }
+}
+
+
+static float diffusion_scale_factor(const float current_radius, const float final_radius, const float zoom, const dt_iop_diffuse_model_t model)
+{
+  if(model == DT_DIFFUSE_GAUSSIAN)
+  {
+    return expf(-(current_radius * current_radius) / (final_radius * final_radius * zoom * zoom));
+  }
+  else if(model == DT_DIFFUSE_CONSTANT)
+  {
+    return (current_radius <= final_radius) ? 1.f : 0.f;
+  }
+  else if(model == DT_DIFFUSE_LINEAR)
+  {
+    return fmaxf(1.f - current_radius / final_radius, 0.f);
+  }
+  else if(model == DT_DIFFUSE_QUADRATIC)
+  {
+    return fmaxf(sqrtf(1.f - current_radius / final_radius), 0.f);
+  }
+  else
+  {
+    return 1.f;
+  }
+}
+
+
+static inline gint reconstruct_highlights(const float *const restrict in, float *const restrict reconstructed,
+                                          const uint8_t *const restrict mask,
+                                          const size_t ch,
+                                          const dt_iop_diffuse_data_t *const data, dt_dev_pixelpipe_iop_t *piece,
+                                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  gint success = TRUE;
+
+  // wavelets scales - either the max kernel size at current resolution or 4 times the blur radius
+  const float zoom = roi_in->scale / piece->iscale;
+  const int current_zoom_scales = get_scales(roi_in, piece);
+  int diffusion_scales;
+  if(data->model == DT_DIFFUSE_GAUSSIAN)
+    diffusion_scales = ceilf(log2f(data->radius * zoom * 4));
+  else
+    diffusion_scales = ceilf(log2f(data->radius * zoom));
+
+  const int scales = MIN(diffusion_scales, current_zoom_scales);
+
+  float structure = data->structure;
+  float texture = data->texture;
+  float edges = expf(-data->edges);
+  float regularization = expf(-data->regularization);
+
+  // wavelets scales buffers
+  float *const restrict LF_even = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch); // low-frequencies RGB
+  float *const restrict LF_odd = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);  // low-frequencies RGB
+  float *const restrict HF_RGB = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);  // high-frequencies RGB
+
+  // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
+  float *const restrict temp1 = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+  float *const restrict temp2 = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+
+  if(!LF_even || !LF_odd || !HF_RGB || !temp1 || !temp2)
+  {
+    dt_control_log(_("filmic highlights reconstruction failed to allocate memory, check your RAM settings"));
+    success = FALSE;
+    goto error;
+  }
+
+  // Init reconstructed with valid parts of image
+  init_reconstruct(reconstructed, roi_out->width, roi_out->height, ch);
+
+  // À trous wavelet decompose
+  // there is a paper from a guy we know that explains it : https://jo.dreggn.org/home/2010_atrous.pdf
+  // the wavelets decomposition here is the same as the equalizer/atrous module,
+  // but simplified because we don't need the edge-aware term, so we can seperate the convolution kernel
+  // with a vertical and horizontal blur, wich is 10 multiply-add instead of 25 by pixel.
+  for(int s = 0; s < scales; ++s)
+  {
+    const float *restrict detail;       // buffer containing this scale's input
+    float *restrict LF;                 // output buffer for the current scale
+    float *restrict HF_RGB_temp;        // temp buffer for HF_RBG terms before blurring
+
+    // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
+    if(s == 0)
+    {
+      detail = in;
+      LF = LF_odd;
+      HF_RGB_temp = LF_even;
+    }
+    else if(s % 2 != 0)
+    {
+      detail = LF_odd;
+      LF = LF_even;
+      HF_RGB_temp = LF_odd;
+    }
+    else
+    {
+      detail = LF_even;
+      LF = LF_odd;
+      HF_RGB_temp = LF_even;
+    }
+
+    const int mult = 1 << s; // fancy-pants C notation for 2^s with integer type, don't be afraid
+
+    // Compute wavelets low-frequency scales
+    blur_2D_Bspline(detail, LF, temp1, roi_out->width, roi_out->height, mult);
+
+    // Compute wavelets high-frequency scales and save the mininum of texture over the RGB channels
+    // Note : HF_RGB = detail - LF, HF_grey = max(HF_RGB)
+    wavelets_detail_level(detail, LF, HF_RGB_temp, roi_out->width, roi_out->height, ch);
+
+    // diffuse particles
+    float *LF_in = NULL;
+    float *LF_out = NULL;
+    float *HF_in = NULL;
+    float *HF_out = NULL;
+
+    const float factor = data->update * diffusion_scale_factor((float)mult, data->radius, zoom, data->model);
+
+    if(s == scales - 1)
+    {
+      // if it's the last scale, then LF is the residual so we blur it too as if it was the next HF
+      const int next_mult = 1 << (s + 1);
+      const float factor_lf = data->update * diffusion_scale_factor((float)(next_mult), data->radius, zoom, data->model);
+
+      for(size_t it = 0; it < data->iterations; it++)
+      {
+        if(it == 0)
+        {
+          LF_in = LF;
+          LF_out = temp2;
+        }
+        else if(it % 2 != 0)
+        {
+          LF_in = temp2;
+          LF_out = LF;
+        }
+        else
+        {
+          LF_in = LF;
+          LF_out = temp2;
+        }
+
+        heat_PDE_inpanting(LF_in, LF_out, mask, roi_out->width, roi_out->height, ch, next_mult,
+                           factor_lf * texture,
+                           structure, edges, regularization);
+      }
+
+      LF = LF_out;
+    }
+
+    for(size_t it = 0; it < data->iterations; it++)
+    {
+      if(it == 0)
+      {
+        HF_in = HF_RGB_temp;
+        HF_out = temp1;
+      }
+      else if(it % 2 != 0)
+      {
+        HF_in = temp1;
+        HF_out = HF_RGB_temp;
+      }
+      else
+      {
+        HF_in = HF_RGB_temp;
+        HF_out = temp1;
+      }
+
+      heat_PDE_inpanting(HF_in, HF_out, mask, roi_out->width, roi_out->height, ch, mult,
+                          factor * texture,
+                          structure, edges, regularization);
+    }
+
+    HF_RGB_temp = HF_out;
+
+    // Collapse wavelets
+    wavelets_reconstruct_RGB(HF_RGB_temp, LF, reconstructed, roi_out->width, roi_out->height, ch, s, scales);
+  }
+
+error:
+  if(temp1) dt_free_align(temp1);
+  if(temp2) dt_free_align(temp2);
+  if(LF_even) dt_free_align(LF_even);
+  if(LF_odd) dt_free_align(LF_odd);
+  if(HF_RGB) dt_free_align(HF_RGB);
+  return success;
+}
+
+
+static inline void build_mask(const float *const restrict input, uint8_t *const restrict mask, const float threshold,
+                              const size_t width, const size_t height, const size_t ch)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+dt_omp_firstprivate(input, mask, height, width, ch, threshold) \
+schedule(dynamic) aligned(mask, input:64)
+#endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    mask[k / ch] = (input[k] > threshold || input[k + 1] > threshold || input[k + 2] > threshold);
+  }
+}
+
+
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict ivoid,
+             void *const restrict ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_diffuse_data_t *const data = (dt_iop_diffuse_data_t *)piece->data;
+
+  if(piece->colors != 4)
+  {
+    dt_control_log(_("filmic works only on RGB input"));
+    return;
+  }
+
+  const size_t ch = 4;
+  float *restrict in = (float *const restrict)ivoid;
+  float *const restrict out = (float *const restrict)ovoid;
+  float *restrict temp = NULL;
+  uint8_t *restrict mask = NULL;
+
+  if(data->threshold > 0.f)
+  {
+    const float scale = piece->iscale / roi_in->scale;
+    const float blur = 32.f / scale;
+
+    // build a boolean mask, TRUE where image is above threshold
+    mask = dt_alloc_align(64,roi_out->width * roi_out->height * sizeof(uint8_t));
+    build_mask(in, mask, data->threshold, roi_out->width, roi_out->height, ch);
+
+    // init the inpainting area with blur
+    temp = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+
+    float RGBmax[4], RGBmin[4];
+    for(int k = 0; k < 4; k++)
+    {
+      RGBmax[k] = INFINITY;
+      RGBmin[k] = 0.f;
+    }
+
+    dt_gaussian_t *g = dt_gaussian_init(roi_out->width, roi_out->height, ch, RGBmax, RGBmin, blur, 0);
+    if(!g) return;
+    dt_gaussian_blur_4c(g, in, temp);
+    dt_gaussian_free(g);
+
+    // add noise and restore valid parts where mask = FALSE
+    const float noise = 0.1 / scale;
+
+    #ifdef _OPENMP
+    #pragma omp parallel for default(none) \
+    dt_omp_firstprivate(in, temp, mask, roi_out, ch, noise) \
+    schedule(dynamic)
+    #endif
+    for(size_t k = 0; k < roi_out->height * roi_out->width * ch; k += ch)
+    {
+      if(mask[k / ch])
+      {
+        const uint32_t i = k / roi_out->width;
+        const uint32_t j = k - i;
+        uint32_t DT_ALIGNED_ARRAY state[4] = { splitmix32(j + 1), splitmix32((j + 1) * (i + 3)), splitmix32(1337), splitmix32(666) };
+        xoshiro128plus(state);
+        xoshiro128plus(state);
+        xoshiro128plus(state);
+        xoshiro128plus(state);
+
+        for(size_t c = 0; c < 4; c++) temp[k + c] = gaussian_noise(temp[k + c], noise, i % 2 || j % 2, state);
+      }
+      else
+      {
+        for(size_t c = 0; c < 4; c++) temp[k + c] = in[k + c];
+      }
+    }
+
+    in = temp;
+  }
+
+  reconstruct_highlights(in, out, mask, ch, data, piece, roi_in, roi_out);
+
+  if(mask) dt_free_align(mask);
+  if(temp) dt_free_align(temp);
+}
+
+
+void gui_update(struct dt_iop_module_t *self)
+{
+  dt_iop_diffuse_gui_data_t *g = (dt_iop_diffuse_gui_data_t *)self->gui_data;
+  dt_iop_diffuse_params_t *p = (dt_iop_diffuse_params_t *)self->params;
+  dt_bauhaus_slider_set_soft(g->iterations, p->iterations);
+  dt_bauhaus_slider_set_soft(g->texture, p->texture);
+  dt_bauhaus_slider_set_soft(g->structure, p->structure);
+  dt_bauhaus_slider_set_soft(g->edges, p->edges);
+  dt_bauhaus_slider_set_soft(g->regularization, p->regularization);
+  dt_bauhaus_slider_set_soft(g->radius, p->radius);
+  dt_bauhaus_slider_set_soft(g->update, p->update);
+  dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
+  dt_bauhaus_combobox_set(g->model, p->model);
+}
+
+void gui_init(struct dt_iop_module_t *self)
+{
+  dt_iop_diffuse_gui_data_t *g = IOP_GUI_ALLOC(diffuse);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion intensity")), FALSE, FALSE, 0);
+
+  g->iterations = dt_bauhaus_slider_from_params(self, "iterations");
+  gtk_widget_set_tooltip_text(g->iterations, _("more iterations make the effect stronger but the module slower.\n"
+                                               "this is analogous to giving more time to the diffusion reaction.\n"
+                                               "if you plan on sharpening or inpainting, more iterations help reconstruction."));
+
+  g->update = dt_bauhaus_slider_from_params(self, "update");
+  dt_bauhaus_slider_set_factor(g->update, 100.0f);
+  dt_bauhaus_slider_set_format(g->update, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->update, _("weight of each iterations update.\n"
+                                           "100 % is suitable for diffusion, inpainting and blurring.\n"
+                                           "lower if noise, halos or any artifact appear as you add more iterations."));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion quality")), FALSE, FALSE, 0);
+
+  g->structure = dt_bauhaus_slider_from_params(self, "structure");
+  dt_bauhaus_slider_set_factor(g->structure, 100.0f);
+  dt_bauhaus_slider_set_format(g->structure, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->structure, _("smoothing or sharpening of smooth details (gradients).\n"
+                                              "positive values diffuse and blur.\n"
+                                              "negative values sharpen.\n"
+                                              "zero does nothing."));
+
+  g->texture = dt_bauhaus_slider_from_params(self, "texture");
+  dt_bauhaus_slider_set_factor(g->texture, 100.0f);
+  dt_bauhaus_slider_set_format(g->texture, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->texture, _("smoothing or sharpening of sharp details (gradients).\n"
+                                            "positive values diffuse and blur.\n"
+                                            "negative values sharpen.\n"
+                                            "zero does nothing."));
+
+  g->edges = dt_bauhaus_slider_from_params(self, "edges");
+  gtk_widget_set_tooltip_text(g->edges, _("anisotropy of the diffusion.\n"
+                                          "high values force the diffusion to be 1D and perpendicular to edges.\n"
+                                          "low values allow the diffusion to be 2D and uniform, like a classic blur."));
+
+  g->regularization = dt_bauhaus_slider_from_params(self, "regularization");
+  gtk_widget_set_tooltip_text(g->regularization, _("normalization of the diffusion.\n"
+                                                   "high values dampen high-magnitude gradients to avoid overshooting at sharp edges.\n"
+                                                   "low values relay the dampening and allow more and more overshooting."));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion spatiality")), FALSE, FALSE, 0);
+
+  g->model = dt_bauhaus_combobox_from_params(self, "model");
+  gtk_widget_set_tooltip_text(g->threshold, _("defines how the diffusion blends as radius increases.\n"
+                                              "gaussian mimics natural diffusion, with large radii barely affected.\n"
+                                              "constant is a regular wavelets blending and affect each radius the same.\n"
+                                              "linear or quadratic define different rates of spatial diffusion."));
+
+  g->radius = dt_bauhaus_slider_from_params(self, "radius");
+  dt_bauhaus_slider_set_format(g->radius, "%.0f px");
+  gtk_widget_set_tooltip_text(g->radius, _("scale of the diffusion.\n"
+                                           "high values diffuse farther, at the expense of computation time.\n"
+                                           "low values diffuse closer.\n"
+                                           "if you plan on denoising, the radius should be around the width of your lens blur."));
+
+  g->threshold = dt_bauhaus_slider_from_params(self, "threshold");
+  gtk_widget_set_tooltip_text(g->threshold, _("luminance threshold for the mask.\n"
+                                              "0. disables the luminance masking and applies the module on the whole image.\n"
+                                              "any higher value will exclude pixels whith luminance lower than the threshold.\n"
+                                              "this can be used to inpaint highlights."));
+}

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -158,17 +158,17 @@ void init_presets(dt_iop_module_so_t *self)
   p.threshold = 0.0f;
   p.variance_threshold = 0.f;
 
-  p.anisotropy_first = -5.f;
+  p.anisotropy_first = +5.f;
   p.anisotropy_second = +5.f;
-  p.anisotropy_third = -5.f;
-  p.anisotropy_fourth = +2.f;
+  p.anisotropy_third = +5.f;
+  p.anisotropy_fourth = +5.f;
 
   p.first = -0.5f;
   p.second = +0.25f;
   p.third = -0.25f;
-  p.fourth = -0.05f;
+  p.fourth = +0.125f;
 
-  p.regularization = 1.f;
+  p.regularization = 2.f;
 
   p.iterations = 4;
   p.radius = 8;
@@ -282,17 +282,17 @@ void init_presets(dt_iop_module_so_t *self)
   p.sharpness = 0.0f;
   p.threshold = 0.0f;
   p.variance_threshold = 0.f;
-  p.regularization = 0.f;
+  p.regularization = 1.f;
 
-  p.anisotropy_first = +5.f;
-  p.anisotropy_second = +5.f;
-  p.anisotropy_third = +5.f;
-  p.anisotropy_fourth = +5.f;
+  p.anisotropy_first = +1.f;
+  p.anisotropy_second = +1.f;
+  p.anisotropy_third = +1.f;
+  p.anisotropy_fourth = +1.f;
 
-  p.first = -0.5f;
-  p.second = -0.5f;
-  p.third = -0.5f;
-  p.fourth = +0.25f;
+  p.first = -0.25f;
+  p.second = -0.25f;
+  p.third = -0.25f;
+  p.fourth = -0.25f;
   dt_gui_presets_add_generic(_("sharpen demosaicing (no AA filter)"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -65,10 +65,10 @@ typedef struct dt_iop_diffuse_params_t
 
   float threshold; // $MIN: 0.  $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
 
-  float first; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "1st order (gradient)"
-  float second; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "2nd order (laplacian)"
-  float third; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "3rd order (gradient of laplacian)"
-  float fourth; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "4th order (laplacian of laplacian)"
+  float first; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "1st order speed"
+  float second; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "2nd order speed"
+  float third; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "3rd order speed"
+  float fourth; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "4th order speed"
 } dt_iop_diffuse_params_t;
 
 
@@ -1316,7 +1316,7 @@ void gui_init(struct dt_iop_module_t *self)
                    "low values diffuse closer.\n"
                    "if you plan on denoising, the radius should be around the width of your lens blur."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion typology")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion speed")), FALSE, FALSE, 0);
 
   g->first = dt_bauhaus_slider_from_params(self, "first");
   dt_bauhaus_slider_set_factor(g->first, 100.0f);
@@ -1331,6 +1331,10 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->second, 4);
   dt_bauhaus_slider_set_factor(g->second, 100.0f);
   dt_bauhaus_slider_set_format(g->second, "%+.2f %%");
+  gtk_widget_set_tooltip_text(g->second, _("smoothing or sharpening of sharp details.\n"
+                                          "positive values diffuse and blur.\n"
+                                          "negative values sharpen.\n"
+                                          "zero does nothing."));
 
   g->third = dt_bauhaus_slider_from_params(self, "third");
   dt_bauhaus_slider_set_digits(g->third, 4);
@@ -1400,9 +1404,17 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->sharpness,
                               _("increase or decrease the sharpness of the highest frequencies"));
 
-
   g->regularization = dt_bauhaus_slider_from_params(self, "regularization");
+  gtk_widget_set_tooltip_text(g->regularization,
+                              _("define the sensitivity of the variance penalty for edges.\n"
+                                "increase to exclude more edges from diffusion,\n"
+                                "if fringes or halos appear."));
+
   g->variance_threshold = dt_bauhaus_slider_from_params(self, "variance_threshold");
+  gtk_widget_set_tooltip_text(g->variance_threshold,
+                              _("define the variance threshold between edge amplification and penalty.\n"
+                                "decrease if you want pixels on smooth surfaces get a diffusion boost,\n"
+                                "while pixels on edges still get penalized."));
 
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion spatiality")), FALSE, FALSE, 0);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -639,7 +639,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           // we use the low freq layer all the type as it is less likely to be nosy
           float gradient[2], laplacian[2]; // x, y for each channel
           find_gradient(neighbour_pixel_LF, c, gradient);
-          find_laplacian(neighbour_pixel_LF, c, laplacian);
+          find_gradient(neighbour_pixel_HF, c, laplacian);
 
           const float magnitude_grad = hypotf(gradient[0], gradient[1]);
           const float magnitude_lapl = hypotf(laplacian[0], laplacian[1]);
@@ -690,7 +690,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           // compute the update
           float acc = 0.f;
           for(size_t k = 0; k < 4; k++) acc += derivatives[k] * ABCD[k];
-          acc = (HF[index + c] + acc / variance) * strength;
+          acc = (HF[index + c] * strength + acc / variance);
 
           // update the solution
           out[index + c] = fmaxf(acc + LF[index + c], 0.f);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -759,7 +759,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
   float *restrict residual; // will store the temp buffer containing the last step of blur
   for(int s = 0; s < scales; ++s)
   {
-    fprintf(stdout, "Wavelet decompose : scale %i\n", s);
+    /* fprintf(stdout, "Wavelet decompose : scale %i\n", s); */
     const int mult = 1 << s;
 
     const float *restrict buffer_in;
@@ -810,8 +810,10 @@ static inline gint wavelets_process(const float *const restrict in, float *const
                                              data->third * KAPPA * norm, data->fourth * KAPPA * norm };
     const float strength = data->sharpness * norm + 1.f;
 
+    /* debug
     fprintf(stdout, "PDE solve : scale %i : mult = %i ; current rad = %.0f ; real rad = %.0f ; norm = %f ; strength = %f\n", s,
             1 << s, current_radius, real_radius, norm, strength);
+    */
 
     const float *restrict buffer_in;
     float *restrict buffer_out;
@@ -991,8 +993,7 @@ error:
   for(int s = 0; s < scales; s++) if(HF[s]) dt_free_align(HF[s]);
 }
 
-#if TRUE
- // HAVE_OPENCL
+#if HAVE_OPENCL
 static inline cl_int wavelets_process_cl(const int devid, cl_mem in, cl_mem reconstructed, cl_mem mask,
                                          const size_t sizes[3], const int width, const int height,
                                          const dt_iop_diffuse_data_t *const data,

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -58,10 +58,10 @@ typedef struct dt_iop_diffuse_params_t
   float regularization;     // $MIN: 0. $MAX: 4.   $DEFAULT: 0. $DESCRIPTION: "edge sensitivity"
   float variance_threshold; // $MIN: -2. $MAX: 2.   $DEFAULT: 0. $DESCRIPTION: "edge threshold"
 
-  float anisotropy_first;         // $MIN: -5. $MAX: 5.   $DEFAULT: 0. $DESCRIPTION: "1st order anisotropy"
-  float anisotropy_second;        // $MIN: -5. $MAX: 5.   $DEFAULT: 0. $DESCRIPTION: "2nd order anisotropy"
-  float anisotropy_third;         // $MIN: -5. $MAX: 5.   $DEFAULT: 0. $DESCRIPTION: "3rd order anisotropy"
-  float anisotropy_fourth;        // $MIN: -5. $MAX: 5.   $DEFAULT: 0. $DESCRIPTION: "4th order anisotropy"
+  float anisotropy_first;         // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "1st order anisotropy"
+  float anisotropy_second;        // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "2nd order anisotropy"
+  float anisotropy_third;         // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "3rd order anisotropy"
+  float anisotropy_fourth;        // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "4th order anisotropy"
 
   float threshold; // $MIN: 0.  $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
 
@@ -158,48 +158,48 @@ void init_presets(dt_iop_module_so_t *self)
   p.threshold = 0.0f;
   p.variance_threshold = 0.f;
 
-  p.anisotropy_first = -4.f;
-  p.anisotropy_second = +4.f;
-  p.anisotropy_third = +4.f;
-  p.anisotropy_fourth = -4.f;
+  p.anisotropy_first = -5.f;
+  p.anisotropy_second = +5.f;
+  p.anisotropy_third = -5.f;
+  p.anisotropy_fourth = +2.f;
 
   p.first = -0.5f;
-  p.second = +0.3333f;
-  p.third = -0.1f;
-  p.fourth = +0.1f;
+  p.second = +0.25f;
+  p.third = -0.25f;
+  p.fourth = -0.05f;
 
-  p.regularization = 2.f;
+  p.regularization = 1.f;
 
-  p.iterations = 8;
+  p.iterations = 4;
   p.radius = 8;
   dt_gui_presets_add_generic(_("lens deblur: soft"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
-  p.iterations = 12;
+  p.iterations = 6;
   p.radius = 12;
   dt_gui_presets_add_generic(_("lens deblur: medium"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
-  p.iterations = 16;
+  p.iterations = 8;
   p.radius = 16;
   dt_gui_presets_add_generic(_("lens deblur: hard"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
-  p.iterations = 20;
+  p.iterations = 10;
   p.radius = 512;
   p.sharpness = 0.f;
   p.variance_threshold = 0.0f;
   p.regularization = 2.f;
 
-  p.first = -0.10f;
-  p.second = +0.2f;
-  p.third = -0.10f;
-  p.fourth = +0.02f;
+  p.first = -0.30f;
+  p.second = +0.15f;
+  p.third = -0.20f;
+  p.fourth = +0.10f;
 
   p.anisotropy_first = 2.f;
-  p.anisotropy_second = 2.f;
+  p.anisotropy_second = 4.f;
   p.anisotropy_third = 2.f;
-  p.anisotropy_fourth = 2.f;
+  p.anisotropy_fourth = 4.f;
 
   dt_gui_presets_add_generic(_("dehaze"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
@@ -211,16 +211,34 @@ void init_presets(dt_iop_module_so_t *self)
   p.variance_threshold = -0.25f;
   p.regularization = 4.f;
 
-  p.anisotropy_first = +4.f;
-  p.anisotropy_second = +4.f;
-  p.anisotropy_third = +4.f;
-  p.anisotropy_fourth = +4.f;
+  p.anisotropy_first = -5.f;
+  p.anisotropy_second = +5.f;
+  p.anisotropy_third = -5.f;
+  p.anisotropy_fourth = +5.f;
 
   p.first = -0.25f;
   p.second = +0.50f;
   p.third = -0.05f;
   p.fourth = +0.10f;
-  dt_gui_presets_add_generic(_("denoise"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  dt_gui_presets_add_generic(_("denoise: soft"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.iterations = 100;
+  p.radius = 8;
+  p.sharpness = 0.f;
+  p.threshold = 0.f;
+  p.variance_threshold = -0.25f;
+  p.regularization = 1.f;
+
+  p.anisotropy_first = 0.f;
+  p.anisotropy_second = 0.f;
+  p.anisotropy_third = 0.f;
+  p.anisotropy_fourth = +5.f;
+
+  p.first = -0.02f;
+  p.second = 0.0f;
+  p.third = 0.0 f;
+  p.fourth = +0.05f;
+  dt_gui_presets_add_generic(_("denoise: soft"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.iterations = 2;
   p.radius = 32;
@@ -264,12 +282,12 @@ void init_presets(dt_iop_module_so_t *self)
   p.sharpness = 0.0f;
   p.threshold = 0.0f;
   p.variance_threshold = 0.f;
-  p.regularization = 2.f;
+  p.regularization = 0.f;
 
-  p.anisotropy_first = +4.f;
-  p.anisotropy_second = +4.f;
-  p.anisotropy_third = +4.f;
-  p.anisotropy_fourth = +4.f;
+  p.anisotropy_first = +5.f;
+  p.anisotropy_second = +5.f;
+  p.anisotropy_third = +5.f;
+  p.anisotropy_fourth = +5.f;
 
   p.first = -0.5f;
   p.second = -0.5f;
@@ -338,6 +356,25 @@ void init_presets(dt_iop_module_so_t *self)
   p.regularization = 3.5f;
   dt_gui_presets_add_generic(_("add local contrast"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.iterations = 32;
+  p.radius = 4;
+  p.sharpness = 0.0f;
+  p.threshold = 1.41f;
+  p.variance_threshold = 0.f;
+  p.regularization = 0.f;
+
+  p.anisotropy_first = +0.f;
+  p.anisotropy_second = +0.f;
+  p.anisotropy_third = +2.f;
+  p.anisotropy_fourth = +2.f;
+
+  p.first = +0.0f;
+  p.second = +0.0f;
+  p.third = +0.02f;
+  p.fourth = +0.02f;
+  dt_gui_presets_add_generic(_("inpaint highlights"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
 
 }
 
@@ -713,9 +750,8 @@ static inline float compute_anisotropy_factor(const float user_param)
 {
   // compute the K param in c evaluation from https://www.researchgate.net/publication/220663968
   // but in a perceptually-even way, for better GUI interaction
-  const float normalize = expf(1.f) - 1.f;
   if(user_param == 0.f) return FLT_MAX;
-  else return expf(fabsf(1.f / user_param) - 1.f) / normalize;
+  else return 1.f / sqf(user_param);
 }
 
 #if DEBUG_DUMP_PFM
@@ -1016,11 +1052,17 @@ static inline cl_int wavelets_process_cl(const int devid, cl_mem in, cl_mem reco
           compute_anisotropy_factor(data->anisotropy_third),
           compute_anisotropy_factor(data->anisotropy_fourth) };
 
+  fprintf(stdout, "anisotropy : %f ; %f ; %f ; %f \n",
+                  anisotropy[0], anisotropy[1], anisotropy[2], anisotropy[3]);
+
   const dt_isotropy_t DT_ALIGNED_PIXEL isotropy_type[4]
       = { check_isotropy_mode(data->anisotropy_first),
           check_isotropy_mode(data->anisotropy_second),
           check_isotropy_mode(data->anisotropy_third),
           check_isotropy_mode(data->anisotropy_fourth) };
+
+  fprintf(stdout, "type : %d ; %d ; %d ; %d \n",
+                  isotropy_type[0], isotropy_type[1], isotropy_type[2], isotropy_type[3]);
 
   float regularization = powf(10.f, data->regularization) - 1.f;
   float variance_threshold = powf(10.f, data->variance_threshold);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2019-2020 darktable developers.
+   Copyright (C) 2021 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -106,9 +106,12 @@ static inline dt_isotropy_t check_isotropy_mode(const float anisotropy)
 {
   // user param is negative, positive or zero. The sign encodes the direction of diffusion, the magnitude encodes the ratio of anisotropy
   // ultimately, the anisotropy factor needs to be positive before going into the exponential
-  if(anisotropy == 0.f) return DT_ISOTROPY_ISOTROPE;
-  else if(anisotropy > 0.f) return DT_ISOTROPY_ISOPHOTE;
-  else return DT_ISOTROPY_GRADIENT; // if(anisotropy > 0.f)
+  if(anisotropy == 0.f)
+    return DT_ISOTROPY_ISOTROPE;
+  else if(anisotropy > 0.f)
+    return DT_ISOTROPY_ISOPHOTE;
+  else
+    return DT_ISOTROPY_GRADIENT; // if(anisotropy > 0.f)
 }
 
 
@@ -258,7 +261,6 @@ void init_presets(dt_iop_module_so_t *self)
   p.fourth = +1.f;
   dt_gui_presets_add_generic(_("surface blur"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-
   p.iterations = 1;
   p.radius = 32;
   p.sharpness = 0.0f;
@@ -374,8 +376,6 @@ void init_presets(dt_iop_module_so_t *self)
   p.third = +0.02f;
   p.fourth = +0.02f;
   dt_gui_presets_add_generic(_("inpaint highlights"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
-
-
 }
 
 // B spline filter
@@ -750,8 +750,10 @@ static inline float compute_anisotropy_factor(const float user_param)
 {
   // compute the K param in c evaluation from https://www.researchgate.net/publication/220663968
   // but in a perceptually-even way, for better GUI interaction
-  if(user_param == 0.f) return FLT_MAX;
-  else return 1.f / sqf(user_param);
+  if(user_param == 0.f)
+    return FLT_MAX;
+  else
+    return 1.f / sqf(user_param);
 }
 
 #if DEBUG_DUMP_PFM

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -54,9 +54,9 @@ typedef struct dt_iop_diffuse_params_t
   // global parameters
   int iterations;           // $MIN: 1   $MAX: 128   $DEFAULT: 1  $DESCRIPTION: "iterations"
   float sharpness;          // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "sharpness"
-  int radius;               // $MIN: 1   $MAX: 1024   $DEFAULT: 8  $DESCRIPTION: "radius"
+  int radius;               // $MIN: 1   $MAX: 512   $DEFAULT: 8  $DESCRIPTION: "radius"
   float regularization;     // $MIN: 0. $MAX: 4.   $DEFAULT: 0. $DESCRIPTION: "edge sensitivity"
-  float variance_threshold; // $MIN: -4. $MAX: 4.   $DEFAULT: 0. $DESCRIPTION: "edge threshold"
+  float variance_threshold; // $MIN: -2. $MAX: 2.   $DEFAULT: 0. $DESCRIPTION: "edge threshold"
 
   float anisotropy_first;         // $MIN: -5. $MAX: 5.   $DEFAULT: 0. $DESCRIPTION: "1st order anisotropy"
   float anisotropy_second;        // $MIN: -5. $MAX: 5.   $DEFAULT: 0. $DESCRIPTION: "2nd order anisotropy"
@@ -158,15 +158,15 @@ void init_presets(dt_iop_module_so_t *self)
   p.threshold = 0.0f;
   p.variance_threshold = 0.f;
 
-  p.anisotropy_first = +2.f;
-  p.anisotropy_second = -4.f;
-  p.anisotropy_third = +2.f;
+  p.anisotropy_first = -4.f;
+  p.anisotropy_second = +4.f;
+  p.anisotropy_third = +4.f;
   p.anisotropy_fourth = -4.f;
 
-  p.first = +0.3333f;
-  p.second = -0.5000f;
-  p.third = +0.02f;
-  p.fourth = -0.04f;
+  p.first = -0.5f;
+  p.second = +0.3333f;
+  p.third = -0.1f;
+  p.fourth = +0.1f;
 
   p.regularization = 2.f;
 
@@ -191,10 +191,10 @@ void init_presets(dt_iop_module_so_t *self)
   p.variance_threshold = 0.0f;
   p.regularization = 2.f;
 
-  p.first = +0.02f;
-  p.second = -0.10;
-  p.third = +0.02;
-  p.fourth = -0.10f;
+  p.first = -0.10f;
+  p.second = +0.2f;
+  p.third = -0.10f;
+  p.fourth = +0.02f;
 
   p.anisotropy_first = 2.f;
   p.anisotropy_second = 2.f;
@@ -206,9 +206,9 @@ void init_presets(dt_iop_module_so_t *self)
 
   p.iterations = 5;
   p.radius = 5;
-  p.sharpness = 0.0f;
-  p.threshold = 0.0f;
-  p.variance_threshold = 0.f;
+  p.sharpness = 0.f;
+  p.threshold = 0.f;
+  p.variance_threshold = -0.25f;
   p.regularization = 4.f;
 
   p.anisotropy_first = +4.f;
@@ -216,10 +216,10 @@ void init_presets(dt_iop_module_so_t *self)
   p.anisotropy_third = +4.f;
   p.anisotropy_fourth = +4.f;
 
-  p.first = +0.3333f;
-  p.second = +0.3333f;
-  p.third = +0.04f;
-  p.fourth = +0.02f;
+  p.first = -0.25f;
+  p.second = +0.50f;
+  p.third = -0.05f;
+  p.fourth = +0.10f;
   dt_gui_presets_add_generic(_("denoise"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.iterations = 2;
@@ -273,9 +273,13 @@ void init_presets(dt_iop_module_so_t *self)
 
   p.first = -0.5f;
   p.second = -0.5f;
-  p.third = -0.25f;
-  p.fourth = -0.25f;
-  dt_gui_presets_add_generic(_("sharpen sensor demosaicing"), self->op, self->version(), &p, sizeof(p), 1,
+  p.third = -0.5f;
+  p.fourth = +0.25f;
+  dt_gui_presets_add_generic(_("sharpen demosaicing (no AA filter)"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.radius = 8;
+  dt_gui_presets_add_generic(_("sharpen demosaicing (AA filter)"), self->op, self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.iterations = 4;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -236,9 +236,9 @@ void init_presets(dt_iop_module_so_t *self)
 
   p.first = -0.02f;
   p.second = 0.0f;
-  p.third = 0.0 f;
+  p.third = 0.0f;
   p.fourth = +0.05f;
-  dt_gui_presets_add_generic(_("denoise: soft"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  dt_gui_presets_add_generic(_("denoise: hard (slow)"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.iterations = 2;
   p.radius = 32;
@@ -1052,8 +1052,10 @@ static inline cl_int wavelets_process_cl(const int devid, cl_mem in, cl_mem reco
           compute_anisotropy_factor(data->anisotropy_third),
           compute_anisotropy_factor(data->anisotropy_fourth) };
 
+  /*
   fprintf(stdout, "anisotropy : %f ; %f ; %f ; %f \n",
                   anisotropy[0], anisotropy[1], anisotropy[2], anisotropy[3]);
+  */
 
   const dt_isotropy_t DT_ALIGNED_PIXEL isotropy_type[4]
       = { check_isotropy_mode(data->anisotropy_first),
@@ -1061,8 +1063,10 @@ static inline cl_int wavelets_process_cl(const int devid, cl_mem in, cl_mem reco
           check_isotropy_mode(data->anisotropy_third),
           check_isotropy_mode(data->anisotropy_fourth) };
 
+  /*
   fprintf(stdout, "type : %d ; %d ; %d ; %d \n",
                   isotropy_type[0], isotropy_type[1], isotropy_type[2], isotropy_type[3]);
+  */
 
   float regularization = powf(10.f, data->regularization) - 1.f;
   float variance_threshold = powf(10.f, data->variance_threshold);


### PR DESCRIPTION
This implements an heat transfer partial derivative equations solver, adapted from https://www.researchgate.net/publication/220663968 and originally meant for image inpainting and reconstruction. However, I have found that it doesn't really reconstruct anything unless you apply a large amount of iterations, which is not compatible with dt's "realtime"-ish purpose. 

The algorithm is adapted for a wavelets framework, which makes it super slow (OpenCL incoming ASAP) but allows to include spatiality in the parameters. It's very close in logic to the filmic highlights reconstruction. Basically, it allows to make pixels spill (or un-spill) on their neighbours.

![Screenshot_20210104_014715](https://user-images.githubusercontent.com/2779157/103493025-3dab5480-4e2f-11eb-9f59-2e91b79d471c.png)

The module comes with 4 presets to showcase what it can do, since it's quite close to physics and can be used in a variety of situations:
1. blind deconvolution by gradient descent, following the steepest gradient direction,
2. anisotropic diffusion, or directional blur if you prefer, propagating colors in the perpendicular direction of edges, (so, either
4. joint sharpening and denoising,
5. highlights inpainting (although I'm not convinced by the results).

## Use case 1

The motivation for this module was to spill image colors outside of its borders, as a special effect for prints:

![Demi-marathon Hadrien-0044-_DSC0487_04](https://user-images.githubusercontent.com/2779157/103493020-37b57380-4e2f-11eb-9308-e9bd3fa2b628.jpg)

This is achieved by underlaying a framing module, for which I had to remove the iop_order fences in rawoverexposed.c and finalscale.c. This seems to make dt crash sometimes, even though it's hard to know what is responsible for the crashes these days.

## Use case 2

Deblur. For this, the module is put right after exposure. Before/After 1/After 2/After 3 (images at 1:1):
![Demi-marathon Hadrien-0044-_DSC0487_06](https://user-images.githubusercontent.com/2779157/103493215-3cc6f280-4e30-11eb-99ac-41ce838206b2.jpg)
![Demi-marathon Hadrien-0044-_DSC0487_05](https://user-images.githubusercontent.com/2779157/103493216-3df81f80-4e30-11eb-875f-dd112cc50bd8.jpg)
![Demi-marathon Hadrien-0044-_DSC0487_07](https://user-images.githubusercontent.com/2779157/103706668-7c671900-4fad-11eb-9486-bbbcc626dfda.jpg)
![Demi-marathon Hadrien-0044-_DSC0487_08](https://user-images.githubusercontent.com/2779157/103707554-1a0f1800-4faf-11eb-845e-b5880c7669b1.jpg)


Notice that it respects the depth of field fairly well and does not display halos. The filter is applied on linear RGB so it's really suited to remove non-uniform lens blur.

## Caveats

The module is slow… Not much I can do besides providing an OpenCL kernel. 1 to 2 iterations are ok, up to 4 iterations is meh, more than 4 iterations is something you can do before taking a walk.

## How to use

Read the tooltips and use the presets. Details below.

### General

Every order of derivatives comes with 3 sliders:
* strength: 
  * positive values make that derivative smoother (diffusion), 
  * negative values make that derivative more oscillatory (sharpening),
* edges directivity: 
  * high values make the 2D derivatives more directional (anisotropic), following a direction perpendicular to the steepest gradient
  * low values makes the 2D derivatives more uniform (isotropic), in a radial direction, more like usual blurs,
* edges regularization:
  * high values apply an higher penalty to derivatives of high magnitude, to avoid overshoot and gradient reversals around edges,
  * low values apply a lower (or even close to none) penalty to derivatives of high magnitude, allowing stronger effects but also overshoots.
  * low magnitude derivatives (zero and close) are never affected by the regularization parameter. The value of the regularization drives the speed of the transition between the low and high magnitude.

Overshoots cause artifacts, such asnoise, gradient reversals (halos, fringes), etc. If they happen, you need to dampen your derivatives (strength and/or regularization).

The speed of diffusion is a general factor applied to all strengths settings at once. As the number of iterations increases, it's a good idea to decrease the speed to avoid issues.

### First order

First order derivatives are linked to simple diffusion, such as hazing and light leaks. Used in sharpening mode, it's very prone to gradients reversals, so don't force on the strength.

### Second order

The second order is isotropic because it is simply the detail layer of the wavelets separation, that uses a B-spline blur. This setting is exactly similar to the luma curve in contrast equalizer, but the wavelets decomposition is applied in linear RGB instead of Lab. Second order derivatives are linked to sharp edges and acutance (local filter), but also to noise.

### Third order

The third order is linked to the smoothness of the second, so it can be used to alleviate noise when the second order is used in sharpening mode.

### Non-local fourth order

The non-local fourth order will increase or decrease the curvature of the second order by sampling points further away. This can be used to inpaint the texture in damaged areas, or smoothen or increase oscillations. Used with large radii (> 128 px), and small strength, it behaves in the same spirit as the local laplacian for local contrast enhancement.

### Spirit

Start with setting the first and second orders roughly, as they yield the more dramatic results, zoomed-out. When you are sort-of pleased with the result, zoom-in and fine-tune with the third order by watching out for noise. Finish with fourth order for non-local effects like increasing the volume of features.

Then finish with the diffusion speed, to boost or temper the correction. For large deblurrings, inpaintings or joint sharpening + denoising, more iterations will be needed with smaller diffusion speed to avoid overshoots. In the literature, such applications need more than 50 iterations.

By combining the weights of each order, you are virtually able to add or remove any kind of diffusion (atmospheric hazing, frosten glass, lens blur, coma, etc.) or even perform edge-aware surface blurs.

While the same method could be used to denoise, it doesn't take advantage of the inter-channels correlations, so it's no better than the usual denoising modules (but could be modified in Y0U0V0 for that purpose).