### PR TITLE
import: speed up files list and folders views

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -717,11 +717,15 @@ static gboolean _update_files_list(gpointer user_data)
   g_object_ref(model);
   gtk_tree_view_set_model(d->from.treeview, NULL);
   gtk_list_store_clear(d->from.store);
+  gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
+                                       GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID, GTK_SORT_ASCENDING);
 #ifdef HAVE_GPHOTO2
   if(d->import_case == DT_IMPORT_CAMERA)
   {
     d->from.nb = _import_from_camera_set_file_list(self);
     gtk_widget_hide(d->from.info);
+    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
+                                         DT_IMPORT_FILENAME, GTK_SORT_ASCENDING);
   }
   else
 #endif
@@ -729,6 +733,8 @@ static gboolean _update_files_list(gpointer user_data)
     char *folder = dt_conf_get_string("ui_last/import_last_directory");
     d->from.nb = !folder[0] ? 0 : _import_set_file_list(folder, strlen(folder), 0, self);
     g_free(folder);
+    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
+                                         DT_IMPORT_DATETIME, GTK_SORT_ASCENDING);
   }
   gtk_tree_view_set_model(d->from.treeview, model);
   g_object_unref(model);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -851,6 +851,8 @@ static gboolean _find_iter_folder(GtkTreeModel *model, GtkTreeIter *iter,
 static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
                               const gchar *folder, const char *selected)
 {
+  // each time a new folder is added, it is set as not expanded and assigned a fake child
+  // when expanded, the children are added and the fake child is reused
   GError *error = NULL;
   GFile *gfolder = g_file_parse_name(folder);
   GFileEnumerator *dir_files = g_file_enumerate_children(gfolder,
@@ -862,6 +864,7 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
                                   G_FILE_QUERY_INFO_NONE, NULL, &error);
 
   gboolean expanded = FALSE;
+  GtkTreeIter iter;
   GtkTreeIter parent2;
   if(!parent)
   {
@@ -870,7 +873,9 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
     gtk_tree_store_set(store, &parent2, DT_FOLDER_NAME, basename,
                                      DT_FOLDER_PATH, folder,
                                      DT_FOLDER_EXPANDED, FALSE, -1);
-    g_free(basename);
+    // fake child
+    gtk_tree_store_append(store, &iter, &parent2);
+    gtk_tree_store_set(store, &iter, DT_FOLDER_EXPANDED, FALSE, -1);
   }
   else
   {
@@ -878,6 +883,7 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
     gtk_tree_model_get(GTK_TREE_MODEL(store), &parent2, DT_FOLDER_EXPANDED, &expanded, -1);
   }
   GFileInfo *info = NULL;
+  gint i = 0;
   while((info = g_file_enumerator_next_file(dir_files, NULL, &error)))
   {
     const char *filename = g_file_info_get_name(info);
@@ -889,16 +895,22 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
     if(filetype == G_FILE_TYPE_DIRECTORY && !ishidden && canread)
     {
       gchar *fullname = g_build_filename(folder, filename, NULL);
-      GtkTreeIter iter;
       if(!expanded)
       {
+        GtkTreeIter child;
         const char *uifilename = g_file_info_get_display_name(info);
         gchar *uifullname = g_build_filename(folder, uifilename, NULL);
         gchar *basename = g_path_get_basename(uifullname);
-        gtk_tree_store_append(store, &iter, &parent2);
+        if(!i)
+          gtk_tree_model_iter_children(GTK_TREE_MODEL(store), &iter, &parent2);
+        else
+          gtk_tree_store_append(store, &iter, &parent2);
         gtk_tree_store_set(store, &iter, DT_FOLDER_NAME, basename,
                                          DT_FOLDER_PATH, fullname,
                                          DT_FOLDER_EXPANDED, FALSE, -1);
+        // fake child
+        gtk_tree_store_append(store, &child, &iter);
+        gtk_tree_store_set(store, &iter, DT_FOLDER_EXPANDED, FALSE, -1);
         g_free(uifullname);
         g_free(basename);
       }
@@ -915,9 +927,16 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
       if(selected[0] && g_str_has_prefix(selected, fullname))
         _get_folders_list(store, &iter, fullname, selected);
       g_free(fullname);
+      i++;
     }
     gtk_tree_store_set(store, &parent2, DT_FOLDER_EXPANDED, TRUE, -1);
     g_object_unref(info);
+  }
+  if(!i)
+  {
+    // remove the fake child as there is no child
+    gtk_tree_model_iter_children(GTK_TREE_MODEL(store), &iter, &parent2);
+    gtk_tree_store_remove(store, &iter);
   }
   if(dir_files)
   {
@@ -926,20 +945,56 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
   }
 }
 
