### PR TITLE
import pref: insert an optional pref dialog before import action

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -727,6 +727,13 @@
     <shortdescription>ignore exif rating</shortdescription>
     <longdescription>ignore exif rating. if not set and exif rating is found, it overrides 'initial import rating'</longdescription>
   </dtconfig>
+  <dtconfig dialog="import">
+    <name>ui_last/pref_before_import</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show import preferences before import action</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig>
     <name>plugins/capture/mode</name>
     <type>int</type>

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -97,7 +97,9 @@ void dt_import_metadata_dialog_new(dt_import_metadata_t *metadata)
   // default metadata
   GtkWidget *apply_metadata = metadata->apply_metadata;
   GtkWidget *grid = gtk_grid_new();
-  gtk_box_pack_start(GTK_BOX(metadata->box), grid, FALSE, FALSE, 0);
+  gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
+  gtk_box_pack_start(GTK_BOX(metadata->box), grid, TRUE, TRUE, 0);
+  gtk_widget_set_name(metadata->box, "import-metadata-fields");
 
   // presets from the metadata plugin
   GtkCellRenderer *renderer;
@@ -153,8 +155,9 @@ void dt_import_metadata_dialog_new(dt_import_metadata_t *metadata)
   gtk_widget_set_tooltip_text(GTK_WIDGET(label), _("metadata to be applied per default"));
 
   GtkWidget *presets = gtk_combo_box_new_with_model(GTK_TREE_MODEL(model));
+  gtk_widget_set_hexpand(presets, TRUE);
   renderer = gtk_cell_renderer_text_new();
-  gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(presets), renderer, FALSE);
+  gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(presets), renderer, TRUE);
   gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(presets), renderer, "text", 0, NULL);
   gtk_grid_attach_next_to(GTK_GRID(grid), presets, label, GTK_POS_RIGHT, 1, 1);
   g_object_unref(model);
@@ -191,6 +194,7 @@ void dt_import_metadata_dialog_new(dt_import_metadata_t *metadata)
         gtk_grid_attach(GTK_GRID(grid), metadata_label[i], 0, line++, 1, 1);
 
         metadata->metadata[i] = gtk_entry_new();
+        gtk_widget_set_hexpand(metadata->metadata[i], TRUE);
         setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
         gchar *str = dt_conf_get_string(setting);
         gtk_entry_set_text(GTK_ENTRY(metadata->metadata[i]), str);
@@ -219,7 +223,7 @@ void dt_import_metadata_dialog_new(dt_import_metadata_t *metadata)
   gtk_grid_attach(GTK_GRID(grid), label, 0, line, 1, 1);
 
   metadata->tags = gtk_entry_new();
-  gtk_widget_set_size_request(metadata->tags, DT_PIXEL_APPLY_DPI(300), -1);
+  gtk_widget_set_hexpand(metadata->tags, TRUE);
   gchar *str = dt_conf_get_string("ui_last/import_last_tags");
   gtk_widget_set_tooltip_text(metadata->tags, _("comma separated list of tags"));
   gtk_entry_set_text(GTK_ENTRY(metadata->tags), str);


### PR DESCRIPTION
fixes #7707

Attempt to answer the concerns risen in #7707.

- keep the hamburger pref
- add an optional step between the plugin import button and the actual import action to show the prefs
- the import action uses the visible (changed or not) prefs
- after importing the user can cancel not to save the prefs which have been used
- a flag allow not to show the in between dialog

![image](https://user-images.githubusercontent.com/23012047/103802261-a5c78980-502d-11eb-974b-5bf5a52c6e56.png)
 
Note: in import from camera, there is still a notebook (tabs), one tab just to define the date. This date setting could be moved to the intermediary dialog (no saving on it). One drawback however, if this intermediary dialog is skipped, the user cannot set the date (but he can always make the dialog appear back).

Note2: I assume than tethering works the same way but I haven't tested.