### PR TITLE
rework lighttable toolbar

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2699,3 +2699,9 @@ spinbutton>button
   color: @bauhaus_fg_hover;
   background-color: rgba(20, 20, 20, 0.5);
 }
+
+/* lighttable toolbox */
+#lighttable_layouts_box *
+{
+  margin: 0 0.2em;
+}

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -684,7 +684,7 @@ static void _dt_selection_changed_callback(gpointer instance, gpointer user_data
 
   // if we are in dynamic mode, zoom = selection count
   if(table->mode == DT_CULLING_MODE_CULLING
-     && dt_view_lighttable_get_culling_zoom_mode(darktable.view_manager) == DT_LIGHTTABLE_ZOOM_DYNAMIC)
+     && dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
   {
     sqlite3_stmt *stmt;
     int sel_count = 0;
@@ -889,7 +889,7 @@ void dt_culling_init(dt_culling_t *table, int offset)
 
   const gboolean culling_dynamic
       = (table->mode == DT_CULLING_MODE_CULLING
-         && dt_view_lighttable_get_culling_zoom_mode(darktable.view_manager) == DT_LIGHTTABLE_ZOOM_DYNAMIC);
+         && dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC);
 
   // get first id
   sqlite3_stmt *stmt;

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -111,6 +111,22 @@ static void _lib_lighttable_update_btn(dt_lib_module_t *self)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), (w == active));
     l = g_list_next(l);
   }
+
+  // and now we set the tooltips
+  if(d->fullpreview)
+    gtk_widget_set_tooltip_text(d->layout_preview, _("click to exit from full preview layout."));
+  else
+    gtk_widget_set_tooltip_text(d->layout_preview, _("click to enter full preview layout."));
+
+  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->fullpreview)
+    gtk_widget_set_tooltip_text(d->layout_culling_fix, _("click to enter culling layout in fixed mode."));
+  else
+    gtk_widget_set_tooltip_text(d->layout_culling_fix, _("click to exit culling layout."));
+
+  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC || d->fullpreview)
+    gtk_widget_set_tooltip_text(d->layout_culling_dynamic, _("click to enter culling layout in dynamic mode."));
+  else
+    gtk_widget_set_tooltip_text(d->layout_culling_dynamic, _("click to exit culling layout."));
 }
 
 static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout)
@@ -242,10 +258,12 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->layout_box, TRUE, TRUE, 0);
 
   d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_tooltip_text(d->layout_filemanager, _("click to enter filemanager layout."));
   g_signal_connect(G_OBJECT(d->layout_filemanager), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_filemanager, TRUE, TRUE, 0);
   d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_tooltip_text(d->layout_zoomable, _("click to enter zoomable lighttable layout."));
   g_signal_connect(G_OBJECT(d->layout_zoomable), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_zoomable, TRUE, TRUE, 0);
@@ -526,7 +544,7 @@ void init_key_accels(dt_lib_module_t *self)
 {
   // view accels
   dt_accel_register_lib_as_view("lighttable", NC_("accel", "toggle filemanager layout"), 0, 0);
-  dt_accel_register_lib_as_view("lighttable", NC_("accel", "toggle zoomable filemanager layout"), 0, 0);
+  dt_accel_register_lib_as_view("lighttable", NC_("accel", "toggle zoomable lighttable layout"), 0, 0);
   dt_accel_register_lib_as_view("lighttable", NC_("accel", "toggle culling mode"), GDK_KEY_x, 0);
   dt_accel_register_lib_as_view("lighttable", NC_("accel", "toggle culling dynamic mode"), GDK_KEY_x,
                                 GDK_CONTROL_MASK);
@@ -544,7 +562,7 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_lib_as_view(
       self, "lighttable", "toggle filemanager layout",
       g_cclosure_new(G_CALLBACK(_lib_lighttable_key_accel_toggle_filemanager), self, NULL));
-  dt_accel_connect_lib_as_view(self, "lighttable", "toggle zoomable filemanager layout",
+  dt_accel_connect_lib_as_view(self, "lighttable", "toggle zoomable lighttable layout",
                                g_cclosure_new(G_CALLBACK(_lib_lighttable_key_accel_toggle_zoomable), self, NULL));
   dt_accel_connect_lib_as_view(
       self, "lighttable", "toggle culling dynamic mode",

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -35,27 +35,27 @@ typedef struct dt_lib_tool_lighttable_t
 {
   GtkWidget *zoom;
   GtkWidget *zoom_entry;
-  GtkWidget *layout_combo;
-  GtkWidget *zoom_mode_cb;
+  GtkWidget *layout_box;
+  GtkWidget *layout_filemanager;
+  GtkWidget *layout_zoomable;
+  GtkWidget *layout_culling_dynamic;
+  GtkWidget *layout_culling_fix;
+  GtkWidget *layout_preview;
   dt_lighttable_layout_t layout, base_layout;
   int current_zoom;
-  dt_lighttable_culling_zoom_mode_t zoom_mode;
+  gboolean fullpreview;
+  gboolean fullpreview_focus;
   gboolean combo_evt_reset;
 } dt_lib_tool_lighttable_t;
 
 /* set zoom proxy function */
 static void _lib_lighttable_set_zoom(dt_lib_module_t *self, gint zoom);
 static gint _lib_lighttable_get_zoom(dt_lib_module_t *self);
-static dt_lighttable_culling_zoom_mode_t _lib_lighttable_get_zoom_mode(dt_lib_module_t *self);
 
 /* get/set layout proxy function */
 static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self);
 static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout);
 
-/* lightable layout changed */
-static void _lib_lighttable_layout_changed(GtkComboBox *widget, gpointer user_data);
-/* lightable culling zoom mode changed */
-static void _lib_lighttable_zoom_mode_changed(GtkComboBox *widget, gpointer user_data);
 /* zoom slider change callback */
 static void _lib_lighttable_zoom_slider_changed(GtkRange *range, gpointer user_data);
 /* zoom entry change callback */
@@ -100,6 +100,132 @@ int position()
   return 1001;
 }
 
