### PR TITLE
reorganise module api specification and loading

### DIFF
--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -65,61 +65,26 @@ static void _default_format_gui_init(struct dt_imageio_module_format_t *self)
 }
 
 static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, const char *libname,
-                                         const char *plugin_name)
+                                         const char *module_name)
 {
+  g_strlcpy(module->plugin_name, module_name, sizeof(module->plugin_name));
+
+#define INCLUDE_API_FROM_MODULE_LOAD "imageio_load_module_format"
+#include "imageio/format/imageio_format_api.h"
+
+  if(!module->gui_init)
+  {
+    if(darktable.gui) goto error;
+    module->gui_init = _default_format_gui_init;
+  }
+  if(!module->dimension) module->dimension = _default_format_dimension;
+  if(!module->flags) module->flags = _default_format_flags;
+  if(!module->levels) module->levels = _default_format_levels;
+
   module->widget = NULL;
   module->parameter_lua_type = LUAA_INVALID_TYPE;
   // Can by set by the module function to false if something went wrong.
   module->ready = TRUE;
-
-  g_strlcpy(module->plugin_name, plugin_name, sizeof(module->plugin_name));
-  dt_print(DT_DEBUG_CONTROL, "[imageio_load_module] loading format module `%s' from %s\n", plugin_name, libname);
-  module->module = g_module_open(libname, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
-  if(!module->module) goto error;
-  int (*version)();
-  if(!g_module_symbol(module->module, "dt_module_dt_version", (gpointer) & (version))) goto error;
-  if(version() != dt_version())
-  {
-    fprintf(
-        stderr,
-        "[imageio_load_module] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !\n",
-        libname, abs(version()), version() < 0 ? "debug" : "opt", abs(dt_version()),
-        dt_version() < 0 ? "debug" : "opt");
-    goto error;
-  }
-  if(!g_module_symbol(module->module, "dt_module_mod_version", (gpointer) & (module->version))) goto error;
-  if(!g_module_symbol(module->module, "name", (gpointer) & (module->name))) goto error;
-  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) goto error;
-  if(!g_module_symbol(module->module, "cleanup", (gpointer) & (module->cleanup))) goto error;
-  if(!g_module_symbol(module->module, "gui_reset", (gpointer) & (module->gui_reset))) goto error;
-  if(darktable.gui)
-  {
-    if(!g_module_symbol(module->module, "gui_init", (gpointer) & (module->gui_init))) goto error;
-  }
-  else
-  {
-    module->gui_init = _default_format_gui_init;
-  }
-  if(!g_module_symbol(module->module, "gui_cleanup", (gpointer) & (module->gui_cleanup))) goto error;
-
-  if(!g_module_symbol(module->module, "mime", (gpointer) & (module->mime))) goto error;
-  if(!g_module_symbol(module->module, "extension", (gpointer) & (module->extension))) goto error;
-  if(!g_module_symbol(module->module, "dimension", (gpointer) & (module->dimension)))
-    module->dimension = _default_format_dimension;
-  if(!g_module_symbol(module->module, "legacy_params", (gpointer) & (module->legacy_params)))
-    module->legacy_params = NULL;
-  if(!g_module_symbol(module->module, "params_size", (gpointer) & (module->params_size))) goto error;
-  if(!g_module_symbol(module->module, "get_params", (gpointer) & (module->get_params))) goto error;
-  if(!g_module_symbol(module->module, "free_params", (gpointer) & (module->free_params))) goto error;
-  if(!g_module_symbol(module->module, "set_params", (gpointer) & (module->set_params))) goto error;
-  if(!g_module_symbol(module->module, "write_image", (gpointer) & (module->write_image))) goto error;
-  if(!g_module_symbol(module->module, "bpp", (gpointer) & (module->bpp))) goto error;
-  if(!g_module_symbol(module->module, "flags", (gpointer) & (module->flags)))
-    module->flags = _default_format_flags;
-  if(!g_module_symbol(module->module, "levels", (gpointer) & (module->levels)))
-    module->levels = _default_format_levels;
-  if(!g_module_symbol(module->module, "read_image", (gpointer) & (module->read_image)))
-    module->read_image = NULL;
 
 #ifdef USE_LUA
   {
@@ -146,7 +111,7 @@ static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, con
 
   return 0;
 error:
-  fprintf(stderr, "[imageio_load_module] failed to open format `%s': %s\n", plugin_name, g_module_error());
+  fprintf(stderr, "[imageio_load_module] failed to open format `%s': %s\n", module_name, g_module_error());
   if(module->module) g_module_close(module->module);
   return 1;
 }
@@ -192,7 +157,7 @@ static int dt_imageio_load_modules_format(dt_imageio_t *iio)
 }
 
 /** Default implementation of supported function, used if storage modules not implements supported() */
