### PR TITLE
refactor: GList loops (Phase 3)

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -511,8 +511,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   {
     if (DT_IOP_ORDER_INFO) fprintf(stderr," selected ops");
     // copy only selected history entries
-    GList *l = g_list_last(ops);
-    while(l)
+    for(const GList *l = g_list_last(ops); l; l = g_list_previous(l))
     {
       const unsigned int num = GPOINTER_TO_UINT(l->data);
 
@@ -528,8 +527,6 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
           mod_list = g_list_prepend(mod_list, hist->module);
         }
       }
-
-      l = g_list_previous(l);
     }
   }
   else

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -910,8 +910,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     // find the finalscale module
     dt_dev_pixelpipe_iop_t *finalscale = NULL;
     {
-      GList *nodes = g_list_last(pipe.nodes);
-      while(nodes)
+      for(const GList *nodes = g_list_last(pipe.nodes); nodes; nodes = g_list_previous(nodes))
       {
         dt_dev_pixelpipe_iop_t *node = (dt_dev_pixelpipe_iop_t *)(nodes->data);
         if(!strcmp(node->module->op, "finalscale"))
@@ -919,7 +918,6 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
           finalscale = node;
           break;
         }
-        nodes = g_list_previous(nodes);
       }
     }
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -272,9 +272,7 @@ static GList *_insert_before(GList *iop_order_list, const char *module, const ch
 
   // first check that new module is missing
 
-  GList *l = iop_order_list;
-
-  while(l)
+  for(const GList *l = iop_order_list; l; l = g_list_next(l))
   {
     const dt_iop_order_entry_t *const restrict entry = (dt_iop_order_entry_t *)l->data;
     if(!strcmp(entry->operation, new_module))
@@ -282,16 +280,13 @@ static GList *_insert_before(GList *iop_order_list, const char *module, const ch
       exists = TRUE;
       break;
     }
-
-    l = g_list_next(l);
   }
 
   // the insert it if needed
 
   if(!exists)
   {
-    l = iop_order_list;
-    while(l)
+    for(GList *l = iop_order_list; l; l = g_list_next(l))
     {
       const dt_iop_order_entry_t *const restrict entry = (dt_iop_order_entry_t *)l->data;
 
@@ -306,8 +301,6 @@ static GList *_insert_before(GList *iop_order_list, const char *module, const ch
         iop_order_list = g_list_insert_before(iop_order_list, l, new_entry);
         break;
       }
-
-      l = g_list_next(l);
     }
   }
 
@@ -377,8 +370,7 @@ GList *dt_ioppr_get_iop_order_link(GList *iop_order_list, const char *op_name, c
 {
   GList *link = NULL;
 
-  GList *iops_order = iop_order_list;
-  while(iops_order)
+  for(GList *iops_order = iop_order_list; iops_order; iops_order = g_list_next(iops_order))
   {
     dt_iop_order_entry_t *order_entry = (dt_iop_order_entry_t *)iops_order->data;
 
@@ -388,8 +380,6 @@ GList *dt_ioppr_get_iop_order_link(GList *iop_order_list, const char *op_name, c
       link = iops_order;
       break;
     }
-
-    iops_order = g_list_next(iops_order);
   }
 
   return link;
@@ -713,12 +703,10 @@ static void _ioppr_reset_iop_order(GList *iop_order_list)
   // iop-order must start with a number > 0 and be incremented. There is no
   // other constraints.
   int iop_order = 1;
-  GList *l = iop_order_list;
-  while(l)
+  for(const GList *l = iop_order_list; l; l = g_list_next(l))
   {
     dt_iop_order_entry_t *e = (dt_iop_order_entry_t *)l->data;
     e->o.iop_order = iop_order++;
-    l = g_list_next(l);
   }
 }
 
@@ -726,10 +714,10 @@ void dt_ioppr_resync_iop_list(dt_develop_t *dev)
 {
   // make sure that the iop_order_list does not contains possibly removed modules
 
-  GList *l = g_list_first(dev->iop_order_list);
+  GList *l = dev->iop_order_list;
   while(l)
   {
-    GList *next = g_list_next(l);
+    GList *next = g_list_next(l); // need to get next pointer now, as we may be deleting this node
     const dt_iop_order_entry_t *const restrict e = (dt_iop_order_entry_t *)l->data;
     const dt_iop_module_t *const restrict mod = dt_iop_get_module_by_op_priority(dev->iop, e->operation, e->instance);
     if(mod == NULL)
@@ -747,7 +735,7 @@ void dt_ioppr_resync_modules_order(dt_develop_t *dev)
 
   // and reset all module iop_order
 
-  GList *modules = g_list_first(dev->iop);
+  GList *modules = dev->iop;
   while(modules)
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
@@ -809,8 +797,7 @@ GList *dt_ioppr_extract_multi_instances_list(GList *iop_order_list)
 {
   GList *mi = NULL;
 
-  GList *l = g_list_first(iop_order_list);
-  while(l)
+  for(const GList *l = iop_order_list; l; l = g_list_next(l))
   {
     const dt_iop_order_entry_t *const restrict entry = (dt_iop_order_entry_t *)l->data;
 
@@ -819,8 +806,6 @@ GList *dt_ioppr_extract_multi_instances_list(GList *iop_order_list)
       dt_iop_order_entry_t *copy = (dt_iop_order_entry_t *)_dup_iop_order_entry((void *)entry, NULL);
       mi = g_list_prepend(mi, copy);
     }
-
-    l = g_list_next(l);
   }
 
   return g_list_reverse(mi);  // list was built in reverse order, so un-reverse it
@@ -833,11 +818,9 @@ GList *dt_ioppr_merge_module_multi_instance_iop_order_list(GList *iop_order_list
 
   int item_nb = 0;
 
-  GList *link = g_list_first(iop_order_list);
+  GList *link = iop_order_list;
 
-  GList *l = g_list_first(multi_instance_list);
-
-  while(l)
+  for(const GList *l = multi_instance_list; l; l = g_list_next(l))
   {
     dt_iop_order_entry_t *entry = (dt_iop_order_entry_t *)l->data;
 
@@ -859,8 +842,6 @@ GList *dt_ioppr_merge_module_multi_instance_iop_order_list(GList *iop_order_list
     {
       iop_order_list = g_list_insert_before(iop_order_list, link, entry);
     }
-
-    l= g_list_next(l);
   }
 
   // if needed removes all other instance of this operation which are superfluous
@@ -887,7 +868,7 @@ GList *dt_ioppr_merge_multi_instance_iop_order_list(GList *iop_order_list, GList
   GList *op = NULL;
 
   GList *copy = dt_ioppr_iop_order_copy_deep(multi_instance_list);
-  GList *l = g_list_first(copy);
+  GList *l = copy;
 
   while(l)
   {
@@ -921,7 +902,7 @@ GList *dt_ioppr_merge_multi_instance_iop_order_list(GList *iop_order_list, GList
     g_list_free(op);
     op = NULL;
 
-    l = g_list_first(copy);
+    l = copy;
   }
 
   return iop_order_list;
@@ -935,8 +916,7 @@ static void _count_iop_module(GList *iop, const char *operation, int *max_multi_
   *max_multi_priority_enabled = 0;
   *count_enabled = 0;
 
-  GList *modules = iop;
-  while(modules)
+  for(const GList *modules = iop; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
     if(!strcmp(mod->op, operation))
@@ -950,7 +930,6 @@ static void _count_iop_module(GList *iop, const char *operation, int *max_multi_
         if(*max_multi_priority_enabled < mod->multi_priority) *max_multi_priority_enabled = mod->multi_priority;
       }
     }
-    modules = g_list_next(modules);
   }
 
   assert(*count >= *count_enabled);
@@ -960,12 +939,10 @@ static int _count_entries_operation(GList *e_list, const char *operation)
 {
   int count = 0;
 
-  GList *l = g_list_first(e_list);
-  while(l)
+  for(const GList *l = e_list; l; l = g_list_next(l))
   {
     dt_iop_order_entry_t *ep = (dt_iop_order_entry_t *)l->data;
     if(!strcmp(ep->operation, operation)) count++;
-    l = g_list_next(l);
   }
 
   return count;
@@ -973,13 +950,10 @@ static int _count_entries_operation(GList *e_list, const char *operation)
 
 static gboolean _operation_already_handled(GList *e_list, const char *operation)
 {
-  GList *l = g_list_previous(e_list);
-
-  while(l)
+  for(const GList *l = g_list_previous(e_list); l; l = g_list_previous(l))
   {
     const dt_iop_order_entry_t *const restrict ep = (dt_iop_order_entry_t *)l->data;
     if(!strcmp(ep->operation, operation)) return TRUE;
-    l = g_list_previous(l);
   }
   return FALSE;
 }
@@ -987,9 +961,8 @@ static gboolean _operation_already_handled(GList *e_list, const char *operation)
 // returns the nth module's priority being active or not
 int _get_multi_priority(dt_develop_t *dev, const char *operation, const int n, const gboolean only_disabled)
 {
-  GList *l = dev->iop;
   int count = 0;
-  while(l)
+  for(const GList *l = dev->iop; l; l = g_list_next(l))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)l->data;
     if((!only_disabled || mod->enabled == FALSE) && !strcmp(mod->op, operation))
@@ -997,8 +970,6 @@ int _get_multi_priority(dt_develop_t *dev, const char *operation, const int n, c
       count++;
       if(count == n) return mod->multi_priority;
     }
-
-    l = g_list_next(l);
   }
 
   return INT_MAX;
@@ -1006,10 +977,9 @@ int _get_multi_priority(dt_develop_t *dev, const char *operation, const int n, c
 
 void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, gboolean append)
 {
-  GList *e_list = entry_list;
 
   // for each priority list to be checked
-  while(e_list)
+  for(GList *e_list = entry_list; e_list; e_list = g_list_next(e_list))
   {
     const dt_iop_order_entry_t *const restrict ep = (dt_iop_order_entry_t *)e_list->data;
 
@@ -1031,9 +1001,7 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, gboolean 
 
     // look for this operation into the target iop-order list and add there as much operation as needed
 
-    GList *l = g_list_last(dev->iop_order_list);
-
-    while(l)
+    for(GList *l = g_list_last(dev->iop_order_list); l; l = g_list_previous(l))
     {
       const dt_iop_order_entry_t *const restrict e = (dt_iop_order_entry_t *)l->data;
       if(!strcmp(e->operation, ep->operation) && !_operation_already_handled(e_list, ep->operation))
@@ -1061,9 +1029,8 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, gboolean 
         // update multi_priority to be unique in iop list
         int multi_priority = start_multi_priority;
         int nb = 0;
-
-        GList *s = entry_list;
-        while(s)
+        
+        for(const GList *s = entry_list; s; s = g_list_next(s))
         {
           dt_iop_order_entry_t *item = (dt_iop_order_entry_t *)s->data;
           if(!strcmp(item->operation, e->operation))
@@ -1080,7 +1047,6 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, gboolean 
               item->instance = multi_priority++;
             }
           }
-          s = g_list_next(s);
         }
 
         multi_priority = start_multi_priority;
@@ -1097,11 +1063,7 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, gboolean 
         }
         break;
       }
-
-      l = g_list_previous(l);
     }
-
-    e_list = g_list_next(e_list);
   }
 
   _ioppr_reset_iop_order(dev->iop_order_list);
@@ -1111,11 +1073,10 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, gboolean 
 
 void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, gboolean append)
 {
-  GList *si_list = g_list_first(st_items);
   GList *e_list = NULL;
 
   // for each priority list to be checked
-  while(si_list)
+  for(const GList *si_list = st_items; si_list; si_list = g_list_next(si_list))
   {
     const dt_style_item_t *const restrict si = (dt_style_item_t *)si_list->data;
 
@@ -1125,8 +1086,6 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, gboolea
     g_strlcpy(n->name, si->multi_name, sizeof(n->name));
     n->o.iop_order = 0;
     e_list = g_list_prepend(e_list, n);
-
-    si_list = g_list_next(si_list);
   }
   e_list = g_list_reverse(e_list);  // list was built in reverse order, so un-reverse it
 
@@ -1134,18 +1093,15 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, gboolea
 
   // write back the multi-priority
 
-  si_list = g_list_first(st_items);
-  GList *el = g_list_first(e_list);
-  while(si_list)
+  GList *el = e_list;
+  for(const GList *si_list = st_items; si_list; si_list = g_list_next(si_list))
   {
     dt_style_item_t *si = (dt_style_item_t *)si_list->data;
     const dt_iop_order_entry_t *const restrict e = (dt_iop_order_entry_t *)el->data;
 
     si->multi_priority = e->instance;
     si->iop_order = dt_ioppr_get_iop_order(dev->iop_order_list, si->operation, si->multi_priority);
-
     el = g_list_next(el);
-    si_list = g_list_next(si_list);
   }
 
   g_list_free(e_list);
@@ -1153,11 +1109,10 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, gboolea
 
 void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, gboolean append)
 {
-  GList *m_list = g_list_first(modules);
   GList *e_list = NULL;
 
   // for each priority list to be checked
-  while(m_list)
+  for(const GList *m_list = modules; m_list; m_list = g_list_next(m_list))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)m_list->data;
 
@@ -1167,8 +1122,6 @@ void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, gboolean app
     g_strlcpy(n->name, mod->multi_name, sizeof(n->name));
     n->o.iop_order = 0;
     e_list = g_list_prepend(e_list, n);
-
-    m_list = g_list_next(m_list);
   }
   e_list = g_list_reverse(e_list);  // list was built in reverse order, so un-reverse it
 
@@ -1176,9 +1129,8 @@ void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, gboolean app
 
   // write back the multi-priority
 
-  m_list = g_list_first(modules);
-  GList *el = g_list_first(e_list);
-  while(m_list)
+  GList *el = e_list;
+  for(const GList *m_list = modules; m_list; m_list = g_list_next(m_list))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)m_list->data;
     dt_iop_order_entry_t *e = (dt_iop_order_entry_t *)el->data;
@@ -1187,7 +1139,6 @@ void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, gboolean app
     mod->iop_order = dt_ioppr_get_iop_order(dev->iop_order_list, mod->op, mod->multi_priority);
 
     el = g_list_next(el);
-    m_list = g_list_next(m_list);
   }
 
   g_list_free_full(e_list, free);
@@ -1198,8 +1149,7 @@ static dt_dev_history_item_t *_ioppr_search_history_by_module(GList *history_lis
 {
   dt_dev_history_item_t *hist_entry = NULL;
 
-  GList *history = g_list_first(history_list);
-  while(history)
+  for(const GList *history = history_list; history; history = g_list_next(history))
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
 
@@ -1208,8 +1158,6 @@ static dt_dev_history_item_t *_ioppr_search_history_by_module(GList *history_lis
       hist_entry = hist;
       break;
     }
-
-    history = g_list_next(history);
   }
 
   return hist_entry;
@@ -1223,7 +1171,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
   dt_iop_module_t *mod_prev = NULL;
 
   // get the first module
-  GList *modules = g_list_first(iop_list);
+  GList *modules = iop_list;
   if(modules)
   {
     mod_prev = (dt_iop_module_t *)(modules->data);
@@ -1300,7 +1248,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
 
     if(reset_list)
     {
-      modules = g_list_first(iop_list);
+      modules = iop_list;
       if(modules)
       {
         mod_prev = (dt_iop_module_t *)(modules->data);
@@ -1323,8 +1271,7 @@ int dt_ioppr_check_so_iop_order(GList *iop_list, GList *iop_order_list)
   int iop_order_missing = 0;
 
   // check if all the modules have their iop_order assigned
-  GList *modules = g_list_first(iop_list);
-  while(modules)
+  for(const GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_so_t *const restrict mod = (dt_iop_module_so_t *)(modules->data);
     const dt_iop_order_entry_t *const restrict entry =
@@ -1334,7 +1281,6 @@ int dt_ioppr_check_so_iop_order(GList *iop_list, GList *iop_order_list)
       iop_order_missing = 1;
       fprintf(stderr, "[dt_ioppr_check_so_iop_order] missing iop_order for module %s\n", mod->op);
     }
-    modules = g_list_next(modules);
   }
 
   return iop_order_missing;
@@ -1382,12 +1328,11 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
   if(module->iop_order < module_next->iop_order)
   {
     // let's first search for module
-    GList *modules = g_list_first(iop_list);
-    while(modules)
+    GList *modules = iop_list;
+    for(; modules; modules = g_list_next(modules))
     {
       const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
       if(mod == module) break;
-      modules = g_list_next(modules);
     }
 
     // we found the module
@@ -1398,8 +1343,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
 
       // now search for module_next and the one previous to that, so iop_order can be calculated
       // also check the rules
-      modules = g_list_next(modules);
-      while(modules)
+      for(modules = g_list_next(modules); modules; modules = g_list_next(modules))
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
 
@@ -1418,8 +1362,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
 
         // is there a rule about swapping this two?
         int rule_found = 0;
-        GList *rules = g_list_first(darktable.iop_order_rules);
-        while(rules)
+        for(const GList *rules = darktable.iop_order_rules; rules; rules = g_list_next(rules))
         {
           const dt_iop_order_rule_t *const restrict rule = (dt_iop_order_rule_t *)rules->data;
 
@@ -1428,13 +1371,10 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
             rule_found = 1;
             break;
           }
-
-          rules = g_list_next(rules);
         }
         if(rule_found) break;
 
         mod1 = mod;
-        modules = g_list_next(modules);
       }
 
       // we reach the module_next module
@@ -1465,11 +1405,10 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
   {
     // let's first search for module
     GList *modules = g_list_last(iop_list);
-    while(modules)
+    for(; modules; modules = g_list_previous(modules))
     {
       const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
       if(mod == module) break;
-      modules = g_list_previous(modules);
     }
 
     // we found the module
@@ -1480,8 +1419,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
 
       // now search for module_next and the one next to that, so iop_order can be calculated
       // also check the rules
-      modules = g_list_previous(modules);
-      while(modules)
+      for(modules = g_list_previous(modules); modules; modules = g_list_previous(modules))
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
 
@@ -1501,8 +1439,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
 
         // is there a rule about swapping this two?
         int rule_found = 0;
-        GList *rules = g_list_first(darktable.iop_order_rules);
-        while(rules)
+        for(const GList *rules = darktable.iop_order_rules; rules; rules = g_list_next(rules))
         {
           const dt_iop_order_rule_t *const restrict rule = (dt_iop_order_rule_t *)rules->data;
 
@@ -1511,13 +1448,10 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
             rule_found = 1;
             break;
           }
-
-          rules = g_list_next(rules);
         }
         if(rule_found) break;
 
         if(mod == module_next) mod2 = mod;
-        modules = g_list_previous(modules);
       }
 
       // we reach the module_next module
@@ -1560,15 +1494,14 @@ gboolean dt_ioppr_check_can_move_after_iop(GList *iop_list, dt_iop_module_t *mod
   gboolean can_move = FALSE;
 
   // moving after module_prev is the same as moving before the very next one after module_prev
-  GList *modules = g_list_last(iop_list);
   dt_iop_module_t *module_next = NULL;
-  while(modules)
+  
+  for(const GList *modules = g_list_last(iop_list); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
     if(mod == module_prev) break;
 
     module_next = mod;
-    modules = g_list_previous(modules);
   }
   if(module_next == NULL)
   {
@@ -1636,51 +1569,41 @@ gboolean dt_ioppr_move_iop_after(struct dt_develop_t *dev, dt_iop_module_t *modu
 
 void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg)
 {
-  GList *modules = g_list_first(iop_list);
-  while(modules)
+  for(const GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
 
     fprintf(stderr, "[%s] module %s %s multi_priority=%i, iop_order=%d\n",
             msg, mod->op, mod->multi_name, mod->multi_priority, mod->iop_order);
-
-    modules = g_list_next(modules);
   }
 }
 
 void dt_ioppr_print_history_iop_order(GList *history_list, const char *msg)
 {
-  GList *history = g_list_first(history_list);
-  while(history)
+  for(const GList *history = history_list; history; history = g_list_next(history))
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
 
     fprintf(stderr, "[%s] module %s %s multi_priority=%i, iop_order=%d\n",
             msg, hist->op_name, hist->multi_name, hist->multi_priority, hist->iop_order);
-
-    history = g_list_next(history);
   }
 }
 
 void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg)
 {
-  GList *iops_order = g_list_first(iop_order_list);
-  while(iops_order)
+  for(const GList *iops_order = iop_order_list; iops_order; iops_order = g_list_next(iops_order))
   {
     dt_iop_order_entry_t *order_entry = (dt_iop_order_entry_t *)(iops_order->data);
 
     fprintf(stderr, "[%s] op %20s (inst %d) iop_order=%d\n",
             msg, order_entry->operation, order_entry->instance, order_entry->o.iop_order);
-
-    iops_order = g_list_next(iops_order);
   }
 }
 
 static GList *_get_fence_modules_list(GList *iop_list)
 {
   GList *fences = NULL;
-  GList *modules = g_list_first(iop_list);
-  while(modules)
+  for(const GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
 
@@ -1688,36 +1611,29 @@ static GList *_get_fence_modules_list(GList *iop_list)
     {
       fences = g_list_prepend(fences, mod);
     }
-
-    modules = g_list_next(modules);
   }
   return g_list_reverse(fences);  // list was built in reverse order, so un-reverse it
 }
 
 static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg)
 {
-  GList *modules = NULL;
-
   // check for IOP_FLAGS_FENCE on each module
   // create a list of fences modules
   GList *fences = _get_fence_modules_list(iop_list);
 
   // check if each module is between the fences
-  modules = g_list_first(iop_list);
-  while(modules)
+  for(const GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
     if(mod->iop_order == INT_MAX)
     {
-      modules = g_list_next(modules);
       continue;
     }
 
     dt_iop_module_t *fence_prev = NULL;
     dt_iop_module_t *fence_next = NULL;
 
-    GList *mod_fences = g_list_first(fences);
-    while(mod_fences)
+    for(const GList *mod_fences = fences; mod_fences; mod_fences = g_list_next(mod_fences))
     {
       dt_iop_module_t *mod_fence = (dt_iop_module_t *)mod_fences->data;
 
@@ -1737,8 +1653,6 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
         else if(mod_fence->iop_order > fence_prev->iop_order)
           fence_prev = mod_fence;
       }
-
-      mod_fences = g_list_next(mod_fences);
     }
 
     // now check if mod is between the fences
@@ -1754,25 +1668,19 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
               fence_prev->op, fence_prev->multi_name, mod->op, mod->multi_name, mod->iop_order, fence_prev->op,
               fence_prev->multi_name, fence_prev->iop_order, imgid, msg);
     }
