### PR TITLE
lua - add event callback indexing and destruction

### DIFF
--- a/data/luarc
+++ b/data/luarc
@@ -237,7 +237,7 @@ if _scripts_install.dt.configuration.has_gui  then
       else
         if not _scripts_install.event_registered then
           _scripts_install.dt.register_event(
-            "view-changed",
+            "_scripts_install", "view-changed",
             function(event, old_view, new_view)
               if new_view.name == "lighttable" and old_view.name == "darkroom" then
                 _scripts_install.install_module()

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -793,10 +793,12 @@ void init(struct dt_lib_module_t *self)
   dt_lua_type_register_type(L, my_type, "show_overlays");
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "global_toolbox-grouping_toggle");
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "global_toolbox-overlay_toggle");
 }

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -39,7 +39,7 @@
 /* backward compatible API change */
 #define LUA_API_VERSION_MINOR 2
 /* bugfixes that should not change anything to the API */
-#define LUA_API_VERSION_PATCH 0
+#define LUA_API_VERSION_PATCH 1
 /* suffix for unstable version */
 #define LUA_API_VERSION_SUFFIX ""
 

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -303,12 +303,14 @@ int dt_lua_init_database(lua_State *L)
   dt_lua_type_register_number_const_type(L, type_id);
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "post-import-film");
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, G_CALLBACK(on_film_imported),
                             NULL);
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "post-import-image");
 

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -100,17 +100,16 @@ int dt_lua_event_trigger_wrapper(lua_State *L)
 
 void dt_lua_event_add(lua_State *L, const char *evt_name)
 {
-  // 1 dt_lua_event_list table
-  // 2 function to register a new event instance (callback)
-  // 3 function to destroy an existing event instance
-  // 4 event handler to call when event occurs
+  // 1 function to register a new event instance (callback)
+  // 2 function to destroy an existing event instance
+  // 3 event handler to call when event occurs
 
   // check we have the correct number of arguments
   int args = lua_gettop(L);
 
-  if(args != 4)
+  if(args != 3)
   {
-    lua_pop(L, args - 1);
+    lua_pop(L, args);
     dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: wrong number of args for %s, expected 4, got %d\n", __FUNCTION__, evt_name, args);
     return;
   }
@@ -552,9 +551,6 @@ int dt_lua_init_early_events(lua_State *L)
   lua_pushstring(L, "register_event");
   lua_pushcfunction(L, &lua_register_event);
   lua_settable(L, -3);
-  lua_pop(L, 1);
-  lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
-  dt_lua_push_darktable_lib(L);
   lua_pushstring(L, "destroy_event");
   lua_pushcfunction(L, &lua_destroy_event);
   lua_settable(L, -3);

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -28,60 +28,149 @@
 
 void dt_lua_event_trigger(lua_State *L, const char *event, int nargs)
 {
+  // 1  event name
+  // 2+ arguments
+
+  // check that events are enabled
   lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
   if(lua_isnil(L, -1))
   { // events have been disabled
     lua_pop(L, nargs+1);
     return;
   }
+
+  // check that the event exists
   lua_getfield(L, -1, event);
   if(lua_isnil(L, -1))
   { // event doesn't exist
     lua_pop(L, nargs + 2);
     return;
   }
+
+  // check that there are callbacks registered for the event
   lua_getfield(L, -1, "in_use");
   if(!lua_toboolean(L, -1))
   {
     lua_pop(L, nargs + 3);
     return;
   }
+
+  // event exists - push the event handler, callback table,
+  // event name, and extra arguments on the stack
   lua_getfield(L, -2, "on_event");
   lua_getfield(L, -3, "data");
   lua_pushstring(L, event);
   for(int i = 1; i <= nargs; i++) lua_pushvalue(L, -6 -nargs);
+
+  // call the event handler
   dt_lua_treated_pcall(L,nargs+2,0);
+
+  // clean up the stack
   lua_pop(L, nargs + 3);
+
+  // redraw
   dt_lua_redraw_screen();
 }
 
 int dt_lua_event_trigger_wrapper(lua_State *L)
 {
+  // event name
+  // extra parameters
   const char*event = luaL_checkstring(L,1);
   int nargs = lua_gettop(L) -1;
   dt_lua_event_trigger(L,event,nargs);
   return 0;
 }
 
+/*
+ *
+ * dt_lua_event_list is a table (array) of tables, 
+ * 1 for each type of event (shortcut, exit, post-image-import, etc.)
+ *
+ * Each event table (structure) contains the following:
+ *   name -        string -       name of the event
+ *   on event -    function -     function to call when event occurs
+ *   on destroy -  function -     function to remove an event instance
+ *   on register - function -     function to add an instance (callback)
+ *   in use -      boolean -       whether any callbacks are registered
+ *   data -        table (array) - callbacks to run when the event is triggered
+ *   index -       table (array) - index tying names to callbacks
+ *
+ */
+
 void dt_lua_event_add(lua_State *L, const char *evt_name)
 {
+  // 1 dt_lua_event_list table
+  // 2 function to register a new event instance (callback)
+  // 3 function to destroy an existing event instance
+  // 4 event handler to call when event occurs
+
+  // check we have the correct number of arguments
+  int args = lua_gettop(L);
+
+  if(args != 4)
+  {
+    lua_pop(L, args - 1);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: wrong number of args for %s, expected 4, got %d\n", __FUNCTION__, evt_name, args);
+    return;
+  }
+
+  // create a table for the new event
   lua_newtable(L);
 
+  // name of the event
   lua_pushstring(L, evt_name);
   lua_setfield(L, -2, "name");
 
-  lua_pushvalue(L, -2);
-  lua_setfield(L, -2, "on_event");
+  // event handler
+  if(lua_isfunction(L, -2))
+  {
+    lua_pushvalue(L, -2);
+    lua_setfield(L, -2, "on_event");
+  }
+  else{
+    dt_print(DT_DEBUG_LUA, "LUA ERROR :%s: function argument not found for on_event for event %s\n", __FUNCTION__, evt_name);
+    return;
+  }
 
-  lua_pushvalue(L, -3);
-  lua_setfield(L, -2, "on_register");
+  // event destruction handler
+  if(lua_isfunction(L, -3))
+  {
+    lua_pushvalue(L, -3);
+    lua_setfield(L, -2, "on_destroy");
+  }
+  else
+  {
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: function argument not found for on_destroy for event %s\n", __FUNCTION__, evt_name);
+    return;
+  }
 
+  // event registration handler
+  if(lua_isfunction(L, -4))
+  {
+    lua_pushvalue(L, -4);
+    lua_setfield(L, -2, "on_register");
+
+  }
+  else
+  {
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: function argument not found for on_register for event %s\n", __FUNCTION__, evt_name);
+    return;
+  }
+
+ // are there any events registered?
   lua_pushboolean(L, false);
   lua_setfield(L, -2, "in_use");
 
+  // data table for containing callbacks to execute when event is triggered
   lua_newtable(L);
   lua_setfield(L, -2, "data");
 
+  // index table for tying names to events
+  lua_newtable(L);
+  lua_setfield(L, -2, "index");
+
+  // add the event to the event list
   lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
 
   lua_getfield(L, -1, evt_name);
@@ -96,38 +185,73 @@ void dt_lua_event_add(lua_State *L, const char *evt_name)
   lua_pushvalue(L, -2);
   lua_setfield(L, -2, evt_name);
 
-  lua_pop(L, 4);
+  lua_pop(L, 5);
 }
 
 
 /*
  * KEYED EVENTS
  * these are events that are triggered with a key
- * i.e the can be registered multiple time with a key parameter and only the handler with the corresponding
+ * i.e they can be registered multiple time with a key parameter and only the handler with the corresponding
  * key will be triggered. there can be only one handler per key
  *
- * when registering, the third argument is the key
+ * when registering, the fourth argument is the key
  * when triggering, the first argument is the key
  *
  * data tables is "event => {key => callback}"
  */
+
 int dt_lua_event_keyed_register(lua_State *L)
 {
   // 1 is the data table
-  // 2 is the event name (checked)
-  // 3 is the action to perform (checked)
-  // 4 is the key itself
-  if(lua_isnoneornil(L, 4))
-    return luaL_error(L, "no key provided when registering event %s", luaL_checkstring(L, 2));
-  lua_getfield(L, 1, luaL_checkstring(L, 4));
+  // 2 is the index table
+  // 3 is the index name
+  // 4 is the event name (checked)
+  // 5 is the action to perform (checked)
+  // 6 is the key itself
+
+  // check the event type (shortcut)
+  if(lua_isnoneornil(L, 6))
+    return luaL_error(L, "no key provided when registering event %s", luaL_checkstring(L, 4));
+
+  // check to make sure they key isn't already registered
+  lua_getfield(L, 1, luaL_checkstring(L, 6));
   if(!lua_isnil(L, -1))
-    return luaL_error(L, "key '%s' already registered for event %s ", luaL_checkstring(L, 4),
-                      luaL_checkstring(L, 2));
+    return luaL_error(L, "key '%s' already registered for event %s ", luaL_checkstring(L, 6),
+                      luaL_checkstring(L, 4));
   lua_pop(L, 1);
+  // save the callback function to the data table referenced by the key name
+  lua_pushvalue(L, 5);
+  lua_setfield(L, 1, luaL_checkstring(L, 6));
+  // save the index name, key name pair to the index table
+  lua_pushvalue(L, 6);
+  lua_setfield(L, 2, luaL_checkstring(L, 3));
 
-  lua_pushvalue(L, 3);
-  lua_setfield(L, 1, luaL_checkstring(L, 4));
+  return 0;
+}
 
+
+int dt_lua_event_keyed_destroy(lua_State *L)
+{
+  // 1 is the data table
+  // 2 is the index table
+  // 3 is the index name
+  // 4 is the event name (checked)
+
+  // get the key name from the index
+  lua_getfield(L, 2, luaL_checkstring(L, 3));
+
+  // check to make sure the key was found
+  if(lua_isnoneornil(L, -1))
+    return luaL_error(L, "no key provided when destroying event %s", luaL_checkstring(L, 4));
+
+  // remove the callback function from the data table using the key
+  lua_pushnil(L);  // set the action to nil to remmove it
+  lua_setfield(L, 1, luaL_checkstring(L, -2));
+
+  // remove the index entry
+  lua_pushnil(L);  // remove the index
+  lua_setfield(L, 2, luaL_checkstring(L, 3));
   return 0;
 }
 
@@ -138,17 +262,27 @@ int dt_lua_event_keyed_trigger(lua_State *L)
   // 2 : the name of the event
   // 3 : the key
   // .. : other parameters
+
+  // check to make sure we have a valid key and push the callback on the stack
   lua_getfield(L, 1, luaL_checkstring(L, 3));
+
+  // if the key didn't return a callback it's an error
   if(lua_isnil(L, -1))
   {
     luaL_error(L, "event %s triggered for unregistered key %s", luaL_checkstring(L, 2),
                luaL_checkstring(L, 3));
   }
+
+  // point the callback_marker at the callback function
   const int callback_marker = lua_gettop(L);
+
+  // push the arguments on the stack
   for(int i = 2; i < callback_marker; i++)
   {
     lua_pushvalue(L, i);
   }
+
+  // execute the callback
   dt_lua_treated_pcall(L,callback_marker-2,0);
   return 0;
 }
