### PR TITLE
Implementing "Details" mask refinement (was contrast mask)

### DIFF
--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -322,6 +322,28 @@ __kernel void calc_detail_blend(global float *luminance, global float *mask, con
   mask[oidx] = detail ? blend : 1.0f - blend;
 }
 
+__kernel void readin_mask(global float *mask, __read_only image2d_t in, const int w, const int height)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+
+  const int idx = mad24(row, w, col);
+  const float val = read_imagef(in, sampleri, (int2)(col, row)).x;
+  mask[idx] = val;
+}
+
+__kernel void writeout_mask(global float *mask, __write_only image2d_t out, const int w, const int height)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w) || (row >= height)) return;
+  const int idx = mad24(row, w, col);
+
+  const float val = mask[idx];
+  write_imagef(out, (int2)(col, row), val);  
+}
+
 __kernel void write_blended_dual(__read_only image2d_t high, __read_only image2d_t low, __write_only image2d_t out, const int w, const int height, global float *mask, const int showmask)
 {
   const int col = get_global_id(0);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -233,7 +233,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self, struct dt_dev
 {
   if(level == 0.0f) return;
 
-  gboolean detail = (level > 0.0f);
+  const gboolean detail = (level > 0.0f);
   const float threshold = _detail_mask_threshold(level, detail);
   
   float *tmp = NULL;
@@ -643,7 +643,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
   {
     // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
     float kernel[9][9];
-    const double temp = -2.0f * 2.0f * 2.0f;
+    const float temp = -8.0f; // -2.0f * 2.0f * 2.0f; for a sigma of 2
     float sum = 0.0f;
     for(int i = -4; i <= 4; i++)
     {
@@ -655,6 +655,9 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
     }
     for(int i = 0; i < 9; i++)
     {
+#if defined(__GNUC__)
+  #pragma GCC ivdep
+#endif
       for(int j = 0; j < 9; j++)
         kernel[i][j] /= sum;
     }

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -241,7 +241,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self, struct dt_dev
   float *warp_mask = NULL;
 
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if(p->luminance_mask_data == NULL) goto error;
+  if(p->luminance_mask_data == NULL) return;
 
   const int iwidth  = p->luminance_mask_roi.width;
   const int iheight = p->luminance_mask_roi.height;
@@ -255,7 +255,6 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self, struct dt_dev
   if((tmp == NULL) || (lum == NULL)) goto error;
 
   dt_masks_calc_detail_mask(p->luminance_mask_data, lum, tmp, iwidth, iheight, threshold, detail);
-  dt_masks_extend_border(lum, iwidth, iheight, 4);
 
   // here we have the slightly blurred full detail mask available
   warp_mask = dt_dev_distort_luminance_mask(p, lum, self);
@@ -591,7 +590,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
   cl_mem out = NULL;
 
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if(p->luminance_mask_data == NULL) goto error;
+  if(p->luminance_mask_data == NULL) return;
 
   const int iwidth  = p->luminance_mask_roi.width;
   const int iheight = p->luminance_mask_roi.height;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1236,6 +1236,9 @@ dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
   b->kernel_blendop_mask_tone_curve = dt_opencl_create_kernel(program, "blendop_mask_tone_curve");
   b->kernel_blendop_set_mask = dt_opencl_create_kernel(program, "blendop_set_mask");
   b->kernel_blendop_display_channel = dt_opencl_create_kernel(program, "blendop_display_channel");
+
+  const int program_rcd = 31;
+  b->kernel_calc_luminance_mask = dt_opencl_create_kernel(program_rcd, "out_luminance_mask");
   return b;
 #else
   return NULL;
@@ -1259,7 +1262,7 @@ void dt_develop_blend_free_cl_global(dt_blendop_cl_global_t *b)
   dt_opencl_free_kernel(b->kernel_blendop_mask_tone_curve);
   dt_opencl_free_kernel(b->kernel_blendop_set_mask);
   dt_opencl_free_kernel(b->kernel_blendop_display_channel);
-
+  dt_opencl_free_kernel(b->kernel_calc_luminance_mask);
   free(b);
 #endif
 }

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -19,11 +19,13 @@
 #include "common/gaussian.h"
 #include "common/guided_filter.h"
 #include "common/imagebuf.h"
+#include "common/interpolation.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
 #include "develop/tiling.h"
+#include "develop/imageop_math.h"
 #include <math.h>
 
 static dt_develop_blend_params_t _default_blendop_params
@@ -40,7 +42,8 @@ static dt_develop_blend_params_t _default_blendop_params
         0.0f,
         0.0f,
         0.0f,
-        { 0, 0, 0, 0 },
+        0.0f, // detail mask threshold
+        { 0, 0, 0 },
         { 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
           0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
           0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
@@ -220,6 +223,66 @@ int dt_develop_blendif_init_masking_profile(struct dt_dev_pixelpipe_iop_t *piece
   return 1;
 }
 
+static float _detail_mask_threshold(const float level, const gboolean detail)
+{
+  // this does some range calculation for smoother ui experience
+  return 0.01f * (detail ? powf(level, 1.5f) : 1.0f - powf(fabs(level), 0.75f ));
+}
+
+static void _refine_with_detail_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *mask, const struct dt_iop_roi_t *const roi_in, const struct dt_iop_roi_t *const roi_out, const float level)
+{
+  if(level == 0.0f) return;
+
+  gboolean detail = (level > 0.0f);
+  const float threshold = _detail_mask_threshold(level, detail);
+  
+  float *tmp = NULL;
+  float *lum = NULL;
+  float *warp_mask = NULL;
+
+  dt_dev_pixelpipe_t *p = piece->pipe;
+  if(p->luminance_mask_data == NULL) goto error;
+
+  const int iwidth  = p->luminance_mask_roi.width;
+  const int iheight = p->luminance_mask_roi.height;
+  const int owidth  = roi_in->width;
+  const int oheight = roi_in->height;
+
+  const int bufsize = MAX(iwidth * iheight, owidth * oheight);
+  
+  tmp = dt_alloc_align_float(bufsize);
+  lum = dt_alloc_align_float(bufsize);
+  if((tmp == NULL) || (lum == NULL)) goto error;
+
+  dt_masks_calc_detail_mask(p->luminance_mask_data, lum, tmp, iwidth, iheight, threshold, detail);
+  dt_masks_extend_border(lum, iwidth, iheight, 4);
+
+  // here we have the slightly blurred full detail mask available
+  warp_mask = dt_dev_distort_luminance_mask(p, lum, self);
+  if(warp_mask == NULL) goto error;
+
+  const int msize = owidth * oheight;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(mask, warp_mask, msize) \
+  schedule(simd:static) aligned(mask, warp_mask : 64) 
+ #endif
+  for(int idx =0; idx < msize; idx++)
+  {
+    mask[idx] = mask[idx] * warp_mask[idx];
+  }
+  dt_free_align(warp_mask);
+  dt_free_align(lum);
+  dt_free_align(tmp);
+  return;
+
+  error:
+  dt_control_log(_("detail mask blending error"));
+  dt_free_align(warp_mask);
+  dt_free_align(lum);
+  dt_free_align(tmp);
+}
+
 void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                               const void *const ivoid, void *const ovoid, const struct dt_iop_roi_t *const roi_in,
                               const struct dt_iop_roi_t *const roi_out)
@@ -355,6 +418,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
       const float fill = (d->mask_combine & DEVELOP_COMBINE_INCL) ? 0.0f : 1.0f;
       dt_iop_image_fill(mask, fill, owidth, oheight, 1); //mask[k] = fill;
     }
+    _refine_with_detail_mask(self, piece, mask, roi_in, roi_out, d->details);
 
     // get parametric mask (if any) and apply global opacity
     switch(blend_csp)
@@ -514,6 +578,172 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 }
 
 #ifdef HAVE_OPENCL
