### PR TITLE
restore default hinter message when module loses GUI focus

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -20,6 +20,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/exif.h"
+#include "common/collection.h"
 #include "common/dtpthread.h"
 #include "common/imagebuf.h"
 #include "common/imageio_rawspeed.h"
@@ -2151,8 +2152,10 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     /* redraw the expander */
     gtk_widget_queue_draw(darktable.develop->gui_module->expander);
 
-    /* and finally remove hinter messages */
-    dt_control_hinter_message(darktable.control, "");
+    /* and finally restore default hinter message */
+//    dt_control_hinter_message(darktable.control, "");
+    dt_collection_hint_message(darktable.collection);
+    
 
     // we also remove the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(darktable.develop->gui_module));


### PR DESCRIPTION
Fixes #4242.  Does not address other instances of the same issue (e.g. in Liquify, clicking the "edit nodes" icon twice clears the hinter message),  but for those the default message gets restored by switching to another module without the need to switch to an entirely different image or jump to Lighttable and back.