### PR TITLE
channelmixerrgb: fix color checker drawing and sampling

### DIFF
--- a/src/chart/common.c
+++ b/src/chart/common.c
@@ -67,6 +67,23 @@ point_t apply_homography(point_t p, const double *h)
   return result;
 }
 
+double apply_homography_scaling(point_t p, const double *h)
+{
+  // The local scaling of areas by the homography mapping is given by
+  // the absolute value of its Jacobian determinant at point p.
+  const double x = p.x * h[0 * 3 + 0] + p.y * h[0 * 3 + 1] + h[0 * 3 + 2];
+  const double y = p.x * h[1 * 3 + 0] + p.y * h[1 * 3 + 1] + h[1 * 3 + 2];
+  const double s = p.x * h[2 * 3 + 0] + p.y * h[2 * 3 + 1] + h[2 * 3 + 2];
+
+  // Components of the Jacobian matrix, without division by s^2, which is factored
+  // out and done for the whole determinant.
+  const double J00 = h[0 * 3 + 0] * s - h[2 * 3 + 0] * x;
+  const double J01 = h[0 * 3 + 1] * s - h[2 * 3 + 1] * x;
+  const double J10 = h[1 * 3 + 0] * s - h[2 * 3 + 0] * y;
+  const double J11 = h[1 * 3 + 1] * s - h[2 * 3 + 1] * y;
+  return fabs(J00 * J11 - J01 * J10) / (s * s * s * s);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces

--- a/src/chart/common.h
+++ b/src/chart/common.h
@@ -48,12 +48,8 @@ typedef struct image_t
 
 int get_homography(const point_t *source, const point_t *target, double *h);
 point_t apply_homography(point_t p, const double *h);
-
-static inline double apply_homography_scaling(point_t p, const double *h)
-{
-  const double s =  p.x * h[2 * 3 + 0] + p.y * h[2 * 3 + 1] + h[2 * 3 + 2];
-  return s;
-}
+// Gives a factor of scaling areas at point p
+double apply_homography_scaling(point_t p, const double *h);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
I missed some details in https://github.com/darktable-org/darktable/pull/7700 about the coordinate transformations... It improved things but didn't completely fix the color checker extraction (or drawing) in positions other than close to the starting position and orientation. 

The `ideal_box` coordinates are now normalized to the interval [0, 1]. Dependence on preview area width and height is removed. This gives correct drawing and sampling of the color checker even in skewed or rotated positions, removing the necessity of performing rotating and perspective correction beforehand.

`apply_homography_scaling` is fixed to give the local scaling of areas based on the Jacobian determinant of the homography mapping. This gives correct scaling of the center circles in the checker grid. The previous implementation appeared to work at first glance but in some orientations shrinks the circles even if the sampling boxes are quite large.

Before this PR (master, ace7b26fc5f7186afbee8e920af972bacc35a780):
![colorchecker_bad](https://user-images.githubusercontent.com/5001906/104784985-1ee38100-5792-11eb-98b2-2d99dedf1a54.png)
In particular, the sampling boxes have bad aspect ratio and the symmetry lines are in the wrong place.

With this PR applied:
![colorchecker_good](https://user-images.githubusercontent.com/5001906/104785003-29057f80-5792-11eb-9e3f-4d42ce5e711b.png)

Please notice also the black sampling areas in the small preview image - these are drawn by the color checker extraction routine to indicate which pixels of the image are really sampled. This is done by debug code that I only enabled locally while testing this PR.

@aurelienpierre , out of curiosity: are the color checker patches extracted from the small preview image (top left in darkroom) or the large one in the center?