### PR TITLE
Fix some glib critical messages for blending modules having no masks.

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -546,7 +546,7 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
     dt_masks_set_edit_mode(data->module, DT_MASKS_EDIT_OFF);
     gtk_widget_hide(GTK_WIDGET(data->masks_box));
   }
-  else
+  else if(data->masks_support)
   {
     for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->masks_shapes[n]), FALSE);
@@ -2097,9 +2097,13 @@ void dt_iop_gui_update_masks(dt_iop_module_t *module)
   }
   dt_bauhaus_combobox_set(bd->masks_combo, 0);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), bd->masks_shown != DT_MASKS_EDIT_OFF);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_polarity),
-                               bp->mask_combine & DEVELOP_COMBINE_MASKS_POS);
+  if(bd->masks_support)
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), bd->masks_shown != DT_MASKS_EDIT_OFF);
+
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_polarity),
+                                 bp->mask_combine & DEVELOP_COMBINE_MASKS_POS);
+  }
 
   // update buttons status
   for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1992,8 +1992,9 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
   else
     dt_dev_masks_selection_change(darktable.develop, 0, FALSE);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit),
-                               value == DT_MASKS_EDIT_OFF ? FALSE : TRUE);
+  if(bd->masks_support)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit),
+                                 value == DT_MASKS_EDIT_OFF ? FALSE : TRUE);
 
   dt_control_queue_redraw_center();
 }

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1857,7 +1857,8 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
       {
         // got focus, show all shapes
-        if(bd->masks_shown == DT_MASKS_EDIT_OFF) dt_masks_set_edit_mode(self, DT_MASKS_EDIT_FULL);
+        if(bd->masks_shown == DT_MASKS_EDIT_OFF)
+          dt_masks_set_edit_mode(self, DT_MASKS_EDIT_FULL);
 
         rt_show_forms_for_current_scale(self);
 


### PR DESCRIPTION
(darktable:1003798): Gtk-CRITICAL **: 18:46:31.257: gtk_toggle_button_set_active: assertion 'GTK_IS_TOGGLE_BUTTON (toggle_button)' failed

The retouch & spot removal modules have no blending masks support.
Activating one of the blending mode was displaying a critial message
on the console as trying to deactivate the edit_masks button which
is not created for such modules.