### PR TITLE
colorbalancergb: improve the color science

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1006,56 +1006,12 @@ static inline void LMS_to_gradingRGB(const float LMS[4], float RGB[4])
 * RGB
 */
 
-
-#ifdef _OPENMP
-#pragma omp declare simd aligned(Ych, LMS: 16)
-#endif
-static inline void LMS_to_Ych(const float LMS[4], float Ych[3])
-{
-  Ych[0] = fmaxf(0.68990272f * LMS[0] + 0.34832189f * LMS[1], 0.f);
-  const float a = LMS[0] + LMS[1] + LMS[2];
-
-  float lms[4];
-  for(size_t c = 0; c < 4; c++) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
-
-  float rgb[4] = { 0.f };
-  LMS_to_gradingRGB(lms, rgb);
-  rgb[0] -= 0.18662246f;
-  rgb[1] -= 0.5847461f;
-
-  Ych[1] = hypotf(rgb[1], rgb[0]);
-  Ych[2] = atan2f(rgb[1], rgb[0]);
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd aligned(Ych, LMS: 16)
-#endif
-static inline void Ych_to_LMS(const float Ych[3], float LMS[4])
-{
-  // Ych is offset such that D65 point has c = 0
-  float rgb[4];
-  rgb[0] = fmaxf(Ych[1] * cosf(Ych[2]) + 0.18662246f, 0.f);
-  rgb[1] = fmaxf(Ych[1] * sinf(Ych[2]) + 0.5847461f, 0.f);
-
-  const float sum = rgb[0] + rgb[1];
-  if(fabsf(sum) > 1.f)
-  {
-    rgb[0] /= sum;
-    rgb[1] /= sum;
-  }
-
-  rgb[2] = 1.f - rgb[0] - rgb[1];
-  rgb[3] = 0.f;
-
-  float lms[4] = { 0.f };
-  gradingRGB_to_LMS(rgb, lms);
-  for(size_t c = 0; c < 4; c++) lms[c] = fmaxf(lms[c], 0.f);
-
-  const float a = 0.68990272f * lms[0] + 0.34832189f * lms[1];
-  for(size_t c = 0; c < 3; c++) LMS[c] = (a == 0.f) ? 0.f : lms[c] * Ych[0] / a;
-}
-
+// coordinates of D65 white point in normalized grading RGB :
+// D65_gradingRGB = [ 0.18600766,  0.5908061,   0.22318624 ]
+// they don't need to be true to measured CIE 1931 2° observer D65
+// but need to be tweaked such that sRGB = [1, 1, 1] yields c = 0 in Ych
+// otherwise highlights get shifted to green or magenta
+// Accurate CIE 1931 2° observer D65 projected directly is [ 0.18662246,  0.5847461 ,  0.22863145]
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, RGB: 16)
@@ -1086,29 +1042,35 @@ static inline void gradingRGB_to_XYZ(const float RGB[4], float XYZ[3])
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(Ych, RGB: 16)
+#pragma omp declare simd aligned(Ych, RGB, D65_pipe: 16) uniform(D65_pipe)
 #endif
-static inline void gradingRGB_to_Ych(float RGB[4], float Ych[3])
+static inline void gradingRGB_to_Ych(float RGB[4], float Ych[3], const float *const DT_RESTRICT D65_pipe)
 {
+  const float DT_ALIGNED_PIXEL D65_gradingRGB[4] = { 0.18600766,  0.5908061,   0.22318624, 0.f };
+  const float *const DT_RESTRICT D65 = (D65_pipe == NULL) ? D65_gradingRGB : D65_pipe;
+
   Ych[0] = fmaxf(0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2], 0.f);
   const float a = RGB[0] + RGB[1] + RGB[2];
   for(size_t c = 0; c < 4; c++) RGB[c] = (a == 0.f) ? 0.f : RGB[c] / a;
 
-  RGB[0] -= 0.18662246f;
-  RGB[1] -= 0.5847461f;
+  RGB[0] -= D65[0];
+  RGB[1] -= D65[1];
 
   Ych[1] = hypotf(RGB[1], RGB[0]);
-  Ych[2] = atan2f(RGB[1], RGB[0]);
+  Ych[2] = (Ych[1] == 0.f) ? 0.f : atan2f(RGB[1], RGB[0]);
 }
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(Ych, RGB: 16)
+#pragma omp declare simd aligned(Ych, RGB, D65_pipe: 16) uniform(D65_pipe)
 #endif
