### PR TITLE
Import session

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -737,7 +737,7 @@
   <dtconfig ui="yes">
     <name>ui_last/import_jobcode</name>
     <type>string</type>
-    <default/>
+    <default>no_name</default>
     <shortdescription>import job</shortdescription>
     <longdescription>name of the import job</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -650,13 +650,6 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig>
-    <name>ui_last/expander_import</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription/>
-    <longdescription/>
-  </dtconfig>
   <dtconfig ui="yes">
     <name>ui_last/import_ignore_jpegs</name>
     <type>bool</type>
@@ -742,11 +735,18 @@
     <longdescription>name of the import job</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
-    <name>ui_last/in_situ</name>
+    <name>ui_last/import_datetime_override</name>
+    <type>string</type>
+    <default/>
+    <shortdescription>override today's date</shortdescription>
+    <longdescription>enter a valid date/time (YYYY-MM-DD[Thh:mm:ss] format) if you want to override the current date/time used when expanding variables:\n$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS).\nlet the field empty otherwise</longdescription>
+  </dtconfig>
+  <dtconfig ui="yes">
+    <name>ui_last/import_keep_open</name>
     <type>bool</type>
-    <default>TRUE</default>
-    <shortdescription>import images as they are</shortdescription>
-    <longdescription>import images where and as they are</longdescription>
+    <default>false</default>
+    <shortdescription>keep this window open</shortdescription>
+    <longdescription>keep this window open to run several imports</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/capture/mode</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -734,6 +734,13 @@
     <shortdescription>ignore exif rating</shortdescription>
     <longdescription>ignore exif rating. if not set and exif rating is found, it overrides 'initial rating'</longdescription>
   </dtconfig>
+  <dtconfig ui="yes">
+    <name>ui_last/import_jobcode</name>
+    <type>string</type>
+    <default/>
+    <shortdescription>import job</shortdescription>
+    <longdescription>name of the import job</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>plugins/capture/mode</name>
     <type>int</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -741,6 +741,13 @@
     <shortdescription>import job</shortdescription>
     <longdescription>name of the import job</longdescription>
   </dtconfig>
+  <dtconfig ui="yes">
+    <name>ui_last/in_situ</name>
+    <type>bool</type>
+    <default>TRUE</default>
+    <shortdescription>import images as they are</shortdescription>
+    <longdescription>import images where and as they are</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>plugins/capture/mode</name>
     <type>int</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -650,6 +650,20 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
+  <dtconfig>
+    <name>ui_last/expander_import</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>ui_last/session_expander_import</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
   <dtconfig ui="yes">
     <name>ui_last/import_ignore_jpegs</name>
     <type>bool</type>

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -117,7 +117,11 @@ static char *_import_session_path_pattern()
     goto bail_out;
   }
 
+#ifdef WIN32
+  res = g_build_path("/", base, sub, (char *)NULL);
+#else
   res = g_build_path(G_DIR_SEPARATOR_S, base, sub, (char *)NULL);
+#endif
 
 bail_out:
   g_free(base);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2182,7 +2182,8 @@ static void *_control_import_alloc()
   return params;
 }
 
-static dt_job_t *_control_import_job_create(GList *imgs, const time_t datetime_override)
+static dt_job_t *_control_import_job_create(GList *imgs, const time_t datetime_override,
+                                            const gboolean inplace)
 {
   dt_job_t *job = dt_control_job_create(&_control_import_job_run, "import");
   if(!job) return NULL;
@@ -2198,8 +2199,7 @@ static dt_job_t *_control_import_job_create(GList *imgs, const time_t datetime_o
   params->index = imgs;
 
   dt_control_import_t *data = params->data;
-  const gboolean insitu = dt_conf_get_bool("ui_last/in_situ");
-  if(insitu)
+  if(inplace)
     data->session = NULL;
   else
   {
@@ -2213,10 +2213,10 @@ static dt_job_t *_control_import_job_create(GList *imgs, const time_t datetime_o
   return job;
 }
 
-void dt_control_import(GList *imgs, const time_t datetime_override)
+void dt_control_import(GList *imgs, const time_t datetime_override, const gboolean inplace)
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
-                     _control_import_job_create(imgs, datetime_override));
+                     _control_import_job_create(imgs, datetime_override, inplace));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2134,10 +2134,22 @@ static int32_t _control_import_job_run(dt_job_t *job)
 
   double fraction = 0.0f;
   int filmid = -1;
+  int first_filmid = -1;
   for(GList *img = t; img; img = g_list_next(img))
   {
     if(data->session)
+    {
       filmid = _control_import_image_copy((char *)img->data, data->session);
+      if(filmid != -1 && first_filmid == -1)
+      {
+        first_filmid = filmid;
+        const char *output_path = dt_import_session_path(data->session, FALSE);
+        dt_conf_set_int("plugins/lighttable/collect/num_rules", 1);
+        dt_conf_set_int("plugins/lighttable/collect/item0", 0);
+        dt_conf_set_string("plugins/lighttable/collect/string0", output_path);
+        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+      }
+    }
     else
       filmid = _control_import_image_insitu((char *)img->data);
     if(filmid != -1)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2149,6 +2149,7 @@ static int32_t _control_import_job_run(dt_job_t *job)
     g_usleep(100);
   }
 
+  dt_control_log(ngettext("imported %d image", "imported %d images", cntr), cntr);
   dt_control_queue_redraw_center();
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, filmid);
@@ -2181,7 +2182,7 @@ static void *_control_import_alloc()
   return params;
 }
 
-static dt_job_t *_control_import_job_create(GList *imgs)
+static dt_job_t *_control_import_job_create(GList *imgs, const time_t datetime_override)
 {
   dt_job_t *job = dt_control_job_create(&_control_import_job_run, "import");
   if(!job) return NULL;
@@ -2205,16 +2206,17 @@ static dt_job_t *_control_import_job_create(GList *imgs)
     data->session = dt_import_session_new();
     char *jobcode = dt_conf_get_string("ui_last/import_jobcode");
     dt_import_session_set_name(data->session, jobcode);
+    if(datetime_override) dt_import_session_set_time(data->session, datetime_override);
     g_free(jobcode);
   }
 
   return job;
 }
 
-void dt_control_import(GList *imgs)
+void dt_control_import(GList *imgs, const time_t datetime_override)
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
-                     _control_import_job_create(imgs));
+                     _control_import_job_create(imgs, datetime_override));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -47,7 +47,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export);
 void dt_control_merge_hdr();
-void dt_control_import(GList *imgs);
+void dt_control_import(GList *imgs, const time_t datetime_override);
 void dt_control_seed_denoise();
 void dt_control_denoise();
 void dt_control_refresh_exif();

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -47,7 +47,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export);
 void dt_control_merge_hdr();
-void dt_control_import(GList *imgs, const time_t datetime_override);
+void dt_control_import(GList *imgs, const time_t datetime_override, const gboolean inplace);
 void dt_control_seed_denoise();
 void dt_control_denoise();
 void dt_control_refresh_exif();

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -47,7 +47,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export);
 void dt_control_merge_hdr();
