### PR TITLE
channelmixerrgb: fix normalization of colorfulness

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2352,7 +2352,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     d->MIX[0][i] = p->red[i] / norm_R;
     d->MIX[1][i] = p->green[i] / norm_G;
     d->MIX[2][i] = p->blue[i] / norm_B;
-    d->saturation[i] = -p->saturation[i] - norm_sat;
+    d->saturation[i] = -p->saturation[i] + norm_sat;
     d->lightness[i] = p->lightness[i] - norm_light;
     d->grey[i] = p->grey[i] / norm_grey; // = NaN if (norm_grey == 0.f) but we don't care since (d->apply_grey == FALSE)
   }


### PR DESCRIPTION
I'm not sure about this but perhaps @aurelienpierre can check. To me it seems, the sign of normalization should be reversed for the colorfulness adjustment. For example, if one sets colorfulness sliders `(R, G, B) = (1, 0, 0)` in the GUI, the normalized values would become `(R, G, B) = (-1/3, -1/3, -4/3)` with current code (R and B are swapped as intended). With this patch applied, it would become `(R, G, B) = (1/3, 1/3, -2/3)` which sums to zero.