### PR TITLE
Refactor masks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ FILE(GLOB SOURCE_FILES
   "common/dwt.c"
   "common/heal.c"
   "develop/masks/circle.c"
+  "develop/masks/ellipse.c"
   "develop/masks/masks.c"
   "develop/format.c"
   "dtgtk/button.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ FILE(GLOB SOURCE_FILES
   "develop/masks/ellipse.c"
   "develop/masks/gradient.c"
   "develop/masks/masks.c"
+  "develop/masks/path.c"
   "develop/format.c"
   "dtgtk/button.c"
   "dtgtk/culling.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ FILE(GLOB SOURCE_FILES
   "develop/tiling.c"
   "common/dwt.c"
   "common/heal.c"
+  "develop/masks/brush.c"
   "develop/masks/circle.c"
   "develop/masks/ellipse.c"
   "develop/masks/gradient.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ FILE(GLOB SOURCE_FILES
   "common/heal.c"
   "develop/masks/circle.c"
   "develop/masks/ellipse.c"
+  "develop/masks/gradient.c"
   "develop/masks/masks.c"
   "develop/format.c"
   "dtgtk/button.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ FILE(GLOB SOURCE_FILES
   "develop/tiling.c"
   "common/dwt.c"
   "common/heal.c"
+  "develop/masks/circle.c"
   "develop/masks/masks.c"
   "develop/format.c"
   "dtgtk/button.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ FILE(GLOB SOURCE_FILES
   "common/heal.c"
   "develop/masks/brush.c"
   "develop/masks/circle.c"
+  "develop/masks/group.c"
   "develop/masks/ellipse.c"
   "develop/masks/gradient.c"
   "develop/masks/masks.c"

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -300,6 +300,8 @@ extern dt_masks_functions_t dt_masks_functions_gradient;
 /** some shape-specific functions which have not yet been migrated to the function table: */
 void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
                             int *inside_border, int *near, int *inside_source);
+void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
+                             int *inside, int *inside_border, int *near, int *inside_source);
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -157,11 +157,48 @@ typedef struct dt_masks_point_group_t
   float opacity;
 } dt_masks_point_group_t;
 
+/** structure used to store pointers to the functions implementing operations on a mask shape */
+/** plus a few per-class descriptive data items */
+typedef struct dt_masks_functions_t
+{
+  int point_struct_size;   // sizeof(struct dt_masks_point_*_t)
+  GSList *(*setup_mouse_actions)(struct dt_masks_form_t *form);
+  void (*set_form_name)(struct dt_masks_form_t *form);
+  void (*set_hint_message)(struct dt_masks_form_gui_t *gui, struct dt_masks_form_t *form,
+                           char *msgbuf, size_t msgbuf_len);
+  void (*duplicate_points)(struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
+  int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
+                           float **border, int *border_count, int source);
+  int (*get_mask)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+                  float **buffer, int *width, int *height, int *posx, int *posy);
+  int (*get_mask_roi)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+                      const dt_iop_roi_t *roi, float *buffer);
+  int (*get_area)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+                  int *width, int *height, int *posx, int *posy);
+  int (*get_source_area)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+                         int *width, int *height, int *posx, int *posy);
+  int (*mouse_moved)(struct dt_iop_module_t *module, float pzx, float pzy, double pressure, int which,
+                     struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
+  int (*mouse_scrolled)(struct dt_iop_module_t *module, float pzx, float pzy, int up, uint32_t state,
+                        struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
+  int (*button_pressed)(struct dt_iop_module_t *module, float pzx, float pzy,
+                        double pressure, int which, int type, uint32_t state,
+                        struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
+  int (*button_released)(struct dt_iop_module_t *module, float pzx, float pzy, int which, uint32_t state,
+                         struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
+  void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index);
+  //TODO:
+  //sanitize_config
+  //read_history_item
+  //write_history_item
+} dt_masks_functions_t;
+  
 /** structure used to define a form */
 typedef struct dt_masks_form_t
 {
   GList *points; // list of point structures
   dt_masks_type_t type;
+  const dt_masks_functions_t *functions;
 
   // position of the source (used only for clone)
   float source[2];

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -194,6 +194,7 @@ typedef struct dt_masks_functions_t
                          struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
   void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
   //TODO:
+  //get_distance
   //read_history_item
   //write_history_item
 } dt_masks_functions_t;
@@ -290,7 +291,9 @@ typedef struct dt_masks_form_gui_t
 } dt_masks_form_gui_t;
 
 /** the shape-specific function tables */
+extern dt_masks_functions_t dt_masks_functions_circle;
 extern dt_masks_functions_t dt_masks_functions_ellipse;
+extern dt_masks_functions_t dt_masks_functions_brush;
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -302,6 +302,8 @@ void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, 
                             int *inside_border, int *near, int *inside_source);
 void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
                              int *inside, int *inside_border, int *near, int *inside_source);
+void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
+                              int *inside, int *inside_border, int *near, int *inside_source);
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -295,6 +295,11 @@ extern dt_masks_functions_t dt_masks_functions_circle;
 extern dt_masks_functions_t dt_masks_functions_ellipse;
 extern dt_masks_functions_t dt_masks_functions_brush;
 extern dt_masks_functions_t dt_masks_functions_path;
+extern dt_masks_functions_t dt_masks_functions_gradient;
+
+/** some shape-specific functions which have not yet been migrated to the function table: */
+void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
+                            int *inside_border, int *near, int *inside_source);
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -304,6 +304,8 @@ void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui,
                              int *inside, int *inside_border, int *near, int *inside_source);
 void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
                               int *inside, int *inside_border, int *near, int *inside_source);
+void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
+                           int corner_count, int *inside, int *inside_border, int *near, int *inside_source);
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -162,11 +162,14 @@ typedef struct dt_masks_point_group_t
 typedef struct dt_masks_functions_t
 {
   int point_struct_size;   // sizeof(struct dt_masks_point_*_t)
-  GSList *(*setup_mouse_actions)(struct dt_masks_form_t *form);
-  void (*set_form_name)(struct dt_masks_form_t *form);
-  void (*set_hint_message)(struct dt_masks_form_gui_t *gui, struct dt_masks_form_t *form,
-                           char *msgbuf, size_t msgbuf_len);
+  void (*sanitize_config)(dt_masks_type_t type_flags);
+  GSList *(*setup_mouse_actions)(const struct dt_masks_form_t *const form);
+  void (*set_form_name)(struct dt_masks_form_t *const form, const size_t nb);
+  void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
+                           const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
   void (*duplicate_points)(struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
+  int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radisu_b, float rotation,
+                    float **points, int *points_count);
   int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
                            float **border, int *border_count, int source);
   int (*get_mask)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
@@ -186,9 +189,8 @@ typedef struct dt_masks_functions_t
                         struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
   int (*button_released)(struct dt_iop_module_t *module, float pzx, float pzy, int which, uint32_t state,
                          struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
-  void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index);
+  void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
   //TODO:
-  //sanitize_config
   //read_history_item
   //write_history_item
 } dt_masks_functions_t;
@@ -283,6 +285,9 @@ typedef struct dt_masks_form_gui_t
   int formid;
   uint64_t pipe_hash;
 } dt_masks_form_gui_t;
+
+/** the shape-specific function tables */
+extern dt_masks_functions_t dt_masks_functions_ellipse;
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -168,15 +168,18 @@ typedef struct dt_masks_functions_t
   void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
                            const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
   void (*duplicate_points)(struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
-  int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radisu_b, float rotation,
+  int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
                     float **points, int *points_count);
   int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
                            float **border, int *border_count, int source);
-  int (*get_mask)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+  int (*get_mask)(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                  struct dt_masks_form_t *const form,
                   float **buffer, int *width, int *height, int *posx, int *posy);
-  int (*get_mask_roi)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+  int (*get_mask_roi)(const dt_iop_module_t *const fmodule, const dt_dev_pixelpipe_iop_t *const piece,
+                      struct dt_masks_form_t *const form,
                       const dt_iop_roi_t *roi, float *buffer);
-  int (*get_area)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
+  int (*get_area)(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                  struct dt_masks_form_t *const form,
                   int *width, int *height, int *posx, int *posy);
   int (*get_source_area)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
                          int *width, int *height, int *posx, int *posy);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -306,6 +306,8 @@ void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *g
                               int *inside, int *inside_border, int *near, int *inside_source);
 void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
                            int corner_count, int *inside, int *inside_border, int *near, int *inside_source);
+void dt_path_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
+                          int corner_count, int *inside, int *inside_border, int *near, int *inside_source);
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -168,6 +168,7 @@ typedef struct dt_masks_functions_t
   void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
                            const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
   void (*duplicate_points)(struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
+  void (*initial_source_pos)(const float iwd, const float iht, float *x, float *y);
   void (*get_distance)(float x, float y, float as, struct dt_masks_form_gui_t *gui, int index, int num_points,
                        int *inside, int *inside_border, int *near, int *inside_source);
   int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
@@ -195,9 +196,6 @@ typedef struct dt_masks_functions_t
   int (*button_released)(struct dt_iop_module_t *module, float pzx, float pzy, int which, uint32_t state,
                          struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
   void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
-  //TODO:
-  //read_history_item
-  //write_history_item
 } dt_masks_functions_t;
   
 /** structure used to define a form */
@@ -292,11 +290,11 @@ typedef struct dt_masks_form_gui_t
 } dt_masks_form_gui_t;
 
 /** the shape-specific function tables */
-extern dt_masks_functions_t dt_masks_functions_circle;
-extern dt_masks_functions_t dt_masks_functions_ellipse;
-extern dt_masks_functions_t dt_masks_functions_brush;
-extern dt_masks_functions_t dt_masks_functions_path;
-extern dt_masks_functions_t dt_masks_functions_gradient;
+extern const dt_masks_functions_t dt_masks_functions_circle;
+extern const dt_masks_functions_t dt_masks_functions_ellipse;
+extern const dt_masks_functions_t dt_masks_functions_brush;
+extern const dt_masks_functions_t dt_masks_functions_path;
+extern const dt_masks_functions_t dt_masks_functions_gradient;
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -168,6 +168,8 @@ typedef struct dt_masks_functions_t
   void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
                            const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
   void (*duplicate_points)(struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
+  void (*get_distance)(float x, float y, float as, struct dt_masks_form_gui_t *gui, int index, int num_points,
+                       int *inside, int *inside_border, int *near, int *inside_source);
   int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
                     float **points, int *points_count);
   int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
