### PR TITLE
GList optimization: use g_list_prepend where possible

### DIFF
--- a/src/cmstest/main.c
+++ b/src/cmstest/main.c
@@ -304,7 +304,7 @@ int main(int argc __attribute__((unused)), char *arg[] __attribute__((unused)))
         monitor->is_primary = is_primary;
         monitor->atom_id = atom_id++;
         monitor->name = g_strdup(output_info->name);
-        monitor_list = g_list_append(monitor_list, monitor);
+        monitor_list = g_list_prepend(monitor_list, monitor);
 
 end:
         XRRFreeCrtcInfo(crtc_info);

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1080,14 +1080,14 @@ GList *dt_collection_get(const dt_collection_t *collection, int limit, gboolean 
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       const int imgid = sqlite3_column_int(stmt, 0);
-      list = g_list_append(list, GINT_TO_POINTER(imgid));
+      list = g_list_prepend(list, GINT_TO_POINTER(imgid));
     }
 
     sqlite3_finalize(stmt);
     g_free(q);
   }
 
-  return list;
+  return g_list_reverse(list);  // list built in reverse order, so un-reverse it
 }
 
 GList *dt_collection_get_all(const dt_collection_t *collection, int limit)

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1362,7 +1362,7 @@ static GList *load_profile_from_dir(const char *subdir)
           prof->display2_pos = -1;
           prof->category_pos = -1;
           prof->work_pos = -1;
-          temp_profiles = g_list_append(temp_profiles, prof);
+          temp_profiles = g_list_prepend(temp_profiles, prof);
         }
 
 icc_loading_done:

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -382,7 +382,7 @@ GList *dt_get_media_type(const dt_printer_info_t *printer)
           dt_medium_info_t *media = (dt_medium_info_t*)malloc(sizeof(dt_medium_info_t));
           g_strlcpy(media->name, choice->choice, MAX_NAME);
           g_strlcpy(media->common_name, choice->text, MAX_NAME);
-          result = g_list_append (result, media);
+          result = g_list_prepend (result, media);
 
           dt_print(DT_DEBUG_PRINT, "[print] new media %2d (%s) (%s)\n", k, media->name, media->common_name);
           choice++;
@@ -393,7 +393,7 @@ GList *dt_get_media_type(const dt_printer_info_t *printer)
   ppdClose(ppd);
   g_unlink(PPDFile);
 
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 dt_medium_info_t *dt_get_medium(GList *media, const char *name)

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -420,7 +420,7 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
 {
   // as this can be called several times during the image lifetime, clean up first
   GList *imgs = NULL;
-  imgs = g_list_append(imgs, GINT_TO_POINTER(img->id));
+  imgs = g_list_prepend(imgs, GINT_TO_POINTER(img->id));
   try
   {
     Exiv2::XmpData::iterator pos;
@@ -1345,7 +1345,7 @@ void dt_exif_apply_default_metadata(dt_image_t *img)
     if(img->id > 0 && str != NULL && str[0] != '\0')
     {
       GList *imgs = NULL;
-      imgs = g_list_append(imgs, GINT_TO_POINTER(img->id));
+      imgs = g_list_prepend(imgs, GINT_TO_POINTER(img->id));
       dt_tag_attach_string_list(str, imgs, FALSE);
       g_list_free(imgs);
     }

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -366,7 +366,7 @@ void dt_film_remove_empty()
 
     if(dt_util_is_dir_empty(folder))
     {
-      if(ask_before_rmdir) empty_dirs = g_list_append(empty_dirs, g_strdup(folder));
+      if(ask_before_rmdir) empty_dirs = g_list_prepend(empty_dirs, g_strdup(folder));
       else rmdir(folder);
     }
   }
@@ -375,7 +375,7 @@ void dt_film_remove_empty()
 
   // dispatch asking for deletion (and subsequent deletion) to the gui thread
   if(empty_dirs)
-    g_idle_add(ask_and_delete, empty_dirs);
+    g_idle_add(ask_and_delete, g_list_reverse(empty_dirs));
 }
 
 gboolean dt_film_is_empty(const int id)
@@ -461,10 +461,10 @@ GList *dt_film_get_image_ids(const int filmid)
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const int id = sqlite3_column_int(stmt, 0);
-    result = g_list_append(result, GINT_TO_POINTER(id));
+    result = g_list_prepend(result, GINT_TO_POINTER(id));
   }
   sqlite3_finalize(stmt);
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -143,13 +143,13 @@ GList *dt_grouping_get_group_images(const int32_t imgid)
       while(sqlite3_step(stmt) == SQLITE_ROW)
       {
         const int image_id = sqlite3_column_int(stmt, 0);
-        imgs = g_list_append(imgs, GINT_TO_POINTER(image_id));
+        imgs = g_list_prepend(imgs, GINT_TO_POINTER(image_id));
       }
       sqlite3_finalize(stmt);
     }
