### PR TITLE
masks: allow drawing in viewport space

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -396,6 +396,27 @@ dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list, const 
     return NULL;
 }
 
+// returns the module at position iop_order
+struct dt_iop_module_t *dt_ioppr_get_pipe_nth_iop_module(GList *iop_list, int iop_order)
+{
+  GList *link = NULL;
+
+  for(GList *iops_order = iop_list; iops_order; iops_order = g_list_next(iops_order))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)iops_order->data;
+    if(module->iop_order == iop_order)
+    {
+      link = iops_order;
+      break;
+    }
+  }
+
+  if(link)
+    return (dt_iop_module_t *)link->data;
+  else
+    return NULL;
+}
+
 // returns the iop_order associated with the iop order entry that matches operation == op_name
 int dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name, const int multi_priority)
 {

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -240,6 +240,9 @@ gboolean dt_ioppr_check_can_move_after_iop(GList *iop_list, struct dt_iop_module
 gboolean dt_ioppr_move_iop_before(struct dt_develop_t *dev, struct dt_iop_module_t *module, struct dt_iop_module_t *module_next);
 gboolean dt_ioppr_move_iop_after(struct dt_develop_t *dev, struct dt_iop_module_t *module, struct dt_iop_module_t *module_prev);
 
+/** returns the dt_iop_order_entry_t at position iop_order in iop_order_list **/
+struct dt_iop_module_t *dt_ioppr_get_pipe_nth_iop_module(GList *iop_list, int iop_order);
+
 // for debug only
 int dt_ioppr_check_iop_order(struct dt_develop_t *dev, const int imgid, const char *msg);
 void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg);

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -25,7 +25,13 @@
 #include "dtgtk/gradientslider.h"
 #include "gui/color_picker_proxy.h"
 
-#define DEVELOP_BLEND_VERSION (10)
+#define DEVELOP_BLEND_VERSION (11)
+
+typedef enum dt_develop_coordinates_t
+{
+  DEVELOP_COORDINATES_RAW_GEODESIC = 0,    // $DESCRIPTION: "raw geodesic coordinates"
+  DEVELOP_COORDINATES_VIEWPORT_PLANAR = 1, // $DESCRIPTION: "viewport planar coordinates"
+} dt_develop_coordinates_t;
 
 typedef enum dt_develop_blend_colorspace_t
 {
@@ -357,6 +363,45 @@ typedef struct dt_develop_blend_params9_t
   gboolean raster_mask_invert;
 } dt_develop_blend_params9_t;
 
+typedef struct dt_develop_blend_params10_t
+{
+  /** what kind of masking to use: off, non-mask (uniformly), hand-drawn mask and/or conditional mask
+   *  or raster mask */
+  uint32_t mask_mode;
+  /** blending color space type */
+  int32_t blend_cst;
+  /** blending mode */
+  uint32_t blend_mode;
+  /** parameter for the blending */
+  float blend_parameter;
+  /** mixing opacity */
+  float opacity;
+  /** how masks are combined */
+  uint32_t mask_combine;
+  /** id of mask in current pipeline */
+  uint32_t mask_id;
+  /** blendif mask */
+  uint32_t blendif;
+  /** feathering radius */
+  float feathering_radius;
+  /** feathering guide */
+  uint32_t feathering_guide;
+  /** blur radius */
+  float blur_radius;
+  /** mask contrast enhancement */
+  float contrast;
+  /** mask brightness adjustment */
+  float brightness;
+  /** some reserved fields for future use */
+  uint32_t reserved[4];
+  /** blendif parameters */
+  float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
+  float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];
+  dt_dev_operation_t raster_mask_source;
+  int raster_mask_instance;
+  int raster_mask_id;
+  gboolean raster_mask_invert;
+} dt_develop_blend_params10_t;
 /** blend parameters current version */
 typedef struct dt_develop_blend_params_t
 {
@@ -398,6 +443,11 @@ typedef struct dt_develop_blend_params_t
   int raster_mask_instance;
   int raster_mask_id;
   gboolean raster_mask_invert;
+
+  // v11 addendum
+  dt_develop_coordinates_t coordinates_reference;
+
+  // new params go here so previous params can be imported with memcpy()
 } dt_develop_blend_params_t;
 
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2610,6 +2610,23 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe,
 {
   GList *modules = pipe->iop;
   GList *pieces = pipe->nodes;
+
+  // If coordinates space is viewport planar, we don't need transforms
+  dt_iop_module_t *current_module = dt_ioppr_get_pipe_nth_iop_module(pipe->iop, iop_order);
+  if(!current_module)
+  {
+    // this function is called from mask drawing methods, through dt_dev_distort_transform()
+    // which passes iop_order = 0.0 and prevents us to find a module.
+    // We fall back to the global dev mask proxy that should be inited in GUI "mask edit" buttons callbacks
+    if(darktable.develop->proxy.masks.coordinates  == DEVELOP_COORDINATES_VIEWPORT_PLANAR)
+      return 1;
+  }
+  else
+  {
+    if(current_module->blend_params->coordinates_reference == DEVELOP_COORDINATES_VIEWPORT_PLANAR)
+      return 1;
+  }
+
   while(modules)
   {
     if(!pieces)
@@ -2659,6 +2676,23 @@ int dt_dev_distort_backtransform_locked(dt_develop_t *dev, dt_dev_pixelpipe_t *p
 {
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
+
+  // If coordinates space is viewport planar, we don't need transforms
+  dt_iop_module_t *current_module = dt_ioppr_get_pipe_nth_iop_module(pipe->iop, iop_order);
+  if(!current_module)
+  {
+    // this function is called from mask drawing methods, through dt_dev_distort_backtransform()
+    // which passes iop_order = 0.0 and prevents us to find a module.
+    // We fall back to the global dev mask proxy that should be inited in GUI "mask edit" buttons callbacks
+    if(darktable.develop->proxy.masks.coordinates  == DEVELOP_COORDINATES_VIEWPORT_PLANAR)
+      return 1;
+  }
+  else
+  {
+    if(current_module->blend_params->coordinates_reference == DEVELOP_COORDINATES_VIEWPORT_PLANAR)
+      return 1;
+  }
+
   while(modules)
   {
     if(!pieces)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -268,6 +268,8 @@ typedef struct dt_develop_t
       void (*list_update)(struct dt_lib_module_t *self);
       /* selected forms change */
       void (*selection_change)(struct dt_lib_module_t *self, int selectid, int throw_event);
+      /* whether the module capturing masks display uses geodesic or planar coordinates and needs distort_transform */
+      int coordinates;
     } masks;
 
     // what is the ID of the module currently doing pipeline chromatic adaptation ?

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -26,6 +26,7 @@
 #include "common/collection.h"
 #include "control/conf.h"
 #include "control/control.h"
+#include "develop/blend.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "gui/accelerators.h"
@@ -3594,7 +3595,11 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn, GdkEventButton *ev
       _start_new_shape(module);
     }
 
-    if(btn) dt_iop_request_focus(module);
+    if(btn)
+    {
+      dt_iop_request_focus(module);
+      darktable.develop->proxy.masks.coordinates = module->blend_params->coordinates_reference;
+    }
   }
   else
   {

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1760,6 +1760,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
   else if(darktable.develop->form_gui->creation && (darktable.develop->form_gui->creation_module == self))
   {
     dt_iop_request_focus(self);
+    darktable.develop->proxy.masks.coordinates = self->blend_params->coordinates_reference;
 
     dt_masks_type_t type = DT_MASKS_CIRCLE;
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->bt_path)))

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -358,6 +358,7 @@ static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_
 
   dt_iop_color_picker_reset(self, TRUE);
 
+  darktable.develop->proxy.masks.coordinates = self->blend_params->coordinates_reference;
   dt_masks_set_edit_mode(self, self->dev->form_gui->edit_mode == DT_MASKS_EDIT_FULL ? DT_MASKS_EDIT_OFF : DT_MASKS_EDIT_FULL);
 
   // update edit shapes status


### PR DESCRIPTION
As pointed in #8634, mask drawing is controlled in viewport space (planar) but acts on the RAW geodesic space (before any distortion), which means the drawing is anamorphic (what you draw is not what you get). This is a huge problem for healing and cloning stamps that will sample pixels before perspective and lens distortions are corrected, meaning edges that appear vertical at drawing time may not be vertical in the actual sample, inducing all sorts of mismatches that will be forever hidden to users.

This PR introduces a "screen" painting mode that disables all distortions and let modules (masks or internal stamps) use the coordinates they receive at input, regardless of the global coordinates changes that happen in the pipe. This will preserve the shape of masks at the expense of voiding them if earlier distortions are changed and will allow to clone-stamp pixels after they are corrected for lens and perspective distortions, which means the view will match what is actually done in the pipe.

Usual crappy mode is kept as a "RAW" mode. No conversion is made when switching modes, so the masks will move in the image, but their coordinates are not changed (we simply change how those coordinates are interpreted).

![Screenshot_20210414_030247-1](https://user-images.githubusercontent.com/2779157/114639847-1f2ae400-9ccf-11eb-95a3-1945129436c4.png)

How it works :

We simply add a coordinates flag in the masking parameters structure, available to all modules uniformly. Since all distortions transforms of the pipeline are called through the same functions (`dt_dev_distort_transform_locked` and `dt_dev_distort_backtransform_locked`), it's a simple matter of checking, in that function, if the module currently calling the transforms has this flag or not. 

But since the GUI nodes drawings call transforms without a module, GUI bits need extra handling. When users click it, each "mask edit" button needs to write its `module->blendop_params->coordinates_reference` to the global `develop->proxy.masks.coordinates`. This global flag will be read in case the transform function is called without module.

BACKUP your database before testing, this will change blendops param structure.

TO DO:
- [x] Wire blendops and pipeline backend transforms
- [x] Wire global masks GUI
- [x] Wire spots clone stamp GUI
- [x] Wire retouch stamps GUI
- [x] Wire liquify GUI

Notes:

Lens correction module is not handled since it is not masked and it should always be the first of distorting modules in the pipe, otherwise the lens profiles are voided.

The few tests I have done seem to show that raster masks don't need any further handling. If a mask is drawn in screen coordinates, reusing it as a raster shows the same mask in same coordinates, which I believe is the expected behaviour.