### PR TITLE
Some optimizing for RDC OpenCL code

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3552,7 +3552,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     }
 
     {
-      const int myborder = 7;
+      const int myborder = 6;
       // manage borders
       size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
       dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_border, 0, sizeof(cl_mem), &cfa);


### PR DESCRIPTION
1. For two kernels it was possible to increase the calculated range so the interpolated border width could be reduced from 7 to 6.

2. The border interpolation kernel now uses an almost identical code compared with the cpu, this leads to even less differences in the integration suite.