### PR TITLE
[icons] fix comments in paint.h so that all icons are picked by show_icons_in_paint_c.pl

### DIFF
--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -253,21 +253,21 @@ void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gin
 void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a used icon for masks */
 void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** Paint a clone tool for retouch*/
+/** Paint a clone tool for retouch */
 void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** Paint a heal tool for retouch*/
+/** Paint a heal tool for retouch */
 void dtgtk_cairo_paint_tool_heal(cairo_t *cr, gint x, gint y, gint w, gint h,  gint flags, void *data);
-/** Paint a fill tool for retouch*/
+/** Paint a fill tool for retouch */
 void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h,  gint flags, void *data);
-/** Paint a blur tool for retouch*/
+/** Paint a blur tool for retouch */
 void dtgtk_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** Paint a past icon for retouch*/
+/** Paint a past icon for retouch */
 void dtgtk_cairo_paint_paste_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** Paint a cut icon for retouch*/
+/** Paint a cut icon for retouch */
 void dtgtk_cairo_paint_cut_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** Paint a display scale for retouch*/
+/** Paint a display scale for retouch */
 void dtgtk_cairo_paint_display_wavelet_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** Paint a auto level icon for retouch*/
+/** Paint a auto level icon for retouch */
 void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
In order to be picked up by `show_icons_in_paint_c.pl` tool the comment has to end with space before `*/`