### PR TITLE
Export format and storage ui and geotagging fixes for narrow panel

### DIFF
--- a/src/imageio/format/copy.c
+++ b/src/imageio/format/copy.c
@@ -21,6 +21,7 @@
 #include "common/imageio_module.h"
 #include "common/utility.h"
 #include "imageio/format/imageio_format_api.h"
+#include "gui/gtk.h"
 #include <glib/gstdio.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -117,13 +118,10 @@ void cleanup(dt_imageio_module_format_t *self)
 
 void gui_init(dt_imageio_module_format_t *self)
 {
-  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  self->widget = box;
+  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  GtkWidget *label
-      = gtk_label_new(_("do a 1:1 copy of the selected files.\nthe global options below do not apply!"));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 0);
+  gtk_container_add(GTK_CONTAINER(self->widget),
+    dt_ui_label_new(_("do a 1:1 copy of the selected files.\nthe global options below do not apply!")));
 }
 void gui_cleanup(dt_imageio_module_format_t *self)
 {

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -573,18 +573,15 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(8));
 
-  GtkWidget *widget;
   int line = 0;
 
   // title
 
-  widget = gtk_label_new(_("title"));
-  gtk_widget_set_halign(widget, GTK_ALIGN_START);
-  g_object_set(G_OBJECT(widget), "xalign", 0.0, (gchar *)0);
-  gtk_grid_attach(grid, widget, 0, ++line, 1, 1);
+  gtk_grid_attach(grid, dt_ui_label_new(_("title")), 0, ++line, 1, 1);
 
   d->title = GTK_ENTRY(gtk_entry_new());
   gtk_entry_set_placeholder_text(d->title, "untitled");
+  gtk_entry_set_width_chars(d->title, 5);
   gtk_widget_set_hexpand(GTK_WIDGET(d->title), TRUE);
   gtk_grid_attach(grid, GTK_WIDGET(d->title), 1, line, 1, 1);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title));
@@ -626,12 +623,10 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // border
 
-  widget = gtk_label_new(_("border"));
-  gtk_widget_set_halign(widget, GTK_ALIGN_START);
-  g_object_set(G_OBJECT(widget), "xalign", 0.0, (gchar *)0);
-  gtk_grid_attach(grid, widget, 0, ++line, 1, 1);
+  gtk_grid_attach(grid, dt_ui_label_new(_("border")), 0, ++line, 1, 1);
 
   d->border = GTK_ENTRY(gtk_entry_new());
+  gtk_entry_set_width_chars(d->border, 5);
   gtk_entry_set_max_length(d->border, sizeof(((dt_imageio_pdf_params_t *)NULL)->border) - 1);
   gtk_entry_set_placeholder_text(d->border, "0 mm");
   gtk_grid_attach(grid, GTK_WIDGET(d->border), 1, line, 1, 1);
@@ -648,10 +643,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // dpi
 
-  widget = gtk_label_new(_("dpi"));
-  gtk_widget_set_halign(widget, GTK_ALIGN_START);
-  g_object_set(G_OBJECT(widget), "xalign", 0.0, (gchar *)0);
-  gtk_grid_attach(grid, widget, 0, ++line, 1, 1);
+  gtk_grid_attach(grid, dt_ui_label_new(_("dpi")), 0, ++line, 1, 1);
 
   d->dpi = GTK_SPIN_BUTTON(gtk_spin_button_new_with_range(1, 5000, 1));
   gtk_grid_attach(grid, GTK_WIDGET(d->dpi), 1, line, 1, 1);

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -155,6 +155,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   GtkWidget *widget;
 
   widget = gtk_entry_new();
+  gtk_entry_set_width_chars(GTK_ENTRY(widget), 0);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
   gchar *dir = dt_conf_get_string("plugins/imageio/storage/gallery/file_directory");
   if(dir)
@@ -183,10 +184,9 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
-  widget = gtk_label_new(_("title"));
-  g_object_set(G_OBJECT(widget), "xalign", 0.0, (gchar *)0);
-  gtk_box_pack_start(GTK_BOX(hbox), widget, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("title")), FALSE, FALSE, 0);
   d->title_entry = GTK_ENTRY(gtk_entry_new());
+  gtk_entry_set_width_chars(d->title_entry, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(d->title_entry), TRUE, TRUE, 0);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title_entry));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title_entry), _("enter the title of the website"));

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -154,6 +154,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   GtkWidget *widget;
 
   widget = gtk_entry_new();
+  gtk_entry_set_width_chars(GTK_ENTRY(widget), 0);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
   gchar *dir = dt_conf_get_string("plugins/imageio/storage/latex/file_directory");
   if(dir)
@@ -183,12 +184,10 @@ void gui_init(dt_imageio_module_storage_t *self)
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(10));
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
-  widget = gtk_label_new(_("title"));
-  gtk_widget_set_halign(widget, GTK_ALIGN_START);
-  g_object_set(G_OBJECT(widget), "xalign", 0.0, (gchar *)0);
-  gtk_box_pack_start(GTK_BOX(hbox), widget, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("title")), FALSE, FALSE, 0);
 
   d->title_entry = GTK_ENTRY(gtk_entry_new());
