### PR TITLE
Fix ungroup button and dt_grouping_remove_from_group

### DIFF
--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -77,8 +77,8 @@ int dt_grouping_remove_from_group(const int32_t image_id)
     }
     else
     {
-      //we've changed nothing, no point in raising signal, bail early
-      return img_group_id;
+      // no change was made, no point in raising signal, bailing early
+      return -1;
     }
   }
   else

--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -45,7 +45,7 @@ int dt_grouping_remove_from_group(const int32_t image_id)
   GList *imgs = NULL;
 
   const dt_image_t *img = dt_image_cache_get(darktable.image_cache, image_id, 'r');
-  int img_group_id = img->group_id;
+  const int img_group_id = img->group_id;
   dt_image_cache_read_release(darktable.image_cache, img);
   if(img_group_id == image_id)
   {
@@ -64,15 +64,22 @@ int dt_grouping_remove_from_group(const int32_t image_id)
       imgs = g_list_prepend(imgs, GINT_TO_POINTER(other_id));
     }
     sqlite3_finalize(stmt);
-
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.images SET group_id = ?1 WHERE group_id = ?2 AND id != ?3", -1, &stmt,
-                                NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, new_group_id);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, img_group_id);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, image_id);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+    if(new_group_id != -1)
+    {
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                  "UPDATE main.images SET group_id = ?1 WHERE group_id = ?2 AND id != ?3", -1, &stmt,
+                                  NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, new_group_id);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, img_group_id);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, image_id);
+      sqlite3_step(stmt);
+      sqlite3_finalize(stmt);
+    }
+    else
+    {
+      //we've changed nothing, no point in raising signal, bail early
+      return img_group_id;
+    }
   }
   else
   {

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -119,9 +119,9 @@ static void _ungroup_helper_function(void)
   {
     const int id = sqlite3_column_int(stmt, 0);
     const int new_group_id = dt_grouping_remove_from_group(id);
-    if(id != new_group_id)
+    if(new_group_id != -1)
     {
-      // new_group_id == imgid if image was ungrouped single image and no change to any group was made
+      // new_group_id == -1 if image to be ungrouped was a single image and no change to any group was made
       imgs = g_list_append(imgs, GINT_TO_POINTER(id));
     }
   }


### PR DESCRIPTION
Fixes #7888

As analyzed by @HansBull, the ungroup button behaviour + possible problems with `dt_grouping_remove_from_group` might have caused.

This commit fixes it by first making sure ungrouping has at least some sense for being enabled and then fixing behaviour of `dt_grouping_remove_from_group`