### PR TITLE
[size_t] make sure multiplications are done in size_t, correct allocations etc

### DIFF
--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -206,7 +206,7 @@ void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in)
       float y = CLAMPS(j / b->sigma_s, 0, b->size_y - 1);
       const int yi = MIN((int)y, b->size_y - 2);
       const float yf = y - yi;
-      const size_t base = (yi + slice_offset) * oy;
+      const size_t base = (size_t)(yi + slice_offset) * oy;
       for(int i = 0; i < b->width; i++)
       {
         size_t index = 4 * (j * b->width + i);

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -463,7 +463,7 @@ static void blur_vertical_1ch(float *const restrict buf, const int height, const
   {
     float L = 0.0f;
     int hits = 0;
-    size_t index = (size_t)x - radius * width;
+    size_t index = (size_t)x - (size_t)radius * width;
     float *const restrict scanline = scanlines;
     for(int y = -radius; y < height; y++)
     {
@@ -562,7 +562,7 @@ static void dt_box_mean_4ch_sse(float *const buf, const int height, const int wi
       __m128 *scanline = scanline_buf + size * dt_get_thread_num();
       __m128 L = _mm_setzero_ps();
       int hits = 0;
-      size_t index = (size_t)x - radius * width;
+      size_t index = (size_t)x - (size_t)radius * width;
       for(int y = -radius; y < height; y++)
       {
         int op = y - radius - 1;

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -151,7 +151,7 @@ static void dwt_decompose_vert(float *const restrict out, const float *const res
     // i.e. we move as many rows in from the edge as we would have been beyond the edge
     // for the top edge, this means we can simply use the absolute value of row-vscale; for the bottom edge,
     //   we need to reflect around height
-    const size_t rowstart = 4 * row * width;
+    const size_t rowstart = (size_t)4 * row * width;
     const int below_row = (row + vscale < height) ? (row + vscale) : 2*(height-1) - (row + vscale);
     const float* const restrict center = in + rowstart;
     const float* const restrict above = in + 4 * abs(row - vscale) * width;
@@ -280,7 +280,7 @@ static void dwt_wavelet_decompose(float *img, dwt_params_t *const p, _dwt_layer_
 
   if(p->merge_from_scale > 0)
   {
-    merged_layers = dt_alloc_align_float(p->width * p->height * p->ch);
+    merged_layers = dt_alloc_align_float((size_t)p->width * p->height * p->ch);
     if(merged_layers == NULL)
     {
       printf("not enough memory for wavelet decomposition");
@@ -429,7 +429,7 @@ static void dwt_denoise_vert_1ch(float *const restrict out, const float *const r
     // i.e. we move as many rows in from the edge as we would have been beyond the edge
     // for the top edge, this means we can simply use the absolute value of row-vscale; for the bottom edge,
     //   we need to reflect around height
-    const size_t rowstart = row * width;
+    const size_t rowstart = (size_t)row * width;
     const int below_row = (row + vscale < height) ? (row + vscale) : 2*(height-1) - (row + vscale);
     const float *const restrict center = in + rowstart;
     const float *const restrict above =  in + abs(row - vscale) * width;
@@ -534,7 +534,7 @@ static void dwt_denoise_horiz_1ch(float *const restrict out, float *const restri
  */
 void dwt_denoise(float *const img, const int width, const int height, const int bands, const float *const noise)
 {
-  float *const details = dt_alloc_align_float(2 * width * height);
+  float *const details = dt_alloc_align_float((size_t)2 * width * height);
   float *const interm = details + width * height;	// temporary storage for use during each pass
 
   // zero the accumulator

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -459,7 +459,7 @@ void eaw_synthesize_sse2(float *const out, const float *const in, const float *c
   dt_omp_firstprivate(boost, detail, height, in, out, threshold, width, maski, mask) \
   schedule(static)
 #endif
-  for(size_t j = 0; j < width * height; j++)
+  for(size_t j = 0; j < (size_t)width * height; j++)
   {
     const __m128 *pin = (__m128 *)in + j;
     const __m128 *pdetail = (__m128 *)detail + j;

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -81,7 +81,7 @@ static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
                                    uint8_t *const restrict image,
                                    const int buf_width, const int buf_height)
 {
-  float *const restrict luma =  dt_alloc_sse_ps(buf_width * buf_height);
+  float *const restrict luma =  dt_alloc_sse_ps((size_t)buf_width * buf_height);
   uint8_t *const restrict focus_peaking = dt_alloc_align(64, sizeof(uint8_t) * buf_width * buf_height * 4);
 
   // Create a luma buffer as the euclidian norm of RGB channels
@@ -108,7 +108,7 @@ schedule(static) collapse(2) aligned(image, luma:64)
   fast_surface_blur(luma, buf_width, buf_height, 12, 0.00001f, 4, DT_GF_BLENDING_LINEAR, 1, 0.0f, exp2f(-8.0f), 1.0f);
 
   // Compute the gradients magnitudes
-  float *const restrict luma_ds =  dt_alloc_sse_ps(buf_width * buf_height);
+  float *const restrict luma_ds =  dt_alloc_sse_ps((size_t)buf_width * buf_height);
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
 dt_omp_firstprivate(luma, luma_ds, buf_height, buf_width) \

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -325,7 +325,7 @@ void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const f
     for(int j = 0; j < ht; j++)
       for(int i = 0; i < wd; i++)
         for(int k = 0; k < ch; k++)
-          out[4 * ((size_t)j * wd + i) + k] = (in[(size_t)j * stride + ch * i + k] - black) * scale;
+          out[4 * ((size_t)j * wd + i) + k] = (in[(size_t)j * stride + (size_t)ch * i + k] - black) * scale;
     return;
   }
   int ii = 0, jj = 0;

--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -186,7 +186,7 @@ static inline void dt_imageio_write_dng(
   if(f)
   {
     dt_imageio_dng_write_tiff_header(f, wd, ht, 1.0f / 100.0f, 1.0f / 4.0f, 50.0f, 100.0f, filter, xtrans, whitelevel);
-    const int k = fwrite(pixel, sizeof(float), wd * ht, f);
+    const int k = fwrite(pixel, sizeof(float), (size_t)wd * ht, f);
     if(k != wd * ht) fprintf(stderr, "[dng_write] Error writing image data to %s\n", filename);
     fclose(f);
     if(exif) dt_exif_write_blob(exif, exif_len, filename, 0);

--- a/src/common/map_locations.c
+++ b/src/common/map_locations.c
@@ -32,6 +32,7 @@ const guint dt_map_location_new(const char *const name)
   char *loc_name = g_strconcat(location_tag_prefix, name, NULL);
   guint locid = -1;
   dt_tag_new(loc_name, &locid);
+  g_free(loc_name);
   return locid;
 }
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -323,7 +323,7 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
       int imgfw= 0, imgfh= 0;
       // be sure that we have the right size values
       dt_image_get_final_size(get_imgid(entry->key), &imgfw, &imgfh);
-      entry->data_size = sizeof(struct dt_mipmap_buffer_dsc) + (imgfw + 4) * (imgfh + 4) * 4;
+      entry->data_size = sizeof(struct dt_mipmap_buffer_dsc) + (size_t)(imgfw + 4) * (imgfh + 4) * 4;
     }
     else if(mip <= DT_MIPMAP_F)
     {
@@ -564,7 +564,7 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
     // header + buffer
   for(int k = DT_MIPMAP_F-1; k >= 0; k--)
     cache->buffer_size[k] = sizeof(struct dt_mipmap_buffer_dsc)
-                                + cache->max_width[k] * cache->max_height[k] * 4;
+                                + (size_t)cache->max_width[k] * cache->max_height[k] * 4;
 
   // clear stats:
   cache->mip_thumbs.stats_requests = 0;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -333,8 +333,8 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
     roi.y = image.crop_y;
     for(int j=0;j<6;j++)
       for(int i = 0; i < 6; i++) d->first_xtrans[j][i] = FCxtrans(j, i, &roi, image.buf_dsc.xtrans);
-    d->pixels = calloc(datai->width * datai->height, sizeof(float));
-    d->weight = calloc(datai->width * datai->height, sizeof(float));
+    d->pixels = calloc((size_t)datai->width * datai->height, sizeof(float));
+    d->weight = calloc((size_t)datai->width * datai->height, sizeof(float));
     d->wd = datai->width;
     d->ht = datai->height;
     d->orientation = image.orientation;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -890,7 +890,7 @@ static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
 
   // we create a buffer of points with all points in the area
   const int w = *width, h = *height;
-  float *const restrict points = dt_alloc_align_float(w * h * 2);
+  float *const restrict points = dt_alloc_align_float((size_t)w * h * 2);
   if(points == NULL)
     return 0;
 
@@ -921,7 +921,7 @@ static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
   start2 = dt_get_wtime();
 
   // we back transform all this points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, w * h))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)w * h))
   {
     dt_free_align(points);
     return 0;
@@ -933,7 +933,7 @@ static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
   start2 = dt_get_wtime();
 
   // we allocate the buffer
-  *buffer = dt_alloc_align_float(w * h);
+  *buffer = dt_alloc_align_float((size_t)w * h);
   if(*buffer == NULL)
   {
     dt_free_align(points);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1619,7 +1619,7 @@ static int dt_ellipse_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
   start2 = dt_get_wtime();
 
   // we back transform all this points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, w * h))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)w * h))
   {
     dt_free_align(points);
     return 0;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1568,7 +1568,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           {
             // we abuse the empty output buffer on host for intermediate storage of data in
             // histogram_collect_cl()
-            size_t outbufsize = roi_out->width * roi_out->height * bpp;
+            size_t outbufsize = bpp * roi_out->width * roi_out->height;
 
             histogram_collect_cl(pipe->devid, piece, cl_mem_input, &roi_in, &(piece->histogram),
                                  piece->histogram_max, *output, outbufsize);
@@ -1578,7 +1578,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             if(piece->histogram && (module->request_histogram & DT_REQUEST_ON)
                && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
             {
-              const size_t buf_size = 4 * piece->histogram_stats.bins_count * sizeof(uint32_t);
+              const size_t buf_size = sizeof(uint32_t) * 4 * piece->histogram_stats.bins_count;
               module->histogram = realloc(module->histogram, buf_size);
               memcpy(module->histogram, piece->histogram, buf_size);
               module->histogram_stats = piece->histogram_stats;
@@ -2171,7 +2171,7 @@ post_process_collect_info:
         {
           const uint8_t *in = (uint8_t *)(*output);
           // FIXME: it would be nice to use dt_imageio_flip_buffers_ui8_to_float() but then we'd need to make another pass to convert RGB to BGR
-          for(size_t k = 0; k < roi_out->width * roi_out->height * 4; k += 4)
+          for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height * 4; k += 4)
           {
             for(size_t c = 0; c < 3; c++)
               buf[k + c] = in[k + 2 - c] / 255.0f;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -787,13 +787,13 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
       {
         origin[0] += overlap;
         region[0] -= overlap;
-        ooffs += overlap * out_bpp;
+        ooffs += (size_t)overlap * out_bpp;
       }
       if(ty > 0)
       {
         origin[1] += overlap;
         region[1] -= overlap;
-        ooffs += overlap * opitch;
+        ooffs += (size_t)overlap * opitch;
       }
 
 /* copy "good" part of tile to output buffer */
@@ -1476,13 +1476,13 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
       {
         origin[0] += overlap;
         region[0] -= overlap;
-        ooffs += overlap * out_bpp;
+        ooffs += (size_t)overlap * out_bpp;
       }
       if(ty > 0)
       {
         origin[1] += overlap;
         region[1] -= overlap;
-        ooffs += overlap * opitch;
+        ooffs += (size_t)overlap * opitch;
       }
 
       if(use_pinned_memory)

--- a/src/iop/ashift_lsd.c
+++ b/src/iop/ashift_lsd.c
@@ -328,7 +328,7 @@ static void enlarge_ntuple_list(ntuple_list n_tuple)
 
   /* realloc memory */
   n_tuple->values = (double *) realloc( (void *) n_tuple->values,
-                      n_tuple->dim * n_tuple->max_size * sizeof(double) );
+                      sizeof(double) * n_tuple->dim * n_tuple->max_size );
   if( n_tuple->values == NULL ) error("not enough memory.");
 }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -286,7 +286,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
 #ifdef _OPENMP
 #pragma omp simd aligned(buf1, out : 64)
 #endif
-  for (size_t k = 0; k < 4 * width * height; k++)
+  for (size_t k = 0; k < (size_t)4 * width * height; k++)
     out[k] += buf1[k];
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -239,7 +239,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     const int height = roi_in->height;
     const int channels = piece->colors;
 
-    const size_t basebuffer = width * height * channels * sizeof(float);
+    const size_t basebuffer = sizeof(float) * channels * width * height;
 
     tiling->factor = 2.0f + (float)dt_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer;
     tiling->maxbuf
@@ -255,7 +255,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     const int height = roi_in->height;
     const int channels = piece->colors;
 
-    const size_t basebuffer = width * height * channels * sizeof(float);
+    const size_t basebuffer = sizeof(float) * channels * width * height;
     const int rad = MIN(roi_in->width, ceilf(256 * roi_in->scale / piece->iscale));
 
     tiling->factor = 2.0f + (float)local_laplacian_memory_use(width, height) / basebuffer;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -345,7 +345,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   // local variables
   //   const int width = W, height = H;
   // temporary array to store simple interpolation of G
-  float *Gtmp = (float(*))calloc((height) * (width), sizeof *Gtmp);
+  float *Gtmp = (float(*))calloc((size_t)(height) * (width), sizeof *Gtmp);
 
   // temporary array to avoid race conflicts, only every second pixel needs to be saved here
   float *RawDataTmp = (float *)malloc(sizeof(float) * height * width / 2 + 4);
@@ -368,7 +368,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
   // block CA shift values and weight assigned to block
   float *blockwt = (float *)buffer1;
-  float(*blockshifts)[2][2] = (float(*)[2][2])(buffer1 + (vblsz * hblsz * sizeof(float)));
+  float(*blockshifts)[2][2] = (float(*)[2][2])(buffer1 + (sizeof(float) * vblsz * hblsz));
 
   double fitparams[2][2][16];
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -143,7 +143,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = 4;
   assert(piece->colors == ch);
 
-  float *const restrict temp = dt_alloc_align_float(width * height * ch);
+  float *const restrict temp = dt_alloc_align_float((size_t)width * height * ch);
 
   const float sigma_1 = data->radius_1 * roi_in->scale / piece->iscale;
   const float sigma_2 = data->radius_2 * roi_in->scale / piece->iscale;
@@ -238,7 +238,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   else
   {
     output = out;
-    dt_simd_memcpy(input, output, width * height * 4);
+    dt_simd_memcpy(input, output, (size_t)width * height * ch);
   }
 
   if(noise != 0.f)

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -151,7 +151,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const float *const restrict in = (const float *const)ivoid;
   float *const restrict out = (float *const)ovoid;
-  const size_t npixels = roi_out->width * roi_out->height;
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
 
   if(d->unbound)
   {

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -492,7 +492,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           = (data->target_var[i][1] > 0.0f) ? data->source_var[mapio[i]][1] / data->target_var[i][1] : 0.0f;
     }
 
-    const size_t npixels = height * width;
+    const size_t npixels = (size_t)height * width;
 // first get delta L of equalized L minus original image L, scaled to fit into [0 .. 100]
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -500,7 +500,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_omp_sharedconst(in, out, data, equalization)        \
     schedule(static)
 #endif
-    for(size_t k = 0; k < 4*npixels; k += 4)
+    for(size_t k = 0; k < npixels * 4; k += 4)
     {
       const float L = in[k];
       out[k] = 0.5f * ((L * (1.0f - equalization)
@@ -761,7 +761,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int height = roi_in->height;
   const int channels = piece->colors;
 
-  const size_t basebuffer = width * height * channels * sizeof(float);
+  const size_t basebuffer = sizeof(float) * channels * width * height;
 
   tiling->factor = 3.0f + (float)dt_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer;
   tiling->maxbuf

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -368,7 +368,7 @@ static void dt_iop_colorreconstruct_bilateral_splat(dt_iop_colorreconstruct_bila
 #endif
   for(int j = 0; j < b->height; j++)
   {
-    size_t index = 4 * j * b->width;
+    size_t index = (size_t)4 * j * b->width;
     for(int i = 0; i < b->width; i++, index += 4)
     {
       float x, y, z, weight, m;
@@ -521,7 +521,7 @@ static void dt_iop_colorreconstruct_bilateral_slice(const dt_iop_colorreconstruc
 #endif
   for(int j = 0; j < roi->height; j++)
   {
-    size_t index = 4 * j * roi->width;
+    size_t index = (size_t)4 * j * roi->width;
     for(int i = 0; i < roi->width; i++, index += 4)
     {
       float x, y, z;
@@ -1176,7 +1176,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int height = roi_in->height;
   const int channels = piece->colors;
 
-  const size_t basebuffer = width * height * channels * sizeof(float);
+  const size_t basebuffer = sizeof(float) * channels * width * height;
 
   tiling->factor = 2.0f + (float)dt_iop_colorreconstruct_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer;
   tiling->maxbuf

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -264,7 +264,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
   reduction(+ : avg_edge_chroma) \
   schedule(simd:static)
 #endif
-  for(size_t j = 0; j < height * width * 4; j += 4)
+  for(size_t j = 0; j < (size_t)height * width * 4; j += 4)
   {
     // edge-detect on color channels
     // method: difference of original to gaussian blurred image:

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1949,7 +1949,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_horiz, 3, sizeof(int), (void *)&height);
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_horiz, 4, 2 * sizeof(int), (void *)&q);
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_horiz, 5, sizeof(int), (void *)&P);
-      dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_horiz, 6, (hblocksize + 2 * P) * sizeof(float),
+      dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_horiz, 6, sizeof(float) * (hblocksize + 2 * P),
                                NULL);
       err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_denoiseprofile_horiz, sizesl, local);
       if(err != CL_SUCCESS) goto error;
@@ -1968,7 +1968,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_vert, 4, 2 * sizeof(int), (void *)&q);
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_vert, 5, sizeof(int), (void *)&P);
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_vert, 6, sizeof(float), (void *)&norm);
-      dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_vert, 7, (vblocksize + 2 * P) * sizeof(float),
+      dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_vert, 7, sizeof(float) * (vblocksize + 2 * P),
                                NULL);
       dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_vert, 8, sizeof(float),
                                (void *)&central_pixel_weight);
@@ -2300,13 +2300,13 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_first, 2, sizeof(int), &height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_first, 3, sizeof(cl_mem), &dev_m);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_first, 4,
-                             flocopt.sizex * flocopt.sizey * 4 * sizeof(float), NULL);
+                             sizeof(float) * 4 * flocopt.sizex * flocopt.sizey, NULL);
     err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_denoiseprofile_reduce_first, lsizes,
                                                  llocal);
     if(err != CL_SUCCESS) goto error;
 
 
-    lsizes[0] = reducesize * slocopt.sizex;
+    lsizes[0] = (size_t)reducesize * slocopt.sizex;
     lsizes[1] = 1;
     lsizes[2] = 1;
     llocal[0] = slocopt.sizex;
@@ -2315,14 +2315,14 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_second, 0, sizeof(cl_mem), &dev_m);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_second, 1, sizeof(cl_mem), &dev_r);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_second, 2, sizeof(int), &bufsize);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_second, 3, slocopt.sizex * 4 * sizeof(float),
+    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_reduce_second, 3, sizeof(float) * 4 * slocopt.sizex,
                              NULL);
     err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_denoiseprofile_reduce_second, lsizes,
                                                  llocal);
     if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_read_buffer_from_device(devid, (void *)sumsum, dev_r, 0,
-                                            (size_t)reducesize * 4 * sizeof(float), CL_TRUE);
+                                            sizeof(float) * 4 * reducesize, CL_TRUE);
     if(err != CL_SUCCESS)
       goto error;
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -193,12 +193,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       const int step = 1 << l;
 #if 1 // scale coefficients
       for(int j = 0; j < height; j += step)
-        for(int i = step / 2; i < width; i += step) out[(size_t)chs * width * j + chs * i + ch] *= coeff;
+        for(int i = step / 2; i < width; i += step) out[(size_t)chs * width * j + (size_t)chs * i + ch] *= coeff;
       for(int j = step / 2; j < height; j += step)
-        for(int i = 0; i < width; i += step) out[(size_t)chs * width * j + chs * i + ch] *= coeff;
+        for(int i = 0; i < width; i += step) out[(size_t)chs * width * j + (size_t)chs * i + ch] *= coeff;
       for(int j = step / 2; j < height; j += step)
         for(int i = step / 2; i < width; i += step)
-          out[(size_t)chs * width * j + chs * i + ch] *= coeff * coeff;
+          out[(size_t)chs * width * j + (size_t)chs * i + ch] *= coeff * coeff;
 #else // soft-thresholding (shrinkage)
 #define wshrink                                                                                              \
   (copysignf(fmaxf(0.0f, fabsf(out[(size_t)chs * width * j + chs * i + ch]) - (1.0 - coeff)),                \

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -456,7 +456,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *const restrict out = (float*)o;
   const float black = d->black;
   const float scale = d->scale;
-  const size_t npixels = roi_out->width * roi_out->height;
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(ch, npixels, black, scale, in, out)  \

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -402,7 +402,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   dt_omp_firstprivate(ch, data, desaturate, ivoid, ovoid, preserve_color, roi_out, saturation, EPS) \
   schedule(static)
 #endif
-  for(size_t k = 0; k < roi_out->height * roi_out->width * ch; k += ch)
+  for(size_t k = 0; k < (size_t)roi_out->height * roi_out->width * ch; k += ch)
   {
     float *in = ((float *)ivoid) + k;
     float *out = ((float *)ovoid) + k;
@@ -532,7 +532,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                       zero, eps) \
   schedule(static)
 #endif
-  for(size_t k = 0; k < roi_out->height * roi_out->width * ch; k += ch)
+  for(size_t k = 0; k < (size_t)roi_out->height * roi_out->width * ch; k += ch)
   {
     float *in = ((float *)ivoid) + k;
     float *out = ((float *)ovoid) + k;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1454,7 +1454,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   float *restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;
-  float *const restrict mask = dt_alloc_sse_ps(roi_out->width * roi_out->height);
+  float *const restrict mask = dt_alloc_sse_ps((size_t)roi_out->width * roi_out->height);
 
   // used to adjuste noise level depending on size. Don't amplify noise if magnified > 100%
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
@@ -1475,14 +1475,14 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     }
   }
 
-  float *const restrict reconstructed = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+  float *const restrict reconstructed = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);
   const gboolean run_fast = (piece->pipe->type & DT_DEV_PIXELPIPE_FAST) == DT_DEV_PIXELPIPE_FAST;
 
   // if fast mode is not in use
   if(!run_fast && recover_highlights && mask && reconstructed)
   {
     // init the blown areas with noise to create particles
-    float *const restrict inpainted =  dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+    float *const restrict inpainted =  dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);
     inpaint_noise(in, mask, inpainted, data->noise_level / scale, data->reconstruct_threshold, data->noise_distribution,
                   roi_out->width, roi_out->height, ch);
 
@@ -1495,8 +1495,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
     if(data->high_quality_reconstruction > 0 && success_1)
     {
-      float *const restrict norms = dt_alloc_sse_ps(roi_out->width * roi_out->height);
-      float *const restrict ratios = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+      float *const restrict norms = dt_alloc_sse_ps((size_t)roi_out->width * roi_out->height);
+      float *const restrict ratios = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);
 
       // reconstruct highlights PASS 2 on ratios
       if(norms && ratios)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -214,7 +214,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_opencl_set_kernel_arg(devid, gd->kernel_highlights_1f_lch_xtrans, 6, sizeof(int), (void *)&roi_out->y);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highlights_1f_lch_xtrans, 7, sizeof(cl_mem), (void *)&dev_xtrans);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highlights_1f_lch_xtrans, 8,
-                               (blocksizex + 4) * (blocksizey + 4) * sizeof(float), NULL);
+                               sizeof(float) * (blocksizex + 4) * (blocksizey + 4), NULL);
 
     err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_highlights_1f_lch_xtrans, sizes, local);
     if(err != CL_SUCCESS) goto error;

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -373,7 +373,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   const float *const restrict in = (float*)ivoid;
   float *const restrict out = (float*)ovoid;
-  const size_t npixels = roi_out->width * roi_out->height;
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
   
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -894,7 +894,7 @@ static void build_round_stamp(float complex **pstamp,
   const float abs_strength = cabs(strength);
 
   float complex *restrict stamp =
-    calloc(sizeof(float complex), stamp_extent->width * stamp_extent->height);
+    calloc(sizeof(float complex), (size_t)stamp_extent->width * stamp_extent->height);
 
   // lookup table: map of distance from center point => warp
   const int table_size = iradius * LOOKUP_OVERSAMPLE;
@@ -1515,7 +1515,7 @@ static cl_int_t apply_global_distortion_map_cl(struct dt_iop_module_t *module,
     (devid, sizeof(dt_iop_roi_t), (void *) roi_out);
 
   cl_mem_t dev_map = dt_opencl_copy_host_to_device_constant
-    (devid, map_extent->width * map_extent->height * sizeof(float complex), (void *) map);
+    (devid, sizeof(float complex) * map_extent->width * map_extent->height, (void *) map);
 
   cl_mem_t dev_map_extent = dt_opencl_copy_host_to_device_constant
     (devid, sizeof(cairo_rectangle_int_t), (void *) map_extent);
@@ -1524,7 +1524,7 @@ static cl_int_t apply_global_distortion_map_cl(struct dt_iop_module_t *module,
     (devid, sizeof(dt_liquify_kernel_descriptor_t), (void *) &kdesc);
 
   cl_mem_t dev_kernel = dt_opencl_copy_host_to_device_constant
-    (devid, (kdesc.size * kdesc.resolution  + 1) * sizeof(float), (void *) k);
+    (devid, sizeof(float) * (kdesc.size * kdesc.resolution  + 1), (void *) k);
 
   if(dev_roi_in == NULL || dev_roi_out == NULL || dev_map == NULL || dev_map_extent == NULL
       || dev_kdesc == NULL || dev_kernel == NULL)

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -341,7 +341,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int height = roi_in->height;
   const int channels = piece->colors;
 
-  const size_t basebuffer = width * height * channels * sizeof(float);
+  const size_t basebuffer = sizeof(float) * channels * width * height;
 
   if(d->lowpass_algo == LOWPASS_ALGO_BILATERAL)
   {

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1005,7 +1005,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   if (clut && level)
   {
-    clut_cl = dt_opencl_copy_host_to_device_constant(devid, level * level * level * 3 * sizeof(float), (void *)clut);
+    clut_cl = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3 * level * level * level, (void *)clut);
     if(clut_cl == NULL)
     {
       fprintf(stderr, "[lut3d process_cl] error allocating memory\n");
@@ -1083,22 +1083,22 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       dt_ioppr_transform_image_colorspace_rgb(ibuf, obuf, width, height,
         work_profile, lut_profile, "work profile to LUT profile");
       if (interpolation == DT_IOP_TETRAHEDRAL)
-        correct_pixel_tetrahedral(obuf, obuf, width * height, clut, level);
+        correct_pixel_tetrahedral(obuf, obuf, (size_t)width * height, clut, level);
       else if (interpolation == DT_IOP_TRILINEAR)
-        correct_pixel_trilinear(obuf, obuf, width * height, clut, level);
+        correct_pixel_trilinear(obuf, obuf, (size_t)width * height, clut, level);
       else
-        correct_pixel_pyramid(obuf, obuf, width * height, clut, level);
+        correct_pixel_pyramid(obuf, obuf, (size_t)width * height, clut, level);
       dt_ioppr_transform_image_colorspace_rgb(obuf, obuf, width, height,
         lut_profile, work_profile, "LUT profile to work profile");
     }
     else
     {
       if (interpolation == DT_IOP_TETRAHEDRAL)
-        correct_pixel_tetrahedral(ibuf, obuf, width * height, clut, level);
+        correct_pixel_tetrahedral(ibuf, obuf, (size_t)width * height, clut, level);
       else if (interpolation == DT_IOP_TRILINEAR)
-        correct_pixel_trilinear(ibuf, obuf, width * height, clut, level);
+        correct_pixel_trilinear(ibuf, obuf, (size_t)width * height, clut, level);
       else
-        correct_pixel_pyramid(ibuf, obuf, width * height, clut, level);
+        correct_pixel_pyramid(ibuf, obuf, (size_t)width * height, clut, level);
     }
   }
   else  // no clut

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -295,7 +295,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int height = roi_in->height;
   const int channels = piece->colors;
 
-  const size_t basebuffer = width * height * channels * sizeof(float);
+  const size_t basebuffer = sizeof(float) * channels * width * height;
   const size_t bilat_mem = dt_bilateral_memory_use(width, height, sigma_s, sigma_r);
 
   tiling->factor = 2.0f + (float)bilat_mem / basebuffer;

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -276,7 +276,7 @@ void process(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const p
     dt_omp_firstprivate(d, in, out, roi_out) \
     aligned(in, out:64) collapse(2)
 #endif
-  for(size_t k = 0; k < roi_out->height * roi_out->width * 4; k += 4)
+  for(size_t k = 0; k < (size_t)roi_out->height * roi_out->width * 4; k += 4)
   {
     for(size_t c = 0; c < 4; c++)
     {

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2883,7 +2883,7 @@ static void rt_intersect_2_rois(dt_iop_roi_t *const roi_1, dt_iop_roi_t *const r
 static void rt_copy_in_to_out(const float *const in, const struct dt_iop_roi_t *const roi_in, float *const out,
                               const struct dt_iop_roi_t *const roi_out, const int ch, const int dx, const int dy)
 {
-  const int rowsize = MIN(roi_out->width, roi_in->width) * ch * sizeof(float);
+  const size_t rowsize = sizeof(float) * ch * MIN(roi_out->width, roi_in->width);
   const int xoffs = roi_out->x - roi_in->x - dx;
   const int yoffs = roi_out->y - roi_in->y - dy;
   const int y_to = MIN(roi_out->height, roi_in->height);
@@ -3493,7 +3493,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
      && (g->mask_display || display_wavelet_scale) && self->dev->gui_attached
      && (self == self->dev->gui_module) && (piece->pipe == self->dev->pipe))
   {
-    for(size_t j = 0; j < roi_rt->width * roi_rt->height * ch; j += ch) in_retouch[j + 3] = 0.f;
+    for(size_t j = 0; j < (size_t)roi_rt->width * roi_rt->height * ch; j += ch) in_retouch[j + 3] = 0.f;
 
     piece->pipe->mask_display = g->mask_display ? DT_DEV_PIXELPIPE_DISPLAY_MASK : DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
     piece->pipe->bypass_blendif = 1;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -595,7 +595,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const float sigma_r = 100.0f; // does not depend on scale
   const float sigma_s = sigma;
 
-  const size_t basebuffer = width * height * channels * sizeof(float);
+  const size_t basebuffer = sizeof(float) * channels * width * height;
 
   if(d->shadhi_algo == SHADHI_ALGO_BILATERAL)
   {

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -688,7 +688,7 @@ static inline void apply_toneequalizer(const float *const restrict in,
                                        const size_t ch,
                                        const dt_iop_toneequalizer_data_t *const d)
 {
-  const size_t num_elem = roi_in->width * roi_in->height;
+  const size_t num_elem = (size_t)roi_in->width * roi_in->height;
   const int min_ev = -8;
   const int max_ev = 0;
   const float* restrict lut = d->correction_lut;

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -135,7 +135,7 @@ void gui_init(dt_lib_module_t *self)
               height = DT_PIXEL_APPLY_DPI(png_height) * darktable.gui->ppd;
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, width);
 
-    d->image_buffer = (guint8 *)calloc(stride * height, sizeof(guint8));
+    d->image_buffer = (guint8 *)calloc((size_t)stride * height, sizeof(guint8));
     d->image
         = dt_cairo_image_surface_create_for_data(d->image_buffer, CAIRO_FORMAT_ARGB32, width, height, stride);
     if(cairo_surface_status(d->image) != CAIRO_STATUS_SUCCESS)

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -349,7 +349,7 @@ static inline cairo_pattern_t *_new_sprite(const uint8_t *data, const int width,
                                            int *_stride, GList **bufs, GList **surfaces, GList **patterns)
 {
   const int32_t stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, width);
-  uint8_t *buf = (uint8_t *)malloc(stride * height);
+  uint8_t *buf = (uint8_t *)malloc((size_t)stride * height);
   for(int y = 0; y < height; y++) memcpy(&buf[y * stride], &(data[y * width]), sizeof(uint8_t) * width);
   cairo_surface_t *surface = cairo_image_surface_create_for_data(buf, CAIRO_FORMAT_A8, width, height, stride);
   cairo_pattern_t *pattern = cairo_pattern_create_for_surface(surface);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -368,7 +368,7 @@ static GdkPixbuf *_view_map_images_count(const int nb_images, const gboolean sam
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, w, h);
-  size_t size = w * h * 4;
+  size_t size = (size_t)w * h * 4;
   uint8_t *buf = (uint8_t *)malloc(size);
   memcpy(buf, data, size);
   GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, w, h, w * 4,
@@ -393,7 +393,7 @@ static GdkPixbuf *_init_image_pin()
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, w, h);
-  size_t size = w * h * 4;
+  size_t size = (size_t)w * h * 4;
   uint8_t *buf = (uint8_t *)malloc(size);
   memcpy(buf, data, size);
   GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, w, h, w * 4,
@@ -441,7 +441,7 @@ static GdkPixbuf *_init_place_pin()
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, w, h);
-  size_t size = w * h * 4;
+  size_t size = (size_t)w * h * 4;
   uint8_t *buf = (uint8_t *)malloc(size);
   memcpy(buf, data, size);
   GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, w, h, w * 4,
@@ -509,7 +509,7 @@ static GdkPixbuf *_draw_ellipse(const float dlongitude, const float dlatitude,
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, w, h);
-  size_t size = w * h * 4;
+  size_t size = (size_t)w * h * 4;
   uint8_t *buf = (uint8_t *)malloc(size);
   memcpy(buf, data, size);
   GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, w, h, w * 4,
@@ -564,7 +564,7 @@ static GdkPixbuf *_draw_rectangle(const float dlongitude, const float dlatitude,
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, w, h);
-  size_t size = w * h * 4;
+  size_t size = (size_t)w * h * 4;
   uint8_t *buf = (uint8_t *)malloc(size);
   memcpy(buf, data, size);
   GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, w, h, w * 4,

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -968,7 +968,7 @@ dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int heig
 
   // we transfer cached image on a cairo_surface (with colorspace transform if needed)
   cairo_surface_t *tmp_surface = NULL;
-  uint8_t *rgbbuf = (uint8_t *)calloc(buf_wd * buf_ht * 4, sizeof(uint8_t));
+  uint8_t *rgbbuf = (uint8_t *)calloc((size_t)buf_wd * buf_ht * 4, sizeof(uint8_t));
   if(rgbbuf)
   {
     gboolean have_lock = FALSE;


### PR DESCRIPTION
Unfortunately calculations like `(size_t)(int) + (int)*(int)` mean `(int)*(int)` still isn't calculated in biggest space.

This pr fixes all `size_t` shenenigans I managed to catch. 