### PR TITLE
imageio_tiff: restore recommended orientation tag

### DIFF
--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -238,6 +238,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
 
   TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
   int resolution = dt_conf_get_int("metadata/resolution");
@@ -414,6 +415,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);
         TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)h);
         TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+        TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
 
 #ifdef MASKS_USE_SAME_FORMAT
         TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, layers);


### PR DESCRIPTION
Reverting part of https://github.com/darktable-org/darktable/pull/6762

Although not mandatory by any spec and default is 1 (top, left) if absent anyway, at least Exif spec lists Orientation as "recommended" rather than "optional".