### PR TITLE
masks : make the samples aware of distortions

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -174,7 +174,7 @@ typedef struct dt_masks_functions_t
   int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
                     float **points, int *points_count);
   int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
-                           float **border, int *border_count, int source);
+                           float **border, int *border_count, int source, const dt_iop_module_t *const module);
   int (*get_mask)(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
                   float **buffer, int *width, int *height, int *posx, int *posy);
@@ -197,7 +197,7 @@ typedef struct dt_masks_functions_t
                          struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
   void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
 } dt_masks_functions_t;
-  
+
 /** structure used to define a form */
 typedef struct dt_masks_form_t
 {
@@ -303,7 +303,7 @@ void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);
 /** get points in real space with respect of distortion dx and dy are used to eventually move the center of
  * the circle */
 int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                               float **border, int *border_count, int source);
+                               float **border, int *border_count, int source, dt_iop_module_t *module);
 
 /** get the rectangle which include the form and his border */
 int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
@@ -381,9 +381,10 @@ int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);
 int dt_masks_events_mouse_enter(struct dt_iop_module_t *module);
 
 /** functions used to manipulate gui data */
-void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);
+void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index,
+                              struct dt_iop_module_t *module);
 void dt_masks_gui_form_remove(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);
-void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui);
+void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module);
 void dt_masks_gui_form_save_creation(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *form,
                                      dt_masks_form_gui_t *gui);
 void dt_masks_group_ungroup(dt_masks_form_t *dest_grp, dt_masks_form_t *grp);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2164,8 +2164,6 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
 
-  float dx = 0.0f, dy = 0.0f, dxs = 0.0f, dys = 0.0f;
-
   // in creation mode
   if(gui->creation)
   {
@@ -2359,11 +2357,11 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   {
     cairo_set_dash(cr, dashed, 0, 0);
 
-    cairo_move_to(cr, gpt->points[nb * 6] + dx, gpt->points[nb * 6 + 1] + dy);
+    cairo_move_to(cr, gpt->points[nb * 6], gpt->points[nb * 6 + 1]);
     int seg = 1, seg2 = 0;
     for(int i = nb * 3; i < gpt->points_count; i++)
     {
-      cairo_line_to(cr, gpt->points[i * 2] + dx, gpt->points[i * 2 + 1] + dy);
+      cairo_line_to(cr, gpt->points[i * 2], gpt->points[i * 2 + 1]);
       // we decide to highlight the form segment by segment
       if(gpt->points[i * 2 + 1] == gpt->points[seg * 6 + 3] && gpt->points[i * 2] == gpt->points[seg * 6 + 2])
       {
@@ -2385,7 +2383,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
         // and we update the segment number
         seg = (seg + 1) % nb;
         seg2++;
-        cairo_move_to(cr, gpt->points[i * 2] + dx, gpt->points[i * 2 + 1] + dy);
+        cairo_move_to(cr, gpt->points[i * 2], gpt->points[i * 2 + 1]);
       }
     }
   }
@@ -2405,8 +2403,8 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
         anchor_size = 5.0f / zoom_scale;
       }
       dt_draw_set_color_overlay(cr, 0.8, 0.8);
-      cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5) + dx,
-                      gpt->points[k * 6 + 3] - (anchor_size * 0.5) + dy, anchor_size, anchor_size);
+      cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5),
+                      gpt->points[k * 6 + 3] - (anchor_size * 0.5), anchor_size, anchor_size);
       cairo_fill_preserve(cr);
 
       if((gui->group_selected == index) && (k == gui->point_dragging || k == gui->point_selected))
@@ -2433,9 +2431,9 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
     cairo_line_to(cr, gui->points[k*6+4]+dx,gui->points[k*6+5]+dy);
     cairo_stroke(cr);*/
     int ffx, ffy;
-    _brush_ctrl2_to_feather(gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy,
-                            gpt->points[k * 6 + 4] + dx, gpt->points[k * 6 + 5] + dy, &ffx, &ffy, TRUE);
-    cairo_move_to(cr, gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy);
+    _brush_ctrl2_to_feather(gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], gpt->points[k * 6 + 4],
+                            gpt->points[k * 6 + 5], &ffx, &ffy, TRUE);
+    cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
     dt_draw_set_color_overlay(cr, 0.3, 0.8);
@@ -2459,11 +2457,11 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   // draw border and corners
   if((gui->group_selected == index) && gpt->border_count > nb * 3 + 2)
   {
-    cairo_move_to(cr, gpt->border[nb * 6] + dx, gpt->border[nb * 6 + 1] + dy);
+    cairo_move_to(cr, gpt->border[nb * 6], gpt->border[nb * 6 + 1]);
 
     for(int i = nb * 3 + 1; i < gpt->border_count; i++)
     {
-      cairo_line_to(cr, gpt->border[i * 2] + dx, gpt->border[i * 2 + 1] + dy);
+      cairo_line_to(cr, gpt->border[i * 2], gpt->border[i * 2 + 1]);
     }
     // we execute the drawing
     if(gui->border_selected)
@@ -2496,8 +2494,8 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       }
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
       cairo_rectangle(cr,
-                      gpt->border[k*6] - (anchor_size*0.5)+dx,
-                      gpt->border[k*6+1] - (anchor_size*0.5)+dy,
+                      gpt->border[k*6] - (anchor_size*0.5),
+                      gpt->border[k*6+1] - (anchor_size*0.5),
                       anchor_size, anchor_size);
       cairo_fill_preserve(cr);
 
@@ -2514,8 +2512,8 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   if(!gui->creation && gpt->source_count > nb * 3 + 2)
   {
     // we draw the line between source and dest
-    cairo_move_to(cr, gpt->source[2] + dxs, gpt->source[3] + dys);
-    cairo_line_to(cr, gpt->points[2] + dx, gpt->points[3] + dy);
+    cairo_move_to(cr, gpt->source[2], gpt->source[3]);
+    cairo_line_to(cr, gpt->points[2], gpt->points[3]);
     cairo_set_dash(cr, dashed, 0, 0);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 2.5 / zoom_scale);
@@ -2537,10 +2535,9 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
     dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_move_to(cr, gpt->source[nb * 6] + dxs, gpt->source[nb * 6 + 1] + dys);
-    for(int i = nb * 3; i < gpt->source_count; i++)
-      cairo_line_to(cr, gpt->source[i * 2] + dxs, gpt->source[i * 2 + 1] + dys);
-    cairo_line_to(cr, gpt->source[nb * 6] + dxs, gpt->source[nb * 6 + 1] + dys);
+    cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
+    for(int i = nb * 3; i < gpt->source_count; i++) cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
+    cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -612,7 +612,7 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
   // we store all points
   float dx = 0.0f, dy = 0.0f;
 
-  if(source && form->points > 0 && transf_direction != DT_DEV_TRANSFORM_DIR_ALL)
+  if(source && form->points && transf_direction != DT_DEV_TRANSFORM_DIR_ALL)
   {
     dt_masks_point_brush_t *pt = (dt_masks_point_brush_t *)form->points->data;
     dx = (pt->corner[0] - form->source[0]) * wd;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -986,8 +986,8 @@ static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t 
   }
 }
 
-static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
-                                    int *points_count, float **border, int *border_count, int source)
+static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
+                                    float **border, int *border_count, int source, const dt_iop_module_t *module)
 {
   return _brush_get_pts_border(dev, form, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
                                border_count, NULL, NULL, source);
@@ -1161,7 +1161,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
 
       // we recreate the form points
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
 
       // we save the move
       dt_masks_update_image(darktable.develop);
@@ -1291,7 +1291,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
 
         // we recreate the form points
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         // we save the move
         dt_masks_update_image(darktable.develop);
         return 1;
@@ -1354,7 +1354,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _brush_init_ctrl_points(form);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         gui->point_edited = gui->point_dragging = gui->point_selected = gui->seg_selected + 1;
         gui->seg_selected = -1;
         dt_control_queue_redraw_center();
@@ -1434,7 +1434,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     // we save the move
     dt_masks_update_image(darktable.develop);
 
@@ -1453,7 +1453,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
 
       // we recreate the form points
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
       // we save the move
       dt_masks_update_image(darktable.develop);
     }
