### PR TITLE
Fixing windows crash for dual demosaicers

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -176,11 +176,20 @@ static inline __m128 dt_prophotoRGB_to_XYZ_sse2(__m128 rgb)
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
+/* This crashes on windows #8025
+   static inline float cbrt_5f(float f)
+  {
+    uint32_t *p = (uint32_t *)&f;
+    *p = *p / 3 + 709921077;
+    return f;
+  }
+*/
 static inline float cbrt_5f(float f)
 {
-  uint32_t *p = (uint32_t *)&f;
-  *p = *p / 3 + 709921077;
-  return f;
+  union { float f ; uint32_t i; } floatint;
+  floatint.f = f;
+  floatint.i = floatint.i / 3 + 709921077;
+  return floatint.f;
 }
 
 #ifdef _OPENMP

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -122,12 +122,9 @@ static void blend_images(float *const restrict rgb_data, float *const restrict b
   dt_omp_firstprivate(luminance, rgb_data, width, height) \
   schedule(simd:static) aligned(luminance, rgb_data : 64) 
 #endif
-  for(int row = 0; row < height; row++)
+  for(size_t idx =0; idx < (size_t) width * height; idx++)
   {
-    for(int col = 0, idx = row * width, oidx = idx * 4; col < width; col++, idx++, oidx += 4)
-    {
-      luminance[idx] = lab_f(0.3333333f * (rgb_data[oidx] + rgb_data[oidx + 1] + rgb_data[oidx + 2]));
-    }
+    luminance[idx] = lab_f(0.3333333f * (rgb_data[4 * idx] + rgb_data[4 * idx + 1] + rgb_data[4 * idx + 2]));
   }
     
   const float scale = 1.0f / 16.0f;


### PR DESCRIPTION
It seems crbt_5f defined in colorspaces_inline_conversions might be broken on
windows systems. (Not understood why the compiler might have a problem here.

Also the loop calculating the luminance data was badly written al ralfbrown pointed out.

Hopefully fixes #8025