-
-
-    modules = g_list_next(modules);
   }
 
   // for each module check if it doesn't break a rule
-  modules = g_list_first(iop_list);
-  while(modules)
+  for(const GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
     if(mod->iop_order == INT_MAX)
     {
-      modules = g_list_next(modules);
       continue;
     }
 
     // we have a module, now check each rule
-    GList *rules = g_list_first(darktable.iop_order_rules);
-    while(rules)
+    for(const GList *rules = darktable.iop_order_rules; rules; rules = g_list_next(rules))
     {
       const dt_iop_order_rule_t *const restrict rule = (dt_iop_order_rule_t *)rules->data;
 
@@ -1780,8 +1688,9 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
       if(strcmp(mod->op, rule->op_prev) == 0)
       {
         // check if there's a rule->op_next module before mod
-        GList *modules_prev = g_list_previous(modules);
-        while(modules_prev)
+        for(const GList *modules_prev = g_list_previous(modules);
+            modules_prev;
+            modules_prev = g_list_previous(modules_prev))
         {
           const dt_iop_module_t *const restrict mod_prev = (dt_iop_module_t *)modules_prev->data;
 
@@ -1791,16 +1700,13 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
                     rule->op_prev, rule->op_next, mod->op, mod->multi_name, mod->iop_order, mod_prev->op,
                     mod_prev->multi_name, mod_prev->iop_order, imgid, msg);
           }
-
-          modules_prev = g_list_previous(modules_prev);
         }
       }
       // mod must be after rule->op_prev
       else if(strcmp(mod->op, rule->op_next) == 0)
       {
         // check if there's a rule->op_prev module after mod
-        GList *modules_next = g_list_next(modules);
-        while(modules_next)
+        for(const GList *modules_next = g_list_next(modules); modules_next;  modules_next = g_list_next(modules_next))
         {
           const dt_iop_module_t *const restrict mod_next = (dt_iop_module_t *)modules_next->data;
 
@@ -1810,15 +1716,9 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
                     rule->op_prev, rule->op_next, mod->op, mod->multi_name, mod->iop_order, mod_next->op,
                     mod_next->multi_name, mod_next->iop_order, imgid, msg);
           }
