### PR TITLE
fix bauhaus combobox popup scrolling

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -301,7 +301,7 @@ static void combobox_popup_scroll(int amt)
   GtkAllocation allocation_w;
   gtk_widget_get_allocation(w, &allocation_w);
   const int ht = allocation_w.height;
-  const int skip = ht;
+  const int skip = darktable.bauhaus->line_height;
   gdk_window_get_origin(gtk_widget_get_window(w), &wx, &wy);
   const dt_bauhaus_combobox_data_t *d = &darktable.bauhaus->current->data.combobox;
   int new_value = CLAMP(d->active + amt, 0, d->num_labels - 1);
@@ -2108,7 +2108,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
       GtkAllocation allocation_w;
       gtk_widget_get_allocation(GTK_WIDGET(w), &allocation_w);
       const int ht = allocation_w.height;
-      const int skip = ht + darktable.bauhaus->line_height;
+      const int skip = darktable.bauhaus->line_height;
       offset = -d->active * darktable.bauhaus->line_height;
       darktable.bauhaus->mouse_x = 0;
       darktable.bauhaus->mouse_y = d->active * skip + ht / 2;


### PR DESCRIPTION
This PR fixes two distinct small UI glitches in bauhaus combobox popups:
1) clicking the combobox without moving the mouse highlights wrong items; the error depends on which item is selected
![image](https://user-images.githubusercontent.com/43290988/105580056-5c47a000-5d8a-11eb-99bb-41fac4ffb4ef.png)

2) scrolling with mouse wheel moves the popup of an incorrect amount, not corresponding to the line height of the popup