### PR TITLE
OpenCL code for RCD and dual demosaicers

### DIFF
--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -733,14 +733,13 @@ ppg_demosaic_redblue (read_only image2d_t in, write_only image2d_t out, const in
  * Demosaic image border
  */
 kernel void
-border_interpolate(read_only image2d_t in, write_only image2d_t out, const int width, const int height, const unsigned int filters)
+border_interpolate(read_only image2d_t in, write_only image2d_t out, const int width, const int height, const unsigned int filters, const int border)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
   if(x >= width || y >= height) return;
 
-  int border = 3;
   int avgwindow = 1;
 
   if(x>=border && x<width-border && y>=border && y<height-border) return;

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -1,0 +1,376 @@
+/*
+    This file is part of darktable,
+    rcd_cl implemented Hanno Schwalm (hanno@schwalm-bremen.de)
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+
+inline float sqrf(float a)
+{
+  return (a * a);
+}
+
+inline float lab_f(float x)
+{
+  const float epsilon = 216.0f / 24389.0f;
+  const float kappa = 24389.0f / 27.0f;
+  return (x > epsilon) ? native_powr(x, (float)(1.0f/3.0f)) : (kappa * x + (float)16.0f) / ((float)116.0f);
+}
+
+inline float calcBlendFactor(float val, float threshold)
+{
+    // sigmoid function
+    // result is in ]0;1] range
+    // inflexion point is at (x, y) (threshold, 0.5)
+    return 1.0f / (1.0f + native_exp(16.0f - (16.0f / threshold) * val));
+}
+
+// Populate cfa and rgb data by normalized input
+__kernel void rcd_populate (__read_only image2d_t in, global float *cfa, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters, const float scale)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= w || y >= height) return;
+
+  const float val = scale * fmax(0.0f, read_imagef(in, sampleri, (int2)(x, y)).x);
+  const int col = FC(y, x, filters);
+
+  global float *rgbcol = rgb0;
+  if(col == 1) rgbcol = rgb1;
+  else if(col == 2) rgbcol = rgb2;
+
+  const int idx = mad24(y, w, x);
+  cfa[idx] = rgbcol[idx] = val;
+}
+
+// Write back-normalized data in rgb channels to output 
+__kernel void rcd_write_output (__write_only image2d_t out, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const float scale)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= w || y >= height) return;
+  const int idx = mad24(y, w, x);
+
+  float4 color;
+  color.x = scale * rgb0[idx];
+  color.y = scale * rgb1[idx];
+  color.z = scale * rgb2[idx];
+
+  write_imagef (out, (int2)(x, y), color);
+}
+
+// Step 1.1: Calculate a squared vertical and horizontal high pass filter on color differences
+__kernel void rcd_step_1_1 (global float *cfa, global float *v_diff, global float *h_diff, const int w, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int row = 3 + y;
+  const int col = 3 + x;
+  if((row > height - 3) || (col > w - 3)) return;
+  const int idx = mad24(row, w, col);
+  const int w2 = 2 * w;
+  const int w3 = 3 * w;
+  
+  v_diff[idx] = sqrf(cfa[idx - w3] - 3.0f * cfa[idx - w2] - cfa[idx - w] + 6.0f * cfa[idx] - cfa[idx + w] - 3.0f * cfa[idx + w2] + cfa[idx + w3]);
+  h_diff[idx] = sqrf(cfa[idx -  3] - 3.0f * cfa[idx -  2] - cfa[idx - 1] + 6.0f * cfa[idx] - cfa[idx + 1] - 3.0f * cfa[idx +  2] + cfa[idx +  3]);
+}
+
+// Step 1.2: Calculate vertical and horizontal local discrimination
+__kernel void rcd_step_1_2 (global float *VH_dir, global float *v_diff, global float *h_diff, const int w, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int row = 4 + y;
+  const int col = 4 + x;
+  if((row > height - 4) || (col > w - 4)) return;
+  const int idx = mad24(row, w, col);
+  const float eps = 1e-5f;
+
+  const float V_Stat = fmax(eps, v_diff[idx - w] + v_diff[idx] + v_diff[idx + w]);
+  const float H_Stat = fmax(eps, h_diff[idx - 1] + h_diff[idx] + h_diff[idx + 1]);
+  VH_dir[idx] = V_Stat / (V_Stat + H_Stat);
+}
+
+// Low pass filter incorporating green, red and blue local samples from the raw data
+__kernel void rcd_step_2_1(global float *lpf, global float *cfa, const int w, const int height, const unsigned int filters)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int row = 2 + y;
+  const int col = 2 + FC(row, 0, filters) + 2 * x;
+  if((col > w - 2) || (row > height - 2)) return;
+  const int idx = mad24(row, w, col);
+
+  lpf[idx / 2] = cfa[idx]
+     + 0.5f * (cfa[idx - w    ] + cfa[idx + w    ] + cfa[idx     - 1] + cfa[idx     + 1])
+    + 0.25f * (cfa[idx - w - 1] + cfa[idx - w + 1] + cfa[idx + w - 1] + cfa[idx + w + 1]);
+}
+
+// Step 3.1: Populate the green channel at blue and red CFA positions
+__kernel void rcd_step_3_1(global float *lpf, global float *cfa, global float *rgb1, global float *VH_Dir, const int w, const int height, const unsigned int filters)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int row = 5 + y;
+  const int col = 5 + FC(row, 1, filters) + 2 * x;
+  if((col > w - 5) || (row > height - 5)) return;
+  const int idx = mad24(row, w, col);
+  const int lidx = idx / 2;
+  const int w2 = 2 * w;
+  const int w3 = 3 * w;
+  const int w4 = 3 * w;
+  const float eps = 1e-5f;
+
+  // Refined vertical and horizontal local discrimination
+  float VH_Central_Value   = VH_Dir[idx];
+  float VH_Neighbourhood_Value = 0.25f * (VH_Dir[idx - w - 1] + VH_Dir[idx - w + 1] + VH_Dir[idx + w - 1] + VH_Dir[idx + w + 1]);
+  float VH_Disc = (fabs( 0.5f - VH_Central_Value ) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
+
+  // Cardinal gradients
+  float N_Grad = eps + fabs(cfa[idx - w] - cfa[idx + w]) + fabs(cfa[idx] - cfa[idx - w2]) + fabs(cfa[idx - w] - cfa[idx - w3]) + fabs(cfa[idx - w2] - cfa[idx - w4]);
+  float S_Grad = eps + fabs(cfa[idx + w] - cfa[idx - w]) + fabs(cfa[idx] - cfa[idx + w2]) + fabs(cfa[idx + w] - cfa[idx + w3]) + fabs(cfa[idx + w2] - cfa[idx + w4]);
+  float W_Grad = eps + fabs(cfa[idx - 1] - cfa[idx + 1]) + fabs(cfa[idx] - cfa[idx -  2]) + fabs(cfa[idx - 1] - cfa[idx -  3]) + fabs(cfa[idx -  2] - cfa[idx -  4]);
+  float E_Grad = eps + fabs(cfa[idx + 1] - cfa[idx - 1]) + fabs(cfa[idx] - cfa[idx +  2]) + fabs(cfa[idx + 1] - cfa[idx +  3]) + fabs(cfa[idx +  2] - cfa[idx +  4]);
+
+  // Cardinal pixel estimations
+  float N_Est = cfa[idx - w] * (1.0f + (lpf[lidx] - lpf[lidx - w]) / (eps + lpf[lidx] + lpf[lidx - w]));
+  float S_Est = cfa[idx + w] * (1.0f + (lpf[lidx] - lpf[lidx + w]) / (eps + lpf[lidx] + lpf[lidx + w]));
+  float W_Est = cfa[idx - 1] * (1.0f + (lpf[lidx] - lpf[lidx - 1]) / (eps + lpf[lidx] + lpf[lidx -  1]));
+  float E_Est = cfa[idx + 1] * (1.0f + (lpf[lidx] - lpf[lidx + 1]) / (eps + lpf[lidx] + lpf[lidx +  1]));
+
+  // Vertical and horizontal estimations
+  float V_Est = (S_Grad * N_Est + N_Grad * S_Est) / (N_Grad + S_Grad);
+  float H_Est = (W_Grad * E_Est + E_Grad * W_Est) / (E_Grad + W_Grad);
+
+  // G@B and G@R interpolation
+  rgb1[idx] = ICLAMP(VH_Disc * H_Est + (1.0f - VH_Disc) * V_Est, 0.0f, 1.0f);
+} 
+
+// Step 4.1: Calculate a squared P/Q diagonals high pass filter on color differences
+__kernel void rcd_step_4_1(global float *cfa, global float *p_diff, global float *q_diff, const unsigned int w, const unsigned int height, const unsigned int filters)
+{
+  unsigned int x = get_global_id(0);
+  unsigned int y = get_global_id(1);
+  unsigned int row = 3 + y;
+  unsigned int col = 3 + (FC(row, 1, filters) & 1) + 2 * x;
+  if((col > w - 3) || (row > height - 3)) return;
+  const unsigned int idx = mad24(row, w, col);
+  const unsigned int w2 = 2 * w;
+  const unsigned int w3 = 3 * w;
+
+  p_diff[idx] = sqrf(cfa[idx - w3 - 3] - 3.0f * cfa[idx - w2 - 2] - cfa[idx - w - 1] + 6.0f * cfa[idx] - cfa[idx + w + 1] - 3.0f * cfa[idx + w2 + 2] + cfa[idx + w3 + 3]);
+  q_diff[idx] = sqrf(cfa[idx - w3 + 3] - 3.0f * cfa[idx - w2 + 2] - cfa[idx - w + 1] + 6.0f * cfa[idx] - cfa[idx + w - 1] - 3.0f * cfa[idx + w2 - 2] + cfa[idx + w3 - 3]);
+}
+
+// Step 4.2: Calculate P/Q diagonal local discrimination
+__kernel void rcd_step_4_2(global float *PQ_dir, global float *p_diff, global float *q_diff, const int w, const int height, const unsigned int filters)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int row = 4 + y;
+  const int col = 4 + (FC(row, 0, filters) & 1) + 2 * x;
+  if((col > w - 4) || (row > height - 4)) return;
+  const int idx = mad24(row, w, col);
+  const int w2 = 2 * w;
+  const int w3 = 3 * w;
+  const float eps = 1e-5f;
+
+  const float P_Stat = fmax(eps, p_diff[idx - w - 1] + p_diff[idx] + p_diff[idx + w + 1]);
+  const float Q_Stat = fmax(eps, q_diff[idx - w + 1] + q_diff[idx] + q_diff[idx + w - 1]);
+  PQ_dir[idx] = P_Stat / (P_Stat + Q_Stat);
+}
+
+// Step 5.1: Populate the red and blue channels at blue and red CFA positions
+__kernel void rcd_step_5_1(global float *PQ_dir, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int row = 5 + y;
+  const int col = 5 + (FC(row, 1, filters) & 1) + 2 * x;
+  if((col > w - 4) || (row > height - 4)) return;
+
+  const int color = 2 - FC(row, col, filters);
+
+  global float *rgbc = rgb0;
+  if(color == 1) rgbc = rgb1;
+  else if(color == 2) rgbc = rgb2;
+ 
+  const int idx = mad24(row, w, col);
+  const int w2 = 2 * w;
+  const int w3 = 3 * w;
+  const float eps = 1e-5f;
+
+  const float PQ_Central_Value   = PQ_dir[idx];
+  const float PQ_Neighbourhood_Value = 0.25f * (PQ_dir[idx - w - 1] + PQ_dir[idx - w + 1] + PQ_dir[idx + w - 1] + PQ_dir[idx + w + 1]);
+  const float PQ_Disc = (fabs(0.5f - PQ_Central_Value) < fabs(0.5f - PQ_Neighbourhood_Value)) ? PQ_Neighbourhood_Value : PQ_Central_Value;
+
+  float NW_Grad = eps + fabs(rgbc[idx - w - 1] - rgbc[idx + w + 1]) + fabs(rgbc[idx - w - 1] - rgbc[idx - w3 - 3]) + fabs(rgb1[idx] - rgb1[idx - w2 - 2]);
+  float NE_Grad = eps + fabs(rgbc[idx - w + 1] - rgbc[idx + w - 1]) + fabs(rgbc[idx - w + 1] - rgbc[idx - w3 + 3]) + fabs(rgb1[idx] - rgb1[idx - w2 + 2]);
+  float SW_Grad = eps + fabs(rgbc[idx + w - 1] - rgbc[idx - w + 1]) + fabs(rgbc[idx + w - 1] - rgbc[idx + w3 - 3]) + fabs(rgb1[idx] - rgb1[idx + w2 - 2]);
+  float SE_Grad = eps + fabs(rgbc[idx + w + 1] - rgbc[idx - w - 1]) + fabs(rgbc[idx + w + 1] - rgbc[idx + w3 + 3]) + fabs(rgb1[idx] - rgb1[idx + w2 + 2]);
+
+  float NW_Est = rgbc[idx - w - 1] - rgb1[idx - w - 1];
+  float NE_Est = rgbc[idx - w + 1] - rgb1[idx - w + 1];
+  float SW_Est = rgbc[idx + w - 1] - rgb1[idx + w - 1];
+  float SE_Est = rgbc[idx + w + 1] - rgb1[idx + w + 1];
+
+  float P_Est = (NW_Grad * SE_Est + SE_Grad * NW_Est) / (NW_Grad + SE_Grad);
+  float Q_Est = (NE_Grad * SW_Est + SW_Grad * NE_Est) / (NE_Grad + SW_Grad);
+
+  rgbc[idx]= ICLAMP(rgb1[idx] + (1.0f - PQ_Disc) * P_Est + PQ_Disc * Q_Est, 0.0f, 1.0f);
+}
+
+// Step 5.2: Populate the red and blue channels at green CFA positions
+__kernel void rcd_step_5_2(global float *VH_dir, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int row = 4 + y;
+  const int col = 4 + (FC(row, 1, filters) & 1) + 2 * x;
+  if((col > w - 4) || (row > height - 4)) return;
+
+  const int idx = mad24(row, w, col);
+  const int w2 = 2 * w;
+  const int w3 = 3 * w;
+  const float eps = 1e-5f;
+
+  // Refined vertical and horizontal local discrimination
+  const float VH_Central_Value   = VH_dir[idx];
+  const float VH_Neighbourhood_Value = 0.25f * (VH_dir[idx - w - 1] + VH_dir[idx - w + 1] + VH_dir[idx + w - 1] + VH_dir[idx + w + 1]);
+  const float VH_Disc = (fabs(0.5f - VH_Central_Value) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
+
+  for(int c = 0; c <= 2; c += 2)
+  {
+    global float *rgbc = (c == 0) ? rgb0 : rgb2;
+    // Cardinal gradients
+    float N_Grad = eps + fabs(rgb1[idx] - rgb1[idx - w2]) + fabs(rgbc[idx - w] - rgbc[idx + w]) + fabs(rgbc[idx - w] - rgbc[idx - w3]);
+    float S_Grad = eps + fabs(rgb1[idx] - rgb1[idx + w2]) + fabs(rgbc[idx + w] - rgbc[idx - w]) + fabs(rgbc[idx + w] - rgbc[idx + w3]);
+    float W_Grad = eps + fabs(rgb1[idx] - rgb1[idx -  2]) + fabs(rgbc[idx - 1] - rgbc[idx + 1]) + fabs(rgbc[idx - 1] - rgbc[idx -  3]);
+    float E_Grad = eps + fabs(rgb1[idx] - rgb1[idx +  2]) + fabs(rgbc[idx + 1] - rgbc[idx - 1]) + fabs(rgbc[idx + 1] - rgbc[idx +  3]);
+
+    // Cardinal colour differences
+    float N_Est = rgbc[idx - w] - rgb1[idx - w];
+    float S_Est = rgbc[idx + w] - rgb1[idx + w];
+    float W_Est = rgbc[idx - 1] - rgb1[idx - 1];
+    float E_Est = rgbc[idx + 1] - rgb1[idx + 1];
+
+    // Vertical and horizontal estimations
+    float V_Est = (N_Grad * S_Est + S_Grad * N_Est) / (N_Grad + S_Grad);
+    float H_Est = (E_Grad * W_Est + W_Grad * E_Est) / (E_Grad + W_Grad);
+
+    // R@G and B@G interpolation
+    rgbc[idx] = ICLAMP(rgb1[idx] + (1.0f - VH_Disc) * V_Est + VH_Disc * H_Est, 0.0f, 1.0f);
+  }
+}
+
+__kernel void dual_luminance_mask(global float *luminance, __read_only image2d_t in, const int w, const int height)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+  const int idx = mad24(row, w, col);
+
+  float4 val = read_imagef(in, sampleri, (int2)(col, row));
+  luminance[idx] = lab_f(0.333333333f * (val.x + val.y + val.z));    
+}
+
+__kernel void dual_calc_blend(global float *luminance, global float *mask, const int w, const int height, const float threshold)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+//  const int row = 2 + y;
+//  const int col = 2 + x;
+  if((col >= w) || (row >= height)) return;
+
+  const int idx = mad24(row, w, col);
+  if((col < 2) || (row < 2) || (col >= w - 2) || (row >= height - 2)) 
+  {
+    mask[idx] = 0.0f;
+  }
+  else
+  {
+    const int w2 = w * 2;
+    const float scale = 1.0f / 16.0f;
+    float contrast = scale * native_sqrt(sqrf(luminance[idx+1] - luminance[idx-1]) + sqrf(luminance[idx +  w] - luminance[idx -  w]) +
+                                         sqrf(luminance[idx+2] - luminance[idx-2]) + sqrf(luminance[idx + w2] - luminance[idx - w2]));
+    mask[idx] = calcBlendFactor(contrast, threshold);
+  }
+}
+
+__kernel void dual_blend_both(__read_only image2d_t high, __read_only image2d_t low, __write_only image2d_t out, const int w, const int height, global float *mask, const int showmask)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+  const int idx = mad24(row, w, col);
+
+  float4 data;
+
+  if(showmask)
+  {
+    data = mask[idx];
+  }
+  else
+  {
+    float4 high_val = read_imagef(high, sampleri, (int2)(col, row));
+    float4 low_val = read_imagef(low, sampleri, (int2)(col, row));
+    float4 blender = mask[idx];
+    data = mix(low_val, high_val, blender);
+  }
+  write_imagef(out, (int2)(col, row), data);
+}
+
+__kernel void dual_fast_blur(global float *src, global float *out, const int w, const int height, const float c42, const float c41, const float c40,
+                             const float c33, const float c32, const float c31, const float c30, const float c22, const float c21,
+                             const float c20, const float c11, const float c10, const float c00)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+  const int i = mad24(row, w, col);
+
+  if((col < 5) || (row < 5) || (col > w - 5) || (row > height - 5)) 
+  {
+    out[i] = 0.0f;
+  }
+  else
+  {
+    const int w2 = 2 * w;
+    const int w3 = 3 * w;
+    const int w4 = 4 * w;
+    const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
+                      c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i -  w - 4] + src[i -  w + 4] + src[i +  w - 4] + src[i +  w + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
+                      c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
+                      c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
+                      c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
+                      c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i -  w - 3] + src[i -  w + 3] + src[i +  w - 3] + src[i +  w + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
+                      c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
+                      c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
+                      c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i -  w - 2] + src[i -  w + 2] + src[i +  w - 2] + src[i +  w + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
+                      c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
+                      c11 * (src[i -  w - 1] + src[i -  w + 1] + src[i +  w - 1] + src[i +  w + 1]) +
+                      c10 * (src[i -  w] + src[i - 1] + src[i + 1] + src[i +  w]) +
+                      c00 * src[i];
+    out[i] = ICLAMP(val, 0.0f, 1.0f);
+  }
+}
+
+
+

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -63,12 +63,7 @@ __kernel void rcd_write_output (__write_only image2d_t out, global float *rgb0, 
   if(col >= w || row >= height) return;
   const int idx = mad24(row, w, col);
 
-  float4 color;
-  color.x = scale * rgb0[idx];
-  color.y = scale * rgb1[idx];
-  color.z = scale * rgb2[idx];
-
-  write_imagef (out, (int2)(col, row), color);
+  write_imagef (out, (int2)(col, row), (float4)(scale * rgb0[idx], scale * rgb1[idx], scale * rgb2[idx], 0.0f));
 }
 
 // Step 1.1: Calculate a squared vertical and horizontal high pass filter on color differences
@@ -76,7 +71,7 @@ __kernel void rcd_step_1_1 (global float *cfa, global float *v_diff, global floa
 {
   const int col = 3 + get_global_id(0);
   const int row = 3 + get_global_id(1);
-  if((row > height - 3) || (col > w - 3)) return;
+  if((row > height - 4) || (col > w - 4)) return;
   const int idx = mad24(row, w, col);
   const int w2 = 2 * w;
   const int w3 = 3 * w;
@@ -90,20 +85,20 @@ __kernel void rcd_step_1_2 (global float *VH_dir, global float *v_diff, global f
 {
   const int col = 4 + get_global_id(0);
   const int row = 4 + get_global_id(1);
-  if((row > height - 4) || (col > w - 4)) return;
+  if((row > height - 5) || (col > w - 5)) return;
   const int idx = mad24(row, w, col);
-  const float eps = 1e-5f;
+  const float eps = 1e-10f;
 
   const float V_Stat = fmax(eps, v_diff[idx - w] + v_diff[idx] + v_diff[idx + w]);
   const float H_Stat = fmax(eps, h_diff[idx - 1] + h_diff[idx] + h_diff[idx + 1]);
   VH_dir[idx] = V_Stat / (V_Stat + H_Stat);
 }
 
-// Low pass filter incorporating green, red and blue local samples from the raw data
+// Step 2.1: Low pass filter incorporating green, red and blue local samples from the raw data
 __kernel void rcd_step_2_1(global float *lpf, global float *cfa, const int w, const int height, const unsigned int filters)
 {
   const int row = 2 + get_global_id(1);
-  const int col = 2 + FC(row, 0, filters) + 2 *get_global_id(0);
+  const int col = 2 + (FC(row, 0, filters) & 1) + 2 *get_global_id(0);
   if((col > w - 2) || (row > height - 2)) return;
   const int idx = mad24(row, w, col);
 
@@ -115,76 +110,80 @@ __kernel void rcd_step_2_1(global float *lpf, global float *cfa, const int w, co
 // Step 3.1: Populate the green channel at blue and red CFA positions
 __kernel void rcd_step_3_1(global float *lpf, global float *cfa, global float *rgb1, global float *VH_Dir, const int w, const int height, const unsigned int filters)
 {
-  const int row = 5 + get_global_id(1);
-  const int col = 5 + FC(row, 1, filters) + 2 * get_global_id(0);
+  const int row = 4 + get_global_id(1);
+  const int col = 4 + (FC(row, 0, filters) & 1) + 2 * get_global_id(0);
   if((col > w - 5) || (row > height - 5)) return;
   const int idx = mad24(row, w, col);
   const int lidx = idx / 2;
   const int w2 = 2 * w;
   const int w3 = 3 * w;
-  const int w4 = 3 * w;
+  const int w4 = 4 * w;
   const float eps = 1e-5f;
 
   // Refined vertical and horizontal local discrimination
-  float VH_Central_Value   = VH_Dir[idx];
-  float VH_Neighbourhood_Value = 0.25f * (VH_Dir[idx - w - 1] + VH_Dir[idx - w + 1] + VH_Dir[idx + w - 1] + VH_Dir[idx + w + 1]);
-  float VH_Disc = (fabs( 0.5f - VH_Central_Value ) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
+  const float VH_Central_Value   = VH_Dir[idx];
+  const float VH_Neighbourhood_Value = 0.25f * (VH_Dir[idx - w - 1] + VH_Dir[idx - w + 1] + VH_Dir[idx + w - 1] + VH_Dir[idx + w + 1]);
+  const float VH_Disc = (fabs( 0.5f - VH_Central_Value ) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
 
+  const float cfai = cfa[idx];
   // Cardinal gradients
-  float N_Grad = eps + fabs(cfa[idx - w] - cfa[idx + w]) + fabs(cfa[idx] - cfa[idx - w2]) + fabs(cfa[idx - w] - cfa[idx - w3]) + fabs(cfa[idx - w2] - cfa[idx - w4]);
-  float S_Grad = eps + fabs(cfa[idx + w] - cfa[idx - w]) + fabs(cfa[idx] - cfa[idx + w2]) + fabs(cfa[idx + w] - cfa[idx + w3]) + fabs(cfa[idx + w2] - cfa[idx + w4]);
-  float W_Grad = eps + fabs(cfa[idx - 1] - cfa[idx + 1]) + fabs(cfa[idx] - cfa[idx -  2]) + fabs(cfa[idx - 1] - cfa[idx -  3]) + fabs(cfa[idx -  2] - cfa[idx -  4]);
-  float E_Grad = eps + fabs(cfa[idx + 1] - cfa[idx - 1]) + fabs(cfa[idx] - cfa[idx +  2]) + fabs(cfa[idx + 1] - cfa[idx +  3]) + fabs(cfa[idx +  2] - cfa[idx +  4]);
+  const float N_Grad = eps + fabs(cfa[idx - w] - cfa[idx + w]) + fabs(cfai - cfa[idx - w2]) + fabs(cfa[idx - w] - cfa[idx - w3]) + fabs(cfa[idx - w2] - cfa[idx - w4]);
+  const float S_Grad = eps + fabs(cfa[idx + w] - cfa[idx - w]) + fabs(cfai - cfa[idx + w2]) + fabs(cfa[idx + w] - cfa[idx + w3]) + fabs(cfa[idx + w2] - cfa[idx + w4]);
+  const float W_Grad = eps + fabs(cfa[idx - 1] - cfa[idx + 1]) + fabs(cfai - cfa[idx -  2]) + fabs(cfa[idx - 1] - cfa[idx -  3]) + fabs(cfa[idx -  2] - cfa[idx -  4]);
+  const float E_Grad = eps + fabs(cfa[idx + 1] - cfa[idx - 1]) + fabs(cfai - cfa[idx +  2]) + fabs(cfa[idx + 1] - cfa[idx +  3]) + fabs(cfa[idx +  2] - cfa[idx +  4]);
 
+  const float lfpi = lpf[lidx];
   // Cardinal pixel estimations
-  float N_Est = cfa[idx - w] * (1.0f + (lpf[lidx] - lpf[lidx - w]) / (eps + lpf[lidx] + lpf[lidx - w]));
-  float S_Est = cfa[idx + w] * (1.0f + (lpf[lidx] - lpf[lidx + w]) / (eps + lpf[lidx] + lpf[lidx + w]));
-  float W_Est = cfa[idx - 1] * (1.0f + (lpf[lidx] - lpf[lidx - 1]) / (eps + lpf[lidx] + lpf[lidx -  1]));
-  float E_Est = cfa[idx + 1] * (1.0f + (lpf[lidx] - lpf[lidx + 1]) / (eps + lpf[lidx] + lpf[lidx +  1]));
+  const float N_Est = cfa[idx - w] * (lfpi + lfpi) / (eps + lfpi + lpf[lidx - w]);
+  const float S_Est = cfa[idx + w] * (lfpi + lfpi) / (eps + lfpi + lpf[lidx + w]);
+  const float W_Est = cfa[idx - 1] * (lfpi + lfpi) / (eps + lfpi + lpf[lidx - 1]);
+  const float E_Est = cfa[idx + 1] * (lfpi + lfpi) / (eps + lfpi + lpf[lidx + 1]);
 
   // Vertical and horizontal estimations
-  float V_Est = (S_Grad * N_Est + N_Grad * S_Est) / (N_Grad + S_Grad);
-  float H_Est = (W_Grad * E_Est + E_Grad * W_Est) / (E_Grad + W_Grad);
+  const float V_Est = (S_Grad * N_Est + N_Grad * S_Est) / (N_Grad + S_Grad);
+  const float H_Est = (W_Grad * E_Est + E_Grad * W_Est) / (E_Grad + W_Grad);
 
   // G@B and G@R interpolation
-  rgb1[idx] = ICLAMP(VH_Disc * H_Est + (1.0f - VH_Disc) * V_Est, 0.0f, 1.0f);
+  rgb1[idx] = mix(V_Est, H_Est, VH_Disc);
 } 
 
-// Step 4.1: Calculate a squared P/Q diagonals high pass filter on color differences
+// Step 4.0: Calculate the square of the P/Q diagonals color difference high pass filter
 __kernel void rcd_step_4_1(global float *cfa, global float *p_diff, global float *q_diff, const int w, const int height, const unsigned int filters)
 {
   const int row = 3 + get_global_id(1);
-  const int col = 3 + (FC(row, 1, filters) & 1) + 2 * get_global_id(0);
+  const int col = 3 + 2 * get_global_id(0);
   if((col > w - 4) || (row > height - 4)) return;
-  const unsigned int idx = mad24(row, w, col);
-  const unsigned int w2 = 2 * w;
-  const unsigned int w3 = 3 * w;
+  const int idx = mad24(row, w, col);
+  const int idx2 = idx / 2;
+  const int w2 = 2 * w;
+  const int w3 = 3 * w;
 
-  p_diff[idx] = sqrf(cfa[idx - w3 - 3] - 3.0f * cfa[idx - w2 - 2] - cfa[idx - w - 1] + 6.0f * cfa[idx] - cfa[idx + w + 1] - 3.0f * cfa[idx + w2 + 2] + cfa[idx + w3 + 3]);
-  q_diff[idx] = sqrf(cfa[idx - w3 + 3] - 3.0f * cfa[idx - w2 + 2] - cfa[idx - w + 1] + 6.0f * cfa[idx] - cfa[idx + w - 1] - 3.0f * cfa[idx + w2 - 2] + cfa[idx + w3 - 3]);
+  p_diff[idx2] = sqrf((cfa[idx - w3 - 3] - cfa[idx - w - 1] - cfa[idx + w + 1] + cfa[idx + w3 + 3]) - 3.0f * (cfa[idx - w2 - 2] + cfa[idx + w2 + 2]) + 6.0f * cfa[idx]);
+  q_diff[idx2] = sqrf((cfa[idx - w3 + 3] - cfa[idx - w + 1] - cfa[idx + w - 1] + cfa[idx + w3 - 3]) - 3.0f * (cfa[idx - w2 + 2] + cfa[idx + w2 - 2]) + 6.0f * cfa[idx]);
 }
 
-// Step 4.2: Calculate P/Q diagonal local discrimination
+// Step 4.1: Calculate P/Q diagonals local discrimination strength
 __kernel void rcd_step_4_2(global float *PQ_dir, global float *p_diff, global float *q_diff, const int w, const int height, const unsigned int filters)
 {
   const int row = 4 + get_global_id(1);
   const int col = 4 + (FC(row, 0, filters) & 1) + 2 *get_global_id(0);
   if((col > w - 4) || (row > height - 4)) return;
   const int idx = mad24(row, w, col);
-  const int w2 = 2 * w;
-  const int w3 = 3 * w;
-  const float eps = 1e-5f;
+  const int idx2 = idx / 2;
+  const int idx3 = (idx - w - 1) / 2;
+  const int idx4 = (idx + w - 1) / 2;  
+  const float eps = 1e-10f;
 
-  const float P_Stat = fmax(eps, p_diff[idx - w - 1] + p_diff[idx] + p_diff[idx + w + 1]);
-  const float Q_Stat = fmax(eps, q_diff[idx - w + 1] + q_diff[idx] + q_diff[idx + w - 1]);
-  PQ_dir[idx] = P_Stat / (P_Stat + Q_Stat);
+  const float P_Stat = fmax(eps, p_diff[idx3]     + p_diff[idx2] + p_diff[idx4 + 1]);
+  const float Q_Stat = fmax(eps, q_diff[idx3 + 1] + q_diff[idx2] + q_diff[idx4]);
+  PQ_dir[idx2] = P_Stat / (P_Stat + Q_Stat);
 }
 
-// Step 5.1: Populate the red and blue channels at blue and red CFA positions
+// Step 4.2: Populate the red and blue channels at blue and red CFA positions
 __kernel void rcd_step_5_1(global float *PQ_dir, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters)
 {
-  const int row = 5 + get_global_id(1);
-  const int col = 5 + (FC(row, 1, filters) & 1) + 2 * get_global_id(0);
+  const int row = 4 + get_global_id(1);
+  const int col = 4 + (FC(row, 0, filters) & 1) + 2 * get_global_id(0);
   if((col > w - 4) || (row > height - 4)) return;
 
   const int color = 2 - FC(row, col, filters);
@@ -194,31 +193,34 @@ __kernel void rcd_step_5_1(global float *PQ_dir, global float *rgb0, global floa
   else if(color == 2) rgbc = rgb2;
  
   const int idx = mad24(row, w, col);
+  const int pqidx = idx / 2;
+  const int pqidx2 = (idx - w - 1) / 2;
+  const int pqidx3 = (idx + w - 1) / 2;
   const int w2 = 2 * w;
   const int w3 = 3 * w;
   const float eps = 1e-5f;
 
-  const float PQ_Central_Value   = PQ_dir[idx];
-  const float PQ_Neighbourhood_Value = 0.25f * (PQ_dir[idx - w - 1] + PQ_dir[idx - w + 1] + PQ_dir[idx + w - 1] + PQ_dir[idx + w + 1]);
+  const float PQ_Central_Value   = PQ_dir[pqidx];
+  const float PQ_Neighbourhood_Value = 0.25f * (PQ_dir[pqidx2] + PQ_dir[pqidx2 + 1] + PQ_dir[pqidx3] + PQ_dir[pqidx3 + 1]);
   const float PQ_Disc = (fabs(0.5f - PQ_Central_Value) < fabs(0.5f - PQ_Neighbourhood_Value)) ? PQ_Neighbourhood_Value : PQ_Central_Value;
 
-  float NW_Grad = eps + fabs(rgbc[idx - w - 1] - rgbc[idx + w + 1]) + fabs(rgbc[idx - w - 1] - rgbc[idx - w3 - 3]) + fabs(rgb1[idx] - rgb1[idx - w2 - 2]);
-  float NE_Grad = eps + fabs(rgbc[idx - w + 1] - rgbc[idx + w - 1]) + fabs(rgbc[idx - w + 1] - rgbc[idx - w3 + 3]) + fabs(rgb1[idx] - rgb1[idx - w2 + 2]);
-  float SW_Grad = eps + fabs(rgbc[idx + w - 1] - rgbc[idx - w + 1]) + fabs(rgbc[idx + w - 1] - rgbc[idx + w3 - 3]) + fabs(rgb1[idx] - rgb1[idx + w2 - 2]);
-  float SE_Grad = eps + fabs(rgbc[idx + w + 1] - rgbc[idx - w - 1]) + fabs(rgbc[idx + w + 1] - rgbc[idx + w3 + 3]) + fabs(rgb1[idx] - rgb1[idx + w2 + 2]);
+  const float NW_Grad = eps + fabs(rgbc[idx - w - 1] - rgbc[idx + w + 1]) + fabs(rgbc[idx - w - 1] - rgbc[idx - w3 - 3]) + fabs(rgb1[idx] - rgb1[idx - w2 - 2]);
+  const float NE_Grad = eps + fabs(rgbc[idx - w + 1] - rgbc[idx + w - 1]) + fabs(rgbc[idx - w + 1] - rgbc[idx - w3 + 3]) + fabs(rgb1[idx] - rgb1[idx - w2 + 2]);
+  const float SW_Grad = eps + fabs(rgbc[idx - w + 1] - rgbc[idx + w - 1]) + fabs(rgbc[idx + w - 1] - rgbc[idx + w3 - 3]) + fabs(rgb1[idx] - rgb1[idx + w2 - 2]);
+  const float SE_Grad = eps + fabs(rgbc[idx - w - 1] - rgbc[idx + w + 1]) + fabs(rgbc[idx + w + 1] - rgbc[idx + w3 + 3]) + fabs(rgb1[idx] - rgb1[idx + w2 + 2]);
 
-  float NW_Est = rgbc[idx - w - 1] - rgb1[idx - w - 1];
-  float NE_Est = rgbc[idx - w + 1] - rgb1[idx - w + 1];
-  float SW_Est = rgbc[idx + w - 1] - rgb1[idx + w - 1];
-  float SE_Est = rgbc[idx + w + 1] - rgb1[idx + w + 1];
+  const float NW_Est = rgbc[idx - w - 1] - rgb1[idx - w - 1];
+  const float NE_Est = rgbc[idx - w + 1] - rgb1[idx - w + 1];
+  const float SW_Est = rgbc[idx + w - 1] - rgb1[idx + w - 1];
+  const float SE_Est = rgbc[idx + w + 1] - rgb1[idx + w + 1];
 
-  float P_Est = (NW_Grad * SE_Est + SE_Grad * NW_Est) / (NW_Grad + SE_Grad);
-  float Q_Est = (NE_Grad * SW_Est + SW_Grad * NE_Est) / (NE_Grad + SW_Grad);
+  const float P_Est = (NW_Grad * SE_Est + SE_Grad * NW_Est) / (NW_Grad + SE_Grad);
+  const float Q_Est = (NE_Grad * SW_Est + SW_Grad * NE_Est) / (NE_Grad + SW_Grad);
 
-  rgbc[idx]= ICLAMP(rgb1[idx] + (1.0f - PQ_Disc) * P_Est + PQ_Disc * Q_Est, 0.0f, 1.0f);
+  rgbc[idx]= rgb1[idx] + mix(P_Est, Q_Est, PQ_Disc);
 }
 
-// Step 5.2: Populate the red and blue channels at green CFA positions
+// Step 4.3: Populate the red and blue channels at green CFA positions
 __kernel void rcd_step_5_2(global float *VH_dir, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters)
 {
   const int row = 4 + get_global_id(1);
@@ -235,27 +237,43 @@ __kernel void rcd_step_5_2(global float *VH_dir, global float *rgb0, global floa
   const float VH_Neighbourhood_Value = 0.25f * (VH_dir[idx - w - 1] + VH_dir[idx - w + 1] + VH_dir[idx + w - 1] + VH_dir[idx + w + 1]);
   const float VH_Disc = (fabs(0.5f - VH_Central_Value) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
 
+  const float rgbi1 = rgb1[idx];
+  const float N1 = eps + fabs(rgbi1 - rgb1[idx - w2]);
+  const float S1 = eps + fabs(rgbi1 - rgb1[idx + w2]);
+  const float W1 = eps + fabs(rgbi1 - rgb1[idx -  2]);
+  const float E1 = eps + fabs(rgbi1 - rgb1[idx +  2]);
+
+  const float rgb1mw1 = rgb1[idx - w];
+  const float rgb1pw1 = rgb1[idx + w];
+  const float rgb1m1 =  rgb1[idx - 1];
+  const float rgb1p1 =  rgb1[idx + 1];
+
+
   for(int c = 0; c <= 2; c += 2)
   {
     global float *rgbc = (c == 0) ? rgb0 : rgb2;
+
+    const float SNabs = fabs(rgbc[idx - w] - rgbc[idx + w]);
+    const float EWabs = fabs(rgbc[idx - 1] - rgbc[idx + 1]);
+ 
     // Cardinal gradients
-    float N_Grad = eps + fabs(rgb1[idx] - rgb1[idx - w2]) + fabs(rgbc[idx - w] - rgbc[idx + w]) + fabs(rgbc[idx - w] - rgbc[idx - w3]);
-    float S_Grad = eps + fabs(rgb1[idx] - rgb1[idx + w2]) + fabs(rgbc[idx + w] - rgbc[idx - w]) + fabs(rgbc[idx + w] - rgbc[idx + w3]);
-    float W_Grad = eps + fabs(rgb1[idx] - rgb1[idx -  2]) + fabs(rgbc[idx - 1] - rgbc[idx + 1]) + fabs(rgbc[idx - 1] - rgbc[idx -  3]);
-    float E_Grad = eps + fabs(rgb1[idx] - rgb1[idx +  2]) + fabs(rgbc[idx + 1] - rgbc[idx - 1]) + fabs(rgbc[idx + 1] - rgbc[idx +  3]);
+    const float N_Grad = N1 + SNabs + fabs(rgbc[idx - w] - rgbc[idx - w3]);
+    const float S_Grad = S1 + SNabs + fabs(rgbc[idx + w] - rgbc[idx + w3]);
+    const float W_Grad = W1 + EWabs + fabs(rgbc[idx - 1] - rgbc[idx -  3]);
+    const float E_Grad = E1 + EWabs + fabs(rgbc[idx + 1] - rgbc[idx +  3]);
 
     // Cardinal colour differences
-    float N_Est = rgbc[idx - w] - rgb1[idx - w];
-    float S_Est = rgbc[idx + w] - rgb1[idx + w];
-    float W_Est = rgbc[idx - 1] - rgb1[idx - 1];
-    float E_Est = rgbc[idx + 1] - rgb1[idx + 1];
+    const float N_Est = rgbc[idx - w] - rgb1mw1;
+    const float S_Est = rgbc[idx + w] - rgb1pw1;
+    const float W_Est = rgbc[idx - 1] - rgb1m1;
+    const float E_Est = rgbc[idx + 1] - rgb1p1;
 
     // Vertical and horizontal estimations
-    float V_Est = (N_Grad * S_Est + S_Grad * N_Est) / (N_Grad + S_Grad);
-    float H_Est = (E_Grad * W_Est + W_Grad * E_Est) / (E_Grad + W_Grad);
+    const float V_Est = (N_Grad * S_Est + S_Grad * N_Est) / (N_Grad + S_Grad);
+    const float H_Est = (E_Grad * W_Est + W_Grad * E_Est) / (E_Grad + W_Grad);
 
     // R@G and B@G interpolation
-    rgbc[idx] = ICLAMP(rgb1[idx] + (1.0f - VH_Disc) * V_Est + VH_Disc * H_Est, 0.0f, 1.0f);
+    rgbc[idx] = rgb1[idx] + mix(V_Est, H_Est, VH_Disc);
   }
 }
 
@@ -285,7 +303,7 @@ __kernel void dual_calc_blend(global float *luminance, global float *mask, const
   {
     const int w2 = w * 2;
     const float scale = 1.0f / 16.0f;
-    float contrast = scale * native_sqrt(sqrf(luminance[idx+1] - luminance[idx-1]) + sqrf(luminance[idx +  w] - luminance[idx -  w]) +
+    const float contrast = scale * native_sqrt(sqrf(luminance[idx+1] - luminance[idx-1]) + sqrf(luminance[idx +  w] - luminance[idx -  w]) +
                                          sqrf(luminance[idx+2] - luminance[idx-2]) + sqrf(luminance[idx + w2] - luminance[idx - w2]));
     mask[idx] = calcBlendFactor(contrast, threshold);
   }
@@ -306,9 +324,9 @@ __kernel void dual_blend_both(__read_only image2d_t high, __read_only image2d_t 
   }
   else
   {
-    float4 high_val = read_imagef(high, sampleri, (int2)(col, row));
-    float4 low_val = read_imagef(low, sampleri, (int2)(col, row));
-    float4 blender = mask[idx];
+    const float4 high_val = read_imagef(high, sampleri, (int2)(col, row));
+    const float4 low_val = read_imagef(low, sampleri, (int2)(col, row));
+    const float4 blender = mask[idx];
     data = mix(low_val, high_val, blender);
   }
   write_imagef(out, (int2)(col, row), data);

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -31,3 +31,5 @@ hazeremoval.cl          27
 lut3d.cl                28
 rgblevels.cl            29
 negadoctor.cl           30
+demosaic_rcd.cl         31
+

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5154,7 +5154,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(scaled)
   {
     // scale aux buffer to output buffer
-    int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
+    const int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     if(err != CL_SUCCESS)
     {
       retval = FALSE;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -161,6 +161,20 @@ typedef struct dt_iop_demosaic_global_data_t
   int kernel_markesteijn_zero;
   int kernel_markesteijn_accu;
   int kernel_markesteijn_final;
+  int kernel_rcd_populate;
+  int kernel_rcd_write_output;
+  int kernel_rcd_step_1_1;
+  int kernel_rcd_step_1_2;
+  int kernel_rcd_step_2_1;
+  int kernel_rcd_step_3_1;
+  int kernel_rcd_step_4_1;
+  int kernel_rcd_step_4_2;
+  int kernel_rcd_step_5_1;
+  int kernel_rcd_step_5_2;
+  int kernel_dual_luminance_mask;
+  int kernel_dual_calc_blend;
+  int kernel_dual_blend_both;
+  int kernel_dual_fast_blur;
 } dt_iop_demosaic_global_data_t;
 
 typedef struct dt_iop_demosaic_data_t
@@ -3328,6 +3342,297 @@ error:
   return FALSE;
 }
 
+static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
+                              cl_mem dev_out, const dt_iop_roi_t *const roi_in,
+                              const dt_iop_roi_t *const roi_out, const gboolean smooth)
+{
+  dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
+  dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
+  const dt_image_t *img = &self->dev->image_storage;
+
+  const int devid = piece->pipe->devid;
+  const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
+
+  cl_mem dev_aux = NULL;
+  cl_mem dev_tmp = NULL;
+  cl_mem dev_green_eq = NULL;
+  cl_mem cfa = NULL;
+  cl_mem rgb0 = NULL;
+  cl_mem rgb1 = NULL;
+  cl_mem rgb2 = NULL;
+  cl_mem VH_dir = NULL;
+  cl_mem PQ_dir = NULL;
+  cl_mem VP_diff = NULL;
+  cl_mem HQ_diff = NULL;
+
+  cl_int err = -999;
+
+  if(qual_flags & DEMOSAIC_FULL_SCALE)
+  {
+     // Full demosaic and then scaling if needed
+    const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
+
+    int width = roi_out->width;
+    int height = roi_out->height;
+
+    // green equilibration
+    if(data->green_eq != DT_IOP_GREEN_EQ_NO)
+    {
+      dev_green_eq = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float));
+      if(dev_green_eq == NULL) goto error;
+      if(!green_equilibration_cl(self, piece, dev_in, dev_green_eq, roi_in)) goto error;
+      dev_in = dev_green_eq;
+    }
+
+    // need to reserve scaled auxiliary buffer or use dev_out
+    if(scaled)
+    {
+      dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+      if(dev_aux == NULL) goto error;
+      width = roi_in->width;
+      height = roi_in->height;
+    }
+    else
+      dev_aux = dev_out;
+
+    dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+    if(dev_tmp == NULL) goto error;
+    cfa = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(cfa == NULL) goto error;
+    VH_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(VH_dir == NULL) goto error;
+    PQ_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(PQ_dir == NULL) goto error;
+    VP_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(VP_diff == NULL) goto error;
+    HQ_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(HQ_diff == NULL) goto error;
+    rgb0 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(rgb0 == NULL) goto error;
+    rgb1 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(rgb1 == NULL) goto error;
+    rgb2 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(rgb2 == NULL) goto error;
+
+    {
+      // populate data
+      size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+      const float scaler = 1.0f / fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 0, sizeof(cl_mem), &dev_in);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 1, sizeof(cl_mem), &cfa);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 2, sizeof(cl_mem), &rgb0);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 3, sizeof(cl_mem), &rgb1);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 4, sizeof(cl_mem), &rgb2);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 5, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 6, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 7, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_populate, 8, sizeof(float), &scaler);    
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_populate, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 1.1: Calculate a squared vertical and horizontal high pass filter on color differences
+      size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_1, 0, sizeof(cl_mem), &cfa);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_1, 1, sizeof(cl_mem), &VP_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_1, 2, sizeof(cl_mem), &HQ_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_1, 3, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_1, 4, sizeof(int), &height);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_1_1, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 1.2: Calculate vertical and horizontal local discrimination
+      size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_2, 0, sizeof(cl_mem), &VH_dir);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_2, 1, sizeof(cl_mem), &VP_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_2, 2, sizeof(cl_mem), &HQ_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_2, 3, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_1_2, 4, sizeof(int), &height);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_1_2, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 2.1: Low pass filter incorporating green, red and blue local samples from the raw data
+      size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_2_1, 0, sizeof(cl_mem), &PQ_dir); // double-use PQ_dir also for lpf
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_2_1, 1, sizeof(cl_mem), &cfa);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_2_1, 2, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_2_1, 3, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_2_1, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_2_1, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 3.1: Populate the green channel at blue and red CFA positions
+      size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 0, sizeof(cl_mem), &PQ_dir); // double-use PQ_dir also for lpf
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 1, sizeof(cl_mem), &cfa);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 2, sizeof(cl_mem), &rgb1);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 3, sizeof(cl_mem), &VH_dir);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 4, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 5, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_3_1, 6, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_3_1, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 4.1: Calculate a squared P/Q diagonals high pass filter on color differences
+      size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_1, 0, sizeof(cl_mem), &cfa);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_1, 1, sizeof(cl_mem), &VP_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_1, 2, sizeof(cl_mem), &HQ_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_1, 3, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_1, 4, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_1, 5, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_4_1, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+    
+    {
+      // Step 4.2: Calculate P/Q diagonal local discrimination
+      size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_2, 0, sizeof(cl_mem), &PQ_dir);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_2, 1, sizeof(cl_mem), &VP_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_2, 2, sizeof(cl_mem), &HQ_diff);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_2, 3, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_2, 4, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_4_2, 5, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_4_2, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 5.1: Populate the red and blue channels at blue and red CFA positions
+      size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 0, sizeof(cl_mem), &PQ_dir);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 1, sizeof(cl_mem), &rgb0);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 2, sizeof(cl_mem), &rgb1);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 3, sizeof(cl_mem), &rgb2);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 4, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 5, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 6, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_5_1, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      // Step 5.2: Populate the red and blue channels at green CFA positions
+      size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 0, sizeof(cl_mem), &VH_dir);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 1, sizeof(cl_mem), &rgb0);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 2, sizeof(cl_mem), &rgb1);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 3, sizeof(cl_mem), &rgb2);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 4, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 5, sizeof(int), &height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_2, 6, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_step_5_2, sizes);
+      if(err != CL_SUCCESS) goto error;    
+    }
+
+    {
+      // write output
+      size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+      const float scaler = fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 0, sizeof(cl_mem), &dev_aux);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 1, sizeof(cl_mem), &rgb0);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 2, sizeof(cl_mem), &rgb1);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 3, sizeof(cl_mem), &rgb2);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 4, sizeof(int), &width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 5, sizeof(int), &height);
+       dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_write_output, 6, sizeof(float), &scaler);    
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_rcd_write_output, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    {
+      const int myborder = 7;
+      // manage borders
+      size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 0, sizeof(cl_mem), &dev_in);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 1, sizeof(cl_mem), &dev_aux);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 2, sizeof(int), (void *)&width);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 3, sizeof(int), (void *)&height);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 5, sizeof(int), (void *)&myborder);
+      err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_border_interpolate, sizes);
+      if(err != CL_SUCCESS) goto error;
+    }
+
+    dt_opencl_release_mem_object(cfa);
+    dt_opencl_release_mem_object(rgb0);
+    dt_opencl_release_mem_object(rgb1);
+    dt_opencl_release_mem_object(rgb2);
+    dt_opencl_release_mem_object(VH_dir);
+    dt_opencl_release_mem_object(PQ_dir);
+    dt_opencl_release_mem_object(VP_diff);
+    dt_opencl_release_mem_object(HQ_diff);
+    if(scaled)
+    {
+      // scale aux buffer to output buffer
+      err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
+      if(err != CL_SUCCESS) goto error;
+    }
+  }
+  else
+  {
+    // sample half-size image:
+    const int zero = 0;
+    cl_mem dev_pix = dev_in;
+    const int width = roi_out->width;
+    const int height = roi_out->height;
+
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 0, sizeof(cl_mem), &dev_pix);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 1, sizeof(cl_mem), &dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 4, sizeof(int), (void *)&zero);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 5, sizeof(int), (void *)&zero);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 6, sizeof(int), (void *)&roi_in->width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 7, sizeof(int), (void *)&roi_in->height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 8, sizeof(float), (void *)&roi_out->scale);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 9, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_zoom_half_size, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }
+
+  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
+  dt_opencl_release_mem_object(dev_green_eq);
+  dt_opencl_release_mem_object(dev_tmp);
+
+  dev_aux = dev_green_eq = dev_tmp = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
+
+  // color smoothing
+  if((data->color_smoothing) && smooth)
+  {
+    if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out))
+      goto error;
+  }
+
+  return TRUE;
+
+error:
+  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
+  dt_opencl_release_mem_object(dev_green_eq);
+  dt_opencl_release_mem_object(dev_tmp);
+  dt_opencl_release_mem_object(cfa);
+  dt_opencl_release_mem_object(rgb0);
+  dt_opencl_release_mem_object(rgb1);
+  dt_opencl_release_mem_object(rgb2);
+  dt_opencl_release_mem_object(VH_dir);
+  dt_opencl_release_mem_object(PQ_dir);
+  dt_opencl_release_mem_object(VP_diff);
+  dt_opencl_release_mem_object(HQ_diff);
+  dev_aux = dev_green_eq = dev_tmp = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
+  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] rcd couldn't enqueue kernel! %d\n", err);
+  return FALSE;
+}
 
 static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
                               cl_mem dev_out, const dt_iop_roi_t *const roi_in,
@@ -3468,14 +3773,15 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       }
 
       {
+        const int myborder = 3;
         // manage borders
         size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
         dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 0, sizeof(cl_mem), &dev_in);
         dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 1, sizeof(cl_mem), &dev_aux);
         dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 2, sizeof(int), (void *)&width);
         dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 3, sizeof(int), (void *)&height);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 4, sizeof(uint32_t),
-                                 (void *)&piece->pipe->dsc.filters);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 5, sizeof(int), (void *)&myborder);
         err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_border_interpolate, sizes);
         if(err != CL_SUCCESS) goto error;
       }
@@ -3564,7 +3870,8 @@ error:
 }
 
 static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
-                          cl_mem dev_out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+                          cl_mem dev_out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                          const gboolean smooth)
 {
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
@@ -3966,7 +4273,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   ips = NULL;
 
   // color smoothing
-  if(data->color_smoothing)
+  if((data->color_smoothing) && smooth)
   {
     if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out))
       goto error;
@@ -3990,7 +4297,7 @@ error:
 
 static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
                                   cl_mem dev_out, const dt_iop_roi_t *const roi_in,
-                                  const dt_iop_roi_t *const roi_out)
+                                  const dt_iop_roi_t *const roi_out, const gboolean smooth)
 {
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
@@ -4633,7 +4940,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       if(err != CL_SUCCESS) goto error;
 
       // VNG processing
-      if(!process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi))
+      if(!process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth))
         goto error;
 
       // adjust for "good" part, dropping linear border where possible
@@ -4726,32 +5033,153 @@ error:
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
+  dt_times_t start_time = { 0 }, end_time = { 0 };
+  const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
+
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   const int demosaicing_method = data->demosaicing_method;
   const int qual_flags = demosaic_qual_flags(piece, &self->dev->image_storage, roi_out);
+  cl_mem high_image = NULL;
+  cl_mem low_image = NULL;
+  cl_mem blend = NULL;
+  cl_mem luminance = NULL;
+  cl_mem dev_aux = NULL;
+  const gboolean dual = ((demosaicing_method & DEMOSAIC_DUAL) && (qual_flags & DEMOSAIC_FULL_SCALE) && (data->dual_thrs > 0.0f));
+  const int devid = piece->pipe->devid;
+  gboolean retval = FALSE;
+
+  if(info) dt_get_times(&start_time);
 
   if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME || demosaicing_method == DT_IOP_DEMOSAIC_PPG)
   {
-    return process_default_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
+    if(!process_default_cl(self, piece, dev_in, dev_out, roi_in, roi_out)) return FALSE;
+  }
+  else if((demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_RCD)
+  {
+    if(dual)
+    {
+      high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+      if(high_image == NULL) return FALSE;
+      if(!process_rcd_cl(self, piece, dev_in, high_image, roi_in, roi_in, FALSE)) goto finish;
+    }
+    else
+    {
+     if(!process_rcd_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE)) return FALSE;
+    }
   }
   else if(demosaicing_method ==  DT_IOP_DEMOSAIC_VNG4 || demosaicing_method == DT_IOP_DEMOSAIC_VNG)
   {
-    return process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
+    if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE)) return FALSE;
   }
   else if((demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) &&
     !(qual_flags & DEMOSAIC_XTRANS_FULL))
   {
-    return process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
+    if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE)) return FALSE;
   }
-  else if(demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3)
+  else if(((demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN ) ||
+          ((demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN_3))
   {
-    return process_markesteijn_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
+    if(dual)
+    {
+      high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+      if(high_image == NULL) return FALSE;
+      if(!process_markesteijn_cl(self, piece, dev_in, high_image, roi_in, roi_in, FALSE)) return FALSE;
+    }
+    else
+    {
+      if(!process_markesteijn_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE)) return FALSE;
+    }
   }
   else
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method '%s' not yet supported by opencl code\n", method2string(demosaicing_method));
     return FALSE;
   }
+
+  if(info)
+  {
+    const float mpixels = (roi_in->width * roi_in->height) / 1.0e6;
+    dt_get_times(&end_time);
+    const float tclock = end_time.clock - start_time.clock;
+    const float uclock = end_time.user - start_time.user;
+    fprintf(stderr," [demosaic] process GPU `%s' did %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us\n",
+      method2string(demosaicing_method & ~DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
+  }
+  if(!dual)
+  {
+    retval = TRUE;
+    goto finish;
+  }
+
+  const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
+
+  int width = roi_out->width;
+  int height = roi_out->height;
+  // need to reserve scaled auxiliary buffer or use dev_out
+  if(scaled)
+  {
+    dev_aux = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+    if(dev_aux == NULL) goto finish;
+    width = roi_in->width;
+    height = roi_in->height;
+  }
+  else
+    dev_aux = dev_out;
+
+  // here we have work to be done only for dual demosaicers
+  blend = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
+  luminance = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
+  low_image = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+  if((blend == NULL) || (low_image == NULL)) goto finish;
+
+  gboolean showmask = FALSE;
+  if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL)
+  {
+    dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+    showmask = (g->show_mask);
+  }
+
+  if(info) dt_get_times(&start_time);
+  if(process_vng_cl(self, piece, dev_in, low_image, roi_in, roi_in, FALSE))
+  {
+    retval = dual_demosaic_cl(self, piece, luminance, blend, high_image, low_image, dev_aux, width, height, showmask);   
+  } 
+
+  if(info)
+  {
+    dt_get_times(&end_time);
+    fprintf(stderr," [demosaic] GPU dual blending %.4f secs (%.4f CPU)\n", end_time.clock - start_time.clock, end_time.user - start_time.user);
+  }
+
+  if(scaled)
+  {
+    // scale aux buffer to output buffer
+    int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
+    if(err != CL_SUCCESS)
+    {
+      retval = FALSE;
+      goto finish;
+    }
+  }
+  
+  // color smoothing
+  if(data->color_smoothing)
+  {
+    if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out))
+    {
+      retval = FALSE;
+      goto finish;
+    }
+  }
+
+  finish:
+  dt_opencl_release_mem_object(high_image);
+  dt_opencl_release_mem_object(low_image);
+  dt_opencl_release_mem_object(luminance);
+  dt_opencl_release_mem_object(blend);
+  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
+  if(!retval) dt_control_log(_("[dual demosaic_cl] internal problem"));
+  return retval;
 }
 #endif
 
@@ -4887,8 +5315,7 @@ void init_global(dt_iop_module_so_t *module)
 
   const int other = 14; // from programs.conf
   gd->kernel_passthrough_monochrome = dt_opencl_create_kernel(other, "passthrough_monochrome");
-  gd->kernel_zoom_passthrough_monochrome
-      = dt_opencl_create_kernel(other, "clip_and_zoom_demosaic_passthrough_monochrome");
+  gd->kernel_zoom_passthrough_monochrome = dt_opencl_create_kernel(other, "clip_and_zoom_demosaic_passthrough_monochrome");
 
   const int vng = 15; // from programs.conf
   gd->kernel_vng_border_interpolate = dt_opencl_create_kernel(vng, "vng_border_interpolate");
@@ -4916,6 +5343,22 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_markesteijn_zero = dt_opencl_create_kernel(markesteijn, "markesteijn_zero");
   gd->kernel_markesteijn_accu = dt_opencl_create_kernel(markesteijn, "markesteijn_accu");
   gd->kernel_markesteijn_final = dt_opencl_create_kernel(markesteijn, "markesteijn_final");
+
+  const int rcd = 31; // from programs.conf
+  gd->kernel_rcd_populate = dt_opencl_create_kernel(rcd, "rcd_populate");
+  gd->kernel_rcd_write_output = dt_opencl_create_kernel(rcd, "rcd_write_output");
+  gd->kernel_rcd_step_1_1 = dt_opencl_create_kernel(rcd, "rcd_step_1_1");
+  gd->kernel_rcd_step_1_2 = dt_opencl_create_kernel(rcd, "rcd_step_1_2");
+  gd->kernel_rcd_step_2_1 = dt_opencl_create_kernel(rcd, "rcd_step_2_1");
+  gd->kernel_rcd_step_3_1 = dt_opencl_create_kernel(rcd, "rcd_step_3_1");
+  gd->kernel_rcd_step_4_1 = dt_opencl_create_kernel(rcd, "rcd_step_4_1");
+  gd->kernel_rcd_step_4_2 = dt_opencl_create_kernel(rcd, "rcd_step_4_2");
+  gd->kernel_rcd_step_5_1 = dt_opencl_create_kernel(rcd, "rcd_step_5_1");
+  gd->kernel_rcd_step_5_2 = dt_opencl_create_kernel(rcd, "rcd_step_5_2");
+  gd->kernel_dual_luminance_mask = dt_opencl_create_kernel(rcd, "dual_luminance_mask");
+  gd->kernel_dual_calc_blend = dt_opencl_create_kernel(rcd, "dual_calc_blend");
+  gd->kernel_dual_blend_both  = dt_opencl_create_kernel(rcd, "dual_blend_both");  
+  gd->kernel_dual_fast_blur = dt_opencl_create_kernel(rcd, "dual_fast_blur"); 
 }
 
 void cleanup_global(dt_iop_module_so_t *module)
@@ -4957,6 +5400,20 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_markesteijn_zero);
   dt_opencl_free_kernel(gd->kernel_markesteijn_accu);
   dt_opencl_free_kernel(gd->kernel_markesteijn_final);
+  dt_opencl_free_kernel(gd->kernel_rcd_populate);
+  dt_opencl_free_kernel(gd->kernel_rcd_write_output);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_1_1);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_1_2);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_2_1);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_3_1);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_4_1);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_4_2);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_5_1);
+  dt_opencl_free_kernel(gd->kernel_rcd_step_5_2);
+  dt_opencl_free_kernel(gd->kernel_dual_luminance_mask);
+  dt_opencl_free_kernel(gd->kernel_dual_calc_blend);
+  dt_opencl_free_kernel(gd->kernel_dual_blend_both);  
+  dt_opencl_free_kernel(gd->kernel_dual_fast_blur);
   free(module->data);
   module->data = NULL;
 }
@@ -5014,16 +5471,16 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
       piece->process_cl_ready = 0;
       break;
     case DT_IOP_DEMOSAIC_RCD:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = 1;
       break;
     case DT_IOP_DEMOSAIC_RCD_VNG:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = 1;
       break;
     case DT_IOP_DEMOSAIC_AMAZE_VNG:
       piece->process_cl_ready = 0;
       break;
     case DT_IOP_DEMOSAIC_MARKEST3_VNG:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = 1;
       break;
     case DT_IOP_DEMOSAIC_VNG:
       piece->process_cl_ready = 1;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3508,7 +3508,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     }
 
     {
-      // Step 5.1: Populate the red and blue channels at blue and red CFA positions
+      // Step 4.3: Populate the red and blue channels at blue and red CFA positions
       size_t sizes[3] = { ROUNDUPWD(width / 2), ROUNDUPHT(height), 1 };
       dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 0, sizeof(cl_mem), &PQ_dir);
       dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_step_5_1, 1, sizeof(cl_mem), &rgb0);
@@ -3554,7 +3554,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       const int myborder = 7;
       // manage borders
       size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 0, sizeof(cl_mem), &dev_in);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 0, sizeof(cl_mem), &cfa);
       dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 1, sizeof(cl_mem), &dev_aux);
       dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 2, sizeof(int), (void *)&width);
       dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 3, sizeof(int), (void *)&height);

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -232,7 +232,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 1, sizeof(cl_mem), &high_image);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 2, sizeof(int), &width);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 3, sizeof(int), &height);
-    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_luminance_mask, sizes);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_luminance_mask, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }  
 
@@ -243,7 +243,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 2, sizeof(int), &width);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 3, sizeof(int), &height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 4, sizeof(float), &contrastf);
-    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_calc_blend, sizes);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_calc_blend, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 
@@ -297,7 +297,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 14, sizeof(int), &c11);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 15, sizeof(int), &c10);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 16, sizeof(int), &c00);
-    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_fast_blur, sizes);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_fast_blur, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 
@@ -310,7 +310,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 4, sizeof(int), &height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 5, sizeof(cl_mem), &luminance);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 6, sizeof(int), &showmask);
-    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_blend_both, sizes);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_blend_both, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -100,15 +100,8 @@ static void fast_blur(float *const restrict src, float *const restrict out, cons
       out[i] = fminf(1.0f, fmaxf(0.0f, val));
     }
   }
-  const float filler = 0.5f;
-  dt_iop_image_fill(out, filler, width, 4, 1);
-  dt_iop_image_fill(&out[(height-4) * width], filler, width, 4, 1);
-  for(int row = 4; row < height - 4; row++)
-  {
-    dt_iop_image_fill(&out[row * width], filler, 4, 1, 1);
-    dt_iop_image_fill(&out[row * width + width - 4], filler, 4, 1, 1);
-  }
 }
+
 
 static void blend_images(float *const restrict rgb_data, float *const restrict blend, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean dual_mask)
 {
@@ -125,14 +118,15 @@ static void blend_images(float *const restrict rgb_data, float *const restrict b
     
   const float scale = 1.0f / 16.0f;
   {
+   dt_iop_image_fill(tmp, 0.0f, width, height, 1);
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(luminance, tmp, width, height, threshold, scale) \
   schedule(simd:static) aligned(luminance, tmp : 64) 
  #endif
-    for(int row = 2; row < height - 2; row++)
+    for(int row = 4; row < height - 4; row++)
     {
-      for(int col = 2, idx = row * width + col; col < width - 2; col++, idx++)
+      for(int col = 4, idx = row * width + col; col < width - 4; col++, idx++)
       {
         float contrast = scale * sqrtf(sqrf(luminance[idx+1] - luminance[idx-1]) + sqrf(luminance[idx + width]   - luminance[idx - width]) +
                                        sqrf(luminance[idx+2] - luminance[idx-2]) + sqrf(luminance[idx + 2*width] - luminance[idx - 2*width]));
@@ -140,21 +134,7 @@ static void blend_images(float *const restrict rgb_data, float *const restrict b
       }
     }
   }
-  for(int row = 0; row < 2; row++)
-  {
-    for(int col = 2; col < width - 2; col++)
-      tmp[row * width + col] = tmp[2 * width + col];
-  }
-  for(int row = height - 2; row < height; row++)
-  {
-    for(int col = 2; col < width - 2; col++)
-      tmp[row * width + col] = tmp[(height - 3) * width + col];
-  }
-  for(int row = 0; row < height; row++)
-  {
-    tmp[row * width]             = tmp[row * width + 1]         = tmp[row * width + 2];         // left border
-    tmp[row * width + width - 2] = tmp[row * width + width - 1] = tmp[row * width + width - 3]; // right border
-  }
+  dt_iop_image_fill(blend, 0.0f, width, height, 1);
   fast_blur(tmp, blend, width, height, 2.0f);
 }
 
@@ -162,7 +142,7 @@ static void blend_images(float *const restrict rgb_data, float *const restrict b
 // and expects the data available in rgb_data as rgba quadruples. 
 static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict rgb_data, const float *const restrict raw_data,
                           dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in, const uint32_t filters, const uint8_t (*const xtrans)[6],
-                          gboolean dual_mask, float dual_threshold)
+                          const gboolean dual_mask, float dual_threshold)
 {
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -230,9 +210,110 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   if(info)
   {
     dt_get_times(&end_blend);
-    fprintf(stderr," [demosaic] dual blending %.4f secs (%.4f CPU)\n", end_blend.clock - start_blend.clock, end_blend.user - start_blend.user);
+    fprintf(stderr," [demosaic] CPU dual blending %.4f secs (%.4f CPU)\n", end_blend.clock - start_blend.clock, end_blend.user - start_blend.user);
   }
   dt_free_align(tmp);
   dt_free_align(blend);
   dt_free_align(vng_image);
 }
+
+
+gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem luminance, cl_mem blend, cl_mem high_image, cl_mem low_image, cl_mem out, const int width, const int height, const int showmask)
+{
+  const int devid = piece->pipe->devid;
+  dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
+  dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
+  const float dual_threshold = data->dual_thrs;
+  const float contrastf = dual_threshold / 100.0f;
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 0, sizeof(cl_mem), &luminance);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 1, sizeof(cl_mem), &high_image);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 3, sizeof(int), &height);
+    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_luminance_mask, sizes);
+    if(err != CL_SUCCESS) return FALSE;
+  }  
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 0, sizeof(cl_mem), &luminance);  
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 1, sizeof(cl_mem), &blend);  
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 4, sizeof(float), &contrastf);
+    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_calc_blend, sizes);
+    if(err != CL_SUCCESS) return FALSE;
+  }
+
+  {
+    // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
+    float kernel[9][9];
+    const double temp = -2.0f * sqrf(2.0f);
+    float sum = 0.0f;
+    for(int i = -4; i <= 4; i++)
+    {
+      for(int j = -4; j <= 4; j++)
+      {
+        kernel[i + 4][j + 4] = expf( (sqrf(i) + sqrf(j)) / temp);
+        sum += kernel[i + 4][j + 4];
+      }
+    }
+    for(int i = 0; i < 9; i++)
+    {
+      for(int j = 0; j < 9; j++)
+        kernel[i][j] /= sum;
+    }
+    const float c42 = kernel[0][2];
+    const float c41 = kernel[0][3];
+    const float c40 = kernel[0][4];
+    const float c33 = kernel[1][1];
+    const float c32 = kernel[1][2];
+    const float c31 = kernel[1][3];
+    const float c30 = kernel[1][4];
+    const float c22 = kernel[2][2];
+    const float c21 = kernel[2][3];
+    const float c20 = kernel[2][4];
+    const float c11 = kernel[3][3];
+    const float c10 = kernel[3][4];
+    const float c00 = kernel[4][4];
+
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 0, sizeof(cl_mem), &blend);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 1, sizeof(cl_mem), &luminance);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 4, sizeof(int), &c42);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 5, sizeof(int), &c41);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 6, sizeof(int), &c40);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 7, sizeof(int), &c33);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 8, sizeof(int), &c32);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 9, sizeof(int), &c31);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 10, sizeof(int), &c30);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 11, sizeof(int), &c22);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 12, sizeof(int), &c21);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 13, sizeof(int), &c20);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 14, sizeof(int), &c11);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 15, sizeof(int), &c10);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 16, sizeof(int), &c00);
+    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_fast_blur, sizes);
+    if(err != CL_SUCCESS) return FALSE;
+  }
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 0, sizeof(cl_mem), &high_image);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 1, sizeof(cl_mem), &low_image);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 2, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 3, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 4, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 5, sizeof(cl_mem), &luminance);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 6, sizeof(int), &showmask);
+    int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_blend_both, sizes);
+    if(err != CL_SUCCESS) return FALSE;
+  }
+
+  return TRUE;
+}
+

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -217,7 +217,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   dt_free_align(vng_image);
 }
 
-
+#ifdef HAVE_OPENCL
 gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem luminance, cl_mem blend, cl_mem high_image, cl_mem low_image, cl_mem out, const int width, const int height, const int showmask)
 {
   const int devid = piece->pipe->devid;
@@ -316,4 +316,6 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
   return TRUE;
 }
+#endif
+
 


### PR DESCRIPTION
Implemented code paths for the recently introduced RCD demosaicer and the dual demosaicer
combinations (except AMaZE).

Some comments about the implementation:

1. As this was my first opencl project i wanted a working solution without worry about artefacts
resulting from badly implemented tricky code. So the kernels so far use global data and don't have
local buffers for caching data. At least for 3 of the implemented kernels significant speedup can
be expected.

2. Despite concerns described above there is already a significant performance gain right now.
Tested on my system (Intel E-2288G (8C/16T), nvidia TU104GL) the performance has already more than
doubled. To give you an idea, pure RCD demosaicing on 45Mpix images is around 0.05sec.

3. The dual demosicing stuff required a few minor mods on the existing code to make the existing
cl demosaicers work with color smoothing. One detail, i also tested the blurring via standard
gaussian code but that was slower most likely because of the buffer translations so i chose to
port the fast approximated gaussian blur used in cpu code. Performance overall has more than doubled,
45mpix images using RCD+VNG take about 0.2sec (which is ~half of doing AMaZE alone)

I would like to get this code merged and tested on other machines before i go into optimizing the
relevant kernels.

A reminder, this pr introduces new OpenCL kernels so clear the cache ...