### PR TITLE
geotagging : only get the selection size at startup

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1831,13 +1831,10 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->map.select_button), "clicked", G_CALLBACK(_select_images), self);
   gtk_grid_attach(grid, d->map.select_button, 1, line, 1, 1);
 
-  _setup_selected_images_list(self);
-  char *nb = dt_util_dstrcat(NULL, "0/%d", d->nb_imgs);
-  d->map.nb_imgs_label = dt_ui_label_new(nb);
+  d->map.nb_imgs_label = dt_ui_label_new("0/0");
   gtk_widget_set_halign(d->map.nb_imgs_label, GTK_ALIGN_END);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->map.nb_imgs_label),
                               _("number of matching images versus selected images"));
-  g_free(nb);
   gtk_grid_attach(grid, d->map.nb_imgs_label, 2, line++, 1, 1);
 
   d->map.apply_gpx_button = dt_ui_button_new(_("apply geo-location"),


### PR DESCRIPTION
if you do a big selection in dt, then close dt and restart, you can see a big "lag" at startup, before the window appears.
Almost half of the lag is spent in getagging to crawl into the whole selection during gui_init. But gui_init seems to only need the size of the selection, and it's almost instantaneous to get it with a "count" query...

I'm not sure if the whole list of images was used for other things, but I doubt it's the case as the list isn't recomputed on selection changed signal...

Here, with a 95K images selection, geotagging init was using 15s. and with this PR 0.008 s.

@phweyland : I don't know anything about geotagging lib, so if you can have a look... TIA ! (and sorry to annoy you again)