-static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[3])
+static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[3], const float *const DT_RESTRICT D65_pipe)
 {
-  RGB[0] = Ych[1] * cosf(Ych[2]) + 0.18662246f;
-  RGB[1] = Ych[1] * sinf(Ych[2]) + 0.5847461f;
-  RGB[2] = fmaxf(1.f - RGB[0] - RGB[1], 0.f);
+  const float DT_ALIGNED_PIXEL D65_gradingRGB[4] = { 0.18600766,  0.5908061,   0.22318624, 0.f };
+  const float *const DT_RESTRICT D65 = (D65_pipe == NULL) ? D65_gradingRGB : D65_pipe;
+
+  RGB[0] = Ych[1] * cosf(Ych[2]) + D65[0];
+  RGB[1] = Ych[1] * sinf(Ych[2]) + D65[1];
+  RGB[2] = 1.f - RGB[0] - RGB[1];
 
   const float a = (0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2]);
   for(size_t c = 0; c < 3; ++c) RGB[c] = (a == 0.f) ? 0.f : RGB[c] * Ych[0] / a;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -476,20 +476,6 @@ static int get_white_balance_coeff(struct dt_iop_module_t *self, float custom_wb
 
 
 #ifdef _OPENMP
-#pragma omp declare simd uniform(v_2) aligned(v_1, v_2:16)
-#endif
-static inline float scalar_product(const float v_1[4], const float v_2[4])
-{
-  // specialized 3×1 dot products 2 4×1 RGB-alpha pixels.
-  // v_2 needs to be uniform along loop increments, e.g. independent from current pixel values
-  // we force an order of computation similar to SSE4 _mm_dp_ps() hoping the compiler will get the clue
-  float DT_ALIGNED_PIXEL premul[4] = { 0.f };
-  for(size_t c = 0; c < 3; c++) premul[c] = v_1[c] * v_2[c];
-  return premul[0] + premul[1] + premul[2];
-}
-
-
-#ifdef _OPENMP
 #pragma omp declare simd aligned(vector:16)
 #endif
 static inline float euclidean_norm(const float vector[4])

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -47,11 +47,12 @@
 #define DEG_TO_RAD(x) ((x + ANGLE_SHIFT) * M_PI / 180.f)
 #define RAD_TO_DEG(x) (x * 180.f / M_PI - ANGLE_SHIFT)
 
-DT_MODULE_INTROSPECTION(1, dt_iop_colorbalancergb_params_t)
+DT_MODULE_INTROSPECTION(2, dt_iop_colorbalancergb_params_t)
 
 
 typedef struct dt_iop_colorbalancergb_params_t
 {
+  /* params of v1 */
   float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
   float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
   float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
@@ -64,18 +65,27 @@ typedef struct dt_iop_colorbalancergb_params_t
   float global_Y;              // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
   float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
   float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-  float shadows_weight;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
-  float midtones_weight;       // $MIN: -6.0 $MAX:   6.0 $DEFAULT: 0.0 $DESCRIPTION: "fulcrum"
-  float highlights_weight;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+  float shadows_weight;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows fall-off"
+  float midtones_weight;       // $MIN: -6.0 $MAX:   6.0 $DEFAULT: 0.0 $DESCRIPTION: "white pivot"
+  float highlights_weight;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights fall-off"
   float chroma_shadows;        // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
   float chroma_highlights;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
   float chroma_global;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
   float chroma_midtones;       // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
-  float saturation_global;     // $MIN: -10.0 $MAX: 10.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation global"
-  float saturation_highlights; // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-  float saturation_midtones;   // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
-  float saturation_shadows;    // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+  float saturation_global;     // $MIN: -5.0 $MAX: 5.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
+  float saturation_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float saturation_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+  float saturation_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
   float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+
+  /* params of v2 */
+  float purity_global;     // $MIN: -5.0 $MAX: 5.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
+  float purity_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float purity_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+  float purity_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+
+  /* add future params after this so the legacy params import can use a blind memcpy */
+
 } dt_iop_colorbalancergb_params_t;
 
 
@@ -87,6 +97,7 @@ typedef struct dt_iop_colorbalancergb_gui_data_t
   GtkWidget *shadows_weight, *midtones_weight, *highlights_weight;
   GtkWidget *chroma_highlights, *chroma_global, *chroma_shadows, *chroma_midtones;
   GtkWidget *saturation_global, *saturation_highlights, *saturation_midtones, *saturation_shadows;
+  GtkWidget *purity_global, *purity_highlights, *purity_midtones, *purity_shadows;
   GtkWidget *hue_angle;
   GtkNotebook *notebook;
 } dt_iop_colorbalancergb_gui_data_t;
@@ -100,6 +111,7 @@ typedef struct dt_iop_colorbalancergb_data_t
   float midtones_Y;
   float chroma_highlights, chroma_global, chroma_shadows, chroma_midtones;
   float saturation_global, saturation_highlights, saturation_midtones, saturation_shadows;
+  float purity_global, purity_highlights, purity_midtones, purity_shadows;
   float hue_angle;
   float shadows_weight, midtones_weight, highlights_weight;
   float *gamut_LUT;
@@ -146,6 +158,51 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 {
   return iop_cs_rgb;
 }
