### PR TITLE
Metadata update speed

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -449,54 +449,57 @@ void dt_selection_select_list(struct dt_selection_t *selection, GList *list)
   dt_collection_hint_message(darktable.collection);
 }
 
-GList *dt_selection_get_list(struct dt_selection_t *selection, const gboolean only_visible, const gboolean ordering)
+// return the query used to get the selection
+// be carefull : if ordering is TRUE, the order depend of only_visible :
+// DESC order if only_visible is TRUE ; ASC order otherwise...
+gchar *dt_selection_get_list_query(struct dt_selection_t *selection, const gboolean only_visible,
+                                   const gboolean ordering)
 {
-  GList *l = NULL;
+  gchar *query = NULL;
   if(only_visible)
   {
     // we don't want to get image hidden because of grouping
-    sqlite3_stmt *stmt;
-    gchar *qq = dt_util_dstrcat(NULL, "SELECT m.imgid"
-                                      " FROM memory.collected_images as m"
-                                      " WHERE m.imgid IN (SELECT s.imgid FROM main.selected_images as s)");
-    if(ordering) qq = dt_util_dstrcat(qq, " ORDER BY m.rowid DESC");
-
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), qq, -1, &stmt, NULL);
-    g_free(qq);
-    while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
-    {
-      l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
-    }
-    if(stmt) sqlite3_finalize(stmt);
+    query = dt_util_dstrcat(NULL, "SELECT m.imgid"
+                                  " FROM memory.collected_images as m"
+                                  " WHERE m.imgid IN (SELECT s.imgid FROM main.selected_images as s)");
+    if(ordering) query = dt_util_dstrcat(query, " ORDER BY m.rowid DESC");
   }
   else
   {
     // we need to get hidden grouped images too, and the
     // selection already contains them, but not in right order
-    sqlite3_stmt *stmt;
-    gchar *qq = NULL;
     if(ordering)
     {
-      qq = dt_util_dstrcat(NULL,
-                           "SELECT DISTINCT ng.id"
-                           " FROM (%s) AS ng"
-                           " WHERE ng.id IN (SELECT s.imgid FROM main.selected_images as s)",
-                           dt_collection_get_query_no_group(dt_selection_get_collection(selection)));
+      query = dt_util_dstrcat(NULL,
+                              "SELECT DISTINCT ng.id"
+                              " FROM (%s) AS ng"
+                              " WHERE ng.id IN (SELECT s.imgid FROM main.selected_images as s)",
+                              dt_collection_get_query_no_group(dt_selection_get_collection(selection)));
     }
     else
     {
-      qq = dt_util_dstrcat(NULL, "SELECT imgid FROM main.selected_images");
+      query = dt_util_dstrcat(NULL, "SELECT imgid FROM main.selected_images");
     }
-
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), qq, -1, &stmt, NULL);
-    g_free(qq);
-    while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
-    {
-      l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
-    }
-    if(ordering) l = g_list_reverse(l);
-    if(stmt) sqlite3_finalize(stmt);
   }
+  return query;
+}
+
+// return a list of all selected imgid
+GList *dt_selection_get_list(struct dt_selection_t *selection, const gboolean only_visible, const gboolean ordering)
+{
+  GList *l = NULL;
+  gchar *query = dt_selection_get_list_query(selection, only_visible, ordering);
+
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  g_free(query);
+  while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
+  }
+  if(only_visible && ordering) l = g_list_reverse(l);
+  if(stmt) sqlite3_finalize(stmt);
+
   return l;
 }
 

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -53,6 +53,8 @@ const struct dt_collection_t *dt_selection_get_collection(struct dt_selection_t 
 /** get the list of selected images */
 GList *dt_selection_get_list(struct dt_selection_t *selection, const gboolean only_visible,
                              const gboolean ordering);
+gchar *dt_selection_get_list_query(struct dt_selection_t *selection, const gboolean only_visible,
+                                   const gboolean ordering);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -46,7 +46,6 @@ typedef enum dt_metadata_pref_cols_t
 
 typedef struct dt_lib_metadata_t
 {
-  int imgsel;
   GtkTextView *textview[DT_METADATA_NUMBER];
   gulong lost_focus_handler[DT_METADATA_NUMBER];
   GtkWidget *swindow[DT_METADATA_NUMBER];
@@ -128,7 +127,6 @@ static void _update(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
 
-  d->imgsel = dt_control_get_mouse_over_id();
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
 
   // first we want to make sure the list of images to act on has changed
@@ -151,6 +149,7 @@ static void _update(dt_lib_module_t *self)
     }
     if(!changed) return;
   }
+  g_list_free(d->last_act_on);
   d->last_act_on = g_list_copy((GList *)imgs);
 
   GList *metadata[DT_METADATA_NUMBER];
@@ -708,7 +707,6 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)calloc(1, sizeof(dt_lib_metadata_t));
   self->data = (void *)d;
 
-  d->imgsel = -1;
   self->timeout_handle = 0;
 
   GtkGrid *grid = (GtkGrid *)gtk_grid_new();

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -139,17 +139,13 @@ static void _update(dt_lib_module_t *self)
 
   // using dt_metadata_get() is not possible here. we want to do all this in a single pass, everything else
   // takes ages.
-  char *images = NULL;
+  gchar *images = dt_view_get_images_to_act_on_query(TRUE);
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
-  while(imgs)
-  {
-    images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));
-    imgs_count++;
-    imgs = g_list_next((GList *)imgs);
-  }
+
+  imgs_count = g_list_length((GList *)imgs);
+
   if(images)
   {
-    images[strlen(images) - 1] = '\0';
     sqlite3_stmt *stmt;
     char *query = NULL;
     query = dt_util_dstrcat(query,

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -195,6 +195,7 @@ typedef enum dt_view_image_over_t
 // no need to free the list - done internally
 const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gboolean force,
                                           const gboolean ordering);
+gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible);
 // get the main image to act on during global changes (libs, accels)
 int dt_view_get_image_to_act_on();
 


### PR DESCRIPTION
As metadata lib do "heavy" things on each image to act on change (selection and mouse hover signal) this can take some noticeable time when the list of images to act on is big. Especially since we do that each time mouse hover change...

This PR enhance 2 things : 
- speedup the work itself by using directly the subquery to retrieve image to act on instead of constructing a string with all the ids. Speedup = x5 from 0.5 s. to 0.09s. with 95K images selected.
- store the last image to act on list and do nothing if it doesn't change. This is especially the case if you have selected multiple images and you move the move between this images or outside thumbtable. The comparison time is insignificant (0.004 s. for 95K images) but if the list doesn't change the gain is great ;)

@phweyland : I hope I've not missed anything... if you can have a look, as your are the specialist here...