-
+void dt_control_import(GList *imgs);
 void dt_control_seed_denoise();
 void dt_control_denoise();
 void dt_control_refresh_exif();

--- a/src/gui/camera_import_dialog.c
+++ b/src/gui/camera_import_dialog.c
@@ -477,7 +477,7 @@ static void _camera_import_dialog_run(_camera_import_dialog_t *data)
         GValue value = {
           0,
         };
-        gtk_tree_model_get_iter(GTK_TREE_MODEL(data->store), &iter, (GtkTreePath *)sp->data);
+        gtk_tree_model_get_iter(GTK_TREE_MODEL(data->store), &iter, (GtkTreePath *)sp_iter->data);
         gtk_tree_model_get_value(GTK_TREE_MODEL(data->store), &iter, 1, &value);
         if(G_VALUE_HOLDS_STRING(&value))
           data->params->result = g_list_prepend(data->params->result, g_strdup(g_value_get_string(&value)));

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -2300,7 +2300,7 @@ void dt_gui_preferences_bool_update(GtkWidget *widget)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), val);
 }
 
-GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key)
+GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const gboolean swap)
 {
   GtkWidget *w_label = gtk_label_new(_(dt_confgen_get_label(key)));
   gtk_label_set_ellipsize(GTK_LABEL(w_label), PANGO_ELLIPSIZE_END);
@@ -2313,8 +2313,8 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key)
   gtk_widget_set_name(w, key);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), dt_conf_get_bool(key));
   const int line = _get_grid_nb_lines(grid);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), w, 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labelev, swap ? 1 : 0, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), w, swap ? 0 : 1, line, 1, 1);
   g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(_gui_preferences_bool_callback), (gpointer)key);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_gui_preferences_bool_reset), (gpointer)w);
   return w;

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -2252,23 +2252,6 @@ static void edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pre
   free(g);
 }
 
-static int
-_get_grid_nb_lines(GtkGrid *grid)
-{
-  int line = 0;
-  gboolean not_empty = TRUE;
-  while(not_empty)
-  {
-    for(int i = 0; i < 2; i++)
-    {
-      not_empty = gtk_grid_get_child_at(grid, i, line) != NULL;
-      if(not_empty) break;
-    }
-    if(not_empty) line++;
-  }
-  return line;
-}
-
 static void
 _gui_preferences_bool_callback(GtkWidget *widget, gpointer data)
 {
@@ -2300,7 +2283,8 @@ void dt_gui_preferences_bool_update(GtkWidget *widget)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), val);
 }
 
-GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const gboolean swap)
+GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const guint col,
+                                   const guint line, const gboolean swap)
 {
   GtkWidget *w_label = gtk_label_new(_(dt_confgen_get_label(key)));
   gtk_label_set_ellipsize(GTK_LABEL(w_label), PANGO_ELLIPSIZE_END);
@@ -2312,9 +2296,8 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const gboolea
   GtkWidget *w = gtk_check_button_new();
   gtk_widget_set_name(w, key);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), dt_conf_get_bool(key));
-  const int line = _get_grid_nb_lines(grid);
-  gtk_grid_attach(GTK_GRID(grid), labelev, swap ? 1 : 0, line, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), w, swap ? 0 : 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labelev, swap ? (col + 1) : col, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), w, swap ? col : (col + 1), line, 1, 1);
   g_signal_connect(G_OBJECT(w), "toggled", G_CALLBACK(_gui_preferences_bool_callback), (gpointer)key);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_gui_preferences_bool_reset), (gpointer)w);
   return w;
@@ -2351,7 +2334,8 @@ void dt_gui_preferences_int_update(GtkWidget *widget)
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), val);
 }
 
-GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key)
+GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key, const guint col,
+                                  const guint line)
 {
   GtkWidget *w_label = gtk_label_new(_(dt_confgen_get_label(key)));
   gtk_label_set_ellipsize(GTK_LABEL(w_label), PANGO_ELLIPSIZE_END);
@@ -2367,9 +2351,8 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key)
   gtk_widget_set_hexpand(w, FALSE);
   gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w), 0);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), dt_conf_get_int(key));
-  const int line = _get_grid_nb_lines(grid);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), w, 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), w, col + 1, line, 1, 1);
   g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(_gui_preferences_int_callback), (gpointer)key);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_gui_preferences_int_reset), (gpointer)w);
   return w;
@@ -2439,7 +2422,8 @@ void dt_gui_preferences_enum_update(GtkWidget *widget)
   g_free(str);
 }
 
-GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key)
+GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key, const guint col,
+                                   const guint line)
 {
   GtkWidget *w_label = gtk_label_new(_(dt_confgen_get_label(key)));
   gtk_label_set_ellipsize(GTK_LABEL(w_label), PANGO_ELLIPSIZE_END);
@@ -2485,9 +2469,8 @@ GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key)
   gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(w), renderer, "text", 1, NULL);
   gtk_combo_box_set_active(GTK_COMBO_BOX(w), pos);
 
-  const int line = _get_grid_nb_lines(grid);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), w, 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), w, col + 1, line, 1, 1);
   g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_gui_preferences_enum_callback), (gpointer)key);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_gui_preferences_enum_reset), (gpointer)w);
   return w;
@@ -2526,7 +2509,8 @@ void dt_gui_preferences_string_update(GtkWidget *widget)
   g_free(str);
 }
 
-GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key)
+GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint col,
+                                     const guint line)
 {
   GtkWidget *w_label = gtk_label_new(_(dt_confgen_get_label(key)));
   gtk_label_set_ellipsize(GTK_LABEL(w_label), PANGO_ELLIPSIZE_END);
@@ -2543,9 +2527,8 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key)
   gtk_widget_set_hexpand(w, TRUE);
   gtk_widget_set_name(w, key);
 
-  const int line = _get_grid_nb_lines(grid);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), w, 1, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), w, col + 1, line, 1, 1);
   g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_gui_preferences_string_callback), (gpointer)key);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_gui_preferences_string_reset), (gpointer)w);
   return w;

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -2496,6 +2496,66 @@ GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key)
   return w;
 }
 
