### PR TITLE
introduce mask indicators in module headers

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2775,6 +2775,13 @@
     <shortdescription>show right-side buttons in processing module headers</shortdescription>
     <longdescription>when the mouse is not over a module, the multi-instance, reset and preset buttons can be hidden:\nalways - always show all buttons,\nactive - only show the buttons when the mouse is over the module,\ndim - buttons are dimmed when mouse is away,\nauto - hide the buttons when the panel is narrow,\nfade - fade out all buttons when panel narrows,\nfit - hide all the buttons if the module name doesn't fit,\nsmooth - fade out all buttons in one header simultaneously,\nglide - gradually hide individual buttons as needed</longdescription>
   </dtconfig>
+  <dtconfig prefs="darkroom" section="modules">
+    <name>darkroom/ui/show_mask_indicator</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show mask indicator in modules header</shortdescription>
+    <longdescription>if enabled, an icon will be shown in the module headers to indicate the modules that have a mask</longdescription>
+  </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -588,6 +588,7 @@ overshoot.right
 #module-preset-button,
 #module-reset-button,
 #module-enable-button,
+#module-mask-indicator,
 #module-instance-button,
 #module-collapse-button,
 #module-always-enabled-button,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1130,6 +1130,9 @@ static void _blendop_masks_modes_none_clicked(GtkWidget *button, GdkEventButton 
     _blendop_masks_mode_callback(DEVELOP_MASK_DISABLED, data);
     data->selected_mask_mode = button;
 
+    // remove the mask indicator
+    add_remove_mask_indicator(module->header, FALSE);
+
     /* and finally remove hinter messages */
     dt_control_hinter_message(darktable.control, "");
   }
@@ -1163,6 +1166,8 @@ static gboolean _blendop_masks_modes_toggle(GtkToggleButton *button, dt_iop_modu
       g_list_nth_data(data->masks_modes_toggles,
                       g_list_index(data->masks_modes, (gconstpointer)DEVELOP_MASK_DISABLED)));
   }
+  // (un)set the mask indicator
+  add_remove_mask_indicator(module->header, was_toggled);
 
   return TRUE;
 }
@@ -2551,6 +2556,9 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
     bd->selected_mask_mode = g_list_nth_data(
         bd->masks_modes_toggles, g_list_index(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED)));
   }
+
+  // (un)set the mask indicator
+  add_remove_mask_indicator(module->header, module->blend_params->mask_mode != DEVELOP_MASK_DISABLED);
 
   // initialization of blending modes
   if(bd->csp != bd->blend_modes_csp)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2292,6 +2292,40 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
   return TRUE;
 }
 
+void add_remove_mask_indicator(GtkWidget *header, gboolean add)
+{
+  GList *children = gtk_container_get_children(GTK_CONTAINER(header));
+  GList *button;
+  gboolean found = FALSE;
+  gboolean show = add && dt_conf_get_bool("darkroom/ui/show_mask_indicator");
+  for(button = g_list_last(children);
+      button && GTK_IS_BUTTON(button->data);
+      button = g_list_previous(button))
+  {
+    if (strcmp(gtk_widget_get_name(button->data), "module-mask-indicator") == 0)
+    {
+      found = TRUE;
+      break;
+    }
+  }
+
+  if(found)
+  {
+    if(!show) gtk_widget_destroy(button->data);
+  }
+  else if(show)
+    {
+      GtkWidget *mi = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask,
+                                             CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
+      gtk_widget_set_tooltip_text(mi, _("this module has a mask"));
+      gtk_widget_set_name(mi, "module-mask-indicator");
+      gtk_widget_set_sensitive(mi, FALSE);
+      gtk_box_pack_end(GTK_BOX(header), mi, FALSE, FALSE, 0);
+    }
+
+  dt_iop_show_hide_header_buttons(header, NULL, FALSE, FALSE);
+}
+
 void dt_iop_gui_set_expander(dt_iop_module_t *module)
 {
   char tooltip[512];

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -455,6 +455,9 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module);
 /** (un)hide iop module header right side buttons */
 gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
 
+/** add/remove mask indicator to iop module header */
+void add_remove_mask_indicator(GtkWidget *header, gboolean add);
+
 /** Set the trouble message for the module.  If non-empty, also flag the module as being in trouble; if empty
  ** or NULL, clear the trouble flag.  If 'toast_message' is non-NULL/non-empty, pop up a toast with that
  ** message when the module does not have a warning-label widget (use %s for the module's name).  **/

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2781,7 +2781,6 @@ void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   FINISH
 }
 
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1971,10 +1971,7 @@ static void _preference_changed_button_hide(gpointer instance, dt_develop_t *dev
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
     if(module->header)
-    {
-      dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, FALSE);
-    }
-
+      add_remove_mask_indicator(module->header, module->blend_params->mask_mode != DEVELOP_MASK_DISABLED);
     modules = g_list_next(modules);
   }
 }


### PR DESCRIPTION
This is an attempt to implement the proposal in #8102 to have a mask visual indicator in module headers

![immagine](https://user-images.githubusercontent.com/43290988/109398249-07c0b300-793c-11eb-8391-a5998685259a.png)

A few remarks:

1. The icon is in reality a toggle button, but for the moment I set it to insensitive, so it is a pure visual indicator. Additional functionality can be added later
2. I used the show mask icon, which I don't like so much TBH. If the PR is merged, I can make a better icon with a separate PR
3. The icon is turned on as soon as one of the blending tabs is chosen. So if the indicator is on it doesn't mean necessarily that  the mask is "non void"


Please test the functionality, and of course any feedback is welcome.
