### PR TITLE
 po/print layouts

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2829,13 +2829,6 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig>
-    <name>plugins/print/print/autofit</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription/>
-    <longdescription/>
-  </dtconfig>
   <dtconfig prefs="misc" section="interface">
     <name>ui_last/display_profile_source</name>
     <type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2829,6 +2829,13 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/print/print/autofit</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
   <dtconfig prefs="misc" section="interface">
     <name>ui_last/display_profile_source</name>
     <type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2829,6 +2829,13 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/print/print/grid_size</name>
+    <type min="0" max="100">float</type>
+    <default>10</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
   <dtconfig prefs="misc" section="interface">
     <name>ui_last/display_profile_source</name>
     <type>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -116,6 +116,7 @@ src/common/opencl.c
 src/common/pdf.h
 src/common/points.h
 src/common/printprof.c
+src/common/printing.c
 src/common/pwstorage/pwstorage.c
 src/common/ratings.c
 src/common/styles.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -806,6 +806,8 @@ if(BUILD_PRINT)
       "common/cups_print.h"
       "common/cups_print.c"
       "common/printprof.c"
+      "common/printing.h"
+      "common/printing.c"
       )
     set(SOURCES ${SOURCES} ${SOURCE_FILES_PRINT})
     list(APPEND LIBS ${CUPS_LIBRARIES})

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -574,7 +574,7 @@ void dt_print_file(const int32_t imgid, const char *filename, const char *job_ti
   cupsFreeOptions (num_options, options);
 }
 
-void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
+void dt_get_print_layout(const dt_print_info_t *prt,
                          const int32_t area_width, const int32_t area_height,
                          int32_t *px, int32_t *py, int32_t *pwidth, int32_t *pheight,
                          int32_t *ax, int32_t *ay, int32_t *awidth, int32_t *aheight)
@@ -582,45 +582,25 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   /* this is where the layout is done for the display and for the print too. So this routine is one
      of the most critical for the print circuitry. */
 
-  double width, height;
-
   // page w/h
-  double pg_width  = prt->paper.width;
-  double pg_height = prt->paper.height;
-
-  if(area_width == 0)
-    width = pg_width;
-  else
-    width = area_width;
-
-  if(area_height == 0)
-    height = pg_height;
-  else
-    height = area_height;
+  float pg_width  = prt->paper.width;
+  float pg_height = prt->paper.height;
 
   /* here, width and height correspond to the area for the picture */
 
   // non-printable
-  double np_top = prt->printer.hw_margin_top;
-  double np_left = prt->printer.hw_margin_left;
-  double np_right = prt->printer.hw_margin_right;
-  double np_bottom = prt->printer.hw_margin_bottom;
+  float np_top = prt->printer.hw_margin_top;
+  float np_left = prt->printer.hw_margin_left;
+  float np_right = prt->printer.hw_margin_right;
+  float np_bottom = prt->printer.hw_margin_bottom;
 
   /* do some arrangements for the landscape mode. */
 
   if(prt->page.landscape)
   {
-    double tmp = pg_width;
+    float tmp = pg_width;
     pg_width = pg_height;
     pg_height = tmp;
-
-    //  only invert if we did not get a specific area
-    if(area_width == 0 && area_height == 0)
-    {
-      tmp = width;
-      width = height;
-      height = tmp;
-    }
 
     // rotate the non-printable margins
     tmp       = np_top;
@@ -631,27 +611,27 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   }
 
   // the image area aspect
-  const double a_aspect = (double)width / (double)height;
+  const float a_aspect = (double)area_width / (double)area_height;
 
   // page aspect
-  const double pg_aspect = pg_width / pg_height;
+  const float pg_aspect = pg_width / pg_height;
 
   // display page
   int32_t p_bottom, p_right;
 
   if(a_aspect > pg_aspect)
   {
-    *px = (width - (height * pg_aspect)) / 2;
+    *px = (area_width - (area_height * pg_aspect)) / 2.0f;
     *py = 0;
-    p_bottom = height;
-    p_right = width - *px;
+    p_bottom = area_height;
+    p_right = area_width - *px;
   }
   else
   {
     *px = 0;
-    *py = (height - (width / pg_aspect)) / 2;
-    p_right = width;
-    p_bottom = height - *py;
+    *py = (area_height - (area_width / pg_aspect)) / 2.0f;
+    p_right = area_width;
+    p_bottom = area_height - *py;
   }
 
   *pwidth = p_right - *px;
@@ -661,10 +641,10 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   // these margins are those set by the user from the GUI, and the top margin is *always*
   // at the top of the screen.
 
-  const double border_top = prt->page.margin_top;
-  const double border_left = prt->page.margin_left;
-  const double border_right = prt->page.margin_right;
-  const double border_bottom = prt->page.margin_bottom;
+  const float border_top = prt->page.margin_top;
+  const float border_left = prt->page.margin_left;
+  const float border_right = prt->page.margin_right;
+  const float border_bottom = prt->page.margin_bottom;
 
   // display picture area, that is removing the non printable areas and user's margins
 

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -590,12 +590,12 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   double pg_width  = prt->paper.width;
   double pg_height = prt->paper.height;
 
-  if (area_width==0)
+  if(area_width == 0)
     width = pg_width;
   else
     width = area_width;
 
-  if (area_height==0)
+  if(area_height == 0)
     height = pg_height;
   else
     height = area_height;
@@ -617,7 +617,7 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
     pg_height = tmp;
 
     //  only invert if we did not get a specific area
