### PR TITLE
Fix timeline zooming for smooth scroll devices

### DIFF
--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1373,13 +1373,17 @@ static gboolean _lib_timeline_scroll_callback(GtkWidget *w, GdkEventScroll *e, g
   if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
     int z = strip->zoom;
-    if(e->direction == GDK_SCROLL_UP)
+    int delta_y = 0;
+    if(dt_gui_get_scroll_unit_deltas(e, NULL, &delta_y))
     {
-      if(z != DT_LIB_TIMELINE_ZOOM_HOUR) z++;
-    }
-    else if(e->direction == GDK_SCROLL_DOWN)
-    {
-      if(z != DT_LIB_TIMELINE_ZOOM_YEAR) z--;
+      if(delta_y < 0)
+      {
+        if(z != DT_LIB_TIMELINE_ZOOM_HOUR) z++;
+      }
+      else if(delta_y > 0)
+      {
+        if(z != DT_LIB_TIMELINE_ZOOM_YEAR) z--;
+      }
     }
 
     // if the zoom as changed, we need to recompute blocks and redraw
@@ -1403,7 +1407,7 @@ static gboolean _lib_timeline_scroll_callback(GtkWidget *w, GdkEventScroll *e, g
     int delta;
     if(dt_gui_get_scroll_unit_delta(e, &delta))
     {
-      int move = -delta;
+      int move = delta;
       if(dt_modifier_is(e->state, GDK_SHIFT_MASK)) move *= 2;
 
       _time_add(&(strip->time_pos), move, strip->zoom);


### PR DESCRIPTION
Change timeline to use `dt_gui_get_scroll_unit_deltas()` to detect zooming direction. Otherwise timeline cannot be scrolled with a smooth scroll device. I found it strange that scrolling timeline left to right moved to different direction than filmstrip. Direction is now changed to be same as filmstrip.