### PR TITLE
colorspaces: check for CLUT in all ICC intents before extracting matrix

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -147,8 +147,7 @@ static const dt_colorspaces_color_profile_t *_get_profile(dt_colorspaces_t *self
                                                           dt_colorspaces_profile_direction_t direction);
 
 static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                  float *lutb, const int lutsize, const int input,
-                                                  const int intent)
+                                                  float *lutb, const int lutsize, const int input)
 {
   // create an OpenCL processable matrix + tone curves from an cmsHPROFILE:
   // NOTE: may be invoked with matrix and LUT pointers set to null to find
@@ -157,11 +156,19 @@ static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matri
   // check this first:
   if(!prof || !cmsIsMatrixShaper(prof)) return 1;
 
-  // if this profile contains LUT, it might also contain swapped matrix,
-  // so the only right way to handle it is to let LCMS apply it.
+  // there are some profiles that contain both a color LUT for some specific
+  // intent and a generic matrix. in some cases the matrix might be
+  // deliberately wrong with swapped blue and red channels in order to easily
+  // detect if a color managed software is applying the LUT or the matrix.
+  // thus, if this profile contains LUT for any intent, it might also contain
+  // swapped matrix, so the only right way to handle it is to let LCMS apply it.
   const int UsedDirection = input ? LCMS_USED_AS_INPUT : LCMS_USED_AS_OUTPUT;
 
-  if(cmsIsCLUT(prof, intent, UsedDirection)) return 1;
+  if(cmsIsCLUT(prof, INTENT_PERCEPTUAL, UsedDirection)
+     || cmsIsCLUT(prof, INTENT_RELATIVE_COLORIMETRIC, UsedDirection)
+     || cmsIsCLUT(prof, INTENT_ABSOLUTE_COLORIMETRIC, UsedDirection)
+     || cmsIsCLUT(prof, INTENT_SATURATION, UsedDirection))
+    return 1;
 
   cmsToneCurve *red_curve = cmsReadTag(prof, cmsSigRedTRCTag);
   cmsToneCurve *green_curve = cmsReadTag(prof, cmsSigGreenTRCTag);
@@ -252,15 +259,15 @@ static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matri
 }
 
 int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                 float *lutb, const int lutsize, const int intent)
+                                                 float *lutb, const int lutsize)
 {
-  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 1, intent);
+  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 1);
 }
 
 int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                  float *lutb, const int lutsize, const int intent)
+                                                  float *lutb, const int lutsize)
 {
-  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 0, intent);
+  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 0);
 }
 
 static cmsHPROFILE dt_colorspaces_create_lab_profile()
@@ -1549,19 +1556,15 @@ dt_colorspaces_t *dt_colorspaces_init()
     dt_colorspaces_color_profile_t *prof = (dt_colorspaces_color_profile_t *)iter->data;
     // FIXME: do want to filter out non-RGB profiles for cases besides histogram profile? colorin is OK with RGB or XYZ, print is OK with anything which LCMS likes, otherwise things are more choosey
     const cmsColorSpaceSignature color_space = cmsGetColorSpace(prof->profile);
-    // The relative colorimetric intent is used for the histogram, clipping indicators and the global color picker.
-    // Some of these also rely on the profile matrix. LUT profiles don't make much sense in these applications
+    // The histogram profile is used for histogram, clipping indicators and the global color picker.
+    // Some of these also assume a matrix profile. LUT profiles don't make much sense in these applications
     // so filter out any profile that doesn't implement the relative colorimetric intent as a matrix (+ TRC).
     // For discussion, see e.g.
     // https://github.com/darktable-org/darktable/issues/7660#issuecomment-760143437
     // For the working profile we also require a matrix profile.
     const gboolean is_valid_matrix_profile
-        = dt_colorspaces_get_matrix_from_output_profile(prof->profile, NULL, NULL, NULL, NULL, 0,
-                                                        DT_INTENT_RELATIVE_COLORIMETRIC)
-              == 0
-          && dt_colorspaces_get_matrix_from_input_profile(prof->profile, NULL, NULL, NULL, NULL, 0,
-                                                          DT_INTENT_RELATIVE_COLORIMETRIC)
-                 == 0;
+        = dt_colorspaces_get_matrix_from_output_profile(prof->profile, NULL, NULL, NULL, NULL, 0) == 0
+          && dt_colorspaces_get_matrix_from_input_profile(prof->profile, NULL, NULL, NULL, NULL, 0) == 0;
     prof->out_pos = ++out_pos;
     prof->display_pos = ++display_pos;
     prof->display2_pos = ++display2_pos;

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -192,11 +192,11 @@ void dt_colorspaces_cleanup_profile(cmsHPROFILE p);
 /** extracts tonecurves and color matrix prof to XYZ from a given input profile, returns 0 on success (curves
  * and matrix are inverted for input) */
 int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                 float *lutb, const int lutsize, const int intent);
