### PR TITLE
history: optimize listing modules used

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -489,6 +489,11 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest, dt_develop_t *d
   return module_added;
 }
 
+static inline gboolean _is_module_to_skip(const int flags)
+{
+  return flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN);
+}
+
 static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_imgid, GList *ops, const gboolean copy_full)
 {
   GList *modules_used = NULL;
@@ -561,7 +566,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
          && !(mod_src->default_enabled && mod_src->enabled
               && !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size) // it's not a enabled by default module with unmodified settings
               && !dt_iop_is_hidden(mod_src))
-         && (copy_full || !dt_history_module_skip_copy(mod_src->flags()))
+         && (copy_full || !_is_module_to_skip(mod_src->flags()))
         )
       {
         mod_list = g_list_append(mod_list, mod_src);
@@ -640,7 +645,7 @@ static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const
       {
         dt_iop_module_so_t *module = (dt_iop_module_so_t *)modules->data;
 
-        if(dt_history_module_skip_copy(module->flags()))
+        if(_is_module_to_skip(module->flags()))
         {
           if(skip_modules)
             skip_modules = dt_util_dstrcat(skip_modules, ",");
@@ -1246,7 +1251,6 @@ int dt_history_compress_on_list(const GList *imgs)
 
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
 {
-  dt_lock_image(imgid);
   gboolean result = FALSE;
   sqlite3_stmt *stmt;
 
@@ -1258,7 +1262,6 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
   if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
   sqlite3_finalize(stmt);
 
-  dt_unlock_image(imgid);
   return result;
 }
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1251,7 +1251,6 @@ int dt_history_compress_on_list(const GList *imgs)
 
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
 {
-  dt_lock_image(imgid);
   gboolean result = FALSE;
   sqlite3_stmt *stmt;
 
@@ -1263,7 +1262,6 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
   if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
   sqlite3_finalize(stmt);
 
-  dt_unlock_image(imgid);
   return result;
 }
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -489,11 +489,6 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest, dt_develop_t *d
   return module_added;
 }
 
-static inline gboolean _is_module_to_skip(const int flags)
-{
-  return flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN);
-}
-
 static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_imgid, GList *ops, const gboolean copy_full)
 {
   GList *modules_used = NULL;
@@ -566,7 +561,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
          && !(mod_src->default_enabled && mod_src->enabled
               && !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size) // it's not a enabled by default module with unmodified settings
               && !dt_iop_is_hidden(mod_src))
-         && (copy_full || !_is_module_to_skip(mod_src->flags()))
+         && (copy_full || !dt_history_module_skip_copy(mod_src->flags()))
         )
       {
         mod_list = g_list_append(mod_list, mod_src);
@@ -645,7 +640,7 @@ static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const
       {
         dt_iop_module_so_t *module = (dt_iop_module_so_t *)modules->data;
 
-        if(_is_module_to_skip(module->flags()))
+        if(dt_history_module_skip_copy(module->flags()))
         {
           if(skip_modules)
             skip_modules = dt_util_dstrcat(skip_modules, ",");
@@ -1251,6 +1246,7 @@ int dt_history_compress_on_list(const GList *imgs)
 
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
 {
+  dt_lock_image(imgid);
   gboolean result = FALSE;
   sqlite3_stmt *stmt;
 
@@ -1262,6 +1258,7 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
   if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
   sqlite3_finalize(stmt);
 
+  dt_unlock_image(imgid);
   return result;
 }
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1249,19 +1249,22 @@ int dt_history_compress_on_list(const GList *imgs)
   return uncompressed;
 }
 
-gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
+GList *dt_history_get_module_operations(int32_t imgid)
 {
-  gboolean result = FALSE;
+  GList *result = NULL;
   sqlite3_stmt *stmt;
 
   DT_DEBUG_SQLITE3_PREPARE_V2(
     dt_database_get(darktable.db),
-    "SELECT imgid FROM main.history WHERE imgid= ?1 AND operation = ?2", -1, &stmt, NULL);
+    "SELECT DISTINCT operation FROM main.history WHERE imgid= ?1", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, operation, -1, SQLITE_TRANSIENT);
-  if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
-  sqlite3_finalize(stmt);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const char* new = (const char *)sqlite3_column_text(stmt, 0);
+    result = g_list_append(result, g_strdup(new));
+  }
 
+  sqlite3_finalize(stmt);
   return result;
 }
 

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -114,8 +114,8 @@ GList *dt_history_get_items(int32_t imgid, gboolean enabled);
 /** get list of history items for image as a nice string */
 char *dt_history_get_items_as_string(int32_t imgid);
 
-/* check if a module exists in the history of corresponding image */
-gboolean dt_history_check_module_exists(int32_t imgid, const char *operation);
+/* get all modules in the history of corresponding image */
+GList *dt_history_get_module_operations(int32_t imgid);
 
 /** calculate history hash and save it to database*/
 void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_hash_t type);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1420,7 +1420,6 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   if(auto_apply_filmic || auto_apply_sharpen || auto_apply_cat)
   {
-    dt_lock_image(imgid);
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
@@ -1434,7 +1433,6 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
         _dev_insert_module(dev, module, imgid);
       }
     }
-    dt_unlock_image(imgid);
   }
 
   // select all presets from one of the following table and add them into memory.history. Note that
@@ -1562,7 +1560,6 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
 {
   //start with those modules that cannot be disabled
-  dt_lock_image(imgid);
   for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
@@ -1588,7 +1585,6 @@ static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
       _dev_insert_module(dev, module, imgid);
     }
   }
-  dt_unlock_image(imgid);
 }
 
 static void _dev_merge_history(dt_develop_t *dev, const int imgid)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1420,6 +1420,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   if(auto_apply_filmic || auto_apply_sharpen || auto_apply_cat)
   {
+    dt_lock_image(imgid);
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
@@ -1433,6 +1434,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
         _dev_insert_module(dev, module, imgid);
       }
     }
+    dt_unlock_image(imgid);
   }
 
   // select all presets from one of the following table and add them into memory.history. Note that
@@ -1560,6 +1562,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
 {
   //start with those modules that cannot be disabled
+  dt_lock_image(imgid);
   for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
@@ -1585,6 +1588,7 @@ static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
       _dev_insert_module(dev, module, imgid);
     }
   }
+  dt_unlock_image(imgid);
 }
 
 static void _dev_merge_history(dt_develop_t *dev, const int imgid)


### PR DESCRIPTION
Instead of calling dozens of times consecutively `dt_history_check_module_exists` with its locking and query, get once a list of all the modules in the history of a image and lock only once.