### PR TITLE
Unset target_clones attribute for -march=native build

### DIFF
--- a/cmake/march-mtune.cmake
+++ b/cmake/march-mtune.cmake
@@ -5,6 +5,7 @@ elseif(NOT BINARY_PACKAGE_BUILD AND (NOT APPLE OR CMAKE_C_COMPILER_ID STREQUAL "
   CHECK_C_COMPILER_FLAG("-march=native" MARCHNATIVE)
   if(MARCHNATIVE)
     set(MARCH "-march=native")
+    add_definitions("-DNATIVE_ARCH")
   else()
     MESSAGE("-- Checking for -mtune=native support")
     CHECK_C_COMPILER_FLAG("-mtune=native" MTUNENATIVE)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -127,11 +127,13 @@ typedef unsigned int u_int;
 /* Create cloned functions for various CPU SSE generations */
 /* See for instructions https://hannes.hauswedell.net/post/2017/12/09/fmv/ */
 /* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
-#if __has_attribute(target_clones) && !defined(_WIN32) && (defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64))
+#if __has_attribute(target_clones) && !defined(_WIN32) && !defined(NATIVE_ARCH)
+# if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
 #define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "avx512f", "fma4")))
-#elif __has_attribute(target_clones) && !defined(_WIN32) && defined(__PPC64__)
+# elif defined(__PPC64__)
 /* __PPC64__ is the only macro tested for in is_supported_platform.h, other macros would fail there anyway. */
 #define __DT_CLONE_TARGETS__ __attribute__((target_clones("default","cpu=power9")))
+# endif
 #else
 #define __DT_CLONE_TARGETS__
 #endif


### PR DESCRIPTION
1. `target_clones` will generate redundant code with `march=native`
2. `target_clones` makes sense for `mtune=generic`
3. `___SSE__` check looks unrelated to `target_clones`