+static void _lib_lighttable_update_btn(dt_lib_module_t *self)
+{
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+
+  // which btn should be active ?
+  GtkWidget *active = d->layout_filemanager;
+  if(d->fullpreview)
+    active = d->layout_preview;
+  else if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
+    active = d->layout_culling_dynamic;
+  else if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    active = d->layout_culling_fix;
+  else if(d->layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
+    active = d->layout_zoomable;
+
+  GList *l = gtk_container_get_children(GTK_CONTAINER(d->layout_box));
+  while(l)
+  {
+    GtkWidget *w = (GtkWidget *)l->data;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), (w == active));
+    l = g_list_next(l);
+  }
+}
+
+static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout)
+{
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+
+  // we deal with fullpreview first.
+  if(!d->fullpreview && layout == DT_LIGHTTABLE_LAYOUT_PREVIEW)
+  {
+    // special case for preview : we don't change previous values, just show full preview
+    d->fullpreview = TRUE;
+    dt_view_lighttable_set_preview_state(darktable.view_manager, TRUE, d->fullpreview_focus);
+    return;
+  }
+  else if(d->fullpreview && layout != DT_LIGHTTABLE_LAYOUT_PREVIEW)
+  {
+    d->fullpreview = FALSE;
+    dt_view_lighttable_set_preview_state(darktable.view_manager, FALSE, FALSE);
+    // and we continue to select the right layout...
+  }
+
+  const int current_layout = dt_conf_get_int("plugins/lighttable/layout");
+  d->layout = layout;
+
+  if(current_layout != layout)
+  {
+    if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
+    {
+      d->current_zoom = MAX(1, MIN(30, dt_collection_get_selected_count(darktable.collection)));
+      if(d->current_zoom == 1) d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
+    }
+    else if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
+    }
+    else
+    {
+      d->current_zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
+    }
+
+    gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
+    gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
+
+    dt_conf_set_int("plugins/lighttable/layout", layout);
+    if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER || layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
+    {
+      d->base_layout = layout;
+      dt_conf_set_int("plugins/lighttable/base_layout", layout);
+    }
+
+    _lib_lighttable_update_btn(self);
+
+    dt_control_queue_redraw_center();
+  }
+  else
+  {
+    dt_control_queue_redraw_center();
+  }
+}
+
+static gboolean _lib_lighttable_layout_btn_release(GtkWidget *w, GdkEventButton *event, dt_lib_module_t *self)
+{
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+  if(d->combo_evt_reset) return FALSE;
+
+  const gboolean active
+      = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w)); // note : this is the state before the change
+  dt_lighttable_layout_t new_layout = DT_LIGHTTABLE_LAYOUT_FILEMANAGER;
+  if(!active)
+  {
+    // that means we want to activate the button
+    if(w == d->layout_preview)
+    {
+      d->fullpreview_focus = ((event->state & (GDK_CONTROL_MASK)) == GDK_CONTROL_MASK);
+      new_layout = DT_LIGHTTABLE_LAYOUT_PREVIEW;
+    }
+    else if(w == d->layout_culling_fix)
+      new_layout = DT_LIGHTTABLE_LAYOUT_CULLING;
+    else if(w == d->layout_culling_dynamic)
+      new_layout = DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC;
+    else if(w == d->layout_zoomable)
+      new_layout = DT_LIGHTTABLE_LAYOUT_ZOOMABLE;
+  }
+  else
+  {
+    // that means we want to deactivate the button
+    if(w == d->layout_preview)
+      new_layout = d->layout;
+    else if(w == d->layout_culling_dynamic || w == d->layout_culling_fix)
+      new_layout = d->base_layout;
+    else
+    {
+      // we can't exit from filemanager or zoomable
+      return TRUE;
+    }
+  }
+
+  _lib_lighttable_change_layout(self, new_layout);
+
+  // now we inverse the current button state to get the right state at the end
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), active);
+  return FALSE;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -111,33 +237,43 @@ void gui_init(dt_lib_module_t *self)
   d->base_layout = MIN(DT_LIGHTTABLE_LAYOUT_LAST - 1, dt_conf_get_int("plugins/lighttable/base_layout"));
 
   if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
