### PR TITLE
Fix swap doubles as floats in encode_colorchecker

### DIFF
--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -921,7 +921,7 @@ static char *encode_colorchecker(int num, const double *point, const double **ta
 
 #define SWAP(a, b)                                                                                                \
   {                                                                                                               \
-    const float tmp = (a);                                                                                        \
+    const double tmp = (a);                                                                                        \
     (a) = (b);                                                                                                    \
     (b) = tmp;                                                                                                    \
   }


### PR DESCRIPTION
This just didn't make sense to me. Sorry if I missed something.