### PR TITLE
more desciptive module message for CA correction

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1586,7 +1586,7 @@ static void _display_ca_error(struct dt_iop_module_t *self)
     dt_iop_set_module_trouble_message(self, _("error"),
                                       _("CA correction supports only RGB colour filter arrays"), NULL);
   else if(g->error == CACORRECT_ERROR_MATH)
-     dt_iop_set_module_trouble_message(self, _("error"),
+     dt_iop_set_module_trouble_message(self, _("bypassed while zooming in"),
                                       _("while calculating the correction parameters the internal maths failed so module is bypassed.\n"
                                         "you can get more info by running dt via the console."), NULL);
   else if(g->error == CACORRECT_ERROR_LIN)
@@ -1594,7 +1594,7 @@ static void _display_ca_error(struct dt_iop_module_t *self)
                                       _("internals maths found too few data points so restricted the order of the fit to linear.\n"
                                         "you might view bad correction results."), NULL);
   else if(g->error == CACORRECT_ERROR_SIZE)
-    dt_iop_set_module_trouble_message(self, _("bypassed"),
+    dt_iop_set_module_trouble_message(self, _("bypassed while zooming in"),
                                       _("to calculate good parameters for raw CA correction we want full sensor data or at least a sensible part of that.\n"
                                         "the image shown in darkroom would look vastly different from developed files so effect is bypassed now."), NULL);
   else


### PR DESCRIPTION
In

[https://discuss.pixls.us/t/darktable-git-master-chormatic-aberration-bypassed/24608](url)

there was a short discussion about a more descriptive error message while zooming in.
I thought this was a good idea.