### PR TITLE
qap : show masks if search is active

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2300,6 +2300,14 @@ void dt_dev_modulegroups_set(dt_develop_t *dev, uint32_t group)
     dev->proxy.modulegroups.set(dev->proxy.modulegroups.module, group);
 }
 
+uint32_t dt_dev_modulegroups_get_activated(dt_develop_t *dev)
+{
+  if(dev->proxy.modulegroups.module && dev->proxy.modulegroups.get_activated)
+    return dev->proxy.modulegroups.get_activated(dev->proxy.modulegroups.module);
+
+  return 0;
+}
+
 uint32_t dt_dev_modulegroups_get(dt_develop_t *dev)
 {
   if(dev->proxy.modulegroups.module && dev->proxy.modulegroups.get)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -228,6 +228,8 @@ typedef struct dt_develop_t
       void (*set)(struct dt_lib_module_t *self, uint32_t group);
       /* get current module group */
       uint32_t (*get)(struct dt_lib_module_t *self);
+      /* get activated module group */
+      uint32_t (*get_activated)(struct dt_lib_module_t *self);
       /* test if iop group flags matches modulegroup */
       gboolean (*test)(struct dt_lib_module_t *self, uint32_t group, struct dt_iop_module_t *module);
       /* switch to modulegroup */
@@ -425,6 +427,8 @@ void dt_dev_modulegroups_search_text_focus(dt_develop_t *dev);
 void dt_dev_modulegroups_set(dt_develop_t *dev, uint32_t group);
 /** get the active modulegroup */
 uint32_t dt_dev_modulegroups_get(dt_develop_t *dev);
+/** get the activated modulegroup */
+uint32_t dt_dev_modulegroups_get_activated(dt_develop_t *dev);
 /** test if iop group flags matches modulegroup */
 gboolean dt_dev_modulegroups_test(dt_develop_t *dev, uint32_t group, struct dt_iop_module_t *module);
 /** reorder the module list */

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3372,7 +3372,8 @@ error:
 // does this gui have focus?
 static int gui_has_focus(struct dt_iop_module_t *self)
 {
-  return (self->dev->gui_module == self && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS);
+  return (self->dev->gui_module == self
+          && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS);
 }
 
 /* this function replaces this sentence, it calls distort_transform() for this module on the pipe

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -353,7 +353,8 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 static int gui_has_focus(struct dt_iop_module_t *self)
 {
-  return (self->dev->gui_module == self && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS);
+  return (self->dev->gui_module == self
+          && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS);
 }
 
 static void keystone_get_matrix(float *k_space, float kxa, float kxb, float kxc, float kxd, float kya,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -474,7 +474,7 @@ void expose(
     image_surface_imgid = dev->image_storage.id;
   }
   else if(dev->preview_pipe->output_imgid != dev->image_storage.id)
-  { 
+  {
     gchar *load_txt;
     float fontsize;
 
@@ -649,7 +649,7 @@ void expose(
   // display mask if we have a current module activated or if the masks manager module is expanded
 
   const gboolean display_masks = (dev->gui_module && dev->gui_module->enabled
-                                  && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+                                  && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
                                  || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
   // execute module callback hook.
@@ -731,7 +731,7 @@ void expose(
       dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
     // module
     if(dev->gui_module && dev->gui_module->gui_post_expose
-       && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+       && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
       dev->gui_module->gui_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
   }
 
@@ -3286,7 +3286,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   if(handled) return;
   // module
   if(dev->gui_module && dev->gui_module->mouse_moved
-     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+     && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
 
@@ -3338,7 +3338,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
   if(handled) return handled;
   // module
   if(dev->gui_module && dev->gui_module->button_released
-     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+     && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->button_released(dev->gui_module, x, y, which, state);
   if(handled) return handled;
   if(which == 1) dt_control_change_cursor(GDK_LEFT_PTR);
@@ -3435,7 +3435,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
   if(handled) return handled;
   // module
   if(dev->gui_module && dev->gui_module->button_pressed
-     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+     && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->button_pressed(dev->gui_module, x, y, pressure, which, type, state);
   if(handled) return handled;
 
@@ -3554,7 +3554,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   if(handled) return;
   // module
   if(dev->gui_module && dev->gui_module->scrolled
-     && dt_dev_modulegroups_get(darktable.develop) != DT_MODULEGROUP_BASICS)
+     && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;
   // free zoom


### PR DESCRIPTION
this fix #8716 

- this ensure we deactivate the qap button in search in occurring (like for for other groups)
- this test for the group activated (and not just the current group which can be deactivated in case of search) in order to do masks stuff