### PR TITLE
thumb : limit flickering in culling & preview

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2642,7 +2642,7 @@ spinbutton>button
 }
 
 /* Set image borders */
-.dt_preview #thumb_image
+.dt_preview #thumb_image, .dt_preview_thumb_image#thumb_image
 {
   margin : 10px;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2364,7 +2364,8 @@ spinbutton>button
   margin: 25px; /* not real pixels, but per thousand of the thumb size */
 }
 
-.dt_thumbnails_2 #thumb_image /* update consistently margins if big thumbnails (less images per row) are shown */
+.dt_thumbnails_2 #thumb_image, /* update consistently margins if big thumbnails (less images per row) are shown */
+.dt_thumbnails_2#thumb_image
 {
   margin: 20px;
 }

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1117,6 +1117,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
 
   GList *newlist = NULL;
   int nbnew = 0;
+  int pos = 0;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   while(sqlite3_step(stmt) == SQLITE_ROW && g_list_length(newlist) <= table->thumbs_count)
   {
@@ -1135,7 +1136,25 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     else
     {
       // we create a completly new thumb
-      dt_thumbnail_t *thumb = dt_thumbnail_new(40, 40, nid, nrow, table->overlays, TRUE, table->show_tooltips);
+      // we set its size to the thumb it replace in the list if any otherwise we set it to something > 0 to trigger
+      // draw events
+      int nw = 40;
+      int nh = 40;
+      if(g_list_length(table->list) > 0)
+      {
+        dt_thumbnail_t *th_model
+            = (dt_thumbnail_t *)g_list_nth_data(table->list, MIN(pos, g_list_length(table->list) - 1));
+        nw = th_model->width;
+        nh = th_model->height;
+      }
+      dt_thumbnail_t *thumb;
+      if(table->mode == DT_CULLING_MODE_PREVIEW)
+        thumb = dt_thumbnail_new(nw, nh, nid, nrow, table->overlays, DT_THUMBNAIL_CONTAINER_PREVIEW,
+                                 table->show_tooltips);
+      else
+        thumb = dt_thumbnail_new(nw, nh, nid, nrow, table->overlays, DT_THUMBNAIL_CONTAINER_CULLING,
+                                 table->show_tooltips);
+
       thumb->display_focus = table->focus;
       thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
       double aspect_ratio = sqlite3_column_double(stmt, 2);
@@ -1151,6 +1170,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     }
     // if it's the offset, we record the imgid
     if(nrow == table->offset) table->offset_imgid = nid;
+    pos++;
   }
 
   // in rare cases, we can have less images than wanted
@@ -1169,6 +1189,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     if(stmt != NULL)
     {
+      pos = 0;
       while(sqlite3_step(stmt) == SQLITE_ROW && g_list_length(newlist) <= table->thumbs_count)
       {
         const int nrow = sqlite3_column_int(stmt, 0);
@@ -1186,7 +1207,25 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
         else
         {
           // we create a completly new thumb
-          dt_thumbnail_t *thumb = dt_thumbnail_new(10, 10, nid, nrow, table->overlays, TRUE, table->show_tooltips);
+          // we set its size to the thumb it replace in the list if any otherwise we set it to something > 0 to
+          // trigger draw events
+          int nw = 40;
+          int nh = 40;
+          if(g_list_length(table->list) > 0)
+          {
+            dt_thumbnail_t *th_model
+                = (dt_thumbnail_t *)g_list_nth_data(table->list, MIN(pos, g_list_length(table->list) - 1));
+            nw = th_model->width;
+            nh = th_model->height;
+          }
+          dt_thumbnail_t *thumb;
+          if(table->mode == DT_CULLING_MODE_PREVIEW)
+            thumb = dt_thumbnail_new(nw, nh, nid, nrow, table->overlays, DT_THUMBNAIL_CONTAINER_PREVIEW,
+                                     table->show_tooltips);
+          else
+            thumb = dt_thumbnail_new(nw, nh, nid, nrow, table->overlays, DT_THUMBNAIL_CONTAINER_CULLING,
+                                     table->show_tooltips);
+
           thumb->display_focus = table->focus;
           thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
           double aspect_ratio = sqlite3_column_double(stmt, 2);
@@ -1202,6 +1241,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
         }
         // if it's the offset, we record the imgid
         if(nrow == table->offset) table->offset_imgid = nid;
+        pos++;
       }
       sqlite3_finalize(stmt);
     }
