### PR TITLE
Update thumbnails while importing a folder

### DIFF
--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -17,6 +17,7 @@
 */
 #include "control/jobs/camera_jobs.h"
 #include "common/darktable.h"
+#include "common/collection.h"
 #include "common/import_session.h"
 #include "common/utility.h"
 #include "control/conf.h"
@@ -282,7 +283,7 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
 {
   // Import downloaded image to import filmroll
   dt_camera_import_t *t = (dt_camera_import_t *)data;
-  dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE);
+  const int32_t imgid = dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE);
   dt_control_queue_redraw_center();
   gchar *basename = g_path_get_basename(filename);
   dt_control_log(ngettext("%d/%d imported to %s", "%d/%d imported to %s", t->import_count + 1),
@@ -292,6 +293,11 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
   t->fraction += 1.0 / g_list_length(t->images);
 
   dt_control_job_set_progress(t->job, t->fraction);
+
+  if((imgid & 3) == 3)
+  {
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  }
 
   if(t->import_count + 1 == g_list_length(t->images))
   {

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/collection.h"
 #include "control/jobs/film_jobs.h"
 #include "common/darktable.h"
 #include "common/film.h"
@@ -253,12 +254,15 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     g_free(cdn);
 
     /* import image */
-    dt_image_import(cfr->id, (const gchar *)image->data, FALSE);
+    const int imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE);
 
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 
-
+    if((imgid & 7) == 7)
+    {
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+    }
   } while((image = g_list_next(image)) != NULL);
 
   g_list_free_full(images, g_free);

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -15,9 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "common/collection.h"
 #include "control/jobs/film_jobs.h"
 #include "common/darktable.h"
+#include "common/collection.h"
 #include "common/film.h"
 #include <stdlib.h>
 
@@ -254,12 +254,12 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     g_free(cdn);
 
     /* import image */
-    const int imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE);
+    const int32_t imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE);
 
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 
-    if((imgid & 7) == 7)
+    if((imgid & 3) == 3)
     {
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
     }


### PR DESCRIPTION
While importing a folder dt takes care of the new images but avoids to spam the system with
exposure events and recalculations of the collection.

**But** as reported in #7111 this means there is no visualising of import progress except the progress bar
and this might be seen as annoying.

Unfortunately the whole thing is deeply bound to the way the lighttable has been made so performant.
We don't have a signal that just updates the collection and does a partly recalculation so i found no other
way than to do a brute-force updating.

I found absolutely no hint that database locking - as i suspected first - is related to this problem.

I am really not sure whether this is the "best" we can do right now ... pinging you both

@AlicVB and @TurboGit -- anything better or just don't care?