@@ -194,7 +196,6 @@ typedef struct dt_masks_functions_t
                          struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
   void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
   //TODO:
-  //get_distance
   //read_history_item
   //write_history_item
 } dt_masks_functions_t;
@@ -296,18 +297,6 @@ extern dt_masks_functions_t dt_masks_functions_ellipse;
 extern dt_masks_functions_t dt_masks_functions_brush;
 extern dt_masks_functions_t dt_masks_functions_path;
 extern dt_masks_functions_t dt_masks_functions_gradient;
-
-/** some shape-specific functions which have not yet been migrated to the function table: */
-void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
-                            int *inside_border, int *near, int *inside_source);
-void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
-                             int *inside, int *inside_border, int *near, int *inside_source);
-void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                              int *inside, int *inside_border, int *near, int *inside_source);
-void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
-                           int corner_count, int *inside, int *inside_border, int *near, int *inside_source);
-void dt_path_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
-                          int corner_count, int *inside, int *inside_border, int *near, int *inside_source);
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -294,6 +294,7 @@ typedef struct dt_masks_form_gui_t
 extern dt_masks_functions_t dt_masks_functions_circle;
 extern dt_masks_functions_t dt_masks_functions_ellipse;
 extern dt_masks_functions_t dt_masks_functions_brush;
+extern dt_masks_functions_t dt_masks_functions_path;
 
 /** init dt_masks_form_gui_t struct with default values */
 void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2963,14 +2963,21 @@ static void _brush_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t
   }
 }
 
+static void _brush_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+{
+  *x = 0.01f * iwd;
+  *y = 0.01f * iht;
+}
+
 // The function table for brushes.  This must be public, i.e. no "static" keyword.
-dt_masks_functions_t dt_masks_functions_brush = {
+const dt_masks_functions_t dt_masks_functions_brush = {
   .point_struct_size = sizeof(struct dt_masks_point_brush_t),
   .sanitize_config = _brush_sanitize_config,
   .setup_mouse_actions = _brush_setup_mouse_actions,
   .set_form_name = _brush_set_form_name,
   .set_hint_message = _brush_set_hint_message,
   .duplicate_points = _brush_duplicate_points,
+  .initial_source_pos = _brush_initial_source_pos,
   .get_distance = _brush_get_distance,
   .get_points_border = _brush_get_points_border,
   .get_mask = _brush_get_mask,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -537,7 +537,7 @@ static inline int _brush_cyclic_cursor(int n, int nb)
 
 /** get all points of the brush and the border */
 /** this takes care of gaps and iop distortions */
-static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, const double iop_order, const int transf_direction,
+static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const double iop_order, const int transf_direction,
                                     dt_dev_pixelpipe_t *pipe, float **points, int *points_count,
                                     float **border, int *border_count, float **payload, int *payload_count,
                                     int source)
@@ -971,10 +971,10 @@ static void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t 
   }
 }
 
-static int dt_brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
-                                      int *points_count, float **border, int *border_count, int source)
+static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
+                                    int *points_count, float **border, int *border_count, int source)
 {
-  return _brush_get_points_border(dev, form, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
+  return _brush_get_pts_border(dev, form, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
                                   border_count, NULL, NULL, source);
 }
 
@@ -1013,9 +1013,9 @@ static float _brush_get_position_in_segment(float x, float y, dt_masks_form_t *f
   return tmin;
 }
 
-static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                          uint32_t state, dt_masks_form_t *form, int parentid,
-                                          dt_masks_form_gui_t *gui, int index)
+static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
+                                        uint32_t state, dt_masks_form_t *form, int parentid,
+                                        dt_masks_form_gui_t *gui, int index)
 {
   if(gui->creation)
   {
@@ -1155,10 +1155,9 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
   return 0;
 }
 
-static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                          double pressure, int which, int type, uint32_t state,
-                                          dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui,
-                                          int index)
+static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
+                                        double pressure, int which, int type, uint32_t state,
+                                        dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
 {
   if(type == GDK_2BUTTON_PRESS || type == GDK_3BUTTON_PRESS) return 1;
   if(!gui) return 0;
@@ -1485,9 +1484,9 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
   return 0;
 }
 
-static int dt_brush_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                           uint32_t state, dt_masks_form_t *form, int parentid,
-                                           dt_masks_form_gui_t *gui, int index)
+static int _brush_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
+                                         uint32_t state, dt_masks_form_t *form, int parentid,
+                                         dt_masks_form_gui_t *gui, int index)
 {
   if(!gui) return 0;
 
@@ -1846,9 +1845,9 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
-                                       int which, dt_masks_form_t *form, int parentid,
-                                       dt_masks_form_gui_t *gui, int index)
+static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
+                                     int which, dt_masks_form_t *form, int parentid,
+                                     dt_masks_form_gui_t *gui, int index)
 {
   const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   const int closeup = dt_control_get_dev_closeup();
@@ -2090,8 +2089,7 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   return 1;
 }
 
-static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index,
-                                        int nb)
+static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index, int nb)
 {
   if(!gui) return;
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
@@ -2499,15 +2497,15 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   }
 }
 
-static int dt_brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                    dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
+                                  dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
 {
   if(!module) return 0;
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_brush_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
-                               &border, &border_count, NULL, NULL, 1))
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+                            &border, &border_count, NULL, NULL, 1))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2549,15 +2547,15 @@ static int dt_brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_io
   return 1;
 }
 
-static int dt_brush_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                             int *width, int *height, int *posx, int *posy)
+static int _brush_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                           dt_masks_form_t *const form, int *width, int *height, int *posx, int *posy)
 {
   if(!module) return 0;
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_brush_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
-                               &border, &border_count, NULL, NULL, 0))
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+                            &border, &border_count, NULL, NULL, 0))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2628,8 +2626,9 @@ static void _brush_falloff(float **buffer, int *p0, int *p1, int posx, int posy,
   }
 }
 
-static int dt_brush_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                             float **buffer, int *width, int *height, int *posx, int *posy)
+static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                           dt_masks_form_t *const form,
+                           float **buffer, int *width, int *height, int *posx, int *posy)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2639,7 +2638,7 @@ static int dt_brush_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;
   int points_count, border_count, payload_count;
-  if(!_brush_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,&points, &points_count,
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,&points, &points_count,
                                &border, &border_count, &payload, &payload_count, 0))
   {
     dt_free_align(points);
@@ -2768,8 +2767,8 @@ static inline void _brush_falloff_roi(float *buffer, const int *p0, const int *p
   }
 }
 
-static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                 dt_masks_form_t *form, const dt_iop_roi_t *roi, float *buffer)
+static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                               dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2787,7 +2786,7 @@ static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
 
   int points_count, border_count, payload_count;
 
-  if(!_brush_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,&points, &points_count,
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,&points, &points_count,
                                &border, &border_count, &payload, &payload_count, 0))
   {
     dt_free_align(points);
@@ -2895,6 +2894,94 @@ static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
 
   return 1;
 }