@@ -1489,8 +1529,11 @@ void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
     // we add or move the thumb at the right position
     if(!gtk_widget_get_parent(thumb->w_main))
     {
+
       gtk_widget_set_margin_start(thumb->w_image_box, old_margin_x);
       gtk_widget_set_margin_top(thumb->w_image_box, old_margin_y);
+      // and we resize the thumb
+      dt_thumbnail_resize(thumb, thumb->width, thumb->height, FALSE);
       gtk_layout_put(GTK_LAYOUT(table->widget), thumb->w_main, thumb->x, thumb->y);
       thumb->zoomx = old_zx;
       thumb->zoomy = old_zy;
@@ -1499,9 +1542,9 @@ void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
     else
     {
       gtk_layout_move(GTK_LAYOUT(table->widget), thumb->w_main, thumb->x, thumb->y);
+      // and we resize the thumb
+      dt_thumbnail_resize(thumb, thumb->width, thumb->height, FALSE);
     }
-    // and we resize the thumb
-    dt_thumbnail_resize(thumb, thumb->width, thumb->height, FALSE);
 
     // we update the active images list
     darktable.view_manager->active_images

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1140,7 +1140,12 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
       // draw events
       int nw = 40;
       int nh = 40;
-      if(g_list_length(table->list) > 0)
+      if(table->mode == DT_CULLING_MODE_PREVIEW)
+      {
+        nw = table->view_width;
+        nh = table->view_height;
+      }
+      else if(g_list_length(table->list) > 0)
       {
         dt_thumbnail_t *th_model
             = (dt_thumbnail_t *)g_list_nth_data(table->list, MIN(pos, g_list_length(table->list) - 1));
@@ -1211,7 +1216,12 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
           // trigger draw events
           int nw = 40;
           int nh = 40;
-          if(g_list_length(table->list) > 0)
+          if(table->mode == DT_CULLING_MODE_PREVIEW)
+          {
+            nw = table->view_width;
+            nh = table->view_height;
+          }
+          else if(g_list_length(table->list) > 0)
           {
             dt_thumbnail_t *th_model
                 = (dt_thumbnail_t *)g_list_nth_data(table->list, MIN(pos, g_list_length(table->list) - 1));

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1152,6 +1152,12 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
         nw = th_model->width;
         nh = th_model->height;
       }
+      else if(g_list_length(newlist) > 0)
+      {
+        dt_thumbnail_t *th_model = (dt_thumbnail_t *)g_list_last(newlist)->data;
+        nw = th_model->width;
+        nh = th_model->height;
+      }
       dt_thumbnail_t *thumb;
       if(table->mode == DT_CULLING_MODE_PREVIEW)
         thumb = dt_thumbnail_new(nw, nh, nid, nrow, table->overlays, DT_THUMBNAIL_CONTAINER_PREVIEW,
@@ -1179,7 +1185,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
   }
 
   // in rare cases, we can have less images than wanted
-  // although there's images before
+  // although there's images before (this shouldn't happen in preview)
   if(table->navigate_inside_selection && g_list_length(newlist) < table->thumbs_count
      && g_list_length(newlist) < _get_selection_count())
   {
@@ -1216,15 +1222,15 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
           // trigger draw events
           int nw = 40;
           int nh = 40;
-          if(table->mode == DT_CULLING_MODE_PREVIEW)
+          if(g_list_length(table->list) > 0)
           {
-            nw = table->view_width;
-            nh = table->view_height;
+            dt_thumbnail_t *th_model = (dt_thumbnail_t *)g_list_first(table->list)->data;
+            nw = th_model->width;
+            nh = th_model->height;
           }
-          else if(g_list_length(table->list) > 0)
+          else if(g_list_length(newlist) > 0)
           {
-            dt_thumbnail_t *th_model
-                = (dt_thumbnail_t *)g_list_nth_data(table->list, MIN(pos, g_list_length(table->list) - 1));
+            dt_thumbnail_t *th_model = (dt_thumbnail_t *)g_list_first(newlist)->data;
             nw = th_model->width;
             nh = th_model->height;
           }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1634,6 +1634,45 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   thumb->height = height;
   gtk_widget_set_size_request(thumb->w_main, width, height);
 
+  // for thumbtable, we need to set the size class to the image widget
+  if(thumb->container == DT_THUMBNAIL_CONTAINER_LIGHTTABLE)
+  {
+    // we get the corresponding size
+    gchar *txt = dt_conf_get_string("plugins/lighttable/thumbnail_sizes");
+    gchar **ts = g_strsplit(txt, "|", -1);
+    int i = 0;
+    while(ts[i])
+    {
+      const int s = g_ascii_strtoll(ts[i], NULL, 10);
+      if(thumb->width < s) break;
+      i++;
+    }
+    g_strfreev(ts);
+    g_free(txt);
+
+    gchar *cl = dt_util_dstrcat(NULL, "dt_thumbnails_%d", i);
+    GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_image);
+    if(!gtk_style_context_has_class(context, cl))
+    {
+      // we remove all previous size class if any
+      GList *l = gtk_style_context_list_classes(context);
+      while(l)
+      {
+        gchar *ll = (gchar *)l->data;
+        if(g_str_has_prefix(ll, "dt_thumbnails_"))
+        {
+          gtk_style_context_remove_class(context, ll);
+        }
+        l = g_list_next(l);
+      }
+      g_list_free(l);
+
+      // we set the new class
+      gtk_style_context_add_class(context, cl);
+    }
+    g_free(cl);
+  }
+
   // file extension
   _thumb_retrieve_margins(thumb);
   gtk_widget_set_margin_start(thumb->w_ext, thumb->img_margin->left);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -314,7 +314,7 @@ static void _thumb_set_image_area(dt_thumbnail_t *thumb)
     int w = 0;
     int h = 0;
     gtk_widget_get_size_request(thumb->w_bottom_eb, &w, &h);
-    image_h = thumb->height - h;
+    image_h = thumb->height - MAX(0, h);
     gtk_widget_get_size_request(thumb->w_altered, &w, &h);
     if(!thumb->zoomable)
     {
@@ -350,8 +350,62 @@ static void _thumb_set_image_area(dt_thumbnail_t *thumb)
   int wi = 0;
   int hi = 0;
   gtk_widget_get_size_request(thumb->w_image, &wi, &hi);
-  const float scale = fminf((float)image_w / wi, (float)image_h / hi);
-  if(scale < 1.0f) gtk_widget_set_size_request(thumb->w_image, wi * scale, hi * scale);
+  if(wi <= 0 || hi <= 0)
+  {
+    // we arrive here if we are inside the creation process
+    float iw = image_w;
+    float ih = image_h;
+    // we can't rely on img->aspect_ratio as the value is round to 1 decimal, so not enough accurate
+    // so we compute it from the larger available mipmap
+    float ar = 0.0f;
+    for(int k = DT_MIPMAP_7; k >= DT_MIPMAP_0; k--)
+    {
+      dt_mipmap_buffer_t tmp;
+      dt_mipmap_cache_get(darktable.mipmap_cache, &tmp, thumb->imgid, k, DT_MIPMAP_TESTLOCK, 'r');
+      if(tmp.buf)
+      {
+        const int mipw = tmp.width;
+        const int miph = tmp.height;
+        dt_mipmap_cache_release(darktable.mipmap_cache, &tmp);
+        if(mipw > 0 && miph > 0)
+        {
+          ar = (float)mipw / miph;
+          break;
+        }
+      }
+    }
+    if(ar < 0.001)
+    {
+      // let's try with the aspect_ratio store in image structure, even if it's less accurate
+      const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->imgid, 'r');
+      if(img)
+      {
+        ar = img->aspect_ratio;
+        dt_image_cache_read_release(darktable.image_cache, img);
+      }
+    }
+
+    if(ar > 0.001)
+    {
+      // we have a valid ratio, let's apply it
+      if(ar < 1.0)
+        iw = ih * ar;
+      else
+        ih = iw / ar;
+      // rescale to ensure it stay in thumbnails bounds
+      const float scale = fminf(1.0, fminf((float)image_w / iw, (float)image_h / ih));
+      iw *= scale;
+      ih *= scale;
+    }
+
+    gtk_widget_set_size_request(thumb->w_image, iw, ih);
+  }
+  else
+  {
+    const float scale = fminf((float)image_w / wi, (float)image_h / hi);
+    if(scale < 1.0f) gtk_widget_set_size_request(thumb->w_image, wi * scale, hi * scale);
+  }
+
   // and we set the size and margins of the imagebox
   gtk_widget_set_size_request(thumb->w_image_box, image_w, image_h);
   gtk_widget_set_margin_start(thumb->w_image_box, thumb->img_margin->left);
@@ -1097,30 +1151,9 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     else if(thumb->container == DT_THUMBNAIL_CONTAINER_CULLING)
       gtk_style_context_add_class(context, "dt_culling_thumb_image");
     gtk_widget_set_name(thumb->w_image, "thumb_image");
-    // we pre-set the size of the imagebox with the aspect ratio so the image is already centered
-    const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->imgid, 'r');
-    int iw = thumb->width;
-    int ih = thumb->height;
-    if(img)
-    {
-      const float ar = img->aspect_ratio;
-      dt_image_cache_read_release(darktable.image_cache, img);
-      if(ar > 0.0001)
-      {
-        if(ar < 1.0)
-          iw = ih * ar;
-        else
-          ih = iw / ar;
-      }
-      // rescale to ensure it stay in thumbnails bounds
-      const float scale = fminf(1.0, fminf((float)thumb->width / iw, (float)thumb->height / ih));
-      iw *= scale;
-      ih *= scale;
-    }
-
     gtk_widget_set_valign(thumb->w_image, GTK_ALIGN_CENTER);
     gtk_widget_set_halign(thumb->w_image, GTK_ALIGN_CENTER);
-    gtk_widget_set_size_request(thumb->w_image, iw, ih);
+    // the size will be defined at the end, inside dt_thumbnail_resize
     gtk_widget_set_events(thumb->w_image, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
                                               | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                                               | GDK_POINTER_MOTION_HINT_MASK | GDK_POINTER_MOTION_MASK);
@@ -1131,7 +1164,6 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     gtk_widget_show(thumb->w_image);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_image_box), thumb->w_image);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_main), thumb->w_image_box);
-    _thumb_retrieve_margins(thumb);
 
     // triangle to indicate current image(s) in filmstrip
     thumb->w_cursor = gtk_drawing_area_new();
