### PR TITLE
allow modules to be resized larger than current content

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3143,8 +3143,6 @@ static gboolean _scroll_wrap_resize(GtkWidget *w, void *cr, const char *config_s
 
   if(content_height < min_height) content_height = min_height;
 
-  if(height > content_height) height = content_height;
-
   height += increment - 1;
   height -= height % increment;
 


### PR DESCRIPTION
Currently if you Ctrl+scroll on a lib module it will keep increasing the stored size of that module but will not physically resize it beyond the current content

This causes confusion (see [here](https://discuss.pixls.us/t/i-find-the-filmroll-concept-a-little-tedious/24603/5)) and makes the user think that some maximum size has been imposed. Then, when larger content is loaded the module increases in size again.

Changes to settings like this should cause immediate visual feedback (the module should be immediately resized)