### PR TITLE
imageio_avif: preserve default UNSPECIFIED enums for CICP

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -346,11 +346,6 @@ int write_image(struct dt_imageio_module_data_t *data,
   if (imgid > 0) {
     gboolean use_icc = FALSE;
 
-#if AVIF_VERSION >= 800
-    image->colorPrimaries = AVIF_COLOR_PRIMARIES_UNKNOWN;
-    image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNKNOWN;
-    image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
-
     switch (over_type) {
       case DT_COLORSPACE_SRGB:
           image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
@@ -396,120 +391,11 @@ int write_image(struct dt_imageio_module_data_t *data,
         break;
     }
 
-    if (image->colorPrimaries == AVIF_COLOR_PRIMARIES_UNKNOWN) {
+    // no change from default, unspecified CICP (2/2/2)
+    if (image->colorPrimaries == AVIF_COLOR_PRIMARIES_UNSPECIFIED) {
       use_icc = TRUE;
     }
-#else /* AVIF_VERSION 700 */
-    avifNclxColorProfile nclx = {
-        .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN,
-    };
 
-    switch (over_type) {
-      case DT_COLORSPACE_SRGB:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT709,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT709,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_REC709:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT709,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT470M,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT709,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_LIN_REC709:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT709,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT709,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_LIN_REC2020:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT2020,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_PQ_REC2020:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT2020,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_HLG_REC2020:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT2020,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_PQ_P3:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_SMPTE432,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      case DT_COLORSPACE_HLG_P3:
-        nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_SMPTE432,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
-#if AVIF_VERSION > 700
-          .range = AVIF_RANGE_FULL,
-#else
-          .fullRangeFlag = AVIF_NCLX_FULL_RANGE,
-#endif
-        };
-        break;
-      default:
-        break;
-    }
-
-    if (nclx.colourPrimaries != AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN) {
-        avifImageSetProfileNCLX(image, &nclx);
-        use_icc = TRUE;
-    }
-#endif
     dt_print(DT_DEBUG_IMAGEIO, "[avif colorprofile profile: %s - %s]\n",
              dt_colorspaces_get_name(over_type, filename),
              use_icc ? "icc" : "nclx");


### PR DESCRIPTION
Also removed legacy libavif support as >=0.8.2 is required anyway.

See the [libavif image constructor](https://github.com/AOMediaCodec/libavif/blob/aaf332a3d562d42bfa1ce9187aa92a115e70ed0e/src/avif.c#L118).