### PR TITLE
lens: fix roi_in computation

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -1045,15 +1045,27 @@ lens_distort_bilinear (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[0] - roi_in_x;
   ry = ppi[1] - roi_in_y;
-  pixel.x = (rx >= 0 && ry >= 0 && rx <= iwidth - 1 && ry <= iheight - 1) ? read_imagef(in, samplerf, (float2)(rx, ry)).x : NAN;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
+  pixel.x = read_imagef(in, samplerf, (float2)(rx, ry)).x;
 
   rx = ppi[2] - roi_in_x;
   ry = ppi[3] - roi_in_y;
-  pixel.yw = (rx >= 0 && ry >= 0 && rx <= iwidth - 1 && ry <= iheight - 1) ? read_imagef(in, samplerf, (float2)(rx, ry)).yw : (float2)NAN;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
+  pixel.yw = read_imagef(in, samplerf, (float2)(rx, ry)).yw;
 
   rx = ppi[4] - roi_in_x;
   ry = ppi[5] - roi_in_y;
-  pixel.z = (rx >= 0 && ry >= 0 && rx <= iwidth - 1 && ry <= iheight - 1) ? read_imagef(in, samplerf, (float2)(rx, ry)).z : NAN;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
+  pixel.z = read_imagef(in, samplerf, (float2)(rx, ry)).z;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
 
@@ -1099,6 +1111,10 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
 
   rx = ppi[0] - (float)roi_in_x;
   ry = ppi[1] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1108,12 +1124,16 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_bicubic((float)i - rx);
     float wy = interpolation_func_bicubic((float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum += read_imagef(in, samplerc, (int2)(i, j)).x * w;
     weight += w;
@@ -1123,6 +1143,10 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
 
   rx = ppi[2] - (float)roi_in_x;
   ry = ppi[3] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1132,12 +1156,16 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_bicubic((float)i - rx);
     float wy = interpolation_func_bicubic((float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum2 += read_imagef(in, samplerc, (int2)(i, j)).yw * w;
     weight += w;
@@ -1147,6 +1175,10 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
 
   rx = ppi[4] - (float)roi_in_x;
   ry = ppi[5] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1156,12 +1188,16 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_bicubic((float)i - rx);
     float wy = interpolation_func_bicubic((float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum += read_imagef(in, samplerc, (int2)(i, j)).z * w;
     weight += w;
@@ -1213,6 +1249,10 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[0] - (float)roi_in_x;
   ry = ppi[1] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1222,12 +1262,16 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_lanczos(2, (float)i - rx);
     float wy = interpolation_func_lanczos(2, (float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum += read_imagef(in, samplerc, (int2)(i, j)).x * w;
     weight += w;
@@ -1237,6 +1281,10 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[2] - (float)roi_in_x;
   ry = ppi[3] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1246,12 +1294,16 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_lanczos(2, (float)i - rx);
     float wy = interpolation_func_lanczos(2, (float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum2 += read_imagef(in, samplerc, (int2)(i, j)).yw * w;
     weight += w;
@@ -1261,6 +1313,10 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[4] - (float)roi_in_x;
   ry = ppi[5] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1270,12 +1326,16 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_lanczos(2, (float)i - rx);
     float wy = interpolation_func_lanczos(2, (float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum += read_imagef(in, samplerc, (int2)(i, j)).z * w;
     weight += w;
@@ -1326,6 +1386,10 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[0] - (float)roi_in_x;
   ry = ppi[1] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1335,12 +1399,16 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_lanczos(3, (float)i - rx);
     float wy = interpolation_func_lanczos(3, (float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum += read_imagef(in, samplerc, (int2)(i, j)).x * w;
     weight += w;
@@ -1350,6 +1418,10 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[2] - (float)roi_in_x;
   ry = ppi[3] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1359,12 +1431,16 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_lanczos(3, (float)i - rx);
     float wy = interpolation_func_lanczos(3, (float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum2 += read_imagef(in, samplerc, (int2)(i, j)).yw * w;
     weight += w;
@@ -1374,6 +1450,10 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
 
   rx = ppi[4] - (float)roi_in_x;
   ry = ppi[5] - (float)roi_in_y;
+  rx = (rx >= 0) ? rx : 0;
+  ry = (ry >= 0) ? ry : 0;
+  rx = (rx <= iwidth - 1) ? rx : iwidth - 1;
+  ry = (ry <= iheight - 1) ? ry : iheight - 1;
 
   tx = rx;
   ty = ry;
@@ -1383,12 +1463,16 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
   for(int jj = 1 - kwidth; jj <= kwidth; jj++)
     for(int ii= 1 - kwidth; ii <= kwidth; ii++)
   {
-    const int i = tx + ii;
-    const int j = ty + jj;
+    int i = tx + ii;
+    int j = ty + jj;
+    i = (i >= 0) ? i : 0;
+    j = (j >= 0) ? j : 0;
+    i = (i <= iwidth - 1) ? i : iwidth - 1;
+    j = (j <= iheight - 1) ? j : iheight - 1;
 
     float wx = interpolation_func_lanczos(3, (float)i - rx);
     float wy = interpolation_func_lanczos(3, (float)j - ry);
-    float w = (i < 0 || j < 0 || i >= iwidth || j >= iheight) ? 0.0f : wx * wy;
+    float w = wx * wy;
 
     sum += read_imagef(in, samplerc, (int2)(i, j)).z * w;
     weight += w;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1057,12 +1057,16 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 #endif
       for(size_t k = 0; k < nbpoints; k++)
       {
-        const float x = buf[6 * k + 0];
-        const float y = buf[6 * k + 3];
-        xm = isnan(x) ? xm : MIN(xm, x);
-        xM = isnan(x) ? xM : MAX(xM, x);
-        ym = isnan(y) ? ym : MIN(ym, y);
-        yM = isnan(y) ? yM : MAX(yM, y);
+        // iterate over RGB channels x and y coordinates
+        for(size_t c = 0; c < 6; c+=2)
+        {
+          const float x = buf[6 * k + c];
+          const float y = buf[6 * k + c + 1];
+          xm = isnan(x) ? xm : MIN(xm, x);
+          xM = isnan(x) ? xM : MAX(xM, x);
+          ym = isnan(y) ? ym : MIN(ym, y);
+          yM = isnan(y) ? yM : MAX(yM, y);
+        }
       }
     }
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -432,8 +432,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
             }
 
             const float *const inptr = (const float *const)ivoid + (size_t)c;
-            const float pi0 = bufptr[c * 2] - roi_in->x;
-            const float pi1 = bufptr[c * 2 + 1] - roi_in->y;
+            const float pi0 = fmaxf(fminf(bufptr[c * 2] - roi_in->x, roi_in->width - 1.0f), 0.0f);
+            const float pi1 = fmaxf(fminf(bufptr[c * 2 + 1] - roi_in->y, roi_in->height - 1.0f), 0.0f);
             out[c] = dt_interpolation_compute_sample(interpolation, inptr, pi0, pi1, roi_in->width,
                                                      roi_in->height, ch, ch_width);
           }
@@ -448,8 +448,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
             // take green channel distortion also for alpha channel
             const float *const inptr = (const float *const)ivoid + (size_t)3;
-            const float pi0 = bufptr[2] - roi_in->x;
-            const float pi1 = bufptr[3] - roi_in->y;
+            const float pi0 = fmaxf(fminf(bufptr[2] - roi_in->x, roi_in->width - 1.0f), 0.0f);
+            const float pi1 = fmaxf(fminf(bufptr[3] - roi_in->y, roi_in->height - 1.0f), 0.0f);
             out[3] = dt_interpolation_compute_sample(interpolation, inptr, pi0, pi1, roi_in->width,
                                                      roi_in->height, ch, ch_width);
           }
@@ -537,8 +537,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
             }
 
             float *bufptr = ((float *)buf) + c;
-            const float pi0 = buf2ptr[c * 2] - roi_in->x;
-            const float pi1 = buf2ptr[c * 2 + 1] - roi_in->y;
+            const float pi0 = fmaxf(fminf(buf2ptr[c * 2] - roi_in->x, roi_in->width - 1.0f), 0.0f);
+            const float pi1 = fmaxf(fminf(buf2ptr[c * 2 + 1] - roi_in->y, roi_in->height - 1.0f), 0.0f);
             out[c] = dt_interpolation_compute_sample(interpolation, bufptr, pi0, pi1, roi_in->width,
                                                      roi_in->height, ch, ch_width);
           }
@@ -553,8 +553,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
             // take green channel distortion also for alpha channel
             float *bufptr = ((float *)buf) + 3;
-            const float pi0 = buf2ptr[2] - roi_in->x;
-            const float pi1 = buf2ptr[3] - roi_in->y;
+            const float pi0 = fmaxf(fminf(buf2ptr[2] - roi_in->x, roi_in->width - 1.0f), 0.0f);
+            const float pi1 = fmaxf(fminf(buf2ptr[3] - roi_in->y, roi_in->height - 1.0f), 0.0f);
             out[3] = dt_interpolation_compute_sample(interpolation, bufptr, pi0, pi1, roi_in->width,
                                                      roi_in->height, ch, ch_width);
           }


### PR DESCRIPTION
With TCA correction, the coordinates of transformation from R, G, and B channels can be different.
Thus, we have to take all of them into account.
Partial fix for #8865. Makes the issue much less problematic: we can crop to eliminate the remaining fringes, while before this the fringes remained even after cropping (regardless of how much we cropped). And zoomed in, the fringes are no more visible.