### PR TITLE
Implementing a contrast mask refinement

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -165,7 +165,6 @@ typedef enum dt_develop_blendif_channels_t
   DEVELOP_BLENDIF_OUTPUT_MASK = 0xF0F0
 } dt_develop_blendif_channels_t;
 
-
 /** blend legacy parameters version 1 */
 typedef struct dt_develop_blend_params1_t
 {

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -387,8 +387,10 @@ typedef struct dt_develop_blend_params_t
   float contrast;
   /** mask brightness adjustment */
   float brightness;
+  /** local_contrast threshold */
+  float local_contrast;
   /** some reserved fields for future use */
-  uint32_t reserved[4];
+  uint32_t reserved[3];
   /** blendif parameters */
   float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
   float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];
@@ -515,6 +517,7 @@ typedef struct dt_iop_gui_blend_data_t
   gboolean output_channels_shown;
 
   GtkWidget *channel_boost_factor_slider;
+  GtkWidget *local_contrast_slider;
 
   GtkWidget *masks_combo;
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2206,9 +2206,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     dt_bauhaus_slider_enable_soft_boundaries(bd->channel_boost_factor_slider, 0.0, 18.0);
     gtk_widget_set_tooltip_text(bd->channel_boost_factor_slider, _("adjust the boost factor of the channel mask"));
     gtk_widget_set_sensitive(bd->channel_boost_factor_slider, FALSE);
-
-    g_signal_connect(G_OBJECT(bd->channel_boost_factor_slider), "value-changed",
-                     G_CALLBACK(_blendop_blendif_boost_factor_callback), bd);
+    g_signal_connect(G_OBJECT(bd->channel_boost_factor_slider), "value-changed", G_CALLBACK(_blendop_blendif_boost_factor_callback), bd);
 
     gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(bd->channel_boost_factor_slider), TRUE, FALSE, 0);
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -119,6 +119,13 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
+typedef enum dt_develop_ctmask_t
+{
+  DT_DEV_CTMASK_NONE = 0,
+  DT_DEV_CTMASK_REQUIRED = 1,
+  DT_DEV_CTMASK_DEMOSAIC = 2,
+  DT_DEV_CTMASK_RAWPREPARE = 4
+} dt_develop_ctmask_t;
 
 typedef enum dt_clipping_preview_mode_t
 {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -119,13 +119,13 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
-typedef enum dt_develop_ctmask_t
+typedef enum dt_develop_lummask_t
 {
-  DT_DEV_CTMASK_NONE = 0,
-  DT_DEV_CTMASK_REQUIRED = 1,
-  DT_DEV_CTMASK_DEMOSAIC = 2,
-  DT_DEV_CTMASK_RAWPREPARE = 4
-} dt_develop_ctmask_t;
+  DT_DEV_LUMINANCE_MASK_NONE = 0,
+  DT_DEV_LUMINANCE_MASK_REQUIRED = 1,
+  DT_DEV_LUMINANCE_MASK_DEMOSAIC = 2,
+  DT_DEV_LUMINANCE_MASK_RAWPREPARE = 4
+} dt_develop_lummask_t;
 
 typedef enum dt_clipping_preview_mode_t
 {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -428,11 +428,11 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          const float initial_ypos, const float xpos, const float ypos, float *px,
                                          float *py, const int adding);
 
-/** ctmask supporting */
+/** luminance mask support */
 void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
 void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
-void dt_masks_prepare_ctmask(float *const src, float *const out, float *const tmp, const int width, const int height);
-void dt_masks_full_ctmask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
+void dt_masks_calc_luminance_mask(float *const src, float *const out, const int width, const int height);
+void dt_masks_calc_contrast_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
 
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -428,6 +428,12 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          const float initial_ypos, const float xpos, const float ypos, float *px,
                                          float *py, const int adding);
 
+/** ctmask supporting */
+void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
+void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
+void dt_masks_prepare_ctmask(float *const src, float *const out, float *const tmp, const int width, const int height);
+void dt_masks_full_ctmask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
+
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);
 

--- a/src/develop/masks/ctmask.c
+++ b/src/develop/masks/ctmask.c
@@ -162,11 +162,3 @@ void dt_masks_full_ctmask(float *const restrict src, float *const restrict out, 
   dt_masks_blur_9x9(tmp, out, width, height, 2.0f);
 }  
 
-#ifdef HAVE_OPENCL
-void dt_masks_full_ctmask_cl(float *const restrict src, float *const restrict out, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean detail)
-{
-
-
-}
-#endif
-

