### PR TITLE
channelmixerrgb: invalidate only preview pipe when extracting or validating profile

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -253,6 +253,14 @@ void dt_dev_invalidate_all(dt_develop_t *dev)
   dev->timestamp++;
 }
 
+void dt_dev_invalidate_preview(dt_develop_t *dev)
+{
+  dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
+  dev->timestamp++;
+  if(dev->pipe) dev->pipe->input_timestamp = dev->timestamp;
+  if(dev->preview2_pipe) dev->preview2_pipe->input_timestamp = dev->timestamp;
+}
+
 void dt_dev_process_preview_job(dt_develop_t *dev)
 {
   if(dev->image_loading)
@@ -2075,6 +2083,16 @@ void dt_dev_reprocess_center(dt_develop_t *dev)
   }
 }
 
+void dt_dev_reprocess_preview(dt_develop_t *dev)
+{
+  if(darktable.gui->reset || !dev || !dev->gui_attached) return;
+
+  dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
+  dev->preview_pipe->cache_obsolete = 1;
+
+  dt_dev_invalidate_preview(dev);
+  dt_control_queue_redraw_center();
+}
 
 void dt_dev_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float *zoom_y, dt_dev_zoom_t zoom,
                               int closeup, float *boxww, float *boxhh)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -383,6 +383,7 @@ void dt_dev_set_histogram_pre(dt_develop_t *dev);
 void dt_dev_get_history_item_label(dt_dev_history_item_t *hist, char *label, const int cnt);
 void dt_dev_reprocess_all(dt_develop_t *dev);
 void dt_dev_reprocess_center(dt_develop_t *dev);
+void dt_dev_reprocess_preview(dt_develop_t *dev);
 
 void dt_dev_get_processed_size(const dt_develop_t *dev, int *procw, int *proch);
 void dt_dev_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float *zoom_y, dt_dev_zoom_t zoom,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1706,7 +1706,38 @@ void validate_color_checker(const float *const restrict in,
   dt_free_align(patches);
 }
 
+static void _check_for_wb_issue_and_set_trouble_message(struct dt_iop_module_t *self)
+{
+  dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  if(self->enabled && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB))
+  {
+    // this module instance is doing chromatic adaptation
+    if(!is_module_cat_on_pipe(self))
+    {
+      // our second biggest problem : another channelmixerrgb instance is doing CAT earlier in the pipe
+      dt_iop_set_module_trouble_message(self, _("double CAT applied"),
+                                        _("you have 2 instances or more of color calibration,\n"
+                                          "all performing chromatic adaptation.\n"
+                                          "this can lead to inconsistencies, unless you\n"
+                                          "use them with masks or know what you are doing."),
+                                        "double CAT applied");
+      return;
+    }
+    else if(!self->dev->proxy.wb_is_D65)
+    {
+      // our first and biggest problem : white balance module is being clever with WB coeffs
+      dt_iop_set_module_trouble_message(self, _("white balance module error"),
+                                        _("the white balance module is not using the camera\n"
+                                          "reference illuminant, which will cause issues here\n"
+                                          "with chromatic adaptation. either set it to reference\n"
+                                          "or disable chromatic adaptation here."),
+                                        "white balance error");
+      return;
+    }
+  }
 
+  dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+}
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
              const void *const restrict ivoid, void *const restrict ovoid,
@@ -1719,6 +1750,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
                                          ivoid, ovoid, roi_in, roi_out))
     return; // image has been copied through to output and module's trouble flag has been updated
+
+  // dt_iop_have_required_input_format() has reset the trouble message.
+  // we must set it again in case of any trouble.
+  _check_for_wb_issue_and_set_trouble_message(self);
 
   float DT_ALIGNED_ARRAY RGB_to_XYZ[3][4];
   float DT_ALIGNED_ARRAY XYZ_to_RGB[3][4];
@@ -3352,38 +3387,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   declare_cat_on_pipe(self, FALSE);
 
-  if(self->enabled && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB))
-  {
-    // this module instance is doing chromatic adaptation
-    if(!is_module_cat_on_pipe(self))
-    {
-      // our second biggest problem : another channelmixerrgb instance is doing CAT earlier in the pipe
-      dt_iop_set_module_trouble_message(self,_("double CAT applied"),
-                                        _("you have 2 instances or more of color calibration,\n"
-                                          "all performing chromatic adaptation.\n"
-                                          "this can lead to inconsistencies, unless you\n"
-                                          "use them with masks or know what you are doing."),
-                                        "double CAT applied");
-    }
-    else if(!self->dev->proxy.wb_is_D65)
-    {
-      // our first and biggest problem : white balance module is being clever with WB coeffs
-      dt_iop_set_module_trouble_message(self,_("white balance module error"),
-                                        _("the white balance module is not using the camera\n"
-                                          "reference illuminant, which will cause issues here\n"
-                                          "with chromatic adaptation. either set it to reference\n"
-                                          "or disable chromatic adaptation here."),
-                                        "white balance error");
-    }
-    else
-    {
-      dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
-    }
-  }
-  else
-  {
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
-  }
+  _check_for_wb_issue_and_set_trouble_message(self);
 
   --darktable.gui->reset;
 }

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1748,7 +1748,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       extract_color_checker(in, out, roi_in, g, RGB_to_XYZ, XYZ_to_RGB, data->adaptation);
       g->run_profile = FALSE;
       dt_iop_gui_leave_critical_section(self);
-      exit = TRUE;
     }
 
     if(data->illuminant_type == DT_ILLUMINANT_DETECT_EDGES || data->illuminant_type == DT_ILLUMINANT_DETECT_SURFACES)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2320,7 +2320,7 @@ static void run_profile_callback(GtkWidget *widget, GdkEventButton *event, gpoin
   g->run_profile = TRUE;
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_reprocess_all(self->dev);
+  dt_dev_reprocess_preview(self->dev);
 }
 
 static void run_validation_callback(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
@@ -2333,7 +2333,7 @@ static void run_validation_callback(GtkWidget *widget, GdkEventButton *event, gp
   g->run_validation = TRUE;
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_reprocess_all(self->dev);
+  dt_dev_reprocess_preview(self->dev);
 }
 
 static void commit_profile_callback(GtkWidget *widget, GdkEventButton *event, gpointer user_data)


### PR DESCRIPTION
This makes obtaining the profile faster. Noticed when debugging https://github.com/darktable-org/darktable/issues/7732. It seems this PR makes it harder to trigger that issue, however it also probably means there still is a race condition lurking somewhere in the pipe computation code (not sure, but looks like it could be) since this commit doesn't fix any race condition per se as far as I can tell.

Also contains a change which makes `channelmixerrgb` run the rest of `process()` after obtaining the profile. This fixes the shifting of the histogram mentioned in https://github.com/darktable-org/darktable/issues/7732#issuecomment-756239876.

Finally, fix flashing of the trouble message - `dt_iop_have_required_input_format()` in the beginning of `process()` clears the trouble message if successful, so reset it if necessary.