### PR TITLE
GTK-ify histogram UI

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -746,12 +746,12 @@ overshoot.right
 
 #main-histogram #button_box
 {
-  margin: 0.5em;   /* spacing between histogram buttons and the edge of histogram */
+  margin-top: 0.5em;   /* spacing between histogram buttons and top of scope */
 }
 
 #main-histogram #button_box > *
 {
-  margin-left:.5em;  /* spacing between histogram button box widgets */
+  margin-right: 0.5em;  /* spacing between histogram button box widgets, also provides right margin for buttons */
 }
 
 #main-histogram .toggle

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -753,8 +753,8 @@ overshoot.right
 #main-histogram .toggle
 {
   border: 1.1px solid alpha(@button_bg, 0.3);
-  min-height: 0.85em;
-  min-width: 0.85em;
+  min-height: 1em;  /* FIXME: what happens if don't set these? -- what is the source */
+  min-width: 1em;
 }
 
 #main-histogram #red_channel_button:checked,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -742,7 +742,12 @@ overshoot.right
 /* Note that there are some pretty odd #'s here to match the behavior of the legacy scope buttons */
 #main-histogram #button_box
 {
-  margin: 0.5em;
+  margin: 0.5em;   /* spacing between histogram buttons and the edge of histogram */
+}
+
+#main-histogram #button_box > *
+{
+  margin-left:.5em;  /* spacing between histogram button box widgets */
 }
 
 #main-histogram .toggle
@@ -756,15 +761,15 @@ overshoot.right
 #main-histogram #green_channel_button:checked,
 #main-histogram #blue_channel_button:checked
 {
-  border-color: alpha(@button_checked_fg, 0.56);
+  border-color: alpha(@button_checked_fg, 0.56);    /* hack to match legacy color of white with alpha of 0.5 */
 }
 
 #main-histogram #scope_type_button,
 #main-histogram #histogram_scale_button,
 #main-histogram #waveform_type_button
 {
-  color: alpha(@button_checked_fg, 0.56);
-  background-color: alpha(@button_bg, 0.3);
+  color: alpha(@button_checked_fg, 0.56);           /* hack to match legacy color of white with alpha of 0.5 */
+  background-color: alpha(darker(@button_bg),0.8);  /* hack to be close to legacy color */
 }
 
 #scope_type_button > #button-canvas,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -739,6 +739,7 @@ overshoot.right
 }
 
 /* scope/histogram */
+/* Note that there are some pretty odd #'s here to match the behavior of the legacy scope buttons */
 #main-histogram #button_box
 {
   margin: 0.5em;
@@ -751,9 +752,26 @@ overshoot.right
   min-width: 0.85em;
 }
 
-#main-histogram .toggle:checked
+#main-histogram #red_channel_button:checked,
+#main-histogram #green_channel_button:checked,
+#main-histogram #blue_channel_button:checked
 {
-  border-color: alpha(@button_checked_fg, 0.6);
+  border-color: alpha(@button_checked_fg, 0.56);
+}
+
+#main-histogram #scope_type_button,
+#main-histogram #histogram_scale_button,
+#main-histogram #waveform_type_button
+{
+  color: alpha(@button_checked_fg, 0.56);
+  background-color: alpha(@button_bg, 0.3);
+}
+
+#scope_type_button > #button-canvas,
+#histogram_scale_button > #button-canvas,
+#waveform_type_button > #button-canvas
+{
+  margin: -14px; /* not real pixels, this is used as a percent extra space */
 }
 
 #main-histogram #red_channel_button

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -738,6 +738,39 @@ overshoot.right
   margin-right: 0.5em;
 }
 
+/* scope/histogram */
+#main-histogram #button_box
+{
+  margin: 0.5em;
+}
+
+#main-histogram .toggle
+{
+  border: 1.1px solid alpha(@button_bg, 0.3);
+  min-height: 0.85em;
+  min-width: 0.85em;
+}
+
+#main-histogram .toggle:checked
+{
+  border-color: alpha(@button_checked_fg, 0.6);
+}
+
+#main-histogram #red_channel_button
+{
+  background-color: alpha(@graph_red, 0.333);
+}
+
+#main-histogram #green_channel_button
+{
+  background-color: alpha(@graph_green, 0.333);
+}
+
+#main-histogram #blue_channel_button
+{
+  background-color: alpha(@graph_blue, 0.333);
+}
+
 /*------------------
   - Dialog windows -
   ------------------*/

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -760,7 +760,8 @@ overshoot.right
 #main-histogram #red_channel_button:checked,
 #main-histogram #green_channel_button:checked,
 #main-histogram #blue_channel_button:checked
