### PR TITLE
Overwrite2

### DIFF
--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -45,8 +45,9 @@ DT_MODULE(3)
 typedef enum dt_disk_onconflict_actions_t
 {
   DT_EXPORT_ONCONFLICT_UNIQUEFILENAME = 0,
-  DT_EXPORT_ONCONFLICT_OVERWRITE = 1,
-  DT_EXPORT_ONCONFLICT_SKIP = 2
+  DT_EXPORT_ONCONFLICT_OVERWRITE  = 1, /* overwrite, but ask confirmation */
+  DT_EXPORT_ONCONFLICT_OVERWRITE2 = 2, /* just overwrite */
+  DT_EXPORT_ONCONFLICT_SKIP = 3
 } dt_disk_onconflict_actions_t;
 
 // gui data
@@ -201,6 +202,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   d->onsave_action = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(d->onsave_action, NULL, N_("on conflict"));
   dt_bauhaus_combobox_add(d->onsave_action, _("create unique filename"));
+  dt_bauhaus_combobox_add(d->onsave_action, _("overwrite, but ask"));
   dt_bauhaus_combobox_add(d->onsave_action, _("overwrite"));
   dt_bauhaus_combobox_add(d->onsave_action, _("skip"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->onsave_action, TRUE, TRUE, 0);


### PR DESCRIPTION
Extension of the export dialog, by allowing an overwrite without further questions, next to the existing option where the user is asked to confirm the overwrite. 