@@ -1725,7 +1725,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1748,7 +1748,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1793,7 +1793,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     // we save the move
     dt_masks_update_image(darktable.develop);
 
@@ -1826,7 +1826,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     // we save the move
     dt_masks_update_image(darktable.develop);
 
@@ -1894,7 +1894,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
     _brush_init_ctrl_points(form);
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1932,7 +1932,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     dt_control_queue_redraw_center();
     return 1;
@@ -1959,7 +1959,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
     _brush_init_ctrl_points(form);
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1991,7 +1991,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -267,7 +267,7 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      // gui->creation_module = NULL;
+      gui->creation_module = NULL;
     }
     else
     {
@@ -371,8 +371,8 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     gui->form_dragging = FALSE;
 
     // we change the center value
-    float wd = darktable.develop->preview_pipe->backbuf_width;
-    float ht = darktable.develop->preview_pipe->backbuf_height;
+    const float wd = darktable.develop->preview_pipe->backbuf_width;
+    const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     circle->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
@@ -444,8 +444,8 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
 {
   if(gui->form_dragging || gui->source_dragging)
   {
-    float wd = darktable.develop->preview_pipe->backbuf_width;
-    float ht = darktable.develop->preview_pipe->backbuf_height;
+    const float wd = darktable.develop->preview_pipe->backbuf_width;
+    const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     if(gui->form_dragging)
@@ -605,8 +605,8 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 {
   (void)radius2; // keep compiler from complaining about unused arg
   (void)rotation;
-  float wd = dev->preview_pipe->iwidth;
-  float ht = dev->preview_pipe->iheight;
+  const float wd = dev->preview_pipe->iwidth;
+  const float ht = dev->preview_pipe->iheight;
 
   // compute the points of the target (center and circumference of circle)
   // we get the point in RAW image reference

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -139,7 +139,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
           return 1;
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
           dt_conf_set_float("plugins/darkroom/spots/circle_border", circle->border);
         else
@@ -156,7 +156,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
           return 1;
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
           dt_conf_set_float("plugins/darkroom/spots/circle_size", circle->radius);
         else
@@ -267,7 +267,7 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      gui->creation_module = NULL;
+      // gui->creation_module = NULL;
     }
     else
     {
@@ -381,7 +381,7 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -420,7 +420,7 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -783,7 +783,8 @@ static void _bounding_box(const float *const points, int num_points, int *width,
 }
 
 static int _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form, float **points,
-                                     int *points_count, float **border, int *border_count, int source)
+                                     int *points_count, float **border, int *border_count, int source,
+                                     const dt_iop_module_t *module)
 {
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
   float x = 0.0f, y = 0.0f;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -444,7 +444,6 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
 {
   if(gui->form_dragging || gui->source_dragging)
   {
-
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -342,7 +342,8 @@ static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radi
 }
 
 static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form, float **points,
-                                      int *points_count, float **border, int *border_count, int source)
+                                      int *points_count, float **border, int *border_count, int source,
+                                      const dt_iop_module_t *module)
 {
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
   float x = 0.0f, y = 0.0f, a = 0.0f, b = 0.0f;
@@ -506,7 +507,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
           dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", ellipse->rotation);
         else
@@ -525,7 +526,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         ellipse->border = CLAMP(ellipse->border, 0.001f * reference, reference);
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
           dt_conf_set_float("plugins/darkroom/spots/ellipse_border", ellipse->border);
         else
@@ -549,7 +550,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         {
           dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", ellipse->radius[0]);
@@ -815,7 +816,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -871,7 +872,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the new parameters
     dt_masks_update_image(darktable.develop);
@@ -923,7 +924,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the rotation
     dt_masks_update_image(darktable.develop);
@@ -977,7 +978,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the rotation
     dt_masks_update_image(darktable.develop);
@@ -1008,7 +1009,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -704,8 +704,8 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
         = (dt_masks_point_ellipse_t *)(malloc(sizeof(dt_masks_point_ellipse_t)));
 
     // we change the center value
-    float wd = darktable.develop->preview_pipe->backbuf_width;
-    float ht = darktable.develop->preview_pipe->backbuf_height;
+    const float wd = darktable.develop->preview_pipe->backbuf_width;
+    const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
@@ -1083,8 +1083,8 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
 {
   if(gui->form_dragging || gui->source_dragging)
   {
-    float wd = darktable.develop->preview_pipe->backbuf_width;
-    float ht = darktable.develop->preview_pipe->backbuf_height;
+    const float wd = darktable.develop->preview_pipe->backbuf_width;
+    const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     if(gui->form_dragging)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -204,6 +204,59 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
   return 0;
 }
 
+static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, float xpos, float ypos, float pzx,
+                                  float pzy, float *anchorx, float *anchory, float *rotation, float *compression)
+{
+  const float pr_d = darktable.develop->preview_downsampling;
+  const float diff = 3.0f * zoom_scale * (pr_d / 2.0);
+  float x0 = 0.0f, y0 = 0.0f;
+  float dx = 0.0f, dy = 0.0f;
+
+  if(!gui->form_dragging
+     || (gui->posx_source - xpos > -diff && gui->posx_source - xpos < diff && gui->posy_source - ypos > -diff
+         && gui->posy_source - ypos < diff))
+  {
+    x0 = pzx;
+    y0 = pzy;
+    // rotation not updated and not yet dragged, in this case let's
+    // pretend that we are using a neutral dx, dy (where the rotation will
+    // still be unchanged). We do that as we don't know the actual rotation
+    // because those points must go through the backtransform.
+    dx = x0 + 100.0f;
+    dy = y0;
+  }
+  else
+  {
+    x0 = gui->posx_source;
+    y0 = gui->posy_source;
+    dx = pzx;
+    dy = pzy;
+  }
+
+  // we change the offset value
+  float pts[8] = { x0, y0, dx, dy, x0 + 10.0f, y0, x0, y0 + 10.0f };
+  dt_dev_distort_backtransform(darktable.develop, pts, 4);
+  *anchorx = pts[0] / darktable.develop->preview_pipe->iwidth;
+  *anchory = pts[1] / darktable.develop->preview_pipe->iheight;
+
+  float rot = atan2f(pts[3] - pts[1], pts[2] - pts[0]);
+  // If the transform has flipped the image about one axis, then the
+  // 'handedness' of the coordinate system is changed. In this case the
+  // rotation angle must be offset by 180 degrees so that the gradient points
+  // in the correct direction as dragged. We test for this by checking the
+  // angle between two vectors that should be 90 degrees apart. If the angle
+  // is -90 degrees, then the image is flipped.
+  float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2(pts[5] - pts[1], pts[4] - pts[0]);
+  // Normalize to the range -180 to 180 degrees
+  check_angle = atan2f(sinf(check_angle), cosf(check_angle));
+  if(check_angle < 0) rot -= M_PI;
+
+  const float compr = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
+
+  *rotation = -rot / M_PI * 180.0f;
+  *compression = MAX(0.0f, compr);
+}
+
 static int _gradient_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
                                             uint32_t state, dt_masks_form_t *form, int parentid,
                                             dt_masks_form_gui_t *gui, int index)
@@ -337,7 +390,6 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
   }
   else if(gui->creation)
   {
-    const float pr_d = darktable.develop->preview_downsampling;
     const float wd = darktable.develop->preview_pipe->backbuf_width;
     const float ht = darktable.develop->preview_pipe->backbuf_height;
 
@@ -345,62 +397,16 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     const int closeup = dt_control_get_dev_closeup();
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1 << closeup, 1);
-    const float diff = 3.0f * zoom_scale * (pr_d / 2.0);
-    float x0 = 0.0f, y0 = 0.0f;
 
-    float dx = 0.0f, dy = 0.0f;
-
-    if(!gui->form_dragging
-       || (gui->posx_source - gui->posx > -diff
-           && gui->posx_source - gui->posx < diff
-           && gui->posy_source - gui->posy > -diff
-           && gui->posy_source - gui->posy < diff))
-    {
-      x0 = pzx * wd;
-      y0 = pzy * ht;
-      // rotation not updated and not yet dragged, in this case let's
-      // pretend that we are using a neutral dx, dy (where the rotation will
-      // still be unchanged). We do that as we don't know the actual rotation
-      // because those points must go through the backtransform.
-      dx = x0 + 100.0f;
-      dy = y0;
-    }
-    else
-    {
-      x0 = gui->posx_source;
-      y0 = gui->posy_source;
-      dx = pzx * wd;
-      dy = pzy * ht;
-    }
-
-    gui->form_dragging = FALSE;
     dt_iop_module_t *crea_module = gui->creation_module;
     // we create the gradient
     dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(malloc(sizeof(dt_masks_point_gradient_t)));
 
-    // we change the offset value
-    float pts[8] = { x0, y0, dx, dy, x0+10.0f, y0, x0, y0+10.0f };
-    dt_dev_distort_backtransform(darktable.develop, pts, 4);
-    gradient->anchor[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
-    gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    _gradient_init_values(zoom_scale, gui, gui->posx, gui->posy, pzx * wd, pzy * ht, &gradient->anchor[0],
+                          &gradient->anchor[1], &gradient->rotation, &gradient->compression);
 
-    float rotation = atan2f(pts[3] - pts[1], pts[2] - pts[0]);
-    // If the transform has flipped the image about one axis, then the
-    // 'handedness' of the coordinate system is changed. In this case the
-    // rotation angle must be offset by 180 degrees so that the gradient points
-    // in the correct direction as dragged. We test for this by checking the
-    // angle between two vectors that should be 90 degrees apart. If the angle
-    // is -90 degrees, then the image is flipped.
-    float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2(pts[5] - pts[1], pts[4] - pts[0]);
-    // Normalize to the range -180 to 180 degrees
-    check_angle = atan2f(sinf(check_angle), cosf(check_angle));
-    if (check_angle < 0)
-      rotation -= M_PI;
+    gui->form_dragging = FALSE;
 
-    const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
-
-    gradient->rotation = -rotation / M_PI * 180.0f;
-    gradient->compression = MAX(0.0f, compression);
     gradient->steepness = 0.0f;
     gradient->curvature = 0.0f;
     gradient->state = DT_MASKS_GRADIENT_STATE_SIGMOIDAL;
@@ -523,367 +529,6 @@ static inline int _gradient_is_canonical(const float x, const float y, const flo
 {
   return (isnormal(x) && isnormal(y) && x >= -wd && x <= 2 * wd && y >= -ht && y <= 2 * ht) ? TRUE : FALSE;
 }
-
-
-static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index,
-                                         int nb)
-{
-  (void)nb;  // unused arg, keep compiler from complaining
-  double dashed[] = { 4.0, 4.0 };
-  dashed[0] /= zoom_scale;
-  dashed[1] /= zoom_scale;
-  const int len = sizeof(dashed) / sizeof(dashed[0]);
-
-  // preview gradient creation
-  if(gui->creation)
-  {
-    const float pr_d = darktable.develop->preview_downsampling;
-    const float iwd = pr_d * darktable.develop->preview_pipe->iwidth;
-    const float iht = pr_d * darktable.develop->preview_pipe->iheight;
-    const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
-    const float distance = 0.1f * MIN(iwd, iht);
-    const float scale = sqrtf(iwd * iwd + iht * iht);
-    const float zoom_x = dt_control_get_dev_zoom_x();
-    const float zoom_y = dt_control_get_dev_zoom_y();
-
-    float xpos = 0.0f, ypos = 0.0f, xpos0 = 0.0f, ypos0 = 0.0f;
-    if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)
-    {
-      xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
-      ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
-    }
-    else
-    {
-      xpos = gui->posx;
-      ypos = gui->posy;
-    }
-
-    // get the rotation angle only if we are not too close from starting point
-    const float diff = 3.0f * zoom_scale * (pr_d / 2.0);
-    float rotation = 0.0f;
-    if(!gui->form_dragging
-       || (gui->posx_source - gui->posx > -diff
-           && gui->posx_source - gui->posx < diff
-           && gui->posy_source - gui->posy > -diff
-           && gui->posy_source - gui->posy < diff))
-    {
-      rotation = 0.0f;
-      xpos0 = xpos;
-      ypos0 = ypos;
-    }
-    else
-    {
-      rotation = atan2f(gui->posy - gui->posy_source, gui->posx - gui->posx_source);
-      xpos0 = gui->posx_source;
-      ypos0 = gui->posy_source;
-    }
-    const float trotation = tanf(rotation);
-
-    cairo_save(cr);
-
-    // draw main line
-    cairo_set_line_width(cr, 5.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-
-    cairo_move_to(cr, 0.0f, ypos - xpos * trotation);
-    cairo_line_to(cr, darktable.develop->preview_pipe->backbuf_width,
-                  ypos + (darktable.develop->preview_pipe->backbuf_width - xpos) * trotation);
-    cairo_stroke_preserve(cr);
-    cairo_set_line_width(cr, 2.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_stroke(cr);
-
-    // draw the arrow
-    const float anchor_x = xpos0;
-    const float anchor_y = ypos0;
-    float pivot_start_x = xpos0 + sinf(rotation) * distance;
-    float pivot_end_x = xpos0 - sinf(rotation) * distance;
-    float pivot_start_y = ypos0 - cosf(rotation) * distance;
-    float pivot_end_y = ypos0 + cosf(rotation) * distance;
-    cairo_set_dash(cr, dashed, 0, 0);
-    cairo_set_line_width(cr, 2.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-
-    // from start to end
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_line_to(cr, pivot_start_x, pivot_start_y);
-    cairo_line_to(cr, pivot_end_x, pivot_end_y);
-    cairo_stroke(cr);
-
-    // start side of the gradient
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
-    cairo_fill_preserve(cr);
-    cairo_stroke(cr);
-
-    // end side of the gradient
-    cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
-    cairo_fill_preserve(cr);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_stroke(cr);
-
-    // draw arrow on the end of the gradient to clearly display the direction
-
-    // size & width of the arrow
-    const float arrow_angle = 0.25f;
-    const float arrow_length = 15.0f / zoom_scale;
-
-    const float a_dx = anchor_x - pivot_end_x;
-    const float a_dy = pivot_end_y - anchor_y;
-    const float angle = atan2f(a_dx, a_dy) - M_PI / 2.0f;
-
-    const float arrow_x1 = pivot_end_x + (arrow_length * cosf(angle + arrow_angle));
-    const float arrow_x2 = pivot_end_x + (arrow_length * cosf(angle - arrow_angle));
-    const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
-    const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
-
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_move_to(cr, pivot_end_x, pivot_end_y);
-    cairo_line_to(cr, arrow_x1, arrow_y1);
-    cairo_line_to(cr, arrow_x2, arrow_y2);
-    cairo_line_to(cr, pivot_end_x, pivot_end_y);
-    cairo_close_path(cr);
-    cairo_fill_preserve(cr);
-    cairo_stroke(cr);
-
-    // and the border
-    pivot_start_x = xpos0 + sinf(rotation) * compression * scale;
-    pivot_end_x = xpos0 - sinf(rotation) * compression * scale;
-    pivot_start_y = ypos0 - cosf(rotation) * compression * scale;
-    pivot_end_y = ypos0 + cosf(rotation) * compression * scale;
-    cairo_set_dash(cr, dashed, len, 0);
-    cairo_set_line_width(cr, 2.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_move_to(cr, 0.0f, pivot_start_y - pivot_start_x * trotation);
-    cairo_line_to(cr, darktable.develop->preview_pipe->backbuf_width,
-                  pivot_start_y + (darktable.develop->preview_pipe->backbuf_width - pivot_start_x) * trotation);
-    cairo_stroke_preserve(cr);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_set_dash(cr, dashed, len, 4);
-    cairo_stroke(cr);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_move_to(cr, 0.0f, pivot_end_y - pivot_end_x * trotation);
-    cairo_line_to(cr, darktable.develop->preview_pipe->backbuf_width,
-                  pivot_end_y + (darktable.develop->preview_pipe->backbuf_width - pivot_end_x) * trotation);
-    cairo_stroke_preserve(cr);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_set_dash(cr, dashed, len, 4);
-    cairo_stroke(cr);
-
-    cairo_restore(cr);
-    return;
-  }
-  const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-  if(!gpt) return;
-  float dx = 0.0f, dy = 0.0f, sinv = 0.0f, cosv = 1.0f;
-  const float xref = gpt->points[0];
-  const float yref = gpt->points[1];
-
-  if((gui->group_selected == index) && gui->form_dragging)
-  {
-    dx = gui->posx + gui->dx - xref;
-    dy = gui->posy + gui->dy - yref;
-  }
-  else if((gui->group_selected == index) && gui->form_rotating)
-  {
-    const float v = atan2f(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
-    sinv = sinf(v);
-    cosv = cosf(v);
-  }
-
-  // draw line
-  if(gpt->points_count > 4)
-  {
-    const float *points = gpt->points + 6;
-    const int points_count = gpt->points_count - 3;
-    const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;
-
-    int count = 0;
-    float x = 0.0f, y = 0.0f;
-
-    while(count < points_count)
-    {
-      if(!isnormal(points[count * 2]))
-      {
-        count++;
-        continue;
-      }
-
-      _gradient_point_transform(xref, yref, points[count * 2] + dx, points[count * 2 + 1] + dy, sinv, cosv, &x, &y);
-
-      if(!_gradient_is_canonical(x, y, wd, ht))
-      {
-        count++;
-        continue;
-      }
-
-      cairo_set_dash(cr, dashed, 0, 0);
-      if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-        cairo_set_line_width(cr, 5.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 3.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
-
-      cairo_move_to(cr, x, y);
-
-      count++;
-      for(; count < points_count && isnormal(points[count * 2]); count++)
-      {
-        _gradient_point_transform(xref, yref, points[count * 2] + dx, points[count * 2 + 1] + dy, sinv, cosv,
-                                &x, &y);
-
-        if(!_gradient_is_canonical(x, y, wd, ht))
-          break;
-
-        cairo_line_to(cr, x, y);
-      }
-      cairo_stroke_preserve(cr);
-      if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
-      cairo_stroke(cr);
-    }
-  }
-
-  // draw border
-  if((gui->group_selected == index) && gpt->border_count > 3)
-  {
-    const float *border = gpt->border;
-    const int border_count = gpt->border_count;
-    const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;
-
-    int count = 0;
-    float x = 0.0f, y = 0.0f;
-
-    while(count < border_count)
-    {
-      if(!isnormal(border[count * 2]))
-      {
-        count++;
-        continue;
-      }
-
-      _gradient_point_transform(xref, yref, border[count * 2] + dx, border[count * 2 + 1] + dy, sinv, cosv, &x, &y);
-
-      if(!_gradient_is_canonical(x, y, wd, ht))
-      {
-        count++;
-        continue;
-      }
-
-      cairo_set_dash(cr, dashed, len, 0);
-      if((gui->group_selected == index) && (gui->border_selected))
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
-
-      cairo_move_to(cr, x, y);
-
-      count++;
-      for(; count < border_count && isnormal(border[count * 2]); count++)
-      {
-        _gradient_point_transform(xref, yref, border[count * 2] + dx, border[count * 2 + 1] + dy,
-                                  sinv, cosv, &x, &y);
-
-        if(!_gradient_is_canonical(x, y, wd, ht))
-          break;
-
-        cairo_line_to(cr, x, y);
-      }
-      cairo_stroke_preserve(cr);
-      if((gui->group_selected == index) && (gui->border_selected))
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
-      cairo_set_dash(cr, dashed, len, 4);
-      cairo_stroke(cr);
-    }
-  }
-
-  float anchor_x = 0.0f, anchor_y = 0.0f;
-  float pivot_start_x = 0.0f, pivot_start_y = 0.0f;
-  float pivot_end_x = 0.0f, pivot_end_y = 0.0f;
-
-  _gradient_point_transform(xref, yref, gpt->points[0] + dx, gpt->points[1] + dy, sinv, cosv, &anchor_x, &anchor_y);
-  _gradient_point_transform(xref, yref, gpt->points[2] + dx, gpt->points[3] + dy, sinv, cosv, &pivot_end_x, &pivot_end_y);
-  _gradient_point_transform(xref, yref, gpt->points[4] + dx, gpt->points[5] + dy, sinv, cosv, &pivot_start_x, &pivot_start_y);
-
-  // draw anchor point
-  {
-    cairo_set_dash(cr, dashed, 0, 0);
-    const float anchor_size = (gui->form_dragging || gui->form_selected) ? 7.0f / zoom_scale : 5.0f / zoom_scale;
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_rectangle(cr, anchor_x - (anchor_size * 0.5), anchor_y - (anchor_size * 0.5), anchor_size, anchor_size);
-    cairo_fill_preserve(cr);
-
-    if((gui->group_selected == index) && (gui->form_dragging || gui->form_selected))
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_stroke(cr);
-  }
-
-
-  // draw pivot points
-  {
-    cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index) && (gui->border_selected))
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-
-    // from start to end
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_move_to(cr, pivot_start_x, pivot_start_y);
-    cairo_line_to(cr, pivot_end_x, pivot_end_y);
-    cairo_stroke(cr);
-
-    // start side of the gradient
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
-    cairo_fill_preserve(cr);
-    cairo_stroke(cr);
-
-    // end side of the gradient
-    cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
-    cairo_fill_preserve(cr);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_stroke(cr);
-
-    // draw arrow on the end of the gradient to clearly display the direction
-
-    // size & width of the arrow
-    const float arrow_angle = 0.25f;
-    const float arrow_length = 15.0f / zoom_scale;
-
-    const float a_dx = anchor_x - pivot_end_x;
-    const float a_dy = pivot_end_y - anchor_y;
-    const float angle = atan2f(a_dx, a_dy) - M_PI/2.0f;
-
-    const float arrow_x1 = pivot_end_x + (arrow_length * cosf(angle + arrow_angle));
-    const float arrow_x2 = pivot_end_x + (arrow_length * cosf(angle - arrow_angle));
-    const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
-    const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
-
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
-    cairo_move_to(cr, pivot_end_x, pivot_end_y);
-    cairo_line_to(cr, arrow_x1, arrow_y1);
-    cairo_line_to(cr, arrow_x2, arrow_y2);
-    cairo_line_to(cr, pivot_end_x, pivot_end_y);
-    cairo_close_path(cr);
-    cairo_fill_preserve(cr);
-    cairo_stroke(cr);
-  }
-}
-
 
 static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotation, float curvature,
                                 float **points, int *points_count)
@@ -1054,6 +699,323 @@ end:
   dt_free_align(points2);
 
   return res;
+}
+
+static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, const float len,
+                                 const gboolean selected, const float zoom_scale, float *pts_line,
+                                 int pts_line_count, const float xref, const float yref, const float dx,
+                                 const float dy, const float sinv, const float cosv)
+{
+  // safeguard in case of malformed arrays of points
+  if(borders && pts_line_count <= 3) return;
+  if(!borders && pts_line_count <= 4) return;
+
+  const float *points = (borders) ? pts_line : pts_line + 6;
+  const int points_count = (borders) ? pts_line_count : pts_line_count - 3;
+  const float wd = darktable.develop->preview_pipe->iwidth;
+  const float ht = darktable.develop->preview_pipe->iheight;
+
+  int count = 0;
+  float x = 0.0f, y = 0.0f;
+
+  while(count < points_count)
+  {
+    if(!isnormal(points[count * 2]))
+    {
+      count++;
+      continue;
+    }
+
+    _gradient_point_transform(xref, yref, points[count * 2] + dx, points[count * 2 + 1] + dy, sinv, cosv, &x, &y);
+
+    if(!_gradient_is_canonical(x, y, wd, ht))
+    {
+      count++;
+      continue;
+    }
+
+    if(borders)
+      cairo_set_dash(cr, dashed, len, 0);
+    else
+      cairo_set_dash(cr, dashed, 0, 0);
+    if(selected)
+      if(borders)
+        cairo_set_line_width(cr, 2.0 / zoom_scale);
+      else
+        cairo_set_line_width(cr, 5.0 / zoom_scale);
+    else if(borders)
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    else
+      cairo_set_line_width(cr, 3.0 / zoom_scale);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+
+    cairo_move_to(cr, x, y);
+
+    count++;
+    for(; count < points_count && isnormal(points[count * 2]); count++)
+    {
+      _gradient_point_transform(xref, yref, points[count * 2] + dx, points[count * 2 + 1] + dy, sinv, cosv, &x, &y);
+
+      if(!_gradient_is_canonical(x, y, wd, ht)) break;
+
+      cairo_line_to(cr, x, y);
+    }
+    cairo_stroke_preserve(cr);
+    if(selected)
+      cairo_set_line_width(cr, 2.0 / zoom_scale);
+    else
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_stroke(cr);
+  }
+}
+
+static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, const gboolean selected,
+                                 const gboolean border_selected, const float zoom_scale, float *pts, int pts_count,
+                                 const float dx, const float dy, const float sinv, const float cosv)
+{
+  if(pts_count < 3) return;
+
+  float anchor_x = 0.0f, anchor_y = 0.0f;
+  float pivot_start_x = 0.0f, pivot_start_y = 0.0f;
+  float pivot_end_x = 0.0f, pivot_end_y = 0.0f;
+
+  _gradient_point_transform(pts[0], pts[1], pts[0] + dx, pts[1] + dy, sinv, cosv, &anchor_x, &anchor_y);
+  _gradient_point_transform(pts[0], pts[1], pts[2] + dx, pts[3] + dy, sinv, cosv, &pivot_end_x, &pivot_end_y);
+  _gradient_point_transform(pts[0], pts[1], pts[4] + dx, pts[5] + dy, sinv, cosv, &pivot_start_x, &pivot_start_y);
+
+  // draw anchor point
+  {
+    cairo_set_dash(cr, dashed, 0, 0);
+    const float anchor_size = (selected) ? 7.0f / zoom_scale : 5.0f / zoom_scale;
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_rectangle(cr, anchor_x - (anchor_size * 0.5), anchor_y - (anchor_size * 0.5), anchor_size, anchor_size);
+    cairo_fill_preserve(cr);
+
+    if(selected)
+      cairo_set_line_width(cr, 2.0 / zoom_scale);
+    else
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    cairo_stroke(cr);
+  }
+
+
+  // draw pivot points
+  {
+    cairo_set_dash(cr, dashed, 0, 0);
+    if(border_selected)
+      cairo_set_line_width(cr, 2.0 / zoom_scale);
+    else
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+
+    // from start to end
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_move_to(cr, pivot_start_x, pivot_start_y);
+    cairo_line_to(cr, pivot_end_x, pivot_end_y);
+    cairo_stroke(cr);
+
+    // start side of the gradient
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
+    cairo_fill_preserve(cr);
+    cairo_stroke(cr);
+
+    // end side of the gradient
+    cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
+    cairo_fill_preserve(cr);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    cairo_stroke(cr);
+
+    // draw arrow on the end of the gradient to clearly display the direction
+
+    // size & width of the arrow
+    const float arrow_angle = 0.25f;
+    const float arrow_length = 15.0f / zoom_scale;
+
+    const float a_dx = anchor_x - pivot_end_x;
+    const float a_dy = pivot_end_y - anchor_y;
+    const float angle = atan2f(a_dx, a_dy) - M_PI / 2.0f;
+
+    const float arrow_x1 = pivot_end_x + (arrow_length * cosf(angle + arrow_angle));
+    const float arrow_x2 = pivot_end_x + (arrow_length * cosf(angle - arrow_angle));
+    const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
+    const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
+
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_move_to(cr, pivot_end_x, pivot_end_y);
+    cairo_line_to(cr, arrow_x1, arrow_y1);
+    cairo_line_to(cr, arrow_x2, arrow_y2);
+    cairo_line_to(cr, pivot_end_x, pivot_end_y);
+    cairo_close_path(cr);
+    cairo_fill_preserve(cr);
+    cairo_stroke(cr);
+  }
+}
+
+static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index, int nb)
+{
+  (void)nb; // unused arg, keep compiler from complaining
+  double dashed[] = { 4.0, 4.0 };
+  dashed[0] /= zoom_scale;
+  dashed[1] /= zoom_scale;
+  const int len = sizeof(dashed) / sizeof(dashed[0]);
+
+  // preview gradient creation
+  if(gui->creation)
+  {
+    const float zoom_x = dt_control_get_dev_zoom_x();
+    const float zoom_y = dt_control_get_dev_zoom_y();
+
+    float xpos = 0.0f, ypos = 0.0f;
+    if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)
+    {
+      xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
+      ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
+    }
+    else
+    {
+      xpos = gui->posx;
+      ypos = gui->posy;
+    }
+
+    float xx = 0.0, yy = 0.0, rotation = 0.0, compression = 0.0;
+    _gradient_init_values(zoom_scale, gui, xpos, ypos, xpos, ypos, &xx, &yy, &rotation, &compression);
+
+    float *points = NULL;
+    int points_count = 0;
+    float *border = NULL;
+    int border_count = 0;
+    int draw = _gradient_get_points(darktable.develop, xx, yy, rotation, 0.0, &points, &points_count);
+    if(draw && compression > 0.0)
+    {
+      draw = _gradient_get_pts_border(darktable.develop, xx, yy, rotation, compression, 0.0, &border,
+                                      &border_count);
+    }
+
+    cairo_save(cr);
+    // draw main line
+    _gradient_draw_lines(FALSE, cr, dashed, len, FALSE, zoom_scale, points, points_count, points[0], points[1],
+                         0.0, 0.0, 0.0, 1.0);
+    // draw borders
+    _gradient_draw_lines(TRUE, cr, dashed, len, FALSE, zoom_scale, border, border_count, points[0], points[1], 0.0,
+                         0.0, 0.0, 1.0);
+    // draw arrow
+    _gradient_draw_arrow(cr, dashed, len, FALSE, FALSE, zoom_scale, points, points_count, 0.0, 0.0, 0.0, 1.0);
+    cairo_restore(cr);
+
+    if(points) dt_free_align(points);
+    if(border) dt_free_align(border);
+    return;
+  }
+  const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  if(!gpt) return;
+  float dx = 0.0f, dy = 0.0f, sinv = 0.0f, cosv = 1.0f;
+  const float xref = gpt->points[0];
+  const float yref = gpt->points[1];
+
+  if((gui->group_selected == index) && gui->form_dragging)
+  {
+    dx = gui->posx + gui->dx - xref;
+    dy = gui->posy + gui->dy - yref;
+  }
+  else if((gui->group_selected == index) && gui->form_rotating)
+  {
+    const float v = atan2f(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
+    sinv = sinf(v);
+    cosv = cosf(v);
+  }
+
+  const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
+  // draw main line
+  _gradient_draw_lines(FALSE, cr, dashed, len, selected, zoom_scale, gpt->points, gpt->points_count, xref, yref,
+                       dx, dy, sinv, cosv);
+  // draw borders
+  if(gui->group_selected == index)
+    _gradient_draw_lines(TRUE, cr, dashed, len, gui->border_selected, zoom_scale, gpt->border, gpt->border_count,
+                         xref, yref, dx, dy, sinv, cosv);
+
+  _gradient_draw_arrow(cr, dashed, len, selected, ((gui->group_selected == index) && (gui->border_selected)),
+                       zoom_scale, gpt->points, gpt->points_count, dx, dy, sinv, cosv);
+  float anchor_x = 0.0f, anchor_y = 0.0f;
+  float pivot_start_x = 0.0f, pivot_start_y = 0.0f;
+  float pivot_end_x = 0.0f, pivot_end_y = 0.0f;
+
+  _gradient_point_transform(xref, yref, gpt->points[0] + dx, gpt->points[1] + dy, sinv, cosv, &anchor_x, &anchor_y);
+  _gradient_point_transform(xref, yref, gpt->points[2] + dx, gpt->points[3] + dy, sinv, cosv, &pivot_end_x,
+                            &pivot_end_y);
+  _gradient_point_transform(xref, yref, gpt->points[4] + dx, gpt->points[5] + dy, sinv, cosv, &pivot_start_x,
+                            &pivot_start_y);
+
+  // draw anchor point
+  {
+    cairo_set_dash(cr, dashed, 0, 0);
+    const float anchor_size = (gui->form_dragging || gui->form_selected) ? 7.0f / zoom_scale : 5.0f / zoom_scale;
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_rectangle(cr, anchor_x - (anchor_size * 0.5), anchor_y - (anchor_size * 0.5), anchor_size, anchor_size);
+    cairo_fill_preserve(cr);
+
+    if((gui->group_selected == index) && (gui->form_dragging || gui->form_selected))
+      cairo_set_line_width(cr, 2.0 / zoom_scale);
+    else
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    cairo_stroke(cr);
+  }
+
+
+  // draw pivot points
+  {
+    cairo_set_dash(cr, dashed, 0, 0);
+    if((gui->group_selected == index) && (gui->border_selected))
+      cairo_set_line_width(cr, 2.0 / zoom_scale);
+    else
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+
+    // from start to end
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_move_to(cr, pivot_start_x, pivot_start_y);
+    cairo_line_to(cr, pivot_end_x, pivot_end_y);
+    cairo_stroke(cr);
+
+    // start side of the gradient
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
+    cairo_fill_preserve(cr);
+    cairo_stroke(cr);
+
+    // end side of the gradient
+    cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
+    cairo_fill_preserve(cr);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    cairo_stroke(cr);
+
+    // draw arrow on the end of the gradient to clearly display the direction
+
+    // size & width of the arrow
+    const float arrow_angle = 0.25f;
+    const float arrow_length = 15.0f / zoom_scale;
+
+    const float a_dx = anchor_x - pivot_end_x;
+    const float a_dy = pivot_end_y - anchor_y;
+    const float angle = atan2f(a_dx, a_dy) - M_PI / 2.0f;
+
+    const float arrow_x1 = pivot_end_x + (arrow_length * cosf(angle + arrow_angle));
+    const float arrow_x2 = pivot_end_x + (arrow_length * cosf(angle - arrow_angle));
+    const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
+    const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
+
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    cairo_move_to(cr, pivot_end_x, pivot_end_y);
+    cairo_line_to(cr, arrow_x1, arrow_y1);
+    cairo_line_to(cr, arrow_x2, arrow_y2);
+    cairo_line_to(cr, pivot_end_x, pivot_end_y);
+    cairo_close_path(cr);
+    cairo_fill_preserve(cr);
+    cairo_stroke(cr);
+  }
 }
 
 static int _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form,

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -122,7 +122,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
         gradient->compression = fminf(fmaxf(gradient->compression, 0.001f) * 1.0f / 0.8f, 1.0f);
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
       dt_conf_set_float("plugins/darkroom/masks/gradient/compression", gradient->compression);
       dt_toast_log(_("compression: %3.2f%%"), gradient->compression*100.0f);
       dt_masks_update_image(darktable.develop);
@@ -137,7 +137,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       dt_toast_log(_("curvature: %3.2f%%"), gradient->curvature*50.0f);
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
       dt_masks_update_image(darktable.develop);
     }
     return 1;