-static int _default_supported(struct dt_imageio_module_storage_t *self,
+static int default_supported(struct dt_imageio_module_storage_t *self,
                               struct dt_imageio_module_format_t *format)
 {
   return 1;
@@ -210,61 +175,25 @@ static void _default_storage_nop(struct dt_imageio_module_storage_t *self)
 }
 
 static int dt_imageio_load_module_storage(dt_imageio_module_storage_t *module, const char *libname,
-                                          const char *plugin_name)
+                                          const char *module_name)
 {
-  module->widget = NULL;
-  module->parameter_lua_type = LUAA_INVALID_TYPE;
-  g_strlcpy(module->plugin_name, plugin_name, sizeof(module->plugin_name));
-  dt_print(DT_DEBUG_CONTROL, "[imageio_load_module] loading storage module `%s' from %s\n", plugin_name, libname);
-  module->module = g_module_open(libname, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
-  if(!module->module) goto error;
-  int (*version)();
-  if(!g_module_symbol(module->module, "dt_module_dt_version", (gpointer) & (version))) goto error;
-  if(version() != dt_version())
+  g_strlcpy(module->plugin_name, module_name, sizeof(module->plugin_name));
+
+#define INCLUDE_API_FROM_MODULE_LOAD "imageio_load_module_storage"
+#include "imageio/storage/imageio_storage_api.h"
+
+  if(!module->gui_init)
   {
-    fprintf(
-        stderr,
-        "[imageio_load_module] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !\n",
-        libname, abs(version()), version() < 0 ? "debug" : "opt", abs(dt_version()),
-        dt_version() < 0 ? "debug" : "opt");
-    goto error;
-  }
-  if(!g_module_symbol(module->module, "dt_module_mod_version", (gpointer) & (module->version))) goto error;
-  if(!g_module_symbol(module->module, "name", (gpointer) & (module->name))) goto error;
-  if(!g_module_symbol(module->module, "gui_reset", (gpointer) & (module->gui_reset))) goto error;
-  if(darktable.gui)
-  {
-    if(!g_module_symbol(module->module, "gui_init", (gpointer) & (module->gui_init))) goto error;
-  }
-  else
-  {
+    if(darktable.gui) goto api_h_error;
     module->gui_init = _default_storage_nop;
   }
-  if(!g_module_symbol(module->module, "gui_cleanup", (gpointer) & (module->gui_cleanup))) goto error;
-  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) goto error;
+  if(!module->dimension) module->dimension = _default_storage_dimension;
+  if(!module->recommended_dimension) module->recommended_dimension = _default_storage_dimension;
+  if(!module->export_dispatched) module->export_dispatched = _default_storage_nop;
 
-  if(!g_module_symbol(module->module, "store", (gpointer) & (module->store))) goto error;
-  if(!g_module_symbol(module->module, "legacy_params", (gpointer) & (module->legacy_params)))
-    module->legacy_params = NULL;
-  if(!g_module_symbol(module->module, "params_size", (gpointer) & (module->params_size))) goto error;
-  if(!g_module_symbol(module->module, "get_params", (gpointer) & (module->get_params))) goto error;
-  if(!g_module_symbol(module->module, "free_params", (gpointer) & (module->free_params))) goto error;
-  if(!g_module_symbol(module->module, "initialize_store", (gpointer) & (module->initialize_store)))
-    module->initialize_store = NULL;
-  if(!g_module_symbol(module->module, "finalize_store", (gpointer) & (module->finalize_store)))
-    module->finalize_store = NULL;
-  if(!g_module_symbol(module->module, "set_params", (gpointer) & (module->set_params))) goto error;
+  module->widget = NULL;
+  module->parameter_lua_type = LUAA_INVALID_TYPE;
 
-  if(!g_module_symbol(module->module, "supported", (gpointer) & (module->supported)))
-    module->supported = _default_supported;
-  if(!g_module_symbol(module->module, "dimension", (gpointer) & (module->dimension)))
-    module->dimension = _default_storage_dimension;
-  if(!g_module_symbol(module->module, "recommended_dimension", (gpointer) & (module->recommended_dimension)))
-    module->recommended_dimension = _default_storage_dimension;
-  if(!g_module_symbol(module->module, "export_dispatched", (gpointer) & (module->export_dispatched)))
-    module->export_dispatched = _default_storage_nop;
-  if(!g_module_symbol(module->module, "ask_user_confirmation", (gpointer) & (module->ask_user_confirmation)))
-    module->ask_user_confirmation = NULL;
 #ifdef USE_LUA
   {
     char pseudo_type_name[1024];
@@ -284,10 +213,6 @@ static int dt_imageio_load_module_storage(dt_imageio_module_storage_t *module, c
 #endif
 
   return 0;
-error:
-  fprintf(stderr, "[imageio_load_module] failed to open storage `%s': %s\n", plugin_name, g_module_error());
-  if(module->module) g_module_close(module->module);
-  return 1;
 }
 
 static int dt_imageio_load_modules_storage(dt_imageio_t *iio)

--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -72,9 +72,12 @@ static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, con
 #define INCLUDE_API_FROM_MODULE_LOAD "imageio_load_module_format"
 #include "imageio/format/imageio_format_api.h"
 
-  if(!module->gui_init)
+  if(darktable.gui)
   {
-    if(darktable.gui) goto error;
+    if(!module->gui_init) goto api_h_error;
+  }
+  else
+  {
     module->gui_init = _default_format_gui_init;
   }
   if(!module->dimension) module->dimension = _default_format_dimension;
@@ -100,7 +103,7 @@ static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, con
     module->init(module);
     if (!module->ready)
     {
-      goto error;
+      goto api_h_error;
     }
 
 #ifdef USE_LUA
@@ -110,10 +113,6 @@ static int dt_imageio_load_module_format(dt_imageio_module_format_t *module, con
 #endif
 
   return 0;
-error:
-  fprintf(stderr, "[imageio_load_module] failed to open format `%s': %s\n", module_name, g_module_error());
-  if(module->module) g_module_close(module->module);
-  return 1;
 }
 
 
@@ -182,9 +181,12 @@ static int dt_imageio_load_module_storage(dt_imageio_module_storage_t *module, c
 #define INCLUDE_API_FROM_MODULE_LOAD "imageio_load_module_storage"
 #include "imageio/storage/imageio_storage_api.h"
 
-  if(!module->gui_init)
+  if(darktable.gui)
   {
-    if(darktable.gui) goto api_h_error;
+    if(!module->gui_init) goto api_h_error;
+  }
+  else
+  {
     module->gui_init = _default_storage_nop;
   }
   if(!module->dimension) module->dimension = _default_storage_dimension;

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -68,7 +68,8 @@ struct dt_dev_pixelpipe_t;
 /* responsible for image encoding, such as jpg,png,etc */
 typedef struct dt_imageio_module_format_t
 {
-  // !!! MUST BE KEPT IN SYNC WITH src/imageio/format/imageio_format_api.h !!!
+#define INCLUDE_API_FROM_MODULE_H
+#include "imageio/format/imageio_format_api.h"
 
   // office use only:
   char plugin_name[128];
@@ -80,55 +81,6 @@ typedef struct dt_imageio_module_format_t
   // data for you to initialize
   void *gui_data;
 
-  // gui and management:
-  /** version */
-  int (*version)();
-  /* get translated module name */
-  const char *(*name)();
-  /* construct widget above */
-  void (*gui_init)(struct dt_imageio_module_format_t *self);
-  /* destroy resources */
-  void (*gui_cleanup)(struct dt_imageio_module_format_t *self);
-  /* reset options to defaults */
-  void (*gui_reset)(struct dt_imageio_module_format_t *self);
-
-  /* construct widget above */
-  void (*init)(struct dt_imageio_module_format_t *self);
-  /* construct widget above */
-  void (*cleanup)(struct dt_imageio_module_format_t *self);
-
-  /* gets the current export parameters from gui/conf and stores in this struct for later use. */
-  void *(*legacy_params)(struct dt_imageio_module_format_t *self, const void *const old_params,
-                         const size_t old_params_size, const int old_version, const int new_version,
-                         size_t *new_size);
-  size_t (*params_size)(struct dt_imageio_module_format_t *self);
-  void *(*get_params)(struct dt_imageio_module_format_t *self);
-  void (*free_params)(struct dt_imageio_module_format_t *self, dt_imageio_module_data_t *data);
-  /* resets the gui to the parameters as given here. return != 0 on fail. */
-  int (*set_params)(struct dt_imageio_module_format_t *self, const void *params, const int size);
-
-  /* returns the mime type of the exported image. */
-  const char *(*mime)(dt_imageio_module_data_t *data);
-  /* this extension (plus dot) is appended to the exported filename. */
-  const char *(*extension)(dt_imageio_module_data_t *data);
-  /* get storage max supported image dimension, return 0 if no dimension restrictions exists. */
-  int (*dimension)(struct dt_imageio_module_format_t *self, dt_imageio_module_data_t *data, uint32_t *width, uint32_t *height);
-
-  // writing functions:
-  /* bits per pixel and color channel we want to write: 8: char x3, 16: uint16_t x3, 32: float x3. */
-  int (*bpp)(dt_imageio_module_data_t *data);
-  /* write to file, with exif if not NULL, and icc profile if supported. */
-  int (*write_image)(dt_imageio_module_data_t *data, const char *filename, const void *in,
-                     dt_colorspaces_color_profile_type_t over_type, const char *over_filename,
-                     void *exif, int exif_len, int imgid, int num, int total, struct dt_dev_pixelpipe_t *pipe,
-                     const gboolean export_masks);
-  /* flag that describes the available precision/levels of output format. mainly used for dithering. */
-  int (*levels)(dt_imageio_module_data_t *data);
-
-  // sometimes we want to tell the world about what we can do
-  int (*flags)(dt_imageio_module_data_t *data);
-
-  int (*read_image)(dt_imageio_module_data_t *data, uint8_t *out);
   luaA_Type parameter_lua_type;
 
   gboolean ready;
@@ -138,7 +90,8 @@ typedef struct dt_imageio_module_format_t
 /* responsible for image storage, such as flickr, harddisk, etc */
 typedef struct dt_imageio_module_storage_t
 {
-  // !!! MUST BE KEPT IN SYNC WITH src/imageio/storage/imageio_storage_api.h !!!
+#define INCLUDE_API_FROM_MODULE_H
+#include "imageio/storage/imageio_storage_api.h"
 
   // office use only:
   char plugin_name[128];
@@ -149,53 +102,6 @@ typedef struct dt_imageio_module_storage_t
 
   // data for you to initialize
   void *gui_data;
-
-  // gui and management:
-  /** version */
-  int (*version)();
-  /* get translated module name */
-  const char *(*name)(const struct dt_imageio_module_storage_t *self);
-  /* construct widget above */
-  void (*gui_init)(struct dt_imageio_module_storage_t *self);
-  /* destroy resources */
-  void (*gui_cleanup)(struct dt_imageio_module_storage_t *self);
-  /* reset options to defaults */
-  void (*gui_reset)(struct dt_imageio_module_storage_t *self);
-  /* allow the module to initialize itself */
-  void (*init)(struct dt_imageio_module_storage_t *self);
-  /* try and see if this format is supported? */
-  int (*supported)(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_format_t *format);
-  /* get storage max supported image dimension, return 0 if no dimension restrictions exists. */
-  int (*dimension)(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data, uint32_t *width, uint32_t *height);
-  /* get storage recommended image dimension, return 0 if no recommendation exists. */
-  int (*recommended_dimension)(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data, uint32_t *width, uint32_t *height);
-
-  /* called once at the beginning (before exporting image), if implemented
-     * can change the list of exported images (including a NULL list)
-   */
-  int (*initialize_store)(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data,
-                          dt_imageio_module_format_t **format, dt_imageio_module_data_t **fdata,
-                          GList **images, const gboolean high_quality, const gboolean upscale);
-  /* this actually does the work */
-  int (*store)(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data,
-               const int imgid, dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata,
-               const int num, const int total, const gboolean high_quality, const gboolean upscale,
-               const gboolean export_masks, dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-               dt_iop_color_intent_t icc_intent, dt_export_metadata_t *metadata_flags);
-  /* called once at the end (after exporting all images), if implemented. */
-  void (*finalize_store)(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data);
-
-  void *(*legacy_params)(struct dt_imageio_module_storage_t *self, const void *const old_params,
-                         const size_t old_params_size, const int old_version, const int new_version,
-                         size_t *new_size);
-  size_t (*params_size)(struct dt_imageio_module_storage_t *self);
-  void *(*get_params)(struct dt_imageio_module_storage_t *self);
-  void (*free_params)(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data);
-  int (*set_params)(struct dt_imageio_module_storage_t *self, const void *params, const int size);
-
-  void (*export_dispatched)(struct dt_imageio_module_storage_t *self);
-
-  char *(*ask_user_confirmation)(struct dt_imageio_module_storage_t *self);
 
   luaA_Type parameter_lua_type;
 } dt_imageio_module_storage_t;

--- a/src/common/module_api.h
+++ b/src/common/module_api.h
@@ -15,6 +15,11 @@
     You should have received a copy of the GNU Lesser General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#undef OPTIONAL
+#undef REQUIRED
+#undef DEFAULT
+
+#undef FULL_API_H
 
 #ifdef INCLUDE_API_FROM_MODULE_LOAD
   #define OPTIONAL(return_type, function_name, ...) \

--- a/src/common/module_api.h
+++ b/src/common/module_api.h
@@ -16,26 +16,68 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#ifdef INCLUDE_API_FROM_MODULE_LOAD
+  #define OPTIONAL(return_type, function_name, ...) \
+      if(!g_module_symbol(module->module, #function_name, (gpointer) & (module->function_name))) \
+          module->function_name = NULL
+  #define REQUIRED(return_type, function_name, ...) \
+      if(!g_module_symbol(module->module, #function_name, (gpointer) & (module->function_name))) \
+          goto api_h_error
+  #define DEFAULT(return_type, function_name, ...) \
+      if(!g_module_symbol(module->module, #function_name, (gpointer) & (module->function_name))) \
+          module->function_name = default_ ## function_name
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+  dt_print(DT_DEBUG_CONTROL, "[" INCLUDE_API_FROM_MODULE_LOAD "] loading `%s' from %s\n", module_name, libname);
+  module->module = g_module_open(libname, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+  if(!module->module) goto api_h_error;
+  int (*version)();
+  if(!g_module_symbol(module->module, "dt_module_dt_version", (gpointer) & (version))) goto api_h_error;
+  if(version() != dt_version())
+  {
+    fprintf(stderr,
+            "[" INCLUDE_API_FROM_MODULE_LOAD "] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !\n",
+            libname, abs(version()), version() < 0 ? "debug" : "opt", abs(dt_version()),
+            dt_version() < 0 ? "debug" : "opt");
+    goto api_h_error;
+  }
+  if(!g_module_symbol(module->module, "dt_module_mod_version", (gpointer) & (module->version))) goto api_h_error;
 
-// these 2 functions are defined by DT_MODULE() macro.
-
-#pragma GCC visibility push(default)
-
-// returns the version of dt's module interface at the time this module was build
-int dt_module_dt_version();
-
-// returns the version of this module
-int dt_module_mod_version();
-
-#pragma GCC visibility pop
-
-#ifdef __cplusplus
-}
+  goto skip_error;
+api_h_error:
+  fprintf(stderr, "[" INCLUDE_API_FROM_MODULE_LOAD "] failed to open `%s': %s\n", module_name, g_module_error());
+  if(module->module) g_module_close(module->module);
+  return 1;
+skip_error:
+  #undef INCLUDE_API_FROM_MODULE_LOAD
+#elif defined(INCLUDE_API_FROM_MODULE_H)
+  #define OPTIONAL(return_type, function_name, ...) return_type (*function_name)(__VA_ARGS__)
+  #define REQUIRED(return_type, function_name, ...) return_type (*function_name)(__VA_ARGS__)
+  #define DEFAULT(return_type, function_name, ...) return_type (*function_name)(__VA_ARGS__)
+  int (*version)();
+  #undef INCLUDE_API_FROM_MODULE_H
+#elif defined(INCLUDE_API_FROM_MODULE_LOAD_BY_SO)
+  #define OPTIONAL(return_type, function_name, ...) module->function_name = so->function_name
+  #define REQUIRED(return_type, function_name, ...) module->function_name = so->function_name
+  #define DEFAULT(return_type, function_name, ...) module->function_name = so->function_name
+  #undef INCLUDE_API_FROM_MODULE_LOAD_BY_SO
+#else
+  #define FULL_API_H
+  #define OPTIONAL(return_type, function_name, ...) return_type function_name(__VA_ARGS__)
+  #define REQUIRED(return_type, function_name, ...) return_type function_name(__VA_ARGS__)
+  #define DEFAULT(return_type, function_name, ...) return_type function_name(__VA_ARGS__)
+  #ifdef __cplusplus
+  extern "C" {
+  #endif
+  // these 2 functions are defined by DT_MODULE() macro.
+  #pragma GCC visibility push(default)
+  // returns the version of dt's module interface at the time this module was build
+  int dt_module_dt_version();
+  // returns the version of this module
+  int dt_module_mod_version();
+  #pragma GCC visibility pop
+  #ifdef __cplusplus
+  }
+  #endif
 #endif
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -290,11 +290,14 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
 #include "iop/iop_api.h"
 
   if(!module->init) module->init = dt_iop_default_init;
-  if(!module->process_tiling_cl) module->process_tiling_cl = darktable.opencl->inited ? default_process_tiling_cl : NULL;
   if(!module->modify_roi_in) module->modify_roi_in = dt_iop_modify_roi_in;
   if(!module->modify_roi_out) module->modify_roi_out = dt_iop_modify_roi_out;
 
+  #ifdef HAVE_OPENCL
+  if(!module->process_tiling_cl) module->process_tiling_cl = darktable.opencl->inited ? default_process_tiling_cl : NULL;
   if(!darktable.opencl->inited) module->process_cl = NULL;
+  #endif // HAVE_OPENCL
+
   module->process_plain = module->process;
   module->process = default_process;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1775,8 +1775,10 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
     /* and we add masks */
     dt_masks_group_get_hash_buffer(grp, str + pos);
 
+    #ifdef HAVE_OPENCL
     // assume process_cl is ready, commit_params can overwrite this.
     if(module->process_cl) piece->process_cl_ready = 1;
+    #endif // HAVE_OPENCL
 
     // register if module allows tiling, commit_params can overwrite this.
     if(module->flags() & IOP_FLAGS_ALLOW_TILING) piece->process_tiling_ready = 1;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -91,7 +91,7 @@ static void dt_iop_modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pi
 }
 
 /* default group for modules which do not implement the default_group() function */
-static int default_group(void)
+static int default_default_group(void)
 {
   return IOP_GROUP_BASIC;
 }
@@ -114,7 +114,7 @@ static int default_operation_tags_filter(void)
   return 0;
 }
 
-static char *default_description(struct dt_iop_module_t *self)
+static const char *default_description(struct dt_iop_module_t *self)
 {
   return g_strdup("");
 }
@@ -281,175 +281,46 @@ void dt_iop_default_init(dt_iop_module_t *module)
   }
 }
 
-int dt_iop_load_module_so(void *m, const char *libname, const char *op)
+int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
 {
   dt_iop_module_so_t *module = (dt_iop_module_so_t *)m;
-  g_strlcpy(module->op, op, 20);
-  module->data = NULL;
-  dt_print(DT_DEBUG_CONTROL, "[iop_load_module] loading iop `%s' from %s\n", op, libname);
-  module->module = g_module_open(libname, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
-  if(!module->module) goto error;
-  int (*version)();
-  if(!g_module_symbol(module->module, "dt_module_dt_version", (gpointer) & (version))) goto error;
-  if(version() != dt_version())
-  {
-    fprintf(stderr,
-            "[iop_load_module] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !\n",
-            libname, abs(version()), version() < 0 ? "debug" : "opt", abs(dt_version()),
-            dt_version() < 0 ? "debug" : "opt");
-    goto error;
-  }
-  if(!g_module_symbol(module->module, "dt_module_mod_version", (gpointer) & (module->version))) goto error;
-  if(!g_module_symbol(module->module, "name", (gpointer) & (module->name))) goto error;
-  if(!g_module_symbol(module->module, "aliases", (gpointer) & (module->aliases))) module->aliases = default_aliases;
-  if(!g_module_symbol(module->module, "default_group", (gpointer) & (module->default_group)))
-    module->default_group = default_group;
-  if(!g_module_symbol(module->module, "flags", (gpointer) & (module->flags))) module->flags = default_flags;
-  if(!g_module_symbol(module->module, "deprecated_msg", (gpointer) & (module->deprecated_msg)))
-    module->deprecated_msg = default_deprecated_msg;
-  if(!g_module_symbol(module->module, "description", (gpointer) & (module->description))) module->description = default_description;
-  if(!g_module_symbol(module->module, "operation_tags", (gpointer) & (module->operation_tags)))
-    module->operation_tags = default_operation_tags;
-  if(!g_module_symbol(module->module, "operation_tags_filter", (gpointer) & (module->operation_tags_filter)))
-    module->operation_tags_filter = default_operation_tags_filter;
-  if(!g_module_symbol(module->module, "input_format", (gpointer) & (module->input_format)))
-    module->input_format = default_input_format;
-  if(!g_module_symbol(module->module, "output_format", (gpointer) & (module->output_format)))
-    module->output_format = default_output_format;
+  g_strlcpy(module->op, module_name, sizeof(module->op));
 
-  if(!g_module_symbol(module->module, "default_colorspace", (gpointer) & (module->default_colorspace))) goto error;
-  if(!g_module_symbol(module->module, "input_colorspace", (gpointer) & (module->input_colorspace)))
-    module->input_colorspace = default_input_colorspace;
-  if(!g_module_symbol(module->module, "output_colorspace", (gpointer) & (module->output_colorspace)))
-    module->output_colorspace = default_output_colorspace;
-  if(!g_module_symbol(module->module, "blend_colorspace", (gpointer) & (module->blend_colorspace)))
-    module->blend_colorspace = default_blend_colorspace;
+#define INCLUDE_API_FROM_MODULE_LOAD "iop_load_module"
+#include "iop/iop_api.h"
 
-  if(!g_module_symbol(module->module, "tiling_callback", (gpointer) & (module->tiling_callback)))
-    module->tiling_callback = default_tiling_callback;
-  if(!g_module_symbol(module->module, "gui_reset", (gpointer) & (module->gui_reset)))
-    module->gui_reset = NULL;
-  if(!g_module_symbol(module->module, "gui_init", (gpointer) & (module->gui_init))) module->gui_init = NULL;
-  if(!g_module_symbol(module->module, "gui_update", (gpointer) & (module->gui_update)))
-    module->gui_update = NULL;
-  if(!g_module_symbol(module->module, "color_picker_apply", (gpointer) & (module->color_picker_apply)))
-    module->color_picker_apply = NULL;
-  if(!g_module_symbol(module->module, "gui_changed", (gpointer) & (module->gui_changed)))
-    module->gui_changed = NULL;
-  if(!g_module_symbol(module->module, "gui_cleanup", (gpointer) & (module->gui_cleanup)))
-    module->gui_cleanup = default_gui_cleanup;
+  if(!module->init) module->init = dt_iop_default_init;
+  if(!module->process_tiling_cl) module->process_tiling_cl = darktable.opencl->inited ? default_process_tiling_cl : NULL;
+  if(!module->modify_roi_in) module->modify_roi_in = dt_iop_modify_roi_in;
+  if(!module->modify_roi_out) module->modify_roi_out = dt_iop_modify_roi_out;
 
-  if(!g_module_symbol(module->module, "gui_post_expose", (gpointer) & (module->gui_post_expose)))
-    module->gui_post_expose = NULL;
-  if(!g_module_symbol(module->module, "gui_focus", (gpointer) & (module->gui_focus)))
-    module->gui_focus = NULL;
-
-  if(!g_module_symbol(module->module, "init_key_accels", (gpointer) & (module->init_key_accels)))
-    module->init_key_accels = NULL;
-  if(!g_module_symbol(module->module, "connect_key_accels", (gpointer) & (module->connect_key_accels)))
-    module->connect_key_accels = NULL;
-
-  if(!g_module_symbol(module->module, "disconnect_key_accels", (gpointer) & (module->disconnect_key_accels)))
-    module->disconnect_key_accels = NULL;
-  if(!g_module_symbol(module->module, "mouse_actions", (gpointer) & (module->mouse_actions)))
-    module->mouse_actions = NULL;
-  if(!g_module_symbol(module->module, "mouse_leave", (gpointer) & (module->mouse_leave)))
-    module->mouse_leave = NULL;
-  if(!g_module_symbol(module->module, "mouse_moved", (gpointer) & (module->mouse_moved)))
-    module->mouse_moved = NULL;
-  if(!g_module_symbol(module->module, "button_released", (gpointer) & (module->button_released)))
-    module->button_released = NULL;
-  if(!g_module_symbol(module->module, "button_pressed", (gpointer) & (module->button_pressed)))
-    module->button_pressed = NULL;
-  if(!g_module_symbol(module->module, "configure", (gpointer) & (module->configure)))
-    module->configure = NULL;
-  if(!g_module_symbol(module->module, "scrolled", (gpointer) & (module->scrolled))) module->scrolled = NULL;
-
-  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init)))
-    module->init = dt_iop_default_init;
-  if(!g_module_symbol(module->module, "cleanup", (gpointer) & (module->cleanup)))
-    module->cleanup = default_cleanup;
-  if(!g_module_symbol(module->module, "init_global", (gpointer) & (module->init_global)))
-    module->init_global = NULL;
-  if(!g_module_symbol(module->module, "cleanup_global", (gpointer) & (module->cleanup_global)))
-    module->cleanup_global = NULL;
-  if(!g_module_symbol(module->module, "init_presets", (gpointer) & (module->init_presets)))
-    module->init_presets = NULL;
-  if(!g_module_symbol(module->module, "commit_params", (gpointer) & (module->commit_params)))
-    module->commit_params = default_commit_params;
-  if(!g_module_symbol(module->module, "change_image", (gpointer) & (module->change_image)))
-    module->change_image = NULL;
-  if(!g_module_symbol(module->module, "reload_defaults", (gpointer) & (module->reload_defaults)))
-    module->reload_defaults = NULL;
-  if(!g_module_symbol(module->module, "init_pipe", (gpointer) & (module->init_pipe)))
-    module->init_pipe = default_init_pipe;
-  if(!g_module_symbol(module->module, "cleanup_pipe", (gpointer) & (module->cleanup_pipe)))
-    module->cleanup_pipe = default_cleanup_pipe;
-
+  if(!darktable.opencl->inited) module->process_cl = NULL;
+  module->process_plain = module->process;
   module->process = default_process;
 
-  if(!g_module_symbol(module->module, "process_tiling", (gpointer) & (module->process_tiling)))
-    module->process_tiling = default_process_tiling;
-
-  if(!g_module_symbol(module->module, "process_sse2", (gpointer) & (module->process_sse2)))
-    module->process_sse2 = NULL;
-
-  if(!g_module_symbol(module->module, "process", (gpointer) & (module->process_plain))) goto error;
-
-  if(!darktable.opencl->inited
-     || !g_module_symbol(module->module, "process_cl", (gpointer) & (module->process_cl)))
-    module->process_cl = NULL;
-  if(!g_module_symbol(module->module, "process_tiling_cl", (gpointer) & (module->process_tiling_cl)))
-    module->process_tiling_cl = darktable.opencl->inited ? default_process_tiling_cl : NULL;
-  if(!g_module_symbol(module->module, "distort_transform", (gpointer) & (module->distort_transform)))
-    module->distort_transform = default_distort_transform;
-  if(!g_module_symbol(module->module, "distort_backtransform", (gpointer) & (module->distort_backtransform)))
-    module->distort_backtransform = default_distort_backtransform;
-  if(!g_module_symbol(module->module, "distort_mask", (gpointer) & (module->distort_mask)))
-    module->distort_mask = NULL;
-
-  if(!g_module_symbol(module->module, "modify_roi_in", (gpointer) & (module->modify_roi_in)))
-    module->modify_roi_in = dt_iop_modify_roi_in;
-  if(!g_module_symbol(module->module, "modify_roi_out", (gpointer) & (module->modify_roi_out)))
-    module->modify_roi_out = dt_iop_modify_roi_out;
-  if(!g_module_symbol(module->module, "legacy_params", (gpointer) & (module->legacy_params)))
-    module->legacy_params = NULL;
-  // allow to select a shape inside an iop
-  if(!g_module_symbol(module->module, "masks_selection_changed", (gpointer) & (module->masks_selection_changed)))
-    module->masks_selection_changed = NULL;
+  module->data = NULL;
 
   // the introspection api
   module->have_introspection = FALSE;
-  module->get_p = default_get_p;
-  module->get_f = default_get_f;
-  module->get_introspection_linear = default_get_introspection_linear;
-  module->get_introspection = default_get_introspection;
-  if(!g_module_symbol(module->module, "introspection_init", (gpointer) & (module->introspection_init)))
-    module->introspection_init = NULL;
   if(module->introspection_init)
   {
     if(!module->introspection_init(module, DT_INTROSPECTION_VERSION))
     {
       // set the introspection related fields in module
       module->have_introspection = TRUE;
-      if(!g_module_symbol(module->module, "get_p", (gpointer) & (module->get_p))) goto error;
-      if(!g_module_symbol(module->module, "get_f", (gpointer) & (module->get_f))) goto error;
-      if(!g_module_symbol(module->module, "get_introspection", (gpointer) & (module->get_introspection)))
-        goto error;
-      if(!g_module_symbol(module->module, "get_introspection_linear",
-                          (gpointer) & (module->get_introspection_linear)))
-        goto error;
+
+      if(module->get_p == default_get_p ||
+         module->get_f == default_get_f ||
+         module->get_introspection_linear == default_get_introspection_linear ||
+         module->get_introspection == default_get_introspection)
+        goto api_h_error;
     }
     else
-      fprintf(stderr, "[iop_load_module] failed to initialize introspection for operation `%s'\n", op);
+      fprintf(stderr, "[iop_load_module] failed to initialize introspection for operation `%s'\n", module_name);
   }
 
   if(module->init_global) module->init_global(module);
   return 0;
-error:
-  fprintf(stderr, "[iop_load_module] failed to open operation `%s': %s\n", op, g_module_error());
-  if(module->module) g_module_close(module->module);
-  return 1;
 }
 
 int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt_develop_t *dev)
@@ -494,70 +365,12 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->module = so->module;
   module->so = so;
 
+#define INCLUDE_API_FROM_MODULE_LOAD_BY_SO
+#include "iop/iop_api.h"
+
   module->version = so->version;
-  module->name = so->name;
-  module->aliases = so->aliases;
-  module->default_group = so->default_group;
-  module->flags = so->flags;
-  module->deprecated_msg = so->deprecated_msg;
-  module->description = so->description;
-  module->operation_tags = so->operation_tags;
-  module->operation_tags_filter = so->operation_tags_filter;
-  module->input_format = so->input_format;
-  module->output_format = so->output_format;
-  module->default_colorspace = so->default_colorspace;
-  module->input_colorspace = so->input_colorspace;
-  module->output_colorspace = so->output_colorspace;
-  module->blend_colorspace = so->blend_colorspace;
-  module->tiling_callback = so->tiling_callback;
-  module->gui_update = so->gui_update;
-  module->gui_reset = so->gui_reset;
-  module->gui_init = so->gui_init;
-  module->color_picker_apply = so->color_picker_apply;
-  module->gui_changed = so->gui_changed;
-  module->gui_cleanup = so->gui_cleanup;
-
-  module->gui_post_expose = so->gui_post_expose;
-  module->gui_focus = so->gui_focus;
-  module->mouse_leave = so->mouse_leave;
-  module->mouse_moved = so->mouse_moved;
-  module->button_released = so->button_released;
-  module->button_pressed = so->button_pressed;
-  module->configure = so->configure;
-  module->scrolled = so->scrolled;
-
-  module->init = so->init;
-  module->original_init = so->original_init;
-  module->cleanup = so->cleanup;
-  module->commit_params = so->commit_params;
-  module->change_image = so->change_image;
-  module->reload_defaults = so->reload_defaults;
-  module->init_pipe = so->init_pipe;
-  module->cleanup_pipe = so->cleanup_pipe;
-  module->process = so->process;
-  module->process_tiling = so->process_tiling;
   module->process_plain = so->process_plain;
-  module->process_sse2 = so->process_sse2;
-  module->process_cl = so->process_cl;
-  module->process_tiling_cl = so->process_tiling_cl;
-  module->distort_transform = so->distort_transform;
-  module->distort_backtransform = so->distort_backtransform;
-  module->distort_mask = so->distort_mask;
-  module->modify_roi_in = so->modify_roi_in;
-  module->modify_roi_out = so->modify_roi_out;
-  module->legacy_params = so->legacy_params;
-  // allow to select a shape inside an iop
-  module->masks_selection_changed = so->masks_selection_changed;
-
-  module->connect_key_accels = so->connect_key_accels;
-  module->disconnect_key_accels = so->disconnect_key_accels;
-  module->mouse_actions = so->mouse_actions;
-
   module->have_introspection = so->have_introspection;
-  module->get_introspection = so->get_introspection;
-  module->get_introspection_linear = so->get_introspection_linear;
-  module->get_p = so->get_p;
-  module->get_f = so->get_f;
 
   module->accel_closures = NULL;
   module->accel_closures_local = NULL;
@@ -1281,7 +1094,7 @@ static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(lab, module->deprecated_msg());
   else
   {
-    gchar *tooltip = module->description(module);
+    gchar *tooltip = (char *)module->description(module);
     gtk_widget_set_tooltip_text(lab, tooltip);
     g_free(tooltip);
   }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -151,7 +151,8 @@ struct dt_iop_module_so_t;
 struct dt_iop_module_t;
 typedef struct dt_iop_module_so_t
 {
-  // !!! MUST BE KEPT IN SYNC WITH src/iop/iop_api.h !!!
+#define INCLUDE_API_FROM_MODULE_H
+#include "iop/iop_api.h"
 
   /** opened module. */
   GModule *module;
@@ -167,143 +168,18 @@ typedef struct dt_iop_module_so_t
   /** button used to show/hide this module in the plugin list. */
   dt_iop_module_state_t state;
 
-  /** this initializes static, hardcoded presets for this module and is called only once per run of dt. */
-  void (*init_presets)(struct dt_iop_module_so_t *self);
-  /** called once per module, at startup. */
-  void (*init_global)(struct dt_iop_module_so_t *self);
-  /** called once per module, at shutdown. */
-  void (*cleanup_global)(struct dt_iop_module_so_t *self);
-  /** called once per module, at startup. */
-  int (*introspection_init)(struct dt_iop_module_so_t *self, int api_version);
-
-  /** callbacks, loaded once, referenced by the instances. */
-  int (*version)(void);
-  const char *(*name)(void);
-  const char *(*aliases)(void);
-  int (*default_group)(void);
-  int (*flags)(void);
-  const char *(*deprecated_msg)(void);
-
-  char *(*description)(struct dt_iop_module_t *self);
-  /* should return a string with 5 lines:
-     line 1 : summary of what it does
-     line 2 : oriented creative or corrective ?
-     line 3 : working space
-     line 4 : input space
-     line 5 : output space
-     => see helper routine dt_iop_set_description()
-  */
-
-  int (*operation_tags)(void);
-  int (*operation_tags_filter)(void);
-
-  /** what do the iop want as an input? */
-  void (*input_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
-  /** what will it output? */
-  void (*output_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                        struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
-
-  /** what default colorspace this iop use? */
-  int (*default_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece);
-  /** what input colorspace it expects? */
-  int (*input_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece);
-  /** what will it output? */
-  int (*output_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                        struct dt_dev_pixelpipe_iop_t *piece);
-  /** what colorspace the blend module operates with? */
-  int (*blend_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                        struct dt_dev_pixelpipe_iop_t *piece);
-
-  void (*tiling_callback)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                          const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                          struct dt_develop_tiling_t *tiling);
-
-  void (*gui_reset)(struct dt_iop_module_t *self);
-  void (*gui_update)(struct dt_iop_module_t *self);
-  void (*gui_init)(struct dt_iop_module_t *self);
-  void (*color_picker_apply)(struct dt_iop_module_t *self, GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
-  void (*gui_changed)(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
-  void (*gui_cleanup)(struct dt_iop_module_t *self);
-  void (*gui_post_expose)(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
-                          int32_t pointerx, int32_t pointery);
-  void (*gui_focus)(struct dt_iop_module_t *self, gboolean in);
-  /** Optional callback for keyboard accelerators */
-  void (*init_key_accels)(struct dt_iop_module_so_t *so);
-  void (*original_init_key_accels)(struct dt_iop_module_so_t *so);
-  void (*connect_key_accels)(struct dt_iop_module_t *self);
-  void (*original_connect_key_accels)(struct dt_iop_module_t *self);
-  void (*disconnect_key_accels)(struct dt_iop_module_t *self);
-  GSList *(*mouse_actions)(struct dt_iop_module_t *self);
-
-  int (*mouse_leave)(struct dt_iop_module_t *self);
-  int (*mouse_moved)(struct dt_iop_module_t *self, double x, double y, double pressure, int which);
-  int (*button_released)(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
-  int (*button_pressed)(struct dt_iop_module_t *self, double x, double y, double pressure, int which,
-                        int type, uint32_t state);
-  int (*scrolled)(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state);
-  void (*configure)(struct dt_iop_module_t *self, int width, int height);
-
-  void (*init)(struct dt_iop_module_t *self); // this MUST set params_size!
-  void (*original_init)(struct dt_iop_module_t *self);
-  void (*cleanup)(struct dt_iop_module_t *self);
-  void (*init_pipe)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece);
-  void (*commit_params)(struct dt_iop_module_t *self, dt_iop_params_t *params,
-                        struct dt_dev_pixelpipe_t *pipe, struct dt_dev_pixelpipe_iop_t *piece);
-  void (*change_image)(struct dt_iop_module_t *self);
-  void (*reload_defaults)(struct dt_iop_module_t *self);
-  void (*cleanup_pipe)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece);
-  void (*modify_roi_in)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                        const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
-  void (*modify_roi_out)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                         struct dt_iop_roi_t *roi_out, const struct dt_iop_roi_t *roi_in);
-  int (*legacy_params)(struct dt_iop_module_t *self, const void *const old_params, const int old_version,
-                       void *new_params, const int new_version);
-  // allow to select a shape inside an iop
-  void (*masks_selection_changed)(struct dt_iop_module_t *self, const int form_selected_id);
-
-  void (*process)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                  void *const o, const struct dt_iop_roi_t *const roi_in,
-                  const struct dt_iop_roi_t *const roi_out);
-  void (*process_tiling)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                         const struct dt_iop_roi_t *const roi_out, const int bpp);
   void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                        const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                        const struct dt_iop_roi_t *const roi_out);
-  void (*process_sse2)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                       const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                       const struct dt_iop_roi_t *const roi_out);
-  int (*process_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                    void *const o, const struct dt_iop_roi_t *const roi_in,
-                    const struct dt_iop_roi_t *const roi_out);
-  int (*process_tiling_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                           const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                           const struct dt_iop_roi_t *const roi_out, const int bpp);
+                      const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                      const struct dt_iop_roi_t *const roi_out);
 
