### PR TITLE
colorin/iop_profile: better handling of CLUT profiles

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -797,22 +797,22 @@ dt_ioppr_set_pipe_input_profile_info(struct dt_develop_t *dev,
 {
   dt_iop_order_iccprofile_info_t *profile_info = dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
 
-  if(isnan(profile_info->matrix_in[0]) || isnan(profile_info->matrix_out[0]))
-  {
-    /* We have a camera input matrix, these are not generated from files but in colorin,
-    * so we need to fetch and replace them from somewhere.
-    */
-    memcpy(profile_info->matrix_in, matrix_in, sizeof(profile_info->matrix_in));
-    mat3inv_float(profile_info->matrix_out, profile_info->matrix_in);
-  }
-
-  if(profile_info == NULL || isnan(profile_info->matrix_in[0]) || isnan(profile_info->matrix_out[0]))
+  if(profile_info == NULL)
   {
     fprintf(stderr,
             "[dt_ioppr_set_pipe_input_profile_info] unsupported input profile %i %s, it will be replaced with "
             "linear rec2020\n",
             type, filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
+  }
+
+  if(profile_info->type >= DT_COLORSPACE_EMBEDDED_ICC && profile_info->type <= DT_COLORSPACE_ALTERNATE_MATRIX)
+  {
+    /* We have a camera input matrix, these are not generated from files but in colorin,
+    * so we need to fetch and replace them from somewhere.
+    */
+    memcpy(profile_info->matrix_in, matrix_in, sizeof(profile_info->matrix_in));
+    mat3inv_float(profile_info->matrix_out, profile_info->matrix_in);
   }
   pipe->input_profile_info = profile_info;
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1656,6 +1656,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       input_format = TYPE_RGBA_FLT;
       break;
     case cmsSigXYZData:
+      // FIXME: even though this is allowed/works, dt_ioppr_generate_profile_info still complains about these profiles
       input_format = TYPE_XYZA_FLT;
       break;
     default:
@@ -1718,7 +1719,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     d->nrgb = NULL;
   }
 
-  // user selected a non-supported output profile, check that:
+  // user selected a non-supported input profile, check that:
   if(!d->xform_cam_Lab && isnan(d->cmatrix[0]))
   {
     if(p->type == DT_COLORSPACE_FILE)


### PR DESCRIPTION
Fix logic in `dt_ioppr_set_pipe_input_profile_info()` for CLUT profiles. As colorin can handle CLUT profiles, don't warn if the user has chosen a CLUT profile.

- If input profile is a camera input matrix, copy in the colorin-supplied matrix, which varies per-camera.

- In all other cases, don't touch the profile matrix. (Luckily, for non camera matrices, the matrix found by colorin should be the matrix of that profile, so the prior code which rewrote its matrix was usually a NOP.)

Previous code produced a spurious warning for CLUT input profiles. Despite the `dt_ioppr_set_pipe_input_profile_info()` falling back to linear rec2020, this didn't change the profile info stored internally in colorin, hence, excepting a colorspace-aware module relocated before colorin or a pre-colorin module using certain blending modes, the fallback profile produced no effect.

(As `dt_ioppr_add_profile_info_to_list()` actually always returns a profile, the NULL check in `dt_ioppr_set_pipe_input_profile_info()` is a NOP. Long term, it could be useful to fix `dt_ioppr_generate_profile_info()` so that it returns NULL on failure, helping distinguish between an error and a CLUT profile. As colorin has done a lot of work to validate the profile, in this case it's not pressing. Potential alternate approach: move profile validation and matrix extraction from colorin to `dt_ioppr_set_pipe_input_profile_info()`?)

Also, fix a comment which appears to have been overlooked in copy/paste in 4264e7175d577d6b9bfefed8afbbbe23f3bf3fb7.

Also, note that for XYZ profiles, `dt_ioppr_set_pipe_input_profile_info()` produces a spurious warning, but don't fix -- it'll be complicated.

Fixes #8794.