+
+static GSList *_brush_setup_mouse_actions(const struct dt_masks_form_t *const form)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[BRUSH creation] change size"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[BRUSH creation] change hardness"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[BRUSH] change opacity"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[BRUSH] change hardness"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
+
+static void _brush_sanitize_config(dt_masks_type_t type)
+{
+  // nothing to do (yet?)
+}
+
+static void _brush_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+{
+  snprintf(form->name, sizeof(form->name), _("brush #%d"), (int)nb);
+}
+
+static void _brush_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
+                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+{
+  // TODO: check if it would be good idea to have same controlls on creation and for selected brush
+  if(gui->creation)
+    g_snprintf(msgbuf, msgbuf_len,
+               _("<b>size</b>: scroll, <b>hardness</b>: shift+scroll\n"
+                 "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+  else if(gui->form_selected)
+    g_snprintf(msgbuf, msgbuf_len,
+               _("<b>hardness</b>: scroll, <b>size</b>: shift+scroll\n"
+                 "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+  else if(gui->border_selected)
+    g_strlcat(msgbuf, _("<b>size</b>: scroll"), msgbuf_len);
+}
+
+static void _brush_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+{
+  for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
+  {
+    dt_masks_point_brush_t *pt = (dt_masks_point_brush_t *)pts->data;
+    dt_masks_point_brush_t *npt = (dt_masks_point_brush_t *)malloc(sizeof(dt_masks_point_brush_t));
+    memcpy(npt, pt, sizeof(dt_masks_point_brush_t));
+    dest->points = g_list_append(dest->points, npt);
+  }
+}
+
+// The function table for brushes.  This must be public, i.e. no "static" keyword.
+dt_masks_functions_t dt_masks_functions_brush = {
+  .point_struct_size = sizeof(struct dt_masks_point_brush_t),
+  .sanitize_config = _brush_sanitize_config,
+  .setup_mouse_actions = _brush_setup_mouse_actions,
+  .set_form_name = _brush_set_form_name,
+  .set_hint_message = _brush_set_hint_message,
+  .duplicate_points = _brush_duplicate_points,
+  .get_points_border = _brush_get_points_border,
+  .get_mask = _brush_get_mask,
+  .get_mask_roi = _brush_get_mask_roi,
+  .get_area = _brush_get_area,
+  .get_source_area = _brush_get_source_area,
+  .mouse_moved = _brush_events_mouse_moved,
+  .mouse_scrolled = _brush_events_mouse_scrolled,
+  .button_pressed = _brush_events_button_pressed,
+  .button_released = _brush_events_button_released,
+  .post_expose = _brush_events_post_expose
+};
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -15,8 +15,10 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/imagebuf.h"
+#include "common/undo.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/blend.h"
@@ -878,9 +880,8 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
 }
 
 /** get the distance between point (x,y) and the brush */
-static void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
-                                  int corner_count, int *inside, int *inside_border, int *near,
-                                  int *inside_source)
+void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
+                           int corner_count, int *inside, int *inside_border, int *near, int *inside_source)
 {
   // initialise returned values
   *inside_source = 0;
@@ -1241,12 +1242,12 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
     }
     else if(gui->source_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
     {
-      dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-      if(!gpt) return 0;
+      dt_masks_form_gui_points_t *guipt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+      if(!guipt) return 0;
       // we start the form dragging
       gui->source_dragging = TRUE;
-      gui->dx = gpt->source[2] - gui->posx;
-      gui->dy = gpt->source[3] - gui->posy;
+      gui->dx = guipt->source[2] - gui->posx;
+      gui->dy = guipt->source[3] - gui->posy;
       return 1;
     }
     else if(gui->form_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
@@ -1395,12 +1396,12 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
         GList *forms = g_list_first(darktable.develop->form_visible->points);
         while(forms)
         {
-          dt_masks_point_group_t *gpt = (dt_masks_point_group_t *)forms->data;
-          if(gpt->formid == form->formid)
+          dt_masks_point_group_t *guipt = (dt_masks_point_group_t *)forms->data;
+          if(guipt->formid == form->formid)
           {
             darktable.develop->form_visible->points
-                = g_list_remove(darktable.develop->form_visible->points, gpt);
-            free(gpt);
+                = g_list_remove(darktable.develop->form_visible->points, guipt);
+            free(guipt);
             break;
           }
           forms = g_list_next(forms);
@@ -1463,12 +1464,12 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       GList *forms = g_list_first(darktable.develop->form_visible->points);
       while(forms)
       {
-        dt_masks_point_group_t *gpt = (dt_masks_point_group_t *)forms->data;
-        if(gpt->formid == form->formid)
+        dt_masks_point_group_t *guipt = (dt_masks_point_group_t *)forms->data;
+        if(guipt->formid == form->formid)
         {
           darktable.develop->form_visible->points
-              = g_list_remove(darktable.develop->form_visible->points, gpt);
-          free(gpt);
+              = g_list_remove(darktable.develop->form_visible->points, guipt);
+          free(guipt);
           break;
         }
         forms = g_list_next(forms);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -880,8 +880,8 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
 }
 
 /** get the distance between point (x,y) and the brush */
-void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
-                           int corner_count, int *inside, int *inside_border, int *near, int *inside_source)
+static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
+                                int corner_count, int *inside, int *inside_border, int *near, int *inside_source)
 {
   // initialise returned values
   *inside_source = 0;
@@ -2065,7 +2065,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
 
   // are we inside the form or the borders or near a segment ???
   int in, inb, near, ins;
-  dt_brush_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins);
+  _brush_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins);
   gui->seg_selected = near;
   if(near < 0)
   {
@@ -2971,6 +2971,7 @@ dt_masks_functions_t dt_masks_functions_brush = {
   .set_form_name = _brush_set_form_name,
   .set_hint_message = _brush_set_hint_message,
   .duplicate_points = _brush_duplicate_points,
+  .get_distance = _brush_get_distance,
   .get_points_border = _brush_get_points_border,
   .get_mask = _brush_get_mask,
   .get_mask_roi = _brush_get_mask_roi,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2952,8 +2952,9 @@ static void _brush_set_hint_message(const dt_masks_form_gui_t *const gui, const 
     g_strlcat(msgbuf, _("<b>size</b>: scroll"), msgbuf_len);
 }
 
-static void _brush_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _brush_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
 {
+  (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
   {
     dt_masks_point_brush_t *pt = (dt_masks_point_brush_t *)pts->data;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -56,9 +56,9 @@ static void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t
   *inside_border = !(dt_masks_point_in_form_near(x,yf,gpt->points,1,gpt->points_count,as,near));
 }
 
-static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                           uint32_t state, dt_masks_form_t *form, int parentid,
-                                           dt_masks_form_gui_t *gui, int index)
+static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
+                                         uint32_t state, dt_masks_form_t *form, int parentid,
+                                         dt_masks_form_gui_t *gui, int index)
 {
   const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
   const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
@@ -171,10 +171,9 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                           double pressure, int which, int type, uint32_t state,
-                                           dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui,
-                                           int index)
+static int _circle_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
+                                         double pressure, int which, int type, uint32_t state,
+                                         dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
 {
   if(!gui) return 0;
   if(gui->source_selected && !gui->creation && gui->edit_mode == DT_MASKS_EDIT_FULL)
@@ -331,9 +330,9 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static int dt_circle_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                            uint32_t state, dt_masks_form_t *form, int parentid,
-                                            dt_masks_form_gui_t *gui, int index)
+static int _circle_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
+                                          uint32_t state, dt_masks_form_t *form, int parentid,
+                                          dt_masks_form_gui_t *gui, int index)
 {
   if(which == 3 && parentid > 0 && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
@@ -405,7 +404,7 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     gui->source_dragging = FALSE;
     if(gui->scrollx != 0.0 || gui->scrolly != 0.0)
     {
-      // if there's no dragging the source is calculated in dt_circle_events_button_pressed()
+      // if there's no dragging the source is calculated in _circle_events_button_pressed()
     }
     else
     {
@@ -441,9 +440,9 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
   return 0;
 }
 
-static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
-                                        int which, dt_masks_form_t *form, int parentid,
-                                        dt_masks_form_gui_t *gui, int index)
+static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
+                                      int which, dt_masks_form_t *form, int parentid,
+                                      dt_masks_form_gui_t *gui, int index)
 {
   if(gui->form_dragging || gui->source_dragging)
   {
@@ -499,8 +498,10 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
   return 0;
 }
 
-static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index)
+static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index,
+                                       int num_points)
 {
+  (void)num_points; // unused arg, keep compiler from complaining
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;
@@ -773,8 +774,8 @@ static void _bounding_box(const float *const points, int num_points, int *width,
   *height = (ymax - ymin);
 }
 
-static int dt_circle_get_points(dt_develop_t *dev, float x, float y, float radius, float **points,
-                                int *points_count)
+static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius, float **points,
+                              int *points_count)
 {
   float wd = dev->preview_pipe->iwidth;
   float ht = dev->preview_pipe->iheight;
@@ -795,8 +796,8 @@ static int dt_circle_get_points(dt_develop_t *dev, float x, float y, float radiu
   return 0;
 }
 
-static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                     dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
+                                   dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
 {
   // we get the circle values
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
@@ -822,10 +823,10 @@ static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_i
   return 1;
 }
 
-static int dt_circle_get_area(const dt_iop_module_t *const restrict module,
-                              const dt_dev_pixelpipe_iop_t *const restrict piece,
-                              dt_masks_form_t *const restrict form,
-                              int *width, int *height, int *posx, int *posy)
+static int _circle_get_area(const dt_iop_module_t *const restrict module,
+                            const dt_dev_pixelpipe_iop_t *const restrict piece,
+                            dt_masks_form_t *const restrict form,
+                            int *width, int *height, int *posx, int *posy)
 {
   // we get the circle values
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
@@ -851,16 +852,16 @@ static int dt_circle_get_area(const dt_iop_module_t *const restrict module,
   return 1;
 }
 
-static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
-                              const dt_dev_pixelpipe_iop_t *const restrict piece,
-                              dt_masks_form_t *const restrict form,
-                              float **buffer, int *width, int *height, int *posx, int *posy)
+static int _circle_get_mask(const dt_iop_module_t *const restrict module,
+                            const dt_dev_pixelpipe_iop_t *const restrict piece,
+                            dt_masks_form_t *const restrict form,
+                            float **buffer, int *width, int *height, int *posx, int *posy)
 {
   double start2 = 0.0;
   if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
   // we get the area
-  if(!dt_circle_get_area(module, piece, form, width, height, posx, posy)) return 0;
+  if(!_circle_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
@@ -962,10 +963,10 @@ static int dt_circle_get_mask(const dt_iop_module_t *const restrict module,
 }
 
 
-static int dt_circle_get_mask_roi(const dt_iop_module_t *const restrict module,
-                                  const dt_dev_pixelpipe_iop_t *const restrict piece,
-                                  dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
-                                  float *const restrict buffer)
+static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
+                                const dt_dev_pixelpipe_iop_t *const restrict piece,
+                                dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
+                                float *const restrict buffer)
 {
   double start1 = 0.0;
   double start2 = start1;
@@ -1220,6 +1221,89 @@ static int dt_circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   return 1;
 }
+
+static GSList *_circle_setup_mouse_actions(const struct dt_masks_form_t *const form)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[CIRCLE] change size"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[CIRCLE] change opacity"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[CIRCLE] change feather size"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+  return lm;
+}
+
+static void _circle_sanitize_config(dt_masks_type_t type)
+{
+  if(type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
+  {
+    dt_conf_get_and_sanitize_float("plugins/darkroom/spots/circle_size", 0.001f, 0.5f);
+    dt_conf_get_and_sanitize_float("plugins/darkroom/spots/circle_border", 0.0005f, 0.5f);
+  }
+  else
+  {
+    dt_conf_get_and_sanitize_float("plugins/darkroom/masks/circle/size", 0.001f, 0.5f);
+    dt_conf_get_and_sanitize_float("plugins/darkroom/masks/circle/border", 0.0005f, 0.5f);
+  }
+}
+
+static void _circle_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+{
+  snprintf(form->name, sizeof(form->name), _("circle #%d"), (int)nb);
+}
+
+static void _circle_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
+                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+{
+  // circle has same controls on creation and on edit
+  g_snprintf(msgbuf, msgbuf_len,
+             _("<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
+               "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+}
+
+static void _circle_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+{
+  for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
+  {
+    dt_masks_point_circle_t *pt = (dt_masks_point_circle_t *)pts->data;
+    dt_masks_point_circle_t *npt = (dt_masks_point_circle_t *)malloc(sizeof(dt_masks_point_circle_t));
+    memcpy(npt, pt, sizeof(dt_masks_point_circle_t));
+    dest->points = g_list_append(dest->points, npt);
+  }
+}
+
+// The function table for ellipses.  This must be public, i.e. no "static" keyword.
+dt_masks_functions_t dt_masks_functions_circle = {
+  .point_struct_size = sizeof(struct dt_masks_point_circle_t),
+  .sanitize_config = _circle_sanitize_config,
+  .setup_mouse_actions = _circle_setup_mouse_actions,
+  .set_form_name = _circle_set_form_name,
+  .set_hint_message = _circle_set_hint_message,
+  .duplicate_points = _circle_duplicate_points,
+  .get_points = _circle_get_points,
+  .get_mask = _circle_get_mask,
+  .get_mask_roi = _circle_get_mask_roi,
+  .get_area = _circle_get_area,
+  .get_source_area = _circle_get_source_area,
+  .mouse_moved = _circle_events_mouse_moved,
+  .mouse_scrolled = _circle_events_mouse_scrolled,
+  .button_pressed = _circle_events_button_pressed,
+  .button_released = _circle_events_button_released,
+  .post_expose = _circle_events_post_expose
+};
 
 
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "bauhaus/bauhaus.h"
 #include "common/debug.h"
+#include "common/undo.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/blend.h"
@@ -23,8 +25,8 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
-static void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
-                                   int *inside_border, int *near, int *inside_source)
+void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
+                            int *inside_border, int *near, int *inside_source)
 {
   // initialise returned values
   *inside_source = 0;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -774,9 +774,11 @@ static void _bounding_box(const float *const points, int num_points, int *width,
   *height = (ymax - ymin);
 }
 
-static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius, float **points,
-                              int *points_count)
+static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius, float radius2, float rotation,
+                              float **points, int *points_count)
 {
+  (void)radius2; // keep compiler from complaining about unused arg
+  (void)rotation;
   float wd = dev->preview_pipe->iwidth;
   float ht = dev->preview_pipe->iheight;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1301,8 +1301,9 @@ static void _circle_set_hint_message(const dt_masks_form_gui_t *const gui, const
                "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
 }
 
-static void _circle_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _circle_duplicate_points(dt_develop_t *dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
 {
+  (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
   {
     dt_masks_point_circle_t *pt = (dt_masks_point_circle_t *)pts->data;
@@ -1320,7 +1321,7 @@ static void _circle_initial_source_pos(const float iwd, const float iht, float *
   *y = -(radius * iht);
 }
 
-// The function table for ellipses.  This must be public, i.e. no "static" keyword.
+// The function table for circles.  This must be public, i.e. no "static" keyword.
 const dt_masks_functions_t dt_masks_functions_circle = {
   .point_struct_size = sizeof(struct dt_masks_point_circle_t),
   .sanitize_config = _circle_sanitize_config,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -25,9 +25,10 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
-void dt_circle_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index, int *inside,
-                            int *inside_border, int *near, int *inside_source)
+static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
+                                 int num_points, int *inside, int *inside_border, int *near, int *inside_source)
 {
+  (void)num_points; // unused arg, keep compiler from complaining
   // initialise returned values
   *inside_source = 0;
   *inside = 0;
@@ -458,9 +459,9 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1<<closeup, 1);
     const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;
     int in, inb, near, ins;
-    dt_circle_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
-                           pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, &in, &inb,
-                           &near, &ins);
+    _circle_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
+                         pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, 0,
+                         &in, &inb, &near, &ins);
     if(ins)
     {
       gui->form_selected = TRUE;
@@ -1297,6 +1298,7 @@ dt_masks_functions_t dt_masks_functions_circle = {
   .set_form_name = _circle_set_form_name,
   .set_hint_message = _circle_set_hint_message,
   .duplicate_points = _circle_duplicate_points,
+  .get_distance = _circle_get_distance,
   .get_points = _circle_get_points,
   .get_mask = _circle_get_mask,
   .get_mask_roi = _circle_get_mask_roi,

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1499,7 +1499,8 @@ static int _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_io
   return 1;
 }
 
-static int _ellipse_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
+static int _ellipse_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                             dt_masks_form_t *const form,
                              int *width, int *height, int *posx, int *posy)
 {
   // we get the ellipse values
@@ -1588,7 +1589,8 @@ static int _ellipse_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   return 1;
 }
 
-static int _ellipse_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
+static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                             dt_masks_form_t *const form,
                              float **buffer, int *width, int *height, int *posx, int *posy)
 {
   double start2 = 0.0;
@@ -1730,8 +1732,8 @@ static inline float fast_atan2(float y, float x)
 }
 
 
-static int _ellipse_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                 dt_masks_form_t *form, const dt_iop_roi_t *roi, float *buffer)
+static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                                 dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
 {
   double start1 = 0.0;
   double start2 = start1;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -2063,8 +2063,9 @@ static void _ellipse_set_form_name(struct dt_masks_form_t *const form, const siz
   snprintf(form->name, sizeof(form->name), _("ellipse #%d"), (int)nb);
 }
 
-static void _ellipse_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _ellipse_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
 {
+  (void)dev; // unused arg, keep compiler from complaining
   for (GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
   {
     dt_masks_point_ellipse_t *pt = (dt_masks_point_ellipse_t *)pts->data;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1516,8 +1516,9 @@ static void _gradient_set_hint_message(const dt_masks_form_gui_t *const gui, con
     g_strlcat(msgbuf, _("<b>rotate</b>: drag"), msgbuf_len);
 }
 
-static void _gradient_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _gradient_duplicate_points(dt_develop_t *dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
 {
+  (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
   {
     dt_masks_point_gradient_t *pt = (dt_masks_point_gradient_t *)pts->data;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -15,12 +15,15 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "bauhaus/bauhaus.h"
 #include "common/debug.h"
+#include "common/undo.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
+#include "develop/openmp_maths.h"
 
 
 static inline void _gradient_point_transform(const float xref, const float yref, const float x, const float y,
@@ -31,8 +34,8 @@ static inline void _gradient_point_transform(const float xref, const float yref,
 }
 
 
-static void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                     int *inside, int *inside_border, int *near, int *inside_source)
+void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
+                              int *inside, int *inside_border, int *near, int *inside_source)
 {
   if(!gui) return;
 

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -34,9 +34,10 @@ static inline void _gradient_point_transform(const float xref, const float yref,
 }
 
 
-void dt_gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                              int *inside, int *inside_border, int *near, int *inside_source)
+static void _gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
+                                   int num_points, int *inside, int *inside_border, int *near, int *inside_source)
 {
+  (void)num_points; // unused arg, keep compiler from complaining
   if(!gui) return;
 
   *inside = *inside_border = *inside_source = 0;
@@ -455,7 +456,7 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     const float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     const float y = pzy * darktable.develop->preview_pipe->backbuf_height;
     int in, inb, near, ins;
-    dt_gradient_get_distance(x, y, as, gui, index, &in, &inb, &near, &ins);
+    _gradient_get_distance(x, y, as, gui, index, 0, &in, &inb, &near, &ins);
 
     const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
 
@@ -1534,6 +1535,7 @@ dt_masks_functions_t dt_masks_functions_gradient = {
   .set_form_name = _gradient_set_form_name,
   .set_hint_message = _gradient_set_hint_message,
   .duplicate_points = _gradient_duplicate_points,
+  .get_distance = _gradient_get_distance,
   .get_points_border = _gradient_get_points_border,
   .get_mask = _gradient_get_mask,
   .get_mask_roi = _gradient_get_mask_roi,

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1528,7 +1528,7 @@ static void _gradient_duplicate_points(dt_masks_form_t *const base, dt_masks_for
 }
 
 // The function table for gradients.  This must be public, i.e. no "static" keyword.
-dt_masks_functions_t dt_masks_functions_gradient = {
+const dt_masks_functions_t dt_masks_functions_gradient = {
   .point_struct_size = sizeof(struct dt_masks_point_gradient_t),
   .sanitize_config = _gradient_sanitize_config,
   .setup_mouse_actions = _gradient_setup_mouse_actions,

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -33,9 +33,6 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     if(!sel) return 0;
     if(sel->functions)
       sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_CIRCLE)
-      return dt_circle_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
-                                             gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
       return dt_path_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
                                            gui->group_edited);
@@ -76,9 +73,6 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     if(sel->functions)
       return sel->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                            fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_CIRCLE)
-      return dt_circle_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
-                                             fpt->parentid, gui, gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
       return dt_path_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel, fpt->parentid,
                                            gui, gui->group_edited);
@@ -104,9 +98,6 @@ static int dt_group_events_button_released(struct dt_iop_module_t *module, float
     if(sel->functions)
       return sel->functions->button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                             gui->group_edited);
-    else if(sel->type & DT_MASKS_CIRCLE)
-      return dt_circle_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
-                                              gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
       return dt_path_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                             gui->group_edited);
@@ -150,9 +141,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     if(sel->functions)
       rep = sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                        gui->group_edited);
-    else if(sel->type & DT_MASKS_CIRCLE)
-      rep = dt_circle_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
-                                         gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
       rep = dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                        gui->group_edited);
@@ -204,8 +192,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
       gui->group_edited = gui->group_selected = pos;
       if(sel->functions)
         return sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
-      else if(sel->type & DT_MASKS_CIRCLE)
-        return dt_circle_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_PATH)
         return dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_GRADIENT)
@@ -232,8 +218,6 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     if (!sel) return;
     if(sel->functions)
       sel->functions->post_expose(cr, zoom_scale, gui, pos, 0);
-    else if(sel->type & DT_MASKS_CIRCLE)
-      dt_circle_events_post_expose(cr, zoom_scale, gui, pos);
     else if(sel->type & DT_MASKS_PATH)
       dt_path_events_post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     else if(sel->type & DT_MASKS_GRADIENT)

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -32,7 +32,7 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return 0;
     if(sel->functions)
-      sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
+      return sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
   }
   return 0;
 }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -33,9 +33,6 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     if(!sel) return 0;
     if(sel->functions)
       sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_GRADIENT)
-      return dt_gradient_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
-                                               gui->group_edited);
   }
   return 0;
 }
