### PR TITLE
Filemanager continuous scrolling

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -601,6 +601,10 @@ static gboolean _move(dt_thumbtable_t *table, const int x, const int y, gboolean
     // we check bounds to allow or not the move
     if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
     {
+      // prevent scrolling more than view_height so that thumbs cannot disappear
+      if (posy > table->view_height) posy = table->view_height;
+      else if (posy < -table->view_height) posy = -table->view_height;
+      
       posx = 0; // to be sure, we don't want horizontal move
       if(posy == 0) return FALSE;
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -604,7 +604,7 @@ static gboolean _move(dt_thumbtable_t *table, const int x, const int y, gboolean
       // prevent scrolling more than view_height so that thumbs cannot disappear
       if (posy > table->view_height) posy = table->view_height;
       else if (posy < -table->view_height) posy = -table->view_height;
-      
+
       posx = 0; // to be sure, we don't want horizontal move
       if(posy == 0) return FALSE;
 
@@ -890,7 +890,7 @@ static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_
 {
   GdkEventScroll *e = (GdkEventScroll *)event;
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
- 
+
    // Handle continuous scrolling separately
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER && e->direction == GDK_SCROLL_SMOOTH
     && !((e->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK))

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -64,6 +64,7 @@ typedef struct dt_thumbtable_t
   // for zoomable, this is the top-left image (which can be out of screen)
   int offset;
   int offset_imgid;
+  gdouble accumulator; // fractional position of the top row in filemanager
 
   int thumbs_per_row; // number of image in a row (1 for filmstrip ; MAX_ZOOM for zoomable)
   int rows; // number of rows (the last one is not fully visible) for filmstrip it's the number of columns

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -592,8 +592,13 @@ gboolean dt_gui_get_scroll_deltas(const GdkEventScroll *event, gdouble *delta_x,
     case GDK_SCROLL_SMOOTH:
       if((delta_x && event->delta_x != 0) || (delta_y && event->delta_y != 0))
       {
+#ifdef GDK_WINDOWING_QUARTZ // on macOS deltas need to be scaled
+        if(delta_x) *delta_x = event->delta_x / 100;
+        if(delta_y) *delta_y = event->delta_y / 100;
+#else
         if(delta_x) *delta_x = event->delta_x;
         if(delta_y) *delta_y = event->delta_y;
+ #endif
         handled = TRUE;
       }
     default:


### PR DESCRIPTION
Continues  #8408.
Allow thumbs to not align at the top of filemanager with `GDK_SCROLL_SMOOTH` events. Provides nicer scrolling experience on a touchpad. Scrollwheel behaviour should not have changed. Tested on macOS 10.14 with touchpad and traditional mouse. I'm unable to test how this works on other OSs and I think smooth scrolling can be handled very differently.

There are a few issues that might need adressing. 

- I have also been experimenting with enabling smooth scrolling for other parts of the UI and scaling by 100 seems appropriate. Does it work on other OSs? 
- When scrolling very fast it is possible to scroll past top row.
- With large amount of thumbs visible scrolling can be slow and not smooth. Previously commented #2226.
- Iops that are also using `dt_gui_get_scroll_deltas()` seem to work as before despite scaling.

It would be nice to hear how this change affects other systems. I'm reverting changes made in #5503 so I'm worried that other systems might not work properly.