-  int (*distort_transform)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
-                           size_t points_count);
-  int (*distort_backtransform)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                               float *points, size_t points_count);
-  void (*distort_mask)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                       float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out);
-
-  // introspection related callbacks
+  // introspection related data
   gboolean have_introspection;
-  dt_introspection_t *(*get_introspection)(void);
-  dt_introspection_field_t *(*get_introspection_linear)(void);
-  void *(*get_p)(const void *param, const char *name);
-  dt_introspection_field_t *(*get_f)(const char *name);
-
 } dt_iop_module_so_t;
 
 typedef struct dt_iop_module_t
 {
-  // !!! MUST BE KEPT IN SYNC WITH src/iop/iop_api.h !!!
+#define INCLUDE_API_FROM_MODULE_H
+#include "iop/iop_api.h"
 
   /** opened module. */
   GModule *module;
@@ -416,161 +292,12 @@ typedef struct dt_iop_module_t
   /** delayed-event handling */
   guint timeout_handle;
 
-  /** version of the parameters in the database. */
-  int (*version)(void);
-  /** get name of the module, to be translated. */
-  const char *(*name)(void);
-  /** get aliases names of the module, to be translated. */
-  const char *(*aliases)(void);
-  /** get the default group this module belongs to. */
-  int (*default_group)(void);
-  /** get the iop module flags. */
-  int (*flags)(void);
-  /** get deprecated message if needed */
-  const char *(*deprecated_msg)(void);
-
-  /** get a descriptive text used for example in a tooltip in more modules */
-  char *(*description)(struct dt_iop_module_t *self);
-
-  int (*operation_tags)(void);
-
-  int (*operation_tags_filter)(void);
-  void (*input_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
-  /** what will it output? */
-  void (*output_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                        struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
-
-  /** what default colorspace this iop use? */
-  int (*default_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece);
-  /** what input colorspace it expects? */
-  int (*input_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece);
-  /** what will it output? */
-  int (*output_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                        struct dt_dev_pixelpipe_iop_t *piece);
-  /** what colorspace the blend module operates with? */
-  int (*blend_colorspace)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                        struct dt_dev_pixelpipe_iop_t *piece);
-
-  /** report back info for tiling: memory usage and overlap. Memory usage: factor * input_size + overhead */
-  void (*tiling_callback)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                          const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                          struct dt_develop_tiling_t *tiling);
-
-  /** callback methods for gui. */
-  /** synch gtk interface with gui params, if necessary. */
-  void (*gui_update)(struct dt_iop_module_t *self);
-  /** reset ui to defaults */
-  void (*gui_reset)(struct dt_iop_module_t *self);
-  /** construct widget. */
-  void (*gui_init)(struct dt_iop_module_t *self);
-  /** apply color picker results */
-  void (*color_picker_apply)(struct dt_iop_module_t *self, GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
-  /** called by standard widget callbacks after value changed */
-  void (*gui_changed)(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
-  /** destroy widget. */
-  void (*gui_cleanup)(struct dt_iop_module_t *self);
-  /** optional method called after darkroom expose. */
-  void (*gui_post_expose)(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
-                          int32_t pointerx, int32_t pointery);
-  /** optional callback to be notified if the module acquires gui focus/loses it. */
-  void (*gui_focus)(struct dt_iop_module_t *self, gboolean in);
-
-  /** optional event callbacks */
-  int (*mouse_leave)(struct dt_iop_module_t *self);
-  int (*mouse_moved)(struct dt_iop_module_t *self, double x, double y, double pressure, int which);
-  int (*button_released)(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
-  int (*button_pressed)(struct dt_iop_module_t *self, double x, double y, double pressure, int which,
-                        int type, uint32_t state);
-  int (*key_pressed)(struct dt_iop_module_t *self, uint16_t which);
-  int (*scrolled)(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state);
-  void (*configure)(struct dt_iop_module_t *self, int width, int height);
-
-  void (*init)(struct dt_iop_module_t *self); // this MUST set params_size!
-  void (*original_init)(struct dt_iop_module_t *self);
-  void (*cleanup)(struct dt_iop_module_t *self);
-  /** this inits the piece of the pipe, allocing piece->data as necessary. */
-  void (*init_pipe)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece);
-  /** this resets the params to factory defaults. used at the beginning of each history synch. */
-  /** this commits (a mutex will be locked to synch pipe/gui) the given history params to the pixelpipe piece.
-   */
-  void (*commit_params)(struct dt_iop_module_t *self, dt_iop_params_t *params,
-                        struct dt_dev_pixelpipe_t *pipe, struct dt_dev_pixelpipe_iop_t *piece);
-  /** this is the chance to update default parameters, after the full raw is loaded. */
-  void (*reload_defaults)(struct dt_iop_module_t *self);
-  /** called after the image has changed in darkroom */
-  void (*change_image)(struct dt_iop_module_t *self);
-  /** this destroys all resources needed by the piece of the pixelpipe. */
-  void (*cleanup_pipe)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                       struct dt_dev_pixelpipe_iop_t *piece);
-  void (*modify_roi_in)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                        const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
-  void (*modify_roi_out)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                         struct dt_iop_roi_t *roi_out, const struct dt_iop_roi_t *roi_in);
-  int (*legacy_params)(struct dt_iop_module_t *self, const void *const old_params, const int old_version,
-                       void *new_params, const int new_version);
-  // allow to select a shape inside an iop
-  void (*masks_selection_changed)(struct dt_iop_module_t *self, const int form_selected_id);
-
-  /** this is the temp homebrew callback to operations.
-    * x,y, and scale are just given for orientation in the framebuffer. i and o are
-    * scaled to the same size width*height and contain a max of 3 floats. other color
-    * formats may be filled by this callback, if the pipeline can handle it. */
-  /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
-  void (*process)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                  void *const o, const struct dt_iop_roi_t *const roi_in,
-                  const struct dt_iop_roi_t *const roi_out);
-  /** a tiling variant of process(). */
-  void (*process_tiling)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                         const struct dt_iop_roi_t *const roi_out, const int bpp);
-  /** WARNING: in IOP implementation, it is called process()!!! */
-  /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
   void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
                         const struct dt_iop_roi_t *const roi_out);
