### PR TITLE
Fixing rcd border zipper artefacts

### DIFF
--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -56,11 +56,11 @@ __kernel void rcd_populate (__read_only image2d_t in, global float *cfa, global 
 }
 
 // Write back-normalized data in rgb channels to output 
-__kernel void rcd_write_output (__write_only image2d_t out, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const float scale)
+__kernel void rcd_write_output (__write_only image2d_t out, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const float scale, const int border)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
-  if(col >= w || row >= height) return;
+  if(!(col >= border && col < w - border && row >= border && row < height - border)) return;
   const int idx = mad24(row, w, col);
 
   write_imagef(out, (int2)(col, row), (float4)(scale * rgb0[idx], scale * rgb1[idx], scale * rgb2[idx], 0.0f));
@@ -379,40 +379,204 @@ __kernel void fastblur_mask_9x9(global float *src, global float *out, const int 
   out[oidx] = ICLAMP(val, 0.0f, 1.0f);
 }
 
-kernel void rcd_border(global float *cfa, write_only image2d_t out, const int width, const int height, const unsigned int filters, const int border, const float scale)
+kernel void rcd_border_green(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+                    const unsigned int filters, local float *buffer, const int border)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of 1*float per pixel with a surrounding border of 3 cells
+  const int stride = xlsz + 2*3;
+  const int maxbuf = mul24(stride, ylsz + 2*3);
+
+  // coordinates of top left pixel of buffer
+  // this is 3 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 3;
+  const int yul = mul24(ygid, ylsz) - 3;
+
+  // populate local memory buffer
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    buffer[bufidx] = read_imagef(in, sampleri, (int2)(xx, yy)).x;
+  }
+
+  // center buffer around current x,y-Pixel
+  buffer += mad24(ylid + 3, stride, xlid + 3);
+
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  if(x >= width - 3 || x < 3 || y >= height - 3 || y < 3) return;
+  if(x >= border && x < width - border && y >= border && y < height - border) return;
+
+  // process all non-green pixels
+  const int row = y;
+  const int col = x;
+  const int c = FC(row, col, filters);
+  float4 color; // output color
+
+  const float pc = buffer[0];
+
+  if     (c == 0) color.x = pc; // red
+  else if(c == 1) color.y = pc; // green1
+  else if(c == 2) color.z = pc; // blue
+  else            color.y = pc; // green2
+
+  // fill green layer for red and blue pixels:
+  if(c == 0 || c == 2)
+  {
+    // look up horizontal and vertical neighbours, sharpened weight:
+    const float pym  = buffer[-1 * stride];
+    const float pym2 = buffer[-2 * stride];
+    const float pym3 = buffer[-3 * stride];
+    const float pyM  = buffer[ 1 * stride];
+    const float pyM2 = buffer[ 2 * stride];
+    const float pyM3 = buffer[ 3 * stride];
+    const float pxm  = buffer[-1];
+    const float pxm2 = buffer[-2];
+    const float pxm3 = buffer[-3];
+    const float pxM  = buffer[ 1];
+    const float pxM2 = buffer[ 2];
+    const float pxM3 = buffer[ 3];
+    const float guessx = (pxm + pc + pxM) * 2.0f - pxM2 - pxm2;
+    const float diffx  = (fabs(pxm2 - pc) +
+                          fabs(pxM2 - pc) +
+                          fabs(pxm  - pxM)) * 3.0f +
+                         (fabs(pxM3 - pxM) + fabs(pxm3 - pxm)) * 2.0f;
+    const float guessy = (pym + pc + pyM) * 2.0f - pyM2 - pym2;
+    const float diffy  = (fabs(pym2 - pc) +
+                          fabs(pyM2 - pc) +
+                          fabs(pym  - pyM)) * 3.0f +
+                         (fabs(pyM3 - pyM) + fabs(pym3 - pym)) * 2.0f;
+    if(diffx > diffy)
+    {
+      // use guessy
+      const float m = fmin(pym, pyM);
+      const float M = fmax(pym, pyM);
+      color.y = fmax(fmin(guessy*0.25f, M), m);
+    }
+    else
+    {
+      const float m = fmin(pxm, pxM);
+      const float M = fmax(pxm, pxM);
+      color.y = fmax(fmin(guessx*0.25f, M), m);
+    }
+  }
+  write_imagef (out, (int2)(x, y), color);
+}
+kernel void rcd_border_redblue(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+                      const unsigned int filters, local float4 *buffer, const int border)
+{
+  // image in contains full green and sparse r b
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of float4 per pixel with a surrounding border of 1 cell
+  const int stride = xlsz + 2;
+  const int maxbuf = mul24(stride, ylsz + 2);
+
+  // coordinates of top left pixel of buffer
+  // this is 1 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 1;
+  const int yul = mul24(ygid, ylsz) - 1;
+
+  // populate local memory buffer
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    buffer[bufidx] = read_imagef(in, sampleri, (int2)(xx, yy));
+  }
+
+  // center buffer around current x,y-Pixel
+  buffer += mad24(ylid + 1, stride, xlid + 1);
+
+  barrier(CLK_LOCAL_MEM_FENCE);
 
   if(x >= width || y >= height) return;
   if(x >= border && x < width - border && y >= border && y < height - border) return;
 
