### PR TITLE
image ordering - preserve order of drag&drop images when using custom sort

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -497,6 +497,7 @@ GList *dt_selection_get_list(struct dt_selection_t *selection, const gboolean on
   {
     l = g_list_prepend(l, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
   }
+  if(!(only_visible && ordering)) l = g_list_reverse(l);
   if(stmt) sqlite3_finalize(stmt);
 
   return l;


### PR DESCRIPTION
Only skip reversing the list of images for export.  Fixes #8844 while still having images exported in the expected order.