-  /** a variant process(), that can contain SSE2 intrinsics. */
-  void (*process_sse2)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                       const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                       const struct dt_iop_roi_t *const roi_out);
-  /** the opencl equivalent of process(). */
-  int (*process_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                    void *const o, const struct dt_iop_roi_t *const roi_in,
-                    const struct dt_iop_roi_t *const roi_out);
-  /** a tiling variant of process_cl(). */
-  int (*process_tiling_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                           const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
-                           const struct dt_iop_roi_t *const roi_out, const int bpp);
-
-  /** this functions are used for distort iop
-   * points is an array of float {x1,y1,x2,y2,...}
-   * size is 2*points_count */
-  /** points before the iop is applied => point after processed */
-  int (*distort_transform)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
-                           size_t points_count);
-  /** reverse points after the iop is applied => point before process */
-  int (*distort_backtransform)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                               float *points, size_t points_count);
-  /** apply the image distortion to a single channel float buffer. only needed by iops that distort the image */
-  void (*distort_mask)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                       float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out);
-
-  /** Key accelerator registration callbacks */
-  void (*connect_key_accels)(struct dt_iop_module_t *self);
-  void (*original_connect_key_accels)(struct dt_iop_module_t *self);
-  void (*disconnect_key_accels)(struct dt_iop_module_t *self);
-  GSList *(*mouse_actions)(struct dt_iop_module_t *self);
 
   // introspection related data
   gboolean have_introspection;
