### PR TITLE
spots : deprecate in favor of retouch

### DIFF
--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -56,6 +56,11 @@ const char *name()
   return _("spot removal");
 }
 
+const char *deprecated_msg()
+{
+  return _("this module is deprecated. please use the retouch module instead.");
+}
+
 const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("remove sensor dust spots"),
@@ -72,7 +77,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS | IOP_FLAGS_DEPRECATED;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1609,7 +1609,6 @@ void init_presets(dt_lib_module_t *self)
   AM("rotatepixels");
   AM("scalepixels");
   AM("sharpen");
-  AM("spots");
 
   SMG(C_("modulegroup", "effect"), "effect");
   AM("bloom");
@@ -1826,7 +1825,6 @@ void init_presets(dt_lib_module_t *self)
   AM("retouch");
   AM("sharpen");
   AM("soften");
-  AM("spots");
   AM("vignette");
   AM("watermark");
   AM("censorize");
@@ -1839,7 +1837,7 @@ void init_presets(dt_lib_module_t *self)
 
   // this is a special preset for all newly deprecated modules
   // so users still have a chance to access them until next release (with warning messages)
-  // this modules are deprecated in 3.4 and should be removed from this group in 3.6
+  // this modules are deprecated in 3.4 and should be removed from this group in 3.8 (1 year later)
   SNQA();
   SMG(C_("modulegroup", "deprecated"), "basic");
   AM("zonesystem");
@@ -1850,6 +1848,8 @@ void init_presets(dt_lib_module_t *self)
   AM("tonemap");
   AM("vibrance");
   AM("basicadj");
+  // this modules are deprecated in 3.6 and should be removed 1 yer later
+  AM("spots");
 
   dt_lib_presets_add(_(DEPRECATED_PRESET_NAME), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 


### PR DESCRIPTION
- spots feature is covered by retouch module with clone tool, with same simple algorithm.
- now that one can set the default tool in retouch, it needs exactly the same user actions in both modules.
- and as explained in #8676 the issue where the source position is false when distort modules are placed before is fixed in retouch and not in spot (harder to fix, due to another internal issue)

BTW : we will have to decide what to do with modules deprecated in 3.4 and modulegroups... we have stated that they should be removed from deprecated special group in 3.6, but that was before we decide to do 3.6 for mid-year... personally, I'm in favor to let them here another cycle, so deprecated modules stay in this group for ~1 year...