### PR TITLE
remember show mask and suppress status while module is in focus

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -554,11 +554,6 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
   }
   else
   {
-    data->module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->showmask), FALSE);
-    data->module->suppress_mask = 0;
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->suppress), FALSE);
-
     gtk_widget_hide(GTK_WIDGET(data->bottom_box));
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3154,6 +3154,9 @@ void leave(dt_view_t *self)
     dt_iop_module_t *module = (dt_iop_module_t *)(dev->iop->data);
     if(!dt_iop_is_hidden(module)) dt_iop_gui_cleanup_module(module);
 
+    // force refresh if module has mask visualized
+    if (module->request_mask_display || module->suppress_mask) dt_iop_refresh_center(module);
+
     dt_accel_cleanup_closures_iop(module);
     module->accel_closures = NULL;
     dt_iop_cleanup_module(module);


### PR DESCRIPTION
With this PR I try to fix #8426 but avoiding to reset the "show mask" and "temporarily switch off mask" buttons while switching between mask modes in blending tabs.
So for example if the show mask is on in drawn mask and the mask mode is changed to uniform and then back, the mask is again visualized and the button stays on, avoiding inconsistency. When the module loses focus button are reset anyway.

Please let me know if this is an acceptable behavior to you.
Another possibility would be forcing a center image refresh so that switching back and forth the mask is not visualized anymore and the button is off, keeping consistency, but adding one maybe unnecessary refresh.