### PR TITLE
censorize: add missing commit_params.

### DIFF
--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -396,6 +396,18 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 #endif
 
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_censorize_params_t *p = (dt_iop_censorize_params_t *)self->params;
+  dt_iop_censorize_data_t *d = (dt_iop_censorize_data_t *)piece->data;
+
+  d->radius_1 = p->radius_1;
+  d->pixelate = p->pixelate;
+  d->radius_2 = p->radius_2;
+  d->noise    = p->noise;
+}
+
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_censorize_gui_data_t *g = (dt_iop_censorize_gui_data_t *)self->gui_data;


### PR DESCRIPTION
Fixes #8266.