-    else imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    else imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
   }
-  return imgs;
+  return g_list_reverse(imgs);
 }
 
 /** add grouped images to images list */
@@ -176,7 +176,7 @@ void dt_grouping_add_grouped_images(GList **images)
         {
           const int image_id = sqlite3_column_int(stmt, 0);
           if(image_id != GPOINTER_TO_INT(imgs->data))
-            gimgs = g_list_append(gimgs, GINT_TO_POINTER(image_id));
+            gimgs = g_list_prepend(gimgs, GINT_TO_POINTER(image_id));
         }
         sqlite3_finalize(stmt);
       }
@@ -185,7 +185,7 @@ void dt_grouping_add_grouped_images(GList **images)
   }
 
   if(gimgs)
-    imgs = g_list_concat(*images, gimgs);
+    imgs = g_list_concat(*images, g_list_reverse(gimgs));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -540,7 +540,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
           if (DT_IOP_ORDER_INFO)
             fprintf(stderr,"\n  module %20s, multiprio %i",  hist->module->op, hist->module->multi_priority);
 
-          mod_list = g_list_append(mod_list, hist->module);
+          mod_list = g_list_prepend(mod_list, hist->module);
         }
       }
 
@@ -564,13 +564,15 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
          && (copy_full || !dt_history_module_skip_copy(mod_src->flags()))
         )
       {
-        mod_list = g_list_append(mod_list, mod_src);
+        mod_list = g_list_prepend(mod_list, mod_src);
       }
 
       modules_src = g_list_next(modules_src);
     }
   }
   if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
+
+  mod_list = g_list_reverse(mod_list);   // list was built in reverse order, so un-reverse it
 
   // update iop-order list to have entries for the new modules
   dt_ioppr_update_for_modules(dev_dest, mod_list, FALSE);
@@ -882,13 +884,13 @@ GList *dt_history_get_items(const int32_t imgid, gboolean enabled)
       }
       item->name = g_strdup(name);
       item->op = g_strdup((gchar *)sqlite3_column_text(stmt, 1));
-      result = g_list_append(result, item);
+      result = g_list_prepend(result, item);
 
       g_free(mname);
     }
   }
   sqlite3_finalize(stmt);
-  return result;
+  return g_list_reverse(result);   // list was built in reverse order, so un-reverse it
 }
 
 char *dt_history_get_items_as_string(const int32_t imgid)
@@ -911,10 +913,11 @@ char *dt_history_get_items_as_string(const int32_t imgid)
     name = g_strconcat(dt_iop_get_localized_name((char *)sqlite3_column_text(stmt, 0)),
                        multi_name ? multi_name : "", " (",
                        (sqlite3_column_int(stmt, 1) == 0) ? onoff[0] : onoff[1], ")", NULL);
-    items = g_list_append(items, name);
+    items = g_list_prepend(items, name);
     g_free(multi_name);
   }
   sqlite3_finalize(stmt);
+  items = g_list_reverse(items); // list was built in reverse order, so un-reverse it
   char *result = dt_util_glist_to_str("\n", items);
   g_list_free_full(items, g_free);
   return result;
@@ -1303,11 +1306,11 @@ GList *dt_history_duplicate(GList *hist)
 
     if(old->forms) new->forms = dt_masks_dup_forms_deep(old->forms, NULL);
 
-    result = g_list_append(result, new);
+    result = g_list_prepend(result, new);
 
     h = g_list_next(h);
   }
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 #if 0

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -581,7 +581,7 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
   if(imgid == -1)
     imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
   else
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
   dt_image_set_locations(imgs, geoloc, undo_on);
   g_list_free(imgs);
@@ -840,7 +840,7 @@ void dt_image_set_aspect_ratio_to(const int32_t imgid, const float aspect_ratio,
 
     if(raise && darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                                 g_list_append(NULL, GINT_TO_POINTER(imgid)));
+                                 g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
   }
 }
 
@@ -864,7 +864,7 @@ void dt_image_set_aspect_ratio_if_different(const int32_t imgid, const float asp
 
     if(raise && darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                                 g_list_append(NULL, GINT_TO_POINTER(imgid)));
+                                 g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
   }
 }
 
@@ -881,7 +881,7 @@ void dt_image_reset_aspect_ratio(const int32_t imgid, const gboolean raise)
 
   if(raise && darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_append(NULL, GINT_TO_POINTER(imgid)));
