### PR TITLE
image_to_act_on : specify gui order for images

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -609,7 +609,7 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
   else
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
@@ -2454,7 +2454,7 @@ void dt_image_synch_xmp(const int selected)
   }
   else
   {
-    const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+    const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
     dt_image_synch_xmps(imgs);
   }
 }

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -588,7 +588,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
   {
     GList *imgs = NULL;
     if(imgid == -1)
-      imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+      imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
     else
       imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
     if(imgs)

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -50,7 +50,9 @@ void dt_selection_select_unaltered(struct dt_selection_t *selection);
 void dt_selection_select_list(struct dt_selection_t *selection, GList *list);
 /** selects a set of images from a list. the list is unaltered */
 const struct dt_collection_t *dt_selection_get_collection(struct dt_selection_t *selection);
-
+/** get the list of selected images */
+GList *dt_selection_get_list(struct dt_selection_t *selection, const gboolean only_visible,
+                             const gboolean ordering);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -98,7 +98,7 @@ void dt_style_item_free(gpointer data)
 static gboolean _apply_style_shortcut_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
                                                guint keyval, GdkModifierType modifier, gpointer data)
 {
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
   dt_styles_apply_to_list(data, imgs, FALSE);
   return TRUE;
 }

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -463,7 +463,7 @@ gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_
   gboolean res = FALSE;
   if(imgid == -1)
   {
-    imgs = (GList *)dt_view_get_images_to_act_on(!group_on, TRUE);
+    imgs = (GList *)dt_view_get_images_to_act_on(!group_on, TRUE, FALSE);
     res = dt_tag_attach_images(tagid, imgs, undo_on);
   }
   else
@@ -565,7 +565,7 @@ gboolean dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
   else
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
@@ -621,7 +621,7 @@ static char *_images_to_act_on_string(const gint imgid, uint32_t *nb)
   }
   else
   {
-    const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+    const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
     while(imgs)
     {
       images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -181,7 +181,7 @@ static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback ex
   }
   if(progress_type != PROGRESS_NONE)
     dt_control_job_add_progress(job, _(message), progress_type == PROGRESS_CANCELLABLE);
-  params->index = g_list_copy((GList *)dt_view_get_images_to_act_on(only_visible, TRUE));
+  params->index = g_list_copy((GList *)dt_view_get_images_to_act_on(only_visible, TRUE, FALSE));
 
   dt_control_job_set_params(job, params, dt_control_image_enumerator_cleanup);
 
@@ -1469,7 +1469,7 @@ static dt_job_t *_control_gpx_apply_job_create(const gchar *filename, int32_t fi
   if(filmid != -1)
     dt_control_image_enumerator_job_film_init(params, filmid);
   else if(!imgs)
-    params->index = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+    params->index = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
   else
     params->index = imgs;
   dt_control_gpx_apply_t *data = params->data;
@@ -2030,7 +2030,7 @@ static dt_job_t *dt_control_datetime_job_create(const long int offset, const cha
   if(imgs)
     params->index = imgs;
   else
-    params->index = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+    params->index = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
 
   dt_control_datetime_t *data = params->data;
   data->offset = offset;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1632,7 +1632,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
 
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
-  table->drag_list = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE));
+  table->drag_list = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE, TRUE));
 
 #ifdef HAVE_MAP
   dt_view_manager_t *vm = darktable.view_manager;
@@ -2176,7 +2176,7 @@ gboolean dt_thumbtable_set_offset_image(dt_thumbtable_t *table, const int imgid,
 static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                             GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE));
+  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE, FALSE));
   dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
 
   // if we are in darkroom we show a message as there might be no other indication
@@ -2218,7 +2218,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
 static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE));
+  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE, FALSE));
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
 
   // if we are in darkroom we show a message as there might be no other indication
