### PR TITLE
Fixing local contrast CPU code precision

### DIFF
--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -424,7 +424,7 @@ static inline float curve_scalar(
     val = g - sigma * 2.0f*mt*t + t2*(- sigma - sigma*highlights);
   }
   // midtone local contrast
-  val += clarity * c * dt_fast_expf(-c*c/(2.0*sigma*sigma/3.0f));
+  val += clarity * c * expf(-c*c/(2.0*sigma*sigma/3.0f));
   return val;
 }
 


### PR DESCRIPTION
As pointed out and discussed in #8382 the dt_fast variant of expf() lead to a subtle precision loss
resulting in many diff-pixels in 0002-local-contrast integration test compared with OpenCL code.

Fixes #8382