-
-          modules_next = g_list_next(modules_next);
         }
       }
-
-      rules = g_list_next(rules);
     }
-
-    modules = g_list_next(modules);
   }
 
   if(fences) g_list_free(fences);
@@ -1835,12 +1735,11 @@ void dt_ioppr_insert_module_instance(struct dt_develop_t *dev, dt_iop_module_t *
   entry->instance = instance;
   entry->o.iop_order = 0;
 
-  GList *l = dev->iop_order_list;
   GList *place = NULL;
 
   int max_instance = -1;
 
-  while(l)
+  for(GList *l = dev->iop_order_list; l; l = g_list_next(l))
   {
     const dt_iop_order_entry_t *const restrict e = (dt_iop_order_entry_t *)l->data;
     if(!strcmp(e->operation, operation) && e->instance > max_instance)
@@ -1848,7 +1747,6 @@ void dt_ioppr_insert_module_instance(struct dt_develop_t *dev, dt_iop_module_t *
       place = l;
       max_instance = e->instance;
     }
-    l = g_list_next(l);
   }
 
   dev->iop_order_list = g_list_insert_before(dev->iop_order_list, place, entry);
@@ -1860,14 +1758,12 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
 
   // check if gamma is the last iop
   {
-    GList *modules = g_list_last(dev->iop);
-    while(modules)
+    GList *modules;
+    for(modules = g_list_last(dev->iop); modules; modules = g_list_previous(dev->iop))
     {
       const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
       if(mod->iop_order != INT_MAX)
         break;
-
-      modules = g_list_previous(dev->iop);
     }
     if(modules)
     {
@@ -1888,8 +1784,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
 
   // some other checks
   {
-    GList *modules = g_list_last(dev->iop);
-    while(modules)
+    for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(dev->iop))
     {
       const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
       if(!mod->default_enabled && mod->iop_order != INT_MAX)
@@ -1907,16 +1802,13 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
                   mod->op, mod->multi_name, mod->iop_order,imgid, msg);
         }
       }
-
-      modules = g_list_previous(dev->iop);
     }
   }
 
   // check if there's duplicate or out-of-order iop_order
   {
     dt_iop_module_t *mod_prev = NULL;
-    GList *modules = g_list_first(dev->iop);
-    while(modules)
+    for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
       if(mod->iop_order != INT_MAX)
@@ -1943,14 +1835,12 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
         }
       }
       mod_prev = mod;
-      modules = g_list_next(modules);
     }
   }
 
   _ioppr_check_rules(dev->iop, imgid, msg);
 
-  GList *history = g_list_first(dev->history);
-  while(history)
+  for(const GList *history = dev->history; history; history = g_list_next(history))
   {
     const dt_dev_history_item_t *const restrict hist = (dt_dev_history_item_t *)(history->data);
 
@@ -1969,8 +1859,6 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
             hist->op_name, hist->multi_name, hist->iop_order, imgid, msg);
       }
     }
-
-    history = g_list_next(history);
   }
 
   return iop_order_ok;
@@ -1983,12 +1871,10 @@ void *dt_ioppr_serialize_iop_order_list(GList *iop_order_list, size_t *size)
   // compute size of all modules
   *size = 0;
 
-  GList *l = iop_order_list;
-  while(l)
+  for(const GList *l = iop_order_list; l; l = g_list_next(l))
   {
     const dt_iop_order_entry_t *const restrict entry = (dt_iop_order_entry_t *)l->data;
     *size += strlen(entry->operation) + sizeof(int32_t) * 2;
-    l = g_list_next(l);
   }
 
   if(*size == 0)
@@ -2000,8 +1886,7 @@ void *dt_ioppr_serialize_iop_order_list(GList *iop_order_list, size_t *size)
   // set set preset iop-order version
   int pos = 0;
 
-  l = iop_order_list;
-  while(l)
+  for(const GList *l = iop_order_list; l; l = g_list_next(l))
   {
     const dt_iop_order_entry_t *const restrict entry = (dt_iop_order_entry_t *)l->data;
     // write the len of the module name
@@ -2016,8 +1901,6 @@ void *dt_ioppr_serialize_iop_order_list(GList *iop_order_list, size_t *size)
     // write the instance number
     memcpy(params+pos, &(entry->instance), sizeof(int32_t));
     pos += sizeof(int32_t);
-
-    l = g_list_next(l);
   }
 
   return params;
@@ -2027,14 +1910,12 @@ char *dt_ioppr_serialize_text_iop_order_list(GList *iop_order_list)
 {
   gchar *text = g_strdup("");
 
-  GList *l = iop_order_list;
-  while(l)
+  for(const GList *l = iop_order_list; l; l = g_list_next(l))
   {
     const dt_iop_order_entry_t *const restrict entry = (dt_iop_order_entry_t *)l->data;
     gchar buf[64];
     snprintf(buf, sizeof(buf), "%s,%d%s", entry->operation, entry->instance, l == g_list_last(iop_order_list) ? "" : ",");
     text = g_strconcat(text, buf, NULL);
-    l = g_list_next(l);
   }
 
   return text;
@@ -2076,9 +1957,7 @@ GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf)
   GList *iop_order_list = NULL;
 
   GList *list = dt_util_str_to_glist(",", buf);
-  GList *l = g_list_first(list);
-
-  while(l)
+  for(GList *l = list; l; l = g_list_next(l))
   {
     dt_iop_order_entry_t *entry = (dt_iop_order_entry_t *)malloc(sizeof(dt_iop_order_entry_t));
     entry->o.iop_order = 0;
@@ -2100,8 +1979,6 @@ GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf)
     // append to the list
 
     iop_order_list = g_list_prepend(iop_order_list, entry);
-
-    l = g_list_next(l);
   }
   iop_order_list = g_list_reverse(iop_order_list);  // list was built in reverse order, so un-reverse it
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1573,8 +1573,7 @@ static gboolean _blendif_change_blend_colorspace(dt_iop_module_t *module, dt_dev
     dt_develop_blend_init_blendif_parameters(module->blend_params, cst);
 
     // look for last history item for this module with the selected blending mode to copy parametric mask settings
-    GList *history = g_list_last(darktable.develop->history);
-    while(history)
+    for(const GList *history = g_list_last(darktable.develop->history); history; history = g_list_previous(history))
     {
       const dt_dev_history_item_t *data = (dt_dev_history_item_t *)(history->data);
       if(data->module == module && data->blend_params->blend_cst == cst)
@@ -1589,7 +1588,6 @@ static gboolean _blendif_change_blend_colorspace(dt_iop_module_t *module, dt_dev
         memcpy(np->blendif_boost_factors, hp->blendif_boost_factors, sizeof(hp->blendif_boost_factors));
         break;
       }
-      history = g_list_previous(history);
     }
 
     dt_iop_gui_blend_data_t *bd = module->blend_data;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -645,12 +645,10 @@ restart:
 
 static inline void _dt_dev_load_pipeline_defaults(dt_develop_t *dev)
 {
-  GList *modules = g_list_last(dev->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_iop_reload_defaults(module);
-    modules = g_list_previous(modules);
   }
 }
 
@@ -2639,15 +2637,13 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
 dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe,
                                                     struct dt_iop_module_t *module)
 {
-  GList *pieces = g_list_last(pipe->nodes);
-  while(pieces)
+  for(const GList *pieces = g_list_last(pipe->nodes); pieces; pieces = g_list_previous(pieces))
   {
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
     if(piece->module == module)
     {
       return piece;
     }
-    pieces = g_list_previous(pieces);
   }
   return NULL;
 }
