### PR TITLE
Lua: return act_on images in sorted order

### DIFF
--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -78,7 +78,7 @@ static int hovered_cb(lua_State *L)
 static int act_on_cb(lua_State *L)
 {
   lua_newtable(L);
-  const GList *image = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
+  const GList *image = dt_view_get_images_to_act_on(FALSE, TRUE, TRUE);
   while(image)
   {
     luaA_push(L, dt_lua_image_t, &image->data);


### PR DESCRIPTION
Some lua scripts require the action images in sorted order,