### PR TITLE
[codebase] use align_float, protect against nulls, don't leak memory etc

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3261,10 +3261,6 @@ void dt_database_perform_maintenance(const struct dt_database_t *db)
   {
     dt_print(DT_DEBUG_SQL, "[db maintenance] maintenance problem. if no errors logged, it should work fine next time.\n");
   }
-  else
-  {
-
-  }
 }
 #undef ERRCHECK
 

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -614,7 +614,7 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   const int width = g->width;
   const int height = g->height;
   const int channels = g->channels;
-  const int bpp = channels * sizeof(float);
+  const size_t bpp = sizeof(float) * channels;
   cl_mem dev_temp1 = g->dev_temp1;
   cl_mem dev_temp2 = g->dev_temp2;
 
@@ -676,8 +676,8 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 9, sizeof(float), (void *)&b2);
   dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 10, sizeof(float), (void *)&coefp);
   dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 11, sizeof(float), (void *)&coefn);
-  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 12, channels * sizeof(float), (void *)&Labmax);
-  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 13, channels * sizeof(float), (void *)&Labmin);
+  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 12, sizeof(float) * channels, (void *)&Labmax);
+  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 13, sizeof(float) * channels, (void *)&Labmin);
   err = dt_opencl_enqueue_kernel_2d(devid, kernel_gaussian_column, sizes);
   if(err != CL_SUCCESS) return err;
 
@@ -712,8 +712,8 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 9, sizeof(float), (void *)&b2);
   dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 10, sizeof(float), (void *)&coefp);
   dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 11, sizeof(float), (void *)&coefn);
-  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 12, channels * sizeof(float), (void *)&Labmax);
-  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 13, channels * sizeof(float), (void *)&Labmin);
+  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 12, sizeof(float) * channels, (void *)&Labmax);
+  dt_opencl_set_kernel_arg(devid, kernel_gaussian_column, 13, sizeof(float) * channels, (void *)&Labmin);
   err = dt_opencl_enqueue_kernel_2d(devid, kernel_gaussian_column, sizes);
   if(err != CL_SUCCESS) return err;
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1271,7 +1271,7 @@ GList *dt_history_duplicate(GList *hist)
   {
     const dt_dev_history_item_t *old = (dt_dev_history_item_t *)(h->data);
 
-    dt_dev_history_item_t *new = (dt_dev_history_item_t *)calloc(1, sizeof(dt_dev_history_item_t));
+    dt_dev_history_item_t *new = (dt_dev_history_item_t *)malloc(sizeof(dt_dev_history_item_t));
 
     memcpy(new, old, sizeof(dt_dev_history_item_t));
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1271,7 +1271,7 @@ GList *dt_history_duplicate(GList *hist)
   {
     const dt_dev_history_item_t *old = (dt_dev_history_item_t *)(h->data);
 
-    dt_dev_history_item_t *new = (dt_dev_history_item_t *)malloc(sizeof(dt_dev_history_item_t));
+    dt_dev_history_item_t *new = (dt_dev_history_item_t *)calloc(1, sizeof(dt_dev_history_item_t));
 
     memcpy(new, old, sizeof(dt_dev_history_item_t));
 
@@ -1294,10 +1294,13 @@ GList *dt_history_duplicate(GList *hist)
       }
     }
 
-    new->params = malloc(params_size);
-    new->blend_params = malloc(sizeof(dt_develop_blend_params_t));
+    if(params_size > 0)
+    {
+      new->params = malloc(params_size);
+      memcpy(new->params, old->params, params_size);
+    }
 
-    memcpy(new->params, old->params, params_size);
+    new->blend_params = malloc(sizeof(dt_develop_blend_params_t));
     memcpy(new->blend_params, old->blend_params, sizeof(dt_develop_blend_params_t));
 
     if(old->forms) new->forms = dt_masks_dup_forms_deep(old->forms, NULL);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1558,7 +1558,7 @@ void dt_history_hash_read(const int32_t imgid, dt_history_hash_values_t *hash)
   sqlite3_finalize(stmt);
 }
 
