### PR TITLE
collect: fix Ctrl+Shift+click to switch folder <> filmroll

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -637,7 +637,8 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
     /* single click on folder with the right mouse button? */
     if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS)
         || (d->view_rule == DT_COLLECTION_PROP_FILMROLL))
-       && (event->type == GDK_BUTTON_PRESS && event->button == 3))
+       && (event->type == GDK_BUTTON_PRESS && event->button == 3)
+       && !(event->state & GDK_SHIFT_MASK && event->state & GDK_CONTROL_MASK))
     {
       row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
       view_popup_menu(treeview, event, d);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -595,7 +595,10 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
        || d->view_rule == DT_COLLECTION_PROP_FILMROLL)
       && event->type == GDK_BUTTON_PRESS && event->button == 3)
      || (!d->singleclick && event->type == GDK_2BUTTON_PRESS && event->button == 1)
-     || (d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == 1))
+     || (d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == 1)
+     || ((d->view_rule == DT_COLLECTION_PROP_FOLDERS || d->view_rule == DT_COLLECTION_PROP_FILMROLL)
+          && (event->type == GDK_BUTTON_PRESS && event->button == 1 && 
+              event->state & GDK_SHIFT_MASK && event->state & GDK_CONTROL_MASK)))
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
     GtkTreePath *path = NULL;


### PR DESCRIPTION
This action was only working on Ctrl+Shift+right-click. Because this also opened the right-click menu, I have also changed Ctrl+Shift+right-click to have the same action as Ctrl+Shift+left-click (switch folder <> film roll)