### PR TITLE
refactor: GList loops (Phase 4)

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2359,8 +2359,8 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
                                 -1, &stmt, NULL);
 
     for (const GList * selected_images_iter = selected_images;
-        selected_images_iter != NULL;
-        selected_images_iter = selected_images_iter->next)
+         selected_images_iter != NULL;
+         selected_images_iter = g_list_next(selected_images_iter))
     {
       const int moved_image_id = GPOINTER_TO_INT(selected_images_iter->data);
 
@@ -2415,8 +2415,8 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
                                 -1, &update_stmt, NULL);
 
     for (const GList * selected_images_iter = selected_images;
-        selected_images_iter != NULL;
-        selected_images_iter = selected_images_iter->next)
+         selected_images_iter != NULL;
+         selected_images_iter = g_list_next(selected_images_iter))
     {
       max_position++;
       const int moved_image_id = GPOINTER_TO_INT(selected_images_iter->data);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -688,7 +688,7 @@ dt_ioppr_get_profile_info_from_list(struct dt_develop_t *dev,
 {
   dt_iop_order_iccprofile_info_t *profile_info = NULL;
 
-  for(GList *profiles = g_list_first(dev->allprofile_info); profiles; profiles = g_list_next(profiles))
+  for(GList *profiles = dev->allprofile_info; profiles; profiles = g_list_next(profiles))
   {
     dt_iop_order_iccprofile_info_t *prof = (dt_iop_order_iccprofile_info_t *)(profiles->data);
     if(prof->type == profile_type && strcmp(prof->filename, profile_filename) == 0)
@@ -900,8 +900,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
   // use introspection to get the params values
   dt_iop_module_so_t *colorin_so = NULL;
   dt_iop_module_t *colorin = NULL;
-  GList *modules = g_list_first(darktable.iop);
-  while(modules)
+  for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_so_t *module_so = (dt_iop_module_so_t *)(modules->data);
     if(!strcmp(module_so->op, "colorin"))
@@ -909,11 +908,10 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
       colorin_so = module_so;
       break;
     }
-    modules = g_list_next(modules);
   }
   if(colorin_so && colorin_so->get_p)
   {
-    for(modules = g_list_first(dev->iop); modules; modules = g_list_next(modules))
+    for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
       if(!strcmp(module->op, "colorin"))
@@ -949,8 +947,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
   // use introspection to get the params values
   dt_iop_module_so_t *colorout_so = NULL;
   dt_iop_module_t *colorout = NULL;
-  GList *modules = g_list_last(darktable.iop);
-  while(modules)
+  for(const GList *modules = g_list_last(darktable.iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_so_t *module_so = (dt_iop_module_so_t *)(modules->data);
     if(!strcmp(module_so->op, "colorout"))
@@ -958,12 +955,10 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
       colorout_so = module_so;
       break;
     }
-    modules = g_list_previous(modules);
   }
   if(colorout_so && colorout_so->get_p)
   {
-    modules = g_list_last(dev->iop);
-    while(modules)
+    for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
       if(!strcmp(module->op, "colorout"))
@@ -971,7 +966,6 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
         colorout = module;
         break;
       }
-      modules = g_list_previous(modules);
     }
   }
   if(colorout)

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -675,7 +675,7 @@ void dt_multiple_styles_apply_to_list(GList *styles, const GList *list, gboolean
     if(mode == DT_STYLE_HISTORY_OVERWRITE)
       dt_history_delete_on_image_ext(imgid, FALSE);
 
-    for (GList *style = styles; style != NULL; style = style->next)
+    for (GList *style = styles; style; style = g_list_next(style))
     {
       dt_styles_apply_to_image((char*)style->data, duplicate, imgid);
     }

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -251,7 +251,7 @@ static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_
   {
     imgs = g_list_sort(imgs, _images_list_cmp);
     // remove duplicates
-    for(GList *img = imgs; img != NULL; img = img->next)
+    for(const GList *img = imgs; img; img = g_list_next(img))
       while(img->next && img->data == img->next->data)
         imgs = g_list_delete_link(imgs, img->next);
     // udpate xmp for updated images
@@ -274,21 +274,19 @@ void dt_undo_do_undo(dt_undo_t *self, uint32_t filter)
 
 static void _undo_clear_list(GList **list, uint32_t filter)
 {
-  GList *l = *list;
-
   // check for first item that is matching the given pattern
 
-  while(l)
+  GList *next;
+  for(GList *l = *list; l; l = next)
   {
     dt_undo_item_t *item = (dt_undo_item_t *)l->data;
-    GList *next = l->next;
+    next = g_list_next(l); // get next node now, because we may delete the current one
     if(item->type & filter)
     {
       //  remove this element
       *list = g_list_remove(*list, item);
       _free_undo_data((void *)item);
     }
-    l = next;
   };
 
   dt_print(DT_DEBUG_UNDO, "[undo] clear list for %d (length %d)\n",
@@ -312,7 +310,7 @@ static void _undo_iterate(GList *list, uint32_t filter, gpointer user_data,
                           void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item))
 {
   // check for first item that is matching the given pattern
-  for(GList *l = list; l; l = l->next)
+  for(GList *l = list; l; l = g_list_next(l))
   {
     dt_undo_item_t *item = (dt_undo_item_t *)l->data;
     if(!item->is_group && (item->type & filter))

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2037,8 +2037,7 @@ void dt_masks_cleanup_unused_from_list(GList *history_list)
   // so we are going to remove for each hist->forms from the top
   int num = g_list_length(history_list);
   int history_end = num;
-  GList *history = g_list_last(history_list);
-  while(history)
+  for(const GList *history = g_list_last(history_list); history; history = g_list_previous(history))
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
     if(hist->forms && strcmp(hist->op_name, "mask_manager") == 0)
@@ -2047,7 +2046,6 @@ void dt_masks_cleanup_unused_from_list(GList *history_list)
       history_end = num - 1;
     }
     num--;
-    history = g_list_previous(history);
   }
 }
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1423,20 +1423,20 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   {
     int row_y = 0, x = 0, row_h = 0;
     int max_row_w = sum_w / per_col;
-    for(GList *slot_iter = slots; slot_iter != NULL; slot_iter = slot_iter->next)
+    for(GList *slot_iter = slots; slot_iter; slot_iter = g_list_next(slot_iter))
     {
       GList *slot = (GList *)slot_iter->data;
 
       // Max width of windows in the slot
       int slot_max_w = 0;
-      for(GList *slot_cw_iter = slot; slot_cw_iter != NULL; slot_cw_iter = slot_cw_iter->next)
+      for(GList *slot_cw_iter = slot; slot_cw_iter; slot_cw_iter = g_list_next(slot_cw_iter))
       {
         dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
         slot_max_w = MAX(slot_max_w, cw->width);
       }
 
       int y = row_y;
-      for(GList *slot_cw_iter = slot; slot_cw_iter != NULL; slot_cw_iter = slot_cw_iter->next)
+      for(GList *slot_cw_iter = slot; slot_cw_iter; slot_cw_iter = g_list_next(slot_cw_iter))
       {
         dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
         cw->x = x + (slot_max_w - cw->width) / 2;
@@ -1469,13 +1469,13 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   total_width -= distance;
   total_height -= distance;
 
-  for(const GList *iter = rows; iter != NULL; iter = iter->next)
+  for(const GList *iter = rows; iter; iter = g_list_next(iter))
   {
     GList *row = (GList *)iter->data;
     int row_w = 0, xoff;
     int max_rh = 0;
 
-    for(GList *slot_cw_iter = row; slot_cw_iter != NULL; slot_cw_iter = slot_cw_iter->next)
+    for(GList *slot_cw_iter = row; slot_cw_iter; slot_cw_iter = g_list_next(slot_cw_iter))
     {
       dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
       row_w = MAX(row_w, cw->x + cw->width);
@@ -1484,7 +1484,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
 
     xoff = (total_width - row_w) / 2;
 
-    for(GList *cw_iter = row; cw_iter != NULL; cw_iter = cw_iter->next)
+    for(GList *cw_iter = row; cw_iter; cw_iter = g_list_next(cw_iter))
     {
       dt_thumbnail_t *cw = (dt_thumbnail_t *)cw_iter->data;
       cw->x += xoff;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1065,52 +1065,47 @@ void dt_gui_favorite_presets_menu_show()
   else
     config = dt_conf_get_string("plugins/darkroom/quick_preset_list");
 
-  GList *modules = g_list_last(darktable.develop->iop);
-  if(modules)
+  for(const GList *modules = g_list_last(darktable.develop->iop); modules; modules = g_list_previous(modules))
   {
-    do
+    dt_iop_module_t *iop = (dt_iop_module_t *)modules->data;
+
+    // check if module is visible in current layout
+    if(dt_dev_modulegroups_is_visible(darktable.develop, iop->so->op))
     {
-      dt_iop_module_t *iop = (dt_iop_module_t *)modules->data;
+      /* query presets for module */
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query,
+                                  -1, &stmt, NULL);
+      DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, iop->op, -1, SQLITE_TRANSIENT);
 
-      // check if module is visible in current layout
-      if(dt_dev_modulegroups_is_visible(darktable.develop, iop->so->op))
+      while(sqlite3_step(stmt) == SQLITE_ROW)
       {
-        /* query presets for module */
-        DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query,
-                                    -1, &stmt, NULL);
-        DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, iop->op, -1, SQLITE_TRANSIENT);
-
-        while(sqlite3_step(stmt) == SQLITE_ROW)
+        const char *name = (char *)sqlite3_column_text(stmt, 0);
+        if(retrieve_list)
         {
-          const char *name = (char *)sqlite3_column_text(stmt, 0);
-          if(retrieve_list)
-          {
-            // we only show it if module is in favorite
-            gchar *key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/favorite", iop->so->op);
-            const gboolean fav = dt_conf_get_bool(key);
-            g_free(key);
-            if(fav) config = dt_util_dstrcat(config, "ꬹ%s|%sꬹ", iop->so->op, name);
-          }
-
-          // check that this preset is in the config list
-          gchar *txt = dt_util_dstrcat(NULL, "ꬹ%s|%sꬹ", iop->so->op, name);
-          if(config && strstr(config, txt))
-          {
-            GtkMenuItem *mi = (GtkMenuItem *)gtk_menu_item_new_with_label(name);
-            gchar *tt = dt_util_dstrcat(NULL, "<b>%s %s</b> %s", iop->name(), iop->multi_name, name);
-            gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), tt);
-            g_free(tt);
-            g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
-            g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_pick_preset), iop);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(mi));
-          }
-          g_free(txt);
+          // we only show it if module is in favorite
+          gchar *key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/favorite", iop->so->op);
+          const gboolean fav = dt_conf_get_bool(key);
+          g_free(key);
+          if(fav) config = dt_util_dstrcat(config, "ꬹ%s|%sꬹ", iop->so->op, name);
         }
 
-        sqlite3_finalize(stmt);
+        // check that this preset is in the config list
+        gchar *txt = dt_util_dstrcat(NULL, "ꬹ%s|%sꬹ", iop->so->op, name);
+        if(config && strstr(config, txt))
+        {
+          GtkMenuItem *mi = (GtkMenuItem *)gtk_menu_item_new_with_label(name);
+          gchar *tt = dt_util_dstrcat(NULL, "<b>%s %s</b> %s", iop->name(), iop->multi_name, name);
+          gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), tt);
+          g_free(tt);
+          g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
+          g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_pick_preset), iop);
+          gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(mi));
+        }
+        g_free(txt);
       }
 
