### PR TITLE
vectorscope variant for histogram

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2453,6 +2453,7 @@
       <enum>
         <option>histogram</option>
         <option>waveform</option>
+        <option>vectorscope</option>
       </enum>
     </type>
     <default>histogram</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2488,11 +2488,11 @@
     <name>plugins/darkroom/histogram/vectorscope</name>
     <type>
       <enum>
-        <option>Luv</option>
-        <option>JzAzBz</option>
+        <option>u*v*</option>
+        <option>AzBz</option>
       </enum>
     </type>
-    <default>Luv</default>
+    <default>u*v*</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2497,6 +2497,13 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/histogram/vectorscope/angle</name>
+    <type>int</type>
+    <default>270</default>
+    <shortdescription/>
+    <longdescription>Angle in degrees to orient the vectorscope. 0 is the color science proper orientation (see CIE 1976 UCS diagram). 270 is what video editors are used to when using a vectorscope (with red/magenta in 12:00 position).</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/histogram/show_red</name>
     <type>bool</type>
     <default>true</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2485,6 +2485,18 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/histogram/vectorscope</name>
+    <type>
+      <enum>
+        <option>Luv</option>
+        <option>JzAzBz</option>
+      </enum>
+    </type>
+    <default>Luv</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/histogram/show_red</name>
     <type>bool</type>
     <default>true</default>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -164,6 +164,9 @@
 @define-color graph_red rgb(237,30,20);
 @define-color graph_green rgb(28,235,26);
 @define-color graph_blue rgb(14,14,233);
+@define-color graph_cyan rgb(20,210,253);
+@define-color graph_magenta rgb(220,14,240);
+@define-color graph_yellow rgb(240,235,26);
 
 @define-color colorlabel_red rgb(230,0,0);
 @define-color colorlabel_green rgb(0,230,0);

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -151,6 +151,7 @@
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
 @define-color graph_bg @grey_10;
+@define-color graph_exterior shade(@graph_bg, 0.9);
 @define-color graph_border @grey_05;
 @define-color graph_fg @grey_75;
 @define-color graph_fg_active @grey_95;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -164,9 +164,6 @@
 @define-color graph_red rgb(237,30,20);
 @define-color graph_green rgb(28,235,26);
 @define-color graph_blue rgb(14,14,233);
-@define-color graph_cyan rgb(20,210,253);
-@define-color graph_magenta rgb(220,14,240);
-@define-color graph_yellow rgb(240,235,26);
 
 @define-color colorlabel_red rgb(230,0,0);
 @define-color colorlabel_green rgb(0,230,0);

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -150,7 +150,7 @@
 @define-color brush_trace alpha(black, .8);
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
-@define-color graph_bg @grey_10;
+@define-color graph_bg @grey_15;
 @define-color graph_exterior shade(@graph_bg, 0.9);
 @define-color graph_border @grey_05;
 @define-color graph_fg @grey_75;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -544,9 +544,12 @@ void dt_bauhaus_load_theme()
   gtk_style_context_lookup_color(ctx, "graph_fg_active", &darktable.bauhaus->graph_fg_active);
   gtk_style_context_lookup_color(ctx, "graph_overlay", &darktable.bauhaus->graph_overlay);
   gtk_style_context_lookup_color(ctx, "inset_histogram", &darktable.bauhaus->inset_histogram);
