### PR TITLE
po/overlapping path sel

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -170,7 +170,7 @@ typedef struct dt_masks_functions_t
   void (*duplicate_points)(struct dt_develop_t *const dev, struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
   void (*initial_source_pos)(const float iwd, const float iht, float *x, float *y);
   void (*get_distance)(float x, float y, float as, struct dt_masks_form_gui_t *gui, int index, int num_points,
-                       int *inside, int *inside_border, int *near, int *inside_source);
+                       int *inside, int *inside_border, int *near, int *inside_source, float *dist);
   int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
                     float **points, int *points_count);
   int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -932,13 +932,14 @@ fail:
 
 /** get the distance between point (x,y) and the brush */
 static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                int corner_count, int *inside, int *inside_border, int *near, int *inside_source)
+                                int corner_count, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
 {
   // initialise returned values
   *inside_source = 0;
   *inside = 0;
   *inside_border = 0;
   *near = -1;
+  *dist = FLT_MAX;
 
   if(!gui) return;
 
@@ -1010,14 +1011,18 @@ static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t 
       //distance from tested point to current form point
       const float yy = gpt->points[i * 2 + 1];
       const float xx = gpt->points[i * 2];
+
+      const float dx = x - xx;
+      const float dy = y - yy;
+      const float dd = (dx * dx) + (dy * dy);
+      *dist = fminf(*dist, dd);
+
       if ((yy-yf)<as && (yy-yf)>-as && (xx-x)<as && (xx-x)>-as)
       {
         if(current_seg == 0)
           *near = corner_count - 1;
         else
           *near = current_seg - 1;
-
-        return;
       }
     }
   }
@@ -2133,7 +2138,8 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
 
   // are we inside the form or the borders or near a segment ???
   int in, inb, near, ins;
-  _brush_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins);
+  float dist;
+  _brush_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins, &dist);
   gui->seg_selected = near;
   if(near < 0)
   {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -951,8 +951,8 @@ static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t 
   // add support for clone masks
   if(gpt->points_count > 2 + corner_count * 3 && gpt->source_count > 2 + corner_count * 3)
   {
-    float dx = -gpt->points[2] + gpt->source[2];
-    float dy = -gpt->points[3] + gpt->source[3];
+    const float dx = -gpt->points[2] + gpt->source[2];
+    const float dy = -gpt->points[3] + gpt->source[3];
 
     int current_seg = 1;
     for(int i = corner_count * 3; i < gpt->points_count; i++)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -26,7 +26,7 @@
 #include "develop/openmp_maths.h"
 
 static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                 int num_points, int *inside, int *inside_border, int *near, int *inside_source)
+                                 int num_points, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
   // initialise returned values
@@ -34,29 +34,41 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   *inside = 0;
   *inside_border = 0;
   *near = -1;
+  *dist = FLT_MAX;
 
   if(!gui) return;
 
-  float yf = (float)y;
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   // we first check if we are inside the source form
-  if(dt_masks_point_in_form_exact(x, yf, gpt->source, 1, gpt->source_count))
+  if(dt_masks_point_in_form_exact(x, y, gpt->source, 1, gpt->source_count))
   {
     *inside_source = 1;
     *inside = 1;
+
+    // distance from source center
+    const float cx = x - gpt->source[0];
+    const float cy = y - gpt->source[1];
+    *dist = (cx * cx) + (cy * cy);
+
     return;
   }
 
+  // distance from center
+
+  const float cx = x - gpt->points[0];
+  const float cy = y - gpt->points[1];
+  *dist = (cx * cx) + (cy * cy);
+
   // we check if it's inside borders
-  if(!dt_masks_point_in_form_exact(x, yf, gpt->border, 1, gpt->border_count)) return;
+  if(!dt_masks_point_in_form_exact(x, y, gpt->border, 1, gpt->border_count)) return;
 
   *inside = 1;
   *near = 0;
 
   // and we check if it's inside form
-  *inside_border = !(dt_masks_point_in_form_near(x, yf, gpt->points, 1, gpt->points_count, as, near));
+  *inside_border = !(dt_masks_point_in_form_near(x, y, gpt->points, 1, gpt->points_count, as, near));
 }
 
 static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
