### PR TITLE
avoid rerunning collection queries on star-rating change

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -865,7 +865,7 @@ static gboolean _event_rating_release(GtkWidget *widget, GdkEventButton *event, 
     if(rating != DT_VIEW_DESERT)
     {
       dt_ratings_apply_on_image(thumb->imgid, rating, TRUE, TRUE, TRUE);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NONE,
                                  g_list_prepend(NULL, GINT_TO_POINTER(thumb->imgid)));
     }
   }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1334,7 +1334,7 @@ static void _dt_collection_changed_callback(gpointer instance, dt_collection_cha
 {
   if(!user_data) return;
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
-  if(query_change == DT_COLLECTION_CHANGE_RELOAD)
+  if(query_change == DT_COLLECTION_CHANGE_RELOAD || query_change == DT_COLLECTION_CHANGE_NONE)
   {
     int old_hover = dt_control_get_mouse_over_id();
     /** Here's how it works
@@ -2181,7 +2181,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
     }
   }
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NONE, imgs);
   return TRUE;
 }
 static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2489,7 +2489,8 @@ static void collection_updated(gpointer instance, dt_collection_change_t query_c
   // update tree
   d->view_rule = -1;
   d->rule[d->active_rule].typing = FALSE;
-  _lib_collect_gui_update(self);
+  if (query_change != DT_COLLECTION_CHANGE_NONE)
+    _lib_collect_gui_update(self);
 }
 
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -367,7 +367,7 @@ static void _lib_filter_update_query(dt_lib_module_t *self)
   dt_collection_set_query_flags(darktable.collection, COLLECTION_QUERY_FULL);
 
   /* updates query */
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NONE, NULL);
 }
 
 static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter)


### PR DESCRIPTION
Since changing the rating of an image can't possibly change the results of a collection filter, skip the (possibly very slow) update of the collection module when the user changes a star rating.

Fixes #9042, at least with respect to star ratings.  Possibly other invocations of `dt_collection_update_query` could be changed from DT_COLLECTION_CHANGE_RELOAD to DT_COLLECTION_CHANGE_NONE.
