### PR TITLE
Map locations: add polygon shape (kind of)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1646,7 +1646,7 @@
   </dtconfig>
   <dtconfig ui="yes">
     <name>plugins/map/epsilon_factor</name>
-    <type min="10" max="100">int</type>
+    <type min="1" max="100">int</type>
     <default>25</default>
     <shortdescription>group size factor</shortdescription>
     <longdescription>increase or decrease the spatial size of images groups on the map. can influence the calculation time</longdescription>
@@ -1678,12 +1678,12 @@
     <shortdescription>Whether to highlight the search result on the map</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig>
+  <dtconfig ui="yes">
     <name>plugins/map/max_outline_nodes</name>
     <type>int</type>
     <default>10000</default>
-    <shortdescription/>
-    <longdescription/>
+    <shortdescription>max polygon points</shortdescription>
+    <longdescription>limit the number of points imported with polygon in find location module</longdescription>
   </dtconfig>
   <dtconfig prefs="otherviews" section="geoloc">
     <name>plugins/lighttable/metadata_view/pretty_location</name>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -48,7 +48,7 @@
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
 #define CURRENT_DATABASE_VERSION_LIBRARY 34
-#define CURRENT_DATABASE_VERSION_DATA     8
+#define CURRENT_DATABASE_VERSION_DATA     9
 
 typedef struct dt_database_t
 {
@@ -2166,6 +2166,13 @@ static int _upgrade_data_schema_step(dt_database_t *db, int version)
 
     new_version = 8;
   }
+  else if(version == 8)
+  {
+    TRY_EXEC("ALTER TABLE data.locations ADD COLUMN polygons BLOB",
+             "[init] can't add column `polygons' column to locations table\n");
+
+    new_version = 9;
+  }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop
 
@@ -2362,7 +2369,7 @@ static void _create_data_schema(dt_database_t *db)
                NULL, NULL, NULL);
   ////////////////////////////// (map) locations
   sqlite3_exec(db->handle, "CREATE TABLE data.locations (tagid INTEGER PRIMARY KEY, "
-               "type INTEGER, longitude REAL, latitude REAL, delta1 REAL, delta2 REAL, ratio FLOAT, "
+               "type INTEGER, longitude REAL, latitude REAL, delta1 REAL, delta2 REAL, ratio FLOAT, polygons BLOB, "
                "FOREIGN KEY(tagid) REFERENCES tags(id))", NULL, NULL, NULL);
 }
 

--- a/src/common/geo.h
+++ b/src/common/geo.h
@@ -32,6 +32,14 @@ typedef struct dt_geo_map_display_point_t
   float lat, lon;
 } dt_geo_map_display_point_t;
 
+typedef struct dt_map_box_t
+{
+  float lon1;
+  float lat1;
+  float lon2;
+  float lat2;
+} dt_map_box_t;
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/map_locations.c
+++ b/src/common/map_locations.c
@@ -84,6 +84,23 @@ gboolean dt_map_location_name_exists(const char *const name)
   return exists;
 }
 
+// gets location's images number
+int dt_map_location_get_images_count(const guint locid)
+{
+  int count = 0;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT COUNT (*)"
+                              "  FROM main.tagged_images"
+                              "  WHERE tagid = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, locid);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+    count = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+  return count;
+}
+
 // retrieve list of tags which are on that path
 GList *dt_map_location_get_locations_by_path(const gchar *path,
                                              const gboolean remove_root)
@@ -140,8 +157,7 @@ GList *dt_map_location_get_locations_by_path(const gchar *path,
   return locs;
 }
 
-GList *dt_map_location_get_locations_on_map(const double lat0, const double lat1,
-                                            const double lon0, const double lon1)
+GList *dt_map_location_get_locations_on_map(const dt_map_box_t *const bbox)
 {
   GList *locs = NULL;
 
@@ -150,16 +166,16 @@ GList *dt_map_location_get_locations_on_map(const double lat0, const double lat1
                               "SELECT *"
                               "  FROM data.locations AS t"
                               "  WHERE latitude IS NOT NULL"
-                              "    AND (latitude + delta1 / 2) > ?2"
-                              "    AND (latitude - delta1 / 2) < ?1"
-                              "    AND (longitude + delta2 / 2) > ?3"
-                              "    AND (longitude - delta2 / 2) < ?4",
+                              "    AND (latitude + delta2) > ?2"
+                              "    AND (latitude - delta2) < ?1"
+                              "    AND (longitude + delta1) > ?3"
+                              "    AND (longitude - delta1) < ?4",
                               -1, &stmt, NULL);
 
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 1, lat0);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 2, lat1);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 3, lon0);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 4, lon1);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 1, bbox->lat1);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 2, bbox->lat2);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 3, bbox->lon1);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 4, bbox->lon2);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -179,6 +195,80 @@ GList *dt_map_location_get_locations_on_map(const double lat0, const double lat1
   sqlite3_finalize(stmt);
 
   return locs;
+}
+
+void dt_map_location_get_polygons(dt_location_draw_t *ld)
+{
+  if(ld->data.shape != MAP_LOCATION_SHAPE_POLYGONS)
+    return;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT polygons FROM data.locations AS t"
+                              "  WHERE tagid = ?1",
+                              -1, &stmt, NULL);
+
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, ld->id);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    ld->data.plg_pts = sqlite3_column_bytes(stmt, 0);
+    dt_geo_map_display_point_t *p = malloc(ld->data.plg_pts);
+    memcpy(p, sqlite3_column_blob(stmt, 0), ld->data.plg_pts);
+    ld->data.plg_pts /= sizeof(dt_geo_map_display_point_t);
+    printf("dt_map_location_get_polygons %d -> %d\n", ld->id, ld->data.plg_pts);
+    GList *pol = NULL;
+    for(int i = 0; i < ld->data.plg_pts; i++, p++)
+      pol = g_list_prepend(pol, p);
+    pol = g_list_reverse(pol);
+    ld->data.polygons = pol;
+  }
+  sqlite3_finalize(stmt);
+}
+
+void dt_map_location_free_polygons(dt_location_draw_t *ld)
+{
+  printf("dt_map_location_free_polygons %d nb points %d\n", ld->id, ld->data.plg_pts);
+  if(ld->data.shape == MAP_LOCATION_SHAPE_POLYGONS && ld->data.polygons)
+  {
+    g_free(ld->data.polygons->data);
+    g_list_free(ld->data.polygons);
+  }
+  ld->data.polygons = NULL;
+  ld->data.plg_pts = 0;
+}
+
+static gboolean _is_point_in_polygon(const dt_geo_map_display_point_t *pt,
+                                     const gint plg_pts, const dt_geo_map_display_point_t *plp)
+{
+  gboolean inside = FALSE;
+  dt_geo_map_display_point_t *p = (dt_geo_map_display_point_t *)plp;
+  float lat1 = plp->lat;
+  float lon1 = plp->lon;
+  float lat2, lon2;
+  printf("_is_point_in_polygon vertices %d lat %f lon %f => lat %f lon %f \n", plg_pts, lat1, lon1, pt->lat, pt->lon);
+  for(int i = 0; i < plg_pts; i++)
+  {
+    if(i < plg_pts - 1)
+    {
+      p++;
+      lat2 = p->lat;
+      lon2 = p->lon;
+    }
+    else
+    {
+      lat2 = plp->lat;
+      lon2 = plp->lon;
+    }
+    if(!(((lat1 > pt->lat) && (lat2 > pt->lat)) ||
+         ((lat1 < pt->lat) && (lat2 < pt->lat))))
+    {
+      const float sl = lon1 + (lon2 - lon1) * (pt->lat - lat1) / (lat2 - lat1);
+      if(pt->lon > sl)
+        inside = !inside;
+    }
+    lat1 = lat2;
+    lon1 = lon2;
+  }
+  return inside;
 }
 
 static void _free_result_item(dt_map_location_t *t, gpointer unused)
@@ -243,7 +333,7 @@ dt_map_location_data_t *dt_map_location_get_data(const guint locid)
 
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    g = (dt_map_location_data_t *)malloc(sizeof(dt_map_location_data_t));
+    g = (dt_map_location_data_t *)g_malloc0(sizeof(dt_map_location_data_t));
     g->shape = sqlite3_column_int(stmt, 0);
     g->lon = sqlite3_column_double(stmt, 1);
     g->lat = sqlite3_column_double(stmt, 2);
