### PR TITLE
po/fix duplicate old hist

### DIFF
--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -325,6 +325,24 @@ void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const int32_t 
   dt_image_cache_write_release(cache, img, DT_IMAGE_CACHE_SAFE);
 }
 
+void dt_image_cache_set_change_timestamp_from_image(dt_image_cache_t *cache, const int32_t imgid, const int32_t sourceid)
+{
+  if(imgid <= 0 || sourceid <= 0) return;
+
+  // get source timestamp
+  const dt_image_t *simg = dt_image_cache_get(cache, sourceid, 'r');
+  const time_t change_timestamp = simg->change_timestamp;
+  dt_image_cache_read_release(cache, simg);
+
+  dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, DT_IMAGE_CACHE_SAFE);
+  if(!entry) return;
+  ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
+  dt_image_t *img = (dt_image_t *)entry->data;
+  img->cache_entry = entry;
+  img->change_timestamp = change_timestamp;
+  dt_image_cache_write_release(cache, img, DT_IMAGE_CACHE_SAFE);
+}
+
 void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const int32_t imgid)
 {
   if(imgid <= 0) return;

--- a/src/common/image_cache.h
+++ b/src/common/image_cache.h
@@ -68,6 +68,7 @@ void dt_image_cache_remove(dt_image_cache_t *cache, const int32_t imgid);
 
 // register timestamps in cache
 void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const int32_t imgid);
+void dt_image_cache_set_change_timestamp_from_image(dt_image_cache_t *cache, const int32_t imgid, const int32_t sourceid);
 void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const int32_t imgid);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -567,6 +567,9 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
     if(newimgid != -1)
     {
       dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL, TRUE, TRUE);
+      // a duplicate should keep the change time stamp of the original
+      dt_image_cache_set_change_timestamp_from_image(darktable.image_cache, newimgid, imgid);
+
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
     }
     t = g_list_next(t);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2289,6 +2289,9 @@ static gboolean _accel_duplicate(GtkAccelGroup *accel_group, GObject *accelerata
   else
     dt_history_copy_and_paste_on_image(sourceid, newimgid, FALSE, NULL, TRUE, TRUE);
 
+  // a duplicate should keep the change time stamp of the original
+  dt_image_cache_set_change_timestamp_from_image(darktable.image_cache, newimgid, sourceid);
+
   dt_undo_end_group(darktable.undo);
 
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2280,8 +2280,8 @@ static gboolean _accel_duplicate(GtkAccelGroup *accel_group, GObject *accelerata
 {
   dt_undo_start_group(darktable.undo, DT_UNDO_DUPLICATE);
 
-  const int sourceid = dt_view_get_image_to_act_on();
-  const int newimgid = dt_image_duplicate(sourceid);
+  const int32_t sourceid = dt_view_get_image_to_act_on();
+  const int32_t newimgid = dt_image_duplicate(sourceid);
   if(newimgid <= 0) return FALSE;
 
   if(GPOINTER_TO_INT(data))


### PR DESCRIPTION
Ensure that a duplicate gets the change_timestamp of the source image.
    
Fix White Balance for old edits that are duplicated before enterring
the darkroom.
    
Continued work for #8599.
