### PR TITLE
Adds a target_clone for the ppc64 builds.

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -128,6 +128,9 @@ typedef unsigned int u_int;
 /* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
 #if __has_attribute(target_clones) && !defined(_WIN32) && (defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64))
 #define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "avx512f", "fma4")))
+#elif __has_attribute(target_clones) && !defined(_WIN32) && defined(__PPC64__)
+/* __PPC64__ is the only macro tested for in is_supported_platform.h, other macros would fail there anyway. */
+#define __DT_CLONE_TARGETS__ __attribute__((target_clones("default","cpu=power9")))
 #else
 #define __DT_CLONE_TARGETS__
 #endif


### PR DESCRIPTION
Extending on the work done by @n0s0r0g in #8103, this should provide a reasonable pair of CPU specific target_clones for the powerpc64le build.