-  float o[3]   = { 0.0f, 0.0f, 0.0f };
-  float sum[3] = { 0.0f, 0.0f, 0.0f };
-  float cnt[3] = { 0.0f, 0.0f, 0.0f };
-
-  for(int j = y - 1; j < y + 2; j++)
-  {
-    for(int i = x - 1; i < x + 2; i++)
-    {
-      if (j > -1 && i > -1 && j < height && i < width)
+  const int row = y;
+  const int col = x;
+  const int c = FC(row, col, filters);
+  float4 color = buffer[0];
+  if(row > 0 && col > 0 && col < width - 1 && row < height - 1)
+  { 
+    if(c == 1 || c == 3)
+    { // calculate red and blue for green pixels:
+      // need 4-nbhood:
+      float4 nt = buffer[-stride];
+      float4 nb = buffer[ stride];
+      float4 nl = buffer[-1];
+      float4 nr = buffer[ 1];
+      if(FC(row, col+1, filters) == 0) // red nb in same row
       {
-        const int c = FC(j, i, filters);
-        sum[c] += cfa[mad24(j, width, i)];
-        cnt[c] += 1.0f;
+        color.z = (nt.z + nb.z + 2.0f*color.y - nt.y - nb.y)*0.5f;
+        color.x = (nl.x + nr.x + 2.0f*color.y - nl.y - nr.y)*0.5f;
+      }
+      else
+      { // blue nb
+        color.x = (nt.x + nb.x + 2.0f*color.y - nt.y - nb.y)*0.5f;
+        color.z = (nl.z + nr.z + 2.0f*color.y - nl.y - nr.y)*0.5f;
+      }
+    }
+    else
+    {
+      // get 4-star-nbhood:
+      float4 ntl = buffer[-stride - 1];
+      float4 ntr = buffer[-stride + 1];
+      float4 nbl = buffer[ stride - 1];
+      float4 nbr = buffer[ stride + 1];
+
+      if(c == 0)
+      { // red pixel, fill blue:
+        const float diff1  = fabs(ntl.z - nbr.z) + fabs(ntl.y - color.y) + fabs(nbr.y - color.y);
+        const float guess1 = ntl.z + nbr.z + 2.0f*color.y - ntl.y - nbr.y;
+        const float diff2  = fabs(ntr.z - nbl.z) + fabs(ntr.y - color.y) + fabs(nbl.y - color.y);
+        const float guess2 = ntr.z + nbl.z + 2.0f*color.y - ntr.y - nbl.y;
+        if     (diff1 > diff2) color.z = guess2 * 0.5f;
+        else if(diff1 < diff2) color.z = guess1 * 0.5f;
+        else color.z = (guess1 + guess2)*0.25f;
+      }
+      else // c == 2, blue pixel, fill red:
+      {
+        const float diff1  = fabs(ntl.x - nbr.x) + fabs(ntl.y - color.y) + fabs(nbr.y - color.y);
+        const float guess1 = ntl.x + nbr.x + 2.0f*color.y - ntl.y - nbr.y;
+        const float diff2  = fabs(ntr.x - nbl.x) + fabs(ntr.y - color.y) + fabs(nbl.y - color.y);
+        const float guess2 = ntr.x + nbl.x + 2.0f*color.y - ntr.y - nbl.y;
+        if     (diff1 > diff2) color.x = guess2 * 0.5f;
+        else if(diff1 < diff2) color.x = guess1 * 0.5f;
+        else color.x = (guess1 + guess2)*0.25f;
       }
     }
   }
-
-  const float cfai = cfa[mad24(y, width, x)];
-  const int f = FC(y, x, filters);
-  for(int c = 0; c < 3; c++)
-  {
-    if(c != f && cnt[c] != 0.0f)
-      o[c] = sum[c] / cnt[c];
-    else
-      o[c] = cfai;
-  }
-  write_imagef(out, (int2)(x, y), (float4)(scale * o[0], scale * o[1], scale * o[2], 0.0f));
+  write_imagef (out, (int2)(x, y), color);
 }
 

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -114,6 +114,7 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
       out[i] = fminf(1.0f, fmaxf(0.0f, val));
     }
   }