@@ -67,9 +64,6 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     if(sel->functions)
       return sel->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                            fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_GRADIENT)
-      return dt_gradient_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
-                                               fpt->parentid, gui, gui->group_edited);
   }
   return 0;
 }
@@ -86,9 +80,6 @@ static int dt_group_events_button_released(struct dt_iop_module_t *module, float
     if(sel->functions)
       return sel->functions->button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                             gui->group_edited);
-    else if(sel->type & DT_MASKS_GRADIENT)
-      return dt_gradient_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
-                                                gui->group_edited);
   }
   return 0;
 }
@@ -123,9 +114,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     if(sel->functions)
       rep = sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                        gui->group_edited);
-    else if(sel->type & DT_MASKS_GRADIENT)
-      rep = dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
-                                           gui->group_edited);
     if(rep) return 1;
     // if a point is in state editing, then we don't want that another form can be selected
     if(gui->point_edited >= 0) return 0;
@@ -168,8 +156,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
       gui->group_edited = gui->group_selected = pos;
       if(sel->functions)
         return sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
-      else if(sel->type & DT_MASKS_GRADIENT)
-        return dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
     }
     fpts = g_list_next(fpts);
     pos++;
@@ -190,8 +176,6 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     if (!sel) return;
     if(sel->functions)
       sel->functions->post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