+static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *mask, const struct dt_iop_roi_t *roi_in,
+                                const struct dt_iop_roi_t *roi_out, const float level, const int devid)
+{
+  if(level == 0.0f) return;
+
+  const int detail = (level > 0.0f);
+  const float threshold = _detail_mask_threshold(level, detail);  
+  float *lum = NULL;
+  cl_mem tmp = NULL;
+  cl_mem blur = NULL;
+  cl_mem out = NULL;
+
+  dt_dev_pixelpipe_t *p = piece->pipe;
+  if(p->luminance_mask_data == NULL) goto error;
+
+  const int iwidth  = p->luminance_mask_roi.width;
+  const int iheight = p->luminance_mask_roi.height;
+  const int owidth  = roi_in->width;
+  const int oheight = roi_in->height;
+
+  lum = dt_alloc_align_float(iwidth * iheight);
+  if(lum == NULL) goto error;
+  tmp = dt_opencl_alloc_device(devid, iwidth, iheight, sizeof(float));
+  if(tmp == NULL) goto error;
+  out = dt_opencl_alloc_device_buffer(devid, iwidth * iheight * sizeof(float));
+  if(out == NULL) goto error;
+  blur = dt_opencl_alloc_device_buffer(devid, iwidth * iheight * sizeof(float));
+  if(blur == NULL) goto error;
+
+  {
+    const int err = dt_opencl_write_host_to_device(devid, p->luminance_mask_data, tmp, iwidth, iheight, sizeof(float));
+    if(err != CL_SUCCESS) goto error;
+  }
+
+  const int program = 31;
+  int kernel_write_mask = dt_opencl_create_kernel(program, "writeout_mask");
+  int kernel_read_mask  = dt_opencl_create_kernel(program, "readin_mask");
+  int kernel_calc_blend = dt_opencl_create_kernel(program, "calc_detail_blend");
+  int kernel_mask_blur  = dt_opencl_create_kernel(program, "fastblur_mask_9x9");
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
+    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 1, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 3, sizeof(int), &iheight);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_read_mask, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }  
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
+    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 1, sizeof(cl_mem), &blur);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 3, sizeof(int), &iheight);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 4, sizeof(float), &threshold);
+    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 5, sizeof(int), &detail);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_calc_blend, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }  
+
+  {
+    // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
+    float kernel[9][9];
+    const double temp = -2.0f * 2.0f * 2.0f;
+    float sum = 0.0f;
+    for(int i = -4; i <= 4; i++)
+    {
+      for(int j = -4; j <= 4; j++)
+      {
+        kernel[i + 4][j + 4] = expf( ((i*i) + (j*j)) / temp);
+        sum += kernel[i + 4][j + 4];
+      }
+    }
+    for(int i = 0; i < 9; i++)
+    {
+      for(int j = 0; j < 9; j++)
+        kernel[i][j] /= sum;
+    }
+    const float c42 = kernel[0][2];
+    const float c41 = kernel[0][3];
+    const float c40 = kernel[0][4];
+    const float c33 = kernel[1][1];
+    const float c32 = kernel[1][2];
+    const float c31 = kernel[1][3];
+    const float c30 = kernel[1][4];
+    const float c22 = kernel[2][2];
+    const float c21 = kernel[2][3];
+    const float c20 = kernel[2][4];
+    const float c11 = kernel[3][3];
+    const float c10 = kernel[3][4];
+    const float c00 = kernel[4][4];
+
+    size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 0, sizeof(cl_mem), &blur);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 1, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 3, sizeof(int), &iheight);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 4, sizeof(int), &c42);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 5, sizeof(int), &c41);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 6, sizeof(int), &c40);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 7, sizeof(int), &c33);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 8, sizeof(int), &c32);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 9, sizeof(int), &c31);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 10, sizeof(int), &c30);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 11, sizeof(int), &c22);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 12, sizeof(int), &c21);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 13, sizeof(int), &c20);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 14, sizeof(int), &c11);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 15, sizeof(int), &c10);
+    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 16, sizeof(int), &c00);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_mask_blur, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }
+
+  {
+    size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
+    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 1, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 3, sizeof(int), &iheight);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_write_mask, sizes);
+    if(err != CL_SUCCESS) goto error;
+  }  
+
+  {
+    const int err = dt_opencl_read_host_from_device(devid, lum, tmp, iwidth, iheight, sizeof(float));
+    if(err != CL_SUCCESS) goto error;
+  }
+
+  dt_opencl_free_kernel(kernel_calc_blend);
+  dt_opencl_free_kernel(kernel_write_mask);
+  dt_opencl_free_kernel(kernel_read_mask);
+  dt_opencl_free_kernel(kernel_mask_blur);
+
+  dt_opencl_release_mem_object(tmp);
+  dt_opencl_release_mem_object(blur);
+  dt_opencl_release_mem_object(out);
+  tmp = blur = out = NULL;
+
+  // here we have the slightly blurred full detail available
+  float *warp_mask = dt_dev_distort_luminance_mask(p, lum, self);
+  if(warp_mask == NULL) goto error;
+
+  const int msize = owidth * oheight;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(mask, warp_mask, msize) \
+  schedule(simd:static) aligned(mask, warp_mask : 64) 
+ #endif
+  for(int idx = 0; idx < msize; idx++)
+  {
+    mask[idx] = mask[idx] * warp_mask[idx];
+  }
+  dt_free_align(warp_mask);
+  return;
+  
+  error:
+  dt_control_log(_("detail mask CL blending problem"));
+  dt_free_align(lum);
+  dt_opencl_release_mem_object(tmp);
+  dt_opencl_release_mem_object(blur);
+  dt_opencl_release_mem_object(out);
+}
+
 int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                                 cl_mem dev_in, cl_mem dev_out, const struct dt_iop_roi_t *roi_in,
                                 const struct dt_iop_roi_t *roi_out)
@@ -735,6 +965,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       const float fill = (d->mask_combine & DEVELOP_COMBINE_INCL) ? 0.0f : 1.0f;
       dt_iop_image_fill(mask, fill, owidth, oheight, 1); //mask[k] = fill;
     }
+    _refine_with_detail_mask_cl(self, piece, mask, roi_in, roi_out, d->details, devid);
 
     // write mask from host to device
     dev_mask_2 = dt_opencl_alloc_device(devid, owidth, oheight, sizeof(float));

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -613,31 +613,27 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
     if(err != CL_SUCCESS) goto error;
   }
 
-  const int program = 31;
-  int kernel_write_mask = dt_opencl_create_kernel(program, "writeout_mask");
-  int kernel_read_mask  = dt_opencl_create_kernel(program, "readin_mask");
-  int kernel_calc_blend = dt_opencl_create_kernel(program, "calc_detail_blend");
-  int kernel_mask_blur  = dt_opencl_create_kernel(program, "fastblur_mask_9x9");
-
   {
     size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 0, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 1, sizeof(cl_mem), &tmp);
-    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 2, sizeof(int), &iwidth);
-    dt_opencl_set_kernel_arg(devid, kernel_read_mask, 3, sizeof(int), &iheight);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_read_mask, sizes);
+    const int kernel = darktable.opencl->blendop->kernel_read_mask;
+    dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(int), &iheight);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }  
 
   {
     size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 0, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 1, sizeof(cl_mem), &blur);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 2, sizeof(int), &iwidth);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 3, sizeof(int), &iheight);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 4, sizeof(float), &threshold);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_blend, 5, sizeof(int), &detail);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_calc_blend, sizes);
+    const int kernel = darktable.opencl->blendop->kernel_calc_blend;
+    dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &blur);
+    dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(int), &iheight);
+    dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(float), &threshold);
+    dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(int), &detail);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }  
 
@@ -677,34 +673,36 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
     const float c00 = kernel[4][4];
 
     size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 0, sizeof(cl_mem), &blur);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 1, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 2, sizeof(int), &iwidth);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 3, sizeof(int), &iheight);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 4, sizeof(int), &c42);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 5, sizeof(int), &c41);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 6, sizeof(int), &c40);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 7, sizeof(int), &c33);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 8, sizeof(int), &c32);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 9, sizeof(int), &c31);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 10, sizeof(int), &c30);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 11, sizeof(int), &c22);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 12, sizeof(int), &c21);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 13, sizeof(int), &c20);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 14, sizeof(int), &c11);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 15, sizeof(int), &c10);