-const gboolean dt_history_hash_is_mipmap_synced(const int32_t imgid)
+gboolean dt_history_hash_is_mipmap_synced(const int32_t imgid)
 {
   gboolean status = FALSE;
   if(imgid == -1) return status;
@@ -1593,7 +1593,7 @@ void dt_history_hash_set_mipmap(const int32_t imgid)
   sqlite3_finalize(stmt);
 }
 
-const dt_history_hash_t dt_history_hash_get_status(const int32_t imgid)
+dt_history_hash_t dt_history_hash_get_status(const int32_t imgid)
 {
   dt_history_hash_t status = 0;
   if(imgid == -1) return status;

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -127,10 +127,10 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation);
 void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_hash_t type);
 
 /** return the hash history status */
-const dt_history_hash_t dt_history_hash_get_status(const int32_t imgid);
+dt_history_hash_t dt_history_hash_get_status(const int32_t imgid);
 
 /** return true if mipmap_hash = current_hash */
-const gboolean dt_history_hash_is_mipmap_synced(const int32_t imgid);
+gboolean dt_history_hash_is_mipmap_synced(const int32_t imgid);
 
 /** update mipmap hash to db (= current_hash) */
 void dt_history_hash_set_mipmap(const int32_t imgid);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -229,6 +229,7 @@ gboolean dt_imageio_has_mono_preview(const char *filename)
   dt_colorspaces_color_profile_type_t color_space;
   uint8_t *tmp = NULL;
   int32_t thumb_width, thumb_height;
+  thumb_width = thumb_height = 0;
   gboolean mono = FALSE;
 
   if(dt_imageio_large_thumbnail(filename, &tmp, &thumb_width, &thumb_height, &color_space))

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -228,8 +228,7 @@ gboolean dt_imageio_has_mono_preview(const char *filename)
 {
   dt_colorspaces_color_profile_type_t color_space;
   uint8_t *tmp = NULL;
-  int32_t thumb_width, thumb_height;
-  thumb_width = thumb_height = 0;
+  int32_t thumb_width, thumb_height = 0;
   gboolean mono = FALSE;
 
   if(dt_imageio_large_thumbnail(filename, &tmp, &thumb_width, &thumb_height, &color_space))

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1973,6 +1973,8 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
 
 void *dt_ioppr_serialize_iop_order_list(GList *iop_order_list, size_t *size)
 {
+  g_return_val_if_fail(iop_order_list != NULL, NULL);
+  g_return_val_if_fail(size != NULL, NULL);
   // compute size of all modules
   *size = 0;
 
@@ -1983,6 +1985,9 @@ void *dt_ioppr_serialize_iop_order_list(GList *iop_order_list, size_t *size)
     *size += strlen(entry->operation) + sizeof(int32_t) * 2;
     l = g_list_next(l);
   }
+
+  if(*size == 0)
+    return NULL;
 
   // allocate the parameter buffer
   char *params = (char *)malloc(*size);

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -116,7 +116,6 @@ static void get_language_names(GList *languages)
   JsonParser *parser = NULL;
   GError *error = NULL;
   char *filename = NULL;
-  char *saved_locale = NULL;
 #ifdef __APPLE__
   char *res_path = dt_osx_get_bundle_res_path();
 #endif
@@ -190,7 +189,7 @@ static void get_language_names(GList *languages)
     goto end;
   }
 
-  saved_locale = strdup(setlocale(LC_ALL, NULL));
+  char *saved_locale = strdup(setlocale(LC_ALL, NULL));
 
   int n_elements = json_reader_count_elements(reader);
   for(int i = 0; i < n_elements; i++)
@@ -199,6 +198,8 @@ static void get_language_names(GList *languages)
     if(!json_reader_is_object(reader))
     {
       fprintf(stderr, "[l10n] error: unexpected layout of `%s' (element %d)\n", filename, i);
+      free(saved_locale);
+      saved_locale = NULL;
       goto end;
     }
 
@@ -285,7 +286,6 @@ end:
   if(error) g_error_free(error);
   if(reader) g_object_unref(reader);
   if(parser) g_object_unref(parser);
-  if(saved_locale) free(saved_locale);
 
 #endif // HAVE_ISO_CODES
 }

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -115,7 +115,8 @@ static void get_language_names(GList *languages)
   JsonReader *reader = NULL;
   JsonParser *parser = NULL;
   GError *error = NULL;
