### PR TITLE
Initialize n->details for DEVELOP_BLEND_VERSION update 10->11

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1879,6 +1879,11 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blur_radius = o->blur_radius;
     n->contrast = o->contrast;
     n->brightness = o->brightness;
+    // fix intermediate devel versions for details mask and initialize n->details to proper values if something was wrong
+    memcpy(&n->details, &o->reserved, sizeof(float));
+    if(isnan(n->details)) n->details = 0.0f;
+    n->details = fminf(1.0f, fmaxf(-1.0f, n->details));
+
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     memcpy(n->blendif_boost_factors, o->blendif_boost_factors, sizeof(float) * DEVELOP_BLENDIF_SIZE);
     memcpy(n->raster_mask_source, o->raster_mask_source, sizeof(n->raster_mask_source));


### PR DESCRIPTION
Unfortunately i missed an update for DEVELOP_BLEND_VERSION while implementing the details mask and as we now have version 11 this must be re-initialized.

Also there have been several devel versions for details mask using different maths and parameters so it is not always possible to keep these pre 3.6 sidecars valid.

For most situations this should be ok.

Mostly Fixes #9085