### PR TITLE
bugfix : Fix filmlight RGB / color balance RGB

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -430,7 +430,7 @@ inline float4 gradingRGB_to_Ych(float4 RGB)
   RGB.y -= pD65[1];
 
   Ych.y = hypot(RGB.y, RGB.x);
-  Ych.z = (Ych.x == 0.f) ? 0.f : atan2(RGB.y, RGB.x);
+  Ych.z = atan2(RGB.y, RGB.x);
   Ych.w = RGB.w;
   return Ych;
 }

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -17,6 +17,17 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+inline float4 matrix_dot(const float4 vector, const float4 matrix[3])
+{
+  float4 output;
+  const float4 vector_copy = { vector.x, vector.y, vector.z, 0.f };
+  output.x = dot(vector_copy, matrix[0]);
+  output.y = dot(vector_copy, matrix[1]);
+  output.z = dot(vector_copy, matrix[2]);
+  output.w = vector.w;
+  return output;
+}
+
 inline float4 Lab_2_LCH(float4 Lab)
 {
   float H = atan2(Lab.z, Lab.y);
@@ -416,65 +427,127 @@ inline float4 JzAzBz_to_JzCzhz(float4 JzAzBz)
 }
 
 
-inline float4 gradingRGB_to_Ych(float4 RGB)
+// Convert CIE 1931 2° XYZ D65 to CIE 2006 LMS D65 (cone space)
+/*
+* The CIE 1931 XYZ 2° observer D65 is converted to CIE 2006 LMS D65 using the approximation by
+* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
+* with even spacing of Munsell colours
+* https://doi.org/10.2352/issn.2169-2629.2019.27.38
+*/
+
+inline float4 XYZ_to_LMS(const float4 XYZ)
 {
-  const float4 D65 = { 0.18600766f,  0.5908061f,   0.22318624f, 0.f };
-  float4 Ych;
-  Ych.x = fmax(0.67282368f * RGB.x + 0.47812261f * RGB.y + 0.01044966f * RGB.z, 0.f);
-  const float a = RGB.x + RGB.y + RGB.z;
-  RGB = (a == 0.f) ? (float4)0.f : RGB / a;
+  const float4 XYZ_D65_to_LMS_2006_D65[3]
+    = { { 0.257085f, 0.859943f, -0.031061f, 0.f },
+        { -0.394427f, 1.175800f, 0.106423f, 0.f },
+        { 0.064856f, -0.076250f, 0.559067f, 0.f } };
 
-  const float *pD65 = &D65;
-
-  RGB.x -= pD65[0];
-  RGB.y -= pD65[1];
-
-  Ych.y = hypot(RGB.y, RGB.x);
-  Ych.z = atan2(RGB.y, RGB.x);
-  Ych.w = RGB.w;
-  return Ych;
+  return matrix_dot(XYZ, XYZ_D65_to_LMS_2006_D65);
 }
 
 
-inline float4 Ych_to_gradingRGB(const float4 Ych)
+inline float4 LMS_to_XYZ(const float4 LMS)
 {
-  const float4 D65 = { 0.18600766f,  0.5908061f,   0.22318624f, 0.f };
+  const float4 LMS_2006_D65_to_XYZ_D65[3]
+    = { { 1.80794659f, -1.29971660f, 0.34785879f, 0.f },
+        { 0.61783960f, 0.39595453f, -0.04104687f, 0.f },
+        { -0.12546960f, 0.20478038f, 1.74274183f, 0.f } };
 
-  const float *pD65 = &D65;
-  float4 RGB;
-  RGB.x = Ych.y * native_cos(Ych.z) + pD65[0];
-  RGB.y = Ych.y * native_sin(Ych.z) + pD65[1];
-  RGB.z = 1.f - RGB.x - RGB.y;
-
-  const float a = (0.67282368f * RGB.x + 0.47812261f * RGB.y + 0.01044966f * RGB.z);
-  RGB = (a == 0.f) ? (float4)0.f : RGB * Ych.x / a;
-  RGB.w = Ych.w;
-  return RGB;
+  return matrix_dot(LMS, LMS_2006_D65_to_XYZ_D65);
 }
 
