### PR TITLE
refactor: revise GSList loops and use prepend instead of append

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -450,12 +450,10 @@ void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries)
 
   if(override_entries)
   {
-    GSList *p = override_entries;
-    while(p)
+    for(GSList *p = override_entries; p; p = g_slist_next(p))
     {
       dt_conf_string_entry_t *entry = (dt_conf_string_entry_t *)p->data;
       g_hash_table_insert(darktable.conf->override_entries, entry->key, entry->value);
-      p = g_slist_next(p);
     }
   }
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -905,15 +905,13 @@ static void _pixelpipe_pick_live_samples(const float *const input, const dt_iop_
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
 
   dt_colorpicker_sample_t *sample = NULL;
-  GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
 
-  while(samples)
+  for(GSList *samples = darktable.lib->proxy.colorpicker.live_samples; samples; samples = g_slist_next(samples))
   {
     sample = samples->data;
 
     if(sample->locked)
     {
-      samples = g_slist_next(samples);
       continue;
     }
 
@@ -921,8 +919,6 @@ static void _pixelpipe_pick_live_samples(const float *const input, const dt_iop_
         sample->box, sample->point, sample->size,
         sample->picked_color_rgb_min, sample->picked_color_rgb_max, sample->picked_color_rgb_mean,
         sample->picked_color_lab_min, sample->picked_color_lab_max, sample->picked_color_lab_mean);
-
-    samples = g_slist_next(samples);
   }
 
   if(xform_rgb2lab) cmsDeleteTransform(xform_rgb2lab);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1005,8 +1005,7 @@ static void _dt_active_images_callback(gpointer instance, gpointer user_data)
   if(!thumb) return;
 
   gboolean active = FALSE;
-  GSList *l = darktable.view_manager->active_images;
-  while(l)
+  for(GSList *l = darktable.view_manager->active_images; l; l = g_slist_next(l))
   {
     int id = GPOINTER_TO_INT(l->data);
     if(id == thumb->imgid)
@@ -1014,7 +1013,6 @@ static void _dt_active_images_callback(gpointer instance, gpointer user_data)
       active = TRUE;
       break;
     }
-    l = g_slist_next(l);
   }
 
   // if there's a change, update the thumb

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2014,8 +2014,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       const int lastid = GPOINTER_TO_INT(g_slist_last(darktable.view_manager->active_images)->data);
       dt_thumbtable_ensure_imgid_visibility(table, lastid);
 
-      GSList *l = darktable.view_manager->active_images;
-      while(l)
+      for(GSList *l = darktable.view_manager->active_images; l; l = g_slist_next(l))
       {
         dt_thumbnail_t *th = _thumbtable_get_thumb(table, GPOINTER_TO_INT(l->data));
         if(th)
@@ -2025,7 +2024,6 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
           th->active = FALSE;
           dt_thumbnail_update_infos(th);
         }