-    dt_opencl_set_kernel_arg(devid, kernel_mask_blur, 16, sizeof(int), &c00);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_mask_blur, sizes);
+    const int clkernel = darktable.opencl->blendop->kernel_mask_blur;
+    dt_opencl_set_kernel_arg(devid, clkernel, 0, sizeof(cl_mem), &blur);
+    dt_opencl_set_kernel_arg(devid, clkernel, 1, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, clkernel, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, clkernel, 3, sizeof(int), &iheight);
+    dt_opencl_set_kernel_arg(devid, clkernel, 4, sizeof(int), &c42);
+    dt_opencl_set_kernel_arg(devid, clkernel, 5, sizeof(int), &c41);
+    dt_opencl_set_kernel_arg(devid, clkernel, 6, sizeof(int), &c40);
+    dt_opencl_set_kernel_arg(devid, clkernel, 7, sizeof(int), &c33);
+    dt_opencl_set_kernel_arg(devid, clkernel, 8, sizeof(int), &c32);
+    dt_opencl_set_kernel_arg(devid, clkernel, 9, sizeof(int), &c31);
+    dt_opencl_set_kernel_arg(devid, clkernel, 10, sizeof(int), &c30);
+    dt_opencl_set_kernel_arg(devid, clkernel, 11, sizeof(int), &c22);
+    dt_opencl_set_kernel_arg(devid, clkernel, 12, sizeof(int), &c21);
+    dt_opencl_set_kernel_arg(devid, clkernel, 13, sizeof(int), &c20);
+    dt_opencl_set_kernel_arg(devid, clkernel, 14, sizeof(int), &c11);
+    dt_opencl_set_kernel_arg(devid, clkernel, 15, sizeof(int), &c10);
+    dt_opencl_set_kernel_arg(devid, clkernel, 16, sizeof(int), &c00);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, clkernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }
 
   {
     size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 0, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 1, sizeof(cl_mem), &tmp);
-    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 2, sizeof(int), &iwidth);
-    dt_opencl_set_kernel_arg(devid, kernel_write_mask, 3, sizeof(int), &iheight);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_write_mask, sizes);
+    const int kernel = darktable.opencl->blendop->kernel_write_mask;
+    dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &tmp);
+    dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &iwidth);
+    dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(int), &iheight);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }  
 
@@ -712,11 +710,6 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
     const int err = dt_opencl_read_host_from_device(devid, lum, tmp, iwidth, iheight, sizeof(float));
     if(err != CL_SUCCESS) goto error;
   }
-
-  dt_opencl_free_kernel(kernel_calc_blend);
-  dt_opencl_free_kernel(kernel_write_mask);
-  dt_opencl_free_kernel(kernel_read_mask);
-  dt_opencl_free_kernel(kernel_mask_blur);
 
   dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(blur);
@@ -1241,6 +1234,10 @@ dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
   b->kernel_calc_Y0_mask = dt_opencl_create_kernel(program_rcd, "calc_Y0_mask");
   b->kernel_calc_scharr_mask = dt_opencl_create_kernel(program_rcd, "calc_scharr_mask");
   b->kernel_write_scharr_mask = dt_opencl_create_kernel(program_rcd, "write_scharr_mask");
+  b->kernel_write_mask = dt_opencl_create_kernel(program_rcd, "writeout_mask");
+  b->kernel_read_mask  = dt_opencl_create_kernel(program_rcd, "readin_mask");
+  b->kernel_calc_blend = dt_opencl_create_kernel(program_rcd, "calc_detail_blend");
+  b->kernel_mask_blur  = dt_opencl_create_kernel(program_rcd, "fastblur_mask_9x9");
 
   return b;
 #else
@@ -1268,6 +1265,10 @@ void dt_develop_blend_free_cl_global(dt_blendop_cl_global_t *b)
   dt_opencl_free_kernel(b->kernel_calc_Y0_mask);
   dt_opencl_free_kernel(b->kernel_calc_scharr_mask);
   dt_opencl_free_kernel(b->kernel_write_scharr_mask);
+  dt_opencl_free_kernel(b->kernel_write_mask);
+  dt_opencl_free_kernel(b->kernel_read_mask);
+  dt_opencl_free_kernel(b->kernel_calc_blend);
+  dt_opencl_free_kernel(b->kernel_mask_blur);
   free(b);
 #endif
 }

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1238,7 +1238,10 @@ dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
   b->kernel_blendop_display_channel = dt_opencl_create_kernel(program, "blendop_display_channel");
 
   const int program_rcd = 31;
-  b->kernel_calc_luminance_mask = dt_opencl_create_kernel(program_rcd, "out_luminance_mask");
+  b->kernel_calc_Y0_mask = dt_opencl_create_kernel(program_rcd, "calc_Y0_mask");
+  b->kernel_calc_scharr_mask = dt_opencl_create_kernel(program_rcd, "calc_scharr_mask");
+  b->kernel_write_scharr_mask = dt_opencl_create_kernel(program_rcd, "write_scharr_mask");
+
   return b;
 #else
   return NULL;
@@ -1262,7 +1265,9 @@ void dt_develop_blend_free_cl_global(dt_blendop_cl_global_t *b)
   dt_opencl_free_kernel(b->kernel_blendop_mask_tone_curve);
   dt_opencl_free_kernel(b->kernel_blendop_set_mask);
   dt_opencl_free_kernel(b->kernel_blendop_display_channel);
-  dt_opencl_free_kernel(b->kernel_calc_luminance_mask);
+  dt_opencl_free_kernel(b->kernel_calc_Y0_mask);
+  dt_opencl_free_kernel(b->kernel_calc_scharr_mask);
+  dt_opencl_free_kernel(b->kernel_write_scharr_mask);
   free(b);
 #endif
 }

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -414,6 +414,7 @@ typedef struct dt_blendop_cl_global_t
   int kernel_blendop_mask_tone_curve;
   int kernel_blendop_set_mask;
   int kernel_blendop_display_channel;
+  int kernel_calc_luminance_mask;
 } dt_blendop_cl_global_t;
 
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -387,8 +387,10 @@ typedef struct dt_develop_blend_params_t
   float contrast;
   /** mask brightness adjustment */
   float brightness;
+  /** details threshold */
+  float details;
   /** some reserved fields for future use */
-  uint32_t reserved[4];
+  uint32_t reserved[3];
   /** blendif parameters */
   float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
   float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];
@@ -515,6 +517,7 @@ typedef struct dt_iop_gui_blend_data_t
   gboolean output_channels_shown;
 
   GtkWidget *channel_boost_factor_slider;
+  GtkWidget *details_slider;
 
   GtkWidget *masks_combo;
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -414,7 +414,9 @@ typedef struct dt_blendop_cl_global_t
   int kernel_blendop_mask_tone_curve;
   int kernel_blendop_set_mask;
   int kernel_blendop_display_channel;
-  int kernel_calc_luminance_mask;
+  int kernel_calc_Y0_mask;
+  int kernel_calc_scharr_mask;
+  int kernel_write_scharr_mask;
 } dt_blendop_cl_global_t;
 
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -417,6 +417,10 @@ typedef struct dt_blendop_cl_global_t
   int kernel_calc_Y0_mask;
   int kernel_calc_scharr_mask;
   int kernel_write_scharr_mask;
+  int kernel_write_mask;
+  int kernel_read_mask;
+  int kernel_calc_blend;
+  int kernel_mask_blur;
 } dt_blendop_cl_global_t;
 
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3040,6 +3040,13 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(bd->masks_invert_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_invert_callback), bd);
 