@@ -160,7 +160,7 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     dt_masks_update_image(darktable.develop);
 
@@ -310,7 +310,7 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -356,7 +356,7 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the rotation
     dt_masks_update_image(darktable.develop);
@@ -381,7 +381,7 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the new parameters
     dt_masks_update_image(darktable.develop);
@@ -1023,9 +1023,9 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   }
 }
 
-static int _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form,
-                                       float **points, int *points_count,
-                                       float **border,  int *border_count, int source)
+static int _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
+                                       float **border, int *border_count, int source,
+                                       const dt_iop_module_t *module)
 {
   (void)source;  // unused arg, keep compiler from complaining
   dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)form->points->data;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -739,14 +739,19 @@ static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, 
     else
       cairo_set_dash(cr, dashed, 0, 0);
     if(selected)
+    {
       if(borders)
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 5.0 / zoom_scale);
-    else if(borders)
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
+    }
     else
-      cairo_set_line_width(cr, 3.0 / zoom_scale);
+    {
+      if(borders)
+        cairo_set_line_width(cr, 1.0 / zoom_scale);
+      else
+        cairo_set_line_width(cr, 3.0 / zoom_scale);
+    }
     dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
     cairo_move_to(cr, x, y);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -478,6 +478,41 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
   }
   if(gui->form_rotating)
   {
+    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+
+    const float wd = darktable.develop->preview_pipe->backbuf_width;
+    const float ht = darktable.develop->preview_pipe->backbuf_height;
+    const float x = pzx * wd;
+    const float y = pzy * ht;
+
+    // we need the reference point
+    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    if(!gpt) return 0;
+    const float xref = gpt->points[0];
+    const float yref = gpt->points[1];
+
+    float pts[8] = { xref, yref, x, y, 0, 0, gui->dx, gui->dy };
+
+    // we remap dx, dy to the right values, as it will be used in next movements
+    gui->dx = xref - gui->posx;
+    gui->dy = yref - gui->posy;
+
+    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+
+    float pts2[8] = { xref, yref, x, y, xref + 10.0f, yref, xref, yref + 10.0f };
+    dt_dev_distort_backtransform(darktable.develop, pts2, 4);
+
+    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    // Normalize to the range -180 to 180 degrees
+    check_angle = atan2f(sinf(check_angle), cosf(check_angle));
+    if(check_angle < 0)
+      gradient->rotation += dv / M_PI * 180.0f;
+    else
+      gradient->rotation -= dv / M_PI * 180.0f;
+
+    // we recreate the form points
+    dt_masks_gui_form_remove(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -939,13 +974,6 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   float dx = 0.0f, dy = 0.0f, sinv = 0.0f, cosv = 1.0f;
   const float xref = gpt->points[0];
   const float yref = gpt->points[1];
-
-  if((gui->group_selected == index) && gui->form_rotating)
-  {
-    const float v = atan2f(gui->posy - yref, gui->posx - xref) - atan2(-gui->dy, -gui->dx);
-    sinv = sinf(v);
-    cosv = cosf(v);
-  }
 
   const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
   // draw main line

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -240,7 +240,7 @@ static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, fl
   float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2(pts[5] - pts[1], pts[4] - pts[0]);
   // Normalize to the range -180 to 180 degrees
   check_angle = atan2f(sinf(check_angle), cosf(check_angle));
-  if(check_angle < 0) rot -= M_PI;
+  if(check_angle < 0.0f) rot -= M_PI;
 
   const float compr = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
 
@@ -496,7 +496,7 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2(pts2[5] - pts2[1], pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
-    if(check_angle < 0)
+    if(check_angle < 0.0f)
       gradient->rotation += dv / M_PI * 180.0f;
     else
       gradient->rotation -= dv / M_PI * 180.0f;
@@ -824,12 +824,12 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
 {
   if(pts_count < 3) return;
 
-  float anchor_x = pts[0];
-  float anchor_y = pts[1];
-  float pivot_end_x = pts[2];
-  float pivot_end_y = pts[3];
-  float pivot_start_x = pts[4];
-  float pivot_start_y = pts[5];
+  const float anchor_x = pts[0];
+  const float anchor_y = pts[1];
+  const float pivot_end_x = pts[2];
+  const float pivot_end_y = pts[3];
+  const float pivot_start_x = pts[4];
+  const float pivot_start_y = pts[5];
 
   // draw anchor point
   {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -175,7 +175,7 @@ void dt_masks_init_form_gui(dt_masks_form_gui_t *gui)
   gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
 }
 
-void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index)
+void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index, dt_iop_module_t *module)
 {
   const int npoints = g_list_length(gui->points);
   if(npoints == index)
@@ -191,10 +191,10 @@ void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, i
 
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(dt_masks_get_points_border(darktable.develop, form, &gpt->points, &gpt->points_count, &gpt->border,
-                                &gpt->border_count, 0))
+                                &gpt->border_count, 0, NULL))
   {
     if(form->type & DT_MASKS_CLONE)
-      dt_masks_get_points_border(darktable.develop, form, &gpt->source, &gpt->source_count, NULL, NULL, 1);
+      dt_masks_get_points_border(darktable.develop, form, &gpt->source, &gpt->source_count, NULL, NULL, 1, module);
     gui->pipe_hash = darktable.develop->preview_pipe->backbuf_hash;
     gui->formid = form->formid;
   }
@@ -229,7 +229,7 @@ void dt_masks_gui_form_remove(dt_masks_form_t *form, dt_masks_form_gui_t *gui, i
   }
 }
 
