### PR TITLE
lua destroy storage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -84,6 +84,10 @@ you are strongly advised to take a backup first.
 
 * bugfix - Changed text_view widget to wrap lines when the text exceeds the width of the widget
 
+* storage removal - add darktable.destroy_storage() to remove a storage from the exporter
+
+* Change API to 7.0.0 for darktable 3.6.0 due to all of the breaking changes this development cycle
+
 ## Changed Dependencies
 
 ## RawSpeed changes

--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -368,6 +368,12 @@ void dt_imageio_insert_storage(dt_imageio_module_storage_t *storage)
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
 }
 
+void dt_imageio_remove_storage(dt_imageio_module_storage_t *storage)
+{
+  darktable.imageio->plugins_storage  = g_list_remove(darktable.imageio->plugins_storage, storage);
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
+}
+
 gchar *dt_imageio_resizing_factor_get_and_parsing(double *num, double *denum)
 {
   double _num, _denum;

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -137,6 +137,8 @@ int dt_imageio_get_index_of_storage(dt_imageio_module_storage_t *storage);
 
 /* add a module into the known module list */
 void dt_imageio_insert_storage(dt_imageio_module_storage_t *storage);
+/* remove a module from the known module list */
+void dt_imageio_remove_storage(dt_imageio_module_storage_t *storage);
 
 // This function returns value of string which stored in the
 // "plugins/lighttable/export/resizing_factor" parameter of the configuration file

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -34,12 +34,13 @@
 // 2.2.0 was 4.0.0 ( removed the ugly yield functions make scripts incompatible)
 // 2.4.0 was 5.0.0 (going to lua 5.3 is a major API bump)
 // 3.2.0 was 6.0.0 (removed facebook, flickr, and picasa from types.dt_imageio_storage_module_t)
+// 3.6.0 was 7.0.0 (added naming to events, selections, and actions)
 /* incompatible API change */
-#define LUA_API_VERSION_MAJOR 6
+#define LUA_API_VERSION_MAJOR 7
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 2
+#define LUA_API_VERSION_MINOR 0
 /* bugfixes that should not change anything to the API */
-#define LUA_API_VERSION_PATCH 3
+#define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */
 #define LUA_API_VERSION_SUFFIX ""
 

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -110,12 +110,12 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_ima
   dt_lua_lock();
   lua_State *L = darktable.lua_state.state;
 
-  push_lua_data(L,d);
-  dt_lua_goto_subtable(L,"files");
+  push_lua_data(L, d);
+  dt_lua_goto_subtable(L, "files");
   luaA_push(L, dt_lua_image_t, &(imgid));
   lua_pushstring(L, complete_name);
   lua_settable(L, -3);
-  lua_pop(L,1);
+  lua_pop(L, 1);
 
 
 
@@ -139,9 +139,9 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_ima
   lua_pushinteger(L, num);
   lua_pushinteger(L, total);
   lua_pushboolean(L, high_quality);
-  push_lua_data(L,d);
-  dt_lua_goto_subtable(L,"extra");
-  dt_lua_treated_pcall(L,8,0);
+  push_lua_data(L, d);
+  dt_lua_goto_subtable(L, "extra");
+  dt_lua_treated_pcall(L, 8, 0);
   lua_pop(L, 2);
   dt_lua_unlock();
   g_free(filename);
@@ -179,14 +179,14 @@ static int initialize_store_wrapper(struct dt_imageio_module_storage_t *self, dt
   lua_pushboolean(L, high_quality);
 
   lua_storage_t *d = (lua_storage_t *)data;
-  push_lua_data(L,d);
-  dt_lua_goto_subtable(L,"extra");
+  push_lua_data(L, d);
+  dt_lua_goto_subtable(L, "extra");
 
-  dt_lua_treated_pcall(L,5,1);
+  dt_lua_treated_pcall(L, 5, 1);
   if(!lua_isnoneornil(L, -1))
   {
     g_list_free(*images);
-    if(lua_type(L,-1) != LUA_TTABLE)
+    if(lua_type(L, -1) != LUA_TTABLE)
     {
       dt_print(DT_DEBUG_LUA, "LUA ERROR initialization function of storage did not return nil or table\n");
       dt_lua_unlock();
@@ -227,13 +227,13 @@ static void finalize_store_wrapper(struct dt_imageio_module_storage_t *self, dt_
   luaA_push_type(L, self->parameter_lua_type, data);
 
   lua_storage_t *d = (lua_storage_t *)data;
-  push_lua_data(L,d);
-  dt_lua_goto_subtable(L,"files");
+  push_lua_data(L, d);
+  dt_lua_goto_subtable(L, "files");
 
-  push_lua_data(L,d);
-  dt_lua_goto_subtable(L,"extra");
+  push_lua_data(L, d);
+  dt_lua_goto_subtable(L, "extra");
 
-  dt_lua_treated_pcall(L,3,0);
+  dt_lua_treated_pcall(L, 3, 0);
   lua_pop(L, 2);
   dt_lua_unlock();
 }
@@ -321,17 +321,17 @@ static int version_wrapper()
 
 static void gui_init_wrapper(struct dt_imageio_module_storage_t *self)
 {
-  lua_storage_gui_t *gui_data =self->gui_data;
+  lua_storage_gui_t *gui_data = self->gui_data;
   self->widget = gui_data->widget->widget;
 }
 
 static void gui_reset_wrapper(struct dt_imageio_module_storage_t *self)
 {
-  lua_storage_gui_t *gui_data =self->gui_data;
+  lua_storage_gui_t *gui_data = self->gui_data;
   dt_lua_async_call_alien(dt_lua_widget_trigger_callback,
-      0,NULL,NULL,
-      LUA_ASYNC_TYPENAME,"lua_widget",gui_data->widget,
-      LUA_ASYNC_TYPENAME,"const char*","reset",
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "lua_widget", gui_data->widget,
+      LUA_ASYNC_TYPENAME, "const char*", "reset",
       LUA_ASYNC_DONE);
 }
 
@@ -438,8 +438,8 @@ static int register_storage(lua_State *L)
   else
   {
     lua_widget widget;
-    luaA_to(L,lua_widget,&widget,7);
-    dt_lua_widget_bind(L,widget);
+    luaA_to(L, lua_widget, &widget, 7);
+    dt_lua_widget_bind(L, widget);
     data->widget = widget;
   }
 
@@ -465,7 +465,7 @@ static int register_storage(lua_State *L)
       luaA_push_type(L, format->parameter_lua_type, fdata);
       format->free_params(format, fdata);
       storage->free_params(storage, sdata);
-      dt_lua_treated_pcall(L,2,1);
+      dt_lua_treated_pcall(L, 2, 1);
       int result = lua_toboolean(L, -1);
       lua_pop(L, 1);
       if(result)
@@ -491,8 +491,26 @@ static int register_storage(lua_State *L)
   return 0;
 }
 
+static int destroy_storage(lua_State *L)
+{
+  const char *module_name = luaL_checkstring(L, 1);
+  dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(module_name);
+  dt_imageio_remove_storage(storage);
+  // free the storage?
+  storage->gui_cleanup(storage);
+  if(storage->widget) g_object_unref(storage->widget);
+  if(storage->module) g_module_close(storage->module);
+  free(storage);
+  return 0;
+}
+
 int dt_lua_init_luastorages(lua_State *L)
 {
+  dt_lua_push_darktable_lib(L);
+  lua_pushstring(L, "destroy_storage");
+  lua_pushcfunction(L, &destroy_storage);
+  lua_settable(L, -3);
+
   dt_lua_push_darktable_lib(L);
   lua_pushstring(L, "register_storage");
   lua_pushcfunction(L, &register_storage);


### PR DESCRIPTION
Added a destroy_storage function to the lua API to remove a lua created storage from the exporter and dispose of it.

Updated the RELEASE_NOTES.

Changed the API to 7.0.0 for the darktable 3.6.0 release because of all the API breaking changes in this release cycle.

To Test:

* require the contrib/gimp.lua script, or start it from script_manager.
* require the attached storage.lua script, or start it from script_manager 
* In the exporter select "Edit with GIMP" from the combobox.
* click the "destroy GIMP storage" storage button and observe the "Edit with GIMP" entry is removed.

[storage.zip](https://github.com/darktable-org/darktable/files/6332427/storage.zip)
