### PR TITLE
Fix opencl kernel includes

### DIFF
--- a/data/kernels/basecurve.cl
+++ b/data/kernels/basecurve.cl
@@ -17,7 +17,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "color_conversion.cl"
+#include "color_conversion.h"
 #include "rgb_norms.h"
 
 /* we use this exp approximation to maintain full identity with cpu path */

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -18,8 +18,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "colorspace.cl"
-#include "color_conversion.cl"
+#include "colorspace.h"
+#include "color_conversion.h"
 #include "rgb_norms.h"
 
 int

--- a/data/kernels/basicadj.cl
+++ b/data/kernels/basicadj.cl
@@ -16,7 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "color_conversion.cl"
+#include "color_conversion.h"
 #include "rgb_norms.h"
 
 float get_gamma(const float x, const float gamma)

--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -16,8 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "colorspace.cl"
-#include "color_conversion.cl"
+#include "colorspace.h"
+#include "color_conversion.h"
 
 typedef enum dt_develop_blend_mode_t
 {

--- a/data/kernels/bloom.cl
+++ b/data/kernels/bloom.cl
@@ -17,7 +17,7 @@
 */
 
 #include "common.h"
-#include "colorspace.cl"
+#include "colorspace.h"
 
 
 /* first step for bloom module: get the thresholded lights into buffer */

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -17,7 +17,7 @@
 */
 
 #include "common.h"
-#include "colorspace.cl"
+#include "colorspace.h"
 
 
 __kernel void

--- a/data/kernels/retouch.cl
+++ b/data/kernels/retouch.cl
@@ -16,7 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "colorspace.cl"
+#include "colorspace.h"
 #include "common.h"
 
 typedef struct dt_iop_roi_t

--- a/data/kernels/rgbcurve.cl
+++ b/data/kernels/rgbcurve.cl
@@ -16,7 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "color_conversion.cl"
+#include "color_conversion.h"
 #include "rgb_norms.h"
 
 kernel void

--- a/data/kernels/rgblevels.cl
+++ b/data/kernels/rgblevels.cl
@@ -16,7 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "color_conversion.cl"
+#include "color_conversion.h"
 #include "rgb_norms.h"
 
 float rgblevels_1c(const float pixel, global const float *levels, const float inv_gamma, read_only image2d_t lut)

--- a/data/kernels/soften.cl
+++ b/data/kernels/soften.cl
@@ -17,7 +17,7 @@
 */
 
 #include "common.h"
-#include "colorspace.cl"
+#include "colorspace.h"
 
 
 /* first step for soften module: generate overexposed image */


### PR DESCRIPTION
Updated opencl kernel includes to use colorspace.h and color_conversion.h