### PR TITLE
basics : allow colorpickers to work as intended

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2185,6 +2185,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     dt_view_accels_refresh(darktable.view_manager);
 
   dt_control_change_cursor(GDK_LEFT_PTR);
+  dt_control_queue_redraw_center();
 }
 
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2122,7 +2122,6 @@ static void popup_callback(GtkButton *button, dt_iop_module_t *module)
 void dt_iop_request_focus(dt_iop_module_t *module)
 {
   if(darktable.gui->reset || (darktable.develop->gui_module == module)) return;
-  if(module && dt_dev_modulegroups_get(darktable.develop) == DT_MODULEGROUP_BASICS) return;
 
   if(darktable.develop->gui_module != module) darktable.develop->focus_hash++;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -40,6 +40,7 @@
 #include "gui/guides.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
+#include "libs/modulegroups.h"
 
 #include <assert.h>
 #include <gtk/gtk.h>
@@ -3373,7 +3374,7 @@ error:
 // does this gui have focus?
 static int gui_has_focus(struct dt_iop_module_t *self)
 {
-  return self->dev->gui_module == self;
+  return (self->dev->gui_module == self && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS);
 }
 
 /* this function replaces this sentence, it calls distort_transform() for this module on the pipe

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -21,8 +21,8 @@
 #endif
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
-#include "common/interpolation.h"
 #include "common/imagebuf.h"
+#include "common/interpolation.h"
 #include "common/math.h"
 #include "common/opencl.h"
 #include "control/conf.h"
@@ -36,6 +36,7 @@
 #include "gui/guides.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
+#include "libs/modulegroups.h"
 
 #include <assert.h>
 #include <gdk/gdkkeysyms.h>
@@ -352,7 +353,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 static int gui_has_focus(struct dt_iop_module_t *self)
 {
-  return self->dev->gui_module == self;
+  return (self->dev->gui_module == self && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS);
 }
 
 static void keystone_get_matrix(float *k_space, float kxa, float kxb, float kxc, float kxd, float kya,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -44,6 +44,7 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "libs/colorpicker.h"
+#include "libs/modulegroups.h"
 #include "views/view.h"
 #include "views/view_api.h"
 #ifdef GDK_WINDOWING_QUARTZ
@@ -593,12 +594,12 @@ void expose(
 
   // display mask if we have a current module activated or if the masks manager module is expanded
 
-  const gboolean display_masks =
-    (dev->gui_module && dev->gui_module->enabled)
-    || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
+  const gboolean display_masks = (dev->gui_module && dev->gui_module->enabled
+                                  && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+                                 || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
   // execute module callback hook.
-  if(dev->gui_module && dev->gui_module->request_color_pick != DT_REQUEST_COLORPICK_OFF && display_masks)
+  if(dev->gui_module && dev->gui_module->request_color_pick != DT_REQUEST_COLORPICK_OFF && dev->gui_module->enabled)
   {
     // The colorpicker bounding rectangle should only be displayed inside the visible image
     const int pwidth = (dev->pipe->output_backbuf_width<<closeup) / darktable.gui->ppd;
@@ -675,7 +676,8 @@ void expose(
     if(dev->form_visible && display_masks)
       dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
     // module
-    if(dev->gui_module && dev->gui_module->gui_post_expose)
+    if(dev->gui_module && dev->gui_module->gui_post_expose
+       && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
       dev->gui_module->gui_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
   }
 
@@ -3273,7 +3275,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   handled = dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
   // module
-  if(dev->gui_module && dev->gui_module->mouse_moved)
+  if(dev->gui_module && dev->gui_module->mouse_moved
+     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
 
@@ -3324,7 +3327,8 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
   if(dev->form_visible) handled = dt_masks_events_button_released(dev->gui_module, x, y, which, state);
   if(handled) return handled;
   // module
-  if(dev->gui_module && dev->gui_module->button_released)
+  if(dev->gui_module && dev->gui_module->button_released
+     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->button_released(dev->gui_module, x, y, which, state);
   if(handled) return handled;
   if(which == 1) dt_control_change_cursor(GDK_LEFT_PTR);
@@ -3420,7 +3424,8 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
     handled = dt_masks_events_button_pressed(dev->gui_module, x, y, pressure, which, type, state);
   if(handled) return handled;
   // module
-  if(dev->gui_module && dev->gui_module->button_pressed)
+  if(dev->gui_module && dev->gui_module->button_pressed
+     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->button_pressed(dev->gui_module, x, y, pressure, which, type, state);
   if(handled) return handled;
 
@@ -3538,7 +3543,8 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   if(dev->form_visible) handled = dt_masks_events_mouse_scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;
   // module
-  if(dev->gui_module && dev->gui_module->scrolled)
+  if(dev->gui_module && dev->gui_module->scrolled
+     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;
   // free zoom


### PR DESCRIPTION
this fix #7730

colorpicker that comes with widgets needs the module focus to work correctly. So we don't prevent modules to have focus when working with basics widgets but we desactivate one by one all all "on canvas" actions and expose, except colorpicker.