+
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
+                  const int new_version)
+{
+  if(old_version == 1 && new_version == 2)
+  {
+    typedef struct dt_iop_colorbalancergb_params_v1_t
+    {
+      float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+      float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+      float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+      float midtones_Y;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+      float midtones_C;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+      float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+      float highlights_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+      float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+      float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+      float global_Y;              // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+      float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+      float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+      float shadows_weight;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+      float midtones_weight;       // $MIN: -6.0 $MAX:   6.0 $DEFAULT: 0.0 $DESCRIPTION: "fulcrum"
+      float highlights_weight;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
+      float chroma_shadows;        // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+      float chroma_highlights;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+      float chroma_global;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
+      float chroma_midtones;       // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+      float saturation_global;     // $MIN: -5.0 $MAX: 5.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation global"
+      float saturation_highlights; // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+      float saturation_midtones;   // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "midtones"
+      float saturation_shadows;    // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+      float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+    } dt_iop_colorbalancergb_params_v1_t;
+
+    // Init params with defaults
+    memcpy(new_params, self->default_params, sizeof(dt_iop_colorbalancergb_params_t));
+
+    // Copy the common part of the params struct
+    memcpy(new_params, old_params, sizeof(dt_iop_colorbalancergb_params_v1_t));
+
+    return 0;
+  }
+  return 1;
+}
+
 
 /* Custom matrix handling for speed */
 static inline void repack_3x3_to_3xSSE(const float input[9], float output[3][4])
@@ -202,11 +259,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   // Matrices from CIE 1931 2° XYZ D50 to Filmlight grading RGB D65 through CIE 2006 LMS
   const float XYZ_to_gradRGB[3][4] = { { 0.53346004f,  0.15226970f , -0.19946283f, 0.f },
-                                          {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
-                                          { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
+                                       {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
+                                       { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
   const float gradRGB_to_XYZ[3][4] = { { 1.67222161f, -0.11185000f,  0.50297636f, 0.f },
-                                          { 0.60120746f,  0.47018395f, -0.08596569f, 0.f },
-                                          {-0.08217531f,  0.05979694f,  1.27957582f, 0.f } };
+                                       { 0.60120746f,  0.47018395f, -0.08596569f, 0.f },
+                                       {-0.08217531f,  0.05979694f,  1.27957582f, 0.f } };
 
   // Premultiply the pipe RGB -> XYZ and XYZ -> grading RGB matrices to spare 2 matrix products per pixel
   float DT_ALIGNED_ARRAY input_matrix[3][4];
@@ -214,13 +271,20 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   mat3mul4((float *)input_matrix, (float *)XYZ_to_gradRGB, (float *)RGB_to_XYZ);
   mat3mul4((float *)output_matrix, (float *)XYZ_to_RGB, (float *)gradRGB_to_XYZ);
 
+  // Test white point of the current space in grading RGB
+  const float white_pipe_RGB[4] = { 1.f, 1.f, 1.f };
+  float white_grading_RGB[4] = { 0.f };
+  dot_product(white_pipe_RGB, input_matrix, white_grading_RGB);
+  const float sum_white = white_grading_RGB[0] + white_grading_RGB[1] + white_grading_RGB[2];
+  for(size_t c = 0; c < 4; c++) white_grading_RGB[c] /= sum_white;
+
   const float *const restrict in = __builtin_assume_aligned(((const float *const restrict)ivoid), 64);
   float *const restrict out = __builtin_assume_aligned(((float *const restrict)ovoid), 64);
   const float *const restrict gamut_LUT = __builtin_assume_aligned(((const float *const restrict)d->gamut_LUT), 64);
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) aligned(in, out: 64)\
-      dt_omp_firstprivate(in, out, roi_in, roi_out, d, input_matrix, output_matrix, gamut_LUT) schedule(static)
+      dt_omp_firstprivate(in, out, roi_in, roi_out, d, input_matrix, output_matrix, gamut_LUT, white_grading_RGB) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)4 * roi_in->width * roi_out->height; k += 4)
   {
@@ -230,57 +294,41 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     float Ych[4] = { 0.f };
     float RGB[4] = { 0.f };
 
-    for(size_t c = 0; c < 4; ++c) Ych[c] = fmaxf(pix_in[c], 0.f);
+    for(size_t c = 0; c < 4; ++c) Ych[c] = fmaxf(pix_in[c], 0.0f);
     dot_product(Ych, input_matrix, RGB);
-    for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c], 0.f);
-    gradingRGB_to_Ych(RGB, Ych);
+    gradingRGB_to_Ych(RGB, Ych, white_grading_RGB);
 
     // Sanitize input : no negative luminance
     float Y = fmaxf(Ych[0], 0.f);
+
+    // Opacities for luma masks
+    const float x_offset = (Y - 0.1845f) / 0.1845f;
+    const float alpha = 1.f / (1.f + expf(x_offset * d->shadows_weight));         // opacity of shadows
+    const float beta = 1.f / (1.f + expf(- x_offset * d->highlights_weight));     // opacity of highlights
+    const float gamma = expf(- 0.1845f * x_offset * x_offset / (d->shadows_weight * d->highlights_weight) / 0.1845);
+    const float alpha_comp = 1.f - alpha;
+    const float beta_comp = 1.f - beta;
 
     // Hue shift - do it now because we need the gamut limit at output hue right after
     Ych[2] += d->hue_angle;
 
     // Get max allowed chroma in working RGB gamut at current output hue
-    const float max_chroma_h = gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
-    const float max_saturation_h = (Y == 0.f) ? 0.f : atan2f(max_chroma_h, Y);
-    float C = fminf(Ych[1], max_chroma_h);
-    float S = fminf(atan2f(C, Y), max_saturation_h);
-    const float radius = (Y == 0.f) ? 0.f : hypotf(C, Y);
+    const float max_chroma_h = (Y == 0.f) ? 0.f : gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
+    float C = (Y == 0.f) ? 0.f : fminf(Ych[1], max_chroma_h);
 
-    // Opacities for luma masks
-    const float alpha = expf(- Y * d->shadows_weight);         // opacity of shadows
-    const float beta = 1.f - expf(- Y * d->highlights_weight); // opacity of highlights
-    const float gamma = expf(-3.0f * (alpha - beta) * (alpha - beta)); // opacity of midtones
-    const float alpha_comp = 1.f - alpha;
-    const float beta_comp = 1.f - beta;
-    //const float sum_of_masks = alpha + beta + gamma;
-
-    // Saturation : mix of chroma and luminance
-    const float boost_shadows_sat = alpha * d->saturation_shadows;
-    const float boost_highlights_sat = beta * d->saturation_highlights;
-    const float boost_midtones_sat = gamma * d->saturation_midtones;
-    const float boost_sat = 1.f + Y * (boost_shadows_sat + boost_midtones_sat + boost_highlights_sat);
-    S = S * boost_sat + d->saturation_global;
-    S = fminf(fmaxf(S, 0.f), max_saturation_h);
-
-    // Chroma : distance to white at constant luminance
+    // Linear chroma : distance to achromatic at constant luminance in scene-referred
     const float boost_shadows_chroma = alpha * d->chroma_shadows;
     const float boost_highlights_chroma = beta * d->chroma_highlights;
     const float boost_midtones_chroma = gamma * d->chroma_midtones;
     float chroma_boost = 1.f + d->chroma_global + (boost_shadows_chroma + boost_highlights_chroma + boost_midtones_chroma) * max_chroma_h / d->max_chroma;
-    chroma_boost = fmaxf(chroma_boost, 0.f);
-
-    // Repack
-    Ych[0] = radius * fmaxf(cosf(S), 0.f);
-    Ych[1] = fminf(chroma_boost * radius * sinf(S), max_chroma_h);
-    Ych_to_gradingRGB(Ych, RGB);
+    Ych[1] = fminf(C * fmaxf(chroma_boost, 0.f), max_chroma_h);
+    Ych_to_gradingRGB(Ych, RGB, white_grading_RGB);
 
     /* Color balance */
 
     // global
     const float *const restrict global = __builtin_assume_aligned(d->global, 16);
-    for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c] + global[c], 0.f);
+    for(size_t c = 0; c < 4; ++c) RGB[c] = RGB[c] + global[c];
 
     // 3 ways : shadows, highlights, midtones
     const float *const restrict highlights = __builtin_assume_aligned(d->highlights, 16);
