### PR TITLE
[export] make export module gui_reset actually reset stuff

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2070,7 +2070,14 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/jpeg/quality</name>
-    <type>int</type>
+    <type min="5" max="100">int</type>
+    <default>95</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/j2k/quality</name>
+    <type min="5" max="100">int</type>
     <default>95</default>
     <shortdescription/>
     <longdescription/>
@@ -2091,7 +2098,7 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/tiff/compresslevel</name>
-    <type>int</type>
+    <type min="0" max="9">int</type>
     <default>6</default>
     <shortdescription/>
     <longdescription/>
@@ -2105,8 +2112,71 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/png/compression</name>
-    <type>int</type>
+    <type min="0" max="9">int</type>
     <default>5</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/webp/comp_type</name>
+    <type min="0" max="1">int</type>
+    <default>0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/webp/quality</name>
+    <type min="5" max="100">int</type>
+    <default>95</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/webp/hint</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/avif/bit_depth</name>
+    <type min="8" max="12">int</type>
+    <default>8</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/avif/color_mode</name>
+    <type min="0">int</type>
+    <default>0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/avif/tiling</name>
+    <type min="0">int</type>
+    <default>0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/avif/compression_type</name>
+    <type min="0">int</type>
+    <default>0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/avif/quality</name>
+    <type min="5" max="100">int</type>
+    <default>92</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/imageio/format/xcf/bpp</name>
+    <type min="8" max="32">int</type>
+    <default>32</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2084,9 +2084,15 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/tiff/bpp</name>
-    <type>int</type>
+    <type>
+      <enum>
+        <option>8</option>
+        <option>16</option>
+        <option>32</option>
+      </enum>
+    </type>
     <default>8</default>
-    <shortdescription/>
+    <shortdescription>TIFF bit depth (bpp)</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig>
@@ -2105,9 +2111,14 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/png/bpp</name>
-    <type>int</type>
+    <type>
+      <enum>
+        <option>8</option>
+        <option>16</option>
+      </enum>
+    </type>
     <default>8</default>
-    <shortdescription/>
+    <shortdescription>PNG bit depth (bpp)</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig>
@@ -2139,10 +2150,16 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
-    <name>plugins/imageio/format/avif/bit_depth</name>
-    <type min="8" max="12">int</type>
+    <name>plugins/imageio/format/avif/bpp</name>
+    <type>
+      <enum>
+        <option>8</option>
+        <option>10</option>
+        <option>12</option>
+      </enum>
+    </type>
     <default>8</default>
-    <shortdescription/>
+    <shortdescription>AVIF bit depth (bpp)</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig>
@@ -2154,9 +2171,9 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/avif/tiling</name>
-    <type min="0">int</type>
-    <default>0</default>
-    <shortdescription/>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>AVIF Tiling</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig>
@@ -2175,9 +2192,15 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/xcf/bpp</name>
-    <type min="8" max="32">int</type>
+    <type>
+      <enum>
+        <option>8</option>
+        <option>16</option>
+        <option>32</option>
+      </enum>
+    </type>
     <default>32</default>
-    <shortdescription/>
+    <shortdescription>XCF bit depth (bpp)</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig prefs="misc" section="other">

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -848,13 +848,13 @@ void gui_init(dt_imageio_module_format_t *self)
    * Quality combo box
    */
   gui->quality = dt_bauhaus_slider_new_with_range(NULL,
-                                                  5, /* min */
-                                                  100, /* max */
+                                                  dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_MIN), /* min */
+                                                  dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_MAX), /* max */
                                                   1, /* step */
