### PR TITLE
Safer gphoto2 device handling

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -888,7 +888,9 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
           if(_camera_initialize(camctl, camera) == FALSE)
           {
             dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to initialize %s on port %s, likely "
-                        "causes are: locked by another application, no access to udev etc.\n", cam->model, cam->port);
+                        "causes are: locked by another application, no access to udev etc.\n", camera->model, camera->port);
+            dt_control_log(_("failed to initialize %s on port %s, likely "
+                        "causes are: locked by another application, no access to udev etc"), camera->model, camera->port);
             g_free(camera);
             cam->used = TRUE;
             continue;
@@ -896,9 +898,10 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
 
           if(camera->can_import == FALSE && camera->can_tether == FALSE)
           {
-            dt_print(
-              DT_DEBUG_CAMCTL, "[camera_control] %s on port %s doesn't support import or tether, skipping\n",
-              camera->model, camera->port);
+            dt_print(DT_DEBUG_CAMCTL, "[camera_control] %s on port %s doesn't support import or tether\n",
+                               camera->model, camera->port);
+            dt_control_log(_("%s on port %s is not interesting because it supports neither tethering nor import"),
+                               camera->model, camera->port);
             g_free(camera);
             cam->boring = TRUE;
             continue;

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -857,9 +857,9 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
         GList *c_lock_item = c->unused_cameras;
         do
         {
-          dt_camera_unused_t *locked_cam = (dt_camera_unused_t *)c_lock_item->data;
-          in_unused |= ((g_strcmp0(locked_cam->model, camera->model) == 0) &&
-                        (g_strcmp0(locked_cam->port, camera->port) == 0));
+          dt_camera_unused_t *unused_cam = (dt_camera_unused_t *)c_lock_item->data;
+          in_unused |= ((g_strcmp0(unused_cam->model, camera->model) == 0) &&
+                        (g_strcmp0(unused_cam->port, camera->port) == 0));
         } while(c_lock_item && (c_lock_item = g_list_next(c_lock_item)) != NULL);
       }
 
@@ -989,7 +989,7 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
     GList *c_lock_item = c->unused_cameras;
     do
     {
-      dt_camera_unused_t *locked_cam = (dt_camera_unused_t *)c_lock_item->data;
+      dt_camera_unused_t *unused_cam = (dt_camera_unused_t *)c_lock_item->data;
       gboolean remove_cam = TRUE;
       for(int i = 0; i < gp_list_count(available_cameras); i++)
       {
@@ -997,13 +997,13 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
         const gchar *myport;
         gp_list_get_name(available_cameras, i, &mymodel);
         gp_list_get_value(available_cameras, i, &myport);
-        if((g_strcmp0(mymodel, locked_cam->model) == 0) && (g_strcmp0(myport, locked_cam->port) == 0))
-          remove_cam = locked_cam->remove;
+        if((g_strcmp0(mymodel, unused_cam->model) == 0) && (g_strcmp0(myport, unused_cam->port) == 0))
+          remove_cam = unused_cam->remove;
       }
       if(remove_cam)
       {
-        dt_print(DT_DEBUG_CAMCTL, "[camera_control] remove %s on port %s from locked list\n",
-                 locked_cam->model, locked_cam->port);
+        dt_print(DT_DEBUG_CAMCTL, "[camera_control] remove %s on port %s from ununsed camera list\n",
+                 unused_cam->model, unused_cam->port);
         dt_camera_unused_t *oldcam = (dt_camera_unused_t *)c_lock_item->data;
         camctl->unused_cameras = c_lock_item = g_list_delete_link(c->unused_cameras, c_lock_item);
         dt_camctl_unused_camera_destroy(oldcam);

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1127,7 +1127,9 @@ static gboolean _camera_initialize(const dt_camctl_t *c, dt_camera_t *cam)
     if((a.operations & GP_OPERATION_CAPTURE_PREVIEW)) cam->can_live_view = TRUE;
     if(cam->can_tether && (a.operations & GP_OPERATION_CONFIG)) cam->can_config = TRUE;
     if(!(a.file_operations & GP_FILE_OPERATION_NONE)) cam->can_import = TRUE;
-
+    if(cam->can_import && (a.file_operations & GP_FILE_OPERATION_PREVIEW)) cam->can_file_preview = TRUE;
+    if(cam->can_import && (a.file_operations & GP_FILE_OPERATION_EXIF)) cam->can_file_exif = TRUE;
+    if(!(a.folder_operations & GP_FOLDER_OPERATION_NONE)) cam->can_directory = TRUE;
     if(gp_camera_init(cam->gpcam, camctl->gpcontext) != GP_OK)
     {
       dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to initialize %s on port %s\n", cam->model,

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -854,13 +854,13 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
       gboolean in_unused = FALSE;
       if(dt_camctl_have_unused_cameras(camctl))
       {
-        GList *c_lock_item = c->unused_cameras;
+        GList *unused_item = c->unused_cameras;
         do
         {
-          dt_camera_unused_t *unused_cam = (dt_camera_unused_t *)c_lock_item->data;
+          dt_camera_unused_t *unused_cam = (dt_camera_unused_t *)unused_item->data;
           in_unused |= ((g_strcmp0(unused_cam->model, camera->model) == 0) &&
                         (g_strcmp0(unused_cam->port, camera->port) == 0));
-        } while(c_lock_item && (c_lock_item = g_list_next(c_lock_item)) != NULL);
+        } while(unused_item && (unused_item = g_list_next(unused_item)) != NULL);
       }
 
       if((citem == NULL) & !in_unused)
@@ -986,10 +986,10 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
   /* check unused_cameras in available_cameras */
   if(dt_camctl_have_unused_cameras(camctl))
   {
-    GList *c_lock_item = c->unused_cameras;
+    GList *unused_item = c->unused_cameras;
     do
     {
-      dt_camera_unused_t *unused_cam = (dt_camera_unused_t *)c_lock_item->data;
+      dt_camera_unused_t *unused_cam = (dt_camera_unused_t *)unused_item->data;
       gboolean remove_cam = TRUE;
       for(int i = 0; i < gp_list_count(available_cameras); i++)
       {
@@ -1004,12 +1004,12 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
       {
         dt_print(DT_DEBUG_CAMCTL, "[camera_control] remove %s on port %s from ununsed camera list\n",
                  unused_cam->model, unused_cam->port);
-        dt_camera_unused_t *oldcam = (dt_camera_unused_t *)c_lock_item->data;
-        camctl->unused_cameras = c_lock_item = g_list_delete_link(c->unused_cameras, c_lock_item);
+        dt_camera_unused_t *oldcam = (dt_camera_unused_t *)unused_item->data;
+        camctl->unused_cameras = unused_item = g_list_delete_link(c->unused_cameras, unused_item);
         dt_camctl_unused_camera_destroy(oldcam);
         changed_camera = TRUE;
       }
-    } while(c_lock_item && (c_lock_item = g_list_next(c_lock_item)) != NULL);
+    } while(unused_item && (unused_item = g_list_next(unused_item)) != NULL);
   }
 
   gp_list_unref(available_cameras);

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -974,7 +974,7 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
   if(changed_camera)
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CAMERA_DETECTED);
-    camctl->tickmask = 0x0F;
+    camctl->tickmask = 0x07;
   }
   else
     camctl->tickmask = 0x1F;  

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -822,14 +822,12 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
     gp_list_get_value(available_cameras, i, &s);
     testcam->port = g_strdup(s);
 
