### PR TITLE
Fix recent-collection segfault

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1464,6 +1464,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
 
     case DT_COLLECTION_PROP_FOLDERS: // folders
       {
+        // replace * at the end with OR-clause to include subfolders
         if ((escaped_length > 0) && (escaped_text[escaped_length-1] == '*'))
         {
           escaped_text[escaped_length-1] = '\0';
@@ -1471,7 +1472,8 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
                                   G_DIR_SEPARATOR_S "%%'))",
                                   escaped_text, escaped_text);
         }
-        else if ((escaped_length > 0) && (escaped_text[escaped_length-1] == '%'))
+        // replace |% at the end with /% to only show subfolders
+        else if ((escaped_length > 1) && (strcmp(escaped_text+escaped_length-2, "|%") == 0 ))
         {
           escaped_text[escaped_length-2] = '\0';
           query = g_strdup_printf("(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s"


### PR DESCRIPTION
Fixes segfaults when clicking on recently used collections > Filmroll %

Replaces #8434 by @HansBull  