### PR TITLE
import: add tags presets combobox

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -706,6 +706,13 @@
     <shortdescription>comma separated tags to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig ui="yes">
+    <name>ui_last/import_last_tags_imported</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>import tags from xmp</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig>
     <name>ui_last/import_last_directory</name>
     <type>string</type>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -881,6 +881,11 @@ dialog scrolledwindow
   margin: 0.2em 0;
 }
 
+#import_presets
+{
+  font-style: italic;
+}
+
 /* Set import from camera or card dialog window */
 dialog .dialog-vbox notebook stack /* set top margin ; between tabs and text below */
 {

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -49,8 +49,7 @@ typedef enum dt_metadata_signal_t
 {
   DT_METADATA_SIGNAL_SHOWN,       // metadata set as shown
   DT_METADATA_SIGNAL_HIDDEN,      // metadata set as hidden
-  DT_METADATA_SIGNAL_NEW_VALUE,   // metadata value changed
-  DT_METADATA_SIGNAL_NEW_PRESETS  // metadata presets changed
+  DT_METADATA_SIGNAL_NEW_VALUE    // metadata value changed
 }
 dt_metadata_signal_t;
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -618,13 +618,10 @@ static void dt_set_darktable_tags()
   }
 }
 
-uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ignore_dt_tags)
+static char *_images_to_act_on_string(const gint imgid, uint32_t *nb)
 {
-  sqlite3_stmt *stmt;
-  dt_set_darktable_tags();
-  char *images = NULL;
   uint32_t nb_selected = 0;
-  uint32_t count = 0;
+  char *images = NULL;
   if(imgid > 0)
   {
     images = dt_util_dstrcat(images, "%d",imgid);
@@ -641,6 +638,18 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
     }
     if(images) images[strlen(images) - 1] = '\0';
   }
+  if(nb)
+    *nb = nb_selected;
+  return images;
+}
+
+uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ignore_dt_tags)
+{
+  sqlite3_stmt *stmt;
+  dt_set_darktable_tags();
+  uint32_t nb_selected = 0;
+  char *images = _images_to_act_on_string(imgid, &nb_selected);
+  uint32_t count = 0;
   if(images)
   {
     char *query = NULL;
@@ -843,7 +852,7 @@ GList *dt_tag_get_hierarchical(gint imgid)
 static GList *_tag_get_tags(const gint imgid, const dt_tag_type_t type)
 {
   GList *tags = NULL;
-  if(imgid < 0) return tags;
+  char *images = _images_to_act_on_string(imgid, NULL);
 
   sqlite3_stmt *stmt;
   dt_set_darktable_tags();
@@ -851,10 +860,10 @@ static GList *_tag_get_tags(const gint imgid, const dt_tag_type_t type)
   snprintf(query, sizeof(query), "SELECT DISTINCT T.id"
                                  "  FROM main.tagged_images AS I"
                                  "  JOIN data.tags T on T.id = I.tagid"
-                                 "  WHERE I.imgid = %d %s",
-           imgid, type == DT_TAG_TYPE_ALL ? "" :
-                  type == DT_TAG_TYPE_DT ? "AND T.id IN memory.darktable_tags" :
-                                           "AND NOT T.id IN memory.darktable_tags");
+                                 "  WHERE I.imgid IN (%s) %s",
+           images, type == DT_TAG_TYPE_ALL ? "" :
+                   type == DT_TAG_TYPE_DT ? "AND T.id IN memory.darktable_tags" :
+                                            "AND NOT T.id IN memory.darktable_tags");
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
@@ -863,7 +872,7 @@ static GList *_tag_get_tags(const gint imgid, const dt_tag_type_t type)
   }
 
   sqlite3_finalize(stmt);
-
+  g_free(images);
   return tags;
 }
 

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -80,6 +80,12 @@ static void _image_info_changed_destroy_callback(gpointer instance, gpointer img
   }
 }
 