-        l = g_slist_next(l);
       }
       g_slist_free(darktable.view_manager->active_images);
       darktable.view_manager->active_images = NULL;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -828,15 +828,13 @@ void dt_accel_connect_instance_iop(dt_iop_module_t *module)
 
 void dt_accel_connect_locals_iop(dt_iop_module_t *module)
 {
-  GSList *l = module->accel_closures_local;
-  while(l)
+  for(GSList *l = module->accel_closures_local; l; l = g_slist_next(l))
   {
     _accel_iop_t *accel = (_accel_iop_t *)l->data;
     if(accel)
     {
       gtk_accel_group_connect_by_path(darktable.control->accelerators, accel->accel->path, accel->closure);
     }
-    l = g_slist_next(l);
   }
 
   module->local_closures_connected = TRUE;
@@ -858,15 +856,13 @@ void dt_accel_disconnect_locals_iop(dt_iop_module_t *module)
 {
   if(!module->local_closures_connected) return;
 
-  GSList *l = module->accel_closures_local;
-  while(l)
+  for(GSList *l = module->accel_closures_local; l; l = g_slist_next(l))
   {
     _accel_iop_t *accel = (_accel_iop_t *)l->data;
     if(accel)
     {
       gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
     }
-    l = g_slist_next(l);
   }
 
   module->local_closures_connected = FALSE;
@@ -1121,34 +1117,24 @@ void dt_accel_deregister_lib(dt_lib_module_t *module, const gchar *path)
 {
   char build_path[1024];
   dt_accel_path_lib(build_path, sizeof(build_path), module->plugin_name, path);
-  GSList *l = module->accel_closures;
-  while(l)
+  for(GSList *l = module->accel_closures; l; l = g_slist_next(l))
   {
     dt_accel_t *accel = (dt_accel_t *)l->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
     {
       module->accel_closures = g_slist_delete_link(module->accel_closures, l);
       gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
-      l = NULL;
-    }
-    else
-    {
-      l = g_slist_next(l);
+      break;
     }
   }
-  GList *ll = darktable.control->accelerator_list;
-  while(ll)
+  for(GList *ll = darktable.control->accelerator_list; ll; ll = g_list_next(ll))
   {
     dt_accel_t *accel = (dt_accel_t *)ll->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
     {
       darktable.control->accelerator_list = g_list_delete_link(darktable.control->accelerator_list, ll);
-      ll = NULL;
       g_free(accel);
-    }
-    else
-    {
-      ll = g_list_next(ll);
+      break;
     }
   }
 }
@@ -1199,37 +1185,26 @@ void dt_accel_deregister_lua(const gchar *path)
 
 void dt_accel_deregister_manual(GSList *list, const gchar *full_path)
 {
-  GSList *l;
   char build_path[1024];
   dt_accel_path_manual(build_path, sizeof(build_path), full_path);
-  l = list;
-  while(l)
+  for(GSList *l = list; l; l = g_slist_next(l))
   {
     dt_accel_t *accel = (dt_accel_t *)l->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
     {
       list = g_slist_delete_link(list, l);
       gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
-      l = NULL;
-    }
-    else
-    {
-      l = g_slist_next(l);
+      break;
     }
   }
-  GList *ll = darktable.control->accelerator_list;
-  while(ll)
+  for(GList *ll = darktable.control->accelerator_list; ll; ll = g_list_next(ll))
   {
     dt_accel_t *accel = (dt_accel_t *)ll->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
     {
       darktable.control->accelerator_list = g_list_delete_link(darktable.control->accelerator_list, ll);
-      ll = NULL;
       g_free(accel);
-    }
-    else
-    {
-      ll = g_list_next(ll);
+      break;
     }
   }
 }
@@ -1246,8 +1221,7 @@ void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, cons
   char build_path[1024];
   dt_accel_path_iop(build_path, sizeof(build_path), module->op, path_preset);
 
-  GSList *l = module->accel_closures;
-  while(l)
+  for(GSList *l = module->accel_closures; l; l = g_slist_next(l))
   {
     _accel_iop_t *iop_accel = (_accel_iop_t *)l->data;
     if(iop_accel && iop_accel->accel && !strncmp(iop_accel->accel->path, build_path, 1024))
@@ -1273,8 +1247,6 @@ void dt_accel_rename_preset_iop(dt_iop_module_t *module, const gchar *path, cons
 
       break;
     }
-
-    l = g_slist_next(l);
   }
 
   g_free(path_preset);
@@ -1286,8 +1258,7 @@ void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, cons
 {
   char build_path[1024];
   dt_accel_path_lib(build_path, sizeof(build_path), module->plugin_name, path);
-  GSList *l = module->accel_closures;
-  while(l)
+  for(GSList *l = module->accel_closures; l; l = g_slist_next(l))
   {
     dt_accel_t *accel = (dt_accel_t *)l->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
@@ -1298,11 +1269,7 @@ void dt_accel_rename_preset_lib(dt_lib_module_t *module, const gchar *path, cons
       snprintf(build_path, sizeof(build_path), "%s/%s", _("preset"), new_path);
       dt_accel_register_lib(module, build_path, tmp_key.accel_key, tmp_key.accel_mods);
       dt_accel_connect_preset_lib(module, new_path);
-      l = NULL;
-    }
-    else
-    {
-      l = g_slist_next(l);
+      break;
     }
   }
 }
@@ -1311,8 +1278,7 @@ void dt_accel_rename_global(const gchar *path, const gchar *new_path)
 {
   char build_path[1024];
   dt_accel_path_global(build_path, sizeof(build_path), path);
-  GList *l = darktable.control->accelerator_list;
-  while(l)
+  for(GList *l = darktable.control->accelerator_list; l; l = g_list_next(l))
   {
     dt_accel_t *accel = (dt_accel_t *)l->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
@@ -1324,11 +1290,7 @@ void dt_accel_rename_global(const gchar *path, const gchar *new_path)
       dt_accel_register_global(new_path, tmp_key.accel_key, tmp_key.accel_mods);
       dt_accel_connect_global(new_path, closure);
       g_closure_unref(closure);
-      l = NULL;
-    }
-    else
-    {
-      l = g_list_next(l);
+      break;
     }
   }
 }
@@ -1337,8 +1299,7 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_path)
 {
   char build_path[1024];
   dt_accel_path_lua(build_path, sizeof(build_path), path);
-  GList *l = darktable.control->accelerator_list;
-  while(l)
+  for(GList *l = darktable.control->accelerator_list; l; l = g_list_next(l))
   {
     dt_accel_t *accel = (dt_accel_t *)l->data;
     if(accel && !strncmp(accel->path, build_path, 1024))
@@ -1350,11 +1311,7 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_path)
       dt_accel_register_lua(new_path, tmp_key.accel_key, tmp_key.accel_mods);
       dt_accel_connect_lua(new_path, closure);
       g_closure_unref(closure);
-      l = NULL;
-    }
-    else
-    {
-      l = g_list_next(l);
+      break;
     }
   }
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1098,6 +1098,7 @@ void dt_accel_deregister_iop(dt_iop_module_t *module, const gchar *path)
         }
 
         l = g_slist_next(l);
