### PR TITLE
optimize GList usage: remove superfluous g_list_length, g_list_nth_data calls

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -252,7 +252,7 @@ static gpointer _camera_get_job(const dt_camctl_t *c, const dt_camera_t *camera)
   gpointer job = NULL;
   if(cam->jobqueue) // are there any queued jobs?
   {
-    job = g_list_nth_data(cam->jobqueue, 0);
+    job = cam->jobqueue->data;
     cam->jobqueue = g_list_remove(cam->jobqueue, job);
   }
   dt_pthread_mutex_unlock(&cam->jobqueue_lock);
@@ -1240,7 +1240,7 @@ int dt_camctl_can_enter_tether_mode(const dt_camctl_t *c, const dt_camera_t *cam
   if(cam == NULL) cam = c->active_camera;
 
   /* check if active cam is available else use first detected one */
-  if(cam == NULL && c->cameras) cam = g_list_nth_data(c->cameras, 0);
+  if(cam == NULL && c->cameras) cam = c->cameras->data;
 
   if(cam && cam->can_tether)
   {
@@ -1261,7 +1261,7 @@ void dt_camctl_tether_mode(const dt_camctl_t *c, const dt_camera_t *cam, gboolea
   if(cam == NULL) cam = c->active_camera;
 
   /* check if active cam is available else use first detected one */
-  if(cam == NULL && c->cameras) cam = g_list_nth_data(c->cameras, 0);
+  if(cam == NULL && c->cameras) cam = c->cameras->data;
 
   if(cam && cam->can_tether)
   {

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -250,7 +250,7 @@ static gpointer _camera_get_job(const dt_camctl_t *c, const dt_camera_t *camera)
   dt_camera_t *cam = (dt_camera_t *)camera;
   dt_pthread_mutex_lock(&cam->jobqueue_lock);
   gpointer job = NULL;
-  if(g_list_length(cam->jobqueue) > 0)
+  if(cam->jobqueue) // are there any queued jobs?
   {
     job = g_list_nth_data(cam->jobqueue, 0);
     cam->jobqueue = g_list_remove(cam->jobqueue, job);
@@ -666,12 +666,12 @@ void dt_camctl_destroy(dt_camctl_t *camctl)
 
 gboolean dt_camctl_have_cameras(const dt_camctl_t *c)
 {
-  return (g_list_length(c->cameras) > 0) ? TRUE : FALSE;
+  return (c->cameras) ? TRUE : FALSE;
 }
 
 gboolean dt_camctl_have_locked_cameras(const dt_camctl_t *c)
 {
-  return (g_list_length(c->locked_cameras) > 0) ? TRUE : FALSE;
+  return (c->locked_cameras) ? TRUE : FALSE;
 }
 
 void dt_camctl_register_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener)

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2002,7 +2002,7 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
   int next = -1;
   if(!collection->clone)
   {
-    if(g_list_length(list) > 0)
+    if(list)
     {
       // for changing offsets, thumbtable needs to know the first untouched imageid after the list
       // we do this here

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1662,7 +1662,8 @@ gboolean dt_history_copy_parts(int imgid)
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo)
 {
   if(darktable.view_manager->copy_paste.copied_imageid <= 0) return FALSE;
-  if(g_list_length((GList *)list) < 1) return FALSE;
+  if(!list) // do we have any images to receive the pasted history?
+    return FALSE;
 
   const int mode = dt_conf_get_int("plugins/lighttable/copy_history/pastemode");
   gboolean merge = FALSE;
@@ -1687,7 +1688,8 @@ gboolean dt_history_paste_on_list(const GList *list, gboolean undo)
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo)
 {
   if(darktable.view_manager->copy_paste.copied_imageid <= 0) return FALSE;
-  if(g_list_length((GList *)list) < 1) return FALSE;
+  if(!list) // do we have any images to receive the pasted history?
+    return FALSE;
 
   const int mode = dt_conf_get_int("plugins/lighttable/copy_history/pastemode");
   gboolean merge = FALSE;
@@ -1728,7 +1730,8 @@ gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo)
 
 gboolean dt_history_delete_on_list(const GList *list, gboolean undo)
 {
-  if(g_list_length((GList *)list) < 1) return FALSE;
+  if(!list)  // do we have any images on which to operate?
+    return FALSE;
 
   if(undo) dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
 

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -316,7 +316,7 @@ static void  _dt_style_update_iop_order(const gchar *name, const int id, const i
   // if we update or if the style does not contains an order then the
   // copy must be done using the imgid iop-order.
 
-  if(update_iop_order || g_list_length(iop_list) == 0)
+  if(update_iop_order || iop_list == NULL)
     iop_list = dt_ioppr_get_iop_order_list(imgid, FALSE);
 
   gchar *iop_list_txt = dt_ioppr_serialize_text_iop_order_list(iop_list);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -286,11 +286,12 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
   const int32_t imgid = dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE, TRUE);
   dt_control_queue_redraw_center();
   gchar *basename = g_path_get_basename(filename);
+  const int num_images = g_list_length(t->images);
   dt_control_log(ngettext("%d/%d imported to %s", "%d/%d imported to %s", t->import_count + 1),
-                 t->import_count + 1, g_list_length(t->images), basename);
+                 t->import_count + 1, num_images, basename);
   g_free(basename);
 
-  t->fraction += 1.0 / g_list_length(t->images);
+  t->fraction += 1.0 / num_images;
 
   dt_control_job_set_progress(t->job, t->fraction);
 
@@ -299,7 +300,7 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
   }
 
-  if(t->import_count + 1 == g_list_length(t->images))
+  if(t->import_count + 1 == num_images)
   {
     // only redraw at the end, to not spam the cpu with exposure events
     dt_control_queue_redraw_center();

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -141,7 +141,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   /* first of all gather all images to import */
   GList *images = NULL;
   images = _film_recursive_get_files(film->dirname, recursive, &images);
-  if(g_list_length(images) == 0)
+  if(images == NULL)
   {
     dt_control_log(_("no supported images were found to be imported"));
     return;
@@ -184,7 +184,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   dt_lua_unlock();
 #endif
 
-  if(g_list_length(images) == 0)
+  if(images == NULL)
   {
     // no error message, lua probably emptied the list on purpose
     return;

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -63,7 +63,7 @@ static GType geotag_arg[] = { G_TYPE_POINTER, G_TYPE_UINT };
 static void _collection_changed_destroy_callback(gpointer instance, int query_change, gpointer imgs,
                                                  const int next, gpointer user_data)
 {
-  if(imgs && g_list_length(imgs) > 0)
+  if(imgs)
   {
     g_list_free(imgs);
     imgs = NULL;
@@ -73,7 +73,7 @@ static void _collection_changed_destroy_callback(gpointer instance, int query_ch
 // callback for the destructor of DT_SIGNAL_IMAGE_INFO_CHANGED
 static void _image_info_changed_destroy_callback(gpointer instance, gpointer imgs, gpointer user_data)
 {
-  if(imgs && g_list_length(imgs) > 0)
+  if(imgs)
   {
     g_list_free(imgs);
     imgs = NULL;
@@ -89,7 +89,7 @@ static void _presets_changed_destroy_callback(gpointer instance, gpointer module
 // callback for the destructor of DT_SIGNAL_GEOTAG_CHANGED
 static void _image_geotag_destroy_callback(gpointer instance, gpointer imgs, const int locid, gpointer user_data)
 {
-  if(imgs && g_list_length(imgs) > 0)
+  if(imgs)
   {
     g_list_free(imgs);
     imgs = NULL;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1276,7 +1276,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     dt_iop_color_picker_reset(self, FALSE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
-    if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+    if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
       const int control_button_pressed = event->state & GDK_CONTROL_MASK;
 
@@ -2109,7 +2109,7 @@ void dt_iop_gui_update_masks(dt_iop_module_t *module)
   /* update masks state */
   dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, module->blend_params->mask_id);
   dt_bauhaus_combobox_clear(bd->masks_combo);
-  if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+  if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
   {
     char txt[512];
     const guint n = g_list_length(grp->points);
@@ -2940,7 +2940,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     //box enclosing the mask mode selection buttons
     bd->masks_modes_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
     //mask selection buttons packing in mask_box
-    for (int i = 0; i < g_list_length(bd->masks_modes_toggles); i++)
+    const int ntoggles = g_list_length(bd->masks_modes_toggles);
+    for (int i = 0; i < ntoggles; i++)
       gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, i)), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(presets_button), FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2940,9 +2940,10 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     //box enclosing the mask mode selection buttons
     bd->masks_modes_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
     //mask selection buttons packing in mask_box
-    const int ntoggles = g_list_length(bd->masks_modes_toggles);
-    for (int i = 0; i < ntoggles; i++)
-      gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, i)), TRUE, TRUE, 0);
+    for(GList *l = bd->masks_modes_toggles; l; l = g_list_next(l))
+    {
+      gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(l->data), TRUE, TRUE, 0);
+    }
     gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(presets_button), FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);
     dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_box), "blending.html");

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1126,7 +1126,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
       // we have to ensure that the name of the widget is correct
       GtkWidget *wlabel;
       GList *childs = gtk_container_get_children(GTK_CONTAINER(module->expander));
-      GtkWidget *header = gtk_bin_get_child(GTK_BIN(g_list_nth_data(childs, 0)));
+      GtkWidget *header = gtk_bin_get_child(GTK_BIN(childs->data));
       g_list_free(childs);
 
       childs = gtk_container_get_children(GTK_CONTAINER(header));

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -252,13 +252,13 @@ static void _brush_catmull_to_bezier(float x1, float y1, float x2, float y2, flo
 /** initialise all control points to eventually match a catmull-rom like spline */
 static void _brush_init_ctrl_points(dt_masks_form_t *form)
 {
-  // if we have less that 2 points, what to do ??
-  if(g_list_length(form->points) < 2) return;
+  // if we have less than 2 points, what to do ??
+  const guint nb = g_list_length(form->points);
+  if(nb < 2) return;
 
   // we need extra points to deal with curve ends
   dt_masks_point_brush_t start_point[2], end_point[2];
 
-  const guint nb = g_list_length(form->points);
   for(int k = 0; k < nb; k++)
   {
     dt_masks_point_brush_t *point3 = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -629,8 +629,7 @@ static int dt_group_get_mask_roi(dt_iop_module_t *const restrict module,
                                  float *const restrict buffer)
 {
   double start = dt_get_wtime();
-  const guint nb = g_list_length(form->points);
-  if(nb == 0) return 0;
+  if(!form->points) return 0;
   int nb_ok = 0;
 
   const int width = roi->width;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -410,13 +410,14 @@ void dt_masks_init_form_gui(dt_masks_form_gui_t *gui)
 
 void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index)
 {
-  if(g_list_length(gui->points) == index)
+  const int npoints = g_list_length(gui->points);
+  if(npoints == index)
   {
     dt_masks_form_gui_points_t *gpt2
         = (dt_masks_form_gui_points_t *)calloc(1, sizeof(dt_masks_form_gui_points_t));
     gui->points = g_list_append(gui->points, gpt2);
   }
-  else if(g_list_length(gui->points) < index)
+  else if(npoints < index)
     return;
 
   dt_masks_gui_form_remove(form, gui, index);
@@ -611,7 +612,7 @@ void dt_masks_gui_form_save_creation(dt_develop_t *dev, dt_iop_module_t *module,
     grpt->formid = form->formid;
     grpt->parentid = grp->formid;
     grpt->state = DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE;
-    if(g_list_length(grp->points) > 0) grpt->state |= DT_MASKS_STATE_UNION;
+    if(grp->points) grpt->state |= DT_MASKS_STATE_UNION;
     grpt->opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
     grp->points = g_list_append(grp->points, grpt);
     // we save the group
@@ -2402,7 +2403,7 @@ void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, 
       dt_masks_iop_update(module);
       dt_masks_update_image(darktable.develop);
     }
-    if(ok && g_list_length(grp->points) == 0) dt_masks_form_remove(module, NULL, grp);
+    if(ok && grp->points == NULL) dt_masks_form_remove(module, NULL, grp);
     return;
   }
 
@@ -2460,7 +2461,7 @@ void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, 
             form_removed = 1;
             dt_masks_iop_update(m);
             dt_masks_update_image(darktable.develop);
-            if(g_list_length(iopgrp->points) == 0) dt_masks_form_remove(m, NULL, iopgrp);
+            if(iopgrp->points == NULL) dt_masks_form_remove(m, NULL, iopgrp);
           }
         }
       }
@@ -2582,7 +2583,7 @@ dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_f
     grpt->formid = form->formid;
     grpt->parentid = grp->formid;
     grpt->state = DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE;
-    if(g_list_length(grp->points) > 0) grpt->state |= DT_MASKS_STATE_UNION;
+    if(grp->points) grpt->state |= DT_MASKS_STATE_UNION;
     grpt->opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
     grp->points = g_list_append(grp->points, grpt);
     return grpt;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -119,9 +119,9 @@ static void _path_catmull_to_bezier(float x1, float y1, float x2, float y2, floa
 static void _path_init_ctrl_points(dt_masks_form_t *form)
 {
   // if we have less that 3 points, what to do ??
-  if(g_list_length(form->points) < 2) return;
-
   const guint nb = g_list_length(form->points);
+  if(nb < 2) return;
+
   for(int k = 0; k < nb; k++)
   {
     dt_masks_point_path_t *point3 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
@@ -160,10 +160,10 @@ static void _path_init_ctrl_points(dt_masks_form_t *form)
 
 static gboolean _path_is_clockwise(dt_masks_form_t *form)
 {
-  if(g_list_length(form->points) > 2)
+  const guint nb = g_list_length(form->points);
+  if(nb > 2)
   {
     float sum = 0.0f;
-    const guint nb = g_list_length(form->points);
     for(int k = 0; k < nb; k++)
     {
       const int k2 = (k + 1) % nb;
@@ -1035,7 +1035,7 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
   else
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/path/border"), 0.5f);
 
-  if(gui->creation && which == 1 && g_list_length(form->points) == 0
+  if(gui->creation && which == 1 && form->points == NULL
      && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
          || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
   {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -122,9 +122,10 @@ static void _path_init_ctrl_points(dt_masks_form_t *form)
   const guint nb = g_list_length(form->points);
   if(nb < 2) return;
 
+  const GList *form_points = form->points;
   for(int k = 0; k < nb; k++)
   {
-    dt_masks_point_path_t *point3 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+    dt_masks_point_path_t *point3 = (dt_masks_point_path_t *)form_points->data;
     // if the point as not be set manually, we redfine it
     if(point3->state & DT_MASKS_POINT_STATE_NORMAL)
     {
@@ -155,6 +156,8 @@ static void _path_init_ctrl_points(dt_masks_form_t *form)
       point3->ctrl2[0] = bx1;
       point3->ctrl2[1] = by1;
     }
+    // keep form_points tracking the kth element of form->points
+    form_points = g_list_next(form_points);
   }
 }
 
@@ -164,13 +167,16 @@ static gboolean _path_is_clockwise(dt_masks_form_t *form)
   if(nb > 2)
   {
     float sum = 0.0f;
+    const GList *form_points = form->points;
     for(int k = 0; k < nb; k++)
     {
       const int k2 = (k + 1) % nb;
-      dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+      dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
       dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k2);
       // edge k
       sum += (point2->corner[0] - point1->corner[0]) * (point2->corner[1] + point1->corner[1]);
+      // keep form_points tracking the kth element of form->points
+      form_points = g_list_next(form_points);
     }
     return (sum < 0);
   }
@@ -547,13 +553,13 @@ static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, con
 
   if(source && nb > 0)
   {
-    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)g_list_nth_data(form->points, 0);
+    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)form->points->data;
     dx = (pt->corner[0] - form->source[0]) * wd;
     dy = (pt->corner[1] - form->source[1]) * ht;
   }
-  for(int k = 0; k < nb; k++)
+  for(const GList *l = form->points; l; l = g_list_next(l))
   {
-    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)l->data;
     dt_masks_dynbuf_add(dpoints, pt->ctrl1[0] * wd - dx);
     dt_masks_dynbuf_add(dpoints, pt->ctrl1[1] * ht - dy);
     dt_masks_dynbuf_add(dpoints, pt->corner[0] * wd - dx);
@@ -587,13 +593,14 @@ static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, con
   }
 
   // we render all segments
+  const GList *form_points = form->points;
   for(int k = 0; k < nb; k++)
   {
     int pb = dborder ? dt_masks_dynbuf_position(dborder) : 0;
     border_init[k * 6 + 2] = -pb;
     int k2 = (k + 1) % nb;
     int k3 = (k + 2) % nb;
-    dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+    dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
     dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k2);
     dt_masks_point_path_t *point3 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k3);
     float p1[5] = { point1->corner[0] * wd - dx, point1->corner[1] * ht - dy, point1->ctrl2[0] * wd - dx,
@@ -604,6 +611,9 @@ static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, con
                     point2->ctrl2[1] * ht - dy, cw * point2->border[1] * MIN(wd, ht) };
     float p4[5] = { point3->corner[0] * wd - dx, point3->corner[1] * ht - dy, point3->ctrl1[0] * wd - dx,
                     point3->ctrl1[1] * ht - dy, cw * point3->border[0] * MIN(wd, ht) };
+
+    // advance form_points for next iteration so that it tracks the kth element of form->points
+    form_points = g_list_next(form_points);
 
     // and we determine all points by recursion (to be sure the distance between 2 points is <=1)
     float rc[2] = { 0 }, rb[2] = { 0 };
@@ -911,7 +921,6 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
     else
     {
       const float amount = up ? 0.97f : 1.03f;
-      guint nb = g_list_length(form->points);
       // resize don't care where the mouse is inside a shape
       if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
@@ -919,14 +928,14 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         _path_get_sizes(module, form, gui, index, &masks_size, &feather_size);
 
         // do not exceed upper limit of 1.0
-        for(int k = 0; k < nb; k++)
+        for(const GList *l = form->points; l; l = g_list_next(l))
         {
-          dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+          const dt_masks_point_path_t *point = (dt_masks_point_path_t *)l->data;
           if(amount > 1.0f && (point->border[0] > 1.0f || point->border[1] > 1.0f)) return 1;
         }
-        for(int k = 0; k < nb; k++)
+        for(const GList *l = form->points; l; l = g_list_next(l))
         {
-          dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+          dt_masks_point_path_t *point = (dt_masks_point_path_t *)l->data;
           point->border[0] *= amount;
           point->border[1] *= amount;
         }
@@ -952,10 +961,12 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         float by = 0.0f;
         float surf = 0.0f;
 
+        guint nb = g_list_length(form->points);
+        const GList *form_points = form->points;
         for(int k = 0; k < nb; k++)
         {
           int k2 = (k + 1) % nb;
-          dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+          dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
           dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k2);
           surf += point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1];
 
@@ -963,6 +974,7 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
                 * (point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1]);
           by += (point1->corner[1] + point2->corner[1])
                 * (point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1]);
+          form_points = g_list_next(form_points);
         }
         bx /= 3.0f * surf;
         by /= 3.0f * surf;
@@ -971,9 +983,9 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         if(amount > 1.0f && surf > 4.0f) return 1;
 
         // now we move each point
-        for(int k = 0; k < nb; k++)
+        for(GList *l = form->points; l; l = g_list_next(l))
         {
-          dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+          dt_masks_point_path_t *point = (dt_masks_point_path_t *)l->data;
           const float x = (point->corner[0] - bx) * amount;
           const float y = (point->corner[1] - by) * amount;
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1074,7 +1074,7 @@ void dt_culling_init(dt_culling_t *table, int offset)
 
 static void _thumbs_prefetch(dt_culling_t *table)
 {
-  if(!table || !table->list) return;
+  if(!table->list) return;
 
   // get the mip level by using the max image size actually shown
   int maxw = 0;
@@ -1355,7 +1355,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
 static gboolean _thumbs_compute_positions(dt_culling_t *table)
 {
   if(!gtk_widget_get_visible(table->widget)) return FALSE;
-  if(!table->list || !table->list) return FALSE;
+  if(!table->list) return FALSE;
 
   // if we have only 1 image, it should take the entire screen
   if(g_list_length(table->list) == 1)

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -121,7 +121,7 @@ static gboolean _compute_sizes(dt_culling_t *table, gboolean force)
   // check the offset
   if(table->list)
   {
-    dt_thumbnail_t *th = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+    dt_thumbnail_t *th = (dt_thumbnail_t *)table->list->data;
     if(th->imgid != table->offset_imgid) ret = TRUE;
   }
 
@@ -467,7 +467,7 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table, const float zoom_delta, co
   else if(table->list)
   {
     // FULL PREVIEW or CULLING with 1 image
-    dt_thumbnail_t *th = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+    dt_thumbnail_t *th = (dt_thumbnail_t *)table->list->data;
     if(_zoom_to_x_root(th, x_root, y_root, zoom_delta))
       _set_table_zoom_ratio(table, th);
   }
@@ -1345,7 +1345,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
   // and we ensure that we have the right offset
   if(table->list)
   {
-    dt_thumbnail_t *thumb = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+    dt_thumbnail_t *thumb = (dt_thumbnail_t *)table->list->data;
     table->offset_imgid = thumb->imgid;
     table->offset = _thumb_get_rowid(thumb->imgid);
   }
@@ -1360,7 +1360,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   // if we have only 1 image, it should take the entire screen
   if(g_list_length(table->list) == 1)
   {
-    dt_thumbnail_t *thumb = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+    dt_thumbnail_t *thumb = (dt_thumbnail_t *)table->list->data;
     thumb->width = table->view_width;
     thumb->height = table->view_height;
     thumb->x = 0;
@@ -1592,7 +1592,7 @@ void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
   int old_margin_y = 0;
   if(table->list)
   {
-    dt_thumbnail_t *thumb = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+    dt_thumbnail_t *thumb = (dt_thumbnail_t *)table->list->data;
     old_zx = thumb->zoomx;
     old_zy = thumb->zoomy;
     old_margin_x = gtk_widget_get_margin_start(thumb->w_image_box);
@@ -1685,9 +1685,9 @@ void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
       }
       l = g_list_next(l);
     }
-    if(!in_list && table->list && table->list)
+    if(!in_list && table->list)
     {
-      dt_thumbnail_t *thumb = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+      dt_thumbnail_t *thumb = (dt_thumbnail_t *)table->list->data;
       dt_control_set_mouse_over_id(thumb->imgid);
     }
   }
@@ -1746,7 +1746,7 @@ void dt_culling_zoom_max(dt_culling_t *table)
   float y = 0;
   if(table->mode == DT_CULLING_MODE_PREVIEW && table->list)
   {
-    dt_thumbnail_t *th = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+    dt_thumbnail_t *th = (dt_thumbnail_t *)table->list->data;
     x = gtk_widget_get_allocated_width(th->w_image_box) / 2.0;
     y = gtk_widget_get_allocated_height(th->w_image_box) / 2.0;
   }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -497,7 +497,7 @@ static int _thumbs_remove_unneeded(dt_thumbtable_t *table)
 // needed == that should appear in the current view (possibly not entirely)
 static int _thumbs_load_needed(dt_thumbtable_t *table)
 {
-  if(g_list_length(table->list) == 0) return 0;
+  if(!table->list) return 0;
   sqlite3_stmt *stmt;
   int changed = 0;
 
@@ -600,7 +600,7 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
 // if clamp, we verify that the move is allowed (collection bounds, etc...)
 static gboolean _move(dt_thumbtable_t *table, const int x, const int y, gboolean clamp)
 {
-  if(!table->list || g_list_length(table->list) == 0) return FALSE;
+  if(!table->list) return FALSE;
   int posx = x;
   int posy = y;
   if(clamp)
@@ -876,7 +876,7 @@ static void _filemanager_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
 void dt_thumbtable_zoom_changed(dt_thumbtable_t *table, const int oldzoom, const int newzoom)
 {
   if(oldzoom == newzoom) return;
-  if(!table->list || g_list_length(table->list) == 0) return;
+  if(!table || !table->list) return;
 
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
   {
@@ -1822,7 +1822,7 @@ dt_thumbtable_t *dt_thumbtable_new()
 
 void dt_thumbtable_scrollbar_changed(dt_thumbtable_t *table, const int x, const int y)
 {
-  if(g_list_length(table->list) == 0 || table->code_scrolling || !table->scrollbars) return;
+  if(!table->list || table->code_scrolling || !table->scrollbars) return;
 
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
   {
@@ -1921,7 +1921,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
     // we store image margin from frist thumb to apply to new ones and limit flickering
     int old_margin_start = 0;
     int old_margin_top = 0;
-    if(g_list_length(table->list) > 0)
+    if(table->list)
     {
       dt_thumbnail_t *first = (dt_thumbnail_t *)g_list_first(table->list)->data;
       old_margin_start = gtk_widget_get_margin_start(first->w_image_box);
@@ -2465,7 +2465,7 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, const int vi
 static gboolean _filemanager_ensure_rowid_visibility(dt_thumbtable_t *table, int rowid)
 {
   if(rowid < 1) rowid = 1;
-  if(!table->list || g_list_length(table->list) == 0) return FALSE;
+  if(!table || !table->list) return FALSE;
   // get first and last fully visible thumbnails
   dt_thumbnail_t *first = (dt_thumbnail_t *)g_list_first(table->list)->data;
   const int pos = MIN(g_list_length(table->list) - 1, table->thumbs_per_row * (table->rows - 1) - 1);
@@ -2492,7 +2492,7 @@ static gboolean _filemanager_ensure_rowid_visibility(dt_thumbtable_t *table, int
 static gboolean _zoomable_ensure_rowid_visibility(dt_thumbtable_t *table, const int rowid)
 {
   if(rowid < 1) return FALSE;
-  if(!table->list || g_list_length(table->list) == 0) return FALSE;
+  if(!table || !table->list) return FALSE;
 
   int minrowid = 0;
   int maxrowid = 0;
@@ -2569,7 +2569,7 @@ gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, const int
 static gboolean _filemanager_check_rowid_visibility(dt_thumbtable_t *table, const int rowid)
 {
   if(rowid < 1) return FALSE;
-  if(!table->list || g_list_length(table->list) == 0) return FALSE;
+  if(!table || !table->list) return FALSE;
   // get first and last fully visible thumbnails
   dt_thumbnail_t *first = (dt_thumbnail_t *)g_list_first(table->list)->data;
   const int pos = MIN(g_list_length(table->list) - 1, table->thumbs_per_row * (table->rows - 1) - 1);
@@ -2578,10 +2578,11 @@ static gboolean _filemanager_check_rowid_visibility(dt_thumbtable_t *table, cons
   if(first->rowid <= rowid && last->rowid >= rowid) return TRUE;
   return FALSE;
 }
+
 static gboolean _zoomable_check_rowid_visibility(dt_thumbtable_t *table, const int rowid)
 {
   if(rowid < 1) return FALSE;
-  if(!table->list || g_list_length(table->list) == 0) return FALSE;
+  if(!table || !table->list) return FALSE;
 
   // is the needed rowid inside the list
   // in this case, is it fully visible ?

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -876,7 +876,7 @@ static void _filemanager_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
 void dt_thumbtable_zoom_changed(dt_thumbtable_t *table, const int oldzoom, const int newzoom)
 {
   if(oldzoom == newzoom) return;
-  if(!table || !table->list) return;
+  if(!table->list) return;
 
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
   {
@@ -2465,7 +2465,7 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, const int vi
 static gboolean _filemanager_ensure_rowid_visibility(dt_thumbtable_t *table, int rowid)
 {
   if(rowid < 1) rowid = 1;
-  if(!table || !table->list) return FALSE;
+  if(!table->list) return FALSE;
   // get first and last fully visible thumbnails
   dt_thumbnail_t *first = (dt_thumbnail_t *)g_list_first(table->list)->data;
   const int pos = MIN(g_list_length(table->list) - 1, table->thumbs_per_row * (table->rows - 1) - 1);
@@ -2492,7 +2492,7 @@ static gboolean _filemanager_ensure_rowid_visibility(dt_thumbtable_t *table, int
 static gboolean _zoomable_ensure_rowid_visibility(dt_thumbtable_t *table, const int rowid)
 {
   if(rowid < 1) return FALSE;
-  if(!table || !table->list) return FALSE;
+  if(!table->list) return FALSE;
 
   int minrowid = 0;
   int maxrowid = 0;
@@ -2555,6 +2555,7 @@ static gboolean _zoomable_ensure_rowid_visibility(dt_thumbtable_t *table, const 
   }
   return FALSE;
 }
+
 gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, const int imgid)
 {
   if(imgid < 1) return FALSE;
@@ -2569,7 +2570,7 @@ gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, const int
 static gboolean _filemanager_check_rowid_visibility(dt_thumbtable_t *table, const int rowid)
 {
   if(rowid < 1) return FALSE;
-  if(!table || !table->list) return FALSE;
+  if(!table->list) return FALSE;
   // get first and last fully visible thumbnails
   dt_thumbnail_t *first = (dt_thumbnail_t *)g_list_first(table->list)->data;
   const int pos = MIN(g_list_length(table->list) - 1, table->thumbs_per_row * (table->rows - 1) - 1);
@@ -2582,7 +2583,7 @@ static gboolean _filemanager_check_rowid_visibility(dt_thumbtable_t *table, cons
 static gboolean _zoomable_check_rowid_visibility(dt_thumbtable_t *table, const int rowid)
 {
   if(rowid < 1) return FALSE;
-  if(!table || !table->list) return FALSE;
+  if(!table->list) return FALSE;
 
   // is the needed rowid inside the list
   // in this case, is it fully visible ?
@@ -2614,6 +2615,7 @@ static gboolean _zoomable_check_rowid_visibility(dt_thumbtable_t *table, const i
   }
   return FALSE;
 }
+
 gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, const int imgid)
 {
   if(imgid < 1) return FALSE;
@@ -2692,6 +2694,7 @@ static gboolean _filemanager_key_move(dt_thumbtable_t *table, dt_thumbtable_move
   if(select && imgid > 0) dt_selection_select_range(darktable.selection, imgid);
   return TRUE;
 }
+
 static gboolean _zoomable_key_move(dt_thumbtable_t *table, dt_thumbtable_move_t move, const gboolean select)
 {
   // let's be sure that the current image is selected

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -470,9 +470,8 @@ static gboolean _thumbtable_update_scrollbars(dt_thumbtable_t *table)
 // uneeded == completly hidden
 static int _thumbs_remove_unneeded(dt_thumbtable_t *table)
 {
-  int pos = 0;
   int changed = 0;
-  GList *l = g_list_nth(table->list, pos);
+  GList *l = table->list->data;
   while(l)
   {
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
@@ -487,8 +486,9 @@ static int _thumbs_remove_unneeded(dt_thumbtable_t *table)
       changed++;
     }
     else
-      pos++;
-    l = g_list_nth(table->list, pos);
+    {
+      l = g_list_next(l);
+    }
   }
   return changed;
 }
@@ -856,7 +856,7 @@ static void _filemanager_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
       if(!thumb)
       {
         // and last, take the first at screen
-        thumb = (dt_thumbnail_t *)g_list_nth_data(table->list, 0);
+        thumb = (dt_thumbnail_t *)table->list->data;
         x = thumb->x + thumb->width / 2;
         y = thumb->y + thumb->height / 2;
       }
@@ -1588,7 +1588,7 @@ static void _event_dnd_get(GtkWidget *widget, GdkDragContext *context, GtkSelect
       {
         gchar pathname[PATH_MAX] = { 0 };
         gboolean from_cache = TRUE;
-        const int id = GPOINTER_TO_INT(g_list_nth_data(l, 0));
+        const int id = GPOINTER_TO_INT(l->data);
         dt_image_full_path(id, pathname, sizeof(pathname), &from_cache);
         gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
         gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data),
@@ -1645,7 +1645,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
     // TODO: have something pretty in the 2nd case, too.
     if(g_list_length(table->drag_list) == 1)
     {
-      const int id = GPOINTER_TO_INT(g_list_nth_data(table->drag_list, 0));
+      const int id = GPOINTER_TO_INT(table->drag_list->data);
       dt_mipmap_buffer_t buf;
       dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, ts, ts);
       dt_mipmap_cache_get(darktable.mipmap_cache, &buf, id, mip, DT_MIPMAP_BLOCKING, 'r');
@@ -2179,7 +2179,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
   if(v->view(v) == DT_VIEW_DARKROOM && g_list_length(imgs) == 1 && darktable.develop->preview_pipe)
   {
     // we verify that the image is the active one
-    const int id = GPOINTER_TO_INT(g_list_nth_data(imgs, 0));
+    const int id = GPOINTER_TO_INT(imgs->data);
     if(id == darktable.develop->preview_pipe->output_imgid)
     {
       const dt_image_t *img = dt_image_cache_get(darktable.image_cache, id, 'r');
@@ -2221,7 +2221,7 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
   if(v->view(v) == DT_VIEW_DARKROOM && g_list_length(imgs) == 1 && darktable.develop->preview_pipe)
   {
     // we verify that the image is the active one
-    const int id = GPOINTER_TO_INT(g_list_nth_data(imgs, 0));
+    const int id = GPOINTER_TO_INT(imgs->data);
     if(id == darktable.develop->preview_pipe->output_imgid)
     {
       GList *res = dt_metadata_get(id, "Xmp.darktable.colorlabels", NULL);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3554,7 +3554,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // show guide lines on request
   if(g->show_guides)
   {
-    dt_guides_t *guide = (dt_guides_t *)g_list_nth_data(darktable.guides, 0);
+    dt_guides_t *guide = (dt_guides_t *)darktable.guides->data;
     double dashes = DT_PIXEL_APPLY_DPI(5.0);
     cairo_save(cr);
     cairo_rectangle(cr, 0, 0, width, height);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2083,10 +2083,8 @@ static void modflags_changed(GtkWidget *widget, gpointer user_data)
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
   int pos = dt_bauhaus_combobox_get(widget);
-  GList *modifiers = g->modifiers;
-  while(modifiers)
+  for(GList *modifiers = g->modifiers;  modifiers; modifiers = g_list_next(modifiers))
   {
-    // could use g_list_nth. this seems safer?
     dt_iop_lensfun_modifier_t *mm = (dt_iop_lensfun_modifier_t *)modifiers->data;
     if(mm->pos == pos)
     {
@@ -2095,7 +2093,6 @@ static void modflags_changed(GtkWidget *widget, gpointer user_data)
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       break;
     }
-    modifiers = g_list_next(modifiers);
   }
 }
 
@@ -2204,17 +2201,14 @@ static void corrections_done(gpointer instance, gpointer user_data)
 
   const char empty_message[] = "";
   char *message = (char *)empty_message;
-  GList *modifiers = g->modifiers;
-  while(modifiers && self->enabled)
+  for(GList *modifiers = g->modifiers; modifiers && self->enabled; modifiers = g_list_next(modifiers))
   {
-    // could use g_list_nth. this seems safer?
     dt_iop_lensfun_modifier_t *mm = (dt_iop_lensfun_modifier_t *)modifiers->data;
     if(mm->modflag == corrections_done)
     {
       message = mm->name;
       break;
     }
-    modifiers = g_list_next(modifiers);
   }
 
   ++darktable.gui->reset;
@@ -2438,17 +2432,14 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->lens_model, "");
 
   int modflag = p->modify_flags & LENSFUN_MODFLAG_MASK;
-  GList *modifiers = g->modifiers;
-  while(modifiers)
+  for(GList *modifiers = g->modifiers; modifiers; modifiers = g_list_next(modifiers))
   {
-    // could use g_list_nth. this seems safer?
     dt_iop_lensfun_modifier_t *mm = (dt_iop_lensfun_modifier_t *)modifiers->data;
     if(mm->modflag == modflag)
     {
       dt_bauhaus_combobox_set(g->modflags, mm->pos);
       break;
     }
-    modifiers = g_list_next(modifiers);
   }
 
   dt_bauhaus_combobox_set(g->target_geom, p->target_geom - LF_UNKNOWN - 1);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1556,7 +1556,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
     dt_iop_color_picker_reset(self, TRUE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
-    if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+    if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
       const int control_button_pressed = event->state & GDK_CONTROL_MASK;
 
@@ -1854,7 +1854,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
       //only show shapes if shapes exist
       dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
-      if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+      if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
       {
         // got focus, show all shapes
         if(bd->masks_shown == DT_MASKS_EDIT_OFF)
@@ -1980,7 +1980,7 @@ void gui_update(dt_iop_module_t *self)
   if(darktable.develop->history_updating) bd->masks_shown = DT_MASKS_EDIT_OFF;
 
   //only toggle shape show button if shapes exist
-  if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+  if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -333,7 +333,7 @@ static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_
   dt_develop_blend_params_t *bp = self->blend_params;
   dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, bp->mask_id);
   //only toggle shape show button if shapes exist
-  if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+  if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));
@@ -705,7 +705,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       dt_develop_blend_params_t *bp = self->blend_params;
       dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, bp->mask_id);
       //only toggle shape show button if shapes exist
-      if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+      if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
       {
         if(bd->masks_shown == DT_MASKS_EDIT_OFF) dt_masks_set_edit_mode(self, DT_MASKS_EDIT_FULL);
 
@@ -774,7 +774,7 @@ void gui_update(dt_iop_module_t *self)
   if(darktable.develop->history_updating) bd->masks_shown = DT_MASKS_EDIT_OFF;
 
   //only toggle shape show button if shapes exist
-  if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+  if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -539,7 +539,7 @@ void _process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
 
       if(d->clone_algo[pos] == 1 && (form->type & DT_MASKS_CIRCLE))
       {
-        dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)g_list_nth_data(form->points, 0);
+        dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)form->points->data;
 
         float points[4];
         masks_point_denormalize(piece, roi_in, circle->center, 1, points);

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -363,6 +363,7 @@ static void _expose_info_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, 
 
   // Let's cook up the middle part of infobar
   gchar center[1024] = { 0 };
+  //FIXME: O(n) iterate down list, instead of O(n^2) from computing its length every time and scanning to successive positions
   for(guint i = 0; i < g_list_length(lib->gui.properties); i++)
   {
     dt_lib_camera_property_t *prop = (dt_lib_camera_property_t *)g_list_nth_data(lib->gui.properties, i);

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -363,10 +363,9 @@ static void _expose_info_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, 
 
   // Let's cook up the middle part of infobar
   gchar center[1024] = { 0 };
-  //FIXME: O(n) iterate down list, instead of O(n^2) from computing its length every time and scanning to successive positions
-  for(guint i = 0; i < g_list_length(lib->gui.properties); i++)
+  for(GList *l = lib->gui.properties; l; l = g_list_next(l))
   {
-    dt_lib_camera_property_t *prop = (dt_lib_camera_property_t *)g_list_nth_data(lib->gui.properties, i);
+    dt_lib_camera_property_t *prop = (dt_lib_camera_property_t *)l->data;
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(prop->osd)) == TRUE)
     {
       g_strlcat(center, "      ", sizeof(center));

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -620,7 +620,7 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
       {
         // range selection
         GList *sels = gtk_tree_selection_get_selected_rows(selection, NULL);
-        GtkTreePath *path2 = (GtkTreePath *)g_list_nth_data(sels, 0);
+        GtkTreePath *path2 = (GtkTreePath *)sels->data;
         gtk_tree_selection_unselect_all(selection);
         if(gtk_tree_path_compare(path, path2) > 0)
           gtk_tree_selection_select_range(selection, path, path2);
@@ -2196,7 +2196,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
   if(gtk_tree_selection_count_selected_rows(selection) < 1) return;
   GList *sels = gtk_tree_selection_get_selected_rows(selection, &model);
-  GtkTreePath *path1 = (GtkTreePath *)g_list_nth_data(sels, 0);
+  GtkTreePath *path1 = (GtkTreePath *)sels->data;
   if(!gtk_tree_model_get_iter(model, &iter, path1)) return;
 
   gchar *text;

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -194,7 +194,7 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
-  if(g_list_length((GList *)imgs) < 1) return;
+  if(!imgs) return;  // do nothing if no images to be acted on
 
   const int missing = dt_history_compress_on_list(imgs);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -974,14 +974,15 @@ static void _lib_modulegroups_toggle(GtkWidget *button, gpointer user_data)
                                   : NULL;
 
   /* block all button callbacks */
-  for(int k = 0; k <= g_list_length(d->groups); k++)
+  const int ngroups = g_list_length(d->groups);
+  for(int k = 0; k <= ngroups; k++)
     g_signal_handlers_block_matched(_buttons_get_from_pos(self, k), G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
                                     _lib_modulegroups_toggle, NULL);
   g_signal_handlers_block_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
 
   /* deactivate all buttons */
   int gid = 0;
-  for(int k = 0; k <= g_list_length(d->groups); k++)
+  for(int k = 0; k <= ngroups; k++)
   {
     const GtkWidget *bt = _buttons_get_from_pos(self, k);
     /* store toggled modulegroup */
@@ -1001,7 +1002,7 @@ static void _lib_modulegroups_toggle(GtkWidget *button, gpointer user_data)
   }
 
   /* unblock all button callbacks */
-  for(int k = 0; k <= g_list_length(d->groups); k++)
+  for(int k = 0; k <= ngroups; k++)
     g_signal_handlers_unblock_matched(_buttons_get_from_pos(self, k), G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
                                       _lib_modulegroups_toggle, NULL);
   g_signal_handlers_unblock_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
@@ -1096,7 +1097,8 @@ static void _lib_modulegroups_switch_group(dt_lib_module_t *self, dt_iop_module_
 {
   /* lets find the group which is not active pipe */
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
-  for(int k = 1; k <= g_list_length(d->groups); k++)
+  const int ngroups = g_list_length(d->groups);
+  for(int k = 1; k <= ngroups; k++)
   {
     if(_lib_modulegroups_test(self, k, module))
     {
@@ -2808,7 +2810,7 @@ static void _buttons_update(dt_lib_module_t *self)
 
   // if there's no groups, we ensure that the preset button is on the search line and we hide the active button
   gtk_widget_set_visible(d->hbox_search_box, d->show_search);
-  if(g_list_length(d->groups) == 0 && d->show_search)
+  if(!d->groups && d->show_search)
   {
     if(gtk_widget_get_parent(self->presets_button) != d->hbox_search_box)
     {

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2215,7 +2215,7 @@ static void _manage_editor_group_update_arrows(GtkWidget *box)
       GList *lw2 = gtk_container_get_children(GTK_CONTAINER(hb));
       if(g_list_length(lw2) > 2)
       {
-        GtkWidget *left = (GtkWidget *)g_list_nth_data(lw2, 0);
+        GtkWidget *left = (GtkWidget *)lw2->data;
         GtkWidget *right = (GtkWidget *)g_list_nth_data(lw2, 2);
         if(pos == 1)
           gtk_widget_hide(left);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -224,7 +224,7 @@ void _display_module_trouble_message_callback(gpointer instance,
   if(module && module->has_trouble && module->widget)
   {
     GList *children = gtk_container_get_children(GTK_CONTAINER(gtk_widget_get_parent(module->widget)));
-    label_widget = g_list_nth_data(children, 0);
+    label_widget = children->data;
     g_list_free(children);
     if(strcmp(gtk_widget_get_name(label_widget), "iop-plugin-warning"))
       label_widget = NULL;
@@ -949,11 +949,10 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
     dt_iop_module_t *module = (dt_iop_module_t *)(g_list_nth_data(dev->iop, i));
 
     // the base module is the one with the lowest multi_priority
-    const guint clen = g_list_length(dev->iop);
     int base_multi_priority = 0;
-    for(int k = 0; k < clen; k++)
+    for(const GList *l = dev->iop; l; l = g_list_next(l))
     {
-      dt_iop_module_t *mod = (dt_iop_module_t *)(g_list_nth_data(dev->iop, k));
+      dt_iop_module_t *mod = (dt_iop_module_t *)l->data;
       if(strcmp(module->op, mod->op) == 0) base_multi_priority = MIN(base_multi_priority, mod->multi_priority);
     }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2135,7 +2135,7 @@ static gboolean _toggle_mask_visibility_callback(GtkAccelGroup *accel_group, GOb
     dt_iop_color_picker_reset(mod, TRUE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, mod->blend_params->mask_id);
-    if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+    if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
     {
       if(bd->masks_shown == DT_MASKS_EDIT_OFF)
         bd->masks_shown = DT_MASKS_EDIT_FULL;


### PR DESCRIPTION
Since an empty GList is always just a NULL pointer, there's no need to scan down the entire list if all we want to know is whether the list is empty or not.

Also consolidated a few repeated calls to g_list_length into a single call whose result is stored in a variable.

May give a slight speed boost, especially for large collections.  I tested import of a directory with 5870 images, removing the configdir and mipmap caches before each run.  Once the disk cache was filled, runs took 3:00 and 3:01 for master, 2:58, 2:56, and 3:01 for this PR.

(There are other places that use g_list_append or g_list_nth* in a loop, producing O(n^2) runtime, that could be optimized to run in linear time.)