-                                                  92, /* default */
+                                                  dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT), /* default */
                                                   0); /* digits */
   dt_bauhaus_widget_set_label(gui->quality,  NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(gui->quality, 95);
+  dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT));
   dt_bauhaus_slider_set_format(gui->quality, "%.2f%%");
 
   gtk_widget_set_tooltip_text(gui->quality,
@@ -913,6 +913,17 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 void gui_reset(dt_imageio_module_format_t *self)
 {
   dt_imageio_avif_gui_t *gui = (dt_imageio_avif_gui_t *)self->gui_data;
+
+  const enum avif_color_mode_e color_mode = dt_confgen_get_int("plugins/imageio/format/avif/color_mode", DT_DEFAULT);
+  const enum avif_tiling_e tiling = dt_confgen_get_int("plugins/imageio/format/avif/tiling", DT_DEFAULT);
+  const enum avif_compression_type_e compression_type = dt_confgen_get_int("plugins/imageio/format/avif/compression_type", DT_DEFAULT);
+  const uint32_t quality = dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT);
+
+  dt_bauhaus_combobox_set(gui->bit_depth, 0); //8bpp
+  dt_bauhaus_combobox_set(gui->color_mode, color_mode);
+  dt_bauhaus_combobox_set(gui->tiling, tiling);
+  dt_bauhaus_combobox_set(gui->compression_type, compression_type);
+  dt_bauhaus_slider_set(gui->quality, quality);
 
   compression_type_changed(GTK_WIDGET(gui->compression_type), self);
   quality_changed(GTK_WIDGET(gui->quality), self);

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -611,8 +611,10 @@ void *get_params(dt_imageio_module_format_t *self)
     return NULL;
   }
 
-  d->bit_depth = dt_conf_get_int("plugins/imageio/format/avif/bit_depth");
-  if(d->bit_depth == 0 || d->bit_depth > 12)
+  gchar * bpp = dt_conf_get_string("plugins/imageio/format/avif/bpp");
+  d->bit_depth = atoi(bpp);
+  g_free(bpp);
+  if(d->bit_depth < 8 || d->bit_depth > 12)
   {
       d->bit_depth = 8;
   }
@@ -634,7 +636,7 @@ void *get_params(dt_imageio_module_format_t *self)
       break;
   }
 
-  d->tiling = dt_conf_get_int("plugins/imageio/format/avif/tiling");
+  d->tiling = !dt_conf_get_bool("plugins/imageio/format/avif/tiling");
 
   return d;
 }
@@ -698,7 +700,7 @@ static void bit_depth_changed(GtkWidget *widget, gpointer user_data)
 {
   const uint32_t idx = dt_bauhaus_combobox_get(widget);
 
-  dt_conf_set_int("plugins/imageio/format/avif/bit_depth", avif_bit_depth[idx].bit_depth);
+  dt_conf_set_int("plugins/imageio/format/avif/bpp", avif_bit_depth[idx].bit_depth);
 }
 
 static void color_mode_changed(GtkWidget *widget, gpointer user_data)
@@ -712,7 +714,7 @@ static void tiling_changed(GtkWidget *widget, gpointer user_data)
 {
   const enum avif_tiling_e tiling = dt_bauhaus_combobox_get(widget);
 
-  dt_conf_set_int("plugins/imageio/format/avif/tiling", tiling);
+  dt_conf_set_bool("plugins/imageio/format/avif/tiling", !tiling);
 }
 
 static void compression_type_changed(GtkWidget *widget, gpointer user_data)
@@ -746,7 +748,7 @@ void gui_init(dt_imageio_module_format_t *self)
       (dt_imageio_avif_gui_t *)malloc(sizeof(dt_imageio_avif_gui_t));
   const uint32_t bit_depth = dt_conf_get_int("plugins/imageio/format/avif/bit_depth");
   const enum avif_color_mode_e color_mode = dt_conf_get_int("plugins/imageio/format/avif/color_mode");
-  const enum avif_tiling_e tiling = dt_conf_get_int("plugins/imageio/format/avif/tiling");
+  const enum avif_tiling_e tiling = !dt_conf_get_bool("plugins/imageio/format/avif/tiling");
   const enum avif_compression_type_e compression_type = dt_conf_get_int("plugins/imageio/format/avif/compression_type");
   const uint32_t quality = dt_conf_get_int("plugins/imageio/format/avif/quality");
 
@@ -915,7 +917,7 @@ void gui_reset(dt_imageio_module_format_t *self)
   dt_imageio_avif_gui_t *gui = (dt_imageio_avif_gui_t *)self->gui_data;
 
   const enum avif_color_mode_e color_mode = dt_confgen_get_int("plugins/imageio/format/avif/color_mode", DT_DEFAULT);
