### PR TITLE
tests: update delta E

### DIFF
--- a/src/tests/integration/deltae
+++ b/src/tests/integration/deltae
@@ -7,7 +7,8 @@
 #      pip3 install colour-science
 
 # Maximum delta allowed, above this value the difference can be detected
-MAX_DELTA_E = 2.0
+MAX_DELTA_E = 2.3
+MAX_AVG_DELTA_E = MAX_DELTA_E / 3.
 
 import cv2
 import colour
@@ -16,7 +17,7 @@ import os
 import sys
 
 if "delta_E" not in dir(colour):
-    print("  Unable to compute delta-E, please upgrade python3-colour")
+    print("  Unable to compute delta-E, please upgrade python3-colour-science")
     exit(0)
 
 expected = sys.argv[1]
@@ -28,21 +29,43 @@ output_rgb = cv2.imread(output)
 expected_lab = cv2.cvtColor(expected_rgb, cv2.COLOR_RGB2Lab)
 output_lab = cv2.cvtColor(output_rgb, cv2.COLOR_RGB2Lab)
 
-delta_E = colour.delta_E(expected_lab, output_lab)
+delta_E = colour.delta_E(expected_lab, output_lab, method="CIE 2000")
 
-max_dE = numpy.max(delta_E)
+num_elem = delta_E.size
+
+max_dE = numpy.amax(delta_E)
 mean_dE = numpy.mean(delta_E)
-count_above = 0
+std_dE = numpy.std(delta_E)
 
-print("      Max  dE         %.4f" % max_dE)
+print("      ----------------------------------")
+print("      Max dE                   : %.5f" % max_dE)
+print("      Avg dE                   : %.5f" % mean_dE)
+print("      Std dE                   : %.5f" % std_dE)
+print("      ----------------------------------")
 
-if(max_dE > MAX_DELTA_E):
-    count_above = numpy.sum(delta_E >= MAX_DELTA_E)
-    print("      Mean dE         %.4f" % mean_dE)
-    print("      Count above max %d" % count_above)
+count_below_avg = numpy.sum(delta_E <= mean_dE)
+print("      Pixels below avg + 0 std : %.2f %%" % (count_below_avg / num_elem * 100.))
+
+count_below_avg = numpy.sum(delta_E <= mean_dE + std_dE)
+print("      Pixels below avg + 1 std : %.2f %%" % (count_below_avg / num_elem * 100.))
+
+count_below_avg = numpy.sum(delta_E <= mean_dE + 3. * std_dE)
+print("      Pixels below avg + 3 std : %.2f %%" % (count_below_avg / num_elem * 100.))
+
+count_below_avg = numpy.sum(delta_E <= mean_dE + 6. * std_dE)
+print("      Pixels below avg + 6 std : %.2f %%" % (count_below_avg / num_elem * 100.))
+
+count_below_avg = numpy.sum(delta_E <= mean_dE + 9. * std_dE)
+print("      Pixels below avg + 9 std : %.2f %%" % (count_below_avg / num_elem * 100.))
+
+print("      ----------------------------------")
+
+count_above = numpy.sum(delta_E >= MAX_DELTA_E)
+print("      Pixels above tolerance   : %.2f %%" % (count_above / num_elem * 100.))
+
+if(max_dE > MAX_DELTA_E or mean_dE > MAX_AVG_DELTA_E):
     exit(2)
-
-if max_dE < 0.01:
+elif(max_dE < 0.01):
     exit(0)
 else:
     exit(1)


### PR DESCRIPTION
1. Use delta E 2000 formula instead of delta E 1976, which is less uniform and tends to be alarming for nothing
2. Raises the maximum delta E to 2.3, which is the Just Noticeable Difference (JND)
3. Express the number of pixels above tolerance in % of the pixel count (the absolute number doesn't mean much)
4. Compute the standard deviation and the pixels frequencies for avg + [0, 1, 3, 6, 9] * std, which gives an idea of the error distribution
5. Adds a blocking condition if the average delta E is > JND / 3.

Result:
```
Test 0037-filmic-reconstruction
      Image mire1.cr2
      CPU & GPU version differ by 35638 pixels
      ----------------------------------
      Max dE                   : 2.06898
      Avg dE                   : 0.00340
      Std dE                   : 0.03761
      ----------------------------------
      Pixels below avg + 0 std : 99.05 %
      Pixels below avg + 1 std : 99.05 %
      Pixels below avg + 3 std : 99.05 %
      Pixels below avg + 6 std : 99.09 %
      Pixels below avg + 9 std : 99.60 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
  OK


Total test 1
Errors     0
```