### PR TITLE
better thumbnail rendering tooltips.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -954,7 +954,7 @@
     </type>
     <default>never</default>
     <shortdescription>thumb use raw file instead of embedded JPEG from size</shortdescription>
-    <longdescription>if the thumbnail size is greater than this value, it will be processed using raw file instead of the embedded preview JPEG (better but slower).</longdescription>
+    <longdescription>if the thumbnail size is greater than this value, it will be processed using raw file instead of the embedded preview JPEG (better but slower).\nif you want all thumbnails and pre-rendered images in best quality you should choose the *always* option.\n(more comments in the manual)</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/thumbnail_hq_min_level</name>
@@ -973,7 +973,7 @@
     </type>
     <default>720p</default>
     <shortdescription>high quality thumb processing from size</shortdescription>
-    <longdescription>if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).</longdescription>
+    <longdescription>if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).\nif you want all thumbnails and pre-rendered images in best quality you should choose the *always* option.\n(more comments in the manual)</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/thumbnail_sizes</name>


### PR DESCRIPTION
Having more tooltip information for the thumbnail rendering options might lead to less confusion about
these options.

Fixes #4192

Pinging @elstoc 
Chris, might this help in the preferences&settings->lighttable->thumbnail section?
*************************************************************************************************************************
We use the term "thumbnail" here, this includes not only the thumbs seen in the lighttable manager but all pre-rendered images like duplicates, culling views or the slideshow. darktable tries to find a compromise between performance on slower machines and best visible output, for best quality is uses it's full developing power, for best performance it uses a downscaled image (or even the jpeg) and processes that data resulting in often visible artefacts.
