### PR TITLE
for_each_channel: if not using OpenMP, only process three channels

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -498,7 +498,7 @@ static inline float *dt_alloc_perthread_float(const size_t n, size_t* padded_siz
   for (size_t _var = 0; _var < 4; _var++)
 #else
 #define for_each_channel(_var, ...) \
-  for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
+  for (size_t _var = 0; _var < 3; _var++)
 #define for_four_channels(_var, ...) \
   for (size_t _var = 0; _var < 4; _var++)
 #endif


### PR DESCRIPTION
If OpenMP (and OpenMP w/SIMD) is not used/available, only iterate over the first three channels. This *should* produce correct results (or at least a caller to `for_each_channel()` should be OK if the fourth channel result is undefined).

The `for_each_channel()` macro gets very little use yet in the code. I tested this in RGB levels and it appeared to make no difference in processing speed.

@ralfbrown: Does this make sense?