### PR TITLE
modulegroups: further adjustments to right-click menu

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2189,7 +2189,7 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(smt), GTK_WIDGET(sm_all));
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr + 1);
   }
-  if(nbr > 0)
+  if(nbr > 0 || nba > 0)
   {
     GtkWidget *smt = gtk_menu_item_new_with_label("add module");
     gtk_widget_set_name(smt, "modulegroups-popup-title");
@@ -2381,7 +2381,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(smt), GTK_WIDGET(sm_all));
     gtk_menu_shell_insert(GTK_MENU_SHELL(pop), smt, nba + nbr + 1);
   }
-  if(nbr > 0)
+  if(nbr > 0 || nba > 0)
   {
     GtkWidget *smt = gtk_menu_item_new_with_label("add widget");
     gtk_widget_set_name(smt, "modulegroups-popup-title");


### PR DESCRIPTION
"add module" and "add widget" headers should be shown if there are recommended OR other widgets/modules

Before:
![widgets-before1](https://user-images.githubusercontent.com/9555491/107283965-fda24780-6a54-11eb-9664-503df1bf6776.png)
![modules-before1](https://user-images.githubusercontent.com/9555491/107283979-03982880-6a55-11eb-9a79-835133c59c07.png)

After:
![widgets-after1](https://user-images.githubusercontent.com/9555491/107284021-0f83ea80-6a55-11eb-8654-972d74efdb8d.png)
![modules-after1](https://user-images.githubusercontent.com/9555491/107284044-16aaf880-6a55-11eb-9e62-c3cab94f722d.png)