-{
+{ /* legacy behavior: checking channel buttons makes a lighter border, doesn't change interior */
+  /* FIXME: would be better to decrease alpha of unchecked channels? */
   border-color: alpha(@button_checked_fg, 0.56);    /* hack to match legacy color of white with alpha of 0.5 */
 }
 
@@ -776,6 +777,7 @@ overshoot.right
 #histogram_scale_button > #button-canvas,
 #waveform_type_button > #button-canvas
 {
+  /* hack to make icons larger to match legacy appearance */
   margin: -14px; /* not real pixels, this is used as a percent extra space */
 }
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -740,6 +740,10 @@ overshoot.right
 
 /* scope/histogram */
 /* Note that there are some pretty odd #'s here to match the behavior of the legacy scope buttons */
+#scope-draw
+{
+}
+
 #main-histogram #button_box
 {
   margin: 0.5em;   /* spacing between histogram buttons and the edge of histogram */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -740,16 +740,12 @@ overshoot.right
 
 /* scope/histogram */
 /* Note that there are some pretty odd #'s here to match the behavior of the legacy scope buttons */
-#scope-draw
-{
-}
-
-#main-histogram #button_box
+#main-histogram buttonbox
 {
   margin-top: 0.5em;   /* spacing between histogram buttons and top of scope */
 }
 
-#main-histogram #button_box > *
+#main-histogram buttonbox > *
 {
   margin-right: 0.5em;  /* spacing between histogram button box widgets, also provides right margin for buttons */
 }
@@ -761,43 +757,43 @@ overshoot.right
   min-width: 1em;
 }
 
-#main-histogram #red_channel_button:checked,
-#main-histogram #green_channel_button:checked,
-#main-histogram #blue_channel_button:checked
-{ /* legacy behavior: checking channel buttons makes a lighter border, doesn't change interior */
-  /* FIXME: would be better to decrease alpha of unchecked channels? */
-  border-color: alpha(@button_checked_fg, 0.56);    /* hack to match legacy color of white with alpha of 0.5 */
-}
-
-#main-histogram #scope_type_button,
-#main-histogram #histogram_scale_button,
-#main-histogram #waveform_type_button
+#scope-type-button,
+#histogram-scale-button,
+#waveform-type-button
 {
   color: alpha(@button_checked_fg, 0.56);           /* hack to match legacy color of white with alpha of 0.5 */
   background-color: alpha(darker(@button_bg),0.8);  /* hack to be close to legacy color */
 }
 
-#scope_type_button > #button-canvas,
-#histogram_scale_button > #button-canvas,
-#waveform_type_button > #button-canvas
+#scope-type-button > #button-canvas,
+#histogram-scale-button > #button-canvas,
+#waveform-type-button > #button-canvas
 {
   /* hack to make icons larger to match legacy appearance */
   margin: -14px; /* not real pixels, this is used as a percent extra space */
 }
 
-#main-histogram #red_channel_button
+#red-channel-button
 {
   background-color: alpha(@graph_red, 0.333);
 }
 
-#main-histogram #green_channel_button
+#green-channel-button
 {
   background-color: alpha(@graph_green, 0.333);
 }
 
-#main-histogram #blue_channel_button
+#blue-channel-button
 {
   background-color: alpha(@graph_blue, 0.333);
+}
+
+#red-channel-button:checked,
+#green-channel-button:checked,
+#blue-channel-button:checked
+{ /* legacy behavior: checking channel buttons makes a lighter border, doesn't change interior */
+  /* FIXME: would be better to decrease alpha of unchecked channels? */
+  border-color: alpha(@button_checked_fg, 0.56);    /* hack to match legacy color of white with alpha of 0.5 */
 }
 
 /*------------------

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1012,6 +1012,106 @@ void dtgtk_cairo_paint_camera(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   FINISH
 }
 
+void dtgtk_cairo_paint_histogram_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.0, 1.0);
+  cairo_curve_to(cr, 0.3, 1.0, 0.3, 0.0, 0.5, 0.0);
+  cairo_curve_to(cr, 0.7, 0.0, 0.7, 1.0, 1.0, 1.0);
+  cairo_fill(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_waveform_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_pattern_t *pat;
+  pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
+
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, 0.0, 0.0, 0.0, 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.2, 0.2, 0.2, 0.2, 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.5, 1.0, 1.0, 1.0, 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.6, 1.0, 1.0, 1.0, 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, 0.2, 0.2, 0.2, 0.5);
+
+  cairo_rectangle(cr, 0.0, 0.0, 0.3, 1.0);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+
+  cairo_save(cr);
+  cairo_scale(cr, 1.0, -1.0);
+  cairo_translate(cr, 0.0, -1.0);
+  cairo_rectangle(cr, 0.2, 0.0, 0.6, 1.0);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+  cairo_restore(cr);
+
+  cairo_rectangle(cr, 0.7, 0.0, 0.3, 1.0);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+
+  cairo_pattern_destroy(pat);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_linear_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.0, 1.0);
+  cairo_line_to(cr, 1.0, 0.0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_logarithmic_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.0, 1.0);
+  cairo_curve_to(cr, 0.0, 0.33, 0.66, 0.0, 1.0, 0.0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_waveform_overlaid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // FIXME: if make a mode comobox (histogram, waveform, RGB parade) then don't need this icon
+  // FIXME: improve this icon to make it look like a waveform in color
+  // FIXME: if don't improve, then just use dtgtk_cairo_paint_color()
+  cairo_rectangle(cr, 0.0, 0.0, 1.0, 1.0);
+  cairo_fill(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // FIMXE: render as three waveform-ish patterns in the three primaries
+  const GdkRGBA *const primaries = darktable.bauhaus->graph_primaries;
+  cairo_set_source_rgba(cr, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha/3.0);
+  cairo_rectangle(cr, 0.0, 0.0, 1.0/3.0, 1.0);
+  cairo_fill(cr);
+  cairo_set_source_rgba(cr, primaries[1].red, primaries[1].green, primaries[1].blue, primaries[1].alpha/3.0);
+  cairo_rectangle(cr, 1.0/3.0, 0.0, 1.0/3.0, 1.0);
+  cairo_fill(cr);
+  cairo_set_source_rgba(cr, primaries[2].red, primaries[2].green, primaries[2].blue, primaries[2].alpha/3.0);
+  cairo_rectangle(cr, 2.0/3.0, 0.0, 1.0/3.0, 1.0);
+  cairo_fill(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -185,6 +185,18 @@ void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_focus_peaking(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint camera icon */
 void dtgtk_cairo_paint_camera(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint histogram scope icon */
+void dtgtk_cairo_paint_histogram_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint waveform scope icon */
+void dtgtk_cairo_paint_waveform_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint linear scale icon */
+void dtgtk_cairo_paint_linear_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint logarithmic scale icon */
+void dtgtk_cairo_paint_logarithmic_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint waveform overlaid icon */
+void dtgtk_cairo_paint_waveform_overlaid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint RGB parade icon */
+void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -43,17 +43,12 @@ DT_MODULE(1)
 
 typedef enum dt_lib_histogram_highlight_t
 {
+  // FIXME: do we need all these states?
   DT_LIB_HISTOGRAM_HIGHLIGHT_OUTSIDE_WIDGET = 0,
+  // FIXME: is this state used anymore?
   DT_LIB_HISTOGRAM_HIGHLIGHT_IN_WIDGET,
   DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT,
   DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE
-#if 0
-  DT_LIB_HISTOGRAM_HIGHLIGHT_TYPE,
-  DT_LIB_HISTOGRAM_HIGHLIGHT_MODE,
-  DT_LIB_HISTOGRAM_HIGHLIGHT_RED,
-  DT_LIB_HISTOGRAM_HIGHLIGHT_GREEN,
-  DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE,
-#endif
 } dt_lib_histogram_highlight_t;
 
 typedef enum dt_lib_histogram_scope_type_t
@@ -108,11 +103,6 @@ typedef struct dt_lib_histogram_t
   dt_lib_histogram_scale_t histogram_scale;
   dt_lib_histogram_waveform_type_t waveform_type;
   gboolean red, green, blue;
-#if 0
-  // button locations
-  float type_x, mode_x, red_x, green_x, blue_x;
-  float button_w, button_h, button_y, button_spacing;
-#endif
 } dt_lib_histogram_t;
 
 const char *name(dt_lib_module_t *self)
@@ -329,184 +319,6 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     dt_free_align(img_display);
 }
 