-    } while((modules = g_list_previous(modules)) != NULL);
+      sqlite3_finalize(stmt);
+    }
   }
   if(retrieve_list) dt_conf_set_string("plugins/darkroom/quick_preset_list", config);
   g_free(config);

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -311,7 +311,6 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     if(res_subj)
     {
       // don't show the internal tags (darktable|...)
-      res_subj = g_list_first(res_subj);
       GList *iter = res_subj;
       while(iter)
       {

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1080,7 +1080,7 @@ static GSList *_get_map_extent(const dt_iop_roi_t *roi_out,
   cairo_region_t *map_region = cairo_region_create();
   GSList *in_roi = NULL;
 
-  for(const GList *i = interpolated; i != NULL; i = i->next)
+  for(const GList *i = interpolated; i; i = g_list_next(i))
   {
     const dt_liquify_warp_t *warp = ((dt_liquify_warp_t *) i->data);
     cairo_rectangle_int_t r;
@@ -1118,7 +1118,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   memset(map, 0, sizeof(float complex) * mapsize);
 
   // build map
-  for(const GSList *i = interpolated; i != NULL; i = i->next)
+  for(const GSList *i = interpolated; i; i = g_slist_next(i))
   {
     const dt_liquify_warp_t *warp = ((dt_liquify_warp_t *) i->data);
     float complex *stamp = NULL;
@@ -1862,7 +1862,7 @@ static void _draw_paths(dt_iop_module_t *module,
     ? NULL
     : interpolate_paths(p);
 
-  for(GList *l = layers; l != NULL; l = l->next)
+  for(const GList *l = layers; l; l = g_list_next(l))
   {
     const dt_liquify_layer_enum_t layer = (dt_liquify_layer_enum_t) GPOINTER_TO_INT(l->data);
     dt_liquify_rgba_t fg_color = dt_liquify_layers[layer].fg;
@@ -1906,7 +1906,7 @@ static void _draw_paths(dt_iop_module_t *module,
 
       if(layer == DT_LIQUIFY_LAYER_RADIUS)
       {
-        for(GList *i = interpolated; i != NULL; i = i->next)
+        for(const GList *i = interpolated; i; i = g_list_next(i))
         {
           const dt_liquify_warp_t *pwarp = ((dt_liquify_warp_t *) i->data);
           draw_circle(cr, pwarp->point, 2.0f * cabsf(pwarp->radius - pwarp->point));
@@ -1917,7 +1917,7 @@ static void _draw_paths(dt_iop_module_t *module,
       }
       else if(layer == DT_LIQUIFY_LAYER_HARDNESS1)
       {
-        for(GList *i = interpolated; i != NULL; i = i->next)
+        for(const GList *i = interpolated; i; i = g_list_next(i))
         {
           const dt_liquify_warp_t *pwarp = ((dt_liquify_warp_t *) i->data);
           draw_circle(cr, pwarp->point, 2.0f * cabsf(pwarp->radius - pwarp->point) * pwarp->control1);
@@ -1927,7 +1927,7 @@ static void _draw_paths(dt_iop_module_t *module,
       }
       else if(layer == DT_LIQUIFY_LAYER_HARDNESS2)
       {
-        for(GList *i = interpolated; i != NULL; i = i->next)
+        for(const GList *i = interpolated; i; i = g_list_next(i))
         {
           const dt_liquify_warp_t *pwarp = ((dt_liquify_warp_t *) i->data);
           draw_circle(cr, pwarp->point, 2.0f * cabsf(pwarp->radius - pwarp->point) * pwarp->control2);
@@ -1938,7 +1938,7 @@ static void _draw_paths(dt_iop_module_t *module,
       else if(layer == DT_LIQUIFY_LAYER_WARPS)
       {
         VERYTHINLINE; FG_COLOR;
-        for(GList *i = interpolated; i != NULL; i = i->next)
+        for(const GList *i = interpolated; i; i = g_list_next(i))
         {
           const dt_liquify_warp_t *pwarp = ((dt_liquify_warp_t *) i->data);
           cairo_move_to(cr, crealf(pwarp->point), cimagf(pwarp->point));
@@ -1946,7 +1946,7 @@ static void _draw_paths(dt_iop_module_t *module,
         }
         cairo_stroke(cr);
 
-        for(GList *i = interpolated; i != NULL; i = i->next)
+        for(const GList *i = interpolated; i; i = g_list_next(i))
         {
           const dt_liquify_warp_t *pwarp = ((dt_liquify_warp_t *) i->data);
           const float rot = get_rot(pwarp->type);
@@ -2243,7 +2243,7 @@ static dt_liquify_hit_t _hit_paths(dt_iop_module_t *module,
 
   float distance = FLT_MAX;
 
-  for(GList *l = layers; l != NULL; l = l->next)
+  for(const GList *l = layers; l; l = g_list_next(l))
   {
     const dt_liquify_layer_enum_t layer = (dt_liquify_layer_enum_t) GPOINTER_TO_INT(l->data);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -887,7 +887,7 @@ static gboolean list_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTre
   {
     GList *list = dt_util_str_to_glist(",", needle);
 
-    for (GList *l = list; l != NULL; l = l->next)
+    for (const GList *l = list; l; l = g_list_next(l))
     {
       if(g_str_has_prefix((char *)l->data, "%"))
       {

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -259,7 +259,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
 
 static void _reset_module_instance(GList *hist, dt_iop_module_t *module, int multi_priority)
 {
-  while (hist)
+  for(; hist; hist = g_list_next(hist))
   {
     dt_dev_history_item_t *hit = (dt_dev_history_item_t *)hist->data;
 
@@ -267,7 +267,6 @@ static void _reset_module_instance(GList *hist, dt_iop_module_t *module, int mul
     {
       hit->module = module;
     }
-    hist = hist->next;
   }
 }
 
@@ -444,8 +443,7 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
 static void _reorder_gui_module_list(dt_develop_t *dev)
 {
   int pos_module = 0;
-  GList *modules = g_list_last(dev->iop);
-  while(modules)
+  for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
@@ -455,8 +453,6 @@ static void _reorder_gui_module_list(dt_develop_t *dev)
       gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER), expander,
                             pos_module++);
     }
-
-    modules = g_list_previous(modules);
   }
 }
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -227,7 +227,7 @@ GList* _get_selected_style_names(GList* selected_styles, GtkTreeModel *model)
 {
   GtkTreeIter iter;
   GList *style_names = NULL;
-  for (GList *style = selected_styles; style != NULL; style = style->next)
+  for (const GList *style = selected_styles; style; style = g_list_next(style))
   {
     GValue value = {0,};
     gtk_tree_model_get_iter(model, &iter, (GtkTreePath *)style->data);
@@ -280,7 +280,7 @@ static void edit_clicked(GtkWidget *w, gpointer user_data)
   GtkTreeModel *model= gtk_tree_view_get_model(d->tree);
 
   GList *styles = gtk_tree_selection_get_selected_rows(selection, &model);
-  for (GList *style = styles; style != NULL; style = style->next)
+  for (const GList *style = styles; style; style = g_list_next(style))
   {
     char *name = NULL;
     GValue value = {0,};
@@ -346,7 +346,7 @@ static void delete_clicked(GtkWidget *w, gpointer user_data)
   if(can_delete)
   {
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
-    for (GList *style = style_names; style != NULL; style = style->next)
+    for (const GList *style = style_names; style; style = g_list_next(style))
     {
       dt_styles_delete_by_name_adv((char*)style->data, single_raise);
     }
@@ -399,7 +399,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
   {
     char *filedir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
 
-    for (GList *style = style_names; style != NULL; style = style->next)
+    for (const GList *style = style_names; style; style = g_list_next(style))
     {
       char stylename[520];
 
@@ -557,17 +557,14 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
   {
     GSList *filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(filechooser));
 
-    for(GSList *filename = filenames; filename != NULL; filename = filename->next)
+    for(const GSList *filename = filenames; filename; filename = g_slist_next(filename))
     {
       /* extract name from xml file */
       gchar *bname = "";
-      xmlDoc *document;
-      xmlNode *root, *node;
-      document = xmlReadFile((char*)filename->data, NULL, 0);
-      root = xmlDocGetRootElement(document);
-      node = root->children->children;
+      xmlDoc *document = xmlReadFile((char*)filename->data, NULL, 0);
+      xmlNode *root = xmlDocGetRootElement(document);
 
-      while(node)
+      for(xmlNode *node = root->children->children; node; node = node->next)
       {
         if(node->type == XML_ELEMENT_NODE)
         {
@@ -579,7 +576,6 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
             break;
           }
         }
-        node = node->next;
       }
 
       // check if style exists
@@ -936,7 +932,7 @@ void gui_reset(dt_lib_module_t *self)
 
   if(can_delete)
   {
-    for (GList *result = all_styles; result != NULL; result = result->next)
+    for (const GList *result = all_styles; result; result = g_list_next(result))
     {
       dt_style_t *style = (dt_style_t *)result->data;
       dt_styles_delete_by_name_adv((char*)style->name, FALSE);

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -385,8 +385,7 @@ static dt_lib_timeline_time_t _time_get_from_pos(int pos, dt_lib_timeline_t *str
   dt_lib_timeline_time_t tt = _time_init();
 
   int x = 0;
-  GList *bl = strip->blocks;
-  while(bl)
+  for(const GList *bl = strip->blocks; bl; bl = g_list_next(bl))
   {
     dt_lib_timeline_block_t *blo = bl->data;
     if(pos < x + blo->width)
@@ -439,7 +438,6 @@ static dt_lib_timeline_time_t _time_get_from_pos(int pos, dt_lib_timeline_t *str
       return tt;
     }
     x += blo->width + 2;
-    bl = bl->next;
   }
 
   return tt;
@@ -455,13 +453,12 @@ static dt_lib_timeline_time_t _time_compute_offset_for_zoom(int pos, dt_lib_time
   // we search the number of the bloc under pos
   int bloc_nb = 0;
   int x = 0;
-  GList *bl = strip->blocks;
-  while(bl)
+  GList *bl;
+  for(bl = strip->blocks; bl; bl = g_list_next(bl))
   {
     dt_lib_timeline_block_t *blo = bl->data;
     if(pos < x + blo->width) break;
     x += blo->width + 2;
-    bl = bl->next;
     bloc_nb++;
   }
   if(!bl)
@@ -1005,9 +1002,8 @@ static gboolean _lib_timeline_draw_callback(GtkWidget *widget, cairo_t *wcr, gpo
     cairo_paint(cr);
 
     // draw content depending of zoom level
-    GList *bl = strip->blocks;
     int posx = 0;
-    while(bl)
+    for(const GList *bl = strip->blocks; bl; bl = g_list_next(bl))
     {
       dt_lib_timeline_block_t *blo = bl->data;
 
@@ -1038,7 +1034,6 @@ static gboolean _lib_timeline_draw_callback(GtkWidget *widget, cairo_t *wcr, gpo
         cairo_fill(cr);
       }
 
-      bl = bl->next;
       posx += wb + 2;
       if(posx >= allocation.width) break;
     }

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -157,7 +157,7 @@ static int get_keys(lua_State *L)
 
   keys = g_list_sort(keys, (GCompareFunc) strcmp);
   lua_newtable(L);
-  for(GList* key = keys; key != NULL; key = key->next)
+  for(const GList* key = keys; key; key = g_list_next(key))
   {
     lua_pushstring(L, key->data);
     luaL_ref(L, -2);
@@ -837,8 +837,7 @@ GtkGrid* init_tab_lua(GtkWidget *dialog, GtkWidget *stack)
   gtk_container_add(GTK_CONTAINER(viewport), grid);
   gtk_stack_add_titled(GTK_STACK(stack), scroll, _("lua options"), _("lua options"));
 
-  pref_element *cur_elt = pref_list;
-  while(cur_elt)
+  for(pref_element *cur_elt = pref_list; cur_elt; cur_elt = cur_elt->next)
   {
     char pref_name[1024];
     get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
@@ -853,7 +852,6 @@ GtkGrid* init_tab_lua(GtkWidget *dialog, GtkWidget *stack)
     gtk_widget_set_tooltip_text(cur_elt->widget, cur_elt->tooltip);
     gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
     gtk_grid_attach(GTK_GRID(grid), cur_elt->widget, 1, line, 1, 1);
-    cur_elt = cur_elt->next;
     line++;
   }
   return GTK_GRID(grid);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1385,7 +1385,7 @@ static dt_map_image_t *_view_map_get_entry_at_pos(dt_view_t *self, const double 
 {
   dt_map_t *lib = (dt_map_t *)self->data;
 
-  for(GSList *iter = lib->images; iter; iter = iter->next)
+  for(const GSList *iter = lib->images; iter; iter = g_slist_next(iter))
   {
     dt_map_image_t *entry = (dt_map_image_t *)iter->data;
     OsmGpsMapImage *image = entry->image;
@@ -1412,7 +1412,7 @@ static GList *_view_map_get_imgs_at_pos(dt_view_t *self, const double x,
   int imgid = -1;
   dt_map_image_t *entry = NULL;
 
-  for(GSList *iter = lib->images; iter; iter = iter->next)
+  for(const GSList *iter = lib->images; iter; iter = g_slist_next(iter))
   {
     entry = (dt_map_image_t *)iter->data;
     OsmGpsMapImage *image = entry->image;
@@ -1618,7 +1618,7 @@ static gboolean _view_map_motion_notify_callback(GtkWidget *widget, GdkEventMoti
       abs(lib->start_drag_y - (int)ceil(e->y_root))) > DT_PIXEL_APPLY_DPI(8))
   {
     const int nb = g_list_length(lib->selected_images);
-    for(GSList *iter = lib->images; iter; iter = iter->next)
+    for(const GSList *iter = lib->images; iter; iter = g_slist_next(iter))
     {
       dt_map_image_t *entry = (dt_map_image_t *)iter->data;
       if(entry->image)
@@ -1638,11 +1638,7 @@ static gboolean _view_map_motion_notify_callback(GtkWidget *widget, GdkEventMoti
       }
     }
 
-    int group_count = 0;
-    for(GList *iter = lib->selected_images; iter != NULL; iter = iter->next)
-    {
-      group_count++;
-    }
+    int group_count = g_list_length(lib->selected_images);
 
     lib->start_drag = FALSE;
     GtkTargetList *targets = gtk_target_list_new(target_list_all, n_targets_all);
@@ -2102,7 +2098,7 @@ static OsmGpsMapPolygon *_view_map_add_polygon(const dt_view_t *view, GList *poi
   OsmGpsMapPolygon *poly = osm_gps_map_polygon_new();
   OsmGpsMapTrack* track = osm_gps_map_track_new();
 
-  for(GList *iter = g_list_first(points); iter; iter = g_list_next(iter))
+  for(GList *iter = points; iter; iter = g_list_next(iter))
   {
     dt_geo_map_display_point_t *p = (dt_geo_map_display_point_t *)iter->data;
     OsmGpsMapPoint* point = osm_gps_map_point_new_degrees(p->lat, p->lon);
@@ -2131,7 +2127,7 @@ static OsmGpsMapTrack *_view_map_add_track(const dt_view_t *view, GList *points)
 
   OsmGpsMapTrack* track = osm_gps_map_track_new();
 
-  for(GList *iter = g_list_first(points); iter; iter = g_list_next(iter))
+  for(GList *iter = points; iter; iter = g_list_next(iter))
   {
     dt_geo_map_display_point_t *p = (dt_geo_map_display_point_t *)iter->data;
     OsmGpsMapPoint* point = osm_gps_map_point_new_degrees(p->lat, p->lon);


### PR DESCRIPTION
Finishing up the work from #8368, #8379, and #8409.

Mopped up reverse-iteration loops not changed in Phase 3, plus changed `while` loops using direct ->next access instead of g_list_next, and normalized existing `for` loops using direct access to use g_list_next for consistency.
