### PR TITLE
improve waveform and RGB parade appearance

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -216,7 +216,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   const size_t bin_width = ceilf(sample_width / (float)d->waveform_max_width);
   const size_t wf_width = ceilf(sample_width / (float)bin_width);
   d->waveform_width = wf_width;
-  const size_t wf_8bit_stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wf_width);
+  const size_t wf_8bit_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, wf_width);
   const size_t wf_height = d->waveform_height;
 
   dt_iop_image_fill(wf_linear, 0.0f, wf_width, wf_height, 4);
@@ -261,16 +261,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
     }
   }
 
-  // colors used to represent primary colors
-  // FIXME: force a recalc/redraw when colors have changed via user entering new CSS in preferences -- is there a signal for this?
-  const GdkRGBA *const css_primaries = darktable.bauhaus->graph_colors;
-  const float DT_ALIGNED_ARRAY primaries_linear[3][4] = {
-    {css_primaries[2].blue, css_primaries[2].green, css_primaries[2].red, 1.0f},
-    {css_primaries[1].blue, css_primaries[1].green, css_primaries[1].red, 1.0f},
-    {css_primaries[0].blue, css_primaries[0].green, css_primaries[0].red, 1.0f},
-  };
-
-  // shortcut for a fast gamma change -- borrow hybrid log-gamma LUT
+  // shortcut to change from linear to display gamma -- borrow hybrid log-gamma LUT
   const dt_iop_order_iccprofile_info_t *const profile =
     dt_ioppr_add_profile_info_to_list(darktable.develop, DT_COLORSPACE_HLG_REC2020, "", DT_INTENT_PERCEPTUAL);
   // lut for all three channels should be the same
@@ -283,9 +274,8 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
       for(size_t x = 0; x < wf_width; x++)
       {
         const float linear = MIN(1.f, wf_linear[4U * (y * wf_width + x) + ch]);
-        uint8_t *const restrict out = wf_8bit + (ch * wf_height + y) * wf_8bit_stride + x * 4;
-        for(size_t k = 0; k < 3; k++)
-          out[k] = lut[(int)(linear * primaries_linear[ch][k] * lutmax)] * 255.0f;
+        const float display = lut[(int)(linear * lutmax)];
+        wf_8bit[(ch * wf_height + y) * wf_8bit_stride + x] = display * 255.f;
       }
 
   if(darktable.unmuted & DT_DEBUG_PERF)
@@ -666,15 +656,18 @@ static void _lib_histogram_draw_histogram(dt_lib_histogram_t *d, cairo_t *cr,
 
 static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t *cr, int ch)
 {
-  const size_t wf_8bit_stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->waveform_width);
-  cairo_surface_t *source
+  // FIXME: force a recalc/redraw when colors have changed via user entering new CSS in preferences -- is there a signal for this?
+  // FIXME: if flip primary here, can we flip it back in procses code instead, to simplify?
+  const GdkRGBA primary = darktable.bauhaus->graph_colors[2-ch];
+  cairo_set_source_rgba(cr, primary.red, primary.green, primary.blue, 0.6);
+  const size_t wf_8bit_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
+  cairo_surface_t *surface
     = dt_cairo_image_surface_create_for_data(d->waveform_8bit + ch * d->waveform_height * wf_8bit_stride,
-                                             CAIRO_FORMAT_RGB24,
+                                             CAIRO_FORMAT_A8,
                                              d->waveform_width, d->waveform_height, wf_8bit_stride);
-  cairo_set_source_surface(cr, source, 0.0, 0.0);
   // FIXME: increase alpha for more intense waveform, especially for RGB parade
-  cairo_paint_with_alpha(cr, 0.5);
-  cairo_surface_destroy(source);
+  cairo_mask_surface(cr, surface, 0., 0.);
+  cairo_surface_destroy(surface);
 }
 
 static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
@@ -1539,7 +1532,7 @@ void gui_init(dt_lib_module_t *self)
   d->waveform_height  = 175;
   d->waveform_linear  = dt_iop_image_alloc(d->waveform_max_width, d->waveform_height, 4);
   d->waveform_8bit    = dt_alloc_align(64, sizeof(uint8_t) * 3 * d->waveform_height *
-                                       cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->waveform_max_width));
+                                       cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_max_width));
 
   // FIXME: what is the appropriate resolution for this: balance memory use, processing speed, helpful resolution
   d->vectorscope_diameter_px = 384;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -646,13 +646,12 @@ static void _lib_histogram_draw_histogram(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_restore(cr);
 }
 
