### PR TITLE
histogram: waveform and rgb parade visual legibility

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1125,31 +1125,30 @@ void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   PREAMBLE(1, 0, 0)
 
-  const GdkRGBA *const primaries = darktable.bauhaus->graph_colors;
   cairo_pattern_t *pat;
 
   pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
-  cairo_pattern_add_color_stop_rgba(pat, 0.0, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha * 0.2);
-  cairo_pattern_add_color_stop_rgba(pat, 0.4, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha * 0.7);
-  cairo_pattern_add_color_stop_rgba(pat, 1.0, primaries[0].red, primaries[0].green, primaries[0].blue, primaries[0].alpha * 0.3);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, 0.8, 0.3, 0.3, 0.2);
+  cairo_pattern_add_color_stop_rgba(pat, 0.4, 0.8, 0.3, 0.3, 0.7);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, 0.8, 0.3, 0.3, 0.3);
   cairo_rectangle(cr, 0.0, 0.1, 1.0/3.0, 0.7);
   cairo_set_source(cr, pat);
   cairo_fill(cr);
   cairo_pattern_destroy(pat);
 
   pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
-  cairo_pattern_add_color_stop_rgba(pat, 0.0, primaries[1].red, primaries[1].green, 0.0, primaries[1].alpha * 0.1);
-  cairo_pattern_add_color_stop_rgba(pat, 0.6, primaries[1].red, primaries[1].green, 0.0, primaries[1].alpha * 0.8);
-  cairo_pattern_add_color_stop_rgba(pat, 1.0, primaries[1].red, primaries[1].green, 0.0, primaries[1].alpha * 0.4);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, 0.4, 0.8, 0.4, 0.1);
+  cairo_pattern_add_color_stop_rgba(pat, 0.6, 0.4, 0.8, 0.4, 0.8);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, 0.4, 0.8, 0.4, 0.4);
   cairo_rectangle(cr, 1.0/3.0, 0.2, 1.0/3.0, 0.7);
   cairo_set_source(cr, pat);
   cairo_fill(cr);
   cairo_pattern_destroy(pat);
 
   pat = cairo_pattern_create_linear(0.0, 0.0, 0.0, 1.0);
-  cairo_pattern_add_color_stop_rgba(pat, 0.0, primaries[2].red, 0.0, primaries[2].blue, primaries[2].alpha * 0.4);
-  cairo_pattern_add_color_stop_rgba(pat, 0.5, primaries[2].red, 0.0, primaries[2].blue, primaries[2].alpha * 0.9);
-  cairo_pattern_add_color_stop_rgba(pat, 1.0, primaries[2].red, 0.0, primaries[2].blue, primaries[2].alpha * 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, 0.4, 0.4, 0.8, 0.4);
+  cairo_pattern_add_color_stop_rgba(pat, 0.5, 0.4, 0.4, 0.8, 0.9);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, 0.4, 0.4, 0.8, 0.5);
   cairo_rectangle(cr, 2.0/3.0, 0.1, 1.0/3.0, 0.7);
   cairo_set_source(cr, pat);
   cairo_fill(cr);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -649,6 +649,7 @@ static void _lib_histogram_draw_histogram(dt_lib_histogram_t *d, cairo_t *cr,
   for(int k = 0; k < 3; k++)
     if(mask[k])
     {
+      // FIXME: this is the last place in dt these are used -- if can eliminate, then can directly set button colors in CSS and simplify things
       set_color(cr, darktable.bauhaus->graph_colors[k]);
       dt_draw_histogram_8(cr, d->histogram, 4, k, d->histogram_scale == DT_LIB_HISTOGRAM_SCALE_LINEAR);
     }
@@ -659,7 +660,7 @@ static void _lib_histogram_draw_histogram(dt_lib_histogram_t *d, cairo_t *cr,
 }
 
 static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t *cr, int ch,
-                                                 double alpha_chroma, double alpha_white)
+                                                 double alpha_chroma, double desat_over, double alpha_over)
 {
   const size_t wf_8bit_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
   cairo_surface_t *surface
@@ -671,7 +672,7 @@ static void _lib_histogram_draw_waveform_channel(dt_lib_histogram_t *d, cairo_t 
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_mask_surface(cr, surface, 0., 0.);
   cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-  cairo_set_source_rgba(cr, 1, 1, 1, alpha_white);
+  cairo_set_source_rgba(cr, ch==2 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==0 ? 1.:desat_over, alpha_over);
   cairo_mask_surface(cr, surface, 0., 0.);
 
   cairo_surface_destroy(surface);
@@ -688,7 +689,7 @@ static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
 
   for(int ch = 0; ch < 3; ch++)
     if(mask[2-ch])
-      _lib_histogram_draw_waveform_channel(d, cr, ch, 0.65, 0.15);
+      _lib_histogram_draw_waveform_channel(d, cr, ch, 0.75, 0.75, 0.35);
   cairo_restore(cr);
 }
 
@@ -699,7 +700,7 @@ static void _lib_histogram_draw_rgb_parade(dt_lib_histogram_t *d, cairo_t *cr, i
               darktable.gui->ppd*height/d->waveform_height);
   for(int ch = 2; ch >= 0; ch--)
   {
-    _lib_histogram_draw_waveform_channel(d, cr, ch, 0.95, 0.75);
+    _lib_histogram_draw_waveform_channel(d, cr, ch, 0.85, 0.85, 0.65);
     cairo_translate(cr, d->waveform_width/darktable.gui->ppd, 0);
   }
   cairo_restore(cr);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -197,12 +197,6 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   // quantity of data.
   const float *const restrict in = DT_IS_ALIGNED((const float *const restrict)input);
   float *const restrict wf_linear = DT_IS_ALIGNED((float *const restrict)d->waveform_linear);
-  // FIXME: does all the aligned/restrict do anything?
-  uint8_t *const restrict wf_img[3] = {
-    DT_IS_ALIGNED((uint8_t *const restrict)d->waveform_img[0]),
-    DT_IS_ALIGNED((uint8_t *const restrict)d->waveform_img[1]),
-    DT_IS_ALIGNED((uint8_t *const restrict)d->waveform_img[2])
-  };
 
   // Use integral sized bins for columns, as otherwise they will be
   // unequal and have banding. Rely on draw to smoothly do horizontal
@@ -214,7 +208,6 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   const size_t bin_width = ceilf(sample_width / (float)d->waveform_max_width);
   const size_t wf_width = ceilf(sample_width / (float)bin_width);
   d->waveform_width = wf_width;
-  const size_t wf_img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, wf_width);
   const size_t wf_height = d->waveform_height;
   dt_iop_image_fill(wf_linear, 0.0f, wf_width, wf_height, 3);
 