--- a/src/develop/masks/ctmask.c
+++ b/src/develop/masks/ctmask.c
@@ -1,0 +1,172 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2013-2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+void dt_masks_extend_border(float *mask, const int width, const int height, const int border)
+{
+  if(border <= 0) return;
+  for(int row = border; row < height - border; row++)
+  {
+    const int idx = row * width;
+    for(int i = 0; i < border; i++)
+    {
+      mask[idx + i] = mask[idx + border];
+      mask[idx + width - i - 1] = mask[idx + width - border -1];   
+    }
+  }
+  for(int col = 0; col < width; col++)
+  {
+    const float top = mask[border * width + MIN(width - border - 1, MAX(col, border))];
+    const float bot = mask[(height - border - 1) * width + MIN(width - border - 1, MAX(col, border))];
+    for(int i = 0; i < border; i++)
+    {
+      mask[col + i * width] = top;
+      mask[col + (height - i - 1) * width] = bot;
+    }   
+  }
+}
+
+void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, const int width, const int height, const float sigma)
+{
+  // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
+  float kernel[9][9];
+  const float temp = 2.0f * sqf(sigma);
+  float sum = 0.0f;
+  for(int i = -4; i <= 4; i++)
+  {
+    for(int j = -4; j <= 4; j++)
+    {
+      kernel[i + 4][j + 4] = expf( -(sqf(i) + sqf(j)) / temp);
+      sum += kernel[i + 4][j + 4];
+    }
+  }
+  for(int i = 0; i < 9; i++)
+  {
+    for(int j = 0; j < 9; j++)
+      kernel[i][j] /= sum;
+  }
+  const float c42 = kernel[0][2];
+  const float c41 = kernel[0][3];
+  const float c40 = kernel[0][4];
+  const float c33 = kernel[1][1];
+  const float c32 = kernel[1][2];
+  const float c31 = kernel[1][3];
+  const float c30 = kernel[1][4];
+  const float c22 = kernel[2][2];
+  const float c21 = kernel[2][3];
+  const float c20 = kernel[2][4];
+  const float c11 = kernel[3][3];
+  const float c10 = kernel[3][4];
+  const float c00 = kernel[4][4];
+  const int w1 = width;
+  const int w2 = 2*width;
+  const int w3 = 3*width;
+  const int w4 = 4*width;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(src, out) \
+  dt_omp_sharedconst(c42, c41, c40, c33, c32, c31, c30, c22, c21, c20, c11, c10, c00, w1, w2, w3, w4, width, height) \
+  schedule(simd:static) aligned(src, out : 64) 
+ #endif
+  for(int row = 4; row < height - 4; row++)
+  {
+#if defined(__clang__)
+        #pragma clang loop vectorize(assume_safety)
+#elif defined(__GNUC__)
+        #pragma GCC ivdep
+#endif
+    for(int col = 4; col < width - 4; col++)
+    {
+      const int i = row * width + col;
+      const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
+                        c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i - w1 - 4] + src[i - w1 + 4] + src[i + w1 - 4] + src[i + w1 + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
+                        c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
+                        c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
+                        c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
+                        c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i - w1 - 3] + src[i - w1 + 3] + src[i + w1 - 3] + src[i + w1 + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
+                        c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
+                        c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
+                        c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i - w1 - 2] + src[i - w1 + 2] + src[i + w1 - 2] + src[i + w1 + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
+                        c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
+                        c11 * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) +
+                        c10 * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) +
+                        c00 * src[i];
+      out[i] = clamp_simd(val);
+    }
+  }
+}
+
+void dt_masks_prepare_ctmask(float *const restrict src, float *const restrict mask, float *const restrict tmp, const int width, const int height)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(tmp, src, width, height) \
+  schedule(simd:static) aligned(mask, src : 64) 
+#endif
+  for(size_t idx =0; idx < (size_t) width * height; idx++)
+  {
+    const float val = 0.333333f * (src[4 * idx] + src[4 * idx + 1] + src[4 * idx + 2]);
+    tmp[idx] = lab_f(val);
+  }
+
+  const float scale = 1.0f / 16.0f;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(mask, tmp, width, height, scale) \
+  schedule(simd:static) aligned(mask, tmp : 64) 
+ #endif
+  for(int row = 2; row < height - 2; row++)
+  {
+    for(int col = 2, idx = row * width + col; col < width - 2; col++, idx++)
+    {
+      mask[idx] = scale * sqrtf(sqf(tmp[idx+1] - tmp[idx-1]) + sqf(tmp[idx + width]   - tmp[idx - width]) +
+                                sqf(tmp[idx+2] - tmp[idx-2]) + sqf(tmp[idx + 2*width] - tmp[idx - 2*width]));
+    }
+  }
+  dt_masks_extend_border(mask, width, height, 2);  
+}
+
+static inline float calcBlendFactor(float val, float threshold)
+{
+    // sigmoid function
+    // result is in ]0;1] range
+    // inflexion point is at (x, y) (threshold, 0.5)
+    return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
+}
+
+void dt_masks_full_ctmask(float *const restrict src, float *const restrict out, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean detail)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(src, tmp, width, height, threshold, detail) \
+  schedule(simd:static) aligned(src, tmp : 64) 
+#endif
+  for(size_t idx =0; idx < (size_t) width * height; idx++)
+  {
+    const float blend = calcBlendFactor(src[idx], threshold);
+    tmp[idx] = detail ? blend : 1.0f - blend;
+  }
+  dt_masks_blur_9x9(tmp, out, width, height, 2.0f);
+}  
+
+#ifdef HAVE_OPENCL
+void dt_masks_full_ctmask_cl(float *const restrict src, float *const restrict out, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean detail)
+{
+
+
+}
+#endif
+

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -24,6 +24,7 @@
 #include "common/undo.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "develop/openmp_maths.h"
 
 #pragma GCC diagnostic ignored "-Wshadow"
 
@@ -2377,6 +2378,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   *px = x;
   *py = y;
 }
+
+#include "ctmask.c"
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -29,6 +29,7 @@
 #include "develop/pixelpipe.h"
 #include "develop/tiling.h"
 #include "develop/masks.h"
+#include "develop/openmp_maths.h"
 #include "gui/gtk.h"
 #include "libs/colorpicker.h"
 #include "libs/lib.h"
@@ -176,6 +177,9 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = 0;
 
+  pipe->ctmask_data = NULL;
+  pipe->want_ctmask = DT_DEV_CTMASK_NONE;
+
   pipe->processing = 0;
   dt_atomic_set_int(&pipe->shutdown,FALSE);
   pipe->opencl_error = 0;
@@ -240,6 +244,8 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
   pipe->output_backbuf_width = 0;
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = 0;
+
+  dt_dev_clear_ctmask(pipe);
 
   if(pipe->forms)
   {
@@ -341,6 +347,10 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
     piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
     const dt_image_t *img = &piece->pipe->image;
     const int imgid = img->id;
+    pipe->want_ctmask &= DT_DEV_CTMASK_REQUIRED;
+    if(dt_image_is_raw(img))
+      pipe->want_ctmask |= DT_DEV_CTMASK_DEMOSAIC;
+    else if(dt_image_is_rawprepare_supported(img)) pipe->want_ctmask |= DT_DEV_CTMASK_RAWPREPARE; 
 
     if(piece->module == hist->module)
     {
@@ -366,6 +376,12 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
       }
       piece->enabled = active;
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
+
+      if(piece->blendop_data)
+      {
+        const dt_develop_blend_params_t *const bp = (const dt_develop_blend_params_t *)piece->blendop_data;
+        if(bp->local_contrast != 0.0f) pipe->want_ctmask |= DT_DEV_CTMASK_REQUIRED;
+      }
     }
   }
   if(hint)
