### PR TITLE
flip/borders/rawprepare: distort_transform speedup

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -220,10 +220,13 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   const int border_size_t = border_tot_height * d->pos_v;
   const int border_size_l = border_tot_width * d->pos_h;
 
+  // nothing to be done if parameters are set to neutral values (no top/left border)
+  if (border_size_l == 0 && border_size_t == 0) return 1;
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(points, points_count, border_size_l, border_size_t)  \
-  schedule(static)
+  schedule(static) if(points_count > 100)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -243,10 +246,13 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   const int border_size_t = border_tot_height * d->pos_v;
   const int border_size_l = border_tot_width * d->pos_h;
 
+  // nothing to be done if parameters are set to neutral values (no top/left border)
+  if (border_size_l == 0 && border_size_t == 0) return 1;
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(points, points_count, border_size_l, border_size_t)  \
-  schedule(static)
+  schedule(static) if(points_count > 100)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -194,12 +194,13 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   // if (!self->enabled) return 2;
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
-  float x, y;
+  // nothing to be done if parameters are set to neutral values (no flip or swap)
+  if (d->orientation == 0) return 1;
 
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
-    x = points[i];
-    y = points[i + 1];
+    float x = points[i];
+    float y = points[i + 1];
     if(d->orientation & ORIENTATION_FLIP_X) x = piece->buf_in.width - points[i];
     if(d->orientation & ORIENTATION_FLIP_Y) y = piece->buf_in.height - points[i + 1];
     if(d->orientation & ORIENTATION_SWAP_XY)
@@ -220,10 +221,12 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   // if (!self->enabled) return 2;
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
-  float x, y;
+  // nothing to be done if parameters are set to neutral values (no flip or swap)
+  if (d->orientation == 0) return 1;
 
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
+    float x, y;
     if(d->orientation & ORIENTATION_SWAP_XY)
     {
       y = points[i];

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -155,6 +155,9 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
 {
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
+  // nothing to be done if parameters are set to neutral values (no top/left crop)
+  if (d->x == 0 && d->y == 0) return 1;
+
   const float scale = piece->buf_in.scale / piece->iscale;
 
   const float x = (float)d->x * scale, y = (float)d->y * scale;
@@ -172,6 +175,9 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
                           size_t points_count)
 {
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
+
+  // nothing to be done if parameters are set to neutral values (no top/left crop)
+  if (d->x == 0 && d->y == 0) return 1;
 
   const float scale = piece->buf_in.scale / piece->iscale;
 


### PR DESCRIPTION
Found this branch still lying around....

Add early exit if there is no active distortion, plus some cleanup.  These iops don't have heavy-weight computation for determining the pixel distortion, so speedup is actually minimal.  But it brings them in line with other iops that have early exits.

Also skip parallelization if there are only a small number of points whose distortion needs to be computed.  The threshold could probably be increased quite a bit, given the relative overhead of thread management compared to the simple distortion arithmetic, but I was being conservative.

