### PR TITLE
RCD demosaicer code maintenance

### DIFF
--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -27,23 +27,25 @@
 */
 
 /*
-* The tiling and sse2 optimised coding has been done by
-* Ingo Weyrich (heckflosse67@gmx.de) in rawtherapee code and has been slightly
-* modified in cooperation.
+* The tiling coding was done by Ingo Weyrich (heckflosse67@gmx.de) from rawtherapee
+*/
+
+/*
+* Luis Sanz Rodríguez significantly optimised the v 2.3 code and simplified the directional
+* coefficients in an exact, shorter and more performant formula.
+* In cooperation with Ingo Weyrich and Luis Sanz Rodríguez this has been tuned for performance.
 * Hanno Schwalm (hanno@schwalm-bremen.de)
 */
 
-/* some notes about the algorithm
-  - the calculated data at the borders are not stable for tiling if we don't use
-    a RCD_BORDER of at least 9. The bordersize is the overlapping region for tiles.
-  - Is it safe to use -Ofast? Yes
+/* Some notes about the algorithm
+* 1. The calculated data at the tiling borders RCD_BORDER must be at least 9 to be stable.
+* 2. For the outermost tiles we only have to discard a 6 pixel border region interpolated otherwise.
+* 3. The tilesize has a significant influence on performance, the default is a good guess for modern
+*    x86/64 machines, tested on Xeon E-2288G, i5-8250U and AMD FX8350.
 */
 
-// this allows to pass RCD_TILESIZE to the code. On some machines larger tilesizes are faster
-// If it is undefined it will be set to 140, which is a good guess for modern x86/64 machines
-// Tested and tuned on Xeon E-2288G, i5-8250U and AMD FX8350 
 #ifndef RCD_TILESIZE
- #define RCD_TILESIZE 140
+  #define RCD_TILESIZE 112
 #endif
 
 // Make sure we use -Ofast only in the rcd code section
@@ -53,13 +55,9 @@
 #endif
 
 #ifdef __GNUC__
-#define INLINE __inline
+  #define INLINE __inline
 #else
-#define INLINE inline
-#endif
-
-#ifdef __SSE__
-#include <x86intrin.h>
+  #define INLINE inline
 #endif
 
 #define FCRCD(row, col) (cfarray[(((row) & 1)<<1) | ((col) & 1)])
@@ -72,100 +70,11 @@
 #define w3 (3 * RCD_TILESIZE)
 #define w4 (4 * RCD_TILESIZE)
 
-#define eps 1e-5    // Tolerance to avoid dividing by zero
+#define eps 1e-5              // Tolerance to avoid dividing by zero
 #define epssq 1e-10
 