-  gtk_style_context_lookup_color(ctx, "graph_red", &darktable.bauhaus->graph_primaries[0]);
-  gtk_style_context_lookup_color(ctx, "graph_green", &darktable.bauhaus->graph_primaries[1]);
-  gtk_style_context_lookup_color(ctx, "graph_blue", &darktable.bauhaus->graph_primaries[2]);
+  gtk_style_context_lookup_color(ctx, "graph_red", &darktable.bauhaus->graph_colors[0]);
+  gtk_style_context_lookup_color(ctx, "graph_green", &darktable.bauhaus->graph_colors[1]);
+  gtk_style_context_lookup_color(ctx, "graph_blue", &darktable.bauhaus->graph_colors[2]);
+  gtk_style_context_lookup_color(ctx, "graph_cyan", &darktable.bauhaus->graph_colors[3]);
+  gtk_style_context_lookup_color(ctx, "graph_magenta", &darktable.bauhaus->graph_colors[4]);
+  gtk_style_context_lookup_color(ctx, "graph_yellow", &darktable.bauhaus->graph_colors[5]);
   gtk_style_context_lookup_color(ctx, "colorlabel_red",
                                  &darktable.bauhaus->colorlabels[DT_COLORLABELS_RED]);
   gtk_style_context_lookup_color(ctx, "colorlabel_yellow",

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -538,6 +538,7 @@ void dt_bauhaus_load_theme()
   gtk_style_context_lookup_color(ctx, "bauhaus_indicator_border", &darktable.bauhaus->indicator_border);
 
   gtk_style_context_lookup_color(ctx, "graph_bg", &darktable.bauhaus->graph_bg);
+  gtk_style_context_lookup_color(ctx, "graph_exterior", &darktable.bauhaus->graph_exterior);
   gtk_style_context_lookup_color(ctx, "graph_border", &darktable.bauhaus->graph_border);
   gtk_style_context_lookup_color(ctx, "graph_grid", &darktable.bauhaus->graph_grid);
   gtk_style_context_lookup_color(ctx, "graph_fg", &darktable.bauhaus->graph_fg);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -547,9 +547,6 @@ void dt_bauhaus_load_theme()
   gtk_style_context_lookup_color(ctx, "graph_red", &darktable.bauhaus->graph_colors[0]);
   gtk_style_context_lookup_color(ctx, "graph_green", &darktable.bauhaus->graph_colors[1]);
   gtk_style_context_lookup_color(ctx, "graph_blue", &darktable.bauhaus->graph_colors[2]);
-  gtk_style_context_lookup_color(ctx, "graph_cyan", &darktable.bauhaus->graph_colors[3]);
-  gtk_style_context_lookup_color(ctx, "graph_magenta", &darktable.bauhaus->graph_colors[4]);
-  gtk_style_context_lookup_color(ctx, "graph_yellow", &darktable.bauhaus->graph_colors[5]);
   gtk_style_context_lookup_color(ctx, "colorlabel_red",
                                  &darktable.bauhaus->colorlabels[DT_COLORLABELS_RED]);
   gtk_style_context_lookup_color(ctx, "colorlabel_yellow",

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -234,7 +234,7 @@ typedef struct dt_bauhaus_t
 
   // colors for graphs
   GdkRGBA graph_bg, graph_border, graph_fg, graph_grid, graph_fg_active, graph_overlay, inset_histogram;
-  GdkRGBA graph_colors[6];               // primaries and secondaries
+  GdkRGBA graph_colors[3];               // primaries
   GdkRGBA colorlabels[DT_COLORLABELS_LAST];
 } dt_bauhaus_t;
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -234,7 +234,7 @@ typedef struct dt_bauhaus_t
 
   // colors for graphs
   GdkRGBA graph_bg, graph_border, graph_fg, graph_grid, graph_fg_active, graph_overlay, inset_histogram;
-  GdkRGBA graph_primaries[3];
+  GdkRGBA graph_colors[6];               // primaries and secondaries
   GdkRGBA colorlabels[DT_COLORLABELS_LAST];
 } dt_bauhaus_t;
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -233,7 +233,7 @@ typedef struct dt_bauhaus_t
   GdkRGBA color_fg, color_fg_insensitive, color_bg, color_border, indicator_border, color_fill;
 
   // colors for graphs
