### PR TITLE
fix memory leaks and uninitialized variable

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3585,20 +3585,23 @@ static void _exif_xmp_read_data(Exiv2::XmpData &xmpData, const int imgid)
   dt_history_hash_read(imgid, &hash);
   if(hash.basic)
   {
-    xmpData["Xmp.darktable.history_basic_hash"]
-            = dt_exif_xmp_encode(hash.basic, hash.basic_len, NULL);
+    char* value = dt_exif_xmp_encode(hash.basic, hash.basic_len, NULL);
+    xmpData["Xmp.darktable.history_basic_hash"] = value;
+    free(value);
     g_free(hash.basic);
   }
   if(hash.auto_apply)
   {
-    xmpData["Xmp.darktable.history_auto_hash"]
-            = dt_exif_xmp_encode(hash.auto_apply, hash.auto_apply_len, NULL);
+    char* value = dt_exif_xmp_encode(hash.auto_apply, hash.auto_apply_len, NULL);
+    xmpData["Xmp.darktable.history_auto_hash"] = value;
+    free(value);
     g_free(hash.auto_apply);
   }
   if(hash.current)
   {
-    xmpData["Xmp.darktable.history_current_hash"]
-            = dt_exif_xmp_encode(hash.current, hash.current_len, NULL);
+    char* value = dt_exif_xmp_encode(hash.current, hash.current_len, NULL);
+    xmpData["Xmp.darktable.history_current_hash"] = value;
+    free(value);
     g_free(hash.current);
   }
 }

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -839,7 +839,8 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     scale = fmin(width >  0 ? fmin((double)width / (double)pipe.processed_width, max_scale) : max_scale,
                  height > 0 ? fmin((double)height / (double)pipe.processed_height, max_scale) : max_scale);
 
-    if (strcmp(dt_conf_get_string("plugins/lighttable/export/resizing"), "scaling") == 0)
+    gchar* resizing = dt_conf_get_string("plugins/lighttable/export/resizing");
+    if (strcmp(resizing, "scaling") == 0)
     {
       // scaling
       double scale_factor = 1;
@@ -853,6 +854,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
         scale = fmin(scale_factor, max_scale);
       }
     }
+    g_free(resizing);
 
     processed_width = scale * pipe.processed_width + 0.8f;
     processed_height = scale * pipe.processed_height + 0.8f;

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -47,6 +47,8 @@ static void _free_confgen_value(void *value)
   g_free(s->min);
   g_free(s->max);
   g_free(s->enum_values);
+  g_free(s->shortdesc);
+  g_free(s->longdesc);
   g_free(s);
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2996,7 +2996,9 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
   int prefer_expanded = dt_conf_get_bool("accel/prefer_expanded") ? 8 : 0;
   int prefer_enabled = dt_conf_get_bool("accel/prefer_enabled") ? 4 : 0;
   int prefer_unmasked = dt_conf_get_bool("accel/prefer_unmasked") ? 2 : 0;
-  int prefer_first = strcmp(dt_conf_get_string("accel/select_order"), "first instance") == 0 ? 1 : 0;
+  gchar* select_order = dt_conf_get_string("accel/select_order");
+  int prefer_first = strcmp(select_order, "first instance") == 0 ? 1 : 0;
+  g_free(select_order);
 
   if(darktable.develop->gui_attached)
   {

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -138,7 +138,7 @@ static void default_commit_params(struct dt_iop_module_t *self, dt_iop_params_t 
 static void default_init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                               dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = malloc(self->params_size);
+  piece->data = calloc(1,self->params_size);
 }
 
 static void default_cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
@@ -211,8 +211,8 @@ void dt_iop_default_init(dt_iop_module_t *module)
 {
   size_t param_size = module->so->get_introspection()->size;
   module->params_size = param_size;
-  module->params = (dt_iop_params_t *)malloc(param_size);
-  module->default_params = (dt_iop_params_t *)malloc(param_size);
+  module->params = (dt_iop_params_t *)calloc(1, param_size);
+  module->default_params = (dt_iop_params_t *)calloc(1, param_size);
 
   module->default_enabled = 0;
   module->has_trouble = FALSE;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -300,7 +300,9 @@ static gboolean toggle_tooltip_visibility(GtkAccelGroup *accel_group, GObject *a
     dt_control_log(_("tooltip visibility can only be toggled if compositing is enabled in your window manager"));
   }
 
-  dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
+  gchar *theme = dt_conf_get_string("ui_last/theme");
+  dt_gui_load_theme(theme);
+  g_free(theme);
   dt_bauhaus_load_theme();
 
   return TRUE;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1555,6 +1555,11 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   /* start the event loop */
   gtk_main();
 
+  if (darktable.gui->surface)
+  {
+    cairo_surface_destroy(darktable.gui->surface);
+    darktable.gui->surface = NULL;
+  }
   dt_cleanup();
 }
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -189,6 +189,14 @@ static void load_themes(void)
   load_themes_dir(configdir);
 }
 