-void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui)
+void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, dt_iop_module_t *module)
 {
   // we test if the image has changed
   if(gui->pipe_hash > 0)
@@ -253,12 +253,12 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *g
         dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
         dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
         if (!sel) return;
-        dt_masks_gui_form_create(sel, gui, pos);
+        dt_masks_gui_form_create(sel, gui, pos, module);
         pos++;
       }
     }
     else
-      dt_masks_gui_form_create(form, gui, 0);
+      dt_masks_gui_form_create(form, gui, 0, module);
   }
 }
 
@@ -403,11 +403,12 @@ int dt_masks_form_duplicate(dt_develop_t *dev, int formid)
 }
 
 int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                               float **border, int *border_count, int source)
+                               float **border, int *border_count, int source, dt_iop_module_t *module)
 {
   if(form->functions && form->functions->get_points_border)
   {
-    return form->functions->get_points_border(dev, form, points, points_count, border, border_count, source);
+    return form->functions->get_points_border(dev, form, points, points_count, border, border_count, source,
+                                              module);
   }
   return 0;
 }
@@ -1178,7 +1179,7 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   // add preview when creating a circle, ellipse and gradient
   if(!(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE) || (form->type & DT_MASKS_GRADIENT))
        && gui->creation))
-    dt_masks_gui_form_test_create(form, gui);
+    dt_masks_gui_form_test_create(form, gui, module);
 
   // draw form
   if(form->type & DT_MASKS_GROUP)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1791,6 +1791,38 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
   }
   else if(gui->form_dragging || gui->source_dragging)
   {
+    // we get point0 new values
+    const float wd = darktable.develop->preview_pipe->backbuf_width;
+    const float ht = darktable.develop->preview_pipe->backbuf_height;
+    float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
+    dt_dev_distort_backtransform(darktable.develop, pts, 1);
+
+    // we move all points
+    if(gui->form_dragging)
+    {
+      dt_masks_point_path_t *point = (dt_masks_point_path_t *)(form->points)->data;
+      const float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
+      const float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
+      for(GList *points = form->points; points; points = g_list_next(points))
+      {
+        point = (dt_masks_point_path_t *)points->data;
+        point->corner[0] += dx;
+        point->corner[1] += dy;
+        point->ctrl1[0] += dx;
+        point->ctrl1[1] += dy;
+        point->ctrl2[0] += dx;
+        point->ctrl2[1] += dy;
+      }
+    }
+    else
+    {
+      form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
+      form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    }
+
+    // we recreate the form points
+    dt_masks_gui_form_remove(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1892,16 +1924,6 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
   float dx = 0, dy = 0, dxs = 0, dys = 0;
-  if((gui->group_selected == index) && gui->form_dragging)
-  {
-    dx = gui->posx + gui->dx - gpt->points[2];
-    dy = gui->posy + gui->dy - gpt->points[3];
-  }
-  if((gui->group_selected == index) && gui->source_dragging)
-  {
-    dxs = gui->posx + gui->dx - gpt->source[2];
-    dys = gui->posy + gui->dy - gpt->source[3];
-  }
 
   // draw path
   if(gpt->points_count > nb * 3 + 6)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -845,8 +845,8 @@ static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *
   else *inside_border = 1;
 }
 
-static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
-                                     int *points_count, float **border, int *border_count, int source)
+static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
+                                   float **border, int *border_count, int source, const dt_iop_module_t *module)
 {
   return _path_get_pts_border(dev, form, 0.f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
                               border_count, source);
@@ -1020,7 +1020,7 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
 
       // we recreate the form points
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
 
       // we save the move
       dt_masks_update_image(darktable.develop);
@@ -1210,7 +1210,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
 
       // we recreate the form points
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
 
       dt_control_queue_redraw_center();
       return 1;
@@ -1259,7 +1259,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
 
         // we recreate the form points
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         gpt->clockwise = _path_is_clockwise(form);
         // we save the move
         dt_masks_update_image(darktable.develop);
@@ -1318,7 +1318,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _path_init_ctrl_points(form);
         dt_masks_gui_form_remove(form, gui, index);
-        dt_masks_gui_form_create(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index, module);
         gui->point_edited = gui->point_dragging = gui->point_selected = gui->seg_selected + 1;
         gui->seg_selected = -1;
         dt_control_queue_redraw_center();
@@ -1387,7 +1387,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     gpt->clockwise = _path_is_clockwise(form);
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1407,7 +1407,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
 
       // we recreate the form points
       dt_masks_gui_form_remove(form, gui, index);
-      dt_masks_gui_form_create(form, gui, index);
+      dt_masks_gui_form_create(form, gui, index, module);
       gpt->clockwise = _path_is_clockwise(form);
       // we save the move
       dt_masks_update_image(darktable.develop);
@@ -1485,7 +1485,7 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1508,7 +1508,7 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1554,7 +1554,7 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     gpt->clockwise = _path_is_clockwise(form);
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1588,7 +1588,7 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     gpt->clockwise = _path_is_clockwise(form);
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1654,7 +1654,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     _path_init_ctrl_points(form);
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1692,7 +1692,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
 
     dt_control_queue_redraw_center();
     return 1;
@@ -1719,7 +1719,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     _path_init_ctrl_points(form);
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1749,7 +1749,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
-    dt_masks_gui_form_create(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
   }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1791,7 +1791,6 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
   }
   else if(gui->form_dragging || gui->source_dragging)
   {
-    // we get point0 new values
     const float wd = darktable.develop->preview_pipe->backbuf_width;
     const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
@@ -1923,18 +1922,17 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   if(!gui) return;
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
-  float dx = 0, dy = 0, dxs = 0, dys = 0;
 
   // draw path
   if(gpt->points_count > nb * 3 + 6)
   {
     cairo_set_dash(cr, dashed, 0, 0);
 
-    cairo_move_to(cr, gpt->points[nb * 6] + dx, gpt->points[nb * 6 + 1] + dy);
+    cairo_move_to(cr, gpt->points[nb * 6], gpt->points[nb * 6 + 1]);
     int seg = 1, seg2 = 0;
     for(int i = nb * 3; i < gpt->points_count; i++)
     {
-      cairo_line_to(cr, gpt->points[i * 2] + dx, gpt->points[i * 2 + 1] + dy);
+      cairo_line_to(cr, gpt->points[i * 2], gpt->points[i * 2 + 1]);
       // we decide to highlight the form segment by segment
       if(gpt->points[i * 2 + 1] == gpt->points[seg * 6 + 3] && gpt->points[i * 2] == gpt->points[seg * 6 + 2])
       {
@@ -1956,7 +1954,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
         // and we update the segment number
         seg = (seg + 1) % nb;
         seg2++;
-        cairo_move_to(cr, gpt->points[i * 2] + dx, gpt->points[i * 2 + 1] + dy);
+        cairo_move_to(cr, gpt->points[i * 2], gpt->points[i * 2 + 1]);
       }
     }
   }
@@ -1976,8 +1974,8 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
         anchor_size = 5.0f / zoom_scale;
       }
       dt_draw_set_color_overlay(cr, 0.8, 0.8);
