### PR TITLE
horizontally expand combos and spins in preferences

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -397,19 +397,6 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
-  GtkWidget *useperfmode = gtk_check_button_new();
-  label = gtk_label_new(_("prefer performance over quality"));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), useperfmode, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(useperfmode,
-                              _("if switched on, thumbnails and previews are rendered at lower quality but 4 times faster"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(useperfmode), dt_conf_get_bool("ui/performance"));
-  g_signal_connect(G_OBJECT(useperfmode), "toggled", G_CALLBACK(use_performance_callback), 0);
-
   //Font size check and spin buttons
   GtkWidget *usesysfont = gtk_check_button_new();
   GtkWidget *fontsize = gtk_spin_button_new_with_range(5.0f, 30.0f, 0.2f);
@@ -442,6 +429,7 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_widget_set_hexpand(fontsize, TRUE);
   gtk_grid_attach_next_to(GTK_GRID(grid), fontsize, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(fontsize, _("font size in points"));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
@@ -462,6 +450,19 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
                                                       "(needs a restart)."));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_dpi_overwrite), dt_conf_get_float("screen_dpi_overwrite"));
   g_signal_connect(G_OBJECT(screen_dpi_overwrite), "value_changed", G_CALLBACK(dpi_scaling_changed_callback), 0);
+
+  GtkWidget *useperfmode = gtk_check_button_new();
+  label = gtk_label_new(_("prefer performance over quality"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), useperfmode, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(useperfmode,
+                              _("if switched on, thumbnails and previews are rendered at lower quality but 4 times faster"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(useperfmode), dt_conf_get_bool("ui/performance"));
+  g_signal_connect(G_OBJECT(useperfmode), "toggled", G_CALLBACK(use_performance_callback), 0);
 
   //checkbox to allow user to modify theme with user.css
   label = gtk_label_new(_("modify selected theme with CSS tweaks below"));

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -672,8 +672,8 @@ gboolean restart_required = FALSE;
     tmp = max * (double)factor; max = tmp;
     widget = gtk_spin_button_new_with_range(min, max, 1);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_widget_set_hexpand(widget, FALSE);
+    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
+    gtk_widget_set_hexpand(widget, TRUE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
     </xsl:text>
@@ -692,8 +692,8 @@ gboolean restart_required = FALSE;
     <xsl:text>    min *= factor; max *= factor;
     widget = gtk_spin_button_new_with_range(min, max, 1);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_widget_set_hexpand(widget, FALSE);
+    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
+    gtk_widget_set_hexpand(widget, TRUE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int64("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
     </xsl:text>
@@ -714,8 +714,8 @@ gboolean restart_required = FALSE;
     <xsl:text>    min *= factor; max *= factor;
     widget = gtk_spin_button_new_with_range(min, max, 0.001f);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_widget_set_hexpand(widget, FALSE);
+    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
+    gtk_widget_set_hexpand(widget, TRUE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 5);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_float("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
     </xsl:text>
@@ -767,7 +767,7 @@ gboolean restart_required = FALSE;
     g_free(str);
 
     widget = gtk_combo_box_new_with_model(GTK_TREE_MODEL(store));
-    gtk_widget_set_hexpand(widget, FALSE);
+    gtk_widget_set_hexpand(widget, TRUE);
     g_object_unref(store);
     GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
     gtk_cell_renderer_set_padding(renderer, 0, 0);
@@ -775,7 +775,7 @@ gboolean restart_required = FALSE;
     gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(widget), renderer, "text", 1, NULL);
     gtk_combo_box_set_active(GTK_COMBO_BOX(widget), pos);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
     </xsl:text>
     <xsl:text> g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
     <xsl:text>


### PR DESCRIPTION
Every time I have to change the font size to test layout changes I am temped to use the spin buttons in the preference dialog. But of course when the font size changes, the preference dialog relayouts as well and the button moves away from the mouse causing me to click next to it. Eventually I always resort to typing or using the scroll wheel (also taking care that the mouse doesn't leave the box). By letting the spin box take the full width of the dialog, this annoyance is much reduced. Moving the "performance/quality" checkbox to the end further reduces the vertical creep.

In the other tabs, letting all combos take full width also, imho, gives a cleaner look with all dropdown buttons aligned on the right side. I've likewise expanded the width of all spinboxes, to be consistent with the first tab, but I'm open to reversing that change if it is generally disliked.

Please vote thumbs up/down/smiley 👍 👎 :smiley: on this comment to help decide the second part of this PR: 
👍 both combos and spinboxes
😄 only combos
👎 yeach! I liked it just the way it was.

Old -> New
<img src="https://user-images.githubusercontent.com/1549490/110306610-ec1d7280-7ff5-11eb-95d2-8c9d2bab0209.png" width=50% height=50%><img src="https://user-images.githubusercontent.com/1549490/110304337-61d40f00-7ff3-11eb-9b1f-22c7ef25da04.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/1549490/110306738-11aa7c00-7ff6-11eb-8e94-935e8dbc06a2.png" width=50% height=50%><img src="https://user-images.githubusercontent.com/1549490/110304370-70bac180-7ff3-11eb-937c-724b1acd3e34.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/1549490/110306864-3999df80-7ff6-11eb-8ba5-04f096985ab0.png" width=50% height=50%><img src="https://user-images.githubusercontent.com/1549490/110304428-80d2a100-7ff3-11eb-8dac-0614903c8a08.png" width=50% height=50%>