+static void
+_gui_preferences_string_callback(GtkWidget *widget, gpointer data)
+{
+  const char *str = gtk_entry_get_text(GTK_ENTRY(widget));
+  dt_conf_set_string((char *)data, str);
+}
+
+void dt_gui_preferences_string_reset(GtkWidget *widget)
+{
+  const char *key = gtk_widget_get_name(widget);
+  const char *str = dt_confgen_get(key, DT_DEFAULT);
+  gtk_entry_set_text(GTK_ENTRY(widget), str);
+}
+
+static gboolean
+_gui_preferences_string_reset(GtkWidget *label, GdkEventButton *event, GtkWidget *widget)
+{
+  if(event->type == GDK_2BUTTON_PRESS)
+  {
+    dt_gui_preferences_string_reset(widget);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+void dt_gui_preferences_string_update(GtkWidget *widget)
+{
+  const char *key = gtk_widget_get_name(widget);
+  char *str = dt_conf_get_string(key);
+  gtk_entry_set_text(GTK_ENTRY(widget), str);
+  g_free(str);
+}
+
+GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key)
+{
+  GtkWidget *w_label = gtk_label_new(_(dt_confgen_get_label(key)));
+  gtk_label_set_ellipsize(GTK_LABEL(w_label), PANGO_ELLIPSIZE_END);
+  gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
+  gtk_widget_set_halign(w_label, GTK_ALIGN_START);
+  GtkWidget *labelev = gtk_event_box_new();
+  gtk_widget_set_hexpand(labelev, TRUE);
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), w_label);
+
+  GtkWidget *w = gtk_entry_new();
+  gchar *str = dt_conf_get_string(key);
+  gtk_entry_set_text(GTK_ENTRY(w), str);
+  g_free(str);
+  gtk_widget_set_hexpand(w, TRUE);
+  gtk_widget_set_name(w, key);
+//  gtk_widget_set_hexpand(w, FALSE);
+
+  const int line = _get_grid_nb_lines(grid);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), w, 1, line, 1, 1);
+  g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_gui_preferences_string_callback), (gpointer)key);
+  g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(_gui_preferences_string_reset), (gpointer)w);
+  return w;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -2307,7 +2307,6 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
   GtkWidget *w = gtk_check_button_new();
@@ -2359,7 +2358,6 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
   gint min = MAX(G_MININT, dt_confgen_get_int(key, DT_MIN));
@@ -2448,7 +2446,6 @@ GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
 
@@ -2536,7 +2533,6 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
 
@@ -2546,7 +2542,6 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key)
   g_free(str);
   gtk_widget_set_hexpand(w, TRUE);
   gtk_widget_set_name(w, key);
-//  gtk_widget_set_hexpand(w, FALSE);
 
   const int line = _get_grid_nb_lines(grid);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -2307,7 +2307,7 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-  gtk_widget_set_hexpand(labelev, TRUE);
+//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
   GtkWidget *w = gtk_check_button_new();
@@ -2359,7 +2359,7 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-  gtk_widget_set_hexpand(labelev, TRUE);
+//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
   gint min = MAX(G_MININT, dt_confgen_get_int(key, DT_MIN));
@@ -2448,7 +2448,7 @@ GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-  gtk_widget_set_hexpand(labelev, TRUE);
+//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
 
@@ -2536,7 +2536,7 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key)
   gtk_widget_set_tooltip_text(w_label, _(dt_confgen_get_tooltip(key)));
   gtk_widget_set_halign(w_label, GTK_ALIGN_START);
   GtkWidget *labelev = gtk_event_box_new();
-  gtk_widget_set_hexpand(labelev, TRUE);
+//  gtk_widget_set_hexpand(labelev, TRUE);
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
 

--- a/src/gui/preferences.h
+++ b/src/gui/preferences.h
@@ -22,7 +22,7 @@
 void dt_gui_preferences_show();
 
 // return the widget for a given preference key
-GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key);
+GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const gboolean swap);
 GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key);
 GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key);
 GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key);

--- a/src/gui/preferences.h
+++ b/src/gui/preferences.h
@@ -25,16 +25,19 @@ void dt_gui_preferences_show();
 GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key);
 GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key);
 GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key);
+GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key);
 
 // update widget with current preference
 void dt_gui_preferences_bool_update(GtkWidget *widget);
 void dt_gui_preferences_int_update(GtkWidget *widget);
 void dt_gui_preferences_enum_update(GtkWidget *widget);
+void dt_gui_preferences_string_update(GtkWidget *widget);
 
 // reset widget to default value
 void dt_gui_preferences_bool_reset(GtkWidget *widget);
 void dt_gui_preferences_int_reset(GtkWidget *widget);
 void dt_gui_preferences_enum_reset(GtkWidget *widget);
+void dt_gui_preferences_string_reset(GtkWidget *widget);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/preferences.h
+++ b/src/gui/preferences.h
@@ -22,10 +22,14 @@
 void dt_gui_preferences_show();
 
 // return the widget for a given preference key
-GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const gboolean swap);
-GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key);
-GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key);
-GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key);
+GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const guint col,
+                                   const guint line, const gboolean swap);
+GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key, const guint col,
+                                  const guint line);
+GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key, const guint col,
+                                   const guint line);
+GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint col,
+                                     const guint line);
 
 // update widget with current preference
 void dt_gui_preferences_bool_update(GtkWidget *widget);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -36,6 +36,7 @@
 #include "dtgtk/expander.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "gui/draw.h"
 #include "gui/import_metadata.h"
 #include "gui/preferences.h"
 #include <gdk/gdkkeysyms.h>
@@ -47,7 +48,10 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
-
+#ifdef _WIN32
+//MSVCRT does not have strptime implemented
+#include "win/strptime.h"
+#endif
 #include <strings.h>
 #include <librsvg/rsvg.h>
 // ugh, ugly hack. why do people break stuff all the time?
@@ -82,12 +86,11 @@ typedef struct dt_lib_import_t
 #ifdef HAVE_GPHOTO2
   dt_camctl_listener_t camctl_listener;
 #endif
-  GtkButton *import_file;
-  GtkButton *import_directory;
+  GtkButton *import_inplace;
+  GtkButton *import_copy;
   GtkButton *import_camera;
   GtkButton *tethered_shoot;
 
-  GtkWidget *prefs_expander, *prefs_toggle, *prefs_widgets;
   GtkWidget *recursive, *ignore_jpegs, *ignore_exif, *rating, *apply_metadata;
   dt_import_metadata_t metadata;
   GtkBox *devices;
@@ -100,10 +103,14 @@ typedef struct dt_lib_import_t
     GtkWidget *w;
     GtkTreeView *treeview;
     gchar *folder;
-    GtkTreeViewColumn *sel_thumb;
     GtkTreeIter iter;
     int event;
     guint nb;
+    GdkPixbuf *eye;
+    GtkTreeViewColumn *pixcol;
+    GtkWidget *img_nb;
+    gboolean inplace;
+    GtkGrid *patterns;
   } from;
 
 #ifdef USE_LUA
