### PR TITLE
lighttable : fix btn state with right click

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -227,10 +227,7 @@ static gboolean _lib_lighttable_layout_btn_release(GtkWidget *w, GdkEventButton 
   }
 
   _lib_lighttable_set_layout(self, new_layout);
-
-  // now we inverse the current button state to get the right state at the end
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), active);
-  return FALSE;
+  return TRUE;
 }
 
 void gui_init(dt_lib_module_t *self)


### PR DESCRIPTION
fix #8890

Now right click correctly update the button state (like left click)
Don't ask me why right click and left click doesn't behave similarly although there's no distinction in the code...