### PR TITLE
Improve debugging output for demosaic & pixelpipe

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -413,15 +413,24 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   GList *history = g_list_nth(dev->history, dev->history_end - 1);
-  if(history) dt_dev_pixelpipe_synch(pipe, dev, history);
+  if(history)
+  {
+    dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
+    dt_print(DT_DEBUG_PARAMS, "[pixelpipe] synch top history module `%s' for pipe %i\n", hist->module->op, pipe->type); 
+    dt_dev_pixelpipe_synch(pipe, dev, history);
+  }
+  else
+  {
+    dt_print(DT_DEBUG_PARAMS, "[pixelpipe] synch top history module missing error for pipe %i\n", pipe->type); 
+  }
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
 }
 
 void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev)
 {
-  dt_print(DT_DEBUG_PARAMS, "[pixelpipe] pipeline state changed for pipe %i\n", pipe->type);
-
   dt_pthread_mutex_lock(&dev->history_mutex);
+
+  dt_print(DT_DEBUG_PARAMS, "[pixelpipe] pipeline state changing for pipe %i, flag %i\n", pipe->type, pipe->changed);
   // case DT_DEV_PIPE_UNCHANGED: case DT_DEV_PIPE_ZOOMED:
   if(pipe->changed & DT_DEV_PIPE_TOP_CHANGED)
   {
@@ -1228,6 +1237,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   }
   if(cache_available)
   {
+    dt_print(DT_DEBUG_PARAMS, "[pixelpipe] dt_dev_pixelpipe_process_rec, cache available for pipe %i with hash %lu\n", pipe->type, (long unsigned int)hash);
     // if(module) printf("found valid buf pos %d in cache for module %s %s %lu\n", pos, module->op, pipe ==
     // dev->preview_pipe ? "[preview]" : "", hash);
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2980,6 +2980,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
       if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO) dt_free_align(in);
     }
+    if(info) dt_get_times(&end_time);
 
     if(scaled)
     {
@@ -3001,17 +3002,17 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     else
       dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                 piece->pipe->dsc.filters);
+    if(info) dt_get_times(&end_time);
   }
   if(data->color_smoothing)
     color_smoothing(o, roi_out, data->color_smoothing);
 
   if(info)
   {
-    dt_get_times(&end_time);
     const float mpixels = (roo.width * roo.height) / 1.0e6;
     const float tclock = end_time.clock - start_time.clock;
     const float uclock = end_time.user - start_time.user;
-    fprintf(stderr," process CPU `%s' %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us, smooth %i\n",
+    dt_print(DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF , "[demosaic] process CPU `%s' %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us, smooth %i\n",
         method2string(demosaicing_method), mpixels, tclock, uclock, mpixels / tclock, data->color_smoothing);
   }
 }
@@ -4971,7 +4972,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
     }
   }
 
-  dt_print(DT_DEBUG_DEMOSAIC, " committed parameters: method: `%s', smooth %i, green %i, CL %i, tiling %i\n",
+  dt_print(DT_DEBUG_DEMOSAIC, "[demosaic] committed parameters: method: `%s', smooth %i, green %i, CL %i, tiling %i\n",
       method2string(d->demosaicing_method), d->color_smoothing, d->green_eq, piece->process_cl_ready, piece->process_tiling_ready);
 }
 


### PR DESCRIPTION
1. for the pixelpipe we tell a valid cache has been found
2. for demosaic we have more precise timing (exclude scaling and color smoothing) and [demosaic]
   to be informative if there are more debug options switched on