-#if 0
-static void _draw_color_toggle(cairo_t *cr, float x, float y, float width, float height, gboolean state,
-                               const GdkRGBA color)
-{
-  // FIXME: use dtgtk_cairo_paint_color()
-  // FIXME: add "cairo_set_source_rgb_with_alpha()" to make cases such as this less verbose
-  cairo_set_source_rgba(cr, color.red, color.green, color.blue, color.alpha/3.0);
-  const float border = MIN(width * .05, height * .05);
-  cairo_rectangle(cr, x + border, y + border, width - 2.0 * border, height - 2.0 * border);
-  cairo_fill_preserve(cr);
-  if(state)
-    cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
-  else
-    cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
-  cairo_set_line_width(cr, border);
-  cairo_stroke(cr);
-}
-
-static void _draw_type_toggle(cairo_t *cr, float x, float y, float width, float height, int type)
-{
-  cairo_save(cr);
-  cairo_translate(cr, x, y);
-
-  // border
-  const float border = MIN(width * .05, height * .05);
-  set_color(cr, darktable.bauhaus->graph_border);
-  cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
-  cairo_fill_preserve(cr);
-  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
-  cairo_set_line_width(cr, border);
-  cairo_stroke(cr);
-
-  // icon
-  // FIXME: move to dtgtk/paint
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
-  cairo_move_to(cr, 2.0 * border, height - 2.0 * border);
-  switch(type)
-  {
-    case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-      cairo_curve_to(cr, 0.3 * width, height - 2.0 * border, 0.3 * width, 2.0 * border,
-                     0.5 * width, 2.0 * border);
-      cairo_curve_to(cr, 0.7 * width, 2.0 * border, 0.7 * width, height - 2.0 * border,
-                     width - 2.0 * border, height - 2.0 * border);
-      cairo_fill(cr);
-      break;
-    case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-    {
-      cairo_pattern_t *pattern;
-      pattern = cairo_pattern_create_linear(0.0, 1.5 * border, 0.0, height - 3.0 * border);
-
-      cairo_pattern_add_color_stop_rgba(pattern, 0.0, 0.0, 0.0, 0.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.2, 0.2, 0.2, 0.2, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.5, 1.0, 1.0, 1.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.6, 1.0, 1.0, 1.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 1.0, 0.2, 0.2, 0.2, 0.5);
-
-      cairo_rectangle(cr, 1.5 * border, 1.5 * border, (width - 3.0 * border) * 0.3, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
-      cairo_fill(cr);
-
-      cairo_save(cr);
-      cairo_scale(cr, 1, -1);
-      cairo_translate(cr, 0, -height);
-      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.2, 1.5 * border,
-                      (width - 3.0 * border) * 0.6, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
-      cairo_fill(cr);
-      cairo_restore(cr);
-
-      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.7, 1.5 * border,
-                      (width - 3.0 * border) * 0.3, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
-      cairo_fill(cr);
-
-      cairo_pattern_destroy(pattern);
-      break;
-    }
-  }
-  cairo_restore(cr);
-}
-
-static void _draw_histogram_scale_toggle(cairo_t *cr, float x, float y, float width, float height, int mode)
-{
-  cairo_save(cr);
-  cairo_translate(cr, x, y);
-
-  // border
-  const float border = MIN(width * .05, height * .05);
-  set_color(cr, darktable.bauhaus->graph_border);
-  cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
-  cairo_fill_preserve(cr);
-  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
-  cairo_set_line_width(cr, border);
-  cairo_stroke(cr);
-
-  // icon
-  // FIXME: move to dtgtk/paint
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
-  cairo_move_to(cr, 2.0 * border, height - 2.0 * border);
-  switch(mode)
-  {
-    case DT_LIB_HISTOGRAM_LINEAR:
-      cairo_line_to(cr, width - 2.0 * border, 2.0 * border);
-      cairo_stroke(cr);
-      break;
-    case DT_LIB_HISTOGRAM_LOGARITHMIC:
-      cairo_curve_to(cr, 2.0 * border, 0.33 * height, 0.66 * width, 2.0 * border, width - 2.0 * border,
-                     2.0 * border);
-      cairo_stroke(cr);
-      break;
-  }
-  cairo_restore(cr);
-}
-
-static void _draw_waveform_mode_toggle(cairo_t *cr, float x, float y, float width, float height, int mode)
-{
-  cairo_save(cr);
-  cairo_translate(cr, x, y);
-
-  // border
-  const float border = MIN(width * .05, height * .05);
-  // FIXME: move to dtgtk/paint
-  switch(mode)
-  {
-    case DT_LIB_HISTOGRAM_WAVEFORM_OVERLAID:
-    {
-      cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.33);
-      cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
-      cairo_fill_preserve(cr);
-      break;
-    }
-    case DT_LIB_HISTOGRAM_WAVEFORM_PARADE:
-    {
-      const GdkRGBA *const primaries = darktable.bauhaus->graph_primaries;
-      cairo_set_source_rgba(cr, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha/3.0);
-      cairo_rectangle(cr, border, border, width / 3.0, height - 2.0 * border);
-      cairo_fill(cr);
-      cairo_set_source_rgba(cr, primaries[1].red, primaries[1].green, primaries[1].blue, primaries[1].alpha/3.0);
-      cairo_rectangle(cr, width / 3.0, border, width / 3.0, height - 2.0 * border);
-      cairo_fill(cr);
-      cairo_set_source_rgba(cr, primaries[2].red, primaries[2].green, primaries[2].blue, primaries[2].alpha/3.0);
-      cairo_rectangle(cr, width * 2.0 / 3.0, border, width / 3.0, height - 2.0 * border);
-      cairo_fill(cr);
-      cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
-      break;
-    }
-  }
-
-  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
-  cairo_set_line_width(cr, border);
-  cairo_stroke(cr);
-
-  cairo_restore(cr);
-}
-
-static gboolean _lib_histogram_configure_callback(GtkWidget *widget, GdkEventConfigure *event, gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
-
-  // FIXME: gtk-ize this, use buttons packed in a GtkBox
-  const int width = event->width;
-  // mode and color buttons position on first expose or widget size change
-  // FIXME: should the button size depend on histogram width or just be set to something reasonable
-  d->button_spacing = 0.02 * width;
-  d->button_w = 0.06 * width;
-  d->button_h = 0.06 * width;
-  d->button_y = d->button_spacing;
-  const float offset = d->button_w + d->button_spacing;
-  d->blue_x = width - offset;
-  d->green_x = d->blue_x - offset;
-  d->red_x = d->green_x - offset;
-  d->mode_x = d->red_x - offset;
-  d->type_x = d->mode_x - offset;
-
-  return TRUE;
-}
-#endif
 
 static void _lib_histogram_draw_histogram(dt_lib_histogram_t *d, cairo_t *cr,
                                           int width, int height, const uint8_t mask[3])