+                               g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
 }
 
 float dt_image_set_aspect_ratio(const int32_t imgid, const gboolean raise)
@@ -1767,7 +1767,7 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
       while(sqlite3_step(duplicates_stmt) == SQLITE_ROW)
       {
         const int32_t id = sqlite3_column_int(duplicates_stmt, 0);
-        dup_list = g_list_append(dup_list, GINT_TO_POINTER(id));
+        dup_list = g_list_prepend(dup_list, GINT_TO_POINTER(id));
         gchar oldxmp[PATH_MAX] = { 0 }, newxmp[PATH_MAX] = { 0 };
         g_strlcpy(oldxmp, oldimg, sizeof(oldxmp));
         g_strlcpy(newxmp, newimg, sizeof(newxmp));
@@ -1785,6 +1785,8 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
         g_object_unref(gnewxmp);
       }
       sqlite3_finalize(duplicates_stmt);
+
+      dup_list = g_list_reverse(dup_list);  // list was built in reverse order, so un-reverse it
 
       // then update database and cache
       // if update was performed in above loop, dt_image_path_append_version()

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -366,11 +366,11 @@ GList *dt_ioppr_get_iop_order_rules()
     memcpy(rule->op_prev, rule_entry[i].op_prev, sizeof(rule->op_prev));
     memcpy(rule->op_next, rule_entry[i].op_next, sizeof(rule->op_next));
 
-    rules = g_list_append(rules, rule);
+    rules = g_list_prepend(rules, rule);
     i++;
   }
 
-  return rules;
+  return g_list_reverse(rules);  // list was built in reverse order, so un-reverse it
 }
 
 GList *dt_ioppr_get_iop_order_link(GList *iop_order_list, const char *op_name, const int multi_priority)
@@ -579,12 +579,12 @@ GList *_table_to_list(const dt_iop_order_entry_t entries[])
     g_strlcpy(entry->operation, entries[k].operation, sizeof(entry->operation));
     entry->instance = 0;
     entry->o.iop_order_f = entries[k].o.iop_order_f;
-    iop_order_list = g_list_append(iop_order_list, entry);
+    iop_order_list = g_list_prepend(iop_order_list, entry);
 
     k++;
   }
 
-  return iop_order_list;
+  return g_list_reverse(iop_order_list);  // list was built in reverse order, so un-reverse it
 }
 
 GList *dt_ioppr_get_iop_order_list_version(dt_iop_order_t version)
@@ -817,13 +817,13 @@ GList *dt_ioppr_extract_multi_instances_list(GList *iop_order_list)
     if(_count_entries_operation(iop_order_list, entry->operation) > 1)
     {
       dt_iop_order_entry_t *copy = (dt_iop_order_entry_t *)_dup_iop_order_entry((void *)entry, NULL);
-      mi = g_list_append(mi, copy);
+      mi = g_list_prepend(mi, copy);
     }
 
     l = g_list_next(l);
   }
 
-  return mi;
+  return g_list_reverse(mi);  // list was built in reverse order, so un-reverse it
 }
 
 GList *dt_ioppr_merge_module_multi_instance_iop_order_list(GList *iop_order_list,
@@ -1125,10 +1125,11 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, gboolea
     n->instance = si->multi_priority;
     g_strlcpy(n->name, si->multi_name, sizeof(n->name));
     n->o.iop_order = 0;
-    e_list = g_list_append(e_list, n);
+    e_list = g_list_prepend(e_list, n);
 
     si_list = g_list_next(si_list);
   }
+  e_list = g_list_reverse(e_list);  // list was built in reverse order, so un-reverse it
 
   dt_ioppr_update_for_entries(dev, e_list, append);
 
@@ -1166,10 +1167,11 @@ void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, gboolean app
     n->instance = mod->multi_priority;
     g_strlcpy(n->name, mod->multi_name, sizeof(n->name));
     n->o.iop_order = 0;
-    e_list = g_list_append(e_list, n);
+    e_list = g_list_prepend(e_list, n);
 
     m_list = g_list_next(m_list);
   }
+  e_list = g_list_reverse(e_list);  // list was built in reverse order, so un-reverse it
 
   dt_ioppr_update_for_entries(dev, e_list, append);
 
@@ -1685,12 +1687,12 @@ static GList *_get_fence_modules_list(GList *iop_list)
 
     if(mod->flags() & IOP_FLAGS_FENCE)
     {
-      fences = g_list_append(fences, mod);
+      fences = g_list_prepend(fences, mod);
     }
 
     modules = g_list_next(modules);
   }
