### PR TITLE
Fix colorin legacy_params() versioning

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -192,7 +192,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 {
 #define DT_IOP_COLOR_ICC_LEN_V5 100
 
-  if(old_version == 1 && new_version == 6)
+  if(old_version == 1 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v1_t
     {
@@ -243,7 +243,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->filename_work[0] = '\0';
     return 0;
   }
-  if(old_version == 2 && new_version == 6)
+  if(old_version == 2 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v2_t
     {
@@ -295,7 +295,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->filename_work[0] = '\0';
     return 0;
   }
-  if(old_version == 3 && new_version == 6)
+  if(old_version == 3 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v3_t
     {
@@ -349,7 +349,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 
     return 0;
   }
-  if(old_version == 4 && new_version == 6)
+  if(old_version == 4 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v4_t
     {
@@ -374,7 +374,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 
     return 0;
   }
-  if(old_version == 5 && new_version == 6)
+  if(old_version == 5 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v5_t
     {


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/8112.

Commit adc61a64273165c4ba18ecf05e7fab769db2c605 bumped the current version from 6 to 7 but missed bumping the version in older migration paths.

Sorry about that! Luckily the fix is easy as the older parameter versions didn't have a selectable working profile, and the default linear Rec709 is sane here. Version 7 of the params didn't actually introduce any changes in the param struct so we are fine just bumping the `new_version` in the migration paths.