@@ -1602,10 +1634,8 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   thumb->height = height;
   gtk_widget_set_size_request(thumb->w_main, width, height);
 
-  // we change the size and margins according to the size change. This will be refined after
-  _thumb_set_image_area(thumb);
-
   // file extension
+  _thumb_retrieve_margins(thumb);
   gtk_widget_set_margin_start(thumb->w_ext, thumb->img_margin->left);
   gtk_widget_set_margin_top(thumb->w_ext, thumb->img_margin->top);
 
@@ -1624,8 +1654,13 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   gtk_label_set_attributes(GTK_LABEL(thumb->w_ext), attrlist);
   pango_attr_list_unref(attrlist);
 
-  // and the overlays
-  _thumb_resize_overlays(thumb);
+  // for overlays different than block, we compute their size here, so we have valid value for th image area compute
+  if(thumb->over != DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK) _thumb_resize_overlays(thumb);
+  // we change the size and margins according to the size change. This will be refined after
+  _thumb_set_image_area(thumb);
+
+  // and the overlays for the block only (the others have been done before)
+  if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK) _thumb_resize_overlays(thumb);
 
   // reset surface
   dt_thumbnail_image_refresh(thumb);

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -45,6 +45,13 @@ typedef enum dt_thumbnail_overlay_t
   DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK
 } dt_thumbnail_overlay_t;
 
