### PR TITLE
histogram: bugfix, set black point on drag

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -944,7 +944,7 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
       d->dragging = 1;
       if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
         d->exposure = dt_dev_exposure_get_exposure(dev);
-      if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE)
+      if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT)
         d->black = dt_dev_exposure_get_black(dev);
       d->button_down_x = event->x;
       d->button_down_y = event->y;


### PR DESCRIPTION
Typo caused exposure's black point value not to be set. Instead, it will always default to 0.

Fixes a bug from my commit 33527929309b83916a89802a5bc0cda7e26e3ad0. Need to be careful about the dynamic expansion key.