### PR TITLE
Resets metadata_view (image information) to "-" when no selection is ongoing

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -361,6 +361,12 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
                                   -1, &stmt, NULL);
       if(sqlite3_step(stmt) == SQLITE_ROW) mouse_over_id = sqlite3_column_int(stmt, 0);
       sqlite3_finalize(stmt);
+
+      // Still -1 => no selection in progress
+      if(mouse_over_id == -1)
+      {
+        goto fill_minuses;
+      }
     }
   }
 
@@ -1208,6 +1214,9 @@ void gui_init(dt_lib_module_t *self)
   /* lets signup for mouse over image change signals */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
                             G_CALLBACK(_mouse_over_image_callback), self);
+
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
+                                  G_CALLBACK(_mouse_over_image_callback), self);
 
   /* lets signup for develop image changed signals */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,


### PR DESCRIPTION
When no image is selected, when the cursor goes out of the image, the
metadata view (image information) keeps the last image information.
This change is about to reset information to "-" when mouse goes out of
an image (with no selection) and when an selection is canceled.
It works quite the same way than the buttons in the "selected image[s]"
module are activated.

Maybe fixes #6482 (not tried)