-  dt_introspection_t *(*get_introspection)(void);
-  dt_introspection_field_t *(*get_introspection_linear)(void);
-  void *(*get_p)(const void *param, const char *name);
-  dt_introspection_field_t *(*get_f)(const char *name);
-
 } dt_iop_module_t;
 
 /** loads and inits the modules in the plugins/ directory. */

--- a/src/imageio/format/imageio_format_api.h
+++ b/src/imageio/format/imageio_format_api.h
@@ -16,7 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "common/module_api.h"
+
+#ifdef FULL_API_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,66 +35,73 @@ struct dt_dev_pixelpipe_t;
 
 /* early definition of modules to do type checking */
 
-// !!! MUST BE KEPT IN SYNC WITH dt_imageio_module_format_t defined in src/common/imageio_module.h !!!
-
 #pragma GCC visibility push(default)
 
+#endif // FULL_API_H
+
 // gui and management:
-/** version */
-int version();
 /* get translated module name */
-const char *name();
+REQUIRED(const char *, name,);
 /* construct widget above */
-void gui_init(struct dt_imageio_module_format_t *self);
+OPTIONAL(void, gui_init, struct dt_imageio_module_format_t *self);
 /* destroy resources */
-void gui_cleanup(struct dt_imageio_module_format_t *self);
+REQUIRED(void, gui_cleanup, struct dt_imageio_module_format_t *self);
 /* reset options to defaults */
-void gui_reset(struct dt_imageio_module_format_t *self);
+REQUIRED(void, gui_reset, struct dt_imageio_module_format_t *self);
 
 /* construct widget above */
-void init(struct dt_imageio_module_format_t *self);
+REQUIRED(void, init, struct dt_imageio_module_format_t *self);
 /* construct widget above */
-void cleanup(struct dt_imageio_module_format_t *self);
+REQUIRED(void, cleanup, struct dt_imageio_module_format_t *self);
 
 /* gets the current export parameters from gui/conf and stores in this struct for later use. */
-void *legacy_params(struct dt_imageio_module_format_t *self, const void *const old_params,
-                    const size_t old_params_size, const int old_version, const int new_version,
-                    size_t *new_size);
-size_t params_size(struct dt_imageio_module_format_t *self);
-void *get_params(struct dt_imageio_module_format_t *self);
-void free_params(struct dt_imageio_module_format_t *self, struct dt_imageio_module_data_t *data);
+OPTIONAL(void *, legacy_params, struct dt_imageio_module_format_t *self, const void *const old_params,
+                                const size_t old_params_size, const int old_version, const int new_version,
+                                size_t *new_size);
+REQUIRED(size_t, params_size, struct dt_imageio_module_format_t *self);
+REQUIRED(void *, get_params, struct dt_imageio_module_format_t *self);
+REQUIRED(void, free_params, struct dt_imageio_module_format_t *self, struct dt_imageio_module_data_t *data);
 /* resets the gui to the parameters as given here. return != 0 on fail. */
-int set_params(struct dt_imageio_module_format_t *self, const void *params, const int size);
+REQUIRED(int, set_params, struct dt_imageio_module_format_t *self, const void *params, const int size);
 
 /* returns the mime type of the exported image. */
-const char *mime(struct dt_imageio_module_data_t *data);
+REQUIRED(const char *, mime, struct dt_imageio_module_data_t *data);
 /* this extension (plus dot) is appended to the exported filename. */
-const char *extension(struct dt_imageio_module_data_t *data);
+REQUIRED(const char *, extension, struct dt_imageio_module_data_t *data);
 /* get storage max supported image dimension, return 0 if no dimension restrictions exists. */
-int dimension(struct dt_imageio_module_format_t *self, struct dt_imageio_module_data_t *data, uint32_t *width,
-              uint32_t *height);
+OPTIONAL(int, dimension, struct dt_imageio_module_format_t *self, struct dt_imageio_module_data_t *data, uint32_t *width,
+                         uint32_t *height);
 
 // writing functions:
 /* bits per pixel and color channel we want to write: 8: char x3, 16: uint16_t x3, 32: float x3. */
-int bpp(struct dt_imageio_module_data_t *data);
+REQUIRED(int, bpp, struct dt_imageio_module_data_t *data);
 /* write to file, with exif if not NULL, and icc profile if supported. */
-int write_image(struct dt_imageio_module_data_t *data, const char *filename, const void *in,
-                dt_colorspaces_color_profile_type_t over_type, const char *over_filename,
-                void *exif, int exif_len, int imgid, int num, int total, struct dt_dev_pixelpipe_t *pipe,
-                const gboolean export_masks);
+REQUIRED(int, write_image, struct dt_imageio_module_data_t *data, const char *filename, const void *in,
+                           dt_colorspaces_color_profile_type_t over_type, const char *over_filename,
+                           void *exif, int exif_len, int imgid, int num, int total, struct dt_dev_pixelpipe_t *pipe,
+                           const gboolean export_masks);
 /* flag that describes the available precision/levels of output format. mainly used for dithering. */
-int levels(struct dt_imageio_module_data_t *data);
+OPTIONAL(int, levels, struct dt_imageio_module_data_t *data);
 
 // sometimes we want to tell the world about what we can do
-int flags(struct dt_imageio_module_data_t *data);
+OPTIONAL(int, flags, struct dt_imageio_module_data_t *data);
 
-int read_image(struct dt_imageio_module_data_t *data, uint8_t *out);
+OPTIONAL(int, read_image, struct dt_imageio_module_data_t *data, uint8_t *out);
+
+#undef OPTIONAL
+#undef REQUIRED
+#undef DEFAULT
+
+#ifdef FULL_API_H
 
 #pragma GCC visibility pop
 
 #ifdef __cplusplus
 }
 #endif
+
+#undef FULL_API_H
+#endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/imageio/format/imageio_format_api.h
+++ b/src/imageio/format/imageio_format_api.h
@@ -88,10 +88,6 @@ OPTIONAL(int, flags, struct dt_imageio_module_data_t *data);
 
 OPTIONAL(int, read_image, struct dt_imageio_module_data_t *data, uint8_t *out);
 
-#undef OPTIONAL
-#undef REQUIRED
-#undef DEFAULT
-
 #ifdef FULL_API_H
 
 #pragma GCC visibility pop
@@ -100,7 +96,6 @@ OPTIONAL(int, read_image, struct dt_imageio_module_data_t *data, uint8_t *out);
 }
 #endif
 
-#undef FULL_API_H
 #endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -16,7 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "common/module_api.h"
+
+#ifdef FULL_API_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,62 +36,70 @@ enum dt_iop_color_intent_t;
 
 /* early definition of modules to do type checking */
 
-// !!! MUST BE KEPT IN SYNC WITH dt_imageio_module_storage_t defined in src/common/imageio_module.h !!!
-
 #pragma GCC visibility push(default)
 
-int version();
+#endif // FULL_API_H
+
 /* get translated module name */
-const char *name(const struct dt_imageio_module_storage_t *self);
+REQUIRED(const char *, name, const struct dt_imageio_module_storage_t *self);
 /* construct widget above */
-void gui_init(struct dt_imageio_module_storage_t *self);
+REQUIRED(void, gui_init, struct dt_imageio_module_storage_t *self);
 /* destroy resources */
-void gui_cleanup(struct dt_imageio_module_storage_t *self);
+REQUIRED(void, gui_cleanup, struct dt_imageio_module_storage_t *self);
 /* reset options to defaults */
-void gui_reset(struct dt_imageio_module_storage_t *self);
+REQUIRED(void, gui_reset, struct dt_imageio_module_storage_t *self);
 /* allow the module to initialize itself */
-void init(struct dt_imageio_module_storage_t *self);
+REQUIRED(void, init, struct dt_imageio_module_storage_t *self);
 /* try and see if this format is supported? */
-int supported(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_format_t *format);
+DEFAULT(int, supported, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_format_t *format);
 /* get storage max supported image dimension, return 0 if no dimension restrictions exists. */
-int dimension(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data,
+OPTIONAL(int, dimension, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data,
               uint32_t *width, uint32_t *height);
 /* get storage recommended image dimension, return 0 if no recommendation exists. */
-int recommended_dimension(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data,
-                          uint32_t *width, uint32_t *height);
+OPTIONAL(int, recommended_dimension, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data,
+                                     uint32_t *width, uint32_t *height);
 
 /* called once at the beginning (before exporting image), if implemented
    * can change the list of exported images (including a NULL list)
  */
-int initialize_store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data,
-                     struct dt_imageio_module_format_t **format, struct dt_imageio_module_data_t **fdata,
-                     GList **images, const gboolean high_quality, const gboolean upscale);
+OPTIONAL(int, initialize_store, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data,
+                                struct dt_imageio_module_format_t **format, struct dt_imageio_module_data_t **fdata,
+                                GList **images, const gboolean high_quality, const gboolean upscale);
 /* this actually does the work */
