### PR TITLE
Performance: re-enable -ffast-math

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,8 +284,8 @@ if(USE_OPENMP)
 endif(USE_OPENMP)
 
 if(USE_DARKTABLE_PROFILING)
-  add_definitions(-DUSE_DARKTABLE_PROFILING)
-  set(SOURCES ${SOURCES} "common/profiling.c")
+	add_definitions(-DUSE_DARKTABLE_PROFILING)
+	set(SOURCES ${SOURCES} "common/profiling.c")
 endif()
 
 #
@@ -612,15 +612,9 @@ if(NOT CUSTOM_CFLAGS)
   #endif()
 
   #-g MUST be set for ALL builds, or there will be no support for them when bugs happen
-
-  # TODO: check if these flags bring some good :
-  # -ftree-loop-distribution -fivopts -fipa-matrix-reorg -ftracer -fvect-cost-model -fvariable-expansion-in-unroller
-  # -fprefetch-loop-arrays -ftree-vect-loop-version -freorder-blocks-and-partition -fmodulo-sched-allow-regmoves
-  # -ftree-loop-im -ftree-loop-ivcanon -fsplit-ivs-in-unroller -funroll-loops
-  # also, in IOPs, in-loops branches could be forced to be compiled as different loops variants
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MARCH} ${DT_REQ_INSTRUCTIONS} -g")
   set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O2")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -ffast-math -fno-finite-math-only")
   if(CMAKE_COMPILER_IS_GNUCC)
     if(BUILD_SSE2_CODEPATHS)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpmath=sse")
@@ -634,7 +628,7 @@ if(NOT CUSTOM_CFLAGS)
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MARCH} ${DT_REQ_INSTRUCTIONS} -g")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -ffast-math -fno-finite-math-only")
   if(CMAKE_COMPILER_IS_GNUCXX)
     if(BUILD_SSE2_CODEPATHS)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpmath=sse")

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -406,8 +406,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
 #endif
 
   // do not use -cl-fast-relaxed-math, this breaks AMD OpenCL
-  // do not use -cl-finite-math-only, this breaks Intel Neo OpenCL
-  options = g_strdup_printf("-w %s -D%s=1 -I%s",
+  options = g_strdup_printf("-w -cl-finite-math-only %s -D%s=1 -I%s",
                             (cl->dev[dev].nvidia_sm_20 ? " -DNVIDIA_SM_20=1" : ""),
                             dt_opencl_get_vendor_by_id(vendor_id), escapedkerneldir);
   cl->dev[dev].options = strdup(options);

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -405,8 +405,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   escapedkerneldir = dt_util_str_replace(kerneldir, " ", "\\ ");
 #endif
 
-  // do not use -cl-fast-relaxed-math, this breaks AMD OpenCL
-  options = g_strdup_printf("-w -cl-finite-math-only %s -D%s=1 -I%s",
+  options = g_strdup_printf("-w -cl-fast-relaxed-math %s -D%s=1 -I%s",
                             (cl->dev[dev].nvidia_sm_20 ? " -DNVIDIA_SM_20=1" : ""),
                             dt_opencl_get_vendor_by_id(vendor_id), escapedkerneldir);
   cl->dev[dev].options = strdup(options);

--- a/src/tests/unittests/iop/test_filmicrgb.c
+++ b/src/tests/unittests/iop/test_filmicrgb.c
@@ -99,12 +99,12 @@ static void test_pixel_rgb_norm_power(void **state)
     p[3] = 2.0f;  // to make sure pixel[3] has no influence
     float norm = pixel_rgb_norm_power(p);
     TR_DEBUG("pixel={%e, %e, %e) => norm=%e", p[0], p[1], p[2], norm);
-    float numerator = powf(p[0], 3) + powf(p[1], 3) + powf(p[2], 3);
-    float denominator = powf(p[0], 2) + powf(p[1], 2) + powf(p[2], 2);
+    float numerator = p[0] * p[0] * p[0] + p[1] * p[1] * p[1] + p[2] * p[2] * p[2];
+    float denominator = p[0] * p[0] + p[1] * p[1] + p[2] * p[2];
     float exp_norm = numerator / denominator;
     assert_float_equal(norm, exp_norm, E);
     assert_true(norm > 0.0f);
-    assert_true(norm <= 1.0f);
+    assert_true(norm <= 1.0f + 1e-6f);
   }
   testimg_free(ti);
 


### PR DESCRIPTION
The `-ffast-math` build option for OpenCL and C `Release` build have been disabled by myself at the beginning of 2019 in a desperate attempt to fix local Laplacian discrepancies, that proved to come from something else.

They have been periodically re-enabled then disabled when problems occurred since then. However, they should be safe (or made safe in the code), because they mostly disable NaN checks, which should never happen in the code in the first place.

In dt, NaN will occur :
* when dividing by zero,
* when taking the log(x) where x = 0 or x > 0,
* when taking the powf(x, p), where p < 1 and x < 0.

Such operations are wrong on a programmatic level as well as on a colorimetric level : pixel can't have negative RGB values since there is no negative light and no negative energy. Such values will, in addition, make various color spaces fail (like Yuv used in color balance and histogram, Yrg in color balance RGB, Yxy, etc.).

So, negatives should be clipped properly whenever relevant in the code, because they need extra gamut care, and we should not rely on compiler's benevolence for such important matters.

In addition, 68eb9aaa6e936b26d21588f487766f587e0cc18c prevents interpolation undershooting. 

I propose to re-enable globally those flags for better performance. Then, in case of black pictures or black squares, the true culprit should be manually found and clipped in code.
