### PR TITLE
modulegroups: Amend add/remove popup menu titles

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1596,15 +1596,16 @@ margin: 0 2px;
   margin-left: 0.5em;
 }
 
-#modulegroups-popup *
-{
- padding-top: 0.1em;
- padding-bottom: 0.1em;
-}
-
-#modulegroups-popup-title *
+#modulegroups-popup-item
 {
   padding-left: 2em;
+  padding-top: 0.1em;
+  padding-bottom: 0.1em;
+}
+
+#modulegroups-popup-title
+{
+  padding-left: 0em;
   padding-bottom: 0.2em;
   font-weight: bold;
   color: @plugin_label_color;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2187,7 +2187,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
 
   if((toggle && nba > 0) || nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label("add module (other)");
+    GtkWidget *smt = gtk_menu_item_new_with_label((nbr > 0) ? "add module (other)" : "add module");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
@@ -2374,7 +2374,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   // we add the titles if we have recommended widgets
   if((toggle && nba > 0) || nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label("add widget (other)");
+    GtkWidget *smt = gtk_menu_item_new_with_label((nbr > 0) ? "add widget (other)" : "add widget");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2187,7 +2187,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
 
   if((toggle && nba > 0) || nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label(ngettext("other", "others", nbo));
+    GtkWidget *smt = gtk_menu_item_new_with_label("add module (other)");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
@@ -2195,7 +2195,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
   }
   if(nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label(ngettext("recommended module", "recommended modules", nbr));
+    GtkWidget *smt = gtk_menu_item_new_with_label("add module (recommended)");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba);
@@ -2204,7 +2204,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
   if(toggle && nba > 0)
   {
     GtkWidget *smt
-        = gtk_menu_item_new_with_label(ngettext("already present module", "already present modules", nba));
+        = gtk_menu_item_new_with_label("remove module");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, 0);
@@ -2374,7 +2374,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   // we add the titles if we have recommended widgets
   if((toggle && nba > 0) || nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label(ngettext("other", "others", nbo));
+    GtkWidget *smt = gtk_menu_item_new_with_label("add widget (other)");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
@@ -2382,7 +2382,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   }
   if(nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label(ngettext("recommended widget", "recommended widgets", nbr));
+    GtkWidget *smt = gtk_menu_item_new_with_label("add widget (recommended)");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba);
@@ -2391,7 +2391,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   if(toggle && nba > 0)
   {
     GtkWidget *smt
-        = gtk_menu_item_new_with_label(ngettext("already present widget", "already present widgets", nba));
+        = gtk_menu_item_new_with_label("remove widget");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, 0);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2144,6 +2144,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
       if(!g_list_find_custom(gr->modules, module->op, _iop_compare))
       {
         GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
+        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
         gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("click to add this module"));
         g_object_set_data(G_OBJECT(smi), "module_op", module->op);
         g_object_set_data(G_OBJECT(smi), "group", gr);
@@ -2173,6 +2174,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
       else if(toggle)
       {
         GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
+        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
         gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("click to remove this module"));
         g_object_set_data(G_OBJECT(smi), "module_op", module->op);
         g_object_set_data(G_OBJECT(smi), "group", gr);
@@ -2191,7 +2193,6 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
-    if(nba + nbr > 0) gtk_menu_shell_insert(GTK_MENU_SHELL(pop), gtk_separator_menu_item_new(), nba + nbr);
   }
   if(nbr > 0)
   {
@@ -2199,7 +2200,6 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba);
-    if(nba > 0) gtk_menu_shell_insert(GTK_MENU_SHELL(pop), gtk_separator_menu_item_new(), nba);
   }
   if(toggle && nba > 0)
   {
@@ -2256,6 +2256,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
       {
         // create submenu for module
         GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
+        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
         GtkMenu *sm = (GtkMenu *)gtk_menu_new();
         gtk_menu_item_set_submenu(smi, GTK_WIDGET(sm));
         int nb = 0;
@@ -2275,6 +2276,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
               gtk_widget_set_tooltip_text(GTK_WIDGET(mi), _("click to remove the widget"));
               g_object_set_data(G_OBJECT(mi), "widget_id", module->op);
               g_signal_connect(G_OBJECT(mi), "activate", callback, self);
+              gtk_widget_set_name(GTK_WIDGET(mi), "modulegroups-popup-item");
               gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(mi), nba);
               nba++;
             }
@@ -2327,6 +2329,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
                 mi = (GtkMenuItem *)gtk_menu_item_new_with_label(tx);
                 g_free(tx);
                 gtk_widget_set_tooltip_text(GTK_WIDGET(mi), _("click to remove the widget"));
+                gtk_widget_set_name(GTK_WIDGET(mi), "modulegroups-popup-item");
                 g_object_set_data_full(G_OBJECT(mi), "widget_id", g_strdup(wid), g_free);
                 g_signal_connect(G_OBJECT(mi), "activate", callback, self);
                 gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(mi), nba);