@@ -262,8 +352,8 @@ void dt_map_location_set_data(const guint locid, const dt_map_location_data_t *g
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "INSERT OR REPLACE INTO data.locations"
-                              "  (tagid, type, longitude, latitude, delta1, delta2, ratio)"
-                              "  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                              "  (tagid, type, longitude, latitude, delta1, delta2, ratio, polygons)"
+                              "  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, locid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, g->shape);
@@ -272,6 +362,15 @@ void dt_map_location_set_data(const guint locid, const dt_map_location_data_t *g
   DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 5, g->delta1);
   DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 6, g->delta2);
   DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, g->ratio);
+  if(g->shape != MAP_LOCATION_SHAPE_POLYGONS)
+  {
+    DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 8, NULL, 0, SQLITE_STATIC);
+  }
+  else
+  {
+    DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 8, g->polygons->data, g->plg_pts * (int)sizeof(dt_geo_map_display_point_t), SQLITE_STATIC);
+    printf("dt_map_location_set_data %d %d\n", g->plg_pts, g->plg_pts * (int)sizeof(dt_geo_map_display_point_t));
+  }
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 }
@@ -279,17 +378,18 @@ void dt_map_location_set_data(const guint locid, const dt_map_location_data_t *g
 // find locations which match with that image
 GList *dt_map_location_find_locations(const guint imgid)
 {
+  printf("dt_map_location_find_locations imgid %d\n", imgid);
   GList *tags = NULL;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT l.tagid FROM main.images AS i"
+                              "SELECT l.tagid, l.type, i.longitude, i.latitude FROM main.images AS i"
                               "  JOIN data.locations AS l"
                               "  ON (l.type = ?2"
                               "      AND ((((i.longitude-l.longitude)*(i.longitude-l.longitude))/"
                                             "(delta1*delta1) +"
                               "            ((i.latitude-l.latitude)*(i.latitude-l.latitude))/"
                                             "(delta2*delta2)) <= 1)"
-                              "    OR (l.type = ?3"
+                              "    OR ((l.type = ?3 OR l.type = ?4)"
                               "        AND i.longitude>=(l.longitude-delta1)"
                               "        AND i.longitude<=(l.longitude+delta1)"
                               "        AND i.latitude>=(l.latitude-delta2)"
@@ -300,46 +400,102 @@ GList *dt_map_location_find_locations(const guint imgid)
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, MAP_LOCATION_SHAPE_ELLIPSE);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, MAP_LOCATION_SHAPE_RECTANGLE);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 4, MAP_LOCATION_SHAPE_POLYGONS);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const int id = sqlite3_column_int(stmt, 0);
-    tags = g_list_prepend(tags, GINT_TO_POINTER(id));
+    if(sqlite3_column_int(stmt, 1) == MAP_LOCATION_SHAPE_POLYGONS)
+    {
+      dt_geo_map_display_point_t pt;
+      pt.lon = sqlite3_column_double(stmt, 2);
+      pt.lat = sqlite3_column_double(stmt, 3);
+      sqlite3_stmt *stmt2;
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                  "SELECT polygons FROM data.locations "
+                                  " WHERE tagid = ?1",
+                                  -1, &stmt2, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, id);
+      if(sqlite3_step(stmt2) == SQLITE_ROW)
+      {
+        const gint plg_pts = sqlite3_column_bytes(stmt2, 0) / sizeof(dt_geo_map_display_point_t);
+        if(_is_point_in_polygon(&pt, plg_pts, sqlite3_column_blob(stmt2, 0)))
+        {
+          printf("dt_map_location_find_locations imgid %d locid %d shape %d\n", imgid, id, sqlite3_column_int(stmt, 1));
+          tags = g_list_prepend(tags, GINT_TO_POINTER(id));
+        }
+      }
+      sqlite3_finalize(stmt2);
+    }
+    else
+    {
+      printf("dt_map_location_find_locations imgid %d locid %d shape %d\n", imgid, id, sqlite3_column_int(stmt, 1));
+      tags = g_list_prepend(tags, GINT_TO_POINTER(id));
+    }
   }
   sqlite3_finalize(stmt);
   return tags;
 }
 
 // find images which match with that location
-GList *_map_location_find_images(const guint locid)
+GList *_map_location_find_images(dt_location_draw_t *ld)
 {
   GList *imgs = NULL;
   sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT i.id FROM main.images AS i"
-                              "  JOIN data.locations AS l"
-                              "  ON (l.type = ?2"
-                              "      AND ((((i.longitude-l.longitude)*(i.longitude-l.longitude))/"
-                                            "(delta1*delta1) +"
-                              "            ((i.latitude-l.latitude)*(i.latitude-l.latitude))/"
-                                            "(delta2*delta2)) <= 1)"
-                              "   OR (l.type = ?3"
-                              "       AND i.longitude>=(l.longitude-delta1)"
-                              "       AND i.longitude<=(l.longitude+delta1)"
-                              "       AND i.latitude>=(l.latitude-delta2)"
-                              "       AND i.latitude<=(l.latitude+delta2)))"
-                              "  WHERE l.tagid = ?1 ",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, locid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, MAP_LOCATION_SHAPE_ELLIPSE);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, MAP_LOCATION_SHAPE_RECTANGLE);
+  if(ld->data.shape == MAP_LOCATION_SHAPE_ELLIPSE)
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT i.id FROM main.images AS i"
+                                "  JOIN data.locations AS l"
+                                "  ON (l.type = ?2"
+                                "      AND ((((i.longitude-l.longitude)*(i.longitude-l.longitude))/"
+                                              "(delta1*delta1) +"
+                                "            ((i.latitude-l.latitude)*(i.latitude-l.latitude))/"
+                                              "(delta2*delta2)) <= 1))"
+                                "  WHERE l.tagid = ?1 ",
+                                -1, &stmt, NULL);
+  else if(ld->data.shape == MAP_LOCATION_SHAPE_RECTANGLE)
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT i.id FROM main.images AS i"
+                                "  JOIN data.locations AS l"
+                                "  ON (l.type = ?2"
+                                "       AND i.longitude>=(l.longitude-delta1)"
+                                "       AND i.longitude<=(l.longitude+delta1)"
+                                "       AND i.latitude>=(l.latitude-delta2)"
+                                "       AND i.latitude<=(l.latitude+delta2))"
+                                "  WHERE l.tagid = ?1 ",
+                                -1, &stmt, NULL);
+  else if(ld->data.shape == MAP_LOCATION_SHAPE_POLYGONS)
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT i.id, i.longitude, i.latitude FROM main.images AS i"
+                                "  JOIN data.locations AS l"
+                                "  ON (l.type = ?2"
+                                "       AND i.longitude>=(l.longitude-delta1)"
+                                "       AND i.longitude<=(l.longitude+delta1)"
+                                "       AND i.latitude>=(l.latitude-delta2)"
+                                "       AND i.latitude<=(l.latitude+delta2))"
+                                "  WHERE l.tagid = ?1 ",
+                                -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, ld->id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, ld->data.shape);
 
+  int i = 0;
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const int id = sqlite3_column_int(stmt, 0);
-    imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
+    if(ld->data.shape == MAP_LOCATION_SHAPE_POLYGONS)
+    {
+      dt_geo_map_display_point_t pt;
+      pt.lon = sqlite3_column_double(stmt, 1);
+      pt.lat = sqlite3_column_double(stmt, 2);
+      if(_is_point_in_polygon(&pt, ld->data.plg_pts, ld->data.polygons->data))
+        imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
+    }
+    else
+      imgs = g_list_prepend(imgs, GINT_TO_POINTER(id));
+    i++;
   }
   sqlite3_finalize(stmt);
+  printf("_map_location_find_images locid %d found %d / %d\n", ld->id, g_list_length(imgs), i);
   return imgs;
 }
 
@@ -387,13 +543,13 @@ void dt_map_location_update_locations(const guint imgid, const GList *tags)
 }
 
 // update location's images - remove old ones and add new ones
