### PR TITLE
masks: refactor/optimize dt_masks_dynbuf_*

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -493,6 +493,20 @@ void dt_masks_dynbuf_add(dt_masks_dynbuf_t *a, float value)
 }
 
 static inline
+void dt_masks_dynbuf_add_2(dt_masks_dynbuf_t *a, float value1, float value2)
+{
+  assert(a != NULL);
+  assert(a->pos <= a->size);
+  if(__builtin_expect(a->pos + 2 >= a->size, 0))
+  {
+    if (a->size == 0 || !_dt_masks_dynbuf_growto(a, 2 * (a->size+1)))
+      return;
+  }
+  a->buffer[a->pos++] = value1;
+  a->buffer[a->pos++] = value2;
+}
+
+static inline
 void dt_masks_dynbuf_add_n(dt_masks_dynbuf_t *a, float* values, const int n)
 {
   assert(a != NULL);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -506,25 +506,6 @@ void dt_masks_dynbuf_add_2(dt_masks_dynbuf_t *a, float value1, float value2)
   a->buffer[a->pos++] = value2;
 }
 
-static inline
-void dt_masks_dynbuf_add_n(dt_masks_dynbuf_t *a, float* values, const int n)
-{
-  assert(a != NULL);
-  assert(a->pos <= a->size);
-  if(__builtin_expect(a->pos + n >= a->size, 0))
-  {
-    if(a->size == 0) return;
-    size_t newsize = a->size;
-    while(a->pos + n >= newsize) newsize *= 2;
-    if (!_dt_masks_dynbuf_growto(a, newsize))
-    {
-      return;
-    }
-  }
-  memcpy(a->buffer + a->pos, values, n * sizeof(float));
-  a->pos += n;
-}
-
 // Return a pointer to N floats past the current end of the dynbuf's contents, marking them as already in use.
 // The caller should then fill in the reserved elements using the returned pointer.
 static inline

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -435,6 +435,28 @@ void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_t 
                                  dt_masks_form_gui_t *gui);
 
 /** code for dynamic handling of intermediate buffers */
+static inline gboolean _dt_masks_dynbuf_growto(dt_masks_dynbuf_t *a, size_t size)
+{
+  const size_t newsize = dt_round_size_sse(sizeof(float) * size) / sizeof(float);
+  float *newbuf = dt_alloc_align_float(newsize);
+  if (!newbuf)
+  {
+    // not much we can do here except emit an error message
+    fprintf(stderr, "critical: out of memory for dynbuf '%s' with size request %zu!\n", a->tag, size);
+    return FALSE;
+  }
+  if (a->buffer)
+  {
+    memcpy(newbuf, a->buffer, a->size * sizeof(float));
+    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n", a->tag,
+             (unsigned long)a->size, newbuf, a->buffer);
+    dt_free_align(a->buffer);
+  }
+  a->size = newsize;
+  a->buffer = newbuf;
+  return TRUE;
+}
+
 static inline
 dt_masks_dynbuf_t *dt_masks_dynbuf_init(size_t size, const char *tag)
 {
@@ -445,11 +467,9 @@ dt_masks_dynbuf_t *dt_masks_dynbuf_init(size_t size, const char *tag)
   {
     g_strlcpy(a->tag, tag, sizeof(a->tag)); //only for debugging purposes
     a->pos = 0;
-    const size_t bufsize = dt_round_size_sse(sizeof(float) * size);
-    a->size = bufsize / sizeof(float);
-    a->buffer = dt_alloc_align_float(a->size);
-    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)\n", a->tag,
-             (unsigned long)a->size, a->buffer);
+    if(_dt_masks_dynbuf_growto(a, size))
+      dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)\n", a->tag,
+               (unsigned long)a->size, a->buffer);
     if(a->buffer == NULL)
     {
       free(a);
@@ -464,26 +484,10 @@ void dt_masks_dynbuf_add(dt_masks_dynbuf_t *a, float value)
 {
   assert(a != NULL);
   assert(a->pos <= a->size);
-  if(a->pos == a->size)
+  if(__builtin_expect(a->pos == a->size, 0))
   {
-    if(a->size == 0) return;
-    float *oldbuffer = a->buffer;
-    size_t oldsize = a->size;
-    a->size *= 2;
-    a->buffer = dt_alloc_align_float(a->size);
-    if(a->buffer == NULL)
-    {
-      // not much we can do here except of emitting an error message
-      fprintf(stderr, "critical: out of memory for dynbuf '%s' with size request %lu!\n", a->tag,
-              (unsigned long)a->size);
-      a->size = oldsize;
-      a->buffer = oldbuffer;
+    if (a->size == 0 || !_dt_masks_dynbuf_growto(a, 2 * a->size))
       return;
-    }
-    memcpy(a->buffer, oldbuffer, oldsize * sizeof(float));
-    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n", a->tag,
-             (unsigned long)a->size, a->buffer, oldbuffer);
-    dt_free_align(oldbuffer);
   }
   a->buffer[a->pos++] = value;
 }
