### PR TITLE
Fix stars in all overlays

### DIFF
--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -153,8 +153,10 @@
 }
 
 /* Make inactive stars more discrete when not hovered */
-
-#thumb_star
+.dt_overlays_always #thumb_star,
+.dt_overlays_always_extended #thumb_star,
+.dt_overlays_mixed #thumb_star,
+.dt_overlays_hover_block #thumb_star
 {
   color: shade(@thumbnail_font_color, 1.5);
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2481,13 +2481,6 @@ spinbutton>button
   color: shade(@thumbnail_font_color, 1.1);
 }
 
-/* Make inactive stars more discrete when not hovered */
-
-#thumb_star
-{
-  color: shade(@thumbnail_font_color, 1.4);
-}
-
 /* Reset color icons to be hidden in following modes, including culling/preview overlays hover block*/
 .dt_overlays_none .dt_thumb_btn,
 .dt_overlays_none #thumb_main:hover .dt_thumb_btn,
@@ -2497,6 +2490,15 @@ spinbutton>button
 {
   color: transparent;
   background-color: transparent;
+}
+
+/* Make inactive stars more discrete when not hovered */
+.dt_overlays_always #thumb_star,
+.dt_overlays_always_extended #thumb_star,
+.dt_overlays_mixed #thumb_star,
+.dt_overlays_hover_block #thumb_star
+{
+  color: shade(@thumbnail_font_color, 1.4);
 }
 
 /* Set hover and selected color icons, extension name and text infos */


### PR DESCRIPTION
I've forgotten to check all overlays modes in lighttable. With my last PR, stars became visible in first overlays where they shouldn't be visible. This PR just fix that mistake.

For 3.4.1 (correct commit merged and integrated in 3.4.1)