+        // if we've run out of global accelerators, switch to processing the local accelerators
         if(!l && current_list == &mod->accel_closures) l = *(current_list = &module->accel_closures_local);
       }
     }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -826,13 +826,13 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           = dt_ioppr_get_histogram_profile_info(self->dev);
       const dt_iop_order_iccprofile_info_t *const work_profile
           = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
-      float pick_mean[4], pick_min[4], pick_max[4];
+      float DT_ALIGNED_PIXEL pick_mean[4], pick_min[4], pick_max[4];
       int converted_cst;
 
       if(work_profile && histogram_profile)
       {
         dt_colorpicker_sample_t *sample = NULL;
-        while(samples)
+        for(; samples; samples = g_slist_next(samples))
         {
           sample = samples->data;
 
@@ -899,8 +899,6 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           cairo_move_to(cr, width * picked_i, 0);
           cairo_line_to(cr, width * picked_i, height);
           cairo_stroke(cr);
-
-          samples = g_slist_next(samples);
         }
       }
     }

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -884,7 +884,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
         if(work_profile && histogram_profile)
         {
           dt_colorpicker_sample_t *sample = NULL;
-          while(samples)
+          for(; samples; samples = g_slist_next(samples))
           {
             sample = samples->data;
 
@@ -921,8 +921,6 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
             cairo_move_to(cr, width * picker_mean[ch], 0);
             cairo_line_to(cr, width * picker_mean[ch], -height);
             cairo_stroke(cr);
-
-            samples = g_slist_next(samples);
           }
       }
       }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1434,13 +1434,11 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)))
     {
       // the global live samples ...
-      GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
-      dt_colorpicker_sample_t *sample = NULL;
       cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3));
 