+  dt_masks_extend_border(out, width, height, 4);
 }
 
 void dt_masks_calc_luminance_mask(float *const restrict src, float *const restrict mask, const int width, const int height)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3401,22 +3401,6 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
     dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
     if(dev_tmp == NULL) goto error;
-    cfa = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(cfa == NULL) goto error;
-    VH_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(VH_dir == NULL) goto error;
-    PQ_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(PQ_dir == NULL) goto error;
-    VP_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(VP_diff == NULL) goto error;
-    HQ_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(HQ_diff == NULL) goto error;
-    rgb0 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(rgb0 == NULL) goto error;
-    rgb1 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(rgb1 == NULL) goto error;
-    rgb2 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
-    if(rgb2 == NULL) goto error;
 
     {
       const int myborder = 3;
@@ -3472,6 +3456,28 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_rcd_border_redblue, sizes, local);
       if(err != CL_SUCCESS) goto error;
     }
+    dt_opencl_release_mem_object(dev_tmp);
+    dev_tmp = NULL;
+
+    cfa = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(cfa == NULL) goto error;
+    VH_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(VH_dir == NULL) goto error;
+    PQ_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(PQ_dir == NULL) goto error;
+    VP_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(VP_diff == NULL) goto error;
+    HQ_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(HQ_diff == NULL) goto error;
+    rgb0 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(rgb0 == NULL) goto error;
+    rgb1 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(rgb1 == NULL) goto error;
+    rgb2 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    if(rgb2 == NULL) goto error;
+
+
+
 
     {
       // populate data
@@ -3651,7 +3657,6 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
   if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
   dt_opencl_release_mem_object(dev_green_eq);
-  dt_opencl_release_mem_object(dev_tmp);
 
   dev_aux = dev_green_eq = dev_tmp = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
 

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -60,15 +60,6 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   dt_masks_calc_luminance_mask(rgb_data, blend, width, height);
   dt_masks_calc_detail_mask(blend, blend, tmp, width, height, contrastf, TRUE);  
 
-  const float filler = 0.0f;
-  dt_iop_image_fill(blend, filler, width, 4, 1);
-  dt_iop_image_fill(&blend[(height-4) * width], filler, width, 4, 1);
-  for(int row = 4; row < height - 4; row++)
-  {
-    dt_iop_image_fill(&blend[row * width], filler, 4, 1, 1);
-    dt_iop_image_fill(&blend[row * width + width - 4], filler, 4, 1, 1);
-  }
-
   if(dual_mask)
   {
 #ifdef _OPENMP
@@ -80,13 +71,6 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
     {
       for(int c = 0; c < 4; c++)
         rgb_data[idx * 4 + c] = blend[idx];
-    }
-    dt_iop_image_fill(rgb_data, filler, width, 4, 4);
-    dt_iop_image_fill(&rgb_data[4 * ((height-4) * width)], filler, width, 4, 4);
-    for(int row = 4; row < height - 4; row++)
-    {
-      dt_iop_image_fill(&rgb_data[4 * row * width], filler, 4, 1, 4);
-      dt_iop_image_fill(&rgb_data[4 * (row * width + width - 4)], filler, 4, 1, 4);
     }
   }
   else

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -109,123 +109,190 @@ static INLINE float sqrf(float a)
   return a * a;
 }
 