-  char *filename;
+  char *filename = NULL;
+  char *saved_locale = NULL;
 #ifdef __APPLE__
   char *res_path = dt_osx_get_bundle_res_path();
 #endif
@@ -189,7 +190,7 @@ static void get_language_names(GList *languages)
     goto end;
   }
 
-  char *saved_locale = strdup(setlocale(LC_ALL, NULL));
+  saved_locale = strdup(setlocale(LC_ALL, NULL));
 
   int n_elements = json_reader_count_elements(reader);
   for(int i = 0; i < n_elements; i++)

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -270,6 +270,7 @@ static void get_language_names(GList *languages)
   {
     setlocale(LC_ALL, saved_locale);
     free(saved_locale);
+    saved_locale = NULL;
   }
 
   json_reader_end_member(reader); // 639-2
@@ -283,6 +284,7 @@ end:
   if(error) g_error_free(error);
   if(reader) g_object_unref(reader);
   if(parser) g_object_unref(parser);
+  if(saved_locale) free(saved_locale);
 
 #endif // HAVE_ISO_CODES
 }

--- a/src/common/map_locations.c
+++ b/src/common/map_locations.c
@@ -27,7 +27,7 @@ const char *location_tag = "darktable|locations";
 const char *location_tag_prefix = "darktable|locations|";
 
 // create a new location
-const guint dt_map_location_new(const char *const name)
+guint dt_map_location_new(const char *const name)
 {
   char *loc_name = g_strconcat(location_tag_prefix, name, NULL);
   guint locid = -1;

--- a/src/common/map_locations.h
+++ b/src/common/map_locations.h
@@ -57,7 +57,7 @@ typedef struct dt_map_location_t
 } dt_map_location_t;
 
 // create a new location
-const guint dt_map_location_new(const char *const name);
+guint dt_map_location_new(const char *const name);
 
 // remove a location
 void dt_map_location_delete(const guint locid);

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -66,7 +66,7 @@ const char *dt_metadata_get_name_by_display_order(const uint32_t order)
   return NULL;
 }
 
-const dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order)
+dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order)
 {
   if(order < DT_METADATA_NUMBER)
   {
@@ -79,7 +79,7 @@ const dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order)
   return -1;
 }
 
-const dt_metadata_t dt_metadata_get_keyid_by_name(const char* name)
+dt_metadata_t dt_metadata_get_keyid_by_name(const char* name)
 {
   if(!name) return -1;
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
@@ -90,7 +90,7 @@ const dt_metadata_t dt_metadata_get_keyid_by_name(const char* name)
   return -1;
 }
 
-const int dt_metadata_get_type_by_display_order(const uint32_t order)
+int dt_metadata_get_type_by_display_order(const uint32_t order)
 {
   if(order < DT_METADATA_NUMBER)
   {
@@ -111,7 +111,7 @@ const char *dt_metadata_get_name(const uint32_t keyid)
     return NULL;
 }
 
-const dt_metadata_t dt_metadata_get_keyid(const char* key)
+dt_metadata_t dt_metadata_get_keyid(const char* key)
 {
   if(!key) return -1;
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
@@ -154,7 +154,7 @@ const char *dt_metadata_get_key_by_subkey(const char *subkey)
   return NULL;
 }
 
-const int dt_metadata_get_type(const uint32_t keyid)
+int dt_metadata_get_type(const uint32_t keyid)
 {
   if(keyid < DT_METADATA_NUMBER)
     return dt_metadata_def[keyid].type;

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -65,19 +65,19 @@ dt_metadata_flag_t;
 const char *dt_metadata_get_name_by_display_order(const uint32_t order);
 
 /** return the metadata keyid by display order */
-const dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order);
+dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order);
 
 /** return the metadata keyid by name */
-const dt_metadata_t dt_metadata_get_keyid_by_name(const char* name);
+dt_metadata_t dt_metadata_get_keyid_by_name(const char* name);
 
 /** return the metadata type by display order */