-      cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5) + dx,
-                      gpt->points[k * 6 + 3] - (anchor_size * 0.5) + dy, anchor_size, anchor_size);
+      cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5),
+                      gpt->points[k * 6 + 3] - (anchor_size * 0.5), anchor_size, anchor_size);
       cairo_fill_preserve(cr);
 
       if((gui->group_selected == index) && (k == gui->point_dragging || k == gui->point_selected))
@@ -1997,17 +1995,16 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   {
     const int k = gui->point_edited;
     // uncomment this part if you want to see "real" control points
-    /*cairo_move_to(cr, gui->points[k*6+2]+dx,gui->points[k*6+3]+dy);
-    cairo_line_to(cr, gui->points[k*6]+dx,gui->points[k*6+1]+dy);
+    /*cairo_move_to(cr, gui->points[k*6+2],gui->points[k*6+3]);
+    cairo_line_to(cr, gui->points[k*6],gui->points[k*6+1]);
     cairo_stroke(cr);
-    cairo_move_to(cr, gui->points[k*6+2]+dx,gui->points[k*6+3]+dy);
-    cairo_line_to(cr, gui->points[k*6+4]+dx,gui->points[k*6+5]+dy);
+    cairo_move_to(cr, gui->points[k*6+2],gui->points[k*6+3]);
+    cairo_line_to(cr, gui->points[k*6+4],gui->points[k*6+5]);
     cairo_stroke(cr);*/
     int ffx = 0, ffy = 0;
-    _path_ctrl2_to_feather(gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy,
-                           gpt->points[k * 6 + 4] + dx, gpt->points[k * 6 + 5] + dy, &ffx, &ffy,
-                           gpt->clockwise);
-    cairo_move_to(cr, gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy);
+    _path_ctrl2_to_feather(gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], gpt->points[k * 6 + 4],
+                           gpt->points[k * 6 + 5], &ffx, &ffy, gpt->clockwise);
+    cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
     dt_draw_set_color_overlay(cr, 0.3, 0.8);
