### PR TITLE
Invert parametric mask when needed on reset

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -714,6 +714,28 @@ static void _blendop_blendif_sliders_callback(GtkDarktableGradientSlider *slider
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
 }
 
+static void _blendop_blendif_sliders_reset_callback(GtkDarktableGradientSlider *slider,
+                                                    dt_iop_gui_blend_data_t *data)
+{
+  if(darktable.gui->reset) return;
+
+  dt_develop_blend_params_t *bp = data->module->blend_params;
+
+  const dt_iop_gui_blendif_channel_t *channel = &data->channel[data->tab];
+
+  const int in_out = (slider == data->filter[1].slider) ? 1 : 0;
+  dt_develop_blendif_channels_t ch = channel->param_channels[in_out];
+
+  // invert the parametric mask if needed
+  if(bp->mask_combine & DEVELOP_COMBINE_INCL)
+    bp->blendif |= (1 << (16 + ch));
+  else
+    bp->blendif &= ~(1 << (16 + ch));
+
+  dt_dev_add_history_item(darktable.develop, data->module, TRUE);
+  _blendop_blendif_update_tab(data->module, data->tab);
+}
+
 static void _blendop_blendif_polarity_callback(GtkToggleButton *togglebutton, dt_iop_gui_blend_data_t *data)
 {
   if(darktable.gui->reset) return;
@@ -2137,6 +2159,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_widget_set_tooltip_text(GTK_WIDGET(sl->head), _(slider_tooltip[in_out]));
 
       g_signal_connect(G_OBJECT(sl->slider), "value-changed", G_CALLBACK(_blendop_blendif_sliders_callback), bd);
+      g_signal_connect(G_OBJECT(sl->slider), "value-reset", G_CALLBACK(_blendop_blendif_sliders_reset_callback), bd);
       g_signal_connect(G_OBJECT(sl->slider), "leave-notify-event", G_CALLBACK(_blendop_blendif_leave), module);
       g_signal_connect(G_OBJECT(sl->slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
       g_signal_connect(G_OBJECT(sl->slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -51,6 +51,7 @@ static gboolean _gradient_slider_key_press_event(GtkWidget *widget, GdkEventKey 
 enum
 {
   VALUE_CHANGED,
+  VALUE_RESET,
   LAST_SIGNAL
 };
 
@@ -301,6 +302,7 @@ static gboolean _gradient_slider_button_press(GtkWidget *widget, GdkEventButton 
     for(int k = 0; k < gslider->positions; k++) gslider->position[k] = gslider->resetvalue[k];
     gtk_widget_queue_draw(widget);
     g_signal_emit_by_name(G_OBJECT(widget), "value-changed");
+    g_signal_emit_by_name(G_OBJECT(widget), "value-reset");
   }
   else if((event->button == 1 || event->button == 3) && event->type == GDK_BUTTON_PRESS)
   {
@@ -471,6 +473,8 @@ static void _gradient_slider_class_init(GtkDarktableGradientSliderClass *klass)
 
   _signals[VALUE_CHANGED] = g_signal_new("value-changed", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
                                          NULL, NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
+  _signals[VALUE_RESET] = g_signal_new("value-reset", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
+                                       NULL, NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
 }
 
 static void _gradient_slider_init(GtkDarktableGradientSlider *gslider)


### PR DESCRIPTION
When a parametric mask channel is reset (and thus disabled), it may need to be inverted to be considered as a no-operation.

This is a proposition to improve the reset as described in https://github.com/darktable-org/darktable/pull/8248#issuecomment-781683323

As I'm not very proficient in GTK programming, @dterrahe, could you have a look to see if this is implemented in the right way? Thanks in advance!