+// callback for the destructor of DT_SIGNAL_PRESETS_CHANGED
+static void _presets_changed_destroy_callback(gpointer instance, gpointer module, gpointer user_data)
+{
+  g_free(module);
+}
+
 // callback for the destructor of DT_SIGNAL_GEOTAG_CHANGED
 static void _image_geotag_destroy_callback(gpointer instance, gpointer imgs, const int locid, gpointer user_data)
 {
@@ -129,7 +135,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     FALSE }, // DT_SIGNAL_FILMROLLS_IMPORTED
   { "dt-filmrolls-removed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_FILMROLLS_REMOVED
-
+  { "dt-presets-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg,
+    G_CALLBACK(_presets_changed_destroy_callback), FALSE }, // DT_SIGNAL_PRESETS_CHANGED
 
   /* Develop related signals */
   { "dt-develop-initialized", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -116,6 +116,9 @@ typedef enum dt_signal_t
   /** \brief This signal is raised only when a filmroll is removed */
   DT_SIGNAL_FILMROLLS_REMOVED,
 
+  /* \brief This signal is raised when a preset is created/updated/deleted */
+  DT_SIGNAL_PRESETS_CHANGED,
+
   /** \brief This signal is raised when darktable.develop is initialized.
       \note any modules that wants to access darktable->develop should connect
       to this signal to be sure darktable.develop is initialized.

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -27,14 +27,25 @@
 /*
     Metadata are displayed in a grid which follows this layout:
     Lines
-    First line: Titles + Presets combobox
-    Next lines: Metadata (DT_METADATA_NUMBER lines) - visibilty depending on metadata preferences
-    Last line: tags
+    First line (DT_META_META_HEADER): Titles + metadata presets combobox
+    Next lines (DT_META_META_VALUE): Metadata - visibilty depending on metadata preferences
+    Before last line (DT_META_TAGS_HEADER): tags presets combobox
+    Last line (DT_META_TAGS_VALUE): tags
     Columns
     First column: metadata names
     Second column: value entry
     Last column: xmp flag - visibility depending on write xmp preferences
 */
+
+typedef enum dt_import_grid_t
+{
+  DT_META_META_HEADER = 0,
+  DT_META_META_VALUE,
+  DT_META_TAGS_HEADER = DT_META_META_VALUE + DT_METADATA_NUMBER,
+  DT_META_TAGS_VALUE,
+  DT_META_TOTAL_SIZE
+} dt_import_grid_t;
+
 
 static void _import_metadata_presets_update(dt_import_metadata_t *metadata);
 
@@ -53,7 +64,7 @@ static void _metadata_save(GtkWidget *widget, dt_import_metadata_t *metadata)
 static void _import_metadata_changed(GtkWidget *widget, dt_import_metadata_t *metadata)
 {
   _metadata_save(widget, metadata);
-  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, 0);
+  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_META_HEADER);
   gtk_combo_box_set_active(GTK_COMBO_BOX(w), -1);
 }
 
@@ -68,20 +79,26 @@ static gboolean _import_metadata_reset(GtkWidget *label, GdkEventButton *event, 
 
 static void _metadata_reset_all(dt_import_metadata_t *metadata, const gboolean hard)
 {
-  for(unsigned int i = 0; i < DT_METADATA_NUMBER + 1; i++)
+  for(unsigned int i = DT_META_META_VALUE; i < DT_META_TOTAL_SIZE; i++)
   {
-    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + 1);
-    const gboolean visible = gtk_widget_get_visible(w);
-    if(hard || visible)
-      gtk_entry_set_text(GTK_ENTRY(w), "");
+    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i);
+    if(GTK_IS_ENTRY(w))
+    {
+      const gboolean visible = gtk_widget_get_visible(w);
+      if(hard || visible)
+        gtk_entry_set_text(GTK_ENTRY(w), "");
+    }
   }
   if(hard)
   {
     // import module reset
-    for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+    for(unsigned int i = DT_META_META_VALUE; i < DT_META_TOTAL_SIZE; i++)
     {
-      GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, i + 1);
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), TRUE);
+      GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, i);
+      if(GTK_IS_TOGGLE_BUTTON(w))
+      {
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), TRUE);
+      }
     }
   }
 }