@@ -705,29 +517,6 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   }
   dt_pthread_mutex_unlock(&d->lock);
 
-#if 0
-  // buttons to control the display of the histogram: linear/log, r, g, b
-  if(d->highlight != DT_LIB_HISTOGRAM_HIGHLIGHT_OUTSIDE_WIDGET)
-  {
-    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-    _draw_type_toggle(cr, d->type_x, d->button_y, d->button_w, d->button_h, d->scope_type);
-    switch(d->scope_type)
-    {
-      case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-        _draw_histogram_scale_toggle(cr, d->mode_x, d->button_y, d->button_w, d->button_h, d->histogram_scale);
-        break;
-      case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-        _draw_waveform_mode_toggle(cr, d->mode_x, d->button_y, d->button_w, d->button_h, d->waveform_type);
-        break;
-      case DT_LIB_HISTOGRAM_SCOPE_N:
-        g_assert_not_reached();
-    }
-    _draw_color_toggle(cr, d->red_x, d->button_y, d->button_w, d->button_h, d->red, darktable.bauhaus->graph_primaries[0]);
-    _draw_color_toggle(cr, d->green_x, d->button_y, d->button_w, d->button_h, d->green, darktable.bauhaus->graph_primaries[1]);
-    _draw_color_toggle(cr, d->blue_x, d->button_y, d->button_w, d->button_h, d->blue, darktable.bauhaus->graph_primaries[2]);
-  }
-#endif
-
   cairo_destroy(cr);
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
@@ -783,81 +572,11 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
     const float posy = y / (float)(allocation.height);
     const dt_lib_histogram_highlight_t prior_highlight = d->highlight;
 
-    // FIXME: rather than roll button code from scratch, take advantage of bauhaus/gtk button code?
+    // FIXME: does this ever happen? maybe if we're grabbing pointer... regardless this should be set by the leave event
     if(posx < 0.0f || posx > 1.0f || posy < 0.0f || posy > 1.0f)
     {
       d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_OUTSIDE_WIDGET;
     }