+  else if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
   {
-    d->zoom_mode = dt_conf_get_int("plugins/lighttable/culling_zoom_mode");
-    if(d->zoom_mode == DT_LIGHTTABLE_ZOOM_DYNAMIC && darktable.collection)
-    {
-      d->current_zoom = MAX(1, MIN(DT_LIGHTTABLE_MAX_ZOOM, dt_collection_get_selected_count(darktable.collection)));
-      if(d->current_zoom == 1) d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
-    }
-    else
-    {
-      d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
-    }
+    d->current_zoom = MAX(1, MIN(DT_LIGHTTABLE_MAX_ZOOM, dt_collection_get_selected_count(darktable.collection)));
+    if(d->current_zoom == 1) d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
   }
   else
     d->current_zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
 
-  /* create layout selection combobox */
-  d->layout_combo = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("zoomable light table"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("file manager"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("culling"));
+  // create the layouts icon list
+  d->layout_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_name(d->layout_box, "lighttable_layouts_box");
+  gtk_box_pack_start(GTK_BOX(self->widget), d->layout_box, TRUE, TRUE, 0);
 
-  gtk_combo_box_set_active(GTK_COMBO_BOX(d->layout_combo), d->layout);
+  d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(d->layout_filemanager), "button-release-event",
+                   G_CALLBACK(_lib_lighttable_layout_btn_release), self);
+  gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_filemanager, TRUE, TRUE, 0);
+  d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(d->layout_zoomable), "button-release-event",
+                   G_CALLBACK(_lib_lighttable_layout_btn_release), self);
+  gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_zoomable, TRUE, TRUE, 0);
+  d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(d->layout_culling_fix), "button-release-event",
+                   G_CALLBACK(_lib_lighttable_layout_btn_release), self);
+  gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_fix, TRUE, TRUE, 0);
+  d->layout_culling_dynamic
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(d->layout_culling_dynamic), "button-release-event",
+                   G_CALLBACK(_lib_lighttable_layout_btn_release), self);
+  gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_dynamic, TRUE, TRUE, 0);
+  d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(d->layout_preview), "button-release-event",
+                   G_CALLBACK(_lib_lighttable_layout_btn_release), self);
+  gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_preview, TRUE, TRUE, 0);
 
-  g_signal_connect(G_OBJECT(d->layout_combo), "changed", G_CALLBACK(_lib_lighttable_layout_changed), (gpointer)self);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), d->layout_combo, TRUE, TRUE, 0);
-
+  _lib_lighttable_update_btn(self);
 
   /* create horizontal zoom slider */
   d->zoom = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 1, DT_LIGHTTABLE_MAX_ZOOM, 1);
@@ -160,38 +296,16 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(d->zoom_entry, "key-press-event", G_CALLBACK(_lib_lighttable_zoom_entry_changed), self);
   gtk_range_set_value(GTK_RANGE(d->zoom), d->current_zoom);
 
-  d->zoom_mode_cb = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->zoom_mode_cb), _("fixed zoom"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->zoom_mode_cb), _("dynamic zoom"));
-  g_signal_connect(G_OBJECT(d->zoom_mode_cb), "changed", G_CALLBACK(_lib_lighttable_zoom_mode_changed),
-                   (gpointer)self);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->zoom_mode_cb, TRUE, TRUE, 0);
-  if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
-  {
-    gtk_widget_show(d->zoom_mode_cb);
-    gtk_combo_box_set_active(GTK_COMBO_BOX(d->zoom_mode_cb), d->zoom_mode == DT_LIGHTTABLE_ZOOM_DYNAMIC);
-  }
-  else
-  {
-    gtk_widget_hide(d->zoom_mode_cb);
-  }
-  gtk_widget_set_no_show_all(d->zoom_mode_cb, TRUE);
-
   _lib_lighttable_zoom_slider_changed(GTK_RANGE(d->zoom), self); // the slider defaults to 1 and GTK doesn't
                                                                  // fire a value-changed signal when setting
                                                                  // it to 1 => empty text box
 