-/* Same as above but compute only Yrg */
-inline float4 gradingRGB_to_Yrg(float4 RGB)
-{
-  float4 Yrg;
-  Yrg.x = fmax(0.67282368f * RGB.x + 0.47812261f * RGB.y + 0.01044966f * RGB.z, 0.f);
-  const float a = RGB.x + RGB.y + RGB.z;
-  RGB = (a == 0.f) ? (float4)0.f : RGB / a;
 
-  Yrg.y = RGB.x;
-  Yrg.z = RGB.y;
-  Yrg.w = RGB.w;
-  return Yrg;
+/*
+* Convert from CIE 2006 LMS D65 to Filmlight RGB defined in
+* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
+* with even spacing of Munsell colours
+* https://doi.org/10.2352/issn.2169-2629.2019.27.38
+*/
+
+inline float4 gradingRGB_to_LMS(const float4 RGB)
+{
+  const float4 filmlightRGB_D65_to_LMS_D65[3]
+    = { { 0.95f, 0.38f, 0.00f, 0.f },
+        { 0.05f, 0.62f, 0.03f, 0.f },
+        { 0.00f, 0.00f, 0.97f, 0.f } };
+
+  return matrix_dot(RGB, filmlightRGB_D65_to_LMS_D65);
 }
 
-inline float4 Yrg_to_gradingRGB(const float4 Yrg)
+inline float4 LMS_to_gradingRGB(const float4 LMS)
 {
-  float4 RGB;
-  RGB.x = Yrg.y;
-  RGB.y = Yrg.z;
-  RGB.z = 1.f - Yrg.y - Yrg.z;
+  const float4 LMS_D65_to_filmlightRGB_D65[3]
+    = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
+        { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
+        {         0.f,          0.f,  1.03092784f, 0.f } };
 
-  const float a = (0.67282368f * RGB.x + 0.47812261f * RGB.y + 0.01044966f * RGB.z);
-  RGB = (a == 0.f) ? (float4)0.f : RGB * Yrg.x / a;
-  RGB.w = Yrg.w;
-  return RGB;
+  return matrix_dot(LMS, LMS_D65_to_filmlightRGB_D65);
+}
+
+
+/*
+* Re-express the Filmlight RGB triplet as Yrg luminance/chromacity coordinates
+*/
+
+inline float4 LMS_to_Yrg(const float4 LMS)
+{
+  // compute luminance
+  const float Y = 0.68990272f * LMS.x + 0.34832189f * LMS.y;
+
+  // normalize LMS
+  const float a = LMS.x + LMS.y + LMS.z;
+  const float4 lms = (a == 0.f) ? 0.f : LMS / a;
+
+  // convert to Filmlight rgb (normalized)
+  const float4 rgb = LMS_to_gradingRGB(lms);
+
+  return (float4)(Y, rgb.x, rgb.y, LMS.w);
+}
+
+
+inline float4 Yrg_to_LMS(const float4 Yrg)
+{
+  const float Y = Yrg.x;
+
+  // reform rgb (normalized) from chroma
+  const float r = Yrg.y;
+  const float g = Yrg.z;
+  const float b = 1.f - r - g;
+  const float4 rgb = { r, g, b, 0.f };
+
+  // convert to lms (normalized)
+  const float4 lms = gradingRGB_to_LMS(rgb);
+
+  // denormalize to LMS
+  const float denom = (0.68990272f * lms.x + 0.34832189f * lms.y);
+  const float a = (denom == 0.f) ? 0.f : Y / denom;
+  return lms * a;
+}
+
+
+/*
+* Re-express Filmlight Yrg in polar coordinates Ych
+*/
+
+inline float4 Yrg_to_Ych(const float4 Yrg)
+{
+  const float D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  const float Y = Yrg.x;
+  const float r = Yrg.y - D65[0];
+  const float g = Yrg.z - D65[1];
+  const float c = hypot(g, r);
+  const float h = atan2(g, r);
+  return (float4)(Y, c, h, Yrg.w);
+}
+
+
+inline float4 Ych_to_Yrg(const float4 Ych)
+{
+  const float D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  const float Y = Ych.x;
+  const float c = Ych.y;
+  const float h = Ych.z;
+  const float r = c * native_cos(h) + D65[0];
+  const float g = c * native_sin(h) + D65[1];
+  return (float4)(Y, r, g, Ych.w);
 }

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -872,7 +872,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
 
   // Convert to JCh
   float JC[2] = { Jab.x, hypot(Jab.y, Jab.z) };               // brightness/chroma vector
-  const float h = (JC[1] == 0.f) ? 0.f : atan2(Jab.z, Jab.y);  // hue : (a, b) angle
+  const float h = atan2(Jab.z, Jab.y);  // hue : (a, b) angle
 
   // Project JC onto S, the saturation eigenvector, with orthogonal vector O.
   // Note : O should be = (C * cosf(T) - J * sinf(T)) = 0 since S is the eigenvector,

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -18,8 +18,7 @@
 
 #pragma once
 
-#include "common/colorspaces_inline_conversions.h"
-
+#include "common/math.h"
 
 typedef enum dt_adaptation_t
 {
@@ -37,16 +36,21 @@ typedef enum dt_adaptation_t
 // but coeffs are wrong in the above, so they come from :
 // http://www2.cmp.uea.ac.uk/Research/compvis/Papers/FinSuss_COL00.pdf
 // At any time, ensure XYZ_to_LMS is the exact matrice inverse of LMS_to_XYZ
+const float DT_ALIGNED_ARRAY XYZ_to_Bradford_LMS[3][4] = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
+                                                           { -0.7502f,  1.7135f,  0.0367f, 0.f },
+                                                           {  0.0389f, -0.0685f,  1.0296f, 0.f } };
+
+const float DT_ALIGNED_ARRAY Bradford_LMS_to_XYZ[3][4] = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
+                                                           {  0.4323f,  0.5184f,  0.0493f, 0.f },
+                                                           { -0.0085f,  0.0400f,  0.9685f, 0.f } };
+
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
 #endif
 static inline void convert_XYZ_to_bradford_LMS(const float XYZ[4], float LMS[4])
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
-  static const float DT_ALIGNED_ARRAY XYZ_to_LMS[3][4] = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
-                                                           { -0.7502f,  1.7135f,  0.0367f, 0.f },
-                                                           {  0.0389f, -0.0685f,  1.0296f, 0.f } };
-  dot_product(XYZ, XYZ_to_LMS, LMS);
+  dot_product(XYZ, XYZ_to_Bradford_LMS, LMS);
 }
 
 #ifdef _OPENMP
@@ -55,26 +59,28 @@ static inline void convert_XYZ_to_bradford_LMS(const float XYZ[4], float LMS[4])
 static inline void convert_bradford_LMS_to_XYZ(const float LMS[4], float XYZ[4])
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
-  static const float DT_ALIGNED_ARRAY LMS_to_XYZ[3][4] = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
-                                                           {  0.4323f,  0.5184f,  0.0493f, 0.f },
-                                                           { -0.0085f,  0.0400f,  0.9685f, 0.f } };
-  dot_product(LMS, LMS_to_XYZ, XYZ);
+  dot_product(LMS, Bradford_LMS_to_XYZ, XYZ);
 }
 
 
 // modified LMS cone response for CAT16, from CIECAM16
 // reference : https://ntnuopen.ntnu.no/ntnu-xmlui/bitstream/handle/11250/2626317/CCIW-23.pdf?sequence=1
 // At any time, ensure XYZ_to_LMS is the exact matrice inverse of LMS_to_XYZ
+const float DT_ALIGNED_ARRAY XYZ_to_CAT16_LMS[3][4] = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
+                                                        { -0.250268f, 1.204414f,  0.045854f, 0.f },
+                                                        { -0.002079f, 0.048952f,  0.953127f, 0.f } };
+
+const float DT_ALIGNED_ARRAY CAT16_LMS_to_XYZ[3][4] = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
+                                                        {  0.38752f ,  0.621447f, -0.008974f, 0.f },
+                                                        { -0.015841f, -0.034123f,  1.049964f, 0.f } };
+
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
 #endif
 static inline void convert_XYZ_to_CAT16_LMS(const float XYZ[4], float LMS[4])
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
-  static const float DT_ALIGNED_ARRAY XYZ_to_LMS[3][4] = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
-                                                           { -0.250268f, 1.204414f,  0.045854f, 0.f },
-                                                           { -0.002079f, 0.048952f,  0.953127f, 0.f } };
-  dot_product(XYZ, XYZ_to_LMS, LMS);
+  dot_product(XYZ, XYZ_to_CAT16_LMS, LMS);
 }
 
 #ifdef _OPENMP
@@ -83,10 +89,7 @@ static inline void convert_XYZ_to_CAT16_LMS(const float XYZ[4], float LMS[4])
 static inline void convert_CAT16_LMS_to_XYZ(const float LMS[4], float XYZ[4])
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
-  static const float DT_ALIGNED_ARRAY LMS_to_XYZ[3][4] = { {  1.862068f, -1.011255f,  0.149187f },
-                                                           {  0.38752f ,  0.621447f, -0.008974f },
-                                                           { -0.015841f, -0.034123f,  1.049964f } };
-  dot_product(LMS, LMS_to_XYZ, XYZ);
+  dot_product(LMS, CAT16_LMS_to_XYZ, XYZ);
 }
 
 
