### PR TITLE
gradient mask : lower curvature step + allow to set up at creation

### DIFF
--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -470,7 +470,12 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
                                         double pressure, int which, dt_masks_form_t *form, int parentid,
                                         dt_masks_form_gui_t *gui, int index)
 {
-  if(gui->form_dragging)
+  if(gui->creation && gui->form_dragging)
+  {
+    dt_control_queue_redraw_center();
+    return 1;
+  }
+  else if(gui->form_dragging)
   {
     // we get the gradient
     dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);


### PR DESCRIPTION
usually when you change curvature of the gradient, you have to be quite precise... and you can still get a "big" curvature with little efforts imho.
If some fell the needs for that, we can even image to set the curvature step in some hidden config entry (but then, we may have to do that for all other params :))

This also add the possibility to change the curvature before adding the gradient. Of course, for the next gradient, the curvature will be back to 0.0 !

This work follow the (true) comment of @elstoc recently. thanks !