-  const enum avif_tiling_e tiling = dt_confgen_get_int("plugins/imageio/format/avif/tiling", DT_DEFAULT);
+  const enum avif_tiling_e tiling = !dt_confgen_get_bool("plugins/imageio/format/avif/tiling", DT_DEFAULT);
   const enum avif_compression_type_e compression_type = dt_confgen_get_int("plugins/imageio/format/avif/compression_type", DT_DEFAULT);
   const uint32_t quality = dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT);
 

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -393,6 +393,9 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 
 void gui_reset(dt_imageio_module_format_t *self)
 {
+  dt_imageio_exr_gui_t *gui = (dt_imageio_exr_gui_t *)self->gui_data;
+
+  dt_bauhaus_combobox_set(gui->compression, dt_confgen_get_int("plugins/imageio/format/exr/compression", DT_DEFAULT));
 }
 
 

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -649,9 +649,14 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), gui->format, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->format), "value-changed", G_CALLBACK(format_changed), NULL);
 
-  gui->quality = dt_bauhaus_slider_new_with_range(NULL, 5, 100, 1, 95, 0);
+  gui->quality = dt_bauhaus_slider_new_with_range(NULL,
+                                                  dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_MIN),
+                                                  dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_MAX),
+                                                  1,
+                                                  dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_DEFAULT),
+                                                  0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(gui->quality, 95);
+  dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_DEFAULT));
   if(quality_last > 0 && quality_last <= 100) dt_bauhaus_slider_set(gui->quality, quality_last);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
@@ -676,6 +681,13 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 
 void gui_reset(dt_imageio_module_format_t *self)
 {
+  const int format_def = dt_confgen_get_int("plugins/imageio/format/j2k/format", DT_DEFAULT);
+  const int preset_def = dt_confgen_get_int("plugins/imageio/format/j2k/preset", DT_DEFAULT);
+  const int quality_def = dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_DEFAULT);
+  dt_imageio_j2k_gui_t *gui = (dt_imageio_j2k_gui_t *)self->gui_data;
+  dt_bauhaus_combobox_set(gui->format, format_def);
+  dt_bauhaus_combobox_set(gui->preset, preset_def);
+  dt_bauhaus_combobox_set(gui->quality, quality_def);
 }
 
 int flags(dt_imageio_module_data_t *data)

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -588,9 +588,14 @@ void gui_init(dt_imageio_module_format_t *self)
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   self->widget = box;
   // quality slider
-  g->quality = dt_bauhaus_slider_new_with_range(NULL, 5, 100, 1, 95, 0);
+  g->quality = dt_bauhaus_slider_new_with_range(NULL,
+                                                dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_MIN),
+                                                dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_MAX),
+                                                1,
+                                                dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_DEFAULT),
+                                                0);
   dt_bauhaus_widget_set_label(g->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(g->quality, 95);
+  dt_bauhaus_slider_set_default(g->quality, dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_DEFAULT));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
   // TODO: add more options: subsample dreggn
@@ -604,7 +609,7 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 void gui_reset(dt_imageio_module_format_t *self)
 {
   dt_imageio_jpeg_gui_data_t *g = (dt_imageio_jpeg_gui_data_t *)self->gui_data;
-  dt_bauhaus_slider_set(g->quality, dt_conf_get_int("plugins/imageio/format/jpeg/quality"));
+  dt_bauhaus_slider_set(g->quality, dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_DEFAULT));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -421,11 +421,11 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_t *d = (dt_imageio_png_t *)calloc(1, sizeof(dt_imageio_png_t));
-  d->bpp = dt_conf_get_int("plugins/imageio/format/png/bpp");
-  if(d->bpp < 12)
+  gchar *bpp = dt_conf_get_string("plugins/imageio/format/png/bpp");
+  d->bpp = atoi(bpp);
+  g_free(bpp);
+  if(d->bpp != 8 && d->bpp != 16)
     d->bpp = 8;
-  else
-    d->bpp = 16;
 
   // PNG compression level might actually be zero!
   if(!dt_conf_key_exists("plugins/imageio/format/png/compression"))
