### PR TITLE
common:cpuid: Fix __get_cpuid() support check

### DIFF
--- a/src/common/cpuid.c
+++ b/src/common/cpuid.c
@@ -34,7 +34,7 @@
 #include <cpuid.h>
 #endif
 
-#if defined(HAVE___GET_GPUID)
+#if defined(HAVE___GET_CPUID)
 dt_cpu_flags_t dt_detect_cpu_features()
 {
   guint32 ax, bx, cx, dx;
@@ -86,7 +86,7 @@ dt_cpu_flags_t dt_detect_cpu_features()
 
   return cpuflags;
 }
-#endif /* __i386__ || __x86_64__ */
+#endif /* defined(HAVE___GET_CPUID) */
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Commit eb6a4fc: cmake: Check for __get_cpuid
introduced a HAVE___GET_CPUID symbol in cmake that is only defined if
__get_cpuid exists.

Commit 56171c7: common:cpuid: Correctly check for __get_cpuid() support
updated cpuid to use the HAVE___GET_GPUID symbol instead of the correct
HAVE___GET_CPUID symbol. Fix this typo.