@@ -168,12 +302,98 @@ int dt_lua_event_keyed_trigger(lua_State *L)
 int dt_lua_event_multiinstance_register(lua_State *L)
 {
   // 1 is the data table
-  // 2 is the event name (checked)
-  // 3 is the action to perform (checked)
+  // 2 is the index table
+  // 3 is the index name
+  // 4 is the event name (checked)
+  // 5 is the action to perform (checked)(callback)
 
-  // simply add the callback to the data table
-  luaL_ref(L, 1);
-  lua_pop(L, 2);
+  // check for duplicate indexes
+  for(int i = 1; i <= luaL_len(L, 2); i++)
+  {
+    lua_rawgeti(L, 2, i);
+    if(strcmp(luaL_checkstring(L, -1), luaL_checkstring(L, 3)) == 0)
+      luaL_error(L, "duplicate index name %s for event type %s\n", luaL_checkstring(L, 3), luaL_checkstring(L, 4));
+    lua_pop(L, 1); // pop the string off the stack
+  }
+
+  // check that table sizes match
+  if(luaL_len(L, 1) != luaL_len(L, 2))
+    luaL_error(L, "index table and data table sizes differ.  %s events are corrupted.\n", luaL_checkstring(L, 4));
+
+  // add the callback
+  luaL_ref(L, 1); // add the callback to the data table
+  lua_pop(L, 1);  // remove the event name from the stack
+
+  /// add the index
+  luaL_ref(L, 2); // add the index name to the index
+  lua_pop(L, 2);  // clear the stack
+  return 0;
+}
+
+int dt_lua_event_multiinstance_destroy(lua_State *L)
+{
+  // 1 is the data table
+  // 2 is the index table
+  // 3 is the index name
+  // 4 is the event name (checked)
+
+  // check that table sizes match
+  if(luaL_len(L, 1) != luaL_len(L, 2))
+    luaL_error(L, "index table and data table sizes differ.  %s events are corrupted.\n", luaL_checkstring(L, 4));
+
+  // find the index name.  The key corresponds to the callback in the data table
+  // set them both to nil to get rid of them
+
+  int index = 0;
+  for(int i = 1; i <= luaL_len(L, 2); i++)
+  {
+    lua_rawgeti(L, 2, i);
+    if(strcmp(luaL_checkstring(L, -1), luaL_checkstring(L, 3)) == 0)
+    {
+      index = i;
+      break;
+    }
+  }
+
+  // get the size of the index table
+  int size = luaL_len(L, 2);
+
+  // if the index was found...
+  if(index){
+    // remove the index
+    lua_pushnil(L);
+    lua_rawseti(L, 1, index);
+
+    // remove the callback
+    lua_pushnil(L);
+    lua_rawseti(L, 2, index);
+
+    // if we removed an from the table that wasn't at the end
+    // we have to shift all the items down to fill the table in
+    if(index < size)
+    {
+      // start with the first entry after the one we remmoved
+      for(int i = index + 1; i <= size; i++)
+      {
+        // move the index
+        lua_rawgeti(L, 1, i);     // push the value on the stack
+        lua_rawseti(L, 1, i - 1); // pull the value from the stack one place down
+        lua_pushnil(L);           // remove the current entry with a nil
+        lua_rawseti(L, 1, i);     // make the current one the hole
+
+        // move the data
+        lua_rawgeti(L, 2, i);     // push the value on the stack
+        lua_rawseti(L, 2, i - 1); // pull the value from the stack one place down
+        lua_pushnil(L);           // remove the current entry with a nil
+        lua_rawseti(L, 2, i);     // make the current one the hole
+      }
+    }
+  }
+
+  // check that table sizes still match
+  if(luaL_len(L, 1) != luaL_len(L, 2))
+    luaL_error(L, "index table and data table sizes differ after event removal.  %s events are corrupted.\n", luaL_checkstring(L, 4));
+
   return 0;
 }
 
