### PR TITLE
Allow RCD fast-math again after checks

### DIFF
--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -412,7 +412,7 @@ kernel void rcd_border_green(read_only image2d_t in, write_only image2d_t out, c
     if(bufidx >= maxbuf) continue;
     const int xx = xul + bufidx % stride;
     const int yy = yul + bufidx / stride;
-    buffer[bufidx] = read_imagef(in, sampleri, (int2)(xx, yy)).x;
+    buffer[bufidx] = fmax(0.0f, read_imagef(in, sampleri, (int2)(xx, yy)).x);
   }
 
   // center buffer around current x,y-Pixel
@@ -427,7 +427,7 @@ kernel void rcd_border_green(read_only image2d_t in, write_only image2d_t out, c
   const int row = y;
   const int col = x;
   const int c = FC(row, col, filters);
-  float4 color; // output color
+  float4 color = 0.0f; // output color
 
   const float pc = buffer[0];
 
@@ -512,7 +512,7 @@ kernel void rcd_border_redblue(read_only image2d_t in, write_only image2d_t out,
     if(bufidx >= maxbuf) continue;
     const int xx = xul + bufidx % stride;
     const int yy = yul + bufidx / stride;
-    buffer[bufidx] = read_imagef(in, sampleri, (int2)(xx, yy));
+    buffer[bufidx] = fmax(0.0f, read_imagef(in, sampleri, (int2)(xx, yy)));
   }
 
   // center buffer around current x,y-Pixel

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -38,7 +38,7 @@
 */
 
 /* Some notes about the algorithm
-* 1. The calculated data at the tiling borders RCD_BORDER must be at least 9 to be stable.
+* 1. The calculated data at the tiling borders RCD_BORDER must be at least 9 to be stable. Why does 8 **not** work?
 * 2. For the outermost tiles we only have to discard a 6 pixel border region interpolated otherwise.
 * 3. The tilesize has a significant influence on performance, the default is a good guess for modern
 *    x86/64 machines, tested on Xeon E-2288G, i5-8250U.
@@ -600,3 +600,4 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
 #undef w4
 #undef eps
 #undef epssq
+


### PR DESCRIPTION
As RCD has been ruled out as the origin of NaNs fired up the pipeline we allow fast-math again for this code section.

The ppg border interpolation has also been checked and there are not div-by-zero or alike.

As the raw input data might have negatives those are checked and clipped to >= 0.0f for both cpu & gpu codepaths.

