### PR TITLE
common: Include stddef.h for size_t

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <math.h>
 #include <stdint.h>
 #ifdef __SSE__


### PR DESCRIPTION
darktable-3.5.0~git2290.0772314d29/src/common/math.h: In function 'dot_product':
darktable-3.5.0~git2290.0772314d29/src/common/math.h:198:7: error: unknown type name 'size_t'
  198 |   for(size_t i = 0; i < 3; ++i) v_out[i] = scalar_product(v_in, M[i]);
      |       ^~~~~~
darktable-3.5.0~git2290.0772314d29/src/common/math.h:198:7: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?

Fixes build with gcc 11 on Fedora 34.