-gboolean dt_map_location_update_images(const guint locid)
+gboolean dt_map_location_update_images(dt_location_draw_t *ld)
 {
   // get previous images
-  GList *imgs = dt_tag_get_images(locid);
+  GList *imgs = dt_tag_get_images(ld->id);
 
   // find images in that location
-  GList *new_imgs = _map_location_find_images(locid);
+  GList *new_imgs = _map_location_find_images(ld);
 
   gboolean res = FALSE;
   // detach images which are not in location anymore
@@ -401,7 +557,7 @@ gboolean dt_map_location_update_images(const guint locid)
   {
     if(!g_list_find(new_imgs, img->data))
     {
-      dt_tag_detach(locid, GPOINTER_TO_INT(img->data), FALSE, FALSE);
+      dt_tag_detach(ld->id, GPOINTER_TO_INT(img->data), FALSE, FALSE);
       res = TRUE;
     }
   }
@@ -411,7 +567,7 @@ gboolean dt_map_location_update_images(const guint locid)
   {
     if(!g_list_find(imgs, img->data))
     {
-      dt_tag_attach(locid, GPOINTER_TO_INT(img->data), FALSE, FALSE);
+      dt_tag_attach(ld->id, GPOINTER_TO_INT(img->data), FALSE, FALSE);
       res = TRUE;
     }
   }
@@ -444,7 +600,36 @@ gboolean dt_map_location_included(const float lon, const float lat,
   return included;
 }
 
+// get the map box containing the polygon + flat polygons
+GList *dt_map_location_convert_polygons(void *polygons, dt_map_box_t *bbox, int *nb_pts)
+{
+  const int nb = g_list_length(polygons);
+  dt_geo_map_display_point_t *points = malloc(nb * sizeof(dt_geo_map_display_point_t));
+  dt_geo_map_display_point_t *p = points;
+  dt_map_box_t bb = {180.0, -90.0, -180, 90.0};
+  GList *npol = NULL;
 
+  for(GList *pol = polygons; pol; pol = g_list_next(pol), p++)
+  {
+    dt_geo_map_display_point_t *pt = (dt_geo_map_display_point_t *)pol->data;
+    p->lat = pt->lat;
+    p->lon = pt->lon;
+    npol = g_list_prepend(npol, p);
+    if(bbox)
+    {
+      bb.lon1 = (pt->lon < bb.lon1) ? pt->lon : bb.lon1;
+      bb.lon2 = (pt->lon > bb.lon2) ? pt->lon : bb.lon2;
+      bb.lat1 = (pt->lat > bb.lat1) ? pt->lat : bb.lat1;
+      bb.lat2 = (pt->lat < bb.lat2) ? pt->lat : bb.lat2;
+    }
+  }
+  npol = g_list_reverse(npol);
+  if(bbox)
+    memcpy(bbox, &bb, sizeof(dt_map_box_t));
+  if(nb_pts)
+    *nb_pts = nb;
+  return (npol);
+}
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/map_locations.h
+++ b/src/common/map_locations.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "common/geo.h"
 #include <glib.h>
 #include <sqlite3.h>
 #include <stdint.h>
@@ -26,6 +27,7 @@ typedef enum dt_map_locations_type_t
 {
   MAP_LOCATION_SHAPE_ELLIPSE,
   MAP_LOCATION_SHAPE_RECTANGLE,
+  MAP_LOCATION_SHAPE_POLYGONS,
   MAP_LOCATION_SHAPE_MAX
 } dt_map_locations_type_t;
 
@@ -40,6 +42,8 @@ typedef struct dt_map_location_data_t
 {
   double lon, lat, delta1, delta2, ratio;
   int shape;
+  GList *polygons;
+  int plg_pts;
 } dt_map_location_data_t;
 
 typedef struct dt_location_draw_t
@@ -68,6 +72,9 @@ void dt_map_location_rename(const guint locid, const char *const name);
 // does the location name already exist
 gboolean dt_map_location_name_exists(const char *const name);
 
+// gets location's images number
+int dt_map_location_get_images_count(const guint locid);
+
 // retrieve list of tags which are on that path
 // to be freed with dt_map_location_free_result()
 GList *dt_map_location_get_locations_by_path(const gchar *path,
@@ -75,8 +82,7 @@ GList *dt_map_location_get_locations_by_path(const gchar *path,
 
 // retrieve list of locations which are on the map
 // to be freed with g_list_free_full(list, g_free)
-GList *dt_map_location_get_locations_on_map(const double lat0, const double lat1,
-                                            const double lon0, const double lon1);
+GList *dt_map_location_get_locations_on_map(const dt_map_box_t *const bbox);
 
 // free map location list
 void dt_map_location_free_result(GList **result);
@@ -97,7 +103,7 @@ GList *dt_map_location_find_locations(const guint imgid);
 void dt_map_location_update_locations(const guint imgid, const GList *tags);
 
 // update location's images - remove old ones and add new ones
-gboolean dt_map_location_update_images(const guint locid);
+gboolean dt_map_location_update_images(dt_location_draw_t *ld);
 
 // return root tag for location geotagging
 const char *dt_map_location_data_tag_root();
@@ -105,6 +111,16 @@ const char *dt_map_location_data_tag_root();
 // tell if the point (lon, lat) belongs to location
 gboolean dt_map_location_included(const float lon, const float lat,
                                   dt_map_location_data_t *g);
+
+// get the map box containing the polygon + flat polygons
+GList *dt_map_location_convert_polygons(void *polygons, dt_map_box_t *bbox, int *nb_pts);
+
+// get the polygons for the given location
+void dt_map_location_get_polygons(dt_location_draw_t *ld);
+
+// free flat polygons
+void dt_map_location_free_polygons(dt_location_draw_t *ld);
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -195,6 +195,10 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
 
   { "dt-trouble-message", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 3, pointer_trouble, NULL,
     FALSE }, // DT_SIGNAL_TROUBLE_MESSAGE
+
+  { "dt-location-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL,
+    TRUE }, // DT_SIGNAL_LOCATION_CHANGED
+
 };
 
 static GType _signal_type;

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -247,6 +247,9 @@ typedef enum dt_signal_t
   /* \brief This signal is raised when a module is in trouble and message is to be displayed */
   DT_SIGNAL_TROUBLE_MESSAGE,
 
+  /* \brief This signal is raised when the user choses a new location from map (module location)*/
+  DT_SIGNAL_LOCATION_CHANGED,
+
   /* do not touch !*/
   DT_SIGNAL_COUNT
 } dt_signal_t;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2070,6 +2070,22 @@ void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h
   FINISH
 }
 
+void dtgtk_cairo_paint_polygon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.0, 0.3);
+  cairo_line_to(cr, 0.7, 0.0);
+  cairo_line_to(cr, 0.5, 0.5);
+  cairo_line_to(cr, 1.0, 0.6);
+  cairo_line_to(cr, 0.6, 1.0);
+  cairo_line_to(cr, 0.3, 0.8);
+  cairo_line_to(cr, 0.0, 0.3);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -175,6 +175,8 @@ void dtgtk_cairo_paint_display2(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 void dtgtk_cairo_paint_rect_landscape(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a portrait rectangle */
 void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a polygon */
+void dtgtk_cairo_paint_polygon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a zoom icon */
 void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a duplicate/multi instance indicator */

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1978,6 +1978,7 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key, const guint co
   GtkWidget *w = gtk_spin_button_new_with_range(min, max, 1.0);
   gtk_widget_set_name(w, key);
   gtk_widget_set_hexpand(w, FALSE);
+  dt_gui_key_accel_block_on_focus_connect(w);
   gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w), 0);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), dt_conf_get_int(key));
   gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -48,14 +48,6 @@ typedef struct dt_lib_datetime_t
   GtkWidget *sign;
 } dt_lib_datetime_t;
 
-typedef struct dt_map_box_t
-{
-  float lon1;
-  float lon2;
-  float lat1;
-  float lat2;
-} dt_map_box_t;
-
 #ifdef HAVE_MAP
 typedef struct dt_lib_tracks_data_t
 {

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -86,9 +86,9 @@ typedef enum dt_map_position_name_sort_id
   DT_MAP_POSITION_SORT_NAME_ID,
 } dt_map_position_name_sort_id;
 
-const DTGTKCairoPaintIconFunc location_shapes[] = { dtgtk_cairo_paint_masks_circle,
-                                                    dtgtk_cairo_paint_rect_landscape,
-                                                    dtgtk_cairo_paint_polygon};
+const DTGTKCairoPaintIconFunc location_shapes[] = { dtgtk_cairo_paint_masks_circle,   // MAP_LOCATION_SHAPE_ELLIPSE
+                                                    dtgtk_cairo_paint_rect_landscape, // MAP_LOCATION_SHAPE_RECTANGLE
+                                                    dtgtk_cairo_paint_polygon};       // MAP_LOCATION_SHAPE_POLYGONS
 
 static gboolean _mouse_scroll(GtkWidget *treeview, GdkEventScroll *event,
                               dt_lib_module_t *self)
@@ -341,7 +341,7 @@ static void _shape_button_clicked(GtkButton *button, dt_lib_module_t *self)
   int shape = dt_conf_get_int("plugins/map/locationshape");
   shape++;
   if((shape > G_N_ELEMENTS(location_shapes) - 1) ||
-     (!d->polygons && location_shapes[shape] == dtgtk_cairo_paint_masks_drawn))
+     (!d->polygons && shape == MAP_LOCATION_SHAPE_POLYGONS))
     shape = 0;
   dt_conf_set_int("plugins/map/locationshape", shape);
 
