### PR TITLE
Prevent colorpicker labels causing continuous resize loop

### DIFF
--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -69,8 +69,6 @@ void dtgtk_expander_set_expanded(GtkDarktableExpander *expander, gboolean expand
 
   if(expander->expanded != expanded)
   {
-    GtkWidget *widget = GTK_WIDGET(expander);
-
     expander->expanded = expanded;
 
     GtkWidget *frame = expander->body;
@@ -78,7 +76,6 @@ void dtgtk_expander_set_expanded(GtkDarktableExpander *expander, gboolean expand
     if(frame)
     {
       gtk_widget_set_visible(frame, expander->expanded);
-      gtk_widget_queue_resize(widget);
     }
   }
 }

--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -23,6 +23,11 @@
 
 G_DEFINE_TYPE(GtkDarktableSidePanel, dtgtk_side_panel, GTK_TYPE_BOX);
 
+static GtkSizeRequestMode dtgtk_side_panel_get_request_mode(GtkWidget *widget)
+{
+  return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+}
+
 static void dtgtk_side_panel_get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size)
 {
   GtkDarktableSidePanelClass *class = DTGTK_SIDE_PANEL_GET_CLASS(widget);
@@ -34,6 +39,7 @@ static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
 {
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(class);
 
+  widget_class->get_request_mode = dtgtk_side_panel_get_request_mode;
   widget_class->get_preferred_width = dtgtk_side_panel_get_preferred_width;
 
   class->width

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2302,18 +2302,6 @@ static GtkWidget *_ui_init_panel_container_bottom(GtkWidget *container)
   return w;
 }
 
-static void _panel_resize_callback(GtkWidget *w, GtkAllocation *allocation, void *user_data)
-{
-  GtkWidget *handle = (GtkWidget *)user_data;
-  if(strcmp(gtk_widget_get_name(handle), "panel-handle-bottom") == 0)
-  {
-    gtk_widget_set_size_request(handle, allocation->width, DT_PIXEL_APPLY_DPI(5));
-  }
-  else
-  {
-    gtk_widget_set_size_request(handle, DT_PIXEL_APPLY_DPI(5), allocation->height);
-  }
-}
 static gboolean _panel_handle_button_callback(GtkWidget *w, GdkEventButton *e, gpointer user_data)
 {
   if(e->button == 1)
@@ -2434,7 +2422,8 @@ static void _ui_init_panel_left(dt_ui_t *ui, GtkWidget *container)
   // we add a transparent overlay over the modules margins to resize the panel
   GtkWidget *handle = gtk_drawing_area_new();
   gtk_widget_set_halign(handle, GTK_ALIGN_END);
-  gtk_widget_set_valign(handle, GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(handle, GTK_ALIGN_FILL);
+  gtk_widget_set_size_request(handle, DT_PIXEL_APPLY_DPI(5), -1);
   gtk_overlay_add_overlay(GTK_OVERLAY(over), handle);
   gtk_widget_set_events(handle, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK
                                     | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
@@ -2444,7 +2433,6 @@ static void _ui_init_panel_left(dt_ui_t *ui, GtkWidget *container)
   g_signal_connect(G_OBJECT(handle), "motion-notify-event", G_CALLBACK(_panel_handle_motion_callback), widget);
   g_signal_connect(G_OBJECT(handle), "leave-notify-event", G_CALLBACK(_panel_handle_cursor_callback), handle);
   g_signal_connect(G_OBJECT(handle), "enter-notify-event", G_CALLBACK(_panel_handle_cursor_callback), handle);
-  g_signal_connect(G_OBJECT(widget), "size_allocate", G_CALLBACK(_panel_resize_callback), handle);
   gtk_widget_show(handle);
 
   gtk_grid_attach(GTK_GRID(container), over, 1, 1, 1, 1);
@@ -2474,7 +2462,8 @@ static void _ui_init_panel_right(dt_ui_t *ui, GtkWidget *container)
   // we add a transparent overlay over the modules margins to resize the panel
   GtkWidget *handle = gtk_drawing_area_new();
   gtk_widget_set_halign(handle, GTK_ALIGN_START);
-  gtk_widget_set_valign(handle, GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(handle, GTK_ALIGN_FILL);
+  gtk_widget_set_size_request(handle, DT_PIXEL_APPLY_DPI(5), -1);
   gtk_overlay_add_overlay(GTK_OVERLAY(over), handle);
   gtk_widget_set_events(handle, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK
                                     | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
@@ -2484,7 +2473,6 @@ static void _ui_init_panel_right(dt_ui_t *ui, GtkWidget *container)
   g_signal_connect(G_OBJECT(handle), "motion-notify-event", G_CALLBACK(_panel_handle_motion_callback), widget);
   g_signal_connect(G_OBJECT(handle), "leave-notify-event", G_CALLBACK(_panel_handle_cursor_callback), handle);
   g_signal_connect(G_OBJECT(handle), "enter-notify-event", G_CALLBACK(_panel_handle_cursor_callback), handle);
-  g_signal_connect(G_OBJECT(widget), "size_allocate", G_CALLBACK(_panel_resize_callback), handle);
   gtk_widget_show(handle);
 
   gtk_grid_attach(GTK_GRID(container), over, 3, 1, 1, 1);
@@ -2539,8 +2527,9 @@ static void _ui_init_panel_bottom(dt_ui_t *ui, GtkWidget *container)
   gtk_container_add(GTK_CONTAINER(over), widget);
   // we add a transparent overlay over the modules margins to resize the panel
   GtkWidget *handle = gtk_drawing_area_new();
-  gtk_widget_set_halign(handle, GTK_ALIGN_CENTER);
+  gtk_widget_set_halign(handle, GTK_ALIGN_FILL);
   gtk_widget_set_valign(handle, GTK_ALIGN_START);
+  gtk_widget_set_size_request(handle, -1, DT_PIXEL_APPLY_DPI(5));
   gtk_overlay_add_overlay(GTK_OVERLAY(over), handle);
   gtk_widget_set_events(handle, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK
                                     | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
@@ -2550,7 +2539,6 @@ static void _ui_init_panel_bottom(dt_ui_t *ui, GtkWidget *container)
   g_signal_connect(G_OBJECT(handle), "motion-notify-event", G_CALLBACK(_panel_handle_motion_callback), widget);
   g_signal_connect(G_OBJECT(handle), "leave-notify-event", G_CALLBACK(_panel_handle_cursor_callback), handle);
   g_signal_connect(G_OBJECT(handle), "enter-notify-event", G_CALLBACK(_panel_handle_cursor_callback), handle);
-  g_signal_connect(G_OBJECT(widget), "size_allocate", G_CALLBACK(_panel_resize_callback), handle);
   gtk_widget_show(handle);
 
   gtk_grid_attach(GTK_GRID(container), over, 1, 2, 3, 1);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -227,8 +227,8 @@ static void _update_sample_label(dt_colorpicker_sample_t *sample)
       break;
   }
 
-  gtk_label_set_text(GTK_LABEL(sample->output_label), text);
-
+  if(g_strcmp0(gtk_label_get_text(GTK_LABEL(sample->output_label)), text))
+    gtk_label_set_text(GTK_LABEL(sample->output_label), text);
   gtk_widget_queue_draw(sample->color_patch);
 }
 


### PR DESCRIPTION
fixes #7631

As @flannelhead figured out, updating the sample labels in the color picker module causes a continuous loop of resizes and when a button pop-up menu is visible at the same time this causes significant CPU. But to a lesser extent any time the color picker module is expanded. The solution he came up with is to only update the GtkLabel text when it actually changes and this works perfectly.

I'm still mystified why the label resize request gets escalated all the way to the top level window. My expectation would be that since the panel is fixed size, the resize cascade stops there, but this is not the case.

I played a little with GTK_DEBUG=resize,geometry but this didn't really give me a good clue to what is going on (or whether this is normal/necessary). I did make a few other changes and simplifications that should reduce the number of superfluous resizes a little, but I'm still wondering if something can be done to make, for example, pulling the panel's resize handles work more smoothly.