### PR TITLE
Fixing hotpixels in green_equilibration_lavg

### DIFF
--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -97,7 +97,7 @@ green_equilibration_lavg(read_only image2d_t in, write_only image2d_t out, const
     const float m1 = (o1_1+o1_2+o1_3+o1_4)/4.0f;
     const float m2 = (o2_1+o2_2+o2_3+o2_4)/4.0f;
     
-    if (m2 > 0.0f && m1 / m2 < maximum * 2.0f)
+    if (m2 > 0.0f && m1 > 0.0f && m1 / m2 < maximum * 2.0f)
     {
       const float c1 = (fabs(o1_1 - o1_2) + fabs(o1_1 - o1_3) + fabs(o1_1 - o1_4) + fabs(o1_2 - o1_3) + fabs(o1_3 - o1_4) + fabs(o1_2 - o1_4)) / 6.0f;
       const float c2 = (fabs(o2_1 - o2_2) + fabs(o2_1 - o2_3) + fabs(o2_1 - o2_4) + fabs(o2_2 - o2_3) + fabs(o2_3 - o2_4) + fabs(o2_2 - o2_4)) / 6.0f;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -479,7 +479,8 @@ static void green_equilibration_lavg(float *out, const float *const in, const in
 
       // prevent divide by zero and ...
       // guard against m1/m2 becoming too large (due to m2 being too small) which results in hot pixels
-      if(m2 > 0.0f && m1 / m2 < maximum * 2.0f)
+      // also m1 must be checked to be positive
+      if(m2 > 0.0f && m1 > 0.0f && m1 / m2 < maximum * 2.0f)
       {
         const float c1 = (fabsf(o1_1 - o1_2) + fabsf(o1_1 - o1_3) + fabsf(o1_1 - o1_4) + fabsf(o1_2 - o1_3)
                           + fabsf(o1_3 - o1_4) + fabsf(o1_2 - o1_4)) / 6.0f;


### PR DESCRIPTION
The input data for the demosaicer module can have negative values most visible due to blackpoint correction. Some of the demosaicers don't like that and present hot pixels.

The green_equilibration_lavg needs to test a bit more if a correction should be applied, negatives can never be right.

Fixing #2654