-    else if(sel->type & DT_MASKS_GRADIENT)
-      dt_gradient_events_post_expose(cr, zoom_scale, gui, pos);
     fpts = g_list_next(fpts);
     pos++;
   }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -39,9 +39,6 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
                                                gui->group_edited);
-    else if(sel->type & DT_MASKS_BRUSH)
-      return dt_brush_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
-                                            gui->group_edited);
   }
   return 0;
 }
@@ -79,9 +76,6 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                                fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_BRUSH)
-      return dt_brush_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
-                                            fpt->parentid, gui, gui->group_edited);
   }
   return 0;
 }
@@ -104,9 +98,6 @@ static int dt_group_events_button_released(struct dt_iop_module_t *module, float
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                                 gui->group_edited);
-    else if(sel->type & DT_MASKS_BRUSH)
-      return dt_brush_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
-                                             gui->group_edited);
   }
   return 0;
 }
@@ -147,9 +138,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     else if(sel->type & DT_MASKS_GRADIENT)
       rep = dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                            gui->group_edited);
-    else if(sel->type & DT_MASKS_BRUSH)
-      rep = dt_brush_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
-                                        gui->group_edited);
     if(rep) return 1;
     // if a point is in state editing, then we don't want that another form can be selected
     if(gui->point_edited >= 0) return 0;
@@ -196,8 +184,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
         return dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_GRADIENT)
         return dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
-      else if(sel->type & DT_MASKS_BRUSH)
-        return dt_brush_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
     }
     fpts = g_list_next(fpts);
     pos++;
@@ -217,13 +203,11 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if (!sel) return;
     if(sel->functions)
-      sel->functions->post_expose(cr, zoom_scale, gui, pos, 0);
+      sel->functions->post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     else if(sel->type & DT_MASKS_PATH)
       dt_path_events_post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     else if(sel->type & DT_MASKS_GRADIENT)
       dt_gradient_events_post_expose(cr, zoom_scale, gui, pos);
-    else if(sel->type & DT_MASKS_BRUSH)
-      dt_brush_events_post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     fpts = g_list_next(fpts);
     pos++;
   }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -31,7 +31,9 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return 0;
-    if(sel->type & DT_MASKS_CIRCLE)
+    if(sel->functions)
+      sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
+    else if(sel->type & DT_MASKS_CIRCLE)
       return dt_circle_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
                                              gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
@@ -40,9 +42,6 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
                                                gui->group_edited);
-    else if(sel->type & DT_MASKS_ELLIPSE)
-      return dt_ellipse_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
-                                              gui->group_edited);
     else if(sel->type & DT_MASKS_BRUSH)
       return dt_brush_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
                                             gui->group_edited);
@@ -74,7 +73,10 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return 0;
-    if(sel->type & DT_MASKS_CIRCLE)
+    if(sel->functions)
+      return sel->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
+                                           fpt->parentid, gui, gui->group_edited);
+    else if(sel->type & DT_MASKS_CIRCLE)
       return dt_circle_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                              fpt->parentid, gui, gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
@@ -83,9 +85,6 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                                fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_ELLIPSE)
-      return dt_ellipse_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
-                                              fpt->parentid, gui, gui->group_edited);
     else if(sel->type & DT_MASKS_BRUSH)
       return dt_brush_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                             fpt->parentid, gui, gui->group_edited);
@@ -102,7 +101,10 @@ static int dt_group_events_button_released(struct dt_iop_module_t *module, float
     dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return 0;
-    if(sel->type & DT_MASKS_CIRCLE)
+    if(sel->functions)
+      return sel->functions->button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
+                                            gui->group_edited);
+    else if(sel->type & DT_MASKS_CIRCLE)
       return dt_circle_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                               gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
@@ -111,9 +113,6 @@ static int dt_group_events_button_released(struct dt_iop_module_t *module, float
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                                 gui->group_edited);
-    else if(sel->type & DT_MASKS_ELLIPSE)
-      return dt_ellipse_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
-                                               gui->group_edited);
     else if(sel->type & DT_MASKS_BRUSH)
       return dt_brush_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                              gui->group_edited);
@@ -148,7 +147,10 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return 0;
     int rep = 0;
-    if(sel->type & DT_MASKS_CIRCLE)
+    if(sel->functions)
+      rep = sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
+                                       gui->group_edited);
+    else if(sel->type & DT_MASKS_CIRCLE)
       rep = dt_circle_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                          gui->group_edited);
     else if(sel->type & DT_MASKS_PATH)
@@ -157,9 +159,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     else if(sel->type & DT_MASKS_GRADIENT)
       rep = dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                            gui->group_edited);
-    else if(sel->type & DT_MASKS_ELLIPSE)
-      rep = dt_ellipse_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
-                                          gui->group_edited);
     else if(sel->type & DT_MASKS_BRUSH)
       rep = dt_brush_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                         gui->group_edited);
@@ -203,14 +202,14 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     if(inside || inside_border || near >= 0 || inside_source)
     {
       gui->group_edited = gui->group_selected = pos;
-      if(sel->type & DT_MASKS_CIRCLE)
+      if(sel->functions)
+        return sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
+      else if(sel->type & DT_MASKS_CIRCLE)
         return dt_circle_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_PATH)
         return dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_GRADIENT)
         return dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
-      else if(sel->type & DT_MASKS_ELLIPSE)
-        return dt_ellipse_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_BRUSH)
         return dt_brush_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
     }
@@ -231,14 +230,14 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if (!sel) return;
-    if(sel->type & DT_MASKS_CIRCLE)
+    if(sel->functions)
+      sel->functions->post_expose(cr, zoom_scale, gui, pos, 0);
+    else if(sel->type & DT_MASKS_CIRCLE)
       dt_circle_events_post_expose(cr, zoom_scale, gui, pos);
     else if(sel->type & DT_MASKS_PATH)
       dt_path_events_post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     else if(sel->type & DT_MASKS_GRADIENT)
       dt_gradient_events_post_expose(cr, zoom_scale, gui, pos);
-    else if(sel->type & DT_MASKS_ELLIPSE)
-      dt_ellipse_events_post_expose(cr, zoom_scale, gui, pos);
     else if(sel->type & DT_MASKS_BRUSH)
       dt_brush_events_post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     fpts = g_list_next(fpts);

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -139,18 +139,9 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     near = -1;
     const float xx = pzx * darktable.develop->preview_pipe->backbuf_width,
                 yy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    if(sel->type & DT_MASKS_CIRCLE)
-      dt_circle_get_distance(xx, yy, as, gui, pos, &inside, &inside_border, &near, &inside_source);
-    else if(sel->type & DT_MASKS_PATH)
-      dt_path_get_distance(xx, yy, as, gui, pos, g_list_length(sel->points), &inside, &inside_border, &near,
-                           &inside_source);
-    else if(sel->type & DT_MASKS_GRADIENT)
-      dt_gradient_get_distance(xx, yy, as, gui, pos, &inside, &inside_border, &near, &inside_source);
-    else if(sel->type & DT_MASKS_ELLIPSE)
-      dt_ellipse_get_distance(xx, yy, as, gui, pos, &inside, &inside_border, &near, &inside_source);
-    else if(sel->type & DT_MASKS_BRUSH)
-      dt_brush_get_distance(xx, yy, as, gui, pos, g_list_length(sel->points), &inside, &inside_border, &near,
-                            &inside_source);
+    if(sel->functions && sel->functions->get_distance)
+      sel->functions->get_distance(xx, yy, as, gui, pos, g_list_length(sel->points),
+                                   &inside, &inside_border, &near, &inside_source);
     if(inside || inside_border || near >= 0 || inside_source)
     {
       gui->group_edited = gui->group_selected = pos;

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -24,15 +24,15 @@
 
 static int _group_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
                                         uint32_t state, dt_masks_form_t *form, int unused1, dt_masks_form_gui_t *gui,
-                                        int group_edited)
+                                        int unused)
 {
-  if(group_edited >= 0)
+  if(gui->group_edited >= 0)
   {
     // we get the form
-    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, group_edited);
+    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(sel && sel->functions)
-      return sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, group_edited);
+      return sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
   }
   return 0;
 }
@@ -70,16 +70,16 @@ static int _group_events_button_pressed(struct dt_iop_module_t *module, float pz
 
 static int _group_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
                                          uint32_t state, dt_masks_form_t *form, int unused1, dt_masks_form_gui_t *gui,
-                                         int group_edited)
+                                         int unused2)
 {
-  if(group_edited >= 0)
+  if(gui->group_edited >= 0)
   {
     // we get the form
-    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, group_edited);
+    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(sel && sel->functions)
       return sel->functions->button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
-                                             group_edited);
+                                             gui->group_edited);
   }
   return 0;
 }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -33,9 +33,6 @@ static int dt_group_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     if(!sel) return 0;
     if(sel->functions)
       sel->functions->mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_PATH)
-      return dt_path_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
-                                           gui->group_edited);
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_mouse_scrolled(module, pzx, pzy, up, state, sel, fpt->parentid, gui,
                                                gui->group_edited);
@@ -70,9 +67,6 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     if(sel->functions)
       return sel->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                            fpt->parentid, gui, gui->group_edited);
-    else if(sel->type & DT_MASKS_PATH)
-      return dt_path_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel, fpt->parentid,
-                                           gui, gui->group_edited);
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_button_pressed(module, pzx, pzy, pressure, which, type, state, sel,
                                                fpt->parentid, gui, gui->group_edited);