@@ -98,26 +115,38 @@ static gboolean _import_metadata_reset_all(GtkWidget *label, GdkEventButton *eve
 static void _import_metadata_toggled(GtkWidget *widget, dt_import_metadata_t *metadata)
 {
   const char *name = gtk_widget_get_name(widget);
-  const int i = dt_metadata_get_keyid_by_name(name);
-  if(i != -1)
+  if(g_strcmp0(name, "tags"))
   {
-    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+    const int i = dt_metadata_get_keyid_by_name(name);
+    if(i != -1)
+    {
+      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      const gboolean imported = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+      const uint32_t flag = dt_conf_get_int(setting);
+      dt_conf_set_int(setting, imported ? flag | DT_METADATA_FLAG_IMPORTED : flag & ~DT_METADATA_FLAG_IMPORTED);
+      g_free(setting);
+    }
+  }
+  else
+  {
     const gboolean imported = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-    const uint32_t flag = dt_conf_get_int(setting);
-    dt_conf_set_int(setting, imported ? flag | DT_METADATA_FLAG_IMPORTED : flag & ~DT_METADATA_FLAG_IMPORTED);
-    g_free(setting);
+    dt_conf_set_bool("ui_last/import_last_tags_imported", imported);
   }
 }
 
 static void _import_tags_changed(GtkWidget *widget, dt_import_metadata_t *metadata)
 {
-  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_METADATA_NUMBER + 1);
+  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_HEADER);
+  gtk_combo_box_set_active(GTK_COMBO_BOX(w), -1);
+  w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_VALUE);
   dt_conf_set_string("ui_last/import_last_tags", gtk_entry_get_text(GTK_ENTRY(w)));
 }
 
 static void _update_layout(dt_import_metadata_t *metadata)
 {
   const gboolean write_xmp = dt_conf_get_bool("write_sidecar_files");
+  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_META_HEADER);
+  gtk_widget_set_visible(w, !write_xmp);
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
     const gboolean internal = dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL;
@@ -127,11 +156,11 @@ static void _update_layout(dt_import_metadata_t *metadata)
     g_free(setting);
     for(int j = 0; j < 3; j++)
     {
-      GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), j, i + 1);
+      w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), j, i + DT_META_META_VALUE);
       gtk_widget_set_visible(w, j < 2 ? visible : visible & !write_xmp);
     }
   }
-  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, 0);
+  w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_TAGS_VALUE);
   gtk_widget_set_visible(w, !write_xmp);
 }
 
@@ -139,12 +168,13 @@ static void _apply_metadata_toggled(GtkWidget *widget, GtkWidget *grid)
 {
   // activate widgets as needed
   const gboolean default_metadata = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-  for(int i = 0; i < DT_METADATA_NUMBER + 2; i++)
+  for(int i = DT_META_META_HEADER; i < DT_META_TOTAL_SIZE; i++)
   {
     for(int j = 0; j < 2 ; j++)
     {
       GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(grid), j, i);
-      gtk_widget_set_sensitive(w, default_metadata);
+      if(GTK_IS_WIDGET(w))
+        gtk_widget_set_sensitive(w, default_metadata);
     }
   }
 }
@@ -158,11 +188,9 @@ static void _metadata_list_changed(gpointer instance, int type, dt_import_metada
 {
   if(type == DT_METADATA_SIGNAL_HIDDEN || type == DT_METADATA_SIGNAL_SHOWN)
     _update_layout(metadata);
-  else if(type == DT_METADATA_SIGNAL_NEW_PRESETS)
-    _import_metadata_presets_update(metadata);
 }
 
-static void _metadata_presets_changed(GtkWidget *widget, dt_import_metadata_t *metadata)
+static void _import_metadata_presets_changed(GtkWidget *widget, dt_import_metadata_t *metadata)
 {
   GtkTreeIter iter;
 
@@ -202,7 +230,9 @@ static void _import_metadata_presets_update(dt_import_metadata_t *metadata)
   GtkTreeIter iter;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT name, op_params FROM data.presets WHERE operation = 'metadata'",
+                              "SELECT name, op_params FROM data.presets "
+                              "WHERE operation = 'metadata' "
+                              "ORDER BY writeprotect DESC, LOWER(name)",
                               -1, &stmt, NULL);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -235,6 +265,124 @@ static void _import_metadata_presets_update(dt_import_metadata_t *metadata)
   sqlite3_finalize(stmt);
 }
 
