### PR TITLE
c&r : fix double crop with crop module

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2623,9 +2623,9 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe,
            || (transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL && module->iop_order >= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL && module->iop_order > iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_INCL && module->iop_order <= iop_order)
-           || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL && module->iop_order < iop_order)) &&
-       !(dev->gui_module
-         && (dev->gui_module->operation_tags_filter() & module->operation_tags())))
+           || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL && module->iop_order < iop_order))
+       && !(dev->gui_module && dev->gui_module != module
+            && (dev->gui_module->operation_tags_filter() & module->operation_tags())))
     {
       module->distort_transform(module, piece, points, points_count);
     }
@@ -2673,7 +2673,7 @@ int dt_dev_distort_backtransform_locked(dt_develop_t *dev, dt_dev_pixelpipe_t *p
            || (transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL && module->iop_order > iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_INCL && module->iop_order <= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL && module->iop_order < iop_order))
-       && !(dev->gui_module
+       && !(dev->gui_module && dev->gui_module != module
             && (dev->gui_module->operation_tags_filter() & module->operation_tags())))
     {
       module->distort_backtransform(module, piece, points, points_count);

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -101,7 +101,8 @@ uint64_t dt_dev_pixelpipe_cache_basichash(int imgid, struct dt_dev_pixelpipe_t *
   {
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)pieces->data;
     dt_develop_t *dev = piece->module->dev;
-    if(!(dev->gui_module && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())))
+    if(!(dev->gui_module && dev->gui_module != piece->module
+         && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())))
     {
       hash = ((hash << 5) + hash) ^ piece->hash;
       if(piece->module->request_color_pick != DT_REQUEST_COLORPICK_OFF)
@@ -137,8 +138,9 @@ uint64_t dt_dev_pixelpipe_cache_basichash_prior(int imgid, struct dt_dev_pixelpi
     if (module == (dt_iop_module_t *)modules->data)
       break;		// we've found the given module, so 'last' now contains the index of the prior active module
     dt_develop_t *dev = piece->module->dev;
-    if (piece->enabled &&
-        !(dev->gui_module && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())))
+    if(piece->enabled
+       && !(dev->gui_module && dev->gui_module != piece->module
+            && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())))
       last = k;
     pieces = g_list_next(pieces);
     modules = g_list_next(modules);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -342,7 +342,7 @@ int operation_tags()
 int operation_tags_filter()
 {
   // switch off watermark, it gets confused.
-  return IOP_TAG_DECORATION;
+  return IOP_TAG_DECORATION | IOP_TAG_CLIPPING;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -1354,7 +1354,13 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       {
         keystone_type_populate(self, FALSE, 0);
       }
+      // weird hack : commit_box use distort_transform routines with gui values to get params
+      // but this values are accurate only if clipping is the gui_module...
+      // so we temporary put back gui_module to clipping and revert once finished
+      dt_iop_module_t *old_gui = self->dev->gui_module;
+      self->dev->gui_module = self;
       commit_box(self, g, p);
+      self->dev->gui_module = old_gui;
       g->clip_max_pipe_hash = 0;
     }
   }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1354,7 +1354,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       {
         keystone_type_populate(self, FALSE, 0);
       }
-      // weird hack : commit_box use distort_transform routines with gui values to get params
+      // hack : commit_box use distort_transform routines with gui values to get params
       // but this values are accurate only if clipping is the gui_module...
       // so we temporary put back gui_module to clipping and revert once finished
       dt_iop_module_t *old_gui = self->dev->gui_module;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -406,7 +406,13 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     }
     else
     {
+      // hack : commit_box use distort_transform routines with gui values to get params
+      // but this values are accurate only if crop is the gui_module...
+      // so we temporary put back gui_module to crop and revert once finished
+      dt_iop_module_t *old_gui = self->dev->gui_module;
+      self->dev->gui_module = self;
       _commit_box(self, g, p);
+      self->dev->gui_module = old_gui;
       g->clip_max_pipe_hash = 0;
     }
   }


### PR DESCRIPTION
fix #8942 

this avoid the "double crop" issue when a crop is done and the c&r module has had the focus : 
- in c&r : be sure to disable the crop module, located later in the pipe, when the module has the focus (otherwise gui handles are confused as they can't go outside the visible image)
- in c&r : ensure right transformation when loosing focus. The problem is that when we have the focus, the gui_data values are computed with a transforms that exclude filtered modules. When we loose the focus, we save them to the module params, but at this point, the module is not anymore the "gui_module" so transformations are wrong... That hasn't cause any problem until now because there was no filtered module after c&r in the pipe (except borders, but that only enlarge image, so the clamping take care of that) I've solved that by temporary put back the gui_module and revert once the computation is done...

Note : due to how cropping values are stored (percentage of input image size) if you change crop area in c&r, that will also change the previously defined crop area in crop...