### PR TITLE
make export overwrite prompt optional

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1616,6 +1616,13 @@
     <shortdescription>ask before deleting a preset</shortdescription>
     <longdescription>will ask for confirmation before deleting or overwriting a preset</longdescription>
   </dtconfig>
+  <dtconfig prefs="security">
+    <name>plugins/lighttable/export/ask_before_export_overwrite</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>ask before exporting in overwrite mode</shortdescription>
+    <longdescription>will ask for confirmation before exporting files in overwrite mode</longdescription>
+  </dtconfig>
   <dtconfig ui="yes">
     <name>plugins/map/show_map_osd</name>
     <type>bool</type>

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -398,7 +398,7 @@ int set_params(dt_imageio_module_storage_t *self, const void *params, const int 
 char *ask_user_confirmation(dt_imageio_module_storage_t *self)
 {
   disk_t *g = (disk_t *)self->gui_data;
-  if(dt_bauhaus_combobox_get(g->onsave_action) == DT_EXPORT_ONCONFLICT_OVERWRITE)
+  if(dt_bauhaus_combobox_get(g->onsave_action) == DT_EXPORT_ONCONFLICT_OVERWRITE && dt_conf_get_bool("plugins/lighttable/export/ask_before_export_overwrite"))
   {
     return g_strdup(_("you are going to export on overwrite mode, this will overwrite any existing images\n\n"
         "do you really want to continue?"));


### PR DESCRIPTION
Adds a new option to the security tab of the preferences dialog to disable the prompt that appears before exporting in overwrite mode

Closes #8462