@@ -182,14 +402,21 @@ int dt_lua_event_multiinstance_trigger(lua_State *L)
   // 1 : the data table
   // 2 : the name of the event
   // .. : other parameters
+
+  // get the top of the argument list
   const int arg_top = lua_gettop(L);
+
+  // step through the data table
   lua_pushnil(L);
-  while(lua_next(L, 1))
+  while(lua_next(L, 1)) // push the callback on the stack
   {
+    // push the arguments on the stack
     for(int i = 2; i <= arg_top; i++)
     {
       lua_pushvalue(L, i);
     }
+
+    // call the callback
     dt_lua_treated_pcall(L,arg_top-1,0);
   }
   return 0;
@@ -199,25 +426,119 @@ int dt_lua_event_multiinstance_trigger(lua_State *L)
 
 static int lua_register_event(lua_State *L)
 {
-  // 1 is event name
-  const char *evt_name = luaL_checkstring(L, 1);
+  // 1 index name
+  // 2 event name
+  // 3 callback function
+  // 4 key (shortcut event only)
+
+  const char *evt_name = luaL_checkstring(L, 2);
+
   const int nparams = lua_gettop(L);
-  // 2 is event handler
-  luaL_checktype(L, 2, LUA_TFUNCTION);
+ 
+  // check the callback is a function
+  luaL_checktype(L, 3, LUA_TFUNCTION);
+
+  // get the event list
   lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
+
+  // get the table for this event and check to make sure it exists
+  lua_getfield(L, -1, evt_name);
+  if(lua_isnil(L, -1))
+  {
+    lua_pop(L, 3);
+    return luaL_error(L, "unknown event type : %s\n", evt_name);
+  }
+
+  // push the event register function on the stack
+  lua_getfield(L, -1, "on_register");
+  // push the callback table on the stack
+  lua_getfield(L, -2, "data");
+  // push the index table on the stack
+  lua_getfield(L, -3, "index");
+
+  // push any arguments on the stack
+  for(int i = 1; i <= nparams; i++){
+    lua_pushvalue(L, i);
+  }
+
+  // call the register function
+  lua_call(L, nparams + 2, 0);
+
+  // mark the event as in use
+  lua_pushboolean(L, true);
+  lua_setfield(L, -2, "in_use");
+
+  //clear the stack
+  lua_pop(L, 2);
+ return 0;
+}
+
+static int lua_destroy_event(lua_State *L)
+{
+  // 1 is the index name
+  // 2 is event name
+
+  const char *evt_name = luaL_checkstring(L, 2);
+
+ const int nparams = lua_gettop(L);
+
+  // get the event list
+  lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
+
+  // get the table for this event and check to make sure it exists
   lua_getfield(L, -1, evt_name);
   if(lua_isnil(L, -1))
   {
     lua_pop(L, 2);
     return luaL_error(L, "unknown event type : %s\n", evt_name);
   }
-  lua_getfield(L, -1, "on_register");
+
+  // push the event destroy function on the stack
+  lua_getfield(L, -1, "on_destroy");
+  // push the callback table on the stack
   lua_getfield(L, -2, "data");
-  for(int i = 1; i <= nparams; i++) lua_pushvalue(L, i);
-  lua_call(L, nparams + 1, 0);
-  lua_pushboolean(L, true);
+  // push the index table on the stack
+  lua_getfield(L, -3, "index");
+
+  // push any arguments on the stack
+  for(int i = 1; i <= nparams; i++){
+    lua_pushvalue(L, i);
+  }
+
+   // call the register function
+  lua_call(L, nparams + 2, 0);
+
+  // check if there are any events left and set in use 
+  // if event type is shortcut, we have to count the tables
+  // otherwise we can just take the size
+
+  // get the index table
+  lua_getfield(L, -1, "index");
+
+  int count = 0;
+  if(strcmp(evt_name, "shortcut") == 0)
+  {
+    // count table items
+    lua_pushnil(L);           // push an empty key for lua_next
+    if(lua_next(L, -2) != 0)  // get the next key, value pair and push it on the stack
+    {
+      count++;        // all we need is one key, value pair to determine in use
+      lua_pop(L, 2);  // remove the kay, value pair from the stack
+    }
+  }
+  else
+    count = luaL_len(L, -1);  // check table size
+  lua_pop(L, 1);              // pop the index table off the stack
+
+  // push true if we have events registered otherwise false
+  if(count)
+    lua_pushboolean(L, true);
+  else
+    lua_pushboolean(L, false);
+
+  // set in use
   lua_setfield(L, -2, "in_use");
-  lua_pop(L, 2);
+
   return 0;
 }
 
