### PR TITLE
import: attempt to remove jump to first image when importing

### DIFF
--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -238,7 +238,7 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
 
   if((imgid & 3) == 3)
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
   }
 
   if(t->import_count + 1 == num_images)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2107,7 +2107,7 @@ static int _control_import_image_copy(const char *filename,
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(imgid));
       if((imgid & 3) == 3)
       {
-        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
         dt_control_queue_redraw_center();
       }
     }
@@ -2128,7 +2128,7 @@ static void _collection_update(double *last_update, double *update_interval)
     // between updates until it hits the pre-set maximum
     if (*update_interval < MAX_UPDATE_INTERVAL)
       *update_interval += 0.1;
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
     dt_control_queue_redraw_center();
   }
 }


### PR DESCRIPTION
attempt to fix #8653

DT_COLLECTION_CHANGE_RELOAD seems to be more appropriate than DT_COLLECTION_CHANGE_NEW_QUERY in that case.
The jump to first image has gone. However I feel still uncomfortable to work on lighttable during import due to temporary freeze.


