### PR TITLE
local numerical prefs: grab focus

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1978,7 +1978,6 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key, const guint co
   GtkWidget *w = gtk_spin_button_new_with_range(min, max, 1.0);
   gtk_widget_set_name(w, key);
   gtk_widget_set_hexpand(w, FALSE);
-  dt_gui_key_accel_block_on_focus_connect(w);
   gtk_spin_button_set_digits(GTK_SPIN_BUTTON(w), 0);
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), dt_conf_get_int(key));
   gtk_grid_attach(GTK_GRID(grid), labelev, col, line, 1, 1);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1167,6 +1167,7 @@ void gui_init(dt_lib_module_t *self)
   guint line = 0;
   d->ignore_exif = dt_gui_preferences_bool(grid, "ui_last/ignore_exif_rating", 0, line++, FALSE);
   d->rating = dt_gui_preferences_int(grid, "ui_last/import_initial_rating", 0, line++);
+  dt_gui_key_accel_block_on_focus_connect(d->rating);
   d->apply_metadata = dt_gui_preferences_bool(grid, "ui_last/import_apply_metadata", 0, line++, FALSE);
   d->metadata.apply_metadata = d->apply_metadata;
   gtk_box_pack_start(GTK_BOX(d->exp.widgets), GTK_WIDGET(grid), FALSE, FALSE, 0);
@@ -1189,6 +1190,7 @@ void gui_init(dt_lib_module_t *self)
 void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
+  dt_gui_key_accel_block_on_focus_disconnect(d->rating);
 #ifdef HAVE_GPHOTO2
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_camera_detected), self);
 #endif

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -145,10 +145,13 @@ void gui_init(dt_lib_module_t *self)
   d->filtered_images_checkbutton = dt_gui_preferences_bool(grid, "plugins/map/filter_images_drawn", 0, line++, FALSE);
   g_signal_connect(G_OBJECT(d->filtered_images_checkbutton), "toggled", G_CALLBACK(_parameter_changed), NULL);
   d->max_images_entry = dt_gui_preferences_int(grid, "plugins/map/max_images_drawn", 0, line++);
+  dt_gui_key_accel_block_on_focus_connect(d->max_images_entry);
   g_signal_connect(G_OBJECT(d->max_images_entry), "value-changed", G_CALLBACK(_parameter_changed), self);
   d->epsilon_factor = dt_gui_preferences_int(grid, "plugins/map/epsilon_factor", 0, line++);
+  dt_gui_key_accel_block_on_focus_connect(d->epsilon_factor);
   g_signal_connect(G_OBJECT(d->epsilon_factor), "value-changed", G_CALLBACK(_parameter_changed), self);
   d->min_images = dt_gui_preferences_int(grid, "plugins/map/min_images_per_group", 0, line++);
+  dt_gui_key_accel_block_on_focus_connect(d->min_images);
   g_signal_connect(G_OBJECT(d->min_images), "value-changed", G_CALLBACK(_parameter_changed), self);
   d->images_thumb = dt_gui_preferences_enum(grid, "plugins/map/images_thumbnail", 0, line++);
   g_signal_connect(G_OBJECT(d->images_thumb), "changed", G_CALLBACK(_parameter_changed), self);
@@ -157,6 +160,10 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
+  dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)self->data;
+  dt_gui_key_accel_block_on_focus_disconnect(d->max_images_entry);
+  dt_gui_key_accel_block_on_focus_disconnect(d->epsilon_factor);
+  dt_gui_key_accel_block_on_focus_disconnect(d->min_images);
   free(self->data);
   self->data = NULL;
 }


### PR DESCRIPTION
 fix #8575

grabs focus blocking shortcut when editing.
But makes appear another issue: when moving from map to lighttable  the following console message is shown:
`(darktable:85546): Gtk-CRITICAL **: 11:58:34.901: _gtk_accel_group_attach: assertion 'g_slist_find (accel_group->priv->acceleratables, object) == NULL' failed`

My understanding: accel keys are somehow attached to views. When one moves from map to lighttable occurs some key accel treatment.
But key accels are managed in modules, like "map settings". This one disconnects properly the widgets in gui_cleanup(). But modules survive to views and their gui_cleanup() is only called when  dt exits.
So when views are switched, something is failing around the key accel management.
At this point ... I'm a bit lost.