-      while(samples)
+      for(GSList *samples = darktable.lib->proxy.colorpicker.live_samples; samples; samples = g_slist_next(samples))
       {
-        sample = samples->data;
+        dt_colorpicker_sample_t *sample = samples->data;
 
         picker_scale(sample->picked_color_lab_mean, picker_mean);
         picker_scale(sample->picked_color_lab_min, picker_min);
@@ -1459,8 +1457,6 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
         cairo_move_to(cr, width * picker_mean[ch], 0);
         cairo_line_to(cr, width * picker_mean[ch], -height);
         cairo_stroke(cr);
-
-        samples = g_slist_next(samples);
       }
 
       // ... and the local sample

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -602,8 +602,7 @@ void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct d
   GSList *options = dt_conf_all_string_entries("plugins/capture/tethering/properties");
   if(options)
   {
-    GSList *item = options;
-    do
+    for(GSList *item = options; item; item = g_slist_next(item))
     {
       dt_conf_string_entry_t *entry = (dt_conf_string_entry_t *)item->data;
 
@@ -615,7 +614,7 @@ void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct d
 
       if((prop = _lib_property_add_new(lib, entry->key, entry->value)) != NULL)
         _lib_property_add_to_gui(prop, lib);
-    } while((item = g_slist_next(item)) != NULL);
+    }
     g_slist_free_full(options, dt_conf_string_entry_free);
   }
   /* build the propertymenu  we do it now because it needs an actual camera */

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -533,14 +533,13 @@ static void _lib_import_single_image_callback(GtkWidget *widget, dt_lib_import_t
     char *filename = NULL;
     dt_film_t film;
     GSList *list = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(filechooser));
-    GSList *it = list;
     int id = 0;
     int filmid = 0;
 
     /* reset filter so that view isn't empty */
     dt_view_filter_reset(darktable.view_manager, TRUE);
 
-    while(it)
+    for(GSList *it = list; it; it = g_slist_next(it))
     {
       filename = (char *)it->data;
       gchar *directory = g_path_get_dirname((const gchar *)filename);
@@ -549,8 +548,8 @@ static void _lib_import_single_image_callback(GtkWidget *widget, dt_lib_import_t
       if(!id) dt_control_log(_("error loading file `%s'"), filename);
       g_free(filename);
       g_free(directory);
-      it = g_slist_next(it);
     }
+    g_slist_free(list); // we've already freed the filenames stored in the list, but still need to free the list itself
 
     if(id)
     {
@@ -607,14 +606,13 @@ static void _lib_import_folder_callback(GtkWidget *widget, dt_lib_module_t* self
 
     char *filename = NULL, *first_filename = NULL;
     GSList *list = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(filechooser));
-    GSList *it = list;
 
     /* reset filter so that view isn't empty */
     dt_view_filter_reset(darktable.view_manager, TRUE);
 
     /* for each selected folder add import job */
     const gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
-    while(it)
+    for (GSList *it = list; it; it = g_slist_next(it))
     {
       filename = (char *)it->data;
       dt_film_import(filename);
@@ -625,8 +623,8 @@ static void _lib_import_folder_callback(GtkWidget *widget, dt_lib_module_t* self
           first_filename = dt_util_dstrcat(first_filename, "%%");
       }
       g_free(filename);
-      it = g_slist_next(it);
     }
+    g_slist_free(list); // we've already freed the filenames stored in the list, but still need to free the list itself
 
     /* update collection to view import */
     if(first_filename)
@@ -637,9 +635,6 @@ static void _lib_import_folder_callback(GtkWidget *widget, dt_lib_module_t* self
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
       g_free(first_filename);
     }
-
-
-    g_slist_free(list);
   }
 
   gtk_widget_destroy(filechooser);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -589,7 +589,7 @@ void expose(
     cairo_scale(cri, zoom_scale, zoom_scale);
     cairo_translate(cri, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
 
-    while(samples)
+    for( ; samples; samples = g_slist_next(samples))
     {
       sample = samples->data;
 
@@ -597,7 +597,6 @@ void expose(
       if(only_selected_sample
          && sample != darktable.lib->proxy.colorpicker.selected_sample)
       {
-        samples = g_slist_next(samples);
         continue;
       }
 
@@ -639,8 +638,6 @@ void expose(
         cairo_line_to(cri, point[0] * wd + .01 * wd - lw, point[1] * ht);
         cairo_stroke(cri);
       }
-
-      samples = g_slist_next(samples);
     }
 
     cairo_restore(cri);
@@ -812,9 +809,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
 
   // change active image
   g_slist_free(darktable.view_manager->active_images);
-  darktable.view_manager->active_images = NULL;
-  darktable.view_manager->active_images
-      = g_slist_append(darktable.view_manager->active_images, GINT_TO_POINTER(imgid));
+  darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(imgid));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 
   // if the previous shown image is selected and the selection is unique
@@ -4080,18 +4075,7 @@ GSList *mouse_actions(const dt_view_t *self)
     lm2 = dev->gui_module->mouse_actions(dev->gui_module);
   }
 
-  dt_mouse_action_t *a;
-  // we concatenate the 2 lists
-  GSList *l = lm2;
-  while(l)
-  {
-    a = (dt_mouse_action_t *)l->data;
-    if(a) lm = g_slist_append(lm, a);
-    l = g_slist_next(l);
-  }
-  g_slist_free(lm2);
-
-  return lm;
+  return g_slist_concat(lm, lm2);
 }
 
 //-----------------------------------------------------------

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -567,9 +567,7 @@ static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int
 
   // set the active image
   g_slist_free(darktable.view_manager->active_images);
-  darktable.view_manager->active_images = NULL;
-  darktable.view_manager->active_images
-      = g_slist_append(darktable.view_manager->active_images, GINT_TO_POINTER(lib->preview->offset_imgid));
+  darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(lib->preview->offset_imgid));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 
   // restore panels

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -98,9 +98,7 @@ static void _film_strip_activated(const int imgid, void *data)
 
   // update the active images list
   g_slist_free(darktable.view_manager->active_images);