@@ -511,7 +511,9 @@ void gui_init(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_gui_t *gui = (dt_imageio_png_gui_t *)malloc(sizeof(dt_imageio_png_gui_t));
   self->gui_data = (void *)gui;
-  int bpp = dt_conf_get_int("plugins/imageio/format/png/bpp");
+  gchar *conf_bpp = dt_conf_get_string("plugins/imageio/format/png/bpp");
+  int bpp = atoi(conf_bpp);
+  g_free(conf_bpp);
 
   // PNG compression level might actually be zero!
   int compression = 5;

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -535,7 +535,12 @@ void gui_init(dt_imageio_module_format_t *self)
   g_signal_connect(G_OBJECT(gui->bit_depth), "value-changed", G_CALLBACK(bit_depth_changed), NULL);
 
   // Compression level slider
-  gui->compression = dt_bauhaus_slider_new_with_range(NULL, 0, 9, 1, 5, 0);
+  gui->compression = dt_bauhaus_slider_new_with_range(NULL,
+                                                      dt_confgen_get_int("plugins/imageio/format/png/compression", DT_MIN),
+                                                      dt_confgen_get_int("plugins/imageio/format/png/compression", DT_MAX),
+                                                      1,
+                                                      dt_confgen_get_int("plugins/imageio/format/png/compression", DT_DEFAULT),
+                                                      0);
   dt_bauhaus_widget_set_label(gui->compression, NULL, N_("compression"));
   dt_bauhaus_slider_set(gui->compression, compression);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->compression), TRUE, TRUE, 0);
@@ -549,6 +554,9 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 
 void gui_reset(dt_imageio_module_format_t *self)
 {
+  dt_imageio_png_gui_t *gui = (dt_imageio_png_gui_t *)self->gui_data;
+  dt_bauhaus_combobox_set(gui->bit_depth, 0); // 8bpp
+  dt_bauhaus_slider_set(gui->compression, dt_confgen_get_int("plugins/imageio/format/png/compression", DT_DEFAULT));
 }
 
 int flags(dt_imageio_module_data_t *data)

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -637,7 +637,9 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_tiff_t *d = (dt_imageio_tiff_t *)calloc(1, sizeof(dt_imageio_tiff_t));
-  d->bpp = dt_conf_get_int("plugins/imageio/format/tiff/bpp");
+  gchar *bpp = dt_conf_get_string("plugins/imageio/format/tiff/bpp");
+  d->bpp = atoi(bpp);
+  g_free(bpp);
   if(d->bpp == 16)
     d->bpp = 16;
   else if(d->bpp == 32)

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -832,7 +832,12 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), gui->compress, TRUE, TRUE, 0);
 
   // Compression level slider
-  gui->compresslevel = dt_bauhaus_slider_new_with_range(NULL, 0, 9, 1, 6, 0);
+  gui->compresslevel = dt_bauhaus_slider_new_with_range(NULL,
+                                                      dt_confgen_get_int("plugins/imageio/format/tiff/compresslevel", DT_MIN),
+                                                      dt_confgen_get_int("plugins/imageio/format/tiff/compresslevel", DT_MAX),
+                                                      1,
+                                                      dt_confgen_get_int("plugins/imageio/format/tiff/compresslevel", DT_DEFAULT),
+                                                      0);
   dt_bauhaus_widget_set_label(gui->compresslevel, NULL, N_("compression level"));
   dt_bauhaus_slider_set(gui->compresslevel, compresslevel);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->compresslevel), TRUE, TRUE, 0);
@@ -860,7 +865,10 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 
 void gui_reset(dt_imageio_module_format_t *self)
 {
-  // TODO: reset to conf? reset to factory defaults?
+  dt_imageio_tiff_gui_t *gui = (dt_imageio_tiff_gui_t *)self->gui_data;
+  dt_bauhaus_combobox_set(gui->bpp, 0); //8bpp
+  dt_bauhaus_slider_set(gui->compresslevel, dt_confgen_get_int("plugins/imageio/format/tiff/compresslevel", DT_DEFAULT));
+  dt_bauhaus_combobox_set(gui->shortfiles, dt_confgen_get_int("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
 }
 
 int flags(dt_imageio_module_data_t *data)

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -328,9 +328,14 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_bauhaus_combobox_set(gui->compression, comp_type);
   gtk_box_pack_start(GTK_BOX(self->widget), gui->compression, TRUE, TRUE, 0);
 
-  gui->quality = dt_bauhaus_slider_new_with_range(NULL, 5, 100, 1, 95, 0);
+  gui->quality = dt_bauhaus_slider_new_with_range(NULL,
+                                                  dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_MIN),
+                                                  dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_MAX),
+                                                  1,
+                                                  dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT),
+                                                  0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(gui->quality, 95);
+  dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT));
   dt_bauhaus_slider_set_format(gui->quality, "%.2f%%");
   gtk_widget_set_tooltip_text(gui->quality, _("applies only to lossy setting"));
   if(quality > 0 && quality <= 100) dt_bauhaus_slider_set(gui->quality, quality);
