### PR TITLE
Fix metadata view

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -669,7 +669,7 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
   {
     *width = img.final_width;
     *height = img.final_height;
-    return 0;
+    return FALSE;
   }
 
   // special case if we try to load embedded preview of raw file
@@ -680,7 +680,7 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
   const gboolean use_raw =
     !dt_conf_is_equal("plugins/lighttable/thumbnail_raw_min_level", "never");
 
-  if(!img.verified_size && !dt_image_altered(imgid) && !use_raw && !incompatible)
+  if(!dt_image_altered(imgid) && !use_raw && !incompatible)
   {
     // we want to be sure to have the real image size.
     // some raw files need a pass via rawspeed to get it.
@@ -689,7 +689,6 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
     dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
     imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
     dt_imageio_open(imgtmp, filename, NULL);
-    imgtmp->verified_size = 1;
     img = *imgtmp;
     dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
   }
@@ -1702,7 +1701,7 @@ uint32_t dt_image_import_lua(const int32_t film_id, const char *filename, gboole
 
 void dt_image_init(dt_image_t *img)
 {
-  img->width = img->height = img->verified_size = 0;
+  img->width = img->height = 0;
   img->final_width = img->final_height = img->p_width = img->p_height = 0;
   img->aspect_ratio = 0.f;
   img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -210,7 +210,7 @@ typedef struct dt_image_t
   // common stuff
 
   // to understand this, look at comment for dt_histogram_roi_t
-  int32_t width, height, verified_size, final_width, final_height, p_width, p_height;
+  int32_t width, height, final_width, final_height, p_width, p_height;
   int32_t crop_x, crop_y, crop_width, crop_height;
   float aspect_ratio;
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -570,41 +570,62 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
     /* EXIF */
     _metadata_update_value(md_exif_model, img->camera_alias, self);
-    _metadata_update_value(md_exif_lens, img->exif_lens, self);
+
+    if(strlen(img->exif_lens) > 0)
+      _metadata_update_value(md_exif_lens, img->exif_lens, self);
+    else
+      _metadata_update_value(md_exif_lens, NODATA_STRING, self);
+
     _metadata_update_value(md_exif_maker, img->camera_maker, self);
 
-    snprintf(value, sizeof(value), "f/%.1f", img->exif_aperture);
-    _metadata_update_value(md_exif_aperture, value, self);
+    if(img->exif_aperture > 0.0f)
+    {
+      snprintf(value, sizeof(value), "f/%.1f", img->exif_aperture);
+      _metadata_update_value(md_exif_aperture, value, self);
+    }
+    else
+      _metadata_update_value(md_exif_aperture, NODATA_STRING, self);
 
-    char *exposure_str = dt_util_format_exposure(img->exif_exposure);
-    _metadata_update_value(md_exif_exposure, exposure_str, self);
-    g_free(exposure_str);
+    if(img->exif_exposure > 0.0f)
+    {
+      char *exposure_str = dt_util_format_exposure(img->exif_exposure);
+      _metadata_update_value(md_exif_exposure, exposure_str, self);
+      g_free(exposure_str);
+    }
+    else
+      _metadata_update_value(md_exif_exposure, NODATA_STRING, self);
 
     if(isnan(img->exif_exposure_bias))
-    {
       _metadata_update_value(md_exif_exposure_bias, NODATA_STRING, self);
-    }
     else
     {
       snprintf(value, sizeof(value), _("%+.2f EV"), img->exif_exposure_bias);
       _metadata_update_value(md_exif_exposure_bias, value, self);
     }
 
-    snprintf(value, sizeof(value), "%.0f mm", img->exif_focal_length);
-    _metadata_update_value(md_exif_focal_length, value, self);
+    if(img->exif_focal_length > 0.0f)
+    {
+      snprintf(value, sizeof(value), "%.0f mm", img->exif_focal_length);
+      _metadata_update_value(md_exif_focal_length, value, self);
+    }
+    else
+      _metadata_update_value(md_exif_focal_length, NODATA_STRING, self);
 
     if(isnan(img->exif_focus_distance) || fpclassify(img->exif_focus_distance) == FP_ZERO)
-    {
       _metadata_update_value(md_exif_focus_distance, NODATA_STRING, self);
-    }
     else
     {
       snprintf(value, sizeof(value), "%.2f m", img->exif_focus_distance);
       _metadata_update_value(md_exif_focus_distance, value, self);
     }
 
-    snprintf(value, sizeof(value), "%.0f", img->exif_iso);
-    _metadata_update_value(md_exif_iso, value, self);
+    if(img->exif_iso > 0.0f)
+    {
+      snprintf(value, sizeof(value), "%.0f", img->exif_iso);
+      _metadata_update_value(md_exif_iso, value, self);
+    }
+    else
+      _metadata_update_value(md_exif_iso, NODATA_STRING, self);
 
     struct tm tt_exif = { 0 };
     if(sscanf(img->exif_datetime_taken, "%d:%d:%d %d:%d:%d", &tt_exif.tm_year, &tt_exif.tm_mon,

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -634,18 +634,22 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     _metadata_update_value(md_exif_width, value, self);
     }
 
-    if(img->verified_size)
+    if(img->final_height > 0)
     {
       snprintf(value, sizeof(value), "%d", img->final_height);
-    _metadata_update_value(md_height, value, self);
-      snprintf(value, sizeof(value), "%d", img->final_width);
-    _metadata_update_value(md_width, value, self);
+      _metadata_update_value(md_height, value, self);
     }
     else
-    {
       _metadata_update_value(md_height, NODATA_STRING, self);
-      _metadata_update_value(md_width, NODATA_STRING, self);
+
+    if(img->final_width > 0)
+    {
+      snprintf(value, sizeof(value), "%d", img->final_width);
+      _metadata_update_value(md_width, value, self);
     }
+    else
+      _metadata_update_value(md_width, NODATA_STRING, self);
+
     /* XMP */
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
     {


### PR DESCRIPTION
This fixes two issues in the metadata view.

1. The verified_size in dt_image_t didn't work the way it was intended, has been fixed plus it has been removed from the struct for cleaner code.
2. For some dng images (from dubious source) we have no valid exif data for some fields, instead of showing meaningless numbers or "inf" strings this falls back to nodata

Fixes #8958 