### PR TITLE
[lua] make darktable.gui.libs visibility work correctly.

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1366,21 +1366,21 @@ gboolean dt_lib_is_visible(dt_lib_module_t *module)
 void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible)
 {
   gchar *key = _get_lib_view_path(module, "_visible");
+  GtkWidget *widget;
   dt_conf_set_bool(key, visible);
   g_free(key);
   if(module->widget)
   {
     if(module->expander)
-    {
-      dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->expander), visible);
-    }
+      widget = module->expander;
     else
-    {
-      if(visible)
-        gtk_widget_show_all(GTK_WIDGET(module->widget));
-      else
-        gtk_widget_hide(GTK_WIDGET(module->widget));
-    }
+      widget = module->widget;
+
+
+    if(visible)
+      gtk_widget_show_all(GTK_WIDGET(widget));
+    else
+      gtk_widget_hide(GTK_WIDGET(widget));
   }
 }
 

--- a/src/lua/lib.c
+++ b/src/lua/lib.c
@@ -46,7 +46,7 @@ static int visible_member(lua_State *L)
   }
   else
   {
-    dt_lib_gui_set_expanded(module, lua_toboolean(L, 3));
+    dt_lib_set_visible(module, lua_toboolean(L, 3));
     return 0;
   }
 }


### PR DESCRIPTION
Setting darktable.gui.libs["libname"].visible to true/false makes the lib expand and collapse, not hide and show.  darktable.gui.libs["libname"].expanded takes care of expanding and collapsing a lib.  In essence we had 2 ways to expand and collapse a module and no way to hide or show it.

To test:

- If you have a ~/.config/darktable/lua directory, temporarily rename it and the luarc
- start darktable.  If the scripts installer doesn't appear go to preferences->lua options and uncheck don't show again then restart darktable.
- In scripts installer select _don't show again_.  Click execute and the module should disappear from the UI.