### PR TITLE
Ensure that preview is centered when zooming out

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -456,8 +456,8 @@ static void _zoom_preset_change(uint64_t val)
   // zoom_x = (1.0/(scale*(1<<closeup)))*(zoom_x - .5f*dev->width )/procw;
   // zoom_y = (1.0/(scale*(1<<closeup)))*(zoom_y - .5f*dev->height)/proch;
 
-  dt_dev_check_zoom_bounds(dev, &zoom_x, &zoom_y, zoom, closeup, NULL, NULL);
   dt_control_set_dev_zoom_scale(scale);
+  dt_dev_check_zoom_bounds(dev, &zoom_x, &zoom_y, zoom, closeup, NULL, NULL);
   dt_control_set_dev_zoom(zoom);
   dt_control_set_dev_closeup(closeup);
   dt_control_set_dev_zoom_x(zoom_x);


### PR DESCRIPTION
Fixes #8383

When setting the zoom level to small, the zoom scale must be set prior
to calling dt_dev_check_zoom_bounds, because when zoom is DT_ZOOM_FREE
it will call dt_dev_get_zoom_scale. If it sees the old value that has
not been scaled by 0.5, it may set zoom_x and zoom_y to nonzero values
causing the preview to be off center.