### PR TITLE
manage module groups: unset keyboard focus

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3532,6 +3532,9 @@ static void _manage_editor_load(const char *preset, dt_lib_module_t *self)
 
   // and we update arrows
   if(!d->edit_ro) _manage_editor_group_update_arrows(d->preset_groups_box);
+
+  //set keyboard focus on the scrollable window (not on a widget)
+  gtk_widget_grab_focus(sw);
 }
 
 static void _manage_preset_change(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)


### PR DESCRIPTION
allocate keyboard focus to the scrollable window, in order to stop the duplicate button of the "modules: all" preset from having keyboard focus (and therefore a darker color) by default

before
![Screenshot_2021-03-26_23-47-26](https://user-images.githubusercontent.com/9555491/112703132-c3b6c480-8e8d-11eb-9cd1-aa17eb9984b8.png)

after
![Screenshot_2021-03-26_23-48-05](https://user-images.githubusercontent.com/9555491/112703143-c87b7880-8e8d-11eb-9890-e520ef589877.png)
