### PR TITLE
homography: use single precision floats at interfaces

### DIFF
--- a/src/chart/common.c
+++ b/src/chart/common.c
@@ -20,25 +20,27 @@
 #include "iop/gaussian_elimination.h"
 
 // using SVD to solve the system with h[8] also being 0 would be better, but this seems to be good enough
-int get_homography(const point_t *source, const point_t *target, double *h)
+int get_homography(const point_t *source, const point_t *target, float *h)
 {
-  const float x1 = source[0].x;
-  const float y1 = source[0].y;
-  const float x2 = source[1].x;
-  const float y2 = source[1].y;
-  const float x3 = source[2].x;
-  const float y3 = source[2].y;
-  const float x4 = source[3].x;
-  const float y4 = source[3].y;
+  // Use double precision internally when solving for the homography
+  // to avoid numerical instabilities.
+  const double x1 = source[0].x;
+  const double y1 = source[0].y;
+  const double x2 = source[1].x;
+  const double y2 = source[1].y;
+  const double x3 = source[2].x;
+  const double y3 = source[2].y;
+  const double x4 = source[3].x;
+  const double y4 = source[3].y;
 
-  const float x_1 = target[0].x;
-  const float y_1 = target[0].y;
-  const float x_2 = target[1].x;
-  const float y_2 = target[1].y;
-  const float x_3 = target[2].x;
-  const float y_3 = target[2].y;
-  const float x_4 = target[3].x;
-  const float y_4 = target[3].y;
+  const double x_1 = target[0].x;
+  const double y_1 = target[0].y;
+  const double x_2 = target[1].x;
+  const double y_2 = target[1].y;
+  const double x_3 = target[2].x;
+  const double y_3 = target[2].y;
+  const double x_4 = target[3].x;
+  const double y_4 = target[3].y;
 
   double P[9*9] = { -x1, -y1, -1.0, 0.0, 0.0,  0.0, x1 * x_1, y1 * x_1, x_1,
                     0.0, 0.0,  0.0, -x1, -y1, -1.0, x1 * y_1, y1 * y_1, y_1,
@@ -50,38 +52,42 @@ int get_homography(const point_t *source, const point_t *target, double *h)
                     0.0, 0.0,  0.0, -x4, -y4, -1.0, x4 * y_4, y4 * y_4, y_4,
                     0.0, 0.0,  0.0, 0.0, 0.0,  0.0,      0.0,      0.0, 1.0};
 
-  for(int i = 0; i < 8; i++) h[i] = 0.0;
-  h[8] = 1.0;
+  double h_tmp[9];
+  for(int i = 0; i < 8; i++) h_tmp[i] = 0.0;
+  h_tmp[8] = 1.0;
 
-  return gauss_solve(P, h, 9);
+  int err_code = gauss_solve(P, h_tmp, 9);
+  if(err_code) for(int i = 0; i < 9; i++) h[i] = h_tmp[i];
+  return err_code;
 }
 
-point_t apply_homography(point_t p, const double *h)
+point_t apply_homography(point_t p, const float *h)
 {
-  const double s =  p.x * h[2 * 3 + 0] + p.y * h[2 * 3 + 1] + h[2 * 3 + 2];
-  const double x = (p.x * h[0 * 3 + 0] + p.y * h[0 * 3 + 1] + h[0 * 3 + 2]) / s;
-  const double y = (p.x * h[1 * 3 + 0] + p.y * h[1 * 3 + 1] + h[1 * 3 + 2]) / s;
+  const float s =  p.x * h[2 * 3 + 0] + p.y * h[2 * 3 + 1] + h[2 * 3 + 2];
+  const float x = (p.x * h[0 * 3 + 0] + p.y * h[0 * 3 + 1] + h[0 * 3 + 2]) / s;
+  const float y = (p.x * h[1 * 3 + 0] + p.y * h[1 * 3 + 1] + h[1 * 3 + 2]) / s;
 
   const point_t result = {.x=x, .y=y};
 
   return result;
 }
 
