### PR TITLE
filechooser: remove hover effect on files/folders

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1975,6 +1975,12 @@ radiobutton:hover label  /* set hover effect on popover menu from star icon */
   color: @field_hover_fg;
 }
 
+filechooser treeview:not(#lutname) *:hover:not(check):not(:selected)
+{
+  background-color: @field_bg;
+  color: @field_fg;
+}
+
 treeview *:active,
 filechooser *:active
 {


### PR DESCRIPTION
Often (usually) the filechooser is opened in "folder select" mode.

In this mode the hover effect occurs on both files and folders and suggests to the user that files are selectable when they are not.

Due to Gtk limitations it appears to be impossible to limit the hover effect to just the folders so the least worst solution is to remove the hover effect entirely.