### PR TITLE
Add places instead of root-folder in import-dialog

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -658,6 +658,34 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>ui_last/import_dialog_paned_places_pos</name>
+    <type>int</type>
+    <default>150</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>ui_last/import_dialog_show_home</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>ui_last/import_dialog_show_pictures</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>ui_last/import_dialog_show_mounted</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>ui_last/import_dialog_width</name>
     <type>int</type>
     <default>800</default>

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1226,10 +1226,12 @@ static void _expand_folder(const char *folder, const gboolean select, dt_lib_mod
         GtkTreeIter parent;
         if(!gtk_tree_model_iter_parent(model, &parent, &iter))
           parent = iter;
-        GtkTreePath *path = gtk_tree_model_get_path(model, &parent);
-        gtk_tree_view_expand_to_path(d->from.folderview, path);
+        GtkTreePath *parent_path = gtk_tree_model_get_path(model, &parent);
+        GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
+        gtk_tree_view_expand_to_path(d->from.folderview, parent_path);
         gtk_tree_view_scroll_to_cell(d->from.folderview, path, NULL, TRUE, 0.5, 0.5);
         gtk_tree_path_free(path);
+        gtk_tree_path_free(parent_path);
         if(select)
         {
           GtkTreeSelection *selection = gtk_tree_view_get_selection(d->from.folderview);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1171,15 +1171,18 @@ static void _set_places_list(GtkWidget *lbox, dt_lib_module_t* self)
     volumes = g_drive_get_volumes (drive->data);    
     for (volume = volumes; volume; volume = volume->next)
     {
-      GMount *placesMount = g_volume_get_mount(volume->data);
-      GFile *placesFile = g_mount_get_root(placesMount);
-      g_object_unref (placesMount);
+      if(g_volume_get_mount(volume->data))
+      {
+        GMount *placesMount = g_volume_get_mount(volume->data);
+        GFile *placesFile = g_mount_get_root(placesMount);
+        g_object_unref (placesMount);
 
-      gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_volume_get_name(volume->data), 
-        DT_PLACES_PATH, g_file_get_path(placesFile), DT_PLACES_CUSTOM, FALSE, -1);
+        gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_volume_get_name(volume->data), 
+          DT_PLACES_PATH, g_file_get_path(placesFile), DT_PLACES_CUSTOM, FALSE, -1);
 
-      if(!g_strcmp0(g_file_get_path(placesFile), last_place))
-        gtk_tree_selection_select_iter(d->placesSelection, &iter);
+        if(!g_strcmp0(g_file_get_path(placesFile), last_place))
+          gtk_tree_selection_select_iter(d->placesSelection, &iter);
+      }
     }
   }
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1252,32 +1252,36 @@ static void _update_places_list(dt_lib_module_t* self)
 
   // add default folders
 
-  GtkTreeIter iter;
+  GtkTreeIter iter, current_iter;
   d->placesSelection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->placesView));
   const gchar *last_place = dt_conf_get_string("ui_last/import_last_place");
+  char *current_place = "";
 
   if(dt_conf_get_bool("ui_last/import_dialog_show_home") && dt_loc_get_home_dir(NULL))
   {
+    current_place = (char *)dt_loc_get_home_dir(NULL);
     gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, _("home"), 
-      DT_PLACES_PATH, (char *)dt_loc_get_home_dir(NULL), DT_PLACES_TYPE, DT_TYPE_HOME, -1);
-    if(!g_strcmp0(dt_loc_get_home_dir(NULL), last_place))
+      DT_PLACES_PATH, current_place, DT_PLACES_TYPE, DT_TYPE_HOME, -1);
+    if(!g_strcmp0(current_place, last_place))
       gtk_tree_selection_select_iter(d->placesSelection, &iter);
+    current_iter = iter;
   }
   
-
   if(dt_conf_get_bool("ui_last/import_dialog_show_pictures") && g_get_user_special_dir(G_USER_DIRECTORY_PICTURES))
   {
-    // set pictures as default
-    if(last_place[0] == '\0')
-    {
-      last_place=g_get_user_special_dir(G_USER_DIRECTORY_PICTURES);
-      dt_conf_set_string("ui_last/import_last_place", last_place);
-    }
-
+    current_place = (char *)g_get_user_special_dir(G_USER_DIRECTORY_PICTURES);
     gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, _("pictures"), 
-      DT_PLACES_PATH, (char *)g_get_user_special_dir(G_USER_DIRECTORY_PICTURES), DT_PLACES_TYPE, DT_TYPE_PIC, -1);
-    if(!g_strcmp0(g_get_user_special_dir(G_USER_DIRECTORY_PICTURES), last_place))
+      DT_PLACES_PATH, current_place, DT_PLACES_TYPE, DT_TYPE_PIC, -1);
+    if(!g_strcmp0(current_place, last_place))
       gtk_tree_selection_select_iter(d->placesSelection, &iter);
+    current_iter = iter;
+  }
+
+  // set home/pictures as default
+  if(last_place[0] == '\0')
+  {
+    dt_conf_set_string("ui_last/import_last_place", current_place);
+    gtk_tree_selection_select_iter(d->placesSelection, &current_iter);
   }
 
   // add mounted drives

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1036,7 +1036,7 @@ static gboolean places_button_press(GtkWidget *view, GdkEventButton *event, dt_l
       GtkTreeSelection *place_selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
       gtk_tree_selection_select_path(place_selection, path);
       dt_conf_set_string("ui_last/import_last_place", folder_path);
-
+      dt_conf_set_string("ui_last/import_last_directory", "");
       _update_folders_list(self);
       _update_files_list(self);
     }

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1040,10 +1040,13 @@ static gboolean places_button_press(GtkWidget *view, GdkEventButton *event, dt_l
       _update_folders_list(self);
       _update_files_list(self);
     }
-    // right-click: delete / hide place
+    // right-click: delete / hide place (if not selected)
     else if(button_pressed == 3)
     {
-      _remove_place(folder_path, iter, self);
+      if(g_strcmp0(folder_path, dt_conf_get_string("ui_last/import_last_place")))
+        _remove_place(folder_path, iter, self);
+      else
+        dt_toast_log(_("you can't delete the selected place"));
     }
 
     g_free(folder_name);
@@ -1373,7 +1376,6 @@ static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   const gchar *current_folders = dt_conf_get_string("ui_last/import_custom_places");
-  const gchar *last_place = dt_conf_get_string("ui_last/import_last_place");
   int type = 0;
   gtk_tree_model_get(GTK_TREE_MODEL(d->placesModel), &iter, DT_PLACES_TYPE, &type, -1);
 
@@ -1388,9 +1390,6 @@ static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t
       dt_util_str_replace(current_folders, dt_util_dstrcat(NULL,"%s,", folder), ""));
 
   _update_places_list(self);
-
-  if(!g_strcmp0(folder, last_place))
-    dt_conf_set_string("ui_last/import_last_place", "");
 }
 
 static GList* _get_custom_places()


### PR DESCRIPTION
Extends #8734 as proposed in [#8596](https://github.com/darktable-org/darktable/issues/8596#issuecomment-813065519)

List of 'places' above the folder-tree replaces the current root-folder-dropdown
- default folders (home, documents, pictures)
- mounted drives
- other folders added by user (using the gtk dialog)