### PR TITLE
liquify: do not run the pipe on button press.

### DIFF
--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3235,8 +3235,6 @@ int button_pressed(struct dt_iop_module_t *module,
 
 done:
   dt_iop_gui_leave_critical_section(module);
-  if(handled)
-    sync_pipe(module, TRUE);
   return handled;
 }
 


### PR DESCRIPTION
This is done on button release. This makes placing a node on the
canvas feel more interactive and there is no point in runing the
pipe until the strength segement is properly placed.

Fixes #8727.