+    bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
+    dt_bauhaus_widget_set_label(bd->details_slider, N_("blend"), N_("details threshold"));
+    dt_bauhaus_slider_set_format(bd->details_slider, _("%.2f"));
+    gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask (using raw data), "
+                                                      "\npositive values selects areas with strong details, "
+                                                      "\nnegative values select flat areas"));
+    g_signal_connect(G_OBJECT(bd->details_slider), "value-changed", G_CALLBACK(_blendop_blendif_details_callback), bd);
     bd->masks_feathering_guide_combo = _combobox_new_from_list(module, _("feathering guide"), dt_develop_feathering_guide_names,
                                                                _("choose to guide mask by input or output image"));
     g_signal_connect(G_OBJECT(bd->masks_feathering_guide_combo), "value-changed",
@@ -3076,11 +3083,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(bd->contrast_slider), "value-changed",
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->contrast);
 
-    bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
-    dt_bauhaus_widget_set_label(bd->details_slider, N_("details"), N_("details threshold"));
-    dt_bauhaus_slider_set_format(bd->details_slider, _("%.2f"));
-    gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask (using raw data).\npositive values selects areas with strong details,\nnegative values select flat areas"));
-    g_signal_connect(G_OBJECT(bd->details_slider), "value-changed", G_CALLBACK(_blendop_blendif_details_callback), bd);
 
     GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_widget_set_name(hbox, "section_label");
@@ -3126,12 +3128,12 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), GTK_WIDGET(bd->masks_combine_combo), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), GTK_WIDGET(bd->masks_invert_combo), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), hbox, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->details_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->masks_feathering_guide_combo, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->feathering_radius_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->blur_radius_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->brightness_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->contrast_slider, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->details_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(bd->bottom_box), TRUE, TRUE, 0);
     dt_gui_add_help_link(GTK_WIDGET(bd->bottom_box), dt_get_help_url("masks_combined"));
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3079,7 +3079,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
     dt_bauhaus_widget_set_label(bd->details_slider, N_("details"), N_("details threshold"));
     dt_bauhaus_slider_set_format(bd->details_slider, _("%.2f"));
-    gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask.\npositive values selects areas with strong details\nnegative values select flat areas"));
+    gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask (using raw data).\npositive values selects areas with strong details,\nnegative values select flat areas"));
     g_signal_connect(G_OBJECT(bd->details_slider), "value-changed", G_CALLBACK(_blendop_blendif_details_callback), bd);
 
     GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -544,6 +544,8 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
       gtk_widget_hide(GTK_WIDGET(data->brightness_slider));
       gtk_widget_set_sensitive(data->contrast_slider, FALSE);
       gtk_widget_hide(GTK_WIDGET(data->contrast_slider));
