### PR TITLE
Color checker calibration : minor bugs and improvements

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1182,7 +1182,7 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
 
     float Dh_prime = h_test_prime - h_ref_prime;
     float Dh_prime_abs = fabsf(Dh_prime);
-    if(C_test_prime == 0.f && C_ref_prime == 0.f)
+    if(C_test_prime == 0.f || C_ref_prime == 0.f)
       Dh_prime = 0.f;
     else if(Dh_prime_abs <= 180.f)
       ;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1252,7 +1252,7 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
         delta_hue += 2.f * M_PI;                                  \
       else if(fabsf(delta_hue) > M_PI && (hue > ref_hue))         \
         delta_hue -= 2.f * M_PI;                                  \
-      w = expf(-sqf(delta_hue) / 2.f);
+      w = sqrtf(expf(-sqf(delta_hue) / 2.f));
 
 
 typedef struct {
@@ -1533,11 +1533,9 @@ void extract_color_checker(const float *const restrict in, float *const restrict
       GET_WEIGHT;
     }
     else if(g->optimization == DT_SOLVE_OPTIMIZE_AVG_DELTA_E)
-      w = g->delta_E_in[k] / 100.f;
+      w = sqrtf(sqrtf(g->delta_E_in[k] / 100.f));
     else if(g->optimization == DT_SOLVE_OPTIMIZE_MAX_DELTA_E)
-      w = sqf(g->delta_E_in[k] / 100.f);
-
-    w = sqrtf(w);
+      w = sqrtf(g->delta_E_in[k] / 100.f);
 
     // fill 3 rows of the y column vector
     for(size_t c = 0; c < 3; c++) Y[k * 3 + c] = w * LMS_ref[c];

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -89,7 +89,7 @@ typedef struct dt_iop_channelmixer_rgb_params_t
   dt_illuminant_t illuminant;      // $DEFAULT: DT_ILLUMINANT_D
   dt_illuminant_fluo_t illum_fluo; // $DEFAULT: DT_ILLUMINANT_FLUO_F3 $DESCRIPTION: "F source"
   dt_illuminant_led_t illum_led;   // $DEFAULT: DT_ILLUMINANT_LED_B5 $DESCRIPTION: "LED source"
-  dt_adaptation_t adaptation;      // $DEFAULT: DT_ADAPTATION_LINEAR_BRADFORD
+  dt_adaptation_t adaptation;      // $DEFAULT: DT_ADAPTATION_CAT16
   float x, y;                      // $DEFAULT: 0.333
   float temperature;               // $MIN: 1667. $MAX: 25000. $DEFAULT: 5003.
   float gamut;                     // $MIN: 0.0 $MAX: 4.0 $DEFAULT: 1.0 $DESCRIPTION: "gamut compression"
@@ -1103,9 +1103,6 @@ static void check_if_close_to_daylight(const float x, const float y, float *temp
   // Check the error between original and test chromaticity
   if(delta_bb < 0.005f || delta_daylight < 0.005f)
   {
-    // Bradford is more accurate for daylight
-    if(adaptation) *adaptation = DT_ADAPTATION_LINEAR_BRADFORD;
-
     if(illuminant)
     {
       if(delta_bb < delta_daylight)
@@ -1118,10 +1115,10 @@ static void check_if_close_to_daylight(const float x, const float y, float *temp
   {
     // error is too big to use a CCT-based model, we fall back to a custom/freestyle chroma selection for the illuminant
     if(illuminant) *illuminant = DT_ILLUMINANT_CUSTOM;
-
-    // CAT16 is less accurate but more robust for non-daylight (produces fewer out-of-gamut colors)
-    if(adaptation) *adaptation = DT_ADAPTATION_CAT16;
   }
+
+  // CAT16 is more accurate no matter the illuminant
+  if(adaptation) *adaptation = DT_ADAPTATION_CAT16;
 }
 
 #define DEG_TO_RAD(x) (x * M_PI / 180.f)


### PR DESCRIPTION
1. ditch the profiling exposure normalization : it was intended to fake an uniform light field over the chart, for cases where the chart is close to the light source and the lighting is non-uniform. After more testing, it has proven to degrade the final delta E all the time, even in those cases.
2. fix some minor mistakes in delta E 2000 computations : only sanity checks for corner cases, in order to better follow the specifications, but it doesn't seem to have any impact on the final results,
3. fix the LSQ solver weighting for better delta E minimization,
4. make CAT16 the default adaptation no matter the input illuminant : after extensive testing, no matter the illuminant, I have found that CAT16 always provides the smaller delta E.