@@ -493,28 +497,37 @@ void dt_masks_dynbuf_add_n(dt_masks_dynbuf_t *a, float* values, const int n)
 {
   assert(a != NULL);
   assert(a->pos <= a->size);
-  if(a->pos + n >= a->size)
+  if(__builtin_expect(a->pos + n >= a->size, 0))
   {
     if(a->size == 0) return;
-    float *oldbuffer = a->buffer;
-    size_t oldsize = a->size;
-    while(a->pos + n >= a->size) a->size *= 2;
-    a->buffer = (float *)dt_alloc_align(64, a->size * sizeof(float));
-    if(a->buffer == NULL)
+    size_t newsize = a->size;
+    while(a->pos + n >= newsize) newsize *= 2;
+    if (!_dt_masks_dynbuf_growto(a, newsize))
     {
-      // not much we can do here except of emitting an error message
-      fprintf(stderr, "critical: out of memory for dynbuf '%s' with size request %lu!\n", a->tag,
-              (unsigned long)a->size);
-      a->size = oldsize;
-      a->buffer = oldbuffer;
       return;
     }
-    memcpy(a->buffer, oldbuffer, oldsize * sizeof(float));
-    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n", a->tag,
-             (unsigned long)a->size, a->buffer, oldbuffer);
-    dt_free_align(oldbuffer);
   }
   memcpy(a->buffer + a->pos, values, n * sizeof(float));
+  a->pos += n;
+}
+
+static inline
+void dt_masks_dynbuf_add_zeros(dt_masks_dynbuf_t *a, float* values, const int n)
+{
+  assert(a != NULL);
+  assert(a->pos <= a->size);
+  if(__builtin_expect(a->pos + n >= a->size, 0))
+  {
+    if(a->size == 0) return;
+    size_t newsize = a->size;
+    while(a->pos + n >= newsize) newsize *= 2;
+    if (!_dt_masks_dynbuf_growto(a, newsize))
+    {
+      return;
+    }
+  }
+  // now that we've ensured a sufficiently large buffer add N zeros to the end of the existing data
+  memset(a->buffer + a->pos, 0, n * sizeof(float));
   a->pos += n;
 }
 

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -512,7 +512,7 @@ void dt_masks_dynbuf_add_n(dt_masks_dynbuf_t *a, float* values, const int n)
 }
 
 static inline
-void dt_masks_dynbuf_add_zeros(dt_masks_dynbuf_t *a, float* values, const int n)
+void dt_masks_dynbuf_add_zeros(dt_masks_dynbuf_t *a, const int n)
 {
   assert(a != NULL);
   assert(a->pos <= a->size);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -511,6 +511,29 @@ void dt_masks_dynbuf_add_n(dt_masks_dynbuf_t *a, float* values, const int n)
   a->pos += n;
 }
 
