### PR TITLE
image: avoid undo multiple Geotag and Datetime signals when not useful

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -489,10 +489,11 @@ static void _set_datetime(const int32_t imgid, const char *datetime)
 
 void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action, GList **imgs)
 {
+  GList *list = (GList *)data;
+  int i = 0;
+
   if(type == DT_UNDO_GEOTAG)
   {
-    GList *list = (GList *)data;
-
     while(list)
     {
       dt_undo_geotag_t *undogeotag = (dt_undo_geotag_t *)list->data;
@@ -502,14 +503,16 @@ void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t dat
 
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undogeotag->imgid));
       list = g_list_next(list);
+      i++;
     }
+    if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
+                              ? _("undone geo location onto %d images")
+                              : _("redone geo location onto %d images"), i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
   }
   else if(type == DT_UNDO_DATETIME)
   {
-    GList *list = (GList *)data;
-
     while(list)
     {
       dt_undo_datetime_t *undodatetime = (dt_undo_datetime_t *)list->data;
@@ -519,9 +522,13 @@ void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t dat
 
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undodatetime->imgid));
       list = g_list_next(list);
+      i++;
     }
+    if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
+                              ? _("undone date time onto %d images")
+                              : _("redone date time onto %d images"), i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy((GList *)data));
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(*imgs));
   }
 }
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2493,81 +2493,92 @@ static void _datetime_undo_data_free(gpointer data)
   g_list_free_full(l, g_free);
 }
 
-static void _image_set_datetime(const int32_t imgid, const char *datetime)
+typedef struct dt_datetime_t
 {
-  if(imgid == -1) return;
+  char dt[DT_DATETIME_LENGTH];
+} _datetime_t;
 
+static void _image_set_datetimes(const GList *img, const GArray *dtime,
+                                 GList **undo, const gboolean undo_on)
+{
+  GList *imgs = (GList *)img;
+  int i = 0;
+  while(imgs)
+  {
+    const int32_t imgid = GPOINTER_TO_INT(imgs->data);
+    // if char *datetime, the returned pointer is not correct => use of _datetime_t
+    const _datetime_t *datetime = &g_array_index(dtime, _datetime_t, i);
+    if(undo_on)
+    {
+      dt_undo_datetime_t *undodatetime = (dt_undo_datetime_t *)malloc(sizeof(dt_undo_datetime_t));
+      undodatetime->imgid = imgid;
+      dt_image_get_datetime(imgid, undodatetime->before);
+
+      memcpy(&undodatetime->after, datetime->dt, DT_DATETIME_LENGTH);
+
+      *undo = g_list_prepend(*undo, undodatetime);
+    }
+
+    _set_datetime(imgid, datetime->dt);
+
+    imgs = g_list_next(imgs);
+    i++;
+  }
+}
+
+void dt_image_set_datetimes(const GList *imgs, const GArray *dtime, const gboolean undo_on)
+{
+  if(!imgs || !dtime || (g_list_length((GList *)imgs) != dtime->len))
+    return;
   GList *undo = NULL;
-  dt_undo_datetime_t *undodatetime = (dt_undo_datetime_t *)malloc(sizeof(dt_undo_datetime_t));
-    undodatetime->imgid = imgid;
-  dt_image_get_datetime(imgid, undodatetime->before);
-  memcpy(undodatetime->after, datetime, sizeof(undodatetime->after));
-  undo = g_list_append(undo, undodatetime);
+  if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_DATETIME);
 
-  _set_datetime(imgid, datetime);
+  _image_set_datetimes(imgs, dtime, &undo, undo_on);
 
-  dt_undo_record(darktable.undo, NULL, DT_UNDO_DATETIME, undo, _pop_undo, _datetime_undo_data_free);
+  if(undo_on)
+  {
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_DATETIME, undo, _pop_undo, _datetime_undo_data_free);
+    dt_undo_end_group(darktable.undo);
+  }
 }
 
