### PR TITLE
More GList speedups: don't scan/copy entire list if not necessary

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2340,18 +2340,13 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
     return;
   }
 
-  const guint selected_images_length = g_list_length(selected_images);
-
-  if (selected_images_length == 0)
-  {
-    return;
-  }
-
   const uint32_t tagid = darktable.collection->tagid;
   // getting the position of the target image
   const int64_t target_image_pos = dt_collection_get_image_position(image_id, tagid);
   if (target_image_pos >= 0)
   {
+    const guint selected_images_length = g_list_length(selected_images);
+
     dt_collection_shift_image_positions(selected_images_length, target_image_pos, tagid);
 
     sqlite3_stmt *stmt = NULL;

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -175,15 +175,13 @@ static void _colorlabels_execute(const GList *imgs, const int labels, GList **un
 void dt_colorlabels_set_labels(const GList *img, const int labels, const gboolean clear_on,
                                const gboolean undo_on)
 {
-  GList *imgs = g_list_copy((GList *)img);
-  if(imgs)
+  if(img)
   {
     GList *undo = NULL;
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_COLORLABELS);
 
-    _colorlabels_execute(imgs, labels, &undo, undo_on, clear_on ? DT_CA_SET : DT_CA_ADD);
+    _colorlabels_execute(img, labels, &undo, undo_on, clear_on ? DT_CA_SET : DT_CA_ADD);
 
-    g_list_free(imgs);
     if(undo_on)
     {
       dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, undo, _pop_undo, _colorlabels_undo_data_free);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -569,6 +569,24 @@ static inline int g_list_shorter_than(const GList *list, unsigned len)
   return 0;
 }
 
+// advance the list by one position, unless already at the final node
+static inline GList *g_list_next_bounded(GList *list)
+{
+  return g_list_next(list) ? g_list_next(list) : list;
+}
+
+static inline const GList *g_list_next_wraparound(const GList *list, const GList *head)
+{
+  return g_list_next(list) ? g_list_next(list) : head;
+}
+
+static inline const GList *g_list_prev_wraparound(const GList *list)
+{
+  // return the prior element of the list, unless already on the first element; in that case, return the last
+  // element of the list.
+  return g_list_previous(list) ? g_list_previous(list) : g_list_last((GList*)list);
+}
+
 void dt_print_mem_usage();
 
 void dt_configure_performance();

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -555,6 +555,20 @@ static inline void copy_pixel(float *const __restrict__ out, const float *const 
   for_each_channel(k,aligned(in,out:16)) out[k] = in[k];
 }
 
+// a few macros and helper functions to speed up certain frequently-used GLib operations
+#define g_list_is_singleton(list) ((list) && (!(list)->next))
+static inline int g_list_shorter_than(const GList *list, unsigned len)
+{
+  // instead of scanning the full list to compute its length and then comparing against the limit,
+  // bail out as soon as the limit is reached.  Usage: g_list_shorter_than(l,4) instead of g_list_length(l)<4
+  while (len-- > 0)
+  {
+    if (!list) return 1;
+    list = g_list_next(list);
+  }
+  return 0;
+}
+
 void dt_print_mem_usage();
 
 void dt_configure_performance();

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -557,16 +557,16 @@ static inline void copy_pixel(float *const __restrict__ out, const float *const 
 
 // a few macros and helper functions to speed up certain frequently-used GLib operations
 #define g_list_is_singleton(list) ((list) && (!(list)->next))
-static inline int g_list_shorter_than(const GList *list, unsigned len)
+static inline gboolean g_list_shorter_than(const GList *list, unsigned len)
 {
   // instead of scanning the full list to compute its length and then comparing against the limit,
   // bail out as soon as the limit is reached.  Usage: g_list_shorter_than(l,4) instead of g_list_length(l)<4
   while (len-- > 0)
   {
-    if (!list) return 1;
+    if (!list) return TRUE;
     list = g_list_next(list);
   }
-  return 0;
+  return FALSE;
 }
 
 // advance the list by one position, unless already at the final node

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1714,8 +1714,7 @@ gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo)
   }
 
   if(undo) dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
-  GList *l = l_copy;
-  while(l)
+  for (const GList *l = l_copy; l; l = g_list_next(l))
   {
     const int dest = GPOINTER_TO_INT(l->data);
     dt_history_copy_and_paste_on_image(darktable.view_manager->copy_paste.copied_imageid,
@@ -1723,7 +1722,6 @@ gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo)
                                        darktable.view_manager->copy_paste.selops,
                                        darktable.view_manager->copy_paste.copy_iop_order,
                                        darktable.view_manager->copy_paste.full_copy);
-    l = g_list_next(l);
   }
   if(undo) dt_undo_end_group(darktable.undo);
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1467,9 +1467,8 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
     g_free(normalized_filename);
     if(raise_signals)
     {
-      GList *imgs = NULL;
-      imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, (GList *)imgs, 0);
+      GList *imgs = g_list_prepend(NULL, GINT_TO_POINTER(id));
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
     }
     return id;
   }
@@ -1676,9 +1675,8 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   if(raise_signals)
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_IMPORT, id);
-    GList *imgs = NULL;
-    imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, (GList *)imgs, 0);
+    GList *imgs = g_list_prepend(NULL, GINT_TO_POINTER(id));
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
   }
 
   // the following line would look logical with new_tags_set being the return value

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1469,7 +1469,7 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
     {
       GList *imgs = NULL;
       imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, g_list_copy((GList *)imgs), 0);
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, (GList *)imgs, 0);
     }
     return id;
   }