-    if (area_width == 0 && area_height == 0)
+    if(area_width == 0 && area_height == 0)
     {
       tmp = width;
       width = height;
@@ -697,7 +697,7 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   *iwidth = *iwpix;
   *iheight = *ihpix;
 
-  if (*iwidth > *awidth)
+  if(*iwidth > *awidth)
   {
     scale =  (double)(*awidth) / (double)*iwidth;
     *iwidth = *awidth;

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -576,10 +576,8 @@ void dt_print_file(const int32_t imgid, const char *filename, const char *job_ti
 
 void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
                          const int32_t area_width, const int32_t area_height,
-                         int32_t *iwpix, int32_t *ihpix,
-                         int32_t *px,    int32_t *py,    int32_t *pwidth, int32_t *pheight,
-                         int32_t *ax,    int32_t *ay,    int32_t *awidth, int32_t *aheight,
-                         int32_t *ix,    int32_t *iy,    int32_t *iwidth, int32_t *iheight)
+                         int32_t *px, int32_t *py, int32_t *pwidth, int32_t *pheight,
+                         int32_t *ax, int32_t *ay, int32_t *awidth, int32_t *aheight)
 {
   /* this is where the layout is done for the display and for the print too. So this routine is one
      of the most critical for the print circuitry. */
@@ -681,35 +679,6 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   *ay      = by;
   *awidth  = br - bx;
   *aheight = bb - by;
-
-  // get the image dimensions if needed
-
-  if(imgid != -1
-     && (*iwpix <= 0 || *ihpix <= 0))
-  {
-    dt_image_get_final_size(imgid, iwpix, ihpix);
-  }
-
-  // compute the scaling for the image to fit into the printable area
-
-  double scale;
-
-  *iwidth = *iwpix;
-  *iheight = *ihpix;
-
-  if(*iwidth > *awidth)
-  {
-    scale =  (double)(*awidth) / (double)*iwidth;
-    *iwidth = *awidth;
-    *iheight = (int32_t)(((double)*iheight + 0.5) * scale);
-  }
-
-  if (*iheight > *aheight)
-  {
-    scale = (double)(*aheight) / (double)*iheight;
-    *iheight = *aheight;
-    *iwidth = (int32_t)(((double)*iwidth + 0.5) * scale);
-  }
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -610,7 +610,7 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
 
   /* do some arrangements for the landscape mode. */
 
-  if (prt->page.landscape)
+  if(prt->page.landscape)
   {
     double tmp = pg_width;
     pg_width = pg_height;
@@ -641,7 +641,7 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
   // display page
   int32_t p_bottom, p_right;
 
-  if (a_aspect > pg_aspect)
+  if(a_aspect > pg_aspect)
   {
     *px = (width - (height * pg_aspect)) / 2;
     *py = 0;
@@ -684,8 +684,11 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
 
   // get the image dimensions if needed
 
-  if (*iwpix <= 0 || *ihpix <= 0)
+  if(imgid != -1
+     && (*iwpix <= 0 || *ihpix <= 0))
+  {
     dt_image_get_final_size(imgid, iwpix, ihpix);
+  }
 
   // compute the scaling for the image to fit into the printable area
 

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -710,49 +710,6 @@ void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
     *iheight = *aheight;
     *iwidth = (int32_t)(((double)*iwidth + 0.5) * scale);
   }
-
-  // now the image position (top-left corner coordinates) in the display area depending on the page
-  // alignment set by the user.
-
-  switch (prt->page.alignment)
-  {
-    case ALIGNMENT_TOP_LEFT:
-      *ix = bx;
-      *iy = by;
-      break;
-    case ALIGNMENT_TOP:
-      *ix = bx + (*awidth - *iwidth) / 2;
-      *iy = by;
-      break;
-    case ALIGNMENT_TOP_RIGHT:
-      *ix = br - *iwidth;
-      *iy = by;
-      break;
-    case ALIGNMENT_LEFT:
-      *ix = bx;
-      *iy = by + (*aheight - *iheight) / 2;
-      break;
-    case ALIGNMENT_CENTER:
-      *ix = bx + (*awidth - *iwidth) / 2;
-      *iy = by + (*aheight - *iheight) / 2;
-      break;
-    case ALIGNMENT_RIGHT:
-      *ix = br - *iwidth;
-      *iy = by + (*aheight - *iheight) / 2;
-      break;
-    case ALIGNMENT_BOTTOM_LEFT:
-      *ix = bx;
-      *iy = bb - *iheight;
-      break;
-    case ALIGNMENT_BOTTOM:
-      *ix = bx + (*awidth - *iwidth) / 2;
-      *iy = bb - *iheight;
-      break;
-    case ALIGNMENT_BOTTOM_RIGHT:
-      *ix = br - *iwidth;
-      *iy = bb - *iheight;
-      break;
-  }
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/cups_print.h
+++ b/src/common/cups_print.h
@@ -48,7 +48,6 @@ typedef struct dt_medium_info_t
 typedef struct dt_page_setup_t
 {
   gboolean landscape;
-  dt_alignment_t alignment;
   double margin_top, margin_bottom, margin_left, margin_right;
 } dt_page_setup_t;
 

--- a/src/common/cups_print.h
+++ b/src/common/cups_print.h
@@ -94,17 +94,16 @@ dt_medium_info_t *dt_get_medium(GList *media, const char *name);
 // print filename using the printer and the page size and setup
 void dt_print_file(const int32_t imgid, const char *filename, const char *job_title, const dt_print_info_t *pinfo);
 
-// given the page settings (media size and border) and the printer (hardware margins) returns the page, image
-// and printable area layout in the area_width and area_height (the area that dt allocate for the central display).
+// given the page settings (media size and border) and the printer (hardware margins) returns the
+// page and printable area layout in the area_width and area_height (the area that dt allocate
+// for the central display).
 //  - the page area (px, py, pwidth, pheight)
 //  - the printable area (ax, ay, awidth and aheight), the area without the borders
-//  - the image position (ix, iy, iwidth, iheight)
 // there is no unit, every returned values are based on the area size.
-void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt, const int32_t area_width, const int32_t area_height,
-                         int32_t *iwpix, int32_t *ihpix,
-                         int32_t *px,    int32_t *py,    int32_t *pwidth, int32_t *pheight,
-                         int32_t *ax,    int32_t *ay,    int32_t *awidth, int32_t *aheight,
-                         int32_t *ix,    int32_t *iy,    int32_t *iwidth, int32_t *iheight);
+void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
+                         const int32_t area_width, const int32_t area_height,
+                         int32_t *px, int32_t *py, int32_t *pwidth, int32_t *pheight,
+                         int32_t *ax, int32_t *ay, int32_t *awidth, int32_t *aheight);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/cups_print.h
+++ b/src/common/cups_print.h
@@ -100,7 +100,7 @@ void dt_print_file(const int32_t imgid, const char *filename, const char *job_ti
 //  - the page area (px, py, pwidth, pheight)
 //  - the printable area (ax, ay, awidth and aheight), the area without the borders
 // there is no unit, every returned values are based on the area size.
-void dt_get_print_layout(const int32_t imgid, const dt_print_info_t *prt,
+void dt_get_print_layout(const dt_print_info_t *prt,
                          const int32_t area_width, const int32_t area_height,
                          int32_t *px, int32_t *py, int32_t *pwidth, int32_t *pheight,
                          int32_t *ax, int32_t *ay, int32_t *awidth, int32_t *aheight);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -316,7 +316,7 @@ int32_t dt_image_duplicate(const int32_t imgid);
 void dt_image_flip(const int32_t imgid, const int32_t cw);
 void dt_image_set_flip(const int32_t imgid, const dt_image_orientation_t user_flip);
 dt_image_orientation_t dt_image_get_orientation(const int32_t imgid);
-/** get max width and height of the final processed image with its current hisotry stack */
+/** get max width and height of the final processed image with its current history stack */
 gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height);
 void dt_image_update_final_size(const int32_t imgid);
 /** set image location lon/lat/ele */

--- a/src/common/pdf.h
+++ b/src/common/pdf.h
@@ -1,6 +1,6 @@
 /*
  *    This file is part of darktable,
- *    Copyright (C) 2015-2020 darktable developers.
+ *    Copyright (C) 2015-2021 darktable developers.
  *
  *    darktable is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -81,8 +81,8 @@ typedef struct dt_pdf_page_t
 
 static const struct
 {
-  char  *name;
-  float  factor;
+  const char  *name;
+  const float  factor;
 } dt_pdf_units[] =
 {
   {N_("mm"),   dt_pdf_mm_to_point(1.0)},
@@ -96,9 +96,9 @@ static const int dt_pdf_units_n = sizeof(dt_pdf_units) / sizeof(dt_pdf_units[0])
 
 static const struct
 {
-  char  *name;
-  float  width;
-  float  height;
+  const char  *name;
+  const float  width;
+  const float  height;
 } dt_pdf_paper_sizes[] =
 {
   {N_("a4"),     dt_pdf_mm_to_point(210),   dt_pdf_mm_to_point(297)},

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -1,0 +1,43 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/printing.h"
+
+int dt_printing_get_image_box(dt_images_box *imgs, const int x, const int y)
+{
+  int box = -1;
+
+  for(int k=0; k<imgs->count; k++)
+  {
+    dt_image_box *b = &imgs->box[k];
+
+    // check if over a box
+    if(x > b->screen.x && x < (b->screen.x + b->screen.width)
+       && y > b->screen.y && y < (b->screen.y + b->screen.height))
+    {
+      box = k;
+      break;
+    }
+  }
+
+  return box;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -18,13 +18,48 @@
 
 #include "common/printing.h"
 
-int dt_printing_get_image_box(dt_images_box *imgs, const int x, const int y)
+void _clear_pos(dt_image_pos *pos)
+{
+  pos->x = pos->y = pos->width = pos->height = 0.0f;
+}
+
+void dt_printing_clear_box(dt_image_box *img)
+{
+  img->imgid = -1;
+  img->max_width = img->max_height = 0;
+  img->exp_width = img->exp_height = 0;
+  img->dis_width = img->dis_height = 0;
+  img->img_width = img->img_height = 0;
+  img->alignment = ALIGNMENT_CENTER;
+  img->buf = NULL;
+
+  _clear_pos(&img->screen);
+  _clear_pos(&img->pos);
+  _clear_pos(&img->print);
+}
+
+void dt_printing_clear_boxes(dt_images_box *imgs)
+{
+  for(int k=0; k<MAX_IMAGE_PER_PAGE; k++)
+    dt_printing_clear_box(&imgs->box[k]);
+
+  _clear_pos(&imgs->screen.page);
+  _clear_pos(&imgs->screen.print_area);
+
+  imgs->count = 0;
+  imgs->motion_over = -1;
+  imgs->page_width = imgs->page_height = 0;
+  imgs->page_width_mm = imgs->page_height_mm = 0;
+  imgs->imgid_to_load = -1;
+}
+
+int dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y)
 {
   int box = -1;
 
   for(int k=0; k<imgs->count; k++)
   {
-    dt_image_box *b = &imgs->box[k];
+    const dt_image_box *b = &imgs->box[k];
 
     // check if over a box
     if(x > b->screen.x && x < (b->screen.x + b->screen.width)
@@ -36,6 +71,237 @@ int dt_printing_get_image_box(dt_images_box *imgs, const int x, const int y)
   }
 
   return box;
+}
+
+void _compute_rel_pos(const dt_images_box *imgs, const dt_image_pos *ref, dt_image_pos *pos)
+{
+  // compute the printing position & width as % of the page
+
+  const float ofsx        = imgs->screen.page.x;
+  const float ofsy        = imgs->screen.page.y;
+  const float page_width  = imgs->screen.page.width;
+  const float page_height = imgs->screen.page.height;
+
+  pos->x      = (ref->x - ofsx) / page_width;
+  pos->y      = (ref->y - ofsy) / page_height;
+  pos->width  = ref->width / page_width;
+  pos->height = ref->height / page_height;
+}
+
+void dt_printing_setup_display(dt_images_box *imgs,
+                               const float px, const float py, const float pwidth, const float pheight,
+                               const float ax, const float ay, const float awidth, const float aheight)
+{
+  imgs->screen.page.x      = px;
+  imgs->screen.page.y      = py;
+  imgs->screen.page.width  = pwidth;
+  imgs->screen.page.height = pheight;
+
+  imgs->screen.print_area.x      = ax;
+  imgs->screen.print_area.y      = ay;
+  imgs->screen.print_area.width  = awidth;
+  imgs->screen.print_area.height = aheight;
+
+  // and now reset the box to be resised accordingly if needed
+  for(int k=0; k<imgs->count; k++)
+  {
+    dt_image_box *box = &imgs->box[k];
+
+    if(box->pos.x > 0)
+    {
+      box->screen.x      = pwidth * box->pos.x + px;
+      box->screen.y      = pheight * box->pos.y + py;
+      box->screen.width  = pwidth * box->pos.width;
+      box->screen.height = pheight * box->pos.height;
+    }
+  }
+}
+
+void dt_printing_setup_box(dt_images_box *imgs, const int idx,
+                           const float x, const float y,
+                           const float width, const float height)
+{
+  const float dx = fminf(imgs->screen.print_area.width,
+                         fmaxf(100.0f, width));
+  const float dy = fminf(imgs->screen.print_area.height,
+                         fmaxf(100.0f, height));
+
+  //  setup screen position & width
+
+  dt_image_box *box = &imgs->box[idx];
+
+  box->screen.x      = fmaxf(imgs->screen.print_area.x, x);
+  box->screen.y      = fmaxf(imgs->screen.print_area.y, y);
+  box->screen.width  = dx;
+  box->screen.height = dy;
+
+  if(box->screen.x + dx > imgs->screen.print_area.x + imgs->screen.print_area.width)
+  {
+    box->screen.width -= (box->screen.x + dx - imgs->screen.print_area.x - imgs->screen.print_area.width);
+  }
+  if(box->screen.y + dy > imgs->screen.print_area.y + imgs->screen.print_area.height)
+  {
+    box->screen.height -= (box->screen.y + dy - imgs->screen.print_area.y - imgs->screen.print_area.height);
+  }
+
+  _compute_rel_pos(imgs, &box->screen, &box->pos);
+
+  if(idx == imgs->count) imgs->count++;
+}
+
+void dt_printing_setup_page(dt_images_box *imgs,
+                            const float page_width, const float page_height,
+                            const int resolution)
+{
+  imgs->page_width_mm = page_width;
+  imgs->page_height_mm = page_height;
+  imgs->page_width  = dt_pdf_point_to_pixel(dt_pdf_mm_to_point(page_width), resolution);
+  imgs->page_height = dt_pdf_point_to_pixel(dt_pdf_mm_to_point(page_height), resolution);
+
+  for(int k=0; k<imgs->count; k++)
+  {
+    dt_image_box *box = &imgs->box[k];
+
+    box->max_width = box->pos.width * imgs->page_width;
+    box->max_height = box->pos.height * imgs->page_height;
+  }
+}
+
+void _align_pos(const dt_image_pos *ref, const dt_alignment_t alignment,
+                const int32_t width, const int32_t height, dt_image_pos *pos)
+{
+  pos->width  = width;
+  pos->height = height;
+
+  switch(alignment)
+  {
+    case ALIGNMENT_TOP_LEFT:
+      pos->x = ref->x;
+      pos->y = ref->y;
+      break;
+    case ALIGNMENT_TOP:
+      pos->x = ref->x + (ref->width - width) / 2;
+      pos->y = ref->y;
+      break;
+    case ALIGNMENT_TOP_RIGHT:
+      pos->x = ref->x + (ref->width - width);
+      pos->y = ref->y;
+      break;
+    case ALIGNMENT_LEFT:
+      pos->x = ref->x;
+      pos->y = ref->y + (ref->height - height) / 2;
+      break;
+    case ALIGNMENT_CENTER:
+      pos->x = ref->x + (ref->width - width) / 2;
+      pos->y = ref->y + (ref->height - height) / 2;
+      break;
+    case ALIGNMENT_RIGHT:
+      pos->x = ref->x + (ref->width - width);
+      pos->y = ref->y + (ref->height - height) / 2;
+      break;
+    case ALIGNMENT_BOTTOM_LEFT:
+      pos->x = ref->x;
+      pos->y = ref->y + (ref->height - height);
+      break;
+    case ALIGNMENT_BOTTOM:
+      pos->x = ref->x + (ref->width - width) / 2;
+      pos->y = ref->y + (ref->height - height);
+      break;
+    case ALIGNMENT_BOTTOM_RIGHT:
+      pos->x = ref->x + (ref->width - width);
+      pos->y = ref->y + (ref->height - height);
+      break;
+  }
+}
+
+void dt_printing_get_screen_pos(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos)
+{
+  _clear_pos(pos);
+
+  _align_pos(&img->screen, img->alignment, img->dis_width, img->dis_height, pos);
+}
+
+void dt_printing_get_screen_rel_pos(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos)
+{
+  dt_image_pos screen_pos;
+
+  dt_printing_get_screen_pos(imgs, img, &screen_pos);
+
+  _compute_rel_pos(imgs, &screen_pos, pos);
+}
+
+void dt_printing_get_image_pos_mm(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos)
+{
+  dt_image_pos rpos;
+
+  dt_printing_get_screen_rel_pos(imgs, img, &rpos);
+
+  pos->x      = rpos.x * imgs->page_width_mm;
+  pos->y      = rpos.y * imgs->page_height_mm;
+  pos->width  = rpos.width * imgs->page_width_mm;
+  pos->height = rpos.height * imgs->page_height_mm;
+}
+
+void dt_printing_get_image_pos(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos)
+{
+  dt_image_pos rpos;
+
+  dt_printing_get_screen_rel_pos(imgs, img, &rpos);
+
+  pos->x      = rpos.x * imgs->page_width;
+  pos->y      = rpos.y * imgs->page_height;
+  pos->width  = rpos.width * imgs->page_width;
+  pos->height = rpos.height * imgs->page_height;
+}
+
+void dt_printing_setup_image(dt_images_box *imgs, const int idx,
+                             const int32_t imgid, const int32_t width, const int32_t height,
+                             const dt_alignment_t alignment)
+{
+  dt_image_box *box = &imgs->box[idx];
+
+  if(box->imgid != imgid)
+    dt_image_get_final_size(imgid, &box->img_width, &box->img_height);
+
+  box->imgid      = imgid;
+  box->exp_width  = width;
+  box->exp_height = height;
+  box->alignment  = alignment;
+
+  const float img_height_percent =  box->exp_height / imgs->page_height;
+
+  // for the print (pdf) the origin is bottom/left, so y must be inverted compared to screen coordinate
+  box->print.x      = box->pos.x * imgs->page_width;
+  box->print.y      = box->pos.y * imgs->page_height;
+  box->print.width  = box->pos.width * imgs->page_width;
+  box->print.height = box->pos.height * imgs->page_height;
+
+  dt_image_pos pos;
+  _align_pos(&box->print, box->alignment, box->exp_width, box->exp_height, &pos);
+
+  box->print.x = pos.x;
+  box->print.y = imgs->page_height - ((box->pos.y + img_height_percent) * imgs->page_height);
+  box->print.width = pos.width;
+  box->print.height = pos.height;
+
+  // compute image size on display
+
+  box->dis_width  = box->img_width;
+  box->dis_height = box->img_height;
+
+  if(box->dis_width > box->screen.width)
+  {
+    const float scale =  box->screen.width / (float)box->dis_width;
+    box->dis_width = box->screen.width;
+    box->dis_height = (int32_t)(((float)box->dis_height + 0.5f) * scale);
+  }
+
+  if(box->dis_height > box->screen.height)
+  {
+    const float scale = box->screen.height / (float)box->dis_height;
+    box->dis_height = box->screen.height;
+    box->dis_width = (int32_t)(((float)box->dis_width + 0.5f) * scale);
+  }
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -268,9 +268,8 @@ void dt_printing_setup_image(dt_images_box *imgs, const int idx,
   box->exp_height = height;
   box->alignment  = alignment;
 
-  const float img_height_percent =  box->exp_height / imgs->page_height;
-
-  // for the print (pdf) the origin is bottom/left, so y must be inverted compared to screen coordinate
+  // for the print (pdf) the origin is bottom/left, so y must be inverted compared to
+  // screen coordinates.
   box->print.x      = box->pos.x * imgs->page_width;
   box->print.y      = box->pos.y * imgs->page_height;
   box->print.width  = box->pos.width * imgs->page_width;
@@ -280,7 +279,7 @@ void dt_printing_setup_image(dt_images_box *imgs, const int idx,
   _align_pos(&box->print, box->alignment, box->exp_width, box->exp_height, &pos);
 
   box->print.x = pos.x;
-  box->print.y = imgs->page_height - ((box->pos.y + img_height_percent) * imgs->page_height);
+  box->print.y = imgs->page_height - (pos.y + pos.height);
   box->print.width = pos.width;
   box->print.height = pos.height;
 

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -53,7 +53,7 @@ void dt_printing_clear_boxes(dt_images_box *imgs)
   imgs->imgid_to_load = -1;
 }
 
-int dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y)
+int32_t dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y)
 {
   int box = -1;
 

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -53,20 +53,39 @@ void dt_printing_clear_boxes(dt_images_box *imgs)
   imgs->imgid_to_load = -1;
 }
 
+static inline float sqrf(float a)
+{
+  return a * a;
+}
+
 int32_t dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y)
 {
   int box = -1;
+  float dist = FLT_MAX;
 
   for(int k=0; k<imgs->count; k++)
   {
     const dt_image_box *b = &imgs->box[k];
 
+    const float x1 = b->screen.x;
+    const float x2 = b->screen.x + b->screen.width;
+    const float y1 = b->screen.y;
+    const float y2 = b->screen.y + b->screen.height;
+
     // check if over a box
-    if(x > b->screen.x && x < (b->screen.x + b->screen.width)
-       && y > b->screen.y && y < (b->screen.y + b->screen.height))
+    if(x > x1 && x < x2 && y > y1 && y < y2)
     {
-      box = k;
-      break;
+      // compute min dist
+      float dd = sqrf(x1 - x);
+      dd = fminf(dd, sqrf(x2 - x));
+      dd = fminf(dd, sqrf(y1 - y));
+      dd = fminf(dd, sqrf(y2 - y));
+
+      if(dd < dist)
+      {
+        box = k;
+        dist = dd;
+      }
     }
   }
 

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -156,11 +156,13 @@ void dt_printing_setup_box(dt_images_box *imgs, const int idx,
 
   if(box->screen.x + dx > imgs->screen.print_area.x + imgs->screen.print_area.width)
   {
-    box->screen.width -= (box->screen.x + dx - imgs->screen.print_area.x - imgs->screen.print_area.width);
+    const float off = (box->screen.x + dx - imgs->screen.print_area.x - imgs->screen.print_area.width);
+    box->screen.x = fmaxf(imgs->screen.print_area.x, box->screen.x - off);
   }
   if(box->screen.y + dy > imgs->screen.print_area.y + imgs->screen.print_area.height)
   {
-    box->screen.height -= (box->screen.y + dy - imgs->screen.print_area.y - imgs->screen.print_area.height);
+    const float off = (box->screen.y + dy - imgs->screen.print_area.y - imgs->screen.print_area.height);
+    box->screen.y = fmaxf(imgs->screen.print_area.y, box->screen.y - off);
   }
 
   _compute_rel_pos(imgs, &box->screen, &box->pos);

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -33,9 +33,9 @@ typedef struct _image_box
   int32_t imgid;
   int32_t max_width, max_height;
   int32_t exp_width, exp_height;
-  dt_image_pos pos;              // relative pos in per 10000
-  dt_image_pos screen;           // current screen pos
-  dt_image_pos print;            // current print pos depending on paper size + DPI
+  dt_image_pos pos;              // relative pos (in per 10000)
+  dt_image_pos screen;           // current screen pos (in pixels)
+  dt_image_pos print;            // current print pos (in mm) depending on paper size + DPI
   uint16_t *buf;
 } dt_image_box;
 
@@ -44,7 +44,7 @@ typedef struct dt_images_box
   gboolean auto_fit;
   int count;
   dt_image_box box[MAX_IMAGE_PER_PAGE];
-  dt_image_pos screen_page;      // this is for reference and is the box of the white page
+  dt_image_pos screen_page;      // this is for reference and is the box of the white page (in mm)
                                  // in print module.
 } dt_images_box;
 

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -69,7 +69,7 @@ typedef struct dt_images_box
 } dt_images_box;
 
 // return the box index or -1 if (x, y) coordinate is not over an image
-int dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y);
+int32_t dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y);
 
 void dt_printing_clear_box(dt_image_box *img);
 void dt_printing_clear_boxes(dt_images_box *imgs);

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -45,7 +45,9 @@ typedef struct dt_images_box
   int count;
   dt_image_box box[MAX_IMAGE_PER_PAGE];
   dt_image_pos screen_page;      // this is for reference and is the box of the white page (in mm)
-                                 // in print module.
+                                 // in print module. it is the full page.
+  dt_image_pos screen_page_area; // this is for reference and is the box of the white page (in mm)
+                                 // in print module. it is the page area (without margins).
 } dt_images_box;
 
 // return the box index or -1 if (x, y) coordinate is not over an image

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -25,7 +25,7 @@
 
 typedef struct _imgage_pos
 {
-  int32_t x, y, width, height;
+  float x, y, width, height;
 } dt_image_pos;
 
 typedef struct _image_box

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -1,0 +1,56 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <glib.h>
+#include <inttypes.h>
+
+#define MAX_IMAGE_PER_PAGE 20
+
+typedef struct _imgage_pos
+{
+  int32_t x, y, width, height;
+} dt_image_pos;
+
+typedef struct _image_box
+{
+  int32_t imgid;
+  int32_t max_width, max_height;
+  int32_t exp_width, exp_height;
+  dt_image_pos pos;              // relative pos in per 10000
+  dt_image_pos screen;           // current screen pos
+  dt_image_pos print;            // current print pos depending on paper size + DPI
+  uint16_t *buf;
+} dt_image_box;
+
+typedef struct dt_images_box
+{
+  gboolean auto_fit;
+  int count;
+  dt_image_box box[MAX_IMAGE_PER_PAGE];
+  dt_image_pos screen_page;      // this is for reference and is the box of the white page
+                                 // in print module.
+} dt_images_box;
+
+// return the box index or -1 if (x, y) coordinate is not over an image
+int dt_printing_get_image_box(dt_images_box *imgs, const int x, const int y);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -60,8 +60,8 @@ typedef struct dt_screen_pos
 typedef struct dt_images_box
 {
   int32_t imgid_to_load;
-  int count;
   int32_t motion_over;
+  int count;
   dt_image_box box[MAX_IMAGE_PER_PAGE];
   float page_width, page_height;       // full print page in pixels
   float page_width_mm, page_height_mm; // full print page in mm

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -20,6 +20,10 @@
 
 #include <glib.h>
 #include <inttypes.h>
+#include "common/pdf.h"
+#include "common/cups_print.h"
+#include "common/image.h"
+
 
 #define MAX_IMAGE_PER_PAGE 20
 
@@ -31,28 +35,70 @@ typedef struct _imgage_pos
 typedef struct _image_box
 {
   int32_t imgid;
-  int32_t max_width, max_height;
-  int32_t exp_width, exp_height;
-  dt_image_pos pos;              // relative pos (in per 10000)
+  int32_t max_width, max_height; // max size for the export (in pixels)
+  int32_t exp_width, exp_height; // final exported size (in pixels)
+  int32_t dis_width, dis_height; // image size on screen (in pixels)
+  int32_t img_width, img_height; // the final image size as it will be exported
+  dt_alignment_t alignment;
+  dt_image_pos pos;              // relative pos from screen.page
   dt_image_pos screen;           // current screen pos (in pixels)
-  dt_image_pos print;            // current print pos (in mm) depending on paper size + DPI
+  dt_image_pos print;            // current print pos (in pixels) depending on paper size + DPI
   uint16_t *buf;
 } dt_image_box;
 
+typedef struct dt_screen_pos
+{
+  dt_image_pos page;       // this is for reference and is the box of the
+                           // white page (in pixels) in print module.
+                           // it is the full page.
+
+  dt_image_pos print_area; // this is for reference and is the box of the
+                           // grey area in the white page (in pixels) in print
+                           // module. it is the print area (without margins).
+} dt_screen_pos;
+
 typedef struct dt_images_box
 {
-  gboolean auto_fit;
+  int32_t imgid_to_load;
   int count;
   int32_t motion_over;
   dt_image_box box[MAX_IMAGE_PER_PAGE];
-  dt_image_pos screen_page;      // this is for reference and is the box of the white page (in mm)
-                                 // in print module. it is the full page.
-  dt_image_pos screen_page_area; // this is for reference and is the box of the white page (in mm)
-                                 // in print module. it is the page area (without margins).
+  float page_width, page_height;       // full print page in pixels
+  float page_width_mm, page_height_mm; // full print page in mm
+  dt_screen_pos screen;
 } dt_images_box;
 
 // return the box index or -1 if (x, y) coordinate is not over an image
-int dt_printing_get_image_box(dt_images_box *imgs, const int x, const int y);
+int dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y);
+
+void dt_printing_clear_box(dt_image_box *img);
+void dt_printing_clear_boxes(dt_images_box *imgs);
+
+/* (x, y) -> (width, height) are in pixels (on screen position) */
+void dt_printing_setup_display(dt_images_box *imgs,
+                               const float px, const float py, const float pwidth, const float pheight,
+                               const float ax, const float ay, const float awidth, const float aheight);
+
+void dt_printing_setup_box(dt_images_box *imgs, const int idx,
+                           const float x, const float y,
+                           const float width, const float height);
+
+/* page_width page_height in mm, compute the max_width and max_height in
+   pixels for the image */
+void dt_printing_setup_page(dt_images_box *imgs,
+                            const float page_width, const float page_height,
+                            const int resolution);
+
+/* setup the image id and exported width x height */
+void dt_printing_setup_image(dt_images_box *imgs, const int idx,
+                             const int32_t imgid, const int32_t width, const int32_t height,
+                             const dt_alignment_t alignment);
+
+/* return the on screen pos with alignement */
+void dt_printing_get_screen_pos(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos);
+void dt_printing_get_screen_rel_pos(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos);
+void dt_printing_get_image_pos_mm(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos);
+void dt_printing_get_image_pos(const dt_images_box *imgs, const dt_image_box *img, dt_image_pos *pos);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -43,6 +43,7 @@ typedef struct dt_images_box
 {
   gboolean auto_fit;
   int count;
+  int32_t motion_over;
   dt_image_box box[MAX_IMAGE_PER_PAGE];
   dt_image_pos screen_page;      // this is for reference and is the box of the white page (in mm)
                                  // in print module. it is the full page.

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3301,6 +3301,20 @@ void dt_gui_menu_popup(GtkMenu *menu, GtkWidget *button, GdkGravity widget_ancho
 #endif
 }
 
+// draw rounded rectangle
+void dt_gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float x, float y)
+{
+  const float radius = height / 5.0f;
+  const float degrees = M_PI / 180.0;
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
+  cairo_arc(cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
+  cairo_arc(cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
+  cairo_arc(cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
+  cairo_close_path(cr);
+  cairo_fill(cr);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -438,6 +438,7 @@ void dt_gui_container_remove_children(GtkContainer *container);
 void dt_gui_container_destroy_children(GtkContainer *container);
 
 void dt_gui_menu_popup(GtkMenu *menu, GtkWidget *button, GdkGravity widget_anchor, GdkGravity menu_anchor);
+void dt_gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float x, float y);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2417,19 +2417,6 @@ static _grab_region_t get_grab(float pzx, float pzy, dt_iop_clipping_gui_data_t 
   return grab;
 }
 
-// draw rounded rectangle
-static void gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float x, float y)
-{
-  const float radius = height / 5.0f;
-  const float degrees = M_PI / 180.0;
-  cairo_new_sub_path(cr);
-  cairo_arc(cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
-  cairo_arc(cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
-  cairo_arc(cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
-  cairo_arc(cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
-  cairo_close_path(cr);
-  cairo_fill(cr);
-}
 // draw symmetry signs
 static void gui_draw_sym(cairo_t *cr, float x, float y, float scale, gboolean active)
 {
@@ -2443,7 +2430,7 @@ static void gui_draw_sym(cairo_t *cr, float x, float y, float scale, gboolean ac
   pango_layout_set_text(layout, "ꝏ", -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   dt_draw_set_color_overlay(cr, 0.5, 0.7);
-  gui_draw_rounded_rectangle(
+  dt_gui_draw_rounded_rectangle(
       cr, ink.width + DT_PIXEL_APPLY_DPI(4) * scale, ink.height + DT_PIXEL_APPLY_DPI(8) * scale,
       x - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(2) * scale, y - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(4) * scale);
   cairo_move_to(cr, x - ink.width / 2.0f, y - 3.0 * ink.height / 4.0f - DT_PIXEL_APPLY_DPI(4) * scale);
@@ -2539,8 +2526,8 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     yp = CLAMPF(yp, y1 + 2.0 * margin, y2 - text_h - 2.0 * margin);
 
     cairo_set_source_rgba(cr, .5, .5, .5, .9);
-    gui_draw_rounded_rectangle(cr, text_w + 2 * margin, text_h + 2 * margin,
-                               xp - margin, yp - margin);
+    dt_gui_draw_rounded_rectangle(cr, text_w + 2 * margin, text_h + 2 * margin,
+                                  xp - margin, yp - margin);
     cairo_set_source_rgb(cr, .7, .7, .7);
     cairo_move_to(cr, xp, yp);
     pango_cairo_show_layout(cr, layout);
@@ -2627,7 +2614,8 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_set_source_rgba(cr, .5, .5, .5, .9);
     const float xp = pzx * wd + DT_PIXEL_APPLY_DPI(20) / zoom_scale;
     const float yp = pzy * ht - ink.height;
-    gui_draw_rounded_rectangle(cr, text_w + 2 * margin, text_h + 2 * margin, xp - margin, yp - margin);
+    dt_gui_draw_rounded_rectangle
+      (cr, text_w + 2 * margin, text_h + 2 * margin, xp - margin, yp - margin);
     cairo_set_source_rgba(cr, .7, .7, .7, .7);
     cairo_move_to(cr, xp, yp);
     pango_cairo_show_layout(cr, layout);
@@ -2842,10 +2830,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
       int c[2] = { (MIN(pts[4], pts[2]) + MAX(pts[0], pts[6])) / 2.0f,
                    (MIN(pts[5], pts[7]) + MAX(pts[1], pts[3])) / 2.0f };
       cairo_set_source_rgba(cr, .5, .5, .5, .9);
-      gui_draw_rounded_rectangle(cr, ink.width + DT_PIXEL_APPLY_DPI(8) * pr_d,
-                                 ink.height + DT_PIXEL_APPLY_DPI(12) * pr_d,
-                                 c[0] - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(4) * pr_d,
-                                 c[1] - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(6) * pr_d);
+      dt_gui_draw_rounded_rectangle(cr, ink.width + DT_PIXEL_APPLY_DPI(8) * pr_d,
+                                    ink.height + DT_PIXEL_APPLY_DPI(12) * pr_d,
+                                    c[0] - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(4) * pr_d,
+                                    c[1] - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(6) * pr_d);
       cairo_move_to(cr, c[0] - ink.width / 2.0, c[1] - 3.0 * ink.height / 4.0);
       dt_draw_set_color_overlay(cr, 0.2, 0.9);
       pango_cairo_show_layout(cr, layout);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1391,20 +1391,6 @@ static _grab_region_t _gui_get_grab(float pzx, float pzy, dt_iop_crop_gui_data_t
   return grab;
 }
 
-// draw rounded rectangle
-static void _gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float x, float y)
-{
-  const float radius = height / 5.0f;
-  const float degrees = M_PI / 180.0;
-  cairo_new_sub_path(cr);
-  cairo_arc(cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
-  cairo_arc(cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
-  cairo_arc(cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
-  cairo_arc(cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
-  cairo_close_path(cr);
-  cairo_fill(cr);
-}
-
 // draw guides and handles over the image
 void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
                      int32_t pointery)
@@ -1486,7 +1472,8 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     yp = CLAMPF(yp, y1 + 2.0 * margin, y2 - text_h - 2.0 * margin);
 
     cairo_set_source_rgba(cr, .5, .5, .5, .9);
-    _gui_draw_rounded_rectangle(cr, text_w + 2 * margin, text_h + 2 * margin, xp - margin, yp - margin);
+    dt_gui_draw_rounded_rectangle
+      (cr, text_w + 2 * margin, text_h + 2 * margin, xp - margin, yp - margin);
     cairo_set_source_rgb(cr, .7, .7, .7);
     cairo_move_to(cr, xp, yp);
     pango_cairo_show_layout(cr, layout);

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -119,10 +119,10 @@ endif(Gphoto2_FOUND)
 
 # the modules specific to map mode
 if(USE_MAP)
-	add_library(location MODULE "location.c")
-	add_library(map_settings MODULE "map_settings.c")
+  add_library(location MODULE "location.c")
+  add_library(map_settings MODULE "map_settings.c")
   add_library(map_locations MODULE "map_locations.c")
-	set(MODULES ${MODULES} location map_settings map_locations)
+  set(MODULES ${MODULES} location map_settings map_locations)
 endif(USE_MAP)
 
 # the modules specific to geotagging module

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1184,7 +1184,7 @@ _unit_changed (GtkWidget *combo, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
-  int unit = dt_bauhaus_combobox_get(combo);
+  const int unit = dt_bauhaus_combobox_get(combo);
   if(unit < 0) return; // shouldn't happen, but it could be -1 if nothing is selected
   ps->unit = unit;
   dt_conf_set_int("plugins/print/print/unit", ps->unit);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1385,6 +1385,18 @@ void _get_control(dt_lib_print_settings_t *ps, float x, float y)
   if(ps->sel_controls == 0) ps->sel_controls = BOX_ALL;
 }
 
+int mouse_leave(struct dt_lib_module_t *self)
+{
+  dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
+
+  if(ps->last_selected != -1)
+  {
+    dt_control_set_mouse_over_id(ps->imgs.box[ps->last_selected].imgid);
+  }
+
+  return 0;
+}
+
 int mouse_moved(struct dt_lib_module_t *self, double x, double y, double pressure, int which)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1951,7 +1951,11 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     const float text_h = DT_PIXEL_APPLY_DPI(16+2);
     const float margin = DT_PIXEL_APPLY_DPI(6);
     const float xp = (x1 + x2 - text_w) * .5f;
-    const float yp = y1 - text_h - (margin * 2.0f);
+    float yp = y1 - text_h - (margin * 2.0f);
+
+    // put text in the center if not enought space on top
+    if(yp < text_h)
+      yp = (y1 + y2 - text_h) * .5f;
 
     cairo_set_source_rgba(cr, .5, .5, .5, .9);
     dt_gui_draw_rounded_rectangle(cr, text_w + 2 * margin, text_h + 2 * margin,

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -378,23 +378,30 @@ static void _create_pdf(dt_job_t *job, dt_images_box imgs, float width, float he
 */
   for(int k=0; k<imgs.count; k++)
   {
+    const int resolution = params->prt.printer.resolution;
+    const dt_image_box *box = &imgs.box[k];
+
     pdf_image[k] =
-      dt_pdf_add_image(pdf, (uint8_t *)imgs.box[k].buf, imgs.box[k].exp_width, imgs.box[k].exp_height,
+      dt_pdf_add_image(pdf, (uint8_t *)box->buf, box->exp_width, box->exp_height,
                        8, icc_id, 0.0);
 
     //  PDF bounding-box has origin on bottom-left
-    pdf_image[k]->bb_x      =
-      dt_pdf_pixel_to_point(imgs.box[k].print.x, params->prt.printer.resolution);
-    pdf_image[k]->bb_y      =
-      dt_pdf_pixel_to_point(imgs.box[k].print.y, params->prt.printer.resolution);
-    pdf_image[k]->bb_width  =
-      dt_pdf_pixel_to_point(imgs.box[k].print.width, params->prt.printer.resolution);
-    pdf_image[k]->bb_height =
-      dt_pdf_pixel_to_point(imgs.box[k].print.height, params->prt.printer.resolution);
+    pdf_image[k]->bb_x      = dt_pdf_pixel_to_point(box->print.x, resolution);
+    pdf_image[k]->bb_y      = dt_pdf_pixel_to_point(box->print.y, resolution);
+    pdf_image[k]->bb_width  = dt_pdf_pixel_to_point(box->print.width, resolution);
+    pdf_image[k]->bb_height = dt_pdf_pixel_to_point(box->print.height, resolution);
   }
 
   params->pdf_page = dt_pdf_add_page(pdf, pdf_image, imgs.count);
   dt_pdf_finish(pdf, &params->pdf_page, 1);
+
+  // now releases all the buf
+  for(int k=0; k<imgs.count; k++)
+  {
+    dt_image_box *box = &imgs.box[k];
+    g_free(box->buf);
+    box->buf = NULL;
+  }
 }
 
 void _fill_box_values(dt_lib_print_settings_t *ps)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1657,6 +1657,8 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
     ps->has_changed = TRUE;
 
     _get_control(ps, x, y);
+
+    dt_control_change_cursor(GDK_HAND1);
   }
   else if(ps->selected != -1 && which == 3)
   {

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -39,7 +39,7 @@
 #include "libs/lib.h"
 #include "libs/lib_api.h"
 
-DT_MODULE(3)
+DT_MODULE(4)
 
 const char *name(dt_lib_module_t *self)
 {
@@ -2765,6 +2765,31 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
 
     *new_size = new_params_size;
     *new_version = 3;
+    return new_params;
+  }
+  else if(old_version == 3)
+  {
+    // no box
+    size_t new_params_size = old_params_size + sizeof(int32_t) + 4 * sizeof(float);
+    void *new_params = calloc(1, new_params_size);
+
+    memcpy(new_params, old_params, old_params_size);
+
+    // single image box specified
+    int32_t idx = old_params_size;
+    *(int32_t *)(new_params + idx) = 1;
+    idx += sizeof(int32_t);
+    *(float *)(new_params + idx) = 0.0f;
+    idx += sizeof(float);
+    *(float *)(new_params + idx) = 0.0f;
+    idx += sizeof(float);
+    *(float *)(new_params + idx) = 100.0f;
+    idx += sizeof(float);
+    *(float *)(new_params + idx) = 100.0f;
+    // idx += sizeof(float);
+
+    *new_size = new_params_size;
+    *new_version = 4;
     return new_params;
   }
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1822,10 +1822,18 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
 
     if(k == ps->selected || img->imgid == -1)
     {
-      _cairo_rectangle(cr, ps->sel_controls,
+      cairo_set_source_rgba(cr, .5, .5, .5, 1.0);
+      _cairo_rectangle(cr, (k == ps->selected) ? ps->sel_controls : 0,
                        img->screen.x, img->screen.y,
                        img->screen.x + img->screen.width, img->screen.y + img->screen.height);
       cairo_stroke(cr);
+    }
+
+    if(k == ps->imgs.motion_over)
+    {
+      cairo_set_source_rgba(cr, .4, .4, .4, 1.0);
+      cairo_rectangle(cr, img->screen.x, img->screen.y, img->screen.width, img->screen.height);
+      cairo_fill(cr);
     }
   }
 
@@ -1969,6 +1977,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->profiles = _get_profiles();
 
+  d->imgs.motion_over = -1;
   d->imgs.count = 0;
   for(int k=0; k<MAX_IMAGE_PER_PAGE; k++)
   {

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -357,7 +357,7 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
   return 0;
 }
 
-static void _create_pdf(dt_job_t *job, dt_images_box imgs, float width, float height)
+static void _create_pdf(dt_job_t *job, dt_images_box imgs, const float width, const float height)
 {
   dt_lib_print_job_t *params = dt_control_job_get_params(job);
 
@@ -441,7 +441,7 @@ void _fill_box_values(dt_lib_print_settings_t *ps)
   --darktable.gui->reset;
 }
 
-static int _export_and_setup_pos(dt_job_t *job, dt_image_box *img, int32_t idx)
+static int _export_and_setup_pos(dt_job_t *job, dt_image_box *img, const int32_t idx)
 {
   dt_lib_print_job_t *params = dt_control_job_get_params(job);
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1601,10 +1601,8 @@ int button_released(struct dt_lib_module_t *self, double x, double y, int which,
       if(ps->x2 < ps->x1) _swap(&ps->x1, &ps->x2);
       if(ps->y2 < ps->y1) _swap(&ps->y1, &ps->y2);
 
-      const float dx = fminf(ps->imgs.screen.print_area.width,
-                             fmaxf(100.0f, ps->x2 - ps->x1));
-      const float dy = fminf(ps->imgs.screen.print_area.height,
-                             fmaxf(100.0f, ps->y2 - ps->y1));
+      const float dx = ps->x2 - ps->x1;
+      const float dy = ps->y2 - ps->y1;
 
       dt_printing_setup_box(&ps->imgs, idx, ps->x1, ps->y1, dx, dy);
       // make the new created box the last edited one

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -526,6 +526,15 @@ static void _page_new_area_clicked(GtkWidget *widget, gpointer user_data)
   ps->creation = TRUE;
 }
 
+static void _page_clear_area_clicked(GtkWidget *widget, gpointer user_data)
+{
+  const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
+
+  dt_printing_clear_boxes(&ps->imgs);
+  dt_control_queue_redraw_center();
+}
+
 static void _page_delete_area_clicked(GtkWidget *widget, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
@@ -2086,14 +2095,27 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *hfitbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   GtkWidget *mfitbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+  GtkGrid *fitbut = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_row_spacing(fitbut, DT_PIXEL_APPLY_DPI(3));
+  gtk_grid_set_column_spacing(fitbut, DT_PIXEL_APPLY_DPI(3));
+  gtk_grid_set_column_homogeneous(fitbut, TRUE);
+  gtk_grid_set_row_homogeneous(fitbut, TRUE);
+
   GtkWidget *bnew = gtk_button_new_with_label(_("new image area"));
   g_signal_connect(G_OBJECT(bnew), "clicked", G_CALLBACK(_page_new_area_clicked), (gpointer)self);
   d->del = gtk_button_new_with_label(_("delete image area"));
   g_signal_connect(G_OBJECT(d->del), "clicked", G_CALLBACK(_page_delete_area_clicked), (gpointer)self);
   gtk_widget_set_sensitive(d->del, FALSE);
 
-  gtk_box_pack_start(GTK_BOX(mfitbox), GTK_WIDGET(bnew), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(mfitbox), GTK_WIDGET(d->del), TRUE, TRUE, 0);
+  GtkWidget *bclear = gtk_button_new_with_label(_("clear layout"));
+  g_signal_connect(G_OBJECT(bclear), "clicked", G_CALLBACK(_page_clear_area_clicked), (gpointer)self);
+
+  gtk_grid_attach(fitbut, GTK_WIDGET(bnew), 0, 0, 2, 1);
+  gtk_grid_attach(fitbut, GTK_WIDGET(d->del), 0, 1, 1, 1);
+  gtk_grid_attach(fitbut, GTK_WIDGET(bclear), 1, 1, 1, 1);
+
+  gtk_box_pack_start(GTK_BOX(mfitbox), GTK_WIDGET(fitbut), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hfitbox), GTK_WIDGET(mfitbox), TRUE, TRUE, 0);
 
   // X x Y

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1283,8 +1283,8 @@ _intent_callback (GtkWidget *widget, dt_lib_module_t *self)
 
 static void _set_orientation(dt_lib_print_settings_t *ps)
 {
-  if (ps->imgs.auto_fit && ps->imgs.box[0].imgid <= 0)
-    return;
+//  if(ps->imgs.auto_fit || ps->imgs.box[0].imgid <= 0)
+//    return;
 
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf,
@@ -1308,8 +1308,8 @@ static void _print_settings_activate_or_update_callback(gpointer instance, int i
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
-  // only update via filmstrip if there is a single image
-  if(ps->imgs.count != 1) return;
+  // only update via filmstrip if autofit
+  if(!ps->imgs.auto_fit) return;
 
   ps->imgs.box[0].imgid = imgid;
   ps->imgs.box[0].screen.width = ps->imgs.box[0].screen.height = 0;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1524,6 +1524,8 @@ int button_released(struct dt_lib_module_t *self, double x, double y, int which,
                              fmaxf(100.0f, ps->y2 - ps->y1));
 
       dt_printing_setup_box(&ps->imgs, idx, ps->x1, ps->y1, dx, dy);
+      // make the new created box the last edited one
+      ps->last_selected = idx;
       _fill_box_values(ps);
     }
   }

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1496,9 +1496,7 @@ int mouse_moved(struct dt_lib_module_t *self, double x, double y, double pressur
     dt_image_box *b = &ps->imgs.box[ps->selected];
     const float dx = x - ps->click_pos_x;
     const float dy = y - ps->click_pos_y;
-    const float signx = dx >= 0 ? 1 : -1;
-    const float signy = dx >= 0 ? 1 : -1;
-    const float dxdy = fmaxf(fabsf(dx), fabsf(dy));
+    const float coef = dx / b->screen.width;
 
     switch(ps->sel_controls)
     {
@@ -1521,20 +1519,20 @@ int mouse_moved(struct dt_lib_module_t *self, double x, double y, double pressur
          ps->y2 = b->screen.y + b->screen.height + dy;
          break;
        case BOX_TOP_LEFT:
-         ps->x1 = b->screen.x + signx * dxdy;
-         ps->y1 = b->screen.y + signy * dxdy;
+         ps->x1 = b->screen.x + dx;
+         ps->y1 = b->screen.y + (coef * b->screen.height);
          break;
        case BOX_TOP_RIGHT:
-         ps->x2 = b->screen.x + b->screen.width + signx * dxdy;
-         ps->y1 = b->screen.y - signy * dxdy;
+         ps->x2 = b->screen.x + b->screen.width + dx;
+         ps->y1 = b->screen.y - (coef * b->screen.height);
          break;
        case BOX_BOTTOM_LEFT:
-         ps->x1 = b->screen.x + signx * dxdy;
-         ps->y2 = b->screen.y + b->screen.height - signy * dxdy;
+         ps->x1 = b->screen.x + dx;
+         ps->y2 = b->screen.y + b->screen.height - (coef * b->screen.height);
          break;
        case BOX_BOTTOM_RIGHT:
-         ps->x2 = b->screen.x + b->screen.width + signx * dxdy;
-         ps->y2 = b->screen.y + b->screen.height + signy * dxdy;
+         ps->x2 = b->screen.x + b->screen.width + dx;
+         ps->y2 = b->screen.y + b->screen.height + (coef * b->screen.height);
          break;
        default:
          break;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1643,6 +1643,15 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
 
     _snap_to_grid(ps, &ps->x1, &ps->y1);
   }
+  else if(ps->selected > 0
+          && (which == 2 || (which == 1 && dt_modifier_is(state, GDK_CONTROL_MASK))))
+  {
+    // middle click (or ctrl-click), move selected image down
+    dt_image_box b;
+    memcpy(&b, &ps->imgs.box[ps->selected], sizeof(dt_image_box));
+    memcpy(&ps->imgs.box[ps->selected], &ps->imgs.box[ps->selected-1], sizeof(dt_image_box));
+    memcpy(&ps->imgs.box[ps->selected-1], &b, sizeof(dt_image_box));
+  }
   else if(ps->selected != -1 && which == 1)
   {
     dt_image_box *b = &ps->imgs.box[ps->selected];

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1677,7 +1677,7 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
         cairo_translate(cr, screen.x, screen.y);
         cairo_scale(cr, scaler, scaler);
         cairo_set_source_surface(cr, surf, 0, 0);
-        cairo_paint(cr);
+        cairo_paint_with_alpha(cr, ps->dragging ? 0.5 : 1.0);
         cairo_surface_destroy(surf);
         cairo_restore(cr);
         if(ps->busy) dt_control_log_busy_leave();

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -403,20 +403,20 @@ void _fill_box_values(dt_lib_print_settings_t *ps)
 
   if(ps->last_selected != -1)
   {
-    dt_image_box *b = &ps->imgs.box[ps->last_selected];
+    dt_image_box *box = &ps->imgs.box[ps->last_selected];
 
     float width, height;
     _get_page_dimention(&ps->prt, &width, &height);
 
-    x = _percent_unit_of(ps, width, b->pos.x);
-    y = _percent_unit_of(ps, height, b->pos.y);
-    swidth = _percent_unit_of(ps, width, b->pos.width);
-    sheight = _percent_unit_of(ps, height, b->pos.height);
+    x       = _percent_unit_of(ps, width, box->pos.x);
+    y       = _percent_unit_of(ps, height, box->pos.y);
+    swidth  = _percent_unit_of(ps, width, box->pos.width);
+    sheight = _percent_unit_of(ps, height, box->pos.height);
 
     for(int i=0; i<9; i++)
     {
       ++darktable.gui->reset;
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ps->dtba[i]), (i == b->alignment));
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ps->dtba[i]), (i == box->alignment));
       --darktable.gui->reset;
     }
   }

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -627,7 +627,7 @@ static int _print_job_run(dt_job_t *job)
   return 0;
 }
 
-static void _page_new_area_clicked (GtkWidget *widget, gpointer user_data)
+static void _page_new_area_clicked(GtkWidget *widget, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -680,7 +680,7 @@ static void _print_job_cleanup(void *p)
   free(params);
 }
 
-static void _print_button_clicked (GtkWidget *widget, gpointer user_data)
+static void _print_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -876,7 +876,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 }
 
 static void
-_printer_changed (GtkWidget *combo, const dt_lib_module_t *self)
+_printer_changed(GtkWidget *combo, const dt_lib_module_t *self)
 {
   const gchar *printer_name = dt_bauhaus_combobox_get_text(combo);
 
@@ -903,7 +903,7 @@ static void _reset_screen_box(dt_lib_print_settings_t *ps)
 }
 
 static void
-_paper_changed (GtkWidget *combo, const dt_lib_module_t *self)
+_paper_changed(GtkWidget *combo, const dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
@@ -925,7 +925,7 @@ _paper_changed (GtkWidget *combo, const dt_lib_module_t *self)
 }
 
 static void
-_media_changed (GtkWidget *combo, const dt_lib_module_t *self)
+_media_changed(GtkWidget *combo, const dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
@@ -945,7 +945,7 @@ _media_changed (GtkWidget *combo, const dt_lib_module_t *self)
 }
 
 static void
-_update_slider (dt_lib_print_settings_t *ps)
+_update_slider(dt_lib_print_settings_t *ps)
 {
   dt_view_print_settings(darktable.view_manager, &ps->prt, &ps->imgs);
 
@@ -1037,7 +1037,7 @@ _update_slider (dt_lib_print_settings_t *ps)
 }
 
 static void
-_top_border_callback (GtkWidget *spin, gpointer user_data)
+_top_border_callback(GtkWidget *spin, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -1060,7 +1060,7 @@ _top_border_callback (GtkWidget *spin, gpointer user_data)
 }
 
 static void
-_bottom_border_callback (GtkWidget *spin, gpointer user_data)
+_bottom_border_callback(GtkWidget *spin, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -1071,7 +1071,7 @@ _bottom_border_callback (GtkWidget *spin, gpointer user_data)
 }
 
 static void
-_left_border_callback (GtkWidget *spin, gpointer user_data)
+_left_border_callback(GtkWidget *spin, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -1082,7 +1082,7 @@ _left_border_callback (GtkWidget *spin, gpointer user_data)
 }
 
 static void
-_right_border_callback (GtkWidget *spin, gpointer user_data)
+_right_border_callback(GtkWidget *spin, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -1093,7 +1093,7 @@ _right_border_callback (GtkWidget *spin, gpointer user_data)
 }
 
 static void
-_lock_callback (GtkWidget *button, gpointer user_data)
+_lock_callback(GtkWidget *button, gpointer user_data)
 {
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
@@ -1164,7 +1164,7 @@ _alignment_callback(GtkWidget *tb, gpointer user_data)
 }
 
 static void
-_orientation_changed (GtkWidget *combo, dt_lib_module_t *self)
+_orientation_changed(GtkWidget *combo, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
@@ -1176,7 +1176,7 @@ _orientation_changed (GtkWidget *combo, dt_lib_module_t *self)
 }
 
 static void
-_unit_changed (GtkWidget *combo, dt_lib_module_t *self)
+_unit_changed(GtkWidget *combo, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
@@ -1324,7 +1324,7 @@ _printer_intent_callback (GtkWidget *widget, dt_lib_module_t *self)
 }
 
 static void
-_printer_bpc_callback (GtkWidget *widget, dt_lib_module_t *self)
+_printer_bpc_callback(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
   ps->v_black_point_compensation = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ps->black_point_compensation));
@@ -1332,7 +1332,7 @@ _printer_bpc_callback (GtkWidget *widget, dt_lib_module_t *self)
 }
 
 static void
-_intent_callback (GtkWidget *widget, dt_lib_module_t *self)
+_intent_callback(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
   const int pos = dt_bauhaus_combobox_get(widget);
@@ -1935,7 +1935,7 @@ static void _y_changed(GtkWidget *widget, gpointer user_data)
   dt_control_queue_redraw_center();
 }
 
-void gui_init (dt_lib_module_t *self)
+void gui_init(dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *d = (dt_lib_print_settings_t*)malloc(sizeof(dt_lib_print_settings_t));
   self->data = d;
@@ -2903,7 +2903,7 @@ void *get_params(dt_lib_module_t *self, int *size)
   return params;
 }
 
-void gui_cleanup (dt_lib_module_t *self)
+void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2083,6 +2083,10 @@ void gui_init(dt_lib_module_t *self)
 
   // pack image dimension hbox here
 
+  label = dt_ui_section_label_new(_("image layout"));
+  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, dt_get_help_url("print_image_layout"));
+
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hboxdim), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hboxinfo), TRUE, TRUE, 0);
 
@@ -2117,12 +2121,19 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_set_row_homogeneous(fitbut, TRUE);
 
   GtkWidget *bnew = gtk_button_new_with_label(_("new image area"));
+  gtk_widget_set_tooltip_text(bnew, _("add a new image area on the page\n"
+                                      "click and drag on the page to place the area\n"
+                                      "drag&drop image from film strip on it"));
+
   g_signal_connect(G_OBJECT(bnew), "clicked", G_CALLBACK(_page_new_area_clicked), (gpointer)self);
+
   d->del = gtk_button_new_with_label(_("delete image area"));
+  gtk_widget_set_tooltip_text(d->del, _("delete the currently selected image area"));
   g_signal_connect(G_OBJECT(d->del), "clicked", G_CALLBACK(_page_delete_area_clicked), (gpointer)self);
   gtk_widget_set_sensitive(d->del, FALSE);
 
   GtkWidget *bclear = gtk_button_new_with_label(_("clear layout"));
+  gtk_widget_set_tooltip_text(bclear, _("remove all image area from the page"));
   g_signal_connect(G_OBJECT(bclear), "clicked", G_CALLBACK(_page_clear_area_clicked), (gpointer)self);
 
   gtk_grid_attach(fitbut, GTK_WIDGET(bnew), 0, 0, 2, 1);
@@ -2137,11 +2148,11 @@ void gui_init(dt_lib_module_t *self)
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
   // d->b_x = gtk_spin_button_new_with_range(0, 1000, 1);
-  gtk_widget_set_tooltip_text(d->b_x, _("x origin"));
+  gtk_widget_set_tooltip_text(d->b_x, _("image area x origin (in current unit)"));
   gtk_entry_set_width_chars(GTK_ENTRY(d->b_x), 5);
 
   // d->b_y = gtk_spin_button_new_with_range(0, 1000, 1);
-  gtk_widget_set_tooltip_text(d->b_y, _("y origin"));
+  gtk_widget_set_tooltip_text(d->b_y, _("image area y origin (in current unit)"));
   gtk_entry_set_width_chars(GTK_ENTRY(d->b_y), 5);
 
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(d->b_x), TRUE, TRUE, 0);
@@ -2152,11 +2163,11 @@ void gui_init(dt_lib_module_t *self)
   // width x height
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
   // d->b_width = gtk_spin_button_new_with_range(0, 1000, 1);
-  gtk_widget_set_tooltip_text(d->b_width, _("width"));
+  gtk_widget_set_tooltip_text(d->b_width, _("image area width (in current unit)"));
   gtk_entry_set_width_chars(GTK_ENTRY(d->b_width), 5);
 
   // d->b_height = gtk_spin_button_new_with_range(0, 1000, 1);
-  gtk_widget_set_tooltip_text(d->b_height, _("height"));
+  gtk_widget_set_tooltip_text(d->b_height, _("image area height (in current unit)"));
   gtk_entry_set_width_chars(GTK_ENTRY(d->b_height), 5);
 
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(d->b_width), TRUE, TRUE, 0);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1303,9 +1303,6 @@ _intent_callback (GtkWidget *widget, dt_lib_module_t *self)
 
 static void _set_orientation(dt_lib_print_settings_t *ps)
 {
-//  if(ps->imgs.auto_fit || ps->imgs.box[0].imgid <= 0)
-//    return;
-
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf,
                       ps->imgs.box[0].imgid, DT_MIPMAP_0, DT_MIPMAP_BEST_EFFORT, 'r');
@@ -1664,6 +1661,9 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
 {
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
+  // initial selection from gui_init is not working???
+  gtk_stack_set_visible_child_name(GTK_STACK(ps->stack), ps->imgs.auto_fit ? "autofit" : "manfit");
+
   if(ps->imgs.auto_fit)
   {
     _get_auto_max_size(&ps->prt, &ps->imgs.box[0]);
@@ -1847,7 +1847,7 @@ void gui_init (dt_lib_module_t *self)
   d->v_piccprofile = NULL;
   d->v_iccprofile = NULL;
   d->v_style = NULL;
-  d->imgs.auto_fit = TRUE;
+  d->imgs.auto_fit = dt_conf_get_bool("plugins/print/print/autofit");
   d->creation = d->dragging = FALSE;
   d->selected = -1;
   d->last_selected = 0;
@@ -1858,10 +1858,14 @@ void gui_init (dt_lib_module_t *self)
 
   d->profiles = _get_profiles();
 
+  d->imgs.count = 0;
   for(int k=0; k<MAX_IMAGE_PER_PAGE; k++)
   {
     d->imgs.box[k].imgid = -1;
+    d->imgs.box[k].screen.x = d->imgs.box[k].screen.y = 0;
     d->imgs.box[k].screen.width = d->imgs.box[k].screen.height = 0;
+    d->imgs.box[k].pos.x = d->imgs.box[k].pos.y = 0;
+    d->imgs.box[k].pos.width = d->imgs.box[k].pos.height = 0;
   }
 
   //  create the spin-button now as values could be set when the printer has no hardware margin
@@ -2113,7 +2117,7 @@ void gui_init (dt_lib_module_t *self)
 
   // auto sized or manual
 
-  d->autofit = gtk_check_button_new_with_label(_("auto fit"));
+  d->autofit = gtk_check_button_new_with_label(_("single image auto fit"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->autofit), TRUE, FALSE, 0);
   g_signal_connect(d->autofit, "toggled", G_CALLBACK(_page_autofit_callback), (gpointer)self);
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -595,17 +595,17 @@ static void _print_button_clicked(GtkWidget *widget, gpointer user_data)
 
   const int imgid = ps->imgs.box[0].imgid;
 
-  if (imgid == -1)
+  if(imgid == -1)
   {
     dt_control_log(_("cannot print until a picture is selected"));
     return;
   }
-  if (strlen(ps->prt.printer.name) == 0 || ps->prt.printer.resolution == 0)
+  if(strlen(ps->prt.printer.name) == 0 || ps->prt.printer.resolution == 0)
   {
     dt_control_log(_("cannot print until a printer is selected"));
     return;
   }
-  if (ps->prt.paper.width == 0 || ps->prt.paper.height == 0)
+  if(ps->prt.paper.width == 0 || ps->prt.paper.height == 0)
   {
     dt_control_log(_("cannot print until a paper is selected"));
     return;
@@ -671,7 +671,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   // if this is a turboprint printer, disable the printer profile
 
-  if (ps->prt.printer.is_turboprint)
+  if(ps->prt.printer.is_turboprint)
     dt_bauhaus_combobox_set(ps->pprofile, 0);
 
   // if there is 0 hardware margins, set the user margin to 17mm
@@ -720,7 +720,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
     const dt_paper_info_t *p = (dt_paper_info_t *)papers->data;
     dt_bauhaus_combobox_add(ps->papers, p->common_name);
 
-    if (ispaperset == FALSE && (!g_strcmp0(default_paper, p->common_name) || default_paper[0] == '\0'))
+    if(ispaperset == FALSE && (!g_strcmp0(default_paper, p->common_name) || default_paper[0] == '\0'))
     {
       dt_bauhaus_combobox_set(ps->papers, np);
       ispaperset = TRUE;
@@ -730,11 +730,11 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
   }
 
   //  paper not found in this printer
-  if (!ispaperset) dt_bauhaus_combobox_set(ps->papers, 0);
+  if(!ispaperset) dt_bauhaus_combobox_set(ps->papers, 0);
 
   const dt_paper_info_t *paper = dt_get_paper(ps->paper_list, default_paper);
 
-  if (paper)
+  if(paper)
     memcpy(&ps->prt.paper, paper, sizeof(dt_paper_info_t));
 
   g_free (default_paper);
@@ -761,7 +761,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
     const dt_medium_info_t *m = (dt_medium_info_t *)media->data;
     dt_bauhaus_combobox_add(ps->media, m->common_name);
 
-    if (ismediaset == FALSE && (!g_strcmp0(default_medium, m->common_name) || default_medium[0] == '\0'))
+    if(ismediaset == FALSE && (!g_strcmp0(default_medium, m->common_name) || default_medium[0] == '\0'))
     {
       dt_bauhaus_combobox_set(ps->media, np);
       ismediaset = TRUE;
@@ -771,11 +771,11 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
   }
 
   //  media not found in this printer
-  if (!ismediaset) dt_bauhaus_combobox_set(ps->media, 0);
+  if(!ismediaset) dt_bauhaus_combobox_set(ps->media, 0);
 
   const dt_medium_info_t *medium = dt_get_medium(ps->media_list, default_medium);
 
-  if (medium)
+  if(medium)
     memcpy(&ps->prt.medium, medium, sizeof(dt_medium_info_t));
 
   g_free (default_medium);
@@ -788,7 +788,7 @@ _printer_changed(GtkWidget *combo, const dt_lib_module_t *self)
 {
   const gchar *printer_name = dt_bauhaus_combobox_get_text(combo);
 
-  if (printer_name)
+  if(printer_name)
     _set_printer (self, printer_name);
 }
 
@@ -803,7 +803,7 @@ _paper_changed(GtkWidget *combo, const dt_lib_module_t *self)
 
   const dt_paper_info_t *paper = dt_get_paper(ps->paper_list, paper_name);
 
-  if (paper)
+  if(paper)
     memcpy(&ps->prt.paper, paper, sizeof(dt_paper_info_t));
 
   float width, height;
@@ -828,7 +828,7 @@ _media_changed(GtkWidget *combo, const dt_lib_module_t *self)
 
   const dt_medium_info_t *medium = dt_get_medium(ps->media_list, medium_name);
 
-  if (medium)
+  if(medium)
     memcpy(&ps->prt.medium, medium, sizeof(dt_medium_info_t));
 
   dt_conf_set_string("plugins/print/print/medium", medium_name);
@@ -1258,7 +1258,7 @@ static void _set_orientation(dt_lib_print_settings_t *ps, int32_t imgid)
   // If there's a mipmap available, figure out orientation based upon
   // its dimensions. Otherwise, don't touch orientation until the
   // mipmap arrives.
-  if (buf.size != DT_MIPMAP_NONE)
+  if(buf.size != DT_MIPMAP_NONE)
   {
     ps->prt.page.landscape = (buf.width > buf.height);
     dt_view_print_settings(darktable.view_manager, &ps->prt, &ps->imgs);
@@ -1356,7 +1356,7 @@ static void _new_printer_callback(dt_printer_info_t *printer, void *user_data)
 
   dt_bauhaus_combobox_add(d->printers, printer->name);
 
-  if (!g_strcmp0(default_printer, printer->name) || default_printer[0]=='\0')
+  if(!g_strcmp0(default_printer, printer->name) || default_printer[0]=='\0')
   {
     dt_bauhaus_combobox_set(d->printers, count);
     _set_printer(self, printer->name);
@@ -2143,7 +2143,7 @@ void gui_init(dt_lib_module_t *self)
   g_free (printer_profile);
 
   // profile not found, maybe a profile has been removed? revert to none
-  if (combo_idx == -1)
+  if(combo_idx == -1)
   {
     dt_conf_set_int("plugins/print/printer/icctype", DT_COLORSPACE_NONE);
     dt_conf_set_string("plugins/print/printer/iccprofile", "");
@@ -2461,7 +2461,7 @@ void gui_init(dt_lib_module_t *self)
     }
   }
 
-  if (combo_idx == -1)
+  if(combo_idx == -1)
   {
     dt_conf_set_int("plugins/print/print/icctype", DT_COLORSPACE_NONE);
     dt_conf_set_string("plugins/print/print/iccprofile", "");
@@ -2512,7 +2512,7 @@ void gui_init(dt_lib_module_t *self)
     dt_style_t *style=(dt_style_t *)st_iter->data;
     dt_bauhaus_combobox_add(d->style, style->name);
     n++;
-    if (g_strcmp0(style->name,current_style)==0)
+    if(g_strcmp0(style->name,current_style)==0)
     {
       g_free(d->v_style);
       d->v_style = g_strdup(current_style);
@@ -2525,7 +2525,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(d->style, _("temporary style to use while printing"));
 
   // style not found, maybe a style has been removed? revert to none
-  if (combo_idx == -1)
+  if(combo_idx == -1)
   {
     dt_conf_set_string("plugins/print/print/style", "");
     g_free(d->v_style);
@@ -2752,12 +2752,12 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 
   // get individual items
   const char *printer = buf;
-  if (!printer) return 1;
+  if(!printer) return 1;
   const int32_t printer_len = strlen(printer) + 1;
   buf += printer_len;
 
   const char *paper = buf;
-  if (!paper) return 1;
+  if(!paper) return 1;
   const int32_t paper_len = strlen(paper) + 1;
   buf += paper_len;
 
@@ -2768,7 +2768,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   buf +=  sizeof(int32_t);
 
   const char *f_profile = buf;
-  if (!f_profile) return 1;
+  if(!f_profile) return 1;
   const int32_t profile_len = strlen(f_profile) + 1;
   buf += profile_len;
 
@@ -2779,7 +2779,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   buf +=  sizeof(int32_t);
 
   const char *f_pprofile = buf;
-  if (!f_pprofile) return 1;
+  if(!f_pprofile) return 1;
   const int32_t pprofile_len = strlen(f_pprofile) + 1;
   buf += pprofile_len;
 
@@ -2790,7 +2790,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   buf += sizeof(int32_t);
 
   const char *style = buf;
-  if (!style) return 1;
+  if(!style) return 1;
   const int32_t style_len = strlen(style) + 1;
   buf += style_len;
 
@@ -2837,13 +2837,13 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
     return 1;
 
   // set the GUI with corresponding values
-  if (printer[0] != '\0')
+  if(printer[0] != '\0')
     dt_bauhaus_combobox_set_from_text(ps->printers, printer);
 
-  if (paper[0] != '\0')
+  if(paper[0] != '\0')
     dt_bauhaus_combobox_set_from_text(ps->papers, paper);
 
-  if (media[0] != '\0')
+  if(media[0] != '\0')
     dt_bauhaus_combobox_set_from_text(ps->media, media);
 
   dt_bauhaus_combobox_set (ps->orientation, landscape);
@@ -2875,7 +2875,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   dt_bauhaus_combobox_set (ps->pintent, pintent);
   ps->prt.printer.intent = pintent;
 
-  if (style[0] != '\0')
+  if(style[0] != '\0')
     dt_bauhaus_combobox_set_from_text(ps->style, style);
   dt_bauhaus_combobox_set (ps->style_mode, style_mode);
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2712,8 +2712,8 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
       pprofile_filename = &pprofile[1]; // the old code had a '/' in the beginning
     }
 
-    int32_t new_profile_len = strlen(profile_filename) + 1;
-    int32_t new_pprofile_len = strlen(pprofile_filename) + 1;
+    const int32_t new_profile_len = strlen(profile_filename) + 1;
+    const int32_t new_pprofile_len = strlen(pprofile_filename) + 1;
 
     // now we got everything to reassemble the new params
     size_t new_params_size = old_params_size - profile_len - pprofile_len;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2791,12 +2791,17 @@ void gui_reset(dt_lib_module_t *self)
   gtk_widget_set_sensitive(GTK_WIDGET(ps->black_point_compensation), FALSE);
   gtk_widget_set_sensitive(GTK_WIDGET(ps->style_mode), FALSE);
 
-  dt_printing_clear_boxes(&ps->imgs);
-
   // reset page orientation to fit the picture if a single one is displayed
 
-  if(ps->imgs.count == 1)
-    _set_orientation(ps, ps->imgs.box[0].imgid);
+  const int32_t imgid = (ps->imgs.count > 0) ? ps->imgs.box[0].imgid : -1;
+  dt_printing_clear_boxes(&ps->imgs);
+  ps->imgs.imgid_to_load = imgid;
+
+  ps->creation = ps->dragging = FALSE;
+  ps->selected = -1;
+  ps->last_selected = -1;
+
+  dt_control_queue_redraw_center();
 }
 
 void init_key_accels(dt_lib_module_t *self)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -147,7 +147,7 @@ static void _y_changed(GtkWidget *widget, gpointer user_data);
 static const int min_borders = -100; // this is in mm
 
 int
-position ()
+position()
 {
   return 990;
 }
@@ -1053,7 +1053,7 @@ _top_border_callback(GtkWidget *spin, gpointer user_data)
 
   ps->prt.page.margin_top = to_mm(ps, value);
 
-  if (ps->lock_activated == TRUE)
+  if(ps->lock_activated == TRUE)
   {
     ps->prt.page.margin_bottom = to_mm(ps, value);
     ps->prt.page.margin_left = to_mm(ps, value);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -134,7 +134,7 @@ typedef struct _dialog_description
   const char *name;
 } dialog_description_t;
 
-static const float units[3] = {1.0, 0.1, 1.0/25.4};
+static const float units[3] = {1.0f, 0.1f, 1.0f/25.4f};
 
 static void _update_slider(dt_lib_print_settings_t *ps);
 static void _width_changed(GtkWidget *widget, gpointer user_data);
@@ -167,7 +167,7 @@ static void _get_page_dimention(dt_print_info_t *prt, float *width, float *heigh
 
 // unit conversion
 
-static double to_mm(dt_lib_print_settings_t *ps, double value)
+static float to_mm(dt_lib_print_settings_t *ps, double value)
 {
   return value / units[ps->unit];
 }
@@ -670,22 +670,22 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   // if there is 0 hardware margins, set the user margin to 17mm
 
-  if (ps->prt.printer.hw_margin_top == 0)
+  if(ps->prt.printer.hw_margin_top == 0)
   {
     ps->prt.page.margin_top = 17;
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(ps->b_top), ps->prt.page.margin_top * units[ps->unit]);
   }
-  if (ps->prt.printer.hw_margin_bottom == 0)
+  if(ps->prt.printer.hw_margin_bottom == 0)
   {
     ps->prt.page.margin_bottom = 17;
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(ps->b_bottom), ps->prt.page.margin_bottom * units[ps->unit]);
   }
-  if (ps->prt.printer.hw_margin_left == 0)
+  if(ps->prt.printer.hw_margin_left == 0)
   {
     ps->prt.page.margin_left = 17;
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(ps->b_left), ps->prt.page.margin_left * units[ps->unit]);
   }
-  if (ps->prt.printer.hw_margin_right == 0)
+  if(ps->prt.printer.hw_margin_right == 0)
   {
     ps->prt.page.margin_right = 17;
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(ps->b_right), ps->prt.page.margin_right * units[ps->unit]);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2163,21 +2163,21 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *hboxdim = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
   label = gtk_label_new(_("image width/height"));
-  gtk_box_pack_start(GTK_BOX(hboxdim),GTK_WIDGET(label),TRUE,TRUE,0);
+  gtk_box_pack_start(GTK_BOX(hboxdim), GTK_WIDGET(label), TRUE, TRUE, DT_PIXEL_APPLY_DPI(3));
   d->width = gtk_label_new(_("width"));
-  gtk_box_pack_start(GTK_BOX(hboxdim),GTK_WIDGET(d->width),TRUE,TRUE,0);
+  gtk_box_pack_start(GTK_BOX(hboxdim), GTK_WIDGET(d->width), TRUE, TRUE, 0);
   label = gtk_label_new(_(" x "));
-  gtk_box_pack_start(GTK_BOX(hboxdim),GTK_WIDGET(label),TRUE,TRUE,0);
+  gtk_box_pack_start(GTK_BOX(hboxdim), GTK_WIDGET(label), TRUE, TRUE, 0);
   d->height = gtk_label_new(_("height"));
-  gtk_box_pack_start(GTK_BOX(hboxdim),GTK_WIDGET(d->height),TRUE,TRUE,0);
+  gtk_box_pack_start(GTK_BOX(hboxdim), GTK_WIDGET(d->height), TRUE, TRUE, 0);
 
   //// image information (downscale/upscale)
 
   GtkWidget *hboxinfo = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
   label = gtk_label_new(_("scale factor"));
-  gtk_box_pack_start(GTK_BOX(hboxinfo),GTK_WIDGET(label),TRUE,TRUE,0);
+  gtk_box_pack_start(GTK_BOX(hboxinfo), GTK_WIDGET(label), TRUE, TRUE, DT_PIXEL_APPLY_DPI(3));
   d->info = gtk_label_new("1.0");
-  gtk_box_pack_start(GTK_BOX(hboxinfo),GTK_WIDGET(d->info),TRUE,TRUE,0);
+  gtk_box_pack_start(GTK_BOX(hboxinfo), GTK_WIDGET(d->info), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(hboxinfo,
                _("image scale factor from native printer DPI:\n"
                  " < 1 means that it is downscaled (best quality)\n"
@@ -2212,6 +2212,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->b_bottom), _("bottom margin"));
   gtk_grid_attach(bds, GTK_WIDGET(d->b_bottom), 1, 2, 1, 1);
 
+  gtk_widget_set_halign(GTK_WIDGET(bds), GTK_ALIGN_CENTER);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(bds), TRUE, TRUE, 0);
 
   g_signal_connect (G_OBJECT (d->b_top), "value-changed",
@@ -2227,6 +2228,9 @@ void gui_init(dt_lib_module_t *self)
 
   const gboolean lock_active = dt_conf_get_bool("plugins/print/print/lock_borders");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->lock_button), lock_active);
+
+  gtk_widget_set_halign(GTK_WIDGET(hboxdim), GTK_ALIGN_CENTER);
+  gtk_widget_set_halign(GTK_WIDGET(hboxinfo), GTK_ALIGN_CENTER);
 
   // pack image dimension hbox here
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1725,34 +1725,46 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ps->grid))
      && (int)_mm_to_hscreen(ps, step, FALSE) > DT_PIXEL_APPLY_DPI(5))
   {
-    cairo_set_source_rgba(cr, 1, .2, .2, 1.0);
-    cairo_set_line_width(cr, 1.0);
+    const double dash[] = { 5.0, 5.0 };
+    cairo_set_source_rgba(cr, 1, .2, .2, 0.6);
 
     // V lines
     float grid_pos = (float)ps->imgs.screen.page.x;
 
     const float h_step = _mm_to_hscreen(ps, step, FALSE);
+    int n = 0;
 
     while(grid_pos < ps->imgs.screen.page.x + ps->imgs.screen.page.width)
     {
+      cairo_set_dash(cr, dash, ((n % 5) == 0) ? 0 : 2, 5);
+      cairo_set_line_width(cr, ((n % 5) == 0) ? 1.0 : 0.5);
       cairo_move_to(cr, grid_pos, ps->imgs.screen.page.y);
       cairo_line_to(cr, grid_pos, ps->imgs.screen.page.y + ps->imgs.screen.page.height);
+      cairo_stroke(cr);
       grid_pos += h_step;
+      n++;
     }
 
     // H lines
     grid_pos = (float)ps->imgs.screen.page.y;
 
     const float v_step = _mm_to_vscreen(ps, step, FALSE);
+    n = 0;
 
     while(grid_pos < ps->imgs.screen.page.y + ps->imgs.screen.page.height)
     {
+      cairo_set_dash(cr, dash, ((n % 5) == 0) ? 0 : 2, 5);
+      cairo_set_line_width(cr, ((n % 5) == 0) ? 1.0 : 0.5);
       cairo_move_to(cr, ps->imgs.screen.page.x, grid_pos);
       cairo_line_to(cr, ps->imgs.screen.page.x + ps->imgs.screen.page.width, grid_pos);
+      cairo_stroke(cr);
       grid_pos += v_step;
+      n++;
     }
-    cairo_stroke(cr);
   }
+
+  // disable dash
+  cairo_set_dash(cr, NULL, 0, 0);
 
   const float scaler = 1.0f / darktable.gui->ppd_thb;
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1637,7 +1637,7 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
 
     _snap_to_grid(ps, &ps->x1, &ps->y1);
   }
-  else if(ps->selected != -1)
+  else if(ps->selected != -1 && which == 1)
   {
     dt_image_box *b = &ps->imgs.box[ps->selected];
 
@@ -1651,6 +1651,19 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
     ps->has_changed = TRUE;
 
     _get_control(ps, x, y);
+  }
+  else if(ps->selected != -1 && which == 3)
+  {
+    dt_image_box *b = &ps->imgs.box[ps->selected];
+
+    // if image present remove it, otherwise remove the box
+    if(b->imgid != -1)
+      b->imgid = -1;
+    else
+      dt_printing_clear_box(b);
+
+    ps->last_selected = ps->selected;
+    ps->has_changed = TRUE;
   }
 
   return 0;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -533,6 +533,7 @@ static void _page_new_area_clicked(GtkWidget *widget, gpointer user_data)
     return;
   }
 
+  dt_control_change_cursor(GDK_PLUS);
   ps->creation = TRUE;
   ps->has_changed = TRUE;
 }
@@ -1480,6 +1481,9 @@ int mouse_moved(struct dt_lib_module_t *self, double x, double y, double pressur
 
   gboolean expose = FALSE;
 
+  if(ps->creation)
+    dt_control_change_cursor(GDK_PLUS);
+
   if(ps->creation && ps->dragging)
   {
     ps->x2 = x;
@@ -1615,6 +1619,8 @@ int button_released(struct dt_lib_module_t *self, double x, double y, int which,
 
   ps->creation = FALSE;
   ps->dragging = FALSE;
+
+  dt_control_change_cursor(GDK_LEFT_PTR);
 
   return 0;
 }

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -16,23 +16,15 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "common/collection.h"
-#include "common/colorlabels.h"
 #include "common/darktable.h"
 #include "common/debug.h"
-#include "common/history.h"
-#include "common/image_cache.h"
-#include "common/mipmap_cache.h"
-#include "common/ratings.h"
 #include "common/selection.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "dtgtk/thumbtable.h"
 #include "gui/accelerators.h"
-#include "gui/drag_and_drop.h"
 #include "gui/gtk.h"
-#include "gui/hist_dialog.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
 #include "views/view.h"

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -185,17 +185,13 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr,
 
   int32_t px=0, py=0, pwidth=0, pheight=0;
   int32_t ax=0, ay=0, awidth=0, aheight=0;
-  int32_t ix=0, iy=0, iwidth=0, iheight=0;
-  int32_t iwpix=0, ihpix=0;
 
   if (prt->pinfo == NULL)
     return;
 
   dt_get_print_layout(-1, prt->pinfo, width, height,
-                      &iwpix, &ihpix,
                       &px, &py, &pwidth, &pheight,
-                      &ax, &ay, &awidth, &aheight,
-                      &ix, &iy, &iwidth, &iheight);
+                      &ax, &ay, &awidth, &aheight);
   // page w/h
   double pg_width  = prt->pinfo->paper.width;
   double pg_height = prt->pinfo->paper.height;

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -324,8 +324,11 @@ int try_enter(dt_view_t *self)
   // and drop the lock again.
   dt_image_cache_read_release(darktable.image_cache, img);
 
-  prt->imgs->count = 1;
-  prt->imgs->box[0].imgid = imgid;
+  if(prt->imgs->auto_fit)
+  {
+    prt->imgs->count = 1;
+    prt->imgs->box[0].imgid = imgid;
+  }
 
   return 0;
 }

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -288,19 +288,22 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   const dt_print_t *prt = (dt_print_t *)self->data;
 
   // if we are not hovering over a thumbnail in the filmstrip -> show metadata of first opened image.
-  int32_t mouse_over_id = dt_control_get_mouse_over_id();
+  const int32_t mouse_over_id = dt_control_get_mouse_over_id();
 
-  if(prt->imgs->count > 0 && mouse_over_id != prt->imgs->box[0].imgid)
+  if(prt->imgs->count == 1 && mouse_over_id != prt->imgs->box[0].imgid)
   {
-    mouse_over_id = prt->imgs->box[0].imgid;
-    dt_control_set_mouse_over_id(mouse_over_id);
+    dt_control_set_mouse_over_id(prt->imgs->box[0].imgid);
   }
-}
-void mouse_leave(dt_view_t *self)
-{
-  // if we are not hovering over a thumbnail in the filmstrip -> show metadata of opened image.
-  const dt_print_t *prt = (dt_print_t *)self->data;
-  dt_control_set_mouse_over_id(prt->imgs->box[0].imgid);
+  else if(prt->imgs->count > 1)
+  {
+    const int bidx = dt_printing_get_image_box(prt->imgs, x, y);
+    if(bidx == -1)
+      dt_control_set_mouse_over_id(-1);
+    else if(mouse_over_id != prt->imgs->box[bidx].imgid)
+    {
+      dt_control_set_mouse_over_id(prt->imgs->box[bidx].imgid);
+    }
+  }
 }
 
 int try_enter(dt_view_t *self)

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -218,6 +218,11 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr, int32_t width, int32
   prt->imgs->screen_page.width = pwidth;
   prt->imgs->screen_page.height = pheight;
 
+  prt->imgs->screen_page_area.x = ax;
+  prt->imgs->screen_page_area.y = ay;
+  prt->imgs->screen_page_area.width = awidth;
+  prt->imgs->screen_page_area.height = aheight;
+
   // display non-printable area
   cairo_set_source_rgb (cr, 0.1, 0.1, 0.1);
 

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -189,7 +189,7 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr,
   if (prt->pinfo == NULL)
     return;
 
-  dt_get_print_layout(-1, prt->pinfo, width, height,
+  dt_get_print_layout(prt->pinfo, width, height,
                       &px, &py, &pwidth, &pheight,
                       &ax, &ay, &awidth, &aheight);
   // page w/h

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -189,11 +189,11 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr, int32_t width, int32
   if (prt->pinfo == NULL)
     return;
 
-  dt_get_print_layout (-1, prt->pinfo, width, height,
-                       &iwpix, &ihpix,
-                       &px, &py, &pwidth, &pheight,
-                       &ax, &ay, &awidth, &aheight,
-                       &ix, &iy, &iwidth, &iheight);
+  dt_get_print_layout(-1, prt->pinfo, width, height,
+                      &iwpix, &ihpix,
+                      &px, &py, &pwidth, &pheight,
+                      &ax, &ay, &awidth, &aheight,
+                      &ix, &iy, &iwidth, &iheight);
   // page w/h
   double pg_width  = prt->pinfo->paper.width;
   double pg_height = prt->pinfo->paper.height;
@@ -205,7 +205,7 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr, int32_t width, int32
   double np_bottom = prt->pinfo->printer.hw_margin_bottom;
 
   // handle the landscape mode if needed
-  if (prt->pinfo->page.landscape)
+  if(prt->pinfo->page.landscape)
   {
     double tmp = pg_width;
     pg_width = pg_height;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1479,10 +1479,10 @@ void dt_view_map_drag_set_icon(const dt_view_manager_t *vm, GdkDragContext *cont
 #endif
 
 #ifdef HAVE_PRINT
-void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo)
+void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo, dt_images_box *imgs)
 {
   if (vm->proxy.print.view)
-    vm->proxy.print.print_settings(vm->proxy.print.view, pinfo);
+    vm->proxy.print.print_settings(vm->proxy.print.view, pinfo, imgs);
 }
 #endif
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -23,6 +23,7 @@
 #include "common/image.h"
 #ifdef HAVE_PRINT
 #include "common/cups_print.h"
+#include "common/printing.h"
 #endif
 #ifdef HAVE_MAP
 #include "common/geo.h"
@@ -345,7 +346,7 @@ typedef struct dt_view_manager_t
     struct
     {
       struct dt_view_t *view;
-      void (*print_settings)(const dt_view_t *view, dt_print_info_t *pinfo);
+      void (*print_settings)(const dt_view_t *view, dt_print_info_t *pinfo, dt_images_box *imgs);
     } print;
 #endif
   } proxy;
@@ -470,7 +471,7 @@ void dt_view_map_drag_set_icon(const dt_view_manager_t *vm, GdkDragContext *cont
  * Print View Proxy
  */
 #ifdef HAVE_PRINT
-void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo);
+void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo, dt_images_box *imgs);
 #endif
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
Allow multiple images on the print module.

This was something that was itching me since long time. I get this started.

What is working ?
- [x] draw box areas
- [x] resize/move box areas
- [x] display box areas on screen/page
- [x] export PDF with multiple areas
- [x] drag&drop images into box area from filmstrip
- [x] grid display
- [x] snap to grid  

The hardest part is done I suppose now but it remains quite some polishing:
- [x] highlight the control being selected/dragged
- [x] allow entering area pos with entry widget to adjust precisely
- [x]  allow to store the areas into the preset
- [x] check/fix that changing page size keeps the area in right places
- [x] make sure the box areas are not outside the print area (or possibly page to allow for border-less printing)