### PR TITLE
FIX: ImageMagick is missing in loaders name list

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -565,6 +565,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
         { N_("rawspeed"), 'r'},
         { N_("netpnm"), 'n'},
         { N_("avif"), 'a'},
+        { N_("ImageMagick"), 'i'},
       };
 
       const int loader = (unsigned int)img->loader < sizeof(loaders) / sizeof(*loaders) ? img->loader : 0;


### PR DESCRIPTION
LOADER_IM was added with value 12 but not added to loaders list.