### PR TITLE
Fix dereference of deleted module elements in mask manager

### DIFF
--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -908,7 +908,8 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
           gtk_tree_model_get_value(model, &iter, TREE_MODULE, &gv2);
           dt_iop_module_t *module = g_value_peek_pointer(&gv2);
           g_value_unset(&gv2);
-          if(module && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
+          if(module && module->blend_data
+             && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
              && !(module->flags() & IOP_FLAGS_NO_MASKS))
           {
             dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/7673

I consider this as a hotfix, because I'd assume that `module` should have been already set to NULL in the first place and checking whether `module` contains elements which are NULL would be not necessary.