-  GdkRGBA graph_bg, graph_border, graph_fg, graph_grid, graph_fg_active, graph_overlay, inset_histogram;
+  GdkRGBA graph_bg, graph_exterior, graph_border, graph_fg, graph_grid, graph_fg_active, graph_overlay, inset_histogram;
   GdkRGBA graph_colors[3];               // primaries
   GdkRGBA colorlabels[DT_COLORLABELS_LAST];
 } dt_bauhaus_t;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1066,10 +1066,9 @@ void dtgtk_cairo_paint_vectorscope(cairo_t *cr, gint x, gint y, gint w, gint h, 
 {
   PREAMBLE(1, 0, 0)
 
-  // FIXME: improve icon -- perhaps a gradient pattern to soften the edge of a drawn mask?
-  cairo_move_to(cr, 0.1, 0.25);
-  cairo_curve_to(cr, 0.2, 0.1, 0.5, 0.25, 0.75, 0.6);
-  cairo_curve_to(cr, 0.7, 0.8, 0.1, 0.6, 0.1, 0.25);
+  cairo_move_to(cr, 0.0, 0.3);
+  cairo_curve_to(cr, 0.1, 0.0, 0.7, 0.3, 1.0, 0.7);
+  cairo_curve_to(cr, 0.9, 0.8, 0.1, 0.8, 0.0, 0.3);
   cairo_fill(cr);
 
   FINISH

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1162,6 +1162,7 @@ void dtgtk_cairo_paint_luv(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 {
   PREAMBLE(1, 0, 0)
 
+  // FIXME: change icon to "u*v*"
   cairo_move_to(cr, 0.0, 0.0);
   cairo_line_to(cr, 0.0, 1.0);
   cairo_line_to(cr, 0.7, 1.0);
@@ -1183,6 +1184,7 @@ void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 {
   PREAMBLE(1, 0, 0)
 
+  // FIXME: change icon to "AzBz" or just "z"
   cairo_move_to(cr, 0.4, 0.0);
   cairo_curve_to(cr, 0.45, 1.0, 0.1, 1.0, 0.0, 0.8);
   cairo_stroke(cr);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1158,6 +1158,44 @@ void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, g
   FINISH
 }
 
+void dtgtk_cairo_paint_luv(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.0, 0.0);
+  cairo_line_to(cr, 0.0, 1.0);
+  cairo_line_to(cr, 0.7, 1.0);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.5, 0.0);
+  cairo_curve_to(cr, 0.5, 0.4, 1.0, 0.4, 1.0, 0.0);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.5, 0.5);
+  cairo_line_to(cr, 0.75, 0.8);
+  cairo_line_to(cr, 1.0, 0.5);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.4, 0.0);
+  cairo_curve_to(cr, 0.45, 1.0, 0.1, 1.0, 0.0, 0.8);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.6, 0.5);
+  cairo_line_to(cr, 1.0, 0.5);
+  cairo_line_to(cr, 0.6, 1.0);
+  cairo_line_to(cr, 1.0, 1.0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1126,7 +1126,7 @@ void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   PREAMBLE(1, 0, 0)
 
-  const GdkRGBA *const primaries = darktable.bauhaus->graph_primaries;
+  const GdkRGBA *const primaries = darktable.bauhaus->graph_colors;
   cairo_pattern_t *pat;
 
   pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1062,6 +1062,19 @@ void dtgtk_cairo_paint_waveform_scope(cairo_t *cr, gint x, gint y, gint w, gint 
   FINISH
 }
 
+void dtgtk_cairo_paint_vectorscope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // FIXME: improve icon -- perhaps a gradient pattern to soften the edge of a drawn mask?
+  cairo_move_to(cr, 0.1, 0.25);
+  cairo_curve_to(cr, 0.2, 0.1, 0.5, 0.25, 0.75, 0.6);
+  cairo_curve_to(cr, 0.7, 0.8, 0.1, 0.6, 0.1, 0.25);
+  cairo_fill(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_linear_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -191,6 +191,8 @@ void dtgtk_cairo_paint_camera(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 void dtgtk_cairo_paint_histogram_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint waveform scope icon */
 void dtgtk_cairo_paint_waveform_scope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint vectorscope icon */
+void dtgtk_cairo_paint_vectorscope(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint linear scale icon */
 void dtgtk_cairo_paint_linear_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint logarithmic scale icon */

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -201,6 +201,10 @@ void dtgtk_cairo_paint_logarithmic_scale(cairo_t *cr, gint x, gint y, gint w, gi
 void dtgtk_cairo_paint_waveform_overlaid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint RGB parade icon */
 void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint Luv icon */
+void dtgtk_cairo_paint_luv(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint JzAzBz icon */
+void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -852,14 +852,14 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
         cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
         for(int k=DT_IOP_RGBCURVE_R; k<DT_IOP_RGBCURVE_MAX_CHANNELS; k++)
         {
-          set_color(cr, darktable.bauhaus->graph_primaries[k]);
+          set_color(cr, darktable.bauhaus->graph_colors[k]);
           dt_draw_histogram_8_zoomed(cr, hist, 4, k, g->zoom_factor, g->offset_x * 255.0, g->offset_y * hist_max,
                                      is_linear);
         }
       }
       else if(autoscale == DT_S_SCALE_MANUAL_RGB)
       {
-        set_color(cr, darktable.bauhaus->graph_primaries[ch]);
+        set_color(cr, darktable.bauhaus->graph_colors[ch]);
         dt_draw_histogram_8_zoomed(cr, hist, 4, ch, g->zoom_factor, g->offset_x * 255.0, g->offset_y * hist_max,
                                    is_linear);
       }

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -477,13 +477,13 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
         cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
         for(int k=DT_IOP_RGBLEVELS_R; k<DT_IOP_RGBLEVELS_MAX_CHANNELS; k++)
         {
-          set_color(cr, darktable.bauhaus->graph_primaries[k]);
+          set_color(cr, darktable.bauhaus->graph_colors[k]);
           dt_draw_histogram_8(cr, hist, 4, k, is_linear);
         }
       }
       else if(p->autoscale == DT_IOP_RGBLEVELS_INDEPENDENT_CHANNELS)
       {
-        set_color(cr, darktable.bauhaus->graph_primaries[ch]);
+        set_color(cr, darktable.bauhaus->graph_colors[ch]);
         dt_draw_histogram_8(cr, hist, 4, ch, is_linear);
       }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -328,7 +328,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       }
       d->hue_ring_coord[k][i][0] = chromaticity[1];
       d->hue_ring_coord[k][i][1] = chromaticity[2];
-      // FIXME: we actually want to know max(abs(x)) and max(abs(y)) so can use more of space, then give somethinglike 110% of each on the display
+      // FIXME: we actually want to know max(abs(x)) and max(abs(y)) so can use more of space, then give something like 110% of each on the display
       max_radius = MAX(max_radius, hypotf(chromaticity[1], chromaticity[2]));
     }
   }
@@ -359,8 +359,8 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       dt_XYZ_D50_2_XYZ_D65(XYZ_D50, XYZ_D65);
       dt_XYZ_2_JzAzBz(XYZ_D65, chromaticity);
     }