-int store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data, const int imgid,
-          struct dt_imageio_module_format_t *format, struct dt_imageio_module_data_t *fdata, const int num,
-          const int total, const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
-          const enum dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-          enum dt_iop_color_intent_t icc_intent, struct dt_export_metadata_t *metadata);
+REQUIRED(int, store, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data, const int imgid,
+                     struct dt_imageio_module_format_t *format, struct dt_imageio_module_data_t *fdata, const int num,
+                     const int total, const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
+                     const enum dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
+                     enum dt_iop_color_intent_t icc_intent, struct dt_export_metadata_t *metadata);
 /* called once at the end (after exporting all images), if implemented. */
-void finalize_store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data);
+OPTIONAL(void, finalize_store, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data);
 
-void *legacy_params(struct dt_imageio_module_storage_t *self, const void *const old_params,
-                    const size_t old_params_size, const int old_version, const int new_version,
-                    size_t *new_size);
-size_t params_size(struct dt_imageio_module_storage_t *self);
-void *get_params(struct dt_imageio_module_storage_t *self);
-void free_params(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data);
-int set_params(struct dt_imageio_module_storage_t *self, const void *params, const int size);
+OPTIONAL(void *, legacy_params, struct dt_imageio_module_storage_t *self, const void *const old_params,
+                 const size_t old_params_size, const int old_version, const int new_version,
+                 size_t *new_size);
+REQUIRED(size_t, params_size, struct dt_imageio_module_storage_t *self);
+REQUIRED(void *, get_params, struct dt_imageio_module_storage_t *self);
+REQUIRED(void, free_params, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data);
+REQUIRED(int, set_params, struct dt_imageio_module_storage_t *self, const void *params, const int size);
 
-void export_dispatched(struct dt_imageio_module_storage_t *self);
+OPTIONAL(void, export_dispatched, struct dt_imageio_module_storage_t *self);
 
-char *ask_user_confirmation(struct dt_imageio_module_storage_t *self);
+OPTIONAL(char *, ask_user_confirmation, struct dt_imageio_module_storage_t *self);
+
+#undef OPTIONAL
+#undef REQUIRED
+#undef DEFAULT
+
+#ifdef FULL_API_H
 
 #pragma GCC visibility pop
 
 #ifdef __cplusplus
 }
 #endif
+
+#undef FULL_API_H
+#endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -86,10 +86,6 @@ OPTIONAL(void, export_dispatched, struct dt_imageio_module_storage_t *self);
 
 OPTIONAL(char *, ask_user_confirmation, struct dt_imageio_module_storage_t *self);
 
-#undef OPTIONAL
-#undef REQUIRED
-#undef DEFAULT
-
 #ifdef FULL_API_H
 
 #pragma GCC visibility pop
@@ -98,7 +94,6 @@ OPTIONAL(char *, ask_user_confirmation, struct dt_imageio_module_storage_t *self
 }
 #endif
 
-#undef FULL_API_H
 #endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -16,7 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "common/module_api.h"
+
+#ifdef FULL_API_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,128 +55,123 @@ typedef void dt_iop_params_t;
 
 /* early definition of modules to do type checking */
 
-// !!! MUST BE KEPT IN SYNC WITH dt_iop_module_so_t and dt_iop_module_t defined in src/develop/imageop.h !!!
-
 #pragma GCC visibility push(default)
 
-/** this initializes static, hardcoded presets for this module and is called only once per run of dt. */
-void init_presets(struct dt_iop_module_so_t *self);
-/** called once per module, at startup. */
-void init_global(struct dt_iop_module_so_t *self);
-/** called once per module, at shutdown. */
-void cleanup_global(struct dt_iop_module_so_t *self);
+#endif // FULL_API_H
 
-/** version of the parameters in the database. */
-int version(void);
+/** this initializes static, hardcoded presets for this module and is called only once per run of dt. */
+OPTIONAL(void, init_presets, struct dt_iop_module_so_t *self);
+/** called once per module, at startup. */
+OPTIONAL(void, init_global, struct dt_iop_module_so_t *self);
+/** called once per module, at shutdown. */
+OPTIONAL(void, cleanup_global, struct dt_iop_module_so_t *self);
+
 /** get name of the module, to be translated. */
-const char *name(void);
+REQUIRED(const char *, name, void);
 /** get the alternative names or keywords of the module, to be translated. Separate variants by a pipe | */
-const char *aliases(void);
+DEFAULT(const char *, aliases, void);
 /** get the default group this module belongs to. */
-int default_group(void);
+DEFAULT(int, default_group, void);
 /** get the iop module flags. */
-int flags(void);
+DEFAULT(int, flags, void);
 /** get the deprecated message if needed, to be translated. */
-const char *deprecated_msg(void);
+DEFAULT(const char *, deprecated_msg, void);
 
 /** get a descriptive text used for example in a tooltip in more modules */
-const char *description(struct dt_iop_module_t *self);
+DEFAULT(const char *, description, struct dt_iop_module_t *self);
 
-int operation_tags(void);
-int operation_tags_filter(void);
+DEFAULT(int, operation_tags, void);
+DEFAULT(int, operation_tags_filter, void);
 
 /** what do the iop want as an input? */
-void input_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                  struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+DEFAULT(void, input_format, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                             struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
 /** what will it output? */
-void output_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                   struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+DEFAULT(void, output_format, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                              struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
 
 /** what default colorspace this iop use? */
-int default_colorspace(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                     struct dt_dev_pixelpipe_iop_t *piece);
+REQUIRED(int, default_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                                  struct dt_dev_pixelpipe_iop_t *piece);
 /** what input colorspace it expects? */
-int input_colorspace(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                     struct dt_dev_pixelpipe_iop_t *piece);
+DEFAULT(int, input_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                                struct dt_dev_pixelpipe_iop_t *piece);
 /** what will it output? */
-int output_colorspace(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                      struct dt_dev_pixelpipe_iop_t *piece);
+DEFAULT(int, output_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                                 struct dt_dev_pixelpipe_iop_t *piece);
 /** what colorspace the blend module operates with? */
-int blend_colorspace(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                      struct dt_dev_pixelpipe_iop_t *piece);
+DEFAULT(int, blend_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                                struct dt_dev_pixelpipe_iop_t *piece);
 
 /** report back info for tiling: memory usage and overlap. Memory usage: factor * input_size + overhead */
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling);
+DEFAULT(void, tiling_callback, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                                const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
+                                struct dt_develop_tiling_t *tiling);
 
 /** callback methods for gui. */
 /** synch gtk interface with gui params, if necessary. */
-void gui_update(struct dt_iop_module_t *self);
+OPTIONAL(void, gui_update, struct dt_iop_module_t *self);
 /** reset ui to defaults */
-void gui_reset(struct dt_iop_module_t *self);
+OPTIONAL(void, gui_reset, struct dt_iop_module_t *self);
 /** construct widget. */
-void gui_init(struct dt_iop_module_t *self);
+OPTIONAL(void, gui_init, struct dt_iop_module_t *self);
 /** apply color picker results */
-void color_picker_apply(struct dt_iop_module_t *self, struct _GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
+OPTIONAL(void, color_picker_apply, struct dt_iop_module_t *self, struct _GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
 /** called by standard widget callbacks after value changed */
-void gui_changed(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
+OPTIONAL(void, gui_changed, struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
 /** destroy widget. */
-void gui_cleanup(struct dt_iop_module_t *self);
+DEFAULT(void, gui_cleanup, struct dt_iop_module_t *self);
 /** optional method called after darkroom expose. */
-void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
-                     int32_t pointerx, int32_t pointery);
+OPTIONAL(void, gui_post_expose, struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
+                                int32_t pointerx, int32_t pointery);
 /** optional callback to be notified if the module acquires gui focus/loses it. */
-void gui_focus(struct dt_iop_module_t *self, gboolean in);
+OPTIONAL(void, gui_focus, struct dt_iop_module_t *self, gboolean in);
 
 /** Optional callback for keyboard accelerators */
-void init_key_accels(struct dt_iop_module_so_t *so);
-void original_init_key_accels(struct dt_iop_module_so_t *so);
+OPTIONAL(void, init_key_accels, struct dt_iop_module_so_t *so);
+OPTIONAL(void, original_init_key_accels, struct dt_iop_module_so_t *so);
 /** Key accelerator registration callbacks */
-void connect_key_accels(struct dt_iop_module_t *self);
-void original_connect_key_accels(struct dt_iop_module_t *self);
-void disconnect_key_accels(struct dt_iop_module_t *self);
-GSList *mouse_actions(struct dt_iop_module_t *self);
+OPTIONAL(void, connect_key_accels, struct dt_iop_module_t *self);
+OPTIONAL(void, disconnect_key_accels, struct dt_iop_module_t *self);
+OPTIONAL(GSList *, mouse_actions, struct dt_iop_module_t *self);
 
 /** optional event callbacks */
-int mouse_leave(struct dt_iop_module_t *self);
-int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which);
-int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
-int button_pressed(struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
-                   uint32_t state);
-int key_pressed(struct dt_iop_module_t *self, uint16_t which);
+OPTIONAL(int, mouse_leave, struct dt_iop_module_t *self);
+OPTIONAL(int, mouse_moved, struct dt_iop_module_t *self, double x, double y, double pressure, int which);
+OPTIONAL(int, button_released, struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
+OPTIONAL(int, button_pressed, struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
+                              uint32_t state);
 
-int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state);
-void configure(struct dt_iop_module_t *self, int width, int height);
+OPTIONAL(int, scrolled, struct dt_iop_module_t *self, double x, double y, int up, uint32_t state);
+OPTIONAL(void, configure, struct dt_iop_module_t *self, int width, int height);
 
-void init(struct dt_iop_module_t *self); // this MUST set params_size!
-void original_init(struct dt_iop_module_t *self);
-void cleanup(struct dt_iop_module_t *self);
+OPTIONAL(void, init, struct dt_iop_module_t *self); // this MUST set params_size!
+DEFAULT(void, cleanup, struct dt_iop_module_t *self);
 
 /** this inits the piece of the pipe, allocing piece->data as necessary. */
-void init_pipe(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-               struct dt_dev_pixelpipe_iop_t *piece);
+DEFAULT(void, init_pipe, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                          struct dt_dev_pixelpipe_iop_t *piece);
 /** this resets the params to factory defaults. used at the beginning of each history synch. */
 /** this commits (a mutex will be locked to synch pipe/gui) the given history params to the pixelpipe piece.
  */
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, struct dt_dev_pixelpipe_t *pipe,
-                   struct dt_dev_pixelpipe_iop_t *piece);
+DEFAULT(void, commit_params, struct dt_iop_module_t *self, dt_iop_params_t *params, struct dt_dev_pixelpipe_t *pipe,
+                              struct dt_dev_pixelpipe_iop_t *piece);
 /** this is the chance to update default parameters, after the full raw is loaded. */
-void reload_defaults(struct dt_iop_module_t *self);
+OPTIONAL(void, reload_defaults, struct dt_iop_module_t *self);
 /** called after the image has changed in darkroom */
-void change_image(struct dt_iop_module_t *self);
+OPTIONAL(void, change_image, struct dt_iop_module_t *self);
 
 /** this destroys all resources needed by the piece of the pixelpipe. */
-void cleanup_pipe(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                  struct dt_dev_pixelpipe_iop_t *piece);
-void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                   const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
-void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                    struct dt_iop_roi_t *roi_out, const struct dt_iop_roi_t *roi_in);
-int legacy_params(struct dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version);
+DEFAULT(void, cleanup_pipe, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                             struct dt_dev_pixelpipe_iop_t *piece);
+OPTIONAL(void, modify_roi_in, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                              const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
+OPTIONAL(void, modify_roi_out, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                               struct dt_iop_roi_t *roi_out, const struct dt_iop_roi_t *roi_in);
+OPTIONAL(int, legacy_params, struct dt_iop_module_t *self, const void *const old_params, const int old_version,
+                             void *new_params, const int new_version);
 // allow to select a shape inside an iop
-void masks_selection_changed(struct dt_iop_module_t *self, const int form_selected_id);
+OPTIONAL(void, masks_selection_changed, struct dt_iop_module_t *self, const int form_selected_id);
 
 /** this is the temp homebrew callback to operations.
   * x,y, and scale are just given for orientation in the framebuffer. i and o are
@@ -182,58 +179,67 @@ void masks_selection_changed(struct dt_iop_module_t *self, const int form_select
   * formats may be filled by this callback, if the pipeline can handle it. */
 /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
 /** must be provided by each IOP. */
-void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-             void *const o, const struct dt_iop_roi_t *const roi_in,
-             const struct dt_iop_roi_t *const roi_out);
+REQUIRED(void, process, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                        void *const o, const struct dt_iop_roi_t *const roi_in,
+                        const struct dt_iop_roi_t *const roi_out);
 /** a tiling variant of process(). */
-void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                    void *const o, const struct dt_iop_roi_t *const roi_in,
-                    const struct dt_iop_roi_t *const roi_out, const int bpp);
+DEFAULT(void, process_tiling, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                               void *const o, const struct dt_iop_roi_t *const roi_in,
+                               const struct dt_iop_roi_t *const roi_out, const int bpp);
 
 #if defined(__SSE__)
 /** a variant process(), that can contain SSE2 intrinsics. */
 /** can be provided by each IOP. */
