### PR TITLE
correct the order in which images are exported

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -497,7 +497,6 @@ GList *dt_selection_get_list(struct dt_selection_t *selection, const gboolean on
   {
     l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
   }
-  if(only_visible && ordering) l = g_list_reverse(l);
   if(stmt) sqlite3_finalize(stmt);
 
   return l;


### PR DESCRIPTION
A recent optimization resulted in images being exported in the opposite order in which they appear in the thumbtable, leading to undesireable results when combined with sequence numbers in the output filenames.

This commit fixes the ordering by removing a now-extraneous list reversal.
