### PR TITLE
nlmeans_core: optimize plain C version for BINARY_PACKAGE_BUILD

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -126,7 +126,7 @@ typedef unsigned int u_int;
 /* Create cloned functions for various CPU SSE generations */
 /* See for instructions https://hannes.hauswedell.net/post/2017/12/09/fmv/ */
 /* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
-#if __has_attribute(target_clones) && !defined(_WIN32) && defined(__SSE__)
+#if __has_attribute(target_clones) && !defined(_WIN32)
 #define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "avx512f", "fma4")))
 #else
 #define __DT_CLONE_TARGETS__

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -385,6 +385,7 @@ static int compute_slice_width(const int width)
   return sl_width;
 }
 
+__DT_CLONE_TARGETS__
 void nlmeans_denoise(const float *const inbuf, float *const outbuf,
                      const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                      const dt_nlmeans_param_t *const params)


### PR DESCRIPTION
1. Allow to use `__DT_CLONE_TARGETS__` macro for non-SSE2 codepath
2. Apply `__DT_CLONE_TARGETS__` macro for `nlmeans_denoise` function

This is an example mentioned in PR #7695 that `target_clones` attribute makes sense for non-SSE2 codepath.

package-*: `BINARY_PACKAGE_BUILD=ON`

pixel pipeline processing took (avg from 3 runs):

0020-denoise-nlmeans:

native: 2.71
native-no-SSE2: 2.83
package-no-SSE2-before: 6.5
package-no-SSE2-after: 3.18 (2.05x)

0027-denoiseprofile-nlmeans:

native: 5.63
native-no-SSE2: 5.69
package-no-SSE2-before: 8.25
package-no-SSE2-after: 5.78 (1.43x)

CPU: `Intel(R) Core(TM) i7-6700`
Threads: 4
Compiler: `gcc (Ubuntu 10.2.0-5ubuntu1~20.04) 10.2.0`