### PR TITLE
Adding another pixel interpolator option

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1960,7 +1960,7 @@
     </type>
     <default>lanczos3</default>
     <shortdescription>pixel interpolator</shortdescription>
-    <longdescription>pixel interpolator used in rotation and lens correction (bilinear, bicubic, lanczos2, lanczos3).</longdescription>
+    <longdescription>pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3).</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/export/dimensions_type</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1936,6 +1936,19 @@
     <longdescription>decrease to speed up preview rendering, may hinder accurate masking</longdescription>
   </dtconfig>
   <dtconfig prefs="processing">
+    <name>plugins/lighttable/export/pixel_interpolator_warp</name>
+    <type>
+      <enum>
+        <option>bilinear</option>
+        <option>bicubic</option>
+        <option>lanczos2</option>
+      </enum>
+    </type>
+    <default>bicubic</default>
+    <shortdescription>warp pixel interpolator</shortdescription>
+    <longdescription>pixel interpolator used in modules for rotation, lens correction, liquify, clipping and final scaling (bilinear, bicubic, lanczos2).</longdescription>
+  </dtconfig>
+  <dtconfig prefs="processing">
     <name>plugins/lighttable/export/pixel_interpolator</name>
     <type>
       <enum>

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1118,6 +1118,25 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
      * prepare later search pass with default fallback */
     type = DT_INTERPOLATION_DEFAULT;
   }
+  else if(type == DT_INTERPOLATION_USERPREF_WARP)
+  {
+    // Find user preferred interpolation method
+    gchar *uipref = dt_conf_get_string("plugins/lighttable/export/pixel_interpolator_warp");
+    for(int i = DT_INTERPOLATION_FIRST; uipref && i < DT_INTERPOLATION_LAST; i++)
+    {
+      if(!strcmp(uipref, dt_interpolator[i].name))
+      {
+        // Found the one
+        itor = &dt_interpolator[i];
+        break;
+      }
+    }
+    g_free(uipref);
+
+    /* In the case the search failed (!uipref or name not found),
+     * prepare later search pass with default fallback */
+    type = DT_INTERPOLATION_DEFAULT_WARP;
+  }
   if(!itor)
   {
     // Did not find the userpref one or we've been asked for a specific one

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -35,7 +35,9 @@ enum dt_interpolation_type
   DT_INTERPOLATION_LANCZOS3,                          /**< Lanczos interpolation (with 3 lobes) */
   DT_INTERPOLATION_LAST,                              /**< Helper for easy iteration on interpolators */
   DT_INTERPOLATION_DEFAULT = DT_INTERPOLATION_BILINEAR,
-  DT_INTERPOLATION_USERPREF /**< can be specified so that user setting is chosen */
+  DT_INTERPOLATION_DEFAULT_WARP = DT_INTERPOLATION_BICUBIC,
+  DT_INTERPOLATION_USERPREF,  /**< can be specified so that user setting is chosen */
+  DT_INTERPOLATION_USERPREF_WARP  /**< can be specified so that user setting is chosen */
 };
 
 /** Interpolation function */

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -964,7 +964,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
     return;
   }
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   float ihomograph[3][3];
   homography((float *)ihomograph, data->rotation, data->lensshift_v, data->lensshift_h, data->shear, data->f_length_kb,
@@ -1128,7 +1128,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     }
   }
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   roi_in->x = fmaxf(0.0f, xm - interpolation->width);
   roi_in->y = fmaxf(0.0f, ym - interpolation->width);
   roi_in->width = fminf(ceilf(orig_w) - roi_in->x, xM - roi_in->x + 1 + interpolation->width);
@@ -2905,7 +2905,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     return;
   }
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   float ihomograph[3][3];
   homography((float *)ihomograph, data->rotation, data->lensshift_v, data->lensshift_h, data->shear, data->f_length_kb,
@@ -3063,7 +3063,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
 
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   int ldkernel = -1;
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -578,7 +578,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
   }
   else
   {
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
     float k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
@@ -950,7 +950,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else
   {
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
     float k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
@@ -1035,7 +1035,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   {
     int crkernel = -1;
 
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
     switch(interpolation->id)
     {
@@ -1381,7 +1381,7 @@ static float _ratio_get_aspect(dt_iop_module_t *self, GtkWidget *combo)
     }
     else
     {
-      const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+      const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
       const float whratio = ((float)(iwd - 2 * interpolation->width) * (fabsf(p->cw) - p->cx))
                             / ((float)(iht - 2 * interpolation->width) * (fabsf(p->ch) - p->cy));
       const float ri = (float)iwd / (float)iht;

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -70,7 +70,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
                   float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   dt_interpolation_resample_roi_1c(itor, out, roi_out, roi_out->width * sizeof(float), in, roi_in,
                                    roi_in->width * sizeof(float));
 }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -394,7 +394,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
 
-  const struct dt_interpolation *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   if(d->inverse)
   {
@@ -619,7 +619,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   int modflags;
   int ldkernel = -1;
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f)
   {
@@ -951,7 +951,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
     return;
   }
 
-  const struct dt_interpolation *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *const interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   // acquire temp memory for distorted pixel coords
   const size_t bufsize = (size_t)roi_out->width * 2 * 3;
@@ -1083,7 +1083,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     if(!isfinite(ym) || !(0 <= ym && ym < orig_h)) ym = 0;
     if(!isfinite(yM) || !(1 <= yM && yM < orig_h)) yM = orig_h;
 
-    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+    const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     roi_in->x = fmaxf(0.0f, xm - interpolation->width);
     roi_in->y = fmaxf(0.0f, ym - interpolation->width);
     roi_in->width = fminf(orig_w - roi_in->x, xM - roi_in->x + interpolation->width);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1019,7 +1019,7 @@ static void apply_global_distortion_map(struct dt_iop_module_t *module,
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
   const struct dt_interpolation * const interpolation =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
   #ifdef _OPENMP
   #pragma omp parallel for schedule (static) default (shared)
@@ -1500,7 +1500,7 @@ static cl_int_t apply_global_distortion_map_cl(struct dt_iop_module_t *module,
   dt_iop_liquify_global_data_t *gd = (dt_iop_liquify_global_data_t *) module->global_data;
   const int devid = piece->pipe->devid;
 
-  const struct dt_interpolation* interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation* interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   dt_liquify_kernel_descriptor_t kdesc = { .size = 0, .resolution = 100 };
   float *k = NULL;
 


### PR DESCRIPTION
As @kofa73 reported there might be issues resulting from a not optimally chosen pixel interpolator. I know there is no optimal solution but maybe we can have two preferences, one for the modules that are prone for artefacts like lens and "the rest of the world".

I am not sure whether this suggestion pr is the right way, let's see what others think about it...

hopefully fixing #8016