@@ -2851,8 +2847,7 @@ int dt_dev_sync_pixelpipe_hash_distort(dt_develop_t *dev, struct dt_dev_pixelpip
 void dt_dev_reorder_gui_module_list(dt_develop_t *dev)
 {
   int pos_module = 0;
-  GList *modules = g_list_last(dev->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
@@ -2862,8 +2857,6 @@ void dt_dev_reorder_gui_module_list(dt_develop_t *dev)
       gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER), expander,
                             pos_module++);
     }
-
-    modules = g_list_previous(modules);
   }
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -590,8 +590,7 @@ dt_iop_module_t *dt_iop_gui_get_previous_visible_module(dt_iop_module_t *module)
 dt_iop_module_t *dt_iop_gui_get_next_visible_module(dt_iop_module_t *module)
 {
   dt_iop_module_t *next = NULL;
-  GList *modules = g_list_last(module->dev->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(module->dev->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
     if(mod == module)
@@ -607,7 +606,6 @@ dt_iop_module_t *dt_iop_gui_get_next_visible_module(dt_iop_module_t *module)
         next = mod;
       }
     }
-    modules = g_list_previous(modules);
   }
   return next;
 }
@@ -2885,12 +2883,10 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
 
 void dt_iop_connect_accels_all()
 {
-  GList *iop_mods = g_list_last(darktable.develop->iop);
-  while(iop_mods)
+  for(const GList *iop_mods = g_list_last(darktable.develop->iop); iop_mods; iop_mods = g_list_previous(iop_mods))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)iop_mods->data;
     dt_iop_connect_accels_multi(mod->so);
-    iop_mods = g_list_previous(iop_mods);
   }
 }
 
@@ -2916,18 +2912,14 @@ dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules, const char *
 int dt_iop_count_instances(dt_iop_module_so_t *module)
 {
   int inst_count = 0;
-  GList *iop_mods = NULL;                 //All modules in iop
-  dt_iop_module_t *mod = NULL;            //Used while iterating module lists
 
-  iop_mods = g_list_last(darktable.develop->iop);
-  while(iop_mods)
+  for(const GList *iop_mods = g_list_last(darktable.develop->iop); iop_mods; iop_mods = g_list_previous(iop_mods))
   {
-    mod = (dt_iop_module_t *)iop_mods->data;
+    dt_iop_module_t *mod = (dt_iop_module_t *)iop_mods->data;
     if(mod->so == module && mod->iop_order != INT_MAX)
     {
       inst_count++;
     }
-    iop_mods = g_list_previous(iop_mods);
   }
   return inst_count;
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -327,15 +327,13 @@ static gboolean _lib_modulegroups_test(dt_lib_module_t *self, uint32_t group, dt
 static gboolean _lib_modulegroups_test_visible(dt_lib_module_t *self, gchar *module)
 {
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
-  GList *l = d->groups;
-  while(l)
+  for(const GList *l = d->groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
     if(g_list_find_custom(gr->modules, module, _iop_compare) != NULL)
     {
       return TRUE;
     }
-    l = g_list_next(l);
   }
   return FALSE;
 }
@@ -465,12 +463,10 @@ static void _basics_hide(dt_lib_module_t *self)
   if(!d->vbox_basic) return;
   gtk_widget_hide(d->vbox_basic);
 
-  GList *l = d->basics;
-  while(l)
+  for(const GList *l = d->basics; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
     _basics_remove_widget(item);
-    l = g_list_next(l);
   }
   gtk_widget_destroy(d->vbox_basic);
   d->vbox_basic = NULL;
@@ -495,8 +491,8 @@ static void _basics_on_off_callback(GtkWidget *btn, dt_lib_modulegroups_basic_it
 static void _basics_on_off_callback2(GtkWidget *widget, GdkEventButton *e, dt_lib_modulegroups_basic_item_t *item)
 {
   // we get the button and change its state
-  GtkToggleButton *btn
-      = (GtkToggleButton *)g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(item->box)), 0);
+  GList *children = gtk_container_get_children(GTK_CONTAINER(item->box));
+  GtkToggleButton *btn = (GtkToggleButton *)children->data;
   if(btn)
   {
     darktable.gui->reset++;
@@ -504,6 +500,7 @@ static void _basics_on_off_callback2(GtkWidget *widget, GdkEventButton *e, dt_li
     darktable.gui->reset--;
     gtk_toggle_button_toggled(btn);
   }
+  g_list_free(children);
 }
 
 static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_item_t *item, DtBauhausWidget *bw,
@@ -567,10 +564,11 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       }
       else
       {
-        GtkWidget *orig_label = (GtkWidget *)g_list_nth_data(
-            gtk_container_get_children(GTK_CONTAINER(item->module->header)), IOP_MODULE_LABEL);
+        GList *children = gtk_container_get_children(GTK_CONTAINER(item->module->header));
+        GtkWidget *orig_label = (GtkWidget *)g_list_nth_data(children, IOP_MODULE_LABEL);
         gtk_widget_set_tooltip_text(lb, gtk_widget_get_tooltip_text(orig_label));
         gtk_widget_set_tooltip_text(btn, gtk_widget_get_tooltip_text(orig_label));
+        g_list_free(children);
       }
 
       gtk_widget_show_all(item->box);
@@ -774,8 +772,7 @@ static void _basics_show(dt_lib_module_t *self)
     if(!dt_iop_is_hidden(module) && !(module->flags() & IOP_FLAGS_DEPRECATED) && module->iop_order != INT_MAX)
     {
       // first, we add on-off buttons if any
-      GList *l = d->basics;
-      while(l)
+      for(const GList *l = d->basics; l; l = g_list_next(l))
       {
         dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
         if(!item->module && g_strcmp0(item->module_op, module->op) == 0)
@@ -788,7 +785,6 @@ static void _basics_show(dt_lib_module_t *self)
             pos++;
           }
         }
-        l = g_list_next(l);
       }
 
       // and we add all other widgets
@@ -803,8 +799,7 @@ static void _basics_show(dt_lib_module_t *self)
           DtBauhausWidget *ww = DT_BAUHAUS_WIDGET(accel->closure->data);
           if(ww->module == module)
           {
-            l = d->basics;
-            while(l)
+            for(const GList *l = d->basics; l; l = g_list_next(l))
             {
               dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
               if(!item->module && g_strcmp0(item->module_op, module->op) == 0
@@ -822,7 +817,6 @@ static void _basics_show(dt_lib_module_t *self)
                 }
                 g_free(tx);
               }
-              l = g_list_next(l);
             }
           }
         }
@@ -880,15 +874,12 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
   // hide deprectade message. it will be shown after if needed
   gtk_widget_set_visible(d->deprecated, FALSE);
 
-  GList *modules = darktable.develop->iop;
-  if(modules)
+  for(const GList *modules = darktable.develop->iop; modules; modules = g_list_next(modules))
   {
     /*
      * iterate over ip modules and do various test to
      * detect if the modules should be shown or not.
      */
-    do
-    {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
       GtkWidget *w = module->expander;
 
@@ -996,7 +987,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
         if(w) gtk_widget_hide(w);
       }
 
-    } while((modules = g_list_next(modules)) != NULL);
   }
   if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
   // now that visibility has been updated set multi-show
@@ -1225,8 +1215,7 @@ static gchar *_preset_retrieve_old_layout_updated()
       ret = dt_util_dstrcat(ret, "ꬹeffects|effect|");
 
     // list of modules
-    GList *modules = g_list_first(darktable.iop);
-    while(modules)
+    for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_so_t *module = (dt_iop_module_so_t *)(modules->data);
 
@@ -1247,7 +1236,6 @@ static gchar *_preset_retrieve_old_layout_updated()
           ret = dt_util_dstrcat(ret, "|%s", module->op);
         }
       }
-      modules = g_list_next(modules);
     }
   }
   return ret;
@@ -1284,8 +1272,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
       ret = dt_util_dstrcat(ret, "ꬹeffect|effect|");
 
     // list of modules
-    GList *modules = g_list_first(darktable.iop);
-    while(modules)
+    for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_so_t *module = (dt_iop_module_so_t *)(modules->data);
 
@@ -1345,7 +1332,6 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
 
         g_free(search);
       }
-      modules = g_list_next(modules);
     }
   }
   return ret;
@@ -1416,27 +1402,21 @@ static gchar *_preset_to_string(dt_lib_module_t *self, gboolean edition)
 
   // basics widgets
   res = dt_util_dstrcat(res, "ꬹ%d||", basics_show ? 1 : 0);
-  GList *l = basics;
-  while(l)
+  for(const GList *l = basics; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
     res = dt_util_dstrcat(res, "|%s", item->id);
-    l = g_list_next(l);
   }
 
-  l = groups;
-  while(l)
+  for(const GList *l = groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *g = (dt_lib_modulegroups_group_t *)l->data;
     res = dt_util_dstrcat(res, "ꬹ%s|%s|", g->name, g->icon);
-    GList *ll = g->modules;
-    while(ll)
+    for(const GList *ll = g->modules; ll; ll = g_list_next(ll))
     {
       gchar *m = (gchar *)ll->data;
       res = dt_util_dstrcat(res, "|%s", m);
-      ll = g_list_next(ll);
     }
-    l = g_list_next(l);
   }
 
   return res;
