### PR TITLE
Improve stars, colorlabels and some spacing

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -86,6 +86,7 @@
 /* Lighttable and film-strip */
 @define-color thumbnail_bg_color @grey_55;
 @define-color thumbnail_star_bg_color @grey_40;
+@define-color thumbnail_star_hover_color @grey_85;
 @define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_selected_bg_color @grey_75;
 @define-color thumbnail_hover_bg_color @grey_90;

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -87,7 +87,7 @@
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_35;
+@define-color thumbnail_font_color @grey_40;
 @define-color thumbnail_bg_color @grey_70;
 @define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_selected_bg_color @grey_80;
@@ -150,4 +150,11 @@
 .dt_overlays_always_extended#preview #thumb_main:hover #thumb_bottom
 {
   background-image: linear-gradient(rgba(246, 246, 246, 0.4) 0%, rgba(246, 246, 246, 0.2) 5%, rgba(226, 226, 226, 0) 100%);
+}
+
+/* Make inactive stars more discrete when not hovered */
+
+#thumb_star
+{
+  color: shade(@thumbnail_font_color, 1.5);
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -133,9 +133,10 @@
 @define-color lighttable_bg_font_color @grey_75;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_25;
+@define-color thumbnail_font_color @grey_30;
 @define-color thumbnail_bg_color @grey_50;
 @define-color thumbnail_star_bg_color @grey_35;
+@define-color thumbnail_star_hover_color @grey_80;
 @define-color thumbnail_fg_color @grey_55;
 @define-color thumbnail_bg50_color @grey_100;
 @define-color thumbnail_selected_bg_color @grey_70;
@@ -2474,6 +2475,13 @@ spinbutton>button
   color: shade(@thumbnail_font_color, 1.1);
 }
 
+/* Make inactive stars more discrete when not hovered */
+
+#thumb_star
+{
+  color: shade(@thumbnail_font_color, 1.4);
+}
+
 /* Reset color icons to be hidden in following modes, including culling/preview overlays hover block*/
 .dt_overlays_none .dt_thumb_btn,
 .dt_overlays_none #thumb_main:hover .dt_thumb_btn,
@@ -2538,7 +2546,7 @@ spinbutton>button
 .dt_overlays_mixed #thumb_star:active,
 .dt_overlays_hover_block #thumb_image:hover #thumb_star:active
 {
-  color: @thumbnail_selected_bg_color;
+  color: @thumbnail_font_color;
   background-color: @thumbnail_font_color;
 }
 
@@ -2550,7 +2558,7 @@ spinbutton>button
 .dt_overlays_mixed #thumb_main:hover #thumb_star:hover,
 .dt_overlays_hover_block #thumb_main:hover #thumb_star:hover
 {
-  color: @thumbnail_hover_fg_color;
+  color: @thumbnail_star_hover_color;
   background-color: @thumbnail_star_bg_color;
 }
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -687,7 +687,7 @@ overshoot.right
 #iop-plugin-ui #section_label,
 #lib-plugin-ui #section_label
 {
-  margin: 12px 0 6px 0;
+  margin: 8px 0 6px 0;
 }
 
 #iop-plugin-ui #section_label.section_label_top,
@@ -705,8 +705,9 @@ overshoot.right
 }
 
 #lib-plugin-ui .section-expander,
-#iop-plugin-ui .section-expander {
-  padding: 12px 0 6px 0;
+#iop-plugin-ui .section-expander
+{
+  padding: 8px 0 6px 0;
 }
 
 #lib-plugin-ui .section-expander #control-button,
@@ -805,6 +806,11 @@ dialog scrolledwindow
 {
   margin: 1px;
   padding: 0px;
+}
+
+#import_metadata grid label
+{
+  margin: 0.2em 0;
 }
 
 /* Set import from camera or card dialog window */
@@ -2729,13 +2735,23 @@ spinbutton>button
 }
 
 /* lighttable toolbox */
-#lighttable_layouts_box *
+#lighttable_layouts_box,
+#footer-toolbar entry
+{
+  margin-right: 0.6em;
+}
+
+#footer-toolbar #dt-toggle-button
 {
   margin: 0 0.2em;
+}
+
+#lighttable_layouts_box #dt-toggle-button
+{
+  margin: 0 0.4em;
 }
 
 .active-menu-item * /* needed for some Pango issues not rendering synthetic bold for all OS */
 {
     font-weight: bold;
 }
-

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1354,7 +1354,7 @@ void dtgtk_cairo_paint_audio(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 0, 0)
+  PREAMBLE(1.1, 0, 0)
 
   const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
 


### PR DESCRIPTION
Fix #7804. See new inactive stars (test for hover effect update too):

![2021-01-15_21-00](https://user-images.githubusercontent.com/45535283/104773089-c8b41500-5774-11eb-8921-ed57858fd5c6.png)

A french user suggested to increase colorlabels to better see them. He propose 1.2 size, that is too big. I've made some tests and think that updating from 1.0 to 1.1 is better. See below comparison between actual master on left (1.0), 1.05 size in middle and this PR, 1.1 on the right:

![colorlabels](https://user-images.githubusercontent.com/45535283/104772695-1d0ac500-5774-11eb-8276-eafd171cc391.jpg)