### PR TITLE
guided_filter.c: consolidate and optimize box-mean filters

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -36,10 +36,13 @@
 #endif
 
 #if defined(__SSE__)
+#define DT_PREFETCH(addr) _mm_prefetch(addr, _MM_HINT_T2)
 #define PREFETCH_NTA(addr) _mm_prefetch(addr, _MM_HINT_NTA)
 #elif defined(__GNUC__) && __GNUC__ > 7
+#define DT_PREFETCH(addr) __builtin_prefetch(addr,1,1)
 #define PREFETCH_NTA(addr) __builtin_prefetch(addr,1,0)
 #else
+#define DT_PREFETCH(addr)
 #define PREFETCH_NTA(addr)
 #endif
 
@@ -184,6 +187,52 @@ static void sub_4wide(float *const restrict accum, const float *const restrict v
     accum[c] -= values[c];
 }
 
+// Put the to-be-vectorized loop into a function by itself to nudge the compiler into actually vectorizing...
+// With optimization enabled, this gets inlined and interleaved with other instructions as though it had been
+// written in place, so we get a net win from better vectorization.
+#if 0
+static void add_4wide_Kahan(float *const restrict accum, const float *const restrict values,
+                            float *const restrict comp)
+{
+  for_four_channels(c,aligned(accum,comp,values))
+  {
+    // Kahan (compensated) summation
+    const float t1 = values[c] - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+#endif
+
+static void load_add_4wide_Kahan(float *const restrict out, float *const restrict accum,
+                                 const float *const restrict values, float *const restrict comp)
+{
+  for_four_channels(c,aligned(accum,comp))
+  {
+    const float v = values[c];
+    out[c] = v;
+    // Kahan (compensated) summation
+    const float t1 = v - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+
+static void sub_4wide_Kahan(float *const restrict accum, const float *const restrict values,
+                            float *const restrict comp)
+{
+  for_four_channels(c,aligned(accum,comp,values))
+  {
+    // Kahan (compensated) summation
+    const float t1 = -values[c] - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+
 static void store_scaled_4wide(float *const restrict out, const float *const restrict in, const float scale)
 {
   for_four_channels(c,aligned(in))
@@ -213,6 +262,42 @@ static void load_add_16wide(float *const restrict out, float *const restrict acc
   }
 }
 
+static void sub_16wide_Kahan(float *const restrict accum, const float *const restrict values,
+                             float *const restrict comp)
+{
+#ifdef _OPENMP
+#pragma omp simd aligned(accum,comp : 64) aligned(values : 16)
+#endif
+  for(size_t c = 0; c < 16; c++)
+  {
+    const float v = -values[c];
+    // Kahan (compensated) summation
+    const float t1 = v - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+
+// copy 16 floats from a possibly-unaligned buffer into aligned temporary space, and also add to accumulator
+static void load_add_16wide_Kahan(float *const restrict out, float *const restrict accum,
+                                  const float *const restrict in, float *const restrict comp)
+{
+#ifdef _OPENMP
+#pragma omp simd aligned(accum, comp, out : 64)
+#endif
+  for (size_t c = 0; c < 16; c++)
+  {
+    const float v = in[c];
+    out[c] = v;
+    // Kahan (compensated) summation
+    const float t1 = v - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+
 // copy 16 floats from aligned temporary space back to the possibly-unaligned user buffer
 static void store_16wide(float *const restrict out, const float *const restrict in)
 {
@@ -231,6 +316,53 @@ static void store_scaled_16wide(float *const restrict out, const float *const re
   for(size_t c = 0; c < 16; c++)
     out[c] = in[c] / scale;
 }
+
+static void sub_Nwide_Kahan(const size_t N, float *const restrict accum, const float *const restrict values,
+                            float *const restrict comp)
+{
+#ifdef _OPENMP
+#pragma omp simd aligned(accum,comp : 64)
+#endif
+  for(size_t c = 0; c < N; c++)
+  {
+    const float v = -values[c];
+    // Kahan (compensated) summation
+    const float t1 = v - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+
+// copy N (<=16) floats from a possibly-unaligned buffer into aligned temporary space, and also add to accumulator
+static void load_add_Nwide_Kahan(const size_t N, float *const restrict out, float *const restrict accum,
+                                 const float *const restrict in, float *const restrict comp)
+{
+#ifdef _OPENMP
+#pragma omp simd aligned(accum, comp : 64)
+#endif
+  for (size_t c = 0; c < N; c++)
+  {
+    const float v = in[c];
+    out[c] = v;
+    // Kahan (compensated) summation
+    const float t1 = v - comp[c];
+    const float t2 = accum[c] + t1;
+    comp[c] = (t2 - accum[c]) - t1;
+    accum[c] = t2;
+  }
+}
+
+static void store_scaled_Nwide(const size_t N, float *const restrict out, const float *const restrict in,
+                               const float scale)
+{
+#ifdef _OPENMP
+#pragma omp simd aligned(in : 64)
+#endif
+  for(size_t c = 0; c < N; c++)
+    out[c] = in[c] / scale;
+}
+
 
 static void blur_horizontal_4ch(float *const restrict buf, const size_t height, const size_t width, const size_t radius,
                                 float *const restrict scanlines)
@@ -256,17 +388,15 @@ static void blur_horizontal_4ch(float *const restrict buf, const size_t height, 
     }
     // process the blur up to the point where we start removing values
     size_t x;
-    for (x = 0; x <= MIN(radius, width-1); x++)
+    for (x = 0; x <= MIN(radius, width-radius-1); x++)
     {
       const int np = x + radius;
-      if(np < width)
+      hits++;
+      for_four_channels(c,aligned(buf,scanline))
       {
-        hits++;
-        for_four_channels(c,aligned(buf))
-          L[c] += buf[index + 4*np + c];
-      }
-      for_four_channels(c,aligned(scanline))
+        L[c] += buf[index + 4*np + c];
         scanline[4*x + c] = L[c] / hits;
+      }
     }
     // process the blur for the bulk of the scan line
     for(; x + radius < width; x++)
@@ -299,6 +429,93 @@ static void blur_horizontal_4ch(float *const restrict buf, const size_t height, 
       for_four_channels(c,aligned(buf, scanline))
         buf[index + 4*x + c] = scanline[4*x + c];
     }
+  }
+  return;
+}
+
+// invoked inside an OpenMP parallel for, so no need to parallelize
+static void blur_horizontal_4ch_Kahan(float *const restrict buf, const size_t width,
+                                      const size_t radius, float *const restrict scratch)
+{
+  float DT_ALIGNED_PIXEL L[4] = { 0, 0, 0, 0 };
+  float DT_ALIGNED_PIXEL comp[4] = { 0, 0, 0, 0 };
+  size_t hits = 0;
+  // add up the left half of the window
+  for (size_t x = 0; x < MIN(radius,width) ; x++)
+  {
+    hits++;
+    load_add_4wide_Kahan(scratch + 4*x, L, buf + 4*x, comp);
+  }
+  // process the blur up to the point where we start removing values from the moving average
+  size_t x;
+  for (x = 0; x <= MIN(radius, width-radius-1); x++)
+  {
+    const int np = x + radius;
+    hits++;
+    load_add_4wide_Kahan(scratch + 4*np, L, buf + 4*np, comp);
+    store_scaled_4wide(buf + 4*x, L, hits);
+  }
+  // process the blur for the bulk of the scan line
+  for(; x + radius < width; x++)
+  {
+    const int op = x - radius - 1;
+    const int np = x + radius;
+    sub_4wide_Kahan(L, scratch + 4*op, comp);
+    load_add_4wide_Kahan(scratch + 4*np, L, buf + 4*np, comp);
+    store_scaled_4wide(buf + 4*x, L, hits);
+  }
+  // process the right end where we have no more values to add to the running sum
+  for(; x < width; x++)
+  {
+    const int op = x - radius - 1;
+    hits--;
+    sub_4wide_Kahan(L, scratch + 4*op, comp);
+    store_scaled_4wide(buf + 4*x, L, hits);
+  }
+  return;
+}
+
+// invoked inside an OpenMP parallel for, so no need to parallelize
+static void blur_horizontal_Nch_Kahan(const size_t N, float *const restrict buf, const size_t width,
+                                      const size_t radius, float *const restrict scratch)
+{
+  if (N > 16) return;
+  if (N != 9) return;  // since we only use 9 channels at the moment, give the compiler a big hint
+
+  float DT_ALIGNED_ARRAY L[16] = { 0, 0, 0, 0 };
+  float DT_ALIGNED_ARRAY comp[16] = { 0, 0, 0, 0 };
+  size_t hits = 0;
+  // add up the left half of the window
+  for (size_t x = 0; x < MIN(radius,width) ; x++)
+  {
+    hits++;
+    load_add_Nwide_Kahan(N, scratch + N*x, L, buf + N*x, comp);
+  }
+  // process the blur up to the point where we start removing values from the moving average
+  size_t x;
+  for (x = 0; x <= MIN(radius, width-radius-1); x++)
+  {
+    const int np = x + radius;
+    hits++;
+    load_add_Nwide_Kahan(N, scratch + N*np, L, buf + N*np, comp);
+    store_scaled_Nwide(N, buf + N*x, L, hits);
+  }
+  // process the blur for the bulk of the scan line
+  for(; x + radius < width; x++)
+  {
+    const int op = x - radius - 1;
+    const int np = x + radius;
+    sub_Nwide_Kahan(N, L, scratch + N*op, comp);
+    load_add_Nwide_Kahan(N, scratch + N*np, L, buf + N*np, comp);
+    store_scaled_Nwide(N, buf + N*x, L, hits);
+  }
+  // process the right end where we have no more values to add to the running sum
+  for(; x < width; x++)
+  {
+    const int op = x - radius - 1;
+    hits--;
+    sub_Nwide_Kahan(N, L, scratch + N*op, comp);
+    store_scaled_Nwide(N, buf + N*x, L, hits);
   }
   return;
 }
@@ -489,6 +706,65 @@ static void blur_vertical_1wide(float *const restrict buf, const size_t height, 
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
+static void blur_vertical_1wide_Kahan(float *const restrict buf, const size_t height, const size_t width,
+                                      const size_t radius, float *const restrict scratch)
+{
+  // To improve cache hit rates, we copy the final result from the scratch space back to the original
+  // location in the buffer as soon as we finish the final read of the buffer.  To reduce the working
+  // set and further improve cache hits, we can treat the scratch space as a circular buffer and cycle
+  // through it repeatedly.  To use a simple bitmask instead of a division, the size we cycle through
+  // needs to be the power of two larger than the window size (2*radius+1).
+  size_t mask = 1;
+  for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
+
+  float L = 0.0f;
+  float c = 0.0f;
+  size_t hits = 0;
+  // add up the left half of the window
+  for (size_t y = 0; y < MIN(radius, height); y++)
+  {
+    hits++;
+    const float v = buf[y*width];
+    L = Kahan_sum(L, &c, v);
+    scratch[y&mask] = v;
+  }
+  // process up to the point where we start removing values from the moving average
+  size_t y;
+  for (y = 0; y <= MIN(radius, height-radius-1); y++)
+  {
+    // weirdly, changing any of the 'np' or 'op' variables in this function to 'size_t' yields a substantial slowdown!
+    const int np = y + radius;
+    hits++;
+    const float v = buf[np*width];
+    L = Kahan_sum(L, &c, v);
+    scratch[np&mask] = v;
+    buf[y*width] = L / hits;
+  }
+  // process the bulk of the column
+  for( ; y < height-radius; y++)
+  {
+    const int op = y - radius - 1;
+    const int np = y + radius;
+    L = Kahan_sum(L, &c, -scratch[op&mask]);
+    const float v = buf[np*width];
+    L = Kahan_sum(L, &c, v);
+    scratch[np&mask] = v;
+    // update the means
+    buf[y*width] = L / hits;
+  }
+  // process the end of the column, where we don't have any more values to add to the mean
+  for( ; y < height; y++)
+  {
+    const int op = y - radius - 1;
+    hits--;
+    L = Kahan_sum(L, &c, scratch[op&mask]);
+    // update the means
+    buf[y*width] = L / hits;
+  }
+  return;
+}
+
+// invoked inside an OpenMP parallel for, so no need to parallelize
 static void blur_vertical_4wide(float *const restrict buf, const size_t height, const size_t width, const size_t radius,
                                 float *const restrict scratch)
 {
@@ -550,6 +826,60 @@ static void blur_vertical_4wide(float *const restrict buf, const size_t height, 
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
+static void blur_vertical_4wide_Kahan(float *const restrict buf, const size_t height, const size_t width,
+                                      const size_t radius, float *const restrict scratch)
+{
+  // To improve cache hit rates, we copy the final result from the scratch space back to the original
+  // location in the buffer as soon as we finish the final read of the buffer.  To reduce the working
+  // set and further improve cache hits, we can treat the scratch space as a circular buffer and cycle
+  // through it repeatedly.  To use a simple bitmask instead of a division, the size we cycle through
+  // needs to be the power of two larger than the window size (2*radius+1).
+  size_t mask = 1;
+  for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
+
+  float DT_ALIGNED_PIXEL L[4] = { 0, 0, 0, 0 };
+  float DT_ALIGNED_PIXEL comp[4] = { 0, 0, 0, 0 };
+  size_t hits = 0;
+  // add up the left half of the window
+  for (size_t y = 0; y < MIN(radius, height); y++)
+  {
+    DT_PREFETCH(buf + (y+16)*width);
+    hits++;
+    load_add_4wide_Kahan(scratch + 4*(y&mask), L, buf + y * width, comp);
+  }
+  // process the blur up to the point where we start removing values
+  size_t y;
+  for (y = 0; y <= MIN(radius, height-radius-1); y++)
+  {
+    // weirdly, changing any of the 'np' or 'op' variables in this function to 'size_t' yields a substantial slowdown!
+    const int np = y + radius;
+    hits++;
+    DT_PREFETCH(buf + (np+16)*width);
+    load_add_4wide_Kahan(scratch + 4*(np&mask), L, buf + np*width, comp);
+    store_scaled_4wide(buf + y*width, L, hits);
+  }
+  // process the blur for the bulk of the scan line
+  for ( ; y < height-radius; y++)
+  {
+    const int np = y + radius;
+    const int op = y - radius - 1;
+    DT_PREFETCH(buf + (np+16)*width);
+    sub_4wide_Kahan(L, scratch + 4*(op&mask), comp);
+    load_add_4wide_Kahan(scratch + 4*(np&mask), L, buf + np*width, comp);
+    store_scaled_4wide(buf + y*width, L, hits);
+  }
+  // process the blur for the end of the scan line, where we don't have any more values to add to the mean
+  for ( ; y < height; y++)
+  {
+    const int op = y - radius - 1;
+    hits--;
+    sub_4wide_Kahan(L, scratch + 4*(op&mask), comp);
+    store_scaled_4wide(buf + y*width, L, hits);
+  }
+  return;
+}
+
+// invoked inside an OpenMP parallel for, so no need to parallelize
 static void blur_vertical_16wide(float *const restrict buf, const size_t height, const size_t width,
                                  const size_t radius, float *const restrict scratch)
 {
@@ -598,6 +928,62 @@ static void blur_vertical_16wide(float *const restrict buf, const size_t height,
     const int op = y - radius - 1;
     hits--;
     sub_16wide(L, scratch + 16*(op&mask));
+    // update the means
+    store_scaled_16wide(buf + y*width, L, hits);
+  }
+  return;
+}
+
+// invoked inside an OpenMP parallel for, so no need to parallelize
+static void blur_vertical_16wide_Kahan(float *const restrict buf, const size_t height, const size_t width,
+                                       const size_t radius, float *const restrict scratch)
+{
+  // To improve cache hit rates, we copy the final result from the scratch space back to the original
+  // location in the buffer as soon as we finish the final read of the buffer.  To reduce the working
+  // set and further improve cache hits, we can treat the scratch space as a circular buffer and cycle
+  // through it repeatedly.  To use a simple bitmask instead of a division, the size we cycle through
+  // needs to be the power of two larger than the window size (2*radius+1).
+  size_t mask = 1;
+  for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
+
+  float DT_ALIGNED_ARRAY L[16] = { 0, 0, 0, 0 };
+  float DT_ALIGNED_ARRAY comp[16] = { 0, 0, 0, 0 };
+  float hits = 0;
+  // add up the left half of the window
+  for (size_t y = 0; y < MIN(radius, height); y++)
+  {
+    DT_PREFETCH(buf + (y+16)*width);
+    hits++;
+    load_add_16wide_Kahan(scratch + 16 * (y&mask), L, buf + y*width, comp);
+  }
+  // process the blur up to the point where we start removing values from the moving average
+  size_t y;
+  for (y = 0; y <= MIN(radius, height-radius-1); y++)
+  {
+    // weirdly, changing any of the 'np' or 'op' variables in this function to 'size_t' yields a substantial slowdown!
+    const int np = y + radius;
+    hits++;
+    DT_PREFETCH(buf + (np+16)*width);
+    load_add_16wide_Kahan(scratch + 16 * (np&mask), L, buf + np*width, comp);
+    store_scaled_16wide(buf + y*width, L, hits);
+  }
+  // process the blur for the bulk of the scan line
+  for ( ; y < height-radius; y++)
+  {
+    const int np = y + radius;
+    const int op = y - radius - 1;
+    DT_PREFETCH(buf + (np+16)*width);
+    sub_16wide_Kahan(L, scratch + 16*(op&mask), comp);
+    load_add_16wide_Kahan(scratch + 16*(np&mask), L, buf + np*width, comp);
+    // update the means
+    store_scaled_16wide(buf + y*width, L, hits);
+  }
+  // process the blur for the end of the scan line, where we don't have any more values to add to the mean
+  for ( ; y < height; y++)
+  {
+    const int op = y - radius - 1;
+    hits--;
+    sub_16wide_Kahan(L, scratch + 16*(op&mask), comp);
     // update the means
     store_scaled_16wide(buf + y*width, L, hits);
   }
@@ -680,21 +1066,22 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
   //   16*filter_window floats for vertical pass
   const size_t eff_height = _compute_effective_height(height,radius);
   const size_t size = MAX(4*width,16*eff_height);
-  float *const restrict scanlines = dt_alloc_align_float(dt_get_num_threads() * size);
+  size_t padded_size;
+  float *const restrict scanlines = dt_alloc_perthread_float(size, &padded_size);
 
   for(unsigned iteration = 0; iteration < iterations; iteration++)
   {
     blur_horizontal_4ch(buf, height, width, radius, scanlines);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, radius, eff_height) \
+  dt_omp_firstprivate(width, height, radius, padded_size) \
   shared(darktable) \
   dt_omp_sharedconst(buf, scanlines) \
   schedule(static)
 #endif
     for (size_t col = 0; col < (width & ~3); col += 4)
     {
-      float *const restrict scratch = scanlines + 16 * dt_get_thread_num() * eff_height;
+      float *const restrict scratch = dt_get_perthread(scanlines,padded_size);
       // we need to multiply width by 4 to get the correct stride for the vertical blur
       blur_vertical_16wide(buf + 4 * col, height, 4*width, radius, scratch);
     }
@@ -709,13 +1096,74 @@ static void dt_box_mean_4ch(float *const buf, const int height, const int width,
   dt_free_align(scanlines);
 }
 
+static void box_mean_vert_1ch_Kahan(float *const buf, const int height, const size_t width, const size_t radius)
+{
+  const size_t eff_height = _compute_effective_height(height,radius);
+  size_t padded_size;
+  float *const restrict scratch_buf = dt_alloc_perthread_float(16*eff_height,&padded_size);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(width, height, radius, padded_size) \
+  dt_omp_sharedconst(buf, scanlines) \
+  schedule(static)
+#endif
+  for (size_t col = 0; col < width; col += 16)
+  {
+    float *const restrict scratch = dt_get_perthread(scratch_buf,padded_size);
+    if (col + 16 <= width)
+    {
+      blur_vertical_16wide_Kahan(buf + col, height, width, radius, scratch);
+    }
+    else
+    {
+      // handle the 1..15 remaining columns
+      size_t col_ = col;
+      for( ; col_ < (width & ~3); col_ += 4)
+        blur_vertical_4wide_Kahan(buf + col_, height, width, radius, scratch);
+      for( ; col_ < width; col_++)
+        blur_vertical_1wide_Kahan(buf + col_, height, width, radius, scratch);
+    }
+  }
+
+  dt_free_align(scratch_buf);
+}
+
+static void dt_box_mean_4ch_Kahan(float *const buf, const size_t height, const size_t width, const int radius,
+                                  const unsigned iterations)
+{
+
+  for(unsigned iteration = 0; iteration < iterations; iteration++)
+  {
+    size_t padded_size;
+    float *const restrict scanlines = dt_alloc_perthread_float(4*width,&padded_size);
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(width, height, radius, padded_size) \
+  dt_omp_sharedconst(buf, scanlines) \
+  schedule(static)
+#endif
+    for (size_t row = 0; row < height; row++)
+    {
+      float *const restrict scratch = dt_get_perthread(scanlines,padded_size);
+      blur_horizontal_4ch_Kahan(buf + row * 4 * width, width, radius, scratch);
+    }
+
+    dt_free_align(scanlines);
+
+    box_mean_vert_1ch_Kahan(buf, height, 4*width, radius);
+  }
+
+}
+
 #ifdef __SSE2__
 static void dt_box_mean_4ch_sse(float *const buf, const int height, const int width, const int radius,
                                 const unsigned iterations)
 {
-  const int size = MAX(width,height);
+  const size_t size = MAX(4*width,4*height);
+  size_t padded_size;
 
-  __m128 *const scanline_buf = dt_alloc_align(64, sizeof(__m128) * dt_get_num_threads() * size * 4);
+  __m128 *const scanline_buf = dt_alloc_perthread(sizeof(__m128), size, &padded_size);
 
   for(unsigned iteration = 0; iteration < iterations; iteration++)
   {
@@ -724,13 +1172,13 @@ static void dt_box_mean_4ch_sse(float *const buf, const int height, const int wi
     /* vertical pass; start by doing four columns of pixels at a time */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, radius)  \
+  dt_omp_firstprivate(width, height, radius, padded_size)  \
   dt_omp_sharedconst(buf, scanline_buf) \
   schedule(static)
 #endif
     for (int col = 0; col < (width & ~3); col += 4)
     {
-      __m128 *const restrict scanline = scanline_buf + 4 * dt_get_thread_num() * height;
+      __m128 *const restrict scanline = dt_get_perthread(scanline_buf,padded_size);
       blur_vertical_4ch_sse(buf + 4 * col, height, 4*width, radius, scanline);
     }
     // finish up the leftover 0-3 columns of pixels
@@ -738,7 +1186,7 @@ static void dt_box_mean_4ch_sse(float *const buf, const int height, const int wi
     const int npoffs = (radius)*width;
     for(int x = (width & ~3); x < width; x++)
     {
-      __m128 *scanline = scanline_buf + size * dt_get_thread_num();
+      __m128 *scanline = dt_get_perthread(scanline_buf,padded_size);
       __m128 L = _mm_setzero_ps();
       int hits = 0;
       size_t index = (size_t)x - (size_t)radius * width;
@@ -808,9 +1256,45 @@ void dt_box_mean(float *const buf, const size_t height, const size_t width, cons
 #endif
       dt_box_mean_4ch(buf,height,width,radius,iterations);
   }
+  else if (ch == (4|BOXFILTER_KAHAN_SUM))
+  {
+    dt_box_mean_4ch_Kahan(buf,height,width,radius,iterations);
+  }
   else if (ch == 2) // used by fast_guided_filter.h
   {
     box_mean_2ch(buf,height,width,radius,iterations);
+  }
+  else
+    dt_unreachable_codepath();
+}
+
+void dt_box_mean_horizontal(float *const restrict buf, const size_t width, const int ch, const int radius,
+                            float *const restrict user_scratch)
+{
+  if (ch == (4|BOXFILTER_KAHAN_SUM))
+  {
+    float *const restrict scratch = user_scratch ? user_scratch : dt_alloc_align_float(4*width);
+    blur_horizontal_4ch_Kahan(buf, width, radius, scratch);
+    if (!user_scratch)
+      dt_free_align(scratch);
+  }
+  else if (ch == (9|BOXFILTER_KAHAN_SUM))
+  {
+    float *const restrict scratch = user_scratch ? user_scratch : dt_alloc_align_float(9*width);
+    blur_horizontal_Nch_Kahan(9, buf, width, radius, scratch);
+    if (!user_scratch)
+      dt_free_align(scratch);
+  }
+  else
+    dt_unreachable_codepath();
+}
+
+void dt_box_mean_vertical(float *const buf, const size_t height, const size_t width, const int ch, const int radius)
+{
+  if ((ch & BOXFILTER_KAHAN_SUM) && (ch & ~BOXFILTER_KAHAN_SUM) <= 16)
+  {
+    size_t channels = ch & ~BOXFILTER_KAHAN_SUM;
+    box_mean_vert_1ch_Kahan(buf, height, channels*width, radius);
   }
   else
     dt_unreachable_codepath();

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -1303,13 +1303,13 @@ static void box_max_1ch(float *const buf, const size_t height, const size_t widt
   float *const restrict scratch_buffers = dt_alloc_perthread_float(scratch_size,&allocsize);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(w, width, height, buf)    \
+  dt_omp_firstprivate(w, width, height, buf, allocsize) \
   dt_omp_sharedconst(scratch_buffers) \
   schedule(static)
 #endif
   for(size_t row = 0; row < height; row++)
   {
-    float *const restrict scratch = scratch_buffers + width * dt_get_thread_num();
+    float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
     memcpy(scratch, buf + row * width, sizeof(float) * width);
     box_max_1d(width, scratch, buf + row * width, 1, w);
   }
@@ -1445,13 +1445,13 @@ static void box_min_1ch(float *const buf, const size_t height, const size_t widt
   float *const restrict scratch_buffers = dt_alloc_perthread_float(scratch_size,&allocsize);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(w, width, height, buf)    \
+  dt_omp_firstprivate(w, width, height, buf, allocsize) \
   dt_omp_sharedconst(scratch_buffers) \
   schedule(static)
 #endif
   for(size_t row = 0; row < height; row++)
   {
-    float *const restrict scratch = scratch_buffers + width * dt_get_thread_num();
+    float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
     memcpy(scratch, buf + row * width, sizeof(float) * width);
     box_min_1d(width, scratch, buf + row * width, 1, w);
   }

--- a/src/common/box_filters.h
+++ b/src/common/box_filters.h
@@ -18,12 +18,24 @@
 
 #pragma once
 
+#include <stdlib.h>
+
 // default number of iterations to run for dt_box_mean
 #define BOX_ITERATIONS 8
 
-// ch = number of channels per pixel.  Supported values: 1 and 4
+// flag to add to number of channels to request the slower but more accurate version using Kahan (compensated)
+// summation
+#define BOXFILTER_KAHAN_SUM 0x1000000
+
+// ch = number of channels per pixel.  Supported values: 1, 2, 4, and 4|Kahan
 void dt_box_mean(float *const buf, const size_t height, const size_t width, const int ch,
                  const int radius, const unsigned interations);
+// run a single iteration horizonally over a single row.  Supported values for ch: 4|Kahan
+// 'scratch' must point at a buffer large enough to hold ch*width floats, or be NULL
+void dt_box_mean_horizontal(float *const restrict buf, const size_t width, const int ch, const int radius,
+                            float *const restrict scratch);
+// run a single iteration vertically over the entire image.  Supported values for ch: 4|Kahan
+void dt_box_mean_vertical(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
 
 void dt_box_min(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
 void dt_box_max(float *const buf, const size_t height, const size_t width, const int ch, const int radius);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -480,10 +480,10 @@ static inline float *dt_calloc_perthread_float(const size_t n, size_t* padded_si
 }
 
 // Given the buffer and object count returned by dt_alloc_perthread, return the current thread's private buffer.
-#define dt_get_perthread(buf, padsize) ((buf) + ((padsize) * dt_get_thread_num()))
+#define dt_get_perthread(buf, padsize) DT_IS_ALIGNED((buf) + ((padsize) * dt_get_thread_num()))
 // Given the buffer and object count returned by dt_alloc_perthread and a thread count in 0..dt_get_num_threads(),
 // return a pointer to the indicated thread's private buffer.
-#define dt_get_bythread(buf, padsize, tnum) ((buf) + ((padsize) * (tnum)))
+#define dt_get_bythread(buf, padsize, tnum) DT_IS_ALIGNED((buf) + ((padsize) * (tnum)))
 
 // Most code in dt assumes that the compiler is capable of auto-vectorization.  In some cases, this will yield
 // suboptimal code if the compiler in fact does NOT auto-vectorize.  Uncomment the following line for such a

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -137,7 +137,7 @@ typedef unsigned int u_int;
 #define DT_ALIGNED_PIXEL __attribute__((aligned(16)))
 
 /* Helper to force stack vectors to be aligned on 64 bits blocks to enable AVX2 */
-#define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64);
+#define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
 
 #ifndef _RELEASE
 #include "common/poison.h"

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -667,7 +667,10 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
   {
     sum_squared[c] = 0.0f;
     for(size_t i = 0; i < nthreads; i++)
-      sum_squared[c] += dt_get_bythread(squared_sums,scratch_size,i)[c];
+    {
+      float *const sq = dt_get_bythread(squared_sums,scratch_size,i);
+      sum_squared[c] += sq[c];
+    }
   }
   dt_free_align(squared_sums);
 }

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -28,7 +28,9 @@
 
 */
 
+#include "common/box_filters.h"
 #include "common/guided_filter.h"
+#include "common/math.h"
 #include "common/opencl.h"
 #include <assert.h>
 #include <float.h>
@@ -87,199 +89,6 @@ static inline float *get_color_pixel(color_image img, size_t i)
   return img.data + i * img.stride;
 }
 
-// calculate the one-dimensional moving average over a window of size 2*w+1 independently for each of four channels
-// input array x has stride 4, output array y has stride stride_y
-static inline void box_mean_1d_4ch(int N, const float *x, float *y, size_t stride_y, int w)
-{
-  float n_box = 0.f, m[4] = { 0.f, 0.f, 0.f, 0.f }, c[4] = { 0.f, 0.f, 0.f, 0.f };
-  if(N > 2 * w)
-  {
-    for(int i = 0, i_end = w + 1; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 4; k++)
-        m[k] = Kahan_sum(m[k], &c[k], x[4*i+k]);
-      n_box++;
-    }
-    for(int i = 0, i_end = w; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 4; k++)
-      {
-        y[i * stride_y + k] = m[k] / n_box;
-        m[k] = Kahan_sum(m[k], &c[k], x[4*(i + w + 1) + k]);
-      }
-      n_box++;
-    }
-    for(int i = w, i_end = N - w - 1; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 4; k++)
-      {
-        y[i * stride_y + k] = m[k] / n_box;
-        m[k] = Kahan_sum(m[k], &c[k], x[4*(i + w + 1) + k]);
-        m[k] = Kahan_sum(m[k], &c[k], -x[4*(i - w) + k]);
-      }
-    }
-    for(int i = N - w - 1, i_end = N; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 4; k++)
-      {
-        y[i * stride_y + k] = m[k] / n_box;
-        m[k] = Kahan_sum(m[k], &c[k], -x[4*(i - w) + k]);
-      }
-      n_box--;
-    }
-  }
-  else
-  {
-    for(int i = 0, i_end = min_i(w + 1, N); i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 4; k++)
-      {
-        m[k] = Kahan_sum(m[k], &c[k], x[4*i + k]);
-      }
-      n_box++;
-    }
-    for(int i = 0; i < N; i++)
-    {
-      SIMD_FOR (int k = 0; k < 4; k++)
-        y[i * stride_y + k] = m[k] / n_box;
-      if(i - w >= 0)
-      {
-        SIMD_FOR (int k = 0; k < 4; k++)
-          m[k] = Kahan_sum(m[k], &c[k], -x[4*(i - w)+k]);
-        n_box--;
-      }
-      if(i + w + 1 < N)
-      {
-        SIMD_FOR (int k = 0; k < 4; k++)
-          m[k] = Kahan_sum(m[k], &c[k], x[4*(i + w + 1)+k]);
-        n_box++;
-      }
-    }
-  }
-}
-
-// calculate the one-dimensional moving average over a window of size 2*w+1 independently for each of eight channels
-// input array x has stride 9, output array y has stride stride_y
-static inline void box_mean_1d_9ch(int N, const float *x, float *y, size_t stride_y, int w)
-{
-  float n_box = 0.f, m[9] = { 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f };
-  float c[9] = { 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f };
-  if(N > 2 * w)
-  {
-    for(int i = 0, i_end = w + 1; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 9; k++)
-        m[k] = Kahan_sum(m[k], &c[k], x[9*i+k]);
-      n_box++;
-    }
-    for(int i = 0, i_end = w; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 9; k++)
-      {
-        y[i * stride_y + k] = m[k] / n_box;
-        m[k] = Kahan_sum(m[k], &c[k], x[9*(i + w + 1) + k]);
-      }
-      n_box++;
-    }
-    for(int i = w, i_end = N - w - 1; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 9; k++)
-      {
-        y[i * stride_y + k] = m[k] / n_box;
-        m[k] = Kahan_sum(m[k], &c[k], x[9*(i + w + 1) + k]);
-        m[k] = Kahan_sum(m[k], &c[k], -x[9*(i - w) + k]);
-      }
-    }
-    for(int i = N - w - 1, i_end = N; i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 9; k++)
-      {
-        y[i * stride_y + k] = m[k] / n_box;
-        m[k] = Kahan_sum(m[k], &c[k], -x[9*(i - w) + k]);
-      }
-      n_box--;
-    }
-  }
-  else
-  {
-    for(int i = 0, i_end = min_i(w + 1, N); i < i_end; i++)
-    {
-      SIMD_FOR (int k = 0; k < 9; k++)
-      {
-        m[k] = Kahan_sum(m[k], &c[k], x[9*i + k]);
-      }
-      n_box++;
-    }
-    for(int i = 0; i < N; i++)
-    {
-      SIMD_FOR (int k = 0; k < 9; k++)
-        y[i * stride_y + k] = m[k] / n_box;
-      if(i - w >= 0)
-      {
-        SIMD_FOR (int k = 0; k < 9; k++)
-          m[k] = Kahan_sum(m[k], &c[k], -x[9*(i - w)+k]);
-        n_box--;
-      }
-      if(i + w + 1 < N)
-      {
-        SIMD_FOR (int k = 0; k < 9; k++)
-          m[k] = Kahan_sum(m[k], &c[k], x[9*(i + w + 1)+k]);
-        n_box++;
-      }
-    }
-  }
-}
-
-// in-place calculate the two-dimensional moving average of a four-channel image over a box of size (2*w+1) x (2*w+1)
-static void box_mean_4ch(color_image img, int w)
-{
-  const size_t size = 4 * max_i(img.width, img.height);
-  float *img_bak = dt_alloc_align_float(dt_get_num_threads() * size);
-  const size_t width = 4 * img.width;
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) dt_omp_firstprivate(w, size, width, img_bak) shared(img)
-#endif
-  for(int i1 = 0; i1 < img.height; i1++)
-  {
-    float *buf = img_bak + dt_get_thread_num() * size;
-    memcpy(buf, img.data + (size_t)i1 * width, sizeof(float) * width);
-    box_mean_1d_4ch(img.width, buf, img.data + (size_t)i1 * width, 4, w);
-  }
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) dt_omp_firstprivate(w, size, width, img_bak) shared(img)
-#endif
-  for(int i0 = 0; i0 < img.width; i0++)
-  {
-    float *buf = img_bak + dt_get_thread_num() * size;
-    for(int i1 = 0; i1 < img.height; i1++)
-      SIMD_FOR (int k = 0; k < 4; k++)
-        buf[4*i1+k] = img.data[4*(i0 + (size_t)i1 * img.width)+k];
-    box_mean_1d_4ch(img.height, buf, img.data + 4*i0, width, w);
-  }
-  dt_free_align(img_bak);
-}
-
-// in-place calculate the two-dimensional moving average of a four-channel image over a box of size (2*w+1) x (2*w+1)
-static void box_means_vert(float *img_bak, int w, color_image mean, color_image var)
-{
-  const size_t size = 9 * max_i(mean.width, mean.height);
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) dt_omp_firstprivate(w, size, img_bak) \
-  shared(mean, var)
-#endif
-  for(int i0 = 0; i0 < mean.width; i0++)
-  {
-    float *buf = img_bak + dt_get_thread_num() * size;
-    for(int i1 = 0; i1 < mean.height; i1++)
-      SIMD_FOR (int k = 0; k < 4; k++)
-        buf[4*i1+k] = mean.data[4*(i0 + (size_t)i1 * mean.width)+k];
-    box_mean_1d_4ch(mean.height, buf, mean.data + 4*i0, 4 * mean.width, w);
-    for(int i1 = 0; i1 < var.height; i1++)
-      SIMD_FOR (int k = 0; k < 9; k++)
-        buf[9*i1+k] = var.data[9*(i0 + (size_t)i1 * var.width)+k];
-    box_mean_1d_9ch(var.height, buf, var.data + 9*i0, 9 * var.width, w);
-  }
-}
 
 // apply guided filter to single-component image img using the 3-components image imgg as a guide
 // the filtering applies a monochrome box filter to a total of 13 image channels:
@@ -314,9 +123,9 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
 #define VAR_GB 7
   color_image mean = new_color_image(width, height, 4);
   color_image variance = new_color_image(width, height, 9);
-  const size_t img_dimen = max_i(mean.width, mean.height);
-  const size_t img_bak_sz = 13 * img_dimen;
-  float *img_bak = dt_alloc_align_float(dt_get_num_threads() * img_bak_sz);
+  const size_t img_dimen = mean.width;
+  size_t img_bak_sz;
+  float *img_bak = dt_alloc_perthread_float(9*img_dimen, &img_bak_sz);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) shared(img, imgg, mean, variance, img_bak) \
   dt_omp_firstprivate(img_bak_sz, img_dimen, w, guide_weight) dt_omp_sharedconst(source)
@@ -324,14 +133,14 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
   for(int j_imgg = source.lower; j_imgg < source.upper; j_imgg++)
   {
     int j = j_imgg - source.lower;
-    // put values directly into temp buffer to avoid a memcpy for the horizontal box mean pass
-    float *const meanpx = img_bak + dt_get_thread_num() * img_bak_sz;
-    float *const varpx = meanpx + 4*img_dimen;
+    float *const restrict meanpx = mean.data + 4 * j * mean.width;
+    float *const restrict varpx = variance.data + 9 * j * variance.width;
     for(int i_imgg = source.left; i_imgg < source.right; i_imgg++)
     {
       size_t i = i_imgg - source.left;
       const float *pixel_ = get_color_pixel(imgg, i_imgg + (size_t)j_imgg * imgg.width);
-      float pixel[3] = { pixel_[0] * guide_weight, pixel_[1] * guide_weight, pixel_[2] * guide_weight };
+      float DT_ALIGNED_PIXEL pixel[4] =
+        { pixel_[0] * guide_weight, pixel_[1] * guide_weight, pixel_[2] * guide_weight, pixel_[3] * guide_weight };
       const float input = img.data[i_imgg + (size_t)j_imgg * img.width];
       meanpx[4*i+INP_MEAN] = input;
       meanpx[4*i+GUIDE_MEAN_R] = pixel[0];
@@ -348,11 +157,13 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
       varpx[9*i+VAR_BB] = pixel[2] * pixel[2];
     }
     // apply horizontal pass of box mean filter while the cache is still hot
-    box_mean_1d_4ch(mean.width, meanpx, mean.data + 4 * j * mean.width, 4, w);
-    box_mean_1d_9ch(variance.width, varpx, variance.data + 9 * j * variance.width, 9, w);
+    float *const restrict scratch = dt_get_perthread(img_bak, img_bak_sz);
+    dt_box_mean_horizontal(meanpx, mean.width, 4|BOXFILTER_KAHAN_SUM, w, scratch);
+    dt_box_mean_horizontal(varpx, variance.width, 9|BOXFILTER_KAHAN_SUM, w, scratch);
   }
-  box_means_vert(img_bak, w, mean, variance);
   dt_free_align(img_bak);
+  dt_box_mean_vertical(mean.data, mean.height, mean.width, 4|BOXFILTER_KAHAN_SUM, w);
+  dt_box_mean_vertical(variance.data, variance.height, variance.width, 9|BOXFILTER_KAHAN_SUM, w);
   // we will recycle memory of 'mean' for the new coefficient arrays a_? and b to reduce memory foot print
   color_image a_b = mean;
   #define A_RED 0
@@ -417,7 +228,9 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
     a_b.data[4*i+B] = b_;
   }
   free_color_image(&variance);
-  box_mean_4ch(a_b, w);
+
+  dt_box_mean(a_b.data, a_b.height, a_b.width, a_b.stride|BOXFILTER_KAHAN_SUM, w, 1);
+
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) \
   shared(target, imgg, a_b, img_out) dt_omp_sharedconst(source) dt_omp_firstprivate(min, max, width, guide_weight)

--- a/src/common/guided_filter.h
+++ b/src/common/guided_filter.h
@@ -80,29 +80,6 @@ static inline int max_i(int a, int b)
   return a > b ? a : b;
 }
 
-// Kahan summation algorithm
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float Kahan_sum(const float m, float *c, const float add)
-{
-   const float t1 = add - (*c);
-   const float t2 = m + t1;
-   *c = (t2 - m) - t1;
-   return t2;
-}
-
-#ifdef __SSE2__
-// vectorized Kahan summation algorithm
-static inline __m128 Kahan_sum_sse(const __m128 m, __m128 *c, const __m128 add)
-{
-   const __m128 t1 = add - (*c);
-   const __m128 t2 = m + t1;
-   *c = (t2 - m) - t1;
-   return t2;
-}
-#endif /* __SSE2__ */
-
 void guided_filter(const float *guide, const float *in, float *out, int width, int height, int ch, int w,
                    float sqrt_eps, float guide_weight, float min, float max);
 

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -67,6 +67,29 @@ static inline float clamp_range_f(const float x, const float low, const float hi
   return x > high ? high : (x < low ? low : x);
 }
 
+// Kahan summation algorithm
+#ifdef _OPENMP
+#pragma omp declare simd aligned(c)
+#endif
+static inline float Kahan_sum(const float m, float *const __restrict__ c, const float add)
+{
+   const float t1 = add - (*c);
+   const float t2 = m + t1;
+   *c = (t2 - m) - t1;
+   return t2;
+}
+
+#ifdef __SSE2__
+// vectorized Kahan summation algorithm
+static inline __m128 Kahan_sum_sse(const __m128 m, __m128 *const __restrict__ c, const __m128 add)
+{
+   const __m128 t1 = add - (*c);
+   const __m128 t2 = m + t1;
+   *c = (t2 - m) - t1;
+   return t2;
+}
+#endif /* __SSE2__ */
+
 static inline float Log2(float x)
 {
   return (x > 0.0f) ? (logf(x) / DT_M_LN2f) : x;

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -429,7 +429,8 @@ void nlmeans_denoise(const float *const inbuf, float *const outbuf,
     {
       // locate our scratch space within the big buffer allocated above
       // we'll offset by chunk_left so that we don't have to subtract on every access
-      float *const col_sums = dt_get_perthread(scratch_buf, padded_scratch_size) + (radius+1) - chunk_left;
+      float *const restrict tmpbuf = dt_get_perthread(scratch_buf, padded_scratch_size);
+      float *const col_sums =  tmpbuf + (radius+1) - chunk_left;
       // determine which horizontal slice of the image to process
       const int chunk_bot = MIN(chunk_top + chk_height, roi_out->height);
       // determine which vertical slice of the image to process
@@ -652,7 +653,8 @@ void nlmeans_denoise_sse2(const float *const inbuf, float *const outbuf,
     {
       // locate our scratch space within the big buffer allocated above
       // we'll offset by chunk_left so that we don't have to subtract on every access
-      float *const col_sums = dt_get_perthread(scratch_buf, padded_scratch_size) + (radius+1) - chunk_left;
+      float *const restrict tmpbuf = dt_get_perthread(scratch_buf, padded_scratch_size);
+      float *const col_sums =  tmpbuf + (radius+1) - chunk_left;
       // determine which horizontal slice of the image to process
       const int chunk_bot = MIN(chunk_top + chk_height, roi_out->height);
       // determine which vertical slice of the image to process

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -156,7 +156,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     {
       const float *in = ((float *)ivoid) + ch * ((size_t)j * roi_in->width + rad);
       float *out = ((float *)ovoid) + ch * ((size_t)j * roi_out->width + rad);
-      float *weights = dt_get_perthread(weights_buf, padded_weights_size);
+      float *weights = (float*)dt_get_perthread(weights_buf, padded_weights_size);
       float *w = weights + rad * wd + rad;
       float sumw;
       for(int i = rad; i < roi_out->width - rad; i++)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -416,7 +416,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
-        float *bufptr = dt_get_perthread(buf, padded_bufsize);
+        float *bufptr = (float*)dt_get_perthread(buf, padded_bufsize);
         modifier->ApplySubpixelGeometryDistortion(roi_out->x, roi_out->y + y, roi_out->width, 1, bufptr);
 
         // reverse transform the global coords from lf to our buffer
@@ -521,7 +521,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
-        float *buf2ptr = dt_get_perthread(buf2, padded_buf2size);
+        float *buf2ptr = (float*)dt_get_perthread(buf2, padded_buf2size);
         modifier->ApplySubpixelGeometryDistortion(roi_out->x, roi_out->y + y, roi_out->width,
                                                   1, buf2ptr);
         // reverse transform the global coords from lf to our buffer
@@ -967,7 +967,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 #endif
   for(int y = 0; y < roi_out->height; y++)
   {
-    float *bufptr = dt_get_perthread(buf, padded_bufsize);
+    float *bufptr = (float*)dt_get_perthread(buf, padded_bufsize);
     modifier->ApplySubpixelGeometryDistortion(roi_out->x, roi_out->y + y, roi_out->width, 1, bufptr);
 
     // reverse transform the global coords from lf to our buffer


### PR DESCRIPTION
These were not previously merged with the other functions in box_filters.c because they use Kahan (compensated) summation instead of simple addition -- quite a bit slower, but eliminates roundoff.

```
0025-exposure-guided-filter
Thr     AVmstr  AVpr    (%ch)
  1      13.1526 11.7020 -11.0%
  2      6.9748   6.1888  -11.3%
  4      3.7882   3.4310  -9.4%
  8      2.1768   2.0352  -6.5%
 12     1.6590   1.6014  -3.5%
 16     1.4388   1.4218  -1.2%
 24     1.2420   1.2670  2.0%
 32     1.1976   1.2050  0.6%

0026-haze-removal
Thr     AVmstr  AVpr    (%ch)
  1      4.7982  4.0132  -16.4%
  2      2.6572  2.2402  -15.7%
  4      1.5042  1.2784  -15.0%
  8      0.9024  0.7956  -11.8%
 12     0.7052  0.6380  -9.5%
 16     0.6132  0.5642  -8.0%
 24     0.5366  0.5164  -3.8%
 32     0.5132  0.5050  -1.6%
```