+// Return a pointer to N floats past the current end of the dynbuf's contents, marking them as already in use.
+// The caller should then fill in the reserved elements using the returned pointer.
+static inline
+float *dt_masks_dynbuf_reserve_n(dt_masks_dynbuf_t *a, const int n)
+{
+  assert(a != NULL);
+  assert(a->pos <= a->size);
+  if(__builtin_expect(a->pos + n >= a->size, 0))
+  {
+    if(a->size == 0) return NULL;
+    size_t newsize = a->size;
+    while(a->pos + n >= newsize) newsize *= 2;
+    if (!_dt_masks_dynbuf_growto(a, newsize))
+    {
+      return NULL;
+    }
+  }
+  // get the current end of the (possibly reallocated) buffer, then mark the next N items as in-use
+  float *reserved = a->buffer + a->pos;
+  a->pos += n;
+  return reserved;
+}
+
 static inline
 void dt_masks_dynbuf_add_zeros(dt_masks_dynbuf_t *a, const int n)
 {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -503,7 +503,7 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
   {
     rpoints[0] = points_max[0];
     rpoints[1] = points_max[1];
-    dt_masks_dynbuf_add_n(dpoints, rpoints, 2);
+    dt_masks_dynbuf_add_2(dpoints, rpoints[0], rpoints[1]);
 
     if(withborder)
     {
@@ -526,7 +526,7 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
 
       rborder[0] = border_max[0];
       rborder[1] = border_max[1];
-      dt_masks_dynbuf_add_n(dborder, rborder, 2);
+      dt_masks_dynbuf_add_2(dborder, rborder[0], rborder[1]);
     }
 
     if(withpayload)
@@ -535,7 +535,7 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
       {
         rpayload[0] = p1[5] + tmax * (p2[5] - p1[5]);
         rpayload[1] = p1[6] + tmax * (p2[6] - p1[6]);
-        dt_masks_dynbuf_add_n(dpayload, rpayload, 2);
+        dt_masks_dynbuf_add_2(dpayload, rpayload[0], rpayload[1]);
       }
     }
 
@@ -786,11 +786,11 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
 
     _brush_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax, rc, rb, rp, dpoints, dborder, dpayload);
 
-    dt_masks_dynbuf_add_n(dpoints, rc, 2);
+    dt_masks_dynbuf_add_2(dpoints, rc[0], rc[1]);
 
     if(dpayload)
     {
-      dt_masks_dynbuf_add_n(dpayload, rp, 2);
+      dt_masks_dynbuf_add_2(dpayload, rp[0], rp[1]);
     }
 
     if(dborder)
@@ -805,7 +805,7 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
         rb[0] = dt_masks_dynbuf_get(dborder, -2);
         rb[1] = dt_masks_dynbuf_get(dborder, -1);
       }
-      dt_masks_dynbuf_add_n(dborder, rb, 2);
+      dt_masks_dynbuf_add_2(dborder, rb[0], rb[1]);
     }
 
     // we first want to be sure that there are no gaps in border
@@ -830,7 +830,7 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     {
       while(dt_masks_dynbuf_position(dpayload) < dt_masks_dynbuf_position(dpoints))
       {
-        dt_masks_dynbuf_add_n(dpayload, rp, 2);
+        dt_masks_dynbuf_add_2(dpayload, rp[0], rp[1]);
       }
     }
   }
@@ -1215,12 +1215,9 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       if(!gui->guipoints) return 1;
       if(!gui->guipoints_payload) gui->guipoints_payload = dt_masks_dynbuf_init(400000, "brush guipoints_payload");
       if(!gui->guipoints_payload) return 1;
-      dt_masks_dynbuf_add(gui->guipoints, pzx * wd);
-      dt_masks_dynbuf_add(gui->guipoints, pzy * ht);
-      dt_masks_dynbuf_add(gui->guipoints_payload, masks_border);
-      dt_masks_dynbuf_add(gui->guipoints_payload, masks_hardness);
-      dt_masks_dynbuf_add(gui->guipoints_payload, masks_density);
-      dt_masks_dynbuf_add(gui->guipoints_payload, pressure);
+      dt_masks_dynbuf_add_2(gui->guipoints, pzx * wd, pzy * ht);
+      dt_masks_dynbuf_add_2(gui->guipoints_payload, masks_border, masks_hardness);
+      dt_masks_dynbuf_add_2(gui->guipoints_payload, masks_density, pressure);
 
       gui->guipoints_count = 1;
 
