### PR TITLE
thumbtable : fix re-enabling drag and drop

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1042,6 +1042,7 @@ static gboolean _event_motion_notify(GtkWidget *widget, GdkEventMotion *event, g
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   table->mouse_inside = TRUE;
 
+  gboolean ret = FALSE;
   if(table->dragging && table->mode == DT_THUMBTABLE_MODE_ZOOM)
   {
     const int dx = ceil(event->x_root) - table->last_x;
@@ -1054,11 +1055,12 @@ static gboolean _event_motion_notify(GtkWidget *widget, GdkEventMotion *event, g
       // we only considers that this is a real move if the total distance is not too low
       table->drag_thumb->moved = ((abs(table->drag_dx) + abs(table->drag_dy)) > DT_PIXEL_APPLY_DPI(8));
     }
+    ret = TRUE;
   }
 
   table->last_x = ceil(event->x_root);
   table->last_y = ceil(event->y_root);
-  return TRUE;
+  return ret;
 }
 
 static gboolean _event_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data)


### PR DESCRIPTION
this fix #6123 

it was due to the callback of event-motion-notify which was return TRUE in all case and don't propagate the event further, which in turn break dnd.
Don't ask me why dnd works if you start dt in filemanager directly...