### PR TITLE
quick access panel - fix alignment of on-off option in module sub-menu

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2295,6 +2295,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
             }
             GtkMenuItem *mii;
             mii = (GtkMenuItem *)gtk_menu_item_new_with_label(_("on-off"));
+            gtk_widget_set_name(GTK_WIDGET(mii), "modulegroups-popup-item2");
             gtk_widget_set_tooltip_text(GTK_WIDGET(mii), _("add this widget"));
             g_object_set_data(G_OBJECT(mii), "widget_id", module->op);
             g_signal_connect(G_OBJECT(mii), "activate", callback, self);


### PR DESCRIPTION
The on-off option is missing a name so is slightly mis-aligned

Before:
![Screenshot_2021-02-10_23-17-52](https://user-images.githubusercontent.com/9555491/107585641-8b696880-6bf6-11eb-806f-8b1472b88d41.jpg)

After:
![Screenshot_2021-02-10_23-18-22](https://user-images.githubusercontent.com/9555491/107585653-8e645900-6bf6-11eb-92d3-4776f24a1a85.jpg)