@@ -1532,16 +1529,13 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         // add a helper node very close to the single spot
         const float x = dt_masks_dynbuf_get(gui->guipoints, -2) + 0.01f;
         const float y = dt_masks_dynbuf_get(gui->guipoints, -1) - 0.01f;
-        dt_masks_dynbuf_add(gui->guipoints, x);
-        dt_masks_dynbuf_add(gui->guipoints, y);
+        dt_masks_dynbuf_add_2(gui->guipoints, x, y);
         const float border = dt_masks_dynbuf_get(gui->guipoints_payload, -4);
         const float hardness = dt_masks_dynbuf_get(gui->guipoints_payload, -3);
         const float density = dt_masks_dynbuf_get(gui->guipoints_payload, -2);
         const float pressure = dt_masks_dynbuf_get(gui->guipoints_payload, -1);
-        dt_masks_dynbuf_add(gui->guipoints_payload, border);
-        dt_masks_dynbuf_add(gui->guipoints_payload, hardness);
-        dt_masks_dynbuf_add(gui->guipoints_payload, density);
-        dt_masks_dynbuf_add(gui->guipoints_payload, pressure);
+        dt_masks_dynbuf_add_2(gui->guipoints_payload, border, hardness);
+        dt_masks_dynbuf_add_2(gui->guipoints_payload, density, pressure);
         gui->guipoints_count++;
       }
 
@@ -1877,15 +1871,13 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
   {
     if(gui->guipoints)
     {
-      dt_masks_dynbuf_add(gui->guipoints, pzx * darktable.develop->preview_pipe->backbuf_width);
-      dt_masks_dynbuf_add(gui->guipoints, pzy * darktable.develop->preview_pipe->backbuf_height);
+      dt_masks_dynbuf_add_2(gui->guipoints, pzx * darktable.develop->preview_pipe->backbuf_width,
+                            pzy * darktable.develop->preview_pipe->backbuf_height);
       const float border = dt_masks_dynbuf_get(gui->guipoints_payload, -4);
       const float hardness = dt_masks_dynbuf_get(gui->guipoints_payload, -3);
       const float density = dt_masks_dynbuf_get(gui->guipoints_payload, -2);
-      dt_masks_dynbuf_add(gui->guipoints_payload, border);
-      dt_masks_dynbuf_add(gui->guipoints_payload, hardness);
-      dt_masks_dynbuf_add(gui->guipoints_payload, density);
-      dt_masks_dynbuf_add(gui->guipoints_payload, pressure);
+      dt_masks_dynbuf_add_2(gui->guipoints_payload, border, hardness);
+      dt_masks_dynbuf_add_2(gui->guipoints_payload, density, pressure);
       gui->guipoints_count++;
     }
     dt_control_queue_redraw_center();

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -608,29 +608,13 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
   // for the border, we store value too
   if(dborder)
   {
-    for(int k = 0; k < nb; k++)
-    {
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-    }
+    dt_masks_dynbuf_add_zeros(dborder, 6 * nb);  // we need six zeros for each border point
   }
 
   // for the payload, we reserve an equivalent number of cells to keep it in sync
   if(dpayload)
   {
-    for(int k = 0; k < nb; k++)
-    {
-      dt_masks_dynbuf_add(dpayload, 0.0f);
-      dt_masks_dynbuf_add(dpayload, 0.0f);
-      dt_masks_dynbuf_add(dpayload, 0.0f);
-      dt_masks_dynbuf_add(dpayload, 0.0f);
-      dt_masks_dynbuf_add(dpayload, 0.0f);
-      dt_masks_dynbuf_add(dpayload, 0.0f);
-    }
+    dt_masks_dynbuf_add_zeros(dpayload, 6 * nb); // we need six zeros for each border point
   }
 
   int cw = 1;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -365,13 +365,22 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
   float incrr = (r2 - r1) / l;
   float rr = r1 + incrr;
   float aa = a1 + incra;
-  for(int i = 1; i < l; i++)
+  // allocate entries in the dynbufs
+  float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
+  float *dborder_ptr = dt_masks_dynbuf_reserve_n(dborder, 2*(l-1));
+  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
+  //  successive angular positions for dborder
+  if (dpoints_ptr && dborder_ptr)
   {
-    dt_masks_dynbuf_add_n(dpoints, cmax, 2);
-    dt_masks_dynbuf_add(dborder, cmax[0] + rr * cosf(aa));
-    dt_masks_dynbuf_add(dborder, cmax[1] + rr * sinf(aa));
-    rr += incrr;
-    aa += incra;
+    for(int i = 1; i < l; i++)
+    {
+      *dpoints_ptr++ = cmax[0];
+      *dpoints_ptr++ = cmax[1];
+      *dborder_ptr++ = cmax[0] + rr * cosf(aa);
+      *dborder_ptr++ = cmax[1] + rr * sinf(aa);
+      rr += incrr;
+      aa += incra;
+    }
   }
 }
 