+      gtk_widget_set_sensitive(data->details_slider, FALSE);
+      gtk_widget_hide(GTK_WIDGET(data->details_slider));
     }
     else
     {
@@ -1089,6 +1091,21 @@ static void _blendop_blendif_boost_factor_callback(GtkWidget *slider, dt_iop_gui
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
 }
 
+static void _blendop_blendif_details_callback(GtkWidget *slider, dt_iop_gui_blend_data_t *data)
+{
+  if(darktable.gui->reset || !data || !data->blendif_inited) return;
+  dt_develop_blend_params_t *bp = data->module->blend_params;
+  const float oldval = bp->details;
+  bp->details = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, data->module, TRUE);
+
+  if((oldval == 0.0f) && (bp->details != 0.0f))
+  {
+    dt_dev_reprocess_all(data->module->dev);
+    dt_control_queue_redraw();
+  }
+}
+
 static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton *event, dt_iop_module_t *module)
 {
   if(darktable.gui->reset) return;
@@ -1247,6 +1264,7 @@ static gboolean _blendop_blendif_reset(GtkButton *button, GdkEventButton *event,
   module->blend_params->blendif = module->default_blendop_params->blendif;
   memcpy(module->blend_params->blendif_parameters, module->default_blendop_params->blendif_parameters,
          4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
+  module->blend_params->details = module->default_blendop_params->details;
 
   dt_iop_color_picker_reset(module, FALSE);
   dt_iop_gui_update_blendif(module);
@@ -2704,6 +2722,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   dt_bauhaus_slider_set(bd->blur_radius_slider, module->blend_params->blur_radius);
   dt_bauhaus_slider_set(bd->brightness_slider, module->blend_params->brightness);
   dt_bauhaus_slider_set(bd->contrast_slider, module->blend_params->contrast);
+  dt_bauhaus_slider_set(bd->details_slider, module->blend_params->details);
 
   /* reset all alternative display modes for blendif */
   memset(bd->altmode, 0, sizeof(bd->altmode));
@@ -2727,6 +2746,9 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   {
     gtk_widget_hide(GTK_WIDGET(bd->top_box));
   }
+
+  const dt_image_t img = module->dev->image_storage;
+  gtk_widget_set_visible(bd->details_slider, dt_image_is_rawprepare_supported(&img));
 
   if((mask_mode & DEVELOP_MASK_ENABLED)
      && ((bd->masks_inited && (mask_mode & DEVELOP_MASK_MASK))
@@ -3054,6 +3076,12 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(bd->contrast_slider), "value-changed",
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->contrast);
 
+    bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
+    dt_bauhaus_widget_set_label(bd->details_slider, N_("details"), N_("details threshold"));
+    dt_bauhaus_slider_set_format(bd->details_slider, _("%.2f"));
+    gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask.\npositive values selects areas with strong details\nnegative values select flat areas"));
+    g_signal_connect(G_OBJECT(bd->details_slider), "value-changed", G_CALLBACK(_blendop_blendif_details_callback), bd);
+
     GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_widget_set_name(hbox, "section_label");
     gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("mask refinement")), TRUE, TRUE, 0);
@@ -3103,6 +3131,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->blur_radius_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->brightness_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->contrast_slider, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->details_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(bd->bottom_box), TRUE, TRUE, 0);
     dt_gui_add_help_link(GTK_WIDGET(bd->bottom_box), dt_get_help_url("masks_combined"));
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -119,6 +119,13 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
+typedef enum dt_develop_lummask_t
+{
+  DT_DEV_LUMINANCE_MASK_NONE = 0,
+  DT_DEV_LUMINANCE_MASK_REQUIRED = 1,
+  DT_DEV_LUMINANCE_MASK_DEMOSAIC = 2,
+  DT_DEV_LUMINANCE_MASK_RAWPREPARE = 4
+} dt_develop_lummask_t;
 
 typedef enum dt_clipping_preview_mode_t
 {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -119,13 +119,13 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
-typedef enum dt_develop_lummask_t
+typedef enum dt_develop_detail_mmask_t
 {
-  DT_DEV_LUMINANCE_MASK_NONE = 0,
-  DT_DEV_LUMINANCE_MASK_REQUIRED = 1,
-  DT_DEV_LUMINANCE_MASK_DEMOSAIC = 2,
-  DT_DEV_LUMINANCE_MASK_RAWPREPARE = 4
-} dt_develop_lummask_t;
+  DT_DEV_DETAIL_MASK_NONE = 0,
+  DT_DEV_DETAIL_MASK_REQUIRED = 1,
+  DT_DEV_DETAIL_MASK_DEMOSAIC = 2,
+  DT_DEV_DETAIL_MASK_RAWPREPARE = 4
+} dt_develop_detail_mask_t;
 
 typedef enum dt_clipping_preview_mode_t
 {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -432,7 +432,7 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
 /** luminance mask support */
 void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
 void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
-void dt_masks_calc_luminance_mask(float *const src, float *const out, const int width, const int height);
+void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float wb[3]);
 void dt_masks_calc_detail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
 
 /** return the list of possible mouse actions */

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -74,9 +74,10 @@
   All other refinements and parametric parameters are untouched.
 
   Some additional comments:
-  1. intentionally this contrast mask refinement has only been implemented for raws. Especially for compressed
+  1. intentionally this details mask refinement has only been implemented for raws. Especially for compressed
      inmages like jpegs or 8bit input the algo didn't work as good.
-  2. Of course credit goes to Ingo @heckflosse from rt team for the original idea.
+  2. Of course credit goes to Ingo @heckflosse from rt team for the original idea. (in the rt world this is knowb
+     as details mask)
   
   hanno@schwalm-bremen.de 21/04/09
 */

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -75,10 +75,12 @@
 
   Some additional comments:
   1. intentionally this details mask refinement has only been implemented for raws. Especially for compressed
-     inmages like jpegs or 8bit input the algo didn't work as good.
-  2. Of course credit goes to Ingo @heckflosse from rt team for the original idea. (in the rt world this is knowb
+     inmages like jpegs or 8bit input the algo didn't work as good because of input precision and compression artefacts.
+  2. In the gui the slider is above the rest of the refinemt sliders to emphasize that blurring & feathering use the
+     mask corrected by detail refinemnt.
+  3. Of course credit goes to Ingo @heckflosse from rt team for the original idea. (in the rt world this is knowb
      as details mask)
-  
+
   hanno@schwalm-bremen.de 21/04/09
 */
 

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -16,6 +16,71 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/* How are "detail masks" implemented?
+
+  The detail masks (DM) are used by the dual demosaicer and as a further refinement step for
+  shape / parametric masks.
+  They contain threshold weighed sigmoid values of pixel-wise local signal variances so they
+  can be understood as "areas with or without local detail". 
+  
+  As the DM using algoritms (like dual demosaicing, sharpening ...) are all pixel peeping we
+  want the "original data" from the sensor to calculate it.
+  (Calculating the mask from the modules roi might not detect such regions at all because of
+  scaling / rotating artefacts, some blurring earlier in the pipeline, color changes ...)
+
+  In all cases the user interface is pretty simple, we just pass a threshold value, which
+  is in the range of -1.0 to 1.0 by an additional slider in the masks refinement section.
+  Positive values will select regions with lots of local detail, negatives select for flat areas.
+  (The dual demosaicer only wants positives as we always look for high frequency content.)
+  A threshold value of 0.0 means bypassing.
+  
+  So the first important point is:
+  We make sure taking the input data for the DM right from the demosaicer for normal raws
+  or from rawprepare in case of monochromes. This means some additional housekeeping for the
+  pixelpipe.
+  If any mask in any module selects a threshold of != 0.0 we leave a flag in the pipe struct
+  telling a) we want a DM and b) we want it from either demosaic or from rawprepare.
+  If such a flag has not been previously set we will force a pipeline reprocessing.
+  
+  gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
+  or it's _cl equivalent write a mask holding luminances for every pixel.
+  This luminance mask (LM) is not scaled but only cropped to the roi of the writing module (demosaic
+  or rawprepare).
+  The pipe gets roi copy of the writing module so we can later scale/distort the LM.
+
+  Calculating the LM is done for performance and lower mem pressure reasons, so we don't have to
+  pass full data to the module. Also the LM can be used by other modules. 
+ 
+  If a mask uses the details refinement step it takes the shared luminance mask LM and calculates an
+  intermediate mask (IM) which is still not scaled but has the roi of the writing module.
+
+  void dt_masks_calc_detail_mask(float *const restrict src, float *const restrict out, float *const restrict tmp,
+                                   const int width, const int height, const float threshold, const gboolean detail)
+ 
+  For For every pixel we calculate
+    a - luminance variances from the neighbors in a 5x5 pixel area.
+    b - the details masks value via a sigmoid function with the variance and threshold as parameters.
+
+  At last the IM is slightly blurred to avoid hard transitions, as there still is no scaling we can use
+  a constant sigma. As the blur_9x9 is pretty fast both in openmp/cl code paths - much faster than dt
+  gaussians - it is used here.
+  Now we have an unscaled detail mask which requires to be transformed through the pipeline using
+
+  float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
+
+  returning a pointer to a distorted mask (DT) with same size as used in the module wanting the refinement.
+  This DM is finally used to refine the original mask.
+
+  All other refinements and parametric parameters are untouched.
+
+  Some additional comments:
+  1. intentionally this contrast mask refinement has only been implemented for raws. Especially for compressed
+     inmages like jpegs or 8bit input the algo didn't work as good.
+  2. Of course credit goes to Ingo @heckflosse from rt team for the original idea.
+  
+  hanno@schwalm-bremen.de 21/04/09
+*/
+
 // We don't want to use the SIMD version as we might access unaligned memory
 static inline float sqrf(float a)
 {

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -216,7 +216,7 @@ void dt_masks_calc_rawdetail_mask(float *const restrict src, float *const restri
       const float gy = 47.0f * (tmp[idx-width-1] - tmp[idx+width-1])
                     + 162.0f * (tmp[idx-width]   - tmp[idx+width])
                      + 47.0f * (tmp[idx-width+1] - tmp[idx+width+1]);
-      float gradient_magnitude = sqrtf(sqrf(gx / 256.0f) + sqrf(gy / 256.0f));
+      const float gradient_magnitude = sqrtf(sqrf(gx / 256.0f) + sqrf(gy / 256.0f));
       mask[idx] = scale * gradient_magnitude;
       // Original code from rt
       // tmp[idx] = scale * sqrtf(sqrf(src[idx+1] - src[idx-1]) + sqrf(src[idx + width]   - src[idx - width]) +

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2577,7 +2577,9 @@ gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const
   if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
   dt_dev_clear_luminance_mask(p);
-
+  const gboolean unwanted = ((darktable.develop->preview_downsampling != 1.0f) &&
+                             ((p->type & DT_DEV_PIXELPIPE_FULL) != DT_DEV_PIXELPIPE_FULL)); 
+  if(unwanted) return FALSE;
   const int width = roi_in->width;
   const int height = roi_in->height;
   float *mask = dt_alloc_align_float((size_t)width * height);
@@ -2599,6 +2601,9 @@ gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
   dt_dev_clear_luminance_mask(p);
+  const gboolean unwanted = ((darktable.develop->preview_downsampling != 1.0f) &&
+                             ((p->type & DT_DEV_PIXELPIPE_FULL) != DT_DEV_PIXELPIPE_FULL)); 
+  if(unwanted) return FALSE;
 
   const int width = roi_in->width;
   const int height = roi_in->height;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2612,16 +2612,14 @@ gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   out = dt_opencl_alloc_device(devid, width, height, sizeof(float));   
   if(out == NULL) goto error;
 
-  const int program = 31;
-  int kernel_calc_luminance_mask = dt_opencl_create_kernel(program, "out_luminance_mask");
-
   {
+    const int kernel = darktable.opencl->blendop->kernel_calc_luminance_mask;
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 0, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 1, sizeof(cl_mem), &in);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, kernel_calc_luminance_mask, 3, sizeof(int), &height);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_calc_luminance_mask, sizes);
+    dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
+    dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &in);
+    dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(int), &height);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }  
 
@@ -2634,7 +2632,6 @@ gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   memcpy(&p->luminance_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
   dt_opencl_release_mem_object(out);
-  dt_opencl_free_kernel(kernel_calc_luminance_mask);
   return FALSE;
 
   error:

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2577,9 +2577,7 @@ gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const
   if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
   dt_dev_clear_luminance_mask(p);
-  const gboolean unwanted = ((darktable.develop->preview_downsampling != 1.0f) &&
-                             ((p->type & DT_DEV_PIXELPIPE_FULL) != DT_DEV_PIXELPIPE_FULL)); 
-  if(unwanted) return FALSE;
+
   const int width = roi_in->width;
   const int height = roi_in->height;
   float *mask = dt_alloc_align_float((size_t)width * height);
@@ -2601,9 +2599,6 @@ gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
   dt_dev_clear_luminance_mask(p);
-  const gboolean unwanted = ((darktable.develop->preview_downsampling != 1.0f) &&
-                             ((p->type & DT_DEV_PIXELPIPE_FULL) != DT_DEV_PIXELPIPE_FULL)); 
-  if(unwanted) return FALSE;
 
   const int width = roi_in->width;
   const int height = roi_in->height;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -385,10 +385,11 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
       }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
 