@@ -2042,11 +2039,11 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       }
       if(dep)
       {
-        cairo_move_to(cr, gpt->border[i * 2] + dx, gpt->border[i * 2 + 1] + dy);
+        cairo_move_to(cr, gpt->border[i * 2], gpt->border[i * 2 + 1]);
         dep = 0;
       }
       else
-        cairo_line_to(cr, gpt->border[i * 2] + dx, gpt->border[i * 2 + 1] + dy);
+        cairo_line_to(cr, gpt->border[i * 2], gpt->border[i * 2 + 1]);
     }
     // we execute the drawing
     if(gui->border_selected)
@@ -2077,8 +2074,8 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
         anchor_size = 5.0f / zoom_scale;
       }
       dt_draw_set_color_overlay(cr, 0.8, 0.8);
-      cairo_rectangle(cr, gpt->border[k * 6] - (anchor_size * 0.5) + dx,
-                      gpt->border[k * 6 + 1] - (anchor_size * 0.5) + dy, anchor_size, anchor_size);
+      cairo_rectangle(cr, gpt->border[k * 6] - (anchor_size * 0.5), gpt->border[k * 6 + 1] - (anchor_size * 0.5),
+                      anchor_size, anchor_size);
       cairo_fill_preserve(cr);
 
       if(gui->point_border_selected == k)