@@ -2539,6 +2555,168 @@ float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const dt_iop_modul
   }
 
   return raster_mask;
+}
+
+void dt_dev_clear_ctmask(dt_dev_pixelpipe_t *pipe)
+{
+  if(pipe->ctmask_data) dt_free_align(pipe->ctmask_data);
+  pipe->ctmask_data = NULL;
+}
+
+gboolean dt_dev_write_ctmask_data(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode)
+{
+  dt_dev_pixelpipe_t *p = piece->pipe;
+  if((p->want_ctmask & DT_DEV_CTMASK_REQUIRED) == 0) return FALSE;
+  if((p->want_ctmask & ~DT_DEV_CTMASK_REQUIRED) != mode) return FALSE;
+
+  dt_dev_clear_ctmask(p);
+
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  float *mask = dt_alloc_align_float((size_t)width * height);
+  float *tmp  = dt_alloc_align_float((size_t)width * height);
+
+  if((tmp == NULL) || (mask == NULL))
+  {
+    dt_free_align(tmp);
+    dt_free_align(mask);
+    return TRUE; 
+  }
+
+  p->ctmask_data = mask;
+  memcpy(&p->ctmask_roi, roi_in, sizeof(dt_iop_roi_t));
+
+  dt_masks_prepare_ctmask(rgb, mask, tmp, width, height);
+
+  dt_free_align(tmp);
+  return FALSE;
+}
+
+#ifdef HAVE_OPENCL
+// cl_mem in got via dt_opencl_alloc_device
+gboolean dt_dev_write_ctmask_data_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode)
+{
+  dt_dev_pixelpipe_t *p = piece->pipe;  
+
+  if((p->want_ctmask & DT_DEV_CTMASK_REQUIRED) == 0) return FALSE;
+  if((p->want_ctmask & ~DT_DEV_CTMASK_REQUIRED) != mode) return FALSE;
+
+  dt_dev_clear_ctmask(p);
+
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+
+  cl_mem tmp = NULL;
+  cl_mem out = NULL;
+  float *mask = NULL;
+  const int devid = p->devid;
+
+  mask = dt_alloc_align_float((size_t)width * height);
+  if(mask == NULL) goto error;
+  tmp = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
+  if(tmp == NULL) goto error;
+  out = dt_opencl_alloc_device(devid, width, height, sizeof(float));   
+  if(out == NULL) goto error;
+
+  const int program = 31;
+  int kernel_calc_luminance_mask = dt_opencl_create_kernel(program, "dual_luminance_mask");
+  int kernel_prepare_ctmask = dt_opencl_create_kernel(program, "prepare_ctmask");   
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 0, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 1, sizeof(cl_mem), &in);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 3, sizeof(int), &height);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_calc_luminance_mask, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }  
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 0, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 1, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 3, sizeof(int), &height);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_prepare_ctmask, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }  
+
+  {
+    const int err = dt_opencl_read_host_from_device(devid, mask, out, width, height, sizeof(float));
+    if(err != CL_SUCCESS) goto error;
+  }
+
+  p->ctmask_data = mask;
+  memcpy(&p->ctmask_roi, roi_in, sizeof(dt_iop_roi_t));
+
+  dt_opencl_release_mem_object(tmp);
+  dt_opencl_release_mem_object(out);
+
+  dt_opencl_free_kernel(kernel_calc_luminance_mask);
+  dt_opencl_free_kernel(kernel_prepare_ctmask);
+  return FALSE;
+
+  error:
+  dt_opencl_release_mem_object(tmp);
+  dt_opencl_release_mem_object(out);
+  dt_free_align(mask);
+  return TRUE;  
+}
+#endif
+
+// this expects the ctmask prepared by the demosaicer and distorts the mask through all pipeline modules
+// until target
+float *dt_dev_distort_ctmask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
+{
+  if(!pipe->ctmask_data) return NULL;
+  gboolean valid = FALSE;
+  const int check = pipe->want_ctmask & ~DT_DEV_CTMASK_REQUIRED;
+
+  GList *source_iter;
+  for(source_iter = pipe->nodes; source_iter; source_iter = g_list_next(source_iter))
+  {
+    const dt_dev_pixelpipe_iop_t *candidate = (dt_dev_pixelpipe_iop_t *)source_iter->data;
+    if(((!strcmp(candidate->module->op, "demosaic")) && candidate->enabled) && (check == DT_DEV_CTMASK_DEMOSAIC))
+    {
+      valid = TRUE;
+      break;
+    }
+    if(((!strcmp(candidate->module->op, "rawprepare")) && candidate->enabled) && (check == DT_DEV_CTMASK_RAWPREPARE))
+    {
+      valid = TRUE;
+      break;
+    }
+  }
+  // We might also read data from pipe input here and construct a mask
+
+  if(!valid) return NULL;
+
+  float *resmask = src;
+  float *inmask  = src;
+  if(source_iter)
+  {
+    for(GList *iter = source_iter; iter; iter = g_list_next(iter))
+    {
+      dt_dev_pixelpipe_iop_t *module = (dt_dev_pixelpipe_iop_t *)iter->data;
+      if(module->enabled)
+      {
+        if(module->module->distort_mask
+              && !(!strcmp(module->module->op, "finalscale") // hack against pipes not using finalscale
+                    && module->processed_roi_in.width == 0
+                    && module->processed_roi_in.height == 0))
+        {
+          float *tmp = dt_alloc_align_float((size_t)module->processed_roi_out.width * module->processed_roi_out.height);
+          module->module->distort_mask(module->module, module, inmask, tmp, &module->processed_roi_in, &module->processed_roi_out);
+          resmask = tmp;
+          if(inmask != src) dt_free_align(inmask);
+          inmask = tmp; 
+        }
+        if(module->module == target_module) break;
+      }
+    }
+  }
+  return resmask;  
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -177,8 +177,8 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = 0;
 
-  pipe->ctmask_data = NULL;
-  pipe->want_ctmask = DT_DEV_CTMASK_NONE;
+  pipe->luminance_mask_data = NULL;
+  pipe->want_luminance_mask = DT_DEV_LUMINANCE_MASK_NONE;
 
   pipe->processing = 0;
   dt_atomic_set_int(&pipe->shutdown,FALSE);
@@ -245,7 +245,7 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = 0;
 
-  dt_dev_clear_ctmask(pipe);
+  dt_dev_clear_luminance_mask(pipe);
 
   if(pipe->forms)
   {
@@ -347,10 +347,10 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
     piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
     const dt_image_t *img = &piece->pipe->image;
     const int imgid = img->id;
-    pipe->want_ctmask &= DT_DEV_CTMASK_REQUIRED;
+    pipe->want_luminance_mask &= DT_DEV_LUMINANCE_MASK_REQUIRED;
     if(dt_image_is_raw(img))
-      pipe->want_ctmask |= DT_DEV_CTMASK_DEMOSAIC;
-    else if(dt_image_is_rawprepare_supported(img)) pipe->want_ctmask |= DT_DEV_CTMASK_RAWPREPARE; 
+      pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_DEMOSAIC;
+    else if(dt_image_is_rawprepare_supported(img)) pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_RAWPREPARE; 
 
     if(piece->module == hist->module)
     {
@@ -380,7 +380,7 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
       if(piece->blendop_data)
       {
         const dt_develop_blend_params_t *const bp = (const dt_develop_blend_params_t *)piece->blendop_data;
-        if(bp->local_contrast != 0.0f) pipe->want_ctmask |= DT_DEV_CTMASK_REQUIRED;
+        if(bp->local_contrast != 0.0f) pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_REQUIRED;
       }
     }
   }
@@ -2557,74 +2557,60 @@ float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const dt_iop_modul
   return raster_mask;
 }
 
