### PR TITLE
po/mask sizes

### DIFF
--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -66,6 +66,13 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
   // add a preview when creating a circle
   if(gui->creation)
   {
+    float masks_size = 0.0f;
+
+    if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
+      masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
+    else
+      masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
+
     if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     {
       float masks_border = 0.0f;
@@ -84,17 +91,10 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
         dt_conf_set_float("plugins/darkroom/spots/circle_border", masks_border);
       else
         dt_conf_set_float("plugins/darkroom/masks/circle/border", masks_border);
-      dt_toast_log(_("feather size: %3.2f%%"), masks_border*100.0f);
+      dt_toast_log(_("feather size: %3.2f%%"), (masks_border / masks_size)*100.0f);
     }
     else if(state == 0)
     {
-      float masks_size = 0.0f;
-
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-        masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
-      else
-        masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
-
       if(up && masks_size > 0.001f)
         masks_size *= 0.97f;
       else if(!up && masks_size < max_mask_size)
@@ -141,7 +141,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
           dt_conf_set_float("plugins/darkroom/spots/circle_border", circle->border);
         else
           dt_conf_set_float("plugins/darkroom/masks/circle/border", circle->border);
-        dt_toast_log(_("feather size: %3.2f%%"), circle->border*100.0f);
+        dt_toast_log(_("feather size: %3.2f%%"), (circle->border/circle->radius)*100.0f);
       }
       else if(gui->edit_mode == DT_MASKS_EDIT_FULL)
       {

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -345,6 +345,20 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
   // add a preview when creating an ellipse
   if(gui->creation)
   {
+    float radius_a = 0.0f;
+    float radius_b = 0.0f;
+
+    if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
+    {
+      radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+      radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+    }
+    else
+    {
+      radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
+      radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+    }
+
     if((state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       float rotation;
@@ -403,24 +417,10 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       else
         dt_conf_set_float("plugins/darkroom/masks/ellipse/border", masks_border);
 
-      dt_toast_log(_("feather size: %3.2f%%"), masks_border*100.0f);
+      dt_toast_log(_("feather size: %3.2f%%"), (masks_border/fmaxf(radius_a, radius_b))*100.0f);
     }
     else if(state == 0)
     {
-      float radius_a = 0.0f;
-      float radius_b = 0.0f;
-
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-      {
-        radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-        radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-      }
-      else
-      {
-        radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-        radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-      }
-
       const float oldradius = radius_a;
 
       if(up && radius_a > 0.001f)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1802,7 +1802,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;
-  int len = sizeof(dashed) / sizeof(dashed[0]);
+  const int len = sizeof(dashed) / sizeof(dashed[0]);
   if(!gui) return;
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
@@ -1888,7 +1888,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   // draw feathers
   if((gui->group_selected == index) && gui->point_edited >= 0)
   {
-    int k = gui->point_edited;
+    const int k = gui->point_edited;
     // uncomment this part if you want to see "real" control points
     /*cairo_move_to(cr, gui->points[k*6+2]+dx,gui->points[k*6+3]+dy);
     cairo_line_to(cr, gui->points[k*6]+dx,gui->points[k*6+1]+dy);
@@ -2663,7 +2663,7 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   // empty the output buffer
   dt_iop_image_fill(buffer, 0.0f, width, height, 1);
 
-  guint nb_corner = g_list_length(form->points);
+  const guint nb_corner = g_list_length(form->points);
 
   // we shift and scale down path and border
   for(int i = nb_corner * 3; i < border_count; i++)


### PR DESCRIPTION
Rework masks toast message for size & feather size.
- the size of the path is displayed
- the feather size for path/circle/ellipse is now displayed in % relative to the mask size

The previous feather information was not useful, it represented a % of "something" not clear to the end user.