### PR TITLE
Show subfolders using Shift-Click like tags

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1466,11 +1466,31 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       break;
 
     case DT_COLLECTION_PROP_FOLDERS: // folders
-      query = dt_util_dstrcat(
-          query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s' OR folder LIKE '%s"
-                 G_DIR_SEPARATOR_S "%%'))",
-          escaped_text, escaped_text);
-      break;
+    {
+      if ((escaped_length > 0) && (escaped_text[escaped_length-1] == '*'))
+      {
+        escaped_text[escaped_length-1] = '\0';
+        query = dt_util_dstrcat(
+            query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s' OR folder LIKE '%s"
+                  G_DIR_SEPARATOR_S "%%'))",
+            escaped_text, escaped_text);
+      }
+      else if ((escaped_length > 0) && (escaped_text[escaped_length-1] == '%'))
+      {
+        escaped_text[escaped_length-2] = '\0';
+        query = dt_util_dstrcat(
+            query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s"
+                  G_DIR_SEPARATOR_S "%%'))",
+            escaped_text);
+      }
+      else
+      {
+        query = dt_util_dstrcat(
+            query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s'))",
+            escaped_text);
+      }
+    }
+    break;
 
     case DT_COLLECTION_PROP_COLORLABEL: // colorlabel
     {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2196,8 +2196,8 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
     {
       if(item == DT_COLLECTION_PROP_FILMROLL)
       {
-      // go to corresponding folder collection
-      _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FOLDERS);
+        // go to corresponding folder collection
+        _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FOLDERS);
       }
       else if(item == DT_COLLECTION_PROP_FOLDERS)
       {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2222,7 +2222,8 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
       text = n_text;
     }
     else if(item == DT_COLLECTION_PROP_TAG ||
-            item == DT_COLLECTION_PROP_GEOTAGGING)
+            item == DT_COLLECTION_PROP_GEOTAGGING ||
+            item == DT_COLLECTION_PROP_FOLDERS)
     {
       if(gtk_tree_model_iter_has_child(model, &iter))
       {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2187,6 +2187,8 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
   const int active = d->active_rule;
   d->rule[active].typing = FALSE;
 
+  gboolean force_update_view = FALSE;
+
   const int item = _combo_get_active_collection(d->rule[active].combo);
   gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
 
@@ -2203,6 +2205,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
       {
         // go to corresponding filmroll collection
         _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FILMROLL);
+        force_update_view = TRUE;
       }
     }
     else if(gtk_tree_selection_count_selected_rows(selection) > 1
@@ -2290,7 +2293,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
   g_free(text);
 
   if(item == DT_COLLECTION_PROP_TAG
-     || item == DT_COLLECTION_PROP_FOLDERS
+     || (item == DT_COLLECTION_PROP_FOLDERS && !force_update_view)
      || item == DT_COLLECTION_PROP_DAY
      || is_time_property(item)
      || item == DT_COLLECTION_PROP_COLORLABEL

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2192,7 +2192,20 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
 
   if(text && strlen(text) > 0)
   {
-    if(gtk_tree_selection_count_selected_rows(selection) > 1
+    if(event->state & GDK_SHIFT_MASK && event->state & GDK_CONTROL_MASK)
+    {
+      if(item == DT_COLLECTION_PROP_FILMROLL)
+      {
+      // go to corresponding folder collection
+      _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FOLDERS);
+      }
+      else if(item == DT_COLLECTION_PROP_FOLDERS)
+      {
+        // go to corresponding filmroll collection
+        _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FILMROLL);
+      }
+    }
+    else if(gtk_tree_selection_count_selected_rows(selection) > 1
        && (item == DT_COLLECTION_PROP_DAY
            || is_time_property(item)
            || item == DT_COLLECTION_PROP_APERTURE
@@ -2267,16 +2280,6 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
         }
         else dt_collection_set_tag_id((dt_collection_t *)darktable.collection, 0);
       }
-    }
-    else if(item == DT_COLLECTION_PROP_FILMROLL && event->state & GDK_SHIFT_MASK)
-    {
-      // go to corresponding folder collection
-      _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FOLDERS);
-    }
-    else if(item == DT_COLLECTION_PROP_FOLDERS && event->state & GDK_SHIFT_MASK)
-    {
-      // go to corresponding filmroll collection
-      _combo_set_active_collection(d->rule[active].combo, DT_COLLECTION_PROP_FILMROLL);
     }
   }
 


### PR DESCRIPTION
suggestion to fix #4976

Using the same logic as tag/geotag, folders show only current level by default, only subfolders using ctrl-click and current+subfolders using shift-click