### PR TITLE
preview & culling: zoom fixes

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1730,6 +1730,7 @@ void dt_culling_zoom_fit(dt_culling_t *table, gboolean only_current)
   }
   else
   {
+    table->zoom_ratio = IMG_TO_FIT;
     GList *l = table->list;
     while(l)
     {

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -427,6 +427,14 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table, float val, double posx, do
   return TRUE;
 }
 
+static void _zoom_max(dt_culling_t *table, gboolean only_current, double posx, double posy)
+{
+  if(only_current)
+    _thumbs_zoom_add(table, 100000.0f, posx, posy, GDK_SHIFT_MASK);
+  else
+    _thumbs_zoom_add(table, 100000.0f, posx, posy, 0);
+}
+
 static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
   GdkEventScroll *e = (GdkEventScroll *)event;
@@ -536,7 +544,18 @@ static gboolean _event_button_press(GtkWidget *widget, GdkEventButton *event, gp
     if(zmax)
       dt_culling_zoom_fit(table, cur);
     else
-      dt_culling_zoom_max(table, cur);
+    {
+      int x = 0;
+      int y = 0;
+      if(g_list_length(table->list) > 0)
+      {
+        dt_thumbnail_t *th = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+        gdk_window_get_origin(gtk_widget_get_window(th->w_image_box), &x, &y);
+        x = event->x_root - x;
+        y = event->y_root - y;
+      }
+      _zoom_max(table, cur, x, y);
+    }
     return TRUE;
   }
 
@@ -1677,11 +1696,9 @@ void dt_culling_zoom_max(dt_culling_t *table, gboolean only_current)
     x = gtk_widget_get_allocated_width(th->w_image_box) / 2.0;
     y = gtk_widget_get_allocated_height(th->w_image_box) / 2.0;
   }
-  if(only_current)
-    _thumbs_zoom_add(table, 100000.0f, x, y, GDK_SHIFT_MASK);
-  else
-    _thumbs_zoom_add(table, 100000.0f, x, y, 0);
+  _zoom_max(table, only_current, x, y);
 }
+
 void dt_culling_zoom_fit(dt_culling_t *table, gboolean only_current)
 {
   if(only_current)

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -416,7 +416,7 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table, float val, double posx, do
         // we take in account that the image may be smaller that the imagebox
         posx -= (gtk_widget_get_allocated_width(th->w_image_box) - iw) / 2;
         posy -= (gtk_widget_get_allocated_height(th->w_image_box) - ih) / 2;
-        // we change the value and samitize them
+        // we change the value and sanitize them
         th->zoomx = fmaxf(iw - th->img_width * z_ratio, fminf(0.0f, posx - (posx - th->zoomx) * z_ratio));
         th->zoomy = fmaxf(ih - th->img_height * z_ratio, fminf(0.0f, posy - (posy - th->zoomy) * z_ratio));
       }

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -59,10 +59,10 @@ typedef struct dt_culling_t
   gboolean selection_sync;            // should the selection follow current culling images
 
   gboolean select_desactivate;
-  
+
   // the global zoom level of all images in the culling view.
-  // scales images from 0 "image to fit" to 1 "image to fill".
-  float zoom_ratio;     
+  // scales images from 0 "image to fit" to 1 "100% zoom".
+  float zoom_ratio;
 
   gboolean panning;      // are we moving zoomed images ?
   double pan_x;          // last position during panning

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -59,6 +59,10 @@ typedef struct dt_culling_t
   gboolean selection_sync;            // should the selection follow current culling images
 
   gboolean select_desactivate;
+  
+  // the global zoom level of all images in the culling view.
+  // scales images from 0 "image to fit" to 1 "image to fill".
+  float zoom_ratio;     
 
   gboolean panning;      // are we moving zoomed images ?
   double pan_x;          // last position during panning

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -90,8 +90,8 @@ gboolean dt_culling_key_move(dt_culling_t *table, dt_culling_move_t move);
 // because this may means that other images have changed
 void dt_culling_change_offset_image(dt_culling_t *table, int offset);
 
-void dt_culling_zoom_max(dt_culling_t *table, gboolean only_current);
-void dt_culling_zoom_fit(dt_culling_t *table, gboolean only_current);
+void dt_culling_zoom_max(dt_culling_t *table);
+void dt_culling_zoom_fit(dt_culling_t *table);
 
 // set the overlays type
 void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -301,7 +301,7 @@ static gboolean _event_cursor_draw(GtkWidget *widget, cairo_t *cr, gpointer user
   return TRUE;
 }
 
