### PR TITLE
iops: fix GtkDarktableDrawingArea resize on scroll

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1084,9 +1084,6 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
   dt_iop_atrous_params_t p = *(dt_iop_atrous_params_t *)self->params;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/atrous/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   const float mix = c->in_curve ? 1.0f : p.mix;
 
   for(int k = 0; k < BANDS; k++)
@@ -1537,11 +1534,13 @@ static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/atrous/aspect_percent");
       dt_conf_set_int("plugins/darkroom/atrous/aspect_percent", aspect + delta_y);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
     else
+    {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.25 / BANDS, 1.0);
-
-    gtk_widget_queue_draw(widget);
+      gtk_widget_queue_draw(widget);
+    }
   }
   return TRUE;
 }

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -962,9 +962,6 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   const float shadows_weight = 2.f + p->shadows_weight * 2.f;
   const float highlights_weight = 2.f + p->highlights_weight * 2.f;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/colorbalancergb/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   // Cache the graph objects to avoid recomputing all the view at each redraw
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -1273,7 +1270,7 @@ static gboolean area_scroll_callback(GtkWidget *widget, GdkEventScroll *event, g
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/colorbalancergb/aspect_percent");
       dt_conf_set_int("plugins/darkroom/colorbalancergb/aspect_percent", aspect + delta_y);
-      gtk_widget_queue_draw(widget);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
 
       return TRUE;
     }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1053,9 +1053,6 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   dt_iop_colorzones_params_t p = *(dt_iop_colorzones_params_t *)self->params;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/colorzones/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   if(p.splines_version == DT_IOP_COLORZONES_SPLINES_V1)
   {
     for(int ch = 0; ch < DT_IOP_COLORZONES_MAX_CHANNELS; ch++)
@@ -1720,7 +1717,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/colorzones/aspect_percent");
       dt_conf_set_int("plugins/darkroom/colorzones/aspect_percent", aspect + delta_y);
-      gtk_widget_queue_draw(widget);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
 
       return TRUE;
     }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3178,9 +3178,6 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
   dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t p = *(dt_iop_denoiseprofile_params_t *)self->params;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/denoiseprofile/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   int ch = (int)c->channel;
   dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.f, p.y[ch][0]);
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
@@ -3487,11 +3484,13 @@ static gboolean denoiseprofile_scrolled(GtkWidget *widget, GdkEventScroll *event
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/denoiseprofile/aspect_percent");
       dt_conf_set_int("plugins/darkroom/denoiseprofile/aspect_percent", aspect + delta_y);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
     else
+    {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.f + 0.1f * delta_y), 0.2f / DT_IOP_DENOISE_PROFILE_BANDS, 1.f);
-
-    gtk_widget_queue_draw(widget);
+      gtk_widget_queue_draw(widget);
+    }
   }
 
   return TRUE;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2688,9 +2688,6 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
   dt_iop_filmic_rgb_compute_spline(p, &g->spline);
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/filmicrgb/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   // Cache the graph objects to avoid recomputing all the view at each redraw
   gtk_widget_get_allocation(widget, &g->allocation);
 
@@ -3693,7 +3690,7 @@ static gboolean area_scroll_callback(GtkWidget *widget, GdkEventScroll *event, g
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/filmicrgb/aspect_percent");
       dt_conf_set_int("plugins/darkroom/filmicrgb/aspect_percent", aspect + delta_y);
-      gtk_widget_queue_draw(widget);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
     return TRUE; // Ensure that scrolling cannot move side panel when no delta
   }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -714,9 +714,6 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/levels/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(GTK_WIDGET(c->area), &allocation);
@@ -975,7 +972,7 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/levels/aspect_percent");
       dt_conf_set_int("plugins/darkroom/levels/aspect_percent", aspect + delta_y);
-      gtk_widget_queue_draw(widget);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
 
       return TRUE;
     }

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -489,9 +489,6 @@ static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_dat
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_iop_lowlight_params_t p = *(dt_iop_lowlight_params_t *)self->params;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/lowlight/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   dt_draw_curve_set_point(c->transition_curve, 0, p.transition_x[DT_IOP_LOWLIGHT_BANDS - 2] - 1.0,
                           p.transition_y[0]);
   for(int k = 0; k < DT_IOP_LOWLIGHT_BANDS; k++)
@@ -801,10 +798,13 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/lowlight/aspect_percent");
       dt_conf_set_int("plugins/darkroom/lowlight/aspect_percent", aspect + delta_y);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
     else
+    {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
-    gtk_widget_queue_draw(widget);
+      gtk_widget_queue_draw(widget);
+    }
   }
 
   return TRUE;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -591,9 +591,6 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
   dt_iop_rawdenoise_params_t p = *(dt_iop_rawdenoise_params_t *)self->params;
 
-  const float aspect = dt_conf_get_int("plugins/darkroom/rawdenoise/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
-
   int ch = (int)c->channel;
   dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p.y[ch][0]);
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
@@ -877,10 +874,13 @@ static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, gp
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/rawdenoise/aspect_percent");
       dt_conf_set_int("plugins/darkroom/rawdenoise/aspect_percent", aspect + delta_y);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
     }
     else
+    {
       c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_RAWDENOISE_BANDS, 1.0);
-    gtk_widget_queue_draw(widget);
+      gtk_widget_queue_draw(widget);
+    }
   }
 
   return TRUE;

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -372,9 +372,6 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
 {
   dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
-
-  const float aspect = dt_conf_get_int("plugins/darkroom/rgblevels/aspect_percent") / 100.0;
-  dtgtk_drawing_area_set_aspect_ratio(widget, aspect);
   
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
@@ -648,7 +645,7 @@ static gboolean _area_scroll_callback(GtkWidget *widget, GdkEventScroll *event, 
       //adjust aspect
       const int aspect = dt_conf_get_int("plugins/darkroom/rgblevels/aspect_percent");
       dt_conf_set_int("plugins/darkroom/rgblevels/aspect_percent", aspect + delta_y);
-      gtk_widget_queue_draw(widget);
+      dtgtk_drawing_area_set_aspect_ratio(widget, aspect / 100.0);
 
       return TRUE;
     }


### PR DESCRIPTION
Changing iop drawing area aspect ratio on widget draw forced a `size-allocate` signal to bubble up the right panel. This caused the histogram to redraw (which can generate distracting perf log messages) and triggered yet another draw event for the resized widget, which created another resize, which created another draw, more pref log messages, etc.

Note that as `dtgtk_drawing_area_set_aspect_ratio()` calls `gtk_widget_queue_draw()`, there is no need to call it directly upon handling a scroll.

A follow-up to #8698. Fixes #8765 to an adequate extent.

There are other cases in which histogram redraws unnecessarily and generates chatter to stdout, but this should stabilize things. Other cases include:

- every time the "search modules" text cursor blinks
- when mouse moves into or out of watermark color choose button
- a single redraw when an iop's GtkDarktableDrawingArea is resized

These are long-standing bugs, extant at least to dt v3.0.