### PR TITLE
collect : limit refresh

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -492,7 +492,7 @@ void dt_collection_reset(const dt_collection_t *collection)
   params->sort = dt_conf_get_int("plugins/collection/sort");
   params->sort_second_order = dt_conf_get_int("plugins/collection/sort_second_order");
   params->descending = dt_conf_get_bool("plugins/collection/descending");
-  dt_collection_update_query(collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 const gchar *dt_collection_get_query(const dt_collection_t *collection)
@@ -1986,10 +1986,11 @@ void dt_collection_deserialize(char *buf)
       if(buf[0] == '$') buf++;
     }
   }
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-void dt_collection_update_query(const dt_collection_t *collection, dt_collection_change_t query_change, GList *list)
+void dt_collection_update_query(const dt_collection_t *collection, dt_collection_change_t query_change,
+                                dt_collection_properties_t changed_property, GList *list)
 {
   int next = -1;
   if(!collection->clone && query_change == DT_COLLECTION_CHANGE_NEW_QUERY && darktable.gui)
@@ -2134,7 +2135,8 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
   if(!collection->clone)
   {
     dt_collection_memory_update();
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, query_change, list, next);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, query_change, changed_property,
+                                  list, next);
   }
 }
 
@@ -2233,7 +2235,8 @@ static void _dt_collection_recount_callback_1(gpointer instance, gpointer user_d
   if(!collection->clone)
   {
     if(old_count != collection->count) dt_collection_hint_message(collection);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_RELOAD, NULL, -1);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_RELOAD,
+                                  DT_COLLECTION_PROP_UNDEF, NULL, -1);
   }
 }
 
@@ -2250,7 +2253,7 @@ static void _dt_collection_filmroll_imported_callback(gpointer instance, uint8_t
   if(!collection->clone)
   {
     if(old_count != collection->count) dt_collection_hint_message(collection);
-    dt_collection_update_query(collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+    dt_collection_update_query(collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
   }
 }
 

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -114,7 +114,10 @@ typedef enum dt_collection_properties_t
   DT_COLLECTION_PROP_MODULE,
   DT_COLLECTION_PROP_ORDER,
 
-  DT_COLLECTION_PROP_LAST
+  DT_COLLECTION_PROP_LAST,
+
+  DT_COLLECTION_PROP_UNDEF,
+  DT_COLLECTION_PROP_RATING // this one goes here as not used currently in collect.c
 } dt_collection_properties_t;
 
 typedef enum dt_collection_rating_comperator_t
@@ -245,7 +248,7 @@ uint32_t dt_collection_get_selected_count(const dt_collection_t *collection);
 
 /** update query by conf vars */
 void dt_collection_update_query(const dt_collection_t *collection, dt_collection_change_t query_change,
-                                GList *list);
+                                dt_collection_properties_t changed_property, GList *list);
 
 /** updates the hint message for collection */
 void dt_collection_hint_message(const dt_collection_t *collection);

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -117,7 +117,8 @@ typedef enum dt_collection_properties_t
   DT_COLLECTION_PROP_LAST,
 
   DT_COLLECTION_PROP_UNDEF,
-  DT_COLLECTION_PROP_RATING // this one goes here as not used currently in collect.c
+  DT_COLLECTION_PROP_RATING, // this one goes here as not used currently in collect.c
+  DT_COLLECTION_PROP_SORT
 } dt_collection_properties_t;
 
 typedef enum dt_collection_rating_comperator_t

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -82,7 +82,7 @@ void dt_film_set_query(const int32_t id)
     dt_conf_set_string("plugins/lighttable/collect/string0", (gchar *)sqlite3_column_text(stmt, 1));
   }
   sqlite3_finalize(stmt);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 /** open film with given id. */

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -912,7 +912,7 @@ void dt_image_set_aspect_ratio_to(const int32_t imgid, const float aspect_ratio,
 
     if(raise && darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                                 g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
+                                 DT_COLLECTION_PROP_ASPECT_RATIO, g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
   }
 }
 
@@ -936,7 +936,7 @@ void dt_image_set_aspect_ratio_if_different(const int32_t imgid, const float asp
 
     if(raise && darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
       dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                                 g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
+                                 DT_COLLECTION_PROP_ASPECT_RATIO, g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
   }
 }
 
@@ -952,7 +952,7 @@ void dt_image_reset_aspect_ratio(const int32_t imgid, const gboolean raise)
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
 
   if(raise && darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_ASPECT_RATIO,
                                g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
 }
 
@@ -1180,7 +1180,7 @@ static int32_t _image_duplicate_with_version(const int32_t imgid, const int32_t 
     }
     dt_grouping_add_to_group(grpid, newid);
 
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
   }
   return newid;
 }
@@ -1388,7 +1388,7 @@ static int _image_read_duplicates(const uint32_t id, const char *filename, const
     {
       // now it is safe to set the duplicate group-id
       dt_grouping_add_to_group(grpid, newid);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
     }
 
     count_xmps_processed++;
@@ -2227,7 +2227,8 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
         // write xmp file
         dt_image_write_sidecar_file(newid);
 
-        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                                   NULL);
       }
 
       g_free(filename);

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -48,8 +48,9 @@ static void _selection_raise_signal()
 }
 
 /* updates the internal collection of an selection */
-static void _selection_update_collection(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                         int next, gpointer user_data);
+static void _selection_update_collection(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         gpointer user_data);
 
 static void _selection_select(dt_selection_t *selection, uint32_t imgid)
 {
@@ -89,7 +90,8 @@ static void _selection_select(dt_selection_t *selection, uint32_t imgid)
   dt_collection_hint_message(darktable.collection);
 }
 
