### PR TITLE
bilateral_slice should ensure L >= 0.0f

### DIFF
--- a/data/kernels/bilateral.cl
+++ b/data/kernels/bilateral.cl
@@ -380,7 +380,7 @@ slice(
         grid[gi+ox+oz]    * (       fx) * (1.0f - fy) * (       fz) +
         grid[gi+oy+oz]    * (1.0f - fx) * (       fy) * (       fz) +
         grid[gi+ox+oy+oz] * (       fx) * (       fy) * (       fz);
-  pixel.x = L + norm * Ldiff;
+  pixel.x = max(0.0f, L + norm * Ldiff);
   write_imagef (out, (int2)(x, y), pixel);
 }
 

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -389,7 +389,7 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
       const float L = in[index];
       // trilinear lookup:
       const size_t gi = image_to_grid(b, i, j, L, &xf, &yf, &zf);
-      const float Lout = L
+      const float Lout = fmaxf( 0.0f, L
                          + norm * (buf[gi] * (1.0f - xf) * (1.0f - yf) * (1.0f - zf)
                                    + buf[gi + ox] * (xf) * (1.0f - yf) * (1.0f - zf)
                                    + buf[gi + oy] * (1.0f - xf) * (yf) * (1.0f - zf)
@@ -397,7 +397,7 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
                                    + buf[gi + oz] * (1.0f - xf) * (1.0f - yf) * (zf)
                                    + buf[gi + ox + oz] * (xf) * (1.0f - yf) * (zf)
                                    + buf[gi + oy + oz] * (1.0f - xf) * (yf) * (zf)
-                                   + buf[gi + ox + oy + oz] * (xf) * (yf) * (zf));
+                                   + buf[gi + ox + oy + oz] * (xf) * (yf) * (zf)));
       out[index] = Lout;
       // and copy color and mask
       out[index + 1] = in[index + 1];


### PR DESCRIPTION
- same as bilateral_slice_to_output
- also in the cl kernel

There seem to be a number of issues around that likely are related to this.

Fixes #5783 
Possibly Fixes #4984
Fixes #5668
Fixes #5625

I don't think this can change any valid edits but ensures a valid L channel.