### PR TITLE
startup speedup

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2803,6 +2803,7 @@ void gui_init(dt_lib_module_t *self)
   GtkBox *box = NULL;
   GtkWidget *w = NULL;
 
+  gboolean has_iop_name_rule = FALSE;
   for(int i = 0; i < MAX_RULES; i++)
   {
     d->rule[i].num = i;
@@ -2818,6 +2819,7 @@ void gui_init(dt_lib_module_t *self)
     dt_bauhaus_combobox_set_selected_text_align(d->rule[i].combo, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
     _populate_collect_combo(d->rule[i].combo);
     dt_bauhaus_combobox_mute_scrolling(d->rule[i].combo);
+    if(_combo_get_active_collection(d->rule[i].combo) == DT_COLLECTION_PROP_MODULE) has_iop_name_rule = TRUE;
 
     g_signal_connect(G_OBJECT(d->rule[i].combo), "value-changed", G_CALLBACK(combo_changed), d->rule + i);
     gtk_box_pack_start(box, d->rule[i].combo, TRUE, TRUE, 0);
@@ -2889,7 +2891,7 @@ void gui_init(dt_lib_module_t *self)
   }
 
   // force redraw collection images because of late update of the table memory.darktable_iop_names
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  if(has_iop_name_rule) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, G_CALLBACK(collection_updated),
                             self);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -384,9 +384,9 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_set_tooltip_text(d->grouping_button, _("expand grouped images"));
   else
     gtk_widget_set_tooltip_text(d->grouping_button, _("collapse grouped images"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->grouping_button), darktable.gui->grouping);
   g_signal_connect(G_OBJECT(d->grouping_button), "clicked", G_CALLBACK(_lib_filter_grouping_button_clicked),
                    NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->grouping_button), darktable.gui->grouping);
 
   /* create the "show/hide overlays" button */
   d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT, NULL);


### PR DESCRIPTION
Various speedups of libs gui_init especially with big collection and/or selections : 
All following timings have been done with a selection of 95K images
- global_toolbox : timings was depending of collection size. reduce time to about nothing. Gain : 1.20-0.05 = 1.15 s.
- collect : limit collection refresh to the "module" rule only. timings was depending of collection size. Gain : 1.6-0.8 = 0.8s.
- tagging : timings was depending of selection size. Gain : 1.38-0.8 = 0.58s. Note that the speedup will also be visible each time the list of tags need to be refreshed.

@phweyland : can you have look, as I've -again :)- changed some of your code ? Thanks !