### PR TITLE
Improve color picker for the parametric mask channels

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1394,9 +1394,9 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     dt_develop_blend_params_t *bp = module->blend_params;
 
     const int tab = data->tab;
-    float raw_min[4], raw_max[4];
-    float picker_min[8], picker_max[8];
-    float picker_values[4];
+    float raw_min[4] DT_ALIGNED_PIXEL, raw_max[4] DT_ALIGNED_PIXEL;
+    float picker_min[8] DT_ALIGNED_PIXEL, picker_max[8] DT_ALIGNED_PIXEL;
+    float picker_values[4] DT_ALIGNED_PIXEL;
 
     const int in_out = ((dt_key_modifier_state() == GDK_CONTROL_MASK) && data->output_channels_shown) ? 1 : 0;
 
@@ -1506,8 +1506,11 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     else
       bp->blendif |= (1 << ch);
 
-    // reverse (hue) channel if needed
-    bp->blendif = (bp->blendif & ~(1 << (16 + ch))) | (reverse_hues ? 1 << (16 + ch) : 0);
+    // set the polarity of the channel to include the picked values
+    if(reverse_hues == ((bp->mask_combine & DEVELOP_COMBINE_INV) == DEVELOP_COMBINE_INV))
+      bp->blendif &= ~(1 << (16 + ch));
+    else
+      bp->blendif |= 1 << (16 + ch);
 
     dt_dev_add_history_item(darktable.develop, module, TRUE);
     _blendop_blendif_update_tab(module, tab);


### PR DESCRIPTION
Proposition to try to improve parametric mask channel definition using the color picker.
It tries to solve the two (independent) issues mentioned in https://github.com/darktable-org/darktable/issues/5653#issuecomment-723492411:

- when selecting a range where the picked values are outside of the range of the parametric mask channel, the feathering was still applied causing the high value pixels not to be selected. This change will clamp the values after feathering (so if the picked values are outside the range of the parametric mask channel, the result will be an open-ended channel, including the high values).

- when color picking a hue, try to find the best (minimal) channel range selection to avoid selecting all hues of the image. This will invert the hue parametric mask channel when needed.

Edit: the channel polarity will always be set when picking colors (including for the non-hue channels). The polarity will be changed to always include the selection in “exclusive” and “inclusive” combine modes, but to always exclude the selection in “exclusive inverted” or “inclusive inverted” combine modes.
- Should the non-hue channel polarities not be touched (to have same behavior as before)?
- Should the channel polarity also be inverted for “inverted” combine modes to always “include” the picked colors?

May fix #5653 and #2693.

Probably that it does not fix the initial comment of #5653, which I think is because the colors seem to be picked from a down-scaled image.

I hope there are not too many regressions. @ralfbrown: could you check if I didn't break any optimization in the color picker implementation? Thanks in advance!