### PR TITLE
import dialog: attempt to manage widget focus

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -840,6 +840,13 @@ dialog .dialog-vbox scrolledwindow
   padding: 0;
 }
 
+dialog button:focus,
+dialog checkbutton check:focus
+{
+  color: @button_hover_fg;
+  background-color: @field_hover_bg;
+}
+
 /* Set title headerbar and main buttons */
 dialog button
 {

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -971,11 +971,13 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
     gtk_box_pack_start(GTK_BOX(content), GTK_WIDGET(import_list), TRUE, TRUE, 0);
     gtk_widget_show_all(d->from.dialog);
     _expander_update(d->from.exp.toggle, d->from.exp.expander);
+    gtk_widget_grab_focus(gtk_dialog_get_widget_for_response(GTK_DIALOG(d->from.dialog), GTK_RESPONSE_ACCEPT));
   }
   else
   {
     gtk_box_pack_start(GTK_BOX(content), GTK_WIDGET(import_list), TRUE, TRUE, 0);
     gtk_widget_show_all(d->from.dialog);
+    gtk_widget_grab_focus(gtk_dialog_get_widget_for_response(GTK_DIALOG(d->from.dialog), GTK_RESPONSE_ACCEPT));
   }
 }
 


### PR DESCRIPTION
also set import button as the default button (as pinpointed by @elstoc).

About widget focus.
This is an attempt to deal with a point I've always missed with dt: proper highlight of the active widget. I know there are the shortcuts which is a good solution for some dt users.
But I miss a good default behavior to know what is the active widget, in a lot a places, in particular in dialogs. And then one is obliged (if no shortcut) to use the mouse to select the desired one.

This PR doesn't pretend to solve the whole issue, but is enough to demonstrate what I mean.
- opening the dialog the active button (import []) is highlighted:  this way it's enough to hit enter to start the importation.
- when hitting tab (or shift-tab) the next (previous) widget is highlighted (except the file list in this case). On checkbox hitting space toggles the value. On entry you can directly enter your text.
- when everything is done, hit tab until highlighting the right button and hit enter.

I've hijacked the hover settings to add the focus ones in the css. Obviously a more generic solution would be better here. It should also be applicable on all widgets able to get focus.