-#if 0
-    // FIXME: simplify this, check for y position, and if it's in range, check for x, and set highlight, and depending on that draw tooltip
-    // FIXME: or alternately use copy_path_flat(), append_path(p), in_fill() and keep around the rectangles for each button
-    else if(x > d->type_x && x < d->type_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
-    {
-      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_TYPE;
-      switch(d->scope_type)
-      {
-        case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-          gtk_widget_set_tooltip_text(widget, _("set mode to waveform"));
-          break;
-        case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-          gtk_widget_set_tooltip_text(widget, _("set mode to histogram"));
-          break;
-        case DT_LIB_HISTOGRAM_SCOPE_N:
-          g_assert_not_reached();
-      }
-    }
-    else if(x > d->mode_x && x < d->mode_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
-    {
-      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_MODE;
-      switch(d->scope_type)
-      {
-        case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-          switch(d->histogram_scale)
-          {
-            case DT_LIB_HISTOGRAM_LOGARITHMIC:
-              gtk_widget_set_tooltip_text(widget, _("set scale to linear"));
-              break;
-            case DT_LIB_HISTOGRAM_LINEAR:
-              gtk_widget_set_tooltip_text(widget, _("set scale to logarithmic"));
-              break;
-            default:
-              g_assert_not_reached();
-          }
-          break;
-        case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-          switch(d->waveform_type)
-          {
-            case DT_LIB_HISTOGRAM_WAVEFORM_OVERLAID:
-              gtk_widget_set_tooltip_text(widget, _("set mode to RGB parade"));
-              break;
-            case DT_LIB_HISTOGRAM_WAVEFORM_PARADE:
-              gtk_widget_set_tooltip_text(widget, _("set mode to waveform"));
-              break;
-            default:
-              g_assert_not_reached();
-          }
-          break;
-        case DT_LIB_HISTOGRAM_SCOPE_N:
-          g_assert_not_reached();
-      }
-    }
-    else if(x > d->red_x && x < d->red_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
-    {
-      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_RED;
-      gtk_widget_set_tooltip_text(widget, d->red ? _("click to hide red channel") : _("click to show red channel"));
-    }
-    else if(x > d->green_x && x < d->green_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
-    {
-      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_GREEN;
-      gtk_widget_set_tooltip_text(widget, d->green ? _("click to hide green channel")
-                                                 : _("click to show green channel"));
-    }
-    else if(x > d->blue_x && x < d->blue_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
-    {
-      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE;
-      gtk_widget_set_tooltip_text(widget, d->blue ? _("click to hide blue channel") : _("click to show blue channel"));
-    }
-#endif
     // FIXME: make the two draggables different widgets, a set for each scope type -- won'tr be updating tooltips all the time, plus might cancel drag more easily
     // FIXME: is there a standard GTK widget that can act as a draggable parameter changer
     else if(hooks_available &&
@@ -877,18 +596,8 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
       d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_IN_WIDGET;
       gtk_widget_set_tooltip_text(widget, _("ctrl+scroll to change display height"));
     }
-    // FIXME: is this enough to handle cursor change, don't need drawable to detect enter?
     if(prior_highlight != d->highlight)
     {
-#if 0
-      if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT ||
-         d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
-        // FIXME: should really use named cursors, and this should be "grab" or "grabbing" depending on whether button is down
-        dt_control_change_cursor(GDK_HAND1);
-      else
-        dt_control_change_cursor(GDK_LEFT_PTR);
-#endif
-      // FIXME: this is right, only updates drawable -- make sure the other code is similarly ok and doesn't touch "self->widget" unnecessarily
       dt_control_queue_redraw_widget(widget);
     }
   }
@@ -916,66 +625,17 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
   dt_develop_t *dev = darktable.develop;
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  const dt_view_type_flags_t view_type = cv->view(cv);
-  const gboolean hooks_available = (view_type == DT_VIEW_DARKROOM) && dt_dev_exposure_hooks_available(dev);
+  // FIXME: instead of testing view type, just test if highlight is on exposure or black point
 
-  if(event->type == GDK_2BUTTON_PRESS && hooks_available &&
-     (d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT || d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE))
+  if((cv->view(cv) == DT_VIEW_DARKROOM) && dt_dev_exposure_hooks_available(dev))
   {
-    dt_dev_exposure_reset_defaults(dev);
-  }
-#if 0
-  else
-  {
-    // FIXME: this handles repeated-click events in buttons weirdly, as it confuses them with doubleclicks
-    if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_TYPE)
+    if(event->type == GDK_2BUTTON_PRESS &&
+       (d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT || d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE))
     {
-      d->scope_type = (d->scope_type + 1) % DT_LIB_HISTOGRAM_SCOPE_N;
-      dt_conf_set_string("plugins/darkroom/histogram/mode",
-                         dt_lib_histogram_scope_type_names[d->scope_type]);
-      // generate data for changed scope and trigger widget redraw
-      if(view_type == DT_VIEW_DARKROOM)
-        dt_dev_process_preview(dev);
-      else
-        dt_control_queue_redraw_center();
+      dt_dev_exposure_reset_defaults(dev);
+      // FIXME: does this trigger a widget redraw?
     }
-    if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_MODE)
-    {
-      switch(d->scope_type)
-      {
-        case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-          d->histogram_scale = (d->histogram_scale + 1) % DT_LIB_HISTOGRAM_N;
-          dt_conf_set_string("plugins/darkroom/histogram/histogram",
-                             dt_lib_histogram_histogram_scale_names[d->histogram_scale]);
-          // FIXME: this should really redraw current iop if its background is a histogram (check request_histogram)
-          darktable.lib->proxy.histogram.is_linear = d->histogram_scale == DT_LIB_HISTOGRAM_LINEAR;
-          break;
-        case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-          d->waveform_type = (d->waveform_type + 1) % DT_LIB_HISTOGRAM_WAVEFORM_N;
-          dt_conf_set_string("plugins/darkroom/histogram/waveform",
-                             dt_lib_histogram_waveform_type_names[d->waveform_type]);
-          break;
-        case DT_LIB_HISTOGRAM_SCOPE_N:
-          g_assert_not_reached();
-      }
-    }
-    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_RED)
-    {
-      d->red = !d->red;
-      dt_conf_set_bool("plugins/darkroom/histogram/show_red", d->red);
-    }
-    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_GREEN)
-    {
-      d->green = !d->green;
-      dt_conf_set_bool("plugins/darkroom/histogram/show_green", d->green);
-    }
-    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE)
-    {
-      d->blue = !d->blue;
-      dt_conf_set_bool("plugins/darkroom/histogram/show_blue", d->blue);
-    }
-#endif
-    else if(hooks_available)
+    else
     {
       // FIXME: once are dragging, should really grab the pointer so dragging continues even if outside of the widget and turn cursor to "grabbing", then when release button would need to ungrab the pointer and turn cursor to "grab" if still are over the widget
       d->dragging = TRUE;
@@ -986,12 +646,10 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
       d->button_down_x = event->x;
       d->button_down_y = event->y;
     }
-#if 0
+    // FIXME: do need to do this? or only when dragging?
+    // update for good measure
+    dt_control_queue_redraw_widget(widget);
   }
-#endif
-  // FIXME: do need to do this? and if so, only the drawable, yes?
-  // update for good measure
-  dt_control_queue_redraw_widget(self->widget);
 
   return TRUE;
 }
@@ -1131,6 +789,7 @@ static gboolean _lib_histogram_scroll_callback(GtkWidget *widget, GdkEventScroll
       dt_develop_t *dev = darktable.develop;
       const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
       const dt_view_type_flags_t view_type = cv->view(cv);
+      // FIXME: instead of testing view type, just test if highlight is on exposure or black point
       if(view_type == DT_VIEW_DARKROOM && dt_dev_exposure_hooks_available(dev))
       {
         // FIXME: as with bauhaus widget, delay processing the next event until the pixelpipe can update based on dev->preview_average_delay
@@ -1214,29 +873,6 @@ static gboolean _lib_histogram_eventbox_leave_notify_callback(GtkWidget *widget,
   gtk_widget_hide(d->button_box);
   return TRUE;
 }
-
-#if 0
-static gboolean _lib_histogram_button_enter_notify_callback(GtkWidget *widget, GdkEventCrossing *event,
-                                                              gpointer user_data)
-{
-  const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  const dt_lib_histogram_t *d = self->data;
-  // FIXME: just pass in d->button_box
-  // FIXME: show or show all?
-  gtk_widget_show(d->button_box);
-  return TRUE;
-}
-
-static gboolean _lib_histogram_button_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event,
-                                                              gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
-  // FIXME: just pass in d->button_box
-  gtk_widget_hide(d->button_box);
-  return TRUE;
-}
-#endif
 
 static gboolean _lib_histogram_collapse_callback(GtkAccelGroup *accel_group,
                                                 GObject *acceleratable, guint keyval,
@@ -1488,7 +1124,6 @@ void gui_init(dt_lib_module_t *self)
   d->scope_draw = gtk_drawing_area_new();
   // FIXME: be consistent about using hyphens or underscores
   gtk_widget_set_name(d->scope_draw, "scope-draw");
-  // FIXME: does double-click really reset?
   gtk_widget_set_tooltip_text(d->scope_draw, _("drag to change exposure,\ndoubleclick resets\nctrl+scroll to change display height"));
   gtk_container_add(GTK_CONTAINER(overlay), d->scope_draw);
 
@@ -1502,10 +1137,10 @@ void gui_init(dt_lib_module_t *self)
   // GtkButtonBox spreads out the icons, so we use GtkBox --
   // homogeneous shouldn't be necessary as icons are equal size, but
   // set it just to show the desired look
+  // FIXME: can set GtkButtonBox to GTK_ALIGN_END to get rid of that behavior, then skip gtk_box_set_homogeneous()?
   gtk_box_set_homogeneous(GTK_BOX(d->button_box), TRUE);
   gtk_overlay_add_overlay(GTK_OVERLAY(overlay), d->button_box);
 
-  // FIXME: only make the draggable/scrollable overlays visible if in darkroom view
   // FIXME: should histogram/waveform each be its own widget, and a GtkStack to switch between them? -- if so, then the each of the histogram/waveform widgets will have its own associated "mode" button, drawable, and sensitive areas for scrolling, but the channel buttons will be shared between them, or will modify the same underlying data
 
   // FIXME: make keyboard accelerators work for these
@@ -1549,7 +1184,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->button_box), d->mode_stack, FALSE, FALSE, 0);
 
   // red channel on/off
