### PR TITLE
[export] Set metadata/resolution alongside of dpi

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2428,9 +2428,9 @@
   </dtconfig>
   <dtconfig>
     <name>metadata/resolution</name>
-    <type>int</type>
+    <type min="72" max="9600">int</type>
     <default>300</default>
-    <shortdescription/>
+    <shortdescription>DPI value for exported files</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -965,6 +965,7 @@ static void _print_dpi_changed(GtkWidget *widget, gpointer user_data)
   const int dpi = atoi(gtk_entry_get_text(GTK_ENTRY(d->print_dpi)));
 
   dt_conf_set_int(CONFIG_PREFIX "print_dpi", dpi);
+  dt_conf_set_int("metadata/resolution", dpi);
 
   _resync_pixel_dimensions(d);
   _size_in_px_update(d);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -853,6 +853,16 @@ static void _dimensions_type_changed(GtkWidget *widget, dt_lib_export_t *d)
     gtk_widget_hide(GTK_WIDGET(d->print_size));
     dt_conf_set_string(CONFIG_PREFIX "resizing", "scaling");
   }
+  if(d_type == DT_DIMENSIONS_CM || d_type == DT_DIMENSIONS_INCH)
+  {
+    // set dpi to user-set dpi
+    dt_conf_set_int("metadata/resolution", dt_conf_get_int(CONFIG_PREFIX "print_dpi"));
+  }
+  else
+  {
+    // reset export dpi to default value for scale/pixel specific export
+    dt_conf_set_int("metadata/resolution", dt_confgen_get_int("metadata/resolution", DT_DEFAULT));
+  }
   _size_in_px_update(d);
 }
 


### PR DESCRIPTION
the `metadata/resolution` was a magic[1] way to set dpi in exif data (and some other tags) to something other than default 300

this PR just adds a possibility to set it in same spot as `print_dpi` setting in export module

Fixes #7941

[1] undocumented

btw: maybe it'd be enough to switch export module to using `metadata/resolution` instead of `CONFIG_PREFIX "print_dpi" `?