@@ -345,4 +348,42 @@ static inline void XYZ_adapt_D50(const float lms_in[4],
   lms_out[0] = lms_in[0] * D50[0] / origin_illuminant[0];
   lms_out[1] = lms_in[1] * D50[1] / origin_illuminant[1];
   lms_out[2] = lms_in[2] * D50[2] / origin_illuminant[2];
+}
+
+/* Pre-solved matrices to adjust white point for triplets in CIE XYZ 1931 2° observer */
+
+const float DT_ALIGNED_ARRAY XYZ_D50_to_D65_CAT16[3][4]
+    = { { 9.89466254e-01f, -4.00304626e-02f, 4.40530317e-02f, 0.f },
+        { -5.40518733e-03f, 1.00666069e+00f, -1.75551955e-03f, 0.f },
+        { -4.03920992e-04f, 1.50768030e-02f, 1.30210211e+00f, 0.f } };
+
+const float DT_ALIGNED_ARRAY XYZ_D50_to_D65_Bradford[3][4]
+    = { { 0.95547342f, -0.02309845f, 0.06325924f, 0.f },
+        { -0.02836971f, 1.00999540f, 0.02104144f, 0.f },
+        { 0.01231401f, -0.02050765f, 1.33036593f, 0.f } };
+
+const float DT_ALIGNED_ARRAY XYZ_D65_to_D50_CAT16[3][4]
+    = { { 1.01085433e+00f, 4.07086103e-02f, -3.41445825e-02f, 0.f },
+        { 5.42814201e-03f, 9.93581926e-01f, 1.15592039e-03f, 0.f },
+        { 2.50722468e-04f, -1.14918759e-02f, 7.67964947e-01f, 0.f } };
+
+const float DT_ALIGNED_ARRAY XYZ_D65_to_D50_Bradford[3][4]
+    = { { 1.04792979f, 0.02294687f, -0.05019227f, 0.f },
+        { 0.02962781f, 0.99043443f, -0.0170738f, 0.f },
+        { -0.00924304f, 0.01505519f, 0.75187428f, 0.f } };
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(IN, OUT:16)
+#endif
+static inline void XYZ_D50_to_D65(const float IN[4], float OUT[4])
+{
+  dot_product(IN, XYZ_D50_to_D65_CAT16, OUT);
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(IN, OUT:16)
+#endif
+static inline void XYZ_D65_to_D50(const float IN[4], float OUT[4])
+{
+  dot_product(IN, XYZ_D65_to_D50_CAT16, OUT);
 }

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -373,17 +373,17 @@ const float DT_ALIGNED_ARRAY XYZ_D65_to_D50_Bradford[3][4]
         { -0.00924304f, 0.01505519f, 0.75187428f, 0.f } };
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(IN, OUT:16)
+#pragma omp declare simd aligned(XYZ_in, XYZ_out:16)
 #endif
-static inline void XYZ_D50_to_D65(const float IN[4], float OUT[4])
+static inline void XYZ_D50_to_D65(const float XYZ_in[4], float XYZ_out[4])
 {
-  dot_product(IN, XYZ_D50_to_D65_CAT16, OUT);
+  dot_product(XYZ_in, XYZ_D50_to_D65_CAT16, XYZ_out);
 }
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(IN, OUT:16)
+#pragma omp declare simd aligned(XYZ_in, XYZ_out:16)
 #endif
-static inline void XYZ_D65_to_D50(const float IN[4], float OUT[4])
+static inline void XYZ_D65_to_D50(const float XYZ_in[4], float XYZ_out[4])
 {
-  dot_product(IN, XYZ_D65_to_D50_CAT16, OUT);
+  dot_product(XYZ_in, XYZ_D65_to_D50_CAT16, XYZ_out);
 }

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "common/math.h"
-#include "common/darktable.h"
 
 #ifdef __SSE2__
 #include "common/sse.h" // also loads darkable.h
@@ -914,65 +913,31 @@ static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float 
   XYZ_D65[2] = XYZ[2];
 }
 
-#ifdef _OPENMP
-#pragma omp declare simd uniform(v_2) aligned(v_1, v_2:16)
-#endif
-static inline float scalar_product(const float v_1[4], const float v_2[4])
-{
-  // specialized 3×1 dot products 2 4×1 RGB-alpha pixels.
-  // v_2 needs to be uniform along loop increments, e.g. independent from current pixel values
-  // we force an order of computation similar to SSE4 _mm_dp_ps() hoping the compiler will get the clue
-  float acc = 0.f;
+// Convert CIE 1931 2° XYZ D65 to CIE 2006 LMS D65 (cone space)
+/*
+* The CIE 1931 XYZ 2° observer D65 is converted to CIE 2006 LMS D65 using the approximation by
+* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
+* with even spacing of Munsell colours
+* https://doi.org/10.2352/issn.2169-2629.2019.27.38
+*/
 
-#ifdef _OPENMP
-#pragma omp simd aligned(v_1, v_2:16) reduction(+:acc)
-#endif
-  for(size_t c = 0; c < 3; c++) acc += v_1[c] * v_2[c];
+static const float DT_ALIGNED_ARRAY XYZ_D65_to_LMS_2006_D65[3][4]
+    = { { 0.257085f, 0.859943f, -0.031061f, 0.f },
+        { -0.394427f, 1.175800f, 0.106423f, 0.f },
+        { 0.064856f, -0.076250f, 0.559067f, 0.f } };
 
-  return acc;
-}
+static const float DT_ALIGNED_ARRAY LMS_2006_D65_to_XYZ_D65[3][4]
+    = { { 1.80794659f, -1.29971660f, 0.34785879f, 0.f },
+        { 0.61783960f, 0.39595453f, -0.04104687f, 0.f },
+        { -0.12546960f, 0.20478038f, 1.74274183f, 0.f } };
 