@@ -257,16 +250,45 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   // lut for all three channels should be the same
   const float *const restrict lut = DT_IS_ALIGNED((const float *const restrict)profile->lut_out[0]);
   const float lutmax = profile->lutsize - 1;
+  const size_t stride_a8 = cairo_format_stride_for_width(CAIRO_FORMAT_A8, wf_width);
+  const size_t stride_argb32 = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, wf_width);
+  uint8_t *const restrict img_tmp = dt_alloc_align(64, sizeof(uint8_t) * wf_height * stride_a8);
+  // FIXME: change these if RGB parade
+  //const double alpha_chroma = 0.75, desat_over = 0.75, alpha_over = 0.35;
+  //const double alpha_chroma = 0.85, desat_over = 0.85, alpha_over = 0.65;
+  const double alpha_chroma = 0.7, desat_over = 0.8, alpha_over = 0.5;
 
   // loops are too small (3 * 360 * 175 max iterations) to need threads
   for(size_t ch = 0; ch < 3; ch++)
+  {
     for(size_t y = 0; y < wf_height; y++)
       for(size_t x = 0; x < wf_width; x++)
       {
         const float linear = MIN(1.f, wf_linear[(ch * wf_height + y) * wf_width + x]);
         const float display = lut[(int)(linear * lutmax)];
-        wf_img[ch][y*wf_img_stride + x] = display * 255.f;
+        img_tmp[y*stride_a8 + x] = display * 255.f;
       }
+    cairo_surface_t *source
+      = cairo_image_surface_create_for_data(img_tmp, CAIRO_FORMAT_A8, wf_width, wf_height, stride_a8);
+    // FIXME: why is this necessary, if the initial draw is via CAIRO_OPERATOR_SOURCE?
+    memset(d->waveform_img[ch], 0, stride_argb32 * wf_height);
+    cairo_surface_t *dest
+      = cairo_image_surface_create_for_data(d->waveform_img[ch], CAIRO_FORMAT_ARGB32, wf_width, wf_height, stride_argb32);
+    cairo_t *cr = cairo_create(dest);
+    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_set_source_rgba(cr, ch==0 ? 1.:0., ch==1 ? 1.:0., ch==2 ? 1.:0., alpha_chroma);
+    cairo_mask_surface(cr, source, 0., 0.);
+    // FIXME: is screen operator enough?
+    cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
+    cairo_set_source_rgba(cr, ch==0 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==2 ? 1.:desat_over, alpha_over);
+    cairo_mask_surface(cr, source, 0., 0.);
+    cairo_surface_destroy(source);
+    cairo_destroy(cr);
+    cairo_surface_flush(dest);
+    cairo_surface_destroy(dest);
+  }
+
+  dt_free_align(img_tmp);
 }
 
 static void _lib_histogram_hue_ring(dt_lib_histogram_t *d, const dt_iop_order_iccprofile_info_t *const vs_prof)