-  _lib_lighttable_layout_changed(GTK_COMBO_BOX(d->layout_combo), self);
-
-  gtk_widget_set_sensitive(
-      d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->zoom_mode != DT_LIGHTTABLE_ZOOM_DYNAMIC));
-  gtk_widget_set_sensitive(
-      d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->zoom_mode != DT_LIGHTTABLE_ZOOM_DYNAMIC));
+  gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
+  gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
 
   darktable.view_manager->proxy.lighttable.module = self;
   darktable.view_manager->proxy.lighttable.set_zoom = _lib_lighttable_set_zoom;
   darktable.view_manager->proxy.lighttable.get_zoom = _lib_lighttable_get_zoom;
-  darktable.view_manager->proxy.lighttable.get_zoom_mode = _lib_lighttable_get_zoom_mode;
   darktable.view_manager->proxy.lighttable.get_layout = _lib_lighttable_get_layout;
   darktable.view_manager->proxy.lighttable.set_layout = _lib_lighttable_set_layout;
 }
@@ -231,7 +345,7 @@ static void _set_zoom(dt_lib_module_t *self, int zoom)
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
   if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
-    if(d->zoom_mode == DT_LIGHTTABLE_ZOOM_FIXED) dt_conf_set_int("plugins/lighttable/culling_num_images", zoom);
+    dt_conf_set_int("plugins/lighttable/culling_num_images", zoom);
   }
   else
     dt_conf_set_int("plugins/lighttable/images_in_row", zoom);
@@ -321,115 +435,6 @@ static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey
   }
 }
 
-static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout)
-{
-  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
-
-  const int current_layout = dt_conf_get_int("plugins/lighttable/layout");
-  d->layout = layout;
-
-  if(current_layout != layout)
-  {
-    if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
-    {
-      gtk_widget_show(d->zoom_mode_cb);
-      if(d->zoom_mode == DT_LIGHTTABLE_ZOOM_DYNAMIC)
-      {
-        d->current_zoom = MAX(1, MIN(30, dt_collection_get_selected_count(darktable.collection)));
-        if(d->current_zoom == 1) d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
-      }
-      else
-      {
-        d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
-      }
-      gtk_combo_box_set_active(GTK_COMBO_BOX(d->zoom_mode_cb), d->zoom_mode == DT_LIGHTTABLE_ZOOM_DYNAMIC);
-    }
-    else
-    {
-      gtk_widget_hide(d->zoom_mode_cb);
-      d->zoom_mode = DT_LIGHTTABLE_ZOOM_FIXED;
-      d->current_zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
-    }
-    gtk_widget_set_sensitive(
-        d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->zoom_mode != DT_LIGHTTABLE_ZOOM_DYNAMIC));
-    gtk_widget_set_sensitive(
-        d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->zoom_mode != DT_LIGHTTABLE_ZOOM_DYNAMIC));
-    gtk_range_set_value(GTK_RANGE(d->zoom), d->current_zoom);
-
-    dt_conf_set_int("plugins/lighttable/layout", layout);
-    if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER || layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
-    {
-      d->base_layout = layout;
-      dt_conf_set_int("plugins/lighttable/base_layout", layout);
-    }
-    d->combo_evt_reset = TRUE;
-    gtk_combo_box_set_active(GTK_COMBO_BOX(d->layout_combo), layout);
-    d->combo_evt_reset = FALSE;
-    dt_control_queue_redraw_center();
-  }
-  else
-  {
-    dt_control_queue_redraw_center();
-  }
-}
-
-static void _lib_lighttable_layout_changed(GtkComboBox *widget, gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
-  if(d->combo_evt_reset) return;
-  const int new_layout = gtk_combo_box_get_active(widget);
-  _lib_lighttable_change_layout(self, new_layout);
-}
-
-static void _lib_lighttable_zoom_mode_changed(GtkComboBox *widget, gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
-
-  dt_lighttable_culling_zoom_mode_t new_mode = DT_LIGHTTABLE_ZOOM_FIXED;
-  if(gtk_combo_box_get_active(GTK_COMBO_BOX(d->zoom_mode_cb)) == 1) new_mode = DT_LIGHTTABLE_ZOOM_DYNAMIC;
-  if(new_mode == d->zoom_mode) return;
-
-  d->zoom_mode = new_mode;
-  if(new_mode == DT_LIGHTTABLE_ZOOM_FIXED)
-  {
-    _lib_lighttable_set_zoom(self, dt_conf_get_int("plugins/lighttable/culling_num_images"));
-  }
-  else
-  {
-    int selnb = dt_collection_get_selected_count(darktable.collection);
-    if(selnb <= 1) selnb = dt_conf_get_int("plugins/lighttable/culling_num_images");
-    _lib_lighttable_set_zoom(self, selnb);
-    // and we set the offset to the first selected image
-    if(selnb != 0)
-    {
-      sqlite3_stmt *stmt;
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "SELECT m.imgid FROM memory.collected_images as m, main.selected_images as s "
-                                  "WHERE m.imgid=s.imgid "
-                                  "ORDER BY m.rowid LIMIT 1",
-                                  -1, &stmt, NULL);
-      if(sqlite3_step(stmt) == SQLITE_ROW)
-      {
-        dt_view_lighttable_change_offset(darktable.view_manager, FALSE, sqlite3_column_int(stmt, 0));
-      }
-      sqlite3_finalize(stmt);
-    }
-  }
-  dt_view_lighttable_culling_init_mode(darktable.view_manager);
-
-  gtk_widget_set_sensitive(
-      d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->zoom_mode != DT_LIGHTTABLE_ZOOM_DYNAMIC));
-  gtk_widget_set_sensitive(
-      d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING || d->zoom_mode != DT_LIGHTTABLE_ZOOM_DYNAMIC));
-
-  if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
-  {
-    dt_conf_set_int("plugins/lighttable/culling_zoom_mode", d->zoom_mode);
-  }
-}
-
 static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout)
 {
   _lib_lighttable_change_layout(self, layout);
@@ -454,12 +459,6 @@ static gint _lib_lighttable_get_zoom(dt_lib_module_t *self)
   return d->current_zoom;
 }
 