-double apply_homography_scaling(point_t p, const double *h)
+float apply_homography_scaling(point_t p, const float *h)
 {
   // The local scaling of areas by the homography mapping is given by
   // the absolute value of its Jacobian determinant at point p.
-  const double x = p.x * h[0 * 3 + 0] + p.y * h[0 * 3 + 1] + h[0 * 3 + 2];
-  const double y = p.x * h[1 * 3 + 0] + p.y * h[1 * 3 + 1] + h[1 * 3 + 2];
-  const double s = p.x * h[2 * 3 + 0] + p.y * h[2 * 3 + 1] + h[2 * 3 + 2];
+  const float x = p.x * h[0 * 3 + 0] + p.y * h[0 * 3 + 1] + h[0 * 3 + 2];
+  const float y = p.x * h[1 * 3 + 0] + p.y * h[1 * 3 + 1] + h[1 * 3 + 2];
+  const float s = p.x * h[2 * 3 + 0] + p.y * h[2 * 3 + 1] + h[2 * 3 + 2];
 
   // Components of the Jacobian matrix, without division by s^2, which is factored
   // out and done for the whole determinant.
-  const double J00 = h[0 * 3 + 0] * s - h[2 * 3 + 0] * x;
-  const double J01 = h[0 * 3 + 1] * s - h[2 * 3 + 1] * x;
-  const double J10 = h[1 * 3 + 0] * s - h[2 * 3 + 0] * y;
-  const double J11 = h[1 * 3 + 1] * s - h[2 * 3 + 1] * y;
-  return fabs(J00 * J11 - J01 * J10) / (s * s * s * s);
+  const float J00 = h[0 * 3 + 0] * s - h[2 * 3 + 0] * x;
+  const float J01 = h[0 * 3 + 1] * s - h[2 * 3 + 1] * x;
+  const float J10 = h[1 * 3 + 0] * s - h[2 * 3 + 0] * y;
+  const float J11 = h[1 * 3 + 1] * s - h[2 * 3 + 1] * y;
+  const float s2 = s * s;
+  return fabsf(J00 * J11 - J01 * J10) / (s2 * s2);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/chart/common.h
+++ b/src/chart/common.h
@@ -46,10 +46,10 @@ typedef struct image_t
   gboolean draw_colored;
 } image_t;
 
-int get_homography(const point_t *source, const point_t *target, double *h);
-point_t apply_homography(point_t p, const double *h);
+int get_homography(const point_t *source, const point_t *target, float *h);
+point_t apply_homography(point_t p, const float *h);
 // Gives a factor of scaling areas at point p
-double apply_homography_scaling(point_t p, const double *h);
+float apply_homography_scaling(point_t p, const float *h);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/chart/dtcairo.c
+++ b/src/chart/dtcairo.c
@@ -46,7 +46,7 @@ void draw_cross(cairo_t *cr, point_t center)
   cairo_line_to(cr, center.x, center.y + 10);
 }
 
-void draw_box(cairo_t *cr, box_t box, const double *homography)
+void draw_box(cairo_t *cr, box_t box, const float *homography)
 {
   point_t p[4];
   p[TOP_LEFT] = p[TOP_RIGHT] = p[BOTTOM_RIGHT] = p[BOTTOM_LEFT] = box.p;
@@ -89,7 +89,7 @@ void draw_boundingbox(cairo_t *cr, point_t *bb)
   for(int i = 0; i < 4; i++) draw_line(cr, bb[i], bb[(i + 1) % 4]);
 }
 
-void draw_f_boxes(cairo_t *cr, const double *homography, chart_t *chart)
+void draw_f_boxes(cairo_t *cr, const float *homography, chart_t *chart)
 {
   GList *iter = chart->f_list;
   while(iter)
@@ -104,7 +104,7 @@ void draw_f_boxes(cairo_t *cr, const double *homography, chart_t *chart)
   }
 }
 
-static void _draw_boxes(cairo_t *cr, const double *homography, GHashTable *table)
+static void _draw_boxes(cairo_t *cr, const float *homography, GHashTable *table)
 {
   GHashTableIter table_iter;
   gpointer key, value;
@@ -117,17 +117,17 @@ static void _draw_boxes(cairo_t *cr, const double *homography, GHashTable *table
   }
 }
 
-void draw_d_boxes(cairo_t *cr, const double *homography, chart_t *chart)
+void draw_d_boxes(cairo_t *cr, const float *homography, chart_t *chart)
 {
   _draw_boxes(cr, homography, chart->d_table);
 }
 
-void draw_color_boxes_outline(cairo_t *cr, const double *homography, chart_t *chart)
+void draw_color_boxes_outline(cairo_t *cr, const float *homography, chart_t *chart)
 {
   _draw_boxes(cr, homography, chart->box_table);
 }
 
