### PR TITLE
toneequal: fix missing cursor

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1645,7 +1645,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
 
   show_guiding_controls(self);
-  gui_cache_init(self);
+  invalidate_luminance_cache(self);
 
   dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
 }


### PR DESCRIPTION
when clicking on the reset parameters button, or moving through the history stack, where the module parameters were not being changed, this was causing the luminance cache to become invalid.

This meant that, even though the module still had focus, the cursor was not updating correctly and only a change that invalidated the preview pipe (tweaking a parameter in another module, for example) caused the luminance cache to be flagged as valid again.