### PR TITLE
filmicrgb v5: get desaturation on Y luminance

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -493,7 +493,21 @@ inline float4 filmic_chroma_v2_v3(const float4 i,
   norm = log_tonemapping_v2(norm, grey_value, black_exposure, dynamic_range);
 
   // Get the desaturation value based on the log value
-  const float4 desaturation = (float4)filmic_desaturate_v2(norm, sigma_toe, sigma_shoulder, saturation);
+  float desat_value;
+  if(colorscience_version == DT_FILMIC_COLORSCIENCE_V3)
+  {
+    // Use the luminance to desaturate - more accurate
+    float4 RGB = norm * ratios;
+    desat_value = fmax(get_pixel_norm(RGB, DT_FILMIC_METHOD_LUMINANCE, profile_info, lut, use_work_profile), NORM_MIN);
+  }
+  else
+  {
+    // Use the usual norm to desaturate - faster
+    desat_value = norm;
+  }
+
+  // Get the desaturation value based on the log value
+  const float4 desaturation = (float4)filmic_desaturate_v2(desat_value, sigma_toe, sigma_shoulder, saturation);
 
   // Filmic S curve on the max RGB
   // Apply the transfer function of the display


### PR DESCRIPTION
Build up on top of filmic v5 merged 3 days ago.

We reform the RGB value (norm * ratios) to compute Y and use this value to get the desaturation coeff, instead of the norm currently used. This is a bit slower but allows more chroma, especially with the max(RGB) norm.

After many discussions over 2 years, it appears that the max(RGB) norm is the only one that makes sense on a physical level. This will make it better-looking and be more conservative about desaturation.

Examples (notice all the variants fully fit within pipeline RGB gamut, set here to Rec2020):

Max RGB, v5:
![DSC08448_01](https://user-images.githubusercontent.com/2779157/115968343-cf061a00-a537-11eb-9f9a-a31066d8de82.jpg)

Max RGB, v4:
![DSC08448_02](https://user-images.githubusercontent.com/2779157/115968371-f6f57d80-a537-11eb-9855-2eedf37c883b.jpg)

Max RGB, v3:
![DSC08448_03](https://user-images.githubusercontent.com/2779157/115968385-04126c80-a538-11eb-8401-c8d3849eb566.jpg)
