### PR TITLE
Iops scrolling is continuous when appropriate

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1526,17 +1526,21 @@ static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    int delta_y;
+    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
     {
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/atrous/aspect_percent");
       dt_conf_set_int("plugins/darkroom/atrous/aspect_percent", aspect + delta_y);
       dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
-    else
+  }
+  else
+  {
+    gdouble delta_y;
+    if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
     {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.25 / BANDS, 1.0);
       gtk_widget_queue_draw(widget);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1682,6 +1682,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
+  gdouble delta;
 
   if(darktable.develop->darkroom_skip_mouse_events)
   {
@@ -1725,20 +1726,20 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 
   if(c->selected < 0 && !c->edit_by_area) return TRUE;
 
-  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
+  if(dt_gui_get_scroll_delta(event, &delta))
   {
     dt_iop_color_picker_reset(self, TRUE);
 
     if(c->edit_by_area)
     {
       const int bands = p->curve_num_nodes[c->channel];
-      c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / bands, 1.0);
+      c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.2 / bands, 1.0);
       gtk_widget_queue_draw(widget);
     }
     else
     {
-      delta_y *= -DT_IOP_COLORZONES_DEFAULT_STEP;
-      return _move_point_internal(self, widget, 0.f, delta_y, event->state);
+      delta *= -DT_IOP_COLORZONES_DEFAULT_STEP;
+      return _move_point_internal(self, widget, 0.f, delta, event->state);
     }
   }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3476,17 +3476,21 @@ static gboolean denoiseprofile_scrolled(GtkWidget *widget, GdkEventScroll *event
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    int delta_y;
+    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
     {
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/denoiseprofile/aspect_percent");
       dt_conf_set_int("plugins/darkroom/denoiseprofile/aspect_percent", aspect + delta_y);
       dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
-    else
+  }
+  else
+  {
+    gdouble delta_y;
+    if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
     {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.f + 0.1f * delta_y), 0.2f / DT_IOP_DENOISE_PROFILE_BANDS, 1.f);
       gtk_widget_queue_draw(widget);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -790,17 +790,21 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    int delta_y;
+    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
     {
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/lowlight/aspect_percent");
       dt_conf_set_int("plugins/darkroom/lowlight/aspect_percent", aspect + delta_y);
       dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
-    else
+  }
+  else
+  {
+    gdouble delta_y;
+    if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
     {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
       gtk_widget_queue_draw(widget);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -866,17 +866,21 @@ static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, gp
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
-  int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
   {
-    if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    int delta_y;
+    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
     {
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/rawdenoise/aspect_percent");
       dt_conf_set_int("plugins/darkroom/rawdenoise/aspect_percent", aspect + delta_y);
       dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
-    else
+  }
+  else
+  {
+    gdouble delta_y;
+    if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
     {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_RAWDENOISE_BANDS, 1.0);
       gtk_widget_queue_draw(widget);


### PR DESCRIPTION
Based on discussion in #8698 this is my proposal for touchpad behaviour. 

I think that following modules should use continous scrolling when changing widgets in their gui. This is achieved by using `dt_gui_get_scroll_deltas`.

- rgb curve (not affected in this PR)
- tone curve (not affected in this PR)
- lowlight
- color zones
- contrast equalizer
- base curve (not affected in this PR)
- denoise profiled
- raw denoise

I am not addressing iops that have scrolling over the center view. That seems to be a more complex issue.