### PR TITLE
fix function declaration

### DIFF
--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -65,7 +65,10 @@ void dt_ioppr_cleanup_profile_info(dt_iop_order_iccprofile_info_t *profile_info)
 /** returns the profile info from dev profiles info list that matches (profile_type, profile_filename)
  * NULL if not found
  */
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_profile_info_from_list(struct dt_develop_t *dev, const int profile_type, const char *profile_filename);
+dt_iop_order_iccprofile_info_t *
+dt_ioppr_get_profile_info_from_list(struct dt_develop_t *dev, dt_colorspaces_color_profile_type_t profile_type,
+                                    const char *profile_filename);
+
 /** adds the profile info from (profile_type, profile_filename) to the dev profiles info list if not already exists
  * returns the generated profile or the existing one
  */


### PR DESCRIPTION
The 2nd parameter in the prototype of `dt_ioppr_get_profile_info_from_list` had a false type. Compare to corresponding function implementation in `iop_profile.c`. Note that I did not declare the 2nd parameter in the function declaration as `const`, while it is `const` in the implementation. This is not a bug, this is intentionally. See https://abseil.io/tips/109 for the why. This write-up is about C++, but the arguments apply to C as well except that C has no references and no function overloading. The two prototypes
```
void foo(int);
void foo(const int);
```
declare the *same* function. Prototypes tell the callee which types of arguments need to be passed. From a callee perspective it is irrelevant if a *copyed* function parameter is changed within the function body. The callee has no way to observe/detect such a change.