### PR TITLE
Remove const type qualifiers from image2d_t to fix OpenCL kernel compilation

### DIFF
--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -331,7 +331,7 @@ inline float4 chroma_adapt_RGB(const float4 RGB,
 */
 
 kernel void
-channelmixerrgb_CAT16(read_only const image2d_t in, write_only image2d_t out,
+channelmixerrgb_CAT16(read_only image2d_t in, write_only image2d_t out,
                       const int width, const int height,
                       constant const float *const RGB_to_XYZ,
                       constant const float *const XYZ_to_RGB,
@@ -411,7 +411,7 @@ channelmixerrgb_CAT16(read_only const image2d_t in, write_only image2d_t out,
 
 
 kernel void
-channelmixerrgb_bradford_linear(read_only const image2d_t in, write_only image2d_t out,
+channelmixerrgb_bradford_linear(read_only image2d_t in, write_only image2d_t out,
                                 const int width, const int height,
                                 constant const float *const RGB_to_XYZ,
                                 constant const float *const XYZ_to_RGB,
@@ -490,7 +490,7 @@ channelmixerrgb_bradford_linear(read_only const image2d_t in, write_only image2d
 }
 
 kernel void
-channelmixerrgb_bradford_full(read_only const image2d_t in, write_only image2d_t out,
+channelmixerrgb_bradford_full(read_only image2d_t in, write_only image2d_t out,
                               const int width, const int height,
                               constant const float *const RGB_to_XYZ,
                               constant const float *const XYZ_to_RGB,
@@ -570,7 +570,7 @@ channelmixerrgb_bradford_full(read_only const image2d_t in, write_only image2d_t
 
 
 kernel void
-channelmixerrgb_XYZ(read_only const image2d_t in, write_only image2d_t out,
+channelmixerrgb_XYZ(read_only image2d_t in, write_only image2d_t out,
                     const int width, const int height,
                     constant const float *const RGB_to_XYZ,
                     constant const float *const XYZ_to_RGB,
@@ -649,7 +649,7 @@ channelmixerrgb_XYZ(read_only const image2d_t in, write_only image2d_t out,
 }
 
 kernel void
-channelmixerrgb_RGB(read_only const image2d_t in, write_only image2d_t out,
+channelmixerrgb_RGB(read_only image2d_t in, write_only image2d_t out,
                     const int width, const int height,
                     constant const float *const RGB_to_XYZ,
                     constant const float *const XYZ_to_RGB,

--- a/data/kernels/color_conversion.h
+++ b/data/kernels/color_conversion.h
@@ -66,14 +66,14 @@ inline float lerp_lookup_unbounded(const float x, read_only image2d_t lut,
   else return x;
 }
 
-inline float lookup(read_only const image2d_t lut, const float x)
+inline float lookup(read_only image2d_t lut, const float x)
 {
   const int xi = clamp((int)(x * 0x10000ul), 0, 0xffff);
   const int2 p = (int2)((xi & 0xff), (xi >> 8));
   return read_imagef(lut, sampleri, p).x;
 }
 
-inline float lookup_unbounded(read_only const image2d_t lut, const float x, constant const float *const a)
+inline float lookup_unbounded(read_only image2d_t lut, const float x, constant const float *const a)
 {
   // in case the tone curve is marked as linear, return the fast
   // path to linear unbounded (does not clip x at 1)
@@ -91,7 +91,7 @@ inline float lookup_unbounded(read_only const image2d_t lut, const float x, cons
 }
 
 inline float4 apply_trc_in(const float4 rgb_in, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                           read_only const image2d_t lut)
+                           read_only image2d_t lut)
 {
   const float R = lerp_lookup_unbounded(rgb_in.x, lut, profile_info->unbounded_coeffs_in[0], 0, profile_info->lutsize);
   const float G = lerp_lookup_unbounded(rgb_in.y, lut, profile_info->unbounded_coeffs_in[1], 1, profile_info->lutsize);
@@ -101,7 +101,7 @@ inline float4 apply_trc_in(const float4 rgb_in, constant const dt_colorspaces_ic
 }
 
 inline float4 apply_trc_out(const float4 rgb_in, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                            read_only const image2d_t lut)
+                            read_only image2d_t lut)
 {
   const float R = lerp_lookup_unbounded(rgb_in.x, lut, profile_info->unbounded_coeffs_out[0], 3, profile_info->lutsize);
   const float G = lerp_lookup_unbounded(rgb_in.y, lut, profile_info->unbounded_coeffs_out[1], 4, profile_info->lutsize);
@@ -111,7 +111,7 @@ inline float4 apply_trc_out(const float4 rgb_in, constant const dt_colorspaces_i
 }
 
 inline float get_rgb_matrix_luminance(const float4 rgb, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                      constant const float *const matrix, read_only const image2d_t lut)
+                                      constant const float *const matrix, read_only image2d_t lut)
 {
   float luminance = 0.f;
 
@@ -129,7 +129,7 @@ inline float get_rgb_matrix_luminance(const float4 rgb, constant const dt_colors
 }
 
 inline float4 rgb_matrix_to_xyz(const float4 rgb, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                constant const float *const matrix, read_only const image2d_t lut)
+                                constant const float *const matrix, read_only image2d_t lut)
 {
   float4 out;
   if(profile_info->nonlinearlut)

--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -20,8 +20,8 @@
 #include "colorspace.h"
 
 kernel void
-colorspaces_transform_lab_to_rgb_matrix(read_only const image2d_t in, write_only image2d_t out, const int width, const int height,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info, read_only const image2d_t lut)
+colorspaces_transform_lab_to_rgb_matrix(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info, read_only image2d_t lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -39,8 +39,8 @@ colorspaces_transform_lab_to_rgb_matrix(read_only const image2d_t in, write_only
 }
 
 kernel void
-colorspaces_transform_rgb_matrix_to_lab(read_only const image2d_t in, write_only image2d_t out, const int width, const int height,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info, read_only const image2d_t lut)
+colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info, read_only image2d_t lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -59,9 +59,9 @@ colorspaces_transform_rgb_matrix_to_lab(read_only const image2d_t in, write_only
 }
 
 kernel void
-colorspaces_transform_rgb_matrix_to_rgb(read_only const image2d_t in, write_only image2d_t out, const int width, const int height,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_from, read_only const image2d_t lut_from,
-    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_to, read_only const image2d_t lut_to,
+colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_from, read_only image2d_t lut_from,
+    constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info_to, read_only image2d_t lut_to,
     constant const float *const matrix)
 {
   const int x = get_global_id(0);

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -32,7 +32,7 @@ inline float calcBlendFactor(float val, float threshold)
 }
 
 // Populate cfa and rgb data by normalized input
-__kernel void rcd_populate (__read_only const image2d_t in, global float *cfa, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters, const float scale)
+__kernel void rcd_populate (__read_only image2d_t in, global float *cfa, global float *rgb0, global float *rgb1, global float *rgb2, const int w, const int height, const unsigned int filters, const float scale)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
@@ -270,7 +270,7 @@ __kernel void rcd_step_5_2(global float *VH_dir, global float *rgb0, global floa
   }
 }
 
-__kernel void calc_Y0_mask(global float *mask, __read_only const image2d_t in, const int w, const int height, const float red, const float green, const float blue)
+__kernel void calc_Y0_mask(global float *mask, __read_only image2d_t in, const int w, const int height, const float red, const float green, const float blue)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
@@ -350,7 +350,7 @@ __kernel void calc_detail_blend(global float *in, global float *out, const int w
   out[idx] = detail ? blend : 1.0f - blend;
 }
 
-__kernel void readin_mask(global float *mask, __read_only const image2d_t in, const int w, const int height)
+__kernel void readin_mask(global float *mask, __read_only image2d_t in, const int w, const int height)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
@@ -372,7 +372,7 @@ __kernel void writeout_mask(global const float *mask, __write_only image2d_t out
   write_imagef(out, (int2)(col, row), val);  
 }
 
-__kernel void write_blended_dual(__read_only const image2d_t high, __read_only const image2d_t low, __write_only image2d_t out, const int w, const int height, global float *mask, const int showmask)
+__kernel void write_blended_dual(__read_only image2d_t high, __read_only image2d_t low, __write_only image2d_t out, const int w, const int height, global float *mask, const int showmask)
 {
   const int col = get_global_id(0);
   const int row = get_global_id(1);
@@ -427,7 +427,7 @@ __kernel void fastblur_mask_9x9(global float *src, global float *out, const int 
   out[oidx] = ICLAMP(val, 0.0f, 1.0f);
 }
 
-kernel void rcd_border_green(read_only const image2d_t in, write_only image2d_t out, const int width, const int height,
+kernel void rcd_border_green(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                     const unsigned int filters, local float *buffer, const int border)
 {
   const int x = get_global_id(0);
@@ -526,7 +526,7 @@ kernel void rcd_border_green(read_only const image2d_t in, write_only image2d_t 
   }
   write_imagef (out, (int2)(x, y), color);
 }
-kernel void rcd_border_redblue(read_only const image2d_t in, write_only image2d_t out, const int width, const int height,
+kernel void rcd_border_redblue(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                       const unsigned int filters, local float4 *buffer, const int border)
 {
   // image in contains full green and sparse r b

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -750,7 +750,7 @@ inline float4 opacity_masks(const float x,
 
 #define LUT_ELEM 360 // gamut LUT number of elements: resolution of 1°
 
-inline float lookup_gamut(read_only const image2d_t gamut_lut, const float x)
+inline float lookup_gamut(read_only image2d_t gamut_lut, const float x)
 {
   const int xi = clamp((int)(LUT_ELEM * (x + M_PI_F) / (2.f * M_PI_F)), 0, LUT_ELEM - 1);
   return read_imagef(gamut_lut, sampleri, (int2)(xi, 0)).x;
@@ -771,7 +771,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
                  const int width, const int height,
                  constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
                  constant const float *const matrix_in, constant const float *const matrix_out,
-                 read_only const image2d_t gamut_lut,
+                 read_only image2d_t gamut_lut,
                  const float shadows_weight, const float highlights_weight, const float midtones_weight, const float mask_grey_fulcrum,
                  const float hue_angle, const float chroma_global, const float4 chroma, const float vibrance,
                  const float4 global_offset, const float4 shadows, const float4 highlights, const float4 midtones,

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -60,9 +60,9 @@ typedef enum dt_iop_filmicrgb_curve_type_t
 } dt_iop_filmicrgb_curve_type_t;
 
 kernel void
-filmic (read_only const image2d_t in, write_only image2d_t out, int width, int height,
+filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
         const float dynamic_range, const float shadows_range, const float grey,
-        read_only const image2d_t table, read_only const image2d_t diff,
+        read_only image2d_t table, read_only image2d_t diff,
         const float contrast, const float power, const int preserve_color,
         const float saturation)
 {
@@ -166,7 +166,7 @@ inline float pixel_rgb_norm_euclidean(const float4 pixel)
 
 inline float get_pixel_norm(const float4 pixel, const dt_iop_filmicrgb_methods_type_t variant,
                             constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                            read_only const image2d_t lut, const int use_work_profile)
+                            read_only image2d_t lut, const int use_work_profile)
 {
   switch(variant)
   {
@@ -310,7 +310,7 @@ inline float log_tonemapping_v2(const float x,
 inline float4 filmic_split_v1(const float4 i,
                               const float dynamic_range, const float black_exposure, const float grey_value,
                               constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                              read_only const image2d_t lut, const int use_work_profile,
+                              read_only image2d_t lut, const int use_work_profile,
                               const float sigma_toe, const float sigma_shoulder, const float saturation,
                               const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
                               const float latitude_min, const float latitude_max, const float output_power,
@@ -347,7 +347,7 @@ inline float4 filmic_split_v1(const float4 i,
 inline float4 filmic_split_v2_v3(const float4 i,
                                  const float dynamic_range, const float black_exposure, const float grey_value,
                                  constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                 read_only const image2d_t lut, const int use_work_profile,
+                                 read_only image2d_t lut, const int use_work_profile,
                                  const float sigma_toe, const float sigma_shoulder, const float saturation,
                                  const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
                                  const float latitude_min, const float latitude_max, const float output_power,
@@ -382,11 +382,11 @@ inline float4 filmic_split_v2_v3(const float4 i,
 }
 
 kernel void
-filmicrgb_split (read_only const image2d_t in, write_only image2d_t out,
+filmicrgb_split (read_only image2d_t in, write_only image2d_t out,
                  const int width, const int height,
                  const float dynamic_range, const float black_exposure, const float grey_value,
                  constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                 read_only const image2d_t lut, const int use_work_profile,
+                 read_only image2d_t lut, const int use_work_profile,
                  const float sigma_toe, const float sigma_shoulder, const float saturation,
                  const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
                  const float latitude_min, const float latitude_max, const float output_power,
@@ -433,7 +433,7 @@ filmicrgb_split (read_only const image2d_t in, write_only image2d_t out,
 inline float4 filmic_chroma_v1(const float4 i,
                                const float dynamic_range, const float black_exposure, const float grey_value,
                                constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                               read_only const image2d_t lut, const int use_work_profile,
+                               read_only image2d_t lut, const int use_work_profile,
                                const float sigma_toe, const float sigma_shoulder, const float saturation,
                                const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
                                const float latitude_min, const float latitude_max, const float output_power,
@@ -474,7 +474,7 @@ inline float4 filmic_chroma_v1(const float4 i,
 inline float4 filmic_chroma_v2_v3(const float4 i,
                                   const float dynamic_range, const float black_exposure, const float grey_value,
                                   constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                  read_only const image2d_t lut, const int use_work_profile,
+                                  read_only image2d_t lut, const int use_work_profile,
                                   const float sigma_toe, const float sigma_shoulder, const float saturation,
                                   const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
                                   const float latitude_min, const float latitude_max, const float output_power,
@@ -524,11 +524,11 @@ inline float4 filmic_chroma_v2_v3(const float4 i,
 }
 
 kernel void
-filmicrgb_chroma (read_only const image2d_t in, write_only image2d_t out,
+filmicrgb_chroma (read_only image2d_t in, write_only image2d_t out,
                  const int width, const int height,
                  const float dynamic_range, const float black_exposure, const float grey_value,
                  constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                 read_only const image2d_t lut, const int use_work_profile,
+                 read_only image2d_t lut, const int use_work_profile,
                  const float sigma_toe, const float sigma_shoulder, const float saturation,
                  const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
                  const float latitude_min, const float latitude_max, const float output_power,
@@ -574,7 +574,7 @@ filmicrgb_chroma (read_only const image2d_t in, write_only image2d_t out,
 
 
 kernel void
-filmic_mask_clipped_pixels(read_only const image2d_t in, write_only image2d_t out,
+filmic_mask_clipped_pixels(read_only image2d_t in, write_only image2d_t out,
                            int width, int height,
                            const float normalize, const float feathering, write_only image2d_t is_clipped)
 {
@@ -596,7 +596,7 @@ filmic_mask_clipped_pixels(read_only const image2d_t in, write_only image2d_t ou
 }
 
 kernel void
-filmic_show_mask(read_only const image2d_t in, write_only image2d_t out,
+filmic_show_mask(read_only image2d_t in, write_only image2d_t out,
                  const int width, const int height)
 {
   const unsigned int x = get_global_id(0);
@@ -610,7 +610,7 @@ filmic_show_mask(read_only const image2d_t in, write_only image2d_t out,
 
 
 kernel void
-filmic_inpaint_noise(read_only const image2d_t in, read_only image2d_t mask, write_only image2d_t out,
+filmic_inpaint_noise(read_only image2d_t in, read_only image2d_t mask, write_only image2d_t out,
                      const int width, const int height, const float noise_level, const float threshold,
                      const dt_noise_distribution_t noise_distribution)
 {
@@ -635,7 +635,7 @@ filmic_inpaint_noise(read_only const image2d_t in, read_only image2d_t mask, wri
   write_imagef(out, (int2)(x, y), o);
 }
 
-kernel void init_reconstruct(read_only const image2d_t in, read_only image2d_t mask, write_only image2d_t out,
+kernel void init_reconstruct(read_only image2d_t in, read_only image2d_t mask, write_only image2d_t out,
                              const int width, const int height)
 {
   // init the reconstructed buffer with non-clipped and partially clipped pixels
@@ -658,7 +658,7 @@ kernel void init_reconstruct(read_only const image2d_t in, read_only image2d_t m
 #define FSIZE 5
 #define FSTART (FSIZE - 1) / 2
 
-kernel void blur_2D_Bspline_vertical(read_only const image2d_t in, write_only image2d_t out,
+kernel void blur_2D_Bspline_vertical(read_only image2d_t in, write_only image2d_t out,
                                      const int width, const int height, const int mult)
 {
   // À-trous B-spline interpolation/blur shifted by mult
@@ -683,7 +683,7 @@ kernel void blur_2D_Bspline_vertical(read_only const image2d_t in, write_only im
   write_imagef(out, (int2)(x, y), fmax(accumulator, 0.f));
 }
 
-kernel void blur_2D_Bspline_horizontal(read_only const image2d_t in, write_only image2d_t out,
+kernel void blur_2D_Bspline_horizontal(read_only image2d_t in, write_only image2d_t out,
                                        const int width, const int height, const int mult)
 {
   // À-trous B-spline interpolation/blur shifted by mult
@@ -722,7 +722,7 @@ inline float fminabsf(const float a, const float b)
                                           (isnan(b)) ? 0.f : b;
 }
 
-kernel void wavelets_detail_level(read_only const image2d_t detail, read_only image2d_t LF,
+kernel void wavelets_detail_level(read_only image2d_t detail, read_only image2d_t LF,
                                       write_only image2d_t HF, write_only image2d_t texture,
                                       const int width, const int height, dt_iop_filmicrgb_reconstruction_type_t variant)
 {
@@ -743,8 +743,8 @@ kernel void wavelets_detail_level(read_only const image2d_t detail, read_only im
   write_imagef(texture, (int2)(x, y), hf);
 }
 
-kernel void wavelets_reconstruct(read_only const image2d_t HF, read_only const image2d_t LF, read_only const image2d_t texture,
-                                 read_only const image2d_t mask,
+kernel void wavelets_reconstruct(read_only image2d_t HF, read_only image2d_t LF, read_only image2d_t texture,
+                                 read_only image2d_t mask,
                                  read_only image2d_t reconstructed_read, write_only image2d_t reconstructed_write,
                                  const int width, const int height,
                                  const float gamma, const float gamma_comp, const float beta, const float beta_comp, const float delta,
@@ -798,7 +798,7 @@ kernel void wavelets_reconstruct(read_only const image2d_t HF, read_only const i
 }
 
 
-kernel void compute_ratios(read_only const image2d_t in, write_only image2d_t norms,
+kernel void compute_ratios(read_only image2d_t in, write_only image2d_t norms,
                            write_only image2d_t ratios,
                            const dt_iop_filmicrgb_methods_type_t variant,
                            const int width, const int height)
@@ -815,7 +815,7 @@ kernel void compute_ratios(read_only const image2d_t in, write_only image2d_t no
 }
 
 
-kernel void restore_ratios(read_only const image2d_t ratios, read_only const image2d_t norms,
+kernel void restore_ratios(read_only image2d_t ratios, read_only image2d_t norms,
                            write_only image2d_t out,
                            const int width, const int height)
 {


### PR DESCRIPTION
OpenCL specifications do not allow imaged2d_t to be of type const. Fixes #9054 