-void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                  void *const o, const struct dt_iop_roi_t *const roi_in,
-                  const struct dt_iop_roi_t *const roi_out);
+OPTIONAL(void, process_sse2, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                             void *const o, const struct dt_iop_roi_t *const roi_in,
+                             const struct dt_iop_roi_t *const roi_out);
 #endif
 
 #ifdef HAVE_OPENCL
 /** the opencl equivalent of process(). */
-int process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
-               cl_mem dev_out, const struct dt_iop_roi_t *const roi_in,
-               const struct dt_iop_roi_t *const roi_out);
+OPTIONAL(int, process_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
+                          cl_mem dev_out, const struct dt_iop_roi_t *const roi_in,
+                          const struct dt_iop_roi_t *const roi_out);
 /** a tiling variant of process_cl(). */
-int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                      void *const o, const struct dt_iop_roi_t *const roi_in,
-                      const struct dt_iop_roi_t *const roi_out, const int bpp);
+OPTIONAL(int, process_tiling_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                                 void *const o, const struct dt_iop_roi_t *const roi_in,
+                                 const struct dt_iop_roi_t *const roi_out, const int bpp);
 #endif
 
 /** this functions are used for distort iop
  * points is an array of float {x1,y1,x2,y2,...}
  * size is 2*points_count */
 /** points before the iop is applied => point after processed */
-int distort_transform(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
-                      size_t points_count);
+DEFAULT(int, distort_transform, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
+                                 size_t points_count);
 /** reverse points after the iop is applied => point before process */
-int distort_backtransform(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
-                          size_t points_count);
+DEFAULT(int, distort_backtransform, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
+                                     size_t points_count);
 
-void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                  float *const out, const struct dt_iop_roi_t *const roi_in, const struct dt_iop_roi_t *const roi_out);
+OPTIONAL(void, distort_mask, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
+                             float *const out, const struct dt_iop_roi_t *const roi_in, const struct dt_iop_roi_t *const roi_out);
 
 // introspection related callbacks, will be auto-implemented if DT_MODULE_INTROSPECTION() is used,
-int introspection_init(struct dt_iop_module_so_t *self, int api_version);
-dt_introspection_t *get_introspection(void);
-dt_introspection_field_t *get_introspection_linear(void);
-void *get_p(const void *param, const char *name);
-dt_introspection_field_t *get_f(const char *name);
+OPTIONAL(int, introspection_init, struct dt_iop_module_so_t *self, int api_version);
+DEFAULT(dt_introspection_t *, get_introspection, void);
+DEFAULT(dt_introspection_field_t *, get_introspection_linear, void);
+DEFAULT(void *, get_p, const void *param, const char *name);
+DEFAULT(dt_introspection_field_t *, get_f, const char *name);
+
+#undef OPTIONAL
+#undef REQUIRED
+#undef DEFAULT
+
+#ifdef FULL_API_H
 
 #pragma GCC visibility pop
 
 #ifdef __cplusplus
 }
 #endif
+
+#undef FULL_API_H
+#endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -226,10 +226,6 @@ DEFAULT(dt_introspection_field_t *, get_introspection_linear, void);
 DEFAULT(void *, get_p, const void *param, const char *name);
 DEFAULT(dt_introspection_field_t *, get_f, const char *name);
 
-#undef OPTIONAL
-#undef REQUIRED
-#undef DEFAULT
-
 #ifdef FULL_API_H
 
 #pragma GCC visibility pop
@@ -238,7 +234,6 @@ DEFAULT(dt_introspection_field_t *, get_f, const char *name);
 }
 #endif
 
