### PR TITLE
In dual demosaicing VNG must always do the vng interpolation

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3910,7 +3910,7 @@ error:
 
 static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
                           cl_mem dev_out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                          const gboolean smooth)
+                          const gboolean smooth, const int only_vng_linear)
 {
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
@@ -4980,7 +4980,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
       if(err != CL_SUCCESS) goto error;
 
       // VNG processing
-      if(!process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth))
+      if(!process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth, qual_flags & DEMOSAIC_ONLY_VNG_LINEAR))
         goto error;
 
       // adjust for "good" part, dropping linear border where possible
@@ -5111,12 +5111,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   }
   else if(demosaicing_method ==  DT_IOP_DEMOSAIC_VNG4 || demosaicing_method == DT_IOP_DEMOSAIC_VNG)
   {
-    if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE)) return FALSE;
+    if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE, FALSE)) return FALSE;
   }
   else if((demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) &&
     !(qual_flags & DEMOSAIC_XTRANS_FULL))
   {
-    if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE)) return FALSE;
+    if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE, qual_flags & DEMOSAIC_ONLY_VNG_LINEAR)) return FALSE;
   }
   else if(((demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN ) ||
           ((demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN_3))
@@ -5153,6 +5153,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     goto finish;
   }
 
+  // This is dual demosaicing only stuff
   const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
 
   int width = roi_out->width;
@@ -5182,7 +5183,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   }
 
   if(info) dt_get_times(&start_time);
-  if(process_vng_cl(self, piece, dev_in, low_image, roi_in, roi_in, FALSE))
+  if(process_vng_cl(self, piece, dev_in, low_image, roi_in, roi_in, FALSE, FALSE))
   {
     if(!color_smoothing_cl(self, piece, low_image, low_image, roi_in, 2))
     {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5204,22 +5204,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     // scale aux buffer to output buffer
     const int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     if(err != CL_SUCCESS)
-    {
       retval = FALSE;
-      goto finish;
-    }
   }
   
-  // color smoothing
-  if(data->color_smoothing)
-  {
-    if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing))
-    {
-      retval = FALSE;
-      goto finish;
-    }
-  }
-
   finish:
   dt_opencl_release_mem_object(high_image);
   dt_opencl_release_mem_object(low_image);

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -24,10 +24,6 @@
    implemented also by Ingo Weyrich.
 */
 
-// dual_demosaic is always called **after** the high-frequency demosaicer (rcd, amaze or one of the non-bayer demosaicers)
-// and expects the data available in rgb_data as rgba quadruples. 
-
-// improve UI experience
 static float slider2contrast(float slider)
 {
   return 0.005f * powf(slider, 1.1f);
@@ -56,7 +52,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   }
   const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
 
-  vng_interpolate(vng_image, raw_data, roi_out, roi_in, filters, xtrans, DEMOSAIC_FULL_SCALE);
+  vng_interpolate(vng_image, raw_data, roi_out, roi_in, filters, xtrans, FALSE);
   color_smoothing(vng_image, roi_out, 2);
 
   dt_times_t start_blend = { 0 }, end_blend = { 0 };


### PR DESCRIPTION
While dual demosaicing the vng_interpolate must not leave after the linear interpolation!

This problem is visible especialyl on high iso images or images with lots of color noise as has been pointed by @kofa73

Fixes #9101