### PR TITLE
RCD and dual demosaicer maintenance updates

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -428,6 +428,12 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          const float initial_ypos, const float xpos, const float ypos, float *px,
                                          float *py, const int adding);
 
+/** luminance mask support */
+void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
+void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
+void dt_masks_calc_luminance_mask(float *const src, float *const out, const int width, const int height);
+void dt_masks_calc_detail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
+
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);
 

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -1,0 +1,167 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2013-2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+void dt_masks_extend_border(float *mask, const int width, const int height, const int border)
+{
+  if(border <= 0) return;
+  for(int row = border; row < height - border; row++)
+  {
+    const int idx = row * width;
+    for(int i = 0; i < border; i++)
+    {
+      mask[idx + i] = mask[idx + border];
+      mask[idx + width - i - 1] = mask[idx + width - border -1];   
+    }
+  }
+  for(int col = 0; col < width; col++)
+  {
+    const float top = mask[border * width + MIN(width - border - 1, MAX(col, border))];
+    const float bot = mask[(height - border - 1) * width + MIN(width - border - 1, MAX(col, border))];
+    for(int i = 0; i < border; i++)
+    {
+      mask[col + i * width] = top;
+      mask[col + (height - i - 1) * width] = bot;
+    }   
+  }
+}
+
+void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, const int width, const int height, const float sigma)
+{
+  // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
+  float kernel[9][9];
+  const float temp = 2.0f * sqf(sigma);
+  float sum = 0.0f;
+  for(int i = -4; i <= 4; i++)
+  {
+    for(int j = -4; j <= 4; j++)
+    {
+      kernel[i + 4][j + 4] = expf( -(sqf(i) + sqf(j)) / temp);
+      sum += kernel[i + 4][j + 4];
+    }
+  }
+  for(int i = 0; i < 9; i++)
+  {
+    for(int j = 0; j < 9; j++)
+      kernel[i][j] /= sum;
+  }
+  const float c42 = kernel[0][2];
+  const float c41 = kernel[0][3];
+  const float c40 = kernel[0][4];
+  const float c33 = kernel[1][1];
+  const float c32 = kernel[1][2];
+  const float c31 = kernel[1][3];
+  const float c30 = kernel[1][4];
+  const float c22 = kernel[2][2];
+  const float c21 = kernel[2][3];
+  const float c20 = kernel[2][4];
+  const float c11 = kernel[3][3];
+  const float c10 = kernel[3][4];
+  const float c00 = kernel[4][4];
+  const int w1 = width;
+  const int w2 = 2*width;
+  const int w3 = 3*width;
+  const int w4 = 4*width;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(src, out) \
+  dt_omp_sharedconst(c42, c41, c40, c33, c32, c31, c30, c22, c21, c20, c11, c10, c00, w1, w2, w3, w4, width, height) \
+  schedule(simd:static) aligned(src, out : 64) 
+ #endif
+  for(int row = 4; row < height - 4; row++)
+  {
+#if defined(__clang__)
+        #pragma clang loop vectorize(assume_safety)
+#elif defined(__GNUC__)
+        #pragma GCC ivdep
+#endif
+    for(int col = 4; col < width - 4; col++)
+    {
+      const int i = row * width + col;
+      const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
+                        c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i - w1 - 4] + src[i - w1 + 4] + src[i + w1 - 4] + src[i + w1 + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
+                        c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
+                        c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
+                        c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
+                        c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i - w1 - 3] + src[i - w1 + 3] + src[i + w1 - 3] + src[i + w1 + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
+                        c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
+                        c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
+                        c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i - w1 - 2] + src[i - w1 + 2] + src[i + w1 - 2] + src[i + w1 + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
+                        c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
+                        c11 * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) +
+                        c10 * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) +
+                        c00 * src[i];
+      out[i] = clamp_simd(val);
+    }
+  }
+}
+
+void dt_masks_calc_luminance_mask(float *const restrict src, float *const restrict mask, const int width, const int height)
+{
+  const int msize = width * height;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(mask, src, msize) \
+  schedule(simd:static) aligned(mask, src : 64) 
+#endif
+  for(int idx =0; idx < msize; idx++)
+  {
+    const float val = 0.333333333f * (src[4 * idx] + src[4 * idx + 1] + src[4 * idx + 2]);
+    mask[idx] = lab_f(val);
+  }
+}
+
+static inline float calcBlendFactor(float val, float threshold)
+{
+    // sigmoid function
+    // result is in ]0;1] range
+    // inflexion point is at (x, y) (threshold, 0.5)
+    return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
+}
+
+void dt_masks_calc_detail_mask(float *const restrict src, float *const restrict out, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean detail)
+{
+  const float scale = 1.0f / 16.0f;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(src, tmp, width, height, scale) \
+  schedule(simd:static) aligned(src, tmp : 64) 
+ #endif
+  for(int row = 2; row < height - 2; row++)
+  {
+    for(int col = 2, idx = row * width + col; col < width - 2; col++, idx++)
+    {
+      tmp[idx] = scale * sqrtf(sqf(src[idx+1] - src[idx-1]) + sqf(src[idx + width]   - src[idx - width]) +
+                                sqf(src[idx+2] - src[idx-2]) + sqf(src[idx + 2*width] - src[idx - 2*width]));
+    }
+  }
+  dt_masks_extend_border(tmp, width, height, 2);  
+
+  const int msize = width * height;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(tmp, msize, threshold, detail) \
+  schedule(simd:static) aligned(tmp : 64) 
+#endif
+  for(int idx = 0; idx < msize; idx++)
+  {
+    const float blend = calcBlendFactor(tmp[idx], threshold);
+    tmp[idx] = detail ? blend : 1.0f - blend;
+  }
+  dt_masks_blur_9x9(tmp, out, width, height, 2.0f);
+}
+

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -24,6 +24,7 @@
 #include "common/undo.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "develop/openmp_maths.h"
 
 #pragma GCC diagnostic ignored "-Wshadow"
 
