### PR TITLE
Double click to unfold tree and include subfolders

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1539,6 +1539,16 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         const gboolean no_location = strcmp(escaped_text, _("tagged")) == 0;
         const gboolean all_tagged = strcmp(escaped_text, _("tagged*")) == 0;
         char *escaped_text2 = g_strstr_len(escaped_text, -1, "|");
+        char *name_clause = g_strdup_printf("t.name LIKE \'%s\' || \'%s\'", 
+            dt_map_location_data_tag_root(), escaped_text2 ? escaped_text2 : "%");
+
+        if (escaped_text2 && (escaped_text2[strlen(escaped_text2)-1] == '*'))
+        {
+          escaped_text2[strlen(escaped_text2)-1] = '\0';
+          name_clause = g_strdup_printf("(t.name LIKE \'%s\' || \'%s\' OR t.name LIKE \'%s\' || \'%s|%%\')", 
+          dt_map_location_data_tag_root(), escaped_text2 , dt_map_location_data_tag_root(), escaped_text2);
+        }
+        
         if(not_tagged || all_tagged)
           query = g_strdup_printf("(id %s IN (SELECT id AS imgid FROM main.images "
                                   "WHERE (longitude IS NOT NULL AND latitude IS NOT NULL))) ",
@@ -1549,10 +1559,9 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
                                          "AND id %s IN (SELECT imgid FROM main.tagged_images AS ti"
                                          "  JOIN data.tags AS t"
                                          "  ON t.id = ti.tagid"
-                                         "     AND t.name LIKE \'%s\' || \'%s\')) ",
+                                         "     AND %s)) ",
                                   no_location ? "not" : "",
-                                  dt_map_location_data_tag_root(),
-                                  escaped_text2 ? escaped_text2 : "%");
+                                  name_clause);
       }
       break;
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -658,6 +658,14 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
       row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
     }
 
+    if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+    {
+      if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
+        gtk_tree_view_collapse_row (GTK_TREE_VIEW(treeview), path);
+      else
+        gtk_tree_view_expand_row (GTK_TREE_VIEW(treeview), path, FALSE);
+    }
+
     gtk_tree_path_free(path);
 
     if((d->view_rule == DT_COLLECTION_PROP_DAY

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2326,9 +2326,9 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
           g_free(text);
           text = n_text;
         }
-        /* if a tag has children, shift-clicking on a parent node should display all images in and under this
+        /* if a tag has children, left-clicking on a parent node should display all images in and under this
          * hierarchy. */
-        else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+        else if(!dt_modifier_is(event->state, GDK_SHIFT_MASK))
         {
           gchar *n_text = g_strconcat(text, "*", NULL);
           g_free(text);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2072,9 +2072,11 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
                                 _("use `%' as wildcard\n"
     /* xgettext:no-c-format */
-                                  "use `|%' to include all sub-hierarchies (ctrl-click)\n"
+                                  "left-click to include hierarchy + sub-hierarchies (suffix `*')\n"
     /* xgettext:no-c-format */
-                                  "use `*' to include hierarchy and sub-hierarchies (shift-click)"));
+                                  "shift+click to include only the current hierarchy (no suffix)\n"
+    /* xgettext:no-c-format */
+                                  "ctrl+click to include only sub-hierarchies (suffix `|%')"));
   }
   else if(property == DT_COLLECTION_PROP_GEOTAGGING)
   {
@@ -2082,9 +2084,11 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
                                 _("use `%' as wildcard\n"
     /* xgettext:no-c-format */
-                                  "use `|%' to include all sub-locations (ctrl-click)\n"
+                                  "left-click to include location + sub-locations (suffix `*')\n"
     /* xgettext:no-c-format */
-                                  "use `*' to include locations and sub-locations (shift-click)"));
+                                  "shift+click to include only the current location (no suffix)\n"
+    /* xgettext:no-c-format */
+                                  "ctrl+click to include only sub-locations (suffix `|%')"));
   }
   else if(property == DT_COLLECTION_PROP_FOLDERS)
   {
@@ -2092,11 +2096,11 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
                                 _("use `%' as wildcard\n"
     /* xgettext:no-c-format */
-                                  "ctrl+click to include only sub-folders\n"
+                                  "left-click to include current + sub-folders (suffix `*')\n"
     /* xgettext:no-c-format */
-                                  "shift+click to include current + sub-folders\n"
+                                  "shift+click to include only the current folder (no suffix)\n"
     /* xgettext:no-c-format */
-                                  "double-click to include only the current folder"));
+                                  "ctrl+click to include only sub-folders (suffix `|%')"));
   }
   else
   {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -599,6 +599,18 @@ static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, dt_lib_c
 
 static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event, dt_lib_collect_t *d)
 {
+  /* Get tree path for row that was clicked */
+  GtkTreePath *path = NULL;
+  int get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &path, NULL, NULL, NULL);
+
+  if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+  {
+    if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
+      gtk_tree_view_collapse_row (GTK_TREE_VIEW(treeview), path);
+    else
+      gtk_tree_view_expand_row (GTK_TREE_VIEW(treeview), path, FALSE);
+  }
+
   if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS
        || d->view_rule == DT_COLLECTION_PROP_FILMROLL)
       && event->type == GDK_BUTTON_PRESS && event->button == 3)