+typedef enum dt_thumbnail_container_t
+{
+  DT_THUMBNAIL_CONTAINER_LIGHTTABLE,
+  DT_THUMBNAIL_CONTAINER_CULLING,
+  DT_THUMBNAIL_CONTAINER_PREVIEW
+} dt_thumbnail_container_t;
+
 typedef enum dt_thumbnail_selection_mode_t
 {
   DT_THUMBNAIL_SEL_MODE_NORMAL = 0, // user can change selection with normal mouse click (+CTRL or +SHIFT)
@@ -58,6 +65,7 @@ typedef struct
   int width, height;         // current thumb size (with the background and the border)
   int x, y;                  // current position at screen
   int img_width, img_height; // current image size (can be greater than the image box in case of zoom)
+  dt_thumbnail_container_t container; // type of container of the thumbnail
 
   gboolean mouse_over;
   gboolean selected;
@@ -136,7 +144,7 @@ typedef struct
 } dt_thumbnail_t;
 
 dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over,
-                                 gboolean zoomable, gboolean tooltip);
+                                 dt_thumbnail_container_t container, gboolean tooltip);
 void dt_thumbnail_destroy(dt_thumbnail_t *thumb);
 GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb);
 void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -509,9 +509,9 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
     {
       if(posy < table->view_height) // we don't load invisible thumbs
       {
-        dt_thumbnail_t *thumb
-            = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
-                               sqlite3_column_int(stmt, 0), table->overlays, FALSE, table->show_tooltips);
+        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
+                                                 sqlite3_column_int(stmt, 0), table->overlays,
+                                                 DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -554,9 +554,9 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
     {
       if(posy + table->thumb_size >= 0) // we don't load invisible thumbs
       {
-        dt_thumbnail_t *thumb
-            = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
-                               sqlite3_column_int(stmt, 0), table->overlays, FALSE, table->show_tooltips);
+        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
+                                                 sqlite3_column_int(stmt, 0), table->overlays,
+                                                 DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -1864,7 +1864,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       {
         // we create a completly new thumb
         dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, nid, nrow, table->overlays,
-                                                 FALSE, table->show_tooltips);
+                                                 DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -423,8 +423,8 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkStyleContext *context = gtk_widget_get_style_context(hb);
     gtk_style_context_add_class(context, "dt_overlays_always");
 
-    dt_thumbnail_t *thumb
-        = dt_thumbnail_new(100, 100, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL, FALSE, TRUE);
+    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
+                                             DT_THUMBNAIL_CONTAINER_LIGHTTABLE, TRUE);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
     thumb->disable_mouseover = TRUE;
     thumb->disable_actions = TRUE;


### PR DESCRIPTION
this fix #7685 

Not so many change, but 2 days of work and lot of headaches ;)

To sum up for those interested : creating thumb with the right size wasn't too hard, but then we face another problem, where the allocation widget size differ from the widget size at first draw (not after) this seems due to the fact that gtk seems to throw draw event during the widget resizing, in particular for those which autosize to their parent... => So we need to set the exact right size *before* showing them... right !

Then comes a margin problem for the image which seems to change between creation time and "shown" time... In fact that was due to the css which define smaller margins for images if they are inside a "fullpreview" container. But of course they aren't at creation time, but when they are packed into the container hence the margin change... (seems obvious, but take me 4 hours to find !)