@@ -2098,8 +2095,8 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
     if((k * 6 + 2) >= 0)
     {
       float x = 0.f, y = 0.f;
-      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, gpt->points[2] + dx, gpt->points[3] + dy,
-                                          gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy, &x, &y, TRUE);
+      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, gpt->points[2], gpt->points[3],
+                                          gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], &x, &y, TRUE);
       dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
     }
     else
@@ -2126,8 +2123,8 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   if(!gui->creation && gpt->source_count > nb * 3 + 6)
   {
     // we draw the line between source and dest
-    cairo_move_to(cr, gpt->source[2] + dxs, gpt->source[3] + dys);
-    cairo_line_to(cr, gpt->points[2] + dx, gpt->points[3] + dy);
+    cairo_move_to(cr, gpt->source[2], gpt->source[3]);
+    cairo_line_to(cr, gpt->points[2], gpt->points[3]);
     cairo_set_dash(cr, dashed, 0, 0);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 2.5 / zoom_scale);
@@ -2149,10 +2146,9 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
     dt_draw_set_color_overlay(cr, 0.3, 0.8);
-    cairo_move_to(cr, gpt->source[nb * 6] + dxs, gpt->source[nb * 6 + 1] + dys);
-    for(int i = nb * 3; i < gpt->source_count; i++)
-      cairo_line_to(cr, gpt->source[i * 2] + dxs, gpt->source[i * 2 + 1] + dys);
-    cairo_line_to(cr, gpt->source[nb * 6] + dxs, gpt->source[nb * 6 + 1] + dys);
+    cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
+    for(int i = nb * 3; i < gpt->source_count; i++) cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
+    cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);


### PR DESCRIPTION
This fix #8677 

The goal is to have a full "what we get is what we see" for drawn masks, as currently the "sample" form before creating it for real isn't distorted.

What need to be done : 
- circle sample (OK)
- ellipse sample (already done in current master)
- gradient sample (OK)
- correct source drawing for cloning forms (not only samples) (OK)
- distort masks when adjusting them too (OK)

Once that in place and the bug in shift fixed (see #8676) drawn masks and cloning should be way easier to use and understand (more predictable)

That won't solve the "I want TRUE circle whatever the distortions" part (I have some other ideas to solve that, though)