-
-#ifdef _OPENMP
-#pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
-#endif
-static inline void dot_product(const float v_in[4], const float M[3][4], float v_out[4])
-{
-  // specialized 3×4 dot products of 4×1 RGB-alpha pixels
-  #ifdef _OPENMP
-  #pragma omp simd aligned(M:64) aligned(v_in, v_out:16)
-  #endif
-  for(size_t i = 0; i < 3; ++i) v_out[i] = scalar_product(v_in, M[i]);
-}
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, XYZ: 16)
 #endif
 static inline void XYZ_to_LMS(const float XYZ[4], float LMS[4])
 {
-  // Convert CIE 1931 2° XYZ D50 to CIE 2006 LMS D65
-  /* XYZ is white-balanced from D50 to D65 using CAT16 which results in the following matrix :
-  * CAT_to_XYZ * WB * XYZ_to_CAT =
-  * [[  9.80760485e-01,  -4.25541784e-17,  -7.61959005e-19],
-  *  [  4.82934624e-17,   1.01555271e+00,  -7.63213113e-18],
-  *  [ -6.47162968e-19,  -5.69389701e-19,   1.30191586e+00]]
-  *
-  * See chromatic_adaptation.h for the details of the algo and D65/D50 values.
-  *
-  * The XYZ 2° D65 is then converted to CIE 2006 LMS using the approximation by
-  * Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
-  * with even spacing of Munsell colours
-  * https://doi.org/10.2352/issn.2169-2629.2019.27.38
-  * resulting in the following matrix :
-  * XYZ_to_LMS =
-  * [[0.257085, 0.859943, -0.031061],
-  *  [-0.394427, 1.175800, 0.196423],
-  *  [0.064856, -0.076250, 0.559067]]
-  */
-  const float mat[3][4] = { { 0.25213881,  0.87331744, -0.04043881, 0.  },
-                            {-0.38683842,  1.19408687,  0.25572622, 0.  },
-                            { 0.0636082 , -0.07743589,  0.72785819, 0.f } };
-  dot_product(XYZ, mat, LMS);
+  dot_product(XYZ, XYZ_D65_to_LMS_2006_D65, LMS);
 }
 
 #ifdef _OPENMP
@@ -980,119 +945,184 @@ static inline void XYZ_to_LMS(const float XYZ[4], float LMS[4])
 #endif
 static inline void LMS_to_XYZ(const float LMS[4], float XYZ[4])
 {
-  // Convert CIE 2006 LMS D65 to CIE 1931 2° XYZ D50 in one step
-  // going through CIE 2006 LMS -> CIE 2° XYZ D65 -> CIE 2° XYZ D50
-
-  /* The following matrix is the inverse of the above*/
-  const float mat[3][4] = { { 1.82871912, -1.30123107,  0.55877659, 0. },
-                            { 0.61270075,  0.38283494, -0.10046468, 0. },
-                            {-0.09462902,  0.1544451 ,  1.31437368, 0. } };
-  dot_product(LMS, mat, XYZ);
+  dot_product(LMS, LMS_2006_D65_to_XYZ_D65, XYZ);
 }