-// The border interpolation has been taken from rt, adapted to dt.
-// The original dcraw based code had much stronger color artefacts in the border region.
-static INLINE void approxit(float *out, const float *cfa, const float *sum, const int idx, const int c)
+/** This is basically ppg adopted to only write data to RCD_MARGIN */
+static void rcd_ppg_border(float *const out, const float *const in, const int width, const int height, const uint32_t filters)
 {
-  float (*rgb)[4] = (void *)out;
-  if(c == 1)
+  // write approximatad 3-pixel border region to out
+  float sum[8];
+  for(int j = 0; j < height; j++)
   {
-    rgb[idx][0] = sum[0] / sum[3];
-    rgb[idx][1] = fmaxf(0.0f, cfa[idx]);
-    rgb[idx][2] = sum[2] / sum[5];
-  }
-  else
-  {
-    rgb[idx][1] =  sum[1] / sum[4];
-    if (c == 0)
+    for(int i = 0; i < width; i++)
     {
-      rgb[idx][0] = fmaxf(0.0f, cfa[idx]);
-      rgb[idx][2] = sum[2] / sum[5];
-    }
-    else
-    {
-      rgb[idx][0] = sum[0] / sum[3];
-      rgb[idx][2] = fmaxf(0.0f, cfa[idx]);
-    }
-  }
-  rgb[idx][3] = 0.0f;
-}
-
-static void rcd_border_interpolate(dt_dev_pixelpipe_iop_t *piece, float *out, const float *cfa, dt_iop_roi_t *const roi_out,
-                                   const dt_iop_roi_t *const roi_in, const uint32_t filters, const int border)
-{
-  const int width = roi_in->width;
-  const int height = roi_in->height;
-
-  if((width < 2 * border) || (height < 2 * border)) return;
-
-  const int cfarray[4] = {FC(roi_in->y, roi_in->x, filters), FC(roi_in->y, roi_in->x + 1, filters), FC(roi_in->y + 1, roi_in->x, filters), FC(roi_in->y + 1, roi_in->x + 1, filters)};
-
-  for(int i = 0; i < height; i++)
-  {
-    float sum[6];
-    for(int j = 0; j < border; j++)
-    {
-      for(int x = 0; x < 6; x++) { sum[x] = 0.0f; }
-      for(int i1 = i - 1; i1 < i + 2; i1++)
+      if(i == 3 && j >= 3 && j < height - 3) i = width - 3;
+      if(i == width) break;
+      memset(sum, 0, sizeof(float) * 8);
+      for(int y = j - 1; y != j + 2; y++)
       {
-        for(int j1 = j - 1; j1 < j + 2; j1++)
+        for(int x = i - 1; x != i + 2; x++)
         {
-          if((i1 > -1) && (i1 < height) && (j1 > -1))
+          if((y >= 0) && (x >= 0) && (y < height) && (x < width))
           {
-            const int c = FCRCD(i1, j1);
-            sum[c] += fmaxf(0.0f, cfa[i1 * width + j1]);
-            sum[c + 3]++;
+            const int f = FC(y, x, filters);
+            sum[f] += in[(size_t)y * width + x];
+            sum[f + 4]++;
           }
         }
       }
-      approxit(out, cfa, sum, i * width + j, FCRCD(i, j));
+      const int f = FC(j, i, filters);
+      for(int c = 0; c < 3; c++)
+      {
+        if(c != f && sum[c + 4] > 0.0f)
+          out[4 * ((size_t)j * width + i) + c] = sum[c] / sum[c + 4];
+        else
+          out[4 * ((size_t)j * width + i) + c] = in[(size_t)j * width + i];
+      }
     }
+  }
 
-    for(int j = width - border; j < width; j++)
+  const float *input = in;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(filters, out, width, height) \
+  shared(input) \
+  schedule(static)
+#endif
+  for(int j = 3; j < height - 3; j++)
+  {
+    float *buf = out + (size_t)4 * width * j + 4 * 3;
+    const float *buf_in = input + (size_t)width * j + 3;
+    for(int i = 3; i < width - 3; i++)
     {
-      for(int x = 0; x < 6; x++) { sum[x] = 0.0f; }
-      for(int i1 = i - 1; i1 < i + 2; i1++)
+      if(i == 9 && j >= 9 && j < height - 9)
       {
-        for(int j1 = j - 1; j1 < j + 2; j1++)
+        i = width - 9;
+        buf = out + (size_t)4 * width * j + 4 * i;
+        buf_in = input + (size_t)width * j + i;
+      }
+      if(i == width) break;
+
+      const int c = FC(j, i, filters);
+      float color[4];
+      const float pc = buf_in[0];
+      if(c == 0 || c == 2)
+      {
+        color[c] = pc;
+        const float pym = buf_in[-width * 1];
+        const float pym2 = buf_in[-width * 2];
+        const float pym3 = buf_in[-width * 3];
+        const float pyM = buf_in[+width * 1];
+        const float pyM2 = buf_in[+width * 2];
+        const float pyM3 = buf_in[+width * 3];
+        const float pxm = buf_in[-1];
+        const float pxm2 = buf_in[-2];
+        const float pxm3 = buf_in[-3];
+        const float pxM = buf_in[+1];
+        const float pxM2 = buf_in[+2];
+        const float pxM3 = buf_in[+3];
+
+        const float guessx = (pxm + pc + pxM) * 2.0f - pxM2 - pxm2;
+        const float diffx = (fabsf(pxm2 - pc) + fabsf(pxM2 - pc) + fabsf(pxm - pxM)) * 3.0f
+                            + (fabsf(pxM3 - pxM) + fabsf(pxm3 - pxm)) * 2.0f;
+        const float guessy = (pym + pc + pyM) * 2.0f - pyM2 - pym2;
+        const float diffy = (fabsf(pym2 - pc) + fabsf(pyM2 - pc) + fabsf(pym - pyM)) * 3.0f
+                            + (fabsf(pyM3 - pyM) + fabsf(pym3 - pym)) * 2.0f;
+        if(diffx > diffy)
         {
-          if((i1 > -1) && (i1 < height ) && (j1 < width))
-          {
-            const int c = FCRCD(i1, j1);
-            sum[c] += fmaxf(0.0f, cfa[i1 * width + j1]);
-            sum[c + 3]++;
-          }
+          // use guessy
+          const float m = fminf(pym, pyM);
+          const float M = fmaxf(pym, pyM);
+          color[1] = fmaxf(fminf(guessy * .25f, M), m);
+        }
+        else
+        {
+          const float m = fminf(pxm, pxM);
+          const float M = fmaxf(pxm, pxM);
+          color[1] = fmaxf(fminf(guessx * .25f, M), m);
         }
       }
-      approxit(out, cfa, sum, i * width + j, FCRCD(i, j));
+      else
+        color[1] = pc;
+
+      color[4] = 0.0f;
+      memcpy(buf, color, sizeof(float) * 4);
+      buf += 4;
+      buf_in++;
     }
   }
-  for(int i = 0; i < border; i++)
+// for all pixels: interpolate colors into float array
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(filters, out, width, height) \
+  schedule(static)
+#endif
+  for(int j = 1; j < height - 1; j++)
   {
-    float sum[6];
-    for(int j = border; j < width - border; j++)
+    float *buf = out + (size_t)4 * width * j + 4;
+    for(int i = 1; i < width - 1; i++)
     {
-      for(int x = 0; x < 6; x++) { sum[x] = 0.0f; }
-      for(int i1 = i - 1; i1 < i + 2; i1++)
+      if(i == RCD_MARGIN && j >= RCD_MARGIN && j < height - RCD_MARGIN)
       {
-        for(int j1 = j - 1; j1 < j + 2; j1++)
+        i = width - RCD_MARGIN;
+        buf = out + (size_t)4 * width * j + 4 * i;
+      }
+      const int c = FC(j, i, filters);
+      float color[4] = { buf[0], buf[1], buf[2], buf[3] };
+
+      // fill all four pixels with correctly interpolated stuff: r/b for green1/2
+      // b for r and r for b
+      if(__builtin_expect(c & 1, 1)) // c == 1 || c == 3)
+      {
+        // calculate red and blue for green pixels:
+        // need 4-nbhood:
+        const float *nt = buf - 4 * width;
+        const float *nb = buf + 4 * width;
+        const float *nl = buf - 4;
+        const float *nr = buf + 4;
+        if(FC(j, i + 1, filters) == 0) // red nb in same row
         {
-          if((i1 > -1) && (i1 < height) && (j1 > -1))
-          {
-            const int c = FCRCD(i1, j1);
-            sum[c] += fmaxf(0.0f, cfa[i1 * width + j1]);
-            sum[c + 3]++;
-          }
+          color[2] = (nt[2] + nb[2] + 2.0f * color[1] - nt[1] - nb[1]) * .5f;
+          color[0] = (nl[0] + nr[0] + 2.0f * color[1] - nl[1] - nr[1]) * .5f;
+        }
+        else
+        {
+          // blue nb
+          color[0] = (nt[0] + nb[0] + 2.0f * color[1] - nt[1] - nb[1]) * .5f;
+          color[2] = (nl[2] + nr[2] + 2.0f * color[1] - nl[1] - nr[1]) * .5f;
         }
       }
-      approxit(out, cfa, sum, i * width + j, FCRCD(i, j));
-    }
-  }
-  for(int i = height - border; i < height; i++)
-  {
-    float sum[6];
-    for(int j = border; j < width - border; j++)
-    {
-      for(int x = 0; x < 6; x++) { sum[x] = 0.0f; }
-      for(int i1 = i - 1; i1 < i + 2; i1++)
+      else
       {
-        for(int j1 = j - 1; j1 < j + 2; j1++)
+        // get 4-star-nbhood:
+        const float *ntl = buf - 4 - 4 * width;
+        const float *ntr = buf + 4 - 4 * width;
+        const float *nbl = buf - 4 + 4 * width;
+        const float *nbr = buf + 4 + 4 * width;
+
+        if(c == 0)
         {
-          if((i1 > -1) && (i1 < height) && (j1 < width))
-          {
-            const int c = FCRCD(i1, j1);
-            sum[c] += fmaxf(0.0f, cfa[i1 * width + j1]);
-            sum[c + 3]++;
-          }
+          // red pixel, fill blue:
+          const float diff1 = fabsf(ntl[2] - nbr[2]) + fabsf(ntl[1] - color[1]) + fabsf(nbr[1] - color[1]);
+          const float guess1 = ntl[2] + nbr[2] + 2.0f * color[1] - ntl[1] - nbr[1];
+          const float diff2 = fabsf(ntr[2] - nbl[2]) + fabsf(ntr[1] - color[1]) + fabsf(nbl[1] - color[1]);
+          const float guess2 = ntr[2] + nbl[2] + 2.0f * color[1] - ntr[1] - nbl[1];
+          if(diff1 > diff2)
+            color[2] = guess2 * .5f;
+          else if(diff1 < diff2)
+            color[2] = guess1 * .5f;
+          else
+            color[2] = (guess1 + guess2) * .25f;
+        }
+        else // c == 2, blue pixel, fill red:
+        {
+          const float diff1 = fabsf(ntl[0] - nbr[0]) + fabsf(ntl[1] - color[1]) + fabsf(nbr[1] - color[1]);
+          const float guess1 = ntl[0] + nbr[0] + 2.0f * color[1] - ntl[1] - nbr[1];
+          const float diff2 = fabsf(ntr[0] - nbl[0]) + fabsf(ntr[1] - color[1]) + fabsf(nbl[1] - color[1]);
+          const float guess2 = ntr[0] + nbl[0] + 2.0f * color[1] - ntr[1] - nbl[1];
+          if(diff1 > diff2)
+            color[0] = guess2 * .5f;
+          else if(diff1 < diff2)
+            color[0] = guess1 * .5f;
+          else
+            color[0] = (guess1 + guess2) * .25f;
         }
       }
-      approxit(out, cfa, sum, i * width + j, FCRCD(i, j));
+      memcpy(buf, color, sizeof(float) * 4);
+      buf += 4;
     }
   }
 }
