### PR TITLE
Category flag for hierarchy-tags

### DIFF
--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -40,6 +40,7 @@ typedef enum dt_tag_flags_t
   DT_TF_PRIVATE     = 1 << 1, // this tag is private. Will be exported only on demand
   DT_TF_ORDER_SET   = 1 << 2, // set if the tag has got an images order
   DT_TF_DESCENDING  = 1 << 31,
+  DT_TF_HIERARCHY   = 1 << 3, // tag is part of hierarchy with category deselected
 } dt_tag_flags_t;
 
 #define DT_TF_ALL (DT_TF_CATEGORY | DT_TF_PRIVATE | DT_TF_ORDER_SET)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1706,6 +1706,16 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
     buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(synonyms));
     if (synonyms_list) gtk_text_buffer_set_text(buffer, synonyms_list, -1);
   }
+  else
+  // non-existing tag (part of hierarchy) is shown as category
+  {
+    GtkWidget *vbox2 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_pack_start(GTK_BOX(vbox), vbox2, FALSE, TRUE, 0);
+    category = gtk_check_button_new_with_label(_("category"));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(category), true);
+    gtk_box_pack_end(GTK_BOX(vbox2), category, FALSE, TRUE, 0);
+  }
+  
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
@@ -1834,6 +1844,22 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
           gtk_tree_store_set(GTK_TREE_STORE(store), &store_iter, DT_LIB_TAGGING_COL_SYNONYM, new_synonyms_list, -1);
       }
       g_free(new_synonyms_list);
+    }
+    else
+    // non-existing tag (part of hierarchy)
+    {
+      gint new_flags = ((gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(category)) ? DT_TF_CATEGORY : 0));
+
+      if (new_flags != (DT_TF_CATEGORY))
+      // category checkbox deselected -> create hierarchy-tag
+      {
+        guint new_tagid = 0;
+        dt_tag_new(tagname, &new_tagid);
+
+        dt_tag_set_flags(new_tagid, DT_TF_HIERARCHY);
+
+       _init_treeview(self, 1);
+      }
     }
   }
   _init_treeview(self, 0);

--- a/src/lua/tags.c
+++ b/src/lua/tags.c
@@ -280,6 +280,19 @@ int dt_lua_tag_get_tagged_images(lua_State *L)
   return 1;
 }
 
+static int dt_lua_tag_is_hierarchy(lua_State *L)
+{
+  dt_lua_tag_t tagid = dt_tag_get_tag_id_by_name(luaL_checkstring(L, 1));
+
+  gint flags = dt_tag_get_flags(tagid);
+
+  gint is_hierarchy = 0;
+  if(flags & DT_TF_HIERARCHY)
+    is_hierarchy = 1;
+
+  luaA_push(L, int, &is_hierarchy);
+  return 1;
+}
 
 int dt_lua_init_tags(lua_State *L)
 {
@@ -331,7 +344,9 @@ int dt_lua_init_tags(lua_State *L)
   lua_pushcfunction(L, dt_lua_tag_get_tagged_images);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, type_id, "get_tagged_images");
-
+  lua_pushcfunction(L, dt_lua_tag_is_hierarchy);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, type_id, "is_hierarchy");
 
   return 0;
 }


### PR DESCRIPTION
Fix #6665

When editing a tag-hierarchy which does not really exist as a tag (e.g. 'AT' in the hierarchy place|AT|Wien), the checkbox 'category' is now visible and checked (to show that this is considered as category)

When unchecking the checkbox 'category', the tag 'place|AT' is created automatically (so it will be exported in simple tag list without hierarchy)

The lua script 'delete_unused_tags' should not delete auto-generated tags:
`  if #t == 0 and dt.tags.is_hierarchy(t.name) == 0 then`