-void _selection_update_collection(gpointer instance, dt_collection_change_t query_change, gpointer imgs, int next,
+void _selection_update_collection(gpointer instance, dt_collection_change_t query_change,
+                                  dt_collection_properties_t changed_property, gpointer imgs, int next,
                                   gpointer user_data)
 {
   dt_selection_t *selection = (dt_selection_t *)user_data;
@@ -111,7 +113,7 @@ const dt_selection_t *dt_selection_new()
   dt_selection_t *s = g_malloc0(sizeof(dt_selection_t));
 
   /* initialize the collection copy */
-  _selection_update_collection(NULL, DT_COLLECTION_CHANGE_RELOAD, NULL, -1, (gpointer)s);
+  _selection_update_collection(NULL, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL, -1, (gpointer)s);
 
   /* initialize last_single_id based on current database */
   s->last_single_id = -1;

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -259,7 +259,7 @@ static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_
     dt_image_synch_xmps(imgs);
   }
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, imgs);
 }
 
 void dt_undo_do_redo(dt_undo_t *self, uint32_t filter)

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -238,7 +238,7 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
 
   if((imgid & 3) == 3)
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
   }
 
   if(t->import_count + 1 == num_images)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -158,7 +158,8 @@ static int32_t _generic_dt_control_fileop_images_job_run(dt_job_t *job,
   }
   dt_film_remove_empty();
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                             g_list_copy(params->index));
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -546,7 +547,8 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   g_free(directory);
 
   // refresh the thumbtable view
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_prepend(NULL, GINT_TO_POINTER(imageid)));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                             g_list_prepend(NULL, GINT_TO_POINTER(imageid)));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
 
@@ -579,7 +581,7 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
       // a duplicate should keep the change time stamp of the original
       dt_image_cache_set_change_timestamp_from_image(darktable.image_cache, newimgid, imgid);
 
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
     }
     t = g_list_next(t);
     fraction += 1.0 / total;
@@ -618,7 +620,8 @@ static int32_t dt_control_flip_images_job_run(dt_job_t *job)
 
   dt_undo_end_group(darktable.undo);
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_ASPECT_RATIO,
+                             g_list_copy(params->index));
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -657,7 +660,8 @@ static int32_t dt_control_monochrome_images_job_run(dt_job_t *job)
 
   dt_undo_end_group(darktable.undo);
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                             g_list_copy(params->index));
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -774,7 +778,8 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
     list = g_list_delete_link(list, list);
   }
   dt_film_remove_empty();
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                             g_list_copy(params->index));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
 
@@ -1090,7 +1095,8 @@ delete_next_file:
   }
   g_list_free(list);
   dt_film_remove_empty();
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                             g_list_copy(params->index));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
   return 0;
@@ -1254,7 +1260,8 @@ static int32_t dt_control_local_copy_images_job_run(dt_job_t *job)
     dt_control_job_set_progress(job, fraction);
   }
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_LOCAL_COPY,
+                             g_list_copy(params->index));
   if(tag_change) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
@@ -1300,7 +1307,8 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);
   }
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                             g_list_copy(params->index));
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   dt_control_queue_redraw_center();
   return 0;
@@ -2107,7 +2115,8 @@ static int _control_import_image_copy(const char *filename,
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(imgid));
       if((imgid & 3) == 3)
       {
-        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                                   NULL);
         dt_control_queue_redraw_center();
       }
     }
@@ -2129,7 +2138,7 @@ static void _collection_update(double *last_update, double *update_interval)
     // between updates until it hits the pre-set maximum
     if (*update_interval < MAX_UPDATE_INTERVAL)
       *update_interval += 0.1;
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
     dt_control_queue_redraw_center();
   }
 }

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -272,7 +272,8 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
     //   one, update the interface
     if(pending >= 4 && curr_time - last_update > 0.5)
     {
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                                 g_list_copy(imgs));
       g_list_free(imgs);
       imgs = NULL;
       // restart the update count and timer

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -52,7 +52,7 @@ static GType uint_arg[] = { G_TYPE_UINT };
 static GType pointer_arg[] = { G_TYPE_POINTER };
 static GType pointer_2arg[] = { G_TYPE_POINTER, G_TYPE_POINTER };
 static GType pointer_trouble[] = { G_TYPE_POINTER, G_TYPE_STRING, G_TYPE_STRING };
-static GType collection_args[] = { G_TYPE_UINT, G_TYPE_POINTER, G_TYPE_UINT };
+static GType collection_args[] = { G_TYPE_UINT, G_TYPE_UINT, G_TYPE_POINTER, G_TYPE_UINT };
 static GType image_export_arg[]
     = { G_TYPE_UINT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_POINTER, G_TYPE_POINTER, G_TYPE_POINTER };
 static GType history_will_change_arg[]
@@ -60,8 +60,8 @@ static GType history_will_change_arg[]
 static GType geotag_arg[] = { G_TYPE_POINTER, G_TYPE_UINT };
 
 // callback for the destructor of DT_SIGNAL_COLLECTION_CHANGED
