### PR TITLE
Fix mask fast 9x9blurring

### DIFF
--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -402,9 +402,7 @@ __kernel void write_blended_dual(__read_only image2d_t high, __read_only image2d
   write_imagef(out, (int2)(col, row), data);
 }
 
-__kernel void fastblur_mask_9x9(global float *src, global float *out, const int w, const int height, const float c42, const float c41, const float c40,
-                             const float c33, const float c32, const float c31, const float c30, const float c22, const float c21,
-                             const float c20, const float c11, const float c10, const float c00)
+__kernel void fastblur_mask_9x9(global float *src, global float *out, const int w, const int height, global float *kern)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
@@ -420,19 +418,19 @@ __kernel void fastblur_mask_9x9(global float *src, global float *out, const int 
   const int w2 = 2 * w;
   const int w3 = 3 * w;
   const int w4 = 4 * w;
-  const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
-                    c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i -  w - 4] + src[i -  w + 4] + src[i +  w - 4] + src[i +  w + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
-                    c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
-                    c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
-                    c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
-                    c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i -  w - 3] + src[i -  w + 3] + src[i +  w - 3] + src[i +  w + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
-                    c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
-                    c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
-                    c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i -  w - 2] + src[i -  w + 2] + src[i +  w - 2] + src[i +  w + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
-                    c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
-                    c11 * (src[i -  w - 1] + src[i -  w + 1] + src[i +  w - 1] + src[i +  w + 1]) +
-                    c10 * (src[i -  w] + src[i - 1] + src[i + 1] + src[i +  w]) +
-                    c00 * src[i];
+  const float val = kern[12] * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
+                    kern[11] * (src[i - w4 - 1] + src[i - w4 + 1] + src[i -  w - 4] + src[i -  w + 4] + src[i +  w - 4] + src[i +  w + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
+                    kern[10] * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
+                    kern[9] * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
+                    kern[8] * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
+                    kern[7] * (src[i - w3 - 1] + src[i - w3 + 1] + src[i -  w - 3] + src[i -  w + 3] + src[i +  w - 3] + src[i +  w + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
+                    kern[6] * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
+                    kern[5] * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
+                    kern[4] * (src[i - w2 - 1] + src[i - w2 + 1] + src[i -  w - 2] + src[i -  w + 2] + src[i +  w - 2] + src[i +  w + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
+                    kern[3] * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
+                    kern[2] * (src[i -  w - 1] + src[i -  w + 1] + src[i +  w - 1] + src[i +  w + 1]) +
+                    kern[1] * (src[i -  w] + src[i - 1] + src[i + 1] + src[i +  w]) +
+                    kern[0] * src[i];
   out[oidx] = ICLAMP(val, 0.0f, 1.0f);
 }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -658,41 +658,32 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
       for(int j = 0; j < 9; j++)
         kernel[i][j] /= sum;
     }
-    const float c42 = kernel[0][2];
-    const float c41 = kernel[0][3];
-    const float c40 = kernel[0][4];
-    const float c33 = kernel[1][1];
-    const float c32 = kernel[1][2];
-    const float c31 = kernel[1][3];
-    const float c30 = kernel[1][4];
-    const float c22 = kernel[2][2];
-    const float c21 = kernel[2][3];
-    const float c20 = kernel[2][4];
-    const float c11 = kernel[3][3];
-    const float c10 = kernel[3][4];
-    const float c00 = kernel[4][4];
 
-    size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
-    const int clkernel = darktable.opencl->blendop->kernel_mask_blur;
-    dt_opencl_set_kernel_arg(devid, clkernel, 0, sizeof(cl_mem), &blur);
-    dt_opencl_set_kernel_arg(devid, clkernel, 1, sizeof(cl_mem), &out);
-    dt_opencl_set_kernel_arg(devid, clkernel, 2, sizeof(int), &iwidth);
-    dt_opencl_set_kernel_arg(devid, clkernel, 3, sizeof(int), &iheight);
-    dt_opencl_set_kernel_arg(devid, clkernel, 4, sizeof(int), &c42);
-    dt_opencl_set_kernel_arg(devid, clkernel, 5, sizeof(int), &c41);
-    dt_opencl_set_kernel_arg(devid, clkernel, 6, sizeof(int), &c40);
-    dt_opencl_set_kernel_arg(devid, clkernel, 7, sizeof(int), &c33);
-    dt_opencl_set_kernel_arg(devid, clkernel, 8, sizeof(int), &c32);
-    dt_opencl_set_kernel_arg(devid, clkernel, 9, sizeof(int), &c31);
-    dt_opencl_set_kernel_arg(devid, clkernel, 10, sizeof(int), &c30);
-    dt_opencl_set_kernel_arg(devid, clkernel, 11, sizeof(int), &c22);
-    dt_opencl_set_kernel_arg(devid, clkernel, 12, sizeof(int), &c21);
-    dt_opencl_set_kernel_arg(devid, clkernel, 13, sizeof(int), &c20);
-    dt_opencl_set_kernel_arg(devid, clkernel, 14, sizeof(int), &c11);
-    dt_opencl_set_kernel_arg(devid, clkernel, 15, sizeof(int), &c10);
-    dt_opencl_set_kernel_arg(devid, clkernel, 16, sizeof(int), &c00);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, clkernel, sizes);
-    if(err != CL_SUCCESS) goto error;
+    float blurmat[13] = { kernel[4][4], kernel[3][4], kernel[3][3],               // 00: c00 c10 c11
+                          kernel[2][4], kernel[2][3], kernel[2][2],               // 03: c20 c21 c22
+                          kernel[1][4], kernel[1][3], kernel[1][2], kernel[1][1], // 06: c30 c31 c32 c33
+                          kernel[0][4], kernel[0][3], kernel[0][2]};              // 10: c40 c41 c42
+    cl_mem dev_blurmat = NULL;
+    dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
+    if(dev_blurmat != NULL)
+    {
+      size_t sizes[3] = { ROUNDUPWD(iwidth), ROUNDUPHT(iheight), 1 };
+      const int clkernel = darktable.opencl->blendop->kernel_mask_blur;
+      dt_opencl_set_kernel_arg(devid, clkernel, 0, sizeof(cl_mem), &blur);
+      dt_opencl_set_kernel_arg(devid, clkernel, 1, sizeof(cl_mem), &out);
+      dt_opencl_set_kernel_arg(devid, clkernel, 2, sizeof(int), &iwidth);
+      dt_opencl_set_kernel_arg(devid, clkernel, 3, sizeof(int), &iheight);
+      dt_opencl_set_kernel_arg(devid, clkernel, 4, sizeof(cl_mem), (void *) &dev_blurmat);
+      const int err = dt_opencl_enqueue_kernel_2d(devid, clkernel, sizes);
+      dt_opencl_release_mem_object(dev_blurmat);
+      if(err != CL_SUCCESS) goto error;
+    }
+    else
+    {
+      dt_opencl_release_mem_object(dev_blurmat);
+      goto error;
+    }
+
   }
 
   {


### PR DESCRIPTION
As suggested by @aurelienpierre there is a more elegant way to pass the kernel parameters.