### PR TITLE
[WIP] sigmoid tone mapping module

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -743,6 +743,10 @@ static inline float dt_camera_rgb_luminance(const float *const rgb)
   return (rgb[0] * 0.2225045f + rgb[1] * 0.7168786f + rgb[2] * 0.0606169f);
 }
 
+static inline float dt_workprofile_rgb_luminance(const float *const rgb, const float matrix_in[9])
+{
+  return (matrix_in[3] * rgb[0] + matrix_in[4] * rgb[1] + matrix_in[5] * rgb[2]);
+}
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_D50, XYZ_D65: 16)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -130,6 +130,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {43.0f }, "colorzones", 0},
   { {44.0f }, "lowlight", 0},
   { {45.0f }, "monochrome", 0},
+  { {45.3f }, "sigmoid", 0},
   { {46.0f }, "filmic", 0},
   { {46.5f }, "filmicrgb", 0},
   { {47.0f }, "colisa", 0},
@@ -230,6 +231,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { {44.0f }, "basecurve", 0},       // conversion from scene-referred to display referred, reverse-engineered
                                   //    on camera JPEG default look
   { {45.0f }, "filmic", 0},          // same, but different (parametric) approach
+  { {45.3f }, "sigmoid", 0},
   { {46.0f }, "filmicrgb", 0},       // same, upgraded
   { {47.0f }, "colisa", 0},          // edit contrast while damaging colour
   { {48.0f }, "tonecurve", 0},       // same

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -666,6 +666,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "ashift", "cacorrectrgb");
           _insert_before(iop_order_list, "graduatednd", "crop");
           _insert_before(iop_order_list, "channelmixerrgb", "diffuse");
+          _insert_before(iop_order_list, "filmic", "sigmoid");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -148,6 +148,7 @@ add_iop(censorize "censorize.c")
 add_iop(colorbalancergb "colorbalancergb.c")
 add_iop(cacorrectrgb "cacorrectrgb.c")
 add_iop(diffuse "diffuse.c")
+add_iop(sigmoid "sigmoid.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -240,7 +240,7 @@ void process_loglogistic_crosstalk(struct dt_iop_module_t *self, dt_dev_pixelpip
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, work_profile, magnitude, paper_exp, film_fog, contrast_power, skew_power) \
+  dt_omp_firstprivate(npixels, work_profile, saturation_factor, magnitude, paper_exp, film_fog, contrast_power, skew_power) \
   dt_omp_sharedconst(in, out) \
   schedule(static)
 #endif

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -52,7 +52,8 @@ typedef enum dt_iop_sigmoid_methods_type_t
   DT_SIGMOID_METHOD_CROSSTALK = 0,     // $DESCRIPTION: "crosstalk"
   DT_SIGMOID_METHOD_HUE = 1,           // $DESCRIPTION: "preserve hue"
   DT_SIGMOID_METHOD_RGB_RATIO = 2,     // $DESCRIPTION: "rgb ratio"
-  DT_SIGMOID_METHOD_INTERPOLATE = 3    // $DESCRIPTION: "interpolate"
+  DT_SIGMOID_METHOD_INTERPOLATE = 3,   // $DESCRIPTION: "interpolate"
+  DT_SIGMOID_METHOD_EXPERIMENTAL = 4   // $DESCRIPTION: "experimental"
 } dt_iop_sigmoid_methods_type_t;
 
 typedef enum dt_iop_sigmoid_negative_values_type_t
@@ -97,7 +98,7 @@ typedef struct dt_iop_sigmoid_params_t
   float display_black_target;  // $MIN: 0.0  $MAX: 10.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
   dt_iop_sigmoid_methods_type_t color_processing;  // $DEFAULT: DT_SIGMOID_METHOD_HUE $DESCRIPTION: "color processing"
   float hue_preservation;                          // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "preserve hue"
-  float chroma_preservation;                       // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION: "preserve chroma"
+  float chroma_preservation;                       // $MIN: -200.0 $MAX: 300.0 $DEFAULT: 0.0 $DESCRIPTION: "preserve chroma"
   float crosstalk_amount;                          // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 4.0 $DESCRIPTION: "crosstalk amount"
   dt_iop_sigmoid_norm_type_t rgb_norm_method;      // $DEFAULT: DT_SIGMOID_METHOD_AVERAGE $DESCRIPTION: "luminance norm"
   dt_iop_sigmoid_negative_values_type_t negative_values_method; // $DEFAULT: DT_SIGMOID_NEGATIVE_DESATURATE $DESCRIPTION: "negative values"