@@ -404,13 +413,22 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
   float incrr = (r2 - r1) / l;
   float rr = r1 + incrr;
   float aa = a1 + incra;
-  for(int i = 1; i < l; i++)
+  // allocate entries in the dynbufs
+  float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
+  float *dborder_ptr = dt_masks_dynbuf_reserve_n(dborder, 2*(l-1));
+  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
+  //  successive angular positions for dborder
+  if (dpoints_ptr && dborder_ptr)
   {
-    dt_masks_dynbuf_add_n(dpoints, cmax, 2);
-    dt_masks_dynbuf_add(dborder, cmax[0] + rr * cosf(aa));
-    dt_masks_dynbuf_add(dborder, cmax[1] + rr * sinf(aa));
-    rr += incrr;
-    aa += incra;
+    for(int i = 1; i < l; i++)
+    {
+      *dpoints_ptr++ = cmax[0];
+      *dpoints_ptr++ = cmax[1];
+      *dborder_ptr++ = cmax[0] + rr * cosf(aa);
+      *dborder_ptr++ = cmax[1] + rr * sinf(aa);
+      rr += incrr;
+      aa += incra;
+    }
   }
 }
 
@@ -433,12 +451,21 @@ static void _brush_points_stamp(float *cmax, float *bmin, dt_masks_dynbuf_t *dpo
   // and now we add the points
   float incra = 2.0f * M_PI / l;
   float aa = a1 + incra;
-  for(int i = 0; i < l; i++)
+  // allocate entries in the dynbufs
+  float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
+  float *dborder_ptr = dt_masks_dynbuf_reserve_n(dborder, 2*(l-1));
+  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
+  //  successive angular positions for dborder
+  if (dpoints_ptr && dborder_ptr)
   {
-    dt_masks_dynbuf_add_n(dpoints, cmax, 2);
-    dt_masks_dynbuf_add(dborder, cmax[0] + rad * cosf(aa));
-    dt_masks_dynbuf_add(dborder, cmax[1] + rad * sinf(aa));
-    aa += incra;
+    for(int i = 0; i < l; i++)
+    {
+      *dpoints_ptr++ = cmax[0];
+      *dpoints_ptr++ = cmax[1];
+      *dborder_ptr++ = cmax[0] + rad * cosf(aa);
+      *dborder_ptr++ = cmax[1] + rad * sinf(aa);
+      aa += incra;
+    }
   }
 }
 
