### PR TITLE
Basic adjustments, new link to full module

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1455,9 +1455,9 @@ margin: 0 2px;
 
 #basics-link
 {
-  min-height: 1.1em;
-  min-width: 1.1em;
-  margin: 0 2px 2px 2px;
+  min-height: 1em;
+  min-width: 1em;
+  margin: 0.3em 0.2em 0 0.1em;
   border: none;
 }
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1478,12 +1478,6 @@ margin: 0 2px;
   margin-top: 1em;
 }
 
-#basics-widget.basics-widget_group_start
-{
-  padding-top: 0.5em;
-  border-top: 0.5px solid @section_label;
-}
-
 #basics-iop_name
 {
   padding-left: 0.25em;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2481,6 +2481,32 @@ void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, 
   FINISH
 }
 
+void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  //arrow
+  cairo_move_to(cr, .5, .5);
+  cairo_line_to(cr, 1., 0.);
+  cairo_stroke(cr);
+  cairo_move_to(cr, .65, 0.);
+  cairo_line_to(cr, 1., 0.);
+  cairo_line_to(cr, 1., .35);
+  cairo_stroke(cr);
+
+  //rounded rectangle
+  cairo_move_to(cr, .8, .6);
+  cairo_line_to(cr, .8, .85);
+  cairo_arc (cr, .65, .85, .15, 0., .5 * M_PI);
+  cairo_line_to(cr, .15, 1.);
+  cairo_arc (cr, .15, .85, .15, .5 * M_PI, M_PI);
+  cairo_line_to(cr, 0., .35);
+  cairo_arc (cr, .15, .35, .15, M_PI, 1.5 * M_PI);
+  cairo_line_to(cr, .4, .2);
+  cairo_stroke(cr);
+
+  FINISH
+}
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2485,6 +2485,8 @@ void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 {
   PREAMBLE(1, 0, 0)
 
+  cairo_set_line_width(cr, .1);
+
   //arrow
   cairo_move_to(cr, .5, .5);
   cairo_line_to(cr, 1., 0.);

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -270,6 +270,9 @@ void dtgtk_cairo_paint_display_wavelet_scale(cairo_t *cr, gint x, gint y, gint w
 /** Paint a auto level icon for retouch*/
 void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
+/** Paint a link icon for basic adjustments*/
+void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -680,7 +680,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
 
 
       // and we add the link to the full iop
-      GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT, NULL);
+      GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, CPF_STYLE_FLAT, NULL);
       gchar *tt = dt_util_dstrcat(NULL, _("go to full version of module %s"), item->module->name());
       gtk_widget_set_tooltip_text(wbt, tt);
       gtk_widget_set_name(wbt, "basics-link");

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -686,7 +686,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
   }
 
   // and we add the link to the full iop
-  GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT, NULL);
   gchar *tt = dt_util_dstrcat(NULL, _("go to full version of module %s"), item->module->name());
   gtk_widget_set_tooltip_text(wbt, tt);
   gtk_widget_set_name(wbt, "basics-link");
