### PR TITLE
PR for testing bug 8528

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -998,6 +998,7 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
 {
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
   gboolean raster = module->blend_params->mask_mode & DEVELOP_MASK_RASTER;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   if(!darktable.gui->reset)
   {
@@ -1020,6 +1021,20 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
       //  if current module is set as the CAT instance, remove that setting
       if(module->dev->proxy.chroma_adaptation == module)
         module->dev->proxy.chroma_adaptation = NULL;
+
+      // if a mask is visualized, reset the mask visualization and buttons
+      if(module->request_mask_display)
+      {
+        // reset the mask visualization and buttons
+        module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
+        module->suppress_mask = 0;
+        if (bd->showmask) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), FALSE);
+        if (bd->suppress) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->suppress), FALSE);
+        ++darktable.gui->reset;
+        if(module->mask_indicator) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->mask_indicator), FALSE);
+        --darktable.gui->reset;
+        dt_iop_refresh_center(module);
+      }
 
       dt_dev_add_history_item(module->dev, module, FALSE);
 


### PR DESCRIPTION
This PR is intended to make #8528 reproducible (not to be merged). It was part of my work on mask indicators, but then I removed it because of the bug.
To reproduce, do the following steps:

- start with a fresh edit
- in module exposure, change exposure substantially in order to have a visible effect
- create a drawn mask to apply the change to a shape
- click the "show mask" button (or the mask indicator) to show the mask
- while the mask is visualized, turn off the module with the on/off button
- turn the module back on
- see the mask is discarded, exposure is applied to the entire image