-void dt_image_add_time_offset(const int32_t imgid, const long int offset)
+static void _image_set_datetime(const GList *img, const char *datetime,
+                                GList **undo, const gboolean undo_on)
 {
-  const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, imgid, 'r');
-  if(!cimg) return;
-
-  // get the datetime_taken and calculate the new time
-  gint year;
-  gint month;
-  gint day;
-  gint hour;
-  gint minute;
-  gint seconds;
-
-  if(sscanf(cimg->exif_datetime_taken, "%d:%d:%d %d:%d:%d", (int *)&year, (int *)&month, (int *)&day,
-            (int *)&hour, (int *)&minute, (int *)&seconds) != 6)
+  GList *imgs = (GList *)img;
+  while(imgs)
   {
-    fprintf(stderr, "broken exif time in db, '%s', imgid %d\n", cimg->exif_datetime_taken, imgid);
-    dt_image_cache_read_release(darktable.image_cache, cimg);
-    return;
+    const int32_t imgid = GPOINTER_TO_INT(imgs->data);
+    if(undo_on)
+    {
+      dt_undo_datetime_t *undodatetime = (dt_undo_datetime_t *)malloc(sizeof(dt_undo_datetime_t));
+      undodatetime->imgid = imgid;
+      dt_image_get_datetime(imgid, undodatetime->before);
+
+      memcpy(&undodatetime->after, datetime, DT_DATETIME_LENGTH);
+
+      *undo = g_list_prepend(*undo, undodatetime);
+    }
+
+    _set_datetime(imgid, datetime);
+
+    imgs = g_list_next(imgs);
   }
-
-  GTimeZone *tz = g_time_zone_new_utc();
-  GDateTime *datetime_original = g_date_time_new(tz, year, month, day, hour, minute, seconds);
-  g_time_zone_unref(tz);
-  if(!datetime_original)
-  {
-    dt_image_cache_read_release(darktable.image_cache, cimg);
-    return;
-  }
-
-  // let's add our offset
-  GDateTime *datetime_new = g_date_time_add_seconds(datetime_original, offset);
-  g_date_time_unref(datetime_original);
-
-  if(!datetime_new)
-  {
-    dt_image_cache_read_release(darktable.image_cache, cimg);
-    return;
-  }
-
-  gchar *datetime = g_date_time_format(datetime_new, "%Y:%m:%d %H:%M:%S");
-  g_date_time_unref(datetime_new);
-
-  // update exif_datetime_taken in img
-  if(datetime)
-  {
-    dt_image_cache_read_release(darktable.image_cache, cimg);
-    _image_set_datetime(imgid, datetime);
-  }
-  else dt_image_cache_read_release(darktable.image_cache, cimg);
-
-  g_free(datetime);
 }
 
-void dt_image_set_datetime(const int32_t imgid, const char *datetime)
+void dt_image_set_datetime(const GList *imgs, const char *datetime, const gboolean undo_on)
 {
-  if(datetime[0])
+  if(!imgs)
+    return;
+  GList *undo = NULL;
+  if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_DATETIME);
+
+  _image_set_datetime(imgs, datetime, &undo, undo_on);
+
+  if(undo_on)
   {
-    _image_set_datetime(imgid, datetime);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_DATETIME, undo, _pop_undo, _datetime_undo_data_free);
+    dt_undo_end_group(darktable.undo);
   }
 }
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -506,8 +506,8 @@ void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t dat
       i++;
     }
     if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
-                              ? _("undone geo location onto %d images")
-                              : _("redone geo location onto %d images"), i);
+                              ? _("geo-location undone for %d images")
+                              : _("geo-location re-applied to %d images"), i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
   }
@@ -525,8 +525,8 @@ void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t dat
       i++;
     }
     if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