@@ -137,16 +144,16 @@ void init_key_accels(dt_lib_module_t *self)
 {
   dt_accel_register_lib(self, NC_("accel", "import from camera"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "tethered shoot"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "import image"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "import folder"), GDK_KEY_i, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+  dt_accel_register_lib(self, NC_("accel", "import - in-place"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "import - copy"), GDK_KEY_i, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 }
 
 void connect_key_accels(dt_lib_module_t *self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
 
-  dt_accel_connect_button_lib(self, "import image", GTK_WIDGET(d->import_file));
-  dt_accel_connect_button_lib(self, "import folder", GTK_WIDGET(d->import_directory));
+  dt_accel_connect_button_lib(self, "import - in-place", GTK_WIDGET(d->import_inplace));
+  dt_accel_connect_button_lib(self, "import - copy", GTK_WIDGET(d->import_copy));
   if(d->tethered_shoot) dt_accel_connect_button_lib(self, "tethered shoot", GTK_WIDGET(d->tethered_shoot));
   if(d->import_camera) dt_accel_connect_button_lib(self, "import from camera", GTK_WIDGET(d->import_camera));
 }
@@ -502,70 +509,28 @@ static GdkPixbuf *_import_get_thumbnail(const gchar *filename)
 return pixbuf;
 }
 
-static void _lib_import_folder_callback(GtkWidget *widget, dt_lib_module_t* self)
+static GdkPixbuf *_eye_thumbnail(GtkWidget *widget)
 {
-  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("import folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_import"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GdkRGBA fg_color;
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+  GtkStateFlags state = gtk_widget_get_state_flags(widget);
+  gtk_style_context_get_color(context, state, &fg_color);
 
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), TRUE);
-
-  char *last_directory = dt_conf_get_string("ui_last/import_last_directory");
-  if(last_directory != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), last_directory);
-    g_free(last_directory);
-  }
-
-  // run the dialog
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
-  {
-    // hide the dialog as soon as possible
-    gtk_widget_hide(filechooser);
-
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/import_last_directory", folder);
-    g_free(folder);
-
-    char *filename = NULL, *first_filename = NULL;
-    GSList *list = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(filechooser));
-
-    /* reset filter so that view isn't empty */
-    dt_view_filter_reset(darktable.view_manager, TRUE);
-
-    /* for each selected folder add import job */
-    const gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
-    for (GSList *it = list; it; it = g_slist_next(it))
-    {
-      filename = (char *)it->data;
-      dt_film_import(filename);
-      if(!first_filename)
-      {
-        first_filename = g_strdup(filename);
-        if(recursive)
-          first_filename = dt_util_dstrcat(first_filename, "%%");
-      }
-      g_free(filename);
-    }
-    g_slist_free(list); // we've already freed the filenames stored in the list, but still need to free the list itself
-
-    /* update collection to view import */
-    if(first_filename)
-    {
-      dt_conf_set_int("plugins/lighttable/collect/num_rules", 1);
-      dt_conf_set_int("plugins/lighttable/collect/item0", 0);
-      dt_conf_set_string("plugins/lighttable/collect/string0", first_filename);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
-      g_free(first_filename);
-    }
-  }
-
-  gtk_widget_destroy(filechooser);
-  gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
+  const int dim = DT_PIXEL_APPLY_DPI(13);
+  cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dim, dim);
+  cairo_t *cr = cairo_create(cst);
+  gdk_cairo_set_source_rgba(cr, &fg_color);
+  dtgtk_cairo_paint_eye(cr, 0, 0, dim, dim, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  cairo_destroy(cr);
+  uint8_t *data = cairo_image_surface_get_data(cst);
+  dt_draw_cairo_to_gdk_pixbuf(data, dim, dim);
+  const size_t size = (size_t)dim * dim * 4;
+  uint8_t *buf = (uint8_t *)malloc(size);
+  memcpy(buf, data, size);
+  GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, dim, dim, dim * 4,
+                                               (GdkPixbufDestroyNotify)free, NULL);
+  cairo_surface_destroy(cst);
+  return pixbuf;
 }
 
 static void _thumb_set_in_listview(GtkTreeModel *model, GtkTreeIter *iter,
@@ -576,7 +541,7 @@ static void _thumb_set_in_listview(GtkTreeModel *model, GtkTreeIter *iter,
   gtk_tree_model_get(model, iter, DT_IMPORT_FILENAME, &filename, -1);
   char *fullname = g_build_filename(d->from.folder, filename, NULL);
 
-  GdkPixbuf *pixbuf = thumb_sel ? _import_get_thumbnail(fullname) : NULL;
+  GdkPixbuf *pixbuf = thumb_sel ? _import_get_thumbnail(fullname) : d->from.eye;
   gtk_list_store_set(d->from.store, iter, DT_IMPORT_SEL_THUMB, thumb_sel,
                                           DT_IMPORT_THUMB, pixbuf, -1);
 
@@ -585,17 +550,31 @@ static void _thumb_set_in_listview(GtkTreeModel *model, GtkTreeIter *iter,
   g_free(fullname);
 }
 
-static void _thumb_toggled(GtkCellRendererToggle *cell_renderer, gchar *path_str, dt_lib_module_t *self)
+static gboolean _thumb_toggled(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  GtkTreeModel *model = GTK_TREE_MODEL(d->from.store);
-  GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
-  GtkTreeIter iter;
-  gtk_tree_model_get_iter(model, &iter, path);
-  gtk_tree_path_free(path);
-  gboolean thumb_sel;
-  gtk_tree_model_get(model, &iter, DT_IMPORT_SEL_THUMB, &thumb_sel, -1);
-  _thumb_set_in_listview(model, &iter, !thumb_sel, self);
+  if((event->type == GDK_BUTTON_PRESS && event->button == 1))
+  {
+    GtkTreePath *path = NULL;
+    GtkTreeViewColumn *column = NULL;
+    // Get tree path for row that was clicked
+    if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), (gint)event->x, (gint)event->y,
+                                     &path, &column, NULL, NULL))
+    {
+      if(column == d->from.pixcol)
+      {
+        GtkTreeIter iter;
+        GtkTreeModel *model = GTK_TREE_MODEL(d->from.store);
+        gtk_tree_model_get_iter(model, &iter, path);
+        gboolean thumb_sel;
+        gtk_tree_model_get(model, &iter, DT_IMPORT_SEL_THUMB, &thumb_sel, -1);
+        _thumb_set_in_listview(model, &iter, !thumb_sel, self);
+        return TRUE;
+      }
+    }
+    gtk_tree_path_free(path);
+  }
+  return FALSE;
 }
 
 static gboolean _thumb_set_listview(gpointer user_data)
