### PR TITLE
Parallelize distorts

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -124,6 +124,9 @@ fastlog (float x)
 
 // multiply 3x3 matrix with 3x1 vector
 // dest needs to be different from v
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
 static inline void mat3mulv(float *const __restrict__ dest, const float *const mat, const float *const __restrict__ v)
 {
   for(int k = 0; k < 3; k++)
@@ -138,6 +141,9 @@ static inline void mat3mulv(float *const __restrict__ dest, const float *const m
 // multiply two 3x3 matrices
 // dest needs to be different from m1 and m2
 // dest = m1 * m2 in this order
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
 static inline void mat3mul(float *const __restrict__ dest, const float *const __restrict__ m1, const float *const __restrict__ m2)
 {
   for(int k = 0; k < 3; k++)
@@ -152,12 +158,18 @@ static inline void mat3mul(float *const __restrict__ dest, const float *const __
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
 static inline void mul_mat_vec_2(const float *m, const float *p, float *o)
 {
   o[0] = p[0] * m[0] + p[1] * m[1];
   o[1] = p[0] * m[2] + p[1] * m[3];
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
 static inline float dt_log2f(const float f)
 {
 #ifdef __GLIBC__
@@ -333,4 +345,3 @@ static inline __m128 sinf_fast_sse(__m128 t)
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
-

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -211,7 +211,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
@@ -224,9 +224,9 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   if (border_size_l == 0 && border_size_t == 0) return 1;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
+#pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(points, points_count, border_size_l, border_size_t)  \
-  schedule(static) if(points_count > 100)
+  schedule(static) if(points_count > 100) aligned(points:64)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -236,7 +236,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
 
   return 1;
 }
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points,
+int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points,
                           size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
@@ -250,9 +250,9 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   if (border_size_l == 0 && border_size_t == 0) return 1;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
+#pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(points, points_count, border_size_l, border_size_t)  \
-  schedule(static) if(points_count > 100)
+  schedule(static) if(points_count > 100) aligned(points:64)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -189,7 +189,7 @@ static void backtransform(const int32_t *x, int32_t *o, const dt_image_orientati
   }
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)
 {
   // if (!self->enabled) return 2;
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
@@ -197,6 +197,11 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   // nothing to be done if parameters are set to neutral values (no flip or swap)
   if (d->orientation == 0) return 1;
 
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(points_count, points, d, piece) \
+    schedule(static) if(points_count > 100) aligned(points:64)
+#endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
     float x = points[i];
@@ -215,7 +220,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
 
   return 1;
 }
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points,
+int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points,
                           size_t points_count)
 {
   // if (!self->enabled) return 2;
@@ -224,6 +229,11 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   // nothing to be done if parameters are set to neutral values (no flip or swap)
   if (d->orientation == 0) return 1;
 
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(points_count, points, d, piece) \
+    schedule(static) if(points_count > 100) aligned(points:64)
+#endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
     float x, y;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1279,13 +1279,20 @@ void modify_roi_in(struct dt_iop_module_t *module,
   cairo_region_destroy(roi_in_region);
 }
 
-static int _distort_xtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count, gboolean inverted)
+static int _distort_xtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, const size_t points_count,
+                               const gboolean inverted)
 {
   const float scale = piece->iscale;
 
   // compute the extent of all points (all computations are done in RAW coordinate)
   float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
 
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(points_count, points, scale) \
+    schedule(static) if(points_count > 100) aligned(points:64) \
+    reduction(min:xmin, ymin) reduction(max:xmax, ymax)
+#endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
     const float x = points[i] * scale;
@@ -1328,6 +1335,11 @@ static int _distort_xtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
     const int y_last = extent.y + extent.height;
 
     // apply distortion to all points (this is a simple displacement given by a vector at this same point in the map)
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(points_count, points, scale, extent, map, map_size, y_last, x_last) \
+    schedule(static) if(points_count > 100) aligned(points:64)
+#endif
     for(size_t i = 0; i < points_count; i++)
     {
       float *px = &points[i*2];
@@ -1366,12 +1378,12 @@ static gboolean is_dragging(const dt_iop_liquify_gui_data_t *g)
   return g->dragging.elem != NULL;
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)
 {
   return _distort_xtransform(self, piece, points, points_count, TRUE);
 }
 
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)
 {
   return _distort_xtransform(self, piece, points, points_count, FALSE);
 }


### PR DESCRIPTION
This is meant to make #8682 reasonably real-time by enabling multithreading and vectorization on distortion transforms and backtransforms when masks have more than 100 control points.

On a 0.5 Mpx image using liquify, lens correction, perspective correction, and crop/rotate in perspective mode, with 3 drawn ellipse masks in exposure module, this gives me a 21% speed-up over the full pipeline runtime (8 cores Intel Xeon Mobile).

The change should be safe since most coordinates changes are translations + scaling. The only risk of race condition is in liquify, but I handle it using min/max reductions. Also, lens can't use SIMD loops since it links an external function.

Note : I tested it also with #8673.