-    d->vectorscope_pt[0] = chromaticity[1] / max_diam;
-    d->vectorscope_pt[1] = chromaticity[2] / max_diam;
+    d->vectorscope_pt[0] = chromaticity[1];
+    d->vectorscope_pt[1] = chromaticity[2];
     goto cleanup;
   }
 
@@ -711,6 +711,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   cairo_save(cr);
 
+  // background
   cairo_pattern_t *p = cairo_pattern_create_radial(0.5 * width, 0.5 * height, factor * 0.5 * min_size,
                                                    0.5 * width, 0.5 * height, factor * 0.5 * hypot(min_size, min_size));
   cairo_pattern_add_color_stop_rgb(p, 0., darktable.bauhaus->graph_bg.red, darktable.bauhaus->graph_bg.green, darktable.bauhaus->graph_bg.blue);
@@ -780,9 +781,8 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     cairo_pattern_t *pattern = cairo_pattern_create_for_surface(source);
     cairo_matrix_t matrix;
     cairo_matrix_init_translate(&matrix, 0.5*diam_px/darktable.gui->ppd, 0.5*diam_px/darktable.gui->ppd);
-    // FIXME: set in terms of scale rather than factor
     cairo_matrix_scale(&matrix, (double)diam_px / min_size / factor / darktable.gui->ppd,
-                       (double) diam_px / min_size / factor / darktable.gui->ppd);
+                       (double)diam_px / min_size / factor / darktable.gui->ppd);
     cairo_pattern_set_matrix(pattern, &matrix);
     cairo_set_source(cr, pattern);
     cairo_paint(cr);
@@ -795,8 +795,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     // point sample
     cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     set_color(cr, darktable.bauhaus->graph_fg);