@@ -927,7 +927,7 @@ static gboolean _click_on_view(GtkWidget *view, GdkEventButton *event, dt_lib_mo
 
 void gui_init(dt_lib_module_t *self)
 {
-  dt_lib_map_locations_t *d = (dt_lib_map_locations_t *)malloc(sizeof(dt_lib_map_locations_t));
+  dt_lib_map_locations_t *d = (dt_lib_map_locations_t *)g_malloc0(sizeof(dt_lib_map_locations_t));
   self->data = d;
 
   self->widget =  gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -88,7 +88,7 @@ typedef enum dt_map_position_name_sort_id
 
 const DTGTKCairoPaintIconFunc location_shapes[] = { dtgtk_cairo_paint_masks_circle,
                                                     dtgtk_cairo_paint_rect_landscape,
-                                                    dtgtk_cairo_paint_masks_drawn};
+                                                    dtgtk_cairo_paint_polygon};
 
 static gboolean _mouse_scroll(GtkWidget *treeview, GdkEventScroll *event,
                               dt_lib_module_t *self)
@@ -415,7 +415,6 @@ static void _view_map_geotag_changed(gpointer instance, GList *imgs, const int n
   // one of the other location has been clicked on the map
   if(newlocid)
   {
-    printf("_view_map_geotag_changed locid %d\n", newlocid);
     GtkTreeIter iter;
     GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->view));
     if(gtk_tree_model_get_iter_first(model, &iter))
@@ -436,7 +435,6 @@ static void _view_map_geotag_changed(gpointer instance, GList *imgs, const int n
   }
   else
   {
-    printf("_view_map_geotag_changed imgs %d\n", g_list_length(imgs));
     for(GList* img = imgs; img; img = g_list_next(img))
     {
       // find new locations for that image
@@ -552,7 +550,6 @@ static void _name_editing_done(GtkCellEditable *editable, dt_lib_module_t *self)
             g.polygons = d->polygons;
             dt_view_map_add_location(darktable.view_manager, &g, locid);
             const int count = dt_map_location_get_images_count(locid);
-  printf("_name_editing_done locid %d count %d\n", locid, count);
             if(g_strstr_len(name, -1, "|"))
             {
               // the user wants to insert some group(s). difficult to handle the tree => reset
@@ -701,10 +698,9 @@ static void _pop_menu_delete_location(GtkWidget *menuitem, dt_lib_module_t *self
     gtk_tree_model_get(model, &iter, DT_MAP_LOCATION_COL_ID, &locid, -1);
     if(locid > 0)
     {
-      // remove the location afterwards to avoid map movement
-      _signal_location_change(self);
       dt_view_map_location_action(darktable.view_manager, MAP_LOCATION_ACTION_REMOVE);
       dt_map_location_delete(locid);
+      _signal_location_change(self);
     }
     // update the treeview
     GtkTreeIter parent;
@@ -999,7 +995,8 @@ void gui_init(dt_lib_module_t *self)
   d->shape_button_handler = g_signal_connect(G_OBJECT(d->shape_button), "clicked",
                                              G_CALLBACK(_shape_button_clicked), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->shape_button ),
-                              _("select the shape of the location\'s limits on the map, circle or rectangle"));
+                              _("select the shape of the location\'s limits on the map, circle or rectangle"
+                                "\nor even polygon if available (select first a polygon place in 'find location' module)"));
 
   d->new_button = dt_ui_button_new(_("new location"),
                                    _("add a new location on the center of the visible map"), NULL);

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -53,7 +53,7 @@ uint32_t container(dt_lib_module_t *self)
 typedef struct dt_lib_map_settings_t
 {
   GtkWidget *show_osd_checkbutton, *filtered_images_checkbutton, *map_source_dropdown;
-  GtkWidget *images_thumb, *max_images_entry, *epsilon_factor, *min_images;
+  GtkWidget *images_thumb, *max_images_entry, *epsilon_factor, *min_images, *max_outline_nodes;
 } dt_lib_map_settings_t;
 
 int position()
@@ -139,6 +139,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
 
   int line = 0;
+  d->max_outline_nodes = dt_gui_preferences_int(grid, "plugins/map/max_outline_nodes", 0, line++);
   d->show_osd_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/show_map_osd", 0, line++, FALSE);
   g_signal_connect(G_OBJECT(d->show_osd_checkbutton), "toggled", G_CALLBACK(_show_osd_toggled), NULL);
   d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn", 0, line++, FALSE);
@@ -165,6 +166,7 @@ void gui_reset(dt_lib_module_t *self)
   dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)self->data;
   dt_gui_preferences_bool_reset(d->show_osd_checkbutton);
   dt_gui_preferences_bool_reset(d->filtered_images_checkbutton);
+  dt_gui_preferences_int_reset(d->max_outline_nodes);
   dt_gui_preferences_int_reset(d->max_images_entry);
   dt_gui_preferences_int_reset(d->epsilon_factor);
   dt_gui_preferences_int_reset(d->min_images);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -77,7 +77,7 @@ typedef struct dt_map_t
   gboolean drop_filmstrip_activated;
   gboolean filter_images_drawn;
   int max_images_drawn;
-  float lat0, lat1, lon0, lon1;
+  dt_map_box_t bbox;
   int time_out;
   int timeout_event_source;
   int thumbnail;
@@ -182,6 +182,12 @@ static void _view_map_build_main_query(dt_map_t *lib);
 static gboolean _view_map_center_on_image_list(dt_view_t *self, const char *table);
 /* center map on the given image */
 static void _view_map_center_on_image(dt_view_t *self, const int32_t imgid);
+
+static OsmGpsMapPolygon *_view_map_add_polygon_location(dt_map_t *lib, dt_location_draw_t *ld);
+static gboolean _view_map_remove_polygon(const dt_view_t *view, OsmGpsMapPolygon *polygon);
+static OsmGpsMapImage *_view_map_draw_location(dt_map_t *lib, dt_location_draw_t *ld,
+                                               const gboolean main);
+static void _view_map_remove_location(dt_map_t *lib, dt_location_draw_t *ld);
 
 const char *name(const dt_view_t *self)
 {
@@ -744,6 +750,7 @@ void cleanup(dt_view_t *self)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_map_selection_changed), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_map_check_preference_changed), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_map_geotag_changed), self);
 
   if(darktable.gui)
   {
@@ -761,8 +768,21 @@ void cleanup(dt_view_t *self)
       g_slist_free_full(lib->images, g_free);
       lib->images = NULL;
     }
+    if(lib->loc.main.id)
+    {
+      _view_map_remove_location(lib, &lib->loc.main);
+      lib->loc.main.id = 0;
+    }
     if(lib->loc.others)
     {
+      printf("others cleanup\n");
+      for(GList *other = lib->loc.others; other; other = g_list_next(other))
+      {
+        dt_location_draw_t *d = (dt_location_draw_t *)other->data;
+        _view_map_remove_location(lib, d);
+        // polygons are freed only from others list
+        dt_map_location_free_polygons(d);
+      }
       g_list_free_full(lib->loc.others, g_free);
       lib->loc.others = NULL;
     }
@@ -838,23 +858,29 @@ static gboolean _view_map_redraw(gpointer user_data)
   return FALSE; // remove the function again
 }
 
