### PR TITLE
Use specific and safe compiler options for RCD demosaicer

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5042,9 +5042,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
       dt_control_log(_("`%s' color matrix not found for 4bayer image!"), camera);
     }
   }
-
-  dt_print(DT_DEBUG_DEMOSAIC, "[demosaic] committed parameters: method: `%s', smooth %i, green %i, CL %i, tiling %i\n",
-      method2string(d->demosaicing_method), d->color_smoothing, d->green_eq, piece->process_cl_ready, piece->process_tiling_ready);
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -48,6 +48,25 @@
   #define RCD_TILESIZE 112
 #endif
 
+/* We don't want to use the -Ofast option in dt as it effects are not well specified and there have been issues
+   leading to crashes. 
+   But we can use the 'fast-math' option in code sections if input data and algorithms are well defined.
+    
+   We have defined input data and make sure there are no divide-by-zero or overflows by chosen eps
+   Reordering of instructions might lead to a slight loss of presision whigh is not significant here.  
+   Not necessary in this code section
+     threadsafe handling of errno
+     signed zero handling
+     handling of math interrupts
+     handling of rounding 
+     handling of overflows
+*/
+
+#ifdef __GNUC__
+  #pragma GCC push_options
+  #pragma GCC optimize ("fast-math") 
+#endif
+
 #ifdef __GNUC__
   #define INLINE __inline
 #else
@@ -76,7 +95,7 @@ static INLINE float intp(float a, float b, float c)
     return a * (b - c) + c;
 }
 
-// We might have negative data in input and want to normalise data 
+// We might have negative data in input and also want to normalise 
 static INLINE float safe_in(float a, float scale)
 {
   return fmaxf(0.0f, a) * scale;
@@ -494,6 +513,11 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
   }
   rcd_border_interpolate(piece, out, in, roi_out, roi_in, filters, RCD_MARGIN);
 }
+
+// revert rcd specific aggressive optimizing 
+#ifdef __GNUC__
+  #pragma GCC pop_options
+#endif
 
 #undef FCRCD
 #undef RCD_BORDER

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -60,11 +60,13 @@
      handling of math interrupts
      handling of rounding 
      handling of overflows
+
+   The 'fp-contract=fast' option enables fused multiply&add if available 
 */
 
 #ifdef __GNUC__
   #pragma GCC push_options
-  #pragma GCC optimize ("fast-math") 
+  #pragma GCC optimize ("fast-math", "fp-contract=fast") 
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
As discussed and merged in #8030 and #8025 the -Ofast option was not a good idea as it is not well specified and lead to problems.

Instead we should use specific floating point pragmas, these are safe for the code in this module.

Also one debugging output section has been removed, it has not proven to be useful but possibly polluted the logs. 