@@ -290,19 +338,91 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     {
       RGB[c] *= beta_comp * (alpha_comp + alpha * shadows[c]) + beta * highlights[c];
       // factorization of : (RGB[c] * (1.f - alpha) + RGB[c] * d->shadows[c] * alpha) * (1.f - beta)  + RGB[c] * d->highlights[c] * beta;
-      RGB[c] = powf(fmaxf(RGB[c] / d->midtones_weight, 0.f), midtones[c]) * d->midtones_weight;
+      const float sign = (RGB[c] < 0.f) ? -1.f : 1.f;
+      RGB[c] = sign * powf(fabsf(RGB[c]) / d->midtones_weight, midtones[c]) * d->midtones_weight;
     }
 
     // for the Y midtones power (gamma), we need to go in Ych again because RGB doesn't preserve color
-    gradingRGB_to_Ych(RGB, Ych);
-    Ych[0] = powf(fmaxf(Ych[0] / d->midtones_weight, 0.f), d->midtones_Y) * d->midtones_weight;
+    gradingRGB_to_Ych(RGB, Ych, white_grading_RGB);
+    Y = Ych[0] = powf(fmaxf(Ych[0] / d->midtones_weight, 0.f), d->midtones_Y) * d->midtones_weight;
+    Ych_to_gradingRGB(Ych, RGB, white_grading_RGB);
 