@@ -244,6 +311,8 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
     dt_control_log(_("[rcd_demosaic] too small area"));
     return;
   }
+
+  rcd_ppg_border(out, in, width, height, filters);
 
   const float scaler = fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
   const float revscaler = 1.0f / scaler;
@@ -514,7 +583,6 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
     dt_free_align(P_CDiff_Hpf);
     dt_free_align(Q_CDiff_Hpf);
   }
-  rcd_border_interpolate(piece, out, in, roi_out, roi_in, filters, RCD_MARGIN);
 }
 
 // revert rcd specific aggressive optimizing

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -208,7 +208,7 @@ static void rcd_ppg_border(float *const out, const float *const in, const int wi
       else
         color[1] = pc;
 
-      color[4] = 0.0f;
+      color[3] = 0.0f;
       memcpy(buf, color, sizeof(float) * 4);
       buf += 4;
       buf_in++;
@@ -228,19 +228,19 @@ static void rcd_ppg_border(float *const out, const float *const in, const int wi
       if(i == RCD_MARGIN && j >= RCD_MARGIN && j < height - RCD_MARGIN)
       {
         i = width - RCD_MARGIN;
-        buf = out + (size_t)4 * width * j + 4 * i;
+        buf = out + (size_t)4 * (width * j + i);
       }
       const int c = FC(j, i, filters);
       float color[4] = { buf[0], buf[1], buf[2], buf[3] };
-
+      const int linesize = 4 * width;
       // fill all four pixels with correctly interpolated stuff: r/b for green1/2
       // b for r and r for b
       if(__builtin_expect(c & 1, 1)) // c == 1 || c == 3)
       {
         // calculate red and blue for green pixels:
         // need 4-nbhood:
-        const float *nt = buf - 4 * width;
-        const float *nb = buf + 4 * width;
+        const float *nt = buf - linesize;
+        const float *nb = buf + linesize;
         const float *nl = buf - 4;
         const float *nr = buf + 4;
         if(FC(j, i + 1, filters) == 0) // red nb in same row
@@ -258,10 +258,10 @@ static void rcd_ppg_border(float *const out, const float *const in, const int wi
       else
       {
         // get 4-star-nbhood:
-        const float *ntl = buf - 4 - 4 * width;
-        const float *ntr = buf + 4 - 4 * width;
-        const float *nbl = buf - 4 + 4 * width;
-        const float *nbr = buf + 4 + 4 * width;
+        const float *ntl = buf - 4 - linesize;
+        const float *ntr = buf + 4 - linesize;
+        const float *nbl = buf - 4 + linesize;
+        const float *nbr = buf + 4 + linesize;
 
         if(c == 0)
         {


### PR DESCRIPTION
RCD has (as all demosaicers) a problem handling the border regions, the size of the border depends on the
demosaicer, for rcd theborder is 6 pixels wide. In other programs this is not as evident as in dt because
they crop after demosaicing and dt uses the roi concept.

So far rcd used the simple border approximation resulting in zipper artefacts.

I checked using other demosaicers to step in just for the border region in a better way, also such a
demosaicer should behave well performance wise. AMaZE misses a GPU implementation, VNG would be fine but
has some color drift, i tried the hq linear demosaicer (Malvar, HE,Cutler) but ended up in using PPG.
(Algo has been slightly modified to avoid calculating the area served by RCD)

There is a very subtle performance penalty, for CPU this is less than 1%, for GPU it seems to be less than 5%.
Also checked the integration suite showing no CPU vs GPU problems.