@@ -594,13 +621,17 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
 
   for(GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
   {
-    dt_masks_point_brush_t *pt = (dt_masks_point_brush_t *)form_points->data;
-    dt_masks_dynbuf_add(dpoints, pt->ctrl1[0] * wd - dx);
-    dt_masks_dynbuf_add(dpoints, pt->ctrl1[1] * ht - dy);
-    dt_masks_dynbuf_add(dpoints, pt->corner[0] * wd - dx);
-    dt_masks_dynbuf_add(dpoints, pt->corner[1] * ht - dy);
-    dt_masks_dynbuf_add(dpoints, pt->ctrl2[0] * wd - dx);
-    dt_masks_dynbuf_add(dpoints, pt->ctrl2[1] * ht - dy);
+    const dt_masks_point_brush_t *const pt = (dt_masks_point_brush_t *)form_points->data;
+    float *const buf = dt_masks_dynbuf_reserve_n(dpoints, 6);
+    if (buf)
+    {
+      buf[0] = pt->ctrl1[0] * wd - dx;
+      buf[1] = pt->ctrl1[1] * ht - dy;
+      buf[2] = pt->corner[0] * wd - dx;
+      buf[3] = pt->corner[1] * ht - dy;
+      buf[4] = pt->ctrl2[0] * wd - dx;
+      buf[5] = pt->ctrl2[1] * ht - dy;
+    }
   }
 
   const guint nb = g_list_length(form->points);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -728,7 +728,7 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
         {
           while(dt_masks_dynbuf_position(dpayload) < dt_masks_dynbuf_position(dpoints))
           {
-            dt_masks_dynbuf_add_n(dpayload, p1 + 5, 2);
+            dt_masks_dynbuf_add_2(dpayload, p1[5], p1[6]);
           }
         }
       }
@@ -749,7 +749,7 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
       {
         while(dt_masks_dynbuf_position(dpayload) < dt_masks_dynbuf_position(dpoints))
         {
-          dt_masks_dynbuf_add_n(dpayload, p1 + 5, 2);
+          dt_masks_dynbuf_add_2(dpayload, p1[5], p1[6]);
         }
       }
     }
@@ -769,7 +769,7 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
       {
         while(dt_masks_dynbuf_position(dpayload) < dt_masks_dynbuf_position(dpoints))
         {
-          dt_masks_dynbuf_add_n(dpayload, p1 + 5, 2);
+          dt_masks_dynbuf_add_2(dpayload, p1[5], p1[6]);
         }
       }
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -998,7 +998,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   double start1 = 0.0;
   double start2 = start1;
 
-  if(darktable.unmuted & DT_DEBUG_PERF) start1 = dt_get_wtime();
+  if(darktable.unmuted & DT_DEBUG_PERF) start2 = start1 = dt_get_wtime();
 
   // we get the circle parameters
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1731,7 +1731,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 {
   double start1 = 0.0;
   double start2 = start1;
-  if(darktable.unmuted & DT_DEBUG_PERF) start1 = dt_get_wtime();
+  if(darktable.unmuted & DT_DEBUG_PERF) start2 = start1 = dt_get_wtime();
 
   // we get the ellipse parameters
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)(g_list_first(form->points)->data);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -186,8 +186,7 @@ static gboolean _path_is_clockwise(dt_masks_form_t *form)
 static int _path_fill_gaps(int lastx, int lasty, int x, int y, dt_masks_dynbuf_t *points)
 {
   dt_masks_dynbuf_reset(points);
-  dt_masks_dynbuf_add(points, x);
-  dt_masks_dynbuf_add(points, y);
+  dt_masks_dynbuf_add_2(points, x, y);
 
   // now we want to be sure everything is continuous
   if(x - lastx > 1)
@@ -200,20 +199,17 @@ static int _path_fill_gaps(int lastx, int lasty, int x, int y, dt_masks_dynbuf_t
       {
         for(int jj = lasty2 + 1; jj < yyy; jj++)
         {
-          dt_masks_dynbuf_add(points, j);
-          dt_masks_dynbuf_add(points, jj);
+          dt_masks_dynbuf_add_2(points, j, jj);
         }
       }
       else if(lasty2 - yyy < -1)
       {
         for(int jj = lasty2 - 1; jj > yyy; jj--)
         {
-          dt_masks_dynbuf_add(points, j);
-          dt_masks_dynbuf_add(points, jj);
+          dt_masks_dynbuf_add_2(points, j, jj);
         }
       }
-      dt_masks_dynbuf_add(points, j);
-      dt_masks_dynbuf_add(points, yyy);
+      dt_masks_dynbuf_add_2(points, j, yyy);
     }
   }
   else if(x - lastx < -1)
