### PR TITLE
vectorscope: fixes, speed-ups, cleanups, & appearance updates

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2160,6 +2160,11 @@ post_process_collect_info:
     }
     if(dev->gui_attached && !dev->gui_leaving && pipe == dev->preview_pipe && (strcmp(module->op, "gamma") == 0))
     {
+      // FIXME: read this from dt_ioppr_get_pipe_output_profile_info()?
+      const dt_iop_order_iccprofile_info_t *const display_profile
+        = dt_ioppr_add_profile_info_to_list(dev, darktable.color_profiles->display_type,
+                                            darktable.color_profiles->display_filename, INTENT_RELATIVE_COLORIMETRIC);
+
       // Since histogram is being treated as the second-to-last link
       // in the pixelpipe and has a "process" call, why not treat it
       // as an iop? Granted, other views such as tether may also
@@ -2181,7 +2186,7 @@ post_process_collect_info:
           }
           darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, buf,
                                                  roi_out->width, roi_out->height,
-                                                 darktable.color_profiles->display_type, darktable.color_profiles->display_filename);
+                                                 display_profile, dt_ioppr_get_histogram_profile_info(dev));
           dt_free_align(buf);
         }
       }
@@ -2189,7 +2194,7 @@ post_process_collect_info:
       {
         darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, input,
                                                roi_in.width, roi_in.height,
-                                               darktable.color_profiles->display_type, darktable.color_profiles->display_filename);
+                                               display_profile, dt_ioppr_get_histogram_profile_info(dev));
       }
     }
   }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -457,8 +457,8 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       }
 
       float b[4] DT_ALIGNED_PIXEL = {scale * count,
-        max_diam * (((float)out_x / diam_px) - 0.5f),
-        max_diam * (((float)out_y / diam_px) - 0.5f)};
+        max_diam * (((out_x + 0.5f) / diam_px) - 0.5f),
+        max_diam * (((out_y + 0.5f) / diam_px) - 0.5f)};
 
       const float intensity = lut[(int)(MIN(1.f, b[0]) * lutmax)];
       float XYZ_D50[4] DT_ALIGNED_PIXEL, RGB[4] DT_ALIGNED_PIXEL;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -572,8 +572,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
       _lib_histogram_process_vectorscope(d, img_display, &roi);
       break;
     case DT_LIB_HISTOGRAM_SCOPE_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
   dt_pthread_mutex_unlock(&d->lock);
   dt_free_align(img_display);
@@ -840,8 +839,7 @@ static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointe
       // grid is drawn with scope, as it depends on chromaticity scale
       break;
     case DT_LIB_HISTOGRAM_SCOPE_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
 
   // FIXME: should set histogram buffer to black if have just entered tether view and nothing is displayed
@@ -869,8 +867,7 @@ static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointe
           _lib_histogram_draw_vectorscope(d, cr, width, height);
         break;
       case DT_LIB_HISTOGRAM_SCOPE_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-        g_assert_not_reached();
+        dt_unreachable_codepath();
     }
   }
   dt_pthread_mutex_unlock(&d->lock);
@@ -1071,8 +1068,7 @@ static void _histogram_scale_update(const dt_lib_histogram_t *d)
                              dtgtk_cairo_paint_linear_scale, CPF_NONE, NULL);
       break;
     case DT_LIB_HISTOGRAM_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
   // FIXME: this should really redraw current iop if its background is a histogram (check request_histogram)
   darktable.lib->proxy.histogram.is_linear = d->histogram_scale == DT_LIB_HISTOGRAM_LINEAR;
@@ -1100,8 +1096,7 @@ static void _waveform_view_update(const dt_lib_histogram_t *d)
       gtk_widget_set_sensitive(d->blue_channel_button, FALSE);
       break;
     case DT_LIB_HISTOGRAM_WAVEFORM_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
 }
 
@@ -1121,7 +1116,7 @@ static void _vectorscope_view_update(dt_lib_histogram_t *d)
                              dtgtk_cairo_paint_jzazbz, CPF_NONE, NULL);
       break;
     case DT_LIB_HISTOGRAM_VECTORSCOPE_N:
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
 }
 
@@ -1155,7 +1150,7 @@ static void _scope_type_update(dt_lib_histogram_t *d)
       _vectorscope_view_update(d);
       break;
     case DT_LIB_HISTOGRAM_SCOPE_N:
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
 }
 
