### PR TITLE
darktable.css: replace scrollbar margin with padding

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1117,7 +1117,7 @@ dialog scrollbar
   border-radius: 0.35em;
   min-height: 0.42em;
   min-width: 0.42em;
-  margin: 0.07em;
+  padding: 0.07em;
 }
 
 /*--------------------------


### PR DESCRIPTION
allows the scroll bars of the side panels to be scrolled even when the mouse is at the far edge of the screen, while keeping the visual style unchanged

Resolves #9059