+
+/*
+* Convert from CIE 2006 LMS D65 to Filmlight RGB defined in
+* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
+* with even spacing of Munsell colours
+* https://doi.org/10.2352/issn.2169-2629.2019.27.38
+*/
+
+static const float DT_ALIGNED_ARRAY filmlightRGB_D65_to_LMS_D65[3][4]
+    = { { 0.95f, 0.38f, 0.00f, 0.f },
+        { 0.05f, 0.62f, 0.03f, 0.f },
+        { 0.00f, 0.00f, 0.97f, 0.f } };
+
+static const float DT_ALIGNED_ARRAY LMS_D65_to_filmlightRGB_D65[3][4]
+    = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
+        { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
+        {         0.f,          0.f,  1.03092784f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
 static inline void gradingRGB_to_LMS(const float RGB[4], float LMS[4])
 {
-  const float mat[3][4] = { { 0.95f, 0.38f, 0.00f, 0.f },
-                            { 0.05f, 0.62f, 0.03f, 0.f },
-                            { 0.00f, 0.00f, 0.97f, 0.f } };
-  dot_product(RGB, mat, LMS);
+  dot_product(RGB, filmlightRGB_D65_to_LMS_D65, LMS);
 }
-
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
 static inline void LMS_to_gradingRGB(const float LMS[4], float RGB[4])
 {
-  const float mat[3][4] = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
-                            { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
-                            {         0.f,          0.f,  1.03092784f, 0.f } };
-  dot_product(LMS, mat, RGB);
+  dot_product(LMS, LMS_D65_to_filmlightRGB_D65, RGB);
 }
 
 
 /*
-* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
-* with even spacing of Munsell colours
-* https://doi.org/10.2352/issn.2169-2629.2019.27.38
-* The following takes the paper's direct transform but fixes the reverse transform
-* which is wrong. D65 coordinates are taken from CIE 1931 XYZ 2° and converted to
-* RGB
+* Re-express the Filmlight RGB triplet as Yrg luminance/chromacity coordinates
 */
 
-// coordinates of D65 white point in normalized grading RGB :
-// D65_gradingRGB = [ 0.18600766,  0.5908061,   0.22318624 ]
-// they don't need to be true to measured CIE 1931 2° observer D65
-// but need to be tweaked such that sRGB = [1, 1, 1] yields c = 0 in Ych
-// otherwise highlights get shifted to green or magenta
-// Accurate CIE 1931 2° observer D65 projected directly is [ 0.18662246,  0.5847461 ,  0.22863145]
-
 #ifdef _OPENMP
-#pragma omp declare simd aligned(XYZ, RGB: 16)
+#pragma omp declare simd aligned(LMS, Yrg: 16)
 #endif
-static inline void XYZ_to_gradingRGB(const float XYZ[4], float RGB[3])
+static inline void LMS_to_Yrg(const float LMS[4], float Yrg[4])
 {
-  // fast path with collapsed matrices to go directly from CIE 1931 2° XYZ D50 to Filmlight grading RGB D65
-  // this should be numerically equivalent to XYZ_to_LMS() followed by LMS_to_gradingRGB()
-  // but saves one matrix product by collapsing the 2 matrices from the above functions
-  const float mat[3][4] = { { 0.53346004f,  0.15226970f , -0.19946283f, 0.f },
-                            {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
-                            { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
-  dot_product(XYZ, mat, RGB);
+  // compute luminance
+  const float Y = 0.68990272f * LMS[0] + 0.34832189f * LMS[1];
+
+  // normalize LMS
+  const float a = LMS[0] + LMS[1] + LMS[2];
+  float DT_ALIGNED_PIXEL lms[4] = { 0.f };
+  for_four_channels(c, aligned(LMS, lms : 16)) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
+
+  // convert to Filmlight rgb (normalized)
+  float DT_ALIGNED_PIXEL rgb[4] = { 0.f };
+  LMS_to_gradingRGB(lms, rgb);
+
+  Yrg[0] = Y;
+  Yrg[1] = rgb[0];
+  Yrg[2] = rgb[1];
 }
 
-
 #ifdef _OPENMP
-#pragma omp declare simd aligned(XYZ, RGB: 16)
+#pragma omp declare simd aligned(Yrg, LMS: 16)
 #endif
-static inline void gradingRGB_to_XYZ(const float RGB[4], float XYZ[3])
+static inline void Yrg_to_LMS(const float Yrg[4], float LMS[4])
 {
-  // inverse of the above
-  const float mat[3][4] = { { 1.67222161f, -0.11185000f,  0.50297636f, 0.f },
-                            { 0.60120746f,  0.47018395f, -0.08596569f, 0.f },
-                            {-0.08217531f,  0.05979694f,  1.27957582f, 0.f } };
-  dot_product(RGB, mat, XYZ);
+  const float Y = Yrg[0];
+
+  // reform rgb (normalized) from chroma
+  const float r = Yrg[1];
+  const float g = Yrg[2];
+  const float b = 1.f - r - g;
+  const float rgb[4] = { r, g, b, 0.f };
+
+  // convert to lms (normalized)
+  float DT_ALIGNED_PIXEL lms[4] = { 0.f };
+  gradingRGB_to_LMS(rgb, lms);
+
+  // denormalize to LMS
+  const float denom = (0.68990272f * lms[0] + 0.34832189f * lms[1]);
+  const float a = (denom == 0.f) ? 0.f : Y / denom;
+  for_four_channels(c, aligned(lms, LMS:16)) LMS[c] = lms[c] * a;
 }
 
+/*
+* Re-express Filmlight Yrg in polar coordinates Ych
+*/
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(Ych, RGB: 16)
+#pragma omp declare simd aligned(Ych, Yrg: 16)
 #endif
-static inline void gradingRGB_to_Ych(float RGB[4], float Ych[3])
+static inline void Yrg_to_Ych(const float Yrg[4], float Ych[4])
 {
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.18600766f,  0.5908061f,   0.22318624f, 0.f };
-
-  Ych[0] = fmaxf(0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2], 0.f);
-  const float a = RGB[0] + RGB[1] + RGB[2];
-
-  for_four_channels(c, aligned(RGB:16)) RGB[c] = (a == 0.f) ? 0.f : RGB[c] / a;
-
-  RGB[0] -= D65[0];
-  RGB[1] -= D65[1];
-
-  Ych[1] = hypotf(RGB[1], RGB[0]);
-  Ych[2] = atan2f(RGB[1], RGB[0]);
+  const float DT_ALIGNED_PIXEL D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  const float Y = Yrg[0];
+  const float r = Yrg[1] - D65[0];
+  const float g = Yrg[2] - D65[1];
+  const float c = hypotf(g, r);
+  const float h = atan2f(g, r);
+  Ych[0] = Y;
+  Ych[1] = c;
+  Ych[2] = h;
 }
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, Yrg: 16)
+#endif
+static inline void Ych_to_Yrg(const float Ych[4], float Yrg[4])
+{
+  const float DT_ALIGNED_PIXEL D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  const float Y = Ych[0];
+  const float c = Ych[1];
+  const float h = Ych[2];
+  const float r = c * cosf(h) + D65[0];
+  const float g = c * sinf(h) + D65[1];
+  Yrg[0] = Y;
+  Yrg[1] = r;
+  Yrg[2] = g;
+}
+
+/*
+* Filmlight RGB utils functions
+*/
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, RGB: 16)
 #endif
 static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[4])
 {
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.18600766f,  0.5908061f,   0.22318624f, 0.f };
-
-  RGB[0] = Ych[1] * cosf(Ych[2]) + D65[0];
-  RGB[1] = Ych[1] * sinf(Ych[2]) + D65[1];
-  RGB[2] = 1.f - RGB[0] - RGB[1];
-
-  const float a = (0.67282368f * RGB[0] + 0.47812261f * RGB[1] + 0.01044966f * RGB[2]);
-  for_four_channels(c, aligned(RGB, Ych:16)) RGB[c] = (a == 0.f) ? 0.f : RGB[c] * Ych[0] / a;
+  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
+  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  Ych_to_Yrg(Ych, Yrg);
+  Yrg_to_LMS(Yrg, LMS);
+  LMS_to_gradingRGB(LMS, RGB);
 }
 
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, RGB: 16)
+#endif
+static inline void gradingRGB_to_Ych(const float RGB[4], float Ych[4])
+{
+  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
+  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  gradingRGB_to_LMS(RGB, LMS);
+  LMS_to_Yrg(LMS, Yrg);
+  Yrg_to_Ych(Yrg, Ych);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, XYZ: 16)
+#endif
+static inline void XYZ_to_Ych(const float XYZ[4], float Ych[4])
+{
+  // WARNING: XYZ needs to be chroma-adapted to D65 before
+  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
+  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  XYZ_to_LMS(XYZ, LMS);
+  LMS_to_Yrg(LMS, Yrg);
+  Yrg_to_Ych(Yrg, Ych);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(Ych, XYZ: 16)
+#endif
+static inline void Ych_to_XYZ(const float Ych[4], float XYZ[4])
+{
+  // WARNING: XYZ is output in D65
+  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
+  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  Ych_to_Yrg(Ych, Yrg);
+  Yrg_to_LMS(Yrg, LMS);
+  LMS_to_XYZ(LMS, XYZ);
+}
 
 #undef DT_RESTRICT
 

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1074,7 +1074,7 @@ static inline void gradingRGB_to_Ych(float RGB[4], float Ych[3])
   RGB[1] -= D65[1];
 
   Ych[1] = hypotf(RGB[1], RGB[0]);
-  Ych[2] = (Ych[1] == 0.f) ? 0.f : atan2f(RGB[1], RGB[0]);
+  Ych[2] = atan2f(RGB[1], RGB[0]);
 }
 
 #ifdef _OPENMP

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "common/chromatic_adaptation.h"
-#include "common/colorspaces_inline_conversions.h"
 #include "common/image.h"
 #include "external/adobe_coeff.c"
 

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -168,6 +168,38 @@ static inline void mul_mat_vec_2(const float *m, const float *p, float *o)
 }
 
 #ifdef _OPENMP