@@ -1214,8 +1209,7 @@ static void _scope_view_clicked(GtkWidget *button, dt_lib_histogram_t *d)
         dt_control_queue_redraw_center();
       break;
     case DT_LIB_HISTOGRAM_SCOPE_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
 }
 
@@ -1364,8 +1358,7 @@ static gboolean _lib_histogram_cycle_mode_callback(GtkAccelGroup *accel_group,
       }
       break;
     case DT_LIB_HISTOGRAM_SCOPE_N:
-      // FIXME: use dt_unreachable_codepath_with_desc()
-      g_assert_not_reached();
+      dt_unreachable_codepath();
   }
 
   return TRUE;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -285,8 +285,6 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
 
   const int diam_px = d->vectorscope_diameter_px;
-  const int out_stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px);
-  uint8_t *const out = d->vectorscope_graph;
   const dt_lib_histogram_vectorscope_type_t vs_type = d->vectorscope_type;
 
   // FIXME: is this available from caller?
@@ -353,43 +351,35 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   const float *const restrict in = DT_IS_ALIGNED((const float *const restrict)input);
   int sample_width = MAX(1, roi->width - roi->crop_width - roi->crop_x);
   int sample_height = MAX(1, roi->height - roi->crop_height - roi->crop_y);
-  size_t pt_sample[2];
+  size_t pt_sample;
 
   // point sample still calculates graph based on whole image
   if(sample_width == 1 && sample_height == 1)
   {
-    pt_sample[0] = roi->crop_x;
-    pt_sample[1] = roi->crop_y;
+    pt_sample = ((size_t)roi->width * roi->crop_y + roi->crop_x) * 4U;
     sample_width = roi->width;
     sample_height = roi->height;
-    roi->crop_x = roi->crop_y = roi->crop_width = roi->crop_height = 0;
+    roi->crop_x = roi->crop_y = 0;
   }
   else
   {
-    pt_sample[0] = pt_sample[1] = SIZE_MAX;
+    pt_sample = SIZE_MAX;
     d->vectorscope_pt[0] = NAN;
   }
 
+  // RGB -> chromaticity (processor-heavy and parallelized)
   // FIXME: pre-allocate?
-  float *const restrict binned = dt_iop_image_alloc(diam_px, diam_px, 4);
-  dt_iop_image_fill(binned, 0.0f, diam_px, diam_px, 4);
-  // FIXME: faster to have bins just record count and multiply by scale after?
-  // FIXME: do something fancy where 16 bits of out are pixel count, the other two are chromaticity?
-  const float gain = 1.f / 50.f;
-  const float scale = gain * (diam_px * diam_px) / (sample_width * sample_height);
-
-  // count into bins
+  // FIXME: combine these -- only need two floats for chromaticity (uv or AzBz) and two for XZ
+  float *const restrict chromaticity = dt_iop_image_alloc(sample_width, sample_height, 4);
+  float *const restrict XYZ_D50 = dt_iop_image_alloc(sample_width, sample_height, 4);
   // FIXME: move verbosed interleaved comments into a method note at the start, as the code itself is succinct and clear
-  float bounds_x = 0.f, bounds_y = 0.f;
-  const size_t in_stride = roi->width;
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, binned, roi, in_stride, pt_sample, d, vs_prof, diam_px, max_diam, scale, vs_type) \
-  reduction(max : bounds_x, bounds_y) \
+  dt_omp_firstprivate(in, XYZ_D50, chromaticity, sample_width, sample_height, roi, vs_prof, vs_type) \
   schedule(static)
 #endif
