### PR TITLE
Fix film roll sorting order

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -540,7 +540,7 @@
     <shortdescription>maximum fps of live view update in tethering view</shortdescription>
     <longdescription>going too fast will result in too many redraws without a real benefit</longdescription>
   </dtconfig>
-  <dtconfig prefs="lighttable" section="general">
+  <dtconfig dialog="collect">
     <name>plugins/collect/filmroll_sort</name>
     <type>
       <enum>
@@ -550,14 +550,28 @@
     </type>
     <default>id</default>
     <shortdescription>sort film rolls by</shortdescription>
-    <longdescription>sets the collections-list order for film rolls</longdescription>
+    <longdescription>order by import time (id) or by foldername</longdescription>
   </dtconfig>
   <dtconfig dialog="collect">
-    <name>plugins/collect/descending</name>
+    <name>plugins/collect/filmroll_descending</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>sort collection recent to older</shortdescription>
-    <longdescription>changes the default collections-list order for folders, times and dates to run from recent to older</longdescription>
+    <shortdescription>sort film rolls descending</shortdescription>
+    <longdescription>true to sort film rolls (by id or folder) from recent to older</longdescription>
+  </dtconfig>
+  <dtconfig dialog="collect">
+    <name>plugins/collect/folder_descending</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>sort folder descending</shortdescription>
+    <longdescription>true to sort folders from recent to older</longdescription>
+  </dtconfig>
+  <dtconfig dialog="collect">
+    <name>plugins/collect/timedate_descending</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>sort times and dates descending</shortdescription>
+    <longdescription>true to sort time and date fields from recent to older</longdescription>
   </dtconfig>
   <dtconfig>
     <name>ui_last/colorpicker_mean</name>

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1212,7 +1212,8 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       break;
   }
 
-  const gint sort_descend = dt_conf_get_bool("plugins/collect/descending");
+  const gint sort_folder_descending = dt_conf_get_bool("plugins/collect/folder_descending");
+  const gint sort_timedate_descending = dt_conf_get_bool("plugins/collect/timedate_descending");
 
   set_properties(dr);
 
@@ -1373,11 +1374,11 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     }
     sqlite3_finalize(stmt);
     g_free(query);
-    sorted_names = g_list_sort(sorted_names, (sort_descend && (property == DT_COLLECTION_PROP_FOLDERS
-                                                              || property == DT_COLLECTION_PROP_DAY
-                                                              || is_time_property(property)
-                                                              )
-                                             ) ? neg_sort_folder_tag : sort_folder_tag
+    sorted_names = g_list_sort(sorted_names, ((sort_folder_descending && property == DT_COLLECTION_PROP_FOLDERS)
+                                              || (sort_timedate_descending && (is_time_property(property) 
+                                                                              || property == DT_COLLECTION_PROP_DAY)
+                                                  ) 
+                                              ) ? neg_sort_folder_tag : sort_folder_tag
                               );
 
     gboolean no_uncategorized = (property == DT_COLLECTION_PROP_TAG) ?
@@ -1832,14 +1833,18 @@ static void list_view(dt_lib_collect_rule_t *dr)
           }
         }
         else
+        // filmroll
         {
           gchar *order_by = NULL;
           if(strcmp(dt_conf_get_string("plugins/collect/filmroll_sort"), "id") == 0)
-            order_by = g_strdup("ORDER BY film_rolls_id DESC");
+            order_by = g_strdup("film_rolls_id");
           else
-            order_by = g_strdup("ORDER BY folder");
+            order_by = g_strdup("folder");
 
-          // filmroll
+          gchar *order_direction = g_strdup("");
+          if(dt_conf_get_bool("plugins/collect/filmroll_descending"))
+            order_direction = g_strdup(" DESC");
+
           g_snprintf(query, sizeof(query),
                      "SELECT folder, film_rolls_id, COUNT(*) AS count"
                      " FROM main.images AS mi"
@@ -1847,9 +1852,11 @@ static void list_view(dt_lib_collect_rule_t *dr)
                      "       FROM main.film_rolls)"
                      "   ON film_id = film_rolls_id "
                      " WHERE %s"
-                     " GROUP BY folder %s", where_ext, order_by);
+                     " GROUP BY folder"
+                     " ORDER BY %s %s", where_ext, order_by, order_direction);
 
           g_free(order_by);
+          g_free(order_direction);
         }
         break;
     }
@@ -2738,6 +2745,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   gtk_widget_show_all(dialog);
   gtk_dialog_run(GTK_DIALOG(dialog));
   gtk_widget_destroy(dialog);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
 }
 
 void set_preferences(void *menu, dt_lib_module_t *self)


### PR DESCRIPTION
fix #6668

Original bug: there is no possibility to sort filmrolls by folder descending.

First suggestion was to use the existing descending-option not only for folders and date/time but also for film-rolls.
Then there was a discussion in #6709 and #6668 that the sorting-order should not be set in preferences but in the module itself for all kinds of collections.

As there now is a separate preference dialog in the collect-module (#7530), I suggested 3 possibilites, 2 users voted for c) so this PR does exactly that.
  