### PR TITLE
Fix syntetic bold

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -104,8 +104,7 @@ button,
 notebook tabs,
 #modules-tabs,
 #blending-tabs,
-tooltip label,
-#active-menu-item /* workaround for Pango issue in Windows not rendering bold for Roboto Light and Segoe UI Light */
+tooltip label
 {
     font-family: "Roboto",
                  "Segoe UI",
@@ -115,7 +114,13 @@ tooltip label,
                   sans-serif;
 }
 
-#active-menu-item /* this is optional, omitting it will make the active item slightly less visible */
+.active-menu-item /* needed for some Pango issues not rendering synthetic bold for all OS */
 {
+    font-family: "Roboto",
+                 "Segoe UI",
+                 "SF Pro Text",
+                 "Ubuntu",
+                 "Cantarell",
+                  sans-serif;
     font-weight: bold;
 }

--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -114,7 +114,7 @@ tooltip label
                   sans-serif;
 }
 
-.active-menu-item /* needed for some Pango issues not rendering synthetic bold for all OS */
+.active-menu-item * /* needed for some Pango issues not rendering synthetic bold for all OS */
 {
     font-family: "Roboto",
                  "Segoe UI",

--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -104,7 +104,8 @@ button,
 notebook tabs,
 #modules-tabs,
 #blending-tabs,
-tooltip label
+tooltip label,
+#active-menu-item /* workaround for Pango issue in Windows not rendering bold for Roboto Light and Segoe UI Light */
 {
     font-family: "Roboto",
                  "Segoe UI",
@@ -112,4 +113,9 @@ tooltip label
                  "Ubuntu",
                  "Cantarell",
                   sans-serif;
+}
+
+#active-menu-item /* this is optional, omitting it will make the active item slightly less visible */
+{
+    font-weight: bold;
 }

--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -104,7 +104,8 @@ button,
 notebook tabs,
 #modules-tabs,
 #blending-tabs,
-tooltip label
+tooltip label,
+.active-menu-item * /* needed for some Pango issues not rendering synthetic bold for all OS */
 {
     font-family: "Roboto",
                  "Segoe UI",
@@ -114,13 +115,7 @@ tooltip label
                   sans-serif;
 }
 
-.active-menu-item * /* needed for some Pango issues not rendering synthetic bold for all OS */
+.active-menu-item * /* this is optional, omitting it will make the selected menu item slightly less visible */
 {
-    font-family: "Roboto",
-                 "Segoe UI",
-                 "SF Pro Text",
-                 "Ubuntu",
-                 "Cantarell",
-                  sans-serif;
     font-weight: bold;
 }

--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -63,8 +63,6 @@ button,
 button *,
 treeview,
 treeview *,
-menu,
-menu *,
 separator,
 eventbox,
 eventbox *,
@@ -72,6 +70,17 @@ box,
 box *
 {
     font-family: "Roboto Light", "Roboto",                  /* best case scenario */
+                 "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
+                 "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
+                 "Ubuntu Light", "Ubuntu",                  /* Ubuntu default */
+                 "Cantarell",                               /* Gnome default */
+                 sans-serif;                                /* default default */
+}
+
+menu,
+menu *
+{
+    font-family: "Roboto",                  /* best case scenario */
                  "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
                  "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
                  "Ubuntu Light", "Ubuntu",                  /* Ubuntu default */

--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -63,6 +63,8 @@ button,
 button *,
 treeview,
 treeview *,
+menu,
+menu *,
 separator,
 eventbox,
 eventbox *,
@@ -70,17 +72,6 @@ box,
 box *
 {
     font-family: "Roboto Light", "Roboto",                  /* best case scenario */
-                 "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
-                 "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
-                 "Ubuntu Light", "Ubuntu",                  /* Ubuntu default */
-                 "Cantarell",                               /* Gnome default */
-                 sans-serif;                                /* default default */
-}
-
-menu,
-menu *
-{
-    font-family: "Roboto",                  /* best case scenario */
                  "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
                  "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
                  "Ubuntu Light", "Ubuntu",                  /* Ubuntu default */

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1545,7 +1545,7 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     {
       mi = gtk_menu_item_new_with_label(_("Lab"));
       if(module_blend_cst == DEVELOP_BLEND_CS_LAB)
-        gtk_widget_set_name(gtk_bin_get_child(GTK_BIN(mi)), "active-menu-item");
+        gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
       g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_LAB), NULL);
       g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
@@ -1553,14 +1553,14 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
 
     mi = gtk_menu_item_new_with_label(_("RGB (display)"));
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_DISPLAY)
-      gtk_widget_set_name(gtk_bin_get_child(GTK_BIN(mi)), "active-menu-item");
+      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_DISPLAY), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
     mi = gtk_menu_item_new_with_label(_("RGB (scene)"));
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_SCENE)
-      gtk_widget_set_name(gtk_bin_get_child(GTK_BIN(mi)), "active-menu-item");
+      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_SCENE), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1533,7 +1533,6 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
   if(module_cst == DEVELOP_BLEND_CS_LAB || module_cst == DEVELOP_BLEND_CS_RGB_DISPLAY
       || module_cst == DEVELOP_BLEND_CS_RGB_SCENE)
   {
-    char *markup;
 
     mi = gtk_menu_item_new_with_label(_("reset to default blend colorspace"));
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_NONE), NULL);
@@ -1546,11 +1545,7 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     {
       mi = gtk_menu_item_new_with_label(_("Lab"));
       if(module_blend_cst == DEVELOP_BLEND_CS_LAB)
-      {
-        markup = g_markup_printf_escaped("<span weight=\"bold\">%s</span>", _("Lab"));
-        gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
-        g_free(markup);
-      }
+        gtk_widget_set_name(gtk_bin_get_child(GTK_BIN(mi)), "active-menu-item");
       g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_LAB), NULL);
       g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
