### PR TITLE
Fix hdr-dng white balance

### DIFF
--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -160,9 +160,10 @@ static inline void dt_imageio_dng_write_tiff_header(
   white.f = whitelevel;
   b = dt_imageio_dng_make_tag(50717, LONG, 1, white.u, b, &cnt); // WhiteLevel in float, actually.
   b = dt_imageio_dng_make_tag(50721, SRATIONAL, 9, 480, b, &cnt); // ColorMatrix1 (XYZ->native cam)
+  b = dt_imageio_dng_make_tag(50728, RATIONAL, 3, 556, b, &cnt); // AsShotNeutral
   // b = dt_imageio_dng_make_tag(50729, RATIONAL, 2, 512, b, &cnt); // AsShotWhiteXY
   b = dt_imageio_dng_make_tag(50778, SHORT, 1, 21 << 16, b, &cnt); // CalibrationIlluminant1
-  b = dt_imageio_dng_make_tag(50728, RATIONAL, 3, 556, b, &cnt); // AsShotNeutral
+
   b = dt_imageio_dng_make_tag(0, 0, 0, 0, b, &cnt); /* Next IFD.  */
   buf[11] = cnt - 1; // write number of directory entries of this ifd
 

--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -78,7 +78,7 @@ static inline void dt_imageio_dng_write_tiff_header(
     const uint8_t xtrans[6][6],
     const float whitelevel,
     const float wb_coeffs[3],
-	const char camera_makermodel[128])
+    const char camera_makermodel[128])
 {
   const uint32_t channels = 1;
   uint8_t *b /*, *offs1, *offs2*/;
@@ -177,8 +177,8 @@ static inline void dt_imageio_dng_write_tiff_header(
   dt_dcraw_adobe_coeff((const char (*))camera_makermodel, (float(*)[12])XYZ_CAM);
   if(!isnan(XYZ_CAM[0]))
   {
-	for(int k= 0; k < 9; k++)  m[k] = round(XYZ_CAM[k] * 10000.0f);
-	den = 10000;
+  for(int k= 0; k < 9; k++)  m[k] = round(XYZ_CAM[k] * 10000.0f);
+  den = 10000;
   }
 
   for(int k = 0; k < 9; k++)
@@ -189,10 +189,10 @@ static inline void dt_imageio_dng_write_tiff_header(
 
   for(int k = 0; k < 3; k++)
    {
- 	// TAG AsShotNeutral: for rawspeed Dngdecoder camera white balance
- 	coeff[k] =1/( (wb_coeffs[k]/ wb_coeffs[1])) ;
- 	coeff[k]*= 1000000;
- 	dt_imageio_dng_write_buf(buf, 556+k*8,(int)coeff[k]);
+    // TAG AsShotNeutral: for rawspeed Dngdecoder camera white balance
+    coeff[k] = 1 / ( (wb_coeffs[k]/ wb_coeffs[1])) ;
+    coeff[k] *= 1000000;
+    dt_imageio_dng_write_buf(buf, 556+k*8,(int)coeff[k]);
     dt_imageio_dng_write_buf(buf, 560+k*8, 1000000);
    }
 
@@ -206,8 +206,8 @@ static inline void dt_imageio_write_dng(
     const int ht, void *exif, const int exif_len, const uint32_t filter,
     const uint8_t xtrans[6][6],
     const float whitelevel,
-	const float wb_coeffs[3],
-	const char camera_model[24])
+    const float wb_coeffs[3],
+    const char camera_model[24])
 {
   FILE *f = g_fopen(filename, "wb");
   if(f)

--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "external/adobe_coeff.c"
 
 
 #define II 1
@@ -75,13 +76,20 @@ static inline void dt_imageio_dng_write_tiff_header(
     FILE *fp, uint32_t xs, uint32_t ys, float Tv, float Av,
     float f, float iso, uint32_t filter,
     const uint8_t xtrans[6][6],
-    const float whitelevel)
+    const float whitelevel,
+    const float wb_coeffs[3],
+	const char camera_makermodel[128])
 {
   const uint32_t channels = 1;
   uint8_t *b /*, *offs1, *offs2*/;
   // uint32_t exif_offs;
   uint8_t buf[1024];
   uint8_t cnt = 0;
+  float coeff[3];
+  float XYZ_CAM[12];
+  // this matrix is generic for XYZ->sRGB / D65
+  int m[9] = { 3240454, -1537138, -498531, -969266, 1876010, 41556, 55643, -204025, 1057225 };
+  int den = 1000000;
 
   memset(buf, 0, sizeof(buf));
   /* TIFF file header.  */
@@ -152,10 +160,9 @@ static inline void dt_imageio_dng_write_tiff_header(
   white.f = whitelevel;
   b = dt_imageio_dng_make_tag(50717, LONG, 1, white.u, b, &cnt); // WhiteLevel in float, actually.
   b = dt_imageio_dng_make_tag(50721, SRATIONAL, 9, 480, b, &cnt); // ColorMatrix1 (XYZ->native cam)
-
-  // b = dt_imageio_dng_make_tag(50728, RATIONAL, 3, 512, b, &cnt); // AsShotNeutral
   // b = dt_imageio_dng_make_tag(50729, RATIONAL, 2, 512, b, &cnt); // AsShotWhiteXY
   b = dt_imageio_dng_make_tag(50778, SHORT, 1, 21 << 16, b, &cnt); // CalibrationIlluminant1
+  b = dt_imageio_dng_make_tag(50728, RATIONAL, 3, 556, b, &cnt); // AsShotNeutral
   b = dt_imageio_dng_make_tag(0, 0, 0, 0, b, &cnt); /* Next IFD.  */
   buf[11] = cnt - 1; // write number of directory entries of this ifd
 
@@ -163,13 +170,30 @@ static inline void dt_imageio_dng_write_tiff_header(
   // printf("offset: %d\n", b - buf); // find out where we're writing data
   // apparently this doesn't need byteswap:
   memcpy(buf+400, xtrans, sizeof(uint8_t)*36);
-  // this matrix is generic for XYZ->sRGB / D65
-  int m[9] = { 3240454, -1537138, -498531, -969266, 1876010, 41556, 55643, -204025, 1057225 };
-  for(int k = 0; k < 9; k++)
+
+  // ColorMatrix1 try to get camera matrix else m[k] like before
+  XYZ_CAM[0]= NAN;
+  dt_dcraw_adobe_coeff((const char (*))camera_makermodel, (float(*)[12])XYZ_CAM);
+  if(!isnan(XYZ_CAM[0]))
   {
-    dt_imageio_dng_write_buf(buf, 480+k*8, m[k]);
-    dt_imageio_dng_write_buf(buf, 484+k*8, 1000000);
+	for(int k= 0; k < 9; k++)  m[k] = round(XYZ_CAM[k] * 10000.0f);
+	den = 10000;
   }
+
+  for(int k = 0; k < 9; k++)
+   {
+     dt_imageio_dng_write_buf(buf, 480+k*8, m[k]);
+     dt_imageio_dng_write_buf(buf, 484+k*8, den);
+   }
+
+  for(int k = 0; k < 3; k++)
+   {
+ 	// TAG AsShotNeutral: for rawspeed Dngdecoder camera white balance
+ 	coeff[k] =1/( (wb_coeffs[k]/ wb_coeffs[1])) ;
+ 	coeff[k]*= 1000000;
+ 	dt_imageio_dng_write_buf(buf, 556+k*8,(int)coeff[k]);
+    dt_imageio_dng_write_buf(buf, 560+k*8, 1000000);
+   }
 
   // dt_imageio_dng_write_buf(buf, offs2-buf, 584);
   int written = fwrite(buf, 1, 584, fp);
@@ -180,12 +204,14 @@ static inline void dt_imageio_write_dng(
     const char *filename, const float *const pixel, const int wd,
     const int ht, void *exif, const int exif_len, const uint32_t filter,
     const uint8_t xtrans[6][6],
-    const float whitelevel)
+    const float whitelevel,
+	const float wb_coeffs[3],
+	const char camera_model[24])
 {
   FILE *f = g_fopen(filename, "wb");
   if(f)
   {
-    dt_imageio_dng_write_tiff_header(f, wd, ht, 1.0f / 100.0f, 1.0f / 4.0f, 50.0f, 100.0f, filter, xtrans, whitelevel);
+    dt_imageio_dng_write_tiff_header(f, wd, ht, 1.0f / 100.0f, 1.0f / 4.0f, 50.0f, 100.0f, filter, xtrans, whitelevel, wb_coeffs, camera_model);
     const int k = fwrite(pixel, sizeof(float), (size_t)wd * ht, f);
     if(k != wd * ht) fprintf(stderr, "[dng_write] Error writing image data to %s\n", filename);
     fclose(f);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -260,6 +260,8 @@ typedef struct dt_control_merge_hdr_t
 
   float whitelevel;
   float epsw;
+  float wb_coeffs[3];
+  char camera_makermodel[128];
 
   // 0 - ok; 1 - errors, abort
   gboolean abort;
@@ -339,6 +341,8 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
     d->wd = datai->width;
     d->ht = datai->height;
     d->orientation = image.orientation;
+    for(int i = 0; i < 3; i++) d->wb_coeffs[i] = image.wb_coeffs[i];
+    g_strlcpy(d->camera_makermodel, image.camera_makermodel,sizeof(d->camera_makermodel));
   }
 
   if(image.buf_dsc.filters == 0u || image.buf_dsc.channels != 1 || image.buf_dsc.datatype != TYPE_UINT16)
@@ -500,7 +504,17 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   char *c = pathname + strlen(pathname);
   while(*c != '.' && c > pathname) c--;
   g_strlcpy(c, "-hdr.dng", sizeof(pathname) - (c - pathname));
-  dt_imageio_write_dng(pathname, d.pixels, d.wd, d.ht, exif, exif_len, d.first_filter, (const uint8_t (*)[6])d.first_xtrans, 1.0f);
+  dt_imageio_write_dng(pathname,
+                       d.pixels,
+                       d.wd,
+                       d.ht,
+                       exif,
+                       exif_len,
+                       d.first_filter,
+                       (const uint8_t (*)[6])d.first_xtrans,
+                       1.0f,
+                       (const float (*))d.wb_coeffs,
+                       (const char (*))d.camera_makermodel);
   free(exif);
 
   dt_control_job_set_progress(job, 1.0);


### PR DESCRIPTION
To get correct White balance for hdr dng, camera matrix is added in hdr dng tiff header : ColorMatrix1 = adobe coeff, so neutral balance is fixed, camera white balance is also added in hdr dng tiff header as AsShotNeutral for rawspeed dng decoder WB, so color calibration can work. Input profile embeded matrix is equal to standard matrix.
Fix #8043