### PR TITLE
memleak fix: free return from dt_util_glist_to_str

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1778,7 +1778,9 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         g_free(name);			// free the original filename
       }
 
-      query = dt_util_dstrcat(NULL, "(%s)", dt_util_glist_to_str(" OR ", list));
+      char *subquery = dt_util_glist_to_str(" OR ", list);
+      query = g_strdup_printf("(%s)", subquery);
+      g_free(subquery);
       g_list_free_full(list, g_free);	// free the SQL clauses as well as the list
 
       break;


### PR DESCRIPTION
Also replace dt_util_dstrcat(NULL,...) by g_strdup_printf.
