### PR TITLE
PPG demosaicer maintenance

### DIFF
--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -566,8 +566,8 @@ ppg_demosaic_green (read_only image2d_t in, write_only image2d_t out, const int 
 
   barrier(CLK_LOCAL_MEM_FENCE);
 
-  if(x >= width || y >= height) return;
-
+  // make sure we dont write the outermost 3 pixels
+  if(x >= width - 3 || x < 3 || y >= height - 3 || y < 3) return;
   // process all non-green pixels
   const int row = y;
   const int col = x;
@@ -740,9 +740,9 @@ border_interpolate(read_only image2d_t in, write_only image2d_t out, const int w
 
   if(x >= width || y >= height) return;
 
-  int avgwindow = 1;
+  const int avgwindow = 1;
 
-  if(x>=border && x<width-border && y>=border && y<height-border) return;
+  if(x >= border && x < width-border && y >= border && y < height-border) return;
 
   float4 o;
   float sum[4] = { 0.0f };
@@ -752,18 +752,18 @@ border_interpolate(read_only image2d_t in, write_only image2d_t out, const int w
   {
     if (j>=0 && i>=0 && j<height && i<width)
     {
-      int f = FC(j,i,filters);
+      const int f = FC(j,i,filters);
       sum[f] += read_imagef(in, sampleri, (int2)(i, j)).x;
       count[f]++;
     }
   }
 
-  float i = read_imagef(in, sampleri, (int2)(x, y)).x;
+  const float i = read_imagef(in, sampleri, (int2)(x, y)).x;
   o.x = count[0] > 0 ? sum[0]/count[0] : i;
   o.y = count[1]+count[3] > 0 ? (sum[1]+sum[3])/(count[1]+count[3]) : i;
   o.z = count[2] > 0 ? sum[2]/count[2] : i;
 
-  int f = FC(y,x,filters);
+  const int f = FC(y,x,filters);
 
   if     (f == 0) o.x = i;
   else if(f == 1) o.y = i;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -341,6 +341,9 @@ static const char* method2string(dt_iop_demosaic_method_t method)
     (a) = tmp;                                                                                               \
   }
 
+#ifdef _OPENMP
+  #pragma omp declare simd aligned(in, out)
+#endif
 static void pre_median_b(float *out, const float *const in, const dt_iop_roi_t *const roi, const uint32_t filters,
                          const int num_passes, const float threshold)
 {
@@ -2568,15 +2571,12 @@ static void passthrough_color(float *out, const float *const in, dt_iop_roi_t *c
 }
 
 /** 1:1 demosaic from in to out, in is full buf, out is translated/cropped (scale == 1.0!) */
+#ifdef _OPENMP
+  #pragma omp declare simd aligned(in, out)
+#endif
 static void demosaic_ppg(float *const out, const float *const in, const dt_iop_roi_t *const roi_out,
                          const dt_iop_roi_t *const roi_in, const uint32_t filters, const float thrs)
 {
-  // offsets only where the buffer ends:
-  const int offx = 3; // MAX(0, 3 - roi_out->x);
-  const int offy = 3; // MAX(0, 3 - roi_out->y);
-  const int offX = 3; // MAX(0, 3 - (roi_in->width  - (roi_out->x + roi_out->width)));
-  const int offY = 3; // MAX(0, 3 - (roi_in->height - (roi_out->y + roi_out->height)));
-
   // these may differ a little, if you're unlucky enough to split a bayer block with cropping or similar.
   // we never want to access the input out of bounds though:
   assert(roi_in->width >= roi_out->width);
@@ -2586,7 +2586,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
   for(int j = 0; j < roi_out->height; j++)
     for(int i = 0; i < roi_out->width; i++)
     {
-      if(i == offx && j >= offy && j < roi_out->height - offY) i = roi_out->width - offX;
+      if(i == 3 && j >= 3 && j < roi_out->height - 3) i = roi_out->width - 3;
       if(i == roi_out->width) break;
       memset(sum, 0, sizeof(float) * 8);
       for(int y = j - 1; y != j + 2; y++)
@@ -2619,37 +2619,22 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
     pre_median(med_in, in, roi_in, filters, 1, thrs);
     input = med_in;
   }
-// for all pixels: interpolate green into float array, or copy color.
+// for all pixels except those in the 3 pixel border:
+// interpolate green from input into out float array, or copy color.
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(filters, out, roi_in, roi_out, offx, offy, offX, offY) \
+  dt_omp_firstprivate(filters, out, roi_in, roi_out) \
   shared(input) \
   schedule(static)
 #endif
-  for(int j = offy; j < roi_out->height - offY; j++)
+  for(int j = 3; j < roi_out->height - 3; j++)
   {
-    float *buf = out + (size_t)4 * roi_out->width * j + 4 * offx;
-    const float *buf_in = input + (size_t)roi_in->width * (j + roi_out->y) + offx + roi_out->x;
-    for(int i = offx; i < roi_out->width - offX; i++)
+    float *buf = out + (size_t)4 * roi_out->width * j + 4 * 3;
+    const float *buf_in = input + (size_t)roi_in->width * (j + roi_out->y) + 3 + roi_out->x;
+    for(int i = 3; i < roi_out->width - 3; i++)
     {
       const int c = FC(j, i, filters);
-#if defined(__SSE__)
-      // prefetch what we need soon (load to cpu caches)
-      _mm_prefetch((char *)buf_in + 256, _MM_HINT_NTA); // TODO: try HINT_T0-3
-      _mm_prefetch((char *)buf_in + roi_in->width + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf_in + 2 * roi_in->width + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf_in + 3 * roi_in->width + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf_in - roi_in->width + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf_in - 2 * roi_in->width + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf_in - 3 * roi_in->width + 256, _MM_HINT_NTA);
-#endif
-
-#if defined(__SSE__)
-      __m128 col = _mm_load_ps(buf);
-      float *color = (float *)&col;
-#else
-      float color[4] = { buf[0], buf[1], buf[2], buf[3] };
-#endif
+      float color[4];
       const float pc = buf_in[0];
       // if(__builtin_expect(c == 0 || c == 2, 1))
       if(c == 0 || c == 2)
@@ -2692,6 +2677,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
       else
         color[1] = pc;
 
+      color[3] = 0.0f;
       // write using MOVNTPS (write combine omitting caches)
       // _mm_stream_ps(buf, col);
       memcpy(buf, color, sizeof(float) * 4);
@@ -2699,10 +2685,9 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
       buf_in++;
     }
   }
-// SFENCE (make sure stuff is stored now)
-// _mm_sfence();
 
-// for all pixels: interpolate colors into float array
+// for all pixels except the outermost row/column:
+// interpolate colors using out as input into float out array
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(filters, out, roi_out) \
@@ -2714,19 +2699,9 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
     for(int i = 1; i < roi_out->width - 1; i++)
     {
       // also prefetch direct nbs top/bottom
-#if defined(__SSE__)
-      _mm_prefetch((char *)buf + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf - roi_out->width * 4 * sizeof(float) + 256, _MM_HINT_NTA);
-      _mm_prefetch((char *)buf + roi_out->width * 4 * sizeof(float) + 256, _MM_HINT_NTA);
-#endif
-
       const int c = FC(j, i, filters);
-#if defined(__SSE__)
-      __m128 col = _mm_load_ps(buf);
-      float *color = (float *)&col;
-#else
       float color[4] = { buf[0], buf[1], buf[2], buf[3] };
-#endif
+
       // fill all four pixels with correctly interpolated stuff: r/b for green1/2
       // b for r and r for b
       if(__builtin_expect(c & 1, 1)) // c == 1 || c == 3)
@@ -3652,6 +3627,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
   cl_mem dev_aux = NULL;
   cl_mem dev_tmp = NULL;
+  cl_mem dev_med = NULL;
   cl_mem dev_green_eq = NULL;
   cl_int err = -999;
 
@@ -3699,8 +3675,28 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
     }
     else if(demosaicing_method == DT_IOP_DEMOSAIC_PPG)
     {
+      dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+      if(dev_tmp == NULL) goto error;
+
+      {
+        const int myborder = 3;
+        // manage borders
+        size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 0, sizeof(cl_mem), &dev_in);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 1, sizeof(cl_mem), &dev_tmp);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 2, sizeof(int), (void *)&width);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 3, sizeof(int), (void *)&height);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 5, sizeof(int), (void *)&myborder);
+        err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_border_interpolate, sizes);
+        if(err != CL_SUCCESS) goto error;
+      }
+
       if(data->median_thrs > 0.0f)
       {
+        dev_med = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
+        if(dev_med == NULL) goto error;
+
         dt_opencl_local_buffer_t locopt
           = (dt_opencl_local_buffer_t){ .xoffset = 2*2, .xfactor = 1, .yoffset = 2*2, .yfactor = 1,
                                         .cellsize = 1 * sizeof(float), .overhead = 0,
@@ -3712,7 +3708,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 0, sizeof(cl_mem), &dev_in);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 1, sizeof(cl_mem), &dev_aux);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 1, sizeof(cl_mem), &dev_med);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 2, sizeof(int), &width);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 3, sizeof(int), &height);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 4, sizeof(uint32_t),
@@ -3724,9 +3720,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         if(err != CL_SUCCESS) goto error;
         dev_in = dev_aux;
       }
