### PR TITLE
reduce bauhaus widget_space vs INNER_PADDING confusion

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1811,7 +1811,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       gboolean first_label = TRUE;
       gboolean show_box_label = TRUE;
       int k = 0, i = 0;
-      const int hovered = (darktable.bauhaus->mouse_y - INNER_PADDING) / darktable.bauhaus->line_height;
+      const int hovered = (darktable.bauhaus->mouse_y - darktable.bauhaus->widget_space) / darktable.bauhaus->line_height;
       gchar *keys = g_utf8_casefold(darktable.bauhaus->keys, -1);
       const PangoEllipsizeMode ellipsis = d->entries_ellipsis;
       wd *= d->scale;
@@ -1839,7 +1839,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
           {
             gchar *esc_label = g_markup_escape_text(entry->label, -1);
             gchar *label = g_strdup_printf("<b>%s</b>", esc_label);
-            label_width = show_pango_text(w, context, cr, label, INNER_PADDING, ht * k + INNER_PADDING,
+            label_width = show_pango_text(w, context, cr, label, INNER_PADDING, ht * k + darktable.bauhaus->widget_space,
                                           max_width, FALSE, FALSE, ellipsis, TRUE);
             g_free(label);
             g_free(esc_label);
@@ -1847,7 +1847,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
           else
             label_width
                 = show_pango_text(w, context, cr, entry->label, wd - INNER_PADDING - darktable.bauhaus->quad_width,
-                                  ht * k + INNER_PADDING, max_width, TRUE, FALSE, ellipsis, FALSE);
+                                  ht * k + darktable.bauhaus->widget_space, max_width, TRUE, FALSE, ellipsis, FALSE);
 
           // prefer the entry over the label wrt. ellipsization when expanded
           if(first_label)
@@ -1868,7 +1868,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       if(show_box_label)
       {
         set_color(cr, text_color);
-        show_pango_text(w, context, cr, w->label, INNER_PADDING, INNER_PADDING,
+        show_pango_text(w, context, cr, w->label, INNER_PADDING, darktable.bauhaus->widget_space,
                         wd - INNER_PADDING - darktable.bauhaus->quad_width - first_label_width,
                         FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE);
       }
@@ -1986,25 +1986,25 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
       {
         //they don't fit: evenly divide the available width between the two in proportion
         const float ratio = label_width / (label_width + combo_width);
-        show_pango_text(w, context, cr, w->label, 0, 0, available_width * ratio - INNER_PADDING * 2,
+        show_pango_text(w, context, cr, w->label, 0, darktable.bauhaus->widget_space, available_width * ratio - INNER_PADDING * 2,
                         FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE);
         if(d->text_align == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT)
-          show_pango_text(w, context, cr, text, width - darktable.bauhaus->quad_width - INNER_PADDING, 0,
+          show_pango_text(w, context, cr, text, width - darktable.bauhaus->quad_width - INNER_PADDING, darktable.bauhaus->widget_space,
                           available_width * (1.0f - ratio),
                           TRUE, FALSE, combo_ellipsis, FALSE);
         else
-          show_pango_text(w, context, cr, text, INNER_PADDING, 0,
+          show_pango_text(w, context, cr, text, INNER_PADDING, darktable.bauhaus->widget_space,
                           available_width * (1.0f - ratio),
                           FALSE, FALSE, combo_ellipsis, FALSE);
       }
       else
       {
-        show_pango_text(w, context, cr, w->label, 0, 0, 0, FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE);
+        show_pango_text(w, context, cr, w->label, 0, darktable.bauhaus->widget_space, 0, FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE);
         if(d->text_align == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT)
-          show_pango_text(w, context, cr, text, width - darktable.bauhaus->quad_width - INNER_PADDING, 0, 0,
+          show_pango_text(w, context, cr, text, width - darktable.bauhaus->quad_width - INNER_PADDING, darktable.bauhaus->widget_space, 0,
                           TRUE, FALSE, combo_ellipsis, FALSE);
         else
-          show_pango_text(w, context, cr, text, INNER_PADDING, 0, 0,
+          show_pango_text(w, context, cr, text, INNER_PADDING, darktable.bauhaus->widget_space, 0,
                           FALSE, FALSE, combo_ellipsis, FALSE);
       }
       break;
@@ -2110,7 +2110,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
       darktable.bauhaus->change_active = 1;
       const dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       if(!d->num_labels) return;
-      tmp.height = darktable.bauhaus->line_height * d->num_labels + 2 * INNER_PADDING;
+      tmp.height = darktable.bauhaus->line_height * d->num_labels + 2 * darktable.bauhaus->widget_space;
       tmp.width *= d->scale;
 
       GtkAllocation allocation_w;
@@ -2131,6 +2131,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
 
   // move popup so mouse is over currently active item, to minimize confusion with scroll wheel:
   if(darktable.bauhaus->current->type == DT_BAUHAUS_COMBOBOX) wy += offset;
+  wx -= darktable.bauhaus->widget_space;
 
   // gtk_widget_get_window will return null if not shown yet.
   // it is needed for gdk_window_move, and gtk_window move will


### PR DESCRIPTION
The bauhaus combobox widget requests space for a margin at top and bottom of widget_space each, but then draws the label and the selected item name at the top of that box, rather than leaving a gap of widget_space.

Similarly, the combobox popup (to show the list) requested margins of INNER_PADDING at top and bottom, but then didn't correct for that when determining the location of the text.

Hopefully both these issues now solved, so that when clicking an item, it shows in the exact same position in the popped up list and the closed combo is correctly placed within its space (slightly improving https://github.com/darktable-org/darktable/pull/8346#issuecomment-792072065) at least if the item doesn't change left/right alignment (as in collect) or ellipsizing.