-    // FIXME we should better test elsewhere for special port drivers
-/*
-    if(!strncmp(camera->port, "disk:", 5))
+    // FIXME we might better test elsewhere for special port drivers, have it active while debugging
+    if(!(strncmp(testcam->port, "disk:", 5)) && !(darktable.unmuted & DT_DEBUG_CAMCTL))
     {
-      g_free(camera);
+      g_free(testcam);
       continue;
     }
-*/
 
     GList *citem;
     // look for freshly connected cameras;

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -63,7 +63,12 @@ typedef struct dt_camera_t
   gboolean can_live_view_advanced;
   /** This camera/device can be remote controlled. */
   gboolean can_config;
-
+  /** This camera can read file previews */
+  gboolean can_file_preview;
+  /** This camera has some directory support */
+  gboolean can_directory;
+  /** This camera has exif support */
+  gboolean can_file_exif;
   /** Flag camera in tethering mode. \see dt_camera_tether_mode() */
   gboolean is_tethering;
 

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -30,11 +30,6 @@
 #include <gphoto2/gphoto2.h>
 #include <gtk/gtk.h>
 
-#define DT_CAMCTL_TIMEOUT_NOW
-#define DT_CAMCTL_TIMEOUT 40
-#define DT_CAMCTL_MAXTIMEOUT 0x7FFFFFFF
-#define DT_CAMCTL_TIMEOUT_MOUNT 4
-
 /** A camera object used for camera actions and callbacks */
 typedef struct dt_camera_t
 {
@@ -92,8 +87,10 @@ typedef struct dt_camera_t
   /** gphoto2 context */
   GPContext *gpcontext;
 
-  /** housekeeping for unmounting */
-  int auto_unmount;
+  /** flag to unmount */
+  gboolean unmount;
+  /** flag true while importing */
+  gboolean is_importing;
   /** Live view */
   gboolean is_live_viewing;
   /** The last preview image from the camera */
@@ -126,11 +123,11 @@ typedef struct dt_camera_unused_t
   /** A pointer to the port string of camera. */
   char *port;
   /** mark the camera as auto unmounted */
-  gboolean unmounted;
+  gboolean boring;
   /** mark the camera as used by another application */
   gboolean used;
   /** if true it will be removed from the list to force a reconnect */
-  gboolean remove;
+  gboolean trymount;
 } dt_camera_unused_t;
 
 /** Camera control status.
@@ -189,7 +186,9 @@ typedef struct dt_camctl_t
 
   const dt_camera_t *active_camera;
 
+  gboolean import_ui;
   int ticker;
+  int tickmask;
 } dt_camctl_t;
 
 

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -337,7 +337,7 @@ static void dt_camera_import_cleanup(void *p)
 
   dt_import_session_destroy(params->shared.session);
 
-  params->camera->auto_unmount = DT_CAMCTL_TIMEOUT_MOUNT;
+  params->camera->is_importing = FALSE;
   free(params);
 }
 
@@ -346,16 +346,14 @@ dt_job_t *dt_camera_import_job_create(GList *images, struct dt_camera_t *camera,
 {
   dt_job_t *job = dt_control_job_create(&dt_camera_import_job_run, "import selected images from camera");
   if(!job)
-  {
-    camera->auto_unmount = DT_CAMCTL_TIMEOUT_MOUNT;
     return NULL;
-  }
   dt_camera_import_t *params = dt_camera_import_alloc();
   if(!params)
   {
     dt_control_job_dispose(job);
     return NULL;
   }
+  camera->is_importing = TRUE;
   dt_control_job_add_progress(job, _("import images from camera"), FALSE);
   dt_control_job_set_params(job, params, dt_camera_import_cleanup);
 

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -337,6 +337,7 @@ static void dt_camera_import_cleanup(void *p)
 
   dt_import_session_destroy(params->shared.session);
 
+  params->camera->auto_unmount = DT_CAMCTL_TIMEOUT_MOUNT;
   free(params);
 }
 
@@ -344,7 +345,11 @@ dt_job_t *dt_camera_import_job_create(GList *images, struct dt_camera_t *camera,
                                       time_t time_override)
 {
   dt_job_t *job = dt_control_job_create(&dt_camera_import_job_run, "import selected images from camera");
-  if(!job) return NULL;
+  if(!job)
+  {
+    camera->auto_unmount = DT_CAMCTL_TIMEOUT_MOUNT;
+    return NULL;
+  }
   dt_camera_import_t *params = dt_camera_import_alloc();
   if(!params)
   {

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -244,12 +244,16 @@ static void _lib_import_mount_callback(GtkToggleButton *button, gpointer data)
 {
   dt_camera_unused_t *camera = (dt_camera_unused_t *)data;
   camera->trymount = TRUE;
+  dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
+  camctl->tickmask = 3;
 }
 
 static void _lib_import_unmount_callback(GtkToggleButton *button, gpointer data)
 {
   dt_camera_t *camera = (dt_camera_t *)data;
   camera->unmount = TRUE;
+  dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
+  camctl->tickmask = 3;
 }
 
 /** update the device list */