-static dt_lighttable_culling_zoom_mode_t _lib_lighttable_get_zoom_mode(dt_lib_module_t *self)
-{
-  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
-  return d->zoom_mode;
-}
-
 static gboolean _lib_lighttable_key_accel_toggle_culling_dynamic_mode(GtkAccelGroup *accel_group,
                                                                       GObject *acceleratable, guint keyval,
                                                                       GdkModifierType modifier, gpointer data)
@@ -467,17 +466,11 @@ static gboolean _lib_lighttable_key_accel_toggle_culling_dynamic_mode(GtkAccelGr
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
 
-  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING)
-  {
-    d->zoom_mode = DT_LIGHTTABLE_ZOOM_DYNAMIC;
-    dt_conf_set_int("plugins/lighttable/culling_zoom_mode", d->zoom_mode);
-    _lib_lighttable_set_layout(self, DT_LIGHTTABLE_LAYOUT_CULLING);
-  }
+  // if we are already in any culling layout, we return to the base layout
+  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING && d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
+    _lib_lighttable_set_layout(self, DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC);
   else
-  {
-    d->zoom_mode = DT_LIGHTTABLE_ZOOM_FIXED;
     _lib_lighttable_set_layout(self, d->base_layout);
-  }
 
   dt_control_queue_redraw_center();
   return TRUE;
@@ -490,12 +483,9 @@ static gboolean _lib_lighttable_key_accel_toggle_culling_mode(GtkAccelGroup *acc
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
 
-  d->zoom_mode = DT_LIGHTTABLE_ZOOM_FIXED;
-  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING)
-  {
-    dt_conf_set_int("plugins/lighttable/culling_zoom_mode", d->zoom_mode);
+  // if we are already in any culling layout, we return to the base layout
+  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING && d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
     _lib_lighttable_set_layout(self, DT_LIGHTTABLE_LAYOUT_CULLING);
-  }
   else
     _lib_lighttable_set_layout(self, d->base_layout);
 
@@ -511,7 +501,10 @@ static gboolean _lib_lighttable_key_accel_toggle_culling_zoom_mode(GtkAccelGroup
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
 
   if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
-    gtk_combo_box_set_active(GTK_COMBO_BOX(d->zoom_mode_cb), d->zoom_mode == DT_LIGHTTABLE_ZOOM_FIXED);
+    _lib_lighttable_set_layout(self, DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC);
+  else if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
+    _lib_lighttable_set_layout(self, DT_LIGHTTABLE_LAYOUT_CULLING);
+
   return TRUE;
 }
 
@@ -561,6 +554,7 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_ZOOMABLE);
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_FILEMANAGER);
   luaA_enum_value(L, dt_lighttable_layout_t, DT_LIGHTTABLE_LAYOUT_CULLING);
+  luaA_enum_value(L, dt_lighttable_layout_t, DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC);
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_LAST);
 }
 #endif

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -168,8 +168,9 @@ static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layo
       d->current_zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
     }
 
-    gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
-    gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
+    gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !d->fullpreview));
+    gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !d->fullpreview));
+    gtk_range_set_value(GTK_RANGE(d->zoom), d->current_zoom);
 
     dt_conf_set_int("plugins/lighttable/layout", layout);
     if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER || layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