@@ -1955,13 +1935,12 @@ static void _manage_editor_groups_cleanup(dt_lib_module_t *self, gboolean editio
 
   GList *l = edition ? d->edit_groups : d->groups;
 
-  while(l)
+  for(; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
     g_free(gr->name);
     g_free(gr->icon);
     g_list_free_full(gr->modules, g_free);
-    l = g_list_next(l);
   }
 
   if(edition)
@@ -1977,11 +1956,10 @@ static void _manage_editor_groups_cleanup(dt_lib_module_t *self, gboolean editio
   }
 
   l = edition ? d->edit_basics : d->basics;
-  while(l)
+  for(; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
     _basics_free_item(item);
-    l = g_list_next(l);
   }
   if(edition)
   {
@@ -2000,8 +1978,7 @@ static void _manage_editor_basics_remove(GtkWidget *widget, GdkEventButton *even
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
 
   const char *id = (char *)g_object_get_data(G_OBJECT(widget), "widget_id");
-  GList *l = d->edit_basics;
-  while(l)
+  for(GList *l = d->edit_basics; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
     if(g_strcmp0(item->id, id) == 0)
@@ -2011,7 +1988,6 @@ static void _manage_editor_basics_remove(GtkWidget *widget, GdkEventButton *even
       gtk_widget_destroy(gtk_widget_get_parent(widget));
       break;
     }
-    l = g_list_next(l);
   }
 }
 
@@ -2031,21 +2007,18 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
 
   // first, we remove all existing modules
   GList *lw = gtk_container_get_children(GTK_CONTAINER(d->edit_basics_box));
-  while(lw)
+  for(const GList *lw_iter = lw; lw_iter; lw_iter = g_list_next(lw_iter))
   {
-    GtkWidget *w = (GtkWidget *)lw->data;
+    GtkWidget *w = (GtkWidget *)lw_iter->data;
     gtk_widget_destroy(w);
-    lw = g_list_next(lw);
   }
   g_list_free(lw);
 
   // and we add the ones from the list
-  GList *modules = g_list_last(darktable.develop->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(darktable.develop->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
-    GList *l = d->edit_basics;
-    while(l)
+    for(const GList *l = d->edit_basics; l; l = g_list_next(l))
     {
       dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
 
@@ -2074,11 +2047,7 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
           gtk_box_pack_start(GTK_BOX(d->edit_basics_box), hb, FALSE, TRUE, 0);
         }
       }
-
-      l = g_list_next(l);
     }
-
-    modules = g_list_previous(modules);
   }
 
   gtk_widget_show_all(d->edit_basics_box);
@@ -2094,8 +2063,7 @@ static void _basics_cleanup_list(dt_lib_module_t *self, gboolean edition)
   {
     dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
     gboolean exists = FALSE;
-    GList *ll = edition ? d->edit_groups : d->groups;
-    while(ll)
+    for(GList *ll = edition ? d->edit_groups : d->groups; ll; ll = g_list_next(ll))
     {
       dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)ll->data;
       if(g_list_find_custom(gr->modules, item->module_op, _iop_compare))
@@ -2103,7 +2071,6 @@ static void _basics_cleanup_list(dt_lib_module_t *self, gboolean edition)
         exists = TRUE;
         break;
       }
-      ll = g_list_next(ll);
     }
     // if the module doesn't exists, let's remove the widget
     if(!exists)
@@ -2183,8 +2150,7 @@ static void _manage_editor_module_remove(GtkWidget *widget, GdkEventButton *even
   const char *module = (char *)g_object_get_data(G_OBJECT(widget), "module_name");
   dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)g_object_get_data(G_OBJECT(widget), "group");
 
-  GList *l = gr->modules;
-  while(l)
+  for(GList *l = gr->modules; l; l = g_list_next(l))
   {
     const char *tx = (char *)l->data;
     if(g_strcmp0(tx, module) == 0)
@@ -2194,7 +2160,6 @@ static void _manage_editor_module_remove(GtkWidget *widget, GdkEventButton *even
       gtk_widget_destroy(gtk_widget_get_parent(widget));
       break;
     }
-    l = g_list_next(l);
   }
   // we also remove eventual widgets of this module in basics
   _basics_cleanup_list(self, TRUE);
@@ -2206,16 +2171,15 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
 
   // first, we remove all existing modules
   GList *lw = gtk_container_get_children(GTK_CONTAINER(gr->iop_box));
-  while(lw)
+  for(const GList *lw_iter = lw; lw_iter; lw_iter = g_list_next(lw_iter))
   {
-    GtkWidget *w = (GtkWidget *)lw->data;
+    GtkWidget *w = (GtkWidget *)lw_iter->data;
     gtk_widget_destroy(w);
-    lw = g_list_next(lw);
   }
+  g_list_free(lw);
 
   // and we add the ones from the list
-  GList *modules2 = g_list_last(darktable.develop->iop);
-  while(modules2)
+  for(GList *modules2 = g_list_last(darktable.develop->iop); modules2; modules2 = g_list_previous(modules2))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules2->data);
     if((!(module->flags() & IOP_FLAGS_DEPRECATED) || !g_strcmp0(gr->name, C_("modulegroup", "deprecated")))
@@ -2243,7 +2207,6 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
         gtk_box_pack_start(GTK_BOX(gr->iop_box), hb, FALSE, TRUE, 0);
       }
     }
-    modules2 = g_list_previous(modules2);
   }
 
   gtk_widget_show_all(gr->iop_box);
@@ -2255,10 +2218,11 @@ static void _manage_editor_group_update_arrows(GtkWidget *box)
   GList *lw = gtk_container_get_children(GTK_CONTAINER(box));
   int pos = 0;
   const int max = g_list_length(lw) - 1;
-  while(lw)
+  for(const GList *lw_iter = lw; lw_iter; lw_iter = g_list_next(lw_iter))
   {
-    GtkWidget *w = (GtkWidget *)lw->data;
-    GtkWidget *hb = (GtkWidget *)gtk_container_get_children(GTK_CONTAINER(w))->data;
+    GtkWidget *w = (GtkWidget *)lw_iter->data;
+    GList *children = gtk_container_get_children(GTK_CONTAINER(w));
+    GtkWidget *hb = (GtkWidget *)children->data;
     if(hb)
     {
       GList *lw2 = gtk_container_get_children(GTK_CONTAINER(hb));
@@ -2275,10 +2239,12 @@ static void _manage_editor_group_update_arrows(GtkWidget *box)
         else
           gtk_widget_show(right);
       }
+      g_list_free(lw2);
     }
-    lw = g_list_next(lw);
+    g_list_free(children);
     pos++;
   }
+  g_list_free(lw);
 }
 
 static void _manage_direct_save(dt_lib_module_t *self)
@@ -2349,8 +2315,7 @@ static void _manage_direct_basics_module_toggle(GtkWidget *widget, dt_lib_module
   }
   else
   {
-    GList *l = d->basics;
-    while(l)
+    for(GList *l = d->basics; l; l = g_list_next(l))
     {
       dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
       if(g_strcmp0(item->id, wid) == 0)
@@ -2359,7 +2324,6 @@ static void _manage_direct_basics_module_toggle(GtkWidget *widget, dt_lib_module
         d->basics = g_list_delete_link(d->basics, l);
         break;
       }
-      l = g_list_next(l);
     }
   }
 
@@ -2439,9 +2403,8 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
 
   GtkMenu *sm_all = (GtkMenu *)gtk_menu_new();
 
-  GList *m2 = g_list_copy(g_list_first(darktable.iop));
-  GList *modules = g_list_sort(m2, _manage_editor_module_so_add_sort);
-  while(modules)
+  GList *m2 = g_list_sort(g_list_copy(darktable.iop), _manage_editor_module_so_add_sort);
+  for(const GList *modules = m2; modules; modules = g_list_next(modules))
   {
     dt_iop_module_so_t *module = (dt_iop_module_so_t *)(modules->data);
 
@@ -2489,7 +2452,6 @@ static void _manage_module_add_popup(GtkWidget *widget, dt_lib_modulegroups_grou
         nba++;
       }
     }
-    modules = g_list_next(modules);
   }
   g_list_free(m2);
 
@@ -2535,9 +2497,8 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
 
   GtkMenu *sm_all = (GtkMenu *)gtk_menu_new();
 
-  GList *m2 = g_list_copy(g_list_first(darktable.develop->iop));
-  GList *modules = g_list_sort(m2, _manage_editor_module_add_sort);
-  while(modules)
+  GList *m2 = g_list_sort(g_list_copy(darktable.develop->iop), _manage_editor_module_add_sort);
+  for(const GList *modules = m2; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
@@ -2606,8 +2567,7 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
       }
 
       // let's go through all widgets from this module
-      GList *la = g_list_last(darktable.control->accelerator_list);
-      while(la)
+      for(GList *la = g_list_last(darktable.control->accelerator_list); la; la = g_list_previous(la))
       {
         dt_accel_t *accel = (dt_accel_t *)la->data;
         gchar *pre = dt_util_dstrcat(NULL, "<Darktable>/image operations/%s/", module->op);
@@ -2661,12 +2621,10 @@ static void _manage_basics_add_popup(GtkWidget *widget, GCallback callback, dt_l
           g_free(ws);
         }
         g_free(pre);
-        la = g_list_previous(la);
       }
       // add submenu to main menu if we got any widgets
       if(nb > 0) gtk_menu_shell_append(GTK_MENU_SHELL(sm_all), GTK_WIDGET(smi));
     }
-    modules = g_list_next(modules);
   }
   g_list_free(m2);
 
@@ -2833,15 +2791,16 @@ static void _buttons_update(dt_lib_module_t *self)
   d->force_show_module = NULL;
 
   // first, we destroy all existing buttons except active one an preset one
-  GList *l = gtk_container_get_children(GTK_CONTAINER(d->hbox_groups));
+  GList *children = gtk_container_get_children(GTK_CONTAINER(d->hbox_groups));
+  GList *l = children;
   if(l) l = g_list_next(l); // skip basics group
   if(l) l = g_list_next(l); // skip active group
-  while(l)
+  for(; l; l = g_list_next(l))
   {
     GtkWidget *bt = (GtkWidget *)l->data;
     gtk_widget_destroy(bt);
-    l = g_list_next(l);
   }
+  g_list_free(children);
   gtk_widget_set_visible(d->basic_btn, d->basics_show);
 
   // if there's no groups, we ensure that the preset button is on the search line and we hide the active button
@@ -2874,8 +2833,7 @@ static void _buttons_update(dt_lib_module_t *self)
   }
 
   // then we repopulate the box with new buttons
-  l = d->groups;
-  while(l)
+  for(l = d->groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
     GtkWidget *bt = dtgtk_togglebutton_new(_buttons_get_icon_fct(gr->icon), CPF_STYLE_FLAT, NULL);
@@ -2886,7 +2844,6 @@ static void _buttons_update(dt_lib_module_t *self)
     gr->button = bt;
     gtk_box_pack_start(GTK_BOX(d->hbox_groups), bt, TRUE, TRUE, 0);
     gtk_widget_show(bt);
-    l = g_list_next(l);
   }
 
   // last, if d->current still valid, we select it otherwise the first one
@@ -3302,25 +3259,25 @@ static void _manage_editor_load(const char *preset, dt_lib_module_t *self)
 
   // we remove all widgets from the box
   GList *lw = gtk_container_get_children(GTK_CONTAINER(d->preset_box));
