### PR TITLE
collection : reset expanded group when query change

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1992,6 +1992,12 @@ void dt_collection_deserialize(char *buf)
 void dt_collection_update_query(const dt_collection_t *collection, dt_collection_change_t query_change, GList *list)
 {
   int next = -1;
+  if(!collection->clone && query_change == DT_COLLECTION_CHANGE_NEW_QUERY && darktable.gui)
+  {
+    // if the query has changed, we reset the expanded group
+    darktable.gui->expanded_group_id = -1;
+  }
+
   if(!collection->clone)
   {
     if(list)


### PR DESCRIPTION
this fix #8436 

This is not the ideal fix, but the simplest, as this reset the expanded_group each time you change the collect query (not in case of refiltering or reloading). But in the other hand, the expanded_group is already lost when restarting dt...

The root problem comes from : https://github.com/darktable-org/darktable/blob/27345c83ba83f0b0a32f6eac73a34702055764a3/src/common/collection.c#L279-L281
this line is needed (for the reason mentioned in the above comment) but I've no idea how to restrict that to the case where one of the image in the group is still in the collection (which are determined by the same query)

So, to simplify, I propose this PR :)