@@ -111,6 +112,8 @@ typedef struct dt_iop_sigmoid_data_t
   float film_fog;
   float film_power;
   float paper_power;
+  float preshaper_exposure;
+  float preshaper_power;
   dt_iop_sigmoid_methods_type_t color_processing;
   float hue_preservation;
   float chroma_preservation;
@@ -205,9 +208,23 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
    * Slope at scene_grey independet of skewness i.e. only changed by the contrast parameter.
    */
 
+  float ref_film_power;
+  if (params->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL)
+  {
+    const float neutral_contrast = 1.2f;
+    module_data->preshaper_power = powf(params->middle_grey_contrast / neutral_contrast, params->chroma_preservation / 100.0f);
+    module_data->preshaper_exposure = powf(MIDDLE_GREY, 1.0f - module_data->preshaper_power);
+    ref_film_power = params->middle_grey_contrast / module_data->preshaper_power;
+  }
+  else
+  {
+    module_data->preshaper_power = 1.0f;
+    module_data->preshaper_exposure = 1.0f;
+    ref_film_power = params->middle_grey_contrast;
+  }
+
   // Calculate a reference slope for no skew and a normalized display
   const float ref_paper_power = 1.0f;
-  const float ref_film_power = params->middle_grey_contrast;
   const float ref_magnitude = 1.0;
   const float ref_film_fog = 0.0f;
   const float ref_paper_exposure = powf(ref_film_fog + MIDDLE_GREY, ref_film_power) * ((ref_magnitude / MIDDLE_GREY) - 1.0f);
@@ -355,6 +372,16 @@ typedef struct dt_iop_sigmoid_value_order_t
   size_t mid;
   size_t max;
 } dt_iop_sigmoid_value_order_t;
+
+// Linear interpolation for both hue and chroma preservation
+// Assumes hue_preservation and chroma_presevation strictly in range [0, 1]
+static inline void preserve_hue_interpolated(const float pix_in[4], float pix_out[4], const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
+{
+  // Hue correction of the middle channel
+  const float full_hue_correction = pix_out[order.min] + ((pix_out[order.max] - pix_out[order.min]) * (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]));
+  const float no_hue_correction = pix_out[order.mid];
+  pix_out[order.mid] = (1.0 - hue_preservation) * no_hue_correction + hue_preservation * full_hue_correction;
+}
 
 // Linear interpolation for both hue and chroma preservation
 // Assumes hue_preservation and chroma_presevation strictly in range [0, 1]
@@ -660,6 +687,109 @@ void process_loglogistic_interpolated(dt_dev_pixelpipe_iop_t *piece, const void 
   }
 }
 