@@ -609,11 +621,8 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
               (dt_modifier_is(event->state, GDK_SHIFT_MASK) || dt_modifier_is(event->state, GDK_CONTROL_MASK)))))
   {
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
-    GtkTreePath *path = NULL;
 
-    /* Get tree path for row that was clicked */
-    if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &path, NULL, NULL,
-                                     NULL))
+    if(get_path)
     {
       if(d->singleclick && dt_modifier_is(event->state, GDK_SHIFT_MASK)
          && gtk_tree_selection_count_selected_rows(selection) > 0
@@ -656,14 +665,6 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
     else
     {
       row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
-    }
-
-    if(event->type == GDK_DOUBLE_BUTTON_PRESS)
-    {
-      if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
-        gtk_tree_view_collapse_row (GTK_TREE_VIEW(treeview), path);
-      else
-        gtk_tree_view_expand_row (GTK_TREE_VIEW(treeview), path, FALSE);
     }
 
     gtk_tree_path_free(path);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -609,9 +609,9 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
     if(event->state == last_state)
     {
       if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
-        gtk_tree_view_collapse_row (GTK_TREE_VIEW(treeview), path);
+        gtk_tree_view_collapse_row(GTK_TREE_VIEW(treeview), path);
       else
-        gtk_tree_view_expand_row (GTK_TREE_VIEW(treeview), path, FALSE);
+        gtk_tree_view_expand_row(GTK_TREE_VIEW(treeview), path, FALSE);
     }
     last_state = event->state;
   }
@@ -2077,7 +2077,7 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
                                 _("use `%' as wildcard\n"
     /* xgettext:no-c-format */
-                                  "left-click to include hierarchy + sub-hierarchies (suffix `*')\n"
+                                  "click to include hierarchy + sub-hierarchies (suffix `*')\n"
     /* xgettext:no-c-format */
                                   "shift+click to include only the current hierarchy (no suffix)\n"
     /* xgettext:no-c-format */
@@ -2089,7 +2089,7 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
                                 _("use `%' as wildcard\n"
     /* xgettext:no-c-format */
-                                  "left-click to include location + sub-locations (suffix `*')\n"
+                                  "click to include location + sub-locations (suffix `*')\n"
     /* xgettext:no-c-format */
                                   "shift+click to include only the current location (no suffix)\n"
     /* xgettext:no-c-format */
@@ -2101,7 +2101,7 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
     /* xgettext:no-c-format */
                                 _("use `%' as wildcard\n"
     /* xgettext:no-c-format */
-                                  "left-click to include current + sub-folders (suffix `*')\n"
+                                  "click to include current + sub-folders (suffix `*')\n"
     /* xgettext:no-c-format */
                                   "shift+click to include only the current folder (no suffix)\n"
     /* xgettext:no-c-format */

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -123,6 +123,7 @@ static void collection_updated(gpointer instance, dt_collection_change_t query_c
 static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColumn *col, GdkEventButton *event, dt_lib_collect_t *d);
 static int is_time_property(int property);
 static void _populate_collect_combo(GtkWidget *w);
+int last_state = 0;
 
 const char *name(dt_lib_module_t *self)
 {
@@ -605,10 +606,14 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
 
   if(event->type == GDK_DOUBLE_BUTTON_PRESS)
   {
-    if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
-      gtk_tree_view_collapse_row (GTK_TREE_VIEW(treeview), path);
-    else
-      gtk_tree_view_expand_row (GTK_TREE_VIEW(treeview), path, FALSE);
+    if(event->state == last_state)
+    {
+      if(gtk_tree_view_row_expanded(GTK_TREE_VIEW(treeview), path))
+        gtk_tree_view_collapse_row (GTK_TREE_VIEW(treeview), path);
+      else
+        gtk_tree_view_expand_row (GTK_TREE_VIEW(treeview), path, FALSE);
+    }
+    last_state = event->state;
   }
 
   if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1150,6 +1150,18 @@ static gboolean _folders_button_press(GtkWidget *view, GdkEventButton *event, dt
     }
     gtk_tree_path_free(path);
   }
+
+  if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+  {
+    GtkTreePath *path = NULL;
+    gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(view), event->x, event->y, &path, NULL, NULL, NULL); 
+    if(gtk_tree_view_row_expanded(d->from.folderview, path))
+      gtk_tree_view_collapse_row (d->from.folderview, path);
+    else
+      gtk_tree_view_expand_row (d->from.folderview, path, FALSE);
+    gtk_tree_path_free(path);
+  }
+
   g_timeout_add_full(G_PRIORITY_DEFAULT_IDLE, 100, _clear_parasitic_selection, self, NULL);
 	return res;
 }


### PR DESCRIPTION
Fixes #8906


- double-click on the name of a tree-element unfolds the subfolders in the tree
- change the shift-behaviour:
  - normal (double) click shows this folder + subfolders
  - shift + (double) click shows only this folder
  - ctrl + (double) click shows only subfolders (like now)