@@ -230,6 +551,12 @@ int dt_lua_init_early_events(lua_State *L)
   dt_lua_push_darktable_lib(L);
   lua_pushstring(L, "register_event");
   lua_pushcfunction(L, &lua_register_event);
+  lua_settable(L, -3);
+  lua_pop(L, 1);
+  lua_getfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
+  dt_lua_push_darktable_lib(L);
+  lua_pushstring(L, "destroy_event");
+  lua_pushcfunction(L, &lua_destroy_event);
   lua_settable(L, -3);
   lua_pop(L, 1);
   return 0;
@@ -260,17 +587,51 @@ static void closure_destroy(gpointer data, GClosure *closure)
 {
   free(data);
 }
+
 static int register_shortcut_event(lua_State *L)
 {
   // 1 is the data table
-  // 2 is the event name (checked)
-  // 3 is the action to perform (checked)
-  // 4 is the key itself
+  // 2 is the index table
+  // 3 is the index name
+  // 4 is the event name (checked)
+  // 5 is the action to perform (checked)
+  // 6 is the key itself
 
-  char *tmp = strdup(luaL_checkstring(L, 4));
+  // duplicate the key for use elsewhere
+  char *tmp = strdup(luaL_checkstring(L, 6));
+
+  // register the event
   int result = dt_lua_event_keyed_register(L); // will raise an error in case of duplicate key
+
+  // register the accelerator in the lua shortcuts
   dt_accel_register_lua(tmp, 0, 0);
+
+  // set up the accelerator path
   dt_accel_connect_lua(tmp, g_cclosure_new(G_CALLBACK(shortcut_callback), tmp, closure_destroy));
+  return result;
+}
+
+static int destroy_shortcut_event(lua_State *L)
+{
+  // 1 is the data table
+  // 2 is the index table
+  // 3 is the index name
+  // 4 is the event name (checked)
+
+  // get the key from the index
+  lua_getfield(L, 2, luaL_checkstring(L, 3));
+
+  // duplicate the key for use elsewhere
+  char *tmp = strdup(luaL_checkstring(L, -1));
+
+  // remove the key from the stack
+  lua_pop(L, 1);
+
+  // destroy the event
+  int result = dt_lua_event_keyed_destroy(L); // will raise an error in case of duplicate key
+
+  // remove the accelerator from the lua shortcuts
+  dt_accel_deregister_lua(tmp);
   return result;
 }
 
