### PR TITLE
Fixes encoding issue on Windows when pathes contain non-ASCII symbols

### DIFF
--- a/src/common/file_location.c
+++ b/src/common/file_location.c
@@ -216,7 +216,9 @@ void dt_check_opendir(const char* context, const char* directory)
   } 
 
 #if _WIN32
-  DWORD attribs = GetFileAttributesA(directory);
+  wchar_t *wdirectory = g_utf8_to_utf16 (directory, -1, NULL, NULL, NULL);
+  DWORD attribs = GetFileAttributesW(wdirectory);
+  g_free(wdirectory);
   if (attribs != INVALID_FILE_ATTRIBUTES &&
       (attribs & FILE_ATTRIBUTE_DIRECTORY))
   {

--- a/src/common/file_location.c
+++ b/src/common/file_location.c
@@ -207,11 +207,11 @@ void dt_loc_init_plugindir(const char* application_directory, const char *plugin
   dt_check_opendir("darktable.plugindir", darktable.plugindir);
 }
 
-void dt_check_opendir(const char* text, const char* directory)
+void dt_check_opendir(const char* context, const char* directory)
 {
   if (!directory)
   {
-    fprintf(stderr, "directory for %s has not been set.\n", text);
+    fprintf(stderr, "directory for %s has not been set.\n", context);
     exit(EXIT_FAILURE);
   } 
 
@@ -220,18 +220,18 @@ void dt_check_opendir(const char* text, const char* directory)
   if (attribs != INVALID_FILE_ATTRIBUTES &&
       (attribs & FILE_ATTRIBUTE_DIRECTORY))
   {
-    dt_print(DT_DEBUG_DEV, "%s: %s\n", text, directory);
+    dt_print(DT_DEBUG_DEV, "%s: %s\n", context, directory);
   }
   else
   {
-    fprintf(stderr, "%s: directory '%s' fails to open.'\n", text, directory);
+    fprintf(stderr, "%s: directory '%s' fails to open.'\n", context, directory);
     exit(EXIT_FAILURE);
   }
 #else
   DIR* dir = opendir(directory);
   if (dir)
   {
-    dt_print(DT_DEBUG_DEV, "%s: %s\n", text, directory);
+    dt_print(DT_DEBUG_DEV, "%s: %s\n", context, directory);
     closedir(dir);
   } 
   else 


### PR DESCRIPTION
Fixes #7489

This PR shall fix the windows issue some users have. I can reproduce the reported issue #7489 on a windows (10) machine by calling

    "C:\Program Files\darktable\bin\darktable.exe" -d dev --configdir "c:\tmp\Söme Üsär" --cachedir "c:\tmp\Söme Üsär"

and I also can confirm that the issue is fixed with this change. 

Basically this PR instead of calling the ANSI version `GetFileAttributesA`  calls the wide-character version `GetFileAttributesW` and we receive the input in `wchar_t` by converting the UTF-8 encoded darktable strings (back) to the UTF-16 encoded Windows strings.