@@ -645,8 +624,7 @@ static void _all_thumb_toggled(GtkTreeViewColumn *column, dt_lib_module_t *self)
 }
 
 static guint _import_from_set_file_list(const gchar *folder, const int root_lgth,
-                                        const gboolean recursive, GtkListStore *store,
-                                        const int n)
+                                        GtkListStore *store, const int n, GdkPixbuf *eye)
 {
   GError *error = NULL;
   GFile *gfolder = g_file_parse_name(folder);
@@ -660,6 +638,7 @@ static guint _import_from_set_file_list(const gchar *folder, const int root_lgth
 
   GFileInfo *info = NULL;
   guint nb = n;
+  const gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
   while((info = g_file_enumerator_next_file(dir_files, NULL, &error)))
   {
     const char *uifilename = g_file_info_get_display_name(info);
@@ -675,18 +654,25 @@ static guint _import_from_set_file_list(const gchar *folder, const int root_lgth
 
     if(recursive && filetype == G_FILE_TYPE_DIRECTORY)
     {
-      nb = _import_from_set_file_list(fullname, root_lgth, recursive, store, nb);
+      nb = _import_from_set_file_list(fullname, root_lgth, store, nb, eye);
     }
     // supported image format to import
     else if(filetype != G_FILE_TYPE_DIRECTORY && dt_supported_image(filename))
     {
-      GtkTreeIter iter;
-      gtk_list_store_append(store, &iter);
-      gtk_list_store_set(store, &iter, DT_IMPORT_UI_FILENAME, &uifullname[root_lgth + 1],
-                                       DT_IMPORT_FILENAME, &fullname[root_lgth + 1],
-                                       DT_IMPORT_UI_DATETIME, dt_txt,
-                                       DT_IMPORT_DATETIME, datetime, -1);
-      nb++;
+      const char *ext = g_strrstr(filename, ".");
+      const gboolean jpg_ok = ext && (!dt_conf_get_bool("ui_last/import_ignore_jpegs")
+                              || (strcmp(ext, ".jpg") && strcmp(ext, ".jpeg")));
+      if(jpg_ok)
+      {
+        GtkTreeIter iter;
+        gtk_list_store_append(store, &iter);
+        gtk_list_store_set(store, &iter, DT_IMPORT_UI_FILENAME, &uifullname[root_lgth + 1],
+                                         DT_IMPORT_FILENAME, &fullname[root_lgth + 1],
+                                         DT_IMPORT_UI_DATETIME, dt_txt,
+                                         DT_IMPORT_DATETIME, datetime,
+                                         DT_IMPORT_THUMB, eye, -1);
+        nb++;
+      }
     }
 
     g_free(dt_txt);
@@ -702,93 +688,152 @@ static guint _import_from_set_file_list(const gchar *folder, const int root_lgth
   }
   return nb;
 }
-static void _update_dialog_title(GtkWidget *dialog, const guint nb_sel, const guint nb)
+
+static void _update_images_number(GtkWidget *label, const guint nb_sel, const guint nb)
 {
-  char title[256] = { 0 };
-  snprintf(title, sizeof(title), ngettext("import %d/%d image", "import %d/%d images", nb_sel), nb_sel, nb);
-  gtk_window_set_title(GTK_WINDOW(dialog), title);
+  char text[256] = { 0 };
+  snprintf(text, sizeof(text), ngettext("%d image out of %d selected", "%d images out of %d selected", nb_sel), nb_sel, nb);
+  gtk_label_set_text(GTK_LABEL(label), text);
 }
 
 static void _import_from_selection_changed(GtkTreeSelection *selection, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   guint nb_sel = gtk_tree_selection_count_selected_rows(selection);
-  _update_dialog_title(d->from.dialog, nb_sel, d->from.nb);
+  _update_images_number(d->from.img_nb, nb_sel, d->from.nb);
   gtk_dialog_set_response_sensitive(GTK_DIALOG(d->from.dialog),
                                     GTK_RESPONSE_ACCEPT, nb_sel ? TRUE : FALSE);
 }
 
-static void _update_layout(GtkWidget *grid)
+static void _update_layout(dt_lib_module_t* self)
 {
+  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   const gboolean usefn = dt_conf_get_bool("session/use_filename");
-  const gboolean insitu = dt_conf_get_bool("ui_last/in_situ");
-  for(int i = 1; i < 6; i++)
+  for(int j = 0; j < 2 ; j++)
   {
-    for(int j = 0; j < 2 ; j++)
-    {
-      GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(grid), j, i);
-      if(GTK_IS_WIDGET(w))
-        gtk_widget_set_sensitive(w, insitu ? FALSE
-                                           : (i == 5) ? !usefn : TRUE);
-    }
+    GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(d->from.patterns), j, 5);
+    if(GTK_IS_WIDGET(w))
+      gtk_widget_set_sensitive(w, !usefn);
   }
 }
-
-static void _insitu_toggled(GtkWidget *widget, GtkWidget *grid)
+static void _usefn_toggled(GtkWidget *widget, dt_lib_module_t* self)
 {
-  _update_layout(grid);
+  _update_layout(self);
 }
 
-static void _usefn_toggled(GtkWidget *widget, GtkWidget *grid)
+static time_t _parse_date_time(const char *date_time_text)
 {
-  _update_layout(grid);
+  struct tm t;
+  memset(&t, 0, sizeof(t));
+
+  const char *end = NULL;
+  if((end = strptime(date_time_text, "%Y-%m-%dT%T", &t)) && *end == 0) return mktime(&t);
+  if((end = strptime(date_time_text, "%Y-%m-%d", &t)) && *end == 0) return mktime(&t);
+
+  return 0;
+}
+
+static void _update_files_list(dt_lib_module_t* self)
+{
+  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
+  GtkTreeModel *model = GTK_TREE_MODEL(d->from.store);
+  g_object_ref(model);
+  gtk_tree_view_set_model(d->from.treeview, NULL);
+  gtk_list_store_clear(d->from.store);
+  d->from.eye = _eye_thumbnail(GTK_WIDGET(d->from.dialog));
+  d->from.nb = _import_from_set_file_list(d->from.folder, strlen(d->from.folder),
+                                          d->from.store, 0, d->from.eye);
+  gtk_tree_view_set_model(d->from.treeview, model);
+}
+
+static void _ignore_jpegs_toggled(GtkWidget *widget, dt_lib_module_t* self)
+{
+  _update_files_list(self);
+}
+
+static void _recursive_toggled(GtkWidget *widget, dt_lib_module_t* self)
+{
+  _update_files_list(self);
 }
 
 static void _import_from_dialog_new(dt_lib_module_t* self)
 {
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  d->from.dialog = gtk_dialog_new_with_buttons("", NULL, GTK_DIALOG_MODAL,
-                                               _("done"), GTK_RESPONSE_NONE, _("import"),
+  d->from.dialog = gtk_dialog_new_with_buttons(d->from.inplace ? _("import - in-place") : _("import - copy"),
+                                               NULL, GTK_DIALOG_MODAL,
+                                               _("cancel"), GTK_RESPONSE_NONE,
+                                               d->from.inplace ? _("import - in-place") : _("import - copy"),
                                                GTK_RESPONSE_ACCEPT, NULL);
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(d->from.dialog);
 #endif
-  gtk_window_set_default_size(GTK_WINDOW(d->from.dialog), DT_PIXEL_APPLY_DPI(300),
-                                                          DT_PIXEL_APPLY_DPI(600));
+  gtk_window_set_default_size(GTK_WINDOW(d->from.dialog), -1,
+                              DT_PIXEL_APPLY_DPI(d->from.inplace ? 600 : 750));
   gtk_window_set_transient_for(GTK_WINDOW(d->from.dialog), GTK_WINDOW(win));
   GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(d->from.dialog));
+  GtkWidget *import_list = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *import_patterns = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *import_metadata = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  // jobcode
+  // images numbers
+  GList *children = gtk_container_get_children(GTK_CONTAINER(d->from.dialog));
+  GtkWidget *box = GTK_WIDGET(children->data);
+  g_list_free(children);
+  children = gtk_container_get_children(GTK_CONTAINER(box));
+  box = GTK_WIDGET(children->data); // action-box
+  g_list_free(children);
+
+  d->from.img_nb = gtk_label_new("");
+  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(d->from.img_nb), TRUE, TRUE, 0);
+
+  // metadata tab
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
 
-  GtkWidget *insitu = dt_gui_preferences_bool(grid, "ui_last/in_situ");
-  dt_gui_preferences_string(grid, "ui_last/import_jobcode");
-  dt_gui_preferences_string(grid, "session/base_directory_pattern");
-  dt_gui_preferences_string(grid, "session/sub_directory_pattern");
-  GtkWidget *usefn = dt_gui_preferences_bool(grid, "session/use_filename");
-  dt_gui_preferences_string(grid, "session/filename_pattern");
+  d->ignore_exif = dt_gui_preferences_bool(grid, "ui_last/ignore_exif_rating", FALSE);
+  d->rating = dt_gui_preferences_int(grid, "ui_last/import_initial_rating");
+  d->metadata.apply_metadata =
+  d->apply_metadata = dt_gui_preferences_bool(grid, "ui_last/import_apply_metadata", FALSE);
 
-  _update_layout(GTK_WIDGET(grid));
-  g_signal_connect(insitu, "toggled", G_CALLBACK(_insitu_toggled), grid);
-  g_signal_connect(usefn, "toggled", G_CALLBACK(_usefn_toggled), grid);
+  gtk_box_pack_start(GTK_BOX(import_metadata), GTK_WIDGET(grid), FALSE, FALSE, 0);
+  d->metadata.box = import_metadata;
+  dt_import_metadata_init(&d->metadata);
 
-  gtk_box_pack_start(GTK_BOX(content), GTK_WIDGET(grid), FALSE, FALSE, 0);
-
-  GtkWidget *label = dt_ui_label_new(_("folder"));
-  gtk_grid_attach(grid, label, 0, 6, 1, 1);
-  label = dt_ui_label_new(d->from.folder);
-  gtk_grid_attach(grid, label, 1, 6, 1, 1);
-
+  // images tab
   // List - setup store
+  grid = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
+
+  // general info
+  int line = 0;
+  grid = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
+  GtkWidget *label = dt_ui_label_new(_("folder"));
+  gtk_grid_attach(grid, label, 0, line, 1, 1);
+  label = dt_ui_label_new(d->from.folder);
+  gtk_grid_attach(grid, label, 1, line++, 3, 1);
+  GtkGrid *grid2 = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_column_spacing(grid2, DT_PIXEL_APPLY_DPI(5));
+  d->recursive = dt_gui_preferences_bool(grid2, "ui_last/import_recursive", TRUE);
+  g_signal_connect(G_OBJECT(d->recursive), "toggled", G_CALLBACK(_recursive_toggled), self);
+  gtk_grid_attach(grid, GTK_WIDGET(grid2), 0, line, 2, 1);
+  gtk_widget_set_hexpand(GTK_WIDGET(grid2), TRUE);
+  grid2 = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_column_spacing(grid2, DT_PIXEL_APPLY_DPI(5));
+  d->ignore_jpegs = dt_gui_preferences_bool(grid2, "ui_last/import_ignore_jpegs", TRUE);
+  g_signal_connect(G_OBJECT(d->ignore_jpegs), "toggled", G_CALLBACK(_ignore_jpegs_toggled), self);
+  gtk_grid_attach(grid, GTK_WIDGET(grid2), 2, line++, 2, 1);
+  gtk_widget_set_hexpand(GTK_WIDGET(grid2), TRUE);
+  gtk_box_pack_start(GTK_BOX(import_list), GTK_WIDGET(grid), FALSE, FALSE, 8);
+
   d->from.store = gtk_list_store_new(DT_IMPORT_NUM_COLS, G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF,
                                      G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT64);
   // fulfill the store
-  gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
+  d->from.eye = _eye_thumbnail(GTK_WIDGET(d->from.dialog));
   d->from.nb = _import_from_set_file_list(d->from.folder, strlen(d->from.folder),
-                                          recursive, d->from.store, 0);
-  _update_dialog_title(d->from.dialog, 0, d->from.nb);
+                                          d->from.store, 0, d->from.eye);
+  _update_images_number(d->from.img_nb, 0, d->from.nb);
 
   // Create the treview with list model data store
   d->from.w = gtk_scrolled_window_new(NULL, NULL);