@@ -668,31 +690,21 @@ static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
                                          int width, int height,
                                          const uint8_t mask[3])
 {
-  const double alpha_chroma = 0.75, desat_over = 0.75, alpha_over = 0.35;
-  const size_t wf_img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
-  cairo_surface_t *surfaces[3] = { NULL, NULL, NULL };
+  const size_t stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, d->waveform_width);
   cairo_save(cr);
+  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_scale(cr, darktable.gui->ppd*width/d->waveform_width,
               darktable.gui->ppd*height/d->waveform_height);
 
-  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   for(int ch = 0; ch < 3; ch++)
-    if(mask[2-ch])
+    if(mask[ch])
     {
-      surfaces[ch]
-        = dt_cairo_image_surface_create_for_data(d->waveform_img[2-ch], CAIRO_FORMAT_A8,
-                                                 d->waveform_width, d->waveform_height, wf_img_stride);
-      cairo_set_source_rgba(cr, ch==2 ? 1.:0., ch==1 ? 1.:0., ch==0 ? 1.:0., alpha_chroma);
-      cairo_mask_surface(cr, surfaces[ch], 0., 0.);
-    }
-
-  cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-  for(int ch = 0; ch < 3; ch++)
-    if(surfaces[ch])
-    {
-      cairo_set_source_rgba(cr, ch==2 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==0 ? 1.:desat_over, alpha_over);
-      cairo_mask_surface(cr, surfaces[ch], 0., 0.);
-      cairo_surface_destroy(surfaces[ch]);
+      cairo_surface_t *cst
+        = dt_cairo_image_surface_create_for_data(d->waveform_img[ch], CAIRO_FORMAT_ARGB32,
+                                                 d->waveform_width, d->waveform_height, stride);
+      cairo_set_source_surface(cr, cst, 0, 0);
+      cairo_paint_with_alpha(cr, 0.7);
+      cairo_surface_destroy(cst);
     }
 
   cairo_restore(cr);
@@ -700,26 +712,21 @@ static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
 
 static void _lib_histogram_draw_rgb_parade(dt_lib_histogram_t *d, cairo_t *cr, int width, int height)
 {
-  const double alpha_chroma = 0.85, desat_over = 0.85, alpha_over = 0.65;
-  const size_t wf_img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
+  const size_t wf_img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, d->waveform_width);
   cairo_save(cr);
   cairo_scale(cr, darktable.gui->ppd*width/(d->waveform_width*3),
               darktable.gui->ppd*height/d->waveform_height);
+  // FIXME: do want this?
+  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
 
