### PR TITLE
memleak fix: ensure return from dt_util_str_to_glist fully freed

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2105,7 +2105,7 @@ GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf)
   }
   iop_order_list = g_list_reverse(iop_order_list);  // list was built in reverse order, so un-reverse it
 
-  g_list_free(list);
+  g_list_free_full(list, g_free);
 
   _ioppr_reset_iop_order(iop_order_list);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -899,7 +899,7 @@ static gboolean list_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTre
       }
     }
 
-    g_list_free(list);
+    g_list_free_full(list, g_free);
 
   }
   else

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -998,6 +998,7 @@ static void _apply_preferences(const char *pref, dt_lib_module_t *self)
       break;  // must be the last setting
     }
   }
+  g_list_free_full(prefs, g_free);
 
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   dt_gui_preferences_bool_update(d->recursive);


### PR DESCRIPTION
The function returns a newly-allocated list of newly-allocated strings, but not all callers were freeing the strings or even the list.

In `get_query_string`, the code additionally failed to free the result of a `dt_util_dstrcat` in a loop.  Since most of the calls of that function in `get_query_string` had a NULL first argument (the variable being passed still having the value NULL from its original initialization), replace them with `g_strdup_printf` as well.