@@ -1678,7 +1678,7 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_IMPORT, id);
     GList *imgs = NULL;
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, g_list_copy((GList *)imgs), 0);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, (GList *)imgs, 0);
   }
 
   // the following line would look logical with new_tags_set being the return value

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -830,7 +830,6 @@ GList *dt_ioppr_merge_module_multi_instance_iop_order_list(GList *iop_order_list
                                                            const char *operation, GList *multi_instance_list)
 {
   const int count_to = _count_entries_operation(iop_order_list, operation);
-  const int count_from = g_list_length(multi_instance_list);
 
   int item_nb = 0;
 
@@ -865,7 +864,7 @@ GList *dt_ioppr_merge_module_multi_instance_iop_order_list(GList *iop_order_list
   }
 
   // if needed removes all other instance of this operation which are superfluous
-  if(count_from < count_to)
+  if(g_list_shorter_than(multi_instance_list, count_to))
   {
     while(link)
     {

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -739,15 +739,13 @@ void dt_metadata_clear(const GList *imgs, const gboolean undo_on)
 void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboolean clear_on,
                              const gboolean undo_on)
 {
-  GList *imgs = g_list_copy((GList *)img);
-  if(imgs)
+  if(img)
   {
     GList *undo = NULL;
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
 
-    _metadata_execute(imgs, metadata, &undo, undo_on, clear_on ? DT_MA_SET : DT_MA_ADD);
+    _metadata_execute(img, metadata, &undo, undo_on, clear_on ? DT_MA_SET : DT_MA_ADD);
 
-    g_list_free(imgs);
     if(undo_on)
     {
       dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -172,9 +172,9 @@ void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
     if(group_on) dt_grouping_add_grouped_images(&imgs);
 
-    const guint count = g_list_length(imgs);
-    if(count > 1)
+    if(!g_list_shorter_than(imgs,2)) // pop up a toast if rating multiple images at once
     {
+      const guint count = g_list_length(imgs);
       if(new_rating == DT_VIEW_REJECT)
         dt_control_log(ngettext("rejecting %d image", "rejecting %d images", count), count);
       else

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -108,10 +108,9 @@ static void _ratings_undo_data_free(gpointer data)
   g_list_free(l);
 }
 
-static void _ratings_apply(GList *imgs, const int rating, GList **undo, const gboolean undo_on)
+static void _ratings_apply(const GList *imgs, const int rating, GList **undo, const gboolean undo_on)
 {
-  GList *images = imgs;
-  while(images)
+  for(const GList *images = imgs; images; images = g_list_next(images))
   {
     const int image_id = GPOINTER_TO_INT(images->data);
     if(undo_on)
@@ -124,22 +123,18 @@ static void _ratings_apply(GList *imgs, const int rating, GList **undo, const gb
     }
 
     _ratings_apply_to_image(image_id, rating);
-
-    images = g_list_next(images);
   }
 }
 
 void dt_ratings_apply_on_list(const GList *img, const int rating, const gboolean undo_on)
 {
-  GList *imgs = g_list_copy((GList *)img);
-  if(imgs)
+  if(img)
   {
     GList *undo = NULL;
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
 
-    _ratings_apply(imgs, rating, &undo, undo_on);
+    _ratings_apply(img, rating, &undo, undo_on);
 
-    g_list_free(imgs);
     if(undo_on)
     {
       dt_undo_record(darktable.undo, NULL, DT_UNDO_RATINGS, undo, _pop_undo, _ratings_undo_data_free);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -656,20 +656,17 @@ void dt_multiple_styles_apply_to_list(GList *styles, const GList *list, gboolean
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
 
-  const guint styles_cnt = g_list_length(styles);
-  const guint images_cnt = g_list_length((GList *)list);
-
-  if(!styles_cnt && !images_cnt)
+  if(!styles && !list)
   {
     dt_control_log(_("no images nor styles selected!"));
     return;
   }
-  else if(!styles_cnt)
+  else if(!styles)
   {
     dt_control_log(_("no styles selected!"));
     return;
   }
-  else if(!images_cnt)
+  else if(!list)
   {
     dt_control_log(_("no image selected!"));
     return;
@@ -679,25 +676,22 @@ void dt_multiple_styles_apply_to_list(GList *styles, const GList *list, gboolean
 
   /* for each selected image apply style */
   dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
-  GList *l = g_list_first((GList *)list);
-  while(l)
+  for(GList *l = g_list_first((GList *)list); l; l = g_list_next(l))
   {
     const int imgid = GPOINTER_TO_INT(l->data);
-    GList *style = NULL;
-
     if(mode == DT_STYLE_HISTORY_OVERWRITE)
       dt_history_delete_on_image_ext(imgid, FALSE);
 
-    for (style = styles; style != NULL; style = style->next)
+    for (GList *style = styles; style != NULL; style = style->next)
     {
       dt_styles_apply_to_image((char*)style->data, duplicate, imgid);
     }
-    l = g_list_next(l);
   }
   dt_undo_end_group(darktable.undo);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
+  const guint styles_cnt = g_list_length(styles);
   dt_control_log(ngettext("style successfully applied!", "styles successfully applied!", styles_cnt));
 }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -436,17 +436,15 @@ gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolea
   if(!img) return FALSE;
   GList *undo = NULL;
   GList *tags = NULL;
-  GList *imgs = g_list_copy((GList *)img);
 
-  if(imgs)
+  if(img)
   {
     tags = g_list_prepend(tags, GINT_TO_POINTER(tagid));
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
-    const gboolean res = _tag_execute(tags, imgs, &undo, undo_on, DT_TA_ATTACH);
+    const gboolean res = _tag_execute(tags, img, &undo, undo_on, DT_TA_ATTACH);
 
     g_list_free(tags);
-    g_list_free(imgs);
     if(undo_on)
     {
       dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
@@ -481,15 +479,13 @@ gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_
 gboolean dt_tag_set_tags(const GList *tags, const GList *img, const gboolean ignore_dt_tags,
                          const gboolean clear_on, const gboolean undo_on)
 {
-  GList *imgs = g_list_copy((GList *)img);
-  if(imgs)
+  if(img)
   {
     GList *undo = NULL;
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
-    const gboolean res = _tag_execute(tags, imgs, &undo, undo_on,
+    const gboolean res = _tag_execute(tags, img, &undo, undo_on,
                                       clear_on ? ignore_dt_tags ? DT_TA_SET : DT_TA_SET_ALL : DT_TA_ATTACH);
-    g_list_free(imgs);
     if(undo_on)
     {
       dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
@@ -524,15 +520,13 @@ gboolean dt_tag_attach_string_list(const gchar *tags, const GList *img, const gb
     }
 
     // attach newly created tags
-    GList *imgs = g_list_copy((GList *)img);
-    if(imgs)
+    if(img)
     {
       GList *undo = NULL;
       if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
-      res = _tag_execute(tagl, imgs, &undo, undo_on, DT_TA_ATTACH);
+      res = _tag_execute(tagl, img, &undo, undo_on, DT_TA_ATTACH);
 
-      g_list_free(imgs);
       if(undo_on)
       {
         dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
@@ -547,18 +541,16 @@ gboolean dt_tag_attach_string_list(const gchar *tags, const GList *img, const gb
 
 gboolean dt_tag_detach_images(const guint tagid, const GList *img, const gboolean undo_on)
 {
-  GList *imgs = g_list_copy((GList *)img);
-  if(imgs)
+  if(img)
   {
     GList *tags = NULL;
     tags = g_list_prepend(tags, GINT_TO_POINTER(tagid));
     GList *undo = NULL;
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
-    const gboolean res = _tag_execute(tags, imgs, &undo, undo_on, DT_TA_DETACH);
+    const gboolean res = _tag_execute(tags, img, &undo, undo_on, DT_TA_DETACH);
 
     g_list_free(tags);
-    g_list_free(imgs);
     if(undo_on)
     {
       dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -255,8 +255,7 @@ static void _brush_catmull_to_bezier(float x1, float y1, float x2, float y2, flo
 static void _brush_init_ctrl_points(dt_masks_form_t *form)
 {
   // if we have less than 2 points, what to do ??
-  const guint nb = g_list_length(form->points);
-  if(nb < 2) return;
+  if(g_list_shorter_than(form->points, 2)) return;
 
   // we need extra points to deal with curve ends
   dt_masks_point_brush_t start_point[2], end_point[2];
@@ -1379,7 +1378,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
   else if(gui->point_selected >= 0 && which == 3)
   {
     // we remove the point (and the entire form if there is too few points)
-    if(g_list_length(form->points) <= 2)
+    if(g_list_shorter_than(form->points, 3))
     {
       // if the form doesn't below to a group, we don't delete it
       if(parentid <= 0) return 1;
@@ -1387,7 +1386,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       // we hide the form
       if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
         dt_masks_change_form_gui(NULL);
-      else if(g_list_length(darktable.develop->form_visible->points) < 2)
+      else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
         dt_masks_change_form_gui(NULL);
       else
       {
@@ -1456,7 +1455,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
       dt_masks_change_form_gui(NULL);
-    else if(g_list_length(darktable.develop->form_visible->points) < 2)
+    else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
       dt_masks_change_form_gui(NULL);
     else
     {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -342,7 +342,7 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
       dt_masks_change_form_gui(NULL);
-    else if(g_list_length(darktable.develop->form_visible->points) < 2)
+    else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
       dt_masks_change_form_gui(NULL);
     else
     {

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -776,7 +776,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
       dt_masks_change_form_gui(NULL);
-    else if(g_list_length(darktable.develop->form_visible->points) < 2)
+    else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
       dt_masks_change_form_gui(NULL);
     else
     {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -213,7 +213,7 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
       dt_masks_change_form_gui(NULL);
-    else if(g_list_length(darktable.develop->form_visible->points) < 2)
+    else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
       dt_masks_change_form_gui(NULL);
     else
     {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -960,7 +960,7 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
 
         for(const GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
         {
-          const GList *next = g_list_next(form_points) ? g_list_next(form_points) : form->points; // next w/ wrap
+          const GList *next = g_list_next_wraparound(form_points, form->points); // next w/ wrap
           dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
           dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)next->data;
           surf += point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1];

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -165,20 +165,16 @@ static void _path_init_ctrl_points(dt_masks_form_t *form)
 
 static gboolean _path_is_clockwise(dt_masks_form_t *form)
 {
-  const guint nb = g_list_length(form->points);
-  if(nb > 2)
+  if(!g_list_shorter_than(form->points,3)) // if we have at least three points...
   {
     float sum = 0.0f;
-    const GList *form_points = form->points;
-    for(int k = 0; k < nb; k++)
+    for(const GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
     {
-      const int k2 = (k + 1) % nb;
+      GList *next = g_list_next(form_points) ? g_list_next(form_points) : form->points; // next, with wraparound
       dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
-      dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k2);
-      // edge k
+      dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)next->data;
       sum += (point2->corner[0] - point1->corner[0]) * (point2->corner[1] + point1->corner[1]);
-      // keep form_points tracking the kth element of form->points
-      form_points = g_list_next(form_points);
+      ;
     }
     return (sum < 0);
   }
@@ -925,7 +921,7 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
       // resize don't care where the mouse is inside a shape
       if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
-        float masks_size, feather_size = 0.0f;
+        float masks_size = 1.0f, feather_size = 0.0f;
         _path_get_sizes(module, form, gui, index, &masks_size, &feather_size);
 
         // do not exceed upper limit of 1.0
@@ -962,20 +958,17 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
         float by = 0.0f;
         float surf = 0.0f;
 
-        guint nb = g_list_length(form->points);
-        const GList *form_points = form->points;
-        for(int k = 0; k < nb; k++)
+        for(const GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
         {
-          int k2 = (k + 1) % nb;
+          const GList *next = g_list_next(form_points) ? g_list_next(form_points) : form->points; // next w/ wrap
           dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
-          dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)g_list_nth_data(form->points, k2);
+          dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)next->data;
           surf += point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1];
 
           bx += (point1->corner[0] + point2->corner[0])
                 * (point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1]);
           by += (point1->corner[1] + point2->corner[1])
                 * (point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1]);
-          form_points = g_list_next(form_points);
         }
         bx /= 3.0f * surf;
         by /= 3.0f * surf;
@@ -1059,7 +1052,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
   else if(gui->creation && (which == 3 || gui->creation_closing_form))
   {
     // we don't want a form with less than 3 points
-    if(g_list_length(form->points) < 4)
+    if(g_list_shorter_than(form->points, 4))
     {
       // we don't really have a way to know if the user wants to cancel the continuous add here
       // or just cancelling this mask, let's assume that this is not a mistake and cancel
@@ -1313,11 +1306,10 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
         // interpolate the border width of the two neighbour points'
-        const int max_index = g_list_length(form->points) - 1;
-        const int left_index = gui->seg_selected;
-        const int right_index = gui->seg_selected == max_index ? 0 : gui->seg_selected + 1;
-        dt_masks_point_path_t *left = (dt_masks_point_path_t *)g_list_nth_data(form->points, left_index);
-        dt_masks_point_path_t *right = (dt_masks_point_path_t *)g_list_nth_data(form->points, right_index);
+        const GList* first = g_list_nth(form->points, gui->seg_selected);
+        const GList* second = g_list_next(first) ? g_list_next(first) : form->points; // next with wraparound
+        dt_masks_point_path_t *left = (dt_masks_point_path_t *)first->data;
+        dt_masks_point_path_t *right = (dt_masks_point_path_t *)second->data;
         bzpt->border[0] = MAX(0.0005f, (left->border[0] + right->border[0]) * 0.5);
         bzpt->border[1] = MAX(0.0005f, (left->border[1] + right->border[1]) * 0.5);
 
@@ -1343,7 +1335,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
   else if(which == 3 && gui->point_selected >= 0)
   {
     // we remove the point (and the entire form if there is too few points)
-    if(g_list_length(form->points) < 4)
+    if(g_list_shorter_than(form->points, 4))
     {
       // if the form doesn't belong to a group, we don't delete it
       if(parentid <= 0) return 1;
@@ -1351,7 +1343,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       // we hide the form
       if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
         dt_masks_change_form_gui(NULL);
-      else if(g_list_length(darktable.develop->form_visible->points) < 2)
+      else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
         dt_masks_change_form_gui(NULL);
       else
       {
@@ -1427,7 +1419,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
       dt_masks_change_form_gui(NULL);
-    else if(g_list_length(darktable.develop->form_visible->points) < 2)
+    else if(g_list_shorter_than(darktable.develop->form_visible->points, 2))
       dt_masks_change_form_gui(NULL);
     else
     {
@@ -1639,7 +1631,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     const float wd = darktable.develop->preview_pipe->backbuf_width;
     const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd, pzy * ht };
-    if(gui->creation && g_list_length(form->points) > 3)
+    if(gui->creation && !g_list_shorter_than(form->points, 4))
     {
       // if we are near the first point, we have to say that the form should be closed
       if(pts[0] - gpt->points[2] < as && pts[0] - gpt->points[2] > -as && pts[1] - gpt->points[3] < as

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -411,7 +411,7 @@ static gboolean _thumbs_zoom_add(dt_culling_t *table, const float zoom_delta, co
     l = g_list_next(l);
   }
 
-  if(g_list_length(table->list) > 1)
+  if(!g_list_shorter_than(table->list, 2))  // at least two images?
   {
     // CULLING with multiple images
     // if shift+ctrl, we only change the current image
@@ -1193,7 +1193,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
   int nbnew = 0;
   int pos = 0;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
-  while(sqlite3_step(stmt) == SQLITE_ROW && g_list_length(newlist) <= table->thumbs_count)
+  while(sqlite3_step(stmt) == SQLITE_ROW && g_list_shorter_than(newlist, table->thumbs_count+1))
   {
     const int nrow = sqlite3_column_int(stmt, 0);
     const int nid = sqlite3_column_int(stmt, 1);
@@ -1262,8 +1262,8 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
 
   // in rare cases, we can have less images than wanted
   // although there's images before (this shouldn't happen in preview)
-  if(table->navigate_inside_selection && g_list_length(newlist) < table->thumbs_count
-     && g_list_length(newlist) < _get_selection_count())
+  if(table->navigate_inside_selection && g_list_shorter_than(newlist, table->thumbs_count)
+     && g_list_shorter_than(newlist, _get_selection_count()))
   {
     const int nb = table->thumbs_count - g_list_length(newlist);
     query = dt_util_dstrcat(NULL,
@@ -1277,7 +1277,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     if(stmt != NULL)
     {
       pos = 0;
-      while(sqlite3_step(stmt) == SQLITE_ROW && g_list_length(newlist) <= table->thumbs_count)
+      while(sqlite3_step(stmt) == SQLITE_ROW && g_list_shorter_than(newlist, table->thumbs_count+1))
       {
         const int nrow = sqlite3_column_int(stmt, 0);
         const int nid = sqlite3_column_int(stmt, 1);
@@ -1360,7 +1360,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   if(!table->list) return FALSE;
 
   // if we have only 1 image, it should take the entire screen
-  if(g_list_length(table->list) == 1)
+  if(g_list_is_singleton(table->list))
   {
     dt_thumbnail_t *thumb = (dt_thumbnail_t *)table->list->data;
     thumb->width = table->view_width;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2276,7 +2276,10 @@ static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable,
   dt_dev_undo_start_record(darktable.develop);
 
   const gboolean ret = dt_history_paste_on_list(imgs, TRUE);
-  if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  if(ret)
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  else
+    g_list_free(imgs);
 
   dt_dev_undo_end_record(darktable.develop);
 
@@ -2290,7 +2293,10 @@ static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *accelera
   dt_dev_undo_start_record(darktable.develop);
 
   const gboolean ret = dt_history_paste_parts_on_list(imgs, TRUE);
-  if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  if(ret)
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  else
+    g_list_free(imgs);
 
   dt_dev_undo_end_record(darktable.develop);
   return TRUE;
@@ -2300,7 +2306,10 @@ static gboolean _accel_hist_discard(GtkAccelGroup *accel_group, GObject *acceler
 {
   GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
   const gboolean ret = dt_history_delete_on_list(imgs, TRUE);
-  if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  if(ret)
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  else
+    g_list_free(imgs);
   return TRUE;
 }
 static gboolean _accel_duplicate(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -635,7 +635,7 @@ static gboolean _move(dt_thumbtable_t *table, const int x, const int y, gboolean
       table->realign_top_try = 0;
 
       dt_thumbnail_t *last = (dt_thumbnail_t *)g_list_last(table->list)->data;
-      if(table->thumbs_per_row == 1 && posy < 0 && g_list_length(table->list) == 1)
+      if(table->thumbs_per_row == 1 && posy < 0 && g_list_is_singleton(table->list))
       {
         // special case for zoom == 1 as we don't want any space under last image (the image would have disappear)
         int nbid = 1;
@@ -1239,8 +1239,8 @@ static void _dt_active_images_callback(gpointer instance, gpointer user_data)
   if(!user_data) return;
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
-  if(g_slist_length(darktable.view_manager->active_images) == 0) return;
-  int activeid = GPOINTER_TO_INT(g_slist_nth_data(darktable.view_manager->active_images, 0));
+  if(!darktable.view_manager->active_images) return;
+  int activeid = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
   dt_thumbtable_set_offset_image(table, activeid, TRUE);
 }
 
@@ -1373,9 +1373,9 @@ static void _dt_collection_changed_callback(gpointer instance, dt_collection_cha
 
     // in filmstrip mode, let's first ensure the offset is the right one. Otherwise we move to it
     int old_offset = -1;
-    if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP && g_slist_length(darktable.view_manager->active_images) > 0)
+    if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP && darktable.view_manager->active_images)
     {
-      const int tmpoff = GPOINTER_TO_INT(g_slist_nth_data(darktable.view_manager->active_images, 0));
+      const int tmpoff = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
       if(tmpoff != table->offset_imgid)
       {
         old_offset = table->offset_imgid;
@@ -1590,7 +1590,7 @@ static void _event_dnd_get(GtkWidget *widget, GdkDragContext *context, GtkSelect
     case DND_TARGET_URI:
     {
       GList *l = table->drag_list;
-      if(g_list_length(l) == 1)
+      if(g_list_is_singleton(l))
       {
         gchar pathname[PATH_MAX] = { 0 };
         gboolean from_cache = TRUE;
@@ -1650,7 +1650,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
     // if we are dragging a single image -> use the thumbnail of that image
     // otherwise use the generic d&d icon
     // TODO: have something pretty in the 2nd case, too.
-    if(g_list_length(table->drag_list) == 1)
+    if(g_list_is_singleton(table->drag_list))
     {
       const int id = GPOINTER_TO_INT(table->drag_list->data);
       dt_mipmap_buffer_t buf;
@@ -2006,7 +2006,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
     // we need to ensure there's no need to load other image on top/bottom
     if(table->mode == DT_THUMBTABLE_MODE_ZOOM) nbnew += _thumbs_load_needed(table);
 
-    if(g_slist_length(darktable.view_manager->active_images) > 0
+    if(darktable.view_manager->active_images
        && (table->mode == DT_THUMBTABLE_MODE_ZOOM || table->mode == DT_THUMBTABLE_MODE_FILEMANAGER))
     {
       // this mean we arrive from filmstrip with some active images
@@ -2183,7 +2183,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
 
   // if we are in darkroom we show a message as there might be no other indication
   const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
-  if(v->view(v) == DT_VIEW_DARKROOM && g_list_length(imgs) == 1 && darktable.develop->preview_pipe)
+  if(v->view(v) == DT_VIEW_DARKROOM && g_list_is_singleton(imgs) && darktable.develop->preview_pipe)
   {
     // we verify that the image is the active one
     const int id = GPOINTER_TO_INT(imgs->data);
@@ -2225,7 +2225,7 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
 
   // if we are in darkroom we show a message as there might be no other indication
   const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
-  if(v->view(v) == DT_VIEW_DARKROOM && g_list_length(imgs) == 1 && darktable.develop->preview_pipe)
+  if(v->view(v) == DT_VIEW_DARKROOM && g_list_is_singleton(imgs) && darktable.develop->preview_pipe)
   {
     // we verify that the image is the active one
     const int id = GPOINTER_TO_INT(imgs->data);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -301,7 +301,7 @@ static void usercss_dialog_callback(GtkDialog *dialog, gint response_id, gpointe
 static void language_callback(GtkWidget *widget, gpointer user_data)
 {
   int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-  dt_l10n_language_t *language = (dt_l10n_language_t *)g_list_nth(darktable.l10n->languages, selected)->data;
+  dt_l10n_language_t *language = (dt_l10n_language_t *)g_list_nth_data(darktable.l10n->languages, selected);
   if(darktable.l10n->sys_default == selected)
   {
     dt_conf_set_string("ui_last/gui_language", "");

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -307,13 +307,17 @@ static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
 
   // at the time the dialog is started, some signals are sent and this in turn call
-  // back dt_view_get_images_to_act_on() which free list and create a new one. So the
-  // above imgs will be invalidated.
+  // back dt_view_get_images_to_act_on() which free list and create a new one. So we
+  // make a copy because the above imgs will be invalidated.
 
-  if(dt_history_paste_parts_on_list(imgs, TRUE))
+  GList* imgs_copy = g_list_copy((GList*)imgs);
+  if(dt_history_paste_parts_on_list(imgs_copy, TRUE))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_copy((GList *)imgs));
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs_copy); // frees imgs_copy
+  }
+  else
+  {
+    g_list_free(imgs_copy);
   }
 }
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -274,13 +274,10 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(res == GTK_RESPONSE_YES)
   {
+    dt_history_delete_on_list(imgs, TRUE);
     GList *imgs_copy = g_list_copy((GList *)imgs);
-    dt_history_delete_on_list(imgs_copy, TRUE);
-
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_copy((GList *)imgs_copy));
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs_copy); // frees imgs_copy
     dt_control_queue_redraw_center();
-    g_list_free(imgs_copy);
   }
 }
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -313,15 +313,11 @@ static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   // back dt_view_get_images_to_act_on() which free list and create a new one. So the
   // above imgs will be invalidated.
 
-  GList *l_copy = g_list_copy((GList *)imgs);
-
   if(dt_history_paste_parts_on_list(imgs, TRUE))
   {
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_copy((GList *)l_copy));
+                               g_list_copy((GList *)imgs));
   }
-  else
-    g_list_free(l_copy);
 }
 
 static void pastemode_combobox_changed(GtkWidget *widget, gpointer user_data)

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -70,20 +70,22 @@ static void _update(dt_lib_module_t *self)
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
 
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
-  const guint act_on_cnt = g_list_length((GList *)imgs);
+  const int act_on_any = imgs != NULL;
+  const int act_on_one = g_list_is_singleton(imgs);
+  const int act_on_mult = act_on_any && !act_on_one;
   const gboolean can_paste
       = darktable.view_manager->copy_paste.copied_imageid > 0
-        && (act_on_cnt > 1
-            || (act_on_cnt == 1
+        && (act_on_mult
+            || (act_on_one
                 && (darktable.view_manager->copy_paste.copied_imageid != dt_view_get_image_to_act_on())));
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->discard_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->compress_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->load_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->write_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->discard_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->compress_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->load_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->write_button), act_on_any);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_button), act_on_cnt == 1);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_parts_button), act_on_cnt == 1);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_button), act_on_one);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_parts_button), act_on_one);
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste), can_paste);
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste_parts), can_paste);
@@ -99,7 +101,8 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
   if(!imgs)
     return;
-  const guint act_on_cnt = g_list_length((GList *)imgs);
+  const int act_on_any = imgs != NULL;  // list length > 0?
+  const int act_on_one = g_list_is_singleton(imgs); // list length == 1?
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *filechooser = gtk_file_chooser_dialog_new(
       _("open sidecar file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN, _("_cancel"),
@@ -107,7 +110,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  if(act_on_cnt == 1)
+  if(act_on_one)
   {
     //single image to load xmp to, assume we want to load from same dir
     const int imgid = GPOINTER_TO_INT(imgs->data);
@@ -177,7 +180,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
                                     g_list_copy((GList *)imgs), 0);
       dt_control_queue_redraw_center();
     }
-    if(act_on_cnt > 0)
+    if(act_on_any)
     {
       //remember last import path if applying history to multiple images
       gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
@@ -247,13 +250,12 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
   gint res = GTK_RESPONSE_YES;
 
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
-  GList *imgs_copy = g_list_copy((GList *)imgs);
 
   if(dt_conf_get_bool("ask_before_discard"))
   {
     const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-    const int number = g_list_length((GList *)imgs_copy);
+    const int number = g_list_length((GList *)imgs);
 
     if (number == 0) return;
 
@@ -272,14 +274,14 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(res == GTK_RESPONSE_YES)
   {
+    GList *imgs_copy = g_list_copy((GList *)imgs);
     dt_history_delete_on_list(imgs_copy, TRUE);
 
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
                                g_list_copy((GList *)imgs_copy));
     dt_control_queue_redraw_center();
+    g_list_free(imgs_copy);
   }
-
-  g_list_free(imgs_copy);
 }
 
 static void paste_button_clicked(GtkWidget *widget, gpointer user_data)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1192,7 +1192,7 @@ static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer use
   for(GList *l = children; l != NULL; l = g_list_next(l))
   {
     GList *hbox = gtk_container_get_children(GTK_CONTAINER(l->data));
-    GtkToggleButton *b = GTK_TOGGLE_BUTTON(g_list_nth(hbox, HIST_WIDGET_MODULE)->data);
+    GtkToggleButton *b = GTK_TOGGLE_BUTTON(g_list_nth_data(hbox, HIST_WIDGET_MODULE));
     if(b != GTK_TOGGLE_BUTTON(widget)) g_object_set(G_OBJECT(b), "active", FALSE, (gchar *)0);
   }
   g_list_free(children);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -191,48 +191,52 @@ static void _update(dt_lib_module_t *self)
   dt_lib_image_t *d = (dt_lib_image_t *)self->data;
   const GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE);
 
-  const guint act_on_cnt = g_list_length((GList *)imgs);
+  const int act_on_any = imgs != NULL;              // list length > 0 ?
+  const int act_on_one = g_list_is_singleton(imgs); // list length == 1 ?
+  const int act_on_mult = act_on_any && !act_on_one;// list length > 1 ?
   const uint32_t selected_cnt = dt_collection_get_selected_count(darktable.collection);
   const gboolean can_paste
-      = d->imageid > 0 && (act_on_cnt > 1 || (act_on_cnt == 1 && (d->imageid != dt_view_get_image_to_act_on())));
+      = d->imageid > 0 && (act_on_mult || (act_on_one && (d->imageid != dt_view_get_image_to_act_on())));
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->remove_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->remove_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), act_on_any);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->move_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->move_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_button), act_on_any);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->create_hdr_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->duplicate_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->create_hdr_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->duplicate_button), act_on_any);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->rotate_ccw_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->rotate_cw_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->reset_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->rotate_ccw_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->rotate_cw_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->reset_button), act_on_any);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->cache_button), act_on_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->uncache_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->cache_button), act_on_any);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->uncache_button), act_on_any);
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->group_button), selected_cnt > 1);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_metadata_button), act_on_cnt == 1);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->copy_metadata_button), act_on_one);
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste_metadata_button), can_paste);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->clear_metadata_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->clear_metadata_button), act_on_any);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->refresh_button), act_on_cnt > 0);
-  if(act_on_cnt > 1)
+  gtk_widget_set_sensitive(GTK_WIDGET(d->refresh_button), act_on_any);
+  if(act_on_mult)
   {
     gtk_widget_set_sensitive(GTK_WIDGET(d->ungroup_button), TRUE);
     gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), TRUE);
     gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), TRUE);
   }
-  else if(act_on_cnt == 0)
+  else if(!act_on_any)
   {
+    // no images to act on!
     gtk_widget_set_sensitive(GTK_WIDGET(d->ungroup_button), FALSE);
     gtk_widget_set_sensitive(GTK_WIDGET(d->set_monochrome_button), FALSE);
     gtk_widget_set_sensitive(GTK_WIDGET(d->set_color_button), FALSE);
   }
   else
   {
+    // exact one image to act on
     const int imgid = dt_view_get_image_to_act_on();
     if(imgid >= 0)
     {

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -331,7 +331,7 @@ static void _lib_location_search_finish(gpointer user_data)
 
   /* if we only got one search result back lets
      set center location and zoom based on place type  */
-  if(g_list_length(lib->places) == 1)
+  if(g_list_is_singleton(lib->places))
   {
     _lib_location_result_t *place = (_lib_location_result_t *)lib->places->data;
     _show_location(lib, place);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -987,7 +987,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
     int depth = 0;
     if(nb > 0)
     {
-      it0 = (GtkTreePath *)g_list_nth_data(gtk_tree_selection_get_selected_rows(selection, NULL), 0);
+      it0 = (GtkTreePath *)gtk_tree_selection_get_selected_rows(selection, NULL)->data;
       depth = gtk_tree_path_get_depth(it0);
     }
     if(depth > 1) from_group = 1;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2262,7 +2262,7 @@ static void _manage_editor_group_update_arrows(GtkWidget *box)
     if(hb)
     {
       GList *lw2 = gtk_container_get_children(GTK_CONTAINER(hb));
-      if(g_list_length(lw2) > 2)
+      if(!g_list_shorter_than(lw2,3)) //do we have at least three?
       {
         GtkWidget *left = (GtkWidget *)lw2->data;
         GtkWidget *right = (GtkWidget *)g_list_nth_data(lw2, 2);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2258,7 +2258,7 @@ static void _manage_editor_group_update_arrows(GtkWidget *box)
   while(lw)
   {
     GtkWidget *w = (GtkWidget *)lw->data;
-    GtkWidget *hb = (GtkWidget *)g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(w)), 0);
+    GtkWidget *hb = (GtkWidget *)gtk_container_get_children(GTK_CONTAINER(w))->data;
     if(hb)
     {
       GList *lw2 = gtk_container_get_children(GTK_CONTAINER(hb));
@@ -3550,7 +3550,7 @@ static void _manage_preset_delete(GtkWidget *widget, GdkEventButton *event, dt_l
     // otherwise we load the first preset
     if(!sel_ok)
     {
-      GtkWidget *ww = (GtkWidget *)g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(d->presets_list)), 0);
+      GtkWidget *ww = (GtkWidget *)gtk_container_get_children(GTK_CONTAINER(d->presets_list))->data;
       if(ww)
       {
         const char *firstn = (char *)g_object_get_data(G_OBJECT(ww), "preset_name");
@@ -3749,7 +3749,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   // or the first one if no selection found
   if(!sel_ok)
   {
-    GtkWidget *w = (GtkWidget *)g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(d->presets_list)), 0);
+    GtkWidget *w = (GtkWidget *)gtk_container_get_children(GTK_CONTAINER(d->presets_list))->data;
     if(w)
     {
       const char *firstn = (char *)g_object_get_data(G_OBJECT(w), "preset_name");

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2262,7 +2262,7 @@ static void _manage_editor_group_update_arrows(GtkWidget *box)
     if(hb)
     {
       GList *lw2 = gtk_container_get_children(GTK_CONTAINER(hb));
-      if(!g_list_shorter_than(lw2,3)) //do we have at least three?
+      if(!g_list_shorter_than(lw2, 3)) //do we have at least three?
       {
         GtkWidget *left = (GtkWidget *)lw2->data;
         GtkWidget *right = (GtkWidget *)g_list_nth_data(lw2, 2);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -390,7 +390,7 @@ _print_button_clicked (GtkWidget *widget, gpointer user_data)
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
   int imgid = -1;
-  if(g_slist_length(dt_view_active_images_get()) > 0)
+  if(dt_view_active_images_get())
     imgid = GPOINTER_TO_INT(g_slist_nth_data(dt_view_active_images_get(), 0));
 
   if (imgid == -1)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -391,7 +391,7 @@ _print_button_clicked (GtkWidget *widget, gpointer user_data)
 
   int imgid = -1;
   if(dt_view_active_images_get())
-    imgid = GPOINTER_TO_INT(g_slist_nth_data(dt_view_active_images_get(), 0));
+    imgid = GPOINTER_TO_INT(dt_view_active_images_get()->data);
 
   if (imgid == -1)
   {

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -451,7 +451,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
             gtk_widget_show_all(dialog_overwrite_export);
 
             // disable check button and skip button when only one style is selected
-            if(g_list_length(style_names) == 1)
+            if(g_list_is_singleton(style_names))
             {
               gtk_widget_set_sensitive(overwrite_dialog_check_button, FALSE);
               gtk_dialog_set_response_sensitive(GTK_DIALOG(dialog_overwrite_export), GTK_RESPONSE_NONE, FALSE);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2456,11 +2456,10 @@ static void _view_map_dnd_get_callback(GtkWidget *widget, GdkDragContext *contex
           if(imgs_nb)
           {
             uint32_t *imgs = malloc(sizeof(uint32_t) * imgs_nb);
-            GList *l = lib->selected_images;
-            for(int i = 0; i < imgs_nb; i++)
+            int i = 0;
+            for(GList *l = lib->selected_images; l; l = g_list_next(l))
             {
-              imgs[i] = GPOINTER_TO_INT(l->data);
-              l = g_list_next(l);
+              imgs[i++] = GPOINTER_TO_INT(l->data);
             }
             gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data),
                                    _DWORD, (guchar *)imgs, imgs_nb * sizeof(uint32_t));

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -219,7 +219,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
 
   lib->image_over = DT_VIEW_DESERT;
   GSList *l = dt_view_active_images_get();
-  if(g_slist_length(l) > 0) lib->image_id = GPOINTER_TO_INT(g_slist_nth_data(l, 0));
+  if(l) lib->image_id = GPOINTER_TO_INT(l->data);
 
   lib->image_over = lib->image_id;
 
@@ -495,10 +495,7 @@ void enter(dt_view_t *self)
   // no active image when entering the tethering view
   lib->image_over = DT_VIEW_DESERT;
   GSList *l = dt_view_active_images_get();
-  if(g_slist_length(l) > 0)
-    lib->image_id = GPOINTER_TO_INT(g_slist_nth_data(l, 0));
-  else
-    lib->image_id = -1;
+  lib->image_id = l ? GPOINTER_TO_INT(l->data): -1;
 
   dt_view_active_images_reset(FALSE);
   dt_view_active_images_add(lib->image_id, TRUE);

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -495,7 +495,7 @@ void enter(dt_view_t *self)
   // no active image when entering the tethering view
   lib->image_over = DT_VIEW_DESERT;
   GSList *l = dt_view_active_images_get();
-  lib->image_id = l ? GPOINTER_TO_INT(l->data): -1;
+  lib->image_id = l ? GPOINTER_TO_INT(l->data) : -1;
 
   dt_view_active_images_reset(FALSE);
   dt_view_active_images_add(lib->image_id, TRUE);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -783,8 +783,7 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
   {
     // we test active images if mouse outside table
     gboolean ok = TRUE;
-    if(!dt_ui_thumbtable(darktable.gui->ui)->mouse_inside
-       && g_slist_length(darktable.view_manager->act_on.active_imgs) > 0)
+    if(!dt_ui_thumbtable(darktable.gui->ui)->mouse_inside && darktable.view_manager->act_on.active_imgs)
     {
       GSList *l1 = darktable.view_manager->act_on.active_imgs;
       GSList *l2 = darktable.view_manager->active_images;
@@ -851,7 +850,7 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
   else
   {
     // collumn 4,5
-    if(g_slist_length(darktable.view_manager->active_images) > 0)
+    if(darktable.view_manager->active_images)
     {
       // collumn 5
       GSList *ll = darktable.view_manager->active_images;
@@ -915,7 +914,7 @@ int dt_view_get_image_to_act_on()
   }
   else
   {
-    if(g_slist_length(darktable.view_manager->active_images) > 0)
+    if(darktable.view_manager->active_images)
     {
       ret = GPOINTER_TO_INT(g_slist_nth_data(darktable.view_manager->active_images, 0));
     }
@@ -1238,7 +1237,7 @@ void dt_view_filter_reset(const dt_view_manager_t *vm, gboolean smart_filter)
 
 void dt_view_active_images_reset(gboolean raise)
 {
-  if(g_slist_length(darktable.view_manager->active_images) < 1) return;
+  if(!darktable.view_manager->active_images) return;
   g_slist_free(darktable.view_manager->active_images);
   darktable.view_manager->active_images = NULL;
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -916,7 +916,7 @@ int dt_view_get_image_to_act_on()
   {
     if(darktable.view_manager->active_images)
     {
-      ret = GPOINTER_TO_INT(g_slist_nth_data(darktable.view_manager->active_images, 0));
+      ret = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
     }
     else
     {


### PR DESCRIPTION
Introduces two functions/macros to check whether a GList has length == 1 or length < N.  Avoids traversing the entire list if we only need to know that it has a certain minimum number of elements.

Further introduces functions g_list_next_wraparound and g_list_prev_wraparound to treat a GList as a circular list without having to resort to `g_list_nth(list,(pos+1)%g_list_length(list))`.

Also fixes a memory leak in copy_history.c (short-circuit return was bypassing deallocation) and memory leaks resulting from failure to free the copy of a list.
