### PR TITLE
fix bold for module presets in lighttable

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -115,7 +115,3 @@ tooltip label,
                   sans-serif;
 }
 
-.active-menu-item * /* this is optional, omitting it will make the selected menu item slightly less visible */
-{
-    font-weight: bold;
-}

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2706,3 +2706,9 @@ spinbutton>button
 {
   margin: 0 0.2em;
 }
+
+.active-menu-item * /* needed for some Pango issues not rendering synthetic bold for all OS */
+{
+    font-weight: bold;
+}
+

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -631,11 +631,8 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo)
     {
       active_preset = cnt;
       writeprotect = sqlite3_column_int(stmt, 2);
-      char *markup;
-      mi = gtk_menu_item_new_with_label("");
-      markup = g_markup_printf_escaped("<span weight='bold'>%s</span>", name);
-      gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);
-      g_free(markup);
+      mi = gtk_menu_item_new_with_label(name);
+      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
     }
     else
     {


### PR DESCRIPTION
Following my recent PR #7671, partially fixing visualization in bold of the selected darkroom module presets under Windows, this PR does the same for modules in lighttable.

EDIT: Also fixes #7806 