-const int dt_metadata_get_type_by_display_order(const uint32_t order);
+int dt_metadata_get_type_by_display_order(const uint32_t order);
 
 /** return the metadata name of the metadata keyid */
 const char *dt_metadata_get_name(const uint32_t keyid);
 
 /** return the keyid of the metadata key */
-const dt_metadata_t dt_metadata_get_keyid(const char* key);
+dt_metadata_t dt_metadata_get_keyid(const char* key);
 
 /** return the key of the metadata keyid */
 const char *dt_metadata_get_key(const uint32_t keyid);
@@ -89,7 +89,7 @@ const char *dt_metadata_get_subkey(const uint32_t keyid);
 const char *dt_metadata_get_key_by_subkey(const char *subkey);
 
 /** return the type of the metadata keyid */
-const int dt_metadata_get_type(const uint32_t keyid);
+int dt_metadata_get_type(const uint32_t keyid);
 
 /** init metadata flags */
 void dt_metadata_init();

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -677,6 +677,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
     if(!cl->dev || !devices)
     {
       free(cl->dev);
+      cl->dev = NULL;
       free(devices);
       dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not allocate memory\n");
       goto finally;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3003,7 +3003,7 @@ int dt_opencl_local_buffer_opt(const int devid, const int kernel, dt_opencl_loca
     while(maxsizes[0] < *blocksizex || maxsizes[1] < *blocksizey
        || localmemsize < ((factors->xfactor * (*blocksizex) + factors->xoffset) *
                           (factors->yfactor * (*blocksizey) + factors->yoffset)) * factors->cellsize + factors->overhead
-       || workgroupsize < (*blocksizex) * (*blocksizey) || kernelworkgroupsize < (*blocksizex) * (*blocksizey))
+       || workgroupsize < (size_t)(*blocksizex) * (*blocksizey) || kernelworkgroupsize < (size_t)(*blocksizex) * (*blocksizey))
     {
       if(*blocksizex == 1 && *blocksizey == 1) return FALSE;
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -700,6 +700,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
       devs += all_num_devices[n];
     }
   }
+  devs = NULL;
 
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] found %d device%s\n", num_devices, num_devices > 1 ? "s" : "");
   if(num_devices == 0) goto finally;
@@ -717,6 +718,8 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
     ++dev;
   }
   free(devices);
+  devices = NULL;
+
   if(dev > 0)
   {
     cl->num_devs = dev;
@@ -852,6 +855,9 @@ finally:
     setlocale(LC_ALL, locale);
     free(locale);
   }
+  if(devices)
+    free(devices);
+
   return;
 }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -703,7 +703,12 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   devs = NULL;
 
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] found %d device%s\n", num_devices, num_devices > 1 ? "s" : "");
-  if(num_devices == 0) goto finally;
+  if(num_devices == 0)
+  {
+    if(devices)
+      free(devices);
+    goto finally;
+  } 
 
   int dev = 0;
   for(int k = 0; k < num_devices; k++)
@@ -855,8 +860,6 @@ finally:
     setlocale(LC_ALL, locale);
     free(locale);
   }
-  if(devices)
-    free(devices);
 
   return;
 }

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -34,7 +34,7 @@ typedef struct dt_undo_ratings_t
   int after;
 } dt_undo_ratings_t;
 
-const int dt_ratings_get(const int imgid)
+int dt_ratings_get(const int imgid)
 {
   int stars = 0;
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -25,7 +25,7 @@
 // first three bits of dt_view_image_over_t
 
 /** get rating tfor the specified image */
-const int dt_ratings_get(const int imgid);
+int dt_ratings_get(const int imgid);
 
 /** apply rating to the specified image */
 void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean toggle_on,

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1695,7 +1695,7 @@ char *dt_tag_get_subtags(const gint imgid, const char *category, const int level
   return tags;
 }
 
-const gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
+gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
                                           gboolean *descending)
 {
   gboolean res = FALSE;
@@ -1721,10 +1721,10 @@ const gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
   return res;
 }
 