-void dt_dev_clear_ctmask(dt_dev_pixelpipe_t *pipe)
+void dt_dev_clear_luminance_mask(dt_dev_pixelpipe_t *pipe)
 {
-  if(pipe->ctmask_data) dt_free_align(pipe->ctmask_data);
-  pipe->ctmask_data = NULL;
+  if(pipe->luminance_mask_data) dt_free_align(pipe->luminance_mask_data);
+  pipe->luminance_mask_data = NULL;
 }
 
-gboolean dt_dev_write_ctmask_data(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode)
+gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if((p->want_ctmask & DT_DEV_CTMASK_REQUIRED) == 0) return FALSE;
-  if((p->want_ctmask & ~DT_DEV_CTMASK_REQUIRED) != mode) return FALSE;
+  if((p->want_luminance_mask & DT_DEV_LUMINANCE_MASK_REQUIRED) == 0) return FALSE;
+  if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
-  dt_dev_clear_ctmask(p);
+  dt_dev_clear_luminance_mask(p);
 
   const int width = roi_in->width;
   const int height = roi_in->height;
   float *mask = dt_alloc_align_float((size_t)width * height);
-  float *tmp  = dt_alloc_align_float((size_t)width * height);
+  if(mask == NULL) return TRUE;
 
-  if((tmp == NULL) || (mask == NULL))
-  {
-    dt_free_align(tmp);
-    dt_free_align(mask);
-    return TRUE; 
-  }
+  p->luminance_mask_data = mask;
+  memcpy(&p->luminance_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
-  p->ctmask_data = mask;
-  memcpy(&p->ctmask_roi, roi_in, sizeof(dt_iop_roi_t));
-
-  dt_masks_prepare_ctmask(rgb, mask, tmp, width, height);
-
-  dt_free_align(tmp);
+  dt_masks_calc_luminance_mask(rgb, mask, width, height);
   return FALSE;
 }
 
 #ifdef HAVE_OPENCL
-// cl_mem in got via dt_opencl_alloc_device
-gboolean dt_dev_write_ctmask_data_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode)
+gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;  
 
-  if((p->want_ctmask & DT_DEV_CTMASK_REQUIRED) == 0) return FALSE;
-  if((p->want_ctmask & ~DT_DEV_CTMASK_REQUIRED) != mode) return FALSE;
+  if((p->want_luminance_mask & DT_DEV_LUMINANCE_MASK_REQUIRED) == 0) return FALSE;
+  if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
-  dt_dev_clear_ctmask(p);
+  dt_dev_clear_luminance_mask(p);
 
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  cl_mem tmp = NULL;
   cl_mem out = NULL;
   float *mask = NULL;
   const int devid = p->devid;
 
   mask = dt_alloc_align_float((size_t)width * height);
   if(mask == NULL) goto error;
-  tmp = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
-  if(tmp == NULL) goto error;
   out = dt_opencl_alloc_device(devid, width, height, sizeof(float));   
   if(out == NULL) goto error;
 
   const int program = 31;
-  int kernel_calc_luminance_mask = dt_opencl_create_kernel(program, "dual_luminance_mask");
-  int kernel_prepare_ctmask = dt_opencl_create_kernel(program, "prepare_ctmask");   
+  int kernel_calc_luminance_mask = dt_opencl_create_kernel(program, "out_luminance_mask");
 
   {
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 0, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 0, sizeof(cl_mem), &out);
     dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 1, sizeof(cl_mem), &in);
     dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 2, sizeof(int), &width);
     dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 3, sizeof(int), &height);
