### PR TITLE
modulegroup + presets fix focus

### DIFF
--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -712,6 +712,13 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
     if(w) gtk_widget_set_sensitive(w, FALSE);
   }
 
+  // put focus on cancel button if 2 first entry desactivated
+  if(!allow_desc_change && !allow_name_change)
+  {
+    GtkWidget *w = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_CANCEL);
+    if(w) gtk_widget_grab_focus(w);
+  }
+
   g_signal_connect(dialog, "response", G_CALLBACK(_edit_preset_response), g);
   gtk_widget_show_all(dialog);
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1489,11 +1489,11 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
 }
 
 // start no quick access
-#define SNQA() \
-  {                                      \
-    g_free(tx);                          \
-    tx=NULL;                             \
-    tx = dt_util_dstrcat(tx, "1ꬹ1");     \
+#define SNQA()                                                                                                    \
+  {                                                                                                               \
+    g_free(tx);                                                                                                   \
+    tx = NULL;                                                                                                    \
+    tx = dt_util_dstrcat(tx, "1ꬹ0||");                                                                          \
   }
 
 // start quick access

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1182,7 +1182,7 @@ static gchar *_preset_retrieve_old_layout_updated()
     // group name and icon
     if(i == 0)
     {
-      ret = dt_util_dstrcat(ret, "ꬹ1|||%s",
+      ret = dt_util_dstrcat(ret, "1ꬹ1|||%s",
                             "exposure/exposure|temperature/temperature|temperature/tint|colorbalance/contrast"
                             "|colorbalance/output saturation|clipping/angle|denoiseprofile|lens|bilat");
       ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
@@ -1235,7 +1235,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
     if(i == 0)
     {
       // we don't have to care about "modern" workflow for temperature as it's more recent than this layout
-      ret = dt_util_dstrcat(ret, "ꬹ1|||%s",
+      ret = dt_util_dstrcat(ret, "1ꬹ1|||%s",
                             "exposure/exposure|temperature/temperature|temperature/tint|colorbalance/contrast"
                             "|colorbalance/output saturation|clipping/angle|denoiseprofile|lens|bilat");
       ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
@@ -1497,28 +1497,28 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   }
 
 // start quick access
-#define SQA()                            \
-  {                                      \
-    g_free(tx);                          \
-    tx=NULL;                             \
-    tx = dt_util_dstrcat(tx, "ꬹ1||");     \
-    if(is_modern)                        \
-    {                                    \
-      AM("channelmixerrgb/temperature"); \
-    }                                    \
-    else                                 \
-    {                                    \
-      AM("temperature/temperature");     \
-      AM("temperature/tint");            \
-    }                                    \
-    AM("exposure/exposure");             \
-    AM("colorbalance/contrast");         \
-    AM("colorbalance/output saturation");\
-    AM("vibrancergb/amount");            \
-    AM("clipping/angle");                \
-    AM("denoiseprofile");                \
-    AM("lens");                          \
-    AM("bilat");                         \
+#define SQA()                                                                                                     \
+  {                                                                                                               \
+    g_free(tx);                                                                                                   \
+    tx = NULL;                                                                                                    \
+    tx = dt_util_dstrcat(tx, "1ꬹ1||");                                                                          \
+    if(is_modern)                                                                                                 \
+    {                                                                                                             \
+      AM("channelmixerrgb/temperature");                                                                          \
+    }                                                                                                             \
+    else                                                                                                          \
+    {                                                                                                             \
+      AM("temperature/temperature");                                                                              \
+      AM("temperature/tint");                                                                                     \
+    }                                                                                                             \
+    AM("exposure/exposure");                                                                                      \
+    AM("colorbalance/contrast");                                                                                  \
+    AM("colorbalance/output saturation");                                                                         \
+    AM("vibrancergb/amount");                                                                                     \
+    AM("clipping/angle");                                                                                         \
+    AM("denoiseprofile");                                                                                         \
+    AM("lens");                                                                                                   \
+    AM("bilat");                                                                                                  \
   }
 
 // start module group


### PR DESCRIPTION
this fix #8557 
this fix #8558 

fix modulegroups built-in preset highlight in the preset menu.
put focus on cancel btn in presets dialog if the name and desc entries are disabled