### PR TITLE
Improve histogram with css

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -751,20 +751,36 @@ overshoot.right
   margin-right: 0.5em;  /* spacing between histogram button box widgets, also provides right margin for buttons */
 }
 
+/* set background color and color of scope/histogram buttons */
+#scope-type-button,
+#histogram-scale-button,
+#waveform-type-button
+{
+  color: alpha(@button_checked_fg, 0.56);
+  background-color: alpha(darker(@button_bg),0.8);
+}
+
+#scope-type-button:hover,
+#histogram-scale-button:hover,
+#waveform-type-button:hover
+{
+  color: @button_fg;
+}
+
 /* set channel buttons at inactive state */
 #red-channel-button
 {
-  background-color: alpha(@graph_red, 0.25);
+  background-color: alpha(@graph_red, 0.2);
 }
 
 #green-channel-button
 {
-  background-color: alpha(@graph_green, 0.25);
+  background-color: alpha(@graph_green, 0.2);
 }
 
 #blue-channel-button
 {
-  background-color: alpha(@graph_blue, 0.25);
+  background-color: alpha(@graph_blue, 0.2);
 }
 
 /* set now them to active state */
@@ -783,9 +799,6 @@ overshoot.right
 }
 
 /* set border of all active buttons */
-#scope-type-button,
-#histogram-scale-button,
-#waveform-type-button,
 #red-channel-button:checked,
 #green-channel-button:checked,
 #blue-channel-button:checked

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -738,7 +738,9 @@ overshoot.right
   margin-right: 0.5em;
 }
 
-/* scope/histogram */
+/*------------------
+  - Scope/Histogram -
+  ------------------*/
 /* Note that there are some pretty odd #'s here to match the behavior of the legacy scope buttons */
 #main-histogram buttonbox
 {
@@ -753,7 +755,6 @@ overshoot.right
 #main-histogram .toggle
 {
   border: 1.1px solid alpha(@button_bg, 0.3);
-  min-height: 1em;  /* FIXME: what happens if don't set these? -- what is the source */
   min-width: 1em;
 }
 
@@ -761,39 +762,54 @@ overshoot.right
 #histogram-scale-button,
 #waveform-type-button
 {
-  color: alpha(@button_checked_fg, 0.56);           /* hack to match legacy color of white with alpha of 0.5 */
-  background-color: alpha(darker(@button_bg),0.8);  /* hack to be close to legacy color */
+  color: alpha(@button_checked_fg, 0.66);           /* hack to match legacy color of white of scope/histogram buttons */
+  background-color: alpha(darker(@button_bg), 0.75);  /* hack to be close to legacy color */
 }
 
 #scope-type-button > #button-canvas,
 #histogram-scale-button > #button-canvas,
 #waveform-type-button > #button-canvas
 {
-  /* hack to make icons larger to match legacy appearance */
+  /* set icons larger to match legacy appearance */
   margin: -14px; /* not real pixels, this is used as a percent extra space */
 }
 
+/* set channel buttons at inactive state */
 #red-channel-button
 {
-  background-color: alpha(@graph_red, 0.333);
+  background-color: alpha(@graph_red, 0.25);
 }
 
 #green-channel-button
 {
-  background-color: alpha(@graph_green, 0.333);
+  background-color: alpha(@graph_green, 0.25);
 }
 
 #blue-channel-button
 {
-  background-color: alpha(@graph_blue, 0.333);
+  background-color: alpha(@graph_blue, 0.25);
+}
+
+/* set now them to active state */
+#red-channel-button:checked
+{
+  background-color: alpha(@graph_red, 0.66);
+}
+
+#green-channel-button:checked
+{
+  background-color: alpha(@graph_green, 0.66);
+}
+#blue-channel-button:checked
+{
+  background-color: alpha(@graph_blue, 0.66);
 }
 
 #red-channel-button:checked,
 #green-channel-button:checked,
 #blue-channel-button:checked
-{ /* legacy behavior: checking channel buttons makes a lighter border, doesn't change interior */
-  /* FIXME: would be better to decrease alpha of unchecked channels? */
-  border-color: alpha(@button_checked_fg, 0.56);    /* hack to match legacy color of white with alpha of 0.5 */
+{
+  border-color: alpha(@button_checked_fg, 0.33);    /* just set a really tight border to better check quickly active state*/
 }
 
 /*------------------

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -741,7 +741,6 @@ overshoot.right
 /*------------------
   - Scope/Histogram -
   ------------------*/
-/* Note that there are some pretty odd #'s here to match the behavior of the legacy scope buttons */
 #main-histogram buttonbox
 {
   margin-top: 0.5em;   /* spacing between histogram buttons and top of scope */
@@ -750,28 +749,6 @@ overshoot.right
 #main-histogram buttonbox > *
 {
   margin-right: 0.5em;  /* spacing between histogram button box widgets, also provides right margin for buttons */
-}
-
-#main-histogram .toggle
-{
-  border: 1.1px solid alpha(@button_bg, 0.3);
-  min-width: 1em;
-}
-
-#scope-type-button,
-#histogram-scale-button,
-#waveform-type-button
-{
-  color: alpha(@button_checked_fg, 0.66);           /* hack to match legacy color of white of scope/histogram buttons */
-  background-color: alpha(darker(@button_bg), 0.75);  /* hack to be close to legacy color */
-}
-
-#scope-type-button > #button-canvas,
-#histogram-scale-button > #button-canvas,
-#waveform-type-button > #button-canvas
-{
-  /* set icons larger to match legacy appearance */
-  margin: -14px; /* not real pixels, this is used as a percent extra space */
 }
 
 /* set channel buttons at inactive state */
@@ -805,6 +782,10 @@ overshoot.right
   background-color: alpha(@graph_blue, 0.66);
 }
 
+/* set border of all active buttons */
+#scope-type-button,
+#histogram-scale-button,
+#waveform-type-button,
 #red-channel-button:checked,
 #green-channel-button:checked,
 #blue-channel-button:checked


### PR DESCRIPTION
This PR adjust some things about @dtorop PR #7922 about histogram.

1. adjust comments to be consistent about all other similar ones in darktable.css file
2. remove first FIXME comment by remove min-height (no effect seeing on this). @dtorop: correct me if you find something, not sure to have understood correctly why you add it with that comment).
3. increase color of histogram/scope buttons to be a little "whiter" and so adjust comment
4. apply last FIXME by making all channels buttons nearly disappear (they remains visible) when not active and more visible with a really tight border when they are active.

@dtorop: of course, as it is based on your work, you review is highly wanted here!