+static void _import_tags_presets_changed(GtkWidget *widget, dt_import_metadata_t *metadata)
+{
+  GtkTreeIter iter;
+
+  if(gtk_combo_box_get_active_iter(GTK_COMBO_BOX(widget), &iter) == TRUE)
+  {
+    GtkTreeModel *model = gtk_combo_box_get_model(GTK_COMBO_BOX(widget));
+    char *tags;
+    gtk_tree_model_get(model, &iter, 1, &tags, -1);
+    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_VALUE);
+    g_signal_handlers_block_by_func(w, _import_tags_changed, metadata);
+    gtk_entry_set_text(GTK_ENTRY(w), tags);
+    g_signal_handlers_unblock_by_func(w, _import_tags_changed, metadata);
+    dt_conf_set_string("ui_last/import_last_tags", tags);
+    g_free(tags);
+  }
+}
+
+static void _import_tags_presets_update(dt_import_metadata_t *metadata)
+{
+  gtk_list_store_clear(metadata->t_model);
+  GtkTreeIter iter;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT name, op_params FROM data.presets "
+                              "WHERE operation = 'tagging' "
+                              "ORDER BY writeprotect DESC, LOWER(name)",
+                              -1, &stmt, NULL);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    void *op_params = (void *)sqlite3_column_blob(stmt, 1);
+    int32_t op_params_size = sqlite3_column_bytes(stmt, 1);
+    if(op_params_size)
+    {
+      char *tags = NULL;
+      gchar **tokens = g_strsplit(op_params, ",", 0);
+      if(tokens)
+      {
+        gchar **entry = tokens;
+        while(*entry)
+        {
+          const guint tagid = strtoul(*entry, NULL, 0);
+          char *tag = dt_tag_get_name(tagid);
+          tags = dt_util_dstrcat(tags, "%s,", tag);
+          g_free(tag);
+          entry++;
+        }
+        if(tags)
+          tags[strlen(tags) - 1] = '\0';
+        g_strfreev(tokens);
+        gtk_list_store_append(metadata->t_model, &iter);
+        gtk_list_store_set(metadata->t_model, &iter,
+                           0, (char *)sqlite3_column_text(stmt, 0),
+                           1, tags, -1);
+        g_free(tags);
+      }
+    }
+  }
+  sqlite3_finalize(stmt);
+}
+
+static void _metadata_presets_changed(gpointer instance, gpointer module, dt_import_metadata_t *metadata)
+{
+  if(!g_strcmp0(module, "metadata"))
+    _import_metadata_presets_update(metadata);
+  else if(!g_strcmp0(module, "tagging"))
+    _import_tags_presets_update(metadata);
+}
+
+static GtkWidget *_set_up_label(GtkWidget *label, const int align, const int line,
+                                dt_import_metadata_t *metadata)
+{
+  gtk_widget_set_visible(label, TRUE);
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  gtk_widget_set_halign(label, align);
+  GtkWidget *labelev = gtk_event_box_new();
+  gtk_widget_set_visible(labelev, TRUE);
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(metadata->grid), labelev, 0, line, 1, 1);
+  return labelev;
+}
+
+static GtkWidget *_set_up_combobox(GtkListStore *model, const int line, dt_import_metadata_t *metadata)
+{
+  GtkWidget *presets = gtk_combo_box_new_with_model(GTK_TREE_MODEL(model));
+  gtk_widget_set_visible(presets, TRUE);
+  gtk_widget_set_hexpand(presets, TRUE);
+  GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
+  gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(presets), renderer, TRUE);
+  gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(presets), renderer, "text", 0, NULL);
+  g_object_set(G_OBJECT(renderer), "ellipsize", PANGO_ELLIPSIZE_END, (gchar *)0);
+  gtk_grid_attach(GTK_GRID(metadata->grid), presets, 1, line, 1, 1);
+  g_object_unref(model);
+  return presets;
+}
+
+static void _set_up_entry(GtkWidget *entry, const char *str, const char *name,
+                             const int line, dt_import_metadata_t *metadata)
+{
+  gtk_widget_set_name(entry, name);
+  gtk_entry_set_text(GTK_ENTRY(entry), str);
+  gtk_widget_set_halign(entry, GTK_ALIGN_FILL);
+  gtk_entry_set_width_chars(GTK_ENTRY(entry), 5);
+  gtk_widget_set_hexpand(entry, TRUE);
+  dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(entry));
+  gtk_grid_attach(GTK_GRID(metadata->grid), entry, 1, line, 1, 1);
+}
+
+static void _set_up_toggle_button(GtkWidget *button, const gboolean state, const char *name,
+                                  const int line, dt_import_metadata_t *metadata)
+{
+  gtk_widget_set_name(button, name);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), state);
+  gtk_grid_attach(GTK_GRID(metadata->grid), button, 2, line, 1, 1);
+  gtk_widget_set_halign(button, GTK_ALIGN_CENTER);
+}
+
 void dt_import_metadata_init(dt_import_metadata_t *metadata)
 {
   // default metadata
@@ -254,32 +402,22 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
 
   metadata->m_model = gtk_list_store_newv(DT_METADATA_NUMBER + 1, types);
   _import_metadata_presets_update(metadata);
+  metadata->t_model = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
+  _import_tags_presets_update(metadata);
 
   // grid headers
-  GtkWidget *label = gtk_label_new(_("preset"));
-  gtk_widget_set_visible(label, TRUE);
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  GtkWidget *labelev = gtk_event_box_new();
-  gtk_widget_set_visible(labelev, TRUE);
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, 0, 1, 1);
+  GtkWidget *label = gtk_label_new(_("metadata presets"));
+  gtk_widget_set_name(label, "import_presets");
+  GtkWidget *labelev =_set_up_label(label, GTK_ALIGN_START, DT_META_META_HEADER, metadata);
   gtk_widget_set_tooltip_text(GTK_WIDGET(label), _("metadata to be applied per default"
                                                    "\ndouble-click on a label to clear the corresponding entry"
                                                    "\ndouble-click on 'preset' to clear all entries"));
   g_signal_connect(GTK_EVENT_BOX(labelev), "button-press-event",
                    G_CALLBACK(_import_metadata_reset_all), metadata);
 