+void process_loglogistic_experimental(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                                      const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
+
+  const float *const in = (const float *)ivoid;
+  float *const out = (float *)ovoid;
+  const size_t npixels = (size_t)roi_in->width * roi_in->height;
+
+  const float white_target = module_data->white_target;
+  const float paper_exp = module_data->paper_exposure;
+  const float film_fog = module_data->film_fog;
+
+  const float contrast_power = module_data->film_power;
+  const float skew_power = module_data->paper_power;
+  const float preshaper_exposure = module_data->preshaper_exposure;
+  const float preshaper_power = module_data->preshaper_power;
+  const float saturation_factor = module_data->crosstalk_amount;
+  const float hue_preservation = module_data->hue_preservation;
+  
+  const dt_iop_sigmoid_negative_values_type_t negative_values_method = module_data->negative_values_method;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  const dt_iop_sigmoid_norm_type_t rgb_norm_method = module_data->rgb_norm_method;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, saturation_factor, negative_values_method, white_target, paper_exp, film_fog, preshaper_exposure, preshaper_power, contrast_power, skew_power, hue_preservation, work_profile, rgb_norm_method) \
+  dt_omp_sharedconst(in, out) \
+  schedule(static)
+#endif
+  for(size_t k = 0; k < 4 * npixels; k += 4)
+  {
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+    float DT_ALIGNED_ARRAY pix_in_strict_positive[4];
+    float DT_ALIGNED_ARRAY rgb_ratio[4];
+
+    // Force negative values to zero
+    negative_values(pix_in, pix_in_strict_positive, negative_values_method);
+
+    // Preserve color ratios by applying the tone curve on a luma estimate and then scale the RGB tripplet uniformly
+    const float scene_luma = get_pixel_norm(pix_in, rgb_norm_method, work_profile);
+    const float mapped_luma = preshaper_exposure * powf(scene_luma, preshaper_power);
+
+    const float scaling_factor = mapped_luma / scene_luma;
+    for(size_t c = 0; c < 3; c++)
+    {
+      rgb_ratio[c] = scaling_factor * pix_in[c];
+    }
+
+    // Desature a bit to get proper roll off to white in highlights
+    const float pixel_average = (rgb_ratio[0] + rgb_ratio[1] + rgb_ratio[2]) / 3.0f;
+    for(size_t c = 0; c < 3; c++)
+    {
+      const float desaturated_value = pixel_average + saturation_factor * (rgb_ratio[c] - pixel_average);
+      pix_out[c] = generalized_loglogistic_sigmoid(desaturated_value, white_target, paper_exp, film_fog, contrast_power, skew_power);
+    }
+
+        // Hue correction by scaling the middle value relative to the max and min values.
+    dt_iop_sigmoid_value_order_t pixel_value_order;
+
+    if (pix_in[0] >= pix_in[1])
+    {
+      if (pix_in[1] > pix_in[2])
+      {  // Case 1: r >= g >  b
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 0, .mid = 1, .min = 2};
+      }
+      else if (pix_in[2] > pix_in[0])
+      {  // Case 2: b >  r >= g
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 2, .mid = 0, .min = 1};
+      }
+      else if (pix_in[2] > pix_in[1])
+      {  // Case 3: r >= b >  g
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 0, .mid = 2, .min = 1};
+      } else
+      {  // Case 4: r == g == b
+        // No change of the middle value, just assign something.
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 0, .mid = 1, .min = 2};
+      }
+    }
+    else
+    {
+      if (pix_in[0] >= pix_in[2])
+      {  // Case 5: g >  r >= b
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 1, .mid = 0, .min = 2};
+      }
+      else if (pix_in[2] > pix_in[1])
+      {  // Case 6: b >  g >  r
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 2, .mid = 1, .min = 0};
+      }
+      else
+      {  // Case 7: g >= b >  r
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 1, .mid = 2, .min = 0};
+      }
+    }
+
+    preserve_hue_interpolated(pix_in, pix_out, pixel_value_order, hue_preservation);
+
+    // Copy over the alpha channel
+    pix_out[3] = pix_in[3];
+  }
+}
+
 /** process, all real work is done here. */
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
@@ -679,9 +809,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     process_loglogistic_ratio(piece, ivoid, ovoid, roi_in, roi_out);
   }
-  else
+  else if (module_data->color_processing == DT_SIGMOID_METHOD_INTERPOLATE)
   {
     process_loglogistic_interpolated(piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else
+  {
+    process_loglogistic_experimental(piece, ivoid, ovoid, roi_in, roi_out);
   }
 }
 
@@ -725,9 +859,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   gtk_widget_set_visible(g->crosstalk_slider, p->color_processing != DT_SIGMOID_METHOD_RGB_RATIO);
   gtk_widget_set_visible(g->negative_values_list, p->color_processing != DT_SIGMOID_METHOD_RGB_RATIO);
-  gtk_widget_set_visible(g->hue_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE);
-  gtk_widget_set_visible(g->chroma_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE);
-  gtk_widget_set_visible(g->rgb_norm_method_list, p->color_processing == DT_SIGMOID_METHOD_RGB_RATIO || p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE);
+  gtk_widget_set_visible(g->hue_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE || p->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL);
+  gtk_widget_set_visible(g->chroma_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE || p->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL);
+  gtk_widget_set_visible(g->rgb_norm_method_list, p->color_processing == DT_SIGMOID_METHOD_RGB_RATIO
+                         || p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE
+                         || p->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL);
 }
 
 void gui_update(dt_iop_module_t *self)
@@ -790,6 +926,7 @@ void gui_init(dt_iop_module_t *self)
   g->color_processing_list = dt_bauhaus_combobox_from_params(self, "color_processing");
   g->hue_preservation_slider = dt_bauhaus_slider_from_params(self, "hue_preservation");
   g->chroma_preservation_slider = dt_bauhaus_slider_from_params(self, "chroma_preservation");
