### PR TITLE
blend-gui: improve mask display precision

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -402,7 +402,7 @@ static inline int _blendif_print_digits_default(float value)
   int digits;
   if(value < 0.0001f) digits = 0;
   else if(value < 0.01f) digits = 2;
-  else if(value < 0.1f) digits = 1;
+  else if(value < 0.999f) digits = 1;
   else digits = 0;
 
   return digits;


### PR DESCRIPTION
When using Ctrl+scroll to modify parametric masks, the label that shows slider positions (as numeric values) currently displays only integer values between 10 and 100 (so the precise adjustments can't be visualised).

Modify so that between 1.0 and 99.9, slider values are displayed to 1 decimal place

Below 1.0, 2 decimal places are still displayed (still useful when in log mode)

Partially addresses the issues discussed in #6695