-  for(int ch = 2; ch >= 0; ch--)
+  for(int ch = 0; ch < 3; ch++)
   {
-    cairo_surface_t *surface
-      = dt_cairo_image_surface_create_for_data(d->waveform_img[2-ch], CAIRO_FORMAT_A8,
+    cairo_surface_t *cst
+      = dt_cairo_image_surface_create_for_data(d->waveform_img[ch], CAIRO_FORMAT_ARGB32,
                                                d->waveform_width, d->waveform_height, wf_img_stride);
-
-    cairo_set_source_rgba(cr, ch==2 ? 1.:0., ch==1 ? 1.:0., ch==0 ? 1.:0., alpha_chroma);
-    cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-    cairo_mask_surface(cr, surface, 0., 0.);
-    cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-    cairo_set_source_rgba(cr, ch==2 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==0 ? 1.:desat_over, alpha_over);
-    cairo_mask_surface(cr, surface, 0., 0.);
-
-    cairo_surface_destroy(surface);
+    cairo_set_source_surface(cr, cst, 0, 0);
+    cairo_paint(cr);
+    cairo_surface_destroy(cst);
     cairo_translate(cr, d->waveform_width/darktable.gui->ppd, 0);
   }
   cairo_restore(cr);
@@ -1597,7 +1604,7 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: combine waveform_8bit and vectorscope_graph, as only ever use one or the other
   for(int ch=0; ch<3; ch++)
     d->waveform_img[ch] = dt_alloc_align(64, sizeof(uint8_t) * d->waveform_height *
-                                         cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_max_width));
+                                         cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, d->waveform_max_width));
 
   // FIXME: what is the appropriate resolution for this: balance memory use, processing speed, helpful resolution
   d->vectorscope_diameter_px = 384;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -665,60 +665,77 @@ static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
                                          int width, int height,
                                          const uint8_t mask[3])
 {
+  // composite before scaling to screen dimensions, as scaling each
+  // layer on draw causes a >2x slowdown
   const double alpha_chroma = 0.75, desat_over = 0.75, alpha_over = 0.35;
-  const size_t wf_img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
-  cairo_surface_t *surfaces[3] = { NULL, NULL, NULL };
+  const size_t img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
+  cairo_surface_t *cs[3] = { NULL, NULL, NULL };
+  cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, d->waveform_width, d->waveform_height);
+
+  cairo_t *crt = cairo_create(cst);
+  cairo_set_operator(crt, CAIRO_OPERATOR_ADD);
+  for(int ch = 0; ch < 3; ch++)
+    if(mask[ch])
+    {
+      cs[ch] = cairo_image_surface_create_for_data(d->waveform_img[ch], CAIRO_FORMAT_A8,
+                                                   d->waveform_width, d->waveform_height, img_stride);
+      cairo_set_source_rgba(crt, ch==0 ? 1.:0., ch==1 ? 1.:0., ch==2 ? 1.:0., alpha_chroma);
+      cairo_mask_surface(crt, cs[ch], 0., 0.);
+    }
+  cairo_set_operator(crt, CAIRO_OPERATOR_HARD_LIGHT);
+  for(int ch = 0; ch < 3; ch++)
+    if(cs[ch])
+    {
+      cairo_set_source_rgba(crt, ch==0 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==2 ? 1.:desat_over, alpha_over);
+      cairo_mask_surface(crt, cs[ch], 0., 0.);
+      cairo_surface_destroy(cs[ch]);
+    }
+  cairo_destroy(crt);
+
+  // scale and write to output buffer
   cairo_save(cr);
-  cairo_scale(cr, darktable.gui->ppd*width/d->waveform_width,
-              darktable.gui->ppd*height/d->waveform_height);
-
+  cairo_scale(cr, (float)width/d->waveform_width, (float)height/d->waveform_height);
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  for(int ch = 0; ch < 3; ch++)
-    if(mask[2-ch])
-    {
-      surfaces[ch]
-        = dt_cairo_image_surface_create_for_data(d->waveform_img[2-ch], CAIRO_FORMAT_A8,
-                                                 d->waveform_width, d->waveform_height, wf_img_stride);
-      cairo_set_source_rgba(cr, ch==2 ? 1.:0., ch==1 ? 1.:0., ch==0 ? 1.:0., alpha_chroma);
-      cairo_mask_surface(cr, surfaces[ch], 0., 0.);
-    }
-
-  cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-  for(int ch = 0; ch < 3; ch++)
-    if(surfaces[ch])
-    {
-      cairo_set_source_rgba(cr, ch==2 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==0 ? 1.:desat_over, alpha_over);
-      cairo_mask_surface(cr, surfaces[ch], 0., 0.);
-      cairo_surface_destroy(surfaces[ch]);
-    }
-
+  cairo_set_source_surface(cr, cst, 0., 0.);
+  cairo_paint(cr);
+  cairo_surface_destroy(cst);
   cairo_restore(cr);
 }
 
 static void _lib_histogram_draw_rgb_parade(dt_lib_histogram_t *d, cairo_t *cr, int width, int height)
 {
+  // same composite-to-temp optimization as in waveform code above
   const double alpha_chroma = 0.85, desat_over = 0.85, alpha_over = 0.65;
-  const size_t wf_img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
-  cairo_save(cr);
-  cairo_scale(cr, darktable.gui->ppd*width/(d->waveform_width*3),
-              darktable.gui->ppd*height/d->waveform_height);
+  const size_t img_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_width);
+  cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, d->waveform_width, d->waveform_height);
 
