### PR TITLE
lens: allow multi-instance

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -175,8 +175,7 @@ int operation_tags()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_ONE_INSTANCE
-    | IOP_FLAGS_UNSAFE_COPY;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_UNSAFE_COPY;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
lens correction can be run in both "correct" and "distort" modes

however, in order to simulate another lens with the "distort" mode, the image (presumably) first has to be corrected, which requires a second instance