### PR TITLE
keep final sizes up to date

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -115,7 +115,7 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
 
   /* make sure mipmaps are recomputed */
   dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
-  dt_image_reset_final_size(imgid);
+  dt_image_update_final_size(imgid);
 
   /* remove darktable|style|* tags */
   dt_tag_detach_by_string("darktable|style|%", imgid, FALSE, FALSE);
@@ -180,7 +180,7 @@ int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only
     // ugly but if not history_only => called from crawler - do not write the xmp
                                  history_only ? DT_IMAGE_CACHE_SAFE : DT_IMAGE_CACHE_RELAXED);
     dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
-    dt_image_reset_final_size(imgid);
+    dt_image_update_final_size(imgid);
   }
   dt_unlock_image(imgid);
   // signal that the mipmap need to be updated
@@ -791,7 +791,7 @@ int dt_history_copy_and_paste_on_image(const int32_t imgid, const int32_t dest_i
   dt_image_synch_xmp(dest_imgid);
 
   dt_mipmap_cache_remove(darktable.mipmap_cache, dest_imgid);
-  dt_image_reset_final_size(imgid);
+  dt_image_update_final_size(imgid);
 
   /* update the aspect ratio. recompute only if really needed for performance reasons */
   if(darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -318,7 +318,7 @@ void dt_image_set_flip(const int32_t imgid, const dt_image_orientation_t user_fl
 dt_image_orientation_t dt_image_get_orientation(const int32_t imgid);
 /** get max width and height of the final processed image with its current hisotry stack */
 gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height);
-void dt_image_reset_final_size(const int32_t imgid);
+void dt_image_update_final_size(const int32_t imgid);
 /** set image location lon/lat/ele */
 void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
                            const gboolean undo_on, const gboolean group_on);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -950,7 +950,7 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
 
     /* remove old obsolete thumbnails */
     dt_mipmap_cache_remove(darktable.mipmap_cache, newimgid);
-    dt_image_reset_final_size(newimgid);
+    dt_image_update_final_size(newimgid);
 
     /* update the aspect ratio. recompute only if really needed for performance reasons */
     if(darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1934,6 +1934,9 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(out_focus_module));
     GtkStyleContext *context = gtk_widget_get_style_context(iop_w);
     gtk_style_context_remove_class(context, "dt_module_focus");
+
+    // if the module change the image size, we update the final sizes
+    if(out_focus_module->modify_roi_out) dt_image_update_final_size(darktable.develop->preview_pipe->output_imgid);
   }
 
   /* set the focus on module */

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -384,6 +384,10 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
 {
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
   g->preview_ready = TRUE;
+  if(self->dev->gui_module != self)
+  {
+    dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
+  }
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
 }
 
@@ -407,7 +411,9 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     }
     else
     {
-      DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
+      // once the pipe is recomputed, we want to update final sizes
+      DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
+                                      G_CALLBACK(_event_preview_updated_callback), self);
       // hack : commit_box use distort_transform routines with gui values to get params
       // but this values are accurate only if crop is the gui_module...
       // so we temporary put back gui_module to crop and revert once finished

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -907,7 +907,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
   if (!dt_history_hash_is_mipmap_synced(dev->image_storage.id))
   {
     dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
-    dt_image_reset_final_size(dev->image_storage.id);
+    dt_image_update_final_size(dev->image_storage.id);
     dt_image_synch_xmp(dev->image_storage.id);
     dt_history_hash_set_mipmap(dev->image_storage.id);
   }
@@ -3100,7 +3100,7 @@ void leave(dt_view_t *self)
   if (!dt_history_hash_is_mipmap_synced(dev->image_storage.id))
   {
     dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
-    dt_image_reset_final_size(dev->image_storage.id);
+    dt_image_update_final_size(dev->image_storage.id);
     // dump new xmp data
     dt_image_synch_xmp(dev->image_storage.id);
     dt_history_hash_set_mipmap(dev->image_storage.id);
@@ -3582,7 +3582,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   closeup = 0;
 
   const gboolean constrained = !dt_modifier_is(state, GDK_CONTROL_MASK);
-  const float stepup = 0.1f * fabsf(1.0f - fitscale) / ppd; 
+  const float stepup = 0.1f * fabsf(1.0f - fitscale) / ppd;
   if(up)
   {
     if(fitscale <= 1.0f && (scale == (1.0f / ppd) || scale == (2.0f / ppd)) && constrained) return; // for large image size
@@ -3672,7 +3672,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       zoom = DT_ZOOM_1;
     }
   }
-  
+
   if(fabsf(scale - 1.0f) < 0.001f) zoom = DT_ZOOM_1;
   if(fabsf(scale - fitscale) < 0.001f) zoom = DT_ZOOM_FIT;
   dt_control_set_dev_zoom_scale(scale);


### PR DESCRIPTION
this fix #8958 

The PR ensure that we always have valid final sizes saved, as soon as we have entered darkroom once. We can't really do that before as that would mean doing a pass in rawspeed for each image, which takes ages... (and we can't rely on initial sizes either as they are wrong for some RAW...)
As we reuse the "already initialized" full pipe to do that, the cost in term of perf is about to nothing (<0.002 s. here)

Note that when using c&r, the final size is not immediately updated : you need to focus other modules 2 times to get it. I know how to fix that (I've done it in crop) but I'm reluctant to modify things in c&r (and the issue is not a huge problem either)