### PR TITLE
[lua] get image from database by image id

### DIFF
--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -208,7 +208,7 @@ static int database_numindex(lua_State *L)
 
 static int database_get_image(lua_State *L)
 {
-  int img_id = luaL_checkinteger(L, -1);
+  const int img_id = luaL_checkinteger(L, -1);
   if(img_id < 1)
   {
     return luaL_error(L, "incorrect image id in database");

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -196,13 +196,11 @@ static int database_numindex(lua_State *L)
   {
     int imgid = sqlite3_column_int(stmt, 0);
     luaA_push(L, dt_lua_image_t, &imgid);
-    sqlite3_finalize(stmt);
   }
   else
-  {
-    sqlite3_finalize(stmt);
     lua_pushnil(L);
-  }
+  
+  sqlite3_finalize(stmt);
   return 1;
 }
 
@@ -222,13 +220,11 @@ static int database_get_image(lua_State *L)
   {
     int imgid = sqlite3_column_int(stmt, 0);
     luaA_push(L, dt_lua_image_t, &imgid);
-    sqlite3_finalize(stmt);
   }
   else
-  {
-    sqlite3_finalize(stmt);
     lua_pushnil(L);
-  }
+
+  sqlite3_finalize(stmt);
   return 1;
 }
 

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -206,6 +206,32 @@ static int database_numindex(lua_State *L)
   return 1;
 }
 
+static int database_get_image(lua_State *L)
+{
+  int img_id = luaL_checkinteger(L, -1);
+  if(img_id < 1)
+  {
+    return luaL_error(L, "incorrect image id in database");
+  }
+  sqlite3_stmt *stmt = NULL;
+  char query[1024];
+  snprintf(query, sizeof(query), "SELECT id FROM main.images WHERE id = %d LIMIT 1",
+           img_id);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    int imgid = sqlite3_column_int(stmt, 0);
+    luaA_push(L, dt_lua_image_t, &imgid);
+    sqlite3_finalize(stmt);
+  }
+  else
+  {
+    sqlite3_finalize(stmt);
+    lua_pushnil(L);
+  }
+  return 1;
+}
+
 static int collection_len(lua_State *L)
 {
   lua_pushinteger(L, dt_collection_get_count(darktable.collection));
@@ -266,6 +292,9 @@ int dt_lua_init_database(lua_State *L)
   lua_pushcfunction(L, dt_lua_copy_image);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, type_id, "copy_image");
+  lua_pushcfunction(L, database_get_image);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, type_id, "get_image");
 
   /* database type */
   dt_lua_push_darktable_lib(L);


### PR DESCRIPTION
Added a get_image function to darktable.database to retrieve the image by imageid.

The only lua function for retrieving an image from the database is darktable.database[index].  This index specifies the row of the image table, not the image id.  As long as no images are removed or trashed, the index and the row id agree, but once an import is done, removed, then reimported the row id differs from the image id by the amount of images removed.  Therefore, the only way to retrieve a specific image is by searching the database.  

Attached is a test script that retrieves the last row of the image table, then retrieves the same image by image id.  If any deleting or removing of images has occurred, then the two numbers should not agree, which demonstrates the problem and the solution.
[test_db_get_image.lua.txt](https://github.com/darktable-org/darktable/files/5839449/test_db_get_image.lua.txt)
