### PR TITLE
fix segfault when importing images with lua

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3278,10 +3278,15 @@ gboolean dt_iop_have_required_input_format(const int req_ch, struct dt_iop_modul
                                            const void *const restrict ivoid, void *const restrict ovoid,
                                            const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
+  ++darktable.gui->reset;
+
   if (ch == req_ch)
   {
     if (module)
       dt_iop_set_module_trouble_message(module, NULL, NULL, NULL);
+
+    --darktable.gui->reset;
+
     return TRUE;
   }
   else
@@ -3300,6 +3305,9 @@ gboolean dt_iop_have_required_input_format(const int req_ch, struct dt_iop_modul
     {
       //TODO: pop up a toast message?
     }
+
+    --darktable.gui->reset;
+
     return FALSE;
   }
 }

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1692,6 +1692,9 @@ void validate_color_checker(const float *const restrict in,
 static void _check_for_wb_issue_and_set_trouble_message(struct dt_iop_module_t *self)
 {
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+
+  ++darktable.gui->reset;
+
   if(self->enabled
      && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB))
   {
@@ -1722,6 +1725,8 @@ static void _check_for_wb_issue_and_set_trouble_message(struct dt_iop_module_t *
   }
 
   dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+
+  --darktable.gui->reset;
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,


### PR DESCRIPTION
This is a first attemp to fix #8221. for testing purposes.
With this PR darktable.gui->reset semaphore is introduced in two functions raising module trouble signal, in order to avoid a segfault that happens in Windows when importing through lua an image while being in darkroom.
