### PR TITLE
Add CSS chunk for label inside section label.

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -80,7 +80,8 @@ box *
 }
 
 button,
-#section_label
+#section_label,
+#section_label *
 {
     font-family: "Roboto Medium", "Roboto",
                  "Segoe UI Semibold", "Segoe UI",
@@ -114,4 +115,3 @@ tooltip label,
                  "Cantarell",
                   sans-serif;
 }
-

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -624,13 +624,18 @@ overshoot.right
 }
 
 /* Labels of controls sections in modules */
-#section_label
+#section_label,
+#section_label *
 {
   padding: 0;
   color: @section_label;
-  border-bottom: 0.035em solid  @section_label;
   font-family: sans-serif;
   font-weight: 500;
+}
+
+#section_label
+{
+  border-bottom: 0.035em solid  @section_label;
 }
 
 #iop-plugin-ui #section_label,

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -528,8 +528,6 @@ void dt_bauhaus_load_theme()
   darktable.bauhaus->line_space = 1.5;
   darktable.bauhaus->line_height = 9;
   darktable.bauhaus->marker_size = 0.25f;
-  darktable.bauhaus->label_font_size = 0.6f;
-  darktable.bauhaus->value_font_size = 0.6f;
 
   GtkWidget *root_window = dt_ui_main_window(darktable.gui->ui);
   GtkStyleContext *ctx = gtk_style_context_new();

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -220,10 +220,6 @@ typedef struct dt_bauhaus_t
   float baseline_size;                   // height of the slider bar
   float border_width;                    // width of the border of the slider marker
   float quad_width;                      // width of the quad area to paint icons
-  float label_font_size;                 // percent of line height to fill with font for labels
-  float value_font_size;                 // percent of line height to fill with font for values
-  char label_font[256];                  // font to draw the label with
-  char value_font[256];                  // font to draw the value with
   PangoFontDescription *pango_font_desc; // no need to recreate this for every string we want to print
   PangoFontDescription *pango_sec_font_desc; // as above but for section labels
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -154,6 +154,8 @@ typedef struct dt_bauhaus_widget_t
   void *quad_paint_data;
   // quad is a toggle button?
   int quad_toggle;
+  // if a section label
+  gboolean is_section;
 
   // function to populate the combo list on the fly
   void (*combo_populate)(GtkWidget *w, struct dt_iop_module_t **module);
@@ -223,6 +225,7 @@ typedef struct dt_bauhaus_t
   char label_font[256];                  // font to draw the label with
   char value_font[256];                  // font to draw the value with
   PangoFontDescription *pango_font_desc; // no need to recreate this for every string we want to print
+  PangoFontDescription *pango_sec_font_desc; // as above but for section labels
 
   // the slider popup has a blinking cursor
   guint cursor_timeout;
@@ -246,6 +249,10 @@ void dt_bauhaus_cleanup();
 
 // load theme colors, fonts, etc
 void dt_bauhaus_load_theme();
+
+// set the bauhaus widget as a module section and in this case the font used will be the one
+// from the CSS section_label.
+void dt_bauhaus_widget_set_section(GtkWidget *w, const gboolean is_section);
 
 // common functions:
 // set the label text:

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2295,6 +2295,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->masks_combo = dt_bauhaus_combobox_new(module);
     dt_bauhaus_widget_set_label(bd->masks_combo, N_("blend"), N_("drawn mask"));
+    dt_bauhaus_widget_set_section(bd->masks_combo, TRUE);
 
     dt_bauhaus_combobox_add(bd->masks_combo, _("no mask used"));
     dt_bauhaus_combobox_set(bd->masks_combo, 0);


### PR DESCRIPTION
This is to fix the rendering of blending section where it cannot be created
as other section labels has having some icons on the right on the same line.

So we add a specific rule to have those label standout as for other
section labels.

(see `parametric mask` & `mask refinement` labels in the screenshots)

before:
![Capture d’écran de 2021-05-03 19-15-38](https://user-images.githubusercontent.com/467069/116910407-e0d97280-ac45-11eb-9412-bae853167391.png)

after:
![Capture d’écran de 2021-05-03 19-25-47](https://user-images.githubusercontent.com/467069/116910419-e636bd00-ac45-11eb-8226-94479eb71206.png)
