### PR TITLE
Make modules and user aware of history problems via dt_dev_pixelpipe_synch

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -334,42 +334,45 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
   dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
   // find piece in nodes list
   dt_dev_pixelpipe_iop_t *piece = NULL;
-  gboolean hint = FALSE;
+
+  const dt_image_t *img = &pipe->image;
+  const int32_t imgid = img->id;
+  const gboolean rawprep_img = dt_image_is_rawprepare_supported(img);
 
   for(GList *nodes = pipe->nodes; nodes; nodes = g_list_next(nodes))
   {
     piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
-    const dt_image_t *img = &piece->pipe->image;
-    const int imgid = img->id;
 
     if(piece->module == hist->module)
     {
-      gboolean active = hist->enabled;
-
-      // demosaic must be OFF for non-raws and ON for raws
-      if(strcmp(piece->module->op, "demosaic") == 0)
-      {
-        if(dt_image_is_raw(img) && !active)
-        {
-          hint = TRUE;
-          active = TRUE;
-          fprintf(stderr,"[dt_dev_pixelpipe_synch] found disabled demosaic in history for raw `%s`, id: %i\n",
-            img->filename, imgid);
-        }
-        else if(!dt_image_is_raw(img) && active)
-        {
-          hint = TRUE;
-          active = FALSE;
-          fprintf(stderr,"[dt_dev_pixelpipe_synch] found enabled demosaic in history for non-raw `%s`, id: %i\n",
-            img->filename, imgid);
-        }
-      }
+      const gboolean active = hist->enabled;
       piece->enabled = active;
+
+      // Styles, presets or history copy&paste might set history items not appropriate for the image.
+      // Fixing that seemed to be almost impossible after long discussions but at least we can test,
+      // correct and add a problem hint here.
+      if((strcmp(piece->module->op, "demosaic") == 0) || (strcmp(piece->module->op, "rawprepare") == 0))
+      {
+        if(rawprep_img && !active)
+          piece->enabled = TRUE;
+        else if(!rawprep_img && active)
+          piece->enabled = FALSE;
+      }
+      else if((strcmp(piece->module->op, "rawdenoise") == 0) ||
+              (strcmp(piece->module->op, "hotpixels") == 0) ||
+              (strcmp(piece->module->op, "cacorrect") == 0))
+      {
+        if(!rawprep_img && active) piece->enabled = FALSE;
+      }
+
+      if(piece->enabled != hist->enabled)
+      {
+        dt_iop_set_module_trouble_message(piece->module, _("problem"), _("usage of the module is not correct for this image.\nlikely introduced by applying a preset, style or history copy&paste"), NULL);
+        dt_print(DT_DEBUG_PARAMS, "[pixelpipe_synch] enabling mismatch for module %s in image %i\n", piece->module->op, imgid);
+      }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
     }
   }
-  if(hint)
-    dt_control_log(_("history problem detected\nplease report via the issue tracker\nincluding the xmp file"));
 }
 
 void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -367,7 +367,10 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
 
       if(piece->enabled != hist->enabled)
       {
-        dt_iop_set_module_trouble_message(piece->module, _("problem"), _("usage of the module is not correct for this image.\nlikely introduced by applying a preset, style or history copy&paste"), NULL);
+        if(piece->enabled)
+          dt_iop_set_module_trouble_message(piece->module, _("enabled as required"), _("history had module disabled but it is required for this type of image.\nlikely introduced by applying a preset, style or history copy&paste"), NULL);
+        else
+          dt_iop_set_module_trouble_message(piece->module, _("disabled as not appropriate"), _("history had module enabled but it is not allowed for this type of image.\nlikely introduced by applying a preset, style or history copy&paste"), NULL);
         dt_print(DT_DEBUG_PARAMS, "[pixelpipe_synch] enabling mismatch for module %s in image %i\n", piece->module->op, imgid);
       }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);


### PR DESCRIPTION
There have been lots of issues all related to history items being added to a developed image via presets, styles or copy&paste from a raw image to a non-raw or vice versa.
So far there was a message resulting from a time when we were not sure where all those problems were coming from and even had crashes.

This pr does more checks - costing a very small amount of cpu time - but gives a hint directly at the affected module so at least the users knows better what has "gone wrong".

The screen message is not necessary any more and had the disadvantage of polluting the screen while in lighttable mode too.

Fixing #8238 #7984 #7625