### PR TITLE
fix: inverted scroll wheel direction in culling & preview

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -548,7 +548,7 @@ static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_
     else
     {
       const int move = delta < 0 ? -1 : 1;
-      _thumbs_move(table, -move);
+      _thumbs_move(table, move);
     }
   }
   return TRUE;


### PR DESCRIPTION
I have obviously made a mistake, navigation with the scroll wheel goes in the wrong direction, sorry for that.

To reproduce:
1. Open filemanager
2. Take note of the selected picture and the following picture
3. Open preview
4. Scroll down -> does not show the expected picture
5. Scroll up to get back to step 3.
6. Press arrow right -> does show the expected picture