-                              ? _("undone date time onto %d images")
-                              : _("redone date time onto %d images"), i);
+                              ? _("date/time undone for %d images")
+                              : _("date/time re-applied to %d images"), i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(*imgs));
   }

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -382,7 +382,9 @@ void dt_image_synch_all_xmp(const gchar *pathname);
 // add an offset to the exif_datetime_taken field
 void dt_image_add_time_offset(const int32_t imgid, const long int offset);
 // set datetime to exif_datetime_taken field
-void dt_image_set_datetime(const int32_t imgid, const char *datetime);
+void dt_image_set_datetime(const GList *imgs, const char *datetime, const gboolean undo_on);
+// set datetimeS to exif_datetime_taken field
+void dt_image_set_datetimes(const GList *imgs, const GArray *dtime, const gboolean undo_on);
 // return image datetime string into the given buffer (size = DT_DATETIME_LENGTH)
 void dt_image_get_datetime(const int32_t imgid, char *datetime);
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -301,6 +301,9 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
 /** set images location lon/lat/ele */
 void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc,
                            const gboolean undo_on);
+/** set images locations lon/lat/ele */
+void dt_image_set_images_locations(const GList *imgs, const GArray *gloc,
+                                   const gboolean undo_on);
 /** get image location lon/lat/ele */
 void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
 /** returns TRUE if current hash is not basic nor auto_apply, FALSE otherwise. */

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1918,8 +1918,8 @@ static int32_t dt_control_datetime_job_run(dt_job_t *job)
 
   const guint total = g_list_length(t);
 
-  const char *mes11 = offset ? N_("adding time offset to %d image") : N_("setting date time to %d image");
-  const char *mes12 = offset ? N_("adding time offset to %d images") : N_("setting date time to %d images");
+  const char *mes11 = offset ? N_("adding time offset to %d image") : N_("setting date/time of %d image");
+  const char *mes12 = offset ? N_("adding time offset to %d images") : N_("setting date/time of %d images");
   snprintf(message, sizeof(message), ngettext(mes11, mes12, total), total);
   dt_control_job_set_progress_message(job, message);
 
@@ -1944,9 +1944,9 @@ static int32_t dt_control_datetime_job_run(dt_job_t *job)
       {
         imgs = g_list_prepend(imgs, grp->data);
         g_array_append_val(dtime, ndt);
+        cntr++;
       }
       g_list_free(grps);
-      cntr++;
     }
     imgs = g_list_reverse(imgs);
     dt_image_set_datetimes(imgs, dtime, TRUE);
@@ -1956,11 +1956,12 @@ static int32_t dt_control_datetime_job_run(dt_job_t *job)
     imgs = g_list_copy(t);
     // takes the option to include the grouped images
     dt_grouping_add_grouped_images(&imgs);
+    cntr = g_list_length(imgs);
     dt_image_set_datetime(imgs, datetime, TRUE);
   }
 
-  const char *mes21 = offset ? N_("added time offset to %d image") : N_("set date time to %d image");
-  const char *mes22 = offset ? N_("added time offset to %d images") : N_("set date time to %d images");
+  const char *mes21 = offset ? N_("added time offset to %d image") : N_("set date/time of %d image");
+  const char *mes22 = offset ? N_("added time offset to %d images") : N_("set date/time of %d images");
   dt_control_log(ngettext(mes21, mes22, cntr), cntr);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1582,28 +1582,28 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   int line = 0;
 
-  GtkWidget *label = dt_ui_label_new(_("date time"));
+  GtkWidget *label = dt_ui_label_new(_("date/time"));
   gtk_widget_set_hexpand(label, TRUE);
   gtk_grid_attach(grid, label, 0, line, 2, 1);
