### PR TITLE
[RFC/WIP] Move overexposed before colorout

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -248,10 +248,10 @@ const dt_iop_order_entry_t v30_order[] = {
   { {67.0f }, "splittoning", 0},     // creative module
   { {68.0f }, "vignette", 0},        // creative module
   { {69.0f }, "colorreconstruct", 0},// try to salvage blown areas before ICC intents in LittleCMS2 do things with them.
+  { {69.5f }, "overexposed", 0},
   { {70.0f }, "colorout", 0},
   { {71.0f }, "clahe", 0},
   { {72.0f }, "finalscale", 0},
-  { {73.0f }, "overexposed", 0},
   { {74.0f }, "rawoverexposed", 0},
   { {75.0f }, "dither", 0},
   { {76.0f }, "borders", 0},


### PR DESCRIPTION
I'd like to propose moving the `overexposed` module before `colorout`, at least for the scene-referred workflow. This PR is by no means complete but introduces a minimal change to observe the effects and benefits of doing it.

### Why?

In the current module order, the `overexposed` module is placed after `colorout`. When editing an image, `colorout` uses the chosen display profile, which is likely to have a small gamut. If one wants to see examine e.g. the saturation clipping in a wider gamut (e.g. having linear Rec2020 RGB as the work space), the clipping indicator is not useful here (it won't show any clipping) because the image is already clipped to a smaller gamut in `colorout`.

Let's have a look at an image where the saturation is exaggerated for illustration purposes (just a random image I had at hand, nothing special). The raw image and XMP are attached.
[clipping_example_image.zip](https://github.com/darktable-org/darktable/files/5900275/clipping_example_image.zip)
Here are the clipping settings:
![clipping_settings](https://user-images.githubusercontent.com/5001906/106392331-f26a6e80-63f9-11eb-84da-5be2fe457534.png)

Clipping indications with `master`, when `system display profile` is used for display profile and `linear Rec2020 RGB` for histogram profile (profile settings are also shown in the image):
![clipping_1](https://user-images.githubusercontent.com/5001906/106392430-758bc480-63fa-11eb-93ec-69360da0650f.png)
Notice no saturation clipping is shown.

One can eliminate the clipping to a smaller gamut and see the real saturation clipping by setting the display profile to linear Rec2020, but then the preview image is obviously incorrect.
![clipping_2](https://user-images.githubusercontent.com/5001906/106392462-a10eaf00-63fa-11eb-8d02-2480a8c5ad4d.png)

With this PR applied and `system display profile` selected as the display profile:
![clipping_3](https://user-images.githubusercontent.com/5001906/106392474-aff56180-63fa-11eb-88e4-722566ff1b92.png)
The preview image and clipping indicators are both correct.

Note: obviously device-specific display profiles are all different, but one can replicate these results also by selecting sRGB as the display profile.

This change particularly affects the saturation clipping indicators. To me it makes more sense to observe the clipping before clipping the image to a smaller gamut, especially when almost all the selectable histogram profiles have a larger gamut than a typical consumer-grade display. This is the case particularly for the scene-referred workflow. A use case for observing saturation clipping in e.g. linear Rec2020 is to catch potential imaginary colors that could cause problems.

Overall this move would make the clipping indicators behave better, independent of the chosen display profile, and less surprising.

### Pitfalls

There are some modules that come after `colorout` but before `overexposed` in the current module order.

For the scene-referred workflow:
* `clahe` (which is deprecated)
* `finalscale` (shouldn't affect the clipping as far as I can tell)

To me it would seem fine here to move `overexposed` before these modules.

For the display-referred workflow:
* `channelmixer`
* `soften`
* `vignette`
* `splittoning`
* `velvia`
* `clahe`
* `finalscale`

Some of these certainly have an effect on the colours and clipping.

### Open questions

* What will happen to old edits? I suppose ones with an unmodified module order will be fine but what about those with custom module order? Can we force `overexposed` to move somehow also in these cases (as it is not user controllable anyway)?
* What about the display-referred workflow? I realize having the `overexposed` module in different places for display-referred and scene-referred workflows may cause documentation issues. But the mindset is pretty different between these workflows anyway, and there are plenty of other differences that are already documented.
* Could this be made a user preference, like the scene-referred vs display-referred and modern/legacy chromatic adaptation are now?
* Minor aesthetic nitpick: the clipping indicator colours in `overexposed` could / should be given fixed XYZ coordinates, ideally well within sRGB, to make them constant even if the work profile changes.