@@ -2633,62 +2619,48 @@ gboolean dt_dev_write_ctmask_data_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, c
   }  
 
   {
-    size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 0, sizeof(cl_mem), &tmp);
-    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 1, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, kernel_prepare_ctmask, 3, sizeof(int), &height);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_prepare_ctmask, sizes);
-    if(err != CL_SUCCESS) goto error;
-  }  
-
-  {
     const int err = dt_opencl_read_host_from_device(devid, mask, out, width, height, sizeof(float));
     if(err != CL_SUCCESS) goto error;
   }
 
-  p->ctmask_data = mask;
-  memcpy(&p->ctmask_roi, roi_in, sizeof(dt_iop_roi_t));
+  p->luminance_mask_data = mask;
+  memcpy(&p->luminance_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
-  dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(out);
 
   dt_opencl_free_kernel(kernel_calc_luminance_mask);
-  dt_opencl_free_kernel(kernel_prepare_ctmask);
   return FALSE;
 
   error:
-  dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(out);
   dt_free_align(mask);
   return TRUE;  
 }
 #endif
 
-// this expects the ctmask prepared by the demosaicer and distorts the mask through all pipeline modules
+// this expects a mask prepared by the demosaicer and distorts the mask through all pipeline modules
 // until target
-float *dt_dev_distort_ctmask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
+float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
 {
-  if(!pipe->ctmask_data) return NULL;
+  if(!pipe->luminance_mask_data) return NULL;
   gboolean valid = FALSE;
-  const int check = pipe->want_ctmask & ~DT_DEV_CTMASK_REQUIRED;
+  const int check = pipe->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED;
 
   GList *source_iter;
   for(source_iter = pipe->nodes; source_iter; source_iter = g_list_next(source_iter))
   {
     const dt_dev_pixelpipe_iop_t *candidate = (dt_dev_pixelpipe_iop_t *)source_iter->data;
-    if(((!strcmp(candidate->module->op, "demosaic")) && candidate->enabled) && (check == DT_DEV_CTMASK_DEMOSAIC))
+    if(((!strcmp(candidate->module->op, "demosaic")) && candidate->enabled) && (check == DT_DEV_LUMINANCE_MASK_DEMOSAIC))
     {
       valid = TRUE;
       break;
     }
-    if(((!strcmp(candidate->module->op, "rawprepare")) && candidate->enabled) && (check == DT_DEV_CTMASK_RAWPREPARE))
+    if(((!strcmp(candidate->module->op, "rawprepare")) && candidate->enabled) && (check == DT_DEV_LUMINANCE_MASK_RAWPREPARE))
     {
       valid = TRUE;
       break;
     }
   }
-  // We might also read data from pipe input here and construct a mask
 
   if(!valid) return NULL;
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -133,9 +133,9 @@ typedef struct dt_dev_pixelpipe_t
 
   // the data for the contrast mask are kept in a buffer filled in by demosaic or pipeline init
   // as we have to scale the mask later ke keep both roi at that stage
-  float *ctmask_data;
-  struct dt_iop_roi_t ctmask_roi;
-  int want_ctmask;
+  float *luminance_mask_data;
+  struct dt_iop_roi_t luminance_mask_roi;
+  int want_luminance_mask;
 
   int output_imgid;
   // working?
@@ -244,15 +244,15 @@ float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const struct dt_io
                               const int raster_mask_id, const struct dt_iop_module_t *target_module,
                               gboolean *free_mask);
 // some helper functions related to the local contrast mask interface
-void dt_dev_clear_ctmask(dt_dev_pixelpipe_t *pipe);
+void dt_dev_clear_luminance_mask(dt_dev_pixelpipe_t *pipe);
 