@@ -308,8 +309,8 @@ void gui_init(dt_lib_module_t *self)
                                                                  // fire a value-changed signal when setting
                                                                  // it to 1 => empty text box
 
-  gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
-  gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC));
+  gtk_widget_set_sensitive(d->zoom_entry, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !d->fullpreview));
+  gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !d->fullpreview));
 
   darktable.view_manager->proxy.lighttable.module = self;
   darktable.view_manager->proxy.lighttable.set_zoom = _lib_lighttable_set_zoom;
@@ -333,11 +334,9 @@ static void _set_zoom(dt_lib_module_t *self, int zoom)
   {
     dt_conf_set_int("plugins/lighttable/culling_num_images", zoom);
   }
-  else
-    dt_conf_set_int("plugins/lighttable/images_in_row", zoom);
-
-  if(d->layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER || d->layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
+  else if(d->layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER || d->layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
   {
+    dt_conf_set_int("plugins/lighttable/images_in_row", zoom);
     dt_thumbtable_zoom_changed(dt_ui_thumbtable(darktable.gui->ui), d->current_zoom, zoom);
   }
 }
@@ -366,7 +365,7 @@ static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey
     {
       // reset
       int i = 0;
-      if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+      if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING || d->layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
         i = dt_conf_get_int("plugins/lighttable/culling_num_images");
       else
         i = dt_conf_get_int("plugins/lighttable/images_in_row");

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -878,9 +878,6 @@ void init_key_accels(dt_view_t *self)
   // Preview key
   dt_accel_register_view(self, NC_("accel", "preview"), GDK_KEY_w, 0);
   dt_accel_register_view(self, NC_("accel", "preview with focus detection"), GDK_KEY_w, GDK_CONTROL_MASK);
-  dt_accel_register_view(self, NC_("accel", "sticky preview"), GDK_KEY_w, GDK_MOD1_MASK);
-  dt_accel_register_view(self, NC_("accel", "sticky preview with focus detection"), GDK_KEY_w,
-                         GDK_MOD1_MASK | GDK_CONTROL_MASK);
 
   // undo/redo
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);
@@ -932,27 +929,6 @@ static gboolean _accel_reset_first_offset(GtkAccelGroup *accel_group, GObject *a
     return dt_thumbtable_reset_first_offset(dt_ui_thumbtable(darktable.gui->ui));
   }
   return FALSE;
-}
-
-static gboolean _accel_sticky_preview(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                      GdkModifierType modifier, gpointer data)
-{
-  dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
-  dt_library_t *lib = (dt_library_t *)self->data;
-
-  // if we are alredy in preview mode, we exit
-  if(lib->preview_state)
-  {
-    _preview_quit(self);
-    return TRUE;
-  }
-
-  const int focus = GPOINTER_TO_INT(data);
-  const int mouse_over_id = dt_control_get_mouse_over_id();
-  if(mouse_over_id < 1) return TRUE;
-  _preview_enter(self, TRUE, focus, mouse_over_id);
-
-  return TRUE;
 }
 
 static gboolean _accel_culling_zoom_100(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -1022,12 +998,6 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "undo", closure);
   closure = g_cclosure_new(G_CALLBACK(_lighttable_redo_callback), (gpointer)self, NULL);
   dt_accel_connect_view(self, "redo", closure);
-
-  // sticky preview (non sticky is managed inside key_pressed)
-  closure = g_cclosure_new(G_CALLBACK(_accel_sticky_preview), GINT_TO_POINTER(FALSE), NULL);
-  dt_accel_connect_view(self, "sticky preview", closure);
-  closure = g_cclosure_new(G_CALLBACK(_accel_sticky_preview), GINT_TO_POINTER(TRUE), NULL);
-  dt_accel_connect_view(self, "sticky preview with focus detection", closure);
 
   // culling & preview zoom
   closure = g_cclosure_new(G_CALLBACK(_accel_culling_zoom_100), (gpointer)self, NULL);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -171,7 +171,7 @@ static void _lighttable_check_layout(dt_view_t *self)
     gtk_widget_hide(dt_ui_thumbtable(darktable.gui->ui)->widget);
 
     // if we arrive from culling, we just need to ensure the offset is right
-    if(layout_old == DT_LIGHTTABLE_LAYOUT_CULLING)
+    if(layout_old == DT_LIGHTTABLE_LAYOUT_CULLING || layout_old == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
     {
       dt_thumbtable_set_offset(dt_ui_thumbtable(darktable.gui->ui), lib->thumbtable_offset, FALSE);
     }
@@ -189,7 +189,7 @@ static void _lighttable_check_layout(dt_view_t *self)
     dt_thumbtable_full_redraw(dt_ui_thumbtable(darktable.gui->ui), TRUE);
     gtk_widget_show(dt_ui_thumbtable(darktable.gui->ui)->widget);
   }
