### PR TITLE
[threadsafety] localtime is not threadsafe, use localtime_r

### DIFF
--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -355,8 +355,9 @@ void dt_control_crawler_show_image_list(GList *images)
     GtkTreeIter iter;
     dt_control_crawler_result_t *item = list_iter->data;
     char timestamp_db[64], timestamp_xmp[64];
-    strftime(timestamp_db, sizeof(timestamp_db), "%c", localtime(&item->timestamp_db));
-    strftime(timestamp_xmp, sizeof(timestamp_xmp), "%c", localtime(&item->timestamp_xmp));
+    struct tm tm_stamp;
+    strftime(timestamp_db, sizeof(timestamp_db), "%c", localtime_r(&item->timestamp_db, &tm_stamp));
+    strftime(timestamp_xmp, sizeof(timestamp_xmp), "%c", localtime_r(&item->timestamp_xmp, &tm_stamp));
     gtk_list_store_append(store, &iter);
     gtk_list_store_set(store, &iter,
                        DT_CONTROL_CRAWLER_COL_SELECTED, 0,

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -294,8 +294,9 @@ static void _metadata_update_tooltip(const int i, const char *tooltip, dt_lib_mo
 static void _metadata_update_timestamp(const int i, const time_t *value, dt_lib_module_t *self)
 {
   char datetime[200];
+  struct tm tm_val;
   // just %c is too long and includes a time zone that we don't know from exif
-  const size_t datetime_len = strftime(datetime, sizeof(datetime), "%a %x %X", localtime(value));
+  const size_t datetime_len = strftime(datetime, sizeof(datetime), "%a %x %X", localtime_r(value, &tm_val));
   if(datetime_len > 0)
   {
     const gboolean valid_utf = g_utf8_validate(datetime, datetime_len, NULL);


### PR DESCRIPTION
Function `localtime` has thread safety issues and causes side-effects. We can safely replace it with threadsafe `localtime_r` with no downsides :)