### PR TITLE
cacorrectrgb: restrict EV difference between channels to [-3,3] EV

### DIFF
--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -245,6 +245,7 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
   }
 }
 
+#define DT_CACORRECTRGB_MAX_EV_DIFF 3.0f
 static void get_manifolds(const float* const restrict in, const size_t width, const size_t height,
                           const size_t ch, const float sigma, const float sigma2,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
@@ -284,7 +285,9 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
     {
       const size_t c = (kc + guide + 1) % 3;
       const float pixel = fmaxf(in[k * 4 + c], 1E-6f);
-      const float log_diff = log2f(pixel / pixelg);
+      // we limit log diff to 3EV maximum as higher range may be due to
+      // noise and may result in artefacts
+      const float log_diff = fminf(fmaxf(log2f(pixel / pixelg), -DT_CACORRECTRGB_MAX_EV_DIFF), DT_CACORRECTRGB_MAX_EV_DIFF);
       manifold_higher[k * 4 + c] = log_diff * weighth;
       manifold_lower[k * 4 + c] = log_diff * weightl;
     }
@@ -399,7 +402,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
         {
           const size_t c = (guide + kc + 1) % 3;
           const float pixel = fmaxf(in[k * 4 + c], 1E-6f);
-          const float log_diff = log2f(pixel) - pixelg;
+          const float log_diff = fminf(fmaxf(log2f(pixel) - pixelg, -DT_CACORRECTRGB_MAX_EV_DIFF), DT_CACORRECTRGB_MAX_EV_DIFF);
           manifold_higher[k * 4 + c] = log_diff * w;
         }
         manifold_higher[k * 4 + guide] = fmaxf(in[k * 4 + guide], 0.0f) * w;
@@ -417,7 +420,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
         {
           const size_t c = (guide + kc + 1) % 3;
           const float pixel = fmaxf(in[k * 4 + c], 1E-6f);
-          const float log_diff = log2f(pixel) - pixelg;
+          const float log_diff = fminf(fmaxf(log2f(pixel) - pixelg, -DT_CACORRECTRGB_MAX_EV_DIFF), DT_CACORRECTRGB_MAX_EV_DIFF);
           manifold_lower[k * 4 + c] = log_diff * w;
         }
         manifold_lower[k * 4 + guide] = fmaxf(in[k * 4 + guide], 0.0f) * w;
@@ -458,6 +461,7 @@ dt_omp_firstprivate(manifolds, blurred_manifold_lower, blurred_manifold_higher, 
   dt_free_align(blurred_manifold_lower);
   dt_free_align(blurred_manifold_higher);
 }
+#undef DT_CACORRECTRGB_MAX_EV_DIFF
 
 static void apply_correction(const float* const restrict in,
                           const float* const restrict manifolds,


### PR DESCRIPTION
when there is noise or when a channel is damaged, close to black pixels
have way too much influence as the log diff between the guide and guided
channel will be very high for these pixels.
As a result, it creates artefacts.
It seems much safer to restrict range to [-3,3] EVs, without getting
particular drawbacks for most natural images (even particularly
saturated ones).

Fixes the issue raised in #7633 by @Mangus78 