-
-      dev_tmp = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4);
-      if(dev_tmp == NULL) goto error;
+      else dev_med = dev_in;
 
       {
         dt_opencl_local_buffer_t locopt
@@ -3739,7 +3733,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
         size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
         size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
-        dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 0, sizeof(cl_mem), &dev_in);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 0, sizeof(cl_mem), &dev_med);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 1, sizeof(cl_mem), &dev_tmp);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 2, sizeof(int), &width);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 3, sizeof(int), &height);
@@ -3773,20 +3767,6 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
                              sizeof(float) * 4 * (locopt.sizex + 2) * (locopt.sizey + 2), NULL);
 
         err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_ppg_redblue, sizes, local);
-        if(err != CL_SUCCESS) goto error;
-      }
-
-      {
-        const int myborder = 3;
-        // manage borders
-        size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 0, sizeof(cl_mem), &dev_in);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 1, sizeof(cl_mem), &dev_aux);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 2, sizeof(int), (void *)&width);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 3, sizeof(int), (void *)&height);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 5, sizeof(int), (void *)&myborder);
-        err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_border_interpolate, sizes);
         if(err != CL_SUCCESS) goto error;
       }
     }
@@ -3852,9 +3832,10 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   }
 
   if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
+  if(dev_med != dev_in) dt_opencl_release_mem_object(dev_med);
   dt_opencl_release_mem_object(dev_green_eq);
   dt_opencl_release_mem_object(dev_tmp);
