### PR TITLE
fix various typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,7 @@ _(if applicable)_
 **Screencast**
 _(if applicable)_
 
-**Which commit intruduced the error**
+**Which commit introduced the error**
 _If possible, please try using `git bisect` to determine which commit introduced the issue and place the result here._
 
 _A bisect is much appreciated and can significantly simplify the developer's job._

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ include(FeatureSummary)
 
 # resolve symbolic links into real path?
 get_filename_component(CMAKE_INSTALL_BINDIR_ABS "${CMAKE_INSTALL_FULL_BINDIR}" REALPATH "${CMAKE_INSTALL_PREFIX}")
-# get relative pathes specific to the system
+# get relative paths specific to the system
 file(RELATIVE_PATH REL_BIN_TO_LIBDIR    ${CMAKE_INSTALL_FULL_BINDIR} "${CMAKE_INSTALL_FULL_LIBDIR}/darktable")
 file(RELATIVE_PATH REL_BIN_TO_SHAREDIR  ${CMAKE_INSTALL_FULL_BINDIR} "${CMAKE_INSTALL_FULL_DATADIR}")
 file(RELATIVE_PATH REL_BIN_TO_LOCALEDIR ${CMAKE_INSTALL_FULL_BINDIR} "${CMAKE_INSTALL_FULL_LOCALEDIR}")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The darktable project welcomes contributions:
 
 * [Code](https://www.darktable.org/development/)
 * [Documentation](https://www.darktable.org/resources/)
-* Testing (and any backtraces if you happpen to crash darktable)
+* Testing (and any backtraces if you happen to crash darktable)
 * Translations
 * [Camera profiles](https://www.darktable.org/resources/camera-support/).
 * Tutorials, screencasts, etc.

--- a/README.md
+++ b/README.md
@@ -317,14 +317,14 @@ the test/unstable one in `~/.config/darktable-test`, so they will not produce da
 
 #### Regular/stable version
 
-Simply lauch it from your desktop application menu, or in terminal, run `darktable` or `/opt/darktable/bin/darktable`. If the installation did not create a launcher in your applications menu, run:
+Simply launch it from your desktop application menu, or in terminal, run `darktable` or `/opt/darktable/bin/darktable`. If the installation did not create a launcher in your applications menu, run:
 
 ```
 sudo ln -s /opt/darktable/share/applications/darktable.desktop /usr/share/applications/darktable.desktop
 ```
 
 You may find darktable configuration files in `~/.config/darktable`.
-In case you are having crashes at startup, try lauching darktable without OpenCL with `darktable --conf opencl=FALSE`.
+In case you are having crashes at startup, try launching darktable without OpenCL with `darktable --conf opencl=FALSE`.
 
 ### Further reading
 

--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -251,7 +251,7 @@ vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int widt
   int color = fcol(y + rin_y, x + rin_x, filters, xtrans);
   int num = 0;
 
-  // average the neightbors
+  // average the neighbors
   for(g = 0; g < 8; g++, ip += 3)
   {
     if(gval[g] <= thold)

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1323,7 +1323,7 @@ filechooser row:hover .sidebar-icon
 #preferences_box .sidebar row:selected,
 #modulegroups-preset-activated
 {
-  border-left-color: @field_hover_bg;   /* make the border left visible with choosed color if category on sidebar is selected */
+  border-left-color: @field_hover_bg;   /* make the border left visible with chosen color if category on sidebar is selected */
 }
 
 filechooser row:hover,

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -380,7 +380,7 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);
 int dt_masks_events_mouse_enter(struct dt_iop_module_t *module);
 
-/** functions used to manipulate gui datas */
+/** functions used to manipulate gui data */
 void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);
 void dt_masks_gui_form_remove(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);
 void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2844,7 +2844,7 @@ static void _brush_set_form_name(struct dt_masks_form_t *const form, const size_
 static void _brush_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
                                      const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
 {
-  // TODO: check if it would be good idea to have same controlls on creation and for selected brush
+  // TODO: check if it would be good idea to have same controls on creation and for selected brush
   if(gui->creation)
     g_snprintf(msgbuf, msgbuf_len,
                _("<b>size</b>: scroll, <b>hardness</b>: shift+scroll\n"

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -177,7 +177,7 @@ static void _thumbs_refocus(dt_culling_t *table)
     }
   }
 
-  // if overid not valid, we use the offest image
+  // if overid not valid, we use the offset image
   if(overid <= 0)
   {
     overid = table->offset_imgid;
@@ -209,7 +209,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
       }
       else
       {
-        // if we are here, that means we don't have enought space to move as wanted. So we move to first position
+        // if we are here, that means we don't have enough space to move as wanted. So we move to first position
         g_free(query);
         sqlite3_finalize(stmt);
         query
@@ -723,7 +723,7 @@ static void _dt_selection_changed_callback(gpointer instance, gpointer user_data
   dt_culling_t *table = (dt_culling_t *)user_data;
   if(!gtk_widget_get_visible(table->widget)) return;
 
-  // if we are in slection synchronisation mode, we exit this mode
+  // if we are in selection synchronisation mode, we exit this mode
   if(table->selection_sync) table->selection_sync = FALSE;
 
   // if we are in dynamic mode, zoom = selection count
@@ -1174,7 +1174,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     }
     else
     {
-      // we create a completly new thumb
+      // we create a completely new thumb
       // we set its size to the thumb it replace in the list if any otherwise we set it to something > 0 to trigger
       // draw events
       int nw = 40;
@@ -1257,7 +1257,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
         }
         else
         {
-          // we create a completly new thumb
+          // we create a completely new thumb
           // we set its size to the thumb it replace in the list if any otherwise we set it to something > 0 to
           // trigger draw events
           int nw = 40;

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -79,8 +79,8 @@ typedef struct dt_culling_t
 dt_culling_t *dt_culling_new(dt_culling_mode_t mode);
 // reload all thumbs from scratch.
 void dt_culling_full_redraw(dt_culling_t *table, gboolean force);
-// intialise culling offset/naviagtion mode, etc before entering.
-// if offset is > 0 it'll be used as offset, otherwise offset wil be determined by other means
+// initialise culling offset/naviagtion mode, etc before entering.
+// if offset is > 0 it'll be used as offset, otherwise offset will be determined by other means
 void dt_culling_init(dt_culling_t *table, int offset);
 // move by key actions.
 // this key accels are not managed here but inside view

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -511,7 +511,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     if(v->view(v) == DT_VIEW_DARKROOM && dev->preview_pipe->output_imgid == thumb->imgid
        && dev->preview_pipe->output_backbuf)
     {
-      // the current thumb is the one currently developped in darkroom
+      // the current thumb is the one currently developed in darkroom
       // better use the preview buffer for surface, in order to stay in sync
       if(thumb->img_surf && cairo_surface_get_reference_count(thumb->img_surf) > 0)
         cairo_surface_destroy(thumb->img_surf);
@@ -1833,7 +1833,7 @@ void dt_thumbnail_image_refresh(dt_thumbnail_t *thumb)
 {
   thumb->img_surf_dirty = TRUE;
 
-  // we ensure that the image is not completly outside the thumbnail, otherwise the image_draw is not triggered
+  // we ensure that the image is not completely outside the thumbnail, otherwise the image_draw is not triggered
   if(gtk_widget_get_margin_start(thumb->w_image_box) >= thumb->width
      || gtk_widget_get_margin_top(thumb->w_image_box) >= thumb->height)
   {

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -156,7 +156,7 @@ void dt_thumbnail_set_mouseover(dt_thumbnail_t *thumb, gboolean over);
 // note that it's just cosmetic as dropping occurs in thumbtable in any case
 void dt_thumbnail_set_drop(dt_thumbnail_t *thumb, gboolean accept_drop);
 
-// update the informations of the image and update icons accordingly
+// update the information of the image and update icons accordingly
 void dt_thumbnail_update_infos(dt_thumbnail_t *thumb);
 
 // check if the image is selected and set its state and background

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -73,11 +73,12 @@ static gchar *_thumbs_get_overlays_class(dt_thumbnail_overlay_t over)
   }
 }
 
-// get the size categorie, depending on the thumb size
+// get the size category, depending on the thumb size
 static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
 {
   // we get the size delimitations to differentiate sizes categories
-  // one we set as many categories as we want (this can be usefull if we want to finetune very precisely css)
+  // one we set as many categories as we want (this can be useful if
+  // we want to finetune css very precisely)
   gchar *txt = dt_conf_get_string("plugins/lighttable/thumbnail_sizes");
   gchar **ts = g_strsplit(txt, "|", -1);
   int i = 0;
@@ -92,7 +93,7 @@ static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
   return i;
 }
 
-// update thumbtable class and overlays mode, depending on size categorie
+// update thumbtable class and overlays mode, depending on size category
 static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
 {
   int ns = _thumbs_get_prefs_size(table);
@@ -458,8 +459,8 @@ static gboolean _thumbtable_update_scrollbars(dt_thumbtable_t *table)
   return FALSE;
 }
 
-// remove all uneeded thumbnails from the list and the widget
-// uneeded == completly hidden
+// remove all unneeded thumbnails from the list and the widget
+// unneeded == completely hidden
 static int _thumbs_remove_unneeded(dt_thumbtable_t *table)
 {
   int changed = 0;
@@ -494,7 +495,7 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
   sqlite3_stmt *stmt;
   int changed = 0;
 
-  // we rememeber image margins for new thumbs (this limit flickering)
+  // we remember image margins for new thumbs (this limit flickering)
   dt_thumbnail_t *first = (dt_thumbnail_t *)table->list->data;
   const int old_margin_start = gtk_widget_get_margin_start(first->w_image_box);
   const int old_margin_top = gtk_widget_get_margin_top(first->w_image_box);
@@ -657,7 +658,7 @@ static gboolean _move(dt_thumbtable_t *table, const int x, const int y, gboolean
     }
     else if(table->mode == DT_THUMBTABLE_MODE_ZOOM)
     {
-      // we stop before thumb area completly disappear from screen
+      // we stop before thumb area completely disappear from screen
       const int space = table->thumb_size * 0.5; // we want at least 1/2 thumb to stay visible
       posy = MIN(table->view_height - space - table->thumbs_area.y, posy);
       posy = MAX(space - table->thumbs_area.y - table->thumbs_area.height, posy);
@@ -755,7 +756,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
   const int new_size = table->view_width / newzoom;
   const double ratio = (double)new_size / (double)table->thumb_size;
 
-  // we get row/collumn numbers of the image under cursor
+  // we get row/column numbers of the image under cursor
   const int anchor_x = (x - table->thumbs_area.x) / table->thumb_size;
   const int anchor_y = (y - table->thumbs_area.y) / table->thumb_size;
   // we compute the new position of this image. This will be our reference to compute sizes of other thumbs
@@ -766,7 +767,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
   for(const GList *l = table->list; l; l = g_list_next(l))
   {
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
-    // we get row/collumn numbers
+    // we get row/column numbers
     const int posx = (th->x - table->thumbs_area.x) / table->thumb_size;
     const int posy = (th->y - table->thumbs_area.y) / table->thumb_size;
     // we compute new position taking anchor image as reference
@@ -1646,7 +1647,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
       dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
     }
   }
-  // if we can reorder, let's update the thumbtable class acoordingly
+  // if we can reorder, let's update the thumbtable class accordingly
   // this will show up vertical bar for the image destination point
   if(darktable.collection->params.sort == DT_COLLECTION_SORT_CUSTOM_ORDER && table->mode != DT_THUMBTABLE_MODE_ZOOM)
   {
@@ -1897,7 +1898,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       posx += empty_start * table->thumb_size;
     }
 
-    // we store image margin from frist thumb to apply to new ones and limit flickering
+    // we store image margin from first thumb to apply to new ones and limit flickering
     int old_margin_start = 0;
     int old_margin_top = 0;
     if(table->list)
@@ -1947,7 +1948,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       }
       else
       {
-        // we create a completly new thumb
+        // we create a completely new thumb
         dt_thumbnail_t *thumb
             = dt_thumbnail_new(table->thumb_size, table->thumb_size, IMG_TO_FIT, nid, nrow, table->overlays,
                                DT_THUMBNAIL_CONTAINER_LIGHTTABLE, table->show_tooltips);

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -68,7 +68,7 @@ typedef struct dt_thumbtable_t
   int thumbs_per_row; // number of image in a row (1 for filmstrip ; MAX_ZOOM for zoomable)
   int rows; // number of rows (the last one is not fully visible) for filmstrip it's the number of columns
   int thumb_size;              // demanded thumb size (real size can differ of 1 due to rounding)
-  int prefs_size;              // size value to dertermine overlays mode and css class
+  int prefs_size;              // size value to determine overlays mode and css class
   int view_width, view_height; // last main widget size
   GdkRectangle thumbs_area;    // coordinate of all the currently loaded thumbs area
 
@@ -91,7 +91,7 @@ typedef struct dt_thumbtable_t
   // as this can change during the drag and drop (esp. because of the image_over_id)
   GList *drag_list;
 
-  // to desactivate scrollbars event because we have updated it by hand in the code
+  // to deactivate scrollbars event because we have updated it by hand in the code
   gboolean code_scrolling;
 
   // are scrollbars shown ?
@@ -119,7 +119,7 @@ gboolean dt_thumbtable_set_offset_image(dt_thumbtable_t *table, int imgid, gbool
 // fired when the zoom level change
 void dt_thumbtable_zoom_changed(dt_thumbtable_t *table, int oldzoom, int newzoom);
 
-// ensure that the mentionned image is visible by moving the view if needed
+// ensure that the mentioned image is visible by moving the view if needed
 gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, int imgid);
 // check if the mentioned image is visible
 gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, int imgid);
@@ -128,7 +128,7 @@ gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, int imgid)
 // this key accels are not managed here but inside view
 gboolean dt_thumbtable_key_move(dt_thumbtable_t *table, dt_thumbtable_move_t move, gboolean select);
 
-// ensure the first image in collection as no offset (is positionned on top-left)
+// ensure the first image in collection as no offset (is positioned on top-left)
 gboolean dt_thumbtable_reset_first_offset(dt_thumbtable_t *table);
 
 // scrollbar change

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -28,7 +28,7 @@
     Metadata are displayed in a grid which follows this layout:
     Lines
     First line (DT_META_META_HEADER): Titles + metadata presets combobox
-    Next lines (DT_META_META_VALUE): Metadata - visibilty depending on metadata preferences
+    Next lines (DT_META_META_VALUE): Metadata - visibility depending on metadata preferences
     Before last line (DT_META_TAGS_HEADER): tags presets combobox
     Last line (DT_META_TAGS_VALUE): tags
     Columns

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -205,7 +205,7 @@ static void _piwigo_load_account(dt_storage_piwigo_gui_data_t *ui)
         if(account->server && strlen(account->server)>0)
           ui->accounts = g_list_append(ui->accounts, account);
         else
-          free(account); // we didn't add acount to list, freeing it
+          free(account); // we didn't add account to list, freeing it
       }
 
       g_object_unref(parser);

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1535,7 +1535,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
 
-    // blurr correction factors
+    // blur correction factors
     float valmax[] = { 10.0f };
     float valmin[] = { 0.1f };
     dt_gaussian_t *red  = dt_gaussian_init(h_width, h_height, 1, valmax, valmin, 30.0f, 0);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -385,7 +385,7 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Kodak ?
-  // can't find spectral sensivity curves and the illuminant under which they are produced,
+  // can't find spectral sensitivity curves and the illuminant under which they are produced,
   // so ¯\_(ツ)_/¯
 
   // basic channel-mixer
@@ -1340,14 +1340,14 @@ static const extraction_result_t _extract_patches(const float *const restrict in
 
   /* match global exposure */
   // white exposure depends on camera settings and raw white point,
-  // we want our profile to be independant from that
+  // we want our profile to be independent from that
   float XYZ_white_ref[4];
   float *XYZ_white_test = patches + g->checker->white * 4;
   dt_Lab_to_XYZ(g->checker->values[g->checker->white].Lab, XYZ_white_ref);
   const float exposure = XYZ_white_ref[1] / XYZ_white_test[1];
 
   // black point is evaluated by rawspeed on each picture using the dark pixels
-  // we want our profile to be also independant from its discrepancies
+  // we want our profile to be also independent from its discrepancies
   float XYZ_black_ref[4];
   float *XYZ_black_test = patches + g->checker->black * 4;
   dt_Lab_to_XYZ(g->checker->values[g->checker->black].Lab, XYZ_black_ref);
@@ -2680,7 +2680,7 @@ static void update_illuminants(dt_iop_module_t *self)
  * Using (x, y) is a robust and interoperable way to describe an illuminant, since it is all the actual pixel code needs
  * to perform the chromatic adaptation. This (x, y) can be computed in many different ways or taken from databases,
  * and possibly from other software, so storing only the result let us room to improve the computation in the future,
- * without loosing compatibility with older versions.
+ * without losing compatibility with older versions.
  *
  * However, it's not a great GUI since x and y are not perceptually scaled. So the `g->illum_x` and `g->illum_y`
  * actually display respectively hue and chroma, in LCh color space, which is designed for illuminants
@@ -3301,7 +3301,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
       check_if_close_to_daylight(p->x, p->y, &(p->temperature), NULL, &(p->adaptation));
 
       if(found)
-        dt_control_log(_("white balance successfuly extracted from raw image"));
+        dt_control_log(_("white balance successfully extracted from raw image"));
     }
     else if(p->illuminant == DT_ILLUMINANT_DETECT_EDGES
             || p->illuminant == DT_ILLUMINANT_DETECT_SURFACES)
@@ -3317,13 +3317,13 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
     if(p->illuminant != DT_ILLUMINANT_CUSTOM && p->illuminant != DT_ILLUMINANT_CAMERA)
     {
-      // We are in any mode defining (x, y) indirectly from an interface, so commit (x, y) explicitely
+      // We are in any mode defining (x, y) indirectly from an interface, so commit (x, y) explicitly
       illuminant_to_xy(p->illuminant, NULL, NULL, &(p->x), &(p->y), p->temperature, p->illum_fluo, p->illum_led);
     }
 
     if(p->illuminant != DT_ILLUMINANT_D && p->illuminant != DT_ILLUMINANT_BB && p->illuminant != DT_ILLUMINANT_CAMERA)
     {
-      // We are in any mode not defining explicitely a temperature, so find the the closest CCT and commit it
+      // We are in any mode not defining explicitly a temperature, so find the the closest CCT and commit it
       check_if_close_to_daylight(p->x, p->y, &(p->temperature), NULL, NULL);
     }
   }

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -148,7 +148,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   const int height = roi_in->height;
   if((width < 16) || (height < 16)) return;
 
-  // If the threshold is zero and we dont't want to see the blend mask we dont't do anything
+  // If the threshold is zero and we don't want to see the blend mask we don't do anything
   if(dual_threshold <= 0.0f) return;
 
   float *blend = dt_alloc_align_float((size_t) width * height);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -873,7 +873,7 @@ inline static void blur_2D_Bspline(const float *const restrict in, float *const 
         const size_t col = CLAMP(mult * (int)(jj - (FSIZE - 1) / 2) + (int)j, (int)0, (int)width - 1);
         indices[jj] = 4 * col;
       }
-      // Compute the horizonal blur of the already vertically-blurred pixel and store the result at the proper
+      // Compute the horizontal blur of the already vertically-blurred pixel and store the result at the proper
       //  row/column location in the output buffer
       sparse_scalar_product(temp, indices, out + (i * width + j) * 4);
     }
@@ -1102,7 +1102,7 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
   // À trous wavelet decompose
   // there is a paper from a guy we know that explains it : https://jo.dreggn.org/home/2010_atrous.pdf
   // the wavelets decomposition here is the same as the equalizer/atrous module,
-  // but simplified because we don't need the edge-aware term, so we can seperate the convolution kernel
+  // but simplified because we don't need the edge-aware term, so we can separate the convolution kernel
   // with a vertical and horizontal blur, which is 10 multiply-add instead of 25 by pixel.
   for(int s = 0; s < scales; ++s)
   {
@@ -1135,7 +1135,7 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
     // Compute wavelets low-frequency scales
     blur_2D_Bspline(detail, LF, temp, roi_out->width, roi_out->height, mult);
 
-    // Compute wavelets high-frequency scales and save the mininum of texture over the RGB channels
+    // Compute wavelets high-frequency scales and save the minimum of texture over the RGB channels
     // Note : HF_RGB = detail - LF, HF_grey = max(HF_RGB)
     wavelets_detail_level(detail, LF, HF_RGB_temp, HF_grey, roi_out->width, roi_out->height, ch);
 
@@ -1586,7 +1586,7 @@ static inline cl_int reconstruct_highlights_cl(cl_mem in, cl_mem mask, cl_mem re
   // À trous wavelet decompose
   // there is a paper from a guy we know that explains it : https://jo.dreggn.org/home/2010_atrous.pdf
   // the wavelets decomposition here is the same as the equalizer/atrous module,
-  // but simplified because we don't need the edge-aware term, so we can seperate the convolution kernel
+  // but simplified because we don't need the edge-aware term, so we can separate the convolution kernel
   // with a vertical and horizontal blur, which is 10 multiply-add instead of 25 by pixel.
   for(int s = 0; s < scales; ++s)
   {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -344,7 +344,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
     _rgbcurve_show_hide_controls(p, g);
 
-    // swithing to manual scale, if G and B not touched yet, just make them identical to global setting (R)
+    // switching to manual scale, if G and B not touched yet, just make them identical to global setting (R)
     if(p->curve_autoscale == DT_S_SCALE_MANUAL_RGB
       && _is_identity(p, DT_IOP_RGBCURVE_G)
       && _is_identity(p, DT_IOP_RGBCURVE_B))

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -864,7 +864,7 @@ void color_finetuning_slider(struct dt_iop_module_t *self)
   dt_iop_temperature_preset_data_t *preset = dt_bauhaus_combobox_get_data(g->presets);
   if(preset != NULL)
   {
-    //we can do realistic/exagerated.
+    //we can do realistic/exaggerated.
 
     double min_tune[3] = {0.0};
     double no_tune[3] = {0.0};
@@ -896,7 +896,7 @@ void color_finetuning_slider(struct dt_iop_module_t *self)
     }
     else
     {
-      //exagerated
+      //exaggerated
 
       for(int ch=0; ch<3; ch++)
       {
@@ -951,7 +951,7 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
 
   if(!color_rgb) return;
 
-  // there are 3 ways to do colored sliders: naive (independed 0->1), smart(er) (dependent 0->1) and real (coeff)
+  // there are 3 ways to do colored sliders: naive (independent 0->1), smart(er) (dependent 0->1) and real (coeff)
 
   if(FALSE)
   {

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -675,7 +675,7 @@ static void _lib_history_will_change_callback(gpointer instance, GList *history,
 
   if(lib->record_undo && (lib->record_history_level == 0))
   {
-    // history is about to change, we want here ot record a snapshot of the history for the undo
+    // history is about to change, here we want to record a snapshot of the history for the undo
     // record previous history
     g_list_free_full(lib->previous_snapshot, free);
     g_list_free_full(lib->previous_iop_order_list, free);

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -269,7 +269,7 @@ static int _time_compare(dt_lib_timeline_time_t t1, dt_lib_timeline_time_t t2)
   return 0;
 }
 
-// add/substract value to a time at certain level
+// add/subtract value to a time at certain level
 static void _time_add(dt_lib_timeline_time_t *t, int val, dt_lib_timeline_zooms_t level)
 {
   if(level == DT_LIB_TIMELINE_ZOOM_YEAR)

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -245,7 +245,7 @@ int dt_lua_event_keyed_destroy(lua_State *L)
     return luaL_error(L, "no key provided when destroying event %s", luaL_checkstring(L, 4));
 
   // remove the callback function from the data table using the key
-  lua_pushnil(L);  // set the action to nil to remmove it
+  lua_pushnil(L);  // set the action to nil to remove it
   lua_setfield(L, 1, luaL_checkstring(L, -2));
 
   // remove the index entry

--- a/src/lua/types.h
+++ b/src/lua/types.h
@@ -43,7 +43,7 @@ typedef double protected_double;  // like double, but NAN is mapped to nil
 typedef double progress_double; // a double in [0.0,1.0] any value out of bound will be silently converted to
                                 // the bound both at push and pull time
 
-// Types added to the lua type system and useable externally
+// Types added to the lua type system and usable externally
 typedef GtkOrientation dt_lua_orientation_t;
 typedef GtkAlign dt_lua_align_t;
 typedef PangoEllipsizeMode dt_lua_ellipsize_mode_t;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -596,7 +596,7 @@ void expose(
     {
       sample = samples->data;
 
-      // only dislay selected sample, skip if not the selected sample
+      // only display selected sample, skip if not the selected sample
       if(only_selected_sample
          && sample != darktable.lib->proxy.colorpicker.selected_sample)
       {
@@ -3069,7 +3069,7 @@ void leave(dt_view_t *self)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_preference_changed_button_hide), dev);
 
-  // reset color assesment mode
+  // reset color assessment mode
   if(dev->iso_12646.enabled)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(dev->iso_12646.button), FALSE);
@@ -3201,7 +3201,7 @@ void mouse_leave(dt_view_t *self)
 }
 
 /* This helper function tests for a position to be within the displayed area
-   of an image. To avoid "border cases" we accept values to be slighly out of area too.
+   of an image. To avoid "border cases" we accept values to be slightly out of area too.
 */
 static int mouse_in_imagearea(dt_view_t *self, double x, double y)
 {
@@ -3887,7 +3887,7 @@ void init_key_accels(dt_view_t *self)
   // toggle gamut check
   dt_accel_register_view(self, NC_("accel", "gamut check"), GDK_KEY_g, GDK_CONTROL_MASK);
 
-  // toggle visability of drawn masks for current gui module
+  // toggle visibility of drawn masks for current gui module
   dt_accel_register_view(self, NC_("accel", "show drawn masks"), 0, 0);
 
   // brush size +/-
@@ -3978,7 +3978,7 @@ void connect_key_accels(dt_view_t *self)
   closure = g_cclosure_new(G_CALLBACK(_overlay_cycle_callback), (gpointer)self->data, NULL);
   dt_accel_connect_view(self, "cycle overlay colors", closure);
 
-  // toggle visability of drawn masks for current gui module
+  // toggle visibility of drawn masks for current gui module
   closure = g_cclosure_new(G_CALLBACK(_toggle_mask_visibility_callback), (gpointer)self->data, NULL);
   dt_accel_connect_view(self, "show drawn masks", closure);
 

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -934,7 +934,7 @@ static gboolean _event_loop_animation(dt_knight_t *d)
 static gboolean _event_loop(gpointer user_data)
 {
   dt_knight_t *d = (dt_knight_t *)user_data;
-  gboolean res = FALSE;  // silence warning about unitialized res
+  gboolean res = FALSE;  // silence warning about uninitialized res
   switch(d->game_state)
   {
     case INTRO:

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -460,7 +460,7 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   struct dt_capture_t *lib = (dt_capture_t *)data;
 
   /* update import session with original filename so that $(FILE_EXTENSION)
-   *     and alikes can be expanded. */
+   *     and alike can be expanded. */
   dt_import_session_set_filename(lib->session, filename);
   const gchar *file = dt_import_session_filename(lib->session, FALSE);
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -759,10 +759,10 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
   gboolean inside_sel = FALSE;
   if(mouseover > 0)
   {
-    // collumn 1,2,3
+    // column 1,2,3
     if(dt_ui_thumbtable(darktable.gui->ui)->mouse_inside)
     {
-      // collumn 1,2
+      // column 1,2
       sqlite3_stmt *stmt;
       gchar *query = dt_util_dstrcat(NULL, "SELECT imgid FROM main.selected_images WHERE imgid=%d", mouseover);
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -775,9 +775,9 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
 
       if(inside_sel)
       {
-        // collumn 1
+        // column 1
 
-        // first, we try to return cached list if we wher already
+        // first, we try to return cached list if we were already
         // inside sel and the selection has not changed
         if(!force
            && darktable.view_manager->act_on.ok
@@ -793,13 +793,13 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
       }
       else
       {
-        // collumn 2
+        // column 2
         _images_to_act_on_insert_in_list(&l, mouseover, only_visible);
       }
     }
     else
     {
-      // collumn 3
+      // column 3
       _images_to_act_on_insert_in_list(&l, mouseover, only_visible);
       // be absolutely sure we have the id in the list (in darkroom,
       // the active image can be out of collection)
@@ -808,10 +808,10 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
   }
   else
   {
-    // collumn 4,5
+    // column 4,5
     if(darktable.view_manager->active_images)
     {
-      // collumn 5
+      // column 5
       for(GSList *ll = darktable.view_manager->active_images; ll; ll = g_slist_next(ll))
       {
         const int id = GPOINTER_TO_INT(ll->data);
@@ -823,7 +823,7 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
     }
     else
     {
-      // collumn 4
+      // column 4
       // we return the list of the selection
       l = dt_selection_get_list(darktable.selection, only_visible, ordered);
     }
@@ -867,10 +867,10 @@ gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible)
   gboolean inside_sel = FALSE;
   if(mouseover > 0)
   {
-    // collumn 1,2,3
+    // column 1,2,3
     if(dt_ui_thumbtable(darktable.gui->ui)->mouse_inside)
     {
-      // collumn 1,2
+      // column 1,2
       sqlite3_stmt *stmt;
       gchar *query = dt_util_dstrcat(NULL, "SELECT imgid FROM main.selected_images WHERE imgid =%d", mouseover);
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -883,18 +883,18 @@ gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible)
 
       if(inside_sel)
       {
-        // collumn 1
+        // column 1
         return dt_selection_get_list_query(darktable.selection, only_visible, FALSE);
       }
       else
       {
-        // collumn 2
+        // column 2
         _images_to_act_on_insert_in_list(&l, mouseover, only_visible);
       }
     }
     else
     {
-      // collumn 3
+      // column 3
       _images_to_act_on_insert_in_list(&l, mouseover, only_visible);
       // be absolutely sure we have the id in the list (in darkroom,
       // the active image can be out of collection)
@@ -903,10 +903,10 @@ gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible)
   }
   else
   {
-    // collumn 4,5
+    // column 4,5
     if(darktable.view_manager->active_images)
     {
-      // collumn 5
+      // column 5
       for(GSList *ll = darktable.view_manager->active_images;
           ll;
           ll = g_slist_next(ll))
@@ -920,12 +920,12 @@ gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible)
     }
     else
     {
-      // collumn 4
+      // column 4
       return dt_selection_get_list_query(darktable.selection, only_visible, FALSE);
     }
   }
 
-  // if we don't return the selection, we return the list of imgid separeted by comma
+  // if we don't return the selection, we return the list of imgid separated by comma
   // in the form it can be used inside queries
   gchar *images = NULL;
   for(; l; l = g_list_next(l))
@@ -1001,7 +1001,7 @@ dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int heig
      && cairo_surface_get_reference_count(*surface) > 0) cairo_surface_destroy(*surface);
   *surface = NULL;
 
-  // get mipmap cahe image
+  // get mipmap cache image
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
   dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(cache, width * darktable.gui->ppd, height * darktable.gui->ppd);
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./src/external,./src/common,./data/pswp -L webp,ba,uint,ue,liquify,ist,inout,hist,dinamic`