### PR TITLE
channelmixerrgb: improve colorfulness correction

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -585,11 +585,7 @@ static inline void luma_chroma(const float input[4], const float saturation[4], 
       coeff_ratio += sqf(1.0f - output[c]) * saturation[c];
   }
   else
-  {
-    for(size_t c = 0; c < 3; c++)
-      coeff_ratio += output[c] * saturation[c];
-  }
-  coeff_ratio /= 3.f;
+    coeff_ratio = scalar_product(output, saturation) / 3.f;
 
   // Adjust the RGB ratios with the pixel correction
   for(size_t c = 0; c < 3; c++)


### PR DESCRIPTION
Replaces https://github.com/darktable-org/darktable/pull/8254 (intended to push to that same branch but I renamed the source branch and apparently that causes the PR to be closed.)

Apply the same scaling and normalization to the colorfulness correction as https://github.com/darktable-org/darktable/pull/8272 did to Filmic. The advantage is that the colorfulness adjustment no longer affects grey pixels.