@@ -475,9 +487,10 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1<<closeup, 1);
     const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;
     int in, inb, near, ins;
+    float dist;
     _circle_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
                          pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, 0,
-                         &in, &inb, &near, &ins);
+                         &in, &inb, &near, &ins, &dist);
     if(ins)
     {
       gui->form_selected = TRUE;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -42,7 +42,7 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   if(!gpt) return;
 
   // we first check if we are inside the source form
-  if(dt_masks_point_in_form_exact(x,yf,gpt->source,1,gpt->source_count))
+  if(dt_masks_point_in_form_exact(x, yf, gpt->source, 1, gpt->source_count))
   {
     *inside_source = 1;
     *inside = 1;
@@ -50,13 +50,13 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   }
 
   // we check if it's inside borders
-  if(!dt_masks_point_in_form_exact(x,yf,gpt->border,1,gpt->border_count)) return;
+  if(!dt_masks_point_in_form_exact(x, yf, gpt->border, 1, gpt->border_count)) return;
 
   *inside = 1;
   *near = 0;
 
   // and we check if it's inside form
-  *inside_border = !(dt_masks_point_in_form_near(x,yf,gpt->points,1,gpt->points_count,as,near));
+  *inside_border = !(dt_masks_point_in_form_near(x, yf, gpt->points, 1, gpt->points_count, as, near));
 }
 
 static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
@@ -262,7 +262,9 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
       // and we switch in edit mode to show all the forms
       // spots and retouch have their own handling of creation_continuous
-      if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
+      if(gui->creation_continuous
+         && (strcmp(crea_module->so->op, "spots") == 0
+             || strcmp(crea_module->so->op, "retouch") == 0))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2124,16 +2124,16 @@ int dt_masks_point_in_form_near(float x, float y, float *points, int points_star
 
   if(points_count > 2 + points_start)
   {
-    int start = isnan(points[points_start * 2]) && !isnan(points[points_start * 2 + 1])
-                    ? points[points_start * 2 + 1]
-                    : points_start;
+    const int start = isnan(points[points_start * 2]) && !isnan(points[points_start * 2 + 1])
+                      ? points[points_start * 2 + 1]
+                      : points_start;
 
-    float yf = (float)y;
+    const float yf = (float)y;
     int nb = 0;
     for(int i = start, next = start + 1; i < points_count;)
     {
-      float y1 = points[i * 2 + 1];
-      float y2 = points[next * 2 + 1];
+      const float y1 = points[i * 2 + 1];
+      const float y2 = points[next * 2 + 1];
       //if we need to jump to skip points (in case of deleted point, because of self-intersection)
       if(isnan(points[next * 2]))
       {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -834,7 +834,8 @@ static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *
   }
 
   // we check if it's inside borders
-  if(!dt_masks_point_in_form_exact(x,yf,gpt->border,corner_count * 3,gpt->border_count)) return;
+  if(!dt_masks_point_in_form_exact(x, yf, gpt->border, corner_count * 3, gpt->border_count))
+    return;
 
   *inside = 1;
 
@@ -857,7 +858,8 @@ static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *
         continue;
       }
       // do we change of path segment ?
-      if(gpt->points[i * 2 + 1] == gpt->points[current_seg * 6 + 3] && gpt->points[i * 2] == gpt->points[current_seg * 6 + 2])
+      if(gpt->points[i * 2 + 1] == gpt->points[current_seg * 6 + 3]
+         && gpt->points[i * 2] == gpt->points[current_seg * 6 + 2])
       {
         current_seg = (current_seg + 1) % corner_count;
       }
@@ -2241,7 +2243,7 @@ static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe
 static int _path_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
                                  dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
 {
-  return _get_area(module, piece, form,width, height, posx, posy, 1);
+  return _get_area(module, piece, form, width, height, posx, posy, 1);
 }
 
 static int _path_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,


### PR DESCRIPTION
Add support for handling overlapping forms.

The selection is done based on the distance of the cursor from the forms' barycenter. Testing with standard masks and on retouch module.

Current status of what is done:

- [x] circle
- [x] ellipse
- [x] path
- [x] gradient
- [x] brush