### PR TITLE
Add the support for FujiFilm GFX100S

### DIFF
--- a/src/external/wb_presets.c
+++ b/src/external/wb_presets.c
@@ -2330,7 +2330,7 @@ const wb_data wb_preset[] =
   { "Canon", "EOS M6", Flash               , 7, { 2.4189453125, 1, 0.92578125, 0 } },
   { "Canon", "EOS M6", Flash               , 8, { 2.552734375, 1, 0.90625, 0 } },
   { "Canon", "EOS M6", Flash               , 9, { 2.7265625, 1, 0.8828125, 0 } },
-  
+
   { "Canon", "EOS M10", Cloudy          , 0, { 2.171053, 1, 1.438596, 0 } },
   { "Canon", "EOS M10", Daylight        , 0, { 1.992408, 1, 1.556399, 0 } },
   { "Canon", "EOS M10", Flash           , 0, { 2.557562, 1, 1.220090, 0 } },
@@ -2947,6 +2947,15 @@ const wb_data wb_preset[] =
   { "Fujifilm", "FinePix X100", "3300K", 0,		{ 1.0066, 1, 2.1060, 0 } },
   { "Fujifilm", "FinePix X100", "5000K", 0,		{ 1.4536, 1, 1.3742, 0 } },
 
+  /* Fujifilm GFX100S firmware 1.00 */
+  { "Fujifilm", "GFX100S", Daylight           , 0, { 1.6920529801324504, 1, 1.8708609271523178, 0 } },
+  { "Fujifilm", "GFX100S", Cloudy             , 0, { 1.8509933774834437, 1, 1.5927152317880795, 0 } },
+  { "Fujifilm", "GFX100S", Incandescent       , 0, { 1.1258278145695364, 1, 2.9304635761589406, 0 } },
+  { "Fujifilm", "GFX100S", DayWhiteFluorescent, 0, { 1.8576158940397351, 1, 1.9205298013245033, 0 } },
+  { "Fujifilm", "GFX100S", DaylightFluorescent, 0, { 2.19205298013245, 1, 1.5827814569536425, 0 } },
+  { "Fujifilm", "GFX100S", WhiteFluorescent   , 0, { 1.7748344370860927, 1, 2.4966887417218544, 0 } },
+  { "Fujifilm", "GFX100S", Underwater         , 0, { 1.6887417218543046, 1, 1.880794701986755, 0 } },
+
   /* Fujifilm X100S firmware 1.20 */
   { "Fujifilm", "X100S", Daylight, 0,		{ 1.874172, 1, 1.490066, 0 } },
   { "Fujifilm", "X100S", Shade, 0,		{ 2.049669, 1, 1.271523, 0 } },
@@ -2980,8 +2989,8 @@ const wb_data wb_preset[] =
   { "Fujifilm", "X100F", WhiteFluorescent, 0,    { 1.9569536423841059, 1, 2.5596026490066226, 0 } },
   { "Fujifilm", "X100F", Incandescent, 0,        { 1.271523178807947, 1, 2.8311258278145695, 0 } },
   { "Fujifilm", "X100F", Underwater, 0,          { 1.9503311258278146, 1, 1.8543046357615893, 0 } },
-  
-  
+
+
   /* Fujifilm X100V firmware 1.10 */
   { "Fujifilm", "X100V", Daylight, 0,                 { 1.784768, 1, 1.768212, 0 } },
   { "Fujifilm", "X100V", Cloudy, 0,                   { 1.94702, 1, 1.516556, 0 } },
@@ -3144,7 +3153,7 @@ const wb_data wb_preset[] =
   { "Fujifilm", "X-Pro2", DaylightFluorescent, 0, { 2.463576, 1, 1.602649, 0 } },
   { "Fujifilm", "X-Pro2", WhiteFluorescent   , 0, { 1.973510, 1, 2.513245, 0 } },
   { "Fujifilm", "X-Pro2", Underwater         , 0, { 1.943709, 1, 1.827815, 0 } },
-  
+
   { "Fujifilm", "X-Pro3", Daylight           , 0, { 1.8675496688741722, 1, 1.8079470198675496, 0 } },
   { "Fujifilm", "X-Pro3", Cloudy             , 0, { 2.013245033112583, 1, 1.5463576158940397, 0 } },
   { "Fujifilm", "X-Pro3", Incandescent       , 0, { 1.2516556291390728, 1, 2.771523178807947, 0 } },


### PR DESCRIPTION
  Adding the support for colormap for the GFX100S using the same value
  of the GFX100

  Adding the support for white balance for the GFX100S after take shot
  and using the script tools/extract_wb.py