### PR TITLE
control_jobs: add some strings to translation catalog.

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1870,8 +1870,8 @@ static int32_t dt_control_datetime_job_run(dt_job_t *job)
   } while((t = g_list_next(t)) != NULL);
   dt_undo_end_group(darktable.undo);
 
-  const char *mes21 = offset ? "added time offset to %d image" : "set date time to %d image";
-  const char *mes22 = offset ? "added time offset to %d images" : "set date time to %d images";
+  const char *mes21 = offset ? N_("added time offset to %d image") : N_("set date time to %d image");
+  const char *mes22 = offset ? N_("added time offset to %d images") : N_("set date time to %d images");
   dt_control_log(ngettext(mes21, mes22, cntr), cntr);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(params->index));


### PR DESCRIPTION
@TurboGit Completing your previous fix.
However, the French translation doesn't appear anymore (with or without  N_()) after rebase while yesterday the offset message was still translated. Normal ? 