+#pragma omp declare simd uniform(v_2) aligned(v_1, v_2:16)
+#endif
+static inline float scalar_product(const float v_1[4], const float v_2[4])
+{
+  // specialized 3×1 dot products 2 4×1 RGB-alpha pixels.
+  // v_2 needs to be uniform along loop increments, e.g. independent from current pixel values
+  // we force an order of computation similar to SSE4 _mm_dp_ps() hoping the compiler will get the clue
+  float acc = 0.f;
+
+#ifdef _OPENMP
+#pragma omp simd aligned(v_1, v_2:16) reduction(+:acc)
+#endif
+  for(size_t c = 0; c < 3; c++) acc += v_1[c] * v_2[c];
+
+  return acc;
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
+#endif
+static inline void dot_product(const float v_in[4], const float M[3][4], float v_out[4])
+{
+  // specialized 3×4 dot products of 4×1 RGB-alpha pixels
+  #ifdef _OPENMP
+  #pragma omp simd aligned(M:64) aligned(v_in, v_out:16)
+  #endif
+  for(size_t i = 0; i < 3; ++i) v_out[i] = scalar_product(v_in, M[i]);
+}
+
+
+#ifdef _OPENMP
 #pragma omp declare simd
 #endif
 static inline float dt_log2f(const float f)

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -22,6 +22,7 @@
 // our includes go first:
 #include "bauhaus/bauhaus.h"
 #include "common/exif.h"
+#include "common/chromatic_adaptation.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/opencl.h"
 #include "develop/blend.h"
@@ -369,7 +370,7 @@ static inline void repack_3x3_to_3xSSE(const float input[9], float output[3][4])
 }
 
 