-  return fences;
+  return g_list_reverse(fences);  // list was built in reverse order, so un-reverse it
 }
 
 static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg)
@@ -2098,10 +2100,11 @@ GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf)
 
     // append to the list
 
-    iop_order_list = g_list_append(iop_order_list, entry);
+    iop_order_list = g_list_prepend(iop_order_list, entry);
 
     l = g_list_next(l);
   }
+  iop_order_list = g_list_reverse(iop_order_list);  // list was built in reverse order, so un-reverse it
 
   g_list_free(list);
 
@@ -2145,10 +2148,11 @@ GList *dt_ioppr_deserialize_iop_order_list(const char *buf, size_t size)
     if(entry->instance < 0 || entry->instance > 1000) { free(entry); goto error; }
 
     // append to the list
-    iop_order_list = g_list_append(iop_order_list, entry);
+    iop_order_list = g_list_prepend(iop_order_list, entry);
 
     size -= (2 * sizeof(int32_t) + len);
   }
+  iop_order_list = g_list_reverse(iop_order_list);  // list was built in reverse order, so un-reverse it
 
   _ioppr_reset_iop_order(iop_order_list);
 

--- a/src/common/module.c
+++ b/src/common/module.c
@@ -54,13 +54,16 @@ GList *dt_module_load_modules(const char *subdir, size_t module_size,
       free(module);
       continue;
     }
-    plugin_list = g_list_append(plugin_list, module);
+    plugin_list = g_list_prepend(plugin_list, module);
 
     if(init_module) init_module(module);
   }
   g_dir_close(dir);
 
-  if(sort_modules) plugin_list = g_list_sort(plugin_list, sort_modules);
+  if(sort_modules)
+    plugin_list = g_list_sort(plugin_list, sort_modules);
+  else
+    plugin_list = g_list_reverse(plugin_list);  // list was built in reverse order, so un-reverse it
 
  return plugin_list;
 }

--- a/src/common/noiseprofiles.c
+++ b/src/common/noiseprofiles.c
@@ -337,7 +337,7 @@ GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
             // everything worked out, add tmp_profile to result
             dt_noiseprofile_t *new_profile = (dt_noiseprofile_t *)malloc(sizeof(dt_noiseprofile_t));
             *new_profile = tmp_profile;
-            result = g_list_append(result, new_profile);
+            result = g_list_prepend(result, new_profile);
 
             g_strfreev(member_names);
           } // profiles

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -155,7 +155,7 @@ void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean
   GList *imgs = NULL;
   int new_rating = rating;
 
-  if(imgid > 0) imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgid > 0) imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
 
   if(imgs)
   {

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -158,9 +158,10 @@ static void _dt_style_cleanup_multi_instance(int id)
 
     d->rowid = sqlite3_column_int(stmt, 0);
     d->mi = last_mi;
-    list = g_list_append(list, d);
+    list = g_list_prepend(list, d);
   }
   sqlite3_finalize(stmt);
+  list = g_list_reverse(list);   // list was built in reverse order, so un-reverse it
 
   /* 2. now update all multi_instance values previously recorded */
 
@@ -904,9 +905,10 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
       memcpy(style_item->blendop_params, (void *)sqlite3_column_blob(stmt, 5), style_item->blendop_params_size);
       style_item->iop_order = 0;
 
-      si_list = g_list_append(si_list, style_item);
+      si_list = g_list_prepend(si_list, style_item);
     }
     sqlite3_finalize(stmt);
+    si_list = g_list_reverse(si_list);  // list was built in reverse order, so un-reverse it
 
     dt_ioppr_update_for_style_items(dev_dest, si_list, FALSE);
 
@@ -1132,11 +1134,11 @@ GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)
       item->operation = g_strdup((char *)sqlite3_column_text(stmt, 3));
       item->multi_name = g_strdup((char *)sqlite3_column_text(stmt, 7));
       item->iop_order = sqlite3_column_double(stmt, 8);
-      result = g_list_append(result, item);
+      result = g_list_prepend(result, item);
     }
     sqlite3_finalize(stmt);
   }
-  return result;
+  return g_list_reverse(result);   // list was built in reverse order, so un-reverse it
 }
 
 char *dt_styles_get_item_list_as_string(const char *name)
@@ -1148,8 +1150,9 @@ char *dt_styles_get_item_list_as_string(const char *name)
   do
   {
     dt_style_item_t *item = (dt_style_item_t *)items->data;
-    names = g_list_append(names, g_strdup(item->name));
+    names = g_list_prepend(names, g_strdup(item->name));
   } while((items = g_list_next(items)));
+  names = g_list_reverse(names);  // list was built in reverse order, so un-reverse it
 
   char *result = dt_util_glist_to_str("\n", names);
   g_list_free_full(names, g_free);
