### PR TITLE
image to act on speedups

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -894,7 +894,7 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                   "SELECT DISTINCT m.imgid FROM memory.collected_images as m "
                                   "WHERE m.imgid IN (SELECT s.imgid FROM main.selected_images as s) "
-                                  "ORDER BY m.rowid",
+                                  "ORDER BY m.rowid DESC",
                                   -1, &stmt, NULL);
       while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
       {
@@ -902,8 +902,6 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
         // take care of eventual duplicates
         l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
       }
-      // put the list in right order as we have prepend for performance reasons
-      l = g_list_reverse(l);
       if(stmt) sqlite3_finalize(stmt);
     }
   }

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -240,6 +240,7 @@ typedef struct dt_view_manager_t
     int image_over;
     gboolean inside_table;
     GSList *active_imgs;
+    gboolean image_over_inside_sel;
   } act_on;
 
   /* reusable db statements


### PR DESCRIPTION
after some discussion with @vithom we have found that currently selecting a huge number of image make dt almost impossible to use : 
here, if you ctrl-a with a collection of 95K images (all database) it takes ~5 min. to update and this each time mouse hovered a new image ! This problem is mainly due to `dt_view_image_to_act_on`...

Here, this PR speedup `dt_view_image_to_act_on` by x1000 (from 300s. to 0.3s.). Here is what has been changed when `dt_view_image_to_act_on` return the selection (other cases aren't problematic as they have very few images) :
- rewrite queries to directly get distinct ids (this avoid the use of `_images_to_act_on_insert_in_list` in loop)
- if we want hidden image, directly use selection (this avoid the use of `_images_to_act_on_insert_in_list` in loop)
- if we want only visible image, rewrite the query to avoid joins
- if the selection don't change and the mouse hover another selected image, use the cached list

I've not found any drawbacks, but please test carefully too, as this is a quite sensible area...