-    // FIXME: set vectorscope_pt such that can be in terms of scale rather than factor
-    cairo_arc(cr, factor*d->vectorscope_pt[0]*min_size, factor*d->vectorscope_pt[1]*min_size,
+    cairo_arc(cr, scale*d->vectorscope_pt[0], scale*d->vectorscope_pt[1],
               DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
     cairo_fill(cr);
   }
@@ -836,10 +835,10 @@ static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointe
   {
     cairo_save(cr);
     cairo_rectangle(cr, 0, 0, width, height);
-    set_color(cr, darktable.bauhaus->graph_border);
-    cairo_stroke_preserve(cr);
     set_color(cr, darktable.bauhaus->graph_bg);
-    cairo_fill(cr);
+    cairo_fill_preserve(cr);
+    set_color(cr, darktable.bauhaus->graph_border);
+    cairo_stroke(cr);
     cairo_restore(cr);
   }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -257,11 +257,6 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   if(!histogram_profile) return;
   // FIXME: as in colorbalancergb, repack matrix for SEE?
 
-  // FIXME: for purposes of interesting display, can we figure out other relevant profile primaries?
-  //color_profile = dt_ioppr_get_pipe_input_profile_info(pipe);
-  //color_profile = dt_ioppr_get_pipe_work_profile_info(pipe);
-  //color_profile = dt_ioppr_get_pipe_output_profile_info(pipe);
-
   // get profile primaries/secondaries in JzAzBz
   // there's no guarantee that there is a chromaticity tag in the
   // profile, so simply feed RGB colors through profile to PCS then
@@ -356,7 +351,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   {
     dt_times_t end_time = { 0 };
     dt_get_times(&end_time);
-    fprintf(stderr, "vectorscope took %.3f secs (%.3f CPU)\n", end_time.clock - start_time.clock, end_time.user - start_time.user);
+    fprintf(stderr, "final vectorscope took %.3f secs (%.3f CPU)\n", end_time.clock - start_time.clock, end_time.user - start_time.user);
   }
 }
 
@@ -592,12 +587,18 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // graticule: histogram profile primaries/secondaries
   // FIXME: also add dots for input/work/output profiles
+  // FIXME: add gamut bounding lines to connect the dots (which need to be plotted in XYZ?)
+  // from Sobotka:
+  // 1. The input encoding primaries. How dd the image start out life? What is valid data within that? What is invalid introduced by error of camera virtual primaries solving or math such as resampling an image such that negative lobes result?
+  // 2. The working reference primaries. How did 1. end up in 2.? Are there negative and therefore nonsensical values in the working space? Should a gamut mapping pass be applied before work, between 1. and 2.?
+  // 3. The output primaries rendition. From a selection of gamut mappings, is one required between 2. and 3.?"
   const GdkRGBA *const colors = darktable.bauhaus->graph_colors;
   for(int k=0; k<6; k++)
   {
-    cairo_set_source_rgba(cr, colors[k].red, colors[k].green, colors[k].blue, colors[k].alpha * 0.7);
+    // FIXME: if/when have a color vectorscope, make these dots gray to complement it
+    cairo_set_source_rgba(cr, colors[k].red, colors[k].green, colors[k].blue, colors[k].alpha * (k<3 ? 0.7 : 0.5));
     cairo_arc(cr, d->vectorscope_graticule[k][0] * min_size * 0.5,
-              d->vectorscope_graticule[k][1] * min_size * 0.5, min_size/(k<3 ? 40.0 : 50.0), 0., M_PI * 2.);
+              d->vectorscope_graticule[k][1] * min_size * 0.5, min_size/(k<3 ? 40.0 : 60.0), 0., M_PI * 2.);
     cairo_fill(cr);
   }
 
@@ -631,12 +632,6 @@ static void _draw_vectorscope_lines(cairo_t *cr, int width, int height)
   cairo_stroke(cr);
   dt_draw_line(cr, 0.0f, -w_ctr, 0.0f, w_ctr);
   cairo_stroke(cr);
-
-  // FIXME: draw more sophisticated view of primaries (input, working, output)
-  // from Sobotka:
-  // 1. The input encoding primaries. How dd the image start out life? What is valid data within that? What is invalid introduced by error of camera virtual primaries solving or math such as resampling an image such that negative lobes result?
-  // 2. The working reference primaries. How did 1. end up in 2.? Are there negative and therefore nonsensical values in the working space? Should a gamut mapping pass be applied before work, between 1. and 2.?
-  // 3. The output primaries rendition. From a selection of gamut mappings, is one required between 2. and 3.?"
 
   cairo_restore(cr);
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1017,14 +1017,14 @@ static void _vectorscope_view_update(dt_lib_histogram_t *d)
       g_assert_not_reached();
   }
 
