### PR TITLE
[RFC] channelmixerrgb: add norm-preserving colorfulness control

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -585,11 +585,7 @@ static inline void luma_chroma(const float input[4], const float saturation[4], 
       coeff_ratio += sqf(1.0f - output[c]) * saturation[c];
   }
   else
-  {
-    for(size_t c = 0; c < 3; c++)
-      coeff_ratio += output[c] * saturation[c];
-  }
-  coeff_ratio /= 3.f;
+    coeff_ratio = scalar_product(output, saturation) / 3.f;
 
   // Adjust the RGB ratios with the pixel correction
   for(size_t c = 0; c < 3; c++)


### PR DESCRIPTION
I came up with a new way to preserve the Euclidean RGB norm under colorfulness adjustment and tried applying it to the color calibration module. The current colorfulness control implemented in that module works mainly pretty well but doesn't preserve the Euclidean norm - it makes grey pixels lighter when decreasing colorfulness and darker when increasing it.

In [`luma_chroma()`](https://github.com/darktable-org/darktable/blob/31d0840d73bde51d4050771206801fcd139d2fca/src/iop/channelmixerrgb.c#L568), the input pixel is first normalized using the Euclidean RGB norm. A grey pixel gets the value `(R, G, B) = (1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3))`. Later in `luma_chroma()`, the colorfulness is adjusted by interpolating between the normalized pixel and white that has `(R, G, B) = (1, 1, 1)`. This is why the luminance changes - a grey pixel is interpolated towards one with a greater Euclidean norm.

Spherical linear interpolation ([slerp](https://en.wikipedia.org/wiki/Slerp)) can be used to interpolate between two vectors that lie on the surface of the same sphere. This PR implements the colorfulness control by slerping between the normalized pixel and a normalized white pixel (`(R, G, B) = (1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3))`).

For the sake of example, here are some screenshots with extreme settings to exaggerate the effect. Color adaptation was set to `none (bypass)` in all the examples. No other adjustments applied in the color calibration module than the colorfulness adjustment.

No colorfulness adjustment applied (color calibration module off):
![no_color_calib](https://user-images.githubusercontent.com/5001906/108267900-794a7580-7174-11eb-86b5-129014edc329.png)

Current algo (v2), notice the greys get much lighter:
![color_calib_v2](https://user-images.githubusercontent.com/5001906/108268031-a9921400-7174-11eb-8bba-08a2c42785c9.png)

The algo introduced here preserves the greys better:
![color_calib_v3](https://user-images.githubusercontent.com/5001906/108268093-bf9fd480-7174-11eb-894c-59ae505d302e.png)

The spherical linear interpolation has also the nice property that the colorfulness adjustment should be quite uniform across the slider range. Also a desirable thing here is that this change makes the colorfulness adjustment more isolated, not affecting other aspects of the image much.

P.S. Since Filmic also applies a pretty similar saturation algorithm, this may be useful also there, at least if the Euclidean norm is selected for chroma preservation, where a similar change of luminance can be observed in the current implementation when playing with the midtones saturation slider. Actually I've done a brief test with good results, actually pretty close to the results one gets with the RGB power norm. I can post that later once I manage to clean it up a bit.