-  dev_aux = dev_green_eq = dev_tmp = NULL;
+  dev_aux = dev_green_eq = dev_tmp = dev_med = NULL;
 
   // color smoothing
   if(data->color_smoothing)
@@ -3867,6 +3848,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
 error:
   if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
+  if(dev_med != dev_in) dt_opencl_release_mem_object(dev_med);
   dt_opencl_release_mem_object(dev_green_eq);
   dt_opencl_release_mem_object(dev_tmp);
   dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] couldn't enqueue kernel! %d\n", err);


### PR DESCRIPTION
The current codepaths between CPU & GPU differ more than necessary because of the way the border is approximated.
This can easily be seen in the integration tests all having border issues.
One of the reasons, in the GPU path the outer 3 pixel region was not corrected

I checked the original implementation in dcraw and checked everything works in dt as is it does there.

Also the CPU code path in general had some issues.
a) SSE and non SSE code results differed in the border region probably because of the way the color[4] was initialized
b) we have a number of const int that are specific for PPG so they don't have to be passed as parameters in the OpenMP
    loop.
c) we know the in & out arrays are simd aligned
d) the SSE cache hints maybe worked in old times or may still work in non-OpenMP environments (i did't test that)
   but using current compiler they seem to make things worse. Also cleaning up SSE specific code is always nice.

Testing CPU performance here on large images (45Mpix), an 8core intel cpu and gcc 10 increases performance almost twofold testing via -d demosaic, the GPU code has not changed at all