-      if(piece->blendop_data)
+      if((piece->blendop_data) && (piece->enabled))
       {
         const dt_develop_blend_params_t *const bp = (const dt_develop_blend_params_t *)piece->blendop_data;
-        if(bp->details != 0.0f) pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_REQUIRED;
+        if(bp->details != 0.0f)
+          pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_REQUIRED;
       }
     }
   }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -385,7 +385,7 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
       }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
 
-      if((piece->blendop_data) && (piece->enabled))
+      if(piece->blendop_data)
       {
         const dt_develop_blend_params_t *const bp = (const dt_develop_blend_params_t *)piece->blendop_data;
         if(bp->details != 0.0f)
@@ -2678,7 +2678,9 @@ float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src,
     for(GList *iter = source_iter; iter; iter = g_list_next(iter))
     {
       dt_dev_pixelpipe_iop_t *module = (dt_dev_pixelpipe_iop_t *)iter->data;
-      if(module->enabled)
+      if(module->enabled
+            && !(module->module->dev->gui_module && module->module->dev->gui_module->operation_tags_filter()
+                 & module->module->operation_tags()))
       {
         if(module->module->distort_mask
               && !(!strcmp(module->module->op, "finalscale") // hack against pipes not using finalscale

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -176,8 +176,8 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = 0;
 
-  pipe->luminance_mask_data = NULL;
-  pipe->want_luminance_mask = DT_DEV_LUMINANCE_MASK_NONE;
+  pipe->rawdetail_mask_data = NULL;
+  pipe->want_detail_mask = DT_DEV_LUMINANCE_MASK_NONE;
 
   pipe->processing = 0;
   dt_atomic_set_int(&pipe->shutdown,FALSE);
@@ -244,7 +244,7 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = 0;
 
-  dt_dev_clear_luminance_mask(pipe);
+  dt_dev_clear_rawdetail_mask(pipe);
 
   if(pipe->forms)
   {
@@ -345,9 +345,9 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
   const gboolean rawprep_img = dt_image_is_rawprepare_supported(img);
   const gboolean raw_img     = dt_image_is_raw(img);
 
-  pipe->want_luminance_mask &= DT_DEV_LUMINANCE_MASK_REQUIRED;
-  if(raw_img)          pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_DEMOSAIC;
-  else if(rawprep_img) pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_RAWPREPARE; 
+  pipe->want_detail_mask &= DT_DEV_LUMINANCE_MASK_REQUIRED;
+  if(raw_img)          pipe->want_detail_mask |= DT_DEV_LUMINANCE_MASK_DEMOSAIC;
+  else if(rawprep_img) pipe->want_detail_mask |= DT_DEV_LUMINANCE_MASK_RAWPREPARE; 
 
   for(GList *nodes = pipe->nodes; nodes; nodes = g_list_next(nodes))
   {
@@ -389,7 +389,7 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
       {
         const dt_develop_blend_params_t *const bp = (const dt_develop_blend_params_t *)piece->blendop_data;
         if(bp->details != 0.0f)
-          pipe->want_luminance_mask |= DT_DEV_LUMINANCE_MASK_REQUIRED;
+          pipe->want_detail_mask |= DT_DEV_LUMINANCE_MASK_REQUIRED;
       }
     }
   }
@@ -2564,41 +2564,50 @@ float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const dt_iop_modul
   return raster_mask;
 }
 
-void dt_dev_clear_luminance_mask(dt_dev_pixelpipe_t *pipe)
+void dt_dev_clear_rawdetail_mask(dt_dev_pixelpipe_t *pipe)
 {
-  if(pipe->luminance_mask_data) dt_free_align(pipe->luminance_mask_data);
-  pipe->luminance_mask_data = NULL;
+  if(pipe->rawdetail_mask_data) dt_free_align(pipe->rawdetail_mask_data);
+  pipe->rawdetail_mask_data = NULL;
 }
 
-gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode)
+gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if((p->want_luminance_mask & DT_DEV_LUMINANCE_MASK_REQUIRED) == 0) return FALSE;
-  if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
+  if((p->want_detail_mask & DT_DEV_LUMINANCE_MASK_REQUIRED) == 0) return FALSE;
+  if((p->want_detail_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
-  dt_dev_clear_luminance_mask(p);
+  dt_dev_clear_rawdetail_mask(p);
 
   const int width = roi_in->width;
   const int height = roi_in->height;
   float *mask = dt_alloc_align_float((size_t)width * height);
-  if(mask == NULL) return TRUE;
+  float *tmp = dt_alloc_align_float((size_t)width * height);
+  if((mask == NULL) || (tmp == NULL)) goto error;
 
-  p->luminance_mask_data = mask;
-  memcpy(&p->luminance_mask_roi, roi_in, sizeof(dt_iop_roi_t));
+  p->rawdetail_mask_data = mask;
+  memcpy(&p->rawdetail_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
-  dt_masks_calc_luminance_mask(rgb, mask, width, height);
+  const float wb[3] = {piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+
+  dt_masks_calc_rawdetail_mask(rgb, mask, tmp, width, height, wb);
+  dt_free_align(tmp);
   return FALSE;
+
+  error:
+  dt_free_align(mask);
+  dt_free_align(tmp);
+  return TRUE;
 }
 
 #ifdef HAVE_OPENCL
-gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode)
+gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;  
 
-  if((p->want_luminance_mask & DT_DEV_LUMINANCE_MASK_REQUIRED) == 0) return FALSE;
-  if((p->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
+  if((p->want_detail_mask & DT_DEV_LUMINANCE_MASK_REQUIRED) == 0) return FALSE;
+  if((p->want_detail_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED) != mode) return FALSE;
 
-  dt_dev_clear_luminance_mask(p);
+  dt_dev_clear_rawdetail_mask(p);
 
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -2628,14 +2637,14 @@ gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
     if(err != CL_SUCCESS) goto error;
   }
 
-  p->luminance_mask_data = mask;
-  memcpy(&p->luminance_mask_roi, roi_in, sizeof(dt_iop_roi_t));
+  p->rawdetail_mask_data = mask;
+  memcpy(&p->rawdetail_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
   dt_opencl_release_mem_object(out);
   return FALSE;
 
   error:
-  dt_dev_clear_luminance_mask(p);
+  dt_dev_clear_rawdetail_mask(p);
   dt_opencl_release_mem_object(out);
   dt_free_align(mask);
   return TRUE;  
@@ -2644,11 +2653,11 @@ gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
 
 // this expects a mask prepared by the demosaicer and distorts the mask through all pipeline modules
 // until target
-float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
+float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
 {
-  if(!pipe->luminance_mask_data) return NULL;
+  if(!pipe->rawdetail_mask_data) return NULL;
   gboolean valid = FALSE;
-  const int check = pipe->want_luminance_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED;
+  const int check = pipe->want_detail_mask & ~DT_DEV_LUMINANCE_MASK_REQUIRED;
 
   GList *source_iter;
   for(source_iter = pipe->nodes; source_iter; source_iter = g_list_next(source_iter))

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -130,6 +130,13 @@ typedef struct dt_dev_pixelpipe_t
   // output buffer (for display)
   uint8_t *output_backbuf;
   int output_backbuf_width, output_backbuf_height;
+
+  // the data for the luminance mask are kept in a buffer written by demosaic or rawprepare
+  // as we have to scale the mask later ke keep roi at that stage
+  float *luminance_mask_data;
+  struct dt_iop_roi_t luminance_mask_roi;
+  int want_luminance_mask;
+
   int output_imgid;
   // working?
   int processing;
@@ -236,6 +243,16 @@ void dt_dev_pixelpipe_remove_node(dt_dev_pixelpipe_t *pipe, struct dt_develop_t 
 float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const struct dt_iop_module_t *raster_mask_source,
                               const int raster_mask_id, const struct dt_iop_module_t *target_module,
                               gboolean *free_mask);
+// some helper functions related to the details mask interface
+void dt_dev_clear_luminance_mask(dt_dev_pixelpipe_t *pipe);
+
+gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
+#ifdef HAVE_OPENCL
+gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
+#endif
+
+// helper function writing the pipe-processed ctmask data to dest 
+float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -133,9 +133,9 @@ typedef struct dt_dev_pixelpipe_t
 
   // the data for the luminance mask are kept in a buffer written by demosaic or rawprepare
   // as we have to scale the mask later ke keep roi at that stage
-  float *luminance_mask_data;
-  struct dt_iop_roi_t luminance_mask_roi;
-  int want_luminance_mask;
+  float *rawdetail_mask_data;
+  struct dt_iop_roi_t rawdetail_mask_roi;
+  int want_detail_mask;
 
   int output_imgid;
   // working?
@@ -244,15 +244,15 @@ float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe, const struct dt_io
                               const int raster_mask_id, const struct dt_iop_module_t *target_module,
                               gboolean *free_mask);
 // some helper functions related to the details mask interface
-void dt_dev_clear_luminance_mask(dt_dev_pixelpipe_t *pipe);
+void dt_dev_clear_rawdetail_mask(dt_dev_pixelpipe_t *pipe);
 
-gboolean dt_dev_write_luminance_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
+gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode);
 #ifdef HAVE_OPENCL
-gboolean dt_dev_write_luminance_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
+gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
 #endif
 
 // helper function writing the pipe-processed ctmask data to dest 
-float *dt_dev_distort_luminance_mask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
+float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3069,13 +3069,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width, roi.width);
     else if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR)
        dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width, roi.width);
-    else // sample half-size raw (Bayer) or 1/3-size raw (X-Trans)
-        if(piece->pipe->dsc.filters == 9u)
-      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
-                                                        xtrans);
+    else if(piece->pipe->dsc.filters == 9u)
+      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width, xtrans);
     else
       dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                 piece->pipe->dsc.filters);