@@ -797,28 +842,8 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   d->from.treeview = GTK_TREE_VIEW(gtk_tree_view_new());
   gtk_container_add(GTK_CONTAINER(d->from.w), GTK_WIDGET(d->from.treeview));
 
-  GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
-  g_signal_connect(renderer, "toggled", G_CALLBACK(_thumb_toggled), self);
-  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("", renderer, "active",
-                                                                       DT_IMPORT_SEL_THUMB, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(d->from.treeview), column);
-  d->from.sel_thumb = column;
-  GtkWidget *button = gtk_check_button_new();
-  gtk_widget_show(button);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), FALSE);
-  gtk_tree_view_column_set_widget(column, button);
-//  FIXME the toggle button is not centered
-//  gtk_tree_view_column_set_alignment(column, 0.5);
-  g_signal_connect(column, "clicked", G_CALLBACK(_all_thumb_toggled), self);
-  gtk_tree_view_column_set_clickable(column, TRUE);
-
-  renderer = gtk_cell_renderer_pixbuf_new();
-  column = gtk_tree_view_column_new_with_attributes(_("thumbnail"), renderer, "pixbuf",
-                                                    DT_IMPORT_THUMB, NULL);
-  gtk_tree_view_append_column(d->from.treeview, column);
-
-  renderer = gtk_cell_renderer_text_new();
-  column = gtk_tree_view_column_new_with_attributes(_("file"), renderer, "text",
+  GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("file"), renderer, "text",
                                                     DT_IMPORT_UI_FILENAME, NULL);
   gtk_tree_view_append_column(d->from.treeview, column);
   gtk_tree_view_column_set_expand(column, TRUE);
@@ -833,6 +858,22 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   gtk_tree_view_append_column(d->from.treeview, column);
   gtk_tree_view_column_set_sort_column_id(column, DT_IMPORT_DATETIME);
 
+  renderer = gtk_cell_renderer_pixbuf_new();
+  column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf",
+                                                    DT_IMPORT_THUMB, NULL);
+  gtk_tree_view_append_column(d->from.treeview, column);
+  GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT, NULL);
+  gtk_widget_show(button);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), FALSE);
+  gtk_tree_view_column_set_widget(column, button);
+  g_signal_connect(column, "clicked", G_CALLBACK(_all_thumb_toggled), self);
+  gtk_tree_view_column_set_alignment(column, 0.5);
+  gtk_tree_view_column_set_clickable(column, TRUE);
+  gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(128));
+  d->from.pixcol = column;
+  g_signal_connect(G_OBJECT(d->from.treeview), "button-press-event",
+                   G_CALLBACK(_thumb_toggled), self);
+
   GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.treeview);
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
   g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(_import_from_selection_changed), self);
@@ -840,7 +881,45 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   gtk_tree_view_set_model(d->from.treeview, GTK_TREE_MODEL(d->from.store));
   gtk_tree_view_set_headers_visible(d->from.treeview, TRUE);
 