@@ -2377,6 +2378,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   *px = x;
   *py = y;
 }
+
+#include "detail.c"
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -20,123 +20,9 @@
    Dual demosaicing has been implemented by Ingo Weyrich <heckflosse67@gmx.de> for
    rawtherapee under GNU General Public License Version 3
    and has been modified to work for darktable by Hanno Schwalm (hanno@schwalm-bremen.de).
-   Also the code for fast_blur has been taken from rawtherapee capturesharpening,
+   Also the code for dt_masks_blur_9x9 has been taken from rawtherapee capturesharpening,
    implemented also by Ingo Weyrich.
 */
-
-static INLINE float calcBlendFactor(float val, float threshold)
-{
-    // sigmoid function
-    // result is in ]0;1] range
-    // inflexion point is at (x, y) (threshold, 0.5)
-    return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
-}
-
-static void fast_blur(float *const restrict src, float *const restrict out, const int width, const int height, const float sigma)
-{
-  // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
-  float kernel[9][9];
-  const double temp = -2.0f * sqrf(sigma);
-  float sum = 0.0f;
-  for(int i = -4; i <= 4; i++)
-  {
-    for(int j = -4; j <= 4; j++)
-    {
-      kernel[i + 4][j + 4] = expf( (sqrf(i) + sqrf(j)) / temp);
-      sum += kernel[i + 4][j + 4];
-    }
-  }
-  for(int i = 0; i < 9; i++)
-  {
-    for(int j = 0; j < 9; j++)
-      kernel[i][j] /= sum;
-  }
-  const float c42 = kernel[0][2];
-  const float c41 = kernel[0][3];
-  const float c40 = kernel[0][4];
-  const float c33 = kernel[1][1];
-  const float c32 = kernel[1][2];
-  const float c31 = kernel[1][3];
-  const float c30 = kernel[1][4];
-  const float c22 = kernel[2][2];
-  const float c21 = kernel[2][3];
-  const float c20 = kernel[2][4];
-  const float c11 = kernel[3][3];
-  const float c10 = kernel[3][4];
-  const float c00 = kernel[4][4];
-  const int w1 = width;
-  const int w2 = 2*width;
-  const int w3 = 3*width;
-  const int w4 = 4*width;
-#ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(src, out) \
-  dt_omp_sharedconst(c42, c41, c40, c33, c32, c31, c30, c22, c21, c20, c11, c10, c00, w1, w2, w3, w4, width, height) \
-  schedule(simd:static) aligned(src, out : 64) 
- #endif
-  for(int row = 4; row < height - 4; row++)
-  {
-#if defined(__clang__)
-        #pragma clang loop vectorize(assume_safety)
-#elif defined(__GNUC__)
-        #pragma GCC ivdep
-#endif
-    for(int col = 4; col < width - 4; col++)
-    {
-      const int i = row * width + col;
-      const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
-                        c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i - w1 - 4] + src[i - w1 + 4] + src[i + w1 - 4] + src[i + w1 + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
-                        c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
-                        c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
-                        c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
-                        c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i - w1 - 3] + src[i - w1 + 3] + src[i + w1 - 3] + src[i + w1 + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
-                        c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
-                        c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
-                        c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i - w1 - 2] + src[i - w1 + 2] + src[i + w1 - 2] + src[i + w1 + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
-                        c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
-                        c11 * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) +
-                        c10 * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) +
-                        c00 * src[i];
-      out[i] = fminf(1.0f, fmaxf(0.0f, val));
-    }
-  }
-}
-
-
-static void blend_images(float *const restrict rgb_data, float *const restrict blend, float *const restrict tmp, const int width, const int height, const float threshold, const gboolean dual_mask)
-{
-  float *const luminance = blend; // re-use this as temporary data
-#ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(luminance, rgb_data, width, height) \
-  schedule(simd:static) aligned(luminance, rgb_data : 64) 
-#endif
-  for(size_t idx =0; idx < (size_t) width * height; idx++)
-  {
-    luminance[idx] = lab_f(0.3333333f * (rgb_data[4 * idx] + rgb_data[4 * idx + 1] + rgb_data[4 * idx + 2]));
-  }
-    
-  const float scale = 1.0f / 16.0f;
-  {
-   dt_iop_image_fill(tmp, 0.0f, width, height, 1);
-#ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(luminance, tmp, width, height, threshold, scale) \
-  schedule(simd:static) aligned(luminance, tmp : 64) 
- #endif
-    for(int row = 4; row < height - 4; row++)
-    {
-      for(int col = 4, idx = row * width + col; col < width - 4; col++, idx++)
-      {
-        float contrast = scale * sqrtf(sqrf(luminance[idx+1] - luminance[idx-1]) + sqrf(luminance[idx + width]   - luminance[idx - width]) +
-                                       sqrf(luminance[idx+2] - luminance[idx-2]) + sqrf(luminance[idx + 2*width] - luminance[idx - 2*width]));
-        tmp[idx] = calcBlendFactor(contrast, threshold);
-      }
-    }
-  }
-  dt_iop_image_fill(blend, 0.0f, width, height, 1);
-  fast_blur(tmp, blend, width, height, 2.0f);
-}
 
 // dual_demosaic is always called **after** the high-frequency demosaicer (rcd, amaze or one of the non-bayer demosaicers)
 // and expects the data available in rgb_data as rgba quadruples. 
