### PR TITLE
po/fix wb modern old

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1283,8 +1283,7 @@ int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so, const 
                                            const int length)
 {
   // we need a dt_iop_module_t for dt_develop_blend_legacy_params()
-  dt_iop_module_t *module;
-  module = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
+  dt_iop_module_t *module = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
   if(dt_iop_load_module_by_so(module, module_so, NULL))
   {
     free(module);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1382,7 +1382,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   if(!(image->flags & DT_IMAGE_AUTO_PRESETS_APPLIED)) run = TRUE;
 
   // flag was already set? only apply presets once in the lifetime of a history stack.
-  // (the flag will be cleared when removing it)
+  // (the flag will be cleared when removing it).
   if(!run || image->id <= 0)
   {
     dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_RELAXED);


### PR DESCRIPTION
    Fix handling of white-balance in old edits.
    
    Old edits had no white-balance written when the params where all defaults.
    For those edits we need to recover the legacy white-balance default (pre
    modern chromatic adaptation).
    
    Fixes #7145.
