### PR TITLE
dt_conf : check default value for existence too

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1818,6 +1818,20 @@
     <shortdescription>panels collapsing state in preview mode</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig>
+    <name>slideshow/ui/panels_collapse_controls</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show borders arrows in slideshow</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>slideshow/ui/panel_collaps_state</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>panels collapsing state in slideshow</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>darkroom/ui/scroll_to_module</name>
     <type>bool</type>

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -498,7 +498,7 @@ int dt_conf_key_exists(const char *key)
   const int res = (g_hash_table_lookup(darktable.conf->table, key) != NULL)
                   || (g_hash_table_lookup(darktable.conf->override_entries, key) != NULL);
   dt_pthread_mutex_unlock(&darktable.conf->mutex);
-  return res;
+  return (res || dt_confgen_value_exists(key, DT_DEFAULT));
 }
 
 static void _conf_add(char *key, char *val, dt_conf_dreggn_t *d)


### PR DESCRIPTION
close #8667 

When we call `dt_conf_key_exists`, only loaded value are checked. That means that if there's a default value in `darktableconfig.xml.in` but this key has never been used, the function will return false...
I've changed that so `dt_conf_exists` consider default values as "existing".

I think it's reasonable, and my test don't have spotted regressions, but that need to be checked by others as this fct is use in lot of places.

this is applied to the default borders arrow in slideshow...