-  GtkWidget *presets = gtk_combo_box_new_with_model(GTK_TREE_MODEL(metadata->m_model));
-  gtk_widget_set_visible(presets, TRUE);
-  gtk_widget_set_hexpand(presets, TRUE);
-  GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
-  gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(presets), renderer, TRUE);
-  gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(presets), renderer, "text", 0, NULL);
-  g_object_set(G_OBJECT(renderer), "ellipsize", PANGO_ELLIPSIZE_END, (gchar *)0);
-  gtk_grid_attach(GTK_GRID(grid), presets, 1, 0, 1, 1);
-  g_object_unref(metadata->m_model);
+
+  GtkWidget *presets = _set_up_combobox(metadata->m_model, DT_META_META_HEADER, metadata);
+  g_signal_connect(presets, "changed", G_CALLBACK(_import_metadata_presets_changed), metadata);
 
   label = gtk_label_new(_("from xmp"));
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
@@ -288,7 +426,7 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
                                 "\n this drives also the \'look for updated xmp files\' and \'load sidecar file\' actions"
                                 "\n CAUTION: not selected metadata are cleaned up when xmp file is updated"
                               ));
-  gtk_grid_attach(GTK_GRID(grid), label, 2, 0, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), label, 2, DT_META_META_HEADER, 1, 1);
 
   // grid content
   // metadata
@@ -298,101 +436,90 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
     char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
     const uint32_t flag = dt_conf_get_int(setting);
     g_free(setting);
+
     GtkWidget *metadata_label = gtk_label_new(_(metadata_name));
-    gtk_widget_set_visible(metadata_label, TRUE);
-    gtk_widget_set_halign(metadata_label, GTK_ALIGN_START);
-    gtk_label_set_ellipsize(GTK_LABEL(metadata_label), PANGO_ELLIPSIZE_END);
-    labelev = gtk_event_box_new();
-    gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-    gtk_container_add(GTK_CONTAINER(labelev), metadata_label);
-    gtk_grid_attach(GTK_GRID(grid), labelev, 0, i + 1, 1, 1);
+    labelev = _set_up_label(metadata_label, GTK_ALIGN_START, i + DT_META_META_VALUE, metadata);
 
     GtkWidget *metadata_entry = gtk_entry_new();
-    gtk_widget_set_name(metadata_entry, metadata_name);
     setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
     gchar *str = dt_conf_get_string(setting);
-    gtk_entry_set_text(GTK_ENTRY(metadata_entry), str);
-    gtk_widget_set_halign(metadata_entry, GTK_ALIGN_FILL);
-    gtk_entry_set_width_chars(GTK_ENTRY(metadata_entry), 5);
-    gtk_widget_set_hexpand(metadata_entry, TRUE);
-    dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(metadata_entry));
+    _set_up_entry(metadata_entry, str, metadata_name, i + DT_META_META_VALUE, metadata);
     g_free(str);
     g_free(setting);
