### PR TITLE
lua fix dirty stack

### DIFF
--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -110,7 +110,7 @@ void dt_lua_event_add(lua_State *L, const char *evt_name)
   if(args != 3)
   {
     lua_pop(L, args);
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: wrong number of args for %s, expected 4, got %d\n", __FUNCTION__, evt_name, args);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s: wrong number of args for %s, expected 3, got %d\n", __FUNCTION__, evt_name, args);
     return;
   }
 

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -510,6 +510,7 @@ int dt_lua_init_luastorages(lua_State *L)
   lua_pushstring(L, "destroy_storage");
   lua_pushcfunction(L, &destroy_storage);
   lua_settable(L, -3);
+  lua_pop(L, 1);
 
   dt_lua_push_darktable_lib(L);
   lua_pushstring(L, "register_storage");


### PR DESCRIPTION
Popped leftover table off the stack to keep the stack clean.

Fixed error message in lua events to show the correct number of required arguments