-  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING || layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
   {
     // record thumbtable offset
     lib->thumbtable_offset = dt_thumbtable_get_offset(dt_ui_thumbtable(darktable.gui->ui));
@@ -224,7 +224,7 @@ static void _lighttable_check_layout(dt_view_t *self)
 
   lib->already_started = TRUE;
 
-  if(layout == DT_LIGHTTABLE_LAYOUT_CULLING || lib->preview_state)
+  if(layout == DT_LIGHTTABLE_LAYOUT_CULLING || layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC || lib->preview_state)
   {
     dt_thumbtable_set_parent(dt_ui_thumbtable(darktable.gui->ui), dt_ui_center_base(darktable.gui->ui),
                              DT_THUMBTABLE_MODE_NONE);
@@ -367,39 +367,6 @@ static gboolean is_image_visible_cb(lua_State *L)
 
 #endif
 
-void init(dt_view_t *self)
-{
-  self->data = calloc(1, sizeof(dt_library_t));
-
-  darktable.view_manager->proxy.lighttable.get_preview_state = _preview_get_state;
-  darktable.view_manager->proxy.lighttable.view = self;
-  darktable.view_manager->proxy.lighttable.change_offset = _lighttable_change_offset;
-  darktable.view_manager->proxy.lighttable.culling_init_mode = _culling_reinit;
-  darktable.view_manager->proxy.lighttable.culling_preview_refresh = _culling_preview_refresh;
-  darktable.view_manager->proxy.lighttable.culling_preview_reload_overlays = _culling_preview_reload_overlays;
-
-  // ensure the memory table is up to date
-  dt_collection_memory_update();
-
-#ifdef USE_LUA
-  lua_State *L = darktable.lua_state.state;
-  const int my_type = dt_lua_module_entry_get_type(L, "view", self->module_name);
-
-  lua_pushlightuserdata(L, self);
-  lua_pushcclosure(L, set_image_visible_cb, 1);
-  dt_lua_gtk_wrap(L);
-  lua_pushcclosure(L, dt_lua_type_member_common, 1);
-  dt_lua_type_register_const_type(L, my_type, "set_image_visible");
-
-  lua_pushlightuserdata(L, self);
-  lua_pushcclosure(L, is_image_visible_cb, 1);
-  dt_lua_gtk_wrap(L);
-  lua_pushcclosure(L, dt_lua_type_member_common, 1);
-  dt_lua_type_register_const_type(L, my_type, "is_image_visible");
-#endif
-}
-
-
 void cleanup(dt_view_t *self)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
@@ -500,8 +467,11 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
           gtk_widget_show(dt_ui_thumbtable(darktable.gui->ui)->widget);
         break;
       case DT_LIGHTTABLE_LAYOUT_CULLING:
+      case DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC:
         if(!gtk_widget_get_visible(lib->culling->widget)) gtk_widget_show(lib->culling->widget);
         gtk_widget_hide(lib->preview->widget);
+        break;
+      case DT_LIGHTTABLE_LAYOUT_PREVIEW:
         break;
       case DT_LIGHTTABLE_LAYOUT_FIRST:
       case DT_LIGHTTABLE_LAYOUT_LAST:
@@ -607,6 +577,47 @@ static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int
 
   // we don't need the scrollbars
   dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
+}
+
+static void _preview_set_state(dt_view_t *self, gboolean state, gboolean focus)
+{
+  if(state)
+    _preview_enter(self, TRUE, focus, dt_control_get_mouse_over_id());
+  else
+    _preview_quit(self);
+}
+
+void init(dt_view_t *self)
+{
+  self->data = calloc(1, sizeof(dt_library_t));
+
+  darktable.view_manager->proxy.lighttable.get_preview_state = _preview_get_state;
+  darktable.view_manager->proxy.lighttable.set_preview_state = _preview_set_state;
+  darktable.view_manager->proxy.lighttable.view = self;
+  darktable.view_manager->proxy.lighttable.change_offset = _lighttable_change_offset;
+  darktable.view_manager->proxy.lighttable.culling_init_mode = _culling_reinit;
+  darktable.view_manager->proxy.lighttable.culling_preview_refresh = _culling_preview_refresh;
+  darktable.view_manager->proxy.lighttable.culling_preview_reload_overlays = _culling_preview_reload_overlays;
+
+  // ensure the memory table is up to date
+  dt_collection_memory_update();
+
+#ifdef USE_LUA
+  lua_State *L = darktable.lua_state.state;
+  const int my_type = dt_lua_module_entry_get_type(L, "view", self->module_name);
+
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, set_image_visible_cb, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "set_image_visible");
+
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, is_image_visible_cb, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "is_image_visible");
+#endif
 }
 
 void leave(dt_view_t *self)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1280,14 +1280,6 @@ gint dt_view_lighttable_get_zoom(dt_view_manager_t *vm)
     return 10;
 }
 
