### PR TITLE
force crash on Linux when using free() to release aligned allocation

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -335,6 +335,9 @@ size_t dt_round_size_sse(const size_t size);
 #ifdef _WIN32
 void dt_free_align(void *mem);
 #define dt_free_align_ptr dt_free_align
+#elif _DEBUG // debug build makes sure that we get a crash on using plain free() on an aligned allocation
+void dt_free_align(void *mem);
+#define dt_free_align_ptr dt_free_align
 #else
 #define dt_free_align(A) free(A)
 #define dt_free_align_ptr free


### PR DESCRIPTION
Per suggestion on #7901, to avoid further occurrences of Windows-only crashes when changing malloc to dt_alloc_align but failing to change the corresponding free to dt_free_align, force the free to crash by returning an offset pointer from dt_alloc_align on Debug builds on non-Windows systems.

Verified that this makes 7879 reproducible on Linux -- Debug build of dt crashes with `double free or corruption` message.