+  dt_bauhaus_slider_set_soft_range(g->chroma_preservation_slider, 0.0f, 100.0f);
   // Cross talk option
   g->crosstalk_slider = dt_bauhaus_slider_from_params(self, "crosstalk_amount");
   dt_bauhaus_slider_set_soft_range(g->crosstalk_slider, 0.0f, 10.0f);

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -1,0 +1,329 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+// our includes go first:
+#include "bauhaus/bauhaus.h"
+#include "common/rgb_norms.h"
+#include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "gui/color_picker_proxy.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+
+#include <gtk/gtk.h>
+#include <stdlib.h>
+
+// To have your module compile and appear in darkroom, add it to CMakeLists.txt, with
+//  add_iop(sigmoid "sigmoid.c")
+// and to iop_order.c, in the initialisation of legacy_order & v30_order with:
+//  { {XX.0f }, "sigmoid", 0},
+
+// Module version number
+DT_MODULE_INTROSPECTION(1, dt_iop_sigmoid_params_t)
+
+
+// Enums used in params_t can have $DESCRIPTIONs that will be used to
+// automatically populate a combobox with dt_bauhaus_combobox_from_params.
+// They are also used in the history changes tooltip.
+// Combobox options will be presented in the same order as defined here.
+// These numbers must not be changed when a new version is introduced.
+typedef enum dt_iop_sigmoid_type_t
+{
+  DT_SIGMOID_LOGLOGISTIC = 0,  // $DESCRIPTION: "Log-Logisitic"
+  DT_SIGMOID_WEIBULL = 1,      // $DESCRIPTION: "Weibull"
+} dt_iop_sigmoid_type_t;
+
+#define MIDDLE_GREY 0.18f
+
+typedef struct dt_iop_sigmoid_params_t
+{
+  // The parameters defined here fully record the state of the module and are stored
+  // (as a serialized binary blob) into the db.
+  // Make sure everything is in here does not depend on temporary memory (pointers etc).
+  // This struct defines the layout of self->params and self->default_params.
+  // You should keep changes to this struct to a minimum.
+  // If you have to change this struct, it will break
+  // user data bases, and you have to increment the version
+  // of DT_MODULE_INTROSPECTION(VERSION) above and provide a legacy_params upgrade path!
+  //
+  // Tags in the comments get picked up by the introspection framework and are
+  // used in gui_init to set range and labels (for widgets and history)
+  // and value checks before commit_params.
+  // If no explicit init() is specified, the default implementation uses $DEFAULT tags
+  // to initialise self->default_params, which is then used in gui_init to set widget defaults.
+
+  float middle_grey_contrast;  // $MIN: 0.1 $MAX: 10.0 $DEFAULT: 1.4 $DESCRIPTION: "Contrast"
+  dt_iop_sigmoid_type_t cumulative_distribution;  // $DEFAULT: DT_SIGMOID_LOGLOGISTIC $DESCRIPTION: "Curve type"
+} dt_iop_sigmoid_params_t;
+
+typedef struct dt_iop_sigmoid_global_data_t
+{} dt_iop_sigmoid_global_data_t;
+
+typedef struct dt_iop_sigmoid_gui_data_t
+{
+  // Whatever you need to make your gui happy and provide access to widgets between gui_init, gui_update etc.
+  // Stored in self->gui_data while in darkroom.
+  // To permanently store per-user gui configuration settings, you could use dt_conf_set/_get.
+  GtkWidget *contrast_slider, *distribution_list;
+} dt_iop_sigmoid_gui_data_t;
+
+
+// this returns a translatable name
+const char *name()
+{
+  // make sure you put all your translatable strings into _() !
+  return _("sigmoid");
+}
+
+int flags()
+{
+  return IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+// where does it appear in the gui?
+int default_group()
+{
+  return IOP_GROUP_TONE | IOP_GROUP_TECHNICAL;
+}
+
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_rgb;
+}
+
+// Whenever new fields are added to (or removed from) dt_iop_..._params_t or when their meaning
+// changes, a translation from the old to the new version must be added here.
+// A verbatim copy of the old struct definition should be copied into the routine with a _v?_t ending.
+// Since this will get very little future testing (because few developers still have very
+// old versions lying around) existing code should be changed as little as possible, if at all.
+//
+// Upgrading from an older version than the previous one should always go through all in between versions
+// (unless there was a bug) so that the end result will always be the same.
+//
+// Be careful with changes to structs that are included in _params_t
+//
+// Individually copy each existing field that is still in the new version. This is robust even if reordered.
+// If only new fields were added at the end, one call can be used:
+//   memcpy(n, o, sizeof *o);
+//
+// Hardcode the default values for new fields that were added, rather than referring to default_params;
+// in future, the field may not exist anymore or the default may change. The best default for a new version
+// to replicate a previous version might not be the optimal default for a fresh image.
+//
+// FIXME: the calling logic needs to be improved to call upgrades from consecutive version in sequence.
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
+                  void *new_params, const int new_version)
+{
+  return 1;
+}
+
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  memcpy(piece->data, p1, self->params_size);
+}
+
+
+static inline float rgb_luma(const float pixel[4], const dt_iop_order_iccprofile_info_t *const work_profile)
+{
+  return (work_profile)
+            ? dt_workprofile_rgb_luminance(pixel, work_profile->matrix_in)
+            : dt_camera_rgb_luminance(pixel);
+}
+
+void process_loglogistic(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                         void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_sigmoid_params_t *d = (dt_iop_sigmoid_params_t *)piece->data;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+
+  const float *const in = (const float *)ivoid;
+  float *const out = (float *)ovoid;
+  const size_t npixels = (size_t)roi_in->width * roi_in->height;
+
+  const float power = d->middle_grey_contrast;
+  const float pivot = (1.0f - MIDDLE_GREY) / MIDDLE_GREY;
+  const float grey = MIDDLE_GREY;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, work_profile, pivot, grey, power) \
+  dt_omp_sharedconst(in, out) \
+  schedule(static)
+#endif
+  for(size_t k = 0; k < 4*npixels; k += 4)
+  {
+    // Desature a bit to get proper roll off to white in highlights
+    // This is taken from the ACES RRT implementation
+    const float luma = rgb_luma(in + k, work_profile);
+    for(size_t c = 0; c < 3; c++)
+    {
+      const float desat = fmaxf(luma + 0.96f * (in[k + c] - luma), 0.0f);
+      out[k + c] = 1.0f - pivot / (pivot + powf(desat / grey, power));
+    }
+    // Copy over the alpha channel
+    out[k + 3] = in[k + 3];
+  }
+}
+
+void process_weibull(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                         void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_sigmoid_params_t *d = (dt_iop_sigmoid_params_t *)piece->data;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+
+  const float *const in = (const float *)ivoid;
+  float *const out = (float *)ovoid;
+  const size_t npixels = (size_t)roi_in->width * roi_in->height;
+
+  const float power = 0.91f * d->middle_grey_contrast;
+  const float scale = MIDDLE_GREY / powf(-logf(1.0f - MIDDLE_GREY), 1.0f / power);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, work_profile, scale, power) \
+  dt_omp_sharedconst(in, out) \
+  schedule(static)
+#endif
+  for(size_t k = 0; k < 4*npixels; k += 4)
+  {
+    // Desature a bit to get proper roll off to white in highlights
+    // This is taken from the ACES RRT implementation
+    const float luma = rgb_luma(in + k, work_profile);
+    for(size_t c = 0; c < 3; c++)
+    {
+      const float desat = fmaxf(luma + 0.96f * (in[k + c] - luma), 0.0f);
+      out[k + c] = 1.0f - expf(-powf(desat / scale, power));
+    }
+    // Copy over the alpha channel
+    out[k + 3] = in[k + 3];
+  }
+}
+
+/** process, all real work is done here. */
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  // this is called for preview and full pipe separately, each with its own pixelpipe piece.
+  // get our data struct:
+  dt_iop_sigmoid_params_t *d = (dt_iop_sigmoid_params_t *)piece->data;
+  const dt_iop_sigmoid_type_t cdf_type = d->cumulative_distribution;
+
+  if (cdf_type == DT_SIGMOID_LOGLOGISTIC)
+  {
+    process_loglogistic(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else
+  {
+    process_weibull(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+}
+
+void init_global(dt_iop_module_so_t *module)
+{
+  module->data = malloc(sizeof(dt_iop_sigmoid_global_data_t));
+}
+
+void cleanup(dt_iop_module_t *module)
+{
+  // Releases any memory allocated in init(module)
+  // Implement this function explicitly if the module allocates additional memory besides (default_)params.
+  // this is rare.
+  free(module->params);
+  module->params = NULL;
+  free(module->default_params);
+  module->default_params = NULL;
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  free(module->data);
+  module->data = NULL;
+}
+
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
+{}
+
+void gui_update(dt_iop_module_t *self)
+{
+  dt_iop_sigmoid_gui_data_t *g = (dt_iop_sigmoid_gui_data_t *)self->gui_data;
+  dt_iop_sigmoid_params_t *p = (dt_iop_sigmoid_params_t *)self->params;
+
+  dt_bauhaus_slider_set(g->contrast_slider, p->middle_grey_contrast);
+  dt_bauhaus_combobox_set_from_value(g->distribution_list, p->cumulative_distribution);
+  gui_changed(self, NULL, NULL);
+}
+
+void gui_init(dt_iop_module_t *self)
+{
+  // Allocates memory for the module's user interface in the darkroom and
+  // sets up the widgets in it.
+  //
+  // self->widget needs to be set to the top level widget.
+  // This can be a (vertical) box, a grid or even a notebook. Modules that are
+  // disabled for certain types of images (for example non-raw) may use a stack
+  // where one of the pages contains just a label explaining why it is disabled.
+  //
+  // Widgets that are directly linked to a field in params_t may be set up using the
+  // dt_bauhaus_..._from_params family. They take a string with the field
+  // name in the params_t struct definition. The $MIN, $MAX and $DEFAULT tags will be
+  // used to set up the widget (slider) ranges and default values and the $DESCRIPTION
+  // is used as the widget label.
+  //
+  // The _from_params calls also set up an automatic callback that updates the field in params
+  // whenever the widget is changed. In addition, gui_changed is called, if it exists,
+  // so that any other required changes, to dependent fields or to gui widgets, can be made.
+  //
+  // Whenever self->params changes (switching images or history) the widget values have to
+  // be updated in gui_update.
+  //
+  // Do not set the value of widgets or configure them depending on field values here;
+  // this should be done in gui_update (or gui_changed or individual widget callbacks)
+  //
+  // If any default values for (slider) widgets or options (in comboboxes) depend on the
+  // type of image, then the widgets have to be updated in reload_params.
+  dt_iop_sigmoid_gui_data_t *g = IOP_GUI_ALLOC(sigmoid);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  g->contrast_slider = dt_bauhaus_slider_from_params(self, "middle_grey_contrast");
+  g->distribution_list = dt_bauhaus_combobox_from_params(self, "cumulative_distribution");
+}
+
+void gui_cleanup(dt_iop_module_t *self)
+{
+  // This only needs to be provided if gui_init allocates any memory or resources besides
+  // self->widget and gui_data_t. The default function (if an explicit one isn't provided here)
+  // takes care of gui_data_t (and gtk destroys the widget anyway). If you override the default,
+  // you have to do whatever you have to do, and also call IOP_GUI_FREE to clean up gui_data_t.
+
+  IOP_GUI_FREE;
+}
+
+/** additional, optional callbacks to capture darkroom center events. */
+// void gui_post_expose(dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
+// int32_t pointery);
+// int mouse_moved(dt_iop_module_t *self, double x, double y, double pressure, int which);
+// int button_pressed(dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
+// uint32_t state);
+// int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
+// int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -56,9 +56,10 @@ typedef enum dt_iop_sigmoid_methods_type_t
 typedef enum dt_iop_sigmoid_norm_type_t
 {
   DT_SIGMOID_METHOD_LUMINANCE = 0,      // $DESCRIPTION: "luminance Y"
-  DT_SIGMOID_METHOD_EUCLIDEAN_NORM = 1, // $DESCRIPTION: "RGB euclidean norm"
-  DT_SIGMOID_METHOD_POWER_NORM = 2,     // $DESCRIPTION: "RGB power norm"
-  DT_SIGMOID_METHOD_MAX_RGB = 3,        // $DESCRIPTION: "max RGB"
+  DT_SIGMOID_METHOD_AVERAGE = 1,        // $DESCRIPTION: "average"
+  DT_SIGMOID_METHOD_EUCLIDEAN_NORM = 2, // $DESCRIPTION: "RGB euclidean norm"
+  DT_SIGMOID_METHOD_POWER_NORM = 3,     // $DESCRIPTION: "RGB power norm"
+  DT_SIGMOID_METHOD_MAX_RGB = 4,        // $DESCRIPTION: "max RGB"
 } dt_iop_sigmoid_norm_type_t;
 
 #define MIDDLE_GREY 0.1845f
@@ -202,6 +203,9 @@ static inline float get_pixel_norm(const float pixel[4], const dt_iop_sigmoid_no
 
     case(DT_SIGMOID_METHOD_EUCLIDEAN_NORM):
       return sqrtf(sqf(pixel[0]) + sqf(pixel[1]) + sqf(pixel[2])) * INVERSE_SQRT_3;
+
+    case(DT_SIGMOID_METHOD_AVERAGE):
+      return (pixel[0] + pixel[1] + pixel[2]) / 3.0f;
 
     case(DT_SIGMOID_METHOD_LUMINANCE):
     default:


### PR DESCRIPTION
Hi darktable developers!
I have wanted to contribute to the darktable source for some time now and I finally found the time to do some "hacking"/exploration this Christmas. I actually managed to make something interesting so I figured I just as well could present myself with a pull request.

Anyway here is the results from some late nights during Christmas, I hope you find it interesting!

### Sigmoid?
I have recently been dealing with strictly positive data for classification at work which has given me a reason to study appropriate probability density functions for this kind of data. Two examples are the [log-logistic](https://en.wikipedia.org/wiki/Log-logistic_distribution) and the [weibull](https://en.wikipedia.org/wiki/Weibull_distribution) which also have easy closed for definitions of the cumulative distribution function, cdf. It struc me that these functions really resembled the S-curve used for tone mapping of images and their cdf properties are pretty nice with any value [0.0, inf] mapping to (0, 1) in a smooth way. The slope of this ramp is also determined by a single shape parameter.


### Compared to the base curve presets
My first test was to compare directly with the base curve presets as those are hardcoded in the module and therefore easy to extract. They look like in the left plot bellow when stack ontop of each other. Kind of similar but not the same. The right plot show what would happen if the base curves where adopted to a scene referred workflow and fix middle grey as 0.18. They all look very similar all the sudden. The two sigmoid functions are plotted ontop. The scale parameter is calculated such that they also hit the point (0.18, 0.18) while the shape is picked to resemble the base curves. I'm actually surprised at both how tightly the base curves algined with each other as well as how well the sigmoids followed them. Notice how the weibull distribution converge towards 1 much quicker then the log-logistic, this is the most notable difference between the two, weibull gives punchier highlights. The log-logistic on the other hand gives a lot of room for preserving details in the highlights!

![Base](https://user-images.githubusercontent.com/7957113/104237659-ac546780-5458-11eb-867d-d9aa79ee8d9d.png)

Another way of plotting the same data is to plot the derivative of the above curves. [Perry Sprawls](http://www.sprawls.org/ppmi2/FILMCON/) has a good article about this kind of curve which is best described as a contrast curve. Its easy to see why its a bit tricky to tone your image using custom base curves! Even some of the presets wiggle like crazy back and forth! The average trend is pretty clear though and both the log-logistic and weibull pdfs follow the trend fairly well.

![Contrast](https://user-images.githubusercontent.com/7957113/104239691-39002500-545b-11eb-8b07-ffdcb04ceb75.png)

Any conclusions from the above? Well I would say its promising, especially when the following is taken into consideration:
* Its controlled by a single easy to understand parameter
* A well defined curve with a smooth stable derivative
* Results is always within the display safe bounds [0, 1]
* Supports very very high dynamic range, no weird out bounds behaviors etc. 

I had loved to include the corresponding curves for darktable filmic, blender filmic and ACES RRTODT but its a bit more work then just extracting the base curve presets so I haven't put in the time to do that.

### Pics or it didn't happen
I don't have any sharable portraits laying around so my sisters dog will be the main subject instead. The picture has only been edited by adjusting exposure and white balance. The difference between them is the tone mapping which is either my sigmoid method, filmic v4 or base curve with the "Canon EOS like" preset and preserve colors = luminance / none. 

![DSC_5870_sigmoid](https://user-images.githubusercontent.com/7957113/104240380-44078500-545c-11eb-9f59-abb8304dc875.jpg)
Sigmoid, log-logistic, contrast = 1.4


![DSC_5870_filmic](https://user-images.githubusercontent.com/7957113/104243017-3a801c00-5460-11eb-8bdf-4166b109daf8.jpg)
Filmic, slightly tuned white and black levels.


![DSC_5870_base_luma](https://user-images.githubusercontent.com/7957113/104243115-5edbf880-5460-11eb-88bf-4e4b2c28f338.jpg)
Base curve, Canon EOS like, preserve colors = luminance


![DSC_5870_base_non](https://user-images.githubusercontent.com/7957113/104243203-8337d500-5460-11eb-9aec-54e3b55a599a.jpg)
Base curve, Canon EOS like, preserve colors = none


I also found this problematic image on the darktable pixls forum https://discuss.pixls.us/t/a-study-in-blue/21706
and I think it gave some interesting results worth sharing.

![image](https://user-images.githubusercontent.com/7957113/104357774-e9c6fc80-550d-11eb-91f3-fafcbcc95d26.png)
Lightroom edit by Egocentrix


![RPN_Kick-In_20180830_3392_sigmoid](https://user-images.githubusercontent.com/7957113/104358830-4545ba00-550f-11eb-9424-d3f6f0070561.jpg)
Sigmoid, contrast = 0.89, slight white balance change and adjusted exposure. That contrast is very very low but worked well for this particular image as it could fit both the intense lights as well as the much darker surrounding in our viewable [0, 1] range.


![RPN_Kick-In_20180830_3392_filmic](https://user-images.githubusercontent.com/7957113/104358843-47a81400-550f-11eb-83f5-3604afaa182a.jpg)
Filmic with tuned black and white level, as well as the same white balance and exposure as for the sigmoid.


### Compared to ACES
The ACES-dev repository has a set of reference images that can be downloaded and compared against.
See: https://github.com/ampas/aces-dev/tree/master/images
Their scene to display transforms has been used in a lot of really good looking movies so I wondered how the sigmoid would compare. The following is the result when using the image /ACES/syntheticChart.01.exr from the linked library.


<img width="1024" alt="syntheticChart 01_ODT Academy sRGB_100nits_dim" src="https://user-images.githubusercontent.com/7957113/104343440-3bff2200-54fc-11eb-8106-7473edfd8c8c.png"> ACES reference ODT: sRGB, 100 nits, dim light


![syntheticChart 01_sigmoid](https://user-images.githubusercontent.com/7957113/104346056-47a01800-54ff-11eb-930f-b3012c27c56f.jpg)
sigmoid, log-logistic, contrast = 1.4


![syntheticChart 01_filmic](https://user-images.githubusercontent.com/7957113/104343634-77015580-54fc-11eb-9ddf-fcd2011acbb1.jpg)
filmic, default values.


![syntheticChart 01_base_lum](https://user-images.githubusercontent.com/7957113/104343724-95ffe780-54fc-11eb-97d6-f459269c409d.jpg)
Base curve, Canon EOS like, preserve colors = luminance


![syntheticChart 01_base_no](https://user-images.githubusercontent.com/7957113/104343783-a748f400-54fc-11eb-9aa7-761e46cbe081.jpg)
Base curve, Canon EOS like, preserve colors = none


### Please try it!
I had loved to get some feedback and see examples from your pictures. I personally so far love how it does one thing very well and then cooperates with the exposure and tone equalizer modules for good results.
**Here are some tips to get you going:**
* Push that exposure! I averaged around +2 EV for my pictures. Do not mind this, its just a matter of middle grey being defined  differently.
* Pay attention to the highlight reconstruction. It can really make a big difference to change to "Lch" or "color" instead of "clip".
* Weak saturation in brighter parts of an image? Use the tone equalizer to reduce the brightness instead of trying to push saturation sliders!
* Weak whites? Change to weibull
* Missing details in the whites? Change to log-logistic

### Missing for being properly done done
* Better name, I feel like it should say what it does rather then what it is. Suggestions are welcome!
* Histogram with EVs as x axis. 0 EV = 0.18
* Plot curve on the histogram similar to the base curve
* Whatever optimization that might be needed