### PR TITLE
collect: avoid to refresh collection when scrolling the list

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -117,6 +117,7 @@ typedef struct dt_bauhaus_combobox_data_t
   char text[180];       // roughly as much as a slider
   PangoEllipsizeMode entries_ellipsis;
   GList *entries;
+  gboolean mute_scrolling;   // if set, prevents to issue "data-changed"
 } dt_bauhaus_combobox_data_t;
 
 typedef union dt_bauhaus_data_t
@@ -342,6 +343,7 @@ void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidg
 void dt_bauhaus_combobox_entry_set_sensitive(GtkWidget *widget, int pos, gboolean sensitive);
 void dt_bauhaus_combobox_set_entries_ellipsis(GtkWidget *widget, PangoEllipsizeMode ellipis);
 PangoEllipsizeMode dt_bauhaus_combobox_get_entries_ellipsis(GtkWidget *widget);
+void dt_bauhaus_combobox_mute_scrolling(GtkWidget *widget);
 
 // key accel parsing:
 // execute a line of input

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2809,6 +2809,7 @@ void gui_init(dt_lib_module_t *self)
     dt_bauhaus_combobox_set_popup_scale(d->rule[i].combo, 2);
     dt_bauhaus_combobox_set_selected_text_align(d->rule[i].combo, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
     _populate_collect_combo(d->rule[i].combo);
+    dt_bauhaus_combobox_mute_scrolling(d->rule[i].combo);
 
     g_signal_connect(G_OBJECT(d->rule[i].combo), "value-changed", G_CALLBACK(combo_changed), d->rule + i);
     gtk_box_pack_start(box, d->rule[i].combo, TRUE, TRUE, 0);


### PR DESCRIPTION
attempt to fix #8186 and to fix #7969 by:
- skipping the collection refresh when scrolling the popup list
- avoiding triggering again "value-changed" after the click on the list (which selects the right record)

