### PR TITLE
[Issue #7166] cairo patch to fix crashes under macOS Big Sur

### DIFF
--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -1,6 +1,6 @@
 How to make disk image with darktable application bundle (64 bit Intel only):
 
-1). Install MacPorts (instructions and prerequisites can be found on official website, use Xcode version less than 12.2), please use default installation path (/opt/local).
+1). Install MacPorts (instructions and prerequisites can be found on official website, use Xcode version less than 12.2, or install the Big Sur patch mentioned below to use Xcode 12.2 and later). Please use default installation path (/opt/local).
     They will need some tuning, so before you build anything add these lines to /opt/local/etc/macports/macports.conf:
      buildfromsource always
      macosx_deployment_target 10.7
@@ -31,7 +31,12 @@ How to make disk image with darktable application bundle (64 bit Intel only):
      $ curl -L https://raw.github.com/darktable-org/darktable/master/packaging/macosx/librsvg-nocargo.patch | patch -d ~/ports -p0
      $ cp -R "$(port dir gmic)" ~/ports/science
      $ curl -L https://raw.github.com/darktable-org/darktable/master/packaging/macosx/gmic-minimal.patch | patch -d ~/ports -p0
-    then append this line:
+
+In case of Big Sur, download the following additional patch:
+     $ cp -R "$(port dir cairo)" ~/ports/graphics 
+     $ curl -Lo ~/ports/graphics/cairo/files/patch.diff https://raw.github.com/darktable-org/darktable/master/packaging/macosx/cairo-big-sur.diff
+
+    Once all the patches have been downloaded, append this line:
      patchfiles-append patch.diff
     to ~/ports/*/*/Portfile files you just copied (except for pugixml, librsvg and gmic) and run:
      $ portindex ~/ports

--- a/packaging/macosx/cairo-big-sur.diff
+++ b/packaging/macosx/cairo-big-sur.diff
@@ -1,0 +1,120 @@
+--- src/cairo-quartz-surface.c.orig
++++ src/cairo-quartz-surface.c
+@@ -211,8 +211,13 @@ CairoQuartzCreateCGImage (cairo_format_t format,
+ 	    return NULL;
+     }
+ 
++		void *data_copy = malloc (height * stride);
++		if (unlikely (!data_copy))
++			return NULL;
++		memcpy (data_copy, data, height * stride);
++
+     dataProvider = CGDataProviderCreateWithData (releaseInfo,
+-						 data,
++						 data_copy,
+ 						 height * stride,
+ 						 releaseCallback);
+ 
+@@ -768,18 +773,10 @@ CairoQuartzCreateGradientFunction (const cairo_gradient_pattern_t *gradient,
+ 
+ /* Obtain a CGImageRef from a #cairo_surface_t * */
+ 
+-typedef struct {
+-    cairo_surface_t *surface;
+-    cairo_image_surface_t *image_out;
+-    void *image_extra;
+-} quartz_source_image_t;
+-
+ static void
+ DataProviderReleaseCallback (void *info, const void *data, size_t size)
+ {
+-    quartz_source_image_t *source_img = info;
+-    _cairo_surface_release_source_image (source_img->surface, source_img->image_out, source_img->image_extra);
+-    free (source_img);
++	free (data);
+ }
+ 
+ static cairo_status_t
+@@ -791,7 +788,6 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 			   CGImageRef            *image_out)
+ {
+     cairo_status_t status;
+-    quartz_source_image_t *source_img;
+     cairo_image_surface_t *image_surface;
+ 
+     if (source->backend && source->backend->type == CAIRO_SURFACE_TYPE_QUARTZ_IMAGE) {
+@@ -814,11 +810,8 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 	}
+     }
+ 
+-    source_img = _cairo_malloc (sizeof (quartz_source_image_t));
+-    if (unlikely (source_img == NULL))
+-	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+-
+-    source_img->surface = source;
++		cairo_image_surface_t *cimage_out;
++		void *image_extra;
+ 
+     if (source->type == CAIRO_SURFACE_TYPE_RECORDING) {
+ 	image_surface = (cairo_image_surface_t *)
+@@ -826,7 +819,6 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 	if (unlikely (image_surface->base.status)) {
+ 	    status = image_surface->base.status;
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+@@ -836,40 +828,35 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 							    NULL);
+ 	if (unlikely (status)) {
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+-	source_img->image_out = image_surface;
+-	source_img->image_extra = NULL;
++	cimage_out = image_surface;
++	image_extra = NULL;
+ 
+ 	cairo_matrix_init_identity (matrix);
+     }
+     else {
+-	status = _cairo_surface_acquire_source_image (source_img->surface,
+-						      &source_img->image_out,
+-						      &source_img->image_extra);
++	status = _cairo_surface_acquire_source_image (source,
++						      &cimage_out,
++						      &image_extra);
+ 	if (unlikely (status)) {
+-	    free (source_img);
+ 	    return status;
+ 	}
+     }
+ 
+-    if (source_img->image_out->width == 0 || source_img->image_out->height == 0) {
++    if (cimage_out->width == 0 || cimage_out->height == 0) {
+ 	*image_out = NULL;
+-	DataProviderReleaseCallback (source_img,
+-				     source_img->image_out->data,
+-				     source_img->image_out->height * source_img->image_out->stride);
+     } else {
+-	*image_out = CairoQuartzCreateCGImage (source_img->image_out->format,
+-					       source_img->image_out->width,
+-					       source_img->image_out->height,
+-					       source_img->image_out->stride,
+-					       source_img->image_out->data,
++	*image_out = CairoQuartzCreateCGImage (cimage_out->format,
++					       cimage_out->width,
++					       cimage_out->height,
++					       cimage_out->stride,
++					       cimage_out->data,
+ 					       TRUE,
+ 					       NULL,
+ 					       DataProviderReleaseCallback,
+-					       source_img);
++					       NULL);
+ 
+ 	/* TODO: differentiate memory error and unsupported surface type */
+ 	if (unlikely (*image_out == NULL))


### PR DESCRIPTION
Patch against cairo @1.16.0 macport to fix the crashes when compiling under Xcode 12.3/SDK11.1.

I also had problems compiling the libgcrypt package, with the getentropy() function not being explicitly declared. I fixed this by adding a line "#include <sys/random.h>" to the revevant file, but since then I haven't been able to reproduce that issue. If it comes up again, I'll add to this PR a patch for it.  