### PR TITLE
Speeding up large imports

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2002,7 +2002,7 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
   int next = -1;
   if(!collection->clone)
   {
-    if(g_list_length(list) > 0)
+    if(list)
     {
       // for changing offsets, thumbtable needs to know the first untouched imageid after the list
       // we do this here
@@ -2165,8 +2165,9 @@ void dt_collection_hint_message(const dt_collection_t *collection)
   gchar *message;
 
   int c = dt_collection_get_count_no_group(collection);
-  int cs = dt_collection_get_selected_count(collection);
-
+  int cs = g_list_length(selected_imgids);
+  g_list_free(selected_imgids);
+ 
   if(cs == 1)
   {
     message = g_strdup_printf(_("%d image of %d (#%d) in current collection is selected"), cs, c, selected);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1147,6 +1147,7 @@ gboolean dt_image_basic(const int32_t imgid)
   return status & DT_HISTORY_HASH_BASIC;
 }
 
+#ifndef _WIN32
 static int _valid_glob_match(const char *const name, size_t offset)
 {
   // verify that the name matched by glob() is a valid sidecar name by checking whether we have an underscore
@@ -1161,6 +1162,7 @@ static int _valid_glob_match(const char *const name, size_t offset)
   }
   return name[i] == '.';
 }
+#endif /* !_WIN32 */
 
 GList* dt_image_find_duplicates(const char* filename)
 {

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -109,7 +109,7 @@ static GList *_film_recursive_get_files(const gchar *path, gboolean recursive, G
     }
     /* or test if we found a supported image format to import */
     else if(!g_file_test(fullname, G_FILE_TEST_IS_DIR) && dt_supported_image(filename))
-      *result = g_list_append(*result, fullname);
+      *result = g_list_prepend(*result, fullname);
     else
       g_free(fullname);
 
@@ -260,7 +260,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 
-    all_imgs = g_list_append(all_imgs, GINT_TO_POINTER(imgid));
+    all_imgs = g_list_prepend(all_imgs, GINT_TO_POINTER(imgid));
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if((imgid & 3) == 3)
     {
@@ -271,6 +271,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   } while((image = g_list_next(image)) != NULL);
 
   g_list_free_full(images, g_free);
+  all_imgs = g_list_reverse(all_imgs);
 
   // only redraw at the end, to not spam the cpu with exposure events
   dt_control_queue_redraw_center();

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -231,6 +231,8 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
   /* loop thru the images and import to current film roll */
   dt_film_t *cfr = film;
   GList *image = g_list_first(images);
+  int pending = 0;
+  double last_update = dt_get_wtime();
   do
   {
     gchar *cdn = g_path_get_dirname((const gchar *)image->data);
@@ -262,16 +264,23 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
 
     /* import image */
     const int32_t imgid = dt_image_import(cfr->id, (const gchar *)image->data, FALSE, FALSE);
+    pending++;  // we have another image which hasn't been reported yet
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
 
     all_imgs = g_list_prepend(all_imgs, GINT_TO_POINTER(imgid));
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
-    if((imgid & 3) == 3)
+    double curr_time = dt_get_wtime();
+    // if we've imported at least four images without an update, and it's been at least half a second since the last
+    //   one, update the interface
+    if(pending >= 4 && curr_time - last_update > 0.5)
     {
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
       g_list_free(imgs);
       imgs = NULL;
+      // restart the update count and timer
+      pending = 0;
+      last_update = curr_time;
     }
   } while((image = g_list_next(image)) != NULL);
 


### PR DESCRIPTION
The recent improvement in import speed led me to look at what else might be causing bottlenecks.  Testing with single large directories showed that the glob() function used for finding sidecars takes an increasing percentage of the time as the directory grows, and the use of g_list_append when collecting the list of files to import causes an O(n^2) factor to become noticeable in the form of a delay before the first image is imported.

This PR reduces the file-scanning delay for a 43,000-file directory from several seconds to perceptually instantaneous and the overall import time by an estimated 60% (I didn't run it until completion).  For a smaller 5876-file directory, import time is reduced 28% (from 1:43 to 1:14).

The glob() overhead could be further reduced, but it's more effort and more invasive of the code: do a single scan for `FOLDER/*_[0-9]*.xmp` and pick out the appropriate names with a binary search as each image is imported.  That would reduce the total sidecar-search time for a directory with N images from O(N^2) to O(N log N).
