### PR TITLE
tags: fix double free

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -964,7 +964,7 @@ GList *dt_tag_get_hierarchical_export(gint imgid, int32_t flags)
     dt_tag_t *t = (dt_tag_t *)tag_iter->data;
     if (export_private_tags || !(t->flags & DT_TF_PRIVATE))
     {
-      tags = g_list_prepend(tags, t->tag);
+      tags = g_list_prepend(tags, g_strdup(t->tag));
     }
   }
 


### PR DESCRIPTION
fix #8489
fix #8490

double memory leak (simple and hierarchical tags) fixed/revealed by @ralfbrown loop cleaning. Thanks ! :)