@@ -2269,7 +2269,7 @@ static gboolean _accel_copy_parts(GtkAccelGroup *accel_group, GObject *accelerat
 static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
 
   dt_dev_undo_start_record(darktable.develop);
 
@@ -2286,7 +2286,7 @@ static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable,
 static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                    GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
 
   dt_dev_undo_start_record(darktable.develop);
 
@@ -2302,7 +2302,7 @@ static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *accelera
 static gboolean _accel_hist_discard(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                     GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+  GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
   const gboolean ret = dt_history_delete_on_list(imgs, TRUE);
   if(ret)
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -69,7 +69,7 @@ static void _update(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   const int act_on_any = imgs != NULL;
   const int act_on_one = g_list_is_singleton(imgs);
   const int act_on_mult = act_on_any && !act_on_one;
@@ -98,7 +98,7 @@ static void write_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 
 static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 {
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
   if(!imgs)
     return;
   const int act_on_any = imgs != NULL;  // list length > 0?
@@ -196,7 +196,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
   if(!imgs) return;  // do nothing if no images to be acted on
 
   const int missing = dt_history_compress_on_list(imgs);
@@ -249,7 +249,7 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   gint res = GTK_RESPONSE_YES;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
 
   if(dt_conf_get_bool("ask_before_discard"))
   {
@@ -292,7 +292,7 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
   dt_conf_set_int("plugins/lighttable/copy_history/pastemode", mode);
 
   /* copy history from previously copied image and past onto selection */
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
 
   if(dt_history_paste_on_list(imgs, TRUE))
   {
@@ -304,7 +304,7 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
 static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   /* copy history from previously copied image and past onto selection */
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
 
   // at the time the dialog is started, some signals are sent and this in turn call
   // back dt_view_get_images_to_act_on() which free list and create a new one. So we

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -181,7 +181,7 @@ static void _update(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   const dt_lib_export_t *d = (dt_lib_export_t *)self->data;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   const gboolean has_act_on = imgs != NULL;
 
   char *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
@@ -372,7 +372,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   gchar *icc_filename = dt_conf_get_string(CONFIG_PREFIX "iccprofile");
   dt_iop_color_intent_t icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent");
 
-  GList *list = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
+  GList *list = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, TRUE));
   dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, export_masks,
                     style, style_append, icc_type, icc_filename, icc_intent, d->metadata_export);
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -189,7 +189,7 @@ static void _update(dt_lib_module_t *self)
 {
   dt_lib_cancel_postponed_update(self);
   dt_lib_image_t *d = (dt_lib_image_t *)self->data;
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE, FALSE);
 
   const int act_on_any = imgs != NULL;              // list length > 0 ?
   const int act_on_one = g_list_is_singleton(imgs); // list length == 1 ?
@@ -315,7 +315,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   const gboolean geotag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags");
   const gboolean dttag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/tags");
   const int imageid = d->imageid;
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   if(imgs)
   {
     // for all the above actions, we don't use the grpu_on tag, as grouped images have already been added to image
@@ -695,7 +695,7 @@ void connect_key_accels(dt_lib_module_t *self)
 }
 
 #ifdef USE_LUA
-typedef struct 
+typedef struct
 {
   const char* key;
   dt_lib_module_t * self;
@@ -749,7 +749,7 @@ static int lua_register_action(lua_State *L)
 
   GtkWidget* button = gtk_button_new_with_label(key);
   const char * tooltip = lua_tostring(L, 3);
-  if(tooltip)  
+  if(tooltip)
   {
     gtk_widget_set_tooltip_text(button, tooltip);
   }
@@ -879,7 +879,7 @@ void init(struct dt_lib_module_t *self)
   lua_setfield(L, -2, "signal_handlers");
   lua_pop(L, 2);
 }
- 
+
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -140,7 +140,7 @@ static void _update(dt_lib_module_t *self)
   // using dt_metadata_get() is not possible here. we want to do all this in a single pass, everything else
   // takes ages.
   char *images = NULL;
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   while(imgs)
   {
     images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));
@@ -218,7 +218,7 @@ static void _write_metadata(dt_lib_module_t *self)
       _append_kv(&key_value, dt_metadata_get_key(keyid), metadata[i]);
   }
 
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   dt_metadata_set_list(imgs, key_value, TRUE);
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
@@ -334,7 +334,7 @@ void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
   d->editing = FALSE;
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   dt_metadata_clear(imgs, TRUE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   dt_image_synch_xmps(imgs);
@@ -937,7 +937,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
     if(metadata[i][0] != '\0') _append_kv(&key_value, dt_metadata_get_key(i), metadata[i]);
   }
 
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   dt_metadata_set_list(imgs, key_value, TRUE);
 
   g_list_free(key_value);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -217,7 +217,7 @@ static void _styles_row_activated_callback(GtkTreeView *view, GtkTreePath *path,
   gchar *name;
   gtk_tree_model_get(model, &iter, DT_STYLES_COL_FULLNAME, &name, -1);
 
-  const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
   if(name) dt_styles_apply_to_list(name, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
 }
 
@@ -253,7 +253,7 @@ static void apply_clicked(GtkWidget *w, gpointer user_data)
 
   if(style_names == NULL) return;
 
-  const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
 
   if(list) dt_multiple_styles_apply_to_list(style_names, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
 
@@ -264,7 +264,7 @@ static void create_clicked(GtkWidget *w, gpointer user_data)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
 
-  const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE);
+  const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
   dt_styles_create_from_list(list);
   _gui_styles_update_view(d);
 }
@@ -712,7 +712,7 @@ static gboolean entry_activated(GtkEntry *entry, gpointer user_data)
   const gchar *name = gtk_entry_get_text(d->entry);
   if(name)
   {
-    const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+    const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
     dt_styles_apply_to_list(name, imgs, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
   }
 
@@ -738,7 +738,7 @@ static void _update(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   dt_lib_styles_t *d = (dt_lib_styles_t *)self->data;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   const gboolean has_act_on = imgs != NULL;
 
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -148,7 +148,7 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   const gboolean has_act_on = imgs != NULL;
 
   const gint dict_tags_sel_cnt =
@@ -977,7 +977,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
       }
       g_strfreev(tokens);
       GList *tags_r = dt_tag_get_tags(-1, TRUE);
-      const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+      const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
       dt_tag_set_tags(tags, imgs, TRUE, TRUE, TRUE);
       gboolean change = FALSE;
       for(GList *tag = tags; tag; tag = g_list_next(tag))
@@ -1067,7 +1067,7 @@ static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_li
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   if(!imgs) return;
 
   GList *affected_images = dt_tag_get_images_from_list(imgs, tagid);
@@ -1273,7 +1273,7 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   const gchar *tag = gtk_entry_get_text(d->entry);
   if(!tag || tag[0] == '\0') return;
 
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   const gboolean res = dt_tag_attach_string_list(tag, imgs, TRUE);
   if(res) dt_image_synch_xmps(imgs);
 
@@ -3175,7 +3175,7 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
 
   if(d->last_tag)
   {
-    const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+    const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
     const gboolean res = dt_tag_attach_string_list(d->last_tag, imgs, TRUE);
     if(res) dt_image_synch_xmps(imgs);
     _init_treeview(self, 0);
@@ -3195,7 +3195,7 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
     return TRUE;  // doesn't work properly with tree treeview
   }
 
-  d->floating_tag_imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE));
+  d->floating_tag_imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(FALSE, TRUE, FALSE));
   gint x, y;
   gint px, py, w, h;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -100,7 +100,7 @@ void gui_cleanup(dt_lib_module_t *self)
 
 static void _lib_colorlabels_button_clicked_callback(GtkWidget *w, gpointer user_data)
 {
-  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(user_data), TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
                              g_list_copy((GList *)imgs));

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -188,7 +188,7 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   dt_lib_ratings_t *d = (dt_lib_ratings_t *)self->data;
   if(d->current > 0)
   {
-    const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
+    const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
     dt_ratings_apply_on_list(imgs, d->current, TRUE);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
                                g_list_copy((GList *)imgs));

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -78,7 +78,7 @@ static int hovered_cb(lua_State *L)
 static int act_on_cb(lua_State *L)
 {
   lua_newtable(L);
-  const GList *image = dt_view_get_images_to_act_on(FALSE, TRUE);
+  const GList *image = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   while(image)
   {
     luaA_push(L, dt_lua_image_t, &image->data);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1268,7 +1268,7 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
       dt_show_times(&start, "[map] dbscan calculation");
 
       // set the groups
-      const GList *sel_imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
+      const GList *sel_imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
       int group = -1;
       for(i = 0; i< img_count; i++)
       {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -757,7 +757,8 @@ static void _images_to_act_on_insert_in_list(GList **list, const int imgid, gboo
 }
 
 // get the list of images to act on during global changes (libs, accels)
-const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gboolean force)
+const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gboolean force,
+                                          const gboolean ordering)
 {
   /** Here's how it works
    *
@@ -771,12 +772,15 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
    *  the mouse can be outside thumbtable in case of filmstrip + mouse in center widget
    *
    *  if only_visible is FALSE, then it will add also not visible images because of grouping
+   *  force define if we try to use cache or not
+   *  if ordering is TRUE, we return the list in the gui order. Otherwise the order is undefined (but quicker)
    **/
 
   const int mouseover = dt_control_get_mouse_over_id();
 
   // if possible, we return the cached list
   if(!force && darktable.view_manager->act_on.ok && darktable.view_manager->act_on.image_over == mouseover
+     && darktable.view_manager->act_on.ordering == ordering
      && darktable.view_manager->act_on.inside_table == dt_ui_thumbtable(darktable.gui->ui)->mouse_inside
      && g_slist_length(darktable.view_manager->act_on.active_imgs)
             == g_slist_length(darktable.view_manager->active_images))
@@ -825,49 +829,14 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
 
         // first, we try to return cached list if we wher already
         // inside sel and the selection has not changed
-        if(!force
-           && darktable.view_manager->act_on.ok
-           && darktable.view_manager->act_on.image_over_inside_sel
-           && darktable.view_manager->act_on.inside_table)
+        if(!force && darktable.view_manager->act_on.ok && darktable.view_manager->act_on.image_over_inside_sel
+           && darktable.view_manager->act_on.inside_table && darktable.view_manager->act_on.ordering == ordering)
         {
           return darktable.view_manager->act_on.images;
         }
 
-        if(only_visible)
-        {
-          // we don't want to get image hidden because of grouping
-          DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                      "SELECT DISTINCT m.imgid"
-                                      " FROM memory.collected_images as m"
-                                      " WHERE m.imgid IN (SELECT s.imgid FROM main.selected_images as s)"
-                                      " ORDER BY m.rowid",
-                                      -1, &stmt, NULL);
-        }
-        else
-        {
-          // we need to get hidden grouped images too, and the
-          // selection already contains them, but not in right order,
-          // so we base the query directly on main request
-          gchar *qq = dt_util_dstrcat(
-              NULL,
-              "SELECT DISTINCT ng.id"
-              " FROM (%s) AS ng"
-              " WHERE ng.id IN (SELECT s.imgid FROM main.selected_images as s)",
-              dt_collection_get_query_no_group(dt_selection_get_collection(darktable.selection)));
-          DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), qq, -1, &stmt, NULL);
-          g_free(qq);
-        }
-
-        while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
-        {
-          // we don't use _images_to_act_on_insert_in_list for
-          // performance reason and because the query already take
-          // care of eventual duplicates
-          l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
-        }
-        // put back the list in right order as we have prepend items for perf reasons
-        l = g_list_reverse(l);
-        if(stmt) sqlite3_finalize(stmt);
+        // we return the list of the selection
+        l = dt_selection_get_list(darktable.selection, only_visible, ordering);
       }
       else
       {
@@ -902,26 +871,14 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
     else
     {
       // collumn 4
-      sqlite3_stmt *stmt;
-      DT_DEBUG_SQLITE3_PREPARE_V2
-        (dt_database_get(darktable.db),
-         "SELECT DISTINCT m.imgid"
-         " FROM memory.collected_images as m"
-         " WHERE m.imgid IN (SELECT s.imgid FROM main.selected_images as s)"
-         " ORDER BY m.rowid DESC", -1, &stmt, NULL);
-      while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
-      {
-        // we don't use _images_to_act_on_insert_in_list for
-        // performance reason and because the query already take care
-        // of eventual duplicates
-        l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
-      }
-      if(stmt) sqlite3_finalize(stmt);
+      // we return the list of the selection
+      l = dt_selection_get_list(darktable.selection, only_visible, ordering);
     }
   }
 
   // let's register the new list as cached
   darktable.view_manager->act_on.image_over_inside_sel = inside_sel;
