### PR TITLE
module warnings: add a pref to hide them

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2800,6 +2800,13 @@
     <shortdescription>detect monochrome previews</shortdescription>
     <longdescription>many monochrome images can be identified via exif and preview data. beware: this slows down imports and reading exif data</longdescription>
  </dtconfig>
+ <dtconfig prefs="processing">
+    <name>plugins/darkroom/show_warnings</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show warning messages</shortdescription>
+    <longdescription>display messages in modules to warn beginner users when non-standard and possibly harmful settings are used in the pipeline.\nthese messages can be false-positive and should be disregarded if you know what you are doing. This option will hide them all the time.</longdescription>
+  </dtconfig>
  <dtconfig>
     <name>screen_dpi_overwrite</name>
     <type>float</type>

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1167,7 +1167,7 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
     fprintf(stderr, "[%s] %s\n", name, stderr_message ? stderr_message : trouble_msg);
   }
 
-  if(!dt_iop_is_hidden(module) && module->gui_data)
+  if(!dt_iop_is_hidden(module) && module->gui_data && dt_conf_get_bool("plugins/darkroom/show_warnings"))
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TROUBLE_MESSAGE,
                                   module, trouble_msg, trouble_tooltip);
 }
@@ -3077,7 +3077,10 @@ void dt_iop_cancel_history_update(dt_iop_module_t *module)
 
 char *dt_iop_warning_message(const char *message)
 {
-  return g_strdup_printf("<span foreground='red'>⚠</span> %s", message);
+  if(dt_conf_get_bool("plugins/darkroom/show_warnings"))
+    return g_strdup_printf("<span foreground='red'>⚠</span> %s", message);
+  else
+    return g_strdup_printf("%s", message);
 }
 
 char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, const char *purpose, const char *input, const char *process,


### PR DESCRIPTION
I'm an acrobat, I don't do safety nets. Also, it's tiresome to get nagged all the time about valid stuff that is indeed non-standard.