### PR TITLE
make module section labels stand out more

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -36,8 +36,7 @@
 
 /* Modules box (plugins) */
 @define-color plugin_bg_color @grey_35;
-@define-color plugin_fg_color @grey_85;
-@define-color section_label @grey_75;
+@define-color plugin_fg_color @fg_color;
 @define-color plugin_label_color @grey_70;
 
 /* Modules controls (sliders and comboboxes) */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -39,7 +39,6 @@
 /* Modules box (plugins) */
 @define-color plugin_bg_color @grey_50;
 @define-color plugin_fg_color @fg_color;
-@define-color section_label @grey_80;
 @define-color plugin_label_color @grey_80;
 
 /* Modules controls (sliders and comboboxes) */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -84,7 +84,7 @@
 /* Modules box (plugins) */
 @define-color plugin_bg_color @grey_20;
 @define-color plugin_fg_color @fg_color;
-@define-color section_label @grey_60;
+@define-color section_label shade(@plugin_fg_color, 0.9);
 @define-color plugin_label_color @grey_65;
 
 /* Modules controls (sliders and comboboxes) */


### PR DESCRIPTION
section labels should have (almost) the same text color as the module control labels so that they stand out more