-    // Gamut mapping
+    /* Perceptual color adjustments */
+
+     // grading RGB to CIE 1931 XYZ 2° D65
+    const float RGB_to_XYZ_D65[3][4] = { { 1.64004888f, -0.10969806f, 0.49329934f, 0.f },
+                                         { 0.61055787f, 0.47749658f, -0.08730269f, 0.f },
+                                         { -0.10698534f, 0.07785058f, 1.66590006f, 0.f } };
+
+    const float XYZ_to_RGB_D65[3][4] = { { 0.54392489f, 0.14993776f, -0.15320716f, 0.f },
+                                         { -0.68327274f, 1.88816348f, 0.30127843f, 0.f },
+                                         { 0.06686186f, -0.07860825f, 0.57635773f, 0.f } };
+
+    // Go to JzAzBz for perceptual saturation
+    // We can't use gradingRGB_to_XYZ() since it also does chromatic adaptation to D50
+    // and JzAzBz uses D65, same as grading RGB. So we use the matrices above instead
+    float DT_ALIGNED_PIXEL Jab[4] = { 0.f };
+    dot_product(RGB, RGB_to_XYZ_D65, Ych);
+    dt_XYZ_2_JzAzBz(Ych, Jab);
+
+    // Convert to JCh
+    float J = Jab[0];
+    C = hypotf(Jab[1], Jab[2]);                           // chroma : distance to achromatic at same luminance
+    float h = (C == 0.f) ? 0.f : atan2f(Jab[2], Jab[1]);  // hue : angle over the plane of constant luminance
+    float T = atan2f(C, J);                               // angle of saturation
+
+    const float sin_T = sinf(T);
+    const float cos_T = cosf(T);
+    const float offset = C / cos_T;
+
+    // Project C and J over the saturation eigenvector.
+    // Note : O should be = (C * cosf(T) - J * sinf(T))
+    // but since S is the eigenvector, its orthogonal direction has no value and O = 0
+    // so we add the distance between the achromatic axis and the current chromaticity
+    // along the orthogonal axis to get some control value
+    float S = C * sin_T + J * cos_T;
+    float O = offset;
+    float radius = hypotf(S, O);
+    O /= (radius > 0.f) ? radius : 1.f;
+    S /= (radius > 0.f) ? radius : 1.f;
+
+    // Saturation : mix of chroma and luminance
+    const float boost_shadows_sat = alpha * d->saturation_shadows;
+    const float boost_highlights_sat = beta * d->saturation_highlights;
+    const float boost_midtones_sat = gamma * d->saturation_midtones;
+    const float boost_sat = 1.f + Y * (boost_shadows_sat + boost_midtones_sat + boost_highlights_sat);
+    O = O * boost_sat + d->saturation_global;
+    O = fmaxf(O, 0.f);
+
+    // Purity : mix of chroma and luminance
+    const float boost_shadows_pur = alpha * d->purity_shadows;
+    const float boost_highlights_pur = beta * d->purity_highlights;
+    const float boost_midtones_pur = gamma * d->purity_midtones;
+    const float boost_pur = 1.f + Y * (boost_shadows_pur + boost_midtones_pur + boost_highlights_pur);
+    S = S * boost_pur + d->purity_global;
+    S = fmaxf(S, 0.f);
+
+    // Project back to JCh
+    O *= radius;
+    S *= radius;
+    O -= offset;
+    C = fmaxf(S * sin_T + O * cos_T, 0.f);
+    J = fmaxf(S * cos_T - O * sin_T, 0.f);
+
+    // Project back to JzAzBz
+    Jab[0] = J;
+    Jab[1] = C * cosf(h);
+    Jab[2] = C * sinf(h);
+
+    dt_JzAzBz_2_XYZ(Jab, Ych);
+    dot_product(Ych, XYZ_to_RGB_D65, RGB);
+    gradingRGB_to_Ych(RGB, Ych, white_grading_RGB);
+
+    /* Gamut mapping */
     const float out_max_chroma_h = gamut_LUT[CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1)];
     Ych[1] = fminf(Ych[1], out_max_chroma_h);
 
-    Ych_to_gradingRGB(Ych, RGB);
-    for(size_t c = 0; c < 4; ++c) RGB[c] = fmaxf(RGB[c], 0.f);
+    Ych_to_gradingRGB(Ych, RGB, white_grading_RGB);
     dot_product(RGB, output_matrix, pix_out);
     for(size_t c = 0; c < 4; ++c) pix_out[c] = fmaxf(pix_out[c], 0.f);
   }
@@ -320,46 +440,52 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->chroma_midtones = p->chroma_midtones;
   d->chroma_shadows = p->chroma_shadows;
 
-  d->saturation_global = M_PI * p->saturation_global / 180.f;
+  d->saturation_global = p->saturation_global / 100.f;
 
   d->saturation_highlights = p->saturation_highlights;
   d->saturation_midtones = p->saturation_midtones;
   d->saturation_shadows = p->saturation_shadows;
+
+  d->purity_global = p->purity_global / 100.f;
+
+  d->purity_highlights = p->purity_highlights;
+  d->purity_midtones = p->purity_midtones;
+  d->purity_shadows = p->purity_shadows;
 
   d->hue_angle = M_PI * p->hue_angle / 180.f;
 
   // measure the grading RGB of a pure white
   const float Ych_norm[4] = { 1.f, 0.f, 0.f, 0.f };
   float RGB_norm[4] = { 0.f };