@@ -2662,7 +2662,7 @@ static void _manage_editor_group_icon_changed(GtkWidget *widget, GdkEventButton 
   gr->icon = g_strdup(ic);
   GtkWidget *pop = gtk_widget_get_parent(gtk_widget_get_parent(widget));
   GtkWidget *btn = gtk_popover_get_relative_to(GTK_POPOVER(pop));
-  dtgtk_button_set_paint(DTGTK_BUTTON(btn), _buttons_get_icon_fct(ic), CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT,
+  dtgtk_button_set_paint(DTGTK_BUTTON(btn), _buttons_get_icon_fct(ic), CPF_STYLE_FLAT,
                          NULL);
   gtk_popover_popdown(GTK_POPOVER(pop));
 }
@@ -2678,7 +2678,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
   GtkWidget *eb, *hb, *ic;
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_basic, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_basic, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("basic icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "basic");
@@ -2688,7 +2688,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_active, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_active, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("active icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "active");
@@ -2698,7 +2698,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_color, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_color, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("color icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "color");
@@ -2708,7 +2708,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_correct, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_correct, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("correct icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "correct");
@@ -2718,7 +2718,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_effect, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_effect, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("effect icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "effect");
@@ -2728,7 +2728,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_favorites, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_favorites, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("favorites icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "favorites");
@@ -2738,7 +2738,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_tone, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_tone, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("tone icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "tone");
@@ -2748,7 +2748,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_grading, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_grading, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("grading icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "grading");
@@ -2758,7 +2758,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_technical, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_technical, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("technical icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "technical");
@@ -2786,7 +2786,7 @@ static GtkWidget *_manage_editor_group_init_basics_box(dt_lib_module_t *self)
   gtk_widget_set_name(hb3, "modulegroups-header-center");
   gtk_widget_set_hexpand(hb3, TRUE);
 
-  btn = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_basics, CPF_DO_NOT_USE_BORDER, NULL);
+  btn = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_basics, 0, NULL);
   gtk_widget_set_name(btn, "modulegroups-group-icon");
   gtk_widget_set_sensitive(btn, FALSE);
   gtk_box_pack_start(GTK_BOX(hb3), btn, FALSE, TRUE, 0);
@@ -2814,7 +2814,7 @@ static GtkWidget *_manage_editor_group_init_basics_box(dt_lib_module_t *self)
   {
     GtkWidget *hb4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple,
-                                     CPF_DO_NOT_USE_BORDER | CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+                                     CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add widgets to the list"));
     gtk_widget_set_name(bt, "modulegroups-add-module-btn");
     g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_manage_editor_basics_add_popup), self);
@@ -2843,7 +2843,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   GtkWidget *btn = NULL;
   if(!d->edit_ro)
   {
-    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DO_NOT_USE_BORDER | CPF_DIRECTION_RIGHT | CPF_STYLE_FLAT,
+    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_RIGHT | CPF_STYLE_FLAT,
                            NULL);
     gtk_widget_set_tooltip_text(btn, _("move group to the left"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -2855,7 +2855,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   gtk_widget_set_name(hb3, "modulegroups-header-center");
   gtk_widget_set_hexpand(hb3, TRUE);
 
-  btn = dtgtk_button_new(_buttons_get_icon_fct(gr->icon), CPF_DO_NOT_USE_BORDER, NULL);
+  btn = dtgtk_button_new(_buttons_get_icon_fct(gr->icon), 0, NULL);
   gtk_widget_set_name(btn, "modulegroups-group-icon");
   gtk_widget_set_tooltip_text(btn, _("group icon"));
   gtk_widget_set_sensitive(btn, !d->edit_ro);
@@ -2873,7 +2873,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
 
   if(!d->edit_ro)
   {
-    btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT, NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
     gtk_widget_set_tooltip_text(btn, _("remove group"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
     g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_group_remove), self);
@@ -2885,7 +2885,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   // right arrow (not if pos == -1 which means this is the last group)
   if(!d->edit_ro)
   {
-    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DO_NOT_USE_BORDER | CPF_DIRECTION_LEFT | CPF_STYLE_FLAT,
+    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_LEFT | CPF_STYLE_FLAT,
                            NULL);
     gtk_widget_set_tooltip_text(btn, _("move group to the right"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -2908,7 +2908,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   {
     GtkWidget *hb4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple,
-                                     CPF_DO_NOT_USE_BORDER | CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+                                     CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add module to the list"));
     gtk_widget_set_name(bt, "modulegroups-add-module-btn");
     g_object_set_data(G_OBJECT(bt), "group", gr);
@@ -3056,7 +3056,7 @@ static void _manage_editor_load(const char *preset, dt_lib_module_t *self)
   if(!d->edit_ro)
   {
     GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple,
-                                     CPF_DO_NOT_USE_BORDER | CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+                                     CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
     g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_manage_editor_group_add), self);
     gtk_box_pack_start(GTK_BOX(hb1), bt, FALSE, FALSE, 0);
   }
@@ -3325,7 +3325,7 @@ static void _manage_preset_update_list(dt_lib_module_t *self)
   // and we finally add the "new preset" button
   GtkWidget *hb2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple,
-                                   CPF_DO_NOT_USE_BORDER | CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+                                   CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
   g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_manage_preset_add), self);
   gtk_widget_set_name(bt, "modulegroups-preset-add-btn");
   gtk_widget_set_tooltip_text(bt, _("add new empty preset"));

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -98,6 +98,7 @@ typedef struct dt_lib_modulegroups_basic_item_t
 
 
   GtkWidget *box;
+  GtkWidget *label_box;
   dt_iop_module_t *module;
 } dt_lib_modulegroups_basic_item_t;
 
@@ -430,9 +431,11 @@ static void _basics_remove_widget(dt_lib_modulegroups_basic_item_t *item)
     }
   }
   // cleanup item
+  if(item->box) gtk_widget_destroy(item->label_box);
   if(item->box) gtk_widget_destroy(item->box);
   if(item->temp_widget) gtk_widget_destroy(item->temp_widget);
   item->box = NULL;
+  item->label_box = NULL;
   item->temp_widget = NULL;
   item->widget = NULL;
   item->old_parent = NULL;
@@ -671,32 +674,33 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
   {
     if(dt_conf_get_bool("plugins/darkroom/modulegroups_basics_sections_labels"))
     {
+      //we add a box
+      item->label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_widget_show(item->label_box);
+
       // we add the section label
       GtkWidget *sect = dt_ui_section_label_new(item->module->name());
       gtk_label_set_xalign(GTK_LABEL(sect), 0.5); // we center the module name
-      gtk_box_pack_start(GTK_BOX(d->vbox_basic), sect, FALSE, FALSE, 0);
+      gtk_box_pack_start(GTK_BOX(item->label_box), sect, TRUE, TRUE, 0);
       gtk_widget_show_all(sect);
 
-
-
-      // and we add the link to the full iop
+      // we add the link to the full iop
       GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, CPF_STYLE_FLAT, NULL);
       gchar *tt = dt_util_dstrcat(NULL, _("go to full version of module %s"), item->module->name());
       gtk_widget_set_tooltip_text(wbt, tt);
       gtk_widget_set_name(wbt, "basics-link");
       g_free(tt);
       g_signal_connect(G_OBJECT(wbt), "button-press-event", G_CALLBACK(_basics_goto_module), item->module);
-      gtk_box_pack_end(GTK_BOX(item->box), wbt, FALSE, FALSE, 0);
+      gtk_box_pack_end(GTK_BOX(item->label_box), wbt, FALSE, FALSE, 0);
       gtk_widget_show(wbt);
 
-
-
+      gtk_box_pack_start(GTK_BOX(d->vbox_basic), item->label_box, FALSE, FALSE, 0);
     }
     else
     {
       // we just add a thin line on top of the widget to show delimitation
-      GtkStyleContext *context = gtk_widget_get_style_context(item->box);
-      gtk_style_context_add_class(context, "basics-widget_group_start");
+      //GtkStyleContext *context = gtk_widget_get_style_context(item->box);
+      //gtk_style_context_add_class(context, "basics-widget_group_start");
     }
   }
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -431,7 +431,7 @@ static void _basics_remove_widget(dt_lib_modulegroups_basic_item_t *item)
     }
   }
   // cleanup item
-  if(item->box) gtk_widget_destroy(item->label_box);
+  if(item->label_box) gtk_widget_destroy(item->label_box);
   if(item->box) gtk_widget_destroy(item->box);
   if(item->temp_widget) gtk_widget_destroy(item->temp_widget);
   item->box = NULL;
@@ -669,10 +669,8 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     }
   }
 
-  // if it's the first widget of a module, we want to show a separation
-  if(new_group)
-  {
-    if(dt_conf_get_bool("plugins/darkroom/modulegroups_basics_sections_labels"))
+  // if it's the first widget of a module, we want to show a header
+  if(new_group && dt_conf_get_bool("plugins/darkroom/modulegroups_basics_sections_labels"))
     {
       //we add a box
       item->label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -696,13 +694,6 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
 
       gtk_box_pack_start(GTK_BOX(d->vbox_basic), item->label_box, FALSE, FALSE, 0);
     }
-    else
-    {
-      // we just add a thin line on top of the widget to show delimitation
-      //GtkStyleContext *context = gtk_widget_get_style_context(item->box);
-      //gtk_style_context_add_class(context, "basics-widget_group_start");
-    }
-  }
 
 
   gtk_box_pack_start(GTK_BOX(d->vbox_basic), item->box, FALSE, FALSE, 0);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -676,6 +676,21 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       gtk_label_set_xalign(GTK_LABEL(sect), 0.5); // we center the module name
       gtk_box_pack_start(GTK_BOX(d->vbox_basic), sect, FALSE, FALSE, 0);
       gtk_widget_show_all(sect);
+
+
+
+      // and we add the link to the full iop
+      GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT, NULL);
+      gchar *tt = dt_util_dstrcat(NULL, _("go to full version of module %s"), item->module->name());
+      gtk_widget_set_tooltip_text(wbt, tt);
+      gtk_widget_set_name(wbt, "basics-link");
+      g_free(tt);
+      g_signal_connect(G_OBJECT(wbt), "button-press-event", G_CALLBACK(_basics_goto_module), item->module);
+      gtk_box_pack_end(GTK_BOX(item->box), wbt, FALSE, FALSE, 0);
+      gtk_widget_show(wbt);
+
+
+
     }
     else
     {
@@ -685,15 +700,6 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     }
   }
 
-  // and we add the link to the full iop
-  GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT, NULL);
-  gchar *tt = dt_util_dstrcat(NULL, _("go to full version of module %s"), item->module->name());
-  gtk_widget_set_tooltip_text(wbt, tt);
-  gtk_widget_set_name(wbt, "basics-link");
-  g_free(tt);
-  g_signal_connect(G_OBJECT(wbt), "button-press-event", G_CALLBACK(_basics_goto_module), item->module);
-  gtk_box_pack_end(GTK_BOX(item->box), wbt, FALSE, FALSE, 0);
-  gtk_widget_show(wbt);
 
   gtk_box_pack_start(GTK_BOX(d->vbox_basic), item->box, FALSE, FALSE, 0);
 }


### PR DESCRIPTION
This will implement #7745 by removing the multiple gear wheels to link to the full module and replacing them with a single button per module, with a new icon

This is the aspect on Linux

![Screenshot from 2021-01-08 20-50-25](https://user-images.githubusercontent.com/43290988/104058758-8b8bd800-51f4-11eb-8dad-6d82c969c413.png)
 .. and on Windows

![immagine](https://user-images.githubusercontent.com/43290988/104058826-a1999880-51f4-11eb-82ea-a3fcc661f341.png)
