### PR TITLE
fix broken link to windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ sudo make install
 
 ##### Windows
 
-See https://github.com/darktable-org/darktable/blob/master/packaging/windows/BUILD.txt
+See https://github.com/darktable-org/darktable/blob/master/packaging/windows/BUILD.md
 
 ### Using
 


### PR DESCRIPTION
the windows build instrations were renamed from .txt to .md, but link in README.md was still pointing to the old .txt name.