### PR TITLE
GTimeVal: move all instances of GTimeVal to GDateTime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -291,8 +291,8 @@ endif()
 # Find all other required libraries for building
 #
 # GTK3 does pull glib, but this allows us to check for the version
-find_package(Glib 2.40 REQUIRED)
-add_definitions("-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40")
+find_package(Glib 2.56 REQUIRED)
+add_definitions("-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56")
 add_definitions("-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_MIN_REQUIRED")
 include_directories(SYSTEM ${Glib_INCLUDE_DIRS})
 list(APPEND LIBS ${Glib_LIBRARIES})

--- a/src/common/gpx.h
+++ b/src/common/gpx.h
@@ -26,15 +26,15 @@ struct dt_gpx_t;
 typedef struct dt_gpx_track_point_t
 {
   gdouble longitude, latitude, elevation;
-  GTimeVal time;
+  GDateTime *time;
   uint32_t segid;
 } dt_gpx_track_point_t;
 
 typedef struct dt_gpx_track_segment_t
 {
   guint id;
-  GTimeVal start_dt;
-  GTimeVal end_dt;
+  GDateTime *start_dt;
+  GDateTime *end_dt;
   char *name;
   dt_gpx_track_point_t *trkpt;
   uint32_t nb_trkpt;
@@ -47,7 +47,7 @@ void dt_gpx_destroy(struct dt_gpx_t *gpx);
 /* fetch the lon,lat coords for time t, if within time range
   of gpx record return TRUE, FALSE is returned if out of time frame
   and closest record of lon,lat is filled */
-gboolean dt_gpx_get_location(struct dt_gpx_t *, GTimeVal *timestamp, dt_image_geoloc_t *geoloc);
+gboolean dt_gpx_get_location(struct dt_gpx_t *, GDateTime *timestamp, dt_image_geoloc_t *geoloc);
 
 // get the list of track segments
 GList *dt_gpx_get_trkseg(struct dt_gpx_t *gpx);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1107,7 +1107,6 @@ static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
   /* go thru each selected image and lookup location in gpx */
   do
   {
-    GTimeVal timestamp;
     GDateTime *exif_time, *utc_time;
     dt_image_geoloc_t geoloc;
     int imgid = GPOINTER_TO_INT(t->data);
@@ -1143,12 +1142,9 @@ static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
     utc_time = g_date_time_to_timezone(exif_time, tz_utc);
     g_date_time_unref(exif_time);
     if(!utc_time) continue;
-    gboolean res = g_date_time_to_timeval(utc_time, &timestamp);
-    g_date_time_unref(utc_time);
-    if(!res) continue;
 
     /* only update image location if time is within gpx tack range */
-    if(dt_gpx_get_location(gpx, &timestamp, &geoloc))
+    if(dt_gpx_get_location(gpx, utc_time, &geoloc))
     {
       // takes the option to include the grouped images
       GList *grps = dt_grouping_get_group_images(imgid);
@@ -1160,6 +1156,7 @@ static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
       g_list_free(grps);
       cntr++;
     }
+    g_date_time_unref(utc_time);
   } while((t = g_list_next(t)) != NULL);
   imgs = g_list_reverse(imgs);
 


### PR DESCRIPTION
fix #8022

- clean up one of the time version from dt (GTimeVal)
- move glib 2.4 to glib 2.56

EDIT: I've measured the gpx execution time and not noticed any degradation.
