### PR TITLE
fix bauhaus popup left jump and margins

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -134,6 +134,13 @@ static int show_pango_text(dt_bauhaus_widget_t *w, GtkStyleContext *context, cai
   //gtk_style_context_get(context, gtk_widget_get_state_flags(GTK_WIDGET(w)), "font", font_desc, NULL);
 
   pango_layout_set_font_description(layout, font_desc);
+
+  PangoAttrList *attrlist = pango_attr_list_new();
+  PangoAttribute *attr = pango_attr_font_features_new("tnum");
+  pango_attr_list_insert(attrlist, attr);
+  pango_layout_set_attributes(layout, attrlist);
+  pango_attr_list_unref(attrlist);
+
   pango_cairo_context_set_resolution(pango_layout_get_context(layout), darktable.gui->dpi);
 
   int pango_width, pango_height;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1814,6 +1814,13 @@ static void init_main_table(GtkWidget *container)
   gtk_widget_set_events(eb, GDK_BUTTON_PRESS_MASK | darktable.gui->scroll_mask);
   g_signal_connect(G_OBJECT(eb), "scroll-event", G_CALLBACK(scrolled), NULL);
   gtk_label_set_ellipsize(GTK_LABEL(darktable.gui->ui->toast_msg), PANGO_ELLIPSIZE_MIDDLE);
+
+  PangoAttrList *attrlist = pango_attr_list_new();
+  PangoAttribute *attr = pango_attr_font_features_new("tnum");
+  pango_attr_list_insert(attrlist, attr);
+  gtk_label_set_attributes(GTK_LABEL(darktable.gui->ui->toast_msg), attrlist);
+  pango_attr_list_unref(attrlist);
+
   gtk_widget_set_name(darktable.gui->ui->toast_msg, "toast-msg");
   gtk_container_add(GTK_CONTAINER(eb), darktable.gui->ui->toast_msg);
   gtk_widget_set_valign(eb, GTK_ALIGN_START);


### PR DESCRIPTION
After #8425 fixed some of the jumping issues with bauhaus pop-ups, of course the remaining ones are even more obvious. This now tries to fix all of them.

@TurboGit if you notice anything that is not perfect now, let me know and I'll try to fix before merging.

Small fixes:
- combobox pop-up label name used to indent slightly more than when not popped up, causing a little jump even when first line selected.
- slider label touched border when popped up (and after above change, combobox too) so added a small margin to the left. This of course meant that everything _within_ the pop-up window had to be shifted by the same relative amount to the right, which is the majority of this PR (and the work of figuring everything out and testing).
- combobox pop-up didn't have enough margin at the bottom.
- slider pop-up didn't ellipsize the label when it wouldn't fit next to the number, so they would overlap. Now (almost) the same as when not popped up.
- when typing into a very small slider pop-up, the cursor size was too large. Now consistent with text size.

The last two are best tested in color balance when in column mode:
![image](https://user-images.githubusercontent.com/1549490/111034312-ef0cce80-840c-11eb-8576-4ca8968f899c.png)

edit: also set tnum for bauhaus and toast so that numbers don't jump around for fonts that have unequal number widths.