+  gtk_entry_set_width_chars(d->title_entry, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(d->title_entry), TRUE, TRUE, 0);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title_entry));
   // TODO: support title, author, subject, keywords (collect tags?)

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -270,6 +270,7 @@ static void _piwigo_set_status(dt_storage_piwigo_gui_data_t *ui, gchar *message,
   gchar mup[512] = { 0 };
   snprintf(mup, sizeof(mup), "<span foreground=\"%s\" ><small>%s</small></span>", color, message);
   gtk_label_set_markup(ui->status_label, mup);
+  gtk_widget_set_tooltip_markup(GTK_WIDGET(ui->status_label), mup);
 }
 
 static int _piwigo_api_post_internal(_piwigo_api_context_t *ctx, GList *args, char *filename, gboolean isauth)
@@ -764,8 +765,6 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   // server
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = gtk_label_new(_("server"));
-  g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);
   ui->server_entry = GTK_ENTRY(gtk_entry_new());
   gtk_widget_set_tooltip_text(GTK_WIDGET(ui->server_entry),
                               _("the server name\ndefault protocol is https\nspecify http:// if non secure server"));
@@ -774,29 +773,25 @@ void gui_init(dt_imageio_module_storage_t *self)
   gtk_entry_set_text(ui->server_entry, last_account?last_account->server:"piwigo.com");
   g_signal_connect(G_OBJECT(ui->server_entry), "changed", G_CALLBACK(_piwigo_server_entry_changed), (gpointer)ui);
   gtk_entry_set_width_chars(GTK_ENTRY(ui->server_entry), 0);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(label), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("server")), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(ui->server_entry), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
   g_free(server);
 
   // login
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = gtk_label_new(_("user"));
-  g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);
   ui->user_entry = GTK_ENTRY(gtk_entry_new());
   gtk_widget_set_hexpand(GTK_WIDGET(ui->user_entry), TRUE);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(ui->user_entry));
   gtk_entry_set_text(ui->user_entry, last_account?last_account->username:"");
   g_signal_connect(G_OBJECT(ui->user_entry), "changed", G_CALLBACK(_piwigo_entry_changed), (gpointer)ui);
   gtk_entry_set_width_chars(GTK_ENTRY(ui->user_entry), 0);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(label), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("user")), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(ui->user_entry), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
   // password
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = gtk_label_new(_("password"));
-  g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);
   ui->pwd_entry = GTK_ENTRY(gtk_entry_new());
   gtk_entry_set_visibility(GTK_ENTRY(ui->pwd_entry), FALSE);
   gtk_widget_set_hexpand(GTK_WIDGET(ui->pwd_entry), TRUE);
@@ -804,7 +799,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   gtk_entry_set_text(ui->pwd_entry, last_account?last_account->password:"");
   g_signal_connect(G_OBJECT(ui->pwd_entry), "changed", G_CALLBACK(_piwigo_entry_changed), (gpointer)ui);
   gtk_entry_set_width_chars(GTK_ENTRY(ui->pwd_entry), 0);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(label), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("password")), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(ui->pwd_entry), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
@@ -816,6 +811,7 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   // status area
   ui->status_label = GTK_LABEL(gtk_label_new(NULL));