-static void _collection_changed_destroy_callback(gpointer instance, int query_change, gpointer imgs,
-                                                 const int next, gpointer user_data)
+static void _collection_changed_destroy_callback(gpointer instance, int query_change, int changed_property,
+                                                 gpointer imgs, const int next, gpointer user_data)
 {
   if(imgs)
   {
@@ -113,13 +113,13 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   { "dt-viewmanager-thumbtable-activate", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg,
     NULL, FALSE }, // DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE
 
-  { "dt-collection-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 3, collection_args,
+  { "dt-collection-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 4, collection_args,
     G_CALLBACK(_collection_changed_destroy_callback), FALSE }, // DT_SIGNAL_COLLECTION_CHANGED
   { "dt-selection-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_SELECTION_CHANGED
   { "dt-tag-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_TAG_CHANGED
-  { "dt-geotag-changed", NULL, NULL, G_TYPE_NONE,  g_cclosure_marshal_generic, 2, geotag_arg,
+  { "dt-geotag-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, geotag_arg,
     G_CALLBACK(_image_geotag_destroy_callback), FALSE }, // DT_SIGNAL_GEOTAG_CHANGED
   { "dt-metadata-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
     FALSE }, // DT_SIGNAL_METADATA_CHANGED

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -65,8 +65,9 @@ typedef enum dt_signal_t
   /** \brief This signal is raised when collection changed. To avoid leaking the list,
     dt_collection_t is connected to this event and responsible of that.
     1 : dt_collection_change_t the reason why the collection has changed
-    2 : GList of imageids that have changed (can be null if it's a global change)
-    3 : next untouched imgid in the list (-1 if no list)
+    2 : dt_collection_properties_t the property that has changed
+    3 : GList of imageids that have changed (can be null if it's a global change)
+    4 : next untouched imgid in the list (-1 if no list)
     no returned value
     */
   /** image list not to be freed by the caller, automatically freed */

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -865,7 +865,7 @@ static gboolean _event_rating_release(GtkWidget *widget, GdkEventButton *event, 
     if(rating != DT_VIEW_DESERT)
     {
       dt_ratings_apply_on_image(thumb->imgid, rating, TRUE, TRUE, TRUE);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING,
                                  g_list_prepend(NULL, GINT_TO_POINTER(thumb->imgid)));
     }
   }
@@ -903,7 +903,8 @@ static gboolean _event_grouping_release(GtkWidget *widget, GdkEventButton *event
     }
     else // expand the group
       darktable.gui->expanded_group_id = thumb->groupid;
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GROUPING,
+                               NULL);
   }
   return FALSE;
 }
@@ -949,7 +950,8 @@ static void _dt_image_info_changed_callback(gpointer instance, gpointer imgs, gp
 
 // this is called each time collected images change
 // we only use this because the image infos may have changed
-static void _dt_collection_changed_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
+static void _dt_collection_changed_callback(gpointer instance, dt_collection_change_t query_change,
+                                            dt_collection_properties_t changed_property, gpointer imgs,
                                             const int next, gpointer user_data)
 {
   if(!user_data || !imgs) return;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1329,7 +1329,8 @@ static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
 }
 
 // this is called each time collected images change
-static void _dt_collection_changed_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
+static void _dt_collection_changed_callback(gpointer instance, dt_collection_change_t query_change,
+                                            dt_collection_properties_t changed_property, gpointer imgs,
                                             const int next, gpointer user_data)
 {
   if(!user_data) return;
@@ -1696,7 +1697,7 @@ static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint
         // set order to "user defined" (this shouldn't trigger anything)
         const int32_t mouse_over_id = dt_control_get_mouse_over_id();
         dt_collection_move_before(mouse_over_id, table->drag_list);
-        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                    g_list_copy(table->drag_list));
         success = TRUE;
       }
@@ -2181,7 +2182,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
     }
   }
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING, imgs);
   return TRUE;
 }
 static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
@@ -2216,7 +2217,8 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
     }
   }
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_COLORLABEL,
+                             imgs);
   return TRUE;
 }
 static gboolean _accel_copy(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
@@ -2240,7 +2242,7 @@ static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable,
 
   const gboolean ret = dt_history_paste_on_list(imgs, TRUE);
   if(ret)
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, imgs);
   else
     g_list_free(imgs);
 
@@ -2257,7 +2259,7 @@ static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *accelera
 
   const gboolean ret = dt_history_paste_parts_on_list(imgs, TRUE);
   if(ret)
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, imgs);
   else
     g_list_free(imgs);
 
@@ -2270,7 +2272,7 @@ static gboolean _accel_hist_discard(GtkAccelGroup *accel_group, GObject *acceler
   GList *imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
   const gboolean ret = dt_history_delete_on_list(imgs, TRUE);
   if(ret)
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, imgs);
   else
     g_list_free(imgs);
   return TRUE;
@@ -2294,7 +2296,7 @@ static gboolean _accel_duplicate(GtkAccelGroup *accel_group, GObject *accelerata
 
   dt_undo_end_group(darktable.undo);
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   return TRUE;
 }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -108,7 +108,8 @@ typedef struct _range_t
 static void _lib_collect_gui_update(dt_lib_module_t *self);
 static void _lib_folders_update_collection(const gchar *filmroll);
 static void entry_changed(GtkEntry *entry, dt_lib_collect_rule_t *dr);
-static void collection_updated(gpointer instance, dt_collection_change_t query_change, gpointer imgs, int next,
+static void collection_updated(gpointer instance, dt_collection_change_t query_change,
+                               dt_collection_properties_t changed_property, gpointer imgs, int next,
                                gpointer self);
 static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColumn *col, GdkEventButton *event, dt_lib_collect_t *d);
 static int is_time_property(int property);
@@ -384,7 +385,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   _lib_collect_gui_update(self);
 
   /* update view */
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
   return 0;
 }
 