-    gtk_grid_attach(GTK_GRID(grid), metadata_entry, 1, i + 1, 1, 1);
     g_signal_connect(GTK_ENTRY(metadata_entry), "changed",
                      G_CALLBACK(_import_metadata_changed), metadata);
     g_signal_connect(GTK_EVENT_BOX(labelev), "button-press-event",
                      G_CALLBACK(_import_metadata_reset), metadata_entry);
 
     GtkWidget *metadata_imported = gtk_check_button_new();
-    gtk_widget_set_name(metadata_imported, metadata_name);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(metadata_imported),
-                                 flag & DT_METADATA_FLAG_IMPORTED);
-    gtk_grid_attach(GTK_GRID(grid), metadata_imported, 2, i + 1, 1, 1);
-    gtk_widget_set_halign(metadata_imported, GTK_ALIGN_CENTER);
+    _set_up_toggle_button(metadata_imported, flag & DT_METADATA_FLAG_IMPORTED,
+                          metadata_name, i + DT_META_META_VALUE, metadata);
     g_signal_connect(GTK_TOGGLE_BUTTON(metadata_imported), "toggled",
                      G_CALLBACK(_import_metadata_toggled), metadata);
   }
 
-  //tags
+  // tags
+  label = gtk_label_new(_("tag presets"));
+  gtk_widget_set_name(label, "import_presets");
+  labelev =_set_up_label(label, GTK_ALIGN_START, DT_META_TAGS_HEADER, metadata);
+
+  presets = _set_up_combobox(metadata->t_model, DT_META_TAGS_HEADER, metadata);
+  g_signal_connect(presets, "changed", G_CALLBACK(_import_tags_presets_changed), metadata);
+
   label = gtk_label_new(_("tags"));
-  gtk_widget_set_visible(label, TRUE);
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_widget_set_visible(labelev, TRUE);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, DT_METADATA_NUMBER + 1, 1, 1);
+  labelev = _set_up_label(label, GTK_ALIGN_START, DT_META_TAGS_VALUE, metadata);
 
   GtkWidget *entry = gtk_entry_new();
   gtk_widget_set_visible(entry, TRUE);
-  gtk_widget_set_hexpand(entry, TRUE);
-  gtk_entry_set_width_chars(GTK_ENTRY(entry), 5);
   gchar *str = dt_conf_get_string("ui_last/import_last_tags");
+  _set_up_entry(entry, str, "tags", DT_META_TAGS_VALUE, metadata);
   gtk_widget_set_tooltip_text(entry, _("comma separated list of tags"));
-  gtk_entry_set_text(GTK_ENTRY(entry), str);
-  dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(entry));
   g_free(str);
-  gtk_grid_attach(GTK_GRID(grid), entry, 1, DT_METADATA_NUMBER + 1, 1, 1);
   g_signal_connect(GTK_ENTRY(entry), "changed",
                    G_CALLBACK(_import_tags_changed), metadata);
   g_signal_connect(GTK_EVENT_BOX(labelev), "button-press-event",
                    G_CALLBACK(_import_metadata_reset), entry);
 
+  GtkWidget *tags_imported = gtk_check_button_new();
+  _set_up_toggle_button(tags_imported, dt_conf_get_bool("ui_last/import_last_tags_imported"),
+                        "tags", DT_META_TAGS_VALUE, metadata);
+
+  // overall
   g_signal_connect(metadata->apply_metadata, "toggled",
                    G_CALLBACK(_apply_metadata_toggled), grid);
   // needed since the apply_metadata starts being turned off,
   // and setting it to off doesn't emit the 'toggled' signal ...
   _apply_metadata_toggled(metadata->apply_metadata, grid);
 
-  g_signal_connect(presets, "changed", G_CALLBACK(_metadata_presets_changed), metadata);
   // connect changed signal
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                             G_CALLBACK(_metadata_prefs_changed), metadata);
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_METADATA_CHANGED,
                             G_CALLBACK(_metadata_list_changed), metadata);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
+                            G_CALLBACK(_metadata_presets_changed), metadata);
   _update_layout(metadata);
 }
 
 void dt_import_metadata_cleanup(dt_import_metadata_t *metadata)
 {
-  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+  for(unsigned int i = DT_META_META_VALUE; i < DT_META_META_VALUE + DT_METADATA_NUMBER; i++)
   {
-    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + 1);
+    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i);
     dt_gui_key_accel_block_on_focus_disconnect(GTK_WIDGET(w));
   }