-  gtk_box_pack_start(GTK_BOX(content), GTK_WIDGET(d->from.w), TRUE, TRUE, 0);
+  gtk_tree_selection_select_all(selection);
+  gtk_box_pack_start(GTK_BOX(import_list), GTK_WIDGET(d->from.w), TRUE, TRUE, 0);
+  // separator
+  gtk_widget_set_name(GTK_WIDGET(d->from.w), "section_label");
+
+  if(!d->from.inplace)
+  {
+    // patterns
+    grid = GTK_GRID(gtk_grid_new());
+    gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
+    dt_gui_preferences_string(grid, "ui_last/import_jobcode");
+    dt_gui_preferences_string(grid, "ui_last/import_datetime_override");
+    dt_gui_preferences_string(grid, "session/base_directory_pattern");
+    dt_gui_preferences_string(grid, "session/sub_directory_pattern");
+    GtkWidget *usefn = dt_gui_preferences_bool(grid, "session/use_filename", FALSE);
+    dt_gui_preferences_string(grid, "session/filename_pattern");
+    gtk_box_pack_start(GTK_BOX(import_patterns), GTK_WIDGET(grid), FALSE, FALSE, 0);
+    d->from.patterns = grid;
+    _update_layout(self);
+    g_signal_connect(usefn, "toggled", G_CALLBACK(_usefn_toggled), self);
+    gtk_box_pack_start(GTK_BOX(import_list), import_patterns, FALSE, FALSE, 0);
+  }
+
+  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  grid = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
+  dt_gui_preferences_bool(grid, "ui_last/import_keep_open", TRUE);
+  gtk_box_pack_end(GTK_BOX(box), GTK_WIDGET(grid), FALSE, FALSE, 0);
+
+  gtk_box_pack_start(GTK_BOX(import_list), GTK_WIDGET(box), FALSE, FALSE, 0);
+
+  // THE NOTEBOOK
+  GtkWidget *notebook = gtk_notebook_new();
+  gtk_notebook_append_page(GTK_NOTEBOOK(notebook), import_list, gtk_label_new(_("images")));
+  gtk_notebook_append_page(GTK_NOTEBOOK(notebook), import_metadata, gtk_label_new(_("metadata")));
+  gtk_box_pack_start(GTK_BOX(content), GTK_WIDGET(notebook), TRUE, TRUE, 0);
+#ifdef USE_LUA
+  gtk_box_pack_start(GTK_BOX(import_metadata), d->extra_lua_widgets, FALSE, FALSE, 0);
+#endif
 }
 
 static void _import_set_collection(char *dirname)
@@ -881,21 +960,31 @@ static void _import_from_dialog_run(dt_lib_module_t* self)
     if(imgs)
     {
       imgs = g_list_reverse(imgs);
-      dt_control_import(imgs);
+      char *dto = dt_conf_get_string("ui_last/import_datetime_override");
+      dto = g_strstrip(dto);
+      const time_t datetime_override = dto[0] ? _parse_date_time(dto) : 0;
+      dt_control_import(imgs, datetime_override);
       _import_set_collection(g_path_get_dirname((char *)imgs->data));
     }
     gtk_tree_selection_unselect_all(selection);
+    if(!dt_conf_get_bool("ui_last/import_keep_open"))
+      break;
   }
-  // Destroy and quit
-  gtk_widget_destroy(d->from.dialog);
 }
 
 static void _import_from_dialog_free(dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   d->from.event = 0;
+  g_object_unref(d->from.eye);
   gtk_list_store_clear(d->from.store);
   g_object_unref(d->from.store);
+  dt_import_metadata_cleanup(&d->metadata);
+#ifdef USE_LUA
+  detach_lua_widgets(d->extra_lua_widgets);
+#endif
+  // Destroy and quit
+  gtk_widget_destroy(d->from.dialog);
 }
 
 static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
@@ -926,6 +1015,7 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
     gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
     dt_conf_set_string("ui_last/import_last_directory", folder);
 
+    d->from.inplace = (widget == GTK_WIDGET(d->import_inplace)) ? TRUE : FALSE;
     _import_from_dialog_new(self);
     _import_from_dialog_run(self);
     _import_from_dialog_free(self);
@@ -968,32 +1058,6 @@ void init(dt_lib_module_t *self)
 }
 #endif
 
-static void _update_gui(dt_lib_module_t *self)
-{
-  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const gboolean active = dt_conf_get_bool("ui_last/expander_import");
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->prefs_toggle), active);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(d->prefs_expander), active);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->prefs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
-}
-
-static void _prefs_button_changed(GtkDarktableToggleButton *widget, dt_lib_module_t *self)
-{
-  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->prefs_toggle));
-  dt_conf_set_bool("ui_last/expander_import", active);
-  _update_gui(self);
-}
-
-static void _prefs_expander_click(GtkWidget *widget, GdkEventButton *e, dt_lib_module_t *self)
-{
-  if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return;
-  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->prefs_toggle));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->prefs_toggle), !active);
-}
-
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -1002,22 +1066,20 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   dt_gui_add_help_link(self->widget, "lighttable_panels.html#import");
 
+  // add import buttons
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  /* add import single image buttons */
-  GtkWidget *widget = dt_ui_button_new(_("image..."), _("select a folder to import from"), "lighttable_panels.html#import_from_fs");
-  d->import_file = GTK_BUTTON(widget);
+  GtkWidget *widget = dt_ui_button_new(_("import - in-place..."), _("select a folder to import from"), "lighttable_panels.html#import_from_fs");
+  d->import_inplace = GTK_BUTTON(widget);
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_import_from_callback), self);
-
-  /* adding the import folder button */
-  widget = dt_ui_button_new(_("folder..."), _("select a folder to import as film roll"), "lighttable_panels.html#import_from_fs");
-  d->import_directory = GTK_BUTTON(widget);
+  widget = dt_ui_button_new(_("import - copy..."), _("select a folder to import from"), "lighttable_panels.html#import_from_fs");
+  d->import_copy = GTK_BUTTON(widget);
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_import_folder_callback), self);
+  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_import_from_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
 #ifdef HAVE_GPHOTO2
@@ -1039,68 +1101,25 @@ void gui_init(dt_lib_module_t *self)
                             self);
 #endif
 