-static void _thumb_set_image_area(dt_thumbnail_t *thumb)
+static void _thumb_set_image_area(dt_thumbnail_t *thumb, float zoom_ratio)
 {
   // let's ensure we have the right margins
   _thumb_retrieve_margins(thumb);
@@ -370,6 +370,8 @@ static void _thumb_set_image_area(dt_thumbnail_t *thumb)
         if(mipw > 0 && miph > 0)
         {
           ar = (float)mipw / miph;
+          iw = mipw;
+          ih = miph;
           break;
         }
       }
@@ -388,14 +390,16 @@ static void _thumb_set_image_area(dt_thumbnail_t *thumb)
     if(ar > 0.001)
     {
       // we have a valid ratio, let's apply it
-      if(ar < 1.0)
-        iw = ih * ar;
-      else
-        ih = iw / ar;
-      // rescale to ensure it stay in thumbnails bounds
-      const float scale = fminf(1.0, fminf((float)image_w / iw, (float)image_h / ih));
-      iw *= scale;
-      ih *= scale;
+      const float scale_to_fit = fminf((float)image_w / iw, (float)image_h / ih);
+      float zoom_scale = 1.0f;
+      if(zoom_ratio != IMG_TO_FIT)
+      {
+        const float zoom_100 = dt_thumbnail_get_zoom100(thumb);
+        zoom_scale = (zoom_100 - 1) * zoom_ratio + 1;
+        thumb->zoom = zoom_scale;
+      }
+      iw = MIN(iw * scale_to_fit * zoom_scale, image_w);
+      ih = MIN(ih * scale_to_fit * zoom_scale, image_h);
     }
 
     gtk_widget_set_size_request(thumb->w_image, iw, ih);
@@ -445,7 +449,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
   {
     int image_w = 0;
     int image_h = 0;
-    _thumb_set_image_area(thumb);
+    _thumb_set_image_area(thumb, IMG_TO_FIT);
     gtk_widget_get_size_request(thumb->w_image_box, &image_w, &image_h);
 
     if(v->view(v) == DT_VIEW_DARKROOM && dev->preview_pipe->output_imgid == thumb->imgid
@@ -1085,7 +1089,7 @@ static gboolean _event_main_drag_motion(GtkWidget *widget, GdkDragContext *dc, g
   return TRUE;
 }
 
-GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
+GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
 {
   // main widget (overlay)
   thumb->w_main = gtk_overlay_new();
@@ -1295,21 +1299,24 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     gtk_widget_set_name(thumb->w_zoom_eb, "thumb_zoom");
     gtk_widget_set_valign(thumb->w_zoom_eb, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_zoom_eb, GTK_ALIGN_START);
-    thumb->w_zoom = gtk_label_new("mini");
+    if(zoom_ratio == IMG_TO_FIT)
+      thumb->w_zoom = gtk_label_new(_("fit"));
+    else
+      thumb->w_zoom = gtk_label_new(_("mini"));
     gtk_widget_set_name(thumb->w_zoom, "thumb_zoom_label");
     gtk_widget_show(thumb->w_zoom);
     gtk_container_add(GTK_CONTAINER(thumb->w_zoom_eb), thumb->w_zoom);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_zoom_eb);
 
-    dt_thumbnail_resize(thumb, thumb->width, thumb->height, TRUE);
+    dt_thumbnail_resize(thumb, thumb->width, thumb->height, TRUE, zoom_ratio);
   }
   gtk_widget_show(thumb->w_main);
   g_object_ref(G_OBJECT(thumb->w_main));
   return thumb->w_main;
 }
 
-dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over,
-                                 dt_thumbnail_container_t container, gboolean tooltip)
+dt_thumbnail_t *dt_thumbnail_new(int width, int height, float zoom_ratio, int imgid, int rowid,
+                                 dt_thumbnail_overlay_t over, dt_thumbnail_container_t container, gboolean tooltip)
 {
   dt_thumbnail_t *thumb = calloc(1, sizeof(dt_thumbnail_t));
   thumb->width = width;
@@ -1344,7 +1351,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
   _image_get_infos(thumb);
 
   // we create the widget
-  dt_thumbnail_create_widget(thumb);
+  dt_thumbnail_create_widget(thumb, zoom_ratio);
 
   // let's see if the images are selected or active or mouse_overed
   _dt_active_images_callback(NULL, thumb);
@@ -1620,7 +1627,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
   }
 }
 