-  // FIXME: should each channel of scope be its own drawable, hence toggle will turn on/off visibility of a layer rather than request a redraw? is better to have one drawable responsive to config (as now), as in the main case it'll be showing all three channels, and no need to merge channels on the fly?
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
   // FIXME: better to have a general tooltip rather than flipping it when the button is pressed
   gtk_widget_set_name(button, "red_channel_button");
@@ -1574,9 +1208,6 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(_blue_channel_toggle), d);
   gtk_box_pack_start(GTK_BOX(d->button_box), button, FALSE, FALSE, 0);
 
-  // FIXME: use gtk_event_box_new() to catch scroll/drag events? or a transparent overlay at top/bottom, with gtk_widget_set_no_show_all() to hide except when mouse is over?
-  // FIXME: could use a GtkActionBar for the buttons at the top?
-
   // The main widget is an overlay which has no window, and hence
   // can't catch events. We need something on top to catch events to
   // show/hide the buttons. The drawable is below the buttons, and
@@ -1587,9 +1218,6 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: should eventbox only contain the buttonbox, if its only job is to show the buttonbox?
   // FIXME: can just make buttonbox the size of the widget with a CSS hover property to make it disappear (not opaque, as it would still be sensitive) when mouse is over it?
   gtk_container_add(GTK_CONTAINER(eventbox), overlay);
-  //gtk_event_box_set_above_child(GTK_EVENT_BOX(self->widget), TRUE);
-  //gtk_event_box_set_visible_window(GTK_EVENT_BOX(self->widget), FALSE);
-  //gtk_overlay_add_overlay(GTK_OVERLAY(overlay), eventbox);
 
   gtk_widget_add_events(eventbox, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK);
   // FIXME: the button box uses padding/margins so that the mouse doesn't show up as returned to the drawable until it is well outside of the buttons -- though maybe it is nice that it remains a pointer between the buttons?
@@ -1620,11 +1248,6 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->scope_draw), "motion-notify-event",
                    G_CALLBACK(_lib_histogram_motion_notify_callback), self);
   g_signal_connect(G_OBJECT(d->scope_draw), "scroll-event", G_CALLBACK(_lib_histogram_scroll_callback), self);
-  // FIXME: don't need to catch configure event if it is only used to draw the custom buttons
-#if 0
-  g_signal_connect(G_OBJECT(d->scope_draw), "configure-event",
-                   G_CALLBACK(_lib_histogram_configure_callback), self);
-#endif
 
   // FIXME: do we even need to save self->widget? most references are to the drawable...
   // FIXME: how does reference counting of widgets work? do we need to dealloc or garbage collect them?

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1258,31 +1258,40 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.histogram.process = dt_lib_histogram_process;
   darktable.lib->proxy.histogram.is_linear = d->histogram_scale == DT_LIB_HISTOGRAM_LINEAR;
 
-  /* create drawingarea */
-  self->widget = gtk_drawing_area_new();
-  gtk_widget_set_name(self->widget, "main-histogram");
+  // create widgets
+  self->widget = gtk_overlay_new();
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
+  // FIXME: is this used?
+  gtk_widget_set_name(self->widget, "main-histogram");
 