-// when map is moving we often get incorrect (even negative) values.
-// keep the last positive values here to limit wrong effects (still not perfect)
-static void _view_map_thumb_angles(dt_map_t *lib, const float lat0, const float lon0,
-                                   float *dlat_min, float *dlon_min)
+static void _view_map_angles(dt_map_t *lib, const gint pixels, const float lat,
+                             const float lon, float *dlat_min, float *dlon_min)
 {
-  OsmGpsMapPoint *pt0 = osm_gps_map_point_new_degrees(lat0, lon0);
+  OsmGpsMapPoint *pt0 = osm_gps_map_point_new_degrees(lat, lon);
   OsmGpsMapPoint *pt1 = osm_gps_map_point_new_degrees(0.0, 0.0);
   gint pixel_x = 0, pixel_y = 0;
   osm_gps_map_convert_geographic_to_screen(lib->map, pt0, &pixel_x, &pixel_y);
-  osm_gps_map_convert_screen_to_geographic(lib->map, pixel_x + thumb_size,
-                                           pixel_y + thumb_size, pt1);
+  osm_gps_map_convert_screen_to_geographic(lib->map, pixel_x + pixels,
+                                           pixel_y + pixels, pt1);
   float lat1 = 0.0, lon1 = 0.0;
   osm_gps_map_point_get_degrees(pt1, &lat1, &lon1);
   osm_gps_map_point_free(pt0);
   osm_gps_map_point_free(pt1);
-  *dlat_min = lat0 - lat1;
-  *dlon_min = lon1 - lon0;
+  *dlat_min = lat - lat1;
+  *dlon_min = lon1 - lon;
+}
+
+// when map is moving we often get incorrect (even negative) values.
+// keep the last positive values here to limit wrong effects (still not perfect)
+static void _view_map_thumb_angles(dt_map_t *lib, const float lat, const float lon,
+                                   float *dlat_min, float *dlon_min)
+{
+  _view_map_angles(lib, thumb_size, lat, lon, dlat_min, dlon_min);
   if(*dlat_min > 0.0 && *dlon_min > 0.0)
   {
     lib->thumb_lat_angle = *dlat_min;
@@ -899,14 +925,13 @@ static double _view_map_get_angles_ratio(const dt_map_t *lib, const float lat0,
 }
 
 static GdkPixbuf *_draw_location(dt_map_t *lib, int *width, int *height,
-                                 const int shape, const double lat, const double lon,
-                                 const double del1, const double del2,
+                                 dt_map_location_data_t *data,
                                  const gboolean main)
 {
-  float pixel_lon = _view_map_angles_to_pixels(lib, lat, lon, del1);
-  float pixel_lat = pixel_lon * del2 / del1;
+  float pixel_lon = _view_map_angles_to_pixels(lib, data->lat, data->lon, data->delta1);
+  float pixel_lat = pixel_lon * data->delta2 * data->ratio / data->delta1;
   GdkPixbuf *draw = NULL;
-  if(shape == MAP_LOCATION_SHAPE_ELLIPSE)
+  if(data->shape == MAP_LOCATION_SHAPE_ELLIPSE)
   {
     draw = _draw_ellipse(pixel_lon, pixel_lat, main);
     if(pixel_lon > pixel_lat)
@@ -914,7 +939,7 @@ static GdkPixbuf *_draw_location(dt_map_t *lib, int *width, int *height,
     else
       pixel_lon = pixel_lat;
   }
-  else if(shape == MAP_LOCATION_SHAPE_RECTANGLE)
+  else if(data->shape == MAP_LOCATION_SHAPE_RECTANGLE)
     draw = _draw_rectangle(pixel_lon, pixel_lat, main);
 
   if(width) *width = (int)pixel_lon;
@@ -922,92 +947,182 @@ static GdkPixbuf *_draw_location(dt_map_t *lib, int *width, int *height,
   return draw;
 }
 
-static OsmGpsMapImage *_view_map_draw_location(dt_map_t *lib, const int shape,
-                                               const double lat, const double lon,
-                                               const double del1, const double del2,
+dt_location_draw_t *_others_location_draw(dt_map_t *lib, const int locid)
+{
+  for(GList *other = lib->loc.others; other; other = g_list_next(other))
+  {
+    dt_location_draw_t *d = (dt_location_draw_t *)other->data;
+    if(d->id == locid)
+      return d;
+  }
+  return NULL;
+}
+
+GList *_others_location(GList *others, const int locid)
+{
+  for(GList *other = others; other; other = g_list_next(other))
+  {
+    dt_location_draw_t *d = (dt_location_draw_t *)other->data;
+    if(d->id == locid)
+      return other;
+  }
+  return NULL;
+}
+
+static OsmGpsMapImage *_view_map_draw_location(dt_map_t *lib, dt_location_draw_t *ld,
                                                const gboolean main)
 {
-  GdkPixbuf *draw = _draw_location(lib, NULL, NULL, shape, lat, lon, del1, del2, main);
-  OsmGpsMapImage *location = NULL;
-  if(draw)
+  printf("_view_map_draw_location %d nb pts %d\n", ld->id, ld->data.plg_pts);
+  if(ld->data.shape != MAP_LOCATION_SHAPE_POLYGONS)
   {
-    location = osm_gps_map_image_add_with_alignment(lib->map, lat, lon, draw, 0.5, 0.5);
-    g_object_unref(draw);
+    GdkPixbuf *draw = _draw_location(lib, NULL, NULL, &ld->data, main);
+    OsmGpsMapImage *location = NULL;
+    if(draw)
+    {
+      location = osm_gps_map_image_add_with_alignment(lib->map, ld->data.lat, ld->data.lon, draw, 0.5, 0.5);
+      g_object_unref(draw);
+    }
+    return location;
   }
-  return location;
+  else
+  {
+    if(!ld->data.polygons && &ld->data == &lib->loc.main.data)
+    {
+      printf("_view_map_draw_location grab polygons %d\n", lib->loc.main.id);
+      dt_location_draw_t *d = _others_location_draw(lib, lib->loc.main.id);
+      if(d)
+      {
+        ld->data.polygons = d->data.polygons;
+        ld->data.plg_pts = d->data.plg_pts;
+      }
+    }
+    if(!ld->data.polygons)
+      dt_map_location_get_polygons(ld);
+    OsmGpsMapPolygon *location = _view_map_add_polygon_location(lib, ld);
+    return (OsmGpsMapImage *)location;
+  }
 }
 
-static void _view_map_draw_locations(const dt_view_t *self)
+static void _view_map_remove_location(dt_map_t *lib, dt_location_draw_t *ld)
 {
-  // remove previous one if any
-  dt_map_t *lib = (dt_map_t *)self->data;
-  if(lib->loc.main.location)
+  printf("view_map_remove_location %d image %p\n", ld->id, ld->location);
+  if(ld->location)
   {
-    osm_gps_map_image_remove(lib->map, lib->loc.main.location);
-    lib->loc.main.location = NULL;
+    if(ld->data.shape != MAP_LOCATION_SHAPE_POLYGONS)
+      osm_gps_map_image_remove(lib->map, ld->location);
+    else
+      osm_gps_map_polygon_remove(lib->map, (OsmGpsMapPolygon *)ld->location);
+    ld->location = NULL;
   }
-  if(lib->loc.main.id)
+}
+
+static void _view_map_delete_other_location(dt_map_t *lib, GList *other)
+{
+  dt_location_draw_t *d = (dt_location_draw_t *)other->data;
+  _view_map_remove_location(lib, d);
+  dt_map_location_free_polygons(d);
+  lib->loc.others = g_list_remove_link(lib->loc.others, other);
+  g_free(other->data);
+  g_list_free(other);
+}
+
+static void _view_map_draw_main_location(dt_map_t *lib, dt_location_draw_t *ld)
+{
+  printf("_view_map_draw_main_location %d over %d\n", ld->id, lib->loc.main.id);
+  if(lib->loc.main.id && (ld != &lib->loc.main))
+  {
+    // save the data to others locations (including polygons)
+    dt_location_draw_t *d = _others_location_draw(lib, lib->loc.main.id);
+    if(!d)
+    {
+      d = g_malloc0(sizeof(dt_location_draw_t));
+      lib->loc.others = g_list_append(lib->loc.others, d);
+    }
+    if(d)
+    {
+      // copy everything except the drawn location
+      memcpy(d, &lib->loc.main, sizeof(dt_location_draw_t));
+      d->location = NULL;
+      if(dt_conf_get_bool("plugins/map/showalllocations"))
+        d->location = _view_map_draw_location(lib, d, FALSE);
+    }
+  }
+  _view_map_remove_location(lib, &lib->loc.main);
+
+  if(ld && ld->id)
+  {
+    memcpy(&lib->loc.main, ld, sizeof(dt_location_draw_t));
+    lib->loc.main.location = _view_map_draw_location(lib, &lib->loc.main, TRUE);
+    dt_location_draw_t *d = _others_location_draw(lib, ld->id);
+    if(d && d->location)
+      _view_map_remove_location(lib, d);
+  }
+}
+
+static void _view_map_draw_other_locations(dt_map_t *lib, dt_map_box_t *bbox)
+{
+  if(!dt_conf_get_bool("plugins/map/showalllocations"))
   {
     for(GList *other = lib->loc.others; other; other = g_list_next(other))
     {
       dt_location_draw_t *d = (dt_location_draw_t *)other->data;
-      // remove from map the corresponding other location if any
-      if(d->id == lib->loc.main.id)
+      printf("_view_map_draw_other_locations\n");
+      _view_map_remove_location(lib, d);
+    }
+  }
+  else
+  {
+    GList *others = dt_map_location_get_locations_on_map(bbox);
+    // remove those which are not any more on the map
+    for(GList *other = lib->loc.others; other; other = g_list_next(other))
+    {
+      dt_location_draw_t *d = (dt_location_draw_t *)other->data;
+      if(d->id != lib->loc.main.id)
       {
-        // refresh the other data from main location
-        memcpy(&d->data, &lib->loc.main.data, sizeof(dt_map_location_data_t));
-        if((OsmGpsMapImage *)d->location)
+        GList *other2 = _others_location(others, d->id);
+        if(!other2)
         {
-          osm_gps_map_image_remove(lib->map, (OsmGpsMapImage *)d->location);
-          d->location = NULL;
+          printf("_view_map_draw_other_locations other remove and delete %d\n", d->id);
+          GList *next = g_list_next(other);
+          _view_map_delete_other_location(lib, other);
+          if(!next) break;
+          other = next;
         }
       }
-      // redraw the missing other location if any
-      else
+    }
+    // add the new ones
+    for(GList *other = others; other; other = g_list_next(other))
+    {
+      dt_location_draw_t *d = (dt_location_draw_t *)other->data;
+      GList *other2 = _others_location(lib->loc.others, d->id);
+      if(!other2)
       {
-        if(!d->location)
-          d->location = (void *)_view_map_draw_location(lib, d->data.shape, d->data.lat, d->data.lon,
-                                                        d->data.delta1, d->data.delta2 * d->data.ratio,
-                                                        FALSE);
+        d = (dt_location_draw_t *)other->data;
+        lib->loc.others = g_list_append(lib->loc.others, other->data);
+        other->data = NULL; // to avoid it gets freed
+        if(d->data.shape == MAP_LOCATION_SHAPE_POLYGONS)
+        {
+          if(d->id == lib->loc.main.id)
+          {
+            d->data.polygons = lib->loc.main.data.polygons;
+            d->data.plg_pts = lib->loc.main.data.plg_pts;
+          }
+          if(!d->data.polygons)
+            dt_map_location_get_polygons(d);
+        }
+        printf("_view_map_draw_other_locations other added %d\n", d->id);
       }
     }
-    // draw the new one
-    lib->loc.main.location = _view_map_draw_location(lib, lib->loc.main.data.shape,
-                                                     lib->loc.main.data.lat, lib->loc.main.data.lon,
-                                                     lib->loc.main.data.delta1,
-                                                     lib->loc.main.data.delta2 * lib->loc.main.data.ratio,
-                                                     TRUE);
-  }
-}
-
-static void _view_map_draw_other_locations(const dt_view_t *self,
-                                           const double lat0, const double lat1,
-                                           const double lon0, const double lon1)
-{
-  dt_map_t *lib = (dt_map_t *)self->data;
-  if(lib->loc.others)
-  {
+    // free the new list
+    g_list_free_full(others, g_free);
+    // display again location except polygons and the selected one
     for(GList *other = lib->loc.others; other; other = g_list_next(other))
     {
       dt_location_draw_t *d = (dt_location_draw_t *)other->data;
-      if((OsmGpsMapImage *)d->location)
-        osm_gps_map_image_remove(lib->map, (OsmGpsMapImage *)d->location);
-    }
-    g_list_free_full(lib->loc.others, g_free);
-    lib->loc.others = NULL;
-  }
-  if(dt_conf_get_bool("plugins/map/showalllocations"))
-  {
-    lib->loc.others = dt_map_location_get_locations_on_map(lat0, lat1, lon0, lon1);
-    for(GList *other = lib->loc.others; other; other = g_list_next(other))
-    {
-      dt_location_draw_t *d = (dt_location_draw_t *)other->data;
-      d->location = NULL;
-      if(lib->loc.main.id != d->id)
+      if((!lib->loc.main.id || lib->loc.main.id != d->id) && !d->location)
       {
-        d->location = (void *)_view_map_draw_location(lib, d->data.shape, d->data.lat, d->data.lon,
-                                                      d->data.delta1, d->data.delta2 * d->data.ratio,
-                                                      FALSE);
+        printf("_view_map_draw_other_locations not main %d\n", d->id);
+        d->location = _view_map_draw_location(lib, d, FALSE);
       }
     }
   }
@@ -1020,7 +1135,7 @@ static void _view_map_update_location_geotag(dt_view_t *self)
   {
     // update coordinates
     dt_map_location_set_data(lib->loc.main.id, &lib->loc.main.data);
-    if(dt_map_location_update_images(lib->loc.main.id))
+    if(dt_map_location_update_images(&lib->loc.main))
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   }
 }
@@ -1162,6 +1277,21 @@ static gboolean _view_map_draw_images(gpointer user_data)
   return needs_redraw;
 }
 
+static void _view_map_get_bounding_box(dt_map_t *lib, dt_map_box_t *bbox)
+{
+  OsmGpsMapPoint bb[2];
+  osm_gps_map_get_bbox(lib->map, &bb[0], &bb[1]);
+  dt_map_box_t box = {0.0};
+
+  osm_gps_map_point_get_degrees(&bb[0], &box.lat1, &box.lon1);
+  osm_gps_map_point_get_degrees(&bb[1], &box.lat2, &box.lon2);
+  box.lat1 = CLAMP(box.lat1, -90.0, 90.0);
+  box.lat2 = CLAMP(box.lat2, -90.0, 90.0);
+  box.lon1 = CLAMP(box.lon1, -180.0, 180.0);
+  box.lon2 = CLAMP(box.lon2, -180.0, 180.0);
+  memcpy(bbox, &box, sizeof(dt_map_box_t));
+}
+
 static void _view_map_changed_callback_delayed(gpointer user_data)
 {
   dt_view_t *self = (dt_view_t *)user_data;
@@ -1194,17 +1324,7 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
     if(prefs_changed) _view_map_build_main_query(lib);
 
     /* get bounding box coords */
-    OsmGpsMapPoint bb[2];
-    osm_gps_map_get_bbox(lib->map, &bb[0], &bb[1]);
-    float bb_0_lat = 0.0, bb_0_lon = 0.0, bb_1_lat = 0.0, bb_1_lon = 0.0;
-    osm_gps_map_point_get_degrees(&bb[0], &bb_0_lat, &bb_0_lon);
-    osm_gps_map_point_get_degrees(&bb[1], &bb_1_lat, &bb_1_lon);
-    bb_0_lat = CLAMP(bb_0_lat, -90.0, 90.0);
-    bb_1_lat = CLAMP(bb_1_lat, -90.0, 90.0);
-    bb_0_lon = CLAMP(bb_0_lon, -180.0, 180.0);
-    bb_1_lon = CLAMP(bb_1_lon, -180.0, 180.0);
-    lib->lat0 = bb_0_lat, lib->lat1 = bb_1_lat;
-    lib->lon0 = bb_0_lon, lib->lon1 = bb_1_lon;
+    _view_map_get_bounding_box(lib, &lib->bbox);
 
     /* get map view state and store  */
     int zoom;
@@ -1219,10 +1339,10 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
     DT_DEBUG_SQLITE3_RESET(lib->main_query);
 
     /* bind bounding box coords for the main query */
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 1, bb_0_lon);
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 2, bb_1_lon);
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 3, bb_0_lat);
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 4, bb_1_lat);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 1, lib->bbox.lon1);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 2, lib->bbox.lon2);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 3, lib->bbox.lat1);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(lib->main_query, 4, lib->bbox.lat2);
 
     // count the images
     int img_count = 0;
