### PR TITLE
collect tags: fix sensitivity regression. make work back image order on tags

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1725,11 +1725,16 @@ const uint32_t dt_tag_get_tag_id_by_name(const char * const name)
 {
   uint32_t tagid = 0;
   if(!name) return tagid;
+  char *sensitive = dt_conf_get_string("plugins/lighttable/tagging/case_sensitivity");
+  const char *query = strcmp(sensitive, _("insensitive")) == 0
+                      ? "SELECT T.id, T.flags FROM data.tags AS T "
+                        "WHERE T.name LIKE ?1"
+                      : "SELECT T.id, T.flags FROM data.tags AS T "
+                        "WHERE T.name = ?1";
+  g_free(sensitive);
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-          "SELECT T.id, T.flags FROM data.tags AS T "
-          "WHERE T.name = ?1",
-          -1, &stmt, NULL);
+                              query, -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -203,7 +203,7 @@ const gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
 void dt_tag_set_tag_order_by_id(const uint32_t tagid, const uint32_t sort,
                                 const gboolean descending);
 
-/** return the tagid of that tag - return 0 if not found*/
+/** return the tagid of that tag - follow tag sensitivity - return 0 if not found*/
 const uint32_t dt_tag_get_tag_id_by_name(const char * const name);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
Tag sensitivity in collect module has introduce a regression on the images ordering per tag.
Only low case tags were still working when sensitivity = "insensitive".
This PR restore the right behavior.