@@ -170,7 +56,18 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   if(info) dt_get_times(&start_blend);
 
   const float contrastf = dual_threshold / 100.0f;
-  blend_images(rgb_data, blend, tmp, width, height, contrastf, dual_mask);
+
+  dt_masks_calc_luminance_mask(rgb_data, blend, width, height);
+  dt_masks_calc_detail_mask(blend, blend, tmp, width, height, contrastf, TRUE);  
+
+  const float filler = 0.0f;
+  dt_iop_image_fill(blend, filler, width, 4, 1);
+  dt_iop_image_fill(&blend[(height-4) * width], filler, width, 4, 1);
+  for(int row = 4; row < height - 4; row++)
+  {
+    dt_iop_image_fill(&blend[row * width], filler, 4, 1, 1);
+    dt_iop_image_fill(&blend[row * width + width - 4], filler, 4, 1, 1);
+  }
 
   if(dual_mask)
   {
@@ -184,7 +81,6 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
       for(int c = 0; c < 4; c++)
         rgb_data[idx * 4 + c] = blend[idx];
     }
-    const float filler = 0.0f;
     dt_iop_image_fill(rgb_data, filler, width, 4, 4);
     dt_iop_image_fill(&rgb_data[4 * ((height-4) * width)], filler, width, 4, 4);
     for(int row = 4; row < height - 4; row++)