-gboolean dt_dev_write_ctmask_data(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
+gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
 #ifdef HAVE_OPENCL
-gboolean dt_dev_write_ctmask_data_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
+gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
 #endif
 
 // helper function writing the pipe-processed ctmask data to dest 
-float *dt_dev_distort_ctmask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
+float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -130,6 +130,13 @@ typedef struct dt_dev_pixelpipe_t
   // output buffer (for display)
   uint8_t *output_backbuf;
   int output_backbuf_width, output_backbuf_height;
+
+  // the data for the contrast mask are kept in a buffer filled in by demosaic or pipeline init
+  // as we have to scale the mask later ke keep both roi at that stage
+  float *ctmask_data;
+  struct dt_iop_roi_t ctmask_roi;
+  int want_ctmask;
+
   int output_imgid;
   // working?
   int processing;
@@ -236,6 +243,16 @@ void dt_dev_pixelpipe_remove_node(dt_dev_pixelpipe_t *pipe, struct dt_develop_t 
 float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const struct dt_iop_module_t *raster_mask_source,
                               const int raster_mask_id, const struct dt_iop_module_t *target_module,
                               gboolean *free_mask);
+// some helper functions related to the local contrast mask interface
+void dt_dev_clear_ctmask(dt_dev_pixelpipe_t *pipe);
+
+gboolean dt_dev_write_ctmask_data(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
+#ifdef HAVE_OPENCL
+gboolean dt_dev_write_ctmask_data_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
+#endif
+
+// helper function writing the pipe-processed ctmask data to dest 
+float *dt_dev_distort_ctmask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2946,7 +2946,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float threshold = 0.0001f * img->exif_iso;
   dt_times_t start_time = { 0 }, end_time = { 0 };
 
-  dt_dev_clear_ctmask(piece->pipe);
+  dt_dev_clear_luminance_mask(piece->pipe);
 
   dt_iop_roi_t roi = *roi_in;
   dt_iop_roi_t roo = *roi_out;
@@ -3073,7 +3073,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         method2string(demosaicing_method & ~DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
     }
 
-    dt_dev_write_ctmask_data(piece, tmp, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+    dt_dev_write_luminance_mask(piece, tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if((demosaicing_method & DEMOSAIC_DUAL) && !run_fast)
     {
@@ -3100,7 +3100,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     else
       dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                 piece->pipe->dsc.filters);
-    dt_dev_write_ctmask_data(piece, (float *)o, &roi, DT_DEV_CTMASK_DEMOSAIC);
+    dt_dev_write_luminance_mask(piece, (float *)o, &roi, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
   }
   if(data->color_smoothing)
     color_smoothing(o, roi_out, data->color_smoothing);
@@ -3582,7 +3582,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_release_mem_object(VP_diff);
     dt_opencl_release_mem_object(HQ_diff);
 
-    dt_dev_write_ctmask_data_cl(piece, dev_aux, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+    dt_dev_write_luminance_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -3799,7 +3799,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       }
     }
 
-    dt_dev_write_ctmask_data_cl(piece, dev_aux, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+    dt_dev_write_luminance_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -4207,7 +4207,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_vng_green_equilibrate, sizes);
       if(err != CL_SUCCESS) goto error;
     }
-    dt_dev_write_ctmask_data_cl(piece, dev_aux, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+    dt_dev_write_luminance_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -4975,7 +4975,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       dt_opencl_release_mem_object(dev_edge_out);
       dev_edge_in = dev_edge_out = NULL;
     }
-    dt_dev_write_ctmask_data_cl(piece, dev_tmp, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+    dt_dev_write_luminance_mask_cl(piece, dev_tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -5051,7 +5051,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_times_t start_time = { 0 }, end_time = { 0 };
   const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
 
-  dt_dev_clear_ctmask(piece->pipe);
+  dt_dev_clear_luminance_mask(piece->pipe);
 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   const int demosaicing_method = data->demosaicing_method;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -30,6 +30,8 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
+#include "develop/openmp_maths.h"
+#include "develop/masks.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "develop/tiling.h"
 #include "gui/accelerators.h"
@@ -2944,6 +2946,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float threshold = 0.0001f * img->exif_iso;
   dt_times_t start_time = { 0 }, end_time = { 0 };
 
+  dt_dev_clear_ctmask(piece->pipe);
+
   dt_iop_roi_t roi = *roi_in;
   dt_iop_roi_t roo = *roi_out;
   roo.x = roo.y = 0;
@@ -3069,6 +3073,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         method2string(demosaicing_method & ~DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
     }
 
+    dt_dev_write_ctmask_data(piece, tmp, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+
     if((demosaicing_method & DEMOSAIC_DUAL) && !run_fast)
     {
       dual_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans, showmask, data->dual_thrs);
@@ -3094,6 +3100,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     else
       dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                 piece->pipe->dsc.filters);
+    dt_dev_write_ctmask_data(piece, (float *)o, &roi, DT_DEV_CTMASK_DEMOSAIC);
   }
   if(data->color_smoothing)
     color_smoothing(o, roi_out, data->color_smoothing);
@@ -3574,6 +3581,9 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_release_mem_object(PQ_dir);
     dt_opencl_release_mem_object(VP_diff);
     dt_opencl_release_mem_object(HQ_diff);
+
+    dt_dev_write_ctmask_data_cl(piece, dev_aux, roi_in, DT_DEV_CTMASK_DEMOSAIC);
+
     if(scaled)
     {
       // scale aux buffer to output buffer
@@ -3788,6 +3798,8 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         if(err != CL_SUCCESS) goto error;
       }
     }
+
+    dt_dev_write_ctmask_data_cl(piece, dev_aux, roi_in, DT_DEV_CTMASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -4195,6 +4207,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_vng_green_equilibrate, sizes);
       if(err != CL_SUCCESS) goto error;
     }
+    dt_dev_write_ctmask_data_cl(piece, dev_aux, roi_in, DT_DEV_CTMASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -4962,7 +4975,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       dt_opencl_release_mem_object(dev_edge_out);
       dev_edge_in = dev_edge_out = NULL;
     }
-
+    dt_dev_write_ctmask_data_cl(piece, dev_tmp, roi_in, DT_DEV_CTMASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -5037,6 +5050,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 {
   dt_times_t start_time = { 0 }, end_time = { 0 };
   const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
+
+  dt_dev_clear_ctmask(piece->pipe);
 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   const int demosaicing_method = data->demosaicing_method;

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -20,123 +20,9 @@
    Dual demosaicing has been implemented by Ingo Weyrich <heckflosse67@gmx.de> for
    rawtherapee under GNU General Public License Version 3
    and has been modified to work for darktable by Hanno Schwalm (hanno@schwalm-bremen.de).
-   Also the code for fast_blur has been taken from rawtherapee capturesharpening,
+   Also the code for dt_masks_blur_9x9 has been taken from rawtherapee capturesharpening,
    implemented also by Ingo Weyrich.
 */
-
-static INLINE float calcBlendFactor(float val, float threshold)
-{
-    // sigmoid function
-    // result is in ]0;1] range
-    // inflexion point is at (x, y) (threshold, 0.5)
-    return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
-}
-
-static void fast_blur(float *const restrict src, float *const restrict out, const int width, const int height, const float sigma)
-{
-  // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
-  float kernel[9][9];
-  const double temp = -2.0f * sqrf(sigma);
-  float sum = 0.0f;
-  for(int i = -4; i <= 4; i++)
-  {
-    for(int j = -4; j <= 4; j++)
-    {
-      kernel[i + 4][j + 4] = expf( (sqrf(i) + sqrf(j)) / temp);
-      sum += kernel[i + 4][j + 4];
-    }
-  }
-  for(int i = 0; i < 9; i++)
-  {
-    for(int j = 0; j < 9; j++)
-      kernel[i][j] /= sum;
-  }
-  const float c42 = kernel[0][2];
-  const float c41 = kernel[0][3];
-  const float c40 = kernel[0][4];
-  const float c33 = kernel[1][1];
-  const float c32 = kernel[1][2];
-  const float c31 = kernel[1][3];
-  const float c30 = kernel[1][4];
-  const float c22 = kernel[2][2];
-  const float c21 = kernel[2][3];
-  const float c20 = kernel[2][4];
-  const float c11 = kernel[3][3];
-  const float c10 = kernel[3][4];
-  const float c00 = kernel[4][4];
-  const int w1 = width;
-  const int w2 = 2*width;
-  const int w3 = 3*width;
-  const int w4 = 4*width;
-#ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(src, out) \
-  dt_omp_sharedconst(c42, c41, c40, c33, c32, c31, c30, c22, c21, c20, c11, c10, c00, w1, w2, w3, w4, width, height) \
-  schedule(simd:static) aligned(src, out : 64) 
- #endif
-  for(int row = 4; row < height - 4; row++)
-  {
-#if defined(__clang__)
-        #pragma clang loop vectorize(assume_safety)
-#elif defined(__GNUC__)
-        #pragma GCC ivdep
-#endif
-    for(int col = 4; col < width - 4; col++)
-    {
-      const int i = row * width + col;
-      const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
-                        c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i - w1 - 4] + src[i - w1 + 4] + src[i + w1 - 4] + src[i + w1 + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
-                        c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
-                        c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
-                        c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
-                        c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i - w1 - 3] + src[i - w1 + 3] + src[i + w1 - 3] + src[i + w1 + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
-                        c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
-                        c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
-                        c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i - w1 - 2] + src[i - w1 + 2] + src[i + w1 - 2] + src[i + w1 + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
-                        c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
-                        c11 * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) +
-                        c10 * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) +
-                        c00 * src[i];
-      out[i] = fminf(1.0f, fmaxf(0.0f, val));
-    }
-  }
-}
-
-
-static void blend_images(float *const restrict rgb_data, float *const restrict blend, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean dual_mask)
-{
-  float *const luminance = blend; // re-use this as temporary data
-#ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(luminance, rgb_data, width, height) \
-  schedule(simd:static) aligned(luminance, rgb_data : 64) 
-#endif
-  for(size_t idx =0; idx < (size_t) width * height; idx++)
-  {
-    luminance[idx] = lab_f(0.3333333f * (rgb_data[4 * idx] + rgb_data[4 * idx + 1] + rgb_data[4 * idx + 2]));
-  }
-    
-  const float scale = 1.0f / 16.0f;
-  {
-   dt_iop_image_fill(tmp, 0.0f, width, height, 1);
-#ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(luminance, tmp, width, height, threshold, scale) \
-  schedule(simd:static) aligned(luminance, tmp : 64) 
- #endif
-    for(int row = 4; row < height - 4; row++)
-    {
-      for(int col = 4, idx = row * width + col; col < width - 4; col++, idx++)
-      {
-        float contrast = scale * sqrtf(sqrf(luminance[idx+1] - luminance[idx-1]) + sqrf(luminance[idx + width]   - luminance[idx - width]) +
-                                       sqrf(luminance[idx+2] - luminance[idx-2]) + sqrf(luminance[idx + 2*width] - luminance[idx - 2*width]));
-        tmp[idx] = calcBlendFactor(contrast, threshold);
-      }
-    }
-  }
-  dt_iop_image_fill(blend, 0.0f, width, height, 1);
-  fast_blur(tmp, blend, width, height, 2.0f);
-}
 
 // dual_demosaic is always called **after** the high-frequency demosaicer (rcd, amaze or one of the non-bayer demosaicers)
 // and expects the data available in rgb_data as rgba quadruples. 
@@ -170,7 +56,18 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   if(info) dt_get_times(&start_blend);
 
   const float contrastf = dual_threshold / 100.0f;
-  blend_images(rgb_data, blend, tmp, width, height, contrastf, dual_mask);
+
+  dt_masks_prepare_ctmask(rgb_data, blend, tmp, width, height);
+  dt_masks_full_ctmask(blend, blend, tmp, width, height, contrastf, TRUE);  
+
+  const float filler = 0.0f;
+  dt_iop_image_fill(blend, filler, width, 4, 1);
+  dt_iop_image_fill(&blend[(height-4) * width], filler, width, 4, 1);
+  for(int row = 4; row < height - 4; row++)
+  {
+    dt_iop_image_fill(&blend[row * width], filler, 4, 1, 1);
+    dt_iop_image_fill(&blend[row * width + width - 4], filler, 4, 1, 1);
+  }
 
   if(dual_mask)
   {
@@ -184,7 +81,6 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
       for(int c = 0; c < 4; c++)
         rgb_data[idx * 4 + c] = blend[idx];
     }
-    const float filler = 0.0f;
     dt_iop_image_fill(rgb_data, filler, width, 4, 4);
     dt_iop_image_fill(&rgb_data[4 * ((height-4) * width)], filler, width, 4, 4);
     for(int row = 4; row < height - 4; row++)
@@ -250,13 +146,13 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   {
     // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
     float kernel[9][9];
-    const double temp = -2.0f * sqrf(2.0f);
+    const double temp = -2.0f * sqf(2.0f);
     float sum = 0.0f;
     for(int i = -4; i <= 4; i++)
     {
       for(int j = -4; j <= 4; j++)
       {
-        kernel[i + 4][j + 4] = expf( (sqrf(i) + sqrf(j)) / temp);
+        kernel[i + 4][j + 4] = expf( (sqf(i) + sqf(j)) / temp);
         sum += kernel[i + 4][j + 4];
       }
     }

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -57,8 +57,8 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
 
   const float contrastf = dual_threshold / 100.0f;
 
-  dt_masks_prepare_ctmask(rgb_data, blend, tmp, width, height);
-  dt_masks_full_ctmask(blend, blend, tmp, width, height, contrastf, TRUE);  
+  dt_masks_calc_luminance_mask(rgb_data, blend, width, height);
+  dt_masks_calc_contrast_mask(blend, blend, tmp, width, height, contrastf, TRUE);  
 
   const float filler = 0.0f;
   dt_iop_image_fill(blend, filler, width, 4, 1);
@@ -133,12 +133,14 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   }  
 
   {
+    const int detail = 1;
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 0, sizeof(cl_mem), &luminance);  
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 1, sizeof(cl_mem), &blend);  
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 2, sizeof(int), &width);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 3, sizeof(int), &height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 4, sizeof(float), &contrastf);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 5, sizeof(int), &detail);
     const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_calc_blend, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -351,7 +351,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
   }
 