@@ -226,20 +222,17 @@ static int _path_fill_gaps(int lastx, int lasty, int x, int y, dt_masks_dynbuf_t
       {
         for(int jj = lasty2 + 1; jj < yyy; jj++)
         {
-          dt_masks_dynbuf_add(points, j);
-          dt_masks_dynbuf_add(points, jj);
+          dt_masks_dynbuf_add_2(points, j, jj);
         }
       }
       else if(lasty2 - yyy < -1)
       {
         for(int jj = lasty2 - 1; jj > yyy; jj--)
         {
-          dt_masks_dynbuf_add(points, j);
-          dt_masks_dynbuf_add(points, jj);
+          dt_masks_dynbuf_add_2(points, j, jj);
         }
       }
-      dt_masks_dynbuf_add(points, j);
-      dt_masks_dynbuf_add(points, yyy);
+      dt_masks_dynbuf_add_2(points, j, yyy);
     }
   }
   return 1;
@@ -333,13 +326,13 @@ static void _path_points_recurs(float *p1, float *p2, double tmin, double tmax, 
                  && (int)border_min[1] - (int)border_max[1] < 1
                  && (int)border_min[1] - (int)border_max[1] > -1))))
   {
-    dt_masks_dynbuf_add_n(dpoints, path_max, 2);
+    dt_masks_dynbuf_add_2(dpoints, path_max[0], path_max[1]);
     rpath[0] = path_max[0];
     rpath[1] = path_max[1];
 
     if(withborder)
     {
-      dt_masks_dynbuf_add_n(dborder, border_max, 2);
+      dt_masks_dynbuf_add_2(dborder, border_max[0], border_max[1]);
       rborder[0] = border_max[0];
       rborder[1] = border_max[1];
     }
@@ -484,16 +477,14 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
               else
               {
                 // we find a new self-intersection portion
-                dt_masks_dynbuf_add(inter, v[k]);
-                dt_masks_dynbuf_add(inter, i);
+                dt_masks_dynbuf_add_2(inter, v[k], i);
                 inter_count++;
               }
             }
             else
             {
               // we find a new self-intersection portion
-              dt_masks_dynbuf_add(inter, v[k]);
-              dt_masks_dynbuf_add(inter, i);
+              dt_masks_dynbuf_add_2(inter, v[k], i);
               inter_count++;
             }
           }
@@ -638,7 +629,7 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
       bmin[1] = dt_masks_dynbuf_get(dborder, -1);
     }
 
-    dt_masks_dynbuf_add_n(dpoints, rc, 2);
+    dt_masks_dynbuf_add_2(dpoints, rc[0], rc[1]);
 
     border_init[k * 6 + 4] = dborder ? -dt_masks_dynbuf_position(dborder) : 0;
 
@@ -654,7 +645,7 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
         rb[0] = dt_masks_dynbuf_get(dborder, -2);
         rb[1] = dt_masks_dynbuf_get(dborder, -1);
       }
-      dt_masks_dynbuf_add_n(dborder, rb, 2);
+      dt_masks_dynbuf_add_2(dborder, rb[0], rb[1]);
 
       (dt_masks_dynbuf_buffer(dborder))[k * 6] = border_init[k * 6] = (dt_masks_dynbuf_buffer(dborder))[pb];
       (dt_masks_dynbuf_buffer(dborder))[k * 6 + 1] = border_init[k * 6 + 1] = (dt_masks_dynbuf_buffer(dborder))[pb + 1];

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -568,15 +568,7 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
   // for the border, we store value too
   if(dborder)
   {
-    for(int k = 0; k < nb; k++)
-    {
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-      dt_masks_dynbuf_add(dborder, 0.0f);
-    }
+    dt_masks_dynbuf_add_zeros(dborder, 6 * nb);  // need six zeros for each border point
   }
 
   float *border_init = dt_alloc_align_float((size_t)6 * nb);


### PR DESCRIPTION
Speeds up brush/path drawing by a few percent.  Verified pixel-identical on tests 0004 and 0081.

Also fixed a display bug for circle/ellipse -- the "init took N seconds" message with "-d masks -d perf" was showing a garbage number because the relevant start-time variable hadn't been set at the start of the function.