### PR DESCRIPTION
Recently there have been two issues each showing a different bug in dt’s gphoto code.

#8967 describes a situation where dt tries to initialize a device and if not successful does so again and again
This “fighting” for the device leads to other apps de- and reconnecting.

#8974 shows a fundamental flaw of the current implementation. When doing a hot unplugging the device handler is left in a broken state.

EDIT: after discussion the overview has been updated!

This pr re-implements the device handling. In more detail:
1. every device that has been detected by gphoto (except disks) is “remembered” in one of two lists.
   List A holds all devices that have been successfully initialised
   List B holds all devices that are currently not used by darktable, whatever the reason is.

2. Reasons for being in list B are:
   a) could not be initialized
   b) device has been found uninteresting (no import or tethering)
   c) device has been unmounted

3. The background thread (BT) looks for available - physically connected - devices every 4 seconds while
   in lighttable mode and deletes all devices from both lists that are not connected any more.
   This can be either a hot unplugging (this should be avoided by the user) - so a removal from list A -
   or a device currently not used - so from List B

4. A device in list B (unused) has a mount button, after a click the device will be initialized and mounted if initialize went fine. After mounting this will be in list A and will have import and tethering buttons if possible, also an unmount button.


5. How do we avoid hot-unplugging? You have to actively unmount the camera device!

What about loading files from a camera or tethering?
In both cases we must not unmount!
  - For tethering we are safe because of not-in-lighttable-mode
  - While the import selection box is open we bypass the updater in the BT

Probably Fixes #8967
Fixes #8974

I tested as good as I could, unfortunately I have no tethering capable camera available.
So further testing by others with such cameras is strongly required (although i am pretty sure), @TurboGit and @johnny-bit had tested tethering before.

There is one thing i would like to get confirmed / discussed. We have key_accels for tethering/import_from_camera and now also for remounting. This is a bit tricky insofar as the key is connected to the last camera connected (this has been this way before). Are we sure we want this? Personally i think we shouldn't have key_accels for these per-device-buttons at all.

Some minor bugs while working on the code have been fixed, also some renaming of structs/elements for a better readability of the code.

Please use the –d camctl option, it’s output has been made less verbose (removing redundant information)