### PR TITLE
PoC Enabling the Base Media File Format support with Exiv2 0.27.4

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -4242,7 +4242,9 @@ void dt_exif_init()
   // preface the exiv2 messages with "[exiv2] "
   Exiv2::LogMsg::setHandler(&dt_exif_log_handler);
 
+#if EXIV2_TEST_VERSION(0,27,4)
   Exiv2::enableBMFF();
+#endif
 
   Exiv2::XmpParser::initialize();
   // this has to stay with the old url (namespace already propagated outside dt)

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -4242,6 +4242,8 @@ void dt_exif_init()
   // preface the exiv2 messages with "[exiv2] "
   Exiv2::LogMsg::setHandler(&dt_exif_log_handler);
 
+  Exiv2::enableBMFF();
+
   Exiv2::XmpParser::initialize();
   // this has to stay with the old url (namespace already propagated outside dt)
   Exiv2::XmpProperties::registerNs("http://darktable.sf.net/", "darktable");

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1333,7 +1333,7 @@ static const extraction_result_t _extract_patches(const float *const restrict in
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] /= (float)num_elem;
 
     // Convert to XYZ
-    float XYZ[3];
+    float XYZ[4];
     dot_product(patches + k * 4, RGB_to_XYZ, XYZ);
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] = XYZ[c];
   }
@@ -1416,11 +1416,11 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   convert_any_XYZ_to_LMS(D50_XYZ, D50_LMS, kind);
 
   // solve the equation to find the scene illuminant
-  float illuminant[3];
+  float illuminant[4];
   for(size_t c = 0; c < 3; c++) illuminant[c] = D50_LMS[c] * LMS_grey_test[c] / LMS_grey_ref[c];
 
   // convert back the illuminant to XYZ then xyY
-  float illuminant_XYZ[3], illuminant_xyY[3];
+  float illuminant_XYZ[4], illuminant_xyY[3];
   convert_any_LMS_to_XYZ(illuminant, illuminant_XYZ, kind);
   const float Y_illu = illuminant_XYZ[1];
   for(size_t c = 0; c < 3; c++) illuminant_XYZ[c] /= Y_illu;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1333,7 +1333,7 @@ static const extraction_result_t _extract_patches(const float *const restrict in
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] /= (float)num_elem;
 
     // Convert to XYZ
-    float XYZ[4];
+    float DT_ALIGNED_PIXEL XYZ[4];
     dot_product(patches + k * 4, RGB_to_XYZ, XYZ);
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] = XYZ[c];
   }


### PR DESCRIPTION
Extended arrays so compilation finishes even with the warnings treated as errors.
Fix for #8339