### PR TITLE
Getting rid of the background jobs config parameter

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -175,13 +175,6 @@
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
   </dtconfig>
   <dtconfig prefs="cpugpu" restart="true">
-    <name>worker_threads</name>
-    <type min="1" max="64">int</type>
-    <default>2</default>
-    <shortdescription>number of background threads</shortdescription>
-    <longdescription>this controls for example how many threads are used to create thumbnails during import. the cache will grow to a maximum of twice this number of full resolution image buffers (needs a restart).</longdescription>
-  </dtconfig>
-  <dtconfig prefs="cpugpu" restart="true">
     <name>host_memory_limit</name>
     <type>int</type>
     <default>1500</default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1634,6 +1634,18 @@ static inline size_t _get_total_memory()
 #endif
 }
 
+int dt_worker_threads()
+{
+  const int atom_cores = _get_num_atom_cores();
+  const size_t threads = dt_get_num_threads();
+  const size_t mem = _get_total_memory();
+  if(mem >= (8lu << 20) && threads >= 4 && atom_cores == 0)
+    return 4;
+  else if(threads >= 2 && atom_cores == 0)
+    return 2;
+  return 1;
+}
+
 void dt_configure_performance()
 {
   const int atom_cores = _get_num_atom_cores();
@@ -1650,7 +1662,6 @@ void dt_configure_performance()
     // But respect if user has set higher values manually earlier
     fprintf(stderr, "[defaults] setting very high quality defaults\n");
 
-    dt_conf_set_int("worker_threads", MAX(8, dt_conf_get_int("worker_threads")));
     // if machine has at least 8GB RAM, use half of the total memory size
     dt_conf_set_int("host_memory_limit", MAX(mem >> 11, dt_conf_get_int("host_memory_limit")));
     dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
@@ -1664,7 +1675,6 @@ void dt_configure_performance()
     // But respect if user has set higher values manually earlier
     fprintf(stderr, "[defaults] setting high quality defaults\n");
 
-    dt_conf_set_int("worker_threads", MAX(8, dt_conf_get_int("worker_threads")));
     dt_conf_set_int("host_memory_limit", MAX(1500, dt_conf_get_int("host_memory_limit")));
     dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL ||!strcmp(demosaic_quality, "always bilinear (fast)"))
@@ -1676,7 +1686,6 @@ void dt_configure_performance()
     // CONFIG 3: For less than 1GB RAM or 2 or less cores, or for atom processors
     // use very low/conservative settings
     fprintf(stderr, "[defaults] setting very conservative defaults\n");
-    dt_conf_set_int("worker_threads", 1);
     dt_conf_set_int("host_memory_limit", 500);
     dt_conf_set_int("singlebuffer_limit", 8);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "always bilinear (fast)");
@@ -1687,7 +1696,6 @@ void dt_configure_performance()
     // CONFIG 4: for everything else use explicit defaults
     fprintf(stderr, "[defaults] setting normal defaults\n");
 
-    dt_conf_set_int("worker_threads", 2);
     dt_conf_set_int("host_memory_limit", 1500);
     dt_conf_set_int("singlebuffer_limit", 16);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -343,7 +343,7 @@ void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
-
+int dt_worker_threads();
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline float *dt_alloc_align_float(size_t pixels)
 {

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -537,7 +537,6 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
   // we want at least 100MB, and consider 8G just still reasonable.
   const int64_t cache_memory = dt_conf_get_int64("cache_memory");
   const size_t max_mem = CLAMPS(cache_memory, 100u << 20, ((size_t)8) << 30);
-  const uint32_t parallel = dt_worker_threads();
   // Fixed sizes for the thumbnail mip levels, selected for coverage of most screen sizes
   int32_t mipsizes[DT_MIPMAP_F][2] = {
     { 180, 110 },             // mip0 - ~1/2 size previous one
@@ -585,8 +584,9 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
   dt_cache_set_allocate_callback(&cache->mip_thumbs.cache, dt_mipmap_cache_allocate_dynamic, cache);
   dt_cache_set_cleanup_callback(&cache->mip_thumbs.cache, dt_mipmap_cache_deallocate_dynamic, cache);
 
-  const int full_entries
-      = MAX(2, parallel); // even with one thread you want two buffers. one for dr one for thumbs.
+  // even with one thread you want two buffers. one for dr one for thumbs.
+  // Also have the nr of cache entries larger than worker threads
+  const int full_entries = 2 * dt_worker_threads();
   const int32_t max_mem_bufs = nearest_power_of_two(full_entries);
 
   // for this buffer, because it can be very busy during import

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -536,10 +536,8 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
   // adjust numbers to be large enough to hold what mem limit suggests.
   // we want at least 100MB, and consider 8G just still reasonable.
   const int64_t cache_memory = dt_conf_get_int64("cache_memory");
-  const int worker_threads = dt_conf_get_int("worker_threads");
   const size_t max_mem = CLAMPS(cache_memory, 100u << 20, ((size_t)8) << 30);
-  const uint32_t parallel = CLAMP(worker_threads, 1, 8);
-
+  const uint32_t parallel = dt_worker_threads();
   // Fixed sizes for the thumbnail mip levels, selected for coverage of most screen sizes
   int32_t mipsizes[DT_MIPMAP_F][2] = {
     { 180, 110 },             // mip0 - ~1/2 size previous one

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -605,7 +605,7 @@ double dt_control_job_get_progress(dt_job_t *job)
 void dt_control_jobs_init(dt_control_t *control)
 {
   // start threads
-  control->num_threads = CLAMP(dt_conf_get_int("worker_threads"), 1, 8);
+  control->num_threads = dt_worker_threads();
   control->thread = (pthread_t *)calloc(control->num_threads, sizeof(pthread_t));
   control->job = (dt_job_t **)calloc(control->num_threads, sizeof(dt_job_t *));
   dt_pthread_mutex_lock(&control->run_mutex);


### PR DESCRIPTION
Take this as a suggestion or as opening a discussion...

imho the background jobs preference setting can lead to confusion and does not help to tune performance at all.

I think all cores should be tuned for computing power via OpenMP, the background jobs can only help slightly for io latency, Maybe up to 4 might be useful, probably only 2 are really beneficial.

Choosing a higher number will degrade performance because
- jobs will fight for the cpu resources while they should be better left to OpenMP threading
- multiply jobs while importing also increase mem pressure which could lead to tiling also with performance consequences
- lighttable latency also gets worse because of mutexes waiting
- OpenCL resources might also be affected

Am i wrong here or do i miss something?