-/* Some macros and inline functions taken from amaze_demosaic_RT */
-// Only include the vector macros/functions for SSE
-#ifdef __SSE2__
-typedef __m128i vmask;
-typedef __m128 vfloat;
-
-#define F2V(a) _mm_set1_ps((a))
-#define LVFU(x) _mm_loadu_ps(&x)
-#define STVFU(x,y) _mm_storeu_ps(&x,y)
-#ifdef __SSE4_1__
-// SSE4.1 => use _mm_blend_ps instead of _mm_set_epi32 and vself
-#define STC2VFU(a,v) {\
-                         __m128 TST1V = _mm_loadu_ps(&a);\
-                         __m128 TST2V = _mm_unpacklo_ps(v,v);\
-                         _mm_storeu_ps(&a, _mm_blend_ps(TST1V,TST2V,5));\
-                         TST1V = _mm_loadu_ps((&a)+4);\
-                         TST2V = _mm_unpackhi_ps(v,v);\
-                         _mm_storeu_ps((&a)+4, _mm_blend_ps(TST1V,TST2V,5));\
-                     }
-#else
-#define STC2VFU(a,v) {\
-                         __m128 TST1V = _mm_loadu_ps(&a);\
-                         __m128 TST2V = _mm_unpacklo_ps(v,v);\
-                         vmask cmask = _mm_set_epi32(0xffffffff,0,0xffffffff,0);\
-                         _mm_storeu_ps(&a, vself(cmask,TST1V,TST2V));\
-                         TST1V = _mm_loadu_ps((&a)+4);\
-                         TST2V = _mm_unpackhi_ps(v,v);\
-                         _mm_storeu_ps((&a)+4, vself(cmask,TST1V,TST2V));\
-                     }
-#endif
-
-static INLINE vfloat LC2VFU(float *a)
-{ // Load 8 floats from a and combine a[0],a[2],a[4] and a[6] into a vector of 4 floats
-  vfloat a1 = _mm_loadu_ps(a);
-  vfloat a2 = _mm_loadu_ps((a) + 4);
-  return _mm_shuffle_ps(a1, a2, _MM_SHUFFLE(2, 0, 2, 0));
-}
-static INLINE vfloat vcast_vf_f(float f)
-{
-  return _mm_set_ps(f, f, f, f);
-}
-static INLINE vmask vorm(vmask x, vmask y)
-{
-  return _mm_or_si128(x, y);
-}
-static INLINE vmask vandm(vmask x, vmask y)
-{
-  return _mm_and_si128(x, y);
-}
-static INLINE vmask vandnotm(vmask x, vmask y)
-{
-  return _mm_andnot_si128(x, y);
-}
-static INLINE vfloat vabsf(vfloat f)
-{
-  return (vfloat)vandnotm((vmask)vcast_vf_f(-0.0f), (vmask)f);
-}
-
-#ifdef __SSE4_1__
-// only one instruction when using SSE4.1
-static INLINE vfloat vself(vmask mask, vfloat x, vfloat y) {
-    return _mm_blendv_ps(y,x,(vfloat)mask);
-}
-
-#else
-// three instructions when using SSE2
-static INLINE vfloat vself(vmask mask, vfloat x, vfloat y) {
-    return (vfloat)vorm(vandm(mask, (vmask)x), vandnotm(mask, (vmask)y));
-}
-#endif
-
-static INLINE vmask vmaskf_lt(vfloat x, vfloat y)
-{
-  return (__m128i)_mm_cmplt_ps(x, y);
-}
-static INLINE vfloat vintpf(vfloat a, vfloat b, vfloat c)
-{
-  return a * (b - c) + c;
-}
-static INLINE vfloat vmaxf(vfloat x, vfloat y)
-{
-  return _mm_max_ps(x, y);
-}
-static INLINE vfloat vminf(vfloat x, vfloat y)
-{
-  return _mm_min_ps(x, y);
-}
-#endif
-
 static INLINE float intp(float a, float b, float c)
-{
+{   // taken from rt code
     // calculate a * b + (1 - a) * c
     // following is valid:
     // intp(a, b+x, c+x) = intp(a, b, c) + x
@@ -179,7 +88,10 @@ static INLINE float safe_in(float a, float scale)
   return fmaxf(0.0f, a) * scale;
 }
 
-/* End of macros and inline functions taken from amaze_demosaic_RT */
+static INLINE float sqrf(float a)
+{
+  return a * a;
+}
 
 // The border interpolation has been taken from rt, adapted to dt.
 // The original dcraw based code had much stronger color artefacts in the border region. 
@@ -329,10 +241,14 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
     memset(PQ_Dir, 0, sizeof(*PQ_Dir) * (RCD_TILESIZE * RCD_TILESIZE / 2));
     float *const cfa =    dt_alloc_align_float((size_t) RCD_TILESIZE * RCD_TILESIZE);
     memset(cfa, 0, sizeof(*cfa) * RCD_TILESIZE * RCD_TILESIZE);
+    float *const P_CDiff_Hpf = dt_alloc_align_float((size_t) RCD_TILESIZE * RCD_TILESIZE / 2);
+    memset(P_CDiff_Hpf, 0, sizeof(*P_CDiff_Hpf) * RCD_TILESIZE * RCD_TILESIZE / 2);
+    float *const Q_CDiff_Hpf = dt_alloc_align_float((size_t) RCD_TILESIZE * RCD_TILESIZE / 2);
+    memset(Q_CDiff_Hpf, 0, sizeof(*Q_CDiff_Hpf) * RCD_TILESIZE * RCD_TILESIZE / 2);  
+ 
     float (*const rgb)[RCD_TILESIZE * RCD_TILESIZE] = (void *)dt_alloc_align_float((size_t)3 * RCD_TILESIZE * RCD_TILESIZE);
 
-    // No overlapping use so re-use same buffer; also note we use divide-by-2 index for lower mem pressure
-    // this divide-by-2 also allows slightly faster sse2 specific code.
+    // No overlapping use so re-use same buffer
     float *const lpf = PQ_Dir;
 
     // There has been a discussion about the schedule strategy, at least on the tested machines the
@@ -375,54 +291,52 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         }
 
         // STEP 1: Find vertical and horizontal interpolation directions
