### PR TITLE
Prefere shallow git copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ which is fine if you don't need to open your edits again in the future, but mayb
 After backing up your `~/.config/darktable` directory as well as the sidecar .XMP files of the pictures you will open
 with the master branch, you may get the source:
 ```bash
-git clone --recurse-submodules https://github.com/darktable-org/darktable.git
+git clone --recurse-submodules --depth 1 https://github.com/darktable-org/darktable.git
 cd darktable
 ```
 
@@ -232,7 +232,7 @@ Minor revisions are tagged with a third digit (like 3.0.1, 3.0.2) and mostly pro
 You may want to compile these stable releases yourself in order to get better performance for your particular computer:
 
 ```bash
-git clone --recurse-submodules https://github.com/darktable-org/darktable.git 
+git clone --recurse-submodules --depth 1 https://github.com/darktable-org/darktable.git
 cd darktable
 git fetch --tags
 git checkout tags/release-3.4.1


### PR DESCRIPTION
With huge git changes it's usually not necessary to clone the whole
repository, only latest state. Also for submodules it's not necessary
to have the full history when the submodule is fixed to certain commit.
This might speedup CI builds and save some bandwidth and space on HDDs.

`git clone --depth 1` will be much faster, in fact it might save 1-2GBs on disk :)