@@ -1006,8 +1007,8 @@ static void _lib_folders_update_collection(const gchar *filmroll)
   if(!darktable.collection->clone)
   {
     dt_collection_memory_update();
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_NEW_QUERY, NULL,
-                            -1);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_NEW_QUERY,
+                                  DT_COLLECTION_PROP_UNDEF, NULL, -1);
   }
 }
 
@@ -2167,7 +2168,7 @@ void gui_reset(dt_lib_module_t *self)
   d->active_rule = 0;
   d->view_rule = -1;
   dt_collection_set_query_flags(darktable.collection, COLLECTION_QUERY_FULL);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 static void combo_changed(GtkWidget *combo, dt_lib_collect_rule_t *d)
@@ -2218,7 +2219,7 @@ static void combo_changed(GtkWidget *combo, dt_lib_collect_rule_t *d)
   c->view_rule = -1;
   if(order_request)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColumn *col, GdkEventButton *event, dt_lib_collect_t *d)
@@ -2366,7 +2367,7 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
                                   darktable.view_manager->proxy.module_collect.module);
   if(order_request)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
   dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                     darktable.view_manager->proxy.module_collect.module);
   dt_control_queue_redraw_center();
@@ -2414,7 +2415,7 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
   }
   dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                   darktable.view_manager->proxy.module_collect.module);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
   dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                     darktable.view_manager->proxy.module_collect.module);
   d->typing = FALSE;
@@ -2461,7 +2462,7 @@ static void menuitem_mode(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
     c->active_rule = active;
     c->view_rule = -1;
   }
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
@@ -2477,11 +2478,11 @@ static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d
   }
   dt_lib_collect_t *c = get_collect(d);
   c->view_rule = -1;
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-static void collection_updated(gpointer instance, dt_collection_change_t query_change, gpointer imgs, int next,
-                               gpointer self)
+static void collection_updated(gpointer instance, dt_collection_change_t query_change,
+                               dt_collection_properties_t changed_property, gpointer imgs, int next, gpointer self)
 {
   dt_lib_module_t *dm = (dt_lib_module_t *)self;
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
@@ -2512,7 +2513,7 @@ static void filmrolls_imported(gpointer instance, int film_id, gpointer self)
 
 static void preferences_changed(gpointer instance, gpointer self)
 {
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 static void filmrolls_removed(gpointer instance, gpointer self)
@@ -2542,7 +2543,7 @@ static void tag_changed(gpointer instance, gpointer self)
     //need to reload collection since we have tags as active collection filter
     dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                     darktable.view_manager->proxy.module_collect.module);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_TAG, NULL);
     dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                       darktable.view_manager->proxy.module_collect.module);
   }
@@ -2559,7 +2560,7 @@ static void tag_changed(gpointer instance, gpointer self)
       // we have tags as one of rules, needs reload.
       dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                       darktable.view_manager->proxy.module_collect.module);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_TAG, NULL);
       dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                         darktable.view_manager->proxy.module_collect.module);
     }
@@ -2583,7 +2584,8 @@ static void _geotag_changed(gpointer instance, GList *imgs, const int locid, gpo
       //need to reload collection since we have geotags as active collection filter
       dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                       darktable.view_manager->proxy.module_collect.module);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GEOTAGGING,
+                                 NULL);
       dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                         darktable.view_manager->proxy.module_collect.module);
     }
@@ -2623,7 +2625,8 @@ static void metadata_changed(gpointer instance, int type, gpointer self)
      || (prop >= DT_COLLECTION_PROP_METADATA
          && prop < DT_COLLECTION_PROP_METADATA + DT_METADATA_NUMBER))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_METADATA,
+                               NULL);
   }
 }
 
@@ -2668,7 +2671,7 @@ static void menuitem_clear(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   }
 
   c->view_rule = -1;
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, dt_lib_collect_rule_t *d)
@@ -2808,7 +2811,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   gtk_widget_show_all(dialog);
   gtk_dialog_run(GTK_DIALOG(dialog));
   gtk_widget_destroy(dialog);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 void set_preferences(void *menu, dt_lib_module_t *self)
@@ -2931,7 +2934,8 @@ void gui_init(dt_lib_module_t *self)
   }
 
   // force redraw collection images because of late update of the table memory.darktable_iop_names
-  if(has_iop_name_rule) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  if(has_iop_name_rule)
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_MODULE, NULL);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, G_CALLBACK(collection_updated),
                             self);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2490,7 +2490,26 @@ static void collection_updated(gpointer instance, dt_collection_change_t query_c
   // update tree
   d->view_rule = -1;
   d->rule[d->active_rule].typing = FALSE;
-  _lib_collect_gui_update(self);
+
+  // determine if we want to refresh the tree or not
+  gboolean refresh = TRUE;
+  if(query_change == DT_COLLECTION_CHANGE_RELOAD && changed_property != DT_COLLECTION_PROP_UNDEF)
+  {
+    // if we only reload the collection, that means that we don't change the query itself
+    // so we only rebuild the treeview if a used property has changed
+    refresh = FALSE;
+    for(int i = 0; i <= d->active_rule; i++)
+    {
+      const int item = _combo_get_active_collection(d->rule[i].combo);
+      if(item == changed_property)
+      {
+        refresh = TRUE;
+        break;
+      }
+    }
+  }
+
+  if(refresh) _lib_collect_gui_update(self);
 }
 
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -174,7 +174,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     }
     else
     {
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                  g_list_copy((GList *)imgs));
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED,
                                     g_list_copy((GList *)imgs), 0);
