### PR TITLE
Hdr8043

### DIFF
--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -84,7 +84,7 @@ static inline void dt_imageio_dng_write_tiff_header(
   uint8_t buf[1024];
   uint8_t cnt = 0;
   float coeff[3];
-  float d65_white[3] = {0.950456, 1, 1.088754};
+
 
   memset(buf, 0, sizeof(buf));
   /* TIFF file header.  */
@@ -169,11 +169,11 @@ static inline void dt_imageio_dng_write_tiff_header(
   //int m[9] = { 3240454, -1537138, -498531, -969266, 1876010, 41556, 55643, -204025, 1057225 };
   for(int k = 0; k < 3; k++)
    {
- 	// TAG AsShotNeutral: try reverse process of rawspeed Dngdecoder for white balance
- 	coeff[k] =1/( (wb_coeffs[k]/ wb_coeffs[1]) * d65_white[k]);
+ 	// TAG AsShotNeutral: for rawspeed Dngdecoder white balance
+ 	coeff[k] =1/( (wb_coeffs[k]/ wb_coeffs[1])) ;
  	coeff[k]*= 1000000;
  	dt_imageio_dng_write_buf(buf, 480+k*8,(int)coeff[k]);
-     dt_imageio_dng_write_buf(buf, 484+k*8, 1000000);
+    dt_imageio_dng_write_buf(buf, 484+k*8, 1000000);
    }
 
   // dt_imageio_dng_write_buf(buf, offs2-buf, 584);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -260,6 +260,7 @@ typedef struct dt_control_merge_hdr_t
 
   float whitelevel;
   float epsw;
+  float wb_coeffs[3];
 
   // 0 - ok; 1 - errors, abort
   gboolean abort;
@@ -339,6 +340,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
     d->wd = datai->width;
     d->ht = datai->height;
     d->orientation = image.orientation;
+    for(int i = 0; i < 3; i++) d->wb_coeffs[i] = image.wb_coeffs[i];
   }
 
   if(image.buf_dsc.filters == 0u || image.buf_dsc.channels != 1 || image.buf_dsc.datatype != TYPE_UINT16)
@@ -500,7 +502,7 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   char *c = pathname + strlen(pathname);
   while(*c != '.' && c > pathname) c--;
   g_strlcpy(c, "-hdr.dng", sizeof(pathname) - (c - pathname));
-  dt_imageio_write_dng(pathname, d.pixels, d.wd, d.ht, exif, exif_len, d.first_filter, (const uint8_t (*)[6])d.first_xtrans, 1.0f);
+  dt_imageio_write_dng(pathname, d.pixels, d.wd, d.ht, exif, exif_len, d.first_filter, (const uint8_t (*)[6])d.first_xtrans, 1.0f,(const float (*))d.wb_coeffs);
   free(exif);
 
   dt_control_job_set_progress(job, 1.0);


### PR DESCRIPTION
Fix #8043 
Suppress ColorMatrix tag in Hdr dng exif header to get standard color matrix,
Add camera white balance in  dng exif header to get it in rawspedd decoder.