-  gtk_widget_add_events(self->widget, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
+  GtkWidget *scope;
+
+  /* create drawingarea */
+  scope = gtk_drawing_area_new();
+
+  // FIXME: these events become less important if are using widgets on top of this
+  gtk_widget_add_events(scope, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK |
                                       darktable.gui->scroll_mask);
 
   /* connect callbacks */
-  gtk_widget_set_tooltip_text(self->widget, _("drag to change exposure,\ndoubleclick resets\nctrl+scroll to change display height"));
-  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_lib_histogram_draw_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "button-press-event",
+  gtk_widget_set_tooltip_text(scope, _("drag to change exposure,\ndoubleclick resets\nctrl+scroll to change display height"));
+  g_signal_connect(G_OBJECT(scope), "draw", G_CALLBACK(_lib_histogram_draw_callback), self);
+  g_signal_connect(G_OBJECT(scope), "button-press-event",
                    G_CALLBACK(_lib_histogram_button_press_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "button-release-event",
+  g_signal_connect(G_OBJECT(scope), "button-release-event",
                    G_CALLBACK(_lib_histogram_button_release_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "motion-notify-event",
+  g_signal_connect(G_OBJECT(scope), "motion-notify-event",
                    G_CALLBACK(_lib_histogram_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "leave-notify-event",
+  g_signal_connect(G_OBJECT(scope), "leave-notify-event",
                    G_CALLBACK(_lib_histogram_leave_notify_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "enter-notify-event",
+  g_signal_connect(G_OBJECT(scope), "enter-notify-event",
                    G_CALLBACK(_lib_histogram_enter_notify_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "scroll-event", G_CALLBACK(_lib_histogram_scroll_callback), self);
-  g_signal_connect(G_OBJECT(self->widget), "configure-event",
+  g_signal_connect(G_OBJECT(scope), "scroll-event", G_CALLBACK(_lib_histogram_scroll_callback), self);
+  g_signal_connect(G_OBJECT(scope), "configure-event",
                    G_CALLBACK(_lib_histogram_configure_callback), self);
+
+  gtk_container_add(GTK_CONTAINER(self->widget), scope);
 
   /* set size of navigation draw area */
   const float histheight = dt_conf_get_int("plugins/darkroom/histogram/height") * 1.0f;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1071,22 +1071,19 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   d->scope_draw = gtk_drawing_area_new();
-  // FIXME: be consistent about using hyphens or underscores
-  gtk_widget_set_name(d->scope_draw, "scope-draw");
   gtk_widget_set_tooltip_text(d->scope_draw, _("drag to change exposure,\ndoubleclick resets\nctrl+scroll to change display height"));
   gtk_container_add(GTK_CONTAINER(overlay), d->scope_draw);
 
+  // FIXME: clicking between or above/right of buttons makes the buttons disappear
   // a row of buttons
-  // FIXME: button box margins "obscure" events to drawable below -- place button box in another widget which provides these margins and doesn't catch events, or is it good that entire top-right of histogram is controls and there aren't thin ribbons of drawable receiving events?
-  d->button_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_name(d->button_box, "button_box");
+  // NOTE: Button box and button margins "obscure" events to drawable
+  // below, hence the entire top-right of histogram doesn't pass
+  // events down. This is probably OK, compared to having ribbons of
+  // drawable events between/above the buttons.
+  d->button_box = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
+  gtk_button_box_set_layout(GTK_BUTTON_BOX(d->button_box), GTK_BUTTONBOX_EXPAND);
   gtk_widget_set_valign(d->button_box, GTK_ALIGN_START);
   gtk_widget_set_halign(d->button_box, GTK_ALIGN_END);
-  // GtkButtonBox spreads out the icons, so we use GtkBox --
-  // homogeneous shouldn't be necessary as icons are equal size, but
-  // set it just to show the desired look
-  // FIXME: can set GtkButtonBox to GTK_ALIGN_END to get rid of that behavior, then skip gtk_box_set_homogeneous()?
-  gtk_box_set_homogeneous(GTK_BOX(d->button_box), TRUE);
   gtk_overlay_add_overlay(GTK_OVERLAY(overlay), d->button_box);
 
   // FIXME: should histogram/waveform each be its own widget, and a GtkStack to switch between them? -- if so, then the each of the histogram/waveform widgets will have its own associated "mode" button, drawable, and sensitive areas for scrolling, but the channel buttons will be shared between them, or will modify the same underlying data
@@ -1100,19 +1097,18 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: this should really be a combobox to allow for more types and not to have to swap the icon on button down
   d->scope_type_button =
     GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_histogram_scope, CPF_NONE, NULL));
-  gtk_widget_set_name(GTK_WIDGET(d->scope_type_button), "scope_type_button");
+  gtk_widget_set_name(GTK_WIDGET(d->scope_type_button), "scope-type-button");
   gtk_toggle_button_set_active(d->scope_type_button,
                                d->scope_type == DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM);
   gtk_box_pack_start(GTK_BOX(d->button_box), GTK_WIDGET(d->scope_type_button), FALSE, FALSE, 0);
 
   // scope mode
   d->mode_stack = gtk_stack_new();
-  gtk_widget_set_name(d->mode_stack, "scope_mode_stack");
 
   // histogram scale
   d->histogram_scale_button =
     GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_logarithmic_scale, CPF_NONE, NULL));
-  gtk_widget_set_name(GTK_WIDGET(d->histogram_scale_button), "histogram_scale_button");
+  gtk_widget_set_name(GTK_WIDGET(d->histogram_scale_button), "histogram-scale-button");
   gtk_toggle_button_set_active(d->histogram_scale_button,
                                d->histogram_scale_button == DT_LIB_HISTOGRAM_LOGARITHMIC);
   _histogram_scale_toggle(d->histogram_scale_button, d);
@@ -1122,7 +1118,7 @@ void gui_init(dt_lib_module_t *self)
   // histogram scale
   d->waveform_type_button =
     GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_waveform_overlaid, CPF_NONE, NULL));
-  gtk_widget_set_name(GTK_WIDGET(d->waveform_type_button), "waveform_type_button");
+  gtk_widget_set_name(GTK_WIDGET(d->waveform_type_button), "waveform-type-button");
   gtk_toggle_button_set_active(d->waveform_type_button,
                                d->waveform_type_button == DT_LIB_HISTOGRAM_WAVEFORM_OVERLAID);
   _waveform_type_toggle(d->waveform_type_button, d);
@@ -1137,7 +1133,7 @@ void gui_init(dt_lib_module_t *self)
   // red channel on/off
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
   // FIXME: better to have a general tooltip rather than flipping it when the button is pressed
-  gtk_widget_set_name(button, "red_channel_button");
+  gtk_widget_set_name(button, "red-channel-button");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), d->red);
   _red_channel_toggle(GTK_TOGGLE_BUTTON(button), d);
   g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(_red_channel_toggle), d);
@@ -1145,7 +1141,7 @@ void gui_init(dt_lib_module_t *self)
 
   // green channel on/off
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
-  gtk_widget_set_name(button, "green_channel_button");
+  gtk_widget_set_name(button, "green-channel-button");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), d->green);
   _green_channel_toggle(GTK_TOGGLE_BUTTON(button), d);
   g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(_green_channel_toggle), d);
@@ -1153,7 +1149,7 @@ void gui_init(dt_lib_module_t *self)
 
   // blue channel on/off
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
-  gtk_widget_set_name(button, "blue_channel_button");
+  gtk_widget_set_name(button, "blue-channel-button");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), d->blue);
   _blue_channel_toggle(GTK_TOGGLE_BUTTON(button), d);
   g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(_blue_channel_toggle), d);
@@ -1246,6 +1242,7 @@ void connect_key_accels(dt_lib_module_t *self)
                      g_cclosure_new(G_CALLBACK(_lib_histogram_cycle_mode_callback), self, NULL));
   dt_accel_connect_lib_as_view(self, "tethering", "cycle histogram modes",
                      g_cclosure_new(G_CALLBACK(_lib_histogram_cycle_mode_callback), self, NULL));