-static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t *cr, int ch)
+static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t *cr, int ch, double alpha)
 {
   // FIXME: force a recalc/redraw when colors have changed via user entering new CSS in preferences -- is there a signal for this?
   // waveform data is BGR, need to flip to RGB
   const GdkRGBA primary = darktable.bauhaus->graph_colors[2-ch];
-  // FIXME: tune alpha for RGB parade
-  cairo_set_source_rgba(cr, primary.red, primary.green, primary.blue, 0.6);
+  cairo_set_source_rgba(cr, primary.red, primary.green, primary.blue, alpha);
   const size_t wf_8bit_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
   cairo_surface_t *surface
     = dt_cairo_image_surface_create_for_data(d->waveform_8bit + (2-ch) * d->waveform_height * wf_8bit_stride,
@@ -673,7 +672,7 @@ static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
 
   for(int ch = 0; ch < 3; ch++)
     if(mask[2-ch])
-      _lib_histogram_draw_waveform_channel(d, cr, ch);
+      _lib_histogram_draw_waveform_channel(d, cr, ch, 0.6);
   cairo_restore(cr);
 }
 
@@ -685,7 +684,7 @@ static void _lib_histogram_draw_rgb_parade(dt_lib_histogram_t *d, cairo_t *cr, i
               darktable.gui->ppd*height/d->waveform_height);
   for(int ch = 2; ch >= 0; ch--)
   {
-    _lib_histogram_draw_waveform_channel(d, cr, ch);
+    _lib_histogram_draw_waveform_channel(d, cr, ch, 0.9);
     cairo_translate(cr, d->waveform_width/darktable.gui->ppd, 0);
   }
   cairo_restore(cr);


### PR DESCRIPTION
Fix color math for waveform. Prior to this PR, linear waveform data is converted to a CSS color (which presumably is Rec.709?) then has a gamma curve applied. Now linear waveform data has a gamma curve applied (important for essentially HDR data), then the result used as a mask to draw a color from CSS. This results in a more saturated waveform graph, with colors closer to the regular histogram colors.

Waveform alpha is tuned to approximately match the brightness of the prior code. RGB parade alpha is now set separately to be brighter, as its channels don't overlay, and otherwise it can be hard to discern individual channel detail.

This code also has some optimizations:

- A Cairo mask is used to draw waveform graph in the color of each channel, instead of drawing each channel from an RGB buffer. This reduces the 8-bit waveform buffer from 738K to 184K.
- The BGR -> RGB flip happens when drawing the waveform, rather than for each pixel processed.
- Linear waveform buffer is now `RGB x width x height` rather than `width x height x RGB32`. This reduces the buffer from 984K to 738K.

All told, the new code should drop buffer usage by 800K (from 1722K to 922K). Waveform process time is unchanged. Waveform draw time is approx 10% faster.

Waveform before this PR:

![image](https://user-images.githubusercontent.com/2311860/116501070-e74e9f80-a87d-11eb-9206-e32a39de1e0f.png)

Waveform with this PR:

![image](https://user-images.githubusercontent.com/2311860/116501079-efa6da80-a87d-11eb-9826-1bbbb2a2da60.png)

RGB parade before this PR:

![image](https://user-images.githubusercontent.com/2311860/116501090-f6355200-a87d-11eb-9b0f-559a6b61bc97.png)

RGB parade with this PR:

![image](https://user-images.githubusercontent.com/2311860/116501107-fc2b3300-a87d-11eb-9322-8a64351efc66.png)

I know there are strong opinions about how waveform should look. FWIW, way to tune this are:

- alpha (currently 0.6)
- colors in CSS (also changes regular histogram and RGB parade)
- "brightness" factor for linear data (also changes RGB parade)
- the "transfer function" (currently hybrid log-gamma) from linear (also changes RGB parade)

I'm open to tuning any of these...

I think there's a general feeling that RGB parade is currently too dim, so I hope that this PR is at least an improvement for this.