### PR TITLE
import : lower the number of raised signals

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -539,7 +539,7 @@ int main(int argc, char *arg[])
 
       gchar *directory = g_path_get_dirname(input);
       filmid = dt_film_new(&film, directory);
-      const int32_t id = dt_image_import(filmid, input, TRUE);
+      const int32_t id = dt_image_import(filmid, input, TRUE, TRUE);
       g_free(directory);
       if(!id)
       {

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -265,7 +265,7 @@ int dt_load_from_string(const gchar *input, gboolean open_image_in_dr, gboolean 
     gchar *directory = g_path_get_dirname((const gchar *)filename);
     dt_film_t film;
     const int filmid = dt_film_new(&film, directory);
-    id = dt_image_import(filmid, filename, TRUE);
+    id = dt_image_import(filmid, filename, TRUE, TRUE);
     g_free(directory);
     if(id)
     {

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -267,6 +267,11 @@ int dt_film_import(const char *dirname)
     free(film);
     return 0;
   }
+
+  // deselect all
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.selected_images", NULL, NULL, NULL);
+
+  // launch import job
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_BG, dt_film_import1_create(film));
 
   return filmid;
@@ -432,7 +437,7 @@ void dt_film_remove(const int id)
   }
   sqlite3_finalize(stmt);
 
-  // due to foreign keys, all images with references to the film roll are deleted, 
+  // due to foreign keys, all images with references to the film roll are deleted,
   // and likewise all entries with references to those images
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "DELETE FROM main.film_rolls WHERE id = ?1", -1,

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1340,10 +1340,12 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
     dt_image_synch_all_xmp(normalized_filename);
     g_free(ext);
     g_free(normalized_filename);
-    GList *imgs = NULL;
-    imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED,
-                                  g_list_copy((GList *)imgs), 0);
+    if(raise_signals)
+    {
+      GList *imgs = NULL;
+      imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, g_list_copy((GList *)imgs), 0);
+    }
     return id;
   }
   sqlite3_finalize(stmt);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -276,7 +276,8 @@ int dt_image_get_xmp_rating_from_flags(const int flags);
 /** finds all xmp duplicates for the given image in the database. */
 GList* dt_image_find_duplicates(const char* filename);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from threads other than lua.*/
-uint32_t dt_image_import(int32_t film_id, const char *filename, gboolean override_ignore_jpegs);
+uint32_t dt_image_import(int32_t film_id, const char *filename, gboolean override_ignore_jpegs,
+                         gboolean raise_signals);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from lua thread.*/
 uint32_t dt_image_import_lua(int32_t film_id, const char *filename, gboolean override_ignore_jpegs);
 /** removes the given image from the database. */

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -184,7 +184,7 @@ void dt_import_session_unref(struct dt_import_session_t *self)
 
 void dt_import_session_import(struct dt_import_session_t *self)
 {
-  const int32_t id = dt_image_import(self->film->id, self->current_filename, TRUE);
+  const int32_t id = dt_image_import(self->film->id, self->current_filename, TRUE, TRUE);
   if(id)
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -283,7 +283,7 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
 {
   // Import downloaded image to import filmroll
   dt_camera_import_t *t = (dt_camera_import_t *)data;
-  const int32_t imgid = dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE);
+  const int32_t imgid = dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE, TRUE);
   dt_control_queue_redraw_center();
   gchar *basename = g_path_get_basename(filename);
   dt_control_log(ngettext("%d/%d imported to %s", "%d/%d imported to %s", t->import_count + 1),

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -512,7 +512,7 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   gchar *directory = g_path_get_dirname((const gchar *)pathname);
   dt_film_t film;
   const int filmid = dt_film_new(&film, directory);
-  const uint32_t imageid = dt_image_import(filmid, pathname, TRUE);
+  const uint32_t imageid = dt_image_import(filmid, pathname, TRUE, TRUE);
   g_free(directory);
 
   // refresh the thumbtable view

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -254,8 +254,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     g_free(cdn);
 
     /* import image */
-    const int32_t imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE);
-
+    const int32_t imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE, FALSE);
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -200,6 +200,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   g_snprintf(message, sizeof(message) - 1, ngettext("importing %d image", "importing %d images", total), total);
   dt_control_job_set_progress_message(job, message);
 
+  GList *imgs = NULL;
 
   /* loop thru the images and import to current film roll */
   dt_film_t *cfr = film;
