### PR TITLE
raise selection changed signal on query update if needed

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2124,6 +2124,11 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, -1);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
+    // if we have remove something from selection, we need to raise a signal
+    if(sqlite3_changes(dt_database_get(darktable.db)) > 0)
+    {
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+    }
 
     /* free allocated strings */
     g_free(complete_query);


### PR DESCRIPTION
this fix #7291

when we recreate the collection of image, we update the selection too to remove image that are not anymore in collection. If we effectively remove some of them, raise the DT_SIGNAL_SELECTION_CHANGED signal 