### PR TITLE
make module header mask indicator actually show mask

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1132,7 +1132,8 @@ static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton 
     // (re)set the header mask indicator too
     ++darktable.gui->reset;
     if(module->mask_indicator)
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->mask_indicator),!is_active);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->mask_indicator),
+                                     module->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE);
     --darktable.gui->reset;
 
     dt_iop_request_focus(module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2322,7 +2322,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
     {
       GtkWidget *mi = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
       module->mask_indicator = mi;
-      gtk_widget_set_tooltip_text(mi, _("this module has a mask"));
+      gtk_widget_set_tooltip_text(mi, _("this module has a mask, click to display"));
       gtk_widget_set_name(mi, "module-mask-indicator");
       g_signal_connect(G_OBJECT(mi), "toggled", G_CALLBACK(_display_mask_indicator_callback), module);
       gtk_box_pack_end(GTK_BOX(module->header), mi, FALSE, FALSE, 0);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2286,38 +2286,49 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
   return TRUE;
 }
 
-void add_remove_mask_indicator(GtkWidget *header, gboolean add)
+static void _display_mask_indicator_callback(GtkToggleButton *bt, dt_iop_module_t *module)
 {
-  GList *children = gtk_container_get_children(GTK_CONTAINER(header));
-  GList *button;
-  gboolean found = FALSE;
-  gboolean show = add && dt_conf_get_bool("darkroom/ui/show_mask_indicator");
-  for(button = g_list_last(children);
-      button && GTK_IS_BUTTON(button->data);
-      button = g_list_previous(button))
-  {
-    if (strcmp(gtk_widget_get_name(button->data), "module-mask-indicator") == 0)
-    {
-      found = TRUE;
-      break;
-    }
-  }
+  if(darktable.gui->reset) return;
 
-  if(found)
+  const gboolean is_active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(bt));
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+
+  module->request_mask_display &= ~DT_DEV_PIXELPIPE_DISPLAY_MASK;
+  module->request_mask_display |= (is_active ? DT_DEV_PIXELPIPE_DISPLAY_MASK : 0);
+
+  // set the module show mask button too
+  ++darktable.gui->reset;
+  if(bd->showmask)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), is_active);
+  --darktable.gui->reset;
+
+  dt_iop_request_focus(module);
+  dt_iop_refresh_center(module);
+}
+
+void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
+{
+  gboolean show = add && dt_conf_get_bool("darkroom/ui/show_mask_indicator");
+
+  if(module->mask_indicator)
   {
-    if(!show) gtk_widget_destroy(button->data);
+    if(!show)
+      {
+        gtk_widget_destroy(module->mask_indicator);
+        module->mask_indicator = NULL;
+      }
   }
   else if(show)
     {
-      GtkWidget *mi = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask,
-                                             CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
+      GtkWidget *mi = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+      module->mask_indicator = mi;
       gtk_widget_set_tooltip_text(mi, _("this module has a mask"));
       gtk_widget_set_name(mi, "module-mask-indicator");
-      gtk_widget_set_sensitive(mi, FALSE);
-      gtk_box_pack_end(GTK_BOX(header), mi, FALSE, FALSE, 0);
+      g_signal_connect(G_OBJECT(mi), "toggled", G_CALLBACK(_display_mask_indicator_callback), module);
+      gtk_box_pack_end(GTK_BOX(module->header), mi, FALSE, FALSE, 0);
     }
 
-  dt_iop_show_hide_header_buttons(header, NULL, FALSE, FALSE);
+  dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, FALSE);
 }
 
 void dt_iop_gui_set_expander(dt_iop_module_t *module)

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -260,7 +260,8 @@ typedef struct dt_iop_module_t
   GtkDarktableToggleButton *off;
   /** this is the module header, contains label and buttons */
   GtkWidget *header;
-
+  /** this is the module mask indicator, inside header */
+  GtkWidget *mask_indicator;
   /** expander containing the widget and flag to store expanded state */
   GtkWidget *expander;
   gboolean expanded;
@@ -456,7 +457,7 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module);
 gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
 
 /** add/remove mask indicator to iop module header */
-void add_remove_mask_indicator(GtkWidget *header, gboolean add);
+void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add);
 
 /** Set the trouble message for the module.  If non-empty, also flag the module as being in trouble; if empty
  ** or NULL, clear the trouble flag.  If 'toast_message' is non-NULL/non-empty, pop up a toast with that

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1962,7 +1962,8 @@ static void _preference_changed_button_hide(gpointer instance, dt_develop_t *dev
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
 
     if(module->header)
-      add_remove_mask_indicator(module->header, module->blend_params->mask_mode != DEVELOP_MASK_DISABLED);
+      add_remove_mask_indicator(module, (module->blend_params->mask_mode != DEVELOP_MASK_DISABLED) &&
+                                (module->blend_params->mask_mode != DEVELOP_MASK_ENABLED));
   }
 }
 
@@ -3121,6 +3122,9 @@ void leave(dt_view_t *self)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(dev->iop->data);
     if(!dt_iop_is_hidden(module)) dt_iop_gui_cleanup_module(module);
+
+    // force refresh if module has mask visualized
+    if (module->request_mask_display || module->suppress_mask) dt_iop_refresh_center(module);
 
     dt_accel_cleanup_closures_iop(module);
     module->accel_closures = NULL;


### PR DESCRIPTION
With #8352, module header mask indicators have been introduced as pure passive indicator that a mask is present
Whit this PR, I try to give them a function, which is to visualize mask on and off.

![image](https://user-images.githubusercontent.com/43290988/110333188-95c62900-8021-11eb-8eea-ebf1a18ea28d.png)

This is quite handy, however I want to draw your attention to some peculiarities

- Only one module at a time can visualize mask
- The mask visualization is disabled if the module loses focus
- Modules with "Uniform" blend mode do not really have a mask (and there is no show mask button in the expander) so I do not visualize a header mask indicator either (changed vs master)
- Modules with Raster Mask: here there is a problem, as those modules do indeed have a mask, but there is no shows mask button in the expander, so the mask indicator is present, but clicking it does not do anything. How to improve this?
- Expanded modules: depending on the blending mode, the show mask button might be visible. In that case the header mask indicator is almost a duplicate of the show mask button. I keep them in synch, so setting on and off one does the same to the other. However the show mask button can also visualize channels with shift+click. In that case the mask indicator is not activated

Please test / review and suggest improvements

P.S. this PR includes the corrections in #8428