-void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force)
+void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force, float zoom_ratio)
 {
   int w = 0;
   int h = 0;
@@ -1696,7 +1703,7 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   // for overlays different than block, we compute their size here, so we have valid value for th image area compute
   if(thumb->over != DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK) _thumb_resize_overlays(thumb);
   // we change the size and margins according to the size change. This will be refined after
-  _thumb_set_image_area(thumb);
+  _thumb_set_image_area(thumb, zoom_ratio);
 
   // and the overlays for the block only (the others have been done before)
   if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK) _thumb_resize_overlays(thumb);
@@ -1845,6 +1852,14 @@ float dt_thumbnail_get_zoom100(dt_thumbnail_t *thumb)
   }
 
   return thumb->zoom_100;
+}
+
+float dt_thumbnail_get_zoom_ratio(dt_thumbnail_t *thumb)
+{
+  if(thumb->zoom_100 < 1.0f) // we only compute the sizes if needed
+    dt_thumbnail_get_zoom100(thumb);
+
+  return (thumb->zoom - 1) / (thumb->zoom_100 - 1);
 }
 
 // force the reload of image infos

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -24,6 +24,7 @@
 #include <gtk/gtk.h>
 
 #define MAX_STARS 5
+#define IMG_TO_FIT 0.0f
 
 typedef enum dt_thumbnail_border_t
 {
@@ -143,11 +144,11 @@ typedef struct
   gboolean busy; // should we show the busy message ?
 } dt_thumbnail_t;
 
-dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over,
+dt_thumbnail_t *dt_thumbnail_new(int width, int height, float zoom_ratio, int imgid, int rowid, dt_thumbnail_overlay_t over,
                                  dt_thumbnail_container_t container, gboolean tooltip);
 void dt_thumbnail_destroy(dt_thumbnail_t *thumb);
-GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb);
-void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force);
+GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio);
+void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force, float zoom_ratio);
 void dt_thumbnail_set_group_border(dt_thumbnail_t *thumb, dt_thumbnail_border_t border);
 void dt_thumbnail_set_mouseover(dt_thumbnail_t *thumb, gboolean over);
 
@@ -171,6 +172,8 @@ void dt_thumbnail_reload_infos(dt_thumbnail_t *thumb);
 void dt_thumbnail_image_refresh_position(dt_thumbnail_t *thumb);
 // get the maximal zoom value (to show 1:1 image)
 float dt_thumbnail_get_zoom100(dt_thumbnail_t *thumb);
+// get the zoom ratio from 0 ("image to fit") to 1 ("max zoom value")
+float dt_thumbnail_get_zoom_ratio(dt_thumbnail_t *thumb);
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -156,7 +156,7 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
     dt_thumbnail_set_overlay(th, over, timeout);
     // and we resize the bottom area
-    dt_thumbnail_resize(th, th->width, th->height, TRUE);
+    dt_thumbnail_resize(th, th->width, th->height, TRUE, IMG_TO_FIT);
     l = g_list_next(l);
   }
 
