### PR TITLE
collect: use integer focal lengths

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1683,7 +1683,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       else if(operator && number1)
         query = g_strdup_printf("(focal_length %s %s)", operator, number1);
       else if(number1)
-        query = g_strdup_printf("(focal_length = %s)", number1);
+        query = g_strdup_printf("(CAST(focal_length AS INTEGER) = CAST(%s AS INTEGER))", number1);
       else
         query = g_strdup_printf("(focal_length LIKE '%%%s%%')", escaped_text);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1724,8 +1724,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
                    "SELECT CAST(focal_length AS INTEGER) AS focal_length, 1, COUNT(*) AS count"
                    " FROM main.images AS mi"
                    " WHERE %s"
-                   " GROUP BY focal_length"
-                   " ORDER BY focal_length",
+                   " GROUP BY CAST(focal_length AS INTEGER)"
+                   " ORDER BY CAST(focal_length AS INTEGER)",
                    where_ext);
         break;
 


### PR DESCRIPTION
when grouping images in the collect module or doing equality comparisons, convert the focal length to an integer first

Resolves #8630