@@ -201,7 +201,7 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 
   const int missing = dt_history_compress_on_list(imgs);
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_copy((GList *)imgs));
   dt_control_queue_redraw_center();
   if (missing)
@@ -276,7 +276,8 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
   {
     dt_history_delete_on_list(imgs, TRUE);
     GList *imgs_copy = g_list_copy((GList *)imgs);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs_copy); // frees imgs_copy
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                               imgs_copy); // frees imgs_copy
     dt_control_queue_redraw_center();
   }
 }
@@ -296,7 +297,7 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(dt_history_paste_on_list(imgs, TRUE))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                g_list_copy((GList *)imgs));
   }
 }
@@ -313,7 +314,8 @@ static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   GList* imgs_copy = g_list_copy((GList*)imgs);
   if(dt_history_paste_parts_on_list(imgs_copy, TRUE))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs_copy); // frees imgs_copy
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                               imgs_copy); // frees imgs_copy
   }
   else
   {
@@ -334,8 +336,9 @@ static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t
   _update(self);
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   _update(self);
 }

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -96,7 +96,7 @@ static void _lib_duplicate_new_clicked_callback(GtkWidget *widget, GdkEventButto
   if (newid <= 0) return;
   dt_history_delete_on_image(newid);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
 }
 static void _lib_duplicate_duplicate_clicked_callback(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)
@@ -105,7 +105,7 @@ static void _lib_duplicate_duplicate_clicked_callback(GtkWidget *widget, GdkEven
   const int newid = dt_image_duplicate(imgid);
   if (newid <= 0) return;
   dt_history_copy_and_paste_on_image(imgid, newid, FALSE, NULL, TRUE, TRUE);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
 }
 
@@ -136,7 +136,7 @@ static void _lib_duplicate_delete(GtkButton *button, dt_lib_module_t *self)
 
   // and we remove the image
   dt_control_delete_image(imgid);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
 }
 
@@ -487,7 +487,8 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 }
 
 static void _lib_duplicate_collection_changed(gpointer instance, dt_collection_change_t query_change,
-                                              gpointer imgs, int next, dt_lib_module_t *self)
+                                              dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                              dt_lib_module_t *self)
 {
   _lib_duplicate_init_callback(instance, self);
 }

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -198,8 +198,9 @@ static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t
   _update(self);
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   _update(self);
 }

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -105,7 +105,7 @@ static void _group_helper_function(void)
     darktable.gui->expanded_group_id = new_group_id;
   else
     darktable.gui->expanded_group_id = -1;
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GROUPING, imgs);
   dt_control_queue_redraw_center();
 }
 
@@ -130,7 +130,8 @@ static void _ungroup_helper_function(void)
   if(imgs != NULL)
   {
     darktable.gui->expanded_group_id = -1;
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_reverse(imgs));
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GROUPING,
+                               g_list_reverse(imgs));
     dt_control_queue_redraw_center();
   }
 }
@@ -274,8 +275,9 @@ static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t
   _update(self);
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   _update(self);
 }
@@ -371,7 +373,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     {
       dt_undo_end_group(darktable.undo);
       dt_image_synch_xmps(imgs);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_METADATA,
                                  g_list_copy((GList *)imgs));
       dt_control_queue_redraw_center();
     }

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1260,18 +1260,18 @@ static void _update_places_list(dt_lib_module_t* self)
   if(dt_conf_get_bool("ui_last/import_dialog_show_home") && dt_loc_get_home_dir(NULL))
   {
     current_place = (char *)dt_loc_get_home_dir(NULL);
-    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, _("home"), 
-      DT_PLACES_PATH, current_place, DT_PLACES_TYPE, DT_TYPE_HOME, -1);
+    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, _("home"), DT_PLACES_PATH,
+                                      current_place, DT_PLACES_TYPE, DT_TYPE_HOME, -1);
     if(!g_strcmp0(current_place, last_place))
       gtk_tree_selection_select_iter(d->placesSelection, &iter);
     current_iter = iter;
   }
-  
+
   if(dt_conf_get_bool("ui_last/import_dialog_show_pictures") && g_get_user_special_dir(G_USER_DIRECTORY_PICTURES))
   {
     current_place = (char *)g_get_user_special_dir(G_USER_DIRECTORY_PICTURES);
-    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, _("pictures"), 
-      DT_PLACES_PATH, current_place, DT_PLACES_TYPE, DT_TYPE_PIC, -1);
+    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, _("pictures"), DT_PLACES_PATH,
+                                      current_place, DT_PLACES_TYPE, DT_TYPE_PIC, -1);
     if(!g_strcmp0(current_place, last_place))
       gtk_tree_selection_select_iter(d->placesSelection, &iter);
     current_iter = iter;
@@ -1293,7 +1293,7 @@ static void _update_places_list(dt_lib_module_t* self)
 
     for (drive = drives; drive; drive = drive->next)
     {
-      volumes = g_drive_get_volumes (drive->data);    
+      volumes = g_drive_get_volumes(drive->data);
       for (volume = volumes; volume; volume = volume->next)
       {
         if(g_volume_get_mount(volume->data))
@@ -1302,8 +1302,9 @@ static void _update_places_list(dt_lib_module_t* self)
           GFile *placesFile = g_mount_get_root(placesMount);
           g_object_unref (placesMount);
 
-          gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_volume_get_name(volume->data), 
-            DT_PLACES_PATH, g_file_get_path(placesFile), DT_PLACES_TYPE, DT_TYPE_MOUNT, -1);
+          gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME,
+                                            g_volume_get_name(volume->data), DT_PLACES_PATH,
+                                            g_file_get_path(placesFile), DT_PLACES_TYPE, DT_TYPE_MOUNT, -1);
 
           if(!g_strcmp0(g_file_get_path(placesFile), last_place))
             gtk_tree_selection_select_iter(d->placesSelection, &iter);