+  gtk_label_set_ellipsize(ui->status_label, PANGO_ELLIPSIZE_END);
   gtk_widget_set_halign(GTK_WIDGET(ui->status_label), GTK_ALIGN_START);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(ui->status_label), FALSE, FALSE, 0);
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -52,11 +52,9 @@ DT_MODULE(7)
 typedef struct dt_lib_export_t
 {
   GtkWidget *dimensions_type, *print_dpi, *print_height, *print_width;
-  GtkWidget *print_size;
   GtkWidget *unit_label;
   GtkWidget *width, *height;
-  GtkWidget *scale, *size_in_px;
-  GtkBox *hbox1, *hbox_scale;
+  GtkWidget *px_size, *print_size, *scale, *size_in_px;
   GtkWidget *storage, *format;
   int format_lut[128];
   uint32_t max_allowed_width , max_allowed_height;
@@ -854,14 +852,14 @@ static void _dimensions_type_changed(GtkWidget *widget, dt_lib_export_t *d)
   {
     if(d_type != DT_DIMENSIONS_PIXELS)
     {
-      gtk_widget_hide(GTK_WIDGET(d->hbox1));
+      gtk_widget_hide(GTK_WIDGET(d->px_size));
       gtk_widget_show(GTK_WIDGET(d->print_size));
       gtk_widget_hide(GTK_WIDGET(d->scale));
       _resync_print_dimensions(d);
     }
     else
     {
-      gtk_widget_show(GTK_WIDGET(d->hbox1));
+      gtk_widget_show(GTK_WIDGET(d->px_size));
       gtk_widget_hide(GTK_WIDGET(d->print_size));
       gtk_widget_hide(GTK_WIDGET(d->scale));
     }
@@ -871,7 +869,7 @@ static void _dimensions_type_changed(GtkWidget *widget, dt_lib_export_t *d)
   else
   {
     gtk_widget_show(GTK_WIDGET(d->scale));
-    gtk_widget_hide(GTK_WIDGET(d->hbox1));
+    gtk_widget_hide(GTK_WIDGET(d->px_size));
     gtk_widget_hide(GTK_WIDGET(d->print_size));
     dt_conf_set_string(CONFIG_PREFIX "resizing", "scaling");
   }
@@ -1234,7 +1232,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->print_size = gtk_flow_box_new();
   gtk_flow_box_set_max_children_per_line(GTK_FLOW_BOX(d->print_size), 5);
-
+  gtk_flow_box_set_column_spacing (GTK_FLOW_BOX(d->print_size), 3);
   gtk_container_add(GTK_CONTAINER(d->print_size), d->print_width);
   gtk_container_add(GTK_CONTAINER(d->print_size), gtk_label_new(_("x")));
   gtk_container_add(GTK_CONTAINER(d->print_size), d->print_height);
@@ -1246,13 +1244,18 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(dpi_box, gtk_label_new(_("dpi")), FALSE, FALSE, 0);
   gtk_container_add(GTK_CONTAINER(d->print_size), GTK_WIDGET(dpi_box));
 
-  d->hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 3));
-  gtk_box_pack_start(d->hbox1, d->width, TRUE, TRUE, 0);
-  gtk_box_pack_start(d->hbox1, gtk_label_new(_("x")), FALSE, FALSE, 0);
-  gtk_box_pack_start(d->hbox1, d->height, TRUE, TRUE, 0);
-  gtk_box_pack_start(d->hbox1, gtk_label_new(_("px")), FALSE, FALSE, 0);
+  d->px_size = gtk_flow_box_new();
+  gtk_flow_box_set_max_children_per_line(GTK_FLOW_BOX(d->px_size), 3);
+  gtk_flow_box_set_column_spacing (GTK_FLOW_BOX(d->px_size), 3);
+  gtk_container_add(GTK_CONTAINER(d->px_size), d->width);
+  gtk_container_add(GTK_CONTAINER(d->px_size), gtk_label_new(_("x")));
+  GtkBox *px_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 3));
+  gtk_box_pack_start(px_box, d->height, TRUE, TRUE, 0);
+  gtk_box_pack_start(px_box, gtk_label_new(_("px")), FALSE, FALSE, 0);
+  gtk_container_add(GTK_CONTAINER(d->px_size), GTK_WIDGET(px_box));
 
   d->scale = gtk_entry_new();
+  gtk_entry_set_width_chars(GTK_ENTRY(d->scale), 5);
   gtk_entry_set_text (GTK_ENTRY(d->scale), dt_conf_get_string(CONFIG_PREFIX "resizing_factor"));
   gtk_widget_set_tooltip_text(d->scale, _("it can be an integer, decimal number or simple fraction.\n"
                                           "zero or empty values are equal to 1.\n"
@@ -1269,7 +1272,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_halign(GTK_WIDGET(d->size_in_px), GTK_ALIGN_END);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->dimensions_type), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->hbox1), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->px_size), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->print_size), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->scale), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->size_in_px), FALSE, FALSE, 0);
@@ -1434,14 +1437,14 @@ void gui_init(dt_lib_module_t *self)
   {
     // scaling
     gtk_widget_show(GTK_WIDGET(d->scale));
-    gtk_widget_hide(GTK_WIDGET(d->hbox1));
+    gtk_widget_hide(GTK_WIDGET(d->px_size));
     gtk_widget_hide(GTK_WIDGET(d->print_size));
   }
   else
   {
     // max size
     gtk_widget_hide(GTK_WIDGET(d->scale));
-    gtk_widget_show(GTK_WIDGET(d->hbox1));
+    gtk_widget_show(GTK_WIDGET(d->px_size));
     gtk_widget_show(GTK_WIDGET(d->print_size));
   }
 


### PR DESCRIPTION
Various adjustments to Entry width and label ellipsizing to fit the UIs of the various file format and storage modules into narrow panels.

Also flowing the times sections in the geo tagging UI to similarly not cause the right side to shift out of view when the module is open in a narrow panel.

Now:
![image](https://user-images.githubusercontent.com/1549490/109991992-bc731f80-7d02-11eb-984d-dfcd26fae659.png)

New:
![image](https://user-images.githubusercontent.com/1549490/109991203-03ace080-7d02-11eb-8af7-e85d890e9f66.png)
![image](https://user-images.githubusercontent.com/1549490/109991296-1b846480-7d02-11eb-9a14-fdcee008118e.png)
![image](https://user-images.githubusercontent.com/1549490/109991378-2f2fcb00-7d02-11eb-9759-8bd051994871.png)