@@ -365,6 +370,13 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 
 void gui_reset(dt_imageio_module_format_t *self)
 {
+  dt_imageio_webp_gui_data_t *gui = (dt_imageio_webp_gui_data_t *)self->gui_data;
+  const int comp_type = dt_confgen_get_int("plugins/imageio/format/webp/comp_type", DT_DEFAULT);
+  const int quality = dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT);
+  const int hint = dt_confgen_get_int("plugins/imageio/format/webp/hint", DT_DEFAULT);
+  dt_bauhaus_combobox_set(gui->compression, comp_type);
+  dt_bauhaus_slider_set(gui->quality, quality);
+  dt_bauhaus_combobox_set(gui->hint, hint);
 }
 
 int flags(dt_imageio_module_data_t *data)

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -230,7 +230,9 @@ void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_xcf_t *d = (dt_imageio_xcf_t *)calloc(1, sizeof(dt_imageio_xcf_t));
 
-  d->bpp = dt_conf_get_int("plugins/imageio/format/xcf/bpp");
+  gchar *conf_bpp = dt_conf_get_string("plugins/imageio/format/xcf/bpp");
+  d->bpp = atoi(conf_bpp);
+  g_free(conf_bpp);
   if(d->bpp != 16 && d->bpp != 32)
     d->bpp = 8;
 
@@ -327,7 +329,11 @@ void gui_init(dt_imageio_module_format_t *self)
 
   int bpp = 32;
   if(dt_conf_key_exists("plugins/imageio/format/xcf/bpp"))
-    bpp = dt_conf_get_int("plugins/imageio/format/xcf/bpp");
+  {
+    gchar *conf_bpp = dt_conf_get_string("plugins/imageio/format/xcf/bpp");
+    bpp = atoi(conf_bpp);
+    g_free(conf_bpp);
+  }
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -354,6 +354,8 @@ void gui_cleanup(dt_imageio_module_format_t *self)
 
 void gui_reset(dt_imageio_module_format_t *self)
 {
+  dt_imageio_xcf_gui_t *gui = (dt_imageio_xcf_gui_t *)self->gui_data;
+  dt_bauhaus_combobox_set(gui->bpp, 2); // bpp = 32
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -222,6 +222,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
   disk_t *d = (disk_t *)self->gui_data;
   // global default can be annoying:
   // gtk_entry_set_text(GTK_ENTRY(d->entry), "$(FILE_FOLDER)/darktable_exported/$(FILE_NAME)");
+  gtk_entry_set_text(d->entry, dt_confgen_get("plugins/imageio/storage/disk/file_directory", DT_DEFAULT));
+  dt_bauhaus_combobox_set(d->onsave_action, dt_confgen_get_int("plugins/imageio/storage/disk/overwrite", DT_DEFAULT));
   dt_conf_set_string("plugins/imageio/storage/disk/file_directory", gtk_entry_get_text(d->entry));
   dt_conf_set_int("plugins/imageio/storage/disk/overwrite", dt_bauhaus_combobox_get(d->onsave_action));
 }

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -210,6 +210,8 @@ void gui_cleanup(dt_imageio_module_storage_t *self)
 void gui_reset(dt_imageio_module_storage_t *self)
 {
   gallery_t *d = (gallery_t *)self->gui_data;
+  gtk_entry_set_text(d->entry, dt_confgen_get("plugins/imageio/storage/gallery/file_directory", DT_DEFAULT));
+  gtk_entry_set_text(d->title_entry, dt_confgen_get("plugins/imageio/storage/gallery/title", DT_DEFAULT));
   dt_conf_set_string("plugins/imageio/storage/gallery/file_directory", gtk_entry_get_text(d->entry));
   dt_conf_set_string("plugins/imageio/storage/gallery/title", gtk_entry_get_text(d->title_entry));
 }

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -213,6 +213,8 @@ void gui_cleanup(dt_imageio_module_storage_t *self)
 void gui_reset(dt_imageio_module_storage_t *self)
 {
   latex_t *d = (latex_t *)self->gui_data;
+  gtk_entry_set_text(d->entry, dt_confgen_get("plugins/imageio/storage/latex/file_directory", DT_DEFAULT));
+  gtk_entry_set_text(d->title_entry, dt_confgen_get("plugins/imageio/storage/latex/title", DT_DEFAULT));
   dt_conf_set_string("plugins/imageio/storage/latex/file_directory", gtk_entry_get_text(d->entry));
   dt_conf_set_string("plugins/imageio/storage/latex/title", gtk_entry_get_text(d->title_entry));
 }

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -562,23 +562,23 @@ void gui_reset(dt_lib_module_t *self)
   // make sure we don't do anything useless:
   if(!dt_control_running()) return;
   dt_lib_export_t *d = (dt_lib_export_t *)self->data;