-  for(size_t in_y = roi->crop_y; in_y < roi->height - roi->crop_height; in_y++)
-    for(size_t in_x = roi->crop_x; in_x < roi->width - roi->crop_width; in_x++)
+  for(size_t y=0; y<sample_height; y++)
+    for(size_t x=0; x<sample_width; x++)
     {
       // FIXME: Are there are unnecessary color math hops? Right now the data
       // comes into dt_lib_histogram_process() in a known profile
@@ -401,18 +391,19 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       // conversion to histogram profile is relative colorimetric, how
       // does this compare to:
       //   RGB (pixelpipe) -> XYZ(PCS, D50) -> chromaticity
-      float XYZ_D50[4] DT_ALIGNED_PIXEL, chromaticity[4] DT_ALIGNED_PIXEL;
+      size_t k = 4U * (y * sample_width + x);
       // this goes to the PCS which has standard illuminant D50
-      dt_ioppr_rgb_matrix_to_xyz(in + 4U * (in_y * in_stride + in_x), XYZ_D50, vs_prof->matrix_in, vs_prof->lut_in,
+      dt_ioppr_rgb_matrix_to_xyz(in + 4U * ((y + roi->crop_y) * roi->width + x + roi->crop_x),
+                                 XYZ_D50+k, vs_prof->matrix_in, vs_prof->lut_in,
                                  vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
       // NOTE: see for comparison/reference rgb_to_JzCzhz() in color_picker.c
       if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
       {
         // FIXME: do have to worry about chromatic adaptation? this assumes that the histogram profile white point is the same as PCS whitepoint (D50) -- if we have a D65 whitepoint profile, how does the result change if we adapt to D65 then convert to L*u*v* with a D65 whitepoint?
         float xyY_D50[4] DT_ALIGNED_PIXEL;
-        dt_XYZ_to_xyY(XYZ_D50, xyY_D50);
+        dt_XYZ_to_xyY(XYZ_D50+k, xyY_D50);
         // using D50 correct u*v* (not u'v') to be relative to the whitepoint (important for vectorscope) and as u*v* is more evenly spaced
-        dt_xyY_to_Luv(xyY_D50, chromaticity);
+        dt_xyY_to_Luv(xyY_D50, chromaticity+k);
       }
       else
       {
@@ -423,38 +414,50 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
         // Bradford. Using Bradford again to adapt back to D65 gives a
         // pretty clean reversal of the transform.
         // FIXME: if the profile whitepoint is D50 (ProPhoto...), then should we use a nicer adaptation (CAT16?) to D65?
-        dt_XYZ_D50_2_XYZ_D65(XYZ_D50, XYZ_D65);
+        dt_XYZ_D50_2_XYZ_D65(XYZ_D50+k, XYZ_D65);
         // FIXME: The bulk of processing time is spent in the XYZ -> JzAzBz conversion in the 2*3 powf() in X'Y'Z' -> L'M'S'. Making a LUT for these, using _apply_trc() to do powf() work. It only needs to be accurate enough to be about on the right pixel for a diam_px x diam_px plot
-        dt_XYZ_2_JzAzBz(XYZ_D65, chromaticity);
-      }
-
-      if(pt_sample[0] == in_x && pt_sample[1] == in_y)
-      {
-        d->vectorscope_pt[0] = chromaticity[1];
-        d->vectorscope_pt[1] = chromaticity[2];
-      }
-
-      bounds_x = MAX(bounds_x, fabsf(chromaticity[1]));
-      bounds_y = MAX(bounds_y, fabsf(chromaticity[2]));
-      const int out_x = diam_px * (chromaticity[1] / max_diam + 0.5f);
-      const int out_y = diam_px * (chromaticity[2] / max_diam + 0.5f);
-
-      // clip any out-of-scale values, so there aren't light edges
-      if(out_x >= 0 && out_x < diam_px-1 && out_y >= 0 && out_y <= diam_px-1)
-      {
-        // FIXME: is this helpful?
-        // FIXME: do need (size_t)4U?
-        float *const restrict b = binned + 4U * (out_y * diam_px + out_x);
-        // FIXME: if necessary average XYZ values if they're in a big range -- test this -- and cast b[3] to an int and store a count
-        // FIXME: this is a repeat assign on multiple iterations, though may be slightly different each time -- instead calculate the out_x/out_y to chromaticity below? -- or average these -- probably no perceptible difference -- or test if unassigned and then assign?
-        // FIXME: make this atomic!
-        b[0] = XYZ_D50[0];
-        // FIXME: we don't care about this, we'll set it from intensity?
-        b[1] = XYZ_D50[1];
-        b[2] = XYZ_D50[2];
-        b[3] += scale;
+        dt_XYZ_2_JzAzBz(XYZ_D65, chromaticity+k);
       }
     }
+
+  // FIXME: pre-allocate?
+  float *const restrict binned = dt_iop_image_alloc(diam_px, diam_px, 4);
+  dt_iop_image_fill(binned, 0.0f, diam_px, diam_px, 4);
+  // FIXME: faster to have bins just record count and multiply by scale after?
+  // FIXME: do something fancy where 16 bits of out are pixel count, the other two are chromaticity?
+  const float gain = 1.f / 50.f;
+  const float scale = gain * (diam_px * diam_px) / (sample_width * sample_height);
+
+  // count into bins by chromaticity (processor light, not paralellized so no races)
+  // FIXME: do bounds work in RGB -> chromaticity above with a reduction(max : bounds_x, bounds_y)?
+  float bounds_x = 0.f, bounds_y = 0.f;
+  const size_t nfloats = sample_width * sample_height * 4U;
+  for(size_t k=0; k < nfloats; k+=4)
+  {
+    if(k == pt_sample)
+    {
+      d->vectorscope_pt[0] = chromaticity[k+1];
+      d->vectorscope_pt[1] = chromaticity[k+2];
+    }
+    bounds_x = MAX(bounds_x, fabsf(chromaticity[k+1]));
+    bounds_y = MAX(bounds_y, fabsf(chromaticity[k+2]));
+    // FIXME: make cx,cy which are float, check 0 <= cx < 1, then multiply by diam_px
+    const int out_x = diam_px * (chromaticity[k+1] / max_diam + 0.5f);
+    const int out_y = diam_px * (chromaticity[k+2] / max_diam + 0.5f);
+
+    // clip any out-of-scale values, so there aren't light edges
+    if(out_x >= 0 && out_x <= diam_px-1 && out_y >= 0 && out_y <= diam_px-1)
+    {
+      float *const restrict b = binned + 4U * (out_y * diam_px + out_x);
+      // FIXME: if necessary average XYZ values if they're in a big range -- test this -- and cast b[3] to an int and store a count
+      // FIXME: this is a repeat assign on multiple iterations, though may be slightly different each time -- instead calculate the out_x/out_y to chromaticity below? -- or average these -- probably no perceptible difference -- or test if unassigned and then assign?
+      b[0] = XYZ_D50[k];
+      // FIXME: we don't care about this, we'll set it from intensity?
+      b[1] = XYZ_D50[k+1];
+      b[2] = XYZ_D50[k+2];
+      b[3] += scale;
+    }
+  }
   d->vectorscope_bounds[0] = bounds_x;
   d->vectorscope_bounds[1] = bounds_y;
 
@@ -463,6 +466,8 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
     dt_ioppr_add_profile_info_to_list(darktable.develop, DT_COLORSPACE_HLG_REC2020, "", DT_INTENT_PERCEPTUAL);
   const float *const restrict lut = DT_IS_ALIGNED((const float *const restrict)profile->lut_out[0]);
   const float lutmax = profile->lutsize - 1;
+  const int out_stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px);
+  uint8_t *const graph = d->vectorscope_graph;
 
   // loop appears to be too small to benefit w/OpenMP
   // FIXME: is this still true?
@@ -471,7 +476,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
     {
       // FIXME: do need (size_t)4U?
       const float *const restrict b = binned + 4U * (out_y * diam_px + out_x);
-      uint8_t *const restrict px = out + out_y * out_stride + out_x * 4U;
+      uint8_t *const restrict px = graph + out_y * out_stride + out_x * 4U;
       const float intensity = lut[(int)(MIN(1.f, b[3]) * lutmax)];
       // FIXME: can use fewer temps
       float XYZ[4] DT_ALIGNED_PIXEL, xyY[4] DT_ALIGNED_PIXEL, Lch[4] DT_ALIGNED_PIXEL, RGB[4] DT_ALIGNED_PIXEL;
@@ -494,6 +499,8 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
     }
 
   dt_free_align(binned);
+  dt_free_align(chromaticity);
+  dt_free_align(XYZ_D50);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -487,11 +487,9 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       dt_xyY_to_XYZ(xyY, XYZ);
       dt_XYZ_to_Rec709_D50(XYZ, RGB);
       // FIXME: instead of doing this pre-colorspace, do a quick hack of XYZ -> xyY, scale the Y, then -> XYZ -> Rec709_D50 -- or if that is fishy because they're tied to stimulus and not response, do the quickest possible conversion (to Luv/Lch?) and scale in that space
-      // FIXME: hack to keep compiler happy -- instead just unroll loop if don't use alpha?
-      RGB[3] = intensity;
-      for_each_channel(ch,aligned(px,RGB:16))
-        // FIXME: this BGR/RGB flip is for pixelpipe vs. Cairo color?
-        // FIXME: this produces px[-1] for ch==3, which will be out of bounds for out_y == out_x == 0?
+      // BGR/RGB flip is for pixelpipe vs. Cairo color?
+      // FIXME: but don't want to flip earlier when binning?
+      for(int ch=0; ch<3; ch++)
         px[2U-ch] = CLAMP((int)(RGB[ch] * 255.0f), 0, 255);
     }
 
