### PR TITLE
channelmixerrgb: restore warning label

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3418,6 +3418,10 @@ void gui_init(struct dt_iop_module_t *self)
   // Page CAT
   self->widget = dt_ui_notebook_page(g->notebook, _("CAT"), _("chromatic adaptation transform"));
 
+  self->warning_label = dt_ui_label_new("");
+  gtk_label_set_line_wrap(GTK_LABEL(self->warning_label), TRUE);
+  gtk_box_pack_start(GTK_BOX(self->widget), self->warning_label, FALSE, FALSE, 4);
+
   g->adaptation = dt_bauhaus_combobox_from_params(self, N_("adaptation"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->adaptation),
                               _("choose the method to adapt the illuminant\n"


### PR DESCRIPTION
Restore the warning label that was removed in 8b7b1ee246bd239c6c598e7accb6c239892d86ae for no apparent reason (maybe a rebase mistake or something like that?) Now the common `warning_label` entry in module struct is used instead of the module-specific one.