-void draw_color_boxes_inside(cairo_t *cr, const double *homography, chart_t *chart, float shrink, float line_width,
+void draw_color_boxes_inside(cairo_t *cr, const float *homography, chart_t *chart, float shrink, float line_width,
                                gboolean colored)
 {
   GHashTableIter table_iter;

--- a/src/chart/dtcairo.h
+++ b/src/chart/dtcairo.h
@@ -27,16 +27,16 @@
 void draw_no_image(cairo_t *cr, GtkWidget *widget);
 void draw_line(cairo_t *cr, point_t start, point_t end);
 void draw_cross(cairo_t *cr, point_t center);
-void draw_box(cairo_t *cr, box_t box, const double *homography);
+void draw_box(cairo_t *cr, box_t box, const float *homography);
 
 void clear_background(cairo_t *cr);
 void center_image(cairo_t *cr, image_t *image);
 void draw_image(cairo_t *cr, image_t *image);
 void draw_boundingbox(cairo_t *cr, point_t *bb);
-void draw_f_boxes(cairo_t *cr, const double *homography, chart_t *chart);
-void draw_d_boxes(cairo_t *cr, const double *homography, chart_t *chart);
-void draw_color_boxes_outline(cairo_t *cr, const double *homography, chart_t *chart);
-void draw_color_boxes_inside(cairo_t *cr, const double *homography, chart_t *chart, float shrink, float line_width,
+void draw_f_boxes(cairo_t *cr, const float *homography, chart_t *chart);
+void draw_d_boxes(cairo_t *cr, const float *homography, chart_t *chart);
+void draw_color_boxes_outline(cairo_t *cr, const float *homography, chart_t *chart);
+void draw_color_boxes_inside(cairo_t *cr, const float *homography, chart_t *chart, float shrink, float line_width,
                                gboolean colored);
 void stroke_boxes(cairo_t *cr, float line_width);
 

--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -92,7 +92,7 @@ static void collect_reference_patches_foreach(gpointer key, gpointer value, gpoi
 static box_t *find_patch(GHashTable *table, gpointer key);
 static void get_boundingbox(const image_t *const image, point_t *bb);
 static box_t get_sample_box(chart_t *chart, box_t *outer_box, float shrink);
-static void get_corners(const double *homography, box_t *box, point_t *corners);
+static void get_corners(const float *homography, box_t *box, point_t *corners);
 static void get_pixel_region(const image_t *const image, const point_t *const corners, int *x_start, int *y_start,
                              int *x_end, int *y_end);
 static void reset_bb(image_t *image);
@@ -136,7 +136,7 @@ static gboolean draw_image_callback(GtkWidget *widget, cairo_t *cr, gpointer use
 
   // draw overlay
   point_t bb[4];
-  double homography[9];
+  float homography[9];
   map_boundingbox_to_view(image, bb);
   // calculating the homography takes hardly any time, so we do it here instead of the move handler.
   // the benefits are that the window size is taken into account and image->bb can't disagree with the cached homography
@@ -1502,7 +1502,7 @@ static box_t *find_patch(GHashTable *table, gpointer key)
 static void get_xyz_sample_from_image(const image_t *const image, float shrink, box_t *box, float *xyz)
 {
   point_t bb[4];
-  double homography[9];
+  float homography[9];
   point_t corners[4];
   box_t inner_box;
   int x_start, y_start, x_end, y_end;
@@ -1578,7 +1578,7 @@ static box_t get_sample_box(chart_t *chart, box_t *outer_box, float shrink)
   return inner_box;
 }
 
-static void get_corners(const double *homography, box_t *box, point_t *corners)
+static void get_corners(const float *homography, box_t *box, point_t *corners)
 {
   corners[TOP_LEFT] = corners[TOP_RIGHT] = corners[BOTTOM_RIGHT] = corners[BOTTOM_LEFT] = box->p;
   corners[TOP_RIGHT].x += box->w;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -144,12 +144,12 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   dt_solving_strategy_t optimization;
   float safety_margin;
 
-  double homography[9*9];          // the perspective correction matrix
-  double inverse_homography[9*9];  // The inverse perspective correction matrix
-  gboolean run_profile;            // order a profiling at next pipeline recompute
-  gboolean run_validation;         // order a profile validation at next pipeline recompute
-  gboolean profile_ready;          // notify that a profile is ready to be applied
-  gboolean checker_ready;          // notify that a checker bounding box is ready to be used
+  float homography[9];          // the perspective correction matrix
+  float inverse_homography[9];  // The inverse perspective correction matrix
+  gboolean run_profile;         // order a profiling at next pipeline recompute
+  gboolean run_validation;      // order a profile validation at next pipeline recompute
+  gboolean profile_ready;       // notify that a profile is ready to be applied
+  gboolean checker_ready;       // notify that a checker bounding box is ready to be used
   float mix[3][4];
 
   GtkWidget *start_profiling;


### PR DESCRIPTION
Switch to `float` at the interfaces. For `get_homography()` we still use double precision to avoid numerical instabilities. Forward calculations (`apply_homography()` and `apply_homography_scaling()`) seem to be fine using floats internally. `channelmixerrgb` checker works still as expected, `darktable-chart` also seems to work according to brief testing.