### PR TITLE
modulegroups : contextmenus refinments

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1605,8 +1605,7 @@ margin: 0 2px;
 
 #modulegroups-popup-title
 {
-  padding-left: 0em;
-  padding-bottom: 0.2em;
+  padding: 0.4em 0 0.2em 0;
   font-weight: bold;
   color: @plugin_label_color;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1596,11 +1596,21 @@ margin: 0 2px;
   margin-left: 0.5em;
 }
 
-#modulegroups-popup-item
+#modulegroups-popup-item,
+#modulegroups-popup-item2,
+#modulegroups-popup-item-all
 {
-  padding-left: 2em;
-  padding-top: 0.1em;
-  padding-bottom: 0.1em;
+  padding: 0.1em 0 0.1em 2em;
+}
+
+#modulegroups-popup-item-all
+{
+  padding-top: 0.4em;
+}
+
+#modulegroups-popup-item2
+{
+  padding-left: 0em;
 }
 
 #modulegroups-popup-title

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2157,12 +2157,12 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
           nbr++;
         }
         GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
-        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
+        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item2");
         gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("click to add this module"));
         g_object_set_data(G_OBJECT(smi), "module_op", module->op);
         g_object_set_data(G_OBJECT(smi), "group", gr);
         g_signal_connect(G_OBJECT(smi), "activate", callback, data);
-        gtk_menu_shell_insert(GTK_MENU_SHELL(sm_all), GTK_WIDGET(smi), nba + nbr);
+        gtk_menu_shell_prepend(GTK_MENU_SHELL(sm_all), GTK_WIDGET(smi));
         nbo++;
       }
       else if(toggle)
@@ -2183,19 +2183,14 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
 
   if((toggle && nba > 0) || nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label((nbr > 0) ? "add module (other)" : "add module");
-    gtk_widget_set_name(smt, "modulegroups-popup-title");
-    gtk_widget_set_sensitive(smt, FALSE);
-    gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
-
-    smt = gtk_menu_item_new_with_label(_("all available modules"));
-    gtk_widget_set_name(smt, "modulegroups-popup-item");
+    GtkWidget *smt = gtk_menu_item_new_with_label(_("all available modules"));
+    gtk_widget_set_name(smt, "modulegroups-popup-item-all");
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(smt), GTK_WIDGET(sm_all));
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr + 1);
   }
   if(nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label("add module (recommended)");
+    GtkWidget *smt = gtk_menu_item_new_with_label("add module");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba);
@@ -2258,7 +2253,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
       {
         // create submenu for module
         GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
-        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
+        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item2");
         GtkMenu *sm = (GtkMenu *)gtk_menu_new();
         gtk_menu_item_set_submenu(smi, GTK_WIDGET(sm));
         int nb = 0;
@@ -2353,8 +2348,8 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
                 gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(mi), nba + nbr);
                 nbr++;
               }
-              GtkMenuItem *mii;
-              mii = (GtkMenuItem *)gtk_menu_item_new_with_label(wn);
+              GtkMenuItem *mii = (GtkMenuItem *)gtk_menu_item_new_with_label(wn);
+              gtk_widget_set_name(GTK_WIDGET(mii), "modulegroups-popup-item2");
               gtk_widget_set_tooltip_text(GTK_WIDGET(mii), _("click to add the widget"));
               g_object_set_data_full(G_OBJECT(mii), "widget_id", g_strdup(wid), g_free);
               g_signal_connect(G_OBJECT(mii), "activate", callback, self);
