### PR TITLE
fix wrong type cast causing crash in undo

### DIFF
--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -656,7 +656,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
       dt_iop_gui_update_blendif(darktable.develop->gui_module);
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)(dev->gui_module->blend_data);
       if(bd)
-        dtgtk_button_set_active(DTGTK_BUTTON(bd->showmask),
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask),
                                 hist->request_mask_display == DT_DEV_PIXELPIPE_DISPLAY_MASK);
     }
   }


### PR DESCRIPTION
This corrects a Glib invalid cast error message in undo system. 
It should also fix #8312 