+
+    // this is used for preview pipes, currently there is now writing mask implemented
+    // we just clear the mask data as we might have changed the preview downsampling
+    dt_dev_clear_luminance_mask(piece->pipe);
   }
   if(data->color_smoothing)
     color_smoothing(o, roi_out, data->color_smoothing);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3076,7 +3076,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     else
       dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                 piece->pipe->dsc.filters);
-    dt_dev_write_luminance_mask(piece, (float *)o, &roi, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
   }
   if(data->color_smoothing)
     color_smoothing(o, roi_out, data->color_smoothing);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2921,7 +2921,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float threshold = 0.0001f * img->exif_iso;
   dt_times_t start_time = { 0 }, end_time = { 0 };
 
-  dt_dev_clear_luminance_mask(piece->pipe);
+  dt_dev_clear_rawdetail_mask(piece->pipe);
 
   dt_iop_roi_t roi = *roi_in;
   dt_iop_roi_t roo = *roi_out;
@@ -3049,7 +3049,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         method2string(demosaicing_method & ~DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
     }
 
-    dt_dev_write_luminance_mask(piece, tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask(piece, tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if((demosaicing_method & DEMOSAIC_DUAL) && !run_fast)
     {
@@ -3077,7 +3077,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     // this is used for preview pipes, currently there is now writing mask implemented
     // we just clear the mask data as we might have changed the preview downsampling
-    dt_dev_clear_luminance_mask(piece->pipe);
+    dt_dev_clear_rawdetail_mask(piece->pipe);
   }
   if(data->color_smoothing)
     color_smoothing(o, roi_out, data->color_smoothing);
@@ -3607,7 +3607,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_release_mem_object(VP_diff);
     dt_opencl_release_mem_object(HQ_diff);
 
-    dt_dev_write_luminance_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -3828,7 +3828,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       }
     }
 
-    dt_dev_write_luminance_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -4238,7 +4238,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_vng_green_equilibrate, sizes);
       if(err != CL_SUCCESS) goto error;
     }
-    dt_dev_write_luminance_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -5006,7 +5006,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       dt_opencl_release_mem_object(dev_edge_out);
       dev_edge_in = dev_edge_out = NULL;
     }
-    dt_dev_write_luminance_mask_cl(piece, dev_tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -5082,7 +5082,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_times_t start_time = { 0 }, end_time = { 0 };
   const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
 
-  dt_dev_clear_luminance_mask(piece->pipe);
+  dt_dev_clear_rawdetail_mask(piece->pipe);
 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   const int demosaicing_method = data->demosaicing_method;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3049,7 +3049,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         method2string(demosaicing_method & ~DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
     }
 
-    dt_dev_write_rawdetail_mask(piece, tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask(piece, tmp, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
 
     if((demosaicing_method & DEMOSAIC_DUAL) && !run_fast)
     {
@@ -3607,7 +3607,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_release_mem_object(VP_diff);
     dt_opencl_release_mem_object(HQ_diff);
 
-    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -3828,7 +3828,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       }
     }
 
-    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -4238,7 +4238,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_vng_green_equilibrate, sizes);
       if(err != CL_SUCCESS) goto error;
     }
-    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
 
     if(scaled)
     {
@@ -5006,7 +5006,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       dt_opencl_release_mem_object(dev_edge_out);
       dev_edge_in = dev_edge_out = NULL;
     }
-    dt_dev_write_rawdetail_mask_cl(piece, dev_tmp, roi_in, DT_DEV_LUMINANCE_MASK_DEMOSAIC);
+    dt_dev_write_rawdetail_mask_cl(piece, dev_tmp, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
 
     if(scaled)
     {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -175,9 +175,7 @@ typedef struct dt_iop_demosaic_global_data_t
   int kernel_rcd_step_5_2;
   int kernel_rcd_border_redblue;
   int kernel_rcd_border_green;
-  int kernel_calc_detail_blend;
   int kernel_write_blended_dual;
-  int kernel_fastblur_mask_9x9;
 } dt_iop_demosaic_global_data_t;
 
 typedef struct dt_iop_demosaic_data_t
@@ -5405,9 +5403,7 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_rcd_step_5_2 = dt_opencl_create_kernel(rcd, "rcd_step_5_2");
   gd->kernel_rcd_border_redblue = dt_opencl_create_kernel(rcd, "rcd_border_redblue");
   gd->kernel_rcd_border_green = dt_opencl_create_kernel(rcd, "rcd_border_green");
-  gd->kernel_calc_detail_blend = dt_opencl_create_kernel(rcd, "calc_detail_blend");
   gd->kernel_write_blended_dual  = dt_opencl_create_kernel(rcd, "write_blended_dual");  
-  gd->kernel_fastblur_mask_9x9 = dt_opencl_create_kernel(rcd, "fastblur_mask_9x9"); 
 }
 
 void cleanup_global(dt_iop_module_so_t *module)
@@ -5461,9 +5457,7 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_rcd_step_5_2);
   dt_opencl_free_kernel(gd->kernel_rcd_border_redblue);
   dt_opencl_free_kernel(gd->kernel_rcd_border_green);
-  dt_opencl_free_kernel(gd->kernel_calc_detail_blend);
   dt_opencl_free_kernel(gd->kernel_write_blended_dual);  
-  dt_opencl_free_kernel(gd->kernel_fastblur_mask_9x9);
   free(module->data);
   module->data = NULL;
 }

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -57,7 +57,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
 
   const float contrastf = dual_threshold / 100.0f;
 
