### PR TITLE
vectorscope: add log scaling

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -722,16 +722,15 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_scale(cr, 1., -1.);
 
   // concentric circles as a scale
-  // FIXME: in log mode, should the circles change?
   set_color(cr, darktable.bauhaus->graph_grid);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
   const float grid_radius = d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV ? 100. : 0.01;
   for(int i = 1; i < 1.f + ceilf(vs_radius/grid_radius); i++)
   {
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
-    cairo_arc(cr, 0., 0., grid_radius * scale * i, 0., M_PI * 2.);
-    cairo_stroke(cr);
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(0.5));
-    cairo_arc(cr, 0., 0., grid_radius * scale * (i - 0.5), 0., M_PI * 2.);
+    float r = grid_radius * i;
+    if(d->histogram_scale == DT_LIB_HISTOGRAM_LOGARITHMIC)
+      r = baselog(r, vs_radius);
+    cairo_arc(cr, 0., 0., r * scale, 0., M_PI * 2.);
     cairo_stroke(cr);
   }
 
@@ -743,7 +742,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // graticule: histogram profile hue ring
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
   float x_prev = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][0];
   float y_prev = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][1];
   log_scale(d, &x_prev, &y_prev, vs_radius);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -743,29 +743,30 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // graticule: histogram profile hue ring
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  float x_prev = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][0];
-  float y_prev = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][1];
-  log_scale(d, &x_prev, &y_prev, vs_radius);
+  float x = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][0];
+  float y = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][1];
+  log_scale(d, &x, &y, vs_radius);
   for(int n=0; n<6; n++)
   {
     for(int h=0; h<VECTORSCOPE_HUES; h++)
     {
-      cairo_move_to(cr, x_prev * scale, y_prev * scale);
+      cairo_move_to(cr, x*scale, y*scale);
       // FIXME: can we pre-make a pattern with the hues radiating out, and use it as the "ink" to draw the hue ring and -- if in false color mode -- the vectorscope? will this be faster then drawing lots of lines each with their own color? will it allow for drawing the hue ring with splines and calculating fewer points? -- we might need a color pattern of the colorspace, then masked once to increase saturation and once for alpha?
       // note that hue_ring_rgb and hue_ring_coord are calculated as float but converted here to double
       cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 0.5);
-      float x = d->hue_ring_coord[n][h][0];
-      float y = d->hue_ring_coord[n][h][1];
+      x = d->hue_ring_coord[n][h][0];
+      y = d->hue_ring_coord[n][h][1];
       log_scale(d, &x, &y, vs_radius);
       cairo_line_to(cr, x*scale, y*scale);
       cairo_stroke(cr);
       if(h==0)
       {
-        cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
-        cairo_fill(cr);
+        cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
+        cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 1.);
+        cairo_fill_preserve(cr);
+        set_color(cr, darktable.bauhaus->graph_grid);
+        cairo_stroke(cr);
       }
-      x_prev = x;
-      y_prev = y;
     }
   }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -746,10 +746,11 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   float y_prev = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][1];
   log_scale(d, &x_prev, &y_prev, vs_radius);
   for(int n=0; n<6; n++)
+  {
     for(int h=0; h<VECTORSCOPE_HUES; h++)
     {
       cairo_move_to(cr, x_prev * scale, y_prev * scale);
-      // FIXME: can we pre-make a pattern with the hues radiating out, and use it as the "ink" to draw the hue ring and -- if in false color mode -- the vectorscope? will this be faster then drawing lots of lines each with their own color? will it allow for drawing the hue ring with splines and calculating fewer points?
+      // FIXME: can we pre-make a pattern with the hues radiating out, and use it as the "ink" to draw the hue ring and -- if in false color mode -- the vectorscope? will this be faster then drawing lots of lines each with their own color? will it allow for drawing the hue ring with splines and calculating fewer points? -- we might need a color pattern of the colorspace, then masked once to increase saturation and once for alpha?
       // note that hue_ring_rgb and hue_ring_coord are calculated as float but converted here to double
       cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 0.5);
       float x = d->hue_ring_coord[n][h][0];
@@ -757,9 +758,15 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       log_scale(d, &x, &y, vs_radius);
       cairo_line_to(cr, x*scale, y*scale);
       cairo_stroke(cr);
+      if(h==0)
+      {
+        cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
+        cairo_fill(cr);
+      }
       x_prev = x;
       y_prev = y;
     }
+  }
 
   // vectorscope graph
   // FIXME: use cairo_pattern_set_filter()?
@@ -860,6 +867,7 @@ static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointe
   switch(d->scope_type)
   {
     case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
+      // FIXME: now that vectorscope grid represents log scale, should histogram grid do the same?
       dt_draw_grid(cr, 4, 0, 0, width, height);
       break;
     case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:


### PR DESCRIPTION
As per suggestion from @TurboGit and @Mark-64. This makes the graph of low chroma images more legible.

There is a button to flip between linear & logarithmic graphing of vectorscope. Moved the colorspace button one to the right, to allow for linear/log button to be in the same place as in the regular histogram. Updated keyboard shortcut code to cycle through vectorscope variants (linear/log and uv/AzBz).

Updated hue ring graph to draw nodes at primary/secondary colors, as in log mode the angles at primaries/secondaries are less visible. Also tuned up graph scale circles.

Removed auto-scaling code, which was buggy and should be obviated by this.

Should fix #8813. Supersedes #8855, which I will close if this PR is a better route. May help with #8858, pending testing.

The log base for scaling is currently fixed via a `#define VECTORSCOPE_BASE_LOG 30`. It would be possible to add a UI to change this (e.g. via shift-scroll, if I could get `dt_gui_get_scroll_unit_delta()` to work on MacOS and Windows) which could obviate the linear/logarithmic button. But it would be nice if a simple button UI were enough.

## Examples

### Low chroma image

Adobe RGB histogram profile

#### linear scale

![image](https://user-images.githubusercontent.com/2311860/117392854-e7275300-aec0-11eb-9f63-df112b1918fd.png)

#### log scale

![image](https://user-images.githubusercontent.com/2311860/117392906-fc9c7d00-aec0-11eb-95f6-d4224ad72f5f.png)

### High chroma image

sRGB histogram profile

#### linear scale

![image](https://user-images.githubusercontent.com/2311860/117393260-bf84ba80-aec1-11eb-94dd-82690e324914.png)

### log scale

![image](https://user-images.githubusercontent.com/2311860/117393286-cb707c80-aec1-11eb-931f-76899245bac7.png)