-  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_METADATA_NUMBER + 1);
+  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_VALUE);
   dt_gui_key_accel_block_on_focus_disconnect(GTK_WIDGET(w));
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_metadata_prefs_changed), metadata);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_metadata_list_changed), metadata);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_metadata_presets_changed), metadata);
 }
 
 void dt_import_metadata_update(dt_import_metadata_t *metadata)
 {
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
-    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + 1);
+    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + DT_META_META_VALUE);
     const gchar *metadata_name = dt_metadata_get_name_by_display_order(i);
     char *setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
     char *meta = dt_conf_get_string(setting);
@@ -401,7 +528,7 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
     g_signal_handlers_unblock_by_func(w, _import_metadata_changed, metadata);
     g_free(meta);
     g_free(setting);
-    w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, i + 1);
+    w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, i + DT_META_META_VALUE);
     setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
     const uint32_t flag = dt_conf_get_int(setting);
     g_signal_handlers_block_by_func(w, _import_metadata_toggled, metadata);
@@ -410,12 +537,17 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
     g_free(setting);
   }
 
-  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_METADATA_NUMBER + 1);
+  GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_VALUE);
   char *tags = dt_conf_get_string("ui_last/import_last_tags");
   g_signal_handlers_block_by_func(w, _import_tags_changed, metadata);
   gtk_entry_set_text(GTK_ENTRY(w), tags);
   g_signal_handlers_unblock_by_func(w, _import_tags_changed, metadata);
   g_free(tags);
+  w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_TAGS_VALUE);
+  const gboolean imported = dt_conf_get_bool("ui_last/import_last_tags_imported");
+  g_signal_handlers_block_by_func(w, _import_metadata_toggled, metadata);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), imported);
+  g_signal_handlers_unblock_by_func(w, _import_metadata_toggled, metadata);
 }
 
 void dt_import_metadata_reset(dt_import_metadata_t *metadata)

--- a/src/gui/import_metadata.h
+++ b/src/gui/import_metadata.h
@@ -22,6 +22,7 @@ typedef struct dt_import_metadata_t
   GtkWidget *apply_metadata;
   GtkWidget *grid;
   GtkListStore *m_model;
+  GtkListStore *t_model;
 } dt_import_metadata_t;
 
 void dt_import_metadata_init(dt_import_metadata_t *metadata);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -207,6 +207,8 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_lib_pre
     sqlite3_finalize(stmt);
 
     dt_gui_store_last_preset(name);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
+                                  g_strdup(g->plugin_name));
   }
   gtk_widget_destroy(GTK_WIDGET(dialog));
   g_free(g->original_name);
@@ -313,6 +315,8 @@ static void menuitem_update_preset(GtkMenuItem *menuitem, dt_lib_module_info_t *
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, name, -1, SQLITE_TRANSIENT);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
+                                  g_strdup(minfo->plugin_name));
   }
 }
 
@@ -402,6 +406,8 @@ static void menuitem_delete_preset(GtkMenuItem *menuitem, dt_lib_module_info_t *
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, minfo->version);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
+                                  g_strdup(minfo->plugin_name));
   }
   g_free(name);
 }
@@ -936,7 +942,12 @@ void dt_lib_init_presets(dt_lib_module_t *module)
     sqlite3_finalize(stmt);
   }
 
-  if(module->init_presets) module->init_presets(module);
+  if(module->init_presets)
+  {
+    module->init_presets(module);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
+                                  g_strdup(module->plugin_name));
+  }
 }
 
 static void dt_lib_init_module(void *m)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -815,7 +815,6 @@ void init_presets(dt_lib_module_t *self)
   add_rights_preset(self, _("CC BY-NC-ND"),
                     _("Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"));
   add_rights_preset(self, _("all rights reserved"), _("all rights reserved."));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_PRESETS);
 }
 
 void *legacy_params(dt_lib_module_t *self, const void *const old_params, const size_t old_params_size,


### PR DESCRIPTION
- import_metadata: align tags ui on metadata
- import_metadata: update combo boxes on any presets change
- import_metadata: code cleaning
- libs: add presets change signal (init, new, update, delete)
- metadata: remove init presets signal (as done above)
- tagging: fix bug on set_params (only new tags were added)
- tags: make _tag_get_tags() answer for imgid = -1 as well

@elstoc, as I cannot test this myself I would appreciate if you could check the metadata combobox still initializes properly for you. TIA.