-  dt_masks_calc_luminance_mask(rgb_data, blend, width, height);
+  dt_masks_calc_rawdetail_mask(rgb_data, blend, tmp, width, height, piece->pipe->dsc.temperature.coeffs);
   dt_masks_calc_detail_mask(blend, blend, tmp, width, height, contrastf, TRUE);  
 
   if(dual_mask)

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -135,13 +135,14 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   {
     const int flag = 1;
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 0, sizeof(cl_mem), &blend);  
-    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 1, sizeof(cl_mem), &detail);  
-    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 3, sizeof(int), &height);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 4, sizeof(float), &contrastf);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_calc_detail_blend, 5, sizeof(int), &flag);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_calc_detail_blend, sizes);
+    const int kernel = darktable.opencl->blendop->kernel_calc_blend;
+    dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &blend);  
+    dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &detail);  
+    dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(float), &contrastf);
+    dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(int), &flag);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 
@@ -178,24 +179,25 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     const float c00 = kernel[4][4];
 
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 0, sizeof(cl_mem), &detail);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 1, sizeof(cl_mem), &blend);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 2, sizeof(int), &width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 3, sizeof(int), &height);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 4, sizeof(int), &c42);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 5, sizeof(int), &c41);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 6, sizeof(int), &c40);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 7, sizeof(int), &c33);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 8, sizeof(int), &c32);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 9, sizeof(int), &c31);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 10, sizeof(int), &c30);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 11, sizeof(int), &c22);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 12, sizeof(int), &c21);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 13, sizeof(int), &c20);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 14, sizeof(int), &c11);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 15, sizeof(int), &c10);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_fastblur_mask_9x9, 16, sizeof(int), &c00);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_fastblur_mask_9x9, sizes);
+    const int clkernel = darktable.opencl->blendop->kernel_mask_blur;
+    dt_opencl_set_kernel_arg(devid, clkernel, 0, sizeof(cl_mem), &detail);
+    dt_opencl_set_kernel_arg(devid, clkernel, 1, sizeof(cl_mem), &blend);
+    dt_opencl_set_kernel_arg(devid, clkernel, 2, sizeof(int), &width);
+    dt_opencl_set_kernel_arg(devid, clkernel, 3, sizeof(int), &height);
+    dt_opencl_set_kernel_arg(devid, clkernel, 4, sizeof(int), &c42);
+    dt_opencl_set_kernel_arg(devid, clkernel, 5, sizeof(int), &c41);
+    dt_opencl_set_kernel_arg(devid, clkernel, 6, sizeof(int), &c40);
+    dt_opencl_set_kernel_arg(devid, clkernel, 7, sizeof(int), &c33);
+    dt_opencl_set_kernel_arg(devid, clkernel, 8, sizeof(int), &c32);
+    dt_opencl_set_kernel_arg(devid, clkernel, 9, sizeof(int), &c31);
+    dt_opencl_set_kernel_arg(devid, clkernel, 10, sizeof(int), &c30);
+    dt_opencl_set_kernel_arg(devid, clkernel, 11, sizeof(int), &c22);
+    dt_opencl_set_kernel_arg(devid, clkernel, 12, sizeof(int), &c21);
+    dt_opencl_set_kernel_arg(devid, clkernel, 13, sizeof(int), &c20);
+    dt_opencl_set_kernel_arg(devid, clkernel, 14, sizeof(int), &c11);
+    dt_opencl_set_kernel_arg(devid, clkernel, 15, sizeof(int), &c10);
+    dt_opencl_set_kernel_arg(devid, clkernel, 16, sizeof(int), &c00);
+    const int err = dt_opencl_enqueue_kernel_2d(devid, clkernel, sizes);
     if(err != CL_SUCCESS) return FALSE;
   }
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -354,7 +354,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
   }
 
-  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
+  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_DETAIL_MASK_RAWPREPARE);
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 }
@@ -514,7 +514,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
   _mm_sfence();
-  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
+  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_DETAIL_MASK_RAWPREPARE);
 }
 #endif
 
@@ -581,7 +581,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
-  err = dt_dev_write_rawdetail_mask_cl(piece, dev_out, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
+  err = dt_dev_write_rawdetail_mask_cl(piece, dev_out, roi_in, DT_DEV_DETAIL_MASK_RAWPREPARE);
   if(err != CL_SUCCESS) goto error;
 
   return TRUE;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -354,7 +354,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
   }
 
-  dt_dev_write_luminance_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
+  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 }
@@ -514,7 +514,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
   _mm_sfence();
-  dt_dev_write_luminance_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
+  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
 }
 #endif
 
@@ -581,7 +581,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
-  err = dt_dev_write_luminance_mask_cl(piece, dev_out, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
+  err = dt_dev_write_rawdetail_mask_cl(piece, dev_out, roi_in, DT_DEV_LUMINANCE_MASK_RAWPREPARE);
   if(err != CL_SUCCESS) goto error;
 
   return TRUE;


### PR DESCRIPTION
After some code integrated in dt master the "detail mask" refinement code is easier to review and test, it implements what is called "contrast mask" in the rt world.

Think of it as refining a given mask based on amount of detail or high frequency content. The code internals are already in use in the dual demosaicer, most of this pr is about integration in the pipeline to get detail values directly from raw data.

Former prs were #8596 and #8501, i concider this pr as correctly working code for 3.6, ready for reviewing.

EDIT 04.20
1. So far this refinement is only available for raw images. I would prefer to keep it this way but would implement it for 3.8 on request
2. refinement is disabled for previews using reduced resolution. I could do that later but would prefer to get more field testing soon as this is completely new stuff.



EDIT 04.29 This is from the docs in todays source
This integrates @rawfiners suggestion to use a scharr operator on Y0

```
/* How are "detail masks" implemented?

  The detail masks (DM) are used by the dual demosaicer and as a further refinement step for
  shape / parametric masks.
  They contain threshold weighed values of pixel-wise local signal changes so they can be
  understood as "areas with or without local detail". 
  
  As the DM using algoritms (like dual demosaicing, sharpening ...) are all pixel peeping we
  want the "original data" from the sensor to calculate it.
  (Calculating the mask from the modules roi might not detect such regions at all because of
  scaling / rotating artefacts, some blurring earlier in the pipeline, color changes ...)

  In all cases the user interface is pretty simple, we just pass a threshold value, which
  is in the range of -1.0 to 1.0 by an additional slider in the masks refinement section.
  Positive values will select regions with lots of local detail, negatives select for flat areas.
  (The dual demosaicer only wants positives as we always look for high frequency content.)
  A threshold value of 0.0 means bypassing.
  
  So the first important point is:
  We make sure taking the input data for the DM right from the demosaicer for normal raws
  or from rawprepare in case of monochromes. This means some additional housekeeping for the
  pixelpipe.
  If any mask in any module selects a threshold of != 0.0 we leave a flag in the pipe struct
  telling a) we want a DM and b) we want it from either demosaic or from rawprepare.
  If such a flag has not been previously set we will force a pipeline reprocessing.
  
  gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode, const float wb[3]);
  or it's _cl equivalent write a preliminary mask holding signal-change values for every pixel.
  These mask values are calculated as
  a) get Y0 for every pixel
  b) apply a scharr operator on it

  This raw detail mask (RM) is not scaled but only cropped to the roi of the writing module (demosaic
  or rawprepare).
  The pipe gets roi copy of the writing module so we can later scale/distort the LM.

  Calculating the RM is done for performance and lower mem pressure reasons, so we don't have to
  pass full data to the module. Also the RM can be used by other modules. 
 
  If a mask uses the details refinement step it takes the raw details mask RM and calculates an
  intermediate mask (IM) which is still not scaled but has the roi of the writing module.
 
  For every pixel we calculate the IM value via a sigmoid function with the threshold and RM as parameters.

  At last the IM is slightly blurred to avoid hard transitions, as there still is no scaling we can use
  a constant sigma. As the blur_9x9 is pretty fast both in openmp/cl code paths - much faster than dt
  gaussians - it is used here.
  Now we have an unscaled detail mask which requires to be transformed through the pipeline using

  float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)

  returning a pointer to a distorted mask (DT) with same size as used in the module wanting the refinement.
  This DM is finally used to refine the original mask.

  All other refinements and parametric parameters are untouched.

  Some additional comments:
  1. intentionally this details mask refinement has only been implemented for raws. Especially for compressed
     inmages like jpegs or 8bit input the algo didn't work as good because of input precision and compression artefacts.
  2. In the gui the slider is above the rest of the refinemt sliders to emphasize that blurring & feathering use the
     mask corrected by detail refinemnt.
  3. Of course credit goes to Ingo @heckflosse from rt team for the original idea. (in the rt world this is knowb
     as details mask)
  4. Thanks to rawfiner for pointing out how to use Y0 and scharr for better maths.

  hanno@schwalm-bremen.de 21/04/29
*/


```