### PR TITLE
icon improvements for waveform and rgb parade

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1028,28 +1028,32 @@ void dtgtk_cairo_paint_waveform_scope(cairo_t *cr, gint x, gint y, gint w, gint 
 {
   PREAMBLE(1, 0, 0)
 
+  cairo_pattern_t *p_src = cairo_get_source(cr);
+  double r, g, b, a;
+  cairo_pattern_get_rgba(p_src, &r, &g, &b, &a);
+
   cairo_pattern_t *pat;
   pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
 
-  cairo_pattern_add_color_stop_rgba(pat, 0.0, 0.0, 0.0, 0.0, 0.5);
-  cairo_pattern_add_color_stop_rgba(pat, 0.2, 0.2, 0.2, 0.2, 0.5);
-  cairo_pattern_add_color_stop_rgba(pat, 0.5, 1.0, 1.0, 1.0, 0.5);
-  cairo_pattern_add_color_stop_rgba(pat, 0.6, 1.0, 1.0, 1.0, 0.5);
-  cairo_pattern_add_color_stop_rgba(pat, 1.0, 0.2, 0.2, 0.2, 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, r, g, b, a * 0.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.1, r, g, b, a * 0.1);
+  cairo_pattern_add_color_stop_rgba(pat, 0.5, r, g, b, a * 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.6, r, g, b, a * 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, r, g, b, a * 0.2);
 
-  cairo_rectangle(cr, 0.0, 0.0, 0.3, 1.0);
+  cairo_rectangle(cr, 0.0, 0.0, 0.3, 0.9);
   cairo_set_source(cr, pat);
   cairo_fill(cr);
 
   cairo_save(cr);
   cairo_scale(cr, 1.0, -1.0);
   cairo_translate(cr, 0.0, -1.0);
-  cairo_rectangle(cr, 0.2, 0.0, 0.6, 1.0);
+  cairo_rectangle(cr, 0.25, 0.0, 0.5, 1.0);
   cairo_set_source(cr, pat);
   cairo_fill(cr);
   cairo_restore(cr);
 
-  cairo_rectangle(cr, 0.7, 0.0, 0.3, 1.0);
+  cairo_rectangle(cr, 0.7, 0.0, 0.3, 0.9);
   cairo_set_source(cr, pat);
   cairo_fill(cr);
 
@@ -1084,11 +1088,23 @@ void dtgtk_cairo_paint_waveform_overlaid(cairo_t *cr, gint x, gint y, gint w, gi
 {
   PREAMBLE(1, 0, 0)
 
-  // FIXME: if make a mode comobox (histogram, waveform, RGB parade) then don't need this icon
-  // FIXME: improve this icon to make it look like a waveform in color
-  // FIXME: if don't improve, then just use dtgtk_cairo_paint_color()
-  cairo_rectangle(cr, 0.0, 0.0, 1.0, 1.0);
+  cairo_pattern_t *p_src = cairo_get_source(cr);
+  double r, g, b, a;
+  cairo_pattern_get_rgba(p_src, &r, &g, &b, &a);
+
+  cairo_pattern_t *pat;
+  pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
+
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, r, g * 0.7, b * 0.9, a * 0.2);
+  cairo_pattern_add_color_stop_rgba(pat, 0.4, r * 0.9, g, b * 0.9, a * 0.8);
+  cairo_pattern_add_color_stop_rgba(pat, 0.7, r, g * 0.9, b, a * 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, r * 0.7, g * 0.5, b, a * 0.2);
+
+  cairo_rectangle(cr, 0.0, 0.15, 1.0, 0.7);
+  cairo_set_source(cr, pat);
   cairo_fill(cr);
+
+  cairo_pattern_destroy(pat);
 
   FINISH
 }
@@ -1097,17 +1113,35 @@ void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   PREAMBLE(1, 0, 0)
 
-  // FIMXE: render as three waveform-ish patterns in the three primaries
   const GdkRGBA *const primaries = darktable.bauhaus->graph_primaries;
-  cairo_set_source_rgba(cr, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha/3.0);
-  cairo_rectangle(cr, 0.0, 0.0, 1.0/3.0, 1.0);
+  cairo_pattern_t *pat;
+
+  pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha * 0.2);
+  cairo_pattern_add_color_stop_rgba(pat, 0.4, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha * 0.7);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha * 0.3);
+  cairo_rectangle(cr, 0.0, 0.1, 1.0/3.0, 0.7);
+  cairo_set_source(cr, pat);
   cairo_fill(cr);
-  cairo_set_source_rgba(cr, primaries[1].red, primaries[1].green, primaries[1].blue, primaries[1].alpha/3.0);
-  cairo_rectangle(cr, 1.0/3.0, 0.0, 1.0/3.0, 1.0);
+  cairo_pattern_destroy(pat);
+
+  pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, primaries[1].red, primaries[1].green, 0.0, primaries[1].alpha * 0.1);
+  cairo_pattern_add_color_stop_rgba(pat, 0.6, primaries[1].red, primaries[1].green, 0.0, primaries[1].alpha * 0.8);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, primaries[1].red, primaries[1].green, 0.0, primaries[1].alpha * 0.4);
+  cairo_rectangle(cr, 1.0/3.0, 0.2, 1.0/3.0, 0.7);
+  cairo_set_source(cr, pat);
   cairo_fill(cr);
-  cairo_set_source_rgba(cr, primaries[2].red, primaries[2].green, primaries[2].blue, primaries[2].alpha/3.0);
-  cairo_rectangle(cr, 2.0/3.0, 0.0, 1.0/3.0, 1.0);
+  cairo_pattern_destroy(pat);
+
+  pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, primaries[2].red, 0.0, primaries[2].blue, primaries[2].alpha * 0.4);
+  cairo_pattern_add_color_stop_rgba(pat, 0.5, primaries[2].red, 0.0, primaries[2].blue, primaries[2].alpha * 0.9);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, primaries[2].red, 0.0, primaries[2].blue, primaries[2].alpha * 0.5);
+  cairo_rectangle(cr, 2.0/3.0, 0.1, 1.0/3.0, 0.7);
+  cairo_set_source(cr, pat);
   cairo_fill(cr);
+  cairo_pattern_destroy(pat);
 
   FINISH
 }


### PR DESCRIPTION
Make the "scope type" waveform icon be transparent, to work better with the theme work done by @Nilvus. Also tune its drawing slightly, as transparency made the prior drawing code look less good.

Change the "waveform type" icons for "overlaid" (e.g. traditional waveform) and rgb parade from solid colors to more waveform-ish looking images.

This PR includes the three CSS fix commits from #7952 in order to be able to see all the changes together.

Prior to #7952:

![image](https://user-images.githubusercontent.com/2311860/105567807-c4eb3a00-5d02-11eb-9294-d9666176b484.png)

![image](https://user-images.githubusercontent.com/2311860/105567811-d5031980-5d02-11eb-89a5-037941a3754b.png)

With #7952 and without this PR:

![image](https://user-images.githubusercontent.com/2311860/105567849-11cf1080-5d03-11eb-87d2-6ed154a2c3bb.png)

![image](https://user-images.githubusercontent.com/2311860/105567840-0380f480-5d03-11eb-956d-36485e0170de.png)

With #7952 and this PR:

![image](https://user-images.githubusercontent.com/2311860/105567871-3a570a80-5d03-11eb-9f04-3d67500d6b06.png)

![image](https://user-images.githubusercontent.com/2311860/105567875-480c9000-5d03-11eb-8ad2-cdb096fea6cd.png)
