### PR TITLE
SQL: eliminate INs and LIKEs where possibile

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1458,7 +1458,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         query = dt_util_dstrcat(query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s%%'))",
                                 escaped_text);
       else
-        query = dt_util_dstrcat(query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s'))",
+        query = dt_util_dstrcat(query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder = '%s'))",
                                 escaped_text);
       break;
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1038,7 +1038,7 @@ void dt_history_compress_on_image(const int32_t imgid)
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "DELETE FROM main.masks_history"
                               " WHERE imgid = ?1 "
-                              "   AND num NOT IN (SELECT MAX(num)"
+                              "   AND num != (SELECT MAX(num)"
                               "                   FROM main.masks_history"
                               "                   WHERE imgid = ?1 AND num < ?2)", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1680,8 +1680,8 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
         (dt_database_get(darktable.db),
          "SELECT id"
          " FROM main.images"
-         " WHERE filename IN (SELECT filename FROM main.images WHERE id = ?1)"
-         "   AND film_id IN (SELECT film_id FROM main.images WHERE id = ?1)",
+         " WHERE filename = (SELECT filename FROM main.images WHERE id = ?1)"
+         "   AND film_id = (SELECT film_id FROM main.images WHERE id = ?1)",
          -1, &duplicates_stmt, NULL);
 
       // first move xmp files of image and duplicates
@@ -2304,7 +2304,7 @@ void dt_image_synch_all_xmp(const gchar *pathname)
       (dt_database_get(darktable.db),
        "SELECT id"
        " FROM main.images"
-       " WHERE film_id IN (SELECT id FROM main.film_rolls "
+       " WHERE film_id = (SELECT id FROM main.film_rolls "
        "                   WHERE folder = ?1)"
        "   AND filename = ?2",
        -1, &stmt, NULL);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -960,8 +960,8 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
   free(imgs);
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT COUNT(*) FROM main.images WHERE filename IN (SELECT filename FROM "
-                              "main.images WHERE id = ?1) AND film_id IN (SELECT film_id FROM main.images WHERE "
+                              "SELECT COUNT(*) FROM main.images WHERE filename = (SELECT filename FROM "
+                              "main.images WHERE id = ?1) AND film_id = (SELECT film_id FROM main.images WHERE "
                               "id = ?1)", -1, &stmt, NULL);
   while(t)
   {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1028,7 +1028,7 @@ static GtkTreeModel *_create_filtered_model(GtkTreeModel *model, dt_lib_collect_
         // Check if this path also matches a filmroll
         gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &pth, -1);
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                    "SELECT id FROM main.film_rolls WHERE folder LIKE ?1", -1, &stmt, NULL);
+                                    "SELECT id FROM main.film_rolls WHERE folder = ?1", -1, &stmt, NULL);
         DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, pth, -1, SQLITE_TRANSIENT);
         if(sqlite3_step(stmt) == SQLITE_ROW) id = sqlite3_column_int(stmt, 0);
         sqlite3_finalize(stmt);


### PR DESCRIPTION
(in)equality operators cost less and should be preferred if subqueries return exactly one row. 