### PR TITLE
show all items in image information

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2728,4 +2728,11 @@
     <shortdescription>height of the collect list</shortdescription>
     <longdescription>maximum height the collect list in lighttable will grow to before scrolling</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/metadata_view/visible</name>
+    <type>string</type>
+    <default>filmroll,image id,group id,filename,version,full path,local copy,import timestamp,change timestamp,export timestamp,print timestamp,flags,model,maker,lens,aperture,exposure,exposure bias,focal length,focus distance,ISO,datetime,width,height,export width,export height,title,description,creator,publisher,rights,notes,version name,latitude,longitude,elevation,tags,categories</default>
+    <shortdescription>show all items</shortdescription>
+    <longdescription>show all items as of init parameters</longdescription>
+  </dtconfig>
 </dtconfiglist>


### PR DESCRIPTION
this will enable all items in image information after a fresh user setup.
the default list is empty which will annoy new users.

quick fix for existing user: press the 'reset parameters' of image information.

why default is different from reset: to be investigated