@@ -1175,10 +1178,10 @@ GList *dt_styles_get_list(const char *filter)
     dt_style_t *s = g_malloc(sizeof(dt_style_t));
     s->name = g_strdup(name);
     s->description = g_strdup(description);
-    result = g_list_append(result, s);
+    result = g_list_prepend(result, s);
   }
   sqlite3_finalize(stmt);
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 static char *dt_style_encode(sqlite3_stmt *stmt, int row)

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -575,7 +575,7 @@ gboolean dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_
   if(imgid == -1)
     imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
   else
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
 
   const gboolean res = dt_tag_detach_images(tagid, imgs, undo_on);
@@ -984,14 +984,14 @@ GList *dt_tag_get_hierarchical_export(gint imgid, int32_t flags)
     dt_tag_t *t = (dt_tag_t *)taglist->data;
     if (export_private_tags || !(t->flags & DT_TF_PRIVATE))
     {
-      tags = g_list_append(tags, t->tag);
+      tags = g_list_prepend(tags, t->tag);
     }
     taglist = g_list_next(taglist);
   }
 
   dt_tag_free_result(&taglist);
 
-  return tags;
+  return g_list_reverse(tags);  // list was built in reverse order, so un-reverse it
 }
 
 gboolean dt_is_tag_attached(const guint tagid, const gint imgid)
@@ -1024,11 +1024,11 @@ GList *dt_tag_get_images(const gint tagid)
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     int id = sqlite3_column_int(stmt, 0);
-    result = g_list_append(result, GINT_TO_POINTER(id));
+    result = g_list_prepend(result, GINT_TO_POINTER(id));
   }
   sqlite3_finalize(stmt);
 
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 GList *dt_tag_get_images_from_list(const GList *img, const gint tagid)
@@ -1057,14 +1057,14 @@ GList *dt_tag_get_images_from_list(const GList *img, const gint tagid)
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       int id = sqlite3_column_int(stmt, 0);
-      result = g_list_append(result, GINT_TO_POINTER(id));
+      result = g_list_prepend(result, GINT_TO_POINTER(id));
     }
 
     sqlite3_finalize(stmt);
     g_free(query);
     g_free(images);
   }
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 uint32_t dt_tag_get_suggestions(GList **result)

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -413,8 +413,9 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
       GList *labels = NULL;
       do
       {
-        labels = g_list_append(labels, (char *)(_(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)))));
+        labels = g_list_prepend(labels, (char *)(_(dt_colorlabels_to_string(GPOINTER_TO_INT(res->data)))));
       } while((res = g_list_next(res)) != NULL);
+      labels = g_list_reverse(labels);  // list was built in reverse order, so un-reverse it
       result = dt_util_glist_to_str(",", labels);
       g_list_free(labels);
     }

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -121,7 +121,7 @@ GList *dt_control_crawler_run()
         item->image_path = g_strdup(image_path);
         item->xmp_path = g_strdup(xmp_path);
 
-        result = g_list_append(result, item);
+        result = g_list_prepend(result, item);
         dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is a newer xmp file.\n", xmp_path, id);
       }
       // older timestamps are the case for all images after the db upgrade. better not report these
@@ -192,7 +192,7 @@ GList *dt_control_crawler_run()
   sqlite3_finalize(stmt);
   sqlite3_finalize(inner_stmt);
 
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -107,9 +107,9 @@ static int32_t dt_camera_capture_job_run(dt_job_t *job)
     do
     {
       // Add value to list
-      values = g_list_append(values, g_strdup(value));
+      values = g_list_prepend(values, g_strdup(value));
       // Check if current values is the same as original value, then lets store item ptr
-      if(strcmp(value, cvalue) == 0) original_value = g_list_last(values)->data;
+      if(strcmp(value, cvalue) == 0) original_value = values->data;
     } while((value = dt_camctl_camera_property_get_next_choice(darktable.camctl, NULL, "shutterspeed"))
             != NULL);
   }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -530,7 +530,7 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   g_free(directory);
 
   // refresh the thumbtable view
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_append(NULL, GINT_TO_POINTER(imageid)));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_prepend(NULL, GINT_TO_POINTER(imageid)));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
 
@@ -680,10 +680,10 @@ static GList *_get_full_pathname(char *imgs)
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, imgs, -1, SQLITE_STATIC);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    list = g_list_append(list, g_strdup((const gchar *)sqlite3_column_text(stmt, 0)));
+    list = g_list_prepend(list, g_strdup((const gchar *)sqlite3_column_text(stmt, 0)));
   }
   sqlite3_finalize(stmt);
