### PR TITLE
Implement a parametric contrast mask

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -348,8 +348,8 @@ void dt_develop_make_contrast_mask(const float *const ivoid, float *mask, const 
 #endif
   for(size_t idx =0; idx < (size_t) width * height; idx++)
   {
-    const float val = labspace ? ivoid[4 * idx] : ivoid[4 * idx] + ivoid[4 * idx + 1] + ivoid[4 * idx + 2];
-    lum[idx] = lab_f(0.33333f * val);
+    const float val = labspace ? 0.02f * ivoid[4 * idx] : 0.333333f * (ivoid[4 * idx] + ivoid[4 * idx + 1] + ivoid[4 * idx + 2]);
+    lum[idx] = lab_f(val);
   }
 
   const float scale = 1.0f / 16.0f;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -329,7 +329,7 @@ void dt_develop_make_contrast_mask(const float *const ivoid, float *mask, const 
 {
   if(level == 0.0f) return;
   gboolean detail = (level > 0.0f);
-  const float threshold = detail ? 0.01f * sqrf(level) : 0.01f * (1.0f - sqrtf(fabs(level)));
+  const float threshold = detail ? 0.01f * sqrf(level) : 0.05f * (1.0f - sqrtf(fabs(level)));
   
   float *tmp = NULL;
   float *lum = NULL;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -80,6 +80,7 @@ typedef enum dt_develop_blend_mode_t
   DEVELOP_BLEND_DIVIDE_REVERSE = 0x27,
   DEVELOP_BLEND_GEOMETRIC_MEAN = 0x28,
   DEVELOP_BLEND_HARMONIC_MEAN = 0x29,
+  DEVELOP_BLEND_LUM_CONTRAST = 0x2A,
 } dt_develop_blend_mode_t;
 
 typedef enum dt_develop_mask_mode_t
@@ -153,8 +154,10 @@ typedef enum dt_develop_blendif_channels_t
   DEVELOP_BLENDIF_Cz_out = 13,
   DEVELOP_BLENDIF_hz_out = 14,
 
-  DEVELOP_BLENDIF_MAX = 14,
-  DEVELOP_BLENDIF_unused = 15,
+  DEVELOP_BLENDIF_loc_contrast = 15,
+
+  DEVELOP_BLENDIF_MAX = 15,
+  DEVELOP_BLENDIF_unused = 16,
 
   DEVELOP_BLENDIF_active = 31,
 
@@ -387,8 +390,10 @@ typedef struct dt_develop_blend_params_t
   float contrast;
   /** mask brightness adjustment */
   float brightness;
+  /** lum_contrast threshold */
+  float lum_contrast;
   /** some reserved fields for future use */
-  uint32_t reserved[4];
+  uint32_t reserved[3];
   /** blendif parameters */
   float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
   float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];
@@ -430,6 +435,7 @@ typedef struct dt_iop_gui_blendif_channel_t
   const dt_iop_gui_blendif_colorstop_t *colorstops;
   gboolean boost_factor_enabled;
   float boost_factor_offset;
+  gboolean lum_contrast_enabled;
   dt_develop_blendif_channels_t param_channels[2];
   dt_dev_pixelpipe_display_mask_t display_channel;
   void (*scale_print)(float value, float boost_factor, char *string, int n);
@@ -515,6 +521,7 @@ typedef struct dt_iop_gui_blend_data_t
   gboolean output_channels_shown;
 
   GtkWidget *channel_boost_factor_slider;
+  GtkWidget *lum_contrast_slider;
 
   GtkWidget *masks_combo;
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1038,6 +1038,11 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
   if(lum_contrast_enabled)
   {
     lum_contrast = bp->lum_contrast;
+    gtk_widget_set_sensitive(GTK_WIDGET(data->filter[0].box), FALSE);
+  }
+  else
+  {
+    gtk_widget_set_sensitive(GTK_WIDGET(data->filter[0].box), TRUE);
   }
   gtk_widget_set_sensitive(GTK_WIDGET(data->lum_contrast_slider), lum_contrast_enabled);
   dt_bauhaus_slider_set_soft(GTK_WIDGET(data->lum_contrast_slider), lum_contrast);
@@ -1969,7 +1974,7 @@ const dt_iop_gui_blendif_channel_t Lab_channels[]
           _blendif_scale_print_hue, NULL, N_("hue") },
         { N_("lC"), N_("slider for local contrast detection"), 1.0f / 100.0f, COLORSTOPS(_gradient_gray),
           FALSE, 0.0f, TRUE,
-          { DEVELOP_BLENDIF_loc_contrast }, DT_DEV_PIXELPIPE_DISPLAY_loc_contrast,
+          { DEVELOP_BLENDIF_loc_contrast, DEVELOP_BLENDIF_loc_contrast }, DT_DEV_PIXELPIPE_DISPLAY_loc_contrast,
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("local contrast") },
         { NULL } };
 
@@ -2000,7 +2005,7 @@ const dt_iop_gui_blendif_channel_t rgb_channels[]
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("luminance") },
         { N_("lC"), N_("slider for local contrast detection"), 1.0f / 100.0f, COLORSTOPS(_gradient_gray),
           FALSE, 0.0f, TRUE,
-          { DEVELOP_BLENDIF_loc_contrast }, DT_DEV_PIXELPIPE_DISPLAY_loc_contrast,
+          { DEVELOP_BLENDIF_loc_contrast, DEVELOP_BLENDIF_loc_contrast }, DT_DEV_PIXELPIPE_DISPLAY_loc_contrast,
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("local contrast") },
         { NULL } };
 
@@ -2032,7 +2037,7 @@ const dt_iop_gui_blendif_channel_t rgbj_channels[]
           _blendif_scale_print_hue, NULL, N_("hue") },
         { N_("lC"), N_("slider for local contrast detection"), 1.0f / 100.0f, COLORSTOPS(_gradient_gray),
           FALSE, 0.0f, TRUE,
-          { DEVELOP_BLENDIF_loc_contrast }, DT_DEV_PIXELPIPE_DISPLAY_loc_contrast,
+          { DEVELOP_BLENDIF_loc_contrast, DEVELOP_BLENDIF_loc_contrast }, DT_DEV_PIXELPIPE_DISPLAY_loc_contrast,
           _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("local contrast") },
         { NULL } };
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -114,7 +114,8 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz = 13 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz = 14 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz = 15 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3,  //show module's output without processing by later iops
+  DT_DEV_PIXELPIPE_DISPLAY_loc_contrast = 16 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 17 << 3,  //show module's output without processing by later iops
   DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;


### PR DESCRIPTION
The code for a "contrast mask" based on local _luminance_ differences is already in use as the selection tool for the dual demosaicers.

This PR implements the idea of the algorithm as an extension of the parametric mask. In addition to the existing parametric parameters we now have

1. another tab lC (read for local contrast or luminance contrast) switching on on the
2. contrast threshold slider

The contrast threshold slider is used in the algorithm to test for the amount of local luminance differences (contrast).
The default is 0 bypassing the mask generating algorithm.

Positive slider values select for contrasty, negative values for flat regions.

This parametric effect can be combined with all other parametric mask settings, also the other settings as mask blur and feathering work as before and can be used in combination.

There is currently no OpenCL code included (this is easy to do) as i would prefer to get this PR reviewed - pinging @AlicVB too - and merged for more testing "in the wild" before finally doing that.

One small note, the underlying algorithm had been done by Ingo (@heckflosse)