+                                                 float *lutb, const int lutsize);
 
 /** extracts tonecurves and color matrix prof to XYZ from a given output profile, returns 0 on success. */
 int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                  float *lutb, const int lutsize, const int intent);
+                                                  float *lutb, const int lutsize);
 
 /** wrapper to get the name from a color profile. this tries to handle character encodings. */
 void dt_colorspaces_get_profile_name(cmsHPROFILE p, const char *language, const char *country, char *name,

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -633,12 +633,12 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
   // get the matrix
   if(rgb_profile)
   {
-    if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in,
-        profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
-        profile_info->lutsize, profile_info->intent) ||
-        dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out,
-            profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
-            profile_info->lutsize, profile_info->intent))
+    if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in, profile_info->lut_in[0],
+                                                    profile_info->lut_in[1], profile_info->lut_in[2],
+                                                    profile_info->lutsize)
+       || dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out,
+                                                        profile_info->lut_out[0], profile_info->lut_out[1],
+                                                        profile_info->lut_out[2], profile_info->lutsize))
     {
       profile_info->matrix_in[0] = NAN;
       profile_info->matrix_out[0] = NAN;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1676,7 +1676,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     // user wants us to clip to a given RGB profile
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                    LUT_SAMPLES, p->intent))
+                                                    LUT_SAMPLES))
     {
       piece->process_cl_ready = 0;
       d->cmatrix[0] = NAN;
@@ -1688,16 +1688,16 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     {
       float lutr[1], lutg[1], lutb[1];
       float omat[9];
-      dt_colorspaces_get_matrix_from_output_profile(d->nrgb, omat, lutr, lutg, lutb, 1, p->intent);
+      dt_colorspaces_get_matrix_from_output_profile(d->nrgb, omat, lutr, lutg, lutb, 1);
       mat3mul(d->nmatrix, omat, d->cmatrix);
-      dt_colorspaces_get_matrix_from_input_profile(d->nrgb, d->lmatrix, lutr, lutg, lutb, 1, p->intent);
+      dt_colorspaces_get_matrix_from_input_profile(d->nrgb, d->lmatrix, lutr, lutg, lutb, 1);
     }
   }
   else
   {
     // default mode: unbound processing
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                    LUT_SAMPLES, p->intent))
+                                                    LUT_SAMPLES))
     {
       piece->process_cl_ready = 0;
       d->cmatrix[0] = NAN;
@@ -1734,7 +1734,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     d->input = dt_colorspaces_get_profile(DT_COLORSPACE_LIN_REC709, "", DT_PROFILE_DIRECTION_IN)->profile;
     d->clear_input = 0;
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                    LUT_SAMPLES, p->intent))
+                                                    LUT_SAMPLES))
     {
       piece->process_cl_ready = 0;
       d->cmatrix[0] = NAN;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -724,10 +724,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
    */
 
   /* get matrix from profile, if softproofing or high quality exporting always go xform codepath */
-  if(d->mode != DT_PROFILE_NORMAL
-     || force_lcms2
+  if(d->mode != DT_PROFILE_NORMAL || force_lcms2
      || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                      LUT_SAMPLES, out_intent))
+                                                      LUT_SAMPLES))
   {
     d->cmatrix[0] = NAN;
     piece->process_cl_ready = 0;
@@ -743,8 +742,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     output = dt_colorspaces_get_profile(DT_COLORSPACE_SRGB, "", DT_PROFILE_DIRECTION_OUT)->profile;
 
     if(d->mode != DT_PROFILE_NORMAL
-       || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1],
-                                                        d->lut[2], LUT_SAMPLES, out_intent))
+       || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
+                                                        LUT_SAMPLES))
     {
       d->cmatrix[0] = NAN;
       piece->process_cl_ready = 0;


### PR DESCRIPTION
If there is a CLUT for any intent, the matrix might be in principle a swapped matrix and should be discarded. This removes the need to pass the chosen intent along to the matrix extraction, which was pretty confusing.