-const uint32_t dt_tag_get_tag_id_by_name(const char * const name)
+uint32_t dt_tag_get_tag_id_by_name(const char * const name)
 {
+  if(!name) return 0;
   uint32_t tagid = 0;
-  if(!name) return tagid;
   char *sensitive = dt_conf_get_string("plugins/lighttable/tagging/case_sensitivity");
   const char *query = strcmp(sensitive, _("insensitive")) == 0
                       ? "SELECT T.id, T.flags FROM data.tags AS T "

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -196,7 +196,7 @@ uint32_t dt_tag_images_count(gint tagid);
 char *dt_tag_get_subtags(const gint imgid, const char *category, const int level);
 
 /** return the images order associated to that tag */
-const gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
+gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
                                           gboolean *descending);
 
 /** save the images order on the tag */
@@ -204,7 +204,7 @@ void dt_tag_set_tag_order_by_id(const uint32_t tagid, const uint32_t sort,
                                 const gboolean descending);
 
 /** return the tagid of that tag - follow tag sensitivity - return 0 if not found*/
-const uint32_t dt_tag_get_tag_id_by_name(const char * const name);
+uint32_t dt_tag_get_tag_id_by_name(const char * const name);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -384,9 +384,9 @@ dt_masks_dynbuf_t *dt_masks_dynbuf_init(size_t size, const char *tag)
   {
     g_strlcpy(a->tag, tag, sizeof(a->tag)); //only for debugging purposes
     a->pos = 0;
-    const size_t bufsize = dt_round_size(size * sizeof(float), 64);
+    const size_t bufsize = dt_round_size_sse(sizeof(float) * size);
     a->size = bufsize / sizeof(float);
-    a->buffer = (float *)dt_alloc_align(64, bufsize);
+    a->buffer = dt_alloc_align_float(a->size);
     dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)\n", a->tag,
              (unsigned long)a->size, a->buffer);
     if(a->buffer == NULL)
@@ -409,7 +409,7 @@ void dt_masks_dynbuf_add(dt_masks_dynbuf_t *a, float value)
     float *oldbuffer = a->buffer;
     size_t oldsize = a->size;
     a->size *= 2;
-    a->buffer = (float *)dt_alloc_align(64, a->size * sizeof(float));
+    a->buffer = dt_alloc_align_float(a->size);
     if(a->buffer == NULL)
     {
       // not much we can do here except of emitting an error message
@@ -420,9 +420,9 @@ void dt_masks_dynbuf_add(dt_masks_dynbuf_t *a, float value)
       return;
     }
     memcpy(a->buffer, oldbuffer, oldsize * sizeof(float));
-    dt_free_align(oldbuffer);
     dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n", a->tag,
              (unsigned long)a->size, a->buffer, oldbuffer);
+    dt_free_align(oldbuffer);
   }
   a->buffer[a->pos++] = value;
 }
@@ -449,9 +449,9 @@ void dt_masks_dynbuf_add_n(dt_masks_dynbuf_t *a, float* values, const int n)
       return;
     }
     memcpy(a->buffer, oldbuffer, oldsize * sizeof(float));
-    dt_free_align(oldbuffer);
     dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n", a->tag,
              (unsigned long)a->size, a->buffer, oldbuffer);
+    dt_free_align(oldbuffer);
   }
   memcpy(a->buffer + a->pos, values, n * sizeof(float));
   a->pos += n;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2277,7 +2277,7 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
   memset(*buffer, 0, sizeof(float) * bufsize);
 
   // we write all the point around the path into the buffer
