### PR TITLE
fix full preview zoom crash

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -678,7 +678,7 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
   // to go the full path (as the thumbnail will be flipped the wrong way round)
   const int incompatible = !strncmp(img.exif_maker, "Phase One", 9);
   const gboolean use_raw =
-    dt_conf_is_equal("plugins/lighttable/thumbnail_raw_min_level", "never");
+    !dt_conf_is_equal("plugins/lighttable/thumbnail_raw_min_level", "never");
 
   if(!img.verified_size && !dt_image_altered(imgid) && !use_raw && !incompatible)
   {


### PR DESCRIPTION
negated result of dt_conf_is_equal to match original test that it replaced

see comments in #8671.

fixes #8659.

