### PR TITLE
windows: Add openssl libraries to windows package (fixes #6856)

### DIFF
--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -96,6 +96,9 @@ if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
     ${MINGW_PATH}/libgmpxx*.dll
   #LIBUSB1
     ${MINGW_PATH}/libusb*.dll
+  #OPENSSL
+    ${MINGW_PATH}/libcrypto*.dll
+    ${MINGW_PATH}/libssl*.dll
     )
 
   if(OpenEXR_FOUND)


### PR DESCRIPTION
Including those files fixes the errors reported in #6856 (confirmed with an artifact from my fork).

The windows build fails due to https://github.com/darktable-org/darktable/pull/8607, so that's needed as well to actually get the nightlies back working.