### PR TITLE
filmicrgb OpenCL : fix an inconsistency with C path

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -708,7 +708,7 @@ kernel void wavelets_reconstruct(read_only image2d_t HF, read_only image2d_t LF,
 
   const float4 i = read_imagef(reconstructed_read, sampleri, (int2)(x, y));
   const float4 o = i + alpha * (delta * details + residual);
-  write_imagef(reconstructed_write, (int2)(x, y), fmax(o, 0.f));
+  write_imagef(reconstructed_write, (int2)(x, y), o);
 }
 
 


### PR DESCRIPTION
wavelets scales can be negative now (and should be to get correct details reconstruction), so clipping makes no sense anymore.