-dt_lighttable_culling_zoom_mode_t dt_view_lighttable_get_culling_zoom_mode(dt_view_manager_t *vm)
-{
-  if(vm->proxy.lighttable.module)
-    return vm->proxy.lighttable.get_zoom_mode(vm->proxy.lighttable.module);
-  else
-    return DT_LIGHTTABLE_ZOOM_FIXED;
-}
-
 void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm)
 {
   if(vm->proxy.lighttable.module) vm->proxy.lighttable.culling_init_mode(vm->proxy.lighttable.view);
@@ -1317,6 +1309,11 @@ gboolean dt_view_lighttable_preview_state(dt_view_manager_t *vm)
     return vm->proxy.lighttable.get_preview_state(vm->proxy.lighttable.view);
   else
     return FALSE;
+}
+
+void dt_view_lighttable_set_preview_state(dt_view_manager_t *vm, gboolean state, gboolean focus)
+{
+  if(vm->proxy.lighttable.module) vm->proxy.lighttable.set_preview_state(vm->proxy.lighttable.view, state, focus);
 }
 
 void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, gint imgid)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -70,7 +70,9 @@ typedef enum dt_lighttable_layout_t
   DT_LIGHTTABLE_LAYOUT_ZOOMABLE = 0,
   DT_LIGHTTABLE_LAYOUT_FILEMANAGER = 1,
   DT_LIGHTTABLE_LAYOUT_CULLING = 2,
-  DT_LIGHTTABLE_LAYOUT_LAST = 3
+  DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC = 3,
+  DT_LIGHTTABLE_LAYOUT_PREVIEW = 4,
+  DT_LIGHTTABLE_LAYOUT_LAST = 5
 } dt_lighttable_layout_t;
 
 typedef enum dt_darkroom_layout_t
@@ -80,13 +82,6 @@ typedef enum dt_darkroom_layout_t
   DT_DARKROOM_LAYOUT_COLOR_ASSESMENT = 1,
   DT_DARKROOM_LAYOUT_LAST = 3
 } dt_darkroom_layout_t;
-
-// flags for culling zoom mode
-typedef enum dt_lighttable_culling_zoom_mode_t
-{
-  DT_LIGHTTABLE_ZOOM_FIXED = 0,
-  DT_LIGHTTABLE_ZOOM_DYNAMIC = 1
-} dt_lighttable_culling_zoom_mode_t;
 
 // mouse actions struct
 typedef enum dt_mouse_action_type_t
@@ -333,8 +328,8 @@ typedef struct dt_view_manager_t
       void (*culling_init_mode)(struct dt_view_t *view);
       void (*culling_preview_refresh)(struct dt_view_t *view);
       void (*culling_preview_reload_overlays)(struct dt_view_t *view);
-      dt_lighttable_culling_zoom_mode_t (*get_zoom_mode)(struct dt_lib_module_t *module);
       gboolean (*get_preview_state)(struct dt_view_t *view);
+      void (*set_preview_state)(struct dt_view_t *view, gboolean state, gboolean focus);
       void (*change_offset)(struct dt_view_t *view, gboolean reset, gint imgid);
     } lighttable;
 
@@ -454,12 +449,12 @@ dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm);
 dt_darkroom_layout_t dt_view_darkroom_get_layout(dt_view_manager_t *vm);
 /** get the lighttable full preview state */
 gboolean dt_view_lighttable_preview_state(dt_view_manager_t *vm);
+/** set the lighttable full preview state */
+void dt_view_lighttable_set_preview_state(dt_view_manager_t *vm, gboolean state, gboolean focus);
 /** sets the lighttable image in row zoom */
 void dt_view_lighttable_set_zoom(dt_view_manager_t *vm, gint zoom);
 /** gets the lighttable image in row zoom */
 gint dt_view_lighttable_get_zoom(dt_view_manager_t *vm);
-/** gets the culling zoom mode */
-dt_lighttable_culling_zoom_mode_t dt_view_lighttable_get_culling_zoom_mode(dt_view_manager_t *vm);
 /** reinit culling for new mode */
 void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm);
 /** force refresh of culling and/or preview */


### PR DESCRIPTION
This fix #5926 
This follow the work on icons by @quovadit in #7762 

The changes : 
- drop the layouts combobox and culling zoom mode combobox in favor of icons
- move sticky preview accels to lighttable lib
- change default accel for sticky preview to 'F' (+ctrl if one want focus detection)
- add shortcuts for filemanager and zoomable (empty by default) so all layouts have their shortcuts