@@ -1319,8 +1320,8 @@ static void _update_places_list(dt_lib_module_t* self)
   {
     GList *next = places->next;
 
-    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_path_get_basename(places->data), 
-      DT_PLACES_PATH, (char *)places->data, DT_PLACES_TYPE, DT_TYPE_CUSTOM, -1);
+    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_path_get_basename(places->data),
+                                      DT_PLACES_PATH, (char *)places->data, DT_PLACES_TYPE, DT_TYPE_CUSTOM, -1);
 
     if(!g_strcmp0(places->data, last_place))
       gtk_tree_selection_select_iter(d->placesSelection, &iter);
@@ -1363,11 +1364,10 @@ static void _add_custom_place(const gchar *folder, dt_lib_module_t* self)
 
   if(!g_strrstr(current_folders, folder))
   {
-    dt_conf_set_string("ui_last/import_custom_places", 
-      dt_util_dstrcat(NULL, "%s%s,", current_folders, folder));
+    dt_conf_set_string("ui_last/import_custom_places", dt_util_dstrcat(NULL, "%s%s,", current_folders, folder));
 
-    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_path_get_basename(folder), 
-      DT_PLACES_PATH, (char *)folder, DT_PLACES_TYPE, DT_TYPE_CUSTOM, -1);
+    gtk_list_store_insert_with_values(d->placesModel, &iter, -1, DT_PLACES_NAME, g_path_get_basename(folder),
+                                      DT_PLACES_PATH, (char *)folder, DT_PLACES_TYPE, DT_TYPE_CUSTOM, -1);
   }
 
   dt_conf_set_string("ui_last/import_last_place", folder);
@@ -1390,8 +1390,8 @@ static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t
   if(type == DT_TYPE_MOUNT)
     dt_conf_set_bool("ui_last/import_dialog_show_mounted", FALSE);
   if(type == DT_TYPE_CUSTOM)
-    dt_conf_set_string("ui_last/import_custom_places", 
-      dt_util_str_replace(current_folders, dt_util_dstrcat(NULL,"%s,", folder), ""));
+    dt_conf_set_string("ui_last/import_custom_places",
+                       dt_util_str_replace(current_folders, dt_util_dstrcat(NULL, "%s,", folder), ""));
 
   _update_places_list(self);
 }
@@ -1726,7 +1726,8 @@ static void _import_set_collection(const char *dirname)
     dt_conf_set_int("plugins/lighttable/collect/num_rules", 1);
     dt_conf_set_int("plugins/lighttable/collect/item0", 0);
     dt_conf_set_string("plugins/lighttable/collect/string0", dirname);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF,
+                               NULL);
   }
 }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -209,8 +209,9 @@ static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t
   _update(self);
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   _update(self);
 }

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -174,8 +174,9 @@ static void _button_pressed(GtkButton *button, gpointer user_data)
   }
 }
 
-static void _lib_recentcollection_updated(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                          int next, gpointer user_data)
+static void _lib_recentcollection_updated(gpointer instance, dt_collection_change_t query_change,
+                                          dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                          gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_recentcollect_t *d = (dt_lib_recentcollect_t *)self->data;
@@ -297,7 +298,7 @@ void gui_reset(dt_lib_module_t *self)
     snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", k);
     dt_conf_set_int(confname, 0);
   }
-  _lib_recentcollection_updated(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, NULL, -1, self);
+  _lib_recentcollection_updated(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -319,7 +320,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_set_name(GTK_WIDGET(d->item[k].button), "recent-collection-button");
     gtk_widget_set_visible(d->item[k].button, FALSE);
   }
-  _lib_recentcollection_updated(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, NULL, -1, self);
+  _lib_recentcollection_updated(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
 
   /* connect collection changed signal */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -85,8 +85,9 @@ static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t
 #endif
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   _update(self);
 }
@@ -167,7 +168,7 @@ void gui_cleanup(dt_lib_module_t *self)
 }
 
 #ifdef USE_LUA
-typedef struct 
+typedef struct
 {
   const char* key;
   dt_lib_module_t * self;
@@ -242,7 +243,7 @@ static int lua_register_selection(lua_State *L)
   const char * tooltip = lua_tostring(L, 3);
   if(tooltip)
     gtk_widget_set_tooltip_text(button, tooltip);
-  
+
   gtk_widget_set_name(button, name);
   gtk_grid_attach_next_to(GTK_GRID(self->widget), button, NULL, GTK_POS_BOTTOM, 2, 1);
 
@@ -302,7 +303,7 @@ static int lua_destroy_selection(lua_State *L)
       // remove the widget
 
       gtk_grid_remove_row(GTK_GRID(self->widget), row);
-      break; 
+      break;
     }
   }
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -763,8 +763,9 @@ static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t
   _update(self);
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   _update(self);
 }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -561,8 +561,9 @@ static void _lib_tagging_tags_changed_callback(gpointer instance, dt_lib_module_
   _init_treeview(self, 1);
 }
 
-static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                        int next, dt_lib_module_t *self)
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   d->collection[0] = '\0';

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -102,7 +102,7 @@ static void _lib_colorlabels_button_clicked_callback(GtkWidget *w, gpointer user
 {
   const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(user_data), TRUE);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_COLORLABEL,
                              g_list_copy((GList *)imgs));
 }
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -55,7 +55,7 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
 /* callback for rating comparator combobox change */
 static void _lib_filter_comparator_changed(GtkComboBox *widget, gpointer user_data);
 /* updates the query and redraws the view */
