### PR TITLE
filmicrgb: add new color science and Euclidean norm with proper scaling

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -19,6 +19,8 @@
 #include "basic.cl"
 #include "noise_generator.h"
 
+#define INVERSE_SQRT_3 0.5773502691896258f
+
 // In case the OpenCL driver doesn't have a dot method
 inline float vdot(const float4 vec1, const float4 vec2)
 {
@@ -31,7 +33,8 @@ typedef enum dt_iop_filmicrgb_methods_type_t
   DT_FILMIC_METHOD_MAX_RGB = 1,
   DT_FILMIC_METHOD_LUMINANCE = 2,
   DT_FILMIC_METHOD_POWER_NORM = 3,
-  DT_FILMIC_METHOD_EUCLIDEAN_NORM = 4
+  DT_FILMIC_METHOD_EUCLIDEAN_NORM_V2 = 5,
+  DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1 = 4,
 } dt_iop_filmicrgb_methods_type_t;
 
 typedef enum dt_iop_filmicrgb_colorscience_type_t
@@ -167,8 +170,11 @@ inline float get_pixel_norm(const float4 pixel, const dt_iop_filmicrgb_methods_t
     case DT_FILMIC_METHOD_POWER_NORM:
       return pixel_rgb_norm_power(pixel);
 
-    case DT_FILMIC_METHOD_EUCLIDEAN_NORM:
+    case DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1:
       return pixel_rgb_norm_euclidean(pixel);
+
+    case DT_FILMIC_METHOD_EUCLIDEAN_NORM_V2:
+      return pixel_rgb_norm_euclidean(pixel) * INVERSE_SQRT_3;
 
     case DT_FILMIC_METHOD_NONE:
     default:

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -588,6 +588,12 @@ static inline float pixel_rgb_norm_power(const float pixel[4])
 static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_methods_type_t variant,
                                    const dt_iop_order_iccprofile_info_t *const work_profile)
 {
+  // a newly added norm should satisfy the condition that it is linear with respect to grey pixels:
+  // norm(R, G, B) = norm(x, x, x) = x
+  // the desaturation code in chroma preservation mode relies on this assumption.
+  // DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1 is an exception to this and is marked as legacy.
+  // DT_FILMIC_METHOD_EUCLIDEAN_NORM_V2 takes the Euclidean norm and scales it such that
+  // norm(1, 1, 1) = 1.
   switch(variant)
   {
     case(DT_FILMIC_METHOD_MAX_RGB):


### PR DESCRIPTION
This one is perceptually a better match with the other norms than the current Euclidean norm because it gives the same values for greys as the other norms. Also implements spherical linear interpolation of saturation like https://github.com/darktable-org/darktable/pull/8254.

Here's a video demonstrating first the RGB power norm, then the existing RGB euclidean norm (v1) and then the newly added Euclidean norm (v2). You can observe the change of luminance and quite weird behaviour with the Euclidean v1 one.

https://user-images.githubusercontent.com/5001906/108592661-9d29d900-7377-11eb-922a-df5cd4c7f51f.mp4



