### PR TITLE
make darkroom loading screen optional

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1935,6 +1935,13 @@
     <shortdescription>reduce resolution of preview image</shortdescription>
     <longdescription>decrease to speed up preview rendering, may hinder accurate masking</longdescription>
   </dtconfig>
+  <dtconfig prefs="darkroom" section="general">
+    <name>darkroom/ui/loading_screen</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show loading screen between images</shortdescription>
+    <longdescription>show grey loading screen when navigating between images in the darkroom\ndisable to just show a toast message</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing">
     <name>plugins/lighttable/export/pixel_interpolator</name>
     <type>

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -478,16 +478,9 @@ void expose(
     image_surface_imgid = dev->image_storage.id;
   }
   else if(dev->preview_pipe->output_imgid != dev->image_storage.id)
-  {
-    dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
-    cairo_paint(cr);
-
-    // waiting message
-    PangoRectangle ink;
-    PangoLayout *layout;
-    PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
-    float fontsize;
+  { 
     gchar *load_txt;
+    float fontsize;
 
     if(dev->image_invalid_cnt)
     {
@@ -510,24 +503,38 @@ void expose(
       load_txt = dt_util_dstrcat(NULL, C_("darkroom", "loading `%s' ..."), dev->image_storage.filename);
     }
 
-    pango_font_description_set_absolute_size(desc, fontsize * PANGO_SCALE);
-    pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
-    layout = pango_cairo_create_layout(cr);
-    pango_layout_set_font_description(layout, desc);
-    pango_layout_set_text(layout, load_txt, -1);
-    pango_layout_get_pixel_extents(layout, &ink, NULL);
-    const float xc = width / 2.0, yc = height * 0.85 - DT_PIXEL_APPLY_DPI(10), wd = ink.width * .5f;
-    cairo_move_to(cr, xc - wd, yc + 1. / 3. * fontsize - fontsize);
-    pango_cairo_layout_path(cr, layout);
-    cairo_set_line_width(cr, 2.0);
-    dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LOG_BG);
-    cairo_stroke_preserve(cr);
-    dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LOG_FG);
-    cairo_fill(cr);
-    pango_font_description_free(desc);
-    g_object_unref(layout);
-    g_free(load_txt);
-    image_surface_imgid = dev->image_storage.id;
+    if(dt_conf_get_bool("darkroom/ui/loading_screen"))
+    {
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
+      cairo_paint(cr);
+
+      // waiting message
+      PangoRectangle ink;
+      PangoLayout *layout;
+      PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
+      pango_font_description_set_absolute_size(desc, fontsize * PANGO_SCALE);
+      pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
+      layout = pango_cairo_create_layout(cr);
+      pango_layout_set_font_description(layout, desc);
+      pango_layout_set_text(layout, load_txt, -1);
+      pango_layout_get_pixel_extents(layout, &ink, NULL);
+      const float xc = width / 2.0, yc = height * 0.85 - DT_PIXEL_APPLY_DPI(10), wd = ink.width * .5f;
+      cairo_move_to(cr, xc - wd, yc + 1. / 3. * fontsize - fontsize);
+      pango_cairo_layout_path(cr, layout);
+      cairo_set_line_width(cr, 2.0);
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LOG_BG);
+      cairo_stroke_preserve(cr);
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LOG_FG);
+      cairo_fill(cr);
+      pango_font_description_free(desc);
+      g_object_unref(layout);
+      g_free(load_txt);
+      image_surface_imgid = dev->image_storage.id;
+    }
+    else
+    {
+      dt_toast_log("%s", load_txt);
+    }
   }
   cairo_restore(cri);
 


### PR DESCRIPTION
Resolves #4085

Disable the preference to just use a toast log over the top of the image