### PR TITLE
Disable fast math for RCD demosaicer again

### DIFF
--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -64,10 +64,12 @@
    The 'fp-contract=fast' option enables fused multiply&add if available
 */
 
+/*
 #ifdef __GNUC__
   #pragma GCC push_options
   #pragma GCC optimize ("fast-math", "fp-contract=fast")
 #endif
+*/
 
 #ifdef __GNUC__
   #define INLINE __inline
@@ -585,10 +587,12 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
   }
 }
 
+/*
 // revert rcd specific aggressive optimizing
 #ifdef __GNUC__
   #pragma GCC pop_options
 #endif
+*/
 
 #undef FCRCD
 #undef RCD_BORDER


### PR DESCRIPTION
There are issues #8755 and #8753 both possibly related to NaNs fired up the pipeline.

I can't reproduce those issues here but maybe i oversaw something in the RCD border interpolation recently introduced that might generate such NaNs so it's good to disable fast-maths here until this is sorted out.