-  dt_dev_write_ctmask_data(piece, (float *const)ovoid, roi_in, DT_DEV_CTMASK_RAWPREPARE);
+  dt_dev_write_luminance_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 }
@@ -509,7 +509,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
   _mm_sfence();
-  dt_dev_write_ctmask_data(piece, (float *const)ovoid, roi_in, DT_DEV_CTMASK_RAWPREPARE);
+  dt_dev_write_luminance_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
 }
 #endif
 
@@ -576,7 +576,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
-  err = dt_dev_write_ctmask_data_cl(piece, dev_out, roi_in, DT_DEV_CTMASK_RAWPREPARE);
+  err = dt_dev_write_luminance_mask_cl(piece, dev_out, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
   if(err != CL_SUCCESS) goto error;
 
   return TRUE;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -23,6 +23,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/imageio_rawspeed.h" // for dt_rawspeed_crop_dcraw_filters
 #include "common/opencl.h"
+#include "common/imagebuf.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/tiling.h"
@@ -195,9 +196,7 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
 void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
                   float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  // TODO
-  memset(out, 0, sizeof(float) * roi_out->width * roi_out->height);
-  fprintf(stderr, "TODO: implement %s() in %s\n", __FUNCTION__, __FILE__);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, TRUE);
 }
 
 // we're not scaling here (bayer input), so just crop borders
