### PR TITLE
Change "copy parts..." to "selective copy...".

### DIFF
--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -368,8 +368,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_set_column_homogeneous(grid, TRUE);
   int line = 0;
 
-  d->copy_parts_button = dt_ui_button_new(_("copy parts..."),
-                                          _("copy part history stack of\nfirst selected image"),
+  d->copy_parts_button = dt_ui_button_new(_("selective copy..."),
+                                          _("choose which modules to copy from the source image"),
                                           "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, d->copy_parts_button, 0, line, 3, 1);
 
@@ -378,8 +378,8 @@ void gui_init(dt_lib_module_t *self)
                                     "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, d->copy_button, 3, line++, 3, 1);
 
-  d->paste_parts = dt_ui_button_new(_("paste parts..."),
-                                    _("paste part history stack to\nall selected images"),
+  d->paste_parts = dt_ui_button_new(_("selective paste..."),
+                                    _("choose which modules to paste to the target image(s)"),
                                     "history_stack.html#history_stack_usage");
   gtk_widget_set_sensitive(d->paste_parts, FALSE);
   gtk_grid_attach(grid, d->paste_parts, 0, line, 3, 1);


### PR DESCRIPTION
It has been reported that a copy if not full copy now as we remove the
unsafe module. And so, to copy "all" modules one need to use
"copy parts..." which is not really clear.

Using "selective copy..." and "selective paste..." seems to be
clearer about how things are handled.