@@ -751,7 +749,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   // vectorscope graph
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px);
-  // FIXME: if use cairo_mask() could calculate a false color vectorscope and draw with appropriate hues? and if so could also simplify waveform drawing code above, to use color mask to alter channel visibility
+  // FIXME: if use cairo_mask() could calculate a false color vectorscope and draw with appropriate hues?
   cairo_surface_t *source = dt_cairo_image_surface_create_for_data(d->vectorscope_graph, CAIRO_FORMAT_RGB24,
                                                                    diam_px, diam_px, stride);
 

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -73,7 +73,8 @@ typedef struct dt_lib_t
       struct dt_lib_module_t *module;
       void (*process)(struct dt_lib_module_t *self, const float *const input,
                       int width, int height,
-                      dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename);
+                      const dt_iop_order_iccprofile_info_t *const profile_info_from,
+                      const dt_iop_order_iccprofile_info_t *const profile_info_to);
       // FIXME: now that PR #5532 is merged, define this as dt_atomic_int and include "common/atomic.h" and use dt_atomic_set_int() and dt_atomic_get_int()
       gboolean is_linear;
     } histogram;

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "common/darktable.h"
-#include "common/colorspaces.h"
+#include "common/iop_profile.h"
 #include "views/view.h"
 #include <gmodule.h>
 #include <gtk/gtk.h>


