### PR TITLE
slightly increase padding between module sections and centre-align

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -84,7 +84,7 @@
 /* Modules box (plugins) */
 @define-color plugin_bg_color @grey_20;
 @define-color plugin_fg_color @fg_color;
-@define-color section_label shade(@plugin_fg_color, 0.9);
+@define-color section_label shade(@plugin_fg_color, 0.95);
 @define-color plugin_label_color @grey_65;
 
 /* Modules controls (sliders and comboboxes) */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -638,7 +638,7 @@ overshoot.right
 #lib-plugin-ui .section-expander,
 #iop-plugin-ui .section-expander
 {
-  margin: 0.35em 0;
+  margin: 0.6em 0 0.35em 0;
 }
 
 #iop-plugin-ui #section_label.section_label_top,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -638,7 +638,7 @@ overshoot.right
 #lib-plugin-ui .section-expander,
 #iop-plugin-ui .section-expander
 {
-  margin: 0.6em 0 0.35em 0;
+  margin: 0.5em 0 0.35em 0;
 }
 
 #iop-plugin-ui #section_label.section_label_top,

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -349,7 +349,7 @@ void dt_ellipsize_combo(GtkComboBox *cbox);
 static inline void dt_ui_section_label_set(GtkWidget *label)
 {
   gtk_widget_set_halign(label, GTK_ALIGN_FILL); // make it span the whole available width
-  gtk_label_set_xalign (GTK_LABEL(label), 0.0f);
+  gtk_label_set_xalign (GTK_LABEL(label), 0.5f);
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END); // ellipsize labels
   gtk_widget_set_name(label, "section_label"); // make sure that we can style these easily
 }
@@ -365,7 +365,7 @@ static inline GtkWidget *dt_ui_label_new(const gchar *str)
 {
   GtkWidget *label = gtk_label_new(str);
   gtk_widget_set_halign(label, GTK_ALIGN_START);
-  gtk_label_set_xalign (GTK_LABEL(label), 0.0f);
+  gtk_label_set_xalign (GTK_LABEL(label), 0.5f);
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   return label;
 };

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -365,7 +365,7 @@ static inline GtkWidget *dt_ui_label_new(const gchar *str)
 {
   GtkWidget *label = gtk_label_new(str);
   gtk_widget_set_halign(label, GTK_ALIGN_START);
-  gtk_label_set_xalign (GTK_LABEL(label), 0.5f);
+  gtk_label_set_xalign (GTK_LABEL(label), 0.0f);
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   return label;
 };


### PR DESCRIPTION
Sections look a little too squashed together. This PR slightly increases their separation and centre-aligns them.

Before / After

![Screenshot_2021-04-29_08-34-04](https://user-images.githubusercontent.com/9555491/116516642-beea9380-a8c5-11eb-9ea5-d6fb4d2aa65b.png) ![Screenshot_2021-04-29_10-26-20](https://user-images.githubusercontent.com/9555491/116529940-602d1600-a8d5-11eb-9d69-a9b0685d0cee.png)


