### PR TITLE
Fix export settings reset on init

### DIFF
--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -596,6 +596,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                                 0);
   dt_bauhaus_widget_set_label(g->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set_default(g->quality, dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_DEFAULT));
+  dt_bauhaus_slider_set(g->quality, dt_conf_get_int("plugins/imageio/format/jpeg/quality"));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
   // TODO: add more options: subsample dreggn

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1509,7 +1509,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
 
   // export metadata presets
-  g_free(d->metadata_export);
   d->metadata_export = dt_lib_export_metadata_get_conf();
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1439,8 +1439,6 @@ void gui_init(dt_lib_module_t *self)
   g_free(setting);
   dt_bauhaus_combobox_set(d->dimensions_type, dt_conf_get_int(CONFIG_PREFIX "dimensions_type"));
 
-  _print_size_update_display(d);
-
   const gboolean is_scaling = dt_conf_is_equal(CONFIG_PREFIX "resizing", "scaling");
   if (is_scaling)
   {
@@ -1456,6 +1454,8 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_show(GTK_WIDGET(d->px_size));
     gtk_widget_show(GTK_WIDGET(d->print_size));
   }
+
+  _print_size_update_display(d);
 
   // Set storage
   setting = dt_conf_get_string(CONFIG_PREFIX "storage_name");

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -561,7 +561,7 @@ void gui_reset(dt_lib_module_t *self)
   if(!dt_control_running()) return;
   dt_lib_export_t *d = (dt_lib_export_t *)self->data;
   gtk_entry_set_text(GTK_ENTRY(d->width), dt_confgen_get(CONFIG_PREFIX "width", DT_DEFAULT));
-  gtk_entry_set_text(GTK_ENTRY(d->height), dt_confgen_get(CONFIG_PREFIX "width", DT_DEFAULT));
+  gtk_entry_set_text(GTK_ENTRY(d->height), dt_confgen_get(CONFIG_PREFIX "height", DT_DEFAULT));
   dt_bauhaus_combobox_set(d->dimensions_type, dt_confgen_get_int(CONFIG_PREFIX "dimensions_type", DT_DEFAULT));
   _print_size_update_display(d);
 
@@ -1430,6 +1430,15 @@ void gui_init(dt_lib_module_t *self)
   // this takes care of keeping hidden widgets hidden
   gtk_widget_show_all(self->widget);
   gtk_widget_set_no_show_all(self->widget, TRUE);
+
+  gchar* setting = dt_conf_get_string(CONFIG_PREFIX "width");
+  gtk_entry_set_text(GTK_ENTRY(d->width), setting);
+  g_free(setting);
+  setting = dt_conf_get_string(CONFIG_PREFIX "height");
+  gtk_entry_set_text(GTK_ENTRY(d->height), setting);
+  g_free(setting);
+  dt_bauhaus_combobox_set(d->dimensions_type, dt_conf_get_int(CONFIG_PREFIX "dimensions_type"));
+
   _print_size_update_display(d);
 
   const gboolean is_scaling = dt_conf_is_equal(CONFIG_PREFIX "resizing", "scaling");
@@ -1448,7 +1457,60 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_show(GTK_WIDGET(d->print_size));
   }
 
-  d->metadata_export = NULL;
+  // Set storage
+  setting = dt_conf_get_string(CONFIG_PREFIX "storage_name");
+  const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(setting));
+  g_free(setting);
+  dt_bauhaus_combobox_set(d->storage, storage_index);
+
+  dt_bauhaus_combobox_set(d->upscale, dt_conf_get_bool(CONFIG_PREFIX "upscale") ? 1 : 0);
+  dt_bauhaus_combobox_set(d->high_quality, dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing") ? 1 : 0);
+  dt_bauhaus_combobox_set(d->export_masks, dt_conf_get_bool(CONFIG_PREFIX "export_masks") ? 1 : 0);
+
+  dt_bauhaus_combobox_set(d->intent, dt_conf_get_int(CONFIG_PREFIX "iccintent") + 1);
+
+  // iccprofile
+  int icctype = dt_conf_get_int(CONFIG_PREFIX "icctype");
+  gchar *iccfilename = dt_conf_get_string(CONFIG_PREFIX "iccprofile");
+  dt_bauhaus_combobox_set(d->profile, 0);
+  if(icctype != DT_COLORSPACE_NONE)
+  {
+    for(GList *profiles = darktable.color_profiles->profiles; profiles; profiles = g_list_next(profiles))
+    {
+      dt_colorspaces_color_profile_t *pp = (dt_colorspaces_color_profile_t *)profiles->data;
+      if(pp->out_pos > -1 &&
+         icctype == pp->type && (icctype != DT_COLORSPACE_FILE || !strcmp(iccfilename, pp->filename)))
+      {
+        dt_bauhaus_combobox_set(d->profile, pp->out_pos + 1);
+        break;
+      }
+    }
+  }
+
+  g_free(iccfilename);
+
+  // style
+  // set it to none if the var is not set or the style doesn't exist anymore
+  gboolean rc = FALSE;
+  setting = NULL;
+  setting = dt_conf_get_string(CONFIG_PREFIX "style");
+  if(setting != NULL && strlen(setting) > 0)
+  {
+    rc = dt_bauhaus_combobox_set_from_text(d->style, setting);
+    if(rc == FALSE) dt_bauhaus_combobox_set(d->style, 0);
+  }
+  else
+    dt_bauhaus_combobox_set(d->style, 0);
+  g_free(setting);
+
+  // style mode to overwrite as it was the initial behavior
+  dt_bauhaus_combobox_set(d->style_mode, dt_conf_get_bool(CONFIG_PREFIX "style_append"));
+
+  gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
+
+  // export metadata presets
+  g_free(d->metadata_export);
+  d->metadata_export = dt_lib_export_metadata_get_conf();
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
                             G_CALLBACK(_image_selection_changed_callback), self);
@@ -1456,8 +1518,6 @@ void gui_init(dt_lib_module_t *self)
                             G_CALLBACK(_mouse_over_image_callback), self);
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                             G_CALLBACK(_collection_updated_callback), self);
-
-  self->gui_reset(self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)


### PR DESCRIPTION
fixes #8314

Due to old approach, the export settings were unnecessary reset on export init.

This PR changes that and makes sure the values get properly initialized.