### PR TITLE
Fix lua text view wrap

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -82,6 +82,8 @@ you are strongly advised to take a backup first.
 
 * action sensitivity - add darktable.gui.libs.image.set_action_sensitive() to set action button sensitivity
 
+* bugfix - Changed text_view widget to wrap lines when the text exceeds the width of the widget
+
 ## Changed Dependencies
 
 ## RawSpeed changes

--- a/src/lua/widget/text_view.c
+++ b/src/lua/widget/text_view.c
@@ -20,20 +20,21 @@
 #include "lua/widget/common.h"
 
 static void text_view_init(lua_State* L);
-static void text_view_cleanup(lua_State* L,lua_widget widget);
+static void text_view_cleanup(lua_State* L, lua_widget widget);
 static dt_lua_widget_type_t textview_type = {
   .name = "text_view",
   .gui_init = text_view_init,
   .gui_cleanup = text_view_cleanup,
   .alloc_size = sizeof(dt_lua_widget_t),
-  .parent= &widget_type
+  .parent = &widget_type
 };
 
 
 static void text_view_init(lua_State* L)
 {
   lua_text_view text_view;
-  luaA_to(L,lua_text_view,&text_view,1);
+  luaA_to(L,lua_text_view, &text_view, 1);
+  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(text_view->widget), GTK_WRAP_WORD);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(text_view->widget));
 }
 
@@ -46,35 +47,35 @@ static gchar* gtk_text_buffer_get_all_text(GtkTextBuffer *buffer)
 {
   GtkTextIter start;
   GtkTextIter end;
-  gtk_text_buffer_get_start_iter(buffer,&start);
-  gtk_text_buffer_get_end_iter(buffer,&end);
-  return gtk_text_buffer_get_text(buffer,&start,&end,false);
+  gtk_text_buffer_get_start_iter(buffer, &start);
+  gtk_text_buffer_get_end_iter(buffer, &end);
+  return gtk_text_buffer_get_text(buffer, &start, &end, false);
 }
 
 static int text_member(lua_State *L)
 {
   lua_text_view textview;
-  luaA_to(L,lua_text_view,&textview,1);
+  luaA_to(L, lua_text_view, &textview, 1);
   GtkTextBuffer * textbuffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(textview->widget));
   if(lua_gettop(L) > 2) {
-    const char * text = luaL_checkstring(L,3);
-    gtk_text_buffer_set_text(textbuffer,text,-1);
+    const char * text = luaL_checkstring(L, 3);
+    gtk_text_buffer_set_text(textbuffer, text, -1);
     return 0;
   }
-  lua_pushstring(L,gtk_text_buffer_get_all_text(textbuffer));
+  lua_pushstring(L, gtk_text_buffer_get_all_text(textbuffer));
   return 1;
 }
 
 static int editable_member(lua_State *L)
 {
   lua_text_view text_view;
-  luaA_to(L,lua_text_view,&text_view,1);
+  luaA_to(L,lua_text_view, &text_view, 1);
   if(lua_gettop(L) > 2) {
-    gboolean editable = lua_toboolean(L,3);
-    gtk_text_view_set_editable(GTK_TEXT_VIEW(text_view->widget),editable);
+    gboolean editable = lua_toboolean(L, 3);
+    gtk_text_view_set_editable(GTK_TEXT_VIEW(text_view->widget), editable);
     return 0;
   }
-  lua_pushboolean(L,gtk_text_view_get_editable(GTK_TEXT_VIEW(text_view->widget)));
+  lua_pushboolean(L, gtk_text_view_get_editable(GTK_TEXT_VIEW(text_view->widget)));
   return 1;
 }
 
@@ -92,15 +93,15 @@ static int tostring_member(lua_State *L)
 
 int dt_lua_init_widget_text_view(lua_State* L)
 {
-  dt_lua_init_widget_type(L,&textview_type,lua_text_view,GTK_TYPE_TEXT_VIEW);
+  dt_lua_init_widget_type(L, &textview_type, lua_text_view, GTK_TYPE_TEXT_VIEW);
 
   lua_pushcfunction(L, tostring_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_setmetafield(L, lua_text_view, "__tostring");
-  lua_pushcfunction(L,text_member);
+  lua_pushcfunction(L, text_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_text_view, "text");
-  lua_pushcfunction(L,editable_member);
+  lua_pushcfunction(L, editable_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_text_view, "editable");
   return 0;

--- a/src/lua/widget/text_view.c
+++ b/src/lua/widget/text_view.c
@@ -34,7 +34,7 @@ static void text_view_init(lua_State* L)
 {
   lua_text_view text_view;
   luaA_to(L,lua_text_view, &text_view, 1);
-  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(text_view->widget), GTK_WRAP_WORD);
+  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(text_view->widget), GTK_WRAP_WORD_CHAR);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(text_view->widget));
 }
 


### PR DESCRIPTION
Set the default wrap for the text_view widget to GTK_WRAP_WORD_CHAR so that it will break lines on a word boundary, but if a key is just held down it will still break the line when the characters reach the right side of the widget.  Fixes #8590 