-  // collapsible section
-  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *header_evb = gtk_event_box_new();
-  GtkStyleContext *context = gtk_widget_get_style_context(destdisp_head);
-  gtk_style_context_add_class(context, "section-expander");
-  GtkWidget *destdisp = dt_ui_section_label_new(_("parameters"));
-  gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
-
-  d->prefs_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->prefs_toggle), TRUE);
-  gtk_widget_set_name(GTK_WIDGET(d->prefs_toggle), "control-button");
-
-  gtk_box_pack_start(GTK_BOX(destdisp_head), header_evb, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), d->prefs_toggle, FALSE, FALSE, 0);
-
-  d->prefs_widgets = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  d->prefs_expander = dtgtk_expander_new(destdisp_head, d->prefs_widgets);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(d->prefs_expander), TRUE);
-  GtkWidget *expander_frame = dtgtk_expander_get_frame(DTGTK_EXPANDER(d->prefs_expander));
-  gtk_widget_set_name(expander_frame, "import_metadata");
-
-  gtk_box_pack_end(GTK_BOX(self->widget), d->prefs_expander, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(d->prefs_toggle), "toggled", G_CALLBACK(_prefs_button_changed),  (gpointer)self);
-  g_signal_connect(G_OBJECT(header_evb), "button-release-event", G_CALLBACK(_prefs_expander_click),
-                   (gpointer)self);
-
-  GtkGrid *grid = GTK_GRID(gtk_grid_new());
-  gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
-  d->recursive = dt_gui_preferences_bool(grid, "ui_last/import_recursive");
-  d->ignore_jpegs = dt_gui_preferences_bool(grid, "ui_last/import_ignore_jpegs");
-  d->ignore_exif = dt_gui_preferences_bool(grid, "ui_last/ignore_exif_rating");
-  d->rating = dt_gui_preferences_int(grid, "ui_last/import_initial_rating");
-  d->apply_metadata = d->metadata.apply_metadata = dt_gui_preferences_bool(grid, "ui_last/import_apply_metadata");
-  gtk_box_pack_start(GTK_BOX(d->prefs_widgets), GTK_WIDGET(grid), FALSE, FALSE, 0);
-  d->metadata.box = d->prefs_widgets;
-  dt_import_metadata_init(&d->metadata);
-
 #ifdef USE_LUA
   /* initialize the lua area  and make sure it survives its parent's destruction*/
   d->extra_lua_widgets = gtk_box_new(GTK_ORIENTATION_VERTICAL,5);
   g_object_ref_sink(d->extra_lua_widgets);
-  gtk_box_pack_start(GTK_BOX(d->prefs_widgets), d->extra_lua_widgets, FALSE, FALSE, 0);
   gtk_container_foreach(GTK_CONTAINER(d->extra_lua_widgets), reset_child, NULL);
 #endif
 
   gtk_widget_show_all(self->widget);
   gtk_widget_set_no_show_all(self->widget, TRUE);
-  _update_gui(self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
 #ifdef HAVE_GPHOTO2
+  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_camera_detected), self);
   /* unregister camctl listener */
   dt_camctl_unregister_listener(darktable.camctl, &d->camctl_listener);
 #endif
-#ifdef USE_LUA
-  detach_lua_widgets(d->extra_lua_widgets);
-#endif
-  dt_import_metadata_cleanup(&d->metadata);
   /* cleanup mem */
   g_free(self->data);
   self->data = NULL;

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -506,7 +506,7 @@ static void _lib_import_folder_callback(GtkWidget *widget, dt_lib_module_t* self
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *filechooser = gtk_file_chooser_dialog_new(
       _("import folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_open"), GTK_RESPONSE_ACCEPT, (char *)NULL);
+      GTK_RESPONSE_CANCEL, _("_import"), GTK_RESPONSE_ACCEPT, (char *)NULL);
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -138,17 +138,18 @@ void gui_init(dt_lib_module_t *self)
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
 
-  d->show_osd_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/show_map_osd", FALSE);
+  int line = 0;
+  d->show_osd_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/show_map_osd", 0, line++, FALSE);
   g_signal_connect(G_OBJECT(d->show_osd_checkbutton), "toggled", G_CALLBACK(_show_osd_toggled), NULL);
-  d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn", FALSE);
+  d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn", 0, line++, FALSE);
   g_signal_connect(G_OBJECT(d->filtered_images_checkbutton), "toggled", G_CALLBACK(_parameter_changed), NULL);
-  d->max_images_entry = dt_gui_preferences_int(grid, "plugins/map/max_images_drawn");
+  d->max_images_entry = dt_gui_preferences_int(grid, "plugins/map/max_images_drawn", 0, line++);
   g_signal_connect(G_OBJECT(d->max_images_entry), "value-changed", G_CALLBACK(_parameter_changed), self);
-  d->epsilon_factor = dt_gui_preferences_int(grid, "plugins/map/epsilon_factor");
+  d->epsilon_factor = dt_gui_preferences_int(grid, "plugins/map/epsilon_factor", 0, line++);
   g_signal_connect(G_OBJECT(d->epsilon_factor), "value-changed", G_CALLBACK(_parameter_changed), self);
-  d->min_images = dt_gui_preferences_int(grid, "plugins/map/min_images_per_group");
+  d->min_images = dt_gui_preferences_int(grid, "plugins/map/min_images_per_group", 0, line++);
   g_signal_connect(G_OBJECT(d->min_images), "value-changed", G_CALLBACK(_parameter_changed), self);
-  d->images_thumb = dt_gui_preferences_enum(grid, "plugins/map/images_thumbnail");
+  d->images_thumb = dt_gui_preferences_enum(grid, "plugins/map/images_thumbnail", 0, line++);
   g_signal_connect(G_OBJECT(d->images_thumb), "changed", G_CALLBACK(_parameter_changed), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(grid), FALSE, FALSE, 0);
 }

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -138,9 +138,9 @@ void gui_init(dt_lib_module_t *self)
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
 
-  d->show_osd_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/show_map_osd");
+  d->show_osd_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/show_map_osd", FALSE);
   g_signal_connect(G_OBJECT(d->show_osd_checkbutton), "toggled", G_CALLBACK(_show_osd_toggled), NULL);
-  d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn");
+  d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn", FALSE);
   g_signal_connect(G_OBJECT(d->filtered_images_checkbutton), "toggled", G_CALLBACK(_parameter_changed), NULL);
   d->max_images_entry = dt_gui_preferences_int(grid, "plugins/map/max_images_drawn");
   g_signal_connect(G_OBJECT(d->max_images_entry), "value-changed", G_CALLBACK(_parameter_changed), self);


### PR DESCRIPTION
Attempt to partially fix #2762, partially fix #8292, fix #6363 and fix #6493.

![image](https://user-images.githubusercontent.com/23012047/109499103-355c4800-7a73-11eb-96ab-d94c17e40d19.png)

![image](https://user-images.githubusercontent.com/23012047/109506291-3b0a5b80-7a7c-11eb-81a2-6164fd378a46.png)


Replace the previous `image...` button behavior.
It is able to import files where they are as today or use the session pattern to import from other folders.
The main difference I can see is to not open darkroom anymore at the end of the import (everything is done in a separated job).

It covers also all the features of `folder...` button. However I haven't removed it because the ui is a bit different and some people could be sensitive to that. The new ui displays all imported files. In case of recursive `folder...` import, this can represent thousands of files. On the other hand the `folder...` button just shows the root folder.
 
Changes:
- displays thumbs on demand
- shows file date/time
- can import & copy files using session pattern as camera import does
- reads usb memory card (but not the cameras (1))
- doesn't use libgphoto2 directly

(1) all file browsers read the cameras as well (thanks to libgphoto2 I think) but  gtkfilechooser seems not to be able to do the same.

Comments, suggestions are welcome.