-static void mat3mul4(float *dst, const float *const m1, const float *const m2)
+static void mat3mul4(float *restrict dst, const float *const restrict m1, const float *const restrict m2)
 {
   for(int k = 0; k < 3; ++k)
   {
@@ -423,28 +424,6 @@ static inline float soft_clip(const float x, const float soft_threshold, const f
   return (x > soft_threshold) ? soft_threshold + (1.f - expf(-(x - soft_threshold) / norm)) * norm : x;
 }
 
-static inline float PQ(const float x)
-{
-  // Perceptual quantizer https://doi.org/10.5594/j18290
-  const float y = powf(x * 1e-4f, 0.1593017578125f);
-  return powf((0.8359375f + 18.8515625f * y) / (1.f + 18.6875f * y),
-              134.034375f);
-}
-
-
-// Matrices from CIE 1931 2° XYZ D50 to Filmlight grading RGB D65 through CIE 2006 LMS
-/*
-* Richard A. Kirk, Chromaticity coordinates for graphic arts based on CIE 2006 LMS
-* with even spacing of Munsell colours
-* https://doi.org/10.2352/issn.2169-2629.2019.27.38
-*/
-const float DT_ALIGNED_ARRAY XYZ_to_gradRGB[3][4] = { { 0.53346004f,  0.15226970f , -0.19946283f, 0.f },
-                                                      {-0.67012691f,  1.91752954f,   0.39223917f, 0.f },
-                                                      { 0.06557547f, -0.07983082f,   0.75036927f, 0.f } };
-const float DT_ALIGNED_ARRAY gradRGB_to_XYZ[3][4] = { { 1.67222161f, -0.11185000f,  0.50297636f, 0.f },
-                                                      { 0.60120746f,  0.47018395f, -0.08596569f, 0.f },
-                                                      {-0.08217531f,  0.05979694f,  1.27957582f, 0.f } };
-
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
@@ -466,11 +445,35 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     repack_3x3_to_3xSSE(work_profile->matrix_out, XYZ_to_RGB);
   }
 
-  // Premultiply the pipe RGB -> XYZ and XYZ -> grading RGB matrices to spare 2 matrix products per pixel
+  // Premultiply the input matrices
+
+  /* What we do here is equivalent to :
+
+    // go to CIE 1931 XYZ 2° D50
+    dot_product(RGB, RGB_to_XYZ, XYZ_D50); // matrice product
+
+    // chroma adapt D50 to D65
+    XYZ_D50_to_65(XYZ_D50, XYZ_D65);       // matrice product
+
+    // go to CIE 2006 LMS
+    XYZ_to_LMS(XYZ_D65, LMS);              // matrice product
+
+  * so we pre-multiply the 3 conversion matrices and operate only one matrix product
+  */
   float DT_ALIGNED_ARRAY input_matrix[3][4];
   float DT_ALIGNED_ARRAY output_matrix[3][4];
-  mat3mul4((float *)input_matrix, (float *)XYZ_to_gradRGB, (float *)RGB_to_XYZ);
-  mat3mul4((float *)output_matrix, (float *)XYZ_to_RGB, (float *)gradRGB_to_XYZ);
+
+  mat3mul4((float *)output_matrix, (float *)XYZ_D50_to_D65_CAT16, (float *)RGB_to_XYZ); // output_matrix used as temp buffer
+  mat3mul4((float *)input_matrix, (float *)XYZ_D65_to_LMS_2006_D65, (float *)output_matrix);
+
+  // Premultiply the output matrix
+
+  /* What we do here is equivalent to :
+    XYZ_D65_to_50(XYZ_D65, XYZ_D50);           // matrix product
+    dot_product(XYZ_D50, XYZ_to_RGB, pix_out); // matrix product
+  */
+
+  mat3mul4((float *)output_matrix, (float *)XYZ_to_RGB, (float *)XYZ_D65_to_D50_CAT16);
 
   const float *const restrict in = __builtin_assume_aligned(((const float *const restrict)ivoid), 64);
   float *const restrict out = __builtin_assume_aligned(((float *const restrict)ovoid), 64);
@@ -506,20 +509,42 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float *const restrict pix_in = __builtin_assume_aligned(in + k, 16);
     float *const restrict pix_out = __builtin_assume_aligned(out + k, 16);
 
-    float DT_ALIGNED_PIXEL Ych[4] = { 0.f };
+    float DT_ALIGNED_PIXEL XYZ_D65[4] = { 0.f };
+    float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
     float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
+    float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
+    float DT_ALIGNED_PIXEL Ych[4] = { 0.f };
 
-    for_four_channels(c, aligned(pix_in:16)) Ych[c] = fmaxf(pix_in[c], 0.0f);
-    dot_product(Ych, input_matrix, RGB);
-    gradingRGB_to_Ych(RGB, Ych);
+    // clip pipeline RGB
+    for_four_channels(c, aligned(pix_in:16)) RGB[c] = fmaxf(pix_in[c], 0.0f);
+
+    // go to CIE 2006 LMS D65
+    dot_product(RGB, input_matrix, LMS);
+
+    /* The previous line is equivalent to :
+      // go to CIE 1931 XYZ 2° D50
+      dot_product(RGB, RGB_to_XYZ, XYZ_D50); // matrice product
+
+      // chroma adapt D50 to D65
+      XYZ_D50_to_65(XYZ_D50, XYZ_D65); // matrice product
+
+      // go to CIE 2006 LMS
+      XYZ_to_LMS(XYZ_D65, LMS); // matrice product
+    */
+
+    // go to Filmlight Yrg
+    LMS_to_Yrg(LMS, Yrg);
+
+    // go to Ych
+    Yrg_to_Ych(Yrg, Ych);
 
     // Sanitize input : no negative luminance
-    float Y = fmaxf(Ych[0], 0.f);
+    Ych[0] = fmaxf(Ych[0], 0.f);
 
     // Opacities for luma masks
     float DT_ALIGNED_PIXEL opacities[4];
     float DT_ALIGNED_PIXEL opacities_comp[4];
-    opacity_masks(powf(Y, 0.4101205819200422f), // center middle grey in 50 %
+    opacity_masks(powf(Ych[0], 0.4101205819200422f), // center middle grey in 50 %
                   d->shadows_weight, d->highlights_weight, d->midtones_weight, d->mask_grey_fulcrum, opacities, opacities_comp);
 
     // Hue shift - do it now because we need the gamut limit at output hue right after
@@ -534,7 +559,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float vibrance = d->vibrance * (1.0f - powf(Ych[1], fabsf(d->vibrance)));
     const float chroma_factor = fmaxf(1.f + chroma_boost + vibrance, 0.f);
     Ych[1] *= chroma_factor;
-    Ych_to_gradingRGB(Ych, RGB);
+
+    // Go to Yrg
+    Ych_to_Yrg(Ych, Yrg);
+
+    // Go to LMS
+    Yrg_to_LMS(Yrg, LMS);
+
+    // Go to Filmlight RGB
+    LMS_to_gradingRGB(LMS, RGB);
 
     // Color balance
     for_four_channels(c, aligned(RGB, opacities, opacities_comp, global, shadows, midtones, highlights:16))
@@ -551,31 +584,22 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       RGB[c] = sign * powf(fabsf(RGB[c]) / d->white_fulcrum, midtones[c]) * d->white_fulcrum;
     }
 
-    // for the Y midtones power (gamma), we need to go in Ych again because RGB doesn't preserve color
-    gradingRGB_to_Ych(RGB, Ych);
-    Y = Ych[0] = powf(fmaxf(Ych[0] / d->white_fulcrum, 0.f), d->midtones_Y) * d->white_fulcrum;
+    // for the non-linear ops we need to go in Yrg again because RGB doesn't preserve color
+    gradingRGB_to_LMS(RGB, LMS);
+    LMS_to_Yrg(LMS, Yrg);
 
-    // then the contrast
-    Y = Ych[0] = d->grey_fulcrum * powf(Ych[0] / d->grey_fulcrum, d->contrast);
-    Ych_to_gradingRGB(Ych, RGB);
+    // Y midtones power (gamma)
+    Yrg[0] = powf(fmaxf(Yrg[0] / d->white_fulcrum, 0.f), d->midtones_Y) * d->white_fulcrum;
+
+    // Y fulcrumed contrast
+    Yrg[0] = d->grey_fulcrum * powf(Yrg[0] / d->grey_fulcrum, d->contrast);
+
+    Yrg_to_LMS(Yrg, LMS);
+    LMS_to_XYZ(LMS, XYZ_D65);
 
     // Perceptual color adjustments
-
-    // grading RGB to CIE 1931 XYZ 2° D65
-    const float DT_ALIGNED_ARRAY RGB_to_XYZ_D65[3][4] = { { 1.64004888f, -0.10969806f, 0.49329934f, 0.f },
-                                                          { 0.61055787f, 0.47749658f, -0.08730269f, 0.f },
-                                                          { -0.10698534f, 0.07785058f, 1.66590006f, 0.f } };
-
-    const float DT_ALIGNED_ARRAY XYZ_to_RGB_D65[3][4] = { { 0.54392489f, 0.14993776f, -0.15320716f, 0.f },
-                                                          { -0.68327274f, 1.88816348f, 0.30127843f, 0.f },
-                                                          { 0.06686186f, -0.07860825f, 0.57635773f, 0.f } };
-
-    // Go to JzAzBz for perceptual saturation
-    // We can't use gradingRGB_to_XYZ() since it also does chromatic adaptation to D50
-    // and JzAzBz uses D65, same as grading RGB. So we use the matrices above instead
     float DT_ALIGNED_PIXEL Jab[4] = { 0.f };
-    dot_product(RGB, RGB_to_XYZ_D65, Ych);
-    dt_XYZ_2_JzAzBz(Ych, Jab);
+    dt_XYZ_2_JzAzBz(XYZ_D65, Jab);
 
     // Convert to JCh
     float JC[2] = { Jab[0], hypotf(Jab[1], Jab[2]) };               // brightness/chroma vector
@@ -614,9 +638,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     Jab[1] = JC[1] * cosf(h);
     Jab[2] = JC[1] * sinf(h);
 
-    dt_JzAzBz_2_XYZ(Jab, Ych);
-    dot_product(Ych, XYZ_to_RGB_D65, RGB);
-    dot_product(RGB, output_matrix, pix_out);
+    dt_JzAzBz_2_XYZ(Jab, XYZ_D65);
+
+    // Project back to D50 pipeline RGB
+    dot_product(XYZ_D65, output_matrix, pix_out);
+
+    /* The previous line is equivalent to :
+      XYZ_D65_to_50(XYZ_D65, XYZ_D50);           // matrix product
+      dot_product(XYZ_D50, XYZ_to_RGB, pix_out); // matrix product
+    */
 
     if(mask_display)
     {
@@ -648,7 +678,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 
-#ifdef HAVE_OPENCL
+#if HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -699,11 +729,35 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     repack_3x3_to_3xSSE(work_profile->matrix_out, XYZ_to_RGB);
   }
 
-  // Premultiply the pipe RGB -> XYZ and XYZ -> grading RGB matrices to spare 2 matrix products per pixel
+  // Premultiply the input matrices
+
+  /* What we do here is equivalent to :
+
+    // go to CIE 1931 XYZ 2° D50
+    dot_product(RGB, RGB_to_XYZ, XYZ_D50); // matrice product
+
+    // chroma adapt D50 to D65
+    XYZ_D50_to_65(XYZ_D50, XYZ_D65);       // matrice product
+
+    // go to CIE 2006 LMS
+    XYZ_to_LMS(XYZ_D65, LMS);              // matrice product
+
+  * so we pre-multiply the 3 conversion matrices and operate only one matrix product
+  */
   float DT_ALIGNED_ARRAY input_matrix[3][4];
   float DT_ALIGNED_ARRAY output_matrix[3][4];
-  mat3mul4((float *)input_matrix, (float *)XYZ_to_gradRGB, (float *)RGB_to_XYZ);
-  mat3mul4((float *)output_matrix, (float *)XYZ_to_RGB, (float *)gradRGB_to_XYZ);
+
+  mat3mul4((float *)output_matrix, (float *)XYZ_D50_to_D65_CAT16, (float *)RGB_to_XYZ); // output_matrix used as temp buffer
+  mat3mul4((float *)input_matrix, (float *)XYZ_D65_to_LMS_2006_D65, (float *)output_matrix);
+
+  // Premultiply the output matrix
+
+  /* What we do here is equivalent to :
+    XYZ_D65_to_50(XYZ_D65, XYZ_D50);           // matrix product
+    dot_product(XYZ_D50, XYZ_to_RGB, pix_out); // matrix product
+  */
+
+  mat3mul4((float *)output_matrix, (float *)XYZ_to_RGB, (float *)XYZ_D65_to_D50_CAT16);
 
   input_matrix_cl = dt_opencl_copy_host_to_device_constant(devid, 12 * sizeof(float), input_matrix);
   output_matrix_cl = dt_opencl_copy_host_to_device_constant(devid, 12 * sizeof(float), output_matrix);
@@ -899,14 +953,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     float DT_ALIGNED_ARRAY RGB_to_XYZ[3][4];
     repack_3x3_to_3xSSE(work_profile->matrix_in, RGB_to_XYZ);
 
-    // XYZ D50 to XYZ D65 using CAT16
-    float DT_ALIGNED_ARRAY D50_to_D65[3][4] = { {  9.80760485e-01f, -4.25541784e-17f, -7.61959005e-19f, 0.f },
-                                                {  4.82934624e-17f,  1.01555271e+00f, -7.63213113e-18f, 0.f  },
-                                                { -6.47162968e-19f, -5.69389701e-19f,  1.30191586e+00f, 0.f } };
-
     // Premultiply both matrices to go from D50 pipeline RGB to D65 XYZ in a single matrix dot product
     float DT_ALIGNED_ARRAY input_matrix[3][4];
-    mat3mul4((float *)input_matrix, (float *)D50_to_D65, (float *)RGB_to_XYZ);
+    mat3mul4((float *)input_matrix, (float *)XYZ_D50_to_D65_CAT16, (float *)RGB_to_XYZ);
 
     // make RGB values vary between [0; 1] in working space, convert to Ych and get the max(c(h)))
 #ifdef _OPENMP
@@ -963,14 +1012,14 @@ void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   if(work_profile == NULL) return; // no point
 
-  float XYZ[4] = { 0.f };
-  float LMS[4] = { 0.f };
+  float DT_ALIGNED_ARRAY XYZ_D50[4] = { 0.f };
+  float DT_ALIGNED_ARRAY XYZ_D65[4] = { 0.f };
 
-  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ, work_profile->matrix_in, work_profile->lut_in,
+  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, work_profile->matrix_in, work_profile->lut_in,
                              work_profile->unbounded_coeffs_in, work_profile->lutsize,
                              work_profile->nonlinearlut);
