### PR TITLE
tether: on hidpi displays, scale center view image properly

### DIFF
--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -346,8 +346,10 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
     }
     else
     {
-      cairo_translate(cr, (width - cairo_image_surface_get_width(surf)) / 2,
-                      (height - cairo_image_surface_get_height(surf)) / 2);
+      const float scaler = 1.0f / darktable.gui->ppd_thb;
+      cairo_translate(cr, (width - cairo_image_surface_get_width(surf) * scaler) / 2,
+                      (height - cairo_image_surface_get_height(surf) * scaler) / 2);
+      cairo_scale(cr, scaler, scaler);
       cairo_set_source_surface(cr, surf, 0.0, 0.0);
       cairo_paint(cr);
       cairo_surface_destroy(surf);


### PR DESCRIPTION
The surface returned by `dt_view_image_get_surface()` will have larger dimensions than the requested size in hidpi mode. (Though not necessarily 1:1 to physical pixels, depending on the setting of `ui/performance`.)

This fixes a bug in which, when in hidpi mode, the currently displayed tether view image is shown too large, cropping its edges.

To see this bug, with a hidpi display, enter tether view and click on an image in the current film roll. Its edges will be cropped, compared to its thumbnail or a view of the same image in darkroom view.

Tether view has been using `dt_view_image_get_surface()` since 6a2e3bb3e223dc501ce01300b72d98bf4fa7f3a6 in #5023. As the tether view apparently was broken at that point (https://github.com/darktable-org/darktable/pull/5023#issuecomment-628459612) it's reasonable that this could have been a hard bug to notice, though I'm surprised it hasn't shown up more since.

Close #8637, assuming that is caused by this bug.