### PR TITLE
gradient: only change curvature on scroll without modifier keys

### DIFF
--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -100,7 +100,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       dt_conf_set_float("plugins/darkroom/masks/gradient/compression", compression);
       dt_toast_log(_("compression: %3.2f%%"), compression*100.0f);
     }
-    else
+    else if (dt_modifier_is(state, 0)) // simple scroll to adjust curvature, calling func adjusts opacity with Ctrl
     {
       float curvature = dt_conf_get_float("plugins/darkroom/masks/gradient/curvature");
       if(up)


### PR DESCRIPTION
The code to handle opacity change with Ctrl-Scroll is in a different function than the code to handle curvature change during gradient creation, but both got triggered without the extra check this PR adds.