@@ -351,6 +350,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
   }
+
+  dt_dev_write_ctmask_data(piece, (float *const)ovoid, roi_in, DT_DEV_CTMASK_RAWPREPARE);
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 }
@@ -508,6 +509,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
   _mm_sfence();
+  dt_dev_write_ctmask_data(piece, (float *const)ovoid, roi_in, DT_DEV_CTMASK_RAWPREPARE);
 }
 #endif
 
@@ -573,6 +575,9 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   }
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
+
+  err = dt_dev_write_ctmask_data_cl(piece, dev_out, roi_in, DT_DEV_CTMASK_RAWPREPARE);
+  if(err != CL_SUCCESS) goto error;
 
   return TRUE;
 

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -103,11 +103,6 @@ static INLINE float safe_in(float a, float scale)
   return fmaxf(0.0f, a) * scale;
 }
 
-static INLINE float sqrf(float a)
-{
-  return a * a;
-}
-
 // The border interpolation has been taken from rt, adapted to dt.
 // The original dcraw based code had much stronger color artefacts in the border region. 
 static INLINE void approxit(float *out, const float *cfa, const float *sum, const int idx, const int c)
@@ -309,7 +304,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
-            bufferV[row - 3][col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+            bufferV[row - 3][col - 4] = sqf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
         }
 
@@ -325,11 +320,11 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 3, indx = row * RCD_TILESIZE + col; col < tileCols - 3; col++, indx++)
           {
-            bufferH[col - 3] = sqrf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
+            bufferH[col - 3] = sqf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
           }
           for(int col = 4, indx = (row + 1) * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++)
           {
-            V2[col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+            V2[col - 4] = sqf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
           for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
@@ -395,8 +390,8 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 3, indx = row * RCD_TILESIZE + col, indx2 = indx / 2; col < tileCols - 3; col+=2, indx+=2, indx2++)
           {
-            P_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
-            Q_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
+            P_CDiff_Hpf[indx2] = sqf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
+            Q_CDiff_Hpf[indx2] = sqf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
           }
         }
         // Step 4.1: Obtain the P/Q diagonals directional discrimination strength


### PR DESCRIPTION
After closing #8501 this is a better approach ... pinging @aurelienpierre and @AxelG-DE 

**What is this about?**
For some use cases we want to discriminate image areas with lots of detail from those without. So it is not the desire about border or shape detection but something that should be understood as looking for pixelwise local contrast.

This idea is used already in darktable's dual demosaicing code (to discriminate areas with high frequency content from those without) and some algorithms in rawtherapee (microcontrast, sharpening, capture sharpening ...) so we know it works really good.

The user interface is pretty simple, for every mask offering a refinement box there is an additional slider defining a threshold for the contrast mask. (details later) Positive slider values select for contrasty, negative values for flat regions.

**What are the use cases of this contrast mask refinement?**
We would like to use modules like sharpening, local contrast, denoising to work only on image areas most suitable. Or we can brighten up some areas with lots of details.
Also the contrast mask will be the basis of yet to be implemented modules, i will certainly port rt's capture sharpening to dt.

**About the first pr discussion**
As @aurelienpierre pointed out in the discussion about #8501, the underlying algorithm is a bit more difficult to implement with darktable's roi concept as the calculated contrast value is not reliable after scaling, rotation or even simple things as exposure corrections.
I tried his suggestions but the original algorithm seems to be better suited for the purpose described above. 

So for calculating the first pixel contrast i kept the "weird thing" and had to find a way keeping "contrast masks" working exactly as in the original implementation. The "weird thing" code has been taken from rt, the originating code is from the microcontrast code there. 

To get you into faster understanding the code, **some implementation details**.

Whenever we set this slider to a value != 0 the demosaic or rawprepare modules are forced to write a *preliminary* contrast mask, it always has the size of the roi_out of that module, it is *not* scaled but only clipped so it still contains pure pixel data.
This preliminary mask is calculated only once whenever the writing module is processed and is later used for *every* mask using a "local contrast" refining step. 

Whenever a mask in any module wants a "local contrast" refinement it
a) takes the preliminary mask and calculates a 'mask overlay' using the threshold to calculate a sigmoid value 0->1 for every pixel
b) the just calculated mask overlay is now transformed through the pipeline using the modules 'distort' functions, the resulting "warped" contrast mask is now combined with the defined drawn or parametric mask.

- opencl code has been impemented
- some shared code with rcd and dual demosaicing has been de-duplicated
- supports all files using rawprepare or/and demosaic.