@@ -1324,8 +1444,9 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
     }
 
     needs_redraw = _view_map_draw_images(self);
-    _view_map_draw_locations(self);
-    _view_map_draw_other_locations(self, bb_0_lat, bb_1_lat, bb_0_lon, bb_1_lon);
+    printf("_view_map_changed_callback_delayed\n");
+    _view_map_draw_main_location(lib, &lib->loc.main);
+    _view_map_draw_other_locations(lib, &lib->bbox);
   }
 
   // not exactly thread safe, but should be good enough for updating the display
@@ -1594,11 +1715,7 @@ static gboolean _view_map_motion_notify_callback(GtkWidget *widget, GdkEventMoti
 
     int width;
     int height;
-    GdkPixbuf *location = _draw_location(lib, &width, &height,
-                                         lib->loc.main.data.shape, lib->loc.main.data.lat,
-                                         lib->loc.main.data.lon, lib->loc.main.data.delta1,
-                                         lib->loc.main.data.delta2 * lib->loc.main.data.ratio,
-                                         TRUE);
+    GdkPixbuf *location = _draw_location(lib, &width, &height, &lib->loc.main.data, TRUE);
     if(location)
     {
       GtkWidget *image = gtk_image_new_from_pixbuf(location);
@@ -1680,6 +1797,7 @@ static gboolean _view_map_motion_notify_callback(GtkWidget *widget, GdkEventMoti
 
 static gboolean _zoom_and_center(const gint x, const gint y, const int direction, dt_view_t *self)
 {
+  printf("_zoom_and_center\n");
     // try to keep the center of zoom at the mouse position
   dt_map_t *lib = (dt_map_t *)self->data;
   int zoom, max_zoom;
@@ -1718,7 +1836,7 @@ static gboolean _zoom_and_center(const gint x, const gint y, const int direction
 static gboolean _view_map_scroll_event(GtkWidget *w, GdkEventScroll *event, dt_view_t *self)
 {
   dt_map_t *lib = (dt_map_t *)self->data;
-
+printf("_view_map_scroll_event\n");
   // check if the click was on image(s) or just some random position
   dt_map_image_t *entry = _view_map_get_entry_at_pos(self, event->x, event->y);
   if(entry)
@@ -1761,7 +1879,7 @@ static gboolean _view_map_scroll_event(GtkWidget *w, GdkEventScroll *event, dt_v
           lib->loc.main.data.delta2 /= 1.1;
         }
       }
-      _view_map_draw_locations(self);
+      _view_map_draw_main_location(lib, &lib->loc.main);
       _view_map_update_location_geotag(self);
       _view_map_signal_change_wait(self, 5);  // wait 5/10 sec after last scroll
       return TRUE;
@@ -1791,7 +1909,8 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
   if(e->button == 1)
   {
     // check if the click was in a location form - crtl gives priority to images
-    if(lib->loc.main.id > 0 && !dt_modifier_is(e->state, GDK_CONTROL_MASK))
+    if(lib->loc.main.id > 0 && (lib->loc.main.data.shape != MAP_LOCATION_SHAPE_POLYGONS)
+                            && !dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
 
       OsmGpsMapPoint *p = osm_gps_map_get_event_location(lib->map, e);
@@ -1809,7 +1928,8 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
       }
     }
     // check if another location is clicked - ctrl gives priority to images
-    if (!dt_modifier_is(e->state, GDK_CONTROL_MASK))
+    if (!dt_modifier_is(e->state, GDK_CONTROL_MASK) &&
+        dt_conf_get_bool("plugins/map/showalllocations"))
     {
       OsmGpsMapPoint *p = osm_gps_map_get_event_location(lib->map, e);
       float lat, lon;
@@ -1886,7 +2006,7 @@ static gboolean _view_map_display_selected(gpointer user_data)
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
   gboolean done = FALSE;
-
+printf("_view_map_display_selected\n");
   // selected images ?
   done = _view_map_center_on_image_list(self, "main.selected_images");
 
@@ -2031,12 +2151,16 @@ void connect_key_accels(dt_view_t *self)
 
 static void _view_map_center_on_location(const dt_view_t *view, gdouble lon, gdouble lat, gdouble zoom)
 {
+  printf("_view_map_center_on_location\n");
   dt_map_t *lib = (dt_map_t *)view->data;
   osm_gps_map_set_center_and_zoom(lib->map, lat, lon, zoom);
 }
 
 static void _view_map_center_on_bbox(const dt_view_t *view, gdouble lon1, gdouble lat1, gdouble lon2, gdouble lat2)
 {
+  printf("_view_map_center_on_bbox %f %f %f %f\n", lat1, lat2, lon1, lon2);
+
+  printf("osm_gps_map_zoom_fit_bbox\n");
   dt_map_t *lib = (dt_map_t *)view->data;
   osm_gps_map_zoom_fit_bbox(lib->map, lat1, lat2, lon1, lon2);
 }
@@ -2094,17 +2218,89 @@ static gboolean _view_map_remove_pin(const dt_view_t *view, OsmGpsMapImage *pin)
 static OsmGpsMapPolygon *_view_map_add_polygon(const dt_view_t *view, GList *points)
 {
   dt_map_t *lib = (dt_map_t *)view->data;
-
   OsmGpsMapPolygon *poly = osm_gps_map_polygon_new();
   OsmGpsMapTrack* track = osm_gps_map_track_new();
 
+  // angles for 1 pixel;
+  float dlat, dlon;
+  _view_map_angles(lib, 1, (lib->bbox.lat1 + lib->bbox.lat2) * 0.5 ,
+                           (lib->bbox.lon1 + lib->bbox.lon2) * 0.5 , &dlat, &dlon);
+
+  float prev_lat = 0.0;
+  float prev_lon = 0.0;
   for(GList *iter = points; iter; iter = g_list_next(iter))
   {
     dt_geo_map_display_point_t *p = (dt_geo_map_display_point_t *)iter->data;
-    OsmGpsMapPoint* point = osm_gps_map_point_new_degrees(p->lat, p->lon);
-    osm_gps_map_track_add_point(track, point);
+    if((fabs(p->lat - prev_lat) > dlat) || (fabs(p->lon - prev_lon) > dlon))
+    {
+      OsmGpsMapPoint* point = osm_gps_map_point_new_degrees(p->lat, p->lon);
+      osm_gps_map_track_add_point(track, point);
+      prev_lat = p->lat;
+      prev_lon = p->lon;
+    }
   }
 
+  g_object_set(poly, "track", track, (gchar *)0);
+  g_object_set(poly, "editable", FALSE, (gchar *)0);
+  g_object_set(poly, "shaded", FALSE, (gchar *)0);
+
+  osm_gps_map_polygon_add(lib->map, poly);
+
+  return poly;
+}
+
+static OsmGpsMapPolygon *_view_map_add_polygon_location(dt_map_t *lib, dt_location_draw_t *ld)
+{
+  OsmGpsMapPolygon *poly = osm_gps_map_polygon_new();
+  OsmGpsMapTrack* track = osm_gps_map_track_new();
+  GdkRGBA color = {.red = 1.0, .green = 1.0, .blue = 0.8, .alpha = 1 };
+  osm_gps_map_track_set_color(track, &color);
+  g_object_set(track, "line-width" , 3.0, (gchar *)0);
+
+  // angles for 1 pixel;
+  float dlat, dlon;
+  _view_map_angles(lib, 1, (lib->bbox.lat1 + lib->bbox.lat2) * 0.5 ,
+                           (lib->bbox.lon1 + lib->bbox.lon2) * 0.5 , &dlat, &dlon);
+  int zoom;
+  g_object_get(G_OBJECT(lib->map), "zoom", &zoom, NULL);
+  // zoom = 20 => mod = 21 ; zoom = 0 => mod = 1
+  const int mod2 = zoom + 1;
+
+ printf("_view_map_add_polygon_location %d nb %d zoom %d mod2 %d\n", ld->id, ld->data.plg_pts, zoom, mod2);
+  // keep a bit of points around the bouding box
+  dt_map_box_t bbox;
+  bbox.lon1 = CLAMP(lib->bbox.lon1 - (lib->bbox.lon2 - lib->bbox.lon1) * 0.25, -180.0, 180);
+  bbox.lon2 = CLAMP(lib->bbox.lon2 + (lib->bbox.lon2 - lib->bbox.lon1) * 0.25, -180.0, 180);
+  bbox.lat1 = CLAMP(lib->bbox.lat1 + (lib->bbox.lat1 - lib->bbox.lat2) * 0.25, -90.0, 90);
+  bbox.lat2 = CLAMP(lib->bbox.lat2 - (lib->bbox.lat1 - lib->bbox.lat2) * 0.25, -90.0, 90);
+
+  int i = 0;
+  int j = 0;
+  float prev_lat = 0.0;
+  float prev_lon = 0.0;
+  for(GList *iter = ld->data.polygons; iter; iter = g_list_next(iter), i++)
+  {
+    dt_geo_map_display_point_t *p = (dt_geo_map_display_point_t *)iter->data;
+    if(p->lat <= bbox.lat1 && p->lat >= bbox.lat2 &&
+       p->lon >= bbox.lon1 && p->lon <= bbox.lon2)
+    {
+      if((fabs(p->lat - prev_lat) > dlat) || (fabs(p->lon - prev_lon) > dlon))
+      {
+        OsmGpsMapPoint* point = osm_gps_map_point_new_degrees(p->lat, p->lon);
+        osm_gps_map_track_add_point(track, point);
+        prev_lat = p->lat;
+        prev_lon = p->lon;
+        j++;
+      }
+    }
+    else if(!(i % mod2))
+    {
+      OsmGpsMapPoint* point = osm_gps_map_point_new_degrees(p->lat, p->lon);
+      osm_gps_map_track_add_point(track, point);
+      j++;
+    }
+  }
+printf("_view_map_add_polygon_location dlat %f dlon %f %d -> %d points\n", dlat, dlon, i, j);
   g_object_set(poly, "track", track, (gchar *)0);
   g_object_set(poly, "editable", FALSE, (gchar *)0);
   g_object_set(poly, "shaded", FALSE, (gchar *)0);
@@ -2196,44 +2392,62 @@ static gboolean _view_map_remove_marker(const dt_view_t *view, dt_geo_map_displa
 
 static void _view_map_add_location(const dt_view_t *view, dt_map_location_data_t *g, const guint locid)
 {
+  printf("_view_map_add_location\n");
   dt_map_t *lib = (dt_map_t *)view->data;
-  lib->loc.main.id = locid;
+  dt_location_draw_t main;
+  main.id = locid;
   if(g)
   {
     if(g->delta1 != 0.0 && g->delta2 != 0.0)
     {
       // existing location
-      memcpy(&lib->loc.main.data, g, sizeof(dt_map_location_data_t));
-
+      memcpy(&main.data, g, sizeof(dt_map_location_data_t));
       const double max_lon = CLAMP(g->lon + g->delta1, -180, 180);
       const double min_lon = CLAMP(g->lon - g->delta1, -180, 180);
       const double max_lat = CLAMP(g->lat + g->delta2, -90, 90);
       const double min_lat = CLAMP(g->lat - g->delta2, -90, 90);
       if(max_lon > min_lon && max_lat > min_lat)
       {
-        if(g->lon < lib->lon0 || g->lon > lib->lon1 ||
-           g->lat > lib->lat0 || g->lat < lib->lat1)
-           _view_map_center_on_bbox(view, min_lon, min_lat, max_lon, max_lat);
-        _view_map_draw_locations(view);
+        // only if new box not imcluded in the current map box
+        if(g->lon < lib->bbox.lon1 || g->lon > lib->bbox.lon2 ||
+           g->lat > lib->bbox.lat1 || g->lat < lib->bbox.lat2)
+           _view_map_center_on_bbox(view, min_lon, max_lat, max_lon, min_lat);
+        _view_map_draw_main_location(lib, &main);
       }
     }
     else
     {
       // this is a new location
-      lib->loc.main.data.shape = g->shape;
-      float lon, lat;
-      g_object_get(G_OBJECT(lib->map), "latitude", &lat, "longitude", &lon, NULL);
-      lib->loc.main.data.lon = lon, lib->loc.main.data.lat = lat;
-      // get a radius angle equivalent to thumb dimension to start with for delta1
-      float dlat, dlon;
-      _view_map_thumb_angles(lib, lib->loc.main.data.lat, lib->loc.main.data.lon, &dlat, &dlon);
-      lib->loc.main.data.ratio = _view_map_get_angles_ratio(lib, lib->loc.main.data.lat,
-                                                            lib->loc.main.data.lon);
-      lib->loc.main.data.delta1 = dlon;
-      lib->loc.main.data.delta2 = dlon / lib->loc.main.data.ratio;
-      _view_map_draw_locations(view);
+      main.data.shape = g->shape;
+      if(g->shape == MAP_LOCATION_SHAPE_POLYGONS)
+      {
+        dt_map_box_t bbox;
+        main.data.polygons = dt_map_location_convert_polygons(g->polygons, &bbox, &main.data.plg_pts);
+        _view_map_center_on_bbox(view, bbox.lon1, bbox.lat2, bbox.lon2, bbox.lat1);
+        main.data.lon = (bbox.lon1 + bbox.lon2) * 0.5;
+        main.data.lat = (bbox.lat1 + bbox.lat2) * 0.5;
+        main.data.ratio = 1;
+//        main.data.ratio = _view_map_get_angles_ratio(lib, main.data.lat, main.data.lon);
+        main.data.delta1 = (bbox.lon2 - bbox.lon1) * 0.5;
+//        main.data.delta2 = main.data.delta1 / main.data.ratio;
+        main.data.delta2 = (bbox.lat1 - bbox.lat2) * 0.5;
+      }
+      else
+      {
+        // create the location on the center of the map
+        float lon, lat;
+        g_object_get(G_OBJECT(lib->map), "latitude", &lat, "longitude", &lon, NULL);
+        main.data.lon = lon, main.data.lat = lat;
+        // get a radius angle equivalent to thumb dimension to start with for delta1
+        float dlat, dlon;
+        _view_map_thumb_angles(lib, main.data.lat, main.data.lon, &dlat, &dlon);
+        main.data.ratio = _view_map_get_angles_ratio(lib, main.data.lat, main.data.lon);
+        main.data.delta1 = dlon;
+        main.data.delta2 = dlon / main.data.ratio;
+      }
+      _view_map_draw_main_location(lib, &main);
       _view_map_update_location_geotag((dt_view_t *)view);
-      _view_map_signal_change_wait((dt_view_t *)view, 1);
+//      _view_map_signal_change_wait((dt_view_t *)view, 1);
     }
   }
 }
@@ -2241,17 +2455,17 @@ static void _view_map_add_location(const dt_view_t *view, dt_map_location_data_t
 static void _view_map_location_action(const dt_view_t *view, const int action)
 {
   dt_map_t *lib = (dt_map_t *)view->data;
-  if(action == MAP_LOCATION_ACTION_REMOVE)
+  if(action == MAP_LOCATION_ACTION_REMOVE && lib->loc.main.id)
   {
+    GList *other = _others_location(lib->loc.others, lib->loc.main.id);
+    if(other)
+      _view_map_delete_other_location(lib, other);
     // remove the main location
-    if(lib->loc.main.location)
-    {
-      osm_gps_map_image_remove(lib->map, lib->loc.main.location);
-    }
-    lib->loc.main.location = NULL;
+    printf("_view_map_location_action remove %d\n", lib->loc.main.id);
+    _view_map_remove_location(lib, &lib->loc.main);
     lib->loc.main.id = 0;
   }
-  _view_map_draw_other_locations(view, lib->lat0, lib->lat1, lib->lon0, lib->lon1);
+  _view_map_draw_other_locations(lib, &lib->bbox);
 }
 
 
@@ -2266,6 +2480,7 @@ static void _view_map_check_preference_changed(gpointer instance, gpointer user_
 static void _view_map_collection_changed(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
                                          int next, gpointer user_data)
 {
+  printf("_view_map_collection_changed\n");
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
   // avoid to centre the map on collection while a location is active
@@ -2320,6 +2535,7 @@ static void _view_map_center_on_image(dt_view_t *self, const int32_t imgid)
 
 static gboolean _view_map_center_on_image_list(dt_view_t *self, const char* table)
 {
+  printf("_view_map_center_on_image_list\n");
   const dt_map_t *lib = (dt_map_t *)self->data;
   double max_longitude = -INFINITY;
   double max_latitude = -INFINITY;
@@ -2404,7 +2620,7 @@ static void _drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, 
         lib->loc.main.data.delta2 = lib->loc.main.data.delta2 * prev_ratio / lib->loc.main.data.ratio;
         osm_gps_map_point_free(pt);
         _view_map_update_location_geotag(self);
-        _view_map_draw_locations(self);
+        _view_map_draw_main_location(lib, &lib->loc.main);
         _view_map_signal_change_wait(self, 1);
         success = TRUE;
       }
@@ -2426,7 +2642,7 @@ static void _drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, 
         dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_view_map_collection_changed), self);
         dt_image_set_locations(imgs, &geoloc, TRUE);
         dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_view_map_collection_changed), self);
-        g_list_free(imgs);
+        DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
         g_signal_emit_by_name(lib->map, "changed");
         success = TRUE;
       }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2217,8 +2217,6 @@ static OsmGpsMapPolygon *_view_map_add_polygon_location(dt_map_t *lib, dt_locati
 {
   OsmGpsMapPolygon *poly = osm_gps_map_polygon_new();
   OsmGpsMapTrack* track = osm_gps_map_track_new();
-  GdkRGBA color = {.red = 1.0, .green = 1.0, .blue = 0.7, .alpha = 1.0 };
-  osm_gps_map_track_set_color(track, &color);
   g_object_set(track, "line-width" , 2.0, "alpha", 0.9, (gchar *)0);
 
   // angles for 1 pixel;


### PR DESCRIPTION
In "find location" module OpenStreetMap is able to provide country and city shapes (in "map settings", set "max polygon points" large enough to receive these data, 150.000 was enough for my tests).

When such a shape is displayed on the map (the red one), a new shape symbol is available in "locations" module (polygon).
Adding a new location with this polygon shape, associates the polygon to the new location.
Such a polygon of location is not modifiable... but records all images inside the polygon.

These locations are also available in collect module (under geotagging).

![image](https://user-images.githubusercontent.com/23012047/112726766-e7195800-8efd-11eb-8ac4-84a99f2e6754.png)