-  for(int ch = 2; ch >= 0; ch--)
+  cairo_t *crt = cairo_create(cst);
+  // Though this scales and throws horizontal data on each composite,
+  // It appears to be fastest and least memory wasteful. The
+  // horizontal resolution will be visually equivalent to waveform.
+  cairo_scale(crt, 1./3., 1.);
+  for(int ch = 0; ch < 3; ch++)
   {
-    cairo_surface_t *surface
-      = dt_cairo_image_surface_create_for_data(d->waveform_img[2-ch], CAIRO_FORMAT_A8,
-                                               d->waveform_width, d->waveform_height, wf_img_stride);
-
-    cairo_set_source_rgba(cr, ch==2 ? 1.:0., ch==1 ? 1.:0., ch==0 ? 1.:0., alpha_chroma);
-    cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-    cairo_mask_surface(cr, surface, 0., 0.);
-    cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-    cairo_set_source_rgba(cr, ch==2 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==0 ? 1.:desat_over, alpha_over);
-    cairo_mask_surface(cr, surface, 0., 0.);
-
-    cairo_surface_destroy(surface);
-    cairo_translate(cr, d->waveform_width/darktable.gui->ppd, 0);
+    cairo_surface_t *cs
+      = cairo_image_surface_create_for_data(d->waveform_img[ch], CAIRO_FORMAT_A8,
+                                            d->waveform_width, d->waveform_height, img_stride);
+    cairo_set_source_rgba(crt, ch==0 ? 1.:0., ch==1 ? 1.:0., ch==2 ? 1.:0., alpha_chroma);
+    cairo_set_operator(crt, CAIRO_OPERATOR_ADD);
+    cairo_mask_surface(crt, cs, 0., 0.);
+    cairo_set_operator(crt, CAIRO_OPERATOR_HARD_LIGHT);
+    cairo_set_source_rgba(crt, ch==0 ? 1.:desat_over, ch==1 ? 1.:desat_over, ch==2 ? 1.:desat_over, alpha_over);
+    cairo_mask_surface(crt, cs, 0., 0.);
+    cairo_surface_destroy(cs);
+    cairo_translate(crt, d->waveform_width, 0);
   }
+  cairo_destroy(crt);
+
+  cairo_save(cr);
+  cairo_scale(cr, (float)width/d->waveform_width, (float)height/d->waveform_height);
+  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
+  cairo_set_source_surface(cr, cst, 0., 0.);
+  cairo_paint(cr);
+  cairo_surface_destroy(cst);
   cairo_restore(cr);
 }
 


### PR DESCRIPTION
Draw each waveform and rgb parade channel in two passes. First draw in the RGB primary of that channel. Second draw again, using "hard light" operator, in a desaturated version of the channel color.

## changes to appearance

This produces more "volume", and more legibility, particularly in the blue channel. The colors should generally appear brighter, but also somewhat less saturated. As "pure" primaries, particulary on a wide gamut display, can be hard to discern, it's easier to discern the less saturated colors.

Note that prior code used colors set via CSS (`graph_red`, `graph_green`, `graph_blue`) to help with legibility. This PR uses the RGB primary in display space instead. Ideally these CSS primaries-for-display could be dropped entirely if the regular histogram can be altered to also no longer used them.

## changes to draw internals/speed

This PR requires 2x Cairo draw operations per scope per channel compared to prior code. To make this not slow things down, it makes all draws at 1:1 scale to a temporary buffer, then scales the result and draws to the widget. This optimization results in slightly faster drawing times than before for waveform, and equivalent drawing times for RGB parade. On this machine, times in seconds:

draw | before this PR | with this PR
-----|----------------|-------------
waveform | 0.010 | 0.009
rgb parade | 0.009 | 0.009

Time to process the waveform/parade histogram appears to be unchanged.

In order to keep RGB parade draw fast, it is now drawn at 1/3 horizontal resolution compared to before. As previously it was drawn at 3x horizontal resolution compared to waveform, this means they now have the same horizontal resolution.

## before/after

### Waveform, before this PR

![image](https://user-images.githubusercontent.com/2311860/119372590-7ab0a000-bc85-11eb-915e-e5c5ad62152d.png)

### Waveform, with this PR

![image](https://user-images.githubusercontent.com/2311860/119372734-a764b780-bc85-11eb-884b-78d8d1357702.png)

### RGB parade, before this PR

![image](https://user-images.githubusercontent.com/2311860/119372505-6371b280-bc85-11eb-8139-d2c2dc02b465.png)

### RGB parade, with this PR

![image](https://user-images.githubusercontent.com/2311860/119372782-b8adc400-bc85-11eb-9def-4260ea49af96.png)

This relates to point 1 of #6227. More generally it's a way to address a sense that the scope displays could be drawn in a more legible way.

## v3.6?

I'm not sure if this should be considered for v3.6. It is a change in behavior and rewrites a fair bit of drawing code, and touches other code. I wouldn't want to rush in a substantial visual change without consideration. I could see people thinking that the waveform now distracts due to brightness. OTOH, I think that these scopes with this PR look a lot better than before.