+static void reload_ui_last_theme(void)
+{
+  gchar *theme = dt_conf_get_string("ui_last/theme");
+  dt_gui_load_theme(theme);
+  g_free(theme);
+  dt_bauhaus_load_theme();
+}
+
 static void theme_callback(GtkWidget *widget, gpointer user_data)
 {
   const int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
@@ -202,15 +210,13 @@ static void theme_callback(GtkWidget *widget, gpointer user_data)
 static void usercss_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_conf_set_bool("themes/usercss", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-  dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
-  dt_bauhaus_load_theme();
+  reload_ui_last_theme();
 }
 
 static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_conf_set_float("font_size", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
-  dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
-  dt_bauhaus_load_theme();
+  reload_ui_last_theme();
 }
 
 static void use_performance_callback(GtkWidget *widget, gpointer user_data)
@@ -237,8 +243,7 @@ static void use_sys_font_callback(GtkWidget *widget, gpointer user_data)
   else
     gtk_widget_set_state_flags(GTK_WIDGET(user_data), GTK_STATE_FLAG_NORMAL, TRUE);
 
-  dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
-  dt_bauhaus_load_theme();
+  reload_ui_last_theme();
 }
 
 static void save_usercss(GtkTextBuffer *buffer)
@@ -274,8 +279,7 @@ static void save_usercss_callback(GtkWidget *widget, gpointer user_data)
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tw->apply_toggle)))
   {
     //reload the theme
-    dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
-    dt_bauhaus_load_theme();
+    reload_ui_last_theme();
   }
   else
   {

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3279,6 +3279,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_develop_ui_pipe_started_callback), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_develop_preview_pipe_finished_callback), self);
 
+  if(g->thumb_preview_buf) dt_free_align(g->thumb_preview_buf);
+  if(g->full_preview_buf) dt_free_align(g->full_preview_buf);
   if(g->desc) pango_font_description_free(g->desc);
   if(g->layout) g_object_unref(g->layout);
   if(g->cr) cairo_destroy(g->cr);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1835,13 +1835,15 @@ static void list_view(dt_lib_collect_rule_t *dr)
         // filmroll
         {
           gchar *order_by = NULL;
-          if(strcmp(dt_conf_get_string("plugins/collect/filmroll_sort"), "id") == 0)
+          gchar *filmroll_sort = dt_conf_get_string("plugins/collect/filmroll_sort");
+          if(strcmp(filmroll_sort, "id") == 0)
             order_by = g_strdup("film_rolls_id DESC");
           else
             if(dt_conf_get_bool("plugins/collect/descending"))
               order_by = g_strdup("folder DESC");
             else
               order_by = g_strdup("folder");
+          g_free(filmroll_sort);
 
           g_snprintf(query, sizeof(query),
                      "SELECT folder, film_rolls_id, COUNT(*) AS count"

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -526,11 +526,13 @@ void _print_size_update_display(dt_lib_export_t *self)
   }
   else
   {
-    if (strcmp(dt_conf_get_string(CONFIG_PREFIX "resizing"), "scaling") != 0)
+    gchar *resizing = dt_conf_get_string(CONFIG_PREFIX "resizing");
+    if (strcmp(resizing, "scaling") != 0)
     {
       // max size
       gtk_widget_set_visible(GTK_WIDGET(self->print_size), TRUE);
     }
+    g_free(resizing);
     gtk_widget_set_sensitive(GTK_WIDGET(self->width), FALSE);
     gtk_widget_set_sensitive(GTK_WIDGET(self->height), FALSE);
 
@@ -1408,7 +1410,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_no_show_all(self->widget, TRUE);
   _print_size_update_display(d);
 
-  if (strcmp(dt_conf_get_string(CONFIG_PREFIX "resizing"), "scaling") == 0)
+  gchar *resizing = dt_conf_get_string(CONFIG_PREFIX "resizing");
+  if (strcmp(resizing, "scaling") == 0)
   {
     // scaling
     gtk_widget_show(GTK_WIDGET(d->scale));
@@ -1422,6 +1425,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_show(GTK_WIDGET(d->hbox1));
     gtk_widget_show(GTK_WIDGET(d->print_size));
   }
+  g_free(resizing);
 
   d->metadata_export = NULL;
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -157,6 +157,7 @@ static void _update(dt_lib_module_t *self)
                             " WHERE id IN (%s)"
                             " GROUP BY key, value ORDER BY value",
                             images);
+    g_free(images);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
 
     while(sqlite3_step(stmt) == SQLITE_ROW)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -908,8 +908,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
       }
 
       /* lets show/hide modules dependent on current group*/
-      const gboolean show_deprecated
-          = !strcmp(dt_conf_get_string("plugins/darkroom/modulegroups_preset"), _(DEPRECATED_PRESET_NAME));
+      gchar *preset = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
+      const gboolean show_deprecated = !strcmp(preset, _(DEPRECATED_PRESET_NAME));
+      g_free(preset);
       gboolean show_module = TRUE;
       switch(d->current)
       {


### PR DESCRIPTION
Found some issues on running Valgrind while tracking down a bug earlier this week.  This PR fixes:

- uninitialized values in iop parameter struct
- un-freed image buffers on program exit
- leaked strings from dt_conf_get_string

There are still  lots and lots of un-freed small allocations from sqlite3 and gtk/pango.  Since Valgrind is so excruciatingly slow, I haven't run multiple images to see whether the amount goes up over time.