@@ -228,35 +124,37 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
   {
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 0, sizeof(cl_mem), &luminance);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 1, sizeof(cl_mem), &high_image);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_luminance_mask, 3, sizeof(int), &height);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_luminance_mask, sizes);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_luminance_mask, 0, sizeof(cl_mem), &luminance);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_luminance_mask, 1, sizeof(cl_mem), &high_image);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_luminance_mask, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_luminance_mask, 3, sizeof(int), &height);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_calc_luminance_mask, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }  
 
   {
+    const int detail = 1;
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 0, sizeof(cl_mem), &luminance);  
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 1, sizeof(cl_mem), &blend);  
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 3, sizeof(int), &height);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_calc_blend, 4, sizeof(float), &contrastf);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_calc_blend, sizes);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 0, sizeof(cl_mem), &luminance);  
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 1, sizeof(cl_mem), &blend);  
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 4, sizeof(float), &contrastf);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 5, sizeof(int), &detail);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_calc_detail_blend, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 
   {
     // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
     float kernel[9][9];
-    const double temp = -2.0f * sqrf(2.0f);
+    const double temp = -2.0f * sqf(2.0f);
     float sum = 0.0f;
     for(int i = -4; i <= 4; i++)
     {
       for(int j = -4; j <= 4; j++)
       {
-        kernel[i + 4][j + 4] = expf( (sqrf(i) + sqrf(j)) / temp);
+        kernel[i + 4][j + 4] = expf( (sqf(i) + sqf(j)) / temp);
         sum += kernel[i + 4][j + 4];
       }
     }
@@ -280,42 +178,41 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     const float c00 = kernel[4][4];
 
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 0, sizeof(cl_mem), &blend);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 1, sizeof(cl_mem), &luminance);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 3, sizeof(int), &height);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 4, sizeof(int), &c42);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 5, sizeof(int), &c41);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 6, sizeof(int), &c40);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 7, sizeof(int), &c33);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 8, sizeof(int), &c32);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 9, sizeof(int), &c31);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 10, sizeof(int), &c30);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 11, sizeof(int), &c22);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 12, sizeof(int), &c21);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 13, sizeof(int), &c20);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 14, sizeof(int), &c11);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 15, sizeof(int), &c10);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_fast_blur, 16, sizeof(int), &c00);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_fast_blur, sizes);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 0, sizeof(cl_mem), &blend);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 1, sizeof(cl_mem), &luminance);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 4, sizeof(int), &c42);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 5, sizeof(int), &c41);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 6, sizeof(int), &c40);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 7, sizeof(int), &c33);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 8, sizeof(int), &c32);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 9, sizeof(int), &c31);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 10, sizeof(int), &c30);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 11, sizeof(int), &c22);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 12, sizeof(int), &c21);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 13, sizeof(int), &c20);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 14, sizeof(int), &c11);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 15, sizeof(int), &c10);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 16, sizeof(int), &c00);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_fastblur_mask_9x9, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 
   {
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 0, sizeof(cl_mem), &high_image);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 1, sizeof(cl_mem), &low_image);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 2, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 3, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 4, sizeof(int), &height);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 5, sizeof(cl_mem), &luminance);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_dual_blend_both, 6, sizeof(int), &showmask);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_dual_blend_both, sizes);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 0, sizeof(cl_mem), &high_image);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 1, sizeof(cl_mem), &low_image);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 2, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 3, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 4, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 5, sizeof(cl_mem), &luminance);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_write_blended_dual, 6, sizeof(int), &showmask);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_write_blended_dual, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 
   return TRUE;
 }
 #endif
-
 

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -103,11 +103,6 @@ static INLINE float safe_in(float a, float scale)
   return fmaxf(0.0f, a) * scale;
 }
 
-static INLINE float sqrf(float a)
-{
-  return a * a;
-}
-
 // The border interpolation has been taken from rt, adapted to dt.
 // The original dcraw based code had much stronger color artefacts in the border region. 
 static INLINE void approxit(float *out, const float *cfa, const float *sum, const int idx, const int c)
@@ -309,7 +304,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
-            bufferV[row - 3][col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+            bufferV[row - 3][col - 4] = sqf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
         }
 
@@ -325,11 +320,11 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 3, indx = row * RCD_TILESIZE + col; col < tileCols - 3; col++, indx++)
           {
-            bufferH[col - 3] = sqrf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
+            bufferH[col - 3] = sqf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
           }
           for(int col = 4, indx = (row + 1) * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++)
           {
-            V2[col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+            V2[col - 4] = sqf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
           for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
@@ -395,8 +390,8 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 3, indx = row * RCD_TILESIZE + col, indx2 = indx / 2; col < tileCols - 3; col+=2, indx+=2, indx2++)
           {
-            P_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
-            Q_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
+            P_CDiff_Hpf[indx2] = sqf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
+            Q_CDiff_Hpf[indx2] = sqf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
           }
         }
         // Step 4.1: Obtain the P/Q diagonals directional discrimination strength


### PR DESCRIPTION
While working on the new 'contrast mask' (should be understood as a 'detail mask' btw) i found

- some functions/variables are named in a misleading way
- i didn't want to duplicate code
- some minor code improvements
- the detail mask was not visible in default darkroom demosaicer setting

So, some files touched for 3.6 code cleanup needed anyway