-  Ych_to_gradingRGB(Ych_norm, RGB_norm);
+  Ych_to_gradingRGB(Ych_norm, RGB_norm, NULL);
 
   // global
   {
     float Ych[4] = { 1.f, p->global_C, DEG_TO_RAD(p->global_H), 0.f };
-    Ych_to_gradingRGB(Ych, d->global);
+    Ych_to_gradingRGB(Ych, d->global, NULL);
     for(size_t c = 0; c < 4; c++) d->global[c] = (d->global[c] - RGB_norm[c]) + RGB_norm[c] * p->global_Y;
   }
 
   // shadows
   {
     float Ych[4] = { 1.f, p->shadows_C, DEG_TO_RAD(p->shadows_H), 0.f };
-    Ych_to_gradingRGB(Ych, d->shadows);
+    Ych_to_gradingRGB(Ych, d->shadows, NULL);
     for(size_t c = 0; c < 4; c++) d->shadows[c] = 1.f + (d->shadows[c] - RGB_norm[c]) + p->shadows_Y;
-    d->shadows_weight = 1.f - p->shadows_weight;
+    d->shadows_weight = 2.f + p->shadows_weight * 2.f;
   }
 
   // highlights
   {
     float Ych[4] = { 1.f, p->highlights_C, DEG_TO_RAD(p->highlights_H), 0.f };
-    Ych_to_gradingRGB(Ych, d->highlights);
+    Ych_to_gradingRGB(Ych, d->highlights, NULL);
     for(size_t c = 0; c < 4; c++) d->highlights[c] = 1.f + (d->highlights[c] - RGB_norm[c]) + p->highlights_Y;
-    d->highlights_weight = 1.f + p->highlights_weight;
+    d->highlights_weight = 2.f + p->highlights_weight * 2.f;
   }
 
   // midtones
   {
     float Ych[4] = { 1.f, p->midtones_C, DEG_TO_RAD(p->midtones_H), 0.f };
-    Ych_to_gradingRGB(Ych, d->midtones);
+    Ych_to_gradingRGB(Ych, d->midtones, NULL);
     for(size_t c = 0; c < 4; c++) d->midtones[c] = 1.f / (1.f + (d->midtones[c] - RGB_norm[c]));
     d->midtones_Y = 1.f / (1.f + p->midtones_Y);
     d->midtones_weight = exp2f(p->midtones_weight);
@@ -392,10 +518,17 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     float DT_ALIGNED_ARRAY input_matrix[3][4];
     mat3mul4((float *)input_matrix, (float *)XYZ_to_gradingRGB, (float *)RGB_to_XYZ);
 
+    // Test white point of the current space in grading RGB
+    const float white_pipe_RGB[4] = { 1.f, 1.f, 1.f };
+    float white_grading_RGB[4] = { 0.f };
+    dot_product(white_pipe_RGB, input_matrix, white_grading_RGB);
+    const float sum_white = white_grading_RGB[0] + white_grading_RGB[1] + white_grading_RGB[2];
+    for(size_t c = 0; c < 4; c++) white_grading_RGB[c] /= sum_white;
+
     // make RGB values vary between [0; 1] in working space, convert to Ych and get the max(c(h)))
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-      dt_omp_firstprivate(input_matrix) schedule(static) dt_omp_sharedconst(LUT)
+      dt_omp_firstprivate(input_matrix, white_grading_RGB) schedule(static) dt_omp_sharedconst(LUT)
 #endif
     for(size_t r = 0; r < STEPS; r++)
       for(size_t g = 0; g < STEPS; g++)
@@ -409,7 +542,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
           float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
           float DT_ALIGNED_PIXEL Ych[4] = { 0.f };
           dot_product(rgb, input_matrix, RGB);
-          gradingRGB_to_Ych(RGB, Ych);
+          gradingRGB_to_Ych(RGB, Ych, white_grading_RGB);
           const size_t index = CLAMP((size_t)(LUT_ELEM / 2. * (Ych[2] + M_PI) / M_PI), 0, LUT_ELEM - 1);
           if(LUT[index] < Ych[1]) LUT[index] = Ych[1];
         }
@@ -452,7 +585,7 @@ void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
                              work_profile->unbounded_coeffs_in, work_profile->lutsize,
                              work_profile->nonlinearlut);
   XYZ_to_gradingRGB(XYZ, LMS);
-  gradingRGB_to_Ych(LMS, Ych);
+  gradingRGB_to_Ych(LMS, Ych, NULL);
 
   if(Ych[2] < 0.f)
     Ych[2] = 2.f * M_PI + Ych[2];
@@ -523,7 +656,7 @@ static void paint_chroma_slider(GtkWidget *w, const float hue)
     float RGB[4] = { 0.f };
     float Ych[4] = { 0.75f, x, h, 0.f };
     float LMS[4] = { 0.f };
-    Ych_to_gradingRGB(Ych, LMS);
+    Ych_to_gradingRGB(Ych, LMS, NULL);
     gradingRGB_to_XYZ(LMS, Ych);
     dt_XYZ_to_Rec709_D65(Ych, RGB);
     const float max_RGB = fmaxf(fmaxf(RGB[0], RGB[1]), RGB[2]);
@@ -575,6 +708,12 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->saturation_midtones, p->saturation_midtones);
   dt_bauhaus_slider_set_soft(g->saturation_shadows, p->saturation_shadows);
 
+
+  dt_bauhaus_slider_set_soft(g->purity_global, p->purity_global);
+  dt_bauhaus_slider_set_soft(g->purity_highlights, p->purity_highlights);
+  dt_bauhaus_slider_set_soft(g->purity_midtones, p->purity_midtones);
+  dt_bauhaus_slider_set_soft(g->purity_shadows, p->purity_shadows);
+
   dt_bauhaus_slider_set_soft(g->global_C, p->global_C);
   dt_bauhaus_slider_set_soft(g->global_H, p->global_H);
   dt_bauhaus_slider_set_soft(g->global_Y, p->global_Y);
@@ -621,34 +760,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->hue_angle, 1.);
   dt_bauhaus_slider_set_format(g->hue_angle, "%.2f °");
   gtk_widget_set_tooltip_text(g->hue_angle, _("rotate all hues by an angle, at the same luminance"));
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("saturation grading")), FALSE, FALSE, 0);
 