-  while(lw)
+  for(const GList *lw_iter = lw; lw_iter; lw_iter = g_list_next(lw_iter))
   {
-    GtkWidget *w = (GtkWidget *)lw->data;
+    GtkWidget *w = (GtkWidget *)lw_iter->data;
     gtk_widget_destroy(w);
-    lw = g_list_next(lw);
   }
+  g_list_free(lw);
 
   // we update all the preset lines
   lw = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
-  while(lw)
+  for(const GList *lw_iter = lw; lw_iter; lw_iter = g_list_next(lw_iter))
   {
-    GtkWidget *w = (GtkWidget *)lw->data;
+    GtkWidget *w = (GtkWidget *)lw_iter->data;
     const char *pr_name = (char *)g_object_get_data(G_OBJECT(w), "preset_name");
     if(g_strcmp0(pr_name, preset) == 0)
       gtk_widget_set_name(w, "modulegroups-preset-activated");
     else if(pr_name)
       gtk_widget_set_name(w, "modulegroups-preset");
-    lw = g_list_next(lw);
   }
+  g_list_free(lw);
 
   // get all presets groups
   if(d->edit_groups) _manage_editor_groups_cleanup(self, TRUE);
@@ -3406,13 +3363,11 @@ static void _manage_editor_load(const char *preset, dt_lib_module_t *self)
   gtk_widget_set_visible(d->edit_basics_groupbox, d->edit_basics_show);
 
   // other groups
-  GList *l = d->edit_groups;
-  while(l)
+  for(const GList *l = d->edit_groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
     GtkWidget *vb2 = _manage_editor_group_init_modules_box(self, gr);
     gtk_box_pack_start(GTK_BOX(d->preset_groups_box), vb2, FALSE, TRUE, 0);
-    l = g_list_next(l);
   }
 
   gtk_widget_set_halign(d->preset_groups_box, GTK_ALIGN_CENTER);
@@ -3534,8 +3489,8 @@ static void _manage_preset_delete(GtkWidget *widget, GdkEventButton *event, dt_l
 
     // we try to reload previous selected preset if it still exists
     gboolean sel_ok = FALSE;
-    GList *l = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
-    while(l)
+    GList *children = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
+    for(const GList *l = children; l; l = g_list_next(l))
     {
       GtkWidget *ww = (GtkWidget *)l->data;
       const char *tx = (char *)g_object_get_data(G_OBJECT(ww), "preset_name");
@@ -3545,17 +3500,19 @@ static void _manage_preset_delete(GtkWidget *widget, GdkEventButton *event, dt_l
         sel_ok = TRUE;
         break;
       }
-      l = g_list_next(l);
     }
+    g_list_free(children);
     // otherwise we load the first preset
     if(!sel_ok)
     {
-      GtkWidget *ww = (GtkWidget *)gtk_container_get_children(GTK_CONTAINER(d->presets_list))->data;
+      GList *children2 = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
+      GtkWidget *ww = (GtkWidget *)children2->data;
       if(ww)
       {
         const char *firstn = (char *)g_object_get_data(G_OBJECT(ww), "preset_name");
         _manage_editor_load(firstn, self);
       }
+      g_list_free(children2);
     }
 
     // if the deleted preset was the one currently in use, load default preset
@@ -3592,12 +3549,12 @@ static void _manage_preset_update_list(dt_lib_module_t *self)
 
   // we first remove all existing entries from the box
   GList *lw = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
-  while(lw)
+  for(const GList *lw_iter = lw; lw_iter; lw_iter = g_list_next(lw_iter))
   {
-    GtkWidget *w = (GtkWidget *)lw->data;
+    GtkWidget *w = (GtkWidget *)lw_iter->data;
     gtk_widget_destroy(w);
-    lw = g_list_next(lw);
   }
+  g_list_free(lw);
 
   // and we repopulate it
   sqlite3_stmt *stmt;
@@ -3731,8 +3688,8 @@ static void _manage_show_window(dt_lib_module_t *self)
   if(dt_conf_key_exists("plugins/darkroom/modulegroups_preset"))
   {
     gchar *preset = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
-    GList *l = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
-    while(l)
+    GList *children = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
+    for(const GList *l = children; l; l = g_list_next(l))
     {
       GtkWidget *w = (GtkWidget *)l->data;
       const char *tx = (char *)g_object_get_data(G_OBJECT(w), "preset_name");
@@ -3742,19 +3699,21 @@ static void _manage_show_window(dt_lib_module_t *self)
         sel_ok = TRUE;
         break;
       }
-      l = g_list_next(l);
     }
+    g_list_free(children);
     g_free(preset);
   }
   // or the first one if no selection found
   if(!sel_ok)
   {
-    GtkWidget *w = (GtkWidget *)gtk_container_get_children(GTK_CONTAINER(d->presets_list))->data;
+    GList *children = gtk_container_get_children(GTK_CONTAINER(d->presets_list));
+    GtkWidget *w = (GtkWidget *)children->data;
     if(w)
     {
       const char *firstn = (char *)g_object_get_data(G_OBJECT(w), "preset_name");
       _manage_editor_load(firstn, self);
     }
+    g_list_free(children);
   }
 
   gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(d->dialog))), hb);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -763,8 +763,7 @@ static void _basics_show(dt_lib_module_t *self)
 
   int pos = 0;
   dt_lib_modulegroups_basic_item_position_t item_pos = FIRST_MODULE;
-  GList *modules = g_list_last(darktable.develop->iop);
-  while(modules)
+  for(GList *modules = g_list_last(darktable.develop->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
@@ -791,8 +790,7 @@ static void _basics_show(dt_lib_module_t *self)
 
       // and we add all other widgets
       gchar *pre = dt_util_dstrcat(NULL, "<Darktable>/image operations/%s/", module->op);
-      GList *la = g_list_last(darktable.control->accelerator_list);
-      while(la)
+      for(const GList *la = g_list_last(darktable.control->accelerator_list); la; la = g_list_previous(la))
       {
         dt_accel_t *accel = (dt_accel_t *)la->data;
         if(accel && accel->closure && accel->closure->data && g_str_has_prefix(accel->path, pre)
@@ -822,11 +820,9 @@ static void _basics_show(dt_lib_module_t *self)
             }
           }
         }
-        la = g_list_previous(la);
       }
       g_free(pre);
     }
-    modules = g_list_previous(modules);
   }
 
   gtk_widget_show(d->vbox_basic);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -527,7 +527,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       // on-off widgets
       item->widget = GTK_WIDGET(item->module->off);
       item->sensitive = gtk_widget_get_sensitive(item->widget);
-      item->tooltip = g_strdup(gtk_widget_get_tooltip_text(item->widget));
+      item->tooltip = gtk_widget_get_tooltip_text(item->widget); // no need to copy, returns a newly-alloced string
 
       // create new basic widget
       item->box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -566,8 +566,10 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       {
         GList *children = gtk_container_get_children(GTK_CONTAINER(item->module->header));
         GtkWidget *orig_label = (GtkWidget *)g_list_nth_data(children, IOP_MODULE_LABEL);
-        gtk_widget_set_tooltip_text(lb, gtk_widget_get_tooltip_text(orig_label));
-        gtk_widget_set_tooltip_text(btn, gtk_widget_get_tooltip_text(orig_label));
+        gchar *tooltip = gtk_widget_get_tooltip_text(orig_label);
+        gtk_widget_set_tooltip_text(lb, tooltip);
+        gtk_widget_set_tooltip_text(btn, tooltip);
+        g_free(tooltip);
         g_list_free(children);
       }
 
@@ -621,7 +623,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
 
     // save old values
     item->sensitive = gtk_widget_get_sensitive(item->widget);
-    item->tooltip = g_strdup(gtk_widget_get_tooltip_text(item->widget));
+    item->tooltip = gtk_widget_get_tooltip_text(item->widget);
     item->label = g_strdup(bw->label);
     item->visible = gtk_widget_get_visible(item->widget);
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -510,11 +510,10 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
   if(ps->paper_list) g_list_free_full(ps->paper_list, free);
 
   ps->paper_list = dt_get_papers (&ps->prt.printer);
-  GList *papers = ps->paper_list;
   int np = 0;
   gboolean ispaperset = FALSE;
 
-  while (papers)
+  for(const GList *papers = ps->paper_list; papers; papers = g_list_next (papers))
   {
     const dt_paper_info_t *p = (dt_paper_info_t *)papers->data;
     dt_bauhaus_combobox_add(ps->papers, p->common_name);
@@ -526,7 +525,6 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
     }
 
     np++;
-    papers = g_list_next (papers);
   }
 
   //  paper not found in this printer
@@ -552,12 +550,11 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
   if(ps->media_list) g_list_free_full(ps->media_list, free);
 
   ps->media_list = dt_get_media_type (&ps->prt.printer);
-  GList *media = ps->media_list;
   gboolean ismediaset = FALSE;
 
   np = 0;
 
-  while (media)
+  for(const GList *media = ps->media_list; media; media = g_list_next (media))
   {
     const dt_medium_info_t *m = (dt_medium_info_t *)media->data;
     dt_bauhaus_combobox_add(ps->media, m->common_name);
@@ -569,7 +566,6 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
     }
 
     np++;
-    media = g_list_next (media);
   }
 
   //  media not found in this printer
@@ -913,8 +909,7 @@ _profile_changed(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
   const int pos = dt_bauhaus_combobox_get(widget);
-  GList *prof = ps->profiles;
-  while(prof)
+  for(const GList *prof = ps->profiles; prof; prof = g_list_next(prof))
   {
     dt_lib_export_profile_t *pp = (dt_lib_export_profile_t *)prof->data;
     if(pp->pos == pos)
@@ -926,7 +921,6 @@ _profile_changed(GtkWidget *widget, dt_lib_module_t *self)
       ps->v_iccprofile = g_strdup(pp->filename);
       return;
     }
-    prof = g_list_next(prof);
   }
   dt_conf_set_int("plugins/print/print/icctype", DT_COLORSPACE_NONE);
   dt_conf_set_string("plugins/print/print/iccprofile", "");
@@ -940,8 +934,7 @@ _printer_profile_changed(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
   const int pos = dt_bauhaus_combobox_get(widget);
-  GList *prof = ps->profiles;
-  while(prof)
+  for(const GList *prof = ps->profiles; prof; prof = g_list_next(prof))
   {
     dt_lib_export_profile_t *pp = (dt_lib_export_profile_t *)prof->data;
     if(pp->ppos == pos)
@@ -956,7 +949,6 @@ _printer_profile_changed(GtkWidget *widget, dt_lib_module_t *self)
       gtk_widget_set_sensitive(GTK_WIDGET(ps->black_point_compensation), TRUE);
       return;
     }
-    prof = g_list_next(prof);
   }
   dt_conf_set_int("plugins/print/printer/icctype", DT_COLORSPACE_NONE);
   dt_conf_set_string("plugins/print/printer/iccprofile", "");
