### PR TITLE
filmicrgb: fix a bug with highlights reconstruction

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -653,10 +653,9 @@ kernel void wavelets_detail_level(read_only image2d_t detail, read_only image2d_
   const float4 d = read_imagef(detail, sampleri, (int2)(x, y));
   const float4 lf = read_imagef(LF, sampleri, (int2)(x, y));
   const float4 hf = d - lf;
-  const float t = fminabsf(fminabsf(hf.x, hf.y), hf.z);
 
   write_imagef(HF, (int2)(x, y), hf);
-  write_imagef(texture, (int2)(x, y), t);
+  write_imagef(texture, (int2)(x, y), hf);
 }
 
 kernel void wavelets_reconstruct(read_only image2d_t HF, read_only image2d_t LF, read_only image2d_t texture, read_only image2d_t mask,
@@ -677,33 +676,38 @@ kernel void wavelets_reconstruct(read_only image2d_t HF, read_only image2d_t LF,
   const float alpha = read_imagef(mask, sampleri, (int2)(x, y)).x;
   const float4 HF_c = read_imagef(HF, sampleri, (int2)(x, y));
   const float4 LF_c = read_imagef(LF, sampleri, (int2)(x, y));
+  const float4 TT_c = read_imagef(texture, sampleri, (int2)(x, y));
 
-  const float grey_texture = gamma * read_imagef(texture, sampleri, (int2)(x, y)).x;
-  const float grey_details = fmaxabsf(fmaxabsf(HF_c.x, HF_c.y), HF_c.z);
-  const float grey_HF = beta_comp * (gamma_comp * grey_details + grey_texture);
-
-  const float4 color_residual = LF_c * beta;
-  float grey_residual;
-  float4 color_details;
+  float4 details;
+  float4 residual;
 
   switch(variant)
   {
     case(DT_FILMIC_RECONSTRUCT_RGB):
     {
-      grey_residual = beta_comp * fmin(fmin(LF_c.x, LF_c.y), LF_c.z);
-      color_details = (HF_c * gamma_comp + fmin(fabs(HF_c / grey_details), (float4)1.f) * grey_texture) * beta;
+      const float grey_texture = fmaxabsf(fmaxabsf(TT_c.x, TT_c.y), TT_c.z);
+      const float grey_details = (HF_c.x + HF_c.y + HF_c.z) / 3.f;
+      const float grey_HF = beta_comp * (gamma_comp * grey_details + gamma * grey_texture);
+      const float grey_residual = beta_comp * (LF_c.x + LF_c.y + LF_c.z) / 3.f;
+
+      details = (gamma_comp * HF_c + gamma * TT_c) * beta + grey_HF;
+      residual = (s == scales - 1) ? grey_residual + LF_c * beta : (float4)0.f;
       break;
     }
     case(DT_FILMIC_RECONSTRUCT_RATIOS):
     {
-      grey_residual = beta_comp * fmax(fmax(LF_c.x, LF_c.y), LF_c.z);
-      color_details = (HF_c * gamma_comp - 0.5f * fmin(fabs(HF_c / grey_details), (float4)1.f) * grey_texture) * beta;
+      const float grey_texture = fmaxabsf(fmaxabsf(TT_c.x, TT_c.y), TT_c.z);
+      const float grey_details = (HF_c.x + HF_c.y + HF_c.z) / 3.f;
+      const float grey_HF = (gamma_comp * grey_details + gamma * grey_texture);
+
+      details = 0.5f * ((gamma_comp * HF_c + gamma * TT_c) + grey_HF);
+      residual = (s == scales - 1) ? LF_c : (float4)0.f;
       break;
     }
   }
 
   const float4 i = read_imagef(reconstructed_read, sampleri, (int2)(x, y));
-  const float4 o = i + alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
+  const float4 o = i + alpha * (delta * details + residual);
   write_imagef(reconstructed_write, (int2)(x, y), fmax(o, 0.f));
 }
 


### PR DESCRIPTION
There have been several reports of unsatisfactory filmic highlight reconstruction:
1. non-smooth regions : (from https://forums.darktable.fr/showthread.php?tid=5439&pid=45254#pid45254)
![image](https://user-images.githubusercontent.com/2779157/104532640-f7b17600-5610-11eb-939a-916289d47ba7.png)
Now fixed:
![Screenshot_20210114_023729](https://user-images.githubusercontent.com/2779157/104532856-80301680-5611-11eb-8506-2ac0c2605673.png)

2. sub-par highlights reconstruction: (from https://discuss.pixls.us/t/3-4-scene-referred-workflow-bad-bokeh-highlights-reconstruction/22135/)
![image](https://user-images.githubusercontent.com/2779157/104532973-bec5d100-5611-11eb-9378-bc6c846d6e4a.png)
Now improved (settings have been changed):
![image](https://user-images.githubusercontent.com/2779157/104533015-d2713780-5611-11eb-927a-09829b81380c.png)

3. black artifacts: (from #7820)
![image](https://user-images.githubusercontent.com/2779157/104533077-f3398d00-5611-11eb-9ad8-af14c1c2a48d.png)
Now fixed:
![syntheticChart 01](https://user-images.githubusercontent.com/2779157/104533093-fb91c800-5611-11eb-9a3f-15beab5409b8.jpg)

This will change current edits in a minor way, but I believe the benefit in smoothness and robustness overtake the drawbacks:

```
Test 0037-filmic-reconstruction
      Image mire1.cr2
      CPU & GPU version differ by 35470 pixels
      ----------------------------------
      Max dE                   : 2.06898
      Avg dE                   : 0.00345
      Std dE                   : 0.03765
      ----------------------------------
      Pixels below avg + 0 std : 99.03 %
      Pixels below avg + 1 std : 99.03 %
      Pixels below avg + 3 std : 99.03 %
      Pixels below avg + 6 std : 99.07 %
      Pixels below avg + 9 std : 99.59 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
  OK


Total test 1
Errors     0
```

What happened ?

1. the details layer blurring was non-local (using pixels far away in the same logic as the a-trous wavelet), which helped in nice cases but not in the symptomatic ones. Now the blurring only takes the 25 closest pixels, for better smoothness.
2. there were 2 divisions, meant to speed-up inpainting, that could result in instabilities for very large and very low numbers, causing the black artifact in the synthetic test image. Although natural images are not likely to have such high gradients, division is now avoided.
3. the chroma reconstruction used the max over the 3 details layers, which was the main cause for the non-smooth bokeh example. This is now replaced by the average.

What changes ?

The colorful vs. grey parameter has no effect on the "high quality" (chroma) reconstruction anymore. This allows to get more agressive on favouring achromatic in the first step of RGB reconstruction, which will recover more luminance details and fix magenta highlights much more efficiently, then inpaint color with the chroma reconstruction. 

The amount of color reconstruction is actually driven by the number of iterations of chroma reconstruction, so this should overall have little impact on current edits since the color/grey setting was so dramatic that it had to be used > 80% to not turn highlights full grey (and had to be decreased as high quality iterations increased).