-  g->saturation_global = dt_bauhaus_slider_from_params(self, "saturation_global");
-  dt_bauhaus_slider_set_soft_range(g->saturation_global, -5., 5.);
-  dt_bauhaus_slider_set_digits(g->saturation_global, 4);
-  dt_bauhaus_slider_set_step(g->saturation_global, .5);
-  dt_bauhaus_slider_set_format(g->saturation_global, "%.2f °");
-  gtk_widget_set_tooltip_text(g->saturation_global, _("add or remove saturation by an absolute amount"));
-
-  g->saturation_shadows = dt_bauhaus_slider_from_params(self, "saturation_shadows");
-  dt_bauhaus_slider_set_digits(g->saturation_shadows, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_shadows, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_shadows, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->saturation_shadows, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
-
-  g->saturation_midtones= dt_bauhaus_slider_from_params(self, "saturation_midtones");
-  dt_bauhaus_slider_set_digits(g->saturation_midtones, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_midtones, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_midtones, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->saturation_midtones, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
-
-  g->saturation_highlights = dt_bauhaus_slider_from_params(self, "saturation_highlights");
-  dt_bauhaus_slider_set_digits(g->saturation_highlights, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_highlights, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_highlights, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->saturation_highlights, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
-
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("chroma grading")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("linear chroma grading")), FALSE, FALSE, 0);
 
   g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
   dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
@@ -674,6 +787,62 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_factor(g->chroma_highlights, 100.0f);
   dt_bauhaus_slider_set_format(g->chroma_highlights, "%.2f %%");
   gtk_widget_set_tooltip_text(g->chroma_highlights, _("increase colorfulness at same luminance mostly in highlights"));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual saturation grading")), FALSE, FALSE, 0);
+
+  g->saturation_global = dt_bauhaus_slider_from_params(self, "saturation_global");
+  dt_bauhaus_slider_set_soft_range(g->saturation_global, -15., 15.);
+  dt_bauhaus_slider_set_digits(g->saturation_global, 4);
+  dt_bauhaus_slider_set_step(g->saturation_global, .5);
+  dt_bauhaus_slider_set_format(g->saturation_global, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_global, _("add or remove saturation by an absolute amount"));
+
+  g->saturation_shadows = dt_bauhaus_slider_from_params(self, "saturation_shadows");
+  dt_bauhaus_slider_set_digits(g->saturation_shadows, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_shadows, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_shadows, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_shadows, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+
+  g->saturation_midtones= dt_bauhaus_slider_from_params(self, "saturation_midtones");
+  dt_bauhaus_slider_set_digits(g->saturation_midtones, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_midtones, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_midtones, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_midtones, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+
+  g->saturation_highlights = dt_bauhaus_slider_from_params(self, "saturation_highlights");
+  dt_bauhaus_slider_set_digits(g->saturation_highlights, 4);
+  dt_bauhaus_slider_set_factor(g->saturation_highlights, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation_highlights, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->saturation_highlights, _("increase or decrease saturation proportionnaly to the original pixel saturation"));
+
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual purity grading")), FALSE, FALSE, 0);
+
+  g->purity_global = dt_bauhaus_slider_from_params(self, "purity_global");
+  dt_bauhaus_slider_set_soft_range(g->purity_global, -15., 15.);
+  dt_bauhaus_slider_set_digits(g->purity_global, 4);
+  dt_bauhaus_slider_set_step(g->purity_global, .5);
+  dt_bauhaus_slider_set_format(g->purity_global, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->purity_global, _("add or remove purity by an absolute amount"));
+
+  g->purity_shadows = dt_bauhaus_slider_from_params(self, "purity_shadows");
+  dt_bauhaus_slider_set_digits(g->purity_shadows, 4);
+  dt_bauhaus_slider_set_factor(g->purity_shadows, 100.0f);
+  dt_bauhaus_slider_set_format(g->purity_shadows, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->purity_shadows, _("increase or decrease purity proportionnaly to the original pixel purity"));
+
+  g->purity_midtones= dt_bauhaus_slider_from_params(self, "purity_midtones");
+  dt_bauhaus_slider_set_digits(g->purity_midtones, 4);
+  dt_bauhaus_slider_set_factor(g->purity_midtones, 100.0f);
+  dt_bauhaus_slider_set_format(g->purity_midtones, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->purity_midtones, _("increase or decrease purity proportionnaly to the original pixel purity"));
+
+  g->purity_highlights = dt_bauhaus_slider_from_params(self, "purity_highlights");
+  dt_bauhaus_slider_set_digits(g->purity_highlights, 4);
+  dt_bauhaus_slider_set_factor(g->purity_highlights, 100.0f);
+  dt_bauhaus_slider_set_format(g->purity_highlights, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->purity_highlights, _("increase or decrease purity proportionnaly to the original pixel purity"));
+
 
   // Page 4-ways
   self->widget = dt_ui_notebook_page(g->notebook, _("4 ways"), _("selective color grading"));
@@ -725,13 +894,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->shadows_C, "%.2f %%");
   gtk_widget_set_tooltip_text(g->shadows_C, _("chroma of the color gain in shadows"));
 
-  g->shadows_weight = dt_bauhaus_slider_from_params(self, "shadows_weight");
-  dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
-  dt_bauhaus_slider_set_step(g->shadows_weight, 0.1);
-  dt_bauhaus_slider_set_format(g->shadows_weight, "%.2f %%");
-  dt_bauhaus_slider_set_factor(g->shadows_weight, 100.0f);
-  gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
-
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("midtones")), FALSE, FALSE, 0);
 
   g->midtones_Y = dt_bauhaus_slider_from_params(self, "midtones_Y");