@@ -91,9 +85,6 @@ static int dt_group_events_button_released(struct dt_iop_module_t *module, float
     if(!sel) return 0;
     if(sel->functions)
       return sel->functions->button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
-                                            gui->group_edited);
-    else if(sel->type & DT_MASKS_PATH)
-      return dt_path_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
                                             gui->group_edited);
     else if(sel->type & DT_MASKS_GRADIENT)
       return dt_gradient_events_button_released(module, pzx, pzy, which, state, sel, fpt->parentid, gui,
@@ -131,9 +122,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     int rep = 0;
     if(sel->functions)
       rep = sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
-                                       gui->group_edited);
-    else if(sel->type & DT_MASKS_PATH)
-      rep = dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
                                        gui->group_edited);
     else if(sel->type & DT_MASKS_GRADIENT)
       rep = dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui,
@@ -180,8 +168,6 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
       gui->group_edited = gui->group_selected = pos;
       if(sel->functions)
         return sel->functions->mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
-      else if(sel->type & DT_MASKS_PATH)
-        return dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
       else if(sel->type & DT_MASKS_GRADIENT)
         return dt_gradient_events_mouse_moved(module, pzx, pzy, pressure, which, sel, fpt->parentid, gui, pos);
     }
@@ -204,8 +190,6 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     if (!sel) return;
     if(sel->functions)
       sel->functions->post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
-    else if(sel->type & DT_MASKS_PATH)
-      dt_path_events_post_expose(cr, zoom_scale, gui, pos, g_list_length(sel->points));
     else if(sel->type & DT_MASKS_GRADIENT)
       dt_gradient_events_post_expose(cr, zoom_scale, gui, pos);
     fpts = g_list_next(fpts);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -167,11 +167,12 @@ static void _set_hinter_message(dt_masks_form_gui_t *gui, const dt_masks_form_t 
 
   int opacity = 100;
 
+  const dt_masks_form_t *sel = form;
   if((ftype & DT_MASKS_GROUP) && (gui->group_edited >= 0))
   {
     // we get the selected form
     const dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
-    const dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
+    sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return;
 
     opacity = _get_opacity(gui, form);
@@ -181,9 +182,9 @@ static void _set_hinter_message(dt_masks_form_gui_t *gui, const dt_masks_form_t 
     opacity = (int)(dt_conf_get_float("plugins/darkroom/masks/opacity") * 100);
   }
 
-  if(form->functions)
+  if(sel->functions)
   {
-    form->functions->set_hint_message(gui, form, opacity, msg, sizeof(msg));
+    sel->functions->set_hint_message(gui, form, opacity, msg, sizeof(msg));
   }
 
   dt_control_hinter_message(darktable.control, msg);
@@ -1334,10 +1335,10 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
     dt_masks_select_form(module, sel);
   }
 
-  if(form->functions)
-    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0);
-  else if(form->type & DT_MASKS_GROUP)
+  if(form->type & DT_MASKS_GROUP)
     return dt_group_events_button_pressed(module, pzx, pzy, pressure, which, type, state, form, gui);
+  else if(form->functions)
+    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0);
 
   return 0;
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -28,7 +28,6 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 
 // clang-format off
-#include "develop/masks/circle.c"
 #include "develop/masks/path.c"
 #include "develop/masks/brush.c"
 #include "develop/masks/gradient.c"

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -28,7 +28,6 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 
 // clang-format off
-#include "develop/masks/path.c"
 #include "develop/masks/group.c"
 // clang-format on
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -148,7 +148,7 @@ GSList *dt_masks_mouse_actions(dt_masks_form_t *form)
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
     a->action = DT_MOUSE_ACTION_RIGHT;
     g_strlcpy(a->name, _("[SHAPE] remove shape"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
+    lm = g_slist_prepend(lm, a);
   }
 
   return lm;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -31,7 +31,6 @@
 #include "develop/masks/path.c"
 #include "develop/masks/brush.c"
 #include "develop/masks/gradient.c"
-#include "develop/masks/ellipse.c"
 #include "develop/masks/group.c"
 // clang-format on
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -29,7 +29,6 @@
 
 // clang-format off
 #include "develop/masks/path.c"
-#include "develop/masks/brush.c"
 #include "develop/masks/group.c"
 // clang-format on
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -57,8 +57,6 @@ dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form)
       size_item = sizeof(struct dt_masks_point_gradient_t);
     else if (form->type & DT_MASKS_GROUP)
       size_item = sizeof(struct dt_masks_point_group_t);
-    else if (form->type & DT_MASKS_PATH)
-      size_item = sizeof(struct dt_masks_point_path_t);
 
     if (size_item != 0)
     {
@@ -158,63 +156,6 @@ GSList *dt_masks_mouse_actions(dt_masks_form_t *form)
     g_strlcpy(a->name, _("[SHAPE] remove shape"), sizeof(a->name));
     lm = g_slist_append(lm, a);
   }
