### PR TITLE
libraries & collections: clarify terminology

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -397,8 +397,8 @@
     <name>ask_before_remove</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>ask before removing images from darktable</shortdescription>
-    <longdescription>always ask the user before any image is removed from darktable</longdescription>
+    <shortdescription>ask before removing images from the library</shortdescription>
+    <longdescription>always ask the user before any image is removed from the library</longdescription>
   </dtconfig>
   <dtconfig prefs="security">
     <name>ask_before_delete</name>
@@ -1319,8 +1319,8 @@
     <name>plugins/lighttable/collect/single-click</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>use single-click in the collect module</shortdescription>
-    <longdescription>check this option to use single-click to select items in the collect module. this will allow you to do range selections for date-time and numeric values.</longdescription>
+    <shortdescription>use single-click in the create collection module</shortdescription>
+    <longdescription>check this option to use single-click to select items in the create collection module. this will allow you to do range selections for date-time and numeric values.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/collect/num_rules</name>

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -835,7 +835,7 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
     gtk_dialog_add_button(GTK_DIALOG(dialog), _("physically delete"), _DT_DELETE_DIALOG_CHOICE_DELETE);
     gtk_dialog_add_button(GTK_DIALOG(dialog), _("physically delete all files"), _DT_DELETE_DIALOG_CHOICE_DELETE_ALL);
   }
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("only remove from the collection"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("only remove from the image library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
   gtk_dialog_add_button(GTK_DIALOG(dialog), _("skip to next file"), _DT_DELETE_DIALOG_CHOICE_CONTINUE);
   gtk_dialog_add_button(GTK_DIALOG(dialog), _("stop process"), _DT_DELETE_DIALOG_CHOICE_STOP);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -116,7 +116,7 @@ static void _populate_collect_combo(GtkWidget *w);
 
 const char *name(dt_lib_module_t *self)
 {
-  return _("collect images");
+  return _("create collection");
 }
 
 void *legacy_params(struct dt_lib_module_t *self,

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -471,7 +471,7 @@ void gui_init(dt_lib_module_t *self)
   int line = 0;
 
 
-  d->remove_button = dt_ui_button_new(_("remove"), _("only remove from darktable, don't delete file on disk"), NULL);
+  d->remove_button = dt_ui_button_new(_("remove"), _("remove images from the image library, without deleting"), NULL);
   gtk_grid_attach(grid, d->remove_button, 0, line, 2, 1);
   g_signal_connect(G_OBJECT(d->remove_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(0));
 
@@ -491,7 +491,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->create_hdr_button, 0, line, 2, 1);
   g_signal_connect(G_OBJECT(d->create_hdr_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(7));
 
-  d->duplicate_button = dt_ui_button_new(_("duplicate"), _("add a duplicate to the collection, including its history stack"), NULL);
+  d->duplicate_button = dt_ui_button_new(_("duplicate"), _("add a duplicate to the image library, including its history stack"), NULL);
   gtk_grid_attach(grid, d->duplicate_button, 2, line++, 2, 1);
   g_signal_connect(G_OBJECT(d->duplicate_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(3));
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -172,20 +172,20 @@ int position()
 
 void init_key_accels(dt_lib_module_t *self)
 {
-  dt_accel_register_lib(self, NC_("accel", "import from camera"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "copy & import from camera"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "tethered shoot"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "import in-place"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "copy and import"), GDK_KEY_i, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+  dt_accel_register_lib(self, NC_("accel", "add to library"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "copy & import"), GDK_KEY_i, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 }
 
 void connect_key_accels(dt_lib_module_t *self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
 
-  dt_accel_connect_button_lib(self, "import in-place", GTK_WIDGET(d->import_inplace));
-  dt_accel_connect_button_lib(self, "copy and import", GTK_WIDGET(d->import_copy));
+  dt_accel_connect_button_lib(self, "add to library", GTK_WIDGET(d->import_inplace));
+  dt_accel_connect_button_lib(self, "copy & import", GTK_WIDGET(d->import_copy));
   if(d->tethered_shoot) dt_accel_connect_button_lib(self, "tethered shoot", GTK_WIDGET(d->tethered_shoot));
-  if(d->import_camera) dt_accel_connect_button_lib(self, "import from camera", GTK_WIDGET(d->import_camera));
+  if(d->import_camera) dt_accel_connect_button_lib(self, "copy & import from camera", GTK_WIDGET(d->import_camera));
 }
 
 #ifdef HAVE_GPHOTO2
@@ -251,7 +251,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
       GtkWidget *vbx = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
       if(camera->can_import == TRUE)
       {
-        gtk_box_pack_start(GTK_BOX(vbx), (ib = gtk_button_new_with_label(_("import from camera"))), FALSE,
+        gtk_box_pack_start(GTK_BOX(vbx), (ib = gtk_button_new_with_label(_("copy & import from camera"))), FALSE,
                            FALSE, 0);
         gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(ib))), PANGO_ELLIPSIZE_END);
         d->import_camera = GTK_BUTTON(ib);
@@ -1402,9 +1402,9 @@ static void _set_expander_content(GtkWidget *rbox, dt_lib_module_t* self)
 
 static const char *const _import_text[] =
 {
-  N_("import in-place"),
-  N_("copy and import"),
-  N_("import from camera")
+  N_("add to library"),
+  N_("copy & import"),
+  N_("copy & import from camera")
 };
 
 const char *folder_tooltip = N_("choose the root of the folder tree below"
@@ -1734,16 +1734,16 @@ void gui_init(dt_lib_module_t *self)
 
   // add import buttons
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *widget = dt_ui_button_new(_("import in-place..."),
-                                       _("import images in-place without renaming"),
+  GtkWidget *widget = dt_ui_button_new(_("add to library..."),
+                                       _("add existing images to the library"),
                                        "lighttable_panels.html#import_from_fs");
   d->import_inplace = GTK_BUTTON(widget);
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_import_from_callback), self);
-  widget = dt_ui_button_new(_("copy and import..."),
-                            _("copy and optionally rename images before importing them"
+  widget = dt_ui_button_new(_("copy & import..."),
+                            _("copy and optionally rename images before adding them to the library"
                               "\npatterns can be defined to rename the images and specify the destination folders"),
                             "lighttable_panels.html#import_from_fs");
   d->import_copy = GTK_BUTTON(widget);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -421,7 +421,7 @@ static int _lighttable_expose_empty(dt_view_t *self, cairo_t *cr, int32_t width,
   cairo_line_to(cr, width * 0.5f, 0.0f);
   dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_LIGHTTABLE_FONT, at);
   cairo_stroke(cr);
-  pango_layout_set_text(layout, _("or add images in the collection module in the left panel"), -1);
+  pango_layout_set_text(layout, _("or add images in the create collection module in the left panel"), -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   cairo_move_to(cr, offx, offy + 6 * ls - ink.height - ink.x);
   dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_FONT);


### PR DESCRIPTION
Use consistent terminology, in order to make some of the lighttable operations a little clearer for new users

- "library" means all of the images darktable knows about
- "collection" is an auto-generated subset of those images

This involves the following changes:

- rename "collect images" to "create collection"
- amend "collection" to "library" when the term is used to mean "all images"
- amend "import in-place" to "add to library" to properly distinguish from "copy & import" which actually creates files, and is more like "traditional" import operations

Resolves #8893