### PR TITLE
[paint.c] make paint.c independent of darktable.bauhaus

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1207,7 +1207,20 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
   if(color < DT_COLORLABELS_LAST)
   {
-    set_color(cr, darktable.bauhaus->colorlabels[color]);
+    GdkRGBA colorlabels[DT_COLORLABELS_LAST];
+    if(data != NULL)
+    {
+      memcpy(&colorlabels, data, sizeof(GdkRGBA) * DT_COLORLABELS_LAST);
+    }
+    else
+    {
+      colorlabels[DT_COLORLABELS_RED]    = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 };
+      colorlabels[DT_COLORLABELS_YELLOW] = (GdkRGBA){.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
+      colorlabels[DT_COLORLABELS_GREEN]  = (GdkRGBA){.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
+      colorlabels[DT_COLORLABELS_BLUE]   = (GdkRGBA){.red = 0.0, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
+      colorlabels[DT_COLORLABELS_PURPLE] = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
+    }
+    set_color(cr, colorlabels[color]);
   }
   else if(color == 7)
   {
@@ -1346,40 +1359,54 @@ void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h,
 {
   PREAMBLE(1, 0, 0)
 
+  GdkRGBA colorlabels[DT_COLORLABELS_LAST];
+  if(data != NULL)
+  {
+    memcpy(&colorlabels, data, sizeof(GdkRGBA) * DT_COLORLABELS_LAST);
+  }
+  else
+  {
+    colorlabels[DT_COLORLABELS_RED]    = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 };
+    colorlabels[DT_COLORLABELS_YELLOW] = (GdkRGBA){.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
+    colorlabels[DT_COLORLABELS_GREEN]  = (GdkRGBA){.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 };
+    colorlabels[DT_COLORLABELS_BLUE]   = (GdkRGBA){.red = 0.0, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
+    colorlabels[DT_COLORLABELS_PURPLE] = (GdkRGBA){.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 };
+  }
+
   const float r = 0.18;
 
   if(flags & CPF_DIRECTION_UP)
   {
     cairo_arc(cr, r, r, r, 0, 2.0f * M_PI);
-    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_RED]);
+    set_color(cr, colorlabels[DT_COLORLABELS_RED]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_DIRECTION_DOWN)
   {
     cairo_arc(cr, 1.0 - r, r, r, 0, 2.0f * M_PI);
-    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_YELLOW]);
+    set_color(cr, colorlabels[DT_COLORLABELS_YELLOW]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_DIRECTION_LEFT)
   {
     cairo_arc(cr, 0.5, 0.5, r, 0, 2.0f * M_PI);
-    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_GREEN]);
+    set_color(cr, colorlabels[DT_COLORLABELS_GREEN]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_DIRECTION_RIGHT)
   {
     cairo_arc(cr, r, 1.0 - r, r, 0, 2.0f * M_PI);
-    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_BLUE]);
+    set_color(cr, colorlabels[DT_COLORLABELS_BLUE]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_BG_TRANSPARENT)
   {
     cairo_arc(cr, 1.0 - r, 1.0 - r, r, 0, 2.0f * M_PI);
-    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_PURPLE]);
+    set_color(cr, colorlabels[DT_COLORLABELS_PURPLE]);
     cairo_fill(cr);
   }
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1193,7 +1193,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     }
 
     // the color labels
-    thumb->w_color = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_label_flower, thumb->colorlabels, NULL);
+    thumb->w_color = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_label_flower, thumb->colorlabels, &darktable.bauhaus->colorlabels);
     gtk_widget_set_name(thumb->w_color, "thumb_colorlabels");
     gtk_widget_set_valign(thumb->w_color, GTK_ALIGN_END);
     gtk_widget_set_halign(thumb->w_color, GTK_ALIGN_END);

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -82,12 +82,14 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
 
     if(flags & CPF_DO_NOT_USE_BORDER)
     {
-      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0, 0, allocation.width, allocation.height, flags, bg_color);
+      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0, 0, allocation.width, allocation.height, flags,
+                                        DTGTK_THUMBNAIL_BTN(widget)->icon_data ? DTGTK_THUMBNAIL_BTN(widget)->icon_data : bg_color);
     }
     else
     {
       DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0.125 * allocation.width, 0.125 * allocation.height,
-                                        0.75 * allocation.width, 0.75 * allocation.height, flags, bg_color);
+                                        0.75 * allocation.width, 0.75 * allocation.height, flags,
+                                        DTGTK_THUMBNAIL_BTN(widget)->icon_data ? DTGTK_THUMBNAIL_BTN(widget)->icon_data : bg_color);
     }
   }
   // and eventually the image border

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "bauhaus/bauhaus.h"
 #include "common/colorlabels.h"
 #include "common/collection.h"
 #include "control/control.h"
@@ -81,7 +82,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *button;
   for(int k = 0; k < 6; k++)
   {
-    button = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_BG_TRANSPARENT), NULL);
+    button = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_BG_TRANSPARENT), &darktable.bauhaus->colorlabels);
     d->buttons[k] = button;
     gtk_widget_set_tooltip_text(button, d->tooltips[k]);
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);


### PR DESCRIPTION
As mentioned in https://github.com/darktable-org/darktable/issues/5926#issuecomment-754789634 the 6b58bc0 caused problem for `show_icons_in_paint_c.pl`

This PR makes sure that noting in paint.c directly depends on existence of global `darktable` struct, so that helper tool can generate png file with all the icons from paint.c :)