### PR TITLE
add explicit dependency on generate_conf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -880,6 +880,7 @@ add_library(lib_darktable SHARED ${DARKTABLE_BINDIR}/preferences_gen.h ${DARKTAB
 # since this isn't the same directory we do have to manually set it
 set_source_files_properties(${DARKTABLE_BINDIR}/version_gen.c PROPERTIES GENERATED TRUE)
 
+add_dependencies(lib_darktable generate_conf)
 add_dependencies(lib_darktable generate_version)
 add_dependencies(lib_darktable generate_preferences)
 


### PR DESCRIPTION
Weirdly, this missing dependency seems to only show up when running
"make -j1".