@@ -1189,7 +1181,6 @@ gui_init (dt_lib_module_t *self)
   dt_bauhaus_widget_set_label(d->pprofile, NULL, N_("profile"));
 
   int combo_idx, n;
-  GList *l = d->profiles;
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->pprofile), TRUE, TRUE, 0);
   int printer_profile_type = dt_conf_get_int("plugins/print/printer/icctype");
@@ -1198,7 +1189,7 @@ gui_init (dt_lib_module_t *self)
   n = 0;
 
   dt_bauhaus_combobox_add(d->pprofile, _("color management in printer driver"));
-  while(l)
+  for(const GList *l = d->profiles; l; l = g_list_next(l))
   {
     dt_lib_export_profile_t *prof = (dt_lib_export_profile_t *)l->data;
     // do not add built-in profiles, these are in no way for printing
@@ -1215,7 +1206,6 @@ gui_init (dt_lib_module_t *self)
         combo_idx = n;
       }
     }
-    l = g_list_next(l);
   }
 
   g_free (printer_profile);
@@ -1416,8 +1406,7 @@ gui_init (dt_lib_module_t *self)
   combo_idx = -1;
   n = 0;
 
-  l = d->profiles;
-  while(l)
+  for(const GList *l = d->profiles; l; l = g_list_next(l))
   {
     dt_lib_export_profile_t *prof = (dt_lib_export_profile_t *)l->data;
     dt_bauhaus_combobox_add(d->profile, prof->name);
@@ -1429,7 +1418,6 @@ gui_init (dt_lib_module_t *self)
       d->v_iccprofile = g_strdup(iccprofile);
       combo_idx = n;
     }
-    l = g_list_next(l);
   }
 
   if (combo_idx == -1)
@@ -1478,9 +1466,9 @@ gui_init (dt_lib_module_t *self)
   gchar *current_style = dt_conf_get_string("plugins/print/print/style");
   combo_idx = -1; n=0;
 
-  while (styles)
+  for(const GList *st_iter = styles; st_iter; st_iter = g_list_next(st_iter))
   {
-    dt_style_t *style=(dt_style_t *)styles->data;
+    dt_style_t *style=(dt_style_t *)st_iter->data;
     dt_bauhaus_combobox_add(d->style, style->name);
     n++;
     if (g_strcmp0(style->name,current_style)==0)
@@ -1489,7 +1477,6 @@ gui_init (dt_lib_module_t *self)
       d->v_style = g_strdup(current_style);
       combo_idx=n;
     }
-    styles=g_list_next(styles);
   }
   g_free(current_style);
   g_list_free_full(styles, dt_style_free);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -149,9 +149,9 @@ static void _gui_styles_update_view(dt_lib_styles_t *d)
   GList *result = dt_styles_get_list(gtk_entry_get_text(d->entry));
   if(result)
   {
-    do
+    for(const GList *res_iter = result; res_iter; res_iter = g_list_next(res_iter))
     {
-      dt_style_t *style = (dt_style_t *)result->data;
+      dt_style_t *style = (dt_style_t *)res_iter->data;
 
       gchar *items_string = (gchar *)dt_styles_get_item_list_as_string(style->name);
       gchar *tooltip = NULL;
@@ -193,7 +193,7 @@ static void _gui_styles_update_view(dt_lib_styles_t *d)
 
       g_free(items_string);
       g_free(tooltip);
-    } while((result = g_list_next(result)) != NULL);
+    }
     g_list_free_full(result, dt_style_free);
   }
 

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -104,13 +104,13 @@ static void _lib_lighttable_update_btn(dt_lib_module_t *self)
   else if(d->layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
     active = d->layout_zoomable;
 
-  GList *l = gtk_container_get_children(GTK_CONTAINER(d->layout_box));
-  while(l)
+  GList *children = gtk_container_get_children(GTK_CONTAINER(d->layout_box));
+  for(const GList *l = children; l; l = g_list_next(l))
   {
     GtkWidget *w = (GtkWidget *)l->data;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), (w == active));
-    l = g_list_next(l);
   }
+  g_list_free(children);
 
   // and now we set the tooltips
   if(d->fullpreview)

--- a/src/libs/tools/module_toolbox.c
+++ b/src/libs/tools/module_toolbox.c
@@ -93,9 +93,8 @@ void gui_cleanup(dt_lib_module_t *self)
 void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct dt_view_t *new_view)
 {
   dt_lib_module_toolbox_t *d = (dt_lib_module_toolbox_t *)self->data;
-  GList *child_elt = d->child_views;
   dt_view_type_flags_t nv= new_view->view(new_view);
-  while(child_elt)
+  for(const GList *child_elt = d->child_views; child_elt; child_elt = g_list_next(child_elt))
   {
     child_data_t* child_data = (child_data_t*)child_elt->data;
     if(child_data->views & nv)
@@ -106,7 +105,6 @@ void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct d
     {
       gtk_widget_hide(child_data->child);
     }
-    child_elt = g_list_next(child_elt);
   }
 }
 

--- a/src/libs/tools/view_toolbox.c
+++ b/src/libs/tools/view_toolbox.c
@@ -92,9 +92,8 @@ void gui_cleanup(dt_lib_module_t *self)
 void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct dt_view_t *new_view)
 {
   dt_lib_view_toolbox_t *d = (dt_lib_view_toolbox_t *)self->data;
-  GList *child_elt = d->child_views;
   dt_view_type_flags_t nv= new_view->view(new_view);
-  while(child_elt)
+  for(const GList *child_elt = d->child_views; child_elt; child_elt = g_list_next(child_elt))
   {
     child_data_t* child_data = (child_data_t*)child_elt->data;
     if(child_data->views & nv)
@@ -105,7 +104,6 @@ void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct d
     {
       gtk_widget_hide(child_data->child);
     }
-    child_elt = g_list_next(child_elt);
   }
 }
 

--- a/src/lua/glist.c
+++ b/src/lua/glist.c
@@ -22,13 +22,11 @@
 
 void dt_lua_push_glist_type(lua_State *L, GList *list, luaA_Type elt_type)
 {
-  GList *elt = list;
   lua_newtable(L);
-  while(elt)
+  for(const GList *elt = list; elt; elt = g_list_next(elt))
   {
     luaA_push_type(L, elt_type, elt->data);
     luaL_ref(L, -2);
-    elt = g_list_next(elt);
   }
 }
 

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -78,12 +78,10 @@ static int hovered_cb(lua_State *L)
 static int act_on_cb(lua_State *L)
 {
   lua_newtable(L);
-  const GList *image = dt_view_get_images_to_act_on(FALSE, TRUE, TRUE);
-  while(image)
+  for(const GList *image = dt_view_get_images_to_act_on(FALSE, TRUE, TRUE); image; image = g_list_next(image))
   {
     luaA_push(L, dt_lua_image_t, &image->data);
     luaL_ref(L, -2);
-    image = g_list_next((GList *)image);
   }
   return 1;
 }

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -170,13 +170,11 @@ static int initialize_store_wrapper(struct dt_imageio_module_storage_t *self, dt
   luaA_push_type(L, self->parameter_lua_type, data);
   luaA_push_type(L, (*format)->parameter_lua_type, *fdata);
 
-  GList *imgids = *images;
   lua_newtable(L);
-  while(imgids)
+  for(const GList *imgids = *images; imgids; imgids = g_list_next(imgids))
   {
     luaA_push(L, dt_lua_image_t, &(imgids->data));
     luaL_ref(L, -2);
-    imgids = g_list_next(imgids);
   }
   lua_pushboolean(L, high_quality);
 
@@ -455,12 +453,9 @@ static int register_storage(lua_State *L)
   luaA_struct_type(darktable.lua_state.state, type_id);
   dt_lua_register_storage_type(darktable.lua_state.state, storage, type_id);
 
-
-
-  GList *it = darktable.imageio->plugins_format;
   if(!lua_isnoneornil(L, 5))
   {
-    while(it)
+    for(GList *it = darktable.imageio->plugins_format; it; it = g_list_next(it))
     {
       lua_pushvalue(L, 5);
       dt_imageio_module_format_t *format = (dt_imageio_module_format_t *)it->data;
@@ -477,17 +472,15 @@ static int register_storage(lua_State *L)
       {
         data->supported_formats = g_list_prepend(data->supported_formats, format);
       }
-      it = g_list_next(it);
     }
   }
   else
   {
     // all formats are supported
-    while(it)
+    for(GList *it = darktable.imageio->plugins_format; it; it = g_list_next(it))
     {
       dt_imageio_module_format_t *format = (dt_imageio_module_format_t *)it->data;
       data->supported_formats = g_list_prepend(data->supported_formats, format);
-      it = g_list_next(it);
     }
   }
 

--- a/src/lua/tags.c
+++ b/src/lua/tags.c
@@ -164,15 +164,11 @@ static int tag_delete(lua_State *L)
   if(dt_tag_remove(tagid, TRUE))
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
-  GList *list_iter;
-  if((list_iter = g_list_first(tagged_images)) != NULL)
+  for(const GList *list_iter = tagged_images; list_iter; list_iter = g_list_next(list_iter))
   {
-    do
-    {
-      dt_image_synch_xmp(GPOINTER_TO_INT(list_iter->data));
-    } while((list_iter = g_list_next(list_iter)) != NULL);
+    dt_image_synch_xmp(GPOINTER_TO_INT(list_iter->data));
   }
-  g_list_free(g_list_first(tagged_images));
+  g_list_free(tagged_images);
 
   return 0;
 }