@@ -755,13 +917,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_factor(g->midtones_C, 100.0f);
   dt_bauhaus_slider_set_format(g->midtones_C, "%.2f %%");
   gtk_widget_set_tooltip_text(g->midtones_C, _("chroma of the color exponent in midtones"));
-
-  g->midtones_weight = dt_bauhaus_slider_from_params(self, "midtones_weight");
-  dt_bauhaus_slider_set_soft_range(g->midtones_weight, -2., +2.);
-  dt_bauhaus_slider_set_step(g->midtones_weight, 0.1);
-  dt_bauhaus_slider_set_digits(g->midtones_weight, 4);
-  dt_bauhaus_slider_set_format(g->midtones_weight, "%.2f EV");
-  gtk_widget_set_tooltip_text(g->midtones_weight, _("peak white luminance value used to normalize the power function"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights")), FALSE, FALSE, 0);
 
@@ -787,12 +942,30 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->highlights_C, "%.2f %%");
   gtk_widget_set_tooltip_text(g->highlights_C, _("chroma of the color gain in highlights"));
 
+  // Page masks
+  self->widget = dt_ui_notebook_page(g->notebook, _("masks"), _("isolate luninances"));
+
+  g->shadows_weight = dt_bauhaus_slider_from_params(self, "shadows_weight");
+  dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
+  dt_bauhaus_slider_set_step(g->shadows_weight, 0.1);
+  dt_bauhaus_slider_set_format(g->shadows_weight, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->shadows_weight, 100.0f);
+  gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
+
+  g->midtones_weight = dt_bauhaus_slider_from_params(self, "midtones_weight");
+  dt_bauhaus_slider_set_soft_range(g->midtones_weight, -2., +2.);
+  dt_bauhaus_slider_set_step(g->midtones_weight, 0.1);
+  dt_bauhaus_slider_set_digits(g->midtones_weight, 4);
+  dt_bauhaus_slider_set_format(g->midtones_weight, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->midtones_weight, _("peak white luminance value used to normalize the power function"));
+
   g->highlights_weight = dt_bauhaus_slider_from_params(self, "highlights_weight");
   dt_bauhaus_slider_set_step(g->highlights_weight, 0.1);
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
   dt_bauhaus_slider_set_format(g->highlights_weight, "%.2f %%");
   dt_bauhaus_slider_set_factor(g->highlights_weight, 100.0f);
   gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
+
 
   // paint backgrounds
   for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
@@ -802,7 +975,7 @@ void gui_init(dt_iop_module_t *self)
     float RGB[4] = { 0.f };
     float Ych[4] = { 0.75f, 0.2f, h, 0.f };
     float LMS[4] = { 0.f };
-    Ych_to_gradingRGB(Ych, LMS);
+    Ych_to_gradingRGB(Ych, LMS, NULL);
     gradingRGB_to_XYZ(LMS, Ych);
     dt_XYZ_to_Rec709_D65(Ych, RGB);
     const float max_RGB = fmaxf(fmaxf(RGB[0], RGB[1]), RGB[2]);


### PR DESCRIPTION
1. do the perceptual saturation in JzAzBz instead of Yrg for better behaviour
2. add a color purity factor in JzAzBz
3. move the perceptual saturation after the color balance, keep only linear chroma before
4. set the white point dynamically from the pipeline color space to fix #7689
5. remove safety clipping in grading RGB space to avoid color destruction.

To understand the difference between chroma, saturation and purity, in the module, here are some swatches. The pixel in the center of each swatch is the reference (input) and is not changed. We then make saturation vary from left to right (left : negative setting, right : positive setting) and purity from bottom to top (top : positive setting, bottom : negative setting). Luminance is approximately on the top-left to bottom right diagonal, and chroma on the bottom-left to top-right diagonal.

![image](https://user-images.githubusercontent.com/2779157/104851976-6f74ee80-58f8-11eb-813e-c88881b0e202.png)
![image](https://user-images.githubusercontent.com/2779157/104851977-71d74880-58f8-11eb-9780-c59e47ac3a11.png)
![image](https://user-images.githubusercontent.com/2779157/104851979-74d23900-58f8-11eb-93f9-247d9d131d55.png)
![image](https://user-images.githubusercontent.com/2779157/104851981-77349300-58f8-11eb-8ad8-66194da72181.png)
![image](https://user-images.githubusercontent.com/2779157/104851982-7996ed00-58f8-11eb-9f90-272786e5c20d.png)
![image](https://user-images.githubusercontent.com/2779157/104851983-7b60b080-58f8-11eb-92ea-5fb5b4f8be21.png)

![image](https://user-images.githubusercontent.com/2779157/104851988-83b8eb80-58f8-11eb-8d42-d87fca38652d.png)
![image](https://user-images.githubusercontent.com/2779157/104851990-861b4580-58f8-11eb-80c2-4340c5b1d7ae.png)
![image](https://user-images.githubusercontent.com/2779157/104851992-87e50900-58f8-11eb-8bf2-85b4edd51055.png)