@@ -279,17 +640,24 @@ int dt_lua_init_events(lua_State *L)
 
   // events that don't really fit anywhere else
   lua_pushcfunction(L, register_shortcut_event);
+  lua_pushcfunction(L, destroy_shortcut_event);
   lua_pushcfunction(L, dt_lua_event_keyed_trigger);
   dt_lua_event_add(L, "shortcut");
 
-
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "intermediate-export-image");
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L,"pre-import");
+
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L,"selection-changed");
   return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/lua/events.h
+++ b/src/lua/events.h
@@ -27,14 +27,25 @@
   Add a new event to the lua API
 * evt_name : the id to use for the event
 EXPECTED STACK
-* -2 : closure to be called on darktable.register_event
+* -3 : closure to be called on darktable.register_event
   in charge of saving the info that will be needed when the event triggers
   including the actual callbacks to use
   * can raise lua_error
-  * 1  : a table to save info for the event (including the callback to user
-  * 2  : event name
-  * 3  : callback to use
-  * 4+ : extra parameters given in register_event
+  * 1  : a table to save info for the event (including the callback to user)
+  * 2  : a table to save the indexing information
+  * 3  : index name
+  * 4  : event name
+  * 5  : callback to use
+  * 6+ : extra parameters given in register_event
+  * should not return anything
+* -2 : closure to be called on darktable.destroy_event
+  in charge of removing the saved info so the callback wont be used
+  the next time the event is triggered
+  * can raise lua error
+  * 1  : a table containing info for the event (including the callback to user)
+  * 2  : a table to save the indexing information
+  * 3  : index name
+  * 4  : event name
   * should not return anything
 * -1 : closure to be called when event is triggered,
   in charge of using the data provided by the register function to call the callbacks
@@ -72,10 +83,13 @@ int dt_lua_event_trigger_wrapper(lua_State *L) ;
 
   the register function does not expect any extra parameter from the lua side
 
+  the destroy function does not expect any extra parameter from the lua side
+
   the trigger will pass the arguments as is to the lua callback
 
   */
 int dt_lua_event_multiinstance_register(lua_State *L);
+int dt_lua_event_multiinstance_destroy(lua_State *L);
 int dt_lua_event_multiinstance_trigger(lua_State *L);
 
 
@@ -86,9 +100,12 @@ int dt_lua_event_multiinstance_trigger(lua_State *L);
 
   the register function wants one extra parameter from lua : the key to register with
 
+  the destroy function wants one extra parameter from lua : the key to destroy
+
   the trigger function wants the bottom most arg to be the key to trigger
   */
 int dt_lua_event_keyed_register(lua_State *L);
+int dt_lua_event_keyed_destroy(lua_State *L);
 int dt_lua_event_keyed_trigger(lua_State *L);
 
 

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -403,6 +403,7 @@ int dt_lua_init_gui(lua_State *L)
 
     // allow to react to highlighting an image
     lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+    lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
     lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
     dt_lua_event_add(L, "mouse-over-image-changed");
     DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, G_CALLBACK(on_mouse_over_image_changed), NULL);

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -49,6 +49,7 @@
 static int dt_lua_init_init(lua_State*L)
 {
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L,"exit");
   return 0;

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -151,6 +151,7 @@ void dt_lua_init(lua_State *L, const char *lua_command)
     (*cur_type)(L);
     cur_type++;
   }
+  dt_lua_debug_stack(L);
   assert(lua_gettop(L)
          == 0); // if you are here, you have probably added an initialisation function that is not stack clean
 

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -151,7 +151,6 @@ void dt_lua_init(lua_State *L, const char *lua_command)
     (*cur_type)(L);
     cur_type++;
   }
-  dt_lua_debug_stack(L);
   assert(lua_gettop(L)
          == 0); // if you are here, you have probably added an initialisation function that is not stack clean
 

--- a/src/lua/view.c
+++ b/src/lua/view.c
@@ -80,6 +80,7 @@ int dt_lua_init_early_view(lua_State *L)
 int dt_lua_init_view(lua_State *L)
 {
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "view-changed");
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED,


### PR DESCRIPTION
Added a name field, to be used as an index, to the register_event function call.  Added a destroy function to remove a registered event.  Bumped the API to 6.2.1.

This change allows the user to control events such as post-import-film, post-import-image, etc. turning them on and off as necessary to apply post-import processing to some images and not others without having to restart darktable.