-  return list;
+  return g_list_reverse(list);  // list was built in reverse order, so un-reverse it
 }
 
 static int32_t dt_control_remove_images_job_run(dt_job_t *job)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1620,11 +1620,12 @@ static void _dev_merge_history(dt_develop_t *dev, const int imgid)
       // get all rowids
       GList *rowids = NULL;
 
+      // get the rowids in descending order since building the list will reverse the order
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "SELECT rowid FROM memory.history ORDER BY rowid ASC",
+                                  "SELECT rowid FROM memory.history ORDER BY rowid DESC",
                                   -1, &stmt, NULL);
       while(sqlite3_step(stmt) == SQLITE_ROW)
-        rowids = g_list_append(rowids, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
+        rowids = g_list_prepend(rowids, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
       sqlite3_finalize(stmt);
 
       // update num accordingly

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -45,7 +45,7 @@ dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form)
 
   // then duplicate the GList *points
 
-  new_form->points = NULL;
+  GList* newpoints = NULL;
 
   if (form->points)
   {
@@ -71,11 +71,12 @@ dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form)
       {
         void *item = malloc(size_item);
         memcpy(item, pt->data, size_item);
-        new_form->points = g_list_append(new_form->points, item);
+        newpoints = g_list_prepend(newpoints, item);
         pt = g_list_next(pt);
       }
     }
   }
+  new_form->points = g_list_reverse(newpoints);  // list was built in reverse order, so un-reverse it
 
   return new_form;
 }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -868,7 +868,7 @@ static gboolean _event_rating_release(GtkWidget *widget, GdkEventButton *event, 
     {
       dt_ratings_apply_on_image(thumb->imgid, rating, TRUE, TRUE, TRUE);
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                                 g_list_append(NULL, GINT_TO_POINTER(thumb->imgid)));
+                                 g_list_prepend(NULL, GINT_TO_POINTER(thumb->imgid)));
     }
   }
   return TRUE;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1609,9 +1609,10 @@ static void _event_dnd_get(GtkWidget *widget, GdkDragContext *context, GtkSelect
           gboolean from_cache = TRUE;
           dt_image_full_path(id, pathname, sizeof(pathname), &from_cache);
           gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
-          images = g_list_append(images, uri);
+          images = g_list_prepend(images, uri);
           l = g_list_next(l);
         }
+        images = g_list_reverse(images); // list was built in reverse order, so un-reverse it
         gchar *uri_list = dt_util_glist_to_str("\r\n", images);
         g_list_free_full(images, g_free);
         gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _BYTE,
@@ -1966,7 +1967,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
           gtk_layout_move(GTK_LAYOUT(table->widget), thumb->w_main, posx, posy);
         }
         dt_thumbnail_resize(thumb, table->thumb_size, table->thumb_size, FALSE, IMG_TO_FIT);
-        newlist = g_list_append(newlist, thumb);
+        newlist = g_list_prepend(newlist, thumb);
         // and we remove the thumb from the old list
         table->list = g_list_remove(table->list, thumb);
       }
@@ -1983,7 +1984,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
         }
         thumb->x = posx;
         thumb->y = posy;
-        newlist = g_list_append(newlist, thumb);
+        newlist = g_list_prepend(newlist, thumb);
         gtk_widget_set_margin_start(thumb->w_image_box, old_margin_start);
         gtk_widget_set_margin_top(thumb->w_image_box, old_margin_top);
         gtk_layout_put(GTK_LAYOUT(table->widget), thumb->w_main, posx, posy);
@@ -1996,7 +1997,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
 
     // now we cleanup all remaining thumbs from old table->list and set it again
     g_list_free_full(table->list, _list_remove_thumb);
-    table->list = newlist;
+    table->list = g_list_reverse(newlist);  // list was built in reverse order, so un-reverse it
 
     _pos_compute_area(table);
 

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -65,11 +65,12 @@ static GList *_gui_hist_get_active_items(dt_history_copy_item_t *d)
       gboolean active = FALSE;
       gint num = 0;
       gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &active, DT_HIST_ITEMS_COL_NUM, &num, -1);
-      if(active && num >= 0) result = g_list_append(result, GINT_TO_POINTER(num));
+      if(active && num >= 0)
+        result = g_list_prepend(result, GINT_TO_POINTER(num));
 
     } while(gtk_tree_model_iter_next(model, &iter));
   }