-  gtk_widget_set_tooltip_text(label, _("enter the new date time (yyyy:mm:dd hh:mm:ss)"
+  gtk_widget_set_tooltip_text(label, _("enter the new date/time (yyyy:mm:dd hh:mm:ss)"
                                        "\nkey in the new numbers or scroll over the cell"));
 
   GtkWidget *box = _gui_init_datetime(&d->dt, 0, self);
   gtk_grid_attach(grid, box, 2, line++, 2, 1);
 
-  label = dt_ui_label_new(_("original date time"));
+  label = dt_ui_label_new(_("original date/time"));
   gtk_grid_attach(grid, label, 0, line, 2, 1);
 
   box = _gui_init_datetime(&d->dt0, 1, self);
   gtk_grid_attach(grid, box, 2, line++, 2, 1);
 
-  label = dt_ui_label_new(_("date time offset"));
+  label = dt_ui_label_new(_("date/time offset"));
   gtk_widget_set_hexpand(label, TRUE);
   gtk_grid_attach(grid, label, 0, line, 2, 1);
   gtk_widget_set_tooltip_text(label, _("offset or difference ([-]dd hh:mm:ss)"));
 
   d->lock_offset = dtgtk_togglebutton_new(dtgtk_cairo_paint_lock, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(d->lock_offset, _("lock date time offset value to apply it onto another selection"));
+  gtk_widget_set_tooltip_text(d->lock_offset, _("lock date/time offset value to apply it onto another selection"));
   gtk_widget_set_halign(d->lock_offset, GTK_ALIGN_START);
   gtk_grid_attach(grid, d->lock_offset, 2, line, 1, 1);
   g_signal_connect(G_OBJECT(d->lock_offset), "clicked", G_CALLBACK(_toggle_lock_button_callback), (gpointer)self);
@@ -1619,7 +1619,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->apply_offset , 0, line, 2, 1);
   g_signal_connect(G_OBJECT(d->apply_offset), "clicked", G_CALLBACK(_apply_offset_callback), self);
 
-  d->apply_datetime = dt_ui_button_new(_("apply date time"), _("apply the same date time to selected images"), NULL);
+  d->apply_datetime = dt_ui_button_new(_("apply date/time"), _("apply the same date/time to selected images"), NULL);
   gtk_widget_set_hexpand(d->apply_datetime, FALSE);
   gtk_grid_attach(grid, d->apply_datetime , 2, line++, 2, 1);
   g_signal_connect(G_OBJECT(d->apply_datetime), "clicked", G_CALLBACK(_apply_datetime_callback), self);
@@ -1703,10 +1703,10 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->map.gpx_view, "gpx_list");
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->map.gpx_view),
                               _("list of track segments in the gpx file, for each segment:"
-                                "\n- the start date time in local time (LT)"
+                                "\n- the start date/time in local time (LT)"
                                 "\n- the number of track points"
                                 "\n- the number of images to be geotagged "
-                                "based on images date time, offset and time zone"
+                                "based on images date/time, offset and time zone"
                                 "\n- more detailled time information hovering the row"));
   renderer = gtk_cell_renderer_toggle_new();
   g_signal_connect(renderer, "toggled", G_CALLBACK(_track_seg_toggled), self);
@@ -1768,7 +1768,7 @@ void gui_init(dt_lib_module_t *self)
   d->map.apply_gpx_button = dt_ui_button_new(_("apply GPX file"),
                                              _("apply location from GPX file to selected images"
                                                "\neven non checked gpx tracks are used"
-                                               "\ndate time offset must be null"), NULL);
+                                               "\ndate/time offset must be null"), NULL);
   gtk_widget_set_hexpand(d->map.apply_gpx_button, TRUE);
   gtk_widget_set_sensitive(d->map.apply_gpx_button, FALSE);
   g_signal_connect(G_OBJECT(d->map.apply_gpx_button), "clicked", G_CALLBACK(_apply_gpx), self);


### PR DESCRIPTION
fix slow execution on undo geotag

for 250 images the gpx apply lasts less than 1 sec but undo lasts more than 30 sec
with that fix undo is done in less than 1 sec too.

A question however. Images of group are included in the geotag process. Are the grouped images always at the same location ? (we could want to group images for another reason, couldn't we ?).