-#undef FULL_API_H
 #endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -80,7 +80,8 @@ typedef struct dt_lib_t
 
 typedef struct dt_lib_module_t
 {
-  // !!! MUST BE KEPT IN SYNC WITH src/libs/lib_api.h !!!
+#define INCLUDE_API_FROM_MODULE_H
+#include "libs/lib_api.h"
 
   /** opened module. */
   GModule *module;
@@ -96,59 +97,6 @@ typedef struct dt_lib_module_t
   void (*_postponed_update)(struct dt_lib_module_t *self);
   /** ID of timer for delayed callback */
   guint timeout_handle;
-
-  /** version */
-  int (*version)(void);
-  /** get name of the module, to be translated. */
-  const char *(*name)(struct dt_lib_module_t *self);
-  /** get the views which the module should be loaded in. */
-  const char **(*views)(struct dt_lib_module_t *self);
-  /** get the container which the module should be placed in */
-  uint32_t (*container)(struct dt_lib_module_t *self);
-  /** check if module should use a expander or not, default implementation
-      will make the module expandable and storing the expanding state,
-      if not the module will always be shown without the expander. */
-  int (*expandable)(struct dt_lib_module_t *self);
-
-  /** constructor */
-  void (*init)(struct dt_lib_module_t *self);
-  /** callback methods for gui. */
-  /** construct widget. */
-  void (*gui_init)(struct dt_lib_module_t *self);
-  /** destroy widget. */
-  void (*gui_cleanup)(struct dt_lib_module_t *self);
-  /** reset to defaults. */
-  void (*gui_reset)(struct dt_lib_module_t *self);
-
-  /** entering a view, only called if lib is displayed on the new view */
-  void (*view_enter)(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct dt_view_t *new_view);
-  /** entering a view, only called if lib is displayed on the old view */
-  void (*view_leave)(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct dt_view_t *new_view);
-
-  /** optional event callbacks for big center widget. */
-  /** optional method called after lighttable expose. */
-  void (*gui_post_expose)(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,
-                          int32_t pointerx, int32_t pointery);
-  int (*mouse_leave)(struct dt_lib_module_t *self);
-  int (*mouse_moved)(struct dt_lib_module_t *self, double x, double y, double pressure, int which);
-  int (*button_released)(struct dt_lib_module_t *self, double x, double y, int which, uint32_t state);
-  int (*button_pressed)(struct dt_lib_module_t *self, double x, double y, double pressure, int which,
-                        int type, uint32_t state);
-  int (*scrolled)(struct dt_lib_module_t *self, double x, double y, int up);
-  void (*configure)(struct dt_lib_module_t *self, int width, int height);
-  int (*position)(const struct dt_lib_module_t *self);
-  /** implement these three if you want customizable presets to be stored in db. */
-  /** legacy_params can run in iterations, just return to what version you updated the preset. */
-  void *(*legacy_params)(struct dt_lib_module_t *self, const void *const old_params,
-                         const size_t old_params_size, const int old_version, int *new_version, size_t *new_size);
-  void *(*get_params)(struct dt_lib_module_t *self, int *size);
-  int (*set_params)(struct dt_lib_module_t *self, const void *params, int size);
-  void (*init_presets)(struct dt_lib_module_t *self);
-  void (*manage_presets)(struct dt_lib_module_t *self);
-  void (*set_preferences)(void *menu, struct dt_lib_module_t *self);
-  /** Optional callbacks for keyboard accelerators */
-  void (*init_key_accels)(struct dt_lib_module_t *self);
-  void (*connect_key_accels)(struct dt_lib_module_t *self);
 
   GSList *accel_closures;
   GtkWidget *reset_button;

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -16,7 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "common/module_api.h"
+
+#ifdef FULL_API_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,71 +33,78 @@ struct dt_view_t;
 
 /* early definition of modules to do type checking */
 
-// !!! MUST BE KEPT IN SYNC WITH dt_lib_module_t defined in src/libs/lib.h !!!
-
 #pragma GCC visibility push(default)
 
-/** version */
-int version(void);
+#endif // FULL_API_H
+
 /** get name of the module, to be translated. */
-const char *name(struct dt_lib_module_t *self);
+REQUIRED(const char *, name, struct dt_lib_module_t *self);
 
 /** get the views which the module should be loaded in. */
-const char **views(struct dt_lib_module_t *self);
+REQUIRED(const char **, views, struct dt_lib_module_t *self);
 /** get the container which the module should be placed in */
-uint32_t container(struct dt_lib_module_t *self);
+REQUIRED(uint32_t, container, struct dt_lib_module_t *self);
 /** check if module should use a expander or not, default implementation
     will make the module expandable and storing the expanding state,
     if not the module will always be shown without the expander. */
-int expandable(struct dt_lib_module_t *self);
+DEFAULT(int, expandable, struct dt_lib_module_t *self);
 
 /** constructor */
-void init(struct dt_lib_module_t *self);
+OPTIONAL(void, init, struct dt_lib_module_t *self);
 /** callback methods for gui. */
 /** construct widget. */
-void gui_init(struct dt_lib_module_t *self);
+REQUIRED(void, gui_init, struct dt_lib_module_t *self);
 /** destroy widget. */
-void gui_cleanup(struct dt_lib_module_t *self);
+REQUIRED(void, gui_cleanup, struct dt_lib_module_t *self);
 /** reset to defaults. */
-void gui_reset(struct dt_lib_module_t *self);
+OPTIONAL(void, gui_reset, struct dt_lib_module_t *self);
 
 /** entering a view, only called if lib is displayed on the new view */
-void view_enter(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view);
+OPTIONAL(void, view_enter, struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view);
 /** entering a view, only called if lib is displayed on the old view */
-void view_leave(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view);
+OPTIONAL(void, view_leave, struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view);
 
 /** optional event callbacks for big center widget. */
 /** optional method called after lighttable expose. */
-void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,
+OPTIONAL(void, gui_post_expose, struct dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,
                      int32_t pointerx, int32_t pointery);
-int mouse_leave(struct dt_lib_module_t *self);
-int mouse_moved(struct dt_lib_module_t *self, double x, double y, double pressure, int which);
-int button_released(struct dt_lib_module_t *self, double x, double y, int which, uint32_t state);
-int button_pressed(struct dt_lib_module_t *self, double x, double y, double pressure, int which, int type,
+OPTIONAL(int, mouse_leave, struct dt_lib_module_t *self);
+OPTIONAL(int, mouse_moved, struct dt_lib_module_t *self, double x, double y, double pressure, int which);
+OPTIONAL(int, button_released, struct dt_lib_module_t *self, double x, double y, int which, uint32_t state);
+OPTIONAL(int, button_pressed, struct dt_lib_module_t *self, double x, double y, double pressure, int which, int type,
                    uint32_t state);
-int scrolled(struct dt_lib_module_t *self, double x, double y, int up);
-void configure(struct dt_lib_module_t *self, int width, int height);
-int position();
+OPTIONAL(int, scrolled, struct dt_lib_module_t *self, double x, double y, int up);
+OPTIONAL(void, configure, struct dt_lib_module_t *self, int width, int height);
+OPTIONAL(int, position, );
 
 /** implement these three if you want customizable presets to be stored in db. */
 /** legacy_params can run in iterations, just return to what version you updated the preset. */
-void *legacy_params(struct dt_lib_module_t *self, const void *const old_params, const size_t old_params_size,
+OPTIONAL(void *,legacy_params, struct dt_lib_module_t *self, const void *const old_params, const size_t old_params_size,
                     const int old_version, int *new_version, size_t *new_size);
-void *get_params(struct dt_lib_module_t *self, int *size);
-int set_params(struct dt_lib_module_t *self, const void *params, int size);
-void init_presets(struct dt_lib_module_t *self);
-void manage_presets(struct dt_lib_module_t *self);
-void set_preferences(void *menu, struct dt_lib_module_t *self);
+OPTIONAL(void *,get_params, struct dt_lib_module_t *self, int *size);
+OPTIONAL(int, set_params, struct dt_lib_module_t *self, const void *params, int size);
+OPTIONAL(void, init_presets, struct dt_lib_module_t *self);
+OPTIONAL(void, manage_presets, struct dt_lib_module_t *self);
+OPTIONAL(void, set_preferences, void *menu, struct dt_lib_module_t *self);
 
 /** Optional callbacks for keyboard accelerators */
-void init_key_accels(struct dt_lib_module_t *self);
-void connect_key_accels(struct dt_lib_module_t *self);
+OPTIONAL(void, init_key_accels, struct dt_lib_module_t *self);
+OPTIONAL(void, connect_key_accels, struct dt_lib_module_t *self);
+
+#undef OPTIONAL
+#undef REQUIRED
+#undef DEFAULT
+
+#ifdef FULL_API_H
 
 #pragma GCC visibility pop
 
 #ifdef __cplusplus
 }
 #endif
+
+#undef FULL_API_H
+#endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -91,10 +91,6 @@ OPTIONAL(void, set_preferences, void *menu, struct dt_lib_module_t *self);
 OPTIONAL(void, init_key_accels, struct dt_lib_module_t *self);
 OPTIONAL(void, connect_key_accels, struct dt_lib_module_t *self);
 
-#undef OPTIONAL
-#undef REQUIRED
-#undef DEFAULT
-
 #ifdef FULL_API_H
 
 #pragma GCC visibility pop
@@ -103,7 +99,6 @@ OPTIONAL(void, connect_key_accels, struct dt_lib_module_t *self);
 }
 #endif
 
-#undef FULL_API_H
 #endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -125,7 +125,8 @@ typedef struct dt_mouse_action_t
 struct dt_view_t;
 typedef struct dt_view_t
 {
-  // !!! MUST BE KEPT IN SYNC WITH src/views/view_api.h !!!
+#define INCLUDE_API_FROM_MODULE_H
+#include "views/view_api.h"
 
   char module_name[64];
   // dlopened module
@@ -137,39 +138,6 @@ typedef struct dt_view_t
   // scroll bar control
   float vscroll_size, vscroll_lower, vscroll_viewport_size, vscroll_pos;
   float hscroll_size, hscroll_lower, hscroll_viewport_size, hscroll_pos;
-  const char *(*name)(const struct dt_view_t *self); // get translatable name
-  uint32_t (*view)(const struct dt_view_t *self); // get the view type
-  uint32_t (*flags)();                            // get the view flags
-  void (*init)(struct dt_view_t *self);           // init *data
-  void (*gui_init)(struct dt_view_t *self);       // create gtk elements, called after libs are created
-  void (*cleanup)(struct dt_view_t *self);        // cleanup *data
-  void (*expose)(struct dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
-                 int32_t pointery);         // expose the module (gtk callback)
-  int (*try_enter)(struct dt_view_t *self); // test if enter can succeed.
-  void (*enter)(struct dt_view_t *self); // mode entered, this module got focus. return non-null on failure.
-  void (*leave)(struct dt_view_t *self); // mode left (is called after the new try_enter has succeeded).
-  void (*reset)(struct dt_view_t *self); // reset default appearance
-
-  // event callbacks:
-  void (*mouse_enter)(struct dt_view_t *self);
-  void (*mouse_leave)(struct dt_view_t *self);
-  void (*mouse_moved)(struct dt_view_t *self, double x, double y, double pressure, int which);
-
-  int (*button_released)(struct dt_view_t *self, double x, double y, int which, uint32_t state);
-  int (*button_pressed)(struct dt_view_t *self, double x, double y, double pressure, int which, int type,
-                        uint32_t state);
-  int (*key_pressed)(struct dt_view_t *self, guint key, guint state);
-  int (*key_released)(struct dt_view_t *self, guint key, guint state);
-  void (*configure)(struct dt_view_t *self, int width, int height);
-  void (*scrolled)(struct dt_view_t *self, double x, double y, int up, int state); // mouse scrolled in view
-  void (*scrollbar_changed)(struct dt_view_t *self, double x, double y); // scrollbar changed in view
-
-  // keyboard accel callbacks
-  void (*init_key_accels)(struct dt_view_t *self);
-  void (*connect_key_accels)(struct dt_view_t *self);
-
-  // list of mouse actions
-  GSList *(*mouse_actions)(const struct dt_view_t *self);
 
   GSList *accel_closures;
   GtkWidget *dynamic_accel_current;

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -16,7 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "common/module_api.h"
+
+#ifdef FULL_API_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,49 +32,58 @@ struct dt_view_t;
 
 /* early definition of modules to do type checking */
 
-// !!! MUST BE KEPT IN SYNC WITH dt_view_t defined in src/views/view.h !!!
-
 #pragma GCC visibility push(default)
 
-const char *name(const struct dt_view_t *self); // get translatable name
-uint32_t view(const struct dt_view_t *self); // get the view type
-uint32_t flags();                            // get flags of the view
-void init(struct dt_view_t *self);           // init *data
-void gui_init(struct dt_view_t *self);       // create gtk elements, called after libs are created
-void cleanup(struct dt_view_t *self);        // cleanup *data
-void expose(struct dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
-            int32_t pointery);         // expose the module (gtk callback)
-int try_enter(struct dt_view_t *self); // test if enter can succeed.
-void enter(struct dt_view_t *self);    // mode entered, this module got focus. return non-null on failure.
-void leave(struct dt_view_t *self);    // mode left (is called after the new try_enter has succeeded).
-void reset(struct dt_view_t *self);    // reset default appearance
+#endif // FULL_API_H
+
+OPTIONAL(const char *, name, const struct dt_view_t *self); // get translatable name
+OPTIONAL(uint32_t, view, const struct dt_view_t *self); // get the view type
+DEFAULT(uint32_t, flags, );                             // get flags of the view
+OPTIONAL(void, init, struct dt_view_t *self);           // init *data
+OPTIONAL(void, gui_init, struct dt_view_t *self);       // create gtk elements, called after libs are created
+OPTIONAL(void, cleanup, struct dt_view_t *self);        // cleanup *data
+OPTIONAL(void, expose, struct dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
+                       int32_t pointery);         // expose the module (gtk callback)
+OPTIONAL(int, try_enter, struct dt_view_t *self); // test if enter can succeed.
+OPTIONAL(void, enter, struct dt_view_t *self);    // mode entered, this module got focus. return non-null on failure.
+OPTIONAL(void, leave, struct dt_view_t *self);    // mode left (is called after the new try_enter has succeeded).
+OPTIONAL(void, reset, struct dt_view_t *self);    // reset default appearance
 
 // event callbacks:
-void mouse_enter(struct dt_view_t *self);
-void mouse_leave(struct dt_view_t *self);
-void mouse_moved(struct dt_view_t *self, double x, double y, double pressure, int which);
+OPTIONAL(void, mouse_enter, struct dt_view_t *self);
+OPTIONAL(void, mouse_leave, struct dt_view_t *self);
+OPTIONAL(void, mouse_moved, struct dt_view_t *self, double x, double y, double pressure, int which);
 
-int button_released(struct dt_view_t *self, double x, double y, int which, uint32_t state);
-int button_pressed(struct dt_view_t *self, double x, double y, double pressure, int which, int type,
-                   uint32_t state);
-int key_pressed(struct dt_view_t *self, guint key, guint state);
-int key_released(struct dt_view_t *self, guint key, guint state);
-void configure(struct dt_view_t *self, int width, int height);
-void scrolled(struct dt_view_t *self, double x, double y, int up, int state); // mouse scrolled in view
-void scrollbar_changed(struct dt_view_t *self, double x, double y); // scrollbars changed in view
+OPTIONAL(int, button_released, struct dt_view_t *self, double x, double y, int which, uint32_t state);
+OPTIONAL(int, button_pressed, struct dt_view_t *self, double x, double y, double pressure,
+                              int which, int type, uint32_t state);
+OPTIONAL(int, key_pressed, struct dt_view_t *self, guint key, guint state);
+OPTIONAL(int, key_released, struct dt_view_t *self, guint key, guint state);
+OPTIONAL(void, configure, struct dt_view_t *self, int width, int height);
+OPTIONAL(void, scrolled, struct dt_view_t *self, double x, double y, int up, int state); // mouse scrolled in view
+OPTIONAL(void, scrollbar_changed, struct dt_view_t *self, double x, double y); // scrollbars changed in view
 
 // keyboard accel callbacks
-void init_key_accels(struct dt_view_t *self);
-void connect_key_accels(struct dt_view_t *self);
+OPTIONAL(void, init_key_accels, struct dt_view_t *self);
+OPTIONAL(void, connect_key_accels, struct dt_view_t *self);
 
 // list of mouse actions
-GSList *mouse_actions(const struct dt_view_t *self);
+OPTIONAL(GSList *, mouse_actions, const struct dt_view_t *self);
+
+#undef OPTIONAL
+#undef REQUIRED
+#undef DEFAULT
+
+#ifdef FULL_API_H
 
 #pragma GCC visibility pop
 
 #ifdef __cplusplus
 }
 #endif
+
+#undef FULL_API_H
+#endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -70,10 +70,6 @@ OPTIONAL(void, connect_key_accels, struct dt_view_t *self);
 // list of mouse actions
 OPTIONAL(GSList *, mouse_actions, const struct dt_view_t *self);
 
-#undef OPTIONAL
-#undef REQUIRED
-#undef DEFAULT
-
 #ifdef FULL_API_H
 
 #pragma GCC visibility pop
@@ -82,7 +78,6 @@ OPTIONAL(GSList *, mouse_actions, const struct dt_view_t *self);
 }
 #endif
 
-#undef FULL_API_H
 #endif // FULL_API_H
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
For #8078 I'm intending to eventually introduce a new module type, input_method, initially with modules for keyboard, midi and gamepad, which besides processing the input will provide a gui for configuration.

This made me look at the way module apis are specified and the fragile interaction between the prototype function definitions which are included in all the module instances and the generic type definition for the module, which contains pointers to those functions, and thirdly the loading routine which looks up the functions in the compiled modules and stores pointers in the module structure. For iops there's a fourth place where each module instance gets its private copy of the generic module's function pointers.

All of these four places needed to be updated and kept in sync with any changes.

This PR proposes to replace that approach with one header file per module type that defines the API and is included in those 3 or 4 different locations where the applicable code for that location is generated. Adding a new method now only requires adding one line in that API header file (and possibly a default fallback function if required).

The function definition is not completely standard anymore. Instead of
`return_type function name(parameters);`
one now uses
`OPTIONAL(return_type, function name, parameters);`
if implementations are not required in each module. Or
`REQUIRED(return_type, function name, parameters);`
if a missing implementation should throw an error at load time. Or
`DEFAULT(return_type, function name, parameters);`
if a default implementation called `default_function_name` is provided that should be used if a module does not provide an implementation.

While this has the drawback of not allowing a direct copy from the _api.h file into a module (some minimal editing is required) it does offset this by immediately making clear which minimal set of methods needs to be implemented. And ensuring/enforcing everything is in sync. While working on this, the benefit already showed in highlighting three methods in iop_api.h that are actually not linked anymore at load time and the fact that the function
`const char *description(struct dt_iop_module_t *self)` quietly lost its _const_ during the loading process.

Exceptions to the standard approach are also more easy to spot, so for example it becomes clear that the treatment of 
`process_tiling_cl `when `darktable.opencl->inited` is FALSE is different from `process_cl`. I have not changed this as I cannot judge whether this is intentional or what the consequences of changing it might be.
