### PR TITLE
New set of css improvement

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -312,6 +312,7 @@ textview
   min-height: 0;
   min-width: 0;
   padding: 0px;
+  font-family: sans;
 }
 
 entry
@@ -488,7 +489,7 @@ overshoot.right
 #lib-plugin-ui-main,
 #blending-box
 {
-  padding: 0.75em;
+  padding: 0.66em;
 }
 
 /* icon buttons in modules main body */
@@ -752,7 +753,7 @@ dialog .dialog-vbox scrolledwindow
 dialog button
 {
   padding: 2px;
-  margin: 1px 2px;
+  margin: 1px;
 }
 
 dialog headerbar
@@ -840,6 +841,12 @@ dialog .dialog-vbox notebook stack box box checkbutton label  /* fix a margin on
     padding: 2px;
 }
 
+/* preferences module dialog window */
+.dialog-action-box
+{
+  margin-top: 5px;
+}
+
 /*--------------------------------------------------------
   - Bauhaus controls (sliders and comboboxes in modules) -
   --------------------------------------------------------*/
@@ -914,6 +921,12 @@ dialog combobox window,
   min-height: 0.4em;
   min-width: 0.4em;
   padding: 0.2em 0;
+}
+
+menuitem arrow
+{
+  border: 0;
+  margin-right: 2px;
 }
 
 popover
@@ -1433,11 +1446,18 @@ margin: 0 2px;
 }
 
 #basics-box #module-enable-button,
-#basics-box-labels #module-enable-button,
-#basics-link
+#basics-box-labels #module-enable-button
 {
   min-height: 1em;
   min-width: 1em;
+  border: none;
+}
+
+#basics-link
+{
+  min-height: 1.1em;
+  min-width: 1.1em;
+  margin: 0 2px 2px 2px;
   border: none;
 }
 
@@ -1537,7 +1557,7 @@ filechooser .sidebar row:selected:hover .sidebar-label,
 #preferences_box .sidebar row,
 #preferences_box .sidebar row:selected
 {
-  border-left: 2px solid @plugin_bg_color; /* be sure border is set but not visible if category on sidebar not selected but keep same size and type for selected category ; color needs to be same as sidebar scrolledwindow background-color few lines above */
+  border-left: 2px solid @bg_color; /* be sure border is set but not visible if category on sidebar not selected but keep same size and type for selected category ; color needs to be same as sidebar scrolledwindow background-color few lines above */
 }
 
 filechooser row:selected .sidebar-icon,  /* set icon instead of border for filechooser dialog window */
@@ -1582,7 +1602,9 @@ filechooser widget treeview
   color: @field_fg;
 }
 
-treeview header button,
+treeview header widget button,
+#iop-plugin-ui treeview header button,
+#lib-plugin-ui treeview header button,
 #preferences_notebook header button,
 .accels_window_list header button
 {
@@ -1595,6 +1617,8 @@ treeview header button,
 }
 
 treeview header label,
+#iop-plugin-ui treeview header label,
+#lib-plugin-ui treeview header label,
 #preferences_notebook header button label,
 .accels_window_list header button label
 {


### PR DESCRIPTION
Fix  #7615 (as it only affects darktable default theme and not elegant now. @markusb)

Fix minor other things in the UI (in the CSS order):
- reduce too large padding in modules to let more space to content
- reduce too large space between buttons in dialog windows
- and increase top margin in some buttons in dialog preferences windows (especially save/cancel ones)
- remove border in arrows in menuitems
- improve size and space of gear icons in new basics group
- remove not wanted left border in not selected tabs in preferences, by setting same background as tabs main background
- fix treeview code (not really visible, just see some issue to have clean code there

For last thing, I've tried to reduce space between lines in new treeview on image infos module as requested by @TurboGit on @phweyland PR merged recently. Unfortunately, even with all padding and margin sets to 0, I can't reduce more than it is actually. Should be some hardcoded settings in Gtk code or it's just the limits of treeview. Said that, I find space better now. Of course, that increase module height but as we can now remove/move items, having a more aerate module is also better. Last version was too tight.