-  return result;
+  return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
 static void _gui_hist_set_items(dt_history_copy_item_t *d, gboolean active)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2366,17 +2366,18 @@ static void draw_paths(struct dt_iop_module_t *module, cairo_t *cr, const float 
   {
     if(gtk_toggle_button_get_active(g->btn_point_tool)
         && (dt_liquify_layers[layer].flags & DT_LIQUIFY_LAYER_FLAG_POINT_TOOL))
-      layers = g_list_append(layers, GINT_TO_POINTER(layer));
+      layers = g_list_prepend(layers, GINT_TO_POINTER(layer));
     if(gtk_toggle_button_get_active(g->btn_line_tool)
         && (dt_liquify_layers[layer].flags & DT_LIQUIFY_LAYER_FLAG_LINE_TOOL))
-      layers = g_list_append(layers, GINT_TO_POINTER(layer));
+      layers = g_list_prepend(layers, GINT_TO_POINTER(layer));
     if(gtk_toggle_button_get_active(g->btn_curve_tool)
         && (dt_liquify_layers[layer].flags & DT_LIQUIFY_LAYER_FLAG_CURVE_TOOL))
-      layers = g_list_append(layers, GINT_TO_POINTER(layer));
+      layers = g_list_prepend(layers, GINT_TO_POINTER(layer));
     if(gtk_toggle_button_get_active(g->btn_node_tool)
         && (dt_liquify_layers[layer].flags & DT_LIQUIFY_LAYER_FLAG_NODE_TOOL))
-      layers = g_list_append(layers, GINT_TO_POINTER(layer));
+      layers = g_list_prepend(layers, GINT_TO_POINTER(layer));
   }
+  layers = g_list_reverse(layers); // list was built in reverse order, so un-reverse it
 
   _draw_paths(module, cr, scale, params, layers);
 
@@ -2393,8 +2394,9 @@ static dt_liquify_hit_t _hit_test_paths(struct dt_iop_module_t *module,
   for(dt_liquify_layer_enum_t layer = 0; layer < DT_LIQUIFY_LAYER_LAST; ++layer)
   {
     if(dt_liquify_layers[layer].flags & DT_LIQUIFY_LAYER_FLAG_HIT_TEST)
-      layers = g_list_append(layers, GINT_TO_POINTER(layer));
+      layers = g_list_prepend(layers, GINT_TO_POINTER(layer));
   }
+  layers = g_list_reverse(layers); // list was built in reverse order, so un-reverse it
 
   hit = _hit_paths(module, params, layers, &pt);
   g_list_free(layers);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1169,7 +1169,7 @@ static void load_watermarks(const char *basedir, dt_iop_watermark_gui_data_t *g)
   {
     const gchar *d_name;
     while((d_name = g_dir_read_name(dir)))
-      files = g_list_append(files, g_strdup(d_name));
+      files = g_list_prepend(files, g_strdup(d_name));
     g_dir_close(dir);
   }
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -139,7 +139,7 @@ static void _lib_duplicate_delete(GtkButton *button, dt_lib_module_t *self)
   // and we remove the image
   dt_control_delete_image(imgid);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                             g_list_append(NULL, GINT_TO_POINTER(imgid)));
+                             g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
 }
 
 static void _lib_duplicate_thumb_press_callback(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -97,8 +97,9 @@ static void _group_helper_function(void)
     int id = sqlite3_column_int(stmt, 0);
     if(new_group_id == -1) new_group_id = id;
     dt_grouping_add_to_group(new_group_id, id);
-    imgs = g_list_append(imgs, GINT_TO_POINTER(id));
+    imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
   }
+  imgs = g_list_reverse(imgs); // list was built in reverse order, so un-reverse it
   sqlite3_finalize(stmt);
   if(darktable.gui->grouping)
     darktable.gui->expanded_group_id = new_group_id;
@@ -122,14 +123,14 @@ static void _ungroup_helper_function(void)
     if(new_group_id != -1)
     {
       // new_group_id == -1 if image to be ungrouped was a single image and no change to any group was made
-      imgs = g_list_append(imgs, GINT_TO_POINTER(id));
+      imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
     }
   }
   sqlite3_finalize(stmt);
   if(imgs != NULL)
   {
     darktable.gui->expanded_group_id = -1;
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_reverse(imgs));
     dt_control_queue_redraw_center();
   }
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1447,7 +1447,6 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   if(!txt) return;
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
 
-  GList *res = NULL;
   gboolean show_search = TRUE;
 
   gchar **gr = g_strsplit(txt, "ꬹ", -1);
@@ -1488,6 +1487,7 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
     }
   }
 
+  GList *res = NULL;
   // read the groups
   for(int i = 2; i < g_strv_length(gr); i++)
   {
@@ -1507,12 +1507,13 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
         {
           group->modules = g_list_append(group->modules, g_strdup(gr2[j]));
         }
-        res = g_list_append(res, group);
+        res = g_list_prepend(res, group);
       }
       g_strfreev(gr2);
     }
   }
   g_strfreev(gr);