@@ -2380,19 +2375,14 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   // we add the titles if we have recommended widgets
   if((toggle && nba > 0) || nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label((nbr > 0) ? "add widget (other)" : "add widget");
-    gtk_widget_set_name(smt, "modulegroups-popup-title");
-    gtk_widget_set_sensitive(smt, FALSE);
-    gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
-
-    smt = gtk_menu_item_new_with_label(_("all available widgets"));
-    gtk_widget_set_name(smt, "modulegroups-popup-item");
+    GtkWidget *smt = gtk_menu_item_new_with_label(_("all available widgets"));
+    gtk_widget_set_name(smt, "modulegroups-popup-item-all");
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(smt), GTK_WIDGET(sm_all));
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr + 1);
   }
   if(nbr > 0)
   {
-    GtkWidget *smt = gtk_menu_item_new_with_label("add widget (recommended)");
+    GtkWidget *smt = gtk_menu_item_new_with_label("add widget");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2123,6 +2123,8 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
   int nba = 0; // nb of already present items
   int nbo = 0; // nb of other items
 
+  GtkMenu *sm_all = (GtkMenu *)gtk_menu_new();
+
   GList *m2 = g_list_copy(g_list_first(darktable.iop));
   GList *modules = g_list_sort(m2, _manage_editor_module_so_add_sort);
   while(modules)
@@ -2133,13 +2135,6 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
     {
       if(!g_list_find_custom(gr->modules, module->op, _iop_compare))
       {
-        GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
-        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
-        gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("click to add this module"));
-        g_object_set_data(G_OBJECT(smi), "module_op", module->op);
-        g_object_set_data(G_OBJECT(smi), "group", gr);
-        g_signal_connect(G_OBJECT(smi), "activate", callback, data);
-
         // does it belong to recommended modules ?
         if(((module->default_group() & IOP_GROUP_BASIC) && g_strcmp0(gr->name, _("base")) == 0)
            || ((module->default_group() & IOP_GROUP_COLOR) && g_strcmp0(gr->name, _("color")) == 0)
@@ -2152,14 +2147,23 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
            || ((module->default_group() & IOP_GROUP_EFFECTS)
                && g_strcmp0(gr->name, C_("modulegroup", "effects")) == 0))
         {
-          gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(smi), nba);
+          GtkMenuItem *smir = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
+          gtk_widget_set_name(GTK_WIDGET(smir), "modulegroups-popup-item");
+          gtk_widget_set_tooltip_text(GTK_WIDGET(smir), _("click to add this module"));
+          g_object_set_data(G_OBJECT(smir), "module_op", module->op);
+          g_object_set_data(G_OBJECT(smir), "group", gr);
+          g_signal_connect(G_OBJECT(smir), "activate", callback, data);
+          gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(smir), nba);
           nbr++;
         }
-        else
-        {
-          gtk_menu_shell_insert(GTK_MENU_SHELL(pop), GTK_WIDGET(smi), nba + nbr);
-          nbo++;
-        }
+        GtkMenuItem *smi = (GtkMenuItem *)gtk_menu_item_new_with_label(module->name());
+        gtk_widget_set_name(GTK_WIDGET(smi), "modulegroups-popup-item");
+        gtk_widget_set_tooltip_text(GTK_WIDGET(smi), _("click to add this module"));
+        g_object_set_data(G_OBJECT(smi), "module_op", module->op);
+        g_object_set_data(G_OBJECT(smi), "group", gr);
+        g_signal_connect(G_OBJECT(smi), "activate", callback, data);
+        gtk_menu_shell_insert(GTK_MENU_SHELL(sm_all), GTK_WIDGET(smi), nba + nbr);
+        nbo++;
       }
       else if(toggle)
       {
@@ -2183,6 +2187,11 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
+
+    smt = gtk_menu_item_new_with_label(_("all available modules"));
+    gtk_widget_set_name(smt, "modulegroups-popup-item");
+    gtk_menu_item_set_submenu(GTK_MENU_ITEM(smt), GTK_WIDGET(sm_all));
+    gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr + 1);
   }
   if(nbr > 0)
   {
@@ -2218,6 +2227,9 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
   int nbr = 0; // nb of recommended items
   int nba = 0; // nb of already present items
   int nbo = 0; // nb of other items
+
+  GtkMenu *sm_all = (GtkMenu *)gtk_menu_new();
+
   GList *m2 = g_list_copy(g_list_first(darktable.develop->iop));
   GList *modules = g_list_sort(m2, _manage_editor_module_add_sort);
   while(modules)
@@ -2358,7 +2370,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
           la = g_list_previous(la);
         }
         // add submenu to main menu if we got any widgets
-        if(nb > 0) gtk_menu_shell_append(GTK_MENU_SHELL(pop), GTK_WIDGET(smi));
+        if(nb > 0) gtk_menu_shell_append(GTK_MENU_SHELL(sm_all), GTK_WIDGET(smi));
       }
     }
     modules = g_list_next(modules);
@@ -2372,6 +2384,11 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
     gtk_widget_set_name(smt, "modulegroups-popup-title");
     gtk_widget_set_sensitive(smt, FALSE);
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr);
+
+    smt = gtk_menu_item_new_with_label(_("all available widgets"));
+    gtk_widget_set_name(smt, "modulegroups-popup-item");
+    gtk_menu_item_set_submenu(GTK_MENU_ITEM(smt), GTK_WIDGET(sm_all));
+    gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr + 1);
   }
   if(nbr > 0)
   {


### PR DESCRIPTION
As discussed in #8075 
this change : 
- put the list of all widgets/modules in a submenu to reduce contextmenu length
- add some padding on top of contextmenu titles as suggested by @Nilvus 

... but @Nilvus, I fear that I'll need your help in css for second level menu in basic widgets : it has a strange arrow and submenu is black...