### PR TITLE
performance: optimize box filters

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -315,7 +315,7 @@ static void blur_vertical_1ch_sse(float *const restrict buf, const int height, c
   size_t y;
   for (y = 0; y <= MIN(radius, height-1); y++)
   {
-    const int np = y + radius;
+    const size_t np = y + radius;
     hits += one;
     L += _mm_loadu_ps(buf+np*width);
     scratch[y] = L / hits;
@@ -443,7 +443,8 @@ static void blur_vertical_1wide(float *const restrict buf, const size_t height, 
   size_t y;
   for (y = 0; y <= MIN(radius, height-radius-1); y++)
   {
-    const size_t np = y + radius;
+    // weirdly, changing any of the 'np' or 'op' variables in this function to 'size_t' yields a substantial slowdown!
+    const int np = y + radius;
     hits++;
     L += buf[np*width];
     scratch[y&mask] = L / hits;
@@ -451,8 +452,8 @@ static void blur_vertical_1wide(float *const restrict buf, const size_t height, 
   // process the bulk of the column
   for( ; y < height-radius; y++)
   {
-    const size_t op = y - radius - 1;
-    const size_t np = y + radius;
+    const int op = y - radius - 1;
+    const int np = y + radius;
     L -= buf[op*width];
     L += buf[np*width];
     // we're now done with the original value, so store the final result while this line is still in cache
@@ -463,7 +464,7 @@ static void blur_vertical_1wide(float *const restrict buf, const size_t height, 
   // process the end of the column, where we don't have any more values to add to the mean
   for( ; y < height; y++)
   {
-    const size_t op = y - radius - 1;
+    const int op = y - radius - 1;
     hits--;
     L -= buf[op*width];
     // we're now done with the original value, so store the final result while this line is still in cache
@@ -572,7 +573,8 @@ static void blur_vertical_16wide(float *const restrict buf, const size_t height,
   size_t y;
   for (y = 0; y <= MIN(radius, height-radius-1); y++)
   {
-    const size_t np = y + radius;
+    // weirdly, changing any of the 'np' or 'op' variables in this function to 'size_t' yields a substantial slowdown!
+    const int np = y + radius;
     hits++;
     add_16wide(L, buf + np*width);
     store_scaled_16wide(scratch + 16*(y&mask), L, hits);
@@ -580,8 +582,8 @@ static void blur_vertical_16wide(float *const restrict buf, const size_t height,
   // process the blur for the bulk of the scan line
   for ( ; y < height-radius; y++)
   {
-    const size_t op = y - radius - 1;
-    const size_t np = y + radius;
+    const int op = y - radius - 1;
+    const int np = y + radius;
     sub_16wide(L, buf + op*width);
     // we're now done with the orig value, so store the final result while this line is still in cache
     store_16wide(buf + op*width, scratch + 16*(op&mask));
@@ -592,7 +594,7 @@ static void blur_vertical_16wide(float *const restrict buf, const size_t height,
   // process the blur for the end of the scan line, where we don't have any more values to add to the mean
   for ( ; y < height; y++)
   {
-    const size_t op = y - radius - 1;
+    const int op = y - radius - 1;
     hits--;
     sub_16wide(L, buf + op*width);
     // we're now done with the orig value, so store the final result while this line is still in cache

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -644,8 +644,7 @@ static void blur_vertical_1ch(float *const restrict buf, const size_t height, co
 }
 
 // determine the size of the scratch buffer needed for vertical passes of the box-mean filter
-//   for plainC code: filter_window = 2**ceil(lg2(2*radius+1))
-//   for SSE code: filter_window = height;
+// filter_window = 2**ceil(lg2(2*radius+1))
 static size_t _compute_effective_height(const size_t height, const size_t radius)
 {
   size_t eff_height = 2;
@@ -696,18 +695,8 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
     for (size_t col = 0; col < (width & ~3); col += 4)
     {
       float *const restrict scratch = scanlines + 16 * dt_get_thread_num() * eff_height;
-#ifdef __SSE2__
-      if (darktable.codepath.SSE2)
-      {
-        // we need to multiply width by 4 to get the correct stride for the vertical blur  //!!!
-        blur_vertical_4ch_sse(buf + 4 * col, height, 4*width, radius, (__m128*)scratch);
-      }
-      else
-#endif /* __SSE2__ */
-      {
-        // we need to multiply width by 4 to get the correct stride for the vertical blur
-        blur_vertical_16wide(buf + 4 * col, height, 4*width, radius, scratch);
-      }
+      // we need to multiply width by 4 to get the correct stride for the vertical blur
+      blur_vertical_16wide(buf + 4 * col, height, 4*width, radius, scratch);
     }
     // handle the 0..3 remaining columns
     for (size_t col = (width & ~3); col < width; col++)

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -609,7 +609,7 @@ static void blur_vertical_1ch(float *const restrict buf, const size_t height, co
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(radius, height, width) \
+  dt_omp_firstprivate(radius, height, width, eff_height) \
   shared(darktable) \
   dt_omp_sharedconst(buf, scanlines) \
   schedule(static)
@@ -687,7 +687,7 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
     blur_horizontal_4ch(buf, height, width, radius, scanlines);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, radius)  \
+  dt_omp_firstprivate(width, height, radius, eff_height) \
   shared(darktable) \
   dt_omp_sharedconst(buf, scanlines) \
   schedule(static)
@@ -939,7 +939,7 @@ static void box_max_1ch(float *const buf, const size_t height, const size_t widt
   }
 #ifdef _OPENMP
 #pragma omp parallel for default(none)           \
-  dt_omp_firstprivate(w, width, height, buf, allocsize) \
+  dt_omp_firstprivate(w, width, height, buf, allocsize, eff_height) \
   dt_omp_sharedconst(scratch_buffers) \
   schedule(static)
 #endif
@@ -948,6 +948,7 @@ static void box_max_1ch(float *const buf, const size_t height, const size_t widt
     float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
     box_max_vert_16wide(height, scratch, buf + col, width, w, eff_height-1);
   }
+  // handle the leftover 0..15 columns
   for (size_t col = width & ~15 ; col < width; col++)
   {
     float *const restrict scratch = scratch_buffers;
@@ -1080,7 +1081,7 @@ static void box_min_1ch(float *const buf, const size_t height, const size_t widt
   }
 #ifdef _OPENMP
 #pragma omp parallel for default(none)           \
-  dt_omp_firstprivate(w, width, height, buf,allocsize) \
+  dt_omp_firstprivate(w, width, height, buf,allocsize, eff_height) \
   dt_omp_sharedconst(scratch_buffers) \
   schedule(static)
 #endif
@@ -1089,6 +1090,7 @@ static void box_min_1ch(float *const buf, const size_t height, const size_t widt
     float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
     box_min_vert_16wide(height, scratch, buf + col, width, w, eff_height-1);
   }
+  // handle the leftover 0..15 columns
   for (size_t col = width & ~15 ; col < width; col++)
   {
     float *const restrict scratch = scratch_buffers;

--- a/src/common/box_filters.h
+++ b/src/common/box_filters.h
@@ -22,9 +22,9 @@
 #define BOX_ITERATIONS 8
 
 // ch = number of channels per pixel.  Supported values: 1 and 4
-void dt_box_mean(float *const buf, const int height, const int width, const int ch,
-                 const int radius, const int interations);
+void dt_box_mean(float *const buf, const size_t height, const size_t width, const int ch,
+                 const int radius, const unsigned interations);
 
-void dt_box_min(float *const buf, const int height, const int width, const int ch, const int radius);
-void dt_box_max(float *const buf, const int height, const int width, const int ch, const int radius);
+void dt_box_min(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
+void dt_box_max(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
 


### PR DESCRIPTION
Improved vectorization and cache utilization, plus added prefetching.
Validated on tests 0026,  0050, and 0051.  Note  that the non-SSE code paths  for 0026 and 0051 give results marginally different than the reference (max dE 1.01149/1.20606), but master has exactly the same differences.

0026-hazeremoval (uses box min and box max):
```
Thr	AVmstr	AVpr	(%ch) 
  1	4.8180	4.2016	-12.8% 
  2	2.6800	2.3554	-12.1%
  4	1.4948	1.3314	-10.9%
  8	0.9068	0.8228	-9.3%
 12	0.7134	0.6590	-7.6%
 16	0.6282	0.5946	-5.3%
 24	0.5578	0.5402	-3.2% 
 32	0.5358	0.5316	-0.8% 
```

0050-bloom (uses 1-channel box mean):
```
Thr   SSEmstr   SSEpr          AVmstr   AVpr
 1     1.278    0.891  (-30%)     1.335   0.955 (-28%)
 4     0.349    0.254  (-27%)     0.363   0.276 (-24%)
 8     0.189    0.141  (-25%)     0.194   0.154 (-21%)
12    0.138    0.107  (-23%)     0.143   0.117 (-18%)
16    0.112    0.088  (-21%)     0.116   0.096 (-17%)
32    0.077    0.074  (-4%)       0.079   0.079
```

0051-soften (uses 4-channel box mean):
```
Thr	AVmstr	AVpr	(%ch)	SSEmstr	SSEpr	(%ch)
  1	6.1230	2.7628	-54.9%	3.3886	2.4320	-28.2%
  2	3.1082	1.4570	-53.1%	1.7428	1.2574	-27.9%
  4	1.5610	0.7686	-50.8%	0.8916	0.6442	-27.7%
  8	0.7906	0.4220	-46.6%	0.4756	0.3768	-20.8%
 12	0.5576	0.3214	-42.4%	0.3612	0.3040	-15.8%
 16	0.4404	0.2834	-35.6%	0.3126	0.2730	-12.7%
 24	0.3304	0.2466	-25.4%	0.2774	0.2466	-11.1%
 32	0.2888	0.2368	-18.0%	0.2574	0.2412	-6.3%
```
