### PR TITLE
show export lib in darkroom

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1452,7 +1452,14 @@
     <name>plugins/darkroom/tagging/visible</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription/>
+    <shortdescription>show the tagging module in the darkroom view (as well as in lighttable)</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/export/visible</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show the export module in the darkroom view (as well as in lighttable)</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig prefs="security">


### PR DESCRIPTION
fixes #6621

This simply applies the same approach that was used for the tagging module to the export module; there's a setting that tells whether it should also be visible in the darkroom. This works, but/and it only exports the currently edited image, independent of how many are selected in the filmstrip. This may or may not be what we want, hence my RFC.

Also, currently there is a dedicated CTRL-E shortcut for the darkroom which picks up all export settings (from the _lighttable/export_ module) and applies them to the current image. This clashes with the CTRL-E shortcut in the export module so we'd have to special case if the module was there. Basically, I'm wondering how many people would _want_ to be able to export from darkroom but would _definitely not_ want to have the export module there. Just from the perspective of code (and UI logic) simplicity, could we just support either full export or no export functionality in darkroom?

For the record, my personal position on this is that I would want any module in any view where its functionality is useful and not duplicating local functionality. Collapsing a module and never expanding it is easier than having to switch to a different view. I'm thinking of metadata editor in darkroom as well.

I've also renamed the module to just "export" rather than "export selected". Most other modules also work on the selected items but don't have that in their name. And this has a pleasing symmetry with the import module (which is exactly on the opposite side of the lighttable).

Update for final version:
- activate full export module in darkroom (if plugins/darkroom/export/visible=TRUE)
- remove CTRL-E shortcut in darkroom (that always used current settings from lighttable, but now would clash with the full module's export button)
- rename module from "export selected" to just "export"