### PR TITLE
fix smooth scrolling on macOS

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -654,8 +654,13 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event, int *delta_x
       // accumulate trackpad/touch scrolls until they make a unit
       // scroll, and only then tell caller that there is a scroll to
       // handle
+#ifdef GDK_WINDOWING_QUARTZ // on macOS deltas need to be scaled
+      acc_x += (2.0 / 300.0) * (event->delta_x + 150) - 1;
+      acc_y += (2.0 / 300.0) * (event->delta_y + 150) - 1;
+#else
       acc_x += event->delta_x;
       acc_y += event->delta_y;
+#endif
       const gdouble amt_x = trunc(acc_x);
       const gdouble amt_y = trunc(acc_y);
       if(amt_x != 0 || amt_y != 0)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -655,8 +655,8 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event, int *delta_x
       // scroll, and only then tell caller that there is a scroll to
       // handle
 #ifdef GDK_WINDOWING_QUARTZ // on macOS deltas need to be scaled
-      acc_x += (2.0 / 300.0) * (event->delta_x + 150) - 1;
-      acc_y += (2.0 / 300.0) * (event->delta_y + 150) - 1;
+      acc_x += event->delta_x / 50;
+      acc_y += event->delta_y / 50;
 #else
       acc_x += event->delta_x;
       acc_y += event->delta_y;


### PR DESCRIPTION
Fixing issue on macOS with smooth scrolling events. Fixes #6068 scrolling issue by scaling the input from _event->delta_x_ and _event->delta_y_.

The scaling amount feels ok on my system. It could be changed to get faster scrolling. Besides lighttable this also affects some modules. I tested module resize, retouch, histogram, zone system and bauhaus comboboxes. They seem to work correctly.

There might be better ways to handle trackpads. https://github.com/darktable-org/darktable/issues/6068#issuecomment-751350041
