### PR TITLE
basics: rework links to full iops

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1455,33 +1455,49 @@ margin: 0 2px;
 
 #basics-link
 {
-  min-height: 1.1em;
-  min-width: 1.1em;
-  margin: 0 2px 2px 2px;
+  min-height: 1em;
+  min-width: 1em;
+  margin: 0 0 0.3em 0.75em;
   border: none;
+}
+
+#basics-header-box #basics-link
+{
+  margin-bottom: 0;
 }
 
 #basics-box-labels #basics-widget,
 #basics-box-labels #section_label
 {
   padding-top: 2px;
-  margin: 0 0.75em 0.25em 0.75em;
+  margin-bottom: 0.25em;
 }
 
 #basics-box #basics-widget
 {
-  margin: 0 0.75em 0.5em 0.75em;
+  margin-bottom: 0.5em;
 }
 
 #basics-box-labels #section_label
 {
-  margin-top: 1em;
+  margin-top: 0.5em;
+  border: none;
 }
 
-#basics-widget.basics-widget_group_start
+#basics-module-hbox
 {
-  padding-top: 0.5em;
-  border-top: 0.5px solid @section_label;
+  margin: 0 0.75em;
+}
+
+#basics-header-box
+{
+  border-bottom: 0.5px solid @section_label;
+  margin: 0 0.75em 0.5em 0.75em;
+}
+
+#basics-header-box-first
+{
+  border: none;
 }
 
 #basics-iop_name

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2633,6 +2633,35 @@ void dtgtk_cairo_paint_lt_mode_fullpreview(cairo_t *cr, gint x, gint y, gint w, 
   FINISH
 }
 
+void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_set_line_width(cr, .1);
+
+  //arrow
+  cairo_move_to(cr, .5, .5);
+  cairo_line_to(cr, 1., 0.);
+  cairo_stroke(cr);
+  cairo_move_to(cr, .65, 0.);
+  cairo_line_to(cr, 1., 0.);
+  cairo_line_to(cr, 1., .35);
+  cairo_stroke(cr);
+
+  //rounded rectangle
+  cairo_move_to(cr, .8, .6);
+  cairo_line_to(cr, .8, .85);
+  cairo_arc (cr, .65, .85, .15, 0., .5 * M_PI);
+  cairo_line_to(cr, .15, 1.);
+  cairo_arc (cr, .15, .85, .15, .5 * M_PI, M_PI);
+  cairo_line_to(cr, 0., .35);
+  cairo_arc (cr, .15, .35, .15, M_PI, 1.5 * M_PI);
+  cairo_line_to(cr, .4, .2);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -283,6 +283,8 @@ void dtgtk_cairo_paint_lt_mode_culling_dynamic(cairo_t *cr, gint x, gint y, gint
 /** Lighttable: Full Preview */
 void dtgtk_cairo_paint_lt_mode_fullpreview(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
+/** Paint a link icon for basic adjustments */
+void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -149,7 +149,6 @@ typedef struct dt_lib_modulegroups_t
   gboolean basics_show;
   GList *basics;
   GtkWidget *vbox_basic;
-  GtkWidget *mod_hbox_basic;
   GtkWidget *mod_vbox_basic;
 } dt_lib_modulegroups_t;
 
@@ -685,13 +684,12 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       gtk_box_pack_start(GTK_BOX(d->vbox_basic), header_box, FALSE, FALSE, 0);
 
       // we create the module box structure
-      d->mod_hbox_basic = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_widget_set_name(d->mod_hbox_basic, "basics-module-hbox");
-      gtk_widget_show(d->mod_hbox_basic);
-      gtk_box_pack_start(GTK_BOX(d->vbox_basic), d->mod_hbox_basic, TRUE, TRUE, 0);
+      GtkWidget *hbox_basic = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_widget_set_name(hbox_basic, "basics-module-hbox");
+      gtk_box_pack_start(GTK_BOX(d->vbox_basic), hbox_basic, TRUE, TRUE, 0);
       d->mod_vbox_basic = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-      gtk_widget_show(d->mod_vbox_basic);
-      gtk_box_pack_start(GTK_BOX(d->mod_hbox_basic), d->mod_vbox_basic, TRUE, TRUE, 0);
+      gtk_box_pack_start(GTK_BOX(hbox_basic), d->mod_vbox_basic, TRUE, TRUE, 0);
+      gtk_widget_show_all(hbox_basic);
 
       // we create the link to the full iop
       GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, CPF_STYLE_FLAT, NULL);
@@ -714,12 +712,11 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       }
       else
       {
-        // the link to the full iop is added to the module h box instead
-        gtk_box_pack_end(GTK_BOX(d->mod_hbox_basic), wbt, FALSE, FALSE, 0);
+        // if there is no section label, we add the link to the module hbox
+        gtk_box_pack_end(GTK_BOX(hbox_basic), wbt, FALSE, FALSE, 0);
 
         // if there is no label, we handle separately in css the first module header
         if (item_pos == FIRST_MODULE) gtk_widget_set_name(header_box, "basics-header-box-first");
-        
       }
     }
 


### PR DESCRIPTION
Continues from #7753.

New proposal for the basics tab, with layout change and new icon for link to the full iops, trying to incorporate all suggestions received.

Managing both options for `plugins/darkroom/modulegroups_basics_sections_labels` required some work.
In the end the solution is pretty simple but it took me some time to figure out.

Here is how it looks with labels...

![immagine](https://user-images.githubusercontent.com/43290988/104125497-5ea40600-5357-11eb-8698-45ba31813038.png)

...and without

![immagine](https://user-images.githubusercontent.com/43290988/104125523-94e18580-5357-11eb-9f79-704677790756.png)

Alignments and spacings can be perhaps further polished in css, but I happily leave this to @Nilvus ;-)

Please make a thorough review of the code.
Closes #7745

