### PR TITLE
imageop: avoid modifying GUI outside GTK thread

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -398,8 +398,13 @@ typedef struct dt_iop_module_t
   GSList *accel_closures;
   GSList *accel_closures_local;
   gboolean local_closures_connected;
-  /** flag in case the module has troubles (bad settings) - if TRUE, show a warning sign next to module label */
-  gboolean has_trouble;
+  /** message set in case the module has troubles (bad settings) - if set (not NULL), show a warning sign next to
+   * module label */
+  gchar *trouble_message;
+  /** tooltip assigned to the module's trouble label */
+  gchar *trouble_tooltip;
+  /** flags whether the trouble message has been updated and requires rerendering */
+  gboolean trouble_message_updated;
   /** the corresponding SO object */
   dt_iop_module_so_t *so;
 
@@ -729,10 +734,10 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module);
 gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
 
 /** Set the trouble message for the module.  If non-empty, also flag the module as being in trouble; if empty
- ** or NULL, clear the trouble flag.  If 'toast_message' is non-NULL/non-empty, pop up a toast with that
- ** message when the module does not have a warning-label widget (use %s for the module's name).  **/
-void dt_iop_set_module_trouble_message(dt_iop_module_t *module, char *const trouble_msg,
-                                       const char *const trouble_tooltip, const char *stderr_message);
+ ** or NULL, clear the trouble flag.  If 'stderr_message' is non-NULL/non-empty, print a message to stderr.
+ ** (use %s for the module's name). If the module has no GUI, trouble_msg will be printed to stderr. **/
+void dt_iop_set_module_trouble_message(dt_iop_module_t *module, const gchar *trouble_msg,
+                                       const gchar *trouble_tooltip, const gchar *stderr_message);
 
 // format modules description going in tooltips
 char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
@@ -742,17 +747,23 @@ char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
 static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
 {
   module->gui_data = (dt_iop_gui_data_t*)calloc(1, size);
-  dt_pthread_mutex_init(&module->gui_lock,NULL);
   return module->gui_data;
 }
 #define IOP_GUI_ALLOC(module) \
   (dt_iop_##module##_gui_data_t *)_iop_gui_alloc(self,sizeof(dt_iop_##module##_gui_data_t))
 
-#define IOP_GUI_FREE \
-  dt_pthread_mutex_destroy(&self->gui_lock);if(self->gui_data){free(self->gui_data);} self->gui_data = NULL
+#define IOP_GUI_FREE                                                                                              \
+  do                                                                                                              \
+  {                                                                                                               \
+    free(self->gui_data);                                                                                         \
+    self->gui_data = NULL;                                                                                        \
+  } while(0)
 
 /* return a warning message, prefixed by the special character ⚠ */
 char *dt_iop_warning_message(const char *message);
+
+/* update the module's warning label */
+void dt_iop_gui_update_warning_label(dt_iop_module_t *module);
 
 /** check whether we have the required number of channels in the input data; if not, copy the input buffer to the
  ** output buffer, set the module's trouble message, and return FALSE */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -266,6 +266,18 @@ void expose(
     dt_dev_process_preview2(dev);
   }
 
+  // an iop's process() might have changed its trouble message.
+  // perform any necessary updates.
+  ++darktable.gui->reset;
+  GList *modules = dev->iop;
+  while(modules)
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
+    dt_iop_gui_update_warning_label(module);
+    modules = g_list_next(modules);
+  }
+  --darktable.gui->reset;
+
   dt_pthread_mutex_t *mutex = NULL;
   int stride;
   const float zoom_y = dt_control_get_dev_zoom_y();


### PR DESCRIPTION
Another fix for potential GUI / GTK race conditions in the spirit of https://github.com/darktable-org/darktable/pull/7923. With 3c27a9457b08c30eb6baf40bc86c0d3afc968dc2, a check was added in some IOP's `process()` that also modifies the module's trouble message GUI widget. This can result in race conditions.

I'm not yet sure if this applies also on 3.4.x but will check shortly.

Edit: doesn't seem to apply on 3.4.x, 3c27a9457b08c30eb6baf40bc86c0d3afc968dc2 is not in that branch and `channelmixerrgb` uses its own warning label there, not the general implementation added in b10d973eb355b363308de692b2deaee217633805.

A lot of stuff going on in this commit, but it does the following:
1. Add the trouble message in the general module data
2. Always initialize the `gui_lock` - this is used to synchronize access to the trouble message data
3. The trouble message widget is updated in `darkroom/expose()`
