### PR TITLE
Codebase fixes from static analysis reports

### DIFF
--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -297,7 +297,7 @@ static inline void dt_color_checker_get_coordinates(const dt_color_checker_t *co
 }
 
 // find a patch matching a name
-static inline const dt_color_checker_patch *const dt_color_checker_get_patch_by_name(const dt_color_checker_t *const target_checker,
+static inline const dt_color_checker_patch* dt_color_checker_get_patch_by_name(const dt_color_checker_t *const target_checker,
                                                                               const char *name, size_t *index)
 {
   size_t idx = -1;

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -250,7 +250,7 @@ void dt_exif_set_exiv2_taglist()
   }
 }
 
-const GList * const dt_exif_get_exiv2_taglist()
+const GList* dt_exif_get_exiv2_taglist()
 {
   if(!exiv2_taglist)
     dt_exif_set_exiv2_taglist();

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -31,7 +31,7 @@ void dt_exif_set_exiv2_taglist();
 
 /** get the list of available tags from Exvi2 */
 /** must not be freed */
-const GList * const dt_exif_get_exiv2_taglist();
+const GList* dt_exif_get_exiv2_taglist();
 
 /** read metadata from file with full path name, XMP data trumps IPTC data trumps EXIF data, store to image
  * struct. returns 0 on success. */

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -24,7 +24,7 @@ typedef struct _help_url
   char *url;
 } dt_help_url;
 
-dt_help_url db[] =
+dt_help_url urls_db[] =
 {
   {"ratings",                    "star_ratings_and_color_labels.html#star_ratings_and_color_labels"},
   {"filter",                     "filtering_and_sort_order.html#filtering_and_sort_order"},
@@ -151,8 +151,8 @@ char *dt_get_help_url(char *name)
 {
   if(name==NULL) return NULL;
 
-  for(int k=0; k< sizeof(db)/2/sizeof(char *); k++)
-    if(!strcmp(db[k].name, name)) return db[k].url;
+  for(int k=0; k< sizeof(urls_db)/2/sizeof(char *); k++)
+    if(!strcmp(urls_db[k].name, name)) return urls_db[k].url;
 
   return NULL;
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2267,10 +2267,10 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
   int pos2 = 1;
   while(modules)
   {
-    dt_iop_module_t *m = (dt_iop_module_t *)modules->data;
-    if((m != module) && (m->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(m->flags() & IOP_FLAGS_NO_MASKS))
+    dt_iop_module_t *other_mod = (dt_iop_module_t *)modules->data;
+    if((other_mod != module) && (other_mod->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(other_mod->flags() & IOP_FLAGS_NO_MASKS))
     {
-      dt_masks_form_t *grp = _group_from_module(m);
+      dt_masks_form_t *grp = _group_from_module(other_mod);
       if(grp)
       {
         if(nb == 0)
@@ -2278,7 +2278,7 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
           dt_bauhaus_combobox_add_aligned(combo, _("use same shapes as"), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
           cids[pos++] = 0; // nothing to do
         }
-        gchar *module_label = dt_history_item_get_name(m);
+        gchar *module_label = dt_history_item_get_name(other_mod);
         dt_bauhaus_combobox_add(combo, module_label);
         g_free(module_label);
         cids[pos++] = -1 * pos2;

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -122,7 +122,7 @@ void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd, GList **enabled, G
         *enabled = g_list_append(*enabled, GINT_TO_POINTER(num));
         if(update != NULL)
         {
-          if(uactive || num == -1)
+          if(uactive)
             *update = g_list_append(*update, GINT_TO_POINTER(update_num));
           else
             *update = g_list_append(*update, GINT_TO_POINTER(-1));

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -56,7 +56,7 @@ typedef struct dt_lib_export_metadata_t
   GList *taglist;
 } dt_lib_export_metadata_t;
 
-GList *dt_exif_get_exiv2_taglist();
+const GList *dt_exif_get_exiv2_taglist();
 
 // find a string on the list
 static gboolean find_metadata_iter_per_text(GtkTreeModel *model, GtkTreeIter *iter, gint col, const char *text)


### PR DESCRIPTION
This PR again changes nothing really ;)

1. Fix remaining unnecessary `const` qualifiers from function returns with pointer types.

Here's reasoning:
returninig `const char*` is fine, returning `char* const` is bad because it's not actually `const char*` (and the const qualifier gets discarded), so returning `const char* const` is weird in a way that one of qualifiers gets discarded

2. in `styles_dialog.c` there was check for `num == -1` which didn't make sense, since in enclosing `if` the branch was taken if `num > 0`
3. in `masks.c` the variable `m` hid param to function call and didn't explain what's going on, so changed that.
4. in `knight.c` couple vars hid global ones
5. in `usermanual_url` the global name `db` was "a bit short" so just to make the analyzer to shut up changed that to `urls_db`