+  res = g_list_reverse(res);  // list was built in reverse order, so un-reverse it
 
   // and we set the values
   if(edition)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1035,14 +1035,14 @@ static GList* _get_profiles ()
   dt_utf8_strlcpy(prof->name, _("sRGB (web-safe)"), sizeof(prof->name));
   prof->pos = -2;
   prof->ppos = -2;
-  list = g_list_append(list, prof);
+  list = g_list_prepend(list, prof);
 
   prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
   prof->type = DT_COLORSPACE_ADOBERGB;
   dt_utf8_strlcpy(prof->name, _("Adobe RGB (compatible)"), sizeof(prof->name));
   prof->pos = -2;
   prof->ppos = -2;
-  list = g_list_append(list, prof);
+  list = g_list_prepend(list, prof);
 
   // add the profiles from datadir/color/out/*.icc
   for(GList *iter = darktable.color_profiles->profiles; iter; iter = g_list_next(iter))
@@ -1056,11 +1056,11 @@ static GList* _get_profiles ()
       prof->type = DT_COLORSPACE_FILE;
       prof->pos = -2;
       prof->ppos = -2;
-      list = g_list_append(list, prof);
+      list = g_list_prepend(list, prof);
     }
   }
 
-  return list;
+  return g_list_reverse(list);  // list was built in reverse order, so un-reverse it
 }
 
 static void _new_printer_callback(dt_printer_info_t *printer, void *user_data)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -232,10 +232,10 @@ GList* _get_selected_style_names(GList* selected_styles, GtkTreeModel *model)
     gtk_tree_model_get_iter(model, &iter, (GtkTreePath *)style->data);
     gtk_tree_model_get_value(model, &iter, DT_STYLES_COL_FULLNAME, &value);
     if(G_VALUE_HOLDS_STRING(&value))
-      style_names = g_list_append(style_names, g_strdup(g_value_get_string(&value)));
+      style_names = g_list_prepend(style_names, g_strdup(g_value_get_string(&value)));
     g_value_unset(&value);
   }
-  return style_names;
+  return g_list_reverse(style_names); // list was built in reverse order, so un-reverse it
 }
 
 static void apply_clicked(GtkWidget *w, gpointer user_data)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1396,9 +1396,10 @@ static void _pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    tagged_images = g_list_append(tagged_images, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
+    tagged_images = g_list_prepend(tagged_images, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
   }
   sqlite3_finalize(stmt);
+  tagged_images = g_list_reverse(tagged_images); // list was built in reverse order, so unreverse it
 
   dt_tag_remove(tagid, TRUE);
   dt_control_log(_("tag %s removed"), tagname);

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -159,7 +159,7 @@ static int import_images(lua_State *L)
     }
     luaA_push(L, dt_lua_image_t, &result);
     // force refresh of thumbtable view
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_append(NULL, GINT_TO_POINTER(result)));
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_prepend(NULL, GINT_TO_POINTER(result)));
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
     dt_control_queue_redraw_center();
 

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -220,7 +220,7 @@ static int rating_member(lua_State *L)
     my_image->flags |= my_score;
     releasewriteimage(L, my_image);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_append(NULL, GINT_TO_POINTER(my_image->id)));
+                               g_list_prepend(NULL, GINT_TO_POINTER(my_image->id)));
     return 0;
   }
 }
@@ -322,7 +322,7 @@ static int colorlabel_member(lua_State *L)
       dt_colorlabels_remove_label(imgid, colorlabel_index);
     }
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_append(NULL, GINT_TO_POINTER(imgid)));
+                               g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
     return 0;
   }
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3210,7 +3210,7 @@ void leave(dt_view_t *self)
 
   // darkroom development could have changed a collection, so update that before being back in lighttable
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                             g_list_append(NULL, GINT_TO_POINTER(darktable.develop->image_storage.id)));
+                             g_list_prepend(NULL, GINT_TO_POINTER(darktable.develop->image_storage.id)));
 
   darktable.develop->image_storage.id = -1;
 


### PR DESCRIPTION
g_list_append in a loop leads to quadratic performance, while g_list_prepend plus g_list_reverse after the loop is linear.  This PR replaces numerous instances of the former.

It also changes g_list_append to g_list_prepend where the input list is known to be empty, as the result is the same but g_list_prepend is faster (no need to check whether input is empty or not).

Where the order of the result is known not to matter (mostly when the constructed list is sorted before use), the g_list_reverse call is omitted.