-  XYZ_to_gradingRGB(XYZ, LMS);
-  gradingRGB_to_Ych(LMS, Ych);
+  XYZ_D50_to_D65(XYZ_D50, XYZ_D65);
+  XYZ_to_Ych(XYZ_D65, Ych);
 
   if(Ych[2] < 0.f)
     Ych[2] = 2.f * M_PI + Ych[2];
@@ -1052,10 +1101,9 @@ static void paint_chroma_slider(GtkWidget *w, const float hue)
 
     float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
     float DT_ALIGNED_PIXEL Ych[4] = { 0.75f, x, h, 0.f };
-    float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
-    Ych_to_gradingRGB(Ych, LMS);
-    gradingRGB_to_XYZ(LMS, Ych);
-    dt_XYZ_to_Rec709_D65(Ych, RGB);
+    float DT_ALIGNED_PIXEL XYZ[4] = { 0.f };
+    Ych_to_XYZ(Ych, XYZ);
+    dt_XYZ_to_Rec709_D65(XYZ, RGB);
     const float max_RGB = fmaxf(fmaxf(RGB[0], RGB[1]), RGB[2]);
     for(size_t c = 0; c < 3; c++) RGB[c] = powf(RGB[c] / max_RGB, 1.f / 2.2f);
     dt_bauhaus_slider_set_stop(w, stop, RGB[0], RGB[1], RGB[2]);
@@ -1760,10 +1808,9 @@ void gui_init(dt_iop_module_t *self)
     const float h = DEG_TO_RAD(stop * (360.f));
     float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
     float DT_ALIGNED_PIXEL Ych[4] = { 0.75f, 0.2f, h, 0.f };
-    float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
-    Ych_to_gradingRGB(Ych, LMS);
-    gradingRGB_to_XYZ(LMS, Ych);
-    dt_XYZ_to_Rec709_D65(Ych, RGB);
+    float DT_ALIGNED_PIXEL XYZ[4] = { 0.f };
+    Ych_to_XYZ(Ych, XYZ);
+    dt_XYZ_to_Rec709_D65(XYZ, RGB);
     const float max_RGB = fmaxf(fmaxf(RGB[0], RGB[1]), RGB[2]);
     for(size_t c = 0; c < 3; c++) RGB[c] = powf(RGB[c] / max_RGB, 1.f / 2.2f);
     dt_bauhaus_slider_set_stop(g->global_H, stop, RGB[0], RGB[1], RGB[2]);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -579,7 +579,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     // Convert to JCh
     float JC[2] = { Jab[0], hypotf(Jab[1], Jab[2]) };               // brightness/chroma vector
-    const float h = (JC[1] == 0.f) ? 0.f : atan2f(Jab[2], Jab[1]);  // hue : (a, b) angle
+    const float h = atan2f(Jab[2], Jab[1]);  // hue : (a, b) angle
 
     // Project JC onto S, the saturation eigenvector, with orthogonal vector O.
     // Note : O should be = (C * cosf(T) - J * sinf(T)) = 0 since S is the eigenvector,


### PR DESCRIPTION
Several mistakes have been made in color space conversions :
1. the D65 <-> D50 matrices were wrong,
2. a typo in the LMS -> XYZ matrice,
3. normalisation in RGB instead of LMS proved to be too inaccurate (although faster).

These led to non-hue-linear changes of chroma and saturation as well as over-corrections of the gamut.

Refactor the color lib for better code re-using. The current refactoring follows the base paper more closely and allows step-by-step debugging when needed, while still allowing contextual optimizations by collapsing matrices products.

Big thanks to @dtorop for the vectorscope which allowed to diagnose and debug these issues.