@@ -258,9 +259,12 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if((imgid & 3) == 3)
     {
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
+      g_list_free(imgs);
+      imgs = NULL;
     }
   } while((image = g_list_next(image)) != NULL);
 

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -201,6 +201,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   dt_control_job_set_progress_message(job, message);
 
   GList *imgs = NULL;
+  GList *all_imgs = NULL;
 
   /* loop thru the images and import to current film roll */
   dt_film_t *cfr = film;
@@ -259,6 +260,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 
+    all_imgs = g_list_append(all_imgs, GINT_TO_POINTER(imgid));
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if((imgid & 3) == 3)
     {
@@ -275,6 +277,8 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, film->id);
+
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, all_imgs, 0);
 
   // FIXME: maybe refactor into function and call it?
   if(cfr && cfr->dir)

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -76,7 +76,7 @@ static int32_t dt_image_import_job_run(dt_job_t *job)
   snprintf(message, sizeof(message), _("importing image %s"), params->filename);
   dt_control_job_set_progress_message(job, message);
 
-  const int id = dt_image_import(params->film_id, params->filename, TRUE);
+  const int id = dt_image_import(params->film_id, params->filename, TRUE, TRUE);
   if(id)
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -969,10 +969,8 @@ static void _dt_collection_changed_callback(gpointer instance, dt_collection_cha
   }
 }
 
-static void _dt_selection_changed_callback(gpointer instance, gpointer user_data)
+void dt_thumbnail_update_selection(dt_thumbnail_t *thumb)
 {
-  if(!user_data) return;
-  dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(!thumb) return;
   if(!gtk_widget_is_visible(thumb->w_main)) return;
 
@@ -992,6 +990,12 @@ static void _dt_selection_changed_callback(gpointer instance, gpointer user_data
     _thumb_update_icons(thumb);
     gtk_widget_queue_draw(thumb->w_main);
   }
+}
+
+static void _dt_selection_changed_callback(gpointer instance, gpointer user_data)
+{
+  if(!user_data) return;
+  dt_thumbnail_update_selection((dt_thumbnail_t *)user_data);
 }
 
 static void _dt_active_images_callback(gpointer instance, gpointer user_data)

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -159,6 +159,9 @@ void dt_thumbnail_set_drop(dt_thumbnail_t *thumb, gboolean accept_drop);
 // update the informations of the image and update icons accordingly
 void dt_thumbnail_update_infos(dt_thumbnail_t *thumb);
 
+// check if the image is selected and set its state and background
+void dt_thumbnail_update_selection(dt_thumbnail_t *thumb);
+
 // force image recomputing
 void dt_thumbnail_image_refresh(dt_thumbnail_t *thumb);
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2026,7 +2026,16 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
     }
 
     // if we force the redraw, we ensure selection is updated
-    if(force) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+    if(force)
+    {
+      GList *l = table->list;
+      while(l)
+      {
+        dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+        dt_thumbnail_update_selection(th);
+        l = g_list_next(l);
+      }
+    }
 
     // be sure the focus is in the right widget (needed for accels)
     gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -598,6 +598,9 @@ static void _lib_import_folder_callback(GtkWidget *widget, dt_lib_module_t* self
   // run the dialog
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
+    // hide the dialog as soon as possible
+    gtk_widget_hide(filechooser);
+
     gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
     dt_conf_set_string("ui_last/import_last_directory", folder);
     g_free(folder);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -545,7 +545,7 @@ static void _lib_import_single_image_callback(GtkWidget *widget, dt_lib_import_t
       filename = (char *)it->data;
       gchar *directory = g_path_get_dirname((const gchar *)filename);
       filmid = dt_film_new(&film, directory);
-      id = dt_image_import(filmid, filename, TRUE);
+      id = dt_image_import(filmid, filename, TRUE, TRUE);
       if(!id) dt_control_log(_("error loading file `%s'"), filename);
       g_free(filename);
       g_free(directory);

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -199,7 +199,7 @@ static int database_numindex(lua_State *L)
   }
   else
     lua_pushnil(L);
-  
+
   sqlite3_finalize(stmt);
   return 1;
 }


### PR DESCRIPTION
this fix #7111 
this avoid raising of `DT_SIGNAL_SELECTION_CHANGED` for each imported image. As this signal raise lot of "child" signals, this speedup the import with big databases and avoid gui freeze.
note that this is only done for "classic" directory import.