### PR TITLE
Handle gphoto2 ptp protocol errors

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -949,7 +949,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
       {
         dt_camera_t *oldcam = (dt_camera_t *)citem->data;
         camctl->cameras = citem = g_list_delete_link(c->cameras, citem);
-        dt_print(DT_DEBUG_CAMCTL, "[camera_control] ERROR: %s on port %s disconnected\n", cam->model, cam->port);
+        dt_print(DT_DEBUG_CAMCTL, "[camera_control] ERROR: %s on port %s disconnected while mounted\n", cam->model, cam->port);
         dt_control_log(_("camera `%s' on port %s disconnected while mounted"), cam->model, cam->port);
         dt_camctl_camera_destroy_struct(oldcam);
         changed_camera = TRUE;
@@ -1070,7 +1070,7 @@ static gboolean _camera_initialize(const dt_camctl_t *c, dt_camera_t *cam)
     err = gp_camera_set_port_info(cam->gpcam, pi);
     if(err != GP_OK)
     {
-      dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to gp_camera_set_port_infogp_port_info_list_get_info %s\n", cam->model);
+      dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to gp_camera_set_port_info %s\n", cam->model);
       return FALSE;
     }
 

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -89,6 +89,8 @@ typedef struct dt_camera_t
 
   /** flag to unmount */
   gboolean unmount;
+  /** flag noting a runtime ptp error condition */
+  gboolean ptperror;
   /** flag true while importing */
   gboolean is_importing;
   /** Live view */


### PR DESCRIPTION
The gphoto2 ptp protocol is somewhat tricky as it has an internal timeout and if this is not met it will throw an error condition.

If this error is fetched we will keep a ptperror condition flag in the dt_camera_t struct and
- leave a message for the user
- unmount the device safely in the backthread to allow a remount

The most easy way to reproduce is with using a mobile phone, most of them allow to be mounted as a ptp device but will ask the user for permission to do so. If that has not been granted the phone will be mounted but the importer gui won't be able to load content.

ToDo: The importer gui might look for the error flag and quit if true for a faster response. Pinging @phweyland here