+  // FIXME: can connect these accelerators directly to the buttons
   dt_accel_connect_lib_as_view(self, "darkroom", "histogram/switch histogram mode",
                      g_cclosure_new(G_CALLBACK(_lib_histogram_change_mode_callback), self, NULL));
   dt_accel_connect_lib_as_view(self, "tethering", "switch histogram mode",

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1411,7 +1411,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *button_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(button_box, "button_box");
   gtk_widget_set_valign(button_box, GTK_ALIGN_START);
-  gtk_widget_set_halign(button_box, GTK_ALIGN_START);
+  gtk_widget_set_halign(button_box, GTK_ALIGN_END);
   // GtkButtonBox spreads out the icons, so we use GtkBox --
   // homogeneous shouldn't be necessary as icons are equal size, but
   // set it just to show the desired look

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -731,6 +731,10 @@ static void _scope_type_toggle(GtkWidget *button, dt_lib_histogram_t *d)
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(cv)  // this may be called on init, before in a view
   {
+    // redraw scope now, even if it isn't up to date, so that there is
+    // immediate feedback on button press even though there will be a
+    // lag to process the scope data
+    dt_control_queue_redraw_widget(d->scope_draw);
     const dt_view_type_flags_t view_type = cv->view(cv);
     if(view_type == DT_VIEW_DARKROOM)
       dt_dev_process_preview(darktable.develop);


### PR DESCRIPTION
This is an attempt to "GTK-ify" the histogram UI. The histogram UI code is some of the oldest in darktable (much unchanged since 2011). It uses hand-coded buttons to change scope type/mode/channels display. The extant code is succinct, efficient, and gives a signature look. But it is brittle when adding new scopes/variants and ways to tune extant scopes, and is not easy to adjust via CSS.

There is interest in adding a vectorscope #4149, vertical waveform display #3005, vertical RGB parade display, and general clean-ups (#6227, etc.). Any of this work would stretch the current UI code even more. Hence this PR to use proper GTK widgets.

Work done:

- Move the icon drawing code from `libs/histogram.c` to `dtgtk/paint.c`.
- Histogram is not one monolithic `GtkDrawingArea`. Separate out each button as a `GtkToggleButton`.
- Buttons can be styled via CSS. Current CSS is to make them look very similar to current look, excepting that they now have rounded corners, as per dt standard.
- GTK-ify code gets rid of some quirks, e.g. double-clicking on the buttons produces sensible results.
- When dragging to change exposure, drag continues even when mouse is pulled outside of the widget. Drag stops when the button is released.

Features lost:

- The buttons used to adjust size/spacing when the panel was resized. No longer.
- I thought this would make the code more succinct. While libs/histogram.c is about 75 lines shorter, overall this change adds nearly 100 LOC.

Potential UI work to do:

- Rethink the styling of the buttons. Make them look/function more like the rest of buttons in darktable. The look in master is expedient for a succinct hand-coded UI. But should the channel checkboxes really be marked "selected" by brightening their border? Etc.
- The new CSS has some odd colors and measurements in an effort to match the current look. Harmonize this with more standard CSS.
- The prior/new appearance is very similar to the old appearance, but if the desire is to match it 1:1, more tuning would be needed (note comparison below).
- Get rid of some other custom behavior which results in verbose code. E.g. should the tooltip change every time the button is clicked, or is one tooltip enough.
- The scope type/mode buttons function as comboboxes but are implemented as clickable bunctions. The current UI made sense when there was only one scope type (histogram) with two modes (linear/logarithmic). We probably at the least want a combobox to choose type (histogram, waveform, etc.). Also, people get confused by the way the buttons currently switch icons -- does a button with a straight line icon mean that the current waveform is linear, or that clicking on that button will set the waveform to linear? This makes users more dependent on the tooltip. A combobox would help.
- The icons representing the switch between waveform and RGB parade are a quick hack on my part. Make these better... This should be easier now that they are in dtgtk/paint.c and the coordiantes make more sense.

Potential further code cleanups:

- Make different drawables for each scope type (histogram, waveform) as the current draw callback is now full of alternating code paths.
- Make the drag regions for exposure adjustment be separate widgets -- may clean up code and put more into GTK's hands.
- Consider having drag regions control other iop's besides exposure. This would take a bunch of iop-plumbing work, but could make the histogram more useful for current workflows. OTOH, maybe we shouldn't be staring at the histogram when adjusting iops.
- Longstanding problem: dragging to change exposure has slow interaction. Crib code from `dt_bauhaus_slider_postponed_value_change()` to make this more fluid. Really, these drag regions should be their own custom widget -- they have a complicated enough behavior.
- The `dt_control_change_cursor()` code uses `gdk_cursor_new_for_display()`. More modern behavior it is to use `gdk_cursor_new_from_name()`. This would allow for distinguishing between a "grab" and a "grabbing" cursor.
- The motion notify code ends with a call to `gdk_window_get_device_position()`. I think this is code from before `gdk_window_set_event_compression()` defaulted to on. I want to try discarded this here and across all the other motion notify callbacks in darktable.
- GTK isn't really friendly to widgets overlayed widgets, and doesn't care about z-order -- despite darktable needing this to make key features work (e.g. thumbnails/thumbtable). I got this to work by having a `GtkOverlay` contain a `GtkButtonBox` above a `GtkDrawingArea`, and packaging that all in an `GtkEventBox`. This works and is stable, but I had to deal with some weird behavior where clicking on the `GtkButtonBox` where there were no buttons generated a drag event which made the `GtkEventBox` get a `leave-notify-event`. The current code works, but there may be a nicer way to do this.

The hope here is to not get too deep into GTK-world, but simply make a flexible/clear set of widgets that allow for adding scope types/features and some tuning up of the GUI's look. I'm putting up this PR now, in hopes that -- if this work is of interest -- it could provide a stable starting point.

Histogram in git master:

![image](https://user-images.githubusercontent.com/2311860/104946335-ddb4c200-5987-11eb-8239-b47552ba02af.png)

Histogram after this PR:

![image](https://user-images.githubusercontent.com/2311860/104946046-83b3fc80-5987-11eb-8987-3ac5b6fdc710.png)