-  dt_bauhaus_combobox_set(d->dimensions_type, dt_conf_get_int(CONFIG_PREFIX "dimensions_type"));
+  gtk_entry_set_text(GTK_ENTRY(d->width), dt_confgen_get(CONFIG_PREFIX "width", DT_DEFAULT));
+  gtk_entry_set_text(GTK_ENTRY(d->height), dt_confgen_get(CONFIG_PREFIX "width", DT_DEFAULT));
+  dt_bauhaus_combobox_set(d->dimensions_type, dt_confgen_get_int(CONFIG_PREFIX "dimensions_type", DT_DEFAULT));
   _print_size_update_display(d);
 
   // Set storage
-  gchar *storage_name = dt_conf_get_string(CONFIG_PREFIX "storage_name");
-  const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(storage_name));
-  g_free(storage_name);
+  const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(dt_confgen_get(CONFIG_PREFIX "storage_name", DT_DEFAULT)));
   dt_bauhaus_combobox_set(d->storage, storage_index);
 
-  dt_bauhaus_combobox_set(d->upscale, dt_conf_get_bool(CONFIG_PREFIX "upscale") ? 1 : 0);
-  dt_bauhaus_combobox_set(d->high_quality, dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing") ? 1 : 0);
-  dt_bauhaus_combobox_set(d->export_masks, dt_conf_get_bool(CONFIG_PREFIX "export_masks") ? 1 : 0);
+  dt_bauhaus_combobox_set(d->upscale, dt_confgen_get_bool(CONFIG_PREFIX "upscale", DT_DEFAULT) ? 1 : 0);
+  dt_bauhaus_combobox_set(d->high_quality, dt_confgen_get_bool(CONFIG_PREFIX "high_quality_processing", DT_DEFAULT) ? 1 : 0);
+  dt_bauhaus_combobox_set(d->export_masks, dt_confgen_get_bool(CONFIG_PREFIX "export_masks", DT_DEFAULT) ? 1 : 0);
 
-  dt_bauhaus_combobox_set(d->intent, dt_conf_get_int(CONFIG_PREFIX "iccintent") + 1);
+  dt_bauhaus_combobox_set(d->intent, dt_confgen_get_int(CONFIG_PREFIX "iccintent", DT_DEFAULT) + 1);
 
   // iccprofile
-  const int icctype = dt_conf_get_int(CONFIG_PREFIX "icctype");
+  int icctype = dt_confgen_get_int(CONFIG_PREFIX "icctype", DT_DEFAULT);
   gchar *iccfilename = dt_conf_get_string(CONFIG_PREFIX "iccprofile");
   dt_bauhaus_combobox_set(d->profile, 0);
   if(icctype != DT_COLORSPACE_NONE)
@@ -600,18 +600,17 @@ void gui_reset(dt_lib_module_t *self)
   // style
   // set it to none if the var is not set or the style doesn't exist anymore
   gboolean rc = FALSE;
-  gchar *style = dt_conf_get_string(CONFIG_PREFIX "style");
-  if(style != NULL)
+  const char *style = dt_confgen_get(CONFIG_PREFIX "style", DT_DEFAULT);
+  if(style != NULL && strlen(style) > 0)
   {
     rc = dt_bauhaus_combobox_set_from_text(d->style, style);
     if(rc == FALSE) dt_bauhaus_combobox_set(d->style, 0);
-    g_free(style);
   }
   else
     dt_bauhaus_combobox_set(d->style, 0);
 
   // style mode to overwrite as it was the initial behavior
-  dt_bauhaus_combobox_set(d->style_mode, dt_conf_get_bool(CONFIG_PREFIX "style_append"));
+  dt_bauhaus_combobox_set(d->style_mode, dt_confgen_get_bool(CONFIG_PREFIX "style_append", DT_DEFAULT));
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
 


### PR DESCRIPTION
fixes #3014

Export module was basically nonsensical - it just made sure that config values are written to config... which makes no sense since config values based on inputs are updated on input change.

This also follows @TurboGit comment in #7859 - that reset should bring module to state it was with fresh config.