-static void _folder_selection_changed(GtkTreeSelection *selection, dt_lib_module_t *self)
+// workaround to erase parasitic selection when click on expander or empty part of the view
+static gboolean _clear_parasitic_selection(gpointer user_data)
+{
+  if(dt_conf_is_equal("ui_last/import_last_directory", ""))
+  {
+    dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+    dt_lib_import_t *d = (dt_lib_import_t *)self->data;
+    GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.folderview);
+    if(gtk_tree_selection_count_selected_rows(selection))
+      gtk_tree_selection_unselect_all(selection);
+  }
+  return FALSE;
+}
+
+static gboolean _button_press(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->from.folderview));
-  GtkTreeIter iter;
-  if(gtk_tree_selection_get_selected(selection, &model, &iter))
+  gboolean res = FALSE;
+  const int button_pressed = (event->type == GDK_BUTTON_PRESS) ? event->button : 0;
+  const gboolean modifier = dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK);
+  if((button_pressed == 1) && !modifier)
   {
-    char *folder;
-    gtk_tree_model_get(model, &iter, DT_FOLDER_PATH, &folder, -1);
-    dt_conf_set_string("ui_last/import_last_directory", folder);
-    g_free(folder);
-    _update_files_list(self);
-    _show_all_thumbs(self);
+    GtkTreePath *path = NULL;
+    if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), event->x, event->y, &path, NULL, NULL, NULL))
+    {
+      GdkRectangle rect;
+      gtk_tree_view_get_cell_area(GTK_TREE_VIEW(view), path, d->from.foldercol, &rect);
+      const gboolean blank = gtk_tree_view_is_blank_at_pos(GTK_TREE_VIEW(view), event->x, event->y,
+                                                           NULL, NULL, NULL, NULL);
+      // select and save new folder only if not click on expander
+      if(blank || (event->x > rect.x))
+      {
+        GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.folderview);
+        gtk_tree_selection_select_path(selection, path);
+        GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
+        GtkTreeIter iter;
+        gtk_tree_model_get_iter(model, &iter, path);
+        char *folder;
+        gtk_tree_model_get(model, &iter, DT_FOLDER_PATH, &folder, -1);
+        dt_conf_set_string("ui_last/import_last_directory", folder);
+        g_free(folder);
+        _update_files_list(self);
+        _show_all_thumbs(self);
+        res = TRUE;
+      }
+    }
+    gtk_tree_path_free(path);
   }
+  g_timeout_add_full(G_PRIORITY_DEFAULT_IDLE, 100, _clear_parasitic_selection, self, NULL);
+	return res;
 }
 
 static void _folder_order_clicked(GtkTreeViewColumn *column, dt_lib_module_t *self)
@@ -951,22 +1006,17 @@ static void _folder_order_clicked(GtkTreeViewColumn *column, dt_lib_module_t *se
 static void _row_expanded(GtkTreeView *view, GtkTreeIter *iter,
                           GtkTreePath *path, dt_lib_module_t *self)
 {
-  GtkTreeIter child, parent = *iter;
   GtkTreeModel *model = gtk_tree_view_get_model(view);
-  if(gtk_tree_model_iter_children(model, &child, &parent))
-  do
-  {
-    char *fullname;
-    gtk_tree_model_get(model, &child, DT_FOLDER_PATH, &fullname, -1);
-    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
-                                         GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
-                                         GTK_SORT_ASCENDING);
-    _get_folders_list(GTK_TREE_STORE(model), &child, fullname, "");
-    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model), DT_FOLDER_PATH,
-                                         dt_conf_get_bool("ui_last/import_last_folder_descending")
-                                         ? GTK_SORT_DESCENDING : GTK_SORT_ASCENDING);
-    g_free(fullname);
-  } while(gtk_tree_model_iter_next(model, &child));
+  gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
+                                       GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
+                                       GTK_SORT_ASCENDING);
+  char *fullname;
+  gtk_tree_model_get(model, iter, DT_FOLDER_PATH, &fullname, -1);
+  _get_folders_list(GTK_TREE_STORE(model), iter, fullname, "");
+  g_free(fullname);
+  gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model), DT_FOLDER_PATH,
+                                       dt_conf_get_bool("ui_last/import_last_folder_descending")
+                                       ? GTK_SORT_DESCENDING : GTK_SORT_ASCENDING);
 }
 
 static void _paned_position_changed(GtkWidget *widget, dt_lib_module_t* self)
@@ -993,6 +1043,7 @@ static void _set_folders_list(GtkWidget *lbox, dt_lib_module_t* self)
   gtk_tree_view_column_set_resizable(column, TRUE);
   gtk_tree_view_set_expander_column(d->from.folderview, column);
   g_signal_connect(d->from.folderview, "row-expanded", G_CALLBACK(_row_expanded), self);
+  g_signal_connect(G_OBJECT(d->from.folderview), "button-press-event", G_CALLBACK(_button_press), self);
   gtk_tree_view_column_set_sort_column_id(column, DT_FOLDER_PATH);
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(store), DT_FOLDER_PATH,
                                 dt_conf_get_bool("ui_last/import_last_folder_descending")