@@ -1558,22 +1553,14 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
 
     mi = gtk_menu_item_new_with_label(_("RGB (display)"));
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_DISPLAY)
-    {
-      markup = g_markup_printf_escaped("<span weight=\"bold\">%s</span>", _("RGB (display)"));
-      gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
-      g_free(markup);
-    }
+      gtk_widget_set_name(gtk_bin_get_child(GTK_BIN(mi)), "active-menu-item");
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_DISPLAY), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
     mi = gtk_menu_item_new_with_label(_("RGB (scene)"));
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_SCENE)
-    {
-      markup = g_markup_printf_escaped("<span weight=\"bold\">%s</span>", _("RGB (scene)"));
-      gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
-      g_free(markup);
-    }
+      gtk_widget_set_name(gtk_bin_get_child(GTK_BIN(mi)), "active-menu-item");
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_SCENE), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1241,6 +1241,14 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
                   MIN(bl_params_size, sizeof(dt_develop_blend_params_t))))
       isdefault = TRUE;
 
+    gchar *label;
+    if(isdefault)
+      label = g_strdup_printf("%s %s", name, _("(default)"));
+    else
+      label = g_strdup_printf("%s", name);
+    mi = gtk_menu_item_new_with_label(label);
+    g_free(label);
+
     if(module
        && !memcmp(params, op_params, MIN(op_params_size, params_size))
        && !memcmp(bl_params, blendop_params, MIN(bl_params_size, sizeof(dt_develop_blend_params_t)))
@@ -1248,29 +1256,7 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
     {
       active_preset = cnt;
       writeprotect = sqlite3_column_int(stmt, 2);
-      char *markup;
-      mi = gtk_menu_item_new_with_label("");
-      if(isdefault)
-      {
-        markup = g_markup_printf_escaped("<span weight=\"bold\">%s %s</span>", name, _("(default)"));
-      }
-      else
-        markup = g_markup_printf_escaped("<span weight=\"bold\">%s</span>", name);
-      gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
-      g_free(markup);
-    }
-    else
-    {
-      if(isdefault)
-      {
-        char *markup;
-        mi = gtk_menu_item_new_with_label("");
-        markup = g_markup_printf_escaped("%s %s", name, _("(default)"));
-        gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
-        g_free(markup);
-      }
-      else
-        mi = gtk_menu_item_new_with_label((const char *)name);
+      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
     }
 
     if(isdisabled)
@@ -1316,14 +1302,13 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
 
       if(darktable.gui->last_preset && found)
       {
-        char *markup = g_markup_printf_escaped("%s <span weight=\"bold\">%s</span>", _("update preset"),
-                                               darktable.gui->last_preset);
-        mi = gtk_menu_item_new_with_label("");
-        gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
+        char *label = g_strdup_printf("%s %s", _("update preset"), darktable.gui->last_preset);
+        mi = gtk_menu_item_new_with_label(label);
+        gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
         g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(darktable.gui->last_preset), g_free);
         g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_update_preset), module);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-        g_free(markup);
+        g_free(label);
       }
     }
   }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1302,13 +1302,14 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
 
       if(darktable.gui->last_preset && found)
       {
-        char *label = g_strdup_printf("%s %s", _("update preset"), darktable.gui->last_preset);
-        mi = gtk_menu_item_new_with_label(label);
-        gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+        char *markup = g_markup_printf_escaped("%s <span weight=\"bold\">%s</span>", _("update preset"),
+                                               darktable.gui->last_preset);
+        mi = gtk_menu_item_new_with_label("");
+        gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
         g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(darktable.gui->last_preset), g_free);
         g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_update_preset), module);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-        g_free(label);
+        g_free(markup);
       }
     }
   }


### PR DESCRIPTION
This will fix #7659 by moving to css the text attributes of the selected item in the "blending options" menu.
It is a draft for testing, as it requires more work.

@Nilvus @johnny-bit  please test it. See my comment in darktable-elegant-darker.css
If you approve it, I will make the same changes in the iop preset menu and in the other darktable-elegant themes