+  darktable.view_manager->act_on.ordering = ordering;
   darktable.view_manager->act_on.image_over = mouseover;
   g_list_free(darktable.view_manager->act_on.images);
   darktable.view_manager->act_on.images = l;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -193,7 +193,8 @@ typedef enum dt_view_image_over_t
 
 // get images to act on for gloabals change (via libs or accels)
 // no need to free the list - done internally
-const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gboolean force);
+const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gboolean force,
+                                          const gboolean ordering);
 // get the main image to act on during global changes (libs, accels)
 int dt_view_get_image_to_act_on();
 
@@ -241,6 +242,7 @@ typedef struct dt_view_manager_t
     gboolean inside_table;
     GSList *active_imgs;
     gboolean image_over_inside_sel;
+    gboolean ordering;
   } act_on;
 
   /* reusable db statements


### PR DESCRIPTION
with recent changes, in the case dt_get_imges_to_act_on should return the selection with hidden images, the images where ordered by imgid and not by the gui order.
In most cases, this is not a problem as this is used to do actions on images where order doesn't matter, but for consistency with other return of dt_get_images_to_act_on and in case someone develop a feature which need the right order, it's better to do it correctly :)

In term of perfs, I have a slowdown of about x1.5 but considering the new timings, this is not really a problem (from 0.12s to 0.18s here with full collection of 95K images selected)