@@ -2344,6 +2347,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
                 gtk_widget_set_tooltip_text(GTK_WIDGET(mi), _("click to add the widget"));
                 g_object_set_data_full(G_OBJECT(mi), "widget_id", g_strdup(wid), g_free);
                 g_signal_connect(G_OBJECT(mi), "activate", callback, self);
+                gtk_widget_set_name(GTK_WIDGET(mi), "modulegroups-popup-item");
                 gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(mi), nba + nbr);
                 nbr++;
               }
@@ -2378,7 +2382,6 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
-    if(nba + nbr > 0) gtk_menu_shell_insert(GTK_MENU_SHELL(pop), gtk_separator_menu_item_new(), nba + nbr);
   }
   if(nbr > 0)
   {
@@ -2386,7 +2389,6 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba);
-    if(nba > 0) gtk_menu_shell_insert(GTK_MENU_SHELL(pop), gtk_separator_menu_item_new(), nba);
   }
   if(toggle && nba > 0)
   {
@@ -2400,8 +2402,8 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   // and we add an entry to completly hide basics widgets group at the beginning
   if(toggle)
   {
-    gtk_menu_shell_insert(GTK_MENU_SHELL(pop), gtk_separator_menu_item_new(), 0);
     GtkWidget *rm = gtk_menu_item_new_with_label(_("hide the basics widgets group"));
+    gtk_widget_set_name(rm, "modulegroups-popup-title");
     gtk_widget_set_tooltip_text(GTK_WIDGET(rm), _("to see it again, use the presets manager"));
     g_signal_connect(G_OBJECT(rm), "activate", G_CALLBACK(_manage_direct_basics_hide), self);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(rm), 0);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2050,16 +2050,6 @@ static void _manage_direct_basics_module_toggle(GtkWidget *widget, dt_lib_module
   _manage_direct_save(self);
 }
 
-static void _manage_direct_basics_hide(GtkWidget *widget, dt_lib_module_t *self)
-{
-  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
-
-  _basics_hide(self);
-  d->basics_show = FALSE;
-
-  _manage_direct_save(self);
-}
-
 static void _manage_editor_basics_add(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
@@ -2397,16 +2387,6 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, 0);
-  }
-
-  // and we add an entry to completly hide basics widgets group at the beginning
-  if(toggle)
-  {
-    GtkWidget *rm = gtk_menu_item_new_with_label(_("hide the basics widgets group"));
-    gtk_widget_set_name(rm, "modulegroups-popup-title");
-    gtk_widget_set_tooltip_text(GTK_WIDGET(rm), _("to see it again, use the presets manager"));
-    g_signal_connect(G_OBJECT(rm), "activate", G_CALLBACK(_manage_direct_basics_hide), self);
-    gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(rm), 0);
   }
 
   gtk_widget_show_all(pop);


### PR DESCRIPTION
Amend so that the titles better reflect the functionality of the menu.

Also, if recommended modules exist, display others with a title of "add module (other)" else just have the label "add module"

Similarly for adding widgets to the basic adjustments module

Also adjusted the style of the menus

Before:

![Screenshot_2021-02-02_16-14-37](https://user-images.githubusercontent.com/9555491/106628737-05a04a00-6572-11eb-8d8d-c79565ac0bc0.png)

After:

![Screenshot_2021-02-02_16-15-55](https://user-images.githubusercontent.com/9555491/106628820-19e44700-6572-11eb-8625-2ad67d5fbbc3.png)