-  int nbp = border_count;
+  const int nbp = border_count;
   if(nbp > 2)
   {
     int lastx = (int)points[(nbp - 1) * 2];

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2406,7 +2406,6 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
   int p0[2] = { 0 }, p1[2] = { 0 };
   float pf1[2] = { 0.0f };
   int last0[2] = { -100, -100 }, last1[2] = { -100, -100 };
-  nbp = 0;
   int next = 0;
   for(int i = nb_corner * 3; i < border_count; i++)
   {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1305,11 +1305,11 @@ void dt_accel_rename_global(const gchar *path, const gchar *new_path)
     {
       GtkAccelKey tmp_key
           = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
+      GClosure* closure = g_closure_ref(accel->closure);
       dt_accel_deregister_global(path);
-      g_closure_ref(accel->closure);
       dt_accel_register_global(new_path, tmp_key.accel_key, tmp_key.accel_mods);
-      dt_accel_connect_global(new_path, accel->closure);
-      g_closure_unref(accel->closure);
+      dt_accel_connect_global(new_path, closure);
+      g_closure_unref(closure);
       l = NULL;
     }
     else
@@ -1331,11 +1331,11 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_path)
     {
       GtkAccelKey tmp_key
           = *(gtk_accel_group_find(darktable.control->accelerators, find_accel_internal, accel->closure));
+      GClosure* closure = g_closure_ref(accel->closure);
       dt_accel_deregister_lua(path);
-      g_closure_ref(accel->closure);
       dt_accel_register_lua(new_path, tmp_key.accel_key, tmp_key.accel_mods);
-      dt_accel_connect_lua(new_path, accel->closure);
-      g_closure_unref(accel->closure);
+      dt_accel_connect_lua(new_path, closure);
+      g_closure_unref(closure);
       l = NULL;
     }
     else

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3010,6 +3010,7 @@ GdkModifierType dt_key_modifier_state()
 static void notebook_size_callback(GtkNotebook *notebook, GdkRectangle *allocation, gpointer *data)
 {
   const int n = gtk_notebook_get_n_pages(notebook);
+  g_return_if_fail(n > 0);
 
   GtkRequestedSize *sizes = g_malloc_n(n, sizeof(GtkRequestedSize));
 

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -204,6 +204,8 @@ static void _piwigo_load_account(dt_storage_piwigo_gui_data_t *ui)
 
         if(account->server && strlen(account->server)>0)
           ui->accounts = g_list_append(ui->accounts, account);
+        else
+          free(account); // we didn't add acount to list, freeing it
       }
 
       g_object_unref(parser);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1253,10 +1253,10 @@ void extract_color_checker(const float *const restrict in, float *const restrict
                            const dt_iop_roi_t *const roi_in, dt_iop_channelmixer_rgb_gui_data_t *g,
                            const float RGB_to_XYZ[3][4], const float XYZ_to_RGB[3][4], const dt_adaptation_t kind)
 {
-  float *const restrict patches = dt_alloc_sse_ps(4 * g->checker->patches);
+  float *const restrict patches = dt_alloc_sse_ps(g->checker->patches * 4);
   float *const restrict patches_luminance = dt_alloc_sse_ps(g->checker->patches);
 
-  dt_simd_memcpy(in, out, roi_in->width * roi_in->height * 4);
+  dt_simd_memcpy(in, out, (size_t)roi_in->width * roi_in->height * 4);
 
   gboolean normalize = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->normalize));
   extraction_result_t extraction_result = _extract_patches(out, roi_in, g, RGB_to_XYZ,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -327,7 +327,7 @@ static inline void interpolate_color_xtrans(const void *const ivoid, void *const
   // dir is 1:left to right, -1: right to left
   int i = (dim == 0) ? 0 : other;
   int j = (dim == 0) ? other : 0;
-  const ssize_t offs = (dim ? roi_out->width : 1) * ((dir < 0) ? -1 : 1);
+  const ssize_t offs = (ssize_t)(dim ? roi_out->width : 1) * ((dir < 0) ? -1 : 1);
   const ssize_t offl = offs - (dim ? 1 : roi_out->width);
   const ssize_t offr = offs + (dim ? 1 : roi_out->width);
   int beg, end;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1052,8 +1052,7 @@ static GtkTreeModel *_create_filtered_model(GtkTreeModel *model, dt_lib_collect_
 
     if(level > 0)
     {
-      if(level > 0 &&
-         gtk_tree_model_iter_n_children(model, &iter) == 0 &&
+      if(gtk_tree_model_iter_n_children(model, &iter) == 0 &&
          gtk_tree_model_iter_parent(model, &child, &iter))
       {
         path = gtk_tree_model_get_path(model, &child);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -733,12 +733,12 @@ static gboolean range_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter
   return FALSE;
 }
 
-const int _combo_get_active_collection(GtkWidget *combo)
+int _combo_get_active_collection(GtkWidget *combo)
 {
   return GPOINTER_TO_UINT(dt_bauhaus_combobox_get_data(combo)) - 1;
 }
 
-const gboolean _combo_set_active_collection(GtkWidget *combo, const int property)
+gboolean _combo_set_active_collection(GtkWidget *combo, const int property)
 {
   const gboolean found = dt_bauhaus_combobox_set_from_value(combo, property + 1);
   // make sure we have a valid collection

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -311,6 +311,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
     {
       // function failed, profiles are not set, color will be wrong, exit.
       gdk_rgba_free(color_out);
+      g_strfreev(sample_parts);
       return FALSE;
     }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -825,7 +825,6 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     memcpy(new_params + pos, metadata[1], metadata_len[1]);
     pos += metadata_len[1];
     memcpy(new_params + pos, metadata[2], metadata_len[2]);
-    pos += metadata_len[2];
 
     *new_size = new_params_size;
     *new_version = 2;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -948,6 +948,8 @@ void *get_params(dt_lib_module_t *self, int *size)
       params = dt_util_dstrcat(params, "%d,", ((dt_tag_t *)taglist->data)->id);
     }
     dt_tag_free_result(&tags);
+    if(params == NULL)
+      return NULL;
     *size = strlen(params);
     params[*size-1]='\0';
   }

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -48,6 +48,7 @@ typedef struct dt_lib_darktable_t
   int image_width, image_height;
   // text with logo font
   cairo_surface_t *text;
+  guint8 *text_img_buffer;
   int text_width, text_height;
 } dt_lib_darktable_t;
 
@@ -166,6 +167,8 @@ done:
 
   /* try to load program name as svg */
   d->text = dt_util_get_logo_text(DT_PIXEL_APPLY_DPI(-1.0));
+  if(d->text)
+    d->text_img_buffer = cairo_image_surface_get_data(d->text);
   /* no png fallback, we'll use text */
   d->text_width = d->text ? dt_cairo_image_surface_get_width(d->text) : 0;
   d->text_height = d->text ? dt_cairo_image_surface_get_height(d->text) : 0;
@@ -181,6 +184,7 @@ void gui_cleanup(dt_lib_module_t *self)
   cairo_surface_destroy(d->image);
   cairo_surface_destroy(d->text);
   free(d->image_buffer);
+  free(d->text_img_buffer);
   g_free(self->data);
   self->data = NULL;
 }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1162,8 +1162,10 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
 
     if(lib->points)
       g_free(lib->points);
-    lib->points = (dt_geo_position_t *)calloc(img_count, sizeof(dt_geo_position_t));
+    lib->points = NULL;
     lib->nb_points = img_count;
+    if(img_count > 0)
+      lib->points = (dt_geo_position_t *)calloc(img_count, sizeof(dt_geo_position_t));
     dt_geo_position_t *p = lib->points;
     if(p)
     {

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -379,7 +379,10 @@ static GdkPixbuf *_view_map_images_count(const int nb_images, const gboolean sam
 
 static GdkPixbuf *_init_image_pin()
 {
-  int w = DT_PIXEL_APPLY_DPI(thumb_size + 2 * thumb_border), h = DT_PIXEL_APPLY_DPI(image_pin_size);
+  const size_t w = DT_PIXEL_APPLY_DPI(thumb_size + 2 * thumb_border);
+  const size_t h = DT_PIXEL_APPLY_DPI(image_pin_size);
+  g_return_val_if_fail(w > 0 && h > 0, NULL);
+
   float r, g, b, a;
   r = ((thumb_frame_color & 0xff000000) >> 24) / 255.0;
   g = ((thumb_frame_color & 0x00ff0000) >> 16) / 255.0;
@@ -404,7 +407,10 @@ static GdkPixbuf *_init_image_pin()
 
 static GdkPixbuf *_init_place_pin()
 {
-  int w = DT_PIXEL_APPLY_DPI(place_pin_size), h = DT_PIXEL_APPLY_DPI(place_pin_size);
+  const size_t w = DT_PIXEL_APPLY_DPI(place_pin_size);
+  const size_t h = DT_PIXEL_APPLY_DPI(place_pin_size);
+  g_return_val_if_fail(w > 0 && h > 0, NULL);
+
   float r, g, b, a;
 
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);


### PR DESCRIPTION
I've tried out clang's static code analyzer and tried to see what I understand from it.

This PR fixes possible bugs/crashes found via static analysis using Clang 11