### PR TITLE
performance: date-time rules in collect module

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -762,6 +762,7 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   gchar *str = NULL;
   gchar *txt = NULL;
   gboolean startwildcard = FALSE;
+  gboolean expanded = FALSE;
 
   gtk_tree_model_get(model, iter, DT_LIB_COLLECT_COL_PATH, &str, DT_LIB_COLLECT_COL_TEXT, &txt, -1);
 
@@ -795,6 +796,7 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   if(dr->typing && g_strrstr(txt2, needle) != NULL)
   {
     gtk_tree_view_expand_to_path(d->view, path);
+    expanded = TRUE;
   }
 
   if(strlen(needle)==0)
@@ -806,14 +808,17 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
     gtk_tree_view_expand_to_path(d->view, path);
     gtk_tree_selection_select_path(gtk_tree_view_get_selection(d->view), path);
     gtk_tree_view_scroll_to_cell(d->view, path, NULL, FALSE, 0.2, 0);
+    expanded = TRUE;
   }
   else if(startwildcard && g_strrstr(haystack, needle+1) != NULL)
   {
     gtk_tree_view_expand_to_path(d->view, path);
+    expanded = TRUE;
   }
   else if(g_str_has_prefix(haystack, needle))
   {
     gtk_tree_view_expand_to_path(d->view, path);
+    expanded = TRUE;
   }
 
   g_free(haystack);
@@ -822,7 +827,7 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   g_free(str);
   g_free(txt);
 
-  return FALSE;
+  return expanded; // if we expanded the path, we can stop iteration (saves half on average)
 }
 
 static gboolean list_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)


### PR DESCRIPTION
With large libraries, the 'date-time' rule in the collect module becomes very slow, as there is basically one entry in the tree view per image in the library.  This not only slows down switching collections, it also slows down any user actions which might potentially change the images contained in the collection.

For a library containing 155k images, the times of the various phases of the tree_view() function are:
-   0.35 sec   SQL lookup (~lines 1345-1380)
-   0.03 sec   sort (~line 1385)
-   1.67 sec   build treeview (~lines 1390-1520)
-   0.41 sec   expand treeview entries corresponding to selected range (~1550-1600)

This patch turns off the tree view's automatic sorting (since elements are added in the desired order), uses prepend instead of append for better efficience of insertion, and `gtk_tree_store_insert_with_values` instead of `gtk_tree_store_insert`+`gtk_tree_store_set` for reduced Gtk signalling.  That reduces the time to build the treeview object from 1.67 seconds to 1.03.

In addition, the string casefolding in the SQL lookup loop is moved inside the only branch where it is actually used, speeding up that loop from 0.35 seconds to 0.19 seconds for date-time rules.

Finally, half (on average) of the 0.41 second to expand the branches of the treeview are saved by stopping iteration on reaching the target branch.

**Additional notes**
- It should be possible to shave an additional 0.4 seconds off the construction time with a more efficient method of propagating counts upward -- disabling that code entirely cuts 0.5 second -- but that's a more involved change than the ones this PR makes.
- The timeline code should use a 'date' rule instead of 'date-time' when possible; a 'date' rule on 155k images takes 0.07 seconds for the SQL lookup, under 0.01 for sorting, 0.01 for construction, and under 0.01 seconds for expansion due to the far smaller number of treeview entries.