### PR TITLE
exposure: increase soft limit

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -834,7 +834,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->exposure, 0.02);
   dt_bauhaus_slider_set_digits(g->exposure, 3);
   dt_bauhaus_slider_set_format(g->exposure, _("%.2f EV"));
-  dt_bauhaus_slider_set_soft_range(g->exposure, -3.0, 3.0);
+  dt_bauhaus_slider_set_soft_range(g->exposure, -3.0, 4.0);
 
   g->autoexpp = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                 dt_bauhaus_slider_new_with_range(self, 0.0, 0.2, .001, 0.01, 3));


### PR DESCRIPTION
With the new scene-referred/filmic workflow I find myself needing to push exposure beyond the soft limit quite regularly and the workflow for this is quite painful when you use a keyboard shortcut for exposure adjustments. This PR adjusts the upper limit to +4EV. 

I would personally be in favour of increasing the lower limit as well (to -2EV). I'm not sure I've ever needed to reduce exposure more than one stop, but this PR leaves the lower limit as-is in order to be slightly less controversial. Another option would be to make the lower limit -4EV but IMO that has no advantage beyond a symmetrical UI.