### PR TITLE
[style/tag] change darktable|style|sytlename to dtstyle|stylename

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -118,7 +118,8 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
   dt_image_reset_final_size(imgid);
 
   /* remove darktable|style|* tags */
-  dt_tag_detach_by_string("darktable|style%", imgid, FALSE, FALSE);
+  dt_tag_detach_by_string("darktable|style|%", imgid, FALSE, FALSE);
+  dt_tag_detach_by_string("dtstyle|%", imgid, FALSE, FALSE);
   dt_tag_detach_by_string("darktable|changed", imgid, FALSE, FALSE);
 
   /* unset change timestamp */

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -119,7 +119,6 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
 
   /* remove darktable|style|* tags */
   dt_tag_detach_by_string("darktable|style|%", imgid, FALSE, FALSE);
-  dt_tag_detach_by_string("dtstyle|%", imgid, FALSE, FALSE);
   dt_tag_detach_by_string("darktable|changed", imgid, FALSE, FALSE);
 
   /* unset change timestamp */

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -944,7 +944,7 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
     /* add tag */
     guint tagid = 0;
     gchar ntag[512] = { 0 };
-    g_snprintf(ntag, sizeof(ntag), "dtstyle|%s", name);
+    g_snprintf(ntag, sizeof(ntag), "darktable|style|%s", name);
     if(dt_tag_new(ntag, &tagid)) dt_tag_attach(tagid, newimgid, FALSE, FALSE);
     if(dt_tag_new("darktable|changed", &tagid))
     {

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -944,7 +944,7 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
     /* add tag */
     guint tagid = 0;
     gchar ntag[512] = { 0 };
-    g_snprintf(ntag, sizeof(ntag), "darktable|style|%s", name);
+    g_snprintf(ntag, sizeof(ntag), "dtstyle|%s", name);
     if(dt_tag_new(ntag, &tagid)) dt_tag_attach(tagid, newimgid, FALSE, FALSE);
     if(dt_tag_new("darktable|changed", &tagid))
     {

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -163,7 +163,7 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
     // check this is a darktable tag
     char *path;
     gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_PATH, &path, -1);
-    if(!g_str_has_prefix(path, "darktable|"))
+    if(!g_str_has_prefix(path, "darktable|") || g_str_has_prefix(path, "darktable|style|"))
       attached_tags_sel = TRUE;
     g_free(path);
   }


### PR DESCRIPTION
Fixed #7699 

Problem is - `darktable|%` tags are kinda important and managed internally by darktable very well... Except style tags. The only way to get rid of style tag is to destroy history (compression doesn't work). Also - if you change enough from style is that the same style? So since styles aren't important let's move autotagging with style to `dtstyle|` based tag - that way user can detach tag at any point or attach or whatever.