### PR TITLE
rcd and dual demosaicers used sqf( inline function wrongfully

### DIFF
--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -15,6 +15,10 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+static inline float sqrf(float a)
+{
+  return a * a;
+}
 
 void dt_masks_extend_border(float *mask, const int width, const int height, const int border)
 {
@@ -44,13 +48,13 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
 {
   // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
   float kernel[9][9];
-  const float temp = 2.0f * sqf(sigma);
+  const float temp = 2.0f * sqrf(sigma);
   float sum = 0.0f;
   for(int i = -4; i <= 4; i++)
   {
     for(int j = -4; j <= 4; j++)
     {
-      kernel[i + 4][j + 4] = expf( -(sqf(i) + sqf(j)) / temp);
+      kernel[i + 4][j + 4] = expf( -(sqrf(i) + sqrf(j)) / temp);
       sum += kernel[i + 4][j + 4];
     }
   }
@@ -105,7 +109,7 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
                         c11 * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) +
                         c10 * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) +
                         c00 * src[i];
-      out[i] = clamp_simd(val);
+      out[i] = fminf(1.0f, fmaxf(0.0f, val));
     }
   }
 }
@@ -145,8 +149,8 @@ void dt_masks_calc_detail_mask(float *const restrict src, float *const restrict 
   {
     for(int col = 2, idx = row * width + col; col < width - 2; col++, idx++)
     {
-      tmp[idx] = scale * sqrtf(sqf(src[idx+1] - src[idx-1]) + sqf(src[idx + width]   - src[idx - width]) +
-                                sqf(src[idx+2] - src[idx-2]) + sqf(src[idx + 2*width] - src[idx - 2*width]));
+      tmp[idx] = scale * sqrtf(sqrf(src[idx+1] - src[idx-1]) + sqrf(src[idx + width]   - src[idx - width]) +
+                               sqrf(src[idx+2] - src[idx-2]) + sqrf(src[idx + 2*width] - src[idx - 2*width]));
     }
   }
   dt_masks_extend_border(tmp, width, height, 2);  

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -24,7 +24,6 @@
 #include "common/undo.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
-#include "develop/openmp_maths.h"
 
 #pragma GCC diagnostic ignored "-Wshadow"
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -30,7 +30,6 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
-#include "develop/openmp_maths.h"
 #include "develop/masks.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "develop/tiling.h"

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -148,13 +148,13 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   {
     // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
     float kernel[9][9];
-    const double temp = -2.0f * sqf(2.0f);
+    const double temp = -2.0f * (2.0f * 2.0f);
     float sum = 0.0f;
     for(int i = -4; i <= 4; i++)
     {
       for(int j = -4; j <= 4; j++)
       {
-        kernel[i + 4][j + 4] = expf( (sqf(i) + sqf(j)) / temp);
+        kernel[i + 4][j + 4] = expf(((i*i) + (j*j)) / temp);
         sum += kernel[i + 4][j + 4];
       }
     }

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -103,6 +103,11 @@ static INLINE float safe_in(float a, float scale)
   return fmaxf(0.0f, a) * scale;
 }
 
+static INLINE float sqrf(float a)
+{
+  return a * a;
+}
+
 // The border interpolation has been taken from rt, adapted to dt.
 // The original dcraw based code had much stronger color artefacts in the border region. 
 static INLINE void approxit(float *out, const float *cfa, const float *sum, const int idx, const int c)
@@ -304,7 +309,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
-            bufferV[row - 3][col - 4] = sqf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+            bufferV[row - 3][col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
         }
 
@@ -320,11 +325,11 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 3, indx = row * RCD_TILESIZE + col; col < tileCols - 3; col++, indx++)
           {
-            bufferH[col - 3] = sqf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
+            bufferH[col - 3] = sqrf((cfa[indx -  3] - cfa[indx -  1] - cfa[indx +  1] + cfa[indx +  3]) - 3.0f * (cfa[indx -  2] + cfa[indx +  2]) + 6.0f * cfa[indx]);
           }
           for(int col = 4, indx = (row + 1) * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++)
           {
-            V2[col - 4] = sqf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
+            V2[col - 4] = sqrf((cfa[indx - w3] - cfa[indx - w1] - cfa[indx + w1] + cfa[indx + w3]) - 3.0f * (cfa[indx - w2] + cfa[indx + w2]) + 6.0f * cfa[indx]);
           }
           for(int col = 4, indx = row * RCD_TILESIZE + col; col < tileCols - 4; col++, indx++ )
           {
@@ -390,8 +395,8 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
         {
           for(int col = 3, indx = row * RCD_TILESIZE + col, indx2 = indx / 2; col < tileCols - 3; col+=2, indx+=2, indx2++)
           {
-            P_CDiff_Hpf[indx2] = sqf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
-            Q_CDiff_Hpf[indx2] = sqf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
+            P_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 - 3] - cfa[indx - w1 - 1] - cfa[indx + w1 + 1] + cfa[indx + w3 + 3]) - 3.0f * (cfa[indx - w2 - 2] + cfa[indx + w2 + 2]) + 6.0f * cfa[indx]);
+            Q_CDiff_Hpf[indx2] = sqrf((cfa[indx - w3 + 3] - cfa[indx - w1 + 1] - cfa[indx + w1 - 1] + cfa[indx + w3 - 3]) - 3.0f * (cfa[indx - w2 + 2] + cfa[indx + w2 - 2]) + 6.0f * cfa[indx]);
           }
         }
         // Step 4.1: Obtain the P/Q diagonals directional discrimination strength


### PR DESCRIPTION
This lead to mem access crashes because of non-aligned and possibly out-of-array access.

likely fixes #8636