--- a/src/lua/widget/box.c
+++ b/src/lua/widget/box.c
@@ -47,9 +47,8 @@ static int orientation_member(lua_State *L)
     gtk_orientable_set_orientation(GTK_ORIENTABLE(box->widget),orientation);
     if(gtk_orientable_get_orientation(GTK_ORIENTABLE(box->widget)) == GTK_ORIENTATION_HORIZONTAL)
     {
-      GList *children, *l;
-      children = gtk_container_get_children(GTK_CONTAINER(box->widget));
-      for(l = children; l != NULL; l = l->next)
+      GList *children = gtk_container_get_children(GTK_CONTAINER(box->widget));
+      for(const GList *l = children; l; l = g_list_next(l))
       {
         gtk_box_set_child_packing(GTK_BOX(box->widget), GTK_WIDGET(l->data), TRUE, TRUE, 0, GTK_PACK_START);
       }

--- a/src/lua/widget/container.c
+++ b/src/lua/widget/container.c
@@ -34,15 +34,14 @@ static int container_reset(lua_State* L)
   lua_container container;
   luaA_to(L,lua_container,&container,1);
   lua_getuservalue(L,1);
-  GList*children = gtk_container_get_children(GTK_CONTAINER(container->widget));
-  GList*curelt = children;
-  while(curelt) {
+  GList *children = gtk_container_get_children(GTK_CONTAINER(container->widget));
+  for(const GList *curelt = children; curelt; curelt = g_list_next(curelt))
+  {      
     lua_pushcfunction(L,dt_lua_widget_trigger_callback);
     GtkWidget* cur_widget = curelt->data;
     luaA_push(L,lua_widget,&cur_widget);
     lua_pushstring(L,"reset");
     lua_call(L,2,0);
-    curelt = g_list_next(curelt);
   }
   lua_pop(L,1);
   g_list_free(children);
@@ -73,11 +72,10 @@ static void on_child_removed(GtkContainer *container,GtkWidget *child,lua_contai
 static void container_cleanup(lua_State* L,lua_widget widget)
 {
   GList * children = gtk_container_get_children(GTK_CONTAINER(widget->widget));
-  GList * cur_child = children;
   g_signal_handlers_disconnect_by_func(widget->widget, G_CALLBACK(on_child_removed), widget);
-  while(cur_child) {
+  for(const GList *cur_child = children; cur_child; cur_child = g_list_next(cur_child))
+  {
     gtk_container_remove(GTK_CONTAINER(widget->widget),GTK_WIDGET(cur_child->data));
-    cur_child = g_list_next(cur_child);
   }
   g_list_free(children);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2698,8 +2698,7 @@ static gboolean _on_drag_motion(GtkWidget *widget, GdkDragContext *dc, gint x, g
       can_moved = dt_ioppr_check_can_move_before_iop(darktable.develop->iop, module_src, module_dest);
   }
 
-  GList *modules = g_list_last(darktable.develop->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(darktable.develop->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
@@ -2709,8 +2708,6 @@ static gboolean _on_drag_motion(GtkWidget *widget, GdkDragContext *dc, gint x, g
       gtk_style_context_remove_class(context, "iop_drop_after");
       gtk_style_context_remove_class(context, "iop_drop_before");
     }
-
-    modules = g_list_previous(modules);
   }
 
   if(can_moved)
@@ -2775,8 +2772,7 @@ static void _on_drag_data_received(GtkWidget *widget, GdkDragContext *dc, gint x
       fprintf(stderr, "[_on_drag_data_received] can't find destination module\n");
   }
 
-  GList *modules = g_list_last(darktable.develop->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(darktable.develop->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
@@ -2786,8 +2782,6 @@ static void _on_drag_data_received(GtkWidget *widget, GdkDragContext *dc, gint x
       gtk_style_context_remove_class(context, "iop_drop_after");
       gtk_style_context_remove_class(context, "iop_drop_before");
     }
-
-    modules = g_list_previous(modules);
   }
 
   gtk_drag_finish(dc, TRUE, FALSE, time);
@@ -2830,8 +2824,7 @@ static void _on_drag_data_received(GtkWidget *widget, GdkDragContext *dc, gint x
 
 static void _on_drag_leave(GtkWidget *widget, GdkDragContext *dc, guint time, gpointer user_data)
 {
-  GList *modules = g_list_last(darktable.develop->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(darktable.develop->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
@@ -2841,8 +2834,6 @@ static void _on_drag_leave(GtkWidget *widget, GdkDragContext *dc, guint time, gp
       gtk_style_context_remove_class(context, "iop_drop_after");
       gtk_style_context_remove_class(context, "iop_drop_before");
     }
-
-    modules = g_list_previous(modules);
   }
 
   GtkWidget *w = g_object_get_data(G_OBJECT(widget), "highlighted");

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1211,8 +1211,7 @@ end:
 
 static void _profile_update_display_cmb(GtkWidget *cmb_display_profile)
 {
-  GList *l = darktable.color_profiles->profiles;
-  while(l)
+  for(const GList *l = darktable.color_profiles->profiles; l; l = g_list_next(l))
   {
     dt_colorspaces_color_profile_t *prof = (dt_colorspaces_color_profile_t *)l->data;
     if(prof->display_pos > -1)
@@ -1228,14 +1227,12 @@ static void _profile_update_display_cmb(GtkWidget *cmb_display_profile)
         }
       }
     }
-    l = g_list_next(l);
   }
 }
 
 static void _profile_update_display2_cmb(GtkWidget *cmb_display_profile)
 {
-  GList *l = darktable.color_profiles->profiles;
-  while(l)
+  for(const GList *l = darktable.color_profiles->profiles; l; l = g_list_next(l))
   {
     dt_colorspaces_color_profile_t *prof = (dt_colorspaces_color_profile_t *)l->data;
     if(prof->display2_pos > -1)
@@ -1251,7 +1248,6 @@ static void _profile_update_display2_cmb(GtkWidget *cmb_display_profile)
         }
       }
     }
-    l = g_list_next(l);
   }
 }
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -423,14 +423,11 @@ void expose(dt_view_t *self, cairo_t *cri, int32_t width, int32_t height, int32_
   cairo_restore(cri);
 
   // post expose to modules
-  GList *modules = darktable.lib->plugins;
-
-  while(modules)
+  for(const GList *modules = darktable.lib->plugins; modules; modules = g_list_next(modules))
   {
     dt_lib_module_t *module = (dt_lib_module_t *)(modules->data);
     if(module->gui_post_expose && dt_lib_is_visible_in_view(module, self))
       module->gui_post_expose(module, cri, width, height, pointerx, pointery);
-    modules = g_list_next(modules);
   }
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -456,17 +456,13 @@ void dt_view_manager_expose(dt_view_manager_t *vm, cairo_t *cr, int32_t width, i
 
     cairo_restore(cr);
     /* expose plugins */
-    GList *plugins = g_list_last(darktable.lib->plugins);
-    while(plugins)
+    for(const GList *plugins = g_list_last(darktable.lib->plugins); plugins; plugins = g_list_previous(plugins))
     {
       dt_lib_module_t *plugin = (dt_lib_module_t *)(plugins->data);
 
       /* does this module belong to current view ?*/
       if(plugin->gui_post_expose && dt_lib_is_visible_in_view(plugin, vm->current_view))
         plugin->gui_post_expose(plugin, cr, vm->current_view->width, vm->current_view->height, px, py);
-
-      /* get next plugin */
-      plugins = g_list_previous(plugins);
     }
   }
 }
@@ -484,17 +480,13 @@ void dt_view_manager_mouse_leave(dt_view_manager_t *vm)
 
   /* lets check if any plugins want to handle mouse move */
   gboolean handled = FALSE;
-  GList *plugins = g_list_last(darktable.lib->plugins);
-  while(plugins)
+  for(const GList *plugins = g_list_last(darktable.lib->plugins); plugins; plugins = g_list_previous(plugins))
   {
     dt_lib_module_t *plugin = (dt_lib_module_t *)(plugins->data);
 
     /* does this module belong to current view ?*/
     if(plugin->mouse_leave && dt_lib_is_visible_in_view(plugin, v))
       if(plugin->mouse_leave(plugin)) handled = TRUE;
-
-    /* get next plugin */
-    plugins = g_list_previous(plugins);
   }
 
   /* if not handled by any plugin let pass to view handler*/
@@ -514,17 +506,13 @@ void dt_view_manager_mouse_moved(dt_view_manager_t *vm, double x, double y, doub
 
   /* lets check if any plugins want to handle mouse move */
   gboolean handled = FALSE;
-  GList *plugins = g_list_last(darktable.lib->plugins);
-  while(plugins)
+  for(const GList *plugins = g_list_last(darktable.lib->plugins); plugins; plugins = g_list_previous(plugins))
   {
     dt_lib_module_t *plugin = (dt_lib_module_t *)(plugins->data);
 
     /* does this module belong to current view ?*/
     if(plugin->mouse_moved && dt_lib_is_visible_in_view(plugin, v))
       if(plugin->mouse_moved(plugin, x, y, pressure, which)) handled = TRUE;
-
-    /* get next plugin */
-    plugins = g_list_previous(plugins);
   }
 
   /* if not handled by any plugin let pass to view handler*/
@@ -538,17 +526,13 @@ int dt_view_manager_button_released(dt_view_manager_t *vm, double x, double y, i
 
   /* lets check if any plugins want to handle button press */
   gboolean handled = FALSE;
-  GList *plugins = g_list_last(darktable.lib->plugins);
-  while(plugins)
+  for(const GList *plugins = g_list_last(darktable.lib->plugins); plugins; plugins = g_list_previous(plugins))
   {
     dt_lib_module_t *plugin = (dt_lib_module_t *)(plugins->data);
 
     /* does this module belong to current view ?*/
     if(plugin->button_released && dt_lib_is_visible_in_view(plugin, v))
       if(plugin->button_released(plugin, x, y, which, state)) handled = TRUE;
-
-    /* get next plugin */
-    plugins = g_list_previous(plugins);
   }
 
   if(handled) return 1;
@@ -567,17 +551,15 @@ int dt_view_manager_button_pressed(dt_view_manager_t *vm, double x, double y, do
 
   /* lets check if any plugins want to handle button press */
   gboolean handled = FALSE;
-  GList *plugins = g_list_last(darktable.lib->plugins);
-  while(plugins && !handled)
+  for(const GList *plugins = g_list_last(darktable.lib->plugins);
+      plugins && !handled;
+      plugins = g_list_previous(plugins))
   {
     dt_lib_module_t *plugin = (dt_lib_module_t *)(plugins->data);
 
     /* does this module belong to current view ?*/
     if(plugin->button_pressed && dt_lib_is_visible_in_view(plugin, v))
       if(plugin->button_pressed(plugin, x, y, pressure, which, type, state)) handled = TRUE;
-
-    /* get next plugin */
-    plugins = g_list_previous(plugins);
   }
 
   if(handled) return 1;


### PR DESCRIPTION
Continuing #8368 and #8379.  More conversion of `while` loops into `for` loops.  I started converting reverse-iterating loops as well (I had been grepping just for g_list_next), so there will be a small Phase 4 PR coming up where I go back over the files from the first two PRs to pick up those loops as well.

Once again found and fixed a bunch of memory leaks resulting from using the returned pointer to a newly-created list to iterate down the list instead of making a copy of it, or failing to free the return value at all.  Also some instances where a function returns a newly-allocated string which gets duplicated without remembering/freeing the original.

dterrahe: there are multiple loops destroying all the children of a container.  I only did the while->for conversion, but will dedupe them with a utility function in a separate PR (also the ones in #8379).  `dt_ui_container_destroy_children` won't work for that, as it takes a `dt_ui_t` arg and a container index.
