### PR TITLE
converts license expression operators to uppercase

### DIFF
--- a/data/darktable.appdata.xml.in
+++ b/data/darktable.appdata.xml.in
@@ -7,7 +7,7 @@
   <id>darktable.desktop</id>
   <name>darktable</name>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+ and GPL-2.0+ and LGPL-2.0+ and BSD-3-Clause and MIT and CC-BY-SA-1.0 and CC-BY-2.5 and CC-BY-NC-3.0</project_license>
+  <project_license>GPL-3.0+ AND GPL-2.0+ AND LGPL-2.0+ AND BSD-3-Clause AND MIT AND CC-BY-SA-1.0 AND CC-BY-2.5 AND CC-BY-NC-3.0</project_license>
   <_summary>Organize and develop images from digital cameras</_summary>
   <translation type="gettext">darktable</translation>
   <description>


### PR DESCRIPTION
From https://bugzilla.redhat.com/show_bug.cgi?id=1965060
gnome-software shows the License of darktable as being "Proprietary".

The problem may be caused by the SPDX license expression in darktable.appdata.xml  [1] file, which contains operators in smallcase when they should be in uppercase [2]. 

```
License expression operators (AND, OR and WITH) should be matched in a case-sensitive manner.
```


References:
[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-project_license
[2] https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/#case-sensitivity