-  if((formtype & DT_MASKS_PATH) == DT_MASKS_PATH)
-  {
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_LEFT;
-    g_strlcpy(a->name, _("[PATH creation] add a smooth node"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->key.accel_mods = GDK_CONTROL_MASK;
-    a->action = DT_MOUSE_ACTION_LEFT;
-    g_strlcpy(a->name, _("[PATH creation] add a sharp node"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_RIGHT;
-    g_strlcpy(a->name, _("[PATH creation] terminate path creation"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->key.accel_mods = GDK_CONTROL_MASK;
-    a->action = DT_MOUSE_ACTION_SCROLL;
-    g_strlcpy(a->name, _("[PATH on node] switch between smooth/sharp node"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_RIGHT;
-    g_strlcpy(a->name, _("[PATH on node] remove the node"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_RIGHT;
-    g_strlcpy(a->name, _("[PATH on feather] reset curvature"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->key.accel_mods = GDK_CONTROL_MASK;
-    a->action = DT_MOUSE_ACTION_LEFT;
-    g_strlcpy(a->name, _("[PATH on segment] add node"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_SCROLL;
-    g_strlcpy(a->name, _("[PATH] change size"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->key.accel_mods = GDK_CONTROL_MASK;
-    a->action = DT_MOUSE_ACTION_SCROLL;
-    g_strlcpy(a->name, _("[PATH] change opacity"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-
-    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->key.accel_mods = GDK_SHIFT_MASK;
-    a->action = DT_MOUSE_ACTION_SCROLL;
-    g_strlcpy(a->name, _("[PATH] change feather size"), sizeof(a->name));
-    lm = g_slist_append(lm, a);
-  }
   if((formtype & DT_MASKS_GRADIENT) == DT_MASKS_GRADIENT)
   {
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
@@ -276,21 +217,6 @@ static void _set_hinter_message(dt_masks_form_gui_t *gui, const dt_masks_form_t 
   if(form->functions)
   {
     form->functions->set_hint_message(gui, form, opacity, msg, sizeof(msg));
-  }
-  else if(formtype & DT_MASKS_PATH)
-  {
-    if(gui->creation && g_list_length(form->points) < 4)
-      g_strlcat(msg, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n<b>cancel</b>: right-click"), sizeof(msg));
-    else if(gui->creation)
-      g_strlcat(msg, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n<b>finnish path</b>: right-click"), sizeof(msg));
-    else if(gui->point_selected >= 0)
-      g_strlcat(msg, _("<b>move node</b>: drag, <b>remove node</b>: right-click\n<b>switch smooth/sharp mode</b>: ctrl+click"), sizeof(msg));
-    else if(gui->feather_selected >= 0)
-      g_strlcat(msg, _("<b>node curvature</b>: drag\n<b>reset curvature</b>: right-click"), sizeof(msg));
-    else if(gui->seg_selected >= 0)
-      g_strlcat(msg, _("<b>move segment</b>: drag\n<b>add node</b>: ctrl+click"), sizeof(msg));
-    else if(gui->form_selected)
-      g_snprintf(msg, sizeof(msg), _("<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
   }
   else if(formtype & DT_MASKS_GRADIENT)
   {
@@ -477,10 +403,8 @@ void dt_masks_gui_form_save_creation(dt_develop_t *dev, dt_iop_module_t *module,
 
     if(form->functions && form->functions->set_form_name)
       form->functions->set_form_name(form, nb);
-    else if(form->type & DT_MASKS_PATH)
-      snprintf(form->name, sizeof(form->name), _("path #%d"), nb);
     else if(form->type & DT_MASKS_GRADIENT)
-      snprintf(form->name, sizeof(form->name), _("gradient #%d"), nb);
+      snprintf(form->name, sizeof(form->name), _("gradient #%d"), (int)nb);
 
     l = dev->forms;
     while(l)
@@ -564,18 +488,6 @@ int dt_masks_form_duplicate(dt_develop_t *dev, int formid)
       pts = g_list_next(pts);
     }
   }
-  else if(fbase->type & DT_MASKS_PATH)
-  {
-    GList *pts = g_list_first(fbase->points);
-    while(pts)
-    {
-      dt_masks_point_path_t *pt = (dt_masks_point_path_t *)pts->data;
-      dt_masks_point_path_t *npt = (dt_masks_point_path_t *)malloc(sizeof(dt_masks_point_path_t));
-      memcpy(npt, pt, sizeof(dt_masks_point_path_t));
-      fdest->points = g_list_append(fdest->points, npt);
-      pts = g_list_next(pts);
-    }
-  }
   else if(fbase->type & DT_MASKS_GRADIENT)
   {
     GList *pts = g_list_first(fbase->points);
@@ -617,10 +529,6 @@ int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float *
       else
         return 1;
     }
-  }
-  else if(form->type & DT_MASKS_PATH)
-  {
-    return dt_path_get_points_border(dev, form, points, points_count, border, border_count, source);
   }
   else if(form->type & DT_MASKS_GRADIENT)
   {
@@ -672,10 +580,6 @@ int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt
 {
   if(form->functions)
     return form->functions->get_area(module, piece, form, width, height, posx, posy);
-  else if(form->type & DT_MASKS_PATH)
-  {
-    return dt_path_get_area(module, piece, form, width, height, posx, posy);
-  }
   else if(form->type & DT_MASKS_GRADIENT)
   {
     return dt_gradient_get_area(module, piece, form, width, height, posx, posy);
@@ -694,10 +598,6 @@ int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   {
     if(form->functions)
       return form->functions->get_source_area(module, piece, form, width, height, posx, posy);
-    else if(form->type & DT_MASKS_PATH)
-    {
-      return dt_path_get_source_area(module, piece, form, width, height, posx, posy);
-    }
   }
   return 0;
 }
@@ -707,10 +607,6 @@ int dt_masks_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt
 {
   if(form->functions)
     return form->functions->get_mask(module, piece, form, buffer, width, height, posx, posy);
-  else if(form->type & DT_MASKS_PATH)
-  {
-    return dt_path_get_mask(module, piece, form, buffer, width, height, posx, posy);
-  }
   else if(form->type & DT_MASKS_GROUP)
   {
     return dt_group_get_mask(module, piece, form, buffer, width, height, posx, posy);
@@ -728,10 +624,6 @@ int dt_masks_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece
   if(form->functions)
   {
     return form->functions->get_mask_roi(module, piece, form, roi, buffer);
-  }
-  else if(form->type & DT_MASKS_PATH)
-  {
-    return dt_path_get_mask_roi(module, piece, form, roi, buffer);
   }
   else if(form->type & DT_MASKS_GROUP)
   {
@@ -1119,6 +1011,8 @@ dt_masks_form_t *dt_masks_create(dt_masks_type_t type)
     form->functions = &dt_masks_functions_ellipse;
   else if (type & DT_MASKS_BRUSH)
     form->functions = &dt_masks_functions_brush;
+  else if (type & DT_MASKS_PATH)
+    form->functions = &dt_masks_functions_path;
   //TODO: else if(...)
 
   if (form->functions && form->functions->sanitize_config)
@@ -1460,8 +1354,6 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
   int rep = 0;
   if(form->functions)
     rep = form->functions->mouse_moved(module, pzx, pzy, pressure, which, form, 0, gui, 0);
-  else if(form->type & DT_MASKS_PATH)
-    rep = dt_path_events_mouse_moved(module, pzx, pzy, pressure, which, form, 0, gui, 0);
   else if(form->type & DT_MASKS_GROUP)
     rep = dt_group_events_mouse_moved(module, pzx, pzy, pressure, which, form, gui);
   else if(form->type & DT_MASKS_GRADIENT)
@@ -1487,8 +1379,6 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
 
   if(form->functions)
     return form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
-  else if(form->type & DT_MASKS_PATH)
-    return dt_path_events_button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
   else if(form->type & DT_MASKS_GROUP)
     return dt_group_events_button_released(module, pzx, pzy, which, state, form, gui);
   else if(form->type & DT_MASKS_GRADIENT)
@@ -1532,8 +1422,6 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
 
   if(form->functions)
     return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0);
-  else if(form->type & DT_MASKS_PATH)
-    return dt_path_events_button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0);
   else if(form->type & DT_MASKS_GROUP)
     return dt_group_events_button_pressed(module, pzx, pzy, pressure, which, type, state, form, gui);
   else if(form->type & DT_MASKS_GRADIENT)
@@ -1558,8 +1446,6 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
 
   if(form->functions)
     ret = form->functions->mouse_scrolled(module, pzx, pzy, up, state, form, 0, gui, 0);
-  else if(form->type & DT_MASKS_PATH)
-    ret = dt_path_events_mouse_scrolled(module, pzx, pzy, up, state, form, 0, gui, 0);
   else if(form->type & DT_MASKS_GROUP)
     ret = dt_group_events_mouse_scrolled(module, pzx, pzy, up, state, form, gui);
   else if(form->type & DT_MASKS_GRADIENT)
@@ -1626,8 +1512,6 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   // draw form
   if(form->functions)
     form->functions->post_expose(cr, zoom_scale, gui, 0, g_list_length(form->points));
-  else if(form->type & DT_MASKS_PATH)
-    dt_path_events_post_expose(cr, zoom_scale, gui, 0, g_list_length(form->points));
   else if(form->type & DT_MASKS_GROUP)
     dt_group_events_post_expose(cr, zoom_scale, form, gui);
   else if(form->type & DT_MASKS_GRADIENT)
@@ -2411,10 +2295,6 @@ int dt_masks_group_get_hash_buffer_length(dt_masks_form_t *form)
     {      
       pos += form->functions->point_struct_size;
     }
-    else if(form->type & DT_MASKS_PATH)
-    {
-      pos += sizeof(dt_masks_point_path_t);
-    }
     else if(form->type & DT_MASKS_GRADIENT)
     {
       pos += sizeof(dt_masks_point_gradient_t);
@@ -2461,11 +2341,6 @@ char *dt_masks_group_get_hash_buffer(dt_masks_form_t *form, char *str)
     {
       memcpy(str + pos,forms->data, form->functions->point_struct_size);
       pos += form->functions->point_struct_size;
-    }
-    else if(form->type & DT_MASKS_PATH)
-    {
-      memcpy(str + pos, forms->data, sizeof(dt_masks_point_path_t));
-      pos += sizeof(dt_masks_point_path_t);
     }
     else if(form->type & DT_MASKS_GRADIENT)
     {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1069,7 +1069,7 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
 
   int rep = 0;
   if(form->functions)
-    rep = form->functions->mouse_moved(module, pzx, pzy, pressure, which, form, 0, gui, gui->group_edited);
+    rep = form->functions->mouse_moved(module, pzx, pzy, pressure, which, form, 0, gui, 0);
 
   if(gui) _set_hinter_message(gui, form);
 
@@ -1090,7 +1090,7 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
   pzy += 0.5f;
 
   if(form->functions)
-    return form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, gui->group_edited);
+    return form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
 
   return 0;
 }
@@ -1129,8 +1129,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   }
 
   if(form->functions)
-    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0,
-                                           gui, gui->group_edited);
+    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0);
 
   return 0;
 }
@@ -1150,7 +1149,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
   int ret = 0;
 
   if(form->functions)
-    ret = form->functions->mouse_scrolled(module, pzx, pzy, up, state, form, 0, gui, gui->group_edited);
+    ret = form->functions->mouse_scrolled(module, pzx, pzy, up, state, form, 0, gui, 0);
 
   if(gui)
   {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1612,67 +1612,41 @@ static void _menu_no_masks(struct dt_iop_module_t *module)
   dt_dev_add_history_item(darktable.develop, module, TRUE);
 }
 
-static void _menu_add_circle(struct dt_iop_module_t *module)
+static void _menu_add_shape(struct dt_iop_module_t *module, dt_masks_type_t type)
 {
   // we want to be sure that the iop has focus
   dt_iop_request_focus(module);
   // we create the new form
-  dt_masks_form_t *spot = dt_masks_create(DT_MASKS_CIRCLE);
-  dt_masks_change_form_gui(spot);
-
+  dt_masks_form_t *form = dt_masks_create(type);
+  dt_masks_change_form_gui(form);
   darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = module;
   dt_control_queue_redraw_center();
+}
+
+static void _menu_add_circle(struct dt_iop_module_t *module)
+{
+  _menu_add_shape(module, DT_MASKS_CIRCLE);
 }
 
 static void _menu_add_path(struct dt_iop_module_t *module)
 {
-  // we want to be sure that the iop has focus
-  dt_iop_request_focus(module);
-  // we create the new form
-  dt_masks_form_t *form = dt_masks_create(DT_MASKS_PATH);
-  dt_masks_change_form_gui(form);
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = module;
-  dt_control_queue_redraw_center();
+  _menu_add_shape(module, DT_MASKS_PATH);
 }
 
 static void _menu_add_gradient(struct dt_iop_module_t *module)
 {
-  // we want to be sure that the iop has focus
-  dt_iop_request_focus(module);
-  // we create the new form
-  dt_masks_form_t *spot = dt_masks_create(DT_MASKS_GRADIENT);
-  dt_masks_change_form_gui(spot);
-
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = module;
-  dt_control_queue_redraw_center();
+  _menu_add_shape(module, DT_MASKS_GRADIENT);
 }
 
 static void _menu_add_ellipse(struct dt_iop_module_t *module)
 {
-  // we want to be sure that the iop has focus
-  dt_iop_request_focus(module);
-  // we create the new form
-  dt_masks_form_t *spot = dt_masks_create(DT_MASKS_ELLIPSE);
-  dt_masks_change_form_gui(spot);
-
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = module;
-  dt_control_queue_redraw_center();
+  _menu_add_shape(module, DT_MASKS_ELLIPSE);
 }
 
 static void _menu_add_brush(struct dt_iop_module_t *module)
 {
-  // we want to be sure that the iop has focus
-  dt_iop_request_focus(module);
-  // we create the new form
-  dt_masks_form_t *form = dt_masks_create(DT_MASKS_BRUSH);
-  dt_masks_change_form_gui(form);
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = module;
-  dt_control_queue_redraw_center();
+  _menu_add_shape(module, DT_MASKS_BRUSH);
 }
 
 static void _menu_add_exist(dt_iop_module_t *module, int formid)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -30,7 +30,6 @@
 // clang-format off
 #include "develop/masks/path.c"
 #include "develop/masks/brush.c"
-#include "develop/masks/gradient.c"
 #include "develop/masks/group.c"
 // clang-format on
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3082,14 +3082,21 @@ static void _path_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t 
   }
 }
 
+static void _path_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+{
+  *x = (0.02f * iwd);
+  *y = (0.02f * iht);
+}
+
 // The function table for paths.  This must be public, i.e. no "static" keyword.
-dt_masks_functions_t dt_masks_functions_path = {
+const dt_masks_functions_t dt_masks_functions_path = {
   .point_struct_size = sizeof(struct dt_masks_point_path_t),
   .sanitize_config = _path_sanitize_config,
   .setup_mouse_actions = _path_setup_mouse_actions,
   .set_form_name = _path_set_form_name,
   .set_hint_message = _path_set_hint_message,
   .duplicate_points = _path_duplicate_points,
+  .initial_source_pos = _path_initial_source_pos,
   .get_distance = _path_get_distance,
   .get_points_border = _path_get_points_border,
   .get_mask = _path_get_mask,

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -776,8 +776,8 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
 }
 
 /** get the distance between point (x,y) and the path */
-void dt_path_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
-                          int corner_count, int *inside, int *inside_border, int *near, int *inside_source)
+static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
+                               int corner_count, int *inside, int *inside_border, int *near, int *inside_source)
 {
   // initialise returned values
   *inside_source = 0;
@@ -1832,7 +1832,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
 
   // are we inside the form or the borders or near a segment ???
   int in = 0, inb = 0, near = 0, ins = 0;
-  dt_path_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins);
+  _path_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins);
   gui->seg_selected = near;
   if(near < 0)
   {
@@ -3090,6 +3090,7 @@ dt_masks_functions_t dt_masks_functions_path = {
   .set_form_name = _path_set_form_name,
   .set_hint_message = _path_set_hint_message,
   .duplicate_points = _path_duplicate_points,
+  .get_distance = _path_get_distance,
   .get_points_border = _path_get_points_border,
   .get_mask = _path_get_mask,
   .get_mask_roi = _path_get_mask_roi,

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -509,7 +509,7 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
 
 /** get all points of the path and the border */
 /** this take care of gaps and self-intersection and iop distortions */
-static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, const double iop_order, const int transf_direction,
+static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const double iop_order, const int transf_direction,
                                    dt_dev_pixelpipe_t *pipe, float **points, int *points_count,
                                    float **border, int *border_count, int source)
 {
@@ -849,11 +849,11 @@ static void dt_path_get_distance(float x, int y, float as, dt_masks_form_gui_t *
   else *inside_border = 1;
 }
 
-static int dt_path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
+static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
                                      int *points_count, float **border, int *border_count, int source)
 {
-  return _path_get_points_border(dev, form, 0.f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
-                                 border_count, source);
+  return _path_get_pts_border(dev, form, 0.f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
+                              border_count, source);
 }
 
 static void _path_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index, float *masks_size, float *feather_size)
@@ -899,9 +899,9 @@ static void _path_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *for
   if(feather_size) *feather_size = fmaxf((fp2[0] - fp1[0]) / wd, (fp2[1] - fp1[1]) / ht);
 }
 
-static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                         uint32_t state, dt_masks_form_t *form, int parentid,
-                                         dt_masks_form_gui_t *gui, int index)
+static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
+                                       uint32_t state, dt_masks_form_t *form, int parentid,
+                                       dt_masks_form_gui_t *gui, int index)
 {
   // resize a shape even if on a node or segment
   if(gui->form_selected || gui->point_selected >= 0 || gui->feather_selected >= 0 || gui->seg_selected >= 0
@@ -1031,10 +1031,9 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
   return 0;
 }
 
-static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                         double pressure, int which, int type, uint32_t state,
-                                         dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui,
-                                         int index)
+static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
+                                       double pressure, int which, int type, uint32_t state,
+                                       dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
 {
   if(type == GDK_2BUTTON_PRESS || type == GDK_3BUTTON_PRESS) return 1;
   if(!gui) return 0;
@@ -1458,9 +1457,9 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
   return 0;
 }
 
-static int dt_path_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                          uint32_t state, dt_masks_form_t *form, int parentid,
-                                          dt_masks_form_gui_t *gui, int index)
+static int _path_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
+                                        uint32_t state, dt_masks_form_t *form, int parentid,
+                                        dt_masks_form_gui_t *gui, int index)
 {
   if(!gui) return 0;
   if(gui->creation) return 1;
@@ -1622,9 +1621,9 @@ static int dt_path_events_button_released(struct dt_iop_module_t *module, float 
   return 0;
 }
 
-static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
-                                      int which, dt_masks_form_t *form, int parentid,
-                                      dt_masks_form_gui_t *gui, int index)
+static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
+                                    int which, dt_masks_form_t *form, int parentid,
+                                    dt_masks_form_gui_t *gui, int index)
 {
   const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   const int closeup = dt_control_get_dev_closeup();
@@ -1858,8 +1857,7 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   return 1;
 }
 
-static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index,
-                                       int nb)
+static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index, int nb)
 {
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
@@ -2118,7 +2116,6 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   }
 }
 
-
 static void _path_bounding_box_raw(const float *const points, const float *border, const int nb_corner, const int num_points, int num_borders,
                                    float *x_min, float *x_max, float *y_min, float *y_max)
 {
@@ -2170,15 +2167,15 @@ static void _path_bounding_box(const float *const points, const float *border, c
   *posy = ymin - 2;
 }
 
-static int _path_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                          int *width, int *height, int *posx, int *posy, int get_source)
+static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                     dt_masks_form_t *const form, int *width, int *height, int *posx, int *posy, int get_source)
 {
   if(!module) return 0;
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count = 0, border_count = 0;
-  if(!_path_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
-                              &border, &border_count, get_source))
+  if(!_path_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+                           &border, &border_count, get_source))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2193,16 +2190,17 @@ static int _path_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece
   return 1;
 }
 
-static int dt_path_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                   dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _path_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
+                                 dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
 {
-  return _path_get_area(module, piece, form,width, height, posx, posy, 1);
+  return _get_area(module, piece, form,width, height, posx, posy, 1);
 }
 
-static int dt_path_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                            int *width, int *height, int *posx, int *posy)
+static int _path_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                          dt_masks_form_t *const form,
+                          int *width, int *height, int *posx, int *posy)
 {
-  return _path_get_area(module, piece, form,width, height, posx, posy, 0);
+  return _get_area(module, piece, form,width, height, posx, posy, 0);
 }
 
 /** we write a falloff segment */
@@ -2230,8 +2228,9 @@ static void _path_falloff(float **buffer, int *p0, int *p1, int posx, int posy, 
   }
 }
 
-static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                            float **buffer, int *width, int *height, int *posx, int *posy)
+static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                          dt_masks_form_t *const form,
+                          float **buffer, int *width, int *height, int *posx, int *posy)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2242,8 +2241,8 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_path_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
-                              &border, &border_count, 0))
+  if(!_path_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+                           &border, &border_count, 0))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2624,8 +2623,9 @@ static void _path_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh)
   }
 }
 
