### PR TITLE
fix retrieval of final size for untouched images

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -663,7 +663,6 @@ void dt_image_update_final_size(const int32_t imgid)
   dt_image_t *imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
   imgtmp->final_width = ww;
   imgtmp->final_height = hh;
-  if(ww > 0 && hh > 0) imgtmp->verified_size = TRUE;
   dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
 }
@@ -682,27 +681,15 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
     return 0;
   }
 
-  // special case if we try to load embedded preview of raw file
-
-  // the orientation for this camera is not read correctly from exiv2, so we need
-  // to go the full path (as the thumbnail will be flipped the wrong way round)
-  const int incompatible = !strncmp(img.exif_maker, "Phase One", 9);
-  const gboolean use_raw =
-    !dt_conf_is_equal("plugins/lighttable/thumbnail_raw_min_level", "never");
-
-  if(!img.verified_size && !dt_image_altered(imgid) && !use_raw && !incompatible)
-  {
-    // we want to be sure to have the real image size.
-    // some raw files need a pass via rawspeed to get it.
-    char filename[PATH_MAX] = { 0 };
-    gboolean from_cache = TRUE;
-    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
-    imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
-    dt_imageio_open(imgtmp, filename, NULL);
-    imgtmp->verified_size = 1;
-    img = *imgtmp;
-    dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
-  }
+  // we want to be sure to have the real image size.
+  // raw files need a pass via rawspeed to get it.
+  char filename[PATH_MAX] = { 0 };
+  gboolean from_cache = TRUE;
+  dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+  imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+  dt_imageio_open(imgtmp, filename, NULL);
+  img = *imgtmp;
+  dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
 
   // and now we can do the pipe stuff to get final image size
   dt_develop_t dev;
@@ -1712,7 +1699,7 @@ uint32_t dt_image_import_lua(const int32_t film_id, const char *filename, gboole
 
 void dt_image_init(dt_image_t *img)
 {
-  img->width = img->height = img->verified_size = 0;
+  img->width = img->height = 0;
   img->final_width = img->final_height = img->p_width = img->p_height = 0;
   img->aspect_ratio = 0.f;
   img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -210,7 +210,7 @@ typedef struct dt_image_t
   // common stuff
 
   // to understand this, look at comment for dt_histogram_roi_t
-  int32_t width, height, verified_size, final_width, final_height, p_width, p_height;
+  int32_t width, height, final_width, final_height, p_width, p_height;
   int32_t crop_x, crop_y, crop_width, crop_height;
   float aspect_ratio;
 

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -119,7 +119,6 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
     img->print_timestamp = sqlite3_column_int(stmt, 32);
     img->final_width = sqlite3_column_int(stmt, 33);
     img->final_height = sqlite3_column_int(stmt, 34);
-    if(img->final_width > 0 && img->final_height > 0) img->verified_size = TRUE;
 
     // buffer size? colorspace?
     if(img->flags & DT_IMAGE_LDR)

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -822,7 +822,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
       case md_width:
         (void)g_strlcpy(text, NODATA_STRING, sizeof(text));
-        if(img->verified_size)
+        if(img->final_width > 0)
         {
           (void)g_snprintf(text, sizeof(text), "%d", img->final_width);
         }
@@ -831,7 +831,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
       case md_height:
         (void)g_strlcpy(text, NODATA_STRING, sizeof(text));
-        if(img->verified_size)
+        if(img->final_height > 0)
         {
           (void)g_snprintf(text, sizeof(text), "%d", img->final_height);
         }


### PR DESCRIPTION
raw files exif sizes are not reliable. To get "real" sizes we need to to a pass in rawspeed to get the cropped areas, etc...

If we don't do that, we have issues in some parts of the code. One example is if you zoom quickly in a full preview image, or switch quickly to new image with scrollwheel when zoomed at 100%. (This doesn't happens each time, but you can get a full crash)

That slow down a little bit the dt_image_get_final_size fct, but as it's used only in specific cases, and as now each image opened in darkroom get the right size directly, this shouldn't be a big issue... Note, that this affect raw files, but the file opening need to occurs for each files as before that, we can't know which file type it is...