-static void _lib_filter_update_query(dt_lib_module_t *self);
+static void _lib_filter_update_query(dt_lib_module_t *self, dt_collection_properties_t changed_property);
 /* make sure that the comparator button matches what is shown in the filter dropdown */
 static gboolean _lib_filter_sync_combobox_and_comparator(dt_lib_module_t *self);
 /* save the images order if the first collect filter is on tag*/
@@ -300,7 +300,7 @@ static void _lib_filter_combobox_changed(GtkComboBox *widget, gpointer user_data
   _lib_filter_sync_combobox_and_comparator(user_data);
 
   /* update the query and view */
-  _lib_filter_update_query(user_data);
+  _lib_filter_update_query(user_data, DT_COLLECTION_PROP_RATING);
 }
 
 /* save the images order if the first collect filter is on tag*/
@@ -339,14 +339,14 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
   _lib_filter_set_tag_order(user_data);
 
   /* update query and view */
-  _lib_filter_update_query(user_data);
+  _lib_filter_update_query(user_data, DT_COLLECTION_PROP_SORT);
 }
 
 static void _lib_filter_comparator_changed(GtkComboBox *widget, gpointer user_data)
 {
   dt_collection_set_rating_comparator(darktable.collection, gtk_combo_box_get_active(widget));
 
-  _lib_filter_update_query(user_data);
+  _lib_filter_update_query(user_data, DT_COLLECTION_PROP_RATING);
 }
 
 static void _lib_filter_sort_combobox_changed(GtkComboBox *widget, gpointer user_data)
@@ -358,16 +358,16 @@ static void _lib_filter_sort_combobox_changed(GtkComboBox *widget, gpointer user
   _lib_filter_set_tag_order(user_data);
 
   /* update the query and view */
-  _lib_filter_update_query(user_data);
+  _lib_filter_update_query(user_data, DT_COLLECTION_PROP_SORT);
 }
 
-static void _lib_filter_update_query(dt_lib_module_t *self)
+static void _lib_filter_update_query(dt_lib_module_t *self, dt_collection_properties_t changed_property)
 {
   /* sometimes changes */
   dt_collection_set_query_flags(darktable.collection, COLLECTION_QUERY_FULL);
 
   /* updates query */
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, changed_property, NULL);
 }
 
 static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter)
@@ -416,7 +416,7 @@ static int sort_cb(lua_State *L)
     dt_collection_set_sort(darktable.collection, (uint32_t)value, 0);
     const dt_collection_sort_t sort = dt_collection_get_sort_field(darktable.collection);
     gtk_combo_box_set_active(GTK_COMBO_BOX(d->sort), _filter_get_items(sort));
-    _lib_filter_update_query(self);
+    _lib_filter_update_query(self, DT_COLLECTION_PROP_SORT);
   }
   luaA_push(L, dt_collection_sort_t, &tmp);
   return 1;
@@ -437,7 +437,7 @@ static int sort_order_cb(lua_State *L)
     gtk_combo_box_set_active(GTK_COMBO_BOX(d->sort), _filter_get_items(sort));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse),
                                dt_collection_get_sort_descending(darktable.collection));
-    _lib_filter_update_query(self);
+    _lib_filter_update_query(self, DT_COLLECTION_PROP_SORT);
   }
   luaA_push(L, dt_collection_sort_order_t, &tmp);
   return 1;
@@ -454,7 +454,7 @@ static int rating_cb(lua_State *L)
     luaA_to(L,dt_collection_filter_t,&value,1);
     dt_collection_set_rating(darktable.collection, (uint32_t)value);
     gtk_combo_box_set_active(GTK_COMBO_BOX(d->filter), dt_collection_get_rating(darktable.collection));
-    _lib_filter_update_query(self);
+    _lib_filter_update_query(self, DT_COLLECTION_PROP_RATING);
   }
   luaA_push(L, dt_collection_filter_t, &tmp);
   return 1;
@@ -471,7 +471,7 @@ static int rating_comparator_cb(lua_State *L)
     luaA_to(L,dt_collection_rating_comperator_t,&value,1);
     dt_collection_set_rating_comparator(darktable.collection, (uint32_t)value);
     gtk_combo_box_set_active(GTK_COMBO_BOX(d->comparator), dt_collection_get_rating_comparator(darktable.collection));
-    _lib_filter_update_query(self);
+    _lib_filter_update_query(self, DT_COLLECTION_PROP_RATING);
   }
   luaA_push(L, dt_collection_rating_comperator_t, &tmp);
   return 1;

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -367,7 +367,7 @@ static void _lib_filter_update_query(dt_lib_module_t *self)
   dt_collection_set_query_flags(darktable.collection, COLLECTION_QUERY_FULL);
 
   /* updates query */
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
 static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -524,7 +524,7 @@ static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user
     gtk_widget_set_tooltip_text(widget, _("collapse grouped images"));
   dt_conf_set_bool("ui_last/grouping", darktable.gui->grouping);
   darktable.gui->expanded_group_id = -1;
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GROUPING, NULL);
 
 #ifdef USE_LUA
   dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -120,8 +120,8 @@ static void _lib_imageinfo_update_message2(gpointer instance, gpointer imgs, dt_
   _lib_imageinfo_update_message(instance, self);
 }
 