@@ -1004,9 +1055,31 @@ static void _set_folders_list(GtkWidget *lbox, dt_lib_module_t* self)
   gtk_tree_view_set_model(d->from.folderview, GTK_TREE_MODEL(store));
   gtk_tree_view_set_headers_visible(d->from.folderview, TRUE);
   gtk_box_pack_end(GTK_BOX(lbox), w, TRUE, TRUE, 0);
+}
 
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->from.folderview));
-  g_signal_connect(selection, "changed", G_CALLBACK(_folder_selection_changed), self);
+static void _expand_folder(const char *folder, const gboolean select, dt_lib_module_t* self)
+{
+  dt_lib_import_t *d = (dt_lib_import_t *)self->data;
+  if(folder && folder[0])
+  {
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->from.folderview));
+    GtkTreeIter iter;
+    if(gtk_tree_model_get_iter_first(model, &iter))
+    {
+      if(_find_iter_folder(model, &iter, folder))
+      {
+        GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
+        gtk_tree_view_expand_to_path(d->from.folderview, path);
+        gtk_tree_view_scroll_to_cell(d->from.folderview, path, NULL, TRUE, 0.5, 0.5);
+        gtk_tree_path_free(path);
+        if(select)
+        {
+          GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.folderview);
+          gtk_tree_selection_select_iter(selection, &iter);
+        }
+      }
+    }
+  }
 }
 
 static void _update_folders_list(dt_lib_module_t* self)
@@ -1027,22 +1100,7 @@ static void _update_folders_list(dt_lib_module_t* self)
                                        ? GTK_SORT_DESCENDING : GTK_SORT_ASCENDING);
   gtk_tree_view_set_model(d->from.folderview, model);
   g_object_unref(model);
-  if(folder[0])
-  {
-    GtkTreeIter iter;
-    if(gtk_tree_model_get_iter_first(model, &iter))
-    {
-      if(_find_iter_folder(model, &iter, folder))
-      {
-        GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
-        gtk_tree_view_expand_to_path(d->from.folderview, path);
-        gtk_tree_view_scroll_to_cell(d->from.folderview, path, NULL, TRUE, 0.5, 0.5);
-        gtk_tree_path_free(path);
-        GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.folderview);
-        gtk_tree_selection_select_iter(selection, &iter);
-      }
-    }
-  }
+  _expand_folder(folder, TRUE, self);
   g_free(folder);
 }
 
@@ -1124,15 +1182,11 @@ static void _root_combobox_changed(GtkWidget *widget, dt_lib_module_t *self)
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   const char *root = dt_bauhaus_combobox_get_text(d->from.root);
   _save_last_root(root);
-  char *last_dir = dt_conf_get_string("ui_last/import_last_directory");
-  if(!g_str_has_prefix(last_dir, root))
-  {
-    dt_conf_set_string("ui_last/import_last_directory", root);
-    dt_conf_set_bool("ui_last/import_recursive", FALSE);
-    dt_gui_preferences_bool_update(d->recursive);
-  }
-  g_free(last_dir);
+  dt_conf_set_string("ui_last/import_last_directory", "");
+  dt_conf_set_bool("ui_last/import_recursive", FALSE);
+  dt_gui_preferences_bool_update(d->recursive);
   _update_folders_list(self);
+  _expand_folder(root, FALSE, self);
   _update_files_list(self);
 }
 
@@ -1159,16 +1213,14 @@ static void _lib_import_select_folder(GtkWidget *widget, dt_lib_module_t *self)
     GSList *list = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(filechooser));
     _save_last_root((char *)list->data);
     _set_root_combo(self);
-    char *last_dir = dt_conf_get_string("ui_last/import_last_directory");
-    if(!g_str_has_prefix(last_dir, (char *)list->data))
-      dt_conf_set_string("ui_last/import_last_directory", (char *)list->data);
-    g_free(last_dir);
+    dt_conf_set_string("ui_last/import_last_directory", "");
     dt_conf_set_bool("ui_last/import_recursive", FALSE);
     dt_gui_preferences_bool_update(d->recursive);
     g_slist_free(list);
+    _update_folders_list(self);
+    _expand_folder(dt_bauhaus_combobox_get_text(d->from.root), FALSE, self);
+    _update_files_list(self);
   }
-  _update_folders_list(self);
-  _update_files_list(self);
   gtk_widget_destroy(filechooser);
 }
 
@@ -1412,6 +1464,7 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
     // folder tree
     _set_folders_list(lbox, self);
     _update_folders_list(self);
+    _expand_folder(dt_bauhaus_combobox_get_text(d->from.root), FALSE, self);
   }
 
   // patterns expander


### PR DESCRIPTION
- disable sorting when fulfilling the files list (f3-4 seconds for nealy 60.000 images on HDD)
 
should help to solve the issue commented by @ralfbrown in #8782.
~~but probably doesn't affect the main issue reported by @Mark-64.~~
Now fixes #8782 as well.
