### PR TITLE
[CI] Explicitly add dependency on python3-six

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,7 @@ jobs:
             mingw-w64-x86_64-python3
             mingw-w64-x86_64-iso-codes
             mingw-w64-x86_64-python3-jsonschema
+            mingw-w64-x86_64-python3-six
             mingw-w64-x86_64-python3-setuptools
             mingw-w64-x86_64-gmic
           update: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,7 @@ jobs:
             mingw-w64-x86_64-python3
             mingw-w64-x86_64-iso-codes
             mingw-w64-x86_64-python3-jsonschema
+            mingw-w64-x86_64-python3-six
             mingw-w64-x86_64-python3-setuptools
             mingw-w64-x86_64-gmic
             mingw-w64-x86_64-nsis


### PR DESCRIPTION
Windows CI jobs are currently failing due to https://github.com/msys2/MINGW-packages/issues/8275

This is a workaround by explicitly depending on the dependency missing in the mingw packaging. Alternative is to wait until upstream fixes it.