-        // Step 1.1: Calculate vertical and horizontal local discrimination
-        for(int row = 4; row < tileRows - 4; row++)
+        float bufferV[3][RCD_TILESIZE - 8];
+        // Step 1.1: Calculate the square of the vertical and horizontal color difference high pass filter
+        for(int row = 3; row < MIN(tileRows - 3, 5); row++ )
         {
-          for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++)
+          for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
-            const float V_Stat = fmaxf(epssq,
-               -2.0f * (cfa[indx]) * (9.f * (cfa[indx - w1] + cfa[indx + w1] - cfa[indx - w3] - cfa[indx + w3] + 2.0f * (cfa[indx - w2] + cfa[indx + w2]) ) + cfa[indx - w4] + cfa[indx + w4] - 19.f * cfa[indx])
-              - 70.f * cfa[indx - w1] * cfa[indx + w1]
-              - 12.f * (cfa[indx - w1] * cfa[indx - w2] - cfa[indx - w1] * cfa[indx - w4] + cfa[indx + w1] * cfa[indx + w2] - cfa[indx + w1] * cfa[indx + w4] + cfa[indx - w2] * cfa[indx + w3] + cfa[indx + w2] * cfa[indx - w3])
-              + 24.f * (cfa[indx - w1] * cfa[indx + w2] + cfa[indx + w1] * cfa[indx - w2])
-              + 16.f * (cfa[indx - w1] * cfa[indx + w3] + cfa[indx + w1] * cfa[indx - w3])
-              - 6.f * (cfa[indx + w4] * (cfa[indx - w1] + cfa[indx + w3]) + cfa[indx - w4] * (cfa[indx + w1] + cfa[indx - w3]))
-              + 46.f * (cfa[indx - w1] * cfa[indx - w1] + cfa[indx + w1] * cfa[indx + w1])
-              - 38.f * (cfa[indx + w1] * cfa[indx + w3] + cfa[indx - w1] * cfa[indx - w3])
-              + 14.f * cfa[indx - w2] * cfa[indx + w2]
-              - 2.0f * ((cfa[indx - w2] - cfa[indx + w2]) * (cfa[indx - w4] - cfa[indx + w4]) - cfa[indx - w3] * cfa[indx + w3])
-              + 11.f * (cfa[indx - w2] * cfa[indx - w2] + cfa[indx + w2] * cfa[indx + w2])
-              + 10.f * (cfa[indx - w3] * cfa[indx - w3] + cfa[indx + w3] * cfa[indx + w3])
-              + cfa[indx - w4] * cfa[indx - w4]
-              + cfa[indx + w4] * cfa[indx + w4]
-              );
-
-            const float cfai = cfa[indx];
-            const float H_Stat = fmaxf(epssq,
-                -18.f * cfai * (cfa[indx -  1] + cfa[indx +  1] + 2.0f * (cfa[indx -  2] + cfa[indx +  2]) - cfa[indx -  3] - cfa[indx +  3])
-                - 2.0f * cfai * (cfa[indx -  4] + cfa[indx +  4] - 19.f * cfai)
-                - cfa[indx -  1] * (70.f * cfa[indx +  1] + 12.f * (cfa[indx -  2] - cfa[indx -  4] - 2.0f * cfa[indx +  2]) + 38.f * cfa[indx -  3] - 16.f * cfa[indx +  3] + 6.f * cfa[indx +  4] - 46.f * cfa[indx -  1])
-                + cfa[indx +  1] * (24.f * cfa[indx -  2] + 12.f * (cfa[indx +  4] - cfa[indx +  2]) + 16.f * cfa[indx -  3] - 38.f * cfa[indx +  3] -  6.f * cfa[indx -  4] + 46.f * cfa[indx +  1])
-                + cfa[indx -  2] * (14.f * cfa[indx +  2] - 12.f * cfa[indx +  3] - 2.0f * cfa[indx -  4] + 2.0f * cfa[indx +  4] + 11.f * cfa[indx -  2])
-                + cfa[indx +  2] * (-12.f * cfa[indx -  3] + 2.0f * (cfa[indx -  4] - cfa[indx +  4]) + 11.f * cfa[indx +  2])
-                + cfa[indx -  3] * (2.0f * cfa[indx +  3] - 6.f * cfa[indx -  4] + 10.f * cfa[indx -  3])
-                + cfa[indx +  3] * (-6.f * cfa[indx +  4] + 10.f * cfa[indx +  3])
-                + cfa[indx -  4] * cfa[indx -  4]
-                + cfa[indx +  4] * cfa[indx +  4]);
-            VH_Dir[indx] = V_Stat / (V_Stat + H_Stat);
+            bufferV[row - 3][col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
+        }
+
+        // Step 1.2: Obtain the vertical and horizontal directional discrimination strength
+        float bufferH[RCD_TILESIZE] __attribute__((aligned(0x10)));
+        // We start with V0, V1 and V2 pointing to row -1, row and row +1
+        // After row is processed V0 must point to the old V1, V1 must point to the old V2 and V2 must point to the old V0
+        // because the old V0 is not used anymore and will be filled with row + 1 data in next iteration
+        float* V0 = bufferV[0];
+        float* V1 = bufferV[1];
+        float* V2 = bufferV[2];
+        for(int row = 4; row < tileRows - 4; row++ )
+        {
+          for(int col = 3, indx = row * RCD_TILESIZE + col; col < tileCols - 3; col++, indx++)
+          {
+            bufferH[col - 3] = sqrf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
+          }
+          for(int col = 4, indx = (row + 1) * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++)
+          {
+            V2[col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+          }
+          for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
+          {
+            float V_Stat = fmaxf(epssq,      V0[col - 4] +      V1[col - 4] +      V2[col - 4]);
+            float H_Stat = fmaxf(epssq, bufferH[col - 4] + bufferH[col - 3] + bufferH[col - 2]);
+            VH_Dir[indx] = V_Stat / ( V_Stat + H_Stat );
+          }
+          float* tmp = V0; V0 = V1; V1 = V2; V2 = tmp;
         }
 
         // STEP 2: Calculate the low pass filter
         // Step 2.1: Low pass filter incorporating green, red and blue local samples from the raw data
-        // as an index>>1 access breaks proper vectorizing we use an extra index for the lpf results
         for(int row = 2; row < tileRows - 2; row++)
         {
           for(int col = 2 + (FCRCD(row, 0) & 1), indx = row * RCD_TILESIZE + col, lp_indx = indx / 2; col < tileCols - 2; col += 2, indx +=2, lp_indx++)
           {
-            lpf[lp_indx] = 0.25f * cfa[indx]
-                        + 0.125f * (cfa[indx - w1] + cfa[indx + w1] + cfa[indx - 1] + cfa[indx + 1])
-                       + 0.0625f * (cfa[indx - w1 - 1] + cfa[indx - w1 + 1] + cfa[indx + w1 - 1] + cfa[indx + w1 + 1]);
+            lpf[lp_indx] = cfa[indx]
+                        + 0.5f * (cfa[indx - w1]     + cfa[indx + w1] +     cfa[indx - 1] +      cfa[indx + 1])
+                       + 0.25f * (cfa[indx - w1 - 1] + cfa[indx - w1 + 1] + cfa[indx + w1 - 1] + cfa[indx + w1 + 1]);
           }
         }
 
@@ -430,46 +344,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         // Step 3.1: Populate the green channel at blue and red CFA positions
         for(int row = 4; row < tileRows - 4; row++)
         {
-          int col = 4 + (FCRCD(row, 0) & 1);
-          int indx = row * RCD_TILESIZE + col;
-          int lp_indx = indx / 2;
-          // There has been quite some performance testing for the generic vs. SSE2 optimized loop, as the generated generic code (-O3)
-          // is not as fast as Ingos optmized code (~4% loss) we keep the SSE2 specific path.
-#ifdef __SSE2__
-          const vfloat zd5v = F2V(0.5f);
-          const vfloat zd25v = F2V(0.25f);
-          const vfloat epsv = F2V(eps);
-          for (; col < tileCols - 7; col += 8, indx += 8, lp_indx +=4)
-          {
-            // Cardinal gradients
-            const vfloat cfai = LC2VFU(&cfa[indx]);
-            const vfloat N_Grad = epsv + (vabsf(LC2VFU(&cfa[indx - w1]) - LC2VFU(&cfa[indx + w1])) + vabsf(cfai - LC2VFU(&cfa[indx - w2]))) + (vabsf(LC2VFU(&cfa[indx - w1]) - LC2VFU(&cfa[indx - w3])) + vabsf(LC2VFU(&cfa[indx - w2]) - LC2VFU(&cfa[indx - w4])));
-            const vfloat S_Grad = epsv + (vabsf(LC2VFU(&cfa[indx - w1]) - LC2VFU(&cfa[indx + w1])) + vabsf(cfai - LC2VFU(&cfa[indx + w2]))) + (vabsf(LC2VFU(&cfa[indx + w1]) - LC2VFU(&cfa[indx + w3])) + vabsf(LC2VFU(&cfa[indx + w2]) - LC2VFU(&cfa[indx + w4])));
-            const vfloat W_Grad = epsv + (vabsf(LC2VFU(&cfa[indx -  1]) - LC2VFU(&cfa[indx +  1])) + vabsf(cfai - LC2VFU(&cfa[indx -  2]))) + (vabsf(LC2VFU(&cfa[indx -  1]) - LC2VFU(&cfa[indx -  3])) + vabsf(LC2VFU(&cfa[indx -  2]) - LC2VFU(&cfa[indx -  4])));
-            const vfloat E_Grad = epsv + (vabsf(LC2VFU(&cfa[indx +  1]) - LC2VFU(&cfa[indx -  1])) + vabsf(cfai - LC2VFU(&cfa[indx +  2]))) + (vabsf(LC2VFU(&cfa[indx +  1]) - LC2VFU(&cfa[indx +  3])) + vabsf(LC2VFU(&cfa[indx +  2]) - LC2VFU(&cfa[indx +  4])));
-
-            // Cardinal pixel estimations
-            const vfloat lpfi = LVFU(lpf[lp_indx]);
-            const vfloat N_Est = LC2VFU(&cfa[indx - w1]) + (LC2VFU(&cfa[indx - w1]) * (lpfi - LVFU(lpf[lp_indx - w1])) / (epsv + lpfi + LVFU(lpf[lp_indx - w1])));
-            const vfloat S_Est = LC2VFU(&cfa[indx + w1]) + (LC2VFU(&cfa[indx + w1]) * (lpfi - LVFU(lpf[lp_indx + w1])) / (epsv + lpfi + LVFU(lpf[lp_indx + w1])));
-            const vfloat W_Est = LC2VFU(&cfa[indx -  1]) + (LC2VFU(&cfa[indx -  1]) * (lpfi - LVFU(lpf[lp_indx -  1])) / (epsv + lpfi + LVFU(lpf[lp_indx -  1])));
-            const vfloat E_Est = LC2VFU(&cfa[indx +  1]) + (LC2VFU(&cfa[indx +  1]) * (lpfi - LVFU(lpf[lp_indx +  1])) / (epsv + lpfi + LVFU(lpf[lp_indx +  1])));
-
-            // Vertical and horizontal estimations
-            const vfloat V_Est = (S_Grad * N_Est + N_Grad * S_Est) / (N_Grad + S_Grad);
-            const vfloat H_Est = (W_Grad * E_Est + E_Grad * W_Est) / (E_Grad + W_Grad);
-
-            // G@B and G@R interpolation
-            // Refined vertical and horizontal local discrimination
-            const vfloat VH_Central_Value = LC2VFU(&VH_Dir[indx]);
-            const vfloat VH_Neighbourhood_Value = zd25v * ((LC2VFU(&VH_Dir[indx - w1 - 1]) + LC2VFU(&VH_Dir[indx - w1 + 1])) + (LC2VFU(&VH_Dir[indx + w1 - 1]) + LC2VFU(&VH_Dir[indx + w1 + 1])));
-
-            const vfloat VH_Disc = vself(vmaskf_lt(vabsf(zd5v - VH_Central_Value), vabsf(zd5v - VH_Neighbourhood_Value)), VH_Neighbourhood_Value, VH_Central_Value);
-            const vfloat result = vintpf(VH_Disc, H_Est, V_Est);
-            STC2VFU(rgb[1][indx], result);
-          }
-#endif
-          for(; col < tileCols - 4; col += 2, indx +=2, lp_indx++)
+          for(int col = 4 + (FCRCD(row, 0) & 1), indx = row * RCD_TILESIZE + col, lpindx = indx / 2; col < tileCols - 4; col += 2, indx += 2, lpindx++)
           {
             const float cfai = cfa[indx];
 
@@ -477,14 +352,14 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
             const float N_Grad = eps + fabs(cfa[indx - w1] - cfa[indx + w1]) + fabs(cfai - cfa[indx - w2]) + fabs(cfa[indx - w1] - cfa[indx - w3]) + fabs(cfa[indx - w2] - cfa[indx - w4]);
             const float S_Grad = eps + fabs(cfa[indx - w1] - cfa[indx + w1]) + fabs(cfai - cfa[indx + w2]) + fabs(cfa[indx + w1] - cfa[indx + w3]) + fabs(cfa[indx + w2] - cfa[indx + w4]);
             const float W_Grad = eps + fabs(cfa[indx -  1] - cfa[indx +  1]) + fabs(cfai - cfa[indx -  2]) + fabs(cfa[indx -  1] - cfa[indx -  3]) + fabs(cfa[indx -  2] - cfa[indx -  4]);
-            const float E_Grad = eps + fabs(cfa[indx +  1] - cfa[indx -  1]) + fabs(cfai - cfa[indx +  2]) + fabs(cfa[indx +  1] - cfa[indx +  3]) + fabs(cfa[indx +  2] - cfa[indx +  4]);
+            const float E_Grad = eps + fabs(cfa[indx -  1] - cfa[indx +  1]) + fabs(cfai - cfa[indx +  2]) + fabs(cfa[indx +  1] - cfa[indx +  3]) + fabs(cfa[indx +  2] - cfa[indx +  4]);
 
-            const float lpfi = lpf[lp_indx];
             // Cardinal pixel estimations
-            const float N_Est = cfa[indx - w1] + (cfa[indx - w1] * (lpfi - lpf[lp_indx - w1]) / (eps + lpfi + lpf[lp_indx - w1]));
-            const float S_Est = cfa[indx + w1] + (cfa[indx + w1] * (lpfi - lpf[lp_indx + w1]) / (eps + lpfi + lpf[lp_indx + w1]));
-            const float W_Est = cfa[indx -  1] + (cfa[indx -  1] * (lpfi - lpf[lp_indx -  1]) / (eps + lpfi + lpf[lp_indx -  1]));
-            const float E_Est = cfa[indx +  1] + (cfa[indx +  1] * (lpfi - lpf[lp_indx +  1]) / (eps + lpfi + lpf[lp_indx +  1]));
+            const float lpfi = lpf[lpindx];
+            const float N_Est = cfa[indx - w1] * (lpfi + lpfi) / (eps + lpfi + lpf[lpindx - w1]);
+            const float S_Est = cfa[indx + w1] * (lpfi + lpfi) / (eps + lpfi + lpf[lpindx + w1]);
+            const float W_Est = cfa[indx -  1] * (lpfi + lpfi) / (eps + lpfi + lpf[lpindx -  1]);
+            const float E_Est = cfa[indx +  1] * (lpfi + lpfi) / (eps + lpfi + lpf[lpindx +  1]);
 
             // Vertical and horizontal estimations
             const float V_Est = (S_Grad * N_Est + N_Grad * S_Est) / (N_Grad + S_Grad);
@@ -501,17 +376,24 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         }
 
         // STEP 4: Populate the red and blue channels
-        // Step 4.1: Calculate P/Q diagonal local discrimination
+
+        // Step 4.0: Calculate the square of the P/Q diagonals color difference high pass filter
+        for(int row = 3; row < tileRows - 3; row++)
+        {
+          for(int col = 3, indx = row * RCD_TILESIZE + col, indx2 = indx / 2; col < tileCols - 3; col+=2, indx+=2, indx2++)
+          {
+            P_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
+            Q_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
+          }
+        }
+        // Step 4.1: Obtain the P/Q diagonals directional discrimination strength
         for(int row = 4; row < tileRows - 4; row++)
         {
-          for(int col = 4 + (FCRCD(row, 0) & 1), indx = row * RCD_TILESIZE + col, pqindx = indx / 2; col < tileCols - 4; col += 2, indx += 2, pqindx++)
+          for(int col = 4 + (FCRCD(row, 0) & 1), indx = row * RCD_TILESIZE + col, indx2 = indx / 2, indx3 = (indx - w1 - 1) / 2, indx4 = (indx + w1 - 1) / 2; col < tileCols - 4; col += 2, indx += 2, indx2++, indx3++, indx4++ )
           {
-            const float cfai = cfa[indx];
-
-            float P_Stat = fmaxf(epssq, - 18.f * cfai * (cfa[indx - w1 - 1] + cfa[indx + w1 + 1] + 2.f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) - cfa[indx - w3 - 3] - cfa[indx + w3 + 3]) - 2.f * cfai * (cfa[indx - w4 - 4] + cfa[indx + w4 + 4] - 19.f * cfai) - cfa[indx - w1 - 1] * (70.f * cfa[indx + w1 + 1] - 12.f * cfa[indx - w2 - 2] + 24.f * cfa[indx + w2 + 2] - 38.f * cfa[indx - w3 - 3] + 16.f * cfa[indx + w3 + 3] + 12.f * cfa[indx - w4 - 4] - 6.f * cfa[indx + w4 + 4] + 46.f * cfa[indx - w1 - 1]) + cfa[indx + w1 + 1] * (24.f * cfa[indx - w2 - 2] - 12.f * cfa[indx + w2 + 2] + 16.f * cfa[indx - w3 - 3] - 38.f * cfa[indx + w3 + 3] - 6.f * cfa[indx - w4 - 4] + 12.f * cfa[indx + w4 + 4] + 46.f * cfa[indx + w1 + 1]) + cfa[indx - w2 - 2] * (14.f * cfa[indx + w2 + 2] - 12.f * cfa[indx + w3 + 3] - 2.f * (cfa[indx - w4 - 4] - cfa[indx + w4 + 4]) + 11.f * cfa[indx - w2 - 2]) - cfa[indx + w2 + 2] * (12.f * cfa[indx - w3 - 3] + 2.f * (cfa[indx - w4 - 4] - cfa[indx + w4 + 4]) + 11.f * cfa[indx + w2 + 2]) + cfa[indx - w3 - 3] * (2.f * cfa[indx + w3 + 3] - 6.f * cfa[indx - w4 - 4] + 10.f * cfa[indx - w3 - 3]) - cfa[indx + w3 + 3] * (6.f * cfa[indx + w4 + 4] + 10.f * cfa[indx + w3 + 3]) + cfa[indx - w4 - 4] * cfa[indx - w4 - 4] + cfa[indx + w4 + 4] * cfa[indx + w4 + 4]);
-            float Q_Stat = fmaxf(epssq, - 18.f * cfai * (cfa[indx + w1 - 1] + cfa[indx - w1 + 1] + 2.f * (cfa[indx + w2 - 2] + cfa[indx - w2 + 2]) - cfa[indx + w3 - 3] - cfa[indx - w3 + 3]) - 2.f * cfai * (cfa[indx + w4 - 4] + cfa[indx - w4 + 4] - 19.f * cfai) - cfa[indx + w1 - 1] * (70.f * cfa[indx - w1 + 1] - 12.f * cfa[indx + w2 - 2] + 24.f * cfa[indx - w2 + 2] - 38.f * cfa[indx + w3 - 3] + 16.f * cfa[indx - w3 + 3] + 12.f * cfa[indx + w4 - 4] - 6.f * cfa[indx - w4 + 4] + 46.f * cfa[indx + w1 - 1]) + cfa[indx - w1 + 1] * (24.f * cfa[indx + w2 - 2] - 12.f * cfa[indx - w2 + 2] + 16.f * cfa[indx + w3 - 3] - 38.f * cfa[indx - w3 + 3] - 6.f * cfa[indx + w4 - 4] + 12.f * cfa[indx - w4 + 4] + 46.f * cfa[indx - w1 + 1]) + cfa[indx + w2 - 2] * (14.f * cfa[indx - w2 + 2] - 12.f * cfa[indx - w3 + 3] - 2.f * (cfa[indx + w4 - 4] - cfa[indx - w4 + 4]) + 11.f * cfa[indx + w2 - 2]) - cfa[indx - w2 + 2] * (12.f * cfa[indx + w3 - 3] + 2.f * (cfa[indx + w4 - 4] - cfa[indx - w4 + 4]) + 11.f * cfa[indx - w2 + 2]) + cfa[indx + w3 - 3] * (2.f * cfa[indx - w3 + 3] - 6.f * cfa[indx + w4 - 4] + 10.f * cfa[indx + w3 - 3]) - cfa[indx - w3 + 3] * (6.f * cfa[indx - w4 + 4] + 10.f * cfa[indx - w3 + 3]) + cfa[indx + w4 - 4] * cfa[indx + w4 - 4] + cfa[indx - w4 + 4] * cfa[indx - w4 + 4]);
-
-            PQ_Dir[pqindx] = P_Stat / (P_Stat + Q_Stat);
+            float P_Stat = fmaxf(epssq, P_CDiff_Hpf[indx3]     + P_CDiff_Hpf[indx2] + P_CDiff_Hpf[indx4 + 1]);
+            float Q_Stat = fmaxf(epssq, Q_CDiff_Hpf[indx3 + 1] + Q_CDiff_Hpf[indx2] + Q_CDiff_Hpf[indx4]);
+            PQ_Dir[indx2] = P_Stat / (P_Stat + Q_Stat);
           }
         }
 
@@ -577,8 +459,8 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
               // Cardinal gradients
               const float N_Grad = N1 + fabs(rgbc_mw1 - rgbc_pw1) + fabs(rgbc_mw1 - rgb[c][indx - w3]);
               const float S_Grad = S1 + fabs(rgbc_pw1 - rgbc_mw1) + fabs(rgbc_pw1 - rgb[c][indx + w3]);
-              const float W_Grad = W1 + fabs(rgbc_m1 - rgbc_p1) + fabs(rgbc_m1 - rgb[c][indx -  3]);
-              const float E_Grad = E1 + fabs(rgbc_p1 - rgbc_m1) + fabs(rgbc_p1 - rgb[c][indx +  3]);
+              const float W_Grad = W1 + fabs(rgbc_m1  - rgbc_p1)  + fabs(rgbc_m1  - rgb[c][indx -  3]);
+              const float E_Grad = E1 + fabs(rgbc_p1  - rgbc_m1)  + fabs(rgbc_p1  - rgb[c][indx +  3]);
 
               // Cardinal colour differences
               const float N_Est = rgbc_mw1 - rgb1mw1;
@@ -591,7 +473,6 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
               const float H_Est = (E_Grad * W_Est + W_Grad * E_Est) / (E_Grad + W_Grad);
 
               // R@G and B@G interpolation
-//            rgb[c][indx] = rgb1 + (1.f - VH_Disc) * V_Est + VH_Disc * H_Est;
               rgb[c][indx] = rgb1 + intp(VH_Disc, H_Est, V_Est);
             }
           }
@@ -620,6 +501,8 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
     dt_free_align(rgb);
     dt_free_align(VH_Dir);
     dt_free_align(PQ_Dir);
+    dt_free_align(P_CDiff_Hpf);
+    dt_free_align(Q_CDiff_Hpf);
   }
 
   rcd_border_interpolate(out, in, cfarray, width, height, RCD_MARGIN, scaler);

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -279,7 +279,6 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         // Step 0: fill data and make sure data are not negative.
         for(int row = rowStart; row < rowEnd; row++)
         {
-          
           int indx = (row - rowStart) * RCD_TILESIZE;
           int in_indx = (row * width + colStart);
           const int c0 = FCRCD(row, colStart);


### PR DESCRIPTION
In collaboration with @heckflosse from rawtherapee and (https://github.com/LuisSR/RCD-Demosaicing) we made some
changes to rcd demosaic.

Advantages are:
1. Slightly faster code
2. Got rid of SSE specific code path, at least for gcc the vectorized code is now as good as the old sse specific code.
3. Almost all demosaicing code is as it is currently tested for rt

The principal maths from Luis Sanz Rodríguez has not been changed, it's just done in a faster way.

As Ingo has pointed out there are some green artefacts in outer 5th  col/row we still should use a border approximation of 6.