-  darktable.view_manager->active_images = NULL;
-  darktable.view_manager->active_images
-      = g_slist_append(darktable.view_manager->active_images, GINT_TO_POINTER(imgid));
+  darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(imgid));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 
   // force redraw

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -886,15 +886,13 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
     if(darktable.view_manager->active_images)
     {
       // collumn 5
-      GSList *ll = darktable.view_manager->active_images;
-      while(ll)
+      for(GSList *ll = darktable.view_manager->active_images; ll; ll = g_slist_next(ll))
       {
         const int id = GPOINTER_TO_INT(ll->data);
         _images_to_act_on_insert_in_list(&l, id, only_visible);
         // be absolutely sure we have the id in the list (in darkroom,
         // the active image can be out of collection)
         if(!only_visible) _images_to_act_on_insert_in_list(&l, id, TRUE);
-        ll = g_slist_next(ll);
       }
     }
     else
@@ -1709,8 +1707,8 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
     bm->list_store = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
     blocs = g_list_prepend(blocs, bm);
 
-    GSList *lm = cv->mouse_actions(cv);
-    while(lm)
+    GSList *actions = cv->mouse_actions(cv);
+    for(GSList *lm = actions; lm; lm = g_slist_next(lm))
     {
       dt_mouse_action_t *ma = (dt_mouse_action_t *)lm->data;
       if(ma)
@@ -1721,9 +1719,8 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
         gtk_list_store_set(bm->list_store, &iter, 0, atxt, 1, ma->name, -1);
         g_free(atxt);
       }
-      lm = g_slist_next(lm);
     }
-    g_slist_free_full(lm, free);
+    g_slist_free(actions); // we've already freed the action records, but still need to free the list itself
   }
 
   // now we create and insert the widget to display all accels by categories


### PR DESCRIPTION
Switched loops of the form
```
GSList *l = list;
while (l)
{
   ...
   l = g_slist_next(l);
}
```
to be
```
for(GSList *l= list; l; l = g_slist_next(l))
{
   ...
}
```
instead, which has three benefits:
1. very clear that we are iterating down a list
2. no need to worry about updating the pointer when using `continue`
3. the code takes fewer lines

The codebase currently has a mix of the two forms.

Found and plugged a pair of small leaks (failure to free list) in the process.

Also switched a few occurrences of g_slist_append on an empty list to the equivalent but faster g_slist_prepend.

(In draft mode because I haven't had a chance to test yet.)