@@ -522,9 +522,9 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
     {
       if(posy < table->view_height) // we don't load invisible thumbs
       {
-        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
-                                                 sqlite3_column_int(stmt, 0), table->overlays,
-                                                 DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
+        dt_thumbnail_t *thumb = dt_thumbnail_new(
+            table->thumb_size, table->thumb_size, IMG_TO_FIT, sqlite3_column_int(stmt, 1),
+            sqlite3_column_int(stmt, 0), table->overlays, DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -567,9 +567,9 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
     {
       if(posy + table->thumb_size >= 0) // we don't load invisible thumbs
       {
-        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
-                                                 sqlite3_column_int(stmt, 0), table->overlays,
-                                                 DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
+        dt_thumbnail_t *thumb = dt_thumbnail_new(
+            table->thumb_size, table->thumb_size, IMG_TO_FIT, sqlite3_column_int(stmt, 1),
+            sqlite3_column_int(stmt, 0), table->overlays, DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -782,7 +782,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
     th->x = anchor_posx - (anchor_x - posx) * new_size;
     th->y = anchor_posy - (anchor_y - posy) * new_size;
     gtk_layout_move(GTK_LAYOUT(table->widget), th->w_main, th->x, th->y);
-    dt_thumbnail_resize(th, new_size, new_size, FALSE);
+    dt_thumbnail_resize(th, new_size, new_size, FALSE, IMG_TO_FIT);
     l = g_list_next(l);
   }
 
@@ -1126,7 +1126,7 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
   {
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
     dt_thumbnail_reload_infos(th);
-    dt_thumbnail_resize(th, th->width, th->height, TRUE);
+    dt_thumbnail_resize(th, th->width, th->height, TRUE, IMG_TO_FIT);
     l = g_list_next(l);
   }
 }
@@ -1868,7 +1868,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
           thumb->y = posy;
           gtk_layout_move(GTK_LAYOUT(table->widget), thumb->w_main, posx, posy);
         }
-        dt_thumbnail_resize(thumb, table->thumb_size, table->thumb_size, FALSE);
+        dt_thumbnail_resize(thumb, table->thumb_size, table->thumb_size, FALSE, IMG_TO_FIT);
         newlist = g_list_append(newlist, thumb);
         // and we remove the thumb from the old list
         table->list = g_list_remove(table->list, thumb);
@@ -1876,8 +1876,9 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       else
       {
         // we create a completly new thumb
-        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, nid, nrow, table->overlays,
-                                                 DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
+        dt_thumbnail_t *thumb
+            = dt_thumbnail_new(table->thumb_size, table->thumb_size, IMG_TO_FIT, nid, nrow, table->overlays,
+                               DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -423,7 +423,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkStyleContext *context = gtk_widget_get_style_context(hb);
     gtk_style_context_add_class(context, "dt_overlays_always");
 
-    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
+    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, IMG_TO_FIT, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
                                              DT_THUMBNAIL_CONTAINER_LIGHTTABLE, TRUE);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
     thumb->disable_mouseover = TRUE;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -938,9 +938,9 @@ static gboolean _accel_culling_zoom_100(GtkAccelGroup *accel_group, GObject *acc
   dt_library_t *lib = (dt_library_t *)self->data;
 
   if(lib->preview_state)
-    dt_culling_zoom_max(lib->preview, FALSE);
+    dt_culling_zoom_max(lib->preview);
   else if(dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING)
-    dt_culling_zoom_max(lib->culling, FALSE);
+    dt_culling_zoom_max(lib->culling);
   else
     return FALSE;
 
@@ -954,9 +954,9 @@ static gboolean _accel_culling_zoom_fit(GtkAccelGroup *accel_group, GObject *acc
   dt_library_t *lib = (dt_library_t *)self->data;
 
   if(lib->preview_state)
-    dt_culling_zoom_fit(lib->preview, FALSE);
+    dt_culling_zoom_fit(lib->preview);
   else if(dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING)
-    dt_culling_zoom_fit(lib->culling, FALSE);
+    dt_culling_zoom_fit(lib->culling);
   else
     return FALSE;
 


### PR DESCRIPTION
Hi

After using darktable for some years I've finally got around to fix some issues that have been annoying me in sticky preview und culling mode regarding zoom handling:

1. added zooming to 100% at mouse pointer position, fixes #6676
2. position shifts when switching to the next image, fixes #6481

This is the first time I am doing anything in C & darktable and I've realised while debugging that there is a lot happening when generating the actual thumbnails, so I've kept the changes minimal.

The 1st commit for zooming to mouse pointer should be very safe, as it only impacts single image preview & culling. It does NOT add zooming to mouse pointer when culling with multiple images (that would require a more complicated change).

The 2nd commit fixes the image position shifts that happen when opening sticky preview and scrolling through different images. When zoomed, every change to the next/previous image also added some seemingly random position shift. This is most notable when looking at multiple similar images to pick the best one (e.g. in terms of facial expressions or sharpness in a specific area).

My solution for the position shift is trivial, but I guess it requires a bit of an explanation. I've been debugging the code for a while and discovered that when changing images, a small 40x40 thumbnail is created, which is eventually scaled up fill the screen.
In the draw method, there is some logic to translate the zoom position:
https://github.com/darktable-org/darktable/blob/374f7b377014dbba5150086e8a24e615174f21e3/src/dtgtk/thumbnail.c#L486-L499

My understanding is, that it should only be applied when an actual zoom happens. When starting with a newly created thumbnail, the position of the first selected image is re-applied using it's dimensions/coordinates (not the ones of the newly generated thumbnail):
https://github.com/darktable-org/darktable/blob/374f7b377014dbba5150086e8a24e615174f21e3/src/dtgtk/culling.c#L1486-L1498

Essentially, the values of `hh` and `ww` are <= 40 px when dealing with a newly created thumbnail, and result in the seemingly random position shift. My change is to NOT change the zoom position when dealing with such a small thumbnail.

I find in practice these changes work very well. @AlicVB do you see any cases I've missed?