-void _lib_imageinfo_update_message3(gpointer instance, int query_change, gpointer imgs, const int next,
-                                    dt_lib_module_t *self)
+void _lib_imageinfo_update_message3(gpointer instance, int query_change, int changed_property, gpointer imgs,
+                                    const int next, dt_lib_module_t *self)
 {
   _lib_imageinfo_update_message(instance, self);
 }

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -190,7 +190,7 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   {
     const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
     dt_ratings_apply_on_list(imgs, d->current, TRUE);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING,
                                g_list_copy((GList *)imgs));
 
     dt_control_queue_redraw_center();

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -867,8 +867,9 @@ static gboolean _time_is_visible(dt_lib_timeline_time_t t, dt_lib_timeline_t *st
   return TRUE;
 }
 
-static void _lib_timeline_collection_changed(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                             int next, gpointer user_data)
+static void _lib_timeline_collection_changed(gpointer instance, dt_collection_change_t query_change,
+                                             dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                             gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_timeline_t *strip = (dt_lib_timeline_t *)self->data;
@@ -962,7 +963,8 @@ static void _selection_collect(dt_lib_timeline_t *strip, dt_lib_timeline_mode_t 
     dt_conf_set_string(confname, coll);
     g_free(coll);
 
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, NULL);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF,
+                               NULL);
   }
 }
 
@@ -1187,7 +1189,8 @@ static gboolean _lib_timeline_button_press_callback(GtkWidget *w, GdkEventButton
       if(dt_conf_get_int(confname) == DT_COLLECTION_PROP_TIME)
       {
         dt_conf_set_int("plugins/lighttable/collect/num_rules", nb_rules - 1);
-        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
+        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                                   NULL);
 
         strip->selecting = FALSE;
       }
@@ -1503,7 +1506,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->timeline, TRUE, TRUE, 0);
 
   // we update the selection with actual collect rules
-  _lib_timeline_collection_changed(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, NULL, -1, self);
+  _lib_timeline_collection_changed(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
 
   /* initialize view manager proxy */
   darktable.view_manager->proxy.timeline.module = self;

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -159,7 +159,8 @@ static int import_images(lua_State *L)
     }
     luaA_push(L, dt_lua_image_t, &result);
     // force refresh of thumbtable view
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_prepend(NULL, GINT_TO_POINTER(result)));
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                               g_list_prepend(NULL, GINT_TO_POINTER(result)));
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
     dt_control_queue_redraw_center();
 

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -219,7 +219,7 @@ static int rating_member(lua_State *L)
     my_image->flags &= ~DT_VIEW_RATINGS_MASK;
     my_image->flags |= my_score;
     releasewriteimage(L, my_image);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_RATING,
                                g_list_prepend(NULL, GINT_TO_POINTER(my_image->id)));
     return 0;
   }
@@ -321,7 +321,7 @@ static int colorlabel_member(lua_State *L)
     {
       dt_colorlabels_remove_label(imgid, colorlabel_index);
     }
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_COLORLABEL,
                                g_list_prepend(NULL, GINT_TO_POINTER(imgid)));
     return 0;
   }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3178,7 +3178,7 @@ void leave(dt_view_t *self)
   dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
 
   // darkroom development could have changed a collection, so update that before being back in lighttable
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_prepend(NULL, GINT_TO_POINTER(darktable.develop->image_storage.id)));
 
   darktable.develop->image_storage.id = -1;
@@ -3582,7 +3582,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
   const gboolean constrained = !dt_modifier_is(state, GDK_CONTROL_MASK);
   const gboolean low_ppd = (darktable.gui->ppd == 1);
-  const float stepup = 0.1f * fabsf(1.0f - fitscale) / ppd; 
+  const float stepup = 0.1f * fabsf(1.0f - fitscale) / ppd;
 
   if(up)
   {
@@ -4244,7 +4244,7 @@ static void second_window_scrolled(GtkWidget *widget, dt_develop_t *dev, double 
 
   const gboolean constrained = !dt_modifier_is(state, GDK_CONTROL_MASK);
   const gboolean low_ppd = (dev->second_window.ppd == 1);
-  const float stepup = 0.1f * fabsf(1.0f - fitscale) / ppd; 
+  const float stepup = 0.1f * fabsf(1.0f - fitscale) / ppd;
   if(up)
   {
     if(fitscale <= 1.0f && (scale == (1.0f / ppd) || scale == (2.0f / ppd)) && constrained) return; // for large image size

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -138,8 +138,9 @@ static void _view_map_drag_set_icon(const dt_view_t *self, GdkDragContext *conte
                              const int imgid, const int count);
 
 /* callback when the collection changes */
-static void _view_map_collection_changed(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                         int next, gpointer user_data);
+static void _view_map_collection_changed(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         gpointer user_data);
 /* callback when the selection changes */
 static void _view_map_selection_changed(gpointer instance, gpointer user_data);
 /* callback when images geotags change */
@@ -2435,8 +2436,9 @@ static void _view_map_check_preference_changed(gpointer instance, gpointer user_
   if(_view_map_prefs_changed(lib)) g_signal_emit_by_name(lib->map, "changed");
 }
 
-static void _view_map_collection_changed(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
-                                         int next, gpointer user_data)
+static void _view_map_collection_changed(gpointer instance, dt_collection_change_t query_change,
+                                         dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                         gpointer user_data)
 {
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;


### PR DESCRIPTION
as discussed in #9042 this allow to specify which property has been changed when requesting collection update. This property is then used in collect module to only refresh the treeview if the property is really used inside the query.
That should limit drastically the number of rebuild.