### PR TITLE
collections: speed up display of tags for tag filter

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1288,9 +1288,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
                                        "FROM main.images AS mi "
                                        "WHERE mi.id NOT IN"
                                        "  (SELECT DISTINCT imgid FROM main.tagged_images AS ti"
-                                       "   WHERE ti.tagid NOT IN"
-                                       "    (SELECT id FROM data.tags WHERE"
-                                       "      SUBSTR(name, 1, 10) = 'darktable|'))",
+                                       "   WHERE ti.tagid NOT IN memory.darktable_tags)",
                                 _("not tagged"));
       }
       break;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2537,7 +2537,6 @@ static void tag_changed(gpointer instance, gpointer self)
   {
     d->view_rule = -1;
     d->rule[d->active_rule].typing = FALSE;
-    _lib_collect_gui_update(self);
 
     //need to reload collection since we have tags as active collection filter
     dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),


### PR DESCRIPTION
I was doing some tag maintenance on my personal image library and noticed some dramatic slowdowns now that it's gotten large....

Found and removed an extraneous widget refresh, and sped up the underlying SQL query.  I know enough about SQL to be dangerous, so somebody should check it to ensure I haven't introduced any corner case breakage.  It does work properly on my library, including combining multiple filter rules, though there is a pre-existing display bug where the count of untagged images is the count in the entire library even when a previous rule has narrowed the pool under consideration.

**Results**
On a library with 219k images and 668 distinct tags (667 case-folded), the previous code took 0.86 seconds to execute the SQL query for
populating the Collections module's tree view of tags in case-sensitive mode and 3.6 seconds in the default case-folded mode.

Flipping around the subquery for the UNION clause to perform the string comparison on data.tags.name to generate a list of tag IDs which can then be tested with an integer (set) comparison instead of a string comparison for every instance of a tag attached to an image saves 0.14 seconds in both case-sensitive and case-folded modes.

Performing an equivalent flip to perform the JOIN with tag names only after de-duplicating the tag IDs reduces the execution time further to 0.66 seconds in case-sensitive mode and 0.67 seconds in case-folded mode.

**Additional notes**
There are further occurences of the pattern of JOINing data.tags and then comparing the name which could be flipped to generating a list of tag IDs from data.tags for use in a WHERE clause.  I'll take a look at them after verification that I haven't broken anything here.

When the Collections module is collapsed, it would make sense to simply ignore the update call resulting from a COLLECTION_NEW_QUERY or COLLECTION_UPDATED signal to avoid adding unnecessary lag to other user actions.  We'd need to ensure that the update call is then issued when the module is expanded.