-static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                                const dt_iop_roi_t *roi, float *buffer)
+static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                              dt_masks_form_t *const form,
+                              const dt_iop_roi_t *roi, float *buffer)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2650,8 +2650,8 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count = 0, border_count = 0;
-  if(!_path_get_points_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
-                              &border, &border_count, 0) || (points_count <= 2))
+  if(!_path_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+                           &border, &border_count, 0) || (points_count <= 2))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2976,6 +2976,132 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
 
   return 1;
 }
+
+static GSList *_path_setup_mouse_actions(const struct dt_masks_form_t *const form)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT;
+  g_strlcpy(a->name, _("[PATH creation] add a smooth node"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_LEFT;
+  g_strlcpy(a->name, _("[PATH creation] add a sharp node"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_RIGHT;
+  g_strlcpy(a->name, _("[PATH creation] terminate path creation"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[PATH on node] switch between smooth/sharp node"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_RIGHT;
+  g_strlcpy(a->name, _("[PATH on node] remove the node"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_RIGHT;
+  g_strlcpy(a->name, _("[PATH on feather] reset curvature"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_LEFT;
+  g_strlcpy(a->name, _("[PATH on segment] add node"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[PATH] change size"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[PATH] change opacity"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[PATH] change feather size"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
+
+static void _path_sanitize_config(dt_masks_type_t type)
+{
+  // nothing to do (yet?)
+}
+
+static void _path_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+{
+  snprintf(form->name, sizeof(form->name), _("path #%d"), (int)nb);
+}
+
+static void _path_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
+                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+{
+  if(gui->creation && g_list_length(form->points) < 4)
+    g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
+                        "<b>cancel</b>: right-click"), msgbuf_len);
+  else if(gui->creation)
+    g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
+                        "<b>finnish path</b>: right-click"), msgbuf_len);
+  else if(gui->point_selected >= 0)
+    g_strlcat(msgbuf, _("<b>move node</b>: drag, <b>remove node</b>: right-click\n"
+                        "<b>switch smooth/sharp mode</b>: ctrl+click"), msgbuf_len);
+  else if(gui->feather_selected >= 0)
+    g_strlcat(msgbuf, _("<b>node curvature</b>: drag\n<b>reset curvature</b>: right-click"), msgbuf_len);
+  else if(gui->seg_selected >= 0)
+    g_strlcat(msgbuf, _("<b>move segment</b>: drag\n<b>add node</b>: ctrl+click"), msgbuf_len);
+  else if(gui->form_selected)
+    g_snprintf(msgbuf, msgbuf_len, _("<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
+                                     "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+}
+
+static void _path_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+{
+  for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
+  {
+    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)pts->data;
+    dt_masks_point_path_t *npt = (dt_masks_point_path_t *)malloc(sizeof(dt_masks_point_path_t));
+    memcpy(npt, pt, sizeof(dt_masks_point_path_t));
+    dest->points = g_list_append(dest->points, npt);
+  }
+}
+
+// The function table for paths.  This must be public, i.e. no "static" keyword.
+dt_masks_functions_t dt_masks_functions_path = {
+  .point_struct_size = sizeof(struct dt_masks_point_path_t),
+  .sanitize_config = _path_sanitize_config,
+  .setup_mouse_actions = _path_setup_mouse_actions,
+  .set_form_name = _path_set_form_name,
+  .set_hint_message = _path_set_hint_message,
+  .duplicate_points = _path_duplicate_points,
+  .get_points_border = _path_get_points_border,
+  .get_mask = _path_get_mask,
+  .get_mask_roi = _path_get_mask_roi,
+  .get_area = _path_get_area,
+  .get_source_area = _path_get_source_area,
+  .mouse_moved = _path_events_mouse_moved,
+  .mouse_scrolled = _path_events_mouse_scrolled,
+  .button_pressed = _path_events_button_pressed,
+  .button_released = _path_events_button_released,
+  .post_expose = _path_events_post_expose
+};
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3071,8 +3071,9 @@ static void _path_set_hint_message(const dt_masks_form_gui_t *const gui, const d
                                      "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
 }
 
-static void _path_duplicate_points(dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _path_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
 {
+  (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = g_list_first(base->points); pts; pts = g_list_next(pts))
   {
     dt_masks_point_path_t *pt = (dt_masks_point_path_t *)pts->data;


### PR DESCRIPTION
Reorganize the shape-handling code for masks such that we don't need long if-else chains to determine which function to call, and to separate out the code into individual compilation units instead of #include'ing six separate .c files into one enormous object module.

This PR is separate from #8281, #8282, #8283, and #8284, though it's possible there will be merge conflicts after applying one or more of those PRs.

