### PR TITLE
Raise trouble message only for true dev struct.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1350,8 +1350,9 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
                                        const char* const trouble_tooltip,
                                        const char *const stderr_message)
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TROUBLE_MESSAGE,
-                                module, trouble_msg, trouble_tooltip, stderr_message);
+  if(!dt_iop_is_hidden(module) && module->gui_data)
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TROUBLE_MESSAGE,
+                                  module, trouble_msg, trouble_tooltip, stderr_message);
 }
 
 static void _iop_gui_update_label(dt_iop_module_t *module)


### PR DESCRIPTION
dt_iop_set_module_trouble_message now only raise a signal for true
dev struct as used in darkroom. During lt thumbs rendering dummy
dev are struct are created to process the pictures. In this case
the gui_data are null and the modules are not ready to receive
any messages.

Also do not raise trouble signal for hidden modules as there is
no point on adding a warning message on them.

Fixes #8262.