-  // redraw empty scope for immediate visual feedback
-  d->vectorscope_graticule[0][0] = NAN;
-  dt_control_queue_redraw_widget(d->scope_draw);
-
   // generate data for changed view and trigger widget redraw
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv)
+  if(cv)  // this may be called by _scope_type_update() on init, before in a view
   {
+    // redraw empty scope for immediate visual feedback
+    d->vectorscope_graticule[0][0] = NAN;
+    dt_control_queue_redraw_widget(d->scope_draw);
+
     if(cv->view(cv) == DT_VIEW_DARKROOM)
       dt_dev_process_preview(darktable.develop);
     else
@@ -1216,7 +1216,7 @@ static gboolean _lib_histogram_cycle_mode_callback(GtkAccelGroup *accel_group,
   switch(d->scope_type)
   {
     case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-      if(d->histogram_scale == DT_LIB_HISTOGRAM_N-1)
+      if(d->histogram_scale == DT_LIB_HISTOGRAM_LOGARITHMIC)
       {
         _scope_view_clicked(d->scope_view_button, d);
       }
@@ -1232,7 +1232,7 @@ static gboolean _lib_histogram_cycle_mode_callback(GtkAccelGroup *accel_group,
       }
       break;
     case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-      if(d->waveform_type == DT_LIB_HISTOGRAM_WAVEFORM_N-1)
+      if(d->waveform_type == DT_LIB_HISTOGRAM_WAVEFORM_OVERLAID)
       {
         _scope_view_clicked(d->scope_view_button, d);
       }
@@ -1248,7 +1248,7 @@ static gboolean _lib_histogram_cycle_mode_callback(GtkAccelGroup *accel_group,
       }
       break;
     case DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE:
-      if(d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_N-1)
+      if(d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
       {
         _scope_view_clicked(d->scope_view_button, d);
       }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -692,7 +692,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // concentric circles as a scale
   set_color(cr, darktable.bauhaus->graph_grid);
-  cairo_set_line_width(cr, vs_radius * 1.5 / min_size);
+  cairo_set_line_width(cr, vs_radius * 2. / min_size);
   const float grid_radius = d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV ? 100. : 0.01;
   for(int i = 1; i < 1.f + ceilf(vs_radius/grid_radius); i++)
   {
@@ -706,23 +706,14 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   // 2. The working reference primaries. How did 1. end up in 2.? Are there negative and therefore nonsensical values in the working space? Should a gamut mapping pass be applied before work, between 1. and 2.?
   // 3. The output primaries rendition. From a selection of gamut mappings, is one required between 2. and 3.?"
 
-  // graticule: histogram profile primaries/secondaries
-  set_color(cr, darktable.bauhaus->graph_fg);
-  for(int k=0; k<6; k++)
-  {
-    cairo_arc(cr, d->hue_ring_coord[k][0][0], d->hue_ring_coord[k][0][1], vs_radius * 0.03, 0., M_PI * 2.);
-    cairo_fill(cr);
-  }
-
   // graticule: histogram profile hue ring
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  cairo_set_line_width(cr, vs_radius * 1.5 / min_size);
+  cairo_set_line_width(cr, vs_radius * 2. / min_size);
   cairo_move_to(cr, d->hue_ring_coord[5][VECTORSCOPE_HUES-1][0], d->hue_ring_coord[5][VECTORSCOPE_HUES-1][1]);
   for(int k=0; k<6; k++)
     for(int i=0; i < VECTORSCOPE_HUES; i++)
     {
       // FIXME: can we pre-make a pattern with the hues radiating out, and use it as the "ink" to draw the hue ring and -- if in false color mode -- the vectorscope? will this be faster then drawing lots of lines each with their own color? will it allow for drawing the hue ring with splines and calculating fewer points?
-      // FIXME: if/when have a color vectorscope, make hue ring gray to complement it?
       // note that hue_ring_rgb and hue_ring_coord are calculated as float but converted here to double
       cairo_set_source_rgba(cr, d->hue_ring_rgb[k][i][0], d->hue_ring_rgb[k][i][1], d->hue_ring_rgb[k][i][2], 0.5);
       cairo_line_to(cr, d->hue_ring_coord[k][i][0], d->hue_ring_coord[k][i][1]);
@@ -744,14 +735,20 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_set_source_surface(cr, source, 0.0, 0.0);
   cairo_paint(cr);
   cairo_surface_destroy(source);
+
   cairo_restore(cr);
+
+  // overlay central circle
+  set_color(cr, darktable.bauhaus->graph_overlay);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5));
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, width / 2., height / 2., DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
+  cairo_stroke(cr);
 }
 
 static void _draw_vectorscope_frame(cairo_t *cr, int width, int height)
 {
   const double min_size = MIN(width, height);
-  // FIXME: need DT_PIXEL_APPLY_DPI()?
-  const double w_ctr = min_size / 25.0;
 
   cairo_save(cr);
 
@@ -764,16 +761,6 @@ static void _draw_vectorscope_frame(cairo_t *cr, int width, int height)
   cairo_fill_preserve(cr);
   cairo_pattern_destroy(p);
   set_color(cr, darktable.bauhaus->graph_border);
-  cairo_stroke(cr);
-
-  cairo_translate(cr, width/2., height/2.);
-
-  // central crosshair
-  set_color(cr, darktable.bauhaus->graph_grid);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
-  dt_draw_line(cr, -w_ctr, 0.0f, w_ctr, 0.0f);
-  cairo_stroke(cr);
-  dt_draw_line(cr, 0.0f, -w_ctr, 0.0f, w_ctr);
   cairo_stroke(cr);
 
   cairo_restore(cr);


### PR DESCRIPTION
This is a first working pass at a vectorscope variant of the histogram:

![image](https://user-images.githubusercontent.com/2311860/105871549-6a363480-5fc7-11eb-9d23-ce91c8dcb7ec.png)

![image](https://user-images.githubusercontent.com/2311860/105871263-23483f00-5fc7-11eb-8475-f661857d36ce.png)

Visible changes:

- A vectorscope is drawn in JzAzBz space (showing the a/b axes).
- The vectorscope is in grayscale, density corresponding to quantity of pixels of a given chromaticity.
- There is a "graticule" consisting of the primaries and secondaries of the current histogram profile.
- The color channel buttons are "insensitive" in vectorscope and (now) RGB parade views as it doesn't make sense in these views to only look at particular channels.

Changes to allow for this:

- The histogram button code has been revamped. Previously the "mode/type" and "view" buttons (the two leftmost) were implemented as toggle buttons. As there are now three modes (histogram, waveform, vectorscope), toggle doesn't work anymore. Clicking these buttons instead switches their icons and the state recorded in a data structure. This change shouldn't be visible to the user, but changed a bunch of code. The UI code should now be tidier (e.g. no stack needed to swap buttons anymore, CSS selectors are simplified).
- There is now CSS to set the secondary colors for the graticule (`graph_cyan`, `graph_magenta`, `graph_yellow`). The primaries use the extant CSS (`graph_red`, `graph_green`, `graph_blue`).

Some improvements to make after this PR:
- It is possible to make a "false color" variant which instead of being drawn in light gray, has each pixel colored according to their corresponding chromaticity values.
- I did a bit of optimization of the vectorscope process code, but it is still significantly slower than the corresponding histogram/waveform code. Here it takes about 0.040 secs. to process a vectorscope, compared to 0.002 sec. for histogram or 0.010 sec. for waveform.
- There is a bug which this PR doesn't fix: the tooltips of the buttons don't show except for just after the buttons are clicked. Otherwise the tooltip for the drawable below shows. This bug may have been around since #7922.
- There are no concentric target-style circles from the graticule, as they didn't seem to refer to anything. It could be worth giving this more thought, though.
- It would be nice if the graticule actually showed some sort of gamut bounding line.
- As suggested by @sobotka (https://github.com/darktable-org/darktable/issues/4149#issuecomment-616238200), it would be interesting to show other primaries in the graticule (input, working, output).
- The gamma/brightness math may need a bit further thought, and can probably be optimized as well.
- Work on the longstanding questions about how bright the various scopes should be, this included.
- Work on longstanding request so that colorpicker selection alters other scopes besides "regular" histogram.

Closes #4149, though it would still be good to refer to all the good ideas in that discussion.