### PR DESCRIPTION
This is a series of fixes to the vectorscope code to follow-up on #8005.

Main visible changes:

- It is faster (approx 3.4x for JzAzBz, 3.7x for Luv). This makes vectorscope as fast to calculate (or faster) than the regular or waveform histogram.
- The graph drawing is revised to give more sense of "volume" in the denser parts of the graph.

Main underlying changes:

- As the image is processed based on PCS (XYZ D50) rather than profiled RGB, don't bother to convert to histogram profile (gets rid of a ~19MB temporary buffer and unneeded color math steps).
- Average 2x2 RGB pixel squares and use their chromaticity for binning, giving 2.5x (Luv) or 2.9x (JzAzBz) speedup, as most of the math is converting RGB to Luv or JzAzBz.
- Use a LUT for converting linear bin counts to display graph, removing a slow powf().
- Don't cache chromaticity #'s when binning, saving another 1.6MB of buffer space.
- Skip graphing math for bins with no chromaticity counts.

Some bugs are fixed:
- Atomically increment bin counts, to eliminate a potential race which could undercount common colors.
- Fix a possible out-of-range reference if a color graphed to (0,0) in the vectorscope.
- Fixed a bug where any chromaticities with a very high u or Az value weren't graphed.

Some minor changes:
- Don't recalculate hue ring until histogram profile changes (hue ring does depend on histogram profile, unlike the vectorscope graph). This gives a minor speed-up, but also clarifies the code.
- Move all the timing code to the main scope process function, instead of having each scope have its own timing code.
- Replace calls to g_assert_not_reached() with dt_unreachable_codepath(), in keeping with recent darktable coding practices.
- Remove some special-case color conversions for point samples -- they're now folded into the main binning loop.

I've got mixed feelings about downsampling the image before processing it for the vectorscope. It does give a huge speedup, but even without that work, this PR gives some speed-up (1.4x for Luv, 1.2x for JzAzBz). It does seem compelling to me that the graph output still looks good (maybe better, as the downsampling removes some one-off chromaticities) and that this makes the code as fast as (or faster than) the other scopes.

This PR doesn't add back in a manual UI for scaling/recentering the vectorscope (see https://github.com/darktable-org/darktable/pull/8005#issuecomment-825773266). I will work on that.

Comparisons:

Before this PR, Luv

![image](https://user-images.githubusercontent.com/2311860/116839389-3fe4ac00-aba0-11eb-8b77-9783bcc83ef8.png)

With this PR, Luv

![image](https://user-images.githubusercontent.com/2311860/116839382-39eecb00-aba0-11eb-90a9-e840aef0d0c4.png)

Before this PR, JzAzBz

![image](https://user-images.githubusercontent.com/2311860/116839402-4a9f4100-aba0-11eb-87b0-23bd1a56068d.png)

With this PR, JzAzBz

![image](https://user-images.githubusercontent.com/2311860/116839398-470bba00-aba0-11eb-8dfd-3559336c1d2a.png)

The added detail in the more intense parts of the graph ("volume") is from adjusting scaling & color math when making the graph. The disappearance of information at the edge of the graph comes from average 2x2 pixel squares before processing, removing some uncommon chromaticities.
