### PR TITLE
Update Ukrainian translation

### DIFF
--- a/po/uk.po
+++ b/po/uk.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-12 16:08+0300\n"
-"PO-Revision-Date: 2021-05-25 12:35+0300\n"
+"POT-Creation-Date: 2021-05-25 07:56+0200\n"
+"PO-Revision-Date: 2021-05-31 15:06+0300\n"
 "Last-Translator: Victor Forsiuk <vvforce@gmail.com>\n"
 "Language-Team: \n"
 "Language: uk\n"
@@ -231,51 +231,51 @@ msgstr "мініатюра використовує raw файл замість 
 #: ../build/bin/preferences_gen.h:3748 ../build/bin/preferences_gen.h:3843
 #: ../build/bin/preferences_gen.h:4985 ../build/bin/preferences_gen.h:5039
 #: ../build/bin/preferences_gen.h:6861 ../build/bin/conf_gen.h:377
-#: ../build/bin/conf_gen.h:986 ../build/bin/conf_gen.h:1002
-#: ../build/bin/conf_gen.h:2717
+#: ../build/bin/conf_gen.h:1010 ../build/bin/conf_gen.h:1026
+#: ../build/bin/conf_gen.h:2756
 msgctxt "preferences"
 msgid "always"
 msgstr "завжди"
 
 #: ../build/bin/preferences_gen.h:3753 ../build/bin/preferences_gen.h:3848
-#: ../build/bin/conf_gen.h:987 ../build/bin/conf_gen.h:1003
+#: ../build/bin/conf_gen.h:1011 ../build/bin/conf_gen.h:1027
 msgctxt "preferences"
 msgid "small"
 msgstr "маленьке зображення"
 
 #: ../build/bin/preferences_gen.h:3758 ../build/bin/preferences_gen.h:3853
-#: ../build/bin/conf_gen.h:988 ../build/bin/conf_gen.h:1004
+#: ../build/bin/conf_gen.h:1012 ../build/bin/conf_gen.h:1028
 msgctxt "preferences"
 msgid "VGA"
 msgstr "VGA"
 
 #: ../build/bin/preferences_gen.h:3763 ../build/bin/preferences_gen.h:3858
-#: ../build/bin/preferences_gen.h:3902 ../build/bin/conf_gen.h:989
-#: ../build/bin/conf_gen.h:1005
+#: ../build/bin/preferences_gen.h:3902 ../build/bin/conf_gen.h:1013
+#: ../build/bin/conf_gen.h:1029
 msgctxt "preferences"
 msgid "720p"
 msgstr "720p"
 
 #: ../build/bin/preferences_gen.h:3768 ../build/bin/preferences_gen.h:3863
-#: ../build/bin/conf_gen.h:990 ../build/bin/conf_gen.h:1006
+#: ../build/bin/conf_gen.h:1014 ../build/bin/conf_gen.h:1030
 msgctxt "preferences"
 msgid "1080p"
 msgstr "1080p"
 
 #: ../build/bin/preferences_gen.h:3773 ../build/bin/preferences_gen.h:3868
-#: ../build/bin/conf_gen.h:991 ../build/bin/conf_gen.h:1007
+#: ../build/bin/conf_gen.h:1015 ../build/bin/conf_gen.h:1031
 msgctxt "preferences"
 msgid "WQXGA"
 msgstr "WQXGA"
 
 #: ../build/bin/preferences_gen.h:3778 ../build/bin/preferences_gen.h:3873
-#: ../build/bin/conf_gen.h:992 ../build/bin/conf_gen.h:1008
+#: ../build/bin/conf_gen.h:1016 ../build/bin/conf_gen.h:1032
 msgctxt "preferences"
 msgid "4K"
 msgstr "4K"
 
 #: ../build/bin/preferences_gen.h:3783 ../build/bin/preferences_gen.h:3878
-#: ../build/bin/conf_gen.h:993 ../build/bin/conf_gen.h:1009
+#: ../build/bin/conf_gen.h:1017 ../build/bin/conf_gen.h:1033
 msgctxt "preferences"
 msgid "5K"
 msgstr "5K"
@@ -284,8 +284,8 @@ msgstr "5K"
 #: ../build/bin/preferences_gen.h:3883 ../build/bin/preferences_gen.h:6562
 #: ../build/bin/preferences_gen.h:6692 ../build/bin/preferences_gen.h:6856
 #: ../build/bin/conf_gen.h:178 ../build/bin/conf_gen.h:198
-#: ../build/bin/conf_gen.h:376 ../build/bin/conf_gen.h:994
-#: ../build/bin/conf_gen.h:1010
+#: ../build/bin/conf_gen.h:376 ../build/bin/conf_gen.h:1018
+#: ../build/bin/conf_gen.h:1034
 msgctxt "preferences"
 msgid "never"
 msgstr "ніколи"
@@ -360,32 +360,32 @@ msgid "pen pressure control for brush masks"
 msgstr "що контролює сила натискання стилуса при малюванні масок"
 
 #: ../build/bin/preferences_gen.h:4093 ../build/bin/preferences_gen.h:4137
-#: ../build/bin/conf_gen.h:1036
+#: ../build/bin/conf_gen.h:1060
 msgctxt "preferences"
 msgid "off"
 msgstr "вимкнено"
 
-#: ../build/bin/preferences_gen.h:4098 ../build/bin/conf_gen.h:1037
+#: ../build/bin/preferences_gen.h:4098 ../build/bin/conf_gen.h:1061
 msgctxt "preferences"
 msgid "hardness (relative)"
 msgstr "жорсткість (відносна)"
 
-#: ../build/bin/preferences_gen.h:4103 ../build/bin/conf_gen.h:1038
+#: ../build/bin/preferences_gen.h:4103 ../build/bin/conf_gen.h:1062
 msgctxt "preferences"
 msgid "hardness (absolute)"
 msgstr "жорсткість (абсолютна)"
 
-#: ../build/bin/preferences_gen.h:4108 ../build/bin/conf_gen.h:1039
+#: ../build/bin/preferences_gen.h:4108 ../build/bin/conf_gen.h:1063
 msgctxt "preferences"
 msgid "opacity (relative)"
 msgstr "непрозорість (відносна)"
 
-#: ../build/bin/preferences_gen.h:4113 ../build/bin/conf_gen.h:1040
+#: ../build/bin/preferences_gen.h:4113 ../build/bin/conf_gen.h:1064
 msgctxt "preferences"
 msgid "opacity (absolute)"
 msgstr "непрозорість (абсолютна)"
 
-#: ../build/bin/preferences_gen.h:4118 ../build/bin/conf_gen.h:1041
+#: ../build/bin/preferences_gen.h:4118 ../build/bin/conf_gen.h:1065
 msgctxt "preferences"
 msgid "brush size (relative)"
 msgstr "розмір пензля (відносний)"
@@ -405,18 +405,18 @@ msgstr ""
 msgid "smoothing of brush strokes"
 msgstr "згладжування мазків пензлем"
 
-#: ../build/bin/preferences_gen.h:4173 ../build/bin/conf_gen.h:1049
+#: ../build/bin/preferences_gen.h:4173 ../build/bin/conf_gen.h:1073
 msgctxt "preferences"
 msgid "low"
 msgstr "слабке"
 
 #: ../build/bin/preferences_gen.h:4178 ../build/bin/preferences_gen.h:4202
-#: ../build/bin/conf_gen.h:1050
+#: ../build/bin/conf_gen.h:1074
 msgctxt "preferences"
 msgid "medium"
 msgstr "середнє"
 
-#: ../build/bin/preferences_gen.h:4183 ../build/bin/conf_gen.h:1051
+#: ../build/bin/preferences_gen.h:4183 ../build/bin/conf_gen.h:1075
 msgctxt "preferences"
 msgid "high"
 msgstr "сильне"
@@ -444,28 +444,28 @@ msgstr ""
 msgid "position of the image information line"
 msgstr "розміщення інформаційного рядка зображення"
 
-#: ../build/bin/preferences_gen.h:4281 ../build/bin/conf_gen.h:1074
+#: ../build/bin/preferences_gen.h:4281 ../build/bin/conf_gen.h:1098
 msgctxt "preferences"
 msgid "top left"
 msgstr "зверху ліворуч"
 
-#: ../build/bin/preferences_gen.h:4286 ../build/bin/conf_gen.h:1075
+#: ../build/bin/preferences_gen.h:4286 ../build/bin/conf_gen.h:1099
 msgctxt "preferences"
 msgid "top right"
 msgstr "зверху праворуч"
 
-#: ../build/bin/preferences_gen.h:4291 ../build/bin/conf_gen.h:1076
+#: ../build/bin/preferences_gen.h:4291 ../build/bin/conf_gen.h:1100
 msgctxt "preferences"
 msgid "top center"
 msgstr "зверху в центрі"
 
 #: ../build/bin/preferences_gen.h:4296 ../build/bin/preferences_gen.h:4320
-#: ../build/bin/conf_gen.h:1077
+#: ../build/bin/conf_gen.h:1101
 msgctxt "preferences"
 msgid "bottom"
 msgstr "низ"
 
-#: ../build/bin/preferences_gen.h:4301 ../build/bin/conf_gen.h:1078
+#: ../build/bin/preferences_gen.h:4301 ../build/bin/conf_gen.h:1102
 msgctxt "preferences"
 msgid "hidden"
 msgstr "приховано"
@@ -495,18 +495,18 @@ msgstr ""
 msgid "demosaicing for zoomed out darkroom mode"
 msgstr "демозаїкізація масштабованих зображень в режимі темної кімнати"
 
-#: ../build/bin/preferences_gen.h:4436 ../build/bin/conf_gen.h:1862
+#: ../build/bin/preferences_gen.h:4436 ../build/bin/conf_gen.h:1886
 msgctxt "preferences"
 msgid "always bilinear (fast)"
 msgstr "завжди білінійна (швидко)"
 
 #: ../build/bin/preferences_gen.h:4441 ../build/bin/preferences_gen.h:4465
-#: ../build/bin/conf_gen.h:1863
+#: ../build/bin/conf_gen.h:1887
 msgctxt "preferences"
 msgid "at most RCD (reasonable)"
 msgstr "RCD (прийнятно)"
 
-#: ../build/bin/preferences_gen.h:4446 ../build/bin/conf_gen.h:1864
+#: ../build/bin/preferences_gen.h:4446 ../build/bin/conf_gen.h:1888
 msgctxt "preferences"
 msgid "full (possibly slow)"
 msgstr "як при повнорозмірному експорті (можливо повільно)"
@@ -530,22 +530,22 @@ msgid "reduce resolution of preview image"
 msgstr "зменшити роздільну здатність попереднього перегляду"
 
 #: ../build/bin/preferences_gen.h:4501 ../build/bin/preferences_gen.h:4535
-#: ../build/bin/conf_gen.h:1872
+#: ../build/bin/conf_gen.h:1896
 msgctxt "preferences"
 msgid "original"
 msgstr "залишити оригінальну"
 
-#: ../build/bin/preferences_gen.h:4506 ../build/bin/conf_gen.h:1873
+#: ../build/bin/preferences_gen.h:4506 ../build/bin/conf_gen.h:1897
 msgctxt "preferences"
 msgid "to 1/2"
 msgstr "до 1/2"
 
-#: ../build/bin/preferences_gen.h:4511 ../build/bin/conf_gen.h:1874
+#: ../build/bin/preferences_gen.h:4511 ../build/bin/conf_gen.h:1898
 msgctxt "preferences"
 msgid "to 1/3"
 msgstr "до 1/3"
 
-#: ../build/bin/preferences_gen.h:4516 ../build/bin/conf_gen.h:1875
+#: ../build/bin/preferences_gen.h:4516 ../build/bin/conf_gen.h:1899
 msgctxt "preferences"
 msgid "to 1/4"
 msgstr "до 1/4"
@@ -579,12 +579,12 @@ msgid "display of individual color channels"
 msgstr "відображення окремих кольорових каналів"
 
 #: ../build/bin/preferences_gen.h:4615 ../build/bin/preferences_gen.h:4639
-#: ../build/bin/conf_gen.h:1059
+#: ../build/bin/conf_gen.h:1083
 msgctxt "preferences"
 msgid "false color"
 msgstr "псевдоколір"
 
-#: ../build/bin/preferences_gen.h:4620 ../build/bin/conf_gen.h:1060
+#: ../build/bin/preferences_gen.h:4620 ../build/bin/conf_gen.h:1084
 msgctxt "preferences"
 msgid "gray scale"
 msgstr "відтінки сірого"
@@ -651,17 +651,17 @@ msgid "white balance slider colors"
 msgstr "колір повзунків балансу білого"
 
 #: ../build/bin/preferences_gen.h:4855 ../build/bin/preferences_gen.h:4884
-#: ../build/bin/conf_gen.h:2671
+#: ../build/bin/conf_gen.h:2710
 msgctxt "preferences"
 msgid "no color"
 msgstr "не змінювати"
 
-#: ../build/bin/preferences_gen.h:4860 ../build/bin/conf_gen.h:2672
+#: ../build/bin/preferences_gen.h:4860 ../build/bin/conf_gen.h:2711
 msgctxt "preferences"
 msgid "illuminant color"
 msgstr "колір джерела світла"
 
-#: ../build/bin/preferences_gen.h:4865 ../build/bin/conf_gen.h:2673
+#: ../build/bin/preferences_gen.h:4865 ../build/bin/conf_gen.h:2712
 msgctxt "preferences"
 msgid "effect emulation"
 msgstr "емуляція ефекту"
@@ -685,17 +685,17 @@ msgid "colorbalance slider block layout"
 msgstr "розкладка блоку повзунків балансу кольорів"
 
 #: ../build/bin/preferences_gen.h:4920 ../build/bin/preferences_gen.h:4949
-#: ../build/bin/conf_gen.h:2707
+#: ../build/bin/conf_gen.h:2746
 msgctxt "preferences"
 msgid "list"
 msgstr "список"
 
-#: ../build/bin/preferences_gen.h:4925 ../build/bin/conf_gen.h:2708
+#: ../build/bin/preferences_gen.h:4925 ../build/bin/conf_gen.h:2747
 msgctxt "preferences"
 msgid "tabs"
 msgstr "вкладки"
 
-#: ../build/bin/preferences_gen.h:4930 ../build/bin/conf_gen.h:2709
+#: ../build/bin/preferences_gen.h:4930 ../build/bin/conf_gen.h:2748
 msgctxt "preferences"
 msgid "columns"
 msgstr "колонки"
@@ -718,39 +718,39 @@ msgstr ""
 msgid "show right-side buttons in processing module headers"
 msgstr "показувати кнопки в заголовках модулів обробки"
 
-#: ../build/bin/preferences_gen.h:4990 ../build/bin/conf_gen.h:2718
+#: ../build/bin/preferences_gen.h:4990 ../build/bin/conf_gen.h:2757
 msgctxt "preferences"
 msgid "active"
 msgstr "при наведенні"
 
-#: ../build/bin/preferences_gen.h:4995 ../build/bin/conf_gen.h:2719
+#: ../build/bin/preferences_gen.h:4995 ../build/bin/conf_gen.h:2758
 msgctxt "preferences"
 msgid "dim"
 msgstr "підсвічувати тьмяні"
 
 #: ../build/bin/preferences_gen.h:5000 ../build/bin/preferences_gen.h:7459
-#: ../build/bin/preferences_gen.h:7495 ../build/bin/conf_gen.h:2145
-#: ../build/bin/conf_gen.h:2720
+#: ../build/bin/preferences_gen.h:7495 ../build/bin/conf_gen.h:2175
+#: ../build/bin/conf_gen.h:2759
 msgctxt "preferences"
 msgid "auto"
 msgstr "авто"
 
-#: ../build/bin/preferences_gen.h:5005 ../build/bin/conf_gen.h:2721
+#: ../build/bin/preferences_gen.h:5005 ../build/bin/conf_gen.h:2760
 msgctxt "preferences"
 msgid "fade"
 msgstr "поступово прибирати"
 
-#: ../build/bin/preferences_gen.h:5010 ../build/bin/conf_gen.h:2722
+#: ../build/bin/preferences_gen.h:5010 ../build/bin/conf_gen.h:2761
 msgctxt "preferences"
 msgid "fit"
 msgstr "пріоритет імені модуля"
 
-#: ../build/bin/preferences_gen.h:5015 ../build/bin/conf_gen.h:2723
+#: ../build/bin/preferences_gen.h:5015 ../build/bin/conf_gen.h:2762
 msgctxt "preferences"
 msgid "smooth"
 msgstr "гасити одночасно при недостатній ширині"
 
-#: ../build/bin/preferences_gen.h:5020 ../build/bin/conf_gen.h:2724
+#: ../build/bin/preferences_gen.h:5020 ../build/bin/conf_gen.h:2763
 msgctxt "preferences"
 msgid "glide"
 msgstr "витісняти при недостатній ширині"
@@ -841,20 +841,20 @@ msgid "pixel interpolator (warp)"
 msgstr "інтерполятор пікселів (деформації)"
 
 #: ../build/bin/preferences_gen.h:5285 ../build/bin/preferences_gen.h:5350
-#: ../build/bin/conf_gen.h:1889 ../build/bin/conf_gen.h:1899
+#: ../build/bin/conf_gen.h:1913 ../build/bin/conf_gen.h:1923
 msgctxt "preferences"
 msgid "bilinear"
 msgstr "білінійний"
 
 #: ../build/bin/preferences_gen.h:5290 ../build/bin/preferences_gen.h:5314
-#: ../build/bin/preferences_gen.h:5355 ../build/bin/conf_gen.h:1890
-#: ../build/bin/conf_gen.h:1900
+#: ../build/bin/preferences_gen.h:5355 ../build/bin/conf_gen.h:1914
+#: ../build/bin/conf_gen.h:1924
 msgctxt "preferences"
 msgid "bicubic"
 msgstr "бікубічний"
 
 #: ../build/bin/preferences_gen.h:5295 ../build/bin/preferences_gen.h:5360
-#: ../build/bin/conf_gen.h:1891 ../build/bin/conf_gen.h:1901
+#: ../build/bin/conf_gen.h:1915 ../build/bin/conf_gen.h:1925
 msgctxt "preferences"
 msgid "lanczos2"
 msgstr "lanczos2"
@@ -873,7 +873,7 @@ msgid "pixel interpolator (scaling)"
 msgstr "інтерполятор пікселів (масштабування)"
 
 #: ../build/bin/preferences_gen.h:5365 ../build/bin/preferences_gen.h:5384
-#: ../build/bin/conf_gen.h:1902
+#: ../build/bin/conf_gen.h:1926
 msgctxt "preferences"
 msgid "lanczos3"
 msgstr "lanczos3"
@@ -912,19 +912,19 @@ msgid "auto-apply pixel workflow defaults"
 msgstr "автозастосування замовчувань робочого процесу"
 
 #: ../build/bin/preferences_gen.h:5461 ../build/bin/preferences_gen.h:5490
-#: ../build/bin/conf_gen.h:2557
+#: ../build/bin/conf_gen.h:2596
 msgctxt "preferences"
 msgid "scene-referred"
 msgstr "на основі сцен"
 
-#: ../build/bin/preferences_gen.h:5466 ../build/bin/conf_gen.h:2558
+#: ../build/bin/preferences_gen.h:5466 ../build/bin/conf_gen.h:2597
 msgctxt "preferences"
 msgid "display-referred"
 msgstr "на основі відображення"
 
 #: ../build/bin/preferences_gen.h:5471 ../build/bin/preferences_gen.h:7464
-#: ../build/bin/conf_gen.h:1598 ../build/bin/conf_gen.h:2146
-#: ../build/bin/conf_gen.h:2559
+#: ../build/bin/conf_gen.h:1622 ../build/bin/conf_gen.h:2176
+#: ../build/bin/conf_gen.h:2598
 msgctxt "preferences"
 msgid "none"
 msgstr "немає"
@@ -945,13 +945,13 @@ msgstr ""
 msgid "auto-apply chromatic adaptation defaults"
 msgstr "метод автозастосування замовчувань хроматичної адаптації"
 
-#: ../build/bin/preferences_gen.h:5526 ../build/bin/conf_gen.h:2567
+#: ../build/bin/preferences_gen.h:5526 ../build/bin/conf_gen.h:2606
 msgctxt "preferences"
 msgid "modern"
 msgstr "сучасний"
 
 #: ../build/bin/preferences_gen.h:5531 ../build/bin/preferences_gen.h:5550
-#: ../build/bin/conf_gen.h:2568
+#: ../build/bin/conf_gen.h:2607
 msgctxt "preferences"
 msgid "legacy"
 msgstr "застарілий"
@@ -1513,17 +1513,17 @@ msgid "method to use for getting the display profile"
 msgstr "метод для отримання профілю монітора"
 
 #: ../build/bin/preferences_gen.h:7094 ../build/bin/preferences_gen.h:7123
-#: ../build/bin/conf_gen.h:2521
+#: ../build/bin/conf_gen.h:2560
 msgctxt "preferences"
 msgid "all"
 msgstr "всі"
 
-#: ../build/bin/preferences_gen.h:7099 ../build/bin/conf_gen.h:2522
+#: ../build/bin/preferences_gen.h:7099 ../build/bin/conf_gen.h:2561
 msgctxt "preferences"
 msgid "xatom"
 msgstr "xatom"
 
-#: ../build/bin/preferences_gen.h:7104 ../build/bin/conf_gen.h:2523
+#: ../build/bin/preferences_gen.h:7104 ../build/bin/conf_gen.h:2562
 msgctxt "preferences"
 msgid "colord"
 msgstr "colord"
@@ -1539,7 +1539,7 @@ msgstr ""
 #. tags
 #: ../build/bin/preferences_gen.h:7136 ../src/develop/lightroom.c:1510
 #: ../src/gui/import_metadata.c:470 ../src/libs/export_metadata.c:310
-#: ../src/libs/image.c:552 ../src/libs/metadata_view.c:167
+#: ../src/libs/image.c:552 ../src/libs/metadata_view.c:161
 msgid "tags"
 msgstr "теги"
 
@@ -1655,12 +1655,12 @@ msgstr "не показувати першоквітневу гру"
 msgid "password storage backend to use"
 msgstr "бекенд для зберігання паролів"
 
-#: ../build/bin/preferences_gen.h:7469 ../build/bin/conf_gen.h:2147
+#: ../build/bin/preferences_gen.h:7469 ../build/bin/conf_gen.h:2177
 msgctxt "preferences"
 msgid "libsecret"
 msgstr "libsecret"
 
-#: ../build/bin/preferences_gen.h:7475 ../build/bin/conf_gen.h:2148
+#: ../build/bin/preferences_gen.h:7475 ../build/bin/conf_gen.h:2178
 msgctxt "preferences"
 msgid "kwallet"
 msgstr "kwallet"
@@ -1682,8 +1682,8 @@ msgstr ""
 "ця зовнішня програма використовується для відтворення аудіофайлів, які деякі "
 "камери можуть записувати, щоб зберігати нотатки до зображень"
 
-#: ../build/bin/preferences_gen.h:7566 ../src/control/jobs/control_jobs.c:2311
-#: ../src/libs/import.c:153
+#: ../build/bin/preferences_gen.h:7566 ../src/control/jobs/control_jobs.c:2312
+#: ../src/libs/import.c:177
 msgid "import"
 msgstr "імпорт"
 
@@ -1813,19 +1813,19 @@ msgctxt "preferences"
 msgid "false"
 msgstr "false"
 
-#: ../build/bin/conf_gen.h:731
+#: ../build/bin/conf_gen.h:755
 msgid "select only new pictures"
 msgstr "вибирати лише нові"
 
-#: ../build/bin/conf_gen.h:732
+#: ../build/bin/conf_gen.h:756
 msgid "only select images that have not already been imported"
 msgstr "вибирати лише ті зображення, які ще не були імпортовані"
 
-#: ../build/bin/conf_gen.h:737
+#: ../build/bin/conf_gen.h:761
 msgid "ignore JPEG images"
 msgstr "ігнорувати JPEG файли"
 
-#: ../build/bin/conf_gen.h:738
+#: ../build/bin/conf_gen.h:762
 msgid ""
 "when having raw+JPEG images together in one directory it makes no sense to "
 "import both. with this flag one can ignore all JPEGs found."
@@ -1833,55 +1833,55 @@ msgstr ""
 "коли в одному каталозі є пари зображень raw+JPEG, немає сенсу імпортувати "
 "обидва. за допомогою цього прапорця можна ігнорувати всі знайдені файли JPEG."
 
-#: ../build/bin/conf_gen.h:743
+#: ../build/bin/conf_gen.h:767
 msgid "apply metadata"
 msgstr "застосовувати метадані"
 
-#: ../build/bin/conf_gen.h:744
+#: ../build/bin/conf_gen.h:768
 msgid "apply some metadata to all newly imported images."
 msgstr "застосувати деякі метадані до всіх імпортованих зображень."
 
-#: ../build/bin/conf_gen.h:749
+#: ../build/bin/conf_gen.h:773
 msgid "recursive directory"
 msgstr "імпортувати з підкаталогами"
 
-#: ../build/bin/conf_gen.h:750
+#: ../build/bin/conf_gen.h:774
 msgid "recursive directory traversal when importing filmrolls"
 msgstr "рекурсивний обхід каталогу під час імпорту фотоплівок"
 
-#: ../build/bin/conf_gen.h:755
+#: ../build/bin/conf_gen.h:779
 msgid "creator to be applied when importing"
 msgstr "автор (застосовується під час імпорту)"
 
-#: ../build/bin/conf_gen.h:761
+#: ../build/bin/conf_gen.h:785
 msgid "publisher to be applied when importing"
 msgstr "видавець (застосовується під час імпорту)"
 
-#: ../build/bin/conf_gen.h:767
+#: ../build/bin/conf_gen.h:791
 msgid "rights to be applied when importing"
 msgstr "права (застосовується під час імпорту)"
 
-#: ../build/bin/conf_gen.h:773
+#: ../build/bin/conf_gen.h:797
 msgid "comma separated tags to be applied when importing"
 msgstr "теги, розділені комами (застосовуються під час імпорту)"
 
-#: ../build/bin/conf_gen.h:779
+#: ../build/bin/conf_gen.h:803
 msgid "import tags from xmp"
 msgstr "імпортувати теги з xmp"
 
-#: ../build/bin/conf_gen.h:805
+#: ../build/bin/conf_gen.h:829
 msgid "initial rating"
 msgstr "початковий рейтинг"
 
-#: ../build/bin/conf_gen.h:806
+#: ../build/bin/conf_gen.h:830
 msgid "initial star rating for all images when importing a filmroll"
 msgstr "початковий рейтинг зірок для всіх зображень під час імпорту фотоплівки"
 
-#: ../build/bin/conf_gen.h:811
+#: ../build/bin/conf_gen.h:835
 msgid "ignore exif rating"
 msgstr "ігнорувати рейтинг з exif"
 
-#: ../build/bin/conf_gen.h:812
+#: ../build/bin/conf_gen.h:836
 msgid ""
 "ignore exif rating. if not set and exif rating is found, it overrides "
 "'initial rating'"
@@ -1889,19 +1889,19 @@ msgstr ""
 "ігнорувати рейтинг з exif. якщо це не встановлено і рейтинг в exif знайдено, "
 "він замінює \"початковий рейтинг\""
 
-#: ../build/bin/conf_gen.h:817
+#: ../build/bin/conf_gen.h:841
 msgid "import job"
 msgstr "завдання імпорту"
 
-#: ../build/bin/conf_gen.h:818
+#: ../build/bin/conf_gen.h:842
 msgid "name of the import job"
 msgstr "ім'я завдання імпорту"
 
-#: ../build/bin/conf_gen.h:823
+#: ../build/bin/conf_gen.h:847
 msgid "override today's date"
 msgstr "замінити сьогоднішню дату"
 
-#: ../build/bin/conf_gen.h:824
+#: ../build/bin/conf_gen.h:848
 msgid ""
 "enter a valid date/time (YYYY-MM-DD[Thh:mm:ss] format) if you want to "
 "override the current date/time used when expanding variables:\n"
@@ -1913,43 +1913,43 @@ msgstr ""
 "$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS).\n"
 "якщо не хочете, залиште поле порожнім"
 
-#: ../build/bin/conf_gen.h:829
+#: ../build/bin/conf_gen.h:853
 msgid "keep this window open"
 msgstr "тримати це вікно відкритим"
 
-#: ../build/bin/conf_gen.h:830
+#: ../build/bin/conf_gen.h:854
 msgid "keep this window open to run several imports"
 msgstr "тримайте це вікно відкритим для запуску декількох імпортів"
 
-#: ../build/bin/conf_gen.h:1559
+#: ../build/bin/conf_gen.h:1583
 msgid "show OSD"
 msgstr "OSD"
 
-#: ../build/bin/conf_gen.h:1560
+#: ../build/bin/conf_gen.h:1584
 msgid "toggle the visibility of the map overlays"
 msgstr "перемикає видимість елементів керування і інформації на мапі"
 
-#: ../build/bin/conf_gen.h:1565
+#: ../build/bin/conf_gen.h:1589
 msgid "filtered images"
 msgstr "фільтрувати"
 
-#: ../build/bin/conf_gen.h:1566
+#: ../build/bin/conf_gen.h:1590
 msgid "when set limit the images drawn to the current filmstrip"
 msgstr "показувати лише зображення з поточної плівки"
 
-#: ../build/bin/conf_gen.h:1573
+#: ../build/bin/conf_gen.h:1597
 msgid "max images"
 msgstr "максимально"
 
-#: ../build/bin/conf_gen.h:1574
+#: ../build/bin/conf_gen.h:1598
 msgid "the maximum number of image thumbnails drawn on the map"
 msgstr "максимальна кількість мініатюр, розміщених на карті"
 
-#: ../build/bin/conf_gen.h:1581
+#: ../build/bin/conf_gen.h:1605
 msgid "group size factor"
 msgstr "розмір групи"
 
-#: ../build/bin/conf_gen.h:1582
+#: ../build/bin/conf_gen.h:1606
 msgid ""
 "increase or decrease the spatial size of images groups on the map. can "
 "influence the calculation time"
@@ -1957,11 +1957,11 @@ msgstr ""
 "збільшити або зменшити просторовий розмір груп зображень на мапі. може "
 "вплинути на час обчислення"
 
-#: ../build/bin/conf_gen.h:1589
+#: ../build/bin/conf_gen.h:1613
 msgid "min images per group"
 msgstr "мінімально в групі"
 
-#: ../build/bin/conf_gen.h:1590
+#: ../build/bin/conf_gen.h:1614
 msgid ""
 "the minimum number of images to set up an images group. can influence the "
 "calculation time."
@@ -1969,88 +1969,88 @@ msgstr ""
 "мінімальна кількість зображень для створення групи зображень. може вплинути "
 "на час обчислення."
 
-#: ../build/bin/conf_gen.h:1596
+#: ../build/bin/conf_gen.h:1620
 msgctxt "preferences"
 msgid "thumbnail"
 msgstr "мініатюри"
 
-#: ../build/bin/conf_gen.h:1597
+#: ../build/bin/conf_gen.h:1621
 msgctxt "preferences"
 msgid "count"
 msgstr "кількість зображень"
 
-#: ../build/bin/conf_gen.h:1599
+#: ../build/bin/conf_gen.h:1623
 msgid "thumbnail display"
 msgstr "показ мініатюр"
 
-#: ../build/bin/conf_gen.h:1600
+#: ../build/bin/conf_gen.h:1624
 msgid ""
 "three options are available: images thumbnails, only the count of images of "
 "the group or nothing"
 msgstr ""
 "доступні три варіанти: мініатюри, лише кількість зображень групи або нічого"
 
-#: ../build/bin/conf_gen.h:1611
+#: ../build/bin/conf_gen.h:1635
 msgid "max polygon points"
 msgstr "макс. точок полігонів"
 
-#: ../build/bin/conf_gen.h:1612
+#: ../build/bin/conf_gen.h:1636
 msgid ""
 "limit the number of points imported with polygon in find location module"
 msgstr ""
 "обмежити кількість точок, імпортованих з багатокутником у модулі пошуку на "
 "мапі"
 
-#: ../build/bin/conf_gen.h:2350
+#: ../build/bin/conf_gen.h:2380
 msgctxt "preferences"
 msgid "histogram"
 msgstr "histogram"
 
-#: ../build/bin/conf_gen.h:2351
+#: ../build/bin/conf_gen.h:2381
 msgctxt "preferences"
 msgid "waveform"
 msgstr "waveform"
 
-#: ../build/bin/conf_gen.h:2352
+#: ../build/bin/conf_gen.h:2382
 msgctxt "preferences"
 msgid "vectorscope"
 msgstr "вектороскоп"
 
-#: ../build/bin/conf_gen.h:2360
+#: ../build/bin/conf_gen.h:2390 ../build/bin/conf_gen.h:2417
 msgctxt "preferences"
 msgid "logarithmic"
 msgstr "logarithmic"
 
-#: ../build/bin/conf_gen.h:2361
+#: ../build/bin/conf_gen.h:2391 ../build/bin/conf_gen.h:2418
 msgctxt "preferences"
 msgid "linear"
 msgstr "linear"
 
-#: ../build/bin/conf_gen.h:2369
+#: ../build/bin/conf_gen.h:2399
 msgctxt "preferences"
 msgid "overlaid"
 msgstr "overlaid"
 
-#: ../build/bin/conf_gen.h:2370
+#: ../build/bin/conf_gen.h:2400
 msgctxt "preferences"
 msgid "parade"
 msgstr "parade"
 
-#: ../build/bin/conf_gen.h:2378
+#: ../build/bin/conf_gen.h:2408
 msgctxt "preferences"
 msgid "u*v*"
 msgstr "u*v*"
 
-#: ../build/bin/conf_gen.h:2379
+#: ../build/bin/conf_gen.h:2409
 msgctxt "preferences"
 msgid "AzBz"
 msgstr "AzBz"
 
-#: ../build/bin/conf_gen.h:2658
+#: ../build/bin/conf_gen.h:2697
 msgid "camera time zone"
 msgstr "часовий пояс камери"
 
-#: ../build/bin/conf_gen.h:2659
+#: ../build/bin/conf_gen.h:2698
 msgid ""
 "most cameras don't store the time zone in EXIF. give the correct time zone "
 "so the GPX data can be correctly matched"
@@ -2078,7 +2078,7 @@ msgstr "корекція по діагоналі"
 #: ../build/lib/darktable/plugins/introspection_ashift.c:257
 #: ../src/common/collection.c:691 ../src/gui/preferences.c:859
 #: ../src/gui/presets.c:600 ../src/libs/camera.c:581
-#: ../src/libs/metadata_view.c:148
+#: ../src/libs/metadata_view.c:142
 msgid "focal length"
 msgstr "фокусна відстань"
 
@@ -2128,7 +2128,7 @@ msgstr "уточнена"
 #: ../src/develop/blend_gui.c:124 ../src/develop/blend_gui.c:2981
 #: ../src/develop/develop.c:2223 ../src/imageio/format/avif.c:812
 #: ../src/imageio/format/exr.cc:376 ../src/imageio/format/j2k.c:666
-#: ../src/iop/ashift.c:4704 ../src/libs/live_view.c:427
+#: ../src/iop/ashift.c:4704 ../src/libs/live_view.c:504
 msgid "off"
 msgstr "вимкнено"
 
@@ -2152,7 +2152,7 @@ msgstr "відстань між експозиціями"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:146
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:239
-#: ../src/libs/metadata_view.c:147
+#: ../src/libs/metadata_view.c:141
 msgid "exposure bias"
 msgstr "зміщення експозиції"
 
@@ -2175,14 +2175,14 @@ msgstr "метод збереження кольорів"
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:251
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:153
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:270
-#: ../src/iop/basecurve.c:2098 ../src/iop/channelmixerrgb.c:3635
-#: ../src/iop/clipping.c:1887 ../src/iop/clipping.c:2145
-#: ../src/iop/clipping.c:2161 ../src/iop/clipping.c:2296
-#: ../src/iop/clipping.c:2323 ../src/iop/crop.c:1237 ../src/iop/crop.c:1264
-#: ../src/iop/lens.cc:2232 ../src/iop/retouch.c:422 ../src/libs/collect.c:1809
+#: ../src/iop/basecurve.c:2098 ../src/iop/channelmixerrgb.c:3823
+#: ../src/iop/clipping.c:1893 ../src/iop/clipping.c:2151
+#: ../src/iop/clipping.c:2167 ../src/iop/clipping.c:2302
+#: ../src/iop/clipping.c:2329 ../src/iop/crop.c:1253 ../src/iop/crop.c:1280
+#: ../src/iop/lens.cc:2232 ../src/iop/retouch.c:422 ../src/libs/collect.c:1813
 #: ../src/libs/colorpicker.c:633 ../src/libs/export.c:1083
-#: ../src/libs/live_view.c:343 ../src/libs/live_view.c:368
-#: ../src/libs/live_view.c:377 ../src/libs/print_settings.c:1463
+#: ../src/libs/live_view.c:420 ../src/libs/live_view.c:445
+#: ../src/libs/live_view.c:454 ../src/libs/print_settings.c:1463
 msgid "none"
 msgstr "немає"
 
@@ -2382,9 +2382,9 @@ msgstr "дуже велика хроматична аберація"
 #: ../src/common/collection.c:1498 ../src/develop/blend_gui.c:2000
 #: ../src/develop/blend_gui.c:2027 ../src/develop/lightroom.c:828
 #: ../src/iop/bilateral.cc:317 ../src/iop/channelmixer.c:625
-#: ../src/iop/channelmixer.c:635 ../src/iop/channelmixerrgb.c:3594
+#: ../src/iop/channelmixer.c:635 ../src/iop/channelmixerrgb.c:3782
 #: ../src/iop/temperature.c:1879 ../src/iop/temperature.c:2030
-#: ../src/libs/collect.c:1710 ../src/views/darkroom.c:2543
+#: ../src/libs/collect.c:1714 ../src/views/darkroom.c:2543
 msgid "red"
 msgstr "червоний"
 
@@ -2392,9 +2392,9 @@ msgstr "червоний"
 #: ../src/common/collection.c:1502 ../src/develop/blend_gui.c:2003
 #: ../src/develop/blend_gui.c:2030 ../src/develop/lightroom.c:832
 #: ../src/iop/bilateral.cc:322 ../src/iop/channelmixer.c:626
-#: ../src/iop/channelmixer.c:641 ../src/iop/channelmixerrgb.c:3595
+#: ../src/iop/channelmixer.c:641 ../src/iop/channelmixerrgb.c:3783
 #: ../src/iop/temperature.c:1863 ../src/iop/temperature.c:1881
-#: ../src/iop/temperature.c:2031 ../src/libs/collect.c:1710
+#: ../src/iop/temperature.c:2031 ../src/libs/collect.c:1714
 #: ../src/views/darkroom.c:2544
 msgid "green"
 msgstr "зелений"
@@ -2403,9 +2403,9 @@ msgstr "зелений"
 #: ../src/common/collection.c:1504 ../src/develop/blend_gui.c:2006
 #: ../src/develop/blend_gui.c:2033 ../src/develop/lightroom.c:834
 #: ../src/iop/bilateral.cc:327 ../src/iop/channelmixer.c:627
-#: ../src/iop/channelmixer.c:647 ../src/iop/channelmixerrgb.c:3596
+#: ../src/iop/channelmixer.c:647 ../src/iop/channelmixerrgb.c:3784
 #: ../src/iop/temperature.c:1883 ../src/iop/temperature.c:2032
-#: ../src/libs/collect.c:1710
+#: ../src/libs/collect.c:1714
 msgid "blue"
 msgstr "синій"
 
@@ -2523,7 +2523,7 @@ msgid "(AI) detect from image edges..."
 msgstr "(AI) виявлення з контурів зображення..."
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:517
-#: ../src/iop/channelmixerrgb.c:3289
+#: ../src/iop/channelmixerrgb.c:3477
 msgid "as shot in camera"
 msgstr "як знято в камері"
 
@@ -2707,7 +2707,7 @@ msgstr "підйом, гамма, підсилення (sRGB)"
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:476
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:488
 #: ../src/develop/blend_gui.c:2014 ../src/develop/blend_gui.c:2041
-#: ../src/iop/atrous.c:1590 ../src/iop/channelmixerrgb.c:3552
+#: ../src/iop/atrous.c:1590 ../src/iop/channelmixerrgb.c:3740
 #: ../src/iop/equalizer.c:391 ../src/iop/nlmeans.c:536
 msgid "chroma"
 msgstr "кольоровість"
@@ -2730,7 +2730,7 @@ msgstr "кольоровість"
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:142
 #: ../src/develop/blend_gui.c:1991 ../src/develop/blend_gui.c:2010
 #: ../src/develop/blend_gui.c:2045 ../src/iop/channelmixer.c:622
-#: ../src/iop/channelmixerrgb.c:3546 ../src/iop/colorbalance.c:2024
+#: ../src/iop/channelmixerrgb.c:3734 ../src/iop/colorbalance.c:2024
 #: ../src/iop/colorize.c:349 ../src/iop/colorreconstruction.c:1290
 #: ../src/iop/colorzones.c:2374 ../src/iop/splittoning.c:476
 msgid "hue"
@@ -2803,7 +2803,7 @@ msgstr "глобальна насиченість"
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:357
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:540
 msgid "hue shift"
-msgstr "зсув відтінку"
+msgstr "зміщення відтінку"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:363
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:544
@@ -2812,7 +2812,7 @@ msgstr "глобально"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:387
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:560
-msgid "mask middle-grey fulcrum"
+msgid "mask middle-gray fulcrum"
 msgstr "опорна точка середнього сірого маски"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:393
@@ -2822,7 +2822,7 @@ msgstr "глобальний резонанс"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:399
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:568
-msgid "contrast grey fulcrum"
+msgid "contrast gray fulcrum"
 msgstr "опорна точка контрасту сірого"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:405
@@ -2905,7 +2905,7 @@ msgid "range extent"
 msgstr "вимір яскравості"
 
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:154
-#: ../src/iop/channelmixerrgb.c:3637
+#: ../src/iop/channelmixerrgb.c:3825
 msgid "saturated colors"
 msgstr "насичені кольори"
 
@@ -2972,7 +2972,7 @@ msgstr "радіус виявлення контурів"
 #: ../build/lib/darktable/plugins/introspection_defringe.c:106
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:219
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:418
-#: ../src/iop/bloom.c:403 ../src/iop/colorbalancergb.c:1710
+#: ../src/iop/bloom.c:403 ../src/iop/colorbalancergb.c:1743
 #: ../src/iop/colorreconstruction.c:1284 ../src/iop/hotpixels.c:376
 #: ../src/iop/sharpen.c:729
 msgid "threshold"
@@ -3356,11 +3356,11 @@ msgstr "версія генератора сплайнів"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:528
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:371
-#: ../src/common/darktable.c:935 ../src/common/database.c:2543
+#: ../src/common/darktable.c:966 ../src/common/database.c:2543
 #: ../src/common/variables.c:465 ../src/develop/imageop_gui.c:302
 #: ../src/imageio/format/pdf.c:655 ../src/imageio/format/pdf.c:680
 #: ../src/libs/export.c:1277 ../src/libs/export.c:1283
-#: ../src/libs/export.c:1290 ../src/libs/metadata_view.c:409
+#: ../src/libs/export.c:1290 ../src/libs/metadata_view.c:686
 msgid "no"
 msgstr "ні"
 
@@ -3547,7 +3547,7 @@ msgstr "крива"
 #: ../build/lib/darktable/plugins/introspection_lowlight.c:43
 #: ../build/lib/darktable/plugins/introspection_lowlight.c:110
 msgid "blue shift"
-msgstr "синій зсув"
+msgstr "синє зміщення"
 
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:96
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:165
@@ -3725,7 +3725,7 @@ msgstr "точка білого"
 #: ../build/lib/darktable/plugins/introspection_relight.c:98
 #: ../src/common/collection.c:694 ../src/gui/preferences.c:851
 #: ../src/gui/presets.c:570 ../src/iop/basicadj.c:597 ../src/iop/exposure.c:107
-#: ../src/iop/exposure.c:832 ../src/libs/metadata_view.c:146
+#: ../src/iop/exposure.c:832 ../src/libs/metadata_view.c:140
 msgid "exposure"
 msgstr "експозиція"
 
@@ -3746,14 +3746,14 @@ msgstr "режим заповнення"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:279
 #: ../build/lib/darktable/plugins/introspection_retouch.c:414
-#: ../src/iop/basicadj.c:621 ../src/iop/channelmixerrgb.c:3599
+#: ../src/iop/basicadj.c:621 ../src/iop/channelmixerrgb.c:3787
 #: ../src/iop/colisa.c:316 ../src/iop/lowpass.c:588 ../src/iop/soften.c:414
 #: ../src/iop/vignette.c:990 ../src/libs/history.c:898
 msgid "brightness"
 msgstr "яскравість"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:428
-#: ../src/libs/metadata_view.c:442
+#: ../src/libs/metadata_view.c:356
 msgid "unused"
 msgstr "не використовується"
 
@@ -3785,7 +3785,7 @@ msgstr "стирати"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:442
 #: ../src/gui/presets.c:58 ../src/iop/watermark.c:1153 ../src/libs/image.c:606
-#: ../src/libs/modulegroups.c:2390
+#: ../src/libs/modulegroups.c:2413
 msgid "color"
 msgstr "колір"
 
@@ -4116,7 +4116,7 @@ msgstr "Друк зображень"
 #: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/latex.c:107
 #: ../src/iop/lut3d.c:1556 ../src/libs/collect.c:426
 #: ../src/libs/copy_history.c:108 ../src/libs/geotagging.c:938
-#: ../src/libs/import.c:1237 ../src/libs/lib.c:235 ../src/libs/styles.c:385
+#: ../src/libs/import.c:1468 ../src/libs/lib.c:235 ../src/libs/styles.c:385
 #: ../src/libs/styles.c:529 ../src/libs/tagging.c:2299
 #: ../src/libs/tagging.c:2340
 msgid "_cancel"
@@ -4266,14 +4266,28 @@ msgstr "невідоме розширення '.%s'"
 msgid "failed to get parameters from format module, aborting export ..."
 msgstr "не вдалося отримати параметри з модуля формату, скасування експорту..."
 
-#: ../src/common/camera_control.c:763
+#: ../src/common/camera_control.c:892
 #, c-format
 msgid ""
-"new camera '%s' found but it is locked by another application\n"
-"make sure it is not mounted on the computer"
+"failed to initialize `%s' on port `%s', likely causes are: locked by another "
+"application, no access to devices etc"
 msgstr ""
-"знайдено нову камеру '%s', але вона заблокована іншою програмою\n"
-"переконайтеся, що вона не змонтована в операційній системі"
+"не вдалося ініціалізувати `%s' на порту `%s', ймовірні причини: заблокований "
+"іншою програмою, відсутність доступу до пристроїв тощо"
+
+#: ../src/common/camera_control.c:903
+#, c-format
+msgid ""
+"`%s' on port `%s' is not interesting because it supports neither tethering "
+"nor import"
+msgstr ""
+"пристрій `%s' на порту `%s' нецікавий, оскільки не підтримує ні дистанційне "
+"керування, ні імпорт"
+
+#: ../src/common/camera_control.c:953
+#, c-format
+msgid "camera `%s' on port %s disconnected while mounted"
+msgstr "камера `%s' на порту %s відключилась під час монтування"
 
 #: ../src/common/collection.c:640
 msgid "too much time to update aspect ratio for the collection"
@@ -4303,19 +4317,19 @@ msgstr "дата зйомки"
 msgid "date-time taken"
 msgstr "час зйомки"
 
-#: ../src/common/collection.c:684 ../src/libs/metadata_view.c:133
+#: ../src/common/collection.c:684 ../src/libs/metadata_view.c:129
 msgid "import timestamp"
 msgstr "час імпорту"
 
-#: ../src/common/collection.c:685 ../src/libs/metadata_view.c:134
+#: ../src/common/collection.c:685 ../src/libs/metadata_view.c:130
 msgid "change timestamp"
 msgstr "час зміни"
 
-#: ../src/common/collection.c:686 ../src/libs/metadata_view.c:135
+#: ../src/common/collection.c:686 ../src/libs/metadata_view.c:131
 msgid "export timestamp"
 msgstr "час експорту"
 
-#: ../src/common/collection.c:687 ../src/libs/metadata_view.c:136
+#: ../src/common/collection.c:687 ../src/libs/metadata_view.c:132
 msgid "print timestamp"
 msgstr "час друку"
 
@@ -4329,25 +4343,25 @@ msgid "color label"
 msgstr "кольорова позначка"
 
 #: ../src/common/collection.c:690 ../src/gui/preferences.c:843
-#: ../src/gui/presets.c:551 ../src/libs/metadata_view.c:144
+#: ../src/gui/presets.c:551 ../src/libs/metadata_view.c:138
 msgid "lens"
 msgstr "об'єктив"
 
 #. iso
 #: ../src/common/collection.c:692 ../src/gui/preferences.c:847
 #: ../src/gui/presets.c:557 ../src/libs/camera.c:589
-#: ../src/libs/metadata_view.c:150
+#: ../src/libs/metadata_view.c:144
 msgid "ISO"
 msgstr "ISO"
 
 #. aperture
 #: ../src/common/collection.c:693 ../src/gui/preferences.c:855
 #: ../src/gui/presets.c:585 ../src/libs/camera.c:576 ../src/libs/camera.c:578
-#: ../src/libs/metadata_view.c:145
+#: ../src/libs/metadata_view.c:139
 msgid "aperture"
 msgstr "діафрагма"
 
-#: ../src/common/collection.c:696 ../src/libs/metadata_view.c:129
+#: ../src/common/collection.c:696 ../src/libs/metadata_view.c:125
 #: ../src/libs/tools/filter.c:87
 msgid "filename"
 msgstr "файл"
@@ -4361,8 +4375,8 @@ msgstr "геотегування"
 msgid "grouping"
 msgstr "групування"
 
-#: ../src/common/collection.c:699 ../src/libs/metadata_view.c:132
-#: ../src/libs/metadata_view.c:450
+#: ../src/common/collection.c:699 ../src/libs/metadata_view.c:128
+#: ../src/libs/metadata_view.c:364
 msgid "local copy"
 msgstr "локальна копія"
 
@@ -4375,36 +4389,36 @@ msgid "module order"
 msgstr "порядок застосування модулів"
 
 #: ../src/common/collection.c:1500 ../src/develop/lightroom.c:830
-#: ../src/iop/temperature.c:1869 ../src/libs/collect.c:1710
+#: ../src/iop/temperature.c:1869 ../src/libs/collect.c:1714
 #: ../src/views/darkroom.c:2545
 msgid "yellow"
 msgstr "жовтий"
 
-#: ../src/common/collection.c:1506 ../src/libs/collect.c:1710
+#: ../src/common/collection.c:1506 ../src/libs/collect.c:1714
 msgid "purple"
 msgstr "пурпурний"
 
 #: ../src/common/collection.c:1520 ../src/common/collection.c:1528
-#: ../src/libs/collect.c:1670
+#: ../src/libs/collect.c:1674
 msgid "basic"
 msgstr "без змін"
 
-#: ../src/common/collection.c:1522 ../src/libs/collect.c:1670
+#: ../src/common/collection.c:1522 ../src/libs/collect.c:1674
 msgid "auto applied"
 msgstr "тільки автозастосовані зміни"
 
-#: ../src/common/collection.c:1524 ../src/libs/collect.c:1670
+#: ../src/common/collection.c:1524 ../src/libs/collect.c:1674
 msgid "altered"
 msgstr "зі змінами"
 
 #: ../src/common/collection.c:1536 ../src/common/collection.c:1610
-#: ../src/libs/collect.c:1158 ../src/libs/collect.c:1282
-#: ../src/libs/collect.c:1304 ../src/libs/collect.c:1404
-#: ../src/libs/collect.c:2312
+#: ../src/libs/collect.c:1163 ../src/libs/collect.c:1292
+#: ../src/libs/collect.c:1314 ../src/libs/collect.c:1417
+#: ../src/libs/collect.c:2316
 msgid "not tagged"
 msgstr "без тегу"
 
-#: ../src/common/collection.c:1537 ../src/libs/collect.c:1304
+#: ../src/common/collection.c:1537 ../src/libs/collect.c:1314
 #: ../src/libs/map_locations.c:768
 msgid "tagged"
 msgstr "з тегом"
@@ -4413,25 +4427,25 @@ msgstr "з тегом"
 msgid "tagged*"
 msgstr "з тегом*"
 
-#: ../src/common/collection.c:1559 ../src/libs/collect.c:1682
+#: ../src/common/collection.c:1559 ../src/libs/collect.c:1686
 msgid "not copied locally"
 msgstr "немає локальної копії"
 
 #. grouping
-#: ../src/common/collection.c:1860 ../src/libs/collect.c:1784
+#: ../src/common/collection.c:1857 ../src/libs/collect.c:1788
 msgid "group leaders"
 msgstr "лідери груп"
 
-#: ../src/common/collection.c:1891 ../src/libs/collect.c:1845
+#: ../src/common/collection.c:1888 ../src/libs/collect.c:1849
 msgid "not defined"
 msgstr "не визначено"
 
-#: ../src/common/collection.c:2171
+#: ../src/common/collection.c:2168
 #, c-format
 msgid "%d image of %d (#%d) in current collection is selected"
 msgstr "в поточній колекції вибрано %d зображення з %d (#%d)"
 
-#: ../src/common/collection.c:2177
+#: ../src/common/collection.c:2174
 #, c-format
 msgid "%d image of %d in current collection is selected"
 msgid_plural "%d images of %d in current collection are selected"
@@ -4588,32 +4602,32 @@ msgstr "помилка під час друку `%s' на `%s'"
 msgid "printing `%s' on `%s'"
 msgstr "друк `%s' на `%s'"
 
-#: ../src/common/darktable.c:259
+#: ../src/common/darktable.c:290
 #, c-format
 msgid "found strange path `%s'"
 msgstr "знайдено дивний шлях `%s'"
 
-#: ../src/common/darktable.c:274
+#: ../src/common/darktable.c:305
 #, c-format
 msgid "error loading directory `%s'"
 msgstr "помилка завантаження каталогу `%s'"
 
-#: ../src/common/darktable.c:297
+#: ../src/common/darktable.c:328
 #, c-format
 msgid "file `%s' has unknown format!"
 msgstr "файл `%s' має невідомий формат!"
 
-#: ../src/common/darktable.c:310 ../src/control/jobs/control_jobs.c:2104
-#: ../src/control/jobs/control_jobs.c:2143
+#: ../src/common/darktable.c:341 ../src/control/jobs/control_jobs.c:2104
+#: ../src/control/jobs/control_jobs.c:2144
 #, c-format
 msgid "error loading file `%s'"
 msgstr "помилка завантаження файлу `%s'"
 
-#: ../src/common/darktable.c:930
+#: ../src/common/darktable.c:961
 msgid "darktable - run performance configuration?"
 msgstr "darktable - налаштувати параметри продуктивності?"
 
-#: ../src/common/darktable.c:931
+#: ../src/common/darktable.c:962
 msgid ""
 "we have an updated performance configuration logic - executing that might "
 "improve the performance of darktable.\n"
@@ -4627,12 +4641,12 @@ msgstr ""
 "вручну змінили їх на власні значення.\n"
 "ви хочете виконати це оновлення конфігурації продуктивності?\n"
 
-#: ../src/common/darktable.c:935 ../src/common/database.c:2543
+#: ../src/common/darktable.c:966 ../src/common/database.c:2543
 #: ../src/common/database.c:3601 ../src/common/variables.c:463
 #: ../src/develop/imageop_gui.c:303 ../src/imageio/format/pdf.c:656
 #: ../src/imageio/format/pdf.c:681 ../src/libs/export.c:1278
 #: ../src/libs/export.c:1284 ../src/libs/export.c:1291
-#: ../src/libs/metadata_view.c:409
+#: ../src/libs/metadata_view.c:686
 msgid "yes"
 msgstr "так"
 
@@ -4698,10 +4712,10 @@ msgstr ""
 msgid "error starting darktable"
 msgstr "помилка запуску darktable"
 
-#: ../src/common/database.c:2536 ../src/libs/collect.c:2798
-#: ../src/libs/export_metadata.c:269 ../src/libs/import.c:1422
-#: ../src/libs/metadata.c:446 ../src/libs/metadata_view.c:1020
-#: ../src/libs/modulegroups.c:3451 ../src/libs/styles.c:439
+#: ../src/common/database.c:2536 ../src/libs/collect.c:2801
+#: ../src/libs/export_metadata.c:269 ../src/libs/import.c:1648
+#: ../src/libs/metadata.c:446 ../src/libs/metadata_view.c:1227
+#: ../src/libs/modulegroups.c:3474 ../src/libs/styles.c:439
 #: ../src/libs/styles.c:614 ../src/libs/tagging.c:1359
 #: ../src/libs/tagging.c:1447 ../src/libs/tagging.c:1528
 #: ../src/libs/tagging.c:1653 ../src/libs/tagging.c:1927
@@ -4743,7 +4757,7 @@ msgstr ""
 msgid "ok"
 msgstr "ok"
 
-#: ../src/common/database.c:2562 ../src/iop/cacorrect.c:1586
+#: ../src/common/database.c:2562 ../src/iop/cacorrect.c:1336
 msgid "error"
 msgstr "помилка"
 
@@ -4789,11 +4803,15 @@ msgid ""
 "\n"
 "<span style='italic'>%s</span>\n"
 "\n"
+"this might take a long time in case of a large database\n"
+"\n"
 "do you want to proceed or quit now to do a backup\n"
 msgstr ""
 "схема бази даних повинна бути оновлена для\n"
 "\n"
 "<span style='italic'>%s</span>\n"
+"\n"
+"це може зайняти багато часу у випадку великої бази даних\n"
 "\n"
 "хочете продовжити чи вийти зараз, щоб зробити резервну копію?\n"
 
@@ -4946,7 +4964,7 @@ msgstr[2] "видалити порожній каталог?"
 
 #: ../src/common/film.c:316 ../src/gui/preferences.c:831
 #: ../src/gui/styles_dialog.c:445 ../src/libs/geotagging.c:839
-#: ../src/libs/import.c:1304
+#: ../src/libs/import.c:1535
 msgid "name"
 msgstr "ім'я"
 
@@ -4965,7 +4983,7 @@ msgstr ""
 #: ../src/common/history.c:873 ../src/common/styles.c:1102
 #: ../src/common/styles.c:1106 ../src/develop/blend_gui.c:125
 #: ../src/develop/develop.c:2223 ../src/imageio/format/avif.c:810
-#: ../src/iop/ashift.c:4705 ../src/libs/live_view.c:428
+#: ../src/iop/ashift.c:4705 ../src/libs/live_view.c:505
 msgid "on"
 msgstr "увімкнено"
 
@@ -5010,49 +5028,49 @@ msgstr "дату/час скасовано. зображень: %d"
 msgid "date/time re-applied to %d images"
 msgstr "дату/час повторно застосовано. зображень: %d"
 
-#: ../src/common/image.c:1916
+#: ../src/common/image.c:1926
 #, c-format
 msgid "cannot access local copy `%s'"
 msgstr "не вдається отримати доступ до локальної копії `%s'"
 
-#: ../src/common/image.c:1923
+#: ../src/common/image.c:1933
 #, c-format
 msgid "cannot write local copy `%s'"
 msgstr "не вдається записати локальну копію `%s'"
 
-#: ../src/common/image.c:1930
+#: ../src/common/image.c:1940
 #, c-format
 msgid "error moving local copy `%s' -> `%s'"
 msgstr "помилка переміщення локальної копії `%s' -> `%s'"
 
-#: ../src/common/image.c:1946
+#: ../src/common/image.c:1956
 #, c-format
 msgid "error moving `%s': file not found"
 msgstr "помилка переміщення `%s': файл не знайдено"
 
-#: ../src/common/image.c:1956
+#: ../src/common/image.c:1966
 #, c-format
 msgid "error moving `%s' -> `%s': file exists"
 msgstr "помилка переміщення `%s' -> `%s': файл існує"
 
-#: ../src/common/image.c:1960
+#: ../src/common/image.c:1970
 #, c-format
 msgid "error moving `%s' -> `%s'"
 msgstr "помилка переміщення `%s' -> `%s'"
 
-#: ../src/common/image.c:2257
+#: ../src/common/image.c:2267
 msgid "cannot create local copy when the original file is not accessible."
 msgstr "неможливо створити локальну копію, коли оригінал недоступний."
 
-#: ../src/common/image.c:2271
+#: ../src/common/image.c:2281
 msgid "cannot create local copy."
 msgstr "неможливо створити локальну копію."
 
-#: ../src/common/image.c:2343 ../src/control/jobs/control_jobs.c:745
+#: ../src/common/image.c:2353 ../src/control/jobs/control_jobs.c:745
 msgid "cannot remove local copy when the original file is not accessible."
 msgstr "неможливо видалити локальну копію, коли оригінал недоступний."
 
-#: ../src/common/image.c:2521
+#: ../src/common/image.c:2531
 #, c-format
 msgid "%d local copy has been synchronized"
 msgid_plural "%d local copies have been synchronized"
@@ -5152,27 +5170,27 @@ msgstr "загальний пуассонівський"
 msgid "noiseprofile file `%s' is not valid"
 msgstr "файл профілю шуму `%s' недійсний"
 
-#: ../src/common/opencl.c:801
+#: ../src/common/opencl.c:799
 msgid ""
 "due to a slow GPU hardware acceleration via opencl has been de-activated."
 msgstr ""
 "через повільний GPU апаратне прискорення за допомогою opencl було "
 "деактивовано."
 
-#: ../src/common/opencl.c:808
+#: ../src/common/opencl.c:806
 msgid ""
 "multiple GPUs detected - opencl scheduling profile has been set accordingly."
 msgstr ""
 "виявлено кілька GPU - профіль планування opencl було встановлено відповідно."
 
-#: ../src/common/opencl.c:815
+#: ../src/common/opencl.c:813
 msgid ""
 "very fast GPU detected - opencl scheduling profile has been set accordingly."
 msgstr ""
 "виявлено дуже швидкий GPU - профіль планування opencl було встановлено "
 "відповідно."
 
-#: ../src/common/opencl.c:822
+#: ../src/common/opencl.c:820
 msgid "opencl scheduling profile set to default."
 msgstr "профіль планування opencl встановлено за замовчуванням."
 
@@ -5316,7 +5334,7 @@ msgid "below sea level"
 msgstr "нижче рівня моря"
 
 #: ../src/common/utility.c:516 ../src/iop/watermark.c:576
-#: ../src/libs/metadata_view.c:730
+#: ../src/libs/metadata_view.c:903
 msgid "m"
 msgstr "м"
 
@@ -5348,7 +5366,7 @@ msgstr "знайдено оновлений xmp файл"
 msgid "_close"
 msgstr "_закрити"
 
-#: ../src/control/crawler.c:417 ../src/libs/import.c:1445
+#: ../src/control/crawler.c:417 ../src/libs/import.c:1671
 #: ../src/libs/select.c:133
 msgid "select all"
 msgstr "вибрати всі"
@@ -5397,7 +5415,7 @@ msgstr[0] "імпортується %d зображення з камери"
 msgstr[1] "імпортується %d зображення з камери"
 msgstr[2] "імпортується %d зображень з камери"
 
-#: ../src/control/jobs/camera_jobs.c:354
+#: ../src/control/jobs/camera_jobs.c:357
 msgid "import images from camera"
 msgstr "імпорт зображень з камери"
 
@@ -5818,7 +5836,7 @@ msgstr "зміщення часу"
 msgid "write sidecar files"
 msgstr "записати xmp файли"
 
-#: ../src/control/jobs/control_jobs.c:2225 ../src/control/jobs/film_jobs.c:223
+#: ../src/control/jobs/control_jobs.c:2226 ../src/control/jobs/film_jobs.c:223
 #, c-format
 msgid "importing %d image"
 msgid_plural "importing %d images"
@@ -5826,7 +5844,7 @@ msgstr[0] "імпортується %d зображення"
 msgstr[1] "імпортується %d зображення"
 msgstr[2] "імпортується %d зображень"
 
-#: ../src/control/jobs/control_jobs.c:2259
+#: ../src/control/jobs/control_jobs.c:2260
 #, c-format
 msgid "importing %d/%d image"
 msgid_plural "importing %d/%d images"
@@ -5834,7 +5852,7 @@ msgstr[0] "імпортується %d/%d зображення"
 msgstr[1] "імпортується %d/%d зображення"
 msgstr[2] "імпортується %d/%d зображень"
 
-#: ../src/control/jobs/control_jobs.c:2266
+#: ../src/control/jobs/control_jobs.c:2267
 #, c-format
 msgid "imported %d image"
 msgid_plural "imported %d images"
@@ -5876,7 +5894,7 @@ msgstr "не вдалося виділити буфер для змішуван�
 msgid "detail mask CL blending problem"
 msgstr "помилка змішування маски деталей (CL)"
 
-#: ../src/develop/blend_gui.c:46 ../src/libs/live_view.c:401
+#: ../src/develop/blend_gui.c:46 ../src/libs/live_view.c:478
 msgctxt "blendmode"
 msgid "normal"
 msgstr "нормальний"
@@ -5886,17 +5904,17 @@ msgctxt "blendmode"
 msgid "normal bounded"
 msgstr "нормальний обмежений"
 
-#: ../src/develop/blend_gui.c:48 ../src/libs/live_view.c:409
+#: ../src/develop/blend_gui.c:48 ../src/libs/live_view.c:486
 msgctxt "blendmode"
 msgid "lighten"
 msgstr "заміна світлим"
 
-#: ../src/develop/blend_gui.c:49 ../src/libs/live_view.c:408
+#: ../src/develop/blend_gui.c:49 ../src/libs/live_view.c:485
 msgctxt "blendmode"
 msgid "darken"
 msgstr "затемнення"
 
-#: ../src/develop/blend_gui.c:50 ../src/libs/live_view.c:405
+#: ../src/develop/blend_gui.c:50 ../src/libs/live_view.c:482
 msgctxt "blendmode"
 msgid "multiply"
 msgstr "множення"
@@ -5916,17 +5934,17 @@ msgctxt "blendmode"
 msgid "subtract"
 msgstr "віднімання"
 
-#: ../src/develop/blend_gui.c:54 ../src/libs/live_view.c:414
+#: ../src/develop/blend_gui.c:54 ../src/libs/live_view.c:491
 msgctxt "blendmode"
 msgid "difference"
 msgstr "різниця"
 
-#: ../src/develop/blend_gui.c:55 ../src/libs/live_view.c:406
+#: ../src/develop/blend_gui.c:55 ../src/libs/live_view.c:483
 msgctxt "blendmode"
 msgid "screen"
 msgstr "екран"
 
-#: ../src/develop/blend_gui.c:56 ../src/libs/live_view.c:407
+#: ../src/develop/blend_gui.c:56 ../src/libs/live_view.c:484
 msgctxt "blendmode"
 msgid "overlay"
 msgstr "перекриття"
@@ -6073,7 +6091,7 @@ msgid "reverse"
 msgstr "зворотна"
 
 #: ../src/develop/blend_gui.c:93 ../src/imageio/format/webp.c:357
-#: ../src/libs/metadata.c:445 ../src/libs/metadata_view.c:1019
+#: ../src/libs/metadata.c:445 ../src/libs/metadata_view.c:1226
 msgid "default"
 msgstr "замовчування"
 
@@ -6095,17 +6113,17 @@ msgid "uniformly"
 msgstr "рівномірно"
 
 #: ../src/develop/blend_gui.c:103 ../src/develop/blend_gui.c:2329
-#: ../src/develop/blend_gui.c:2994 ../src/develop/imageop.c:2349
+#: ../src/develop/blend_gui.c:2994 ../src/develop/imageop.c:2355
 msgid "drawn mask"
 msgstr "намальована маска"
 
 #: ../src/develop/blend_gui.c:104 ../src/develop/blend_gui.c:2141
-#: ../src/develop/blend_gui.c:3001 ../src/develop/imageop.c:2351
+#: ../src/develop/blend_gui.c:3001 ../src/develop/imageop.c:2357
 msgid "parametric mask"
 msgstr "параметрична маска"
 
 #: ../src/develop/blend_gui.c:105 ../src/develop/blend_gui.c:2510
-#: ../src/develop/blend_gui.c:3019 ../src/develop/imageop.c:2353
+#: ../src/develop/blend_gui.c:3019 ../src/develop/imageop.c:2359
 msgid "raster mask"
 msgstr "растрова маска"
 
@@ -6146,12 +6164,12 @@ msgid "input after blur"
 msgstr "вхід після розмиття"
 
 #: ../src/develop/blend_gui.c:854 ../src/develop/blend_gui.c:2198
-#: ../src/develop/imageop.c:3093
+#: ../src/develop/imageop.c:3099
 msgid "input"
 msgstr "на вході"
 
 #: ../src/develop/blend_gui.c:854 ../src/develop/blend_gui.c:2198
-#: ../src/develop/imageop.c:3095
+#: ../src/develop/imageop.c:3101
 msgid "output"
 msgstr "на виході"
 
@@ -6233,13 +6251,13 @@ msgid "sliders for gray value"
 msgstr "повзунки для значення сірого"
 
 #: ../src/develop/blend_gui.c:1997 ../src/develop/blend_gui.c:2024
-#: ../src/iop/channelmixerrgb.c:3600 ../src/iop/levels.c:674
+#: ../src/iop/channelmixerrgb.c:3788 ../src/iop/levels.c:674
 #: ../src/views/darkroom.c:2542
 msgid "gray"
 msgstr "сірий"
 
 #: ../src/develop/blend_gui.c:1998 ../src/develop/blend_gui.c:2025
-#: ../src/iop/channelmixerrgb.c:3594 ../src/iop/denoiseprofile.c:3544
+#: ../src/iop/channelmixerrgb.c:3782 ../src/iop/denoiseprofile.c:3544
 #: ../src/iop/rawdenoise.c:907 ../src/iop/rgbcurve.c:1382
 #: ../src/iop/rgblevels.c:956
 msgid "R"
@@ -6250,7 +6268,7 @@ msgid "sliders for red channel"
 msgstr "повзунки для каналу червоного"
 
 #: ../src/develop/blend_gui.c:2001 ../src/develop/blend_gui.c:2028
-#: ../src/iop/channelmixerrgb.c:3595 ../src/iop/denoiseprofile.c:3545
+#: ../src/iop/channelmixerrgb.c:3783 ../src/iop/denoiseprofile.c:3545
 #: ../src/iop/rawdenoise.c:908 ../src/iop/rgbcurve.c:1383
 #: ../src/iop/rgblevels.c:957
 msgid "G"
@@ -6261,7 +6279,7 @@ msgid "sliders for green channel"
 msgstr "повзунки для каналу зеленого"
 
 #: ../src/develop/blend_gui.c:2004 ../src/develop/blend_gui.c:2031
-#: ../src/iop/channelmixerrgb.c:3596 ../src/iop/denoiseprofile.c:3546
+#: ../src/iop/channelmixerrgb.c:3784 ../src/iop/denoiseprofile.c:3546
 #: ../src/iop/rawdenoise.c:909 ../src/iop/rgbcurve.c:1384
 #: ../src/iop/rgblevels.c:958
 msgid "B"
@@ -6692,44 +6710,44 @@ msgstr "scene-referred default"
 msgid "%s: module `%s' version mismatch: %d != %d"
 msgstr "%s: невідповідність версій модуля `%s': %d != %d"
 
-#: ../src/develop/imageop.c:936
+#: ../src/develop/imageop.c:939
 msgid "new instance"
 msgstr "новий екземпляр"
 
-#: ../src/develop/imageop.c:942
+#: ../src/develop/imageop.c:945
 msgid "duplicate instance"
 msgstr "зробити дублікат екземпляра"
 
-#: ../src/develop/imageop.c:948 ../src/libs/masks.c:1162
+#: ../src/develop/imageop.c:951 ../src/libs/masks.c:1162
 msgid "move up"
 msgstr "підняти"
 
-#: ../src/develop/imageop.c:954 ../src/libs/masks.c:1165
+#: ../src/develop/imageop.c:957 ../src/libs/masks.c:1165
 msgid "move down"
 msgstr "опустити"
 
-#: ../src/develop/imageop.c:960 ../src/gui/presets.c:479
+#: ../src/develop/imageop.c:963 ../src/gui/presets.c:479
 #: ../src/libs/image.c:177 ../src/libs/tagging.c:1359
 #: ../src/libs/tagging.c:1447
 msgid "delete"
 msgstr "видалити"
 
-#: ../src/develop/imageop.c:967 ../src/libs/modulegroups.c:3451
-#: ../src/libs/modulegroups.c:3804
+#: ../src/develop/imageop.c:970 ../src/libs/modulegroups.c:3474
+#: ../src/libs/modulegroups.c:3827
 msgid "rename"
 msgstr "перейменувати"
 
-#: ../src/develop/imageop.c:1037 ../src/develop/imageop.c:2448
+#: ../src/develop/imageop.c:1040 ../src/develop/imageop.c:2454
 #, c-format
 msgid "%s is switched on"
 msgstr "%s включено"
 
-#: ../src/develop/imageop.c:1037 ../src/develop/imageop.c:2448
+#: ../src/develop/imageop.c:1040 ../src/develop/imageop.c:2454
 #, c-format
 msgid "%s is switched off"
 msgstr "%s виключено"
 
-#: ../src/develop/imageop.c:1433 ../src/gui/accelerators.c:59
+#: ../src/develop/imageop.c:1436 ../src/gui/accelerators.c:59
 #: ../src/gui/accelerators.c:967 ../src/gui/accelerators.c:1049
 #: ../src/gui/accelerators.c:1203 ../src/gui/accelerators.c:1219
 #: ../src/gui/accelerators.c:1250 ../src/gui/preferences.c:1567
@@ -6738,28 +6756,28 @@ msgstr "%s виключено"
 msgid "preset"
 msgstr "пресет"
 
-#: ../src/develop/imageop.c:1487
+#: ../src/develop/imageop.c:1490
 msgctxt "accel"
 msgid "fusion"
 msgstr "злиття"
 
-#: ../src/develop/imageop.c:2343
+#: ../src/develop/imageop.c:2349
 msgid "unknown mask"
 msgstr "невідома маска"
 
-#: ../src/develop/imageop.c:2347
+#: ../src/develop/imageop.c:2353
 msgid "drawn + parametric mask"
 msgstr "намальована і параметрична маски"
 
-#: ../src/develop/imageop.c:2356
+#: ../src/develop/imageop.c:2362
 msgid "this module has a"
 msgstr "тут є"
 
-#: ../src/develop/imageop.c:2360
+#: ../src/develop/imageop.c:2366
 msgid "click to display (module must be activated first)"
 msgstr "натисніть для показу (спочатку модуль має бути активовано)"
 
-#: ../src/develop/imageop.c:2417
+#: ../src/develop/imageop.c:2423
 msgid ""
 "multiple instance actions\n"
 "right-click creates new instance"
@@ -6767,7 +6785,7 @@ msgstr ""
 "дії з екземплярами модуля\n"
 "права кнопка миші створює новий екземпляр"
 
-#: ../src/develop/imageop.c:2428
+#: ../src/develop/imageop.c:2434
 msgid ""
 "reset parameters\n"
 "ctrl+click to reapply any automatic presets"
@@ -6776,12 +6794,12 @@ msgstr ""
 "ctrl+клік - повторно застосувати будь-які автоматичні пресети"
 
 #. Adding the outer container
-#: ../src/develop/imageop.c:2436 ../src/gui/preferences.c:813
+#: ../src/develop/imageop.c:2442 ../src/gui/preferences.c:813
 #: ../src/libs/lib.c:1205
 msgid "presets"
 msgstr "пресети"
 
-#: ../src/develop/imageop.c:2438
+#: ../src/develop/imageop.c:2444
 msgid ""
 "presets\n"
 "right-click to apply on new instance"
@@ -6789,23 +6807,23 @@ msgstr ""
 "пресети\n"
 "права кнопка миші - застосувати в новому екземплярі"
 
-#: ../src/develop/imageop.c:2719 ../src/develop/imageop.c:2741
+#: ../src/develop/imageop.c:2725 ../src/develop/imageop.c:2747
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
-#: ../src/develop/imageop.c:3092
+#: ../src/develop/imageop.c:3098
 msgid "purpose"
 msgstr "призначення"
 
-#: ../src/develop/imageop.c:3094
+#: ../src/develop/imageop.c:3100
 msgid "process"
 msgstr "обробка"
 
-#: ../src/develop/imageop.c:3164
+#: ../src/develop/imageop.c:3170
 msgid "unsupported input"
 msgstr "непідтримуваний вхід"
 
-#: ../src/develop/imageop.c:3165
+#: ../src/develop/imageop.c:3171
 msgid ""
 "you have placed this module at\n"
 "a position in the pipeline where\n"
@@ -7133,7 +7151,7 @@ msgstr ""
 #: ../src/develop/masks/path.c:3109
 msgid ""
 "<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
-"<b>finnish path</b>: right-click"
+"<b>finish path</b>: right-click"
 msgstr ""
 "<b>додати вузол</b>: клік, <b>додати гострий вузол</b>:ctrl+клік\n"
 "<b>закінчити контур</b>: правий клік"
@@ -7162,11 +7180,11 @@ msgstr ""
 "<b>перемістити сегмент</b>: перетягнути\n"
 "<b>додати вузол</b>: ctrl+клік"
 
-#: ../src/develop/pixelpipe_hb.c:381
+#: ../src/develop/pixelpipe_hb.c:382
 msgid "enabled as required"
 msgstr "увімкнено за необхідності"
 
-#: ../src/develop/pixelpipe_hb.c:381
+#: ../src/develop/pixelpipe_hb.c:382
 msgid ""
 "history had module disabled but it is required for this type of image.\n"
 "likely introduced by applying a preset, style or history copy&paste"
@@ -7174,11 +7192,11 @@ msgstr ""
 "в історії був вимкнений модуль, але він потрібен для цього типу зображень.\n"
 "ймовірно, причиною є застосування пресету, стилю, або копіювання історії"
 
-#: ../src/develop/pixelpipe_hb.c:383
+#: ../src/develop/pixelpipe_hb.c:384
 msgid "disabled as not appropriate"
 msgstr "вимкнено як непідходящий"
 
-#: ../src/develop/pixelpipe_hb.c:383
+#: ../src/develop/pixelpipe_hb.c:384
 msgid ""
 "history had module enabled but it is not allowed for this type of image.\n"
 "likely introduced by applying a preset, style or history copy&paste"
@@ -7187,7 +7205,7 @@ msgstr ""
 "зображень.\n"
 "ймовірно, причиною є застосування пресету, стилю, або копіювання історії"
 
-#: ../src/develop/pixelpipe_hb.c:2396
+#: ../src/develop/pixelpipe_hb.c:2398
 msgid ""
 "darktable discovered problems with your OpenCL setup; disabling OpenCL for "
 "this session!"
@@ -7200,28 +7218,28 @@ msgstr ""
 msgid "tiling failed for module '%s'. output might be garbled."
 msgstr "невдалий тайлінг для модуля '%s'. вихід може бути спотворений."
 
-#: ../src/dtgtk/culling.c:229
+#: ../src/dtgtk/culling.c:231
 msgid "you have reached the start of your selection"
 msgstr "ви дійшли до початку своєї колекції"
 
-#: ../src/dtgtk/culling.c:238
+#: ../src/dtgtk/culling.c:240
 msgid "you have reached the start of your collection"
 msgstr "ви дійшли до початку своєї колекції"
 
-#: ../src/dtgtk/culling.c:281
+#: ../src/dtgtk/culling.c:283
 msgid "you have reached the end of your selection"
 msgstr "ви дійшли до кінця своєї колекції"
 
-#: ../src/dtgtk/culling.c:305
+#: ../src/dtgtk/culling.c:307
 msgid "you have reached the end of your collection"
 msgstr "ви дійшли до кінця своєї колекції"
 
-#: ../src/dtgtk/culling.c:399
+#: ../src/dtgtk/culling.c:401
 #, c-format
 msgid "zooming is limited to %d images"
 msgstr "максимальна кількість зображень: %d"
 
-#: ../src/dtgtk/culling.c:983
+#: ../src/dtgtk/culling.c:985
 msgid "no image selected !"
 msgstr "жодне зображення не вибрано!"
 
@@ -7246,12 +7264,12 @@ msgstr "згруповані зображення"
 msgid "fit"
 msgstr "заповнення"
 
-#: ../src/dtgtk/thumbtable.c:1141
+#: ../src/dtgtk/thumbtable.c:1182
 msgid ""
 "you have changed the settings related to how thumbnails are generated.\n"
 msgstr "ви змінили налаштування, пов’язані з тим, як генеруються мініатюри.\n"
 
-#: ../src/dtgtk/thumbtable.c:1143
+#: ../src/dtgtk/thumbtable.c:1184
 msgid ""
 "all cached thumbnails need to be invalidated.\n"
 "\n"
@@ -7259,7 +7277,7 @@ msgstr ""
 "усі кешовані мініатюри потрібно визнати недійсними.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1145
+#: ../src/dtgtk/thumbtable.c:1186
 #, c-format
 msgid ""
 "cached thumbnails starting from level %d need to be invalidated.\n"
@@ -7268,7 +7286,7 @@ msgstr ""
 "кешовані мініатюри, починаючи з рівня %d, потрібно визнати недійсними.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1148
+#: ../src/dtgtk/thumbtable.c:1189
 #, c-format
 msgid ""
 "cached thumbnails below level %d need to be invalidated.\n"
@@ -7277,7 +7295,7 @@ msgstr ""
 "кешовані мініатюри нижче рівня %d потрібно визнати недійсними.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1150
+#: ../src/dtgtk/thumbtable.c:1191
 #, c-format
 msgid ""
 "cached thumbnails between level %d and %d need to be invalidated.\n"
@@ -7286,163 +7304,163 @@ msgstr ""
 "кешовані мініатюри між рівнями %d і %d потрібно визнати недійсними.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1153
+#: ../src/dtgtk/thumbtable.c:1194
 msgid "do you want to do that now?"
 msgstr "хочете зробити це зараз?"
 
-#: ../src/dtgtk/thumbtable.c:1161
+#: ../src/dtgtk/thumbtable.c:1202
 msgid "cached thumbnails invalidation"
 msgstr "анулювання кешованих мініатюр"
 
-#: ../src/dtgtk/thumbtable.c:2167 ../src/libs/metadata_view.c:465
+#: ../src/dtgtk/thumbtable.c:2215 ../src/libs/metadata_view.c:379
 msgid "image rejected"
 msgstr "зображення відхилено"
 
-#: ../src/dtgtk/thumbtable.c:2169 ../src/dtgtk/thumbtable.c:2171
-#: ../src/dtgtk/thumbtable.c:2173 ../src/dtgtk/thumbtable.c:2175
-#: ../src/dtgtk/thumbtable.c:2177
+#: ../src/dtgtk/thumbtable.c:2217 ../src/dtgtk/thumbtable.c:2219
+#: ../src/dtgtk/thumbtable.c:2221 ../src/dtgtk/thumbtable.c:2223
+#: ../src/dtgtk/thumbtable.c:2225
 #, c-format
 msgid "image rated to %s"
 msgstr "рейтинг зображення: %s"
 
-#: ../src/dtgtk/thumbtable.c:2179
+#: ../src/dtgtk/thumbtable.c:2227
 msgid "image rated to 0 star"
 msgstr "рейтинг зображення: 0 зірок"
 
-#: ../src/dtgtk/thumbtable.c:2212
+#: ../src/dtgtk/thumbtable.c:2260
 #, c-format
 msgid "colorlabels set to %s"
 msgstr "кольорові позначки встановлено в %s"
 
-#: ../src/dtgtk/thumbtable.c:2214
+#: ../src/dtgtk/thumbtable.c:2262
 msgid "all colorlabels removed"
 msgstr "всі кольорові позначки видалено"
 
 #. setup rating key accelerators
-#: ../src/dtgtk/thumbtable.c:2339
+#: ../src/dtgtk/thumbtable.c:2387
 msgctxt "accel"
 msgid "views/thumbtable/rate 0"
 msgstr "режими/стіл мініатюр/рейтинг: 0"
 
-#: ../src/dtgtk/thumbtable.c:2340
+#: ../src/dtgtk/thumbtable.c:2388
 msgctxt "accel"
 msgid "views/thumbtable/rate 1"
 msgstr "режими/стіл мініатюр/рейтинг: 1"
 
-#: ../src/dtgtk/thumbtable.c:2341
+#: ../src/dtgtk/thumbtable.c:2389
 msgctxt "accel"
 msgid "views/thumbtable/rate 2"
 msgstr "режими/стіл мініатюр/рейтинг: 2"
 
-#: ../src/dtgtk/thumbtable.c:2342
+#: ../src/dtgtk/thumbtable.c:2390
 msgctxt "accel"
 msgid "views/thumbtable/rate 3"
 msgstr "режими/стіл мініатюр/рейтинг: 3"
 
-#: ../src/dtgtk/thumbtable.c:2343
+#: ../src/dtgtk/thumbtable.c:2391
 msgctxt "accel"
 msgid "views/thumbtable/rate 4"
 msgstr "режими/стіл мініатюр/рейтинг: 4"
 
-#: ../src/dtgtk/thumbtable.c:2344
+#: ../src/dtgtk/thumbtable.c:2392
 msgctxt "accel"
 msgid "views/thumbtable/rate 5"
 msgstr "режими/стіл мініатюр/рейтинг: 5"
 
-#: ../src/dtgtk/thumbtable.c:2345
+#: ../src/dtgtk/thumbtable.c:2393
 msgctxt "accel"
 msgid "views/thumbtable/rate reject"
 msgstr "режими/стіл мініатюр/рейтинг: відхилити"
 
 #. setup history key accelerators
-#: ../src/dtgtk/thumbtable.c:2348
+#: ../src/dtgtk/thumbtable.c:2396
 msgctxt "accel"
 msgid "views/thumbtable/copy history"
 msgstr "режими/стіл мініатюр/копіювати історію змін"
 
-#: ../src/dtgtk/thumbtable.c:2349
+#: ../src/dtgtk/thumbtable.c:2397
 msgctxt "accel"
 msgid "views/thumbtable/copy history parts"
 msgstr "режими/стіл мініатюр/копіювати історію змін частково"
 
-#: ../src/dtgtk/thumbtable.c:2351
+#: ../src/dtgtk/thumbtable.c:2399
 msgctxt "accel"
 msgid "views/thumbtable/paste history"
 msgstr "режими/стіл мініатюр/вставити історію змін"
 
-#: ../src/dtgtk/thumbtable.c:2352
+#: ../src/dtgtk/thumbtable.c:2400
 msgctxt "accel"
 msgid "views/thumbtable/paste history parts"
 msgstr "режими/стіл мініатюр/вставити історію змін частково"
 
-#: ../src/dtgtk/thumbtable.c:2354
+#: ../src/dtgtk/thumbtable.c:2402
 msgctxt "accel"
 msgid "views/thumbtable/discard history"
 msgstr "режими/стіл мініатюр/видалити історію"
 
-#: ../src/dtgtk/thumbtable.c:2356
+#: ../src/dtgtk/thumbtable.c:2404
 msgctxt "accel"
 msgid "views/thumbtable/duplicate image"
 msgstr "режими/стіл мініатюр/зробити дублікат зображення"
 
-#: ../src/dtgtk/thumbtable.c:2357
+#: ../src/dtgtk/thumbtable.c:2405
 msgctxt "accel"
 msgid "views/thumbtable/duplicate image virgin"
 msgstr "режими/стіл мініатюр/зробити дублікат зображення без обробки"
 
 #. setup color label accelerators
-#: ../src/dtgtk/thumbtable.c:2361
+#: ../src/dtgtk/thumbtable.c:2409
 msgctxt "accel"
 msgid "views/thumbtable/color red"
 msgstr "режими/стіл мініатюр/позначити червоним"
 
-#: ../src/dtgtk/thumbtable.c:2362
+#: ../src/dtgtk/thumbtable.c:2410
 msgctxt "accel"
 msgid "views/thumbtable/color yellow"
 msgstr "режими/стіл мініатюр/позначити жовтим"
 
-#: ../src/dtgtk/thumbtable.c:2363
+#: ../src/dtgtk/thumbtable.c:2411
 msgctxt "accel"
 msgid "views/thumbtable/color green"
 msgstr "режими/стіл мініатюр/позначити зеленим"
 
-#: ../src/dtgtk/thumbtable.c:2364
+#: ../src/dtgtk/thumbtable.c:2412
 msgctxt "accel"
 msgid "views/thumbtable/color blue"
 msgstr "режими/стіл мініатюр/позначити синім"
 
-#: ../src/dtgtk/thumbtable.c:2365
+#: ../src/dtgtk/thumbtable.c:2413
 msgctxt "accel"
 msgid "views/thumbtable/color purple"
 msgstr "режими/стіл мініатюр/позначити пурпуровим"
 
-#: ../src/dtgtk/thumbtable.c:2366
+#: ../src/dtgtk/thumbtable.c:2414
 msgctxt "accel"
 msgid "views/thumbtable/clear color labels"
 msgstr "режими/стіл мініатюр/очистити кольорові позначки"
 
 #. setup selection accelerators
-#: ../src/dtgtk/thumbtable.c:2369
+#: ../src/dtgtk/thumbtable.c:2417
 msgctxt "accel"
 msgid "views/thumbtable/select all"
 msgstr "режими/стіл мініатюр/вибрати все"
 
-#: ../src/dtgtk/thumbtable.c:2370
+#: ../src/dtgtk/thumbtable.c:2418
 msgctxt "accel"
 msgid "views/thumbtable/select none"
 msgstr "режими/стіл мініатюр/очистити вибір"
 
-#: ../src/dtgtk/thumbtable.c:2372
+#: ../src/dtgtk/thumbtable.c:2420
 msgctxt "accel"
 msgid "views/thumbtable/invert selection"
 msgstr "режими/стіл мініатюр/інвертувати вибір"
 
-#: ../src/dtgtk/thumbtable.c:2373
+#: ../src/dtgtk/thumbtable.c:2421
 msgctxt "accel"
 msgid "views/thumbtable/select film roll"
 msgstr "режими/стіл мініатюр/вибрати плівку"
 
-#: ../src/dtgtk/thumbtable.c:2374
+#: ../src/dtgtk/thumbtable.c:2422
 msgctxt "accel"
 msgid "views/thumbtable/select untouched"
 msgstr "режими/стіл мініатюр/вибрати необроблені"
@@ -8403,12 +8421,12 @@ msgstr "darktable потрібно перезапустити, щоб налаш
 
 #. exif
 #: ../src/gui/preferences.c:835 ../src/gui/presets.c:535
-#: ../src/libs/metadata_view.c:142
+#: ../src/libs/metadata_view.c:136
 msgid "model"
 msgstr "модель"
 
 #: ../src/gui/preferences.c:839 ../src/gui/presets.c:543
-#: ../src/libs/metadata_view.c:143
+#: ../src/libs/metadata_view.c:137
 msgid "maker"
 msgstr "виробник"
 
@@ -8483,14 +8501,14 @@ msgstr "конфлікт прискорювачів"
 
 #: ../src/gui/preferences.c:1549 ../src/gui/presets.c:173
 #: ../src/gui/presets.c:415 ../src/libs/lib.c:385
-#: ../src/libs/modulegroups.c:3682
+#: ../src/libs/modulegroups.c:3705
 #, c-format
 msgid "do you really want to delete the preset `%s'?"
 msgstr "ви дійсно хочете видалити пресет `%s'?"
 
 #: ../src/gui/preferences.c:1553 ../src/gui/presets.c:177
 #: ../src/gui/presets.c:419 ../src/libs/lib.c:389
-#: ../src/libs/modulegroups.c:3686
+#: ../src/libs/modulegroups.c:3709
 msgid "delete preset?"
 msgstr "видалити пресет?"
 
@@ -8506,7 +8524,7 @@ msgstr "виберіть файл для імпорту"
 
 #: ../src/gui/preferences.c:1639 ../src/gui/preferences.c:1728
 #: ../src/libs/collect.c:427 ../src/libs/copy_history.c:109
-#: ../src/libs/geotagging.c:939 ../src/libs/import.c:1238
+#: ../src/libs/geotagging.c:939 ../src/libs/import.c:1469
 #: ../src/libs/styles.c:530
 msgid "_open"
 msgstr "_відкрити"
@@ -8543,7 +8561,7 @@ msgstr "всі файли"
 msgid "normal images"
 msgstr "звичайні зображення"
 
-#: ../src/gui/presets.c:58 ../src/libs/metadata_view.c:445
+#: ../src/gui/presets.c:58 ../src/libs/metadata_view.c:359
 msgid "raw"
 msgstr "raw"
 
@@ -8552,7 +8570,7 @@ msgid "HDR"
 msgstr "HDR"
 
 #: ../src/gui/presets.c:58 ../src/iop/monochrome.c:77 ../src/libs/image.c:602
-#: ../src/libs/metadata_view.c:453
+#: ../src/libs/metadata_view.c:367
 msgid "monochrome"
 msgstr "монохром"
 
@@ -8707,8 +8725,8 @@ msgstr "ви дійсно хочете оновити пресет `%s'?"
 msgid "update preset?"
 msgstr "оновити пресет?"
 
-#: ../src/gui/presets.c:1099 ../src/libs/modulegroups.c:3769
-#: ../src/libs/modulegroups.c:3778
+#: ../src/gui/presets.c:1099 ../src/libs/modulegroups.c:3792
+#: ../src/libs/modulegroups.c:3801
 msgid "manage module layouts"
 msgstr "керування розкладкою модулів"
 
@@ -8716,31 +8734,31 @@ msgstr "керування розкладкою модулів"
 msgid "manage quick presets"
 msgstr "керування швидкими пресетами"
 
-#: ../src/gui/presets.c:1274
+#: ../src/gui/presets.c:1278
 msgid "manage quick presets list..."
 msgstr "список швидких пресетів..."
 
-#: ../src/gui/presets.c:1407
+#: ../src/gui/presets.c:1411
 msgid "(default)"
 msgstr "(за умовчанням)"
 
-#: ../src/gui/presets.c:1426
+#: ../src/gui/presets.c:1430
 msgid "disabled: wrong module version"
 msgstr "вимкнено: неправильна версія модуля"
 
-#: ../src/gui/presets.c:1451 ../src/libs/lib.c:671
+#: ../src/gui/presets.c:1455 ../src/libs/lib.c:671
 msgid "edit this preset.."
 msgstr "редагувати цей пресет..."
 
-#: ../src/gui/presets.c:1455 ../src/libs/lib.c:675
+#: ../src/gui/presets.c:1459 ../src/libs/lib.c:675
 msgid "delete this preset"
 msgstr "видалити цей пресет"
 
-#: ../src/gui/presets.c:1461 ../src/libs/lib.c:683
+#: ../src/gui/presets.c:1465 ../src/libs/lib.c:683
 msgid "store new preset.."
 msgstr "зберегти новий пресет..."
 
-#: ../src/gui/presets.c:1467 ../src/libs/lib.c:695
+#: ../src/gui/presets.c:1471 ../src/libs/lib.c:695
 msgid "update preset"
 msgstr "оновити пресет"
 
@@ -8876,7 +8894,7 @@ msgstr "тип стиснення для зображення"
 #. digits
 #: ../src/imageio/format/avif.c:858 ../src/imageio/format/j2k.c:658
 #: ../src/imageio/format/jpeg.c:584 ../src/imageio/format/webp.c:337
-#: ../src/iop/cacorrect.c:1593 ../src/libs/camera.c:595
+#: ../src/iop/cacorrect.c:1343 ../src/libs/camera.c:595
 msgid "quality"
 msgstr "якість"
 
@@ -9494,7 +9512,7 @@ msgstr "keystone|distortion"
 msgid "distort perspective automatically"
 msgstr "спотворювати перспективу автоматично"
 
-#: ../src/iop/ashift.c:127 ../src/iop/basecurve.c:339 ../src/iop/cacorrect.c:92
+#: ../src/iop/ashift.c:127 ../src/iop/basecurve.c:339 ../src/iop/cacorrect.c:88
 #: ../src/iop/cacorrectrgb.c:167 ../src/iop/colorreconstruction.c:135
 #: ../src/iop/defringe.c:81 ../src/iop/denoiseprofile.c:669
 #: ../src/iop/dither.c:103 ../src/iop/flip.c:101 ../src/iop/hazeremoval.c:111
@@ -9508,8 +9526,8 @@ msgstr "коригуюче"
 
 #: ../src/iop/ashift.c:128 ../src/iop/ashift.c:130 ../src/iop/atrous.c:140
 #: ../src/iop/basicadj.c:147 ../src/iop/bilateral.cc:100
-#: ../src/iop/bilateral.cc:102 ../src/iop/channelmixerrgb.c:199
-#: ../src/iop/channelmixerrgb.c:201 ../src/iop/clipping.c:322
+#: ../src/iop/bilateral.cc:102 ../src/iop/channelmixerrgb.c:209
+#: ../src/iop/channelmixerrgb.c:211 ../src/iop/clipping.c:322
 #: ../src/iop/clipping.c:324 ../src/iop/colorin.c:137 ../src/iop/crop.c:143
 #: ../src/iop/crop.c:144 ../src/iop/demosaic.c:213
 #: ../src/iop/denoiseprofile.c:670 ../src/iop/denoiseprofile.c:672
@@ -9559,19 +9577,19 @@ msgid "lens shift (%s)"
 msgstr "зміщення об'єктива (%s)"
 
 #: ../src/iop/ashift.c:4485 ../src/iop/ashift.c:4486 ../src/iop/ashift.c:4583
-#: ../src/iop/ashift.c:4584 ../src/iop/clipping.c:1889
-#: ../src/iop/clipping.c:2146 ../src/iop/clipping.c:2163
+#: ../src/iop/ashift.c:4584 ../src/iop/clipping.c:1895
+#: ../src/iop/clipping.c:2152 ../src/iop/clipping.c:2169
 msgid "horizontal"
 msgstr "горизонтально"
 
 #: ../src/iop/ashift.c:4485 ../src/iop/ashift.c:4486 ../src/iop/ashift.c:4583
-#: ../src/iop/ashift.c:4584 ../src/iop/clipping.c:1888
-#: ../src/iop/clipping.c:2147 ../src/iop/clipping.c:2162
+#: ../src/iop/ashift.c:4584 ../src/iop/clipping.c:1894
+#: ../src/iop/clipping.c:2153 ../src/iop/clipping.c:2168
 msgid "vertical"
 msgstr "вертикально"
 
-#: ../src/iop/ashift.c:4703 ../src/iop/clipping.c:2289 ../src/iop/crop.c:1230
-#: ../src/libs/live_view.c:336
+#: ../src/iop/ashift.c:4703 ../src/iop/clipping.c:2295 ../src/iop/crop.c:1246
+#: ../src/libs/live_view.c:413
 msgid "guides"
 msgstr "напрямні"
 
@@ -9599,7 +9617,7 @@ msgstr "корекція зображення вздовж однієї з ді�
 msgid "display guide lines overlay"
 msgstr "показати напрямні лінії поверх зображення"
 
-#: ../src/iop/ashift.c:4778 ../src/iop/clipping.c:2170
+#: ../src/iop/ashift.c:4778 ../src/iop/clipping.c:2176
 msgid "automatically crop to avoid black edges"
 msgstr "автоматично обрізати, щоб уникнути чорних країв"
 
@@ -9739,7 +9757,7 @@ msgid "frequential, RGB"
 msgstr "частотний, RGB"
 
 #: ../src/iop/atrous.c:142 ../src/iop/colorbalance.c:160
-#: ../src/iop/colorbalancergb.c:171
+#: ../src/iop/colorbalancergb.c:172
 msgid "linear, Lab, scene-referred"
 msgstr "лінійний, Lab, на основі сцен"
 
@@ -9962,7 +9980,7 @@ msgid "linear, RGB, display-referred"
 msgstr "лінійний, RGB, на основі відображення"
 
 #: ../src/iop/basecurve.c:341 ../src/iop/basicadj.c:148
-#: ../src/iop/colorbalance.c:161 ../src/iop/colorbalancergb.c:172
+#: ../src/iop/colorbalance.c:161 ../src/iop/colorbalancergb.c:173
 #: ../src/iop/dither.c:105 ../src/iop/filmicrgb.c:338
 #: ../src/iop/graduatednd.c:152 ../src/iop/negadoctor.c:158
 #: ../src/iop/profile_gamma.c:103 ../src/iop/rgbcurve.c:144
@@ -10290,7 +10308,7 @@ msgstr "2:1"
 msgid "16:9"
 msgstr "16:9"
 
-#: ../src/iop/borders.c:973 ../src/iop/clipping.c:2184 ../src/iop/crop.c:1126
+#: ../src/iop/borders.c:973 ../src/iop/clipping.c:2190 ../src/iop/crop.c:1142
 msgid "golden cut"
 msgstr "золотий перетин"
 
@@ -10310,7 +10328,7 @@ msgstr "DIN"
 msgid "4:3"
 msgstr "4:3"
 
-#: ../src/iop/borders.c:978 ../src/iop/clipping.c:2174 ../src/iop/crop.c:1116
+#: ../src/iop/borders.c:978 ../src/iop/clipping.c:2180 ../src/iop/crop.c:1132
 #: ../src/libs/collect.c:260
 msgid "square"
 msgstr "квадрат"
@@ -10347,7 +10365,7 @@ msgstr "2/3"
 msgid "size of the border in percent of the full image"
 msgstr "розмір облямівки в процентах від повного зображення"
 
-#: ../src/iop/borders.c:1041 ../src/iop/clipping.c:2271 ../src/iop/crop.c:1212
+#: ../src/iop/borders.c:1041 ../src/iop/clipping.c:2277 ../src/iop/crop.c:1228
 msgid "aspect"
 msgstr "співвідношення сторін"
 
@@ -10422,15 +10440,15 @@ msgid "pick frame line color from image"
 msgstr "виберіть колір лінії рамки із зображення"
 
 #. make sure you put all your translatable strings into _() !
-#: ../src/iop/cacorrect.c:86
+#: ../src/iop/cacorrect.c:82
 msgid "raw chromatic aberrations"
 msgstr "raw хроматичні аберації"
 
-#: ../src/iop/cacorrect.c:91
+#: ../src/iop/cacorrect.c:87
 msgid "correct chromatic aberrations for Bayer sensors"
 msgstr "коригувати хроматичні аберації для сенсорів з фільтрами Баєра"
 
-#: ../src/iop/cacorrect.c:93 ../src/iop/cacorrect.c:95
+#: ../src/iop/cacorrect.c:89 ../src/iop/cacorrect.c:91
 #: ../src/iop/cacorrectrgb.c:168 ../src/iop/cacorrectrgb.c:170
 #: ../src/iop/demosaic.c:211 ../src/iop/highlights.c:88
 #: ../src/iop/highlights.c:90 ../src/iop/hotpixels.c:74
@@ -10441,23 +10459,23 @@ msgstr "коригувати хроматичні аберації для сен
 msgid "linear, raw, scene-referred"
 msgstr "лінійний, raw, на основі сцен"
 
-#: ../src/iop/cacorrect.c:94 ../src/iop/cacorrectrgb.c:169
+#: ../src/iop/cacorrect.c:90 ../src/iop/cacorrectrgb.c:169
 #: ../src/iop/demosaic.c:212 ../src/iop/invert.c:123
 #: ../src/iop/rawdenoise.c:132 ../src/iop/rawprepare.c:115
 #: ../src/iop/temperature.c:203
 msgid "linear, raw"
 msgstr "лінійний, raw"
 
-#: ../src/iop/cacorrect.c:1587
+#: ../src/iop/cacorrect.c:1337
 msgid "CA correction supports only RGB colour filter arrays"
 msgstr ""
 "корекція хроматичних аберацій підтримує лише масиви кольорових фільтрів RGB"
 
-#: ../src/iop/cacorrect.c:1589 ../src/iop/cacorrect.c:1597
+#: ../src/iop/cacorrect.c:1339 ../src/iop/cacorrect.c:1347
 msgid "bypassed while zooming in"
 msgstr "вимкнено при малій видимій області"
 
-#: ../src/iop/cacorrect.c:1590
+#: ../src/iop/cacorrect.c:1340
 msgid ""
 "while calculating the correction parameters the internal maths failed so "
 "module is bypassed.\n"
@@ -10466,7 +10484,7 @@ msgstr ""
 "алгоритм не зміг обчислити параметри корекції, тому дію модуля відключено.\n"
 "ви можете отримати більше інформації, запустивши darktable через консоль."
 
-#: ../src/iop/cacorrect.c:1594
+#: ../src/iop/cacorrect.c:1344
 msgid ""
 "internals maths found too few data points so restricted the order of the fit "
 "to linear.\n"
@@ -10476,7 +10494,7 @@ msgstr ""
 "підгонки лінійним.\n"
 "ви можете побачити погані результати виправлення."
 
-#: ../src/iop/cacorrect.c:1598
+#: ../src/iop/cacorrect.c:1348
 msgid ""
 "to calculate good parameters for raw CA correction we want full sensor data "
 "or at least a sensible part of that.\n"
@@ -10488,15 +10506,15 @@ msgstr ""
 "зображення, показане в темній кімнаті, буде сильно відрізнятися від "
 "оброблених файлів, тому зараз дію модуля відключено."
 
-#: ../src/iop/cacorrect.c:1710
+#: ../src/iop/cacorrect.c:1460
 msgid "iteration runs, default is twice"
 msgstr "кількість проходів, за замовчуванням два"
 
-#: ../src/iop/cacorrect.c:1713
+#: ../src/iop/cacorrect.c:1463
 msgid "activate colorshift correction for blue & red channels"
 msgstr "активувати корекцію зміщення кольорів для синього та червоного каналів"
 
-#: ../src/iop/cacorrect.c:1720
+#: ../src/iop/cacorrect.c:1470
 msgid ""
 "automatic chromatic aberration correction\n"
 "only for bayer raw files"
@@ -10644,7 +10662,7 @@ msgstr ""
 "цей модуль застарілий. краще використовувати модуль 'калібрування кольору' "
 "замість нього."
 
-#: ../src/iop/channelmixer.c:136 ../src/iop/channelmixerrgb.c:195
+#: ../src/iop/channelmixer.c:136 ../src/iop/channelmixerrgb.c:205
 msgid ""
 "perform color space corrections\n"
 "such as white balance, channels mixing\n"
@@ -10654,9 +10672,9 @@ msgstr ""
 "такі як баланс білого, змішування каналів\n"
 "і перетворення на монохром з емуляцією плівки"
 
-#: ../src/iop/channelmixer.c:139 ../src/iop/channelmixerrgb.c:198
+#: ../src/iop/channelmixer.c:139 ../src/iop/channelmixerrgb.c:208
 #: ../src/iop/clipping.c:321 ../src/iop/colorbalance.c:159
-#: ../src/iop/colorbalancergb.c:170 ../src/iop/colorchecker.c:126
+#: ../src/iop/colorbalancergb.c:171 ../src/iop/colorchecker.c:126
 #: ../src/iop/colorcorrection.c:77 ../src/iop/crop.c:142 ../src/iop/lut3d.c:139
 msgid "corrective or creative"
 msgstr "коригуюче чи креативне"
@@ -10682,11 +10700,11 @@ msgstr "кількість зеленого каналу у вихідному �
 msgid "amount of blue channel in the output channel"
 msgstr "кількість синього каналу у вихідному каналі"
 
-#: ../src/iop/channelmixer.c:662 ../src/iop/channelmixerrgb.c:441
+#: ../src/iop/channelmixer.c:662 ../src/iop/channelmixerrgb.c:451
 msgid "swap R and B"
 msgstr "поміняти R і B"
 
-#: ../src/iop/channelmixer.c:668 ../src/iop/channelmixerrgb.c:415
+#: ../src/iop/channelmixer.c:668 ../src/iop/channelmixerrgb.c:425
 msgid "swap G and B"
 msgstr "поміняти G і B"
 
@@ -10750,67 +10768,67 @@ msgstr "ч/б Kodak T-max 400"
 msgid "B/W Kodak Tri-X 400"
 msgstr "ч/б Kodak Tri-X 400"
 
-#: ../src/iop/channelmixerrgb.c:185
+#: ../src/iop/channelmixerrgb.c:195
 msgid "color calibration"
 msgstr "калібрування кольору"
 
-#: ../src/iop/channelmixerrgb.c:190
+#: ../src/iop/channelmixerrgb.c:200
 msgid "channel mixer|white balance|monochrome"
 msgstr "channel mixer|white balance|monochrome"
 
-#: ../src/iop/channelmixerrgb.c:200
+#: ../src/iop/channelmixerrgb.c:210
 msgid "linear, RGB or XYZ"
 msgstr "лінійний, RGB або XYZ"
 
-#: ../src/iop/channelmixerrgb.c:320
+#: ../src/iop/channelmixerrgb.c:330
 msgid "B&W : luminance-based"
 msgstr "Ч/Б: на основі яскравості"
 
-#: ../src/iop/channelmixerrgb.c:349
+#: ../src/iop/channelmixerrgb.c:359
 msgid "B&W : Ilford HP5+"
 msgstr "Ч/Б : Ilford HP5+"
 
-#: ../src/iop/channelmixerrgb.c:358
+#: ../src/iop/channelmixerrgb.c:368
 msgid "B&W : Ilford Delta 100"
 msgstr "Ч/Б : Ilford Delta 100"
 
-#: ../src/iop/channelmixerrgb.c:368
+#: ../src/iop/channelmixerrgb.c:378
 msgid "B&W : Ilford Delta 400 - 3200"
 msgstr "Ч/Б : Ilford Delta 400 - 3200"
 
-#: ../src/iop/channelmixerrgb.c:377
+#: ../src/iop/channelmixerrgb.c:387
 msgid "B&W : Ilford FP2"
 msgstr "Ч/Б : Ilford FP2"
 
-#: ../src/iop/channelmixerrgb.c:386
+#: ../src/iop/channelmixerrgb.c:396
 msgid "B&W : Fuji Acros 100"
 msgstr "Ч/Б : Fuji Acros 100"
 
-#: ../src/iop/channelmixerrgb.c:402
+#: ../src/iop/channelmixerrgb.c:412
 msgid "basic channel mixer"
 msgstr "спрощений змішувач каналів"
 
-#: ../src/iop/channelmixerrgb.c:428
+#: ../src/iop/channelmixerrgb.c:438
 msgid "swap G and R"
 msgstr "поміняти G і R"
 
-#: ../src/iop/channelmixerrgb.c:1628 ../src/iop/channelmixerrgb.c:1677
+#: ../src/iop/channelmixerrgb.c:1638 ../src/iop/channelmixerrgb.c:1687
 msgid "very good"
 msgstr "дуже хороша"
 
-#: ../src/iop/channelmixerrgb.c:1630 ../src/iop/channelmixerrgb.c:1679
+#: ../src/iop/channelmixerrgb.c:1640 ../src/iop/channelmixerrgb.c:1689
 msgid "good"
 msgstr "хороша"
 
-#: ../src/iop/channelmixerrgb.c:1632 ../src/iop/channelmixerrgb.c:1681
+#: ../src/iop/channelmixerrgb.c:1642 ../src/iop/channelmixerrgb.c:1691
 msgid "passable"
 msgstr "прийнятна"
 
-#: ../src/iop/channelmixerrgb.c:1634 ../src/iop/channelmixerrgb.c:1683
+#: ../src/iop/channelmixerrgb.c:1644 ../src/iop/channelmixerrgb.c:1693
 msgid "bad"
 msgstr "погана"
 
-#: ../src/iop/channelmixerrgb.c:1641
+#: ../src/iop/channelmixerrgb.c:1651
 #, c-format
 msgid ""
 "\n"
@@ -10847,7 +10865,7 @@ msgstr ""
 "компенсація експозиції : \t%+.2f EV\n"
 "зміщення чорного кольору : \t%+.4f"
 
-#: ../src/iop/channelmixerrgb.c:1687
+#: ../src/iop/channelmixerrgb.c:1697
 #, c-format
 msgid ""
 "\n"
@@ -10868,11 +10886,11 @@ msgstr ""
 
 #. our second biggest problem : another channelmixerrgb instance is doing CAT
 #. earlier in the pipe.
-#: ../src/iop/channelmixerrgb.c:1709
+#: ../src/iop/channelmixerrgb.c:1719
 msgid "double CAT applied"
 msgstr "подвійне CAT застосовано"
 
-#: ../src/iop/channelmixerrgb.c:1710
+#: ../src/iop/channelmixerrgb.c:1720
 msgid ""
 "you have 2 instances or more of color calibration,\n"
 "all performing chromatic adaptation.\n"
@@ -10885,11 +10903,11 @@ msgstr ""
 "використовуєте їх з масками, або знаєте, для чого це робите."
 
 #. our first and biggest problem : white balance module is being clever with WB coeffs
-#: ../src/iop/channelmixerrgb.c:1720
+#: ../src/iop/channelmixerrgb.c:1730
 msgid "white balance module error"
 msgstr "помилка модуля балансу білого"
 
-#: ../src/iop/channelmixerrgb.c:1721
+#: ../src/iop/channelmixerrgb.c:1731
 msgid ""
 "the white balance module is not using the camera\n"
 "reference illuminant, which will cause issues here\n"
@@ -10901,16 +10919,20 @@ msgstr ""
 "з хроматичною адаптацією. або встановіть його в референсе\n"
 "значення або відключіть тут хроматичну адаптацію."
 
-#: ../src/iop/channelmixerrgb.c:1794
+#: ../src/iop/channelmixerrgb.c:1804
 msgid "auto-detection of white balance completed"
 msgstr "автовизначення балансу білого завершено"
 
-#: ../src/iop/channelmixerrgb.c:3054
+#: ../src/iop/channelmixerrgb.c:1941
+msgid "channelmixerrgb works only on RGB input"
+msgstr "channelmixerrgb (калібрування кольору) працює лише з RGB входом"
+
+#: ../src/iop/channelmixerrgb.c:3242
 #, c-format
 msgid "CCT: %.0f K (daylight)"
 msgstr "CCT: %.0f K (денне світло)"
 
-#: ../src/iop/channelmixerrgb.c:3056
+#: ../src/iop/channelmixerrgb.c:3244
 msgid ""
 "approximated correlated color temperature.\n"
 "this illuminant can be accurately modeled by a daylight spectrum,\n"
@@ -10920,12 +10942,12 @@ msgstr ""
 "цей освітлювач можна точно змоделювати за спектром денного світла,\n"
 "тому його температура є релевантною та значущою з D-освітлювачем."
 
-#: ../src/iop/channelmixerrgb.c:3062
+#: ../src/iop/channelmixerrgb.c:3250
 #, c-format
 msgid "CCT: %.0f K (black body)"
 msgstr "CCT: %.0f K (чорне тіло)"
 
-#: ../src/iop/channelmixerrgb.c:3064
+#: ../src/iop/channelmixerrgb.c:3252
 msgid ""
 "approximated correlated color temperature.\n"
 "this illuminant can be accurately modeled by a black body spectrum,\n"
@@ -10936,12 +10958,12 @@ msgstr ""
 "тому його температура є релевантною та значущою з планківським "
 "випромінювачем."
 
-#: ../src/iop/channelmixerrgb.c:3070
+#: ../src/iop/channelmixerrgb.c:3258
 #, c-format
 msgid "CCT: %.0f K (invalid)"
 msgstr "CCT: %.0f K (недійсна)"
 
-#: ../src/iop/channelmixerrgb.c:3072
+#: ../src/iop/channelmixerrgb.c:3260
 msgid ""
 "approximated correlated color temperature.\n"
 "this illuminant cannot be accurately modeled by a daylight or black body "
@@ -10955,12 +10977,12 @@ msgstr ""
 "тому його температура не є релевантною та значущою і вам потрібно "
 "використовувати спеціальний освітлювач."
 
-#: ../src/iop/channelmixerrgb.c:3079
+#: ../src/iop/channelmixerrgb.c:3267
 #, c-format
 msgid "CCT: undefined"
 msgstr "CCT: невизначена"
 
-#: ../src/iop/channelmixerrgb.c:3081
+#: ../src/iop/channelmixerrgb.c:3269
 msgid ""
 "the approximated correlated color temperature\n"
 "cannot be computed at all so you need to use a custom illuminant."
@@ -10969,16 +10991,16 @@ msgstr ""
 "неможливо обчислити взагалі, тому вам потрібно використовувати спеціальний "
 "освітлювач."
 
-#: ../src/iop/channelmixerrgb.c:3314
+#: ../src/iop/channelmixerrgb.c:3502
 msgid "white balance successfully extracted from raw image"
 msgstr "баланс білого успішно отримано з raw зображення"
 
 #. We need to recompute only the full preview
-#: ../src/iop/channelmixerrgb.c:3320
+#: ../src/iop/channelmixerrgb.c:3508
 msgid "auto-detection of white balance started…"
 msgstr "розпочато автоматичне виявлення балансу білого..."
 
-#: ../src/iop/channelmixerrgb.c:3375
+#: ../src/iop/channelmixerrgb.c:3563
 msgid ""
 "color calibration: the sum of the grey channel parameters is zero, "
 "normalization will be disabled."
@@ -10987,21 +11009,21 @@ msgstr ""
 "нормалізація буде відключена."
 
 #. Page CAT
-#: ../src/iop/channelmixerrgb.c:3490
+#: ../src/iop/channelmixerrgb.c:3678
 msgid "CAT"
 msgstr "CAT"
 
-#: ../src/iop/channelmixerrgb.c:3490
+#: ../src/iop/channelmixerrgb.c:3678
 msgid "chromatic adaptation transform"
 msgstr ""
 "перетворення хроматичної адаптації\n"
 "\"chromatic adaptation transform\" - CAT"
 
-#: ../src/iop/channelmixerrgb.c:3492
+#: ../src/iop/channelmixerrgb.c:3680
 msgid "adaptation"
 msgstr "адаптація"
 
-#: ../src/iop/channelmixerrgb.c:3494
+#: ../src/iop/channelmixerrgb.c:3682
 msgid ""
 "choose the method to adapt the illuminant\n"
 "and the colorspace in which the module works: \n"
@@ -11021,7 +11043,7 @@ msgstr ""
 "• XYZ - це просте масштабування в просторі XYZ. не рекомендується.\n"
 "• немає - відключає будь-яку адаптацію і використовує робочий RGB конвеєра."
 
-#: ../src/iop/channelmixerrgb.c:3511
+#: ../src/iop/channelmixerrgb.c:3699
 msgid ""
 "this is the color of the scene illuminant before chromatic adaptation\n"
 "this color will be turned into pure white by the adaptation."
@@ -11029,103 +11051,103 @@ msgstr ""
 "це колір джерела світла до хроматичної адаптації\n"
 "цей колір адаптацією перетвориться на чисто білий."
 
-#: ../src/iop/channelmixerrgb.c:3518 ../src/iop/temperature.c:2059
+#: ../src/iop/channelmixerrgb.c:3706 ../src/iop/temperature.c:2059
 msgid "set white balance to detected from area"
 msgstr "встановити баланс білого на виявлений з області зображення"
 
-#: ../src/iop/channelmixerrgb.c:3522
+#: ../src/iop/channelmixerrgb.c:3710
 msgid "illuminant"
 msgstr "освітлювач"
 
-#: ../src/iop/channelmixerrgb.c:3528 ../src/iop/temperature.c:1995
+#: ../src/iop/channelmixerrgb.c:3716 ../src/iop/temperature.c:1995
 msgid "temperature"
 msgstr "температура"
 
-#: ../src/iop/channelmixerrgb.c:3572
+#: ../src/iop/channelmixerrgb.c:3760
 msgid "input red"
 msgstr "вхідний червоний"
 
-#: ../src/iop/channelmixerrgb.c:3579
+#: ../src/iop/channelmixerrgb.c:3767
 msgid "input green"
 msgstr "вхідний зелений"
 
-#: ../src/iop/channelmixerrgb.c:3586
+#: ../src/iop/channelmixerrgb.c:3774
 msgid "input blue"
 msgstr "вхідний синій"
 
-#: ../src/iop/channelmixerrgb.c:3597
+#: ../src/iop/channelmixerrgb.c:3785
 msgid "colorfulness"
 msgstr "барвистість"
 
-#: ../src/iop/channelmixerrgb.c:3612
+#: ../src/iop/channelmixerrgb.c:3800
 msgid "calibrate with a color checker"
 msgstr "калібрувати за допомогою мішені"
 
-#: ../src/iop/channelmixerrgb.c:3615
+#: ../src/iop/channelmixerrgb.c:3803
 msgid "use a color checker target to autoset CAT and channels"
 msgstr "використати кольорову мішень для автовстановлення CAT і каналів"
 
-#: ../src/iop/channelmixerrgb.c:3622
+#: ../src/iop/channelmixerrgb.c:3810
 msgid "chart"
 msgstr "мішень"
 
-#: ../src/iop/channelmixerrgb.c:3623
+#: ../src/iop/channelmixerrgb.c:3811
 msgid "Xrite ColorChecker 24 pre-2014"
 msgstr "Xrite ColorChecker 24 pre-2014"
 
-#: ../src/iop/channelmixerrgb.c:3624
+#: ../src/iop/channelmixerrgb.c:3812
 msgid "Xrite ColorChecker 24 post-2014"
 msgstr "Xrite ColorChecker 24 post-2014"
 
-#: ../src/iop/channelmixerrgb.c:3625
+#: ../src/iop/channelmixerrgb.c:3813
 msgid "Datacolor SpyderCheckr 24 pre-2018"
 msgstr "Datacolor SpyderCheckr 24 pre-2018"
 
-#: ../src/iop/channelmixerrgb.c:3626
+#: ../src/iop/channelmixerrgb.c:3814
 msgid "Datacolor SpyderCheckr 24 post-2018"
 msgstr "Datacolor SpyderCheckr 24 post-2018"
 
-#: ../src/iop/channelmixerrgb.c:3627
+#: ../src/iop/channelmixerrgb.c:3815
 msgid "Datacolor SpyderCheckr 48 pre-2018"
 msgstr "Datacolor SpyderCheckr 48 pre-2018"
 
-#: ../src/iop/channelmixerrgb.c:3628
+#: ../src/iop/channelmixerrgb.c:3816
 msgid "Datacolor SpyderCheckr 48 post-2018"
 msgstr "Datacolor SpyderCheckr 48 post-2018"
 
-#: ../src/iop/channelmixerrgb.c:3630
+#: ../src/iop/channelmixerrgb.c:3818
 msgid "choose the vendor and the type of your chart"
 msgstr "виберіть виробника та тип вашої мішені"
 
-#: ../src/iop/channelmixerrgb.c:3634
+#: ../src/iop/channelmixerrgb.c:3822
 msgid "optimize for"
 msgstr "ціль оптимізації"
 
-#: ../src/iop/channelmixerrgb.c:3636
+#: ../src/iop/channelmixerrgb.c:3824
 msgid "neutral colors"
 msgstr "нейтральні кольори"
 
-#: ../src/iop/channelmixerrgb.c:3638
+#: ../src/iop/channelmixerrgb.c:3826
 msgid "skin and soil colors"
 msgstr "кольори шкіри та грунту"
 
-#: ../src/iop/channelmixerrgb.c:3639
+#: ../src/iop/channelmixerrgb.c:3827
 msgid "foliage colors"
 msgstr "кольори листя"
 
-#: ../src/iop/channelmixerrgb.c:3640
+#: ../src/iop/channelmixerrgb.c:3828
 msgid "sky and water colors"
 msgstr "кольори неба та води"
 
-#: ../src/iop/channelmixerrgb.c:3641
+#: ../src/iop/channelmixerrgb.c:3829
 msgid "average delta E"
 msgstr "середня ΔE*"
 
-#: ../src/iop/channelmixerrgb.c:3642
+#: ../src/iop/channelmixerrgb.c:3830
 msgid "maximum delta E"
 msgstr "максимальна ΔE*"
 
-#: ../src/iop/channelmixerrgb.c:3644
+#: ../src/iop/channelmixerrgb.c:3832
 msgid ""
 "choose the colors that will be optimized with higher priority.\n"
 "neutral colors gives the lowest average delta E but a high maximum delta E\n"
@@ -11140,11 +11162,11 @@ msgstr ""
 "немає - компроміс між ними\n"
 "інші варіанти задають особливу поведінку для захисту деяких відтінків"
 
-#: ../src/iop/channelmixerrgb.c:3652
+#: ../src/iop/channelmixerrgb.c:3840
 msgid "patch scale"
 msgstr "масштаб зразків"
 
-#: ../src/iop/channelmixerrgb.c:3653
+#: ../src/iop/channelmixerrgb.c:3841
 msgid ""
 "reduce the radius of the patches to select the more or less central part.\n"
 "useful when the perspective correction is sloppy or\n"
@@ -11154,19 +11176,19 @@ msgstr ""
 "корисно, коли корекція перспективи є неакуратною або\n"
 "рамка зразків відкидає тіні по краях зразків."
 
-#: ../src/iop/channelmixerrgb.c:3661
+#: ../src/iop/channelmixerrgb.c:3849
 msgid "the delta E is using the CIE 2000 formula."
 msgstr "для ΔE* використовується формула CIE 2000."
 
-#: ../src/iop/channelmixerrgb.c:3667
+#: ../src/iop/channelmixerrgb.c:3855
 msgid "accept the computed profile and set it in the module"
 msgstr "прийняти обчислений профіль і встановити його в модулі"
 
-#: ../src/iop/channelmixerrgb.c:3672
+#: ../src/iop/channelmixerrgb.c:3860
 msgid "recompute the profile"
 msgstr "перерахувати профіль"
 
-#: ../src/iop/channelmixerrgb.c:3677
+#: ../src/iop/channelmixerrgb.c:3865
 msgid "check the output delta E"
 msgstr "перевірити вихідну ΔE*"
 
@@ -11208,142 +11230,142 @@ msgstr "reframe|perspective|keystone|distortion"
 msgid "change the framing and correct the perspective"
 msgstr "змінити кадрування та виправити перспективу"
 
-#: ../src/iop/clipping.c:1381 ../src/iop/clipping.c:2173 ../src/iop/crop.c:432
-#: ../src/iop/crop.c:1115
+#: ../src/iop/clipping.c:1387 ../src/iop/clipping.c:2179 ../src/iop/crop.c:448
+#: ../src/iop/crop.c:1131
 msgid "original image"
 msgstr "як в оригіналі"
 
-#: ../src/iop/clipping.c:1685 ../src/iop/crop.c:736
+#: ../src/iop/clipping.c:1691 ../src/iop/crop.c:752
 msgid "invalid ratio format. it should be \"number:number\""
 msgstr "недійсний формат співвідношення. це має бути \"число:число\""
 
-#: ../src/iop/clipping.c:1701 ../src/iop/crop.c:752
+#: ../src/iop/clipping.c:1707 ../src/iop/crop.c:768
 msgid "invalid ratio format. it should be a positive number"
 msgstr "недійсний формат співвідношення. це має бути додатне число"
 
-#: ../src/iop/clipping.c:1890 ../src/iop/clipping.c:2164
+#: ../src/iop/clipping.c:1896 ../src/iop/clipping.c:2170
 msgid "full"
 msgstr "повна"
 
-#: ../src/iop/clipping.c:1891
+#: ../src/iop/clipping.c:1897
 msgid "old system"
 msgstr "стара система"
 
-#: ../src/iop/clipping.c:1892
+#: ../src/iop/clipping.c:1898
 msgid "correction applied"
 msgstr "корекцію застосовано"
 
-#: ../src/iop/clipping.c:2141
+#: ../src/iop/clipping.c:2147
 msgid "main"
 msgstr "головне"
 
-#: ../src/iop/clipping.c:2144 ../src/libs/live_view.c:367
+#: ../src/iop/clipping.c:2150 ../src/libs/live_view.c:444
 msgid "flip"
 msgstr "віддзеркалити"
 
-#: ../src/iop/clipping.c:2148 ../src/iop/clipping.c:2326
-#: ../src/iop/colorbalance.c:1890 ../src/iop/crop.c:1267
-#: ../src/libs/live_view.c:371
+#: ../src/iop/clipping.c:2154 ../src/iop/clipping.c:2332
+#: ../src/iop/colorbalance.c:1890 ../src/iop/crop.c:1283
+#: ../src/libs/live_view.c:448
 msgid "both"
 msgstr "обидва"
 
-#: ../src/iop/clipping.c:2150
+#: ../src/iop/clipping.c:2156
 msgid "mirror image horizontally and/or vertically"
 msgstr "віддзеркалити зображення в горизонтальній і/або вертикальній площині"
 
-#: ../src/iop/clipping.c:2153
+#: ../src/iop/clipping.c:2159
 msgid "angle"
 msgstr "кут"
 
-#: ../src/iop/clipping.c:2157
+#: ../src/iop/clipping.c:2163
 msgid "right-click and drag a line on the image to drag a straight line"
 msgstr ""
 "клікніть правою кнопкою та перетягніть лінію на зображенні, щоб вказати "
 "пряму лінію"
 
-#: ../src/iop/clipping.c:2160
+#: ../src/iop/clipping.c:2166
 msgid "keystone"
 msgstr "корекція перспективи"
 
-#: ../src/iop/clipping.c:2165
+#: ../src/iop/clipping.c:2171
 msgid "set perspective correction for your image"
 msgstr "встановити корекцію перспективи для вашого зображення"
 
-#: ../src/iop/clipping.c:2172 ../src/iop/crop.c:1114
+#: ../src/iop/clipping.c:2178 ../src/iop/crop.c:1130
 msgid "freehand"
 msgstr "вільне"
 
-#: ../src/iop/clipping.c:2175 ../src/iop/crop.c:1117
+#: ../src/iop/clipping.c:2181 ../src/iop/crop.c:1133
 msgid "10:8 in print"
 msgstr "10:8, друк"
 
-#: ../src/iop/clipping.c:2176 ../src/iop/crop.c:1118
+#: ../src/iop/clipping.c:2182 ../src/iop/crop.c:1134
 msgid "5:4, 4x5, 8x10"
 msgstr "5:4, 4x5, 8x10"
 
-#: ../src/iop/clipping.c:2177 ../src/iop/crop.c:1119
+#: ../src/iop/clipping.c:2183 ../src/iop/crop.c:1135
 msgid "11x14"
 msgstr "11x14"
 
-#: ../src/iop/clipping.c:2178 ../src/iop/crop.c:1120
+#: ../src/iop/clipping.c:2184 ../src/iop/crop.c:1136
 msgid "8.5x11, letter"
 msgstr "8.5x11, letter"
 
-#: ../src/iop/clipping.c:2179 ../src/iop/crop.c:1121
+#: ../src/iop/clipping.c:2185 ../src/iop/crop.c:1137
 msgid "4:3, VGA, TV"
 msgstr "4:3, VGA, TV"
 
-#: ../src/iop/clipping.c:2180 ../src/iop/crop.c:1122
+#: ../src/iop/clipping.c:2186 ../src/iop/crop.c:1138
 msgid "5x7"
 msgstr "5x7"
 
-#: ../src/iop/clipping.c:2181 ../src/iop/crop.c:1123
+#: ../src/iop/clipping.c:2187 ../src/iop/crop.c:1139
 msgid "ISO 216, DIN 476, A4"
 msgstr "ISO 216, DIN 476, A4"
 
-#: ../src/iop/clipping.c:2182 ../src/iop/crop.c:1124
+#: ../src/iop/clipping.c:2188 ../src/iop/crop.c:1140
 msgid "3:2, 4x6, 35mm"
 msgstr "3:2, 4x6, 35мм"
 
-#: ../src/iop/clipping.c:2183 ../src/iop/crop.c:1125
+#: ../src/iop/clipping.c:2189 ../src/iop/crop.c:1141
 msgid "16:10, 8x5"
 msgstr "16:10, 8x5"
 
-#: ../src/iop/clipping.c:2185 ../src/iop/crop.c:1127
+#: ../src/iop/clipping.c:2191 ../src/iop/crop.c:1143
 msgid "16:9, HDTV"
 msgstr "16:9, HDTV"
 
-#: ../src/iop/clipping.c:2186 ../src/iop/crop.c:1128
+#: ../src/iop/clipping.c:2192 ../src/iop/crop.c:1144
 msgid "widescreen"
 msgstr "широкий екран"
 
-#: ../src/iop/clipping.c:2187 ../src/iop/crop.c:1129
+#: ../src/iop/clipping.c:2193 ../src/iop/crop.c:1145
 msgid "2:1, univisium"
 msgstr "2:1, univisium"
 
-#: ../src/iop/clipping.c:2188 ../src/iop/crop.c:1130
+#: ../src/iop/clipping.c:2194 ../src/iop/crop.c:1146
 msgid "cinemascope"
 msgstr "сінемаскоп"
 
-#: ../src/iop/clipping.c:2189 ../src/iop/crop.c:1131
+#: ../src/iop/clipping.c:2195 ../src/iop/crop.c:1147
 msgid "21:9"
 msgstr "21:9"
 
-#: ../src/iop/clipping.c:2190 ../src/iop/crop.c:1132
+#: ../src/iop/clipping.c:2196 ../src/iop/crop.c:1148
 msgid "anamorphic"
 msgstr "анаморф"
 
-#: ../src/iop/clipping.c:2191 ../src/iop/crop.c:1133
+#: ../src/iop/clipping.c:2197 ../src/iop/crop.c:1149
 msgid "3:1, panorama"
 msgstr "3:1, панорама"
 
-#: ../src/iop/clipping.c:2223 ../src/iop/clipping.c:2235 ../src/iop/crop.c:1165
-#: ../src/iop/crop.c:1177
+#: ../src/iop/clipping.c:2229 ../src/iop/clipping.c:2241 ../src/iop/crop.c:1181
+#: ../src/iop/crop.c:1193
 #, c-format
 msgid "invalid ratio format for `%s'. it should be \"number:number\""
 msgstr "недійсний формат співвідношення для `%s'. це має бути \"число:число\""
 
-#: ../src/iop/clipping.c:2282 ../src/iop/crop.c:1223
+#: ../src/iop/clipping.c:2288 ../src/iop/crop.c:1239
 msgid ""
 "set the aspect ratio\n"
 "the list is sorted: from most square to least square"
@@ -11351,61 +11373,61 @@ msgstr ""
 "встановити співвідношення сторін\n"
 "список відсортовано: від більш квадратних до менш квадратних"
 
-#: ../src/iop/clipping.c:2318 ../src/iop/crop.c:1259
-#: ../src/libs/live_view.c:363
+#: ../src/iop/clipping.c:2324 ../src/iop/crop.c:1275
+#: ../src/libs/live_view.c:440
 msgid "display guide lines to help compose your photograph"
 msgstr "відображати напрямні лінії, щоб допомогти компонувати фотографію"
 
-#: ../src/iop/clipping.c:2322 ../src/iop/clipping.c:2327 ../src/iop/crop.c:1263
-#: ../src/iop/crop.c:1268 ../src/libs/live_view.c:372
+#: ../src/iop/clipping.c:2328 ../src/iop/clipping.c:2333 ../src/iop/crop.c:1279
+#: ../src/iop/crop.c:1284 ../src/libs/live_view.c:449
 msgid "flip guides"
 msgstr "перевернути напрямні"
 
-#: ../src/iop/clipping.c:2324 ../src/iop/crop.c:1265
-#: ../src/libs/live_view.c:369
+#: ../src/iop/clipping.c:2330 ../src/iop/crop.c:1281
+#: ../src/libs/live_view.c:446
 msgid "horizontally"
 msgstr "горизонтально"
 
-#: ../src/iop/clipping.c:2325 ../src/iop/crop.c:1266
-#: ../src/libs/live_view.c:370
+#: ../src/iop/clipping.c:2331 ../src/iop/crop.c:1282
+#: ../src/libs/live_view.c:447
 msgid "vertically"
 msgstr "вертикально"
 
-#: ../src/iop/clipping.c:2334 ../src/iop/crop.c:1278
+#: ../src/iop/clipping.c:2340 ../src/iop/crop.c:1294
 msgid "margins"
 msgstr "поля"
 
-#: ../src/iop/clipping.c:2340 ../src/iop/crop.c:1306
+#: ../src/iop/clipping.c:2346 ../src/iop/crop.c:1322
 msgid "the left margin cannot overlap with the right margin"
 msgstr "ліве поле не може накладатися на праве"
 
-#: ../src/iop/clipping.c:2347 ../src/iop/crop.c:1313
+#: ../src/iop/clipping.c:2353 ../src/iop/crop.c:1329
 msgid "the right margin cannot overlap with the left margin"
 msgstr "праве поле не може перекриватися з лівим"
 
-#: ../src/iop/clipping.c:2353 ../src/iop/crop.c:1319
+#: ../src/iop/clipping.c:2359 ../src/iop/crop.c:1335
 msgid "the top margin cannot overlap with the bottom margin"
 msgstr "верхнє поле не може перекриватися з нижнім"
 
-#: ../src/iop/clipping.c:2360 ../src/iop/crop.c:1326
+#: ../src/iop/clipping.c:2366 ../src/iop/crop.c:1342
 msgid "the bottom margin cannot overlap with the top margin"
 msgstr "нижнє поле не може накладатися на верхнє"
 
-#: ../src/iop/clipping.c:3456 ../src/iop/crop.c:1777
+#: ../src/iop/clipping.c:3480 ../src/iop/crop.c:1798
 msgid "commit"
 msgstr "застосувати"
 
-#: ../src/iop/clipping.c:3467 ../src/iop/crop.c:1788
+#: ../src/iop/clipping.c:3491 ../src/iop/crop.c:1809
 #, c-format
 msgid "[%s on borders] crop"
 msgstr "[%s на краях] обрізати"
 
-#: ../src/iop/clipping.c:3469 ../src/iop/crop.c:1790
+#: ../src/iop/clipping.c:3493 ../src/iop/crop.c:1811
 #, c-format
 msgid "[%s on borders] crop keeping ratio"
 msgstr "[%s на краях] обрізати зі збереженням співвідношення сторін"
 
-#: ../src/iop/clipping.c:3470 ../src/iop/crop.c:1791
+#: ../src/iop/clipping.c:3494 ../src/iop/crop.c:1812
 #, c-format
 msgid "[%s] define/rotate horizon"
 msgstr "[%s] визначити/повернути горизонт"
@@ -11430,11 +11452,11 @@ msgstr "колірний баланс"
 msgid "lift gamma gain|cdl|color grading|contrast|saturation|hue"
 msgstr "lift gamma gain|cdl|color grading|contrast|saturation|hue"
 
-#: ../src/iop/colorbalance.c:158 ../src/iop/colorbalancergb.c:169
+#: ../src/iop/colorbalance.c:158 ../src/iop/colorbalancergb.c:170
 msgid "affect color, brightness and contrast"
 msgstr "впливає на колір, яскравість і контраст"
 
-#: ../src/iop/colorbalance.c:162 ../src/iop/colorbalancergb.c:173
+#: ../src/iop/colorbalance.c:162 ../src/iop/colorbalancergb.c:174
 msgid "non-linear, Lab, scene-referred"
 msgstr "нелінійний, Lab, на основі сцен"
 
@@ -11542,7 +11564,7 @@ msgid "RGBL"
 msgstr "RGBL"
 
 #. Page master
-#: ../src/iop/colorbalance.c:1902 ../src/iop/colorbalancergb.c:1456
+#: ../src/iop/colorbalance.c:1902 ../src/iop/colorbalancergb.c:1489
 msgid "master"
 msgstr "основні параметри"
 
@@ -11637,73 +11659,73 @@ msgstr "нормалізувати гістограму і центрувати 
 
 #: ../src/iop/colorbalance.c:2099
 msgid "optimize the RGB curves to remove color casts"
-msgstr "оптимізувати криві RGB для видалення підфарбування"
+msgstr "оптимізувати криві RGB для видалення обарвлення"
 
-#: ../src/iop/colorbalancergb.c:159
+#: ../src/iop/colorbalancergb.c:160
 msgid "color balance rgb"
 msgstr "колірний баланс rgb"
 
-#: ../src/iop/colorbalancergb.c:164
+#: ../src/iop/colorbalancergb.c:165
 msgid ""
 "offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance"
 msgstr ""
 "offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance"
 
-#: ../src/iop/colorbalancergb.c:670
+#: ../src/iop/colorbalancergb.c:693
 msgid "colorbalance works only on RGB input"
 msgstr "колірний баланс працює лише з RGB входом"
 
-#: ../src/iop/colorbalancergb.c:1095 ../src/iop/colorzones.c:2218
+#: ../src/iop/colorbalancergb.c:1128 ../src/iop/colorzones.c:2218
 #: ../src/iop/retouch.c:1817 ../src/iop/toneequal.c:1838
 msgid "cannot display masks when the blending mask is displayed"
 msgstr "неможливо відображати маски, коли відображається маска змішування"
 
-#: ../src/iop/colorbalancergb.c:1456
+#: ../src/iop/colorbalancergb.c:1489
 msgid "global grading"
 msgstr "глобальний грейдинг"
 
-#: ../src/iop/colorbalancergb.c:1462
+#: ../src/iop/colorbalancergb.c:1495
 msgid "rotate all hues by an angle, at the same luminance"
 msgstr "обертати всі відтінки на певний кут з однаковою яскравістю"
 
-#: ../src/iop/colorbalancergb.c:1469
+#: ../src/iop/colorbalancergb.c:1502
 msgid "increase colorfulness mostly on low-chroma colors"
 msgstr "збільшити барвистість переважно низькохроматичних відтінків"
 
-#: ../src/iop/colorbalancergb.c:1476
+#: ../src/iop/colorbalancergb.c:1509
 msgid "increase the contrast at constant chromaticity"
 msgstr "збільшити контраст при незмінній хроматичності"
 
-#: ../src/iop/colorbalancergb.c:1478
+#: ../src/iop/colorbalancergb.c:1511
 msgid "linear chroma grading"
 msgstr "лінійний грейдинг кольоровості"
 
-#: ../src/iop/colorbalancergb.c:1485
+#: ../src/iop/colorbalancergb.c:1518
 msgid "increase colorfulness at same luminance globally"
 msgstr "збільшити барвистість при однаковій яскравості глобально"
 
-#: ../src/iop/colorbalancergb.c:1491
+#: ../src/iop/colorbalancergb.c:1524
 msgid "increase colorfulness at same luminance mostly in shadows"
 msgstr "збільшити барвистість при однаковій яскравості в тінях"
 
-#: ../src/iop/colorbalancergb.c:1497
+#: ../src/iop/colorbalancergb.c:1530
 msgid "increase colorfulness at same luminance mostly in midtones"
 msgstr "збільшити барвистість при однаковій яскравості в середніх тонах"
 
-#: ../src/iop/colorbalancergb.c:1503
+#: ../src/iop/colorbalancergb.c:1536
 msgid "increase colorfulness at same luminance mostly in highlights"
 msgstr "збільшити барвистість при однаковій яскравості в світлих тонах"
 
-#: ../src/iop/colorbalancergb.c:1505
+#: ../src/iop/colorbalancergb.c:1538
 msgid "perceptual saturation grading"
 msgstr "перцепційний грейдинг насиченості"
 
-#: ../src/iop/colorbalancergb.c:1512
+#: ../src/iop/colorbalancergb.c:1545
 msgid "add or remove saturation by an absolute amount"
 msgstr "додати чи прибрати насиченість в абсолютній величині"
 
-#: ../src/iop/colorbalancergb.c:1519 ../src/iop/colorbalancergb.c:1526
-#: ../src/iop/colorbalancergb.c:1533
+#: ../src/iop/colorbalancergb.c:1552 ../src/iop/colorbalancergb.c:1559
+#: ../src/iop/colorbalancergb.c:1566
 msgid ""
 "increase or decrease saturation proportionally to the original pixel "
 "saturation"
@@ -11711,16 +11733,16 @@ msgstr ""
 "збільшувати або зменшувати насиченість пропорційно оригінальній насиченості "
 "пікселів"
 
-#: ../src/iop/colorbalancergb.c:1536
+#: ../src/iop/colorbalancergb.c:1569
 msgid "perceptual brilliance grading"
 msgstr "перцепційний грейдинг блискучості"
 
-#: ../src/iop/colorbalancergb.c:1543
+#: ../src/iop/colorbalancergb.c:1576
 msgid "add or remove brilliance by an absolute amount"
 msgstr "додати чи прибрати блискучість в абсолютній величині"
 
-#: ../src/iop/colorbalancergb.c:1550 ../src/iop/colorbalancergb.c:1557
-#: ../src/iop/colorbalancergb.c:1564
+#: ../src/iop/colorbalancergb.c:1583 ../src/iop/colorbalancergb.c:1590
+#: ../src/iop/colorbalancergb.c:1597
 msgid ""
 "increase or decrease brilliance proportionally to the original pixel "
 "brilliance"
@@ -11729,126 +11751,132 @@ msgstr ""
 "пікселів"
 
 #. Page 4-ways
-#: ../src/iop/colorbalancergb.c:1568
+#: ../src/iop/colorbalancergb.c:1601
 msgid "4 ways"
 msgstr "4 діапазони"
 
-#: ../src/iop/colorbalancergb.c:1568
+#: ../src/iop/colorbalancergb.c:1601
 msgid "selective color grading"
 msgstr "вибірковий грейдинг"
 
-#: ../src/iop/colorbalancergb.c:1570
+#: ../src/iop/colorbalancergb.c:1603
 msgid "global offset"
 msgstr "глобальне зміщення"
 
-#: ../src/iop/colorbalancergb.c:1577
+#: ../src/iop/colorbalancergb.c:1610
 msgid "global luminance offset"
 msgstr "глобальне зміщення яскравості"
 
-#: ../src/iop/colorbalancergb.c:1584
+#: ../src/iop/colorbalancergb.c:1617
 msgid "hue of the global color offset"
 msgstr "глобальне зміщення відтінку"
 
-#: ../src/iop/colorbalancergb.c:1591
+#: ../src/iop/colorbalancergb.c:1624
 msgid "chroma of the global color offset"
 msgstr "глобальне зміщення кольоровості"
 
-#: ../src/iop/colorbalancergb.c:1593
+#: ../src/iop/colorbalancergb.c:1626
 msgid "shadows lift"
 msgstr "підйом тіней"
 
-#: ../src/iop/colorbalancergb.c:1600
+#: ../src/iop/colorbalancergb.c:1633
 msgid "luminance gain in shadows"
 msgstr "посилення яскравості в тінях"
 
-#: ../src/iop/colorbalancergb.c:1607
+#: ../src/iop/colorbalancergb.c:1640
 msgid "hue of the color gain in shadows"
 msgstr "посилення відтінку в тінях"
 
-#: ../src/iop/colorbalancergb.c:1615
+#: ../src/iop/colorbalancergb.c:1648
 msgid "chroma of the color gain in shadows"
 msgstr "посилення кольоровості в тінях"
 
-#: ../src/iop/colorbalancergb.c:1617
+#: ../src/iop/colorbalancergb.c:1650
 msgid "highlights gain"
 msgstr "підсилення світлих тонів"
 
-#: ../src/iop/colorbalancergb.c:1624
+#: ../src/iop/colorbalancergb.c:1657
 msgid "luminance gain in highlights"
 msgstr "посилення яскравості в світлих тонах"
 
-#: ../src/iop/colorbalancergb.c:1631
+#: ../src/iop/colorbalancergb.c:1664
 msgid "hue of the color gain in highlights"
 msgstr "посилення відтінку в світлих тонах"
 
-#: ../src/iop/colorbalancergb.c:1639
+#: ../src/iop/colorbalancergb.c:1672
 msgid "chroma of the color gain in highlights"
 msgstr "посилення кольоровості в світлих тонах"
 
-#: ../src/iop/colorbalancergb.c:1641
+#: ../src/iop/colorbalancergb.c:1674
 msgid "power"
 msgstr "показник степеня"
 
-#: ../src/iop/colorbalancergb.c:1648
+#: ../src/iop/colorbalancergb.c:1681
 msgid "luminance exponent in midtones"
 msgstr "експонента яскравості в середніх тонах"
 
-#: ../src/iop/colorbalancergb.c:1655
+#: ../src/iop/colorbalancergb.c:1688
 msgid "hue of the color exponent in midtones"
 msgstr "експонента відтінку в середніх тонах"
 
-#: ../src/iop/colorbalancergb.c:1663
+#: ../src/iop/colorbalancergb.c:1696
 msgid "chroma of the color exponent in midtones"
 msgstr "експонента кольоровості в середніх тонах"
 
 #. Page masks
-#: ../src/iop/colorbalancergb.c:1666
+#: ../src/iop/colorbalancergb.c:1699
 msgid "masks"
 msgstr "маски"
 
-#: ../src/iop/colorbalancergb.c:1666
+#: ../src/iop/colorbalancergb.c:1699
 msgid "isolate luminances"
 msgstr "ізоляція яскравостей"
 
-#: ../src/iop/colorbalancergb.c:1668
+#: ../src/iop/colorbalancergb.c:1701
 msgid "luminance ranges"
 msgstr "діапазони яскравості"
 
-#: ../src/iop/colorbalancergb.c:1682
+#: ../src/iop/colorbalancergb.c:1715
 msgid "weight of the shadows over the whole tonal range"
 msgstr "вага тіней у всьому тональному діапазоні"
 
-#: ../src/iop/colorbalancergb.c:1693
-msgid "position of the middle-grey reference for masking"
+#: ../src/iop/colorbalancergb.c:1726
+msgid "position of the middle-gray reference for masking"
 msgstr "положення середньо-сірого еталону для маскування"
 
-#: ../src/iop/colorbalancergb.c:1704
+#: ../src/iop/colorbalancergb.c:1737
 msgid "weights of highlights over the whole tonal range"
 msgstr "вага світлих тонів у всьому тональному діапазоні"
 
-#: ../src/iop/colorbalancergb.c:1717 ../src/iop/colorbalancergb.c:1725
+#: ../src/iop/colorbalancergb.c:1750
 msgid "peak white luminance value used to normalize the power function"
 msgstr ""
 "пікове значення яскравості білого, що використовується для нормалізації "
 "степеневої функції"
 
-#: ../src/iop/colorbalancergb.c:1727
+#: ../src/iop/colorbalancergb.c:1758
+msgid "peak gray luminance value used to normalize the power function"
+msgstr ""
+"пікове значення яскравості сірого, що використовується для нормалізації "
+"степеневої функції"
+
+#: ../src/iop/colorbalancergb.c:1760
 msgid "mask preview settings"
 msgstr "параметри попереднього перегляду маски"
 
-#: ../src/iop/colorbalancergb.c:1730
+#: ../src/iop/colorbalancergb.c:1763
 msgid "checkerboard color 1"
 msgstr "шахівниця, колір 1"
 
-#: ../src/iop/colorbalancergb.c:1733 ../src/iop/colorbalancergb.c:1742
+#: ../src/iop/colorbalancergb.c:1766 ../src/iop/colorbalancergb.c:1775
 msgid "select color of the checkerboard from a swatch"
 msgstr "вибрати колір шахівниці зі зразка"
 
-#: ../src/iop/colorbalancergb.c:1739
+#: ../src/iop/colorbalancergb.c:1772
 msgid "checkerboard color 2"
 msgstr "шахівниця, колір 2"
 
-#: ../src/iop/colorbalancergb.c:1749
+#: ../src/iop/colorbalancergb.c:1782
 msgid "checkerboard size"
 msgstr "розмір шахівниці"
 
@@ -12205,21 +12233,21 @@ msgstr "вихідний метод"
 #: ../src/iop/colorout.c:870 ../src/libs/export.c:1328
 #: ../src/libs/print_settings.c:1235 ../src/libs/print_settings.c:1448
 #: ../src/views/darkroom.c:2384 ../src/views/darkroom.c:2391
-#: ../src/views/lighttable.c:1313 ../src/views/lighttable.c:1320
+#: ../src/views/lighttable.c:1320 ../src/views/lighttable.c:1327
 msgid "perceptual"
 msgstr "перцепційний"
 
 #: ../src/iop/colorout.c:871 ../src/libs/export.c:1329
 #: ../src/libs/print_settings.c:1236 ../src/libs/print_settings.c:1449
 #: ../src/views/darkroom.c:2385 ../src/views/darkroom.c:2392
-#: ../src/views/lighttable.c:1314 ../src/views/lighttable.c:1321
+#: ../src/views/lighttable.c:1321 ../src/views/lighttable.c:1328
 msgid "relative colorimetric"
 msgstr "відносний колориметричний"
 
 #: ../src/iop/colorout.c:872 ../src/libs/export.c:1330
 #: ../src/libs/print_settings.c:1237 ../src/libs/print_settings.c:1450
 #: ../src/views/darkroom.c:2386 ../src/views/darkroom.c:2393
-#: ../src/views/lighttable.c:1315 ../src/views/lighttable.c:1322
+#: ../src/views/lighttable.c:1322 ../src/views/lighttable.c:1329
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "насиченість"
@@ -12227,7 +12255,7 @@ msgstr "насиченість"
 #: ../src/iop/colorout.c:873 ../src/libs/export.c:1331
 #: ../src/libs/print_settings.c:1238 ../src/libs/print_settings.c:1451
 #: ../src/views/darkroom.c:2387 ../src/views/darkroom.c:2394
-#: ../src/views/lighttable.c:1316 ../src/views/lighttable.c:1323
+#: ../src/views/lighttable.c:1323 ../src/views/lighttable.c:1330
 msgid "absolute colorimetric"
 msgstr "абсолютний колориметричний"
 
@@ -12452,7 +12480,7 @@ msgstr "reframe|distortion"
 msgid "change the framing"
 msgstr "змінити кадрування"
 
-#: ../src/iop/crop.c:1108
+#: ../src/iop/crop.c:1124
 msgid "crop settings"
 msgstr "налаштування кадрування"
 
@@ -12509,16 +12537,16 @@ msgid "reconstruct full RGB pixels from a sensor color filter array reading"
 msgstr ""
 "реконструювати повні RGB-пікселі з даних масиву кольорових фільтрів сенсора"
 
-#: ../src/iop/demosaic.c:5224
+#: ../src/iop/demosaic.c:5228
 msgid "[dual demosaic_cl] internal problem"
 msgstr "[dual demosaic_cl] внутрішня проблема"
 
-#: ../src/iop/demosaic.c:5563
+#: ../src/iop/demosaic.c:5571
 #, c-format
 msgid "`%s' color matrix not found for 4bayer image!"
 msgstr "матрицю кольорів `%s' не знайдено для Quad Bayer зображення!"
 
-#: ../src/iop/demosaic.c:5713
+#: ../src/iop/demosaic.c:5721
 msgid ""
 "bayer sensor demosaicing method, PPG and RCD are fast, AMaZE is slow.\n"
 "dual demosaicers double processing time."
@@ -12526,7 +12554,7 @@ msgstr ""
 "метод демозаїкізації матриці Баєра. PPG і RCD швидкі, AMaZE повільний.\n"
 "подвійні демозаїки подвоюють час обробки."
 
-#: ../src/iop/demosaic.c:5717
+#: ../src/iop/demosaic.c:5725
 msgid ""
 "xtrans sensor demosaicing method, Markesteijn 3-pass and frequency domain "
 "chroma are slow.\n"
@@ -12536,7 +12564,7 @@ msgstr ""
 "domain chroma повільні.\n"
 "подвійні демозаїки подвоюють час обробки."
 
-#: ../src/iop/demosaic.c:5722
+#: ../src/iop/demosaic.c:5730
 msgid ""
 "threshold for edge-aware median.\n"
 "set to 0.0 to switch off.\n"
@@ -12546,7 +12574,7 @@ msgstr ""
 "0.0 - вимикає медіанну фільтрацію.\n"
 "1.0 - ігнорувати контури."
 
-#: ../src/iop/demosaic.c:5727
+#: ../src/iop/demosaic.c:5735
 msgid ""
 "contrast threshold for dual demosaic.\n"
 "set to 0.0 for high frequency content.\n"
@@ -12556,26 +12584,26 @@ msgstr ""
 "0.0 - для високочастотного вмісту.\n"
 "1.0 - для плоского вмісту."
 
-#: ../src/iop/demosaic.c:5730
+#: ../src/iop/demosaic.c:5738
 msgid "display blending mask"
 msgstr "показати маску змішування"
 
-#: ../src/iop/demosaic.c:5737
+#: ../src/iop/demosaic.c:5745
 msgid "how many color smoothing median steps after demosaicing"
 msgstr ""
 "кількість медіанних проходів згладжування кольорів після демозаїкізації"
 
-#: ../src/iop/demosaic.c:5740
+#: ../src/iop/demosaic.c:5748
 msgid "green channels matching method"
 msgstr "метод вирівнювання зелених каналів"
 
-#: ../src/iop/demosaic.c:5746
-msgid ""
-"demosaicing\n"
-"only needed for raw images."
-msgstr ""
-"демозаїкізація\n"
-"потрібна лише для raw."
+#: ../src/iop/demosaic.c:5754
+msgid "not applicable"
+msgstr "не застосовується"
+
+#: ../src/iop/demosaic.c:5755
+msgid "demosaicing is only used for color raw images"
+msgstr "демозаїкізація використовується лише для кольорових raw зображень"
 
 #: ../src/iop/denoiseprofile.c:656
 msgid "wavelets: chroma only"
@@ -12809,7 +12837,7 @@ msgid ""
 "decrease if shadows are too purple.\n"
 "increase if shadows are too green."
 msgstr ""
-"коригувати підфарбування у тінях.\n"
+"коригувати обарвлення у тінях.\n"
 "зменшити, якщо тіні занадто пурпурні.\n"
 "збільшити, якщо тіні занадто зелені."
 
@@ -13095,7 +13123,7 @@ msgstr ""
 
 #. geotagging
 #: ../src/iop/filmic.c:1662 ../src/iop/filmicrgb.c:3867
-#: ../src/libs/metadata_view.c:162
+#: ../src/libs/metadata_view.c:156
 msgid "latitude"
 msgstr "широта"
 
@@ -13144,7 +13172,7 @@ msgstr ""
 #: ../src/iop/filmic.c:1705 ../src/libs/export.c:1326
 #: ../src/libs/print_settings.c:1234 ../src/libs/print_settings.c:1445
 #: ../src/views/darkroom.c:2383 ../src/views/darkroom.c:2390
-#: ../src/views/lighttable.c:1312 ../src/views/lighttable.c:1319
+#: ../src/views/lighttable.c:1319 ../src/views/lighttable.c:1326
 msgid "intent"
 msgstr "метод"
 
@@ -13206,7 +13234,7 @@ msgstr "цільова точка середнього сірого"
 
 #: ../src/iop/filmic.c:1755
 msgid ""
-"midde grey value of the target display or color space.\n"
+"middle grey value of the target display or color space.\n"
 "you should never touch that unless you know what you are doing."
 msgstr ""
 "значення середньо-сірого цільового дисплея або кольорового простору.\n"
@@ -13368,7 +13396,7 @@ msgstr ""
 #: ../src/iop/toneequal.c:3081 ../src/iop/toneequal.c:3085
 #: ../src/iop/toneequal.c:3089 ../src/iop/toneequal.c:3093
 #: ../src/iop/toneequal.c:3097 ../src/iop/toneequal.c:3101
-#: ../src/iop/toneequal.c:3105 ../src/libs/metadata_view.c:589
+#: ../src/iop/toneequal.c:3105 ../src/libs/metadata_view.c:756
 #: ../src/views/darkroom.c:2309
 #, c-format
 msgid "%+.2f EV"
@@ -13559,7 +13587,7 @@ msgstr ""
 
 #: ../src/iop/filmicrgb.c:3907
 msgid ""
-"midde gray value of the target display or color space.\n"
+"middle gray value of the target display or color space.\n"
 "you should never touch that unless you know what you are doing."
 msgstr ""
 "значення середньо-сірого цільового дисплея або кольорового простору.\n"
@@ -14225,7 +14253,7 @@ msgstr "масштаб"
 msgid "auto scale"
 msgstr "автоматичне масштабування"
 
-#: ../src/iop/lens.cc:2373 ../src/libs/modulegroups.c:2391
+#: ../src/iop/lens.cc:2373 ../src/libs/modulegroups.c:2414
 msgid "correct"
 msgstr "коригувати"
 
@@ -14834,7 +14862,7 @@ msgstr ""
 #. WB shadows
 #: ../src/iop/negadoctor.c:884
 msgid "shadows color cast"
-msgstr "підфарбування тіней"
+msgstr "обарвлення тіней"
 
 #: ../src/iop/negadoctor.c:890
 msgid "select color of shadows from a swatch"
@@ -14856,7 +14884,7 @@ msgid ""
 "the highlights illuminant white balance will help\n"
 "recovering the global white balance in difficult cases."
 msgstr ""
-"коригувати підфарбування в тінях, щоб найтемніші тони були\n"
+"коригувати обарвлення в тінях, щоб найтемніші тони були\n"
 "дійсно ахроматичними. встановлення цього значення перед\n"
 "освітлювачем світлих тонів допоможе відновити\n"
 "глобальний балансу білого у складних випадках."
@@ -14896,8 +14924,8 @@ msgid ""
 msgstr ""
 "коригувати колір освітлювача, щоб найсвітліші тони були\n"
 "дійсно ахроматичними. встановлення цього значення після\n"
-"підфарбування тіней допоможе відновити\n"
-"глобальний балансу білого у складних випадках."
+"обарвлення тіней допоможе відновити\n"
+"глобальний баланс білого у складних випадках."
 
 #: ../src/iop/negadoctor.c:944
 msgid "illuminant green gain"
@@ -15191,7 +15219,7 @@ msgstr ""
 msgid "toggle tool for picking median lightness in image"
 msgstr "вибрати медіанну яскравість із зображення"
 
-#: ../src/iop/relight.c:286 ../src/libs/metadata_view.c:152
+#: ../src/iop/relight.c:286 ../src/libs/metadata_view.c:146
 #: ../src/libs/print_settings.c:1300
 msgid "width"
 msgstr "ширина"
@@ -16721,23 +16749,23 @@ msgstr "шукати плівку..."
 msgid "remove..."
 msgstr "видалити..."
 
-#: ../src/libs/collect.c:1192
+#: ../src/libs/collect.c:1197
 msgid "uncategorized"
 msgstr "без категорії"
 
-#: ../src/libs/collect.c:1682
+#: ../src/libs/collect.c:1686
 msgid "copied locally"
 msgstr "є локальна копія"
 
-#: ../src/libs/collect.c:1784
+#: ../src/libs/collect.c:1788
 msgid "group followers"
 msgstr "члени груп"
 
-#: ../src/libs/collect.c:2029
+#: ../src/libs/collect.c:2033
 msgid "use <, <=, >, >=, <>, =, [;] as operators"
 msgstr "використовуйте <, <=, >, >=, <>, =, [;] як оператори"
 
-#: ../src/libs/collect.c:2034
+#: ../src/libs/collect.c:2038
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "type dates in the form : YYYY:MM:DD HH:MM:SS (only the year is mandatory)"
@@ -16745,12 +16773,12 @@ msgstr ""
 "використовуйте <, <=, >, >=, <>, =, [;] як оператори\n"
 "вказуйте дати в форматі : YYYY:MM:DD HH:MM:SS (лише рік є обов'язковим)"
 
-#: ../src/libs/collect.c:2041
+#: ../src/libs/collect.c:2045
 #, no-c-format
 msgid "use `%' as wildcard and `,' to separate values"
 msgstr "використовуйте `%' для вибору всього і `,' для розділення значень"
 
-#: ../src/libs/collect.c:2047
+#: ../src/libs/collect.c:2051
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -16761,7 +16789,7 @@ msgstr ""
 "використовуйте `|%' для включення всіх субієрархій (ctrl-клік)\n"
 "використовуйте `*' для включення ієрархії та субієрархій (shift-клік)"
 
-#: ../src/libs/collect.c:2057
+#: ../src/libs/collect.c:2061
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -16772,7 +16800,7 @@ msgstr ""
 "використовуйте `|%' для включення всіх вкладених місць (ctrl-клік)\n"
 "використовуйте `*' для включення місць та вкладених місць (shift-клік)"
 
-#: ../src/libs/collect.c:2067
+#: ../src/libs/collect.c:2071
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -16785,79 +16813,79 @@ msgstr ""
 "shift+клік - включати поточний каталог + підкаталоги\n"
 "подвійний клік - включати лише поточний каталог"
 
-#: ../src/libs/collect.c:2078
+#: ../src/libs/collect.c:2082
 #, no-c-format
 msgid "use `%' as wildcard"
 msgstr "використовуйте `%' для вибору всього"
 
-#: ../src/libs/collect.c:2130 ../src/libs/collect.c:2145
-#: ../src/libs/collect.c:2680
+#: ../src/libs/collect.c:2134 ../src/libs/collect.c:2149
+#: ../src/libs/collect.c:2683
 msgid "clear this rule"
 msgstr "очистити це правило"
 
-#: ../src/libs/collect.c:2134
+#: ../src/libs/collect.c:2138
 msgid "clear this rule or add new rules"
 msgstr "очистити це правило чи додати нові правила"
 
-#: ../src/libs/collect.c:2686
+#: ../src/libs/collect.c:2689
 msgid "narrow down search"
 msgstr "фільтр типу 'І' (звузити пошук)"
 
-#: ../src/libs/collect.c:2691
+#: ../src/libs/collect.c:2694
 msgid "add more images"
 msgstr "фільтр типу 'АБО' (додати до колекції)"
 
-#: ../src/libs/collect.c:2696
+#: ../src/libs/collect.c:2699
 msgid "exclude images"
 msgstr "фільтр типу 'КРІМ' (виключити з колекції)"
 
-#: ../src/libs/collect.c:2703
+#: ../src/libs/collect.c:2706
 msgid "change to: and"
 msgstr "змінити на 'І'"
 
-#: ../src/libs/collect.c:2708
+#: ../src/libs/collect.c:2711
 msgid "change to: or"
 msgstr "змінити на 'АБО'"
 
-#: ../src/libs/collect.c:2713
+#: ../src/libs/collect.c:2716
 msgid "change to: except"
 msgstr "змінити на 'КРІМ'"
 
-#: ../src/libs/collect.c:2743
+#: ../src/libs/collect.c:2746
 msgid "files"
 msgstr "файли"
 
-#: ../src/libs/collect.c:2748 ../src/libs/export_metadata.c:289
+#: ../src/libs/collect.c:2751 ../src/libs/export_metadata.c:289
 #: ../src/libs/image.c:463 ../src/libs/image.c:568 ../src/libs/metadata.c:486
-#: ../src/libs/metadata.c:657 ../src/libs/metadata_view.c:1051
+#: ../src/libs/metadata.c:657 ../src/libs/metadata_view.c:1258
 msgid "metadata"
 msgstr "метадані"
 
-#: ../src/libs/collect.c:2766
+#: ../src/libs/collect.c:2769
 msgid "times"
 msgstr "позначки часу"
 
-#: ../src/libs/collect.c:2774
+#: ../src/libs/collect.c:2777
 msgid "capture details"
 msgstr "деталі зйомки"
 
-#: ../src/libs/collect.c:2783 ../src/libs/tools/darktable.c:65
+#: ../src/libs/collect.c:2786 ../src/libs/tools/darktable.c:65
 msgid "darktable"
 msgstr "darktable"
 
-#: ../src/libs/collect.c:2796
+#: ../src/libs/collect.c:2799
 msgid "collections settings"
 msgstr "налаштування колекцій зображень"
 
-#: ../src/libs/collect.c:2799 ../src/libs/export_metadata.c:269
-#: ../src/libs/metadata.c:446 ../src/libs/metadata_view.c:1020
+#: ../src/libs/collect.c:2802 ../src/libs/export_metadata.c:269
+#: ../src/libs/metadata.c:446 ../src/libs/metadata_view.c:1227
 #: ../src/libs/tagging.c:1528 ../src/libs/tagging.c:1653
 #: ../src/libs/tagging.c:1927
 msgid "save"
 msgstr "зберегти"
 
-#: ../src/libs/collect.c:2813 ../src/libs/export.c:1106
-#: ../src/libs/metadata.c:580 ../src/libs/metadata_view.c:1131
+#: ../src/libs/collect.c:2816 ../src/libs/export.c:1106
+#: ../src/libs/metadata.c:580 ../src/libs/metadata_view.c:1338
 msgid "preferences..."
 msgstr "уподобання..."
 
@@ -17115,7 +17143,7 @@ msgid "create a 'virgin' duplicate of the image without any development"
 msgstr "створити дублікат зображення без жодної обробки"
 
 #: ../src/libs/duplicate.c:545 ../src/libs/image.c:494
-#: ../src/libs/modulegroups.c:3801
+#: ../src/libs/modulegroups.c:3824
 msgid "duplicate"
 msgstr "зняти копію"
 
@@ -17649,11 +17677,11 @@ msgstr "кількість відповідних зображень проти 
 msgid "histogram"
 msgstr "гістограма"
 
-#: ../src/libs/histogram.c:981 ../src/libs/histogram.c:1600
+#: ../src/libs/histogram.c:980 ../src/libs/histogram.c:1600
 msgid "ctrl+scroll to change display height"
 msgstr "ctrl+прокрутка для зміни висоти відображення"
 
-#: ../src/libs/histogram.c:988
+#: ../src/libs/histogram.c:987
 msgid ""
 "drag to change black point,\n"
 "doubleclick resets\n"
@@ -17663,7 +17691,7 @@ msgstr ""
 "подвійний клік скидає\n"
 "ctrl+прокрутка для зміни висоти відображення"
 
-#: ../src/libs/histogram.c:993
+#: ../src/libs/histogram.c:992
 msgid ""
 "drag to change exposure,\n"
 "doubleclick resets\n"
@@ -17673,68 +17701,68 @@ msgstr ""
 "подвійний клік скидає\n"
 "ctrl+прокрутка для зміни висоти відображення"
 
-#: ../src/libs/histogram.c:1106 ../src/libs/histogram.c:1153
+#: ../src/libs/histogram.c:1105 ../src/libs/histogram.c:1152
 msgid "set scale to linear"
 msgstr "встановити лінійну шкалу"
 
-#: ../src/libs/histogram.c:1111 ../src/libs/histogram.c:1158
+#: ../src/libs/histogram.c:1110 ../src/libs/histogram.c:1157
 msgid "set scale to logarithmic"
 msgstr "встановити логарифмічну шкалу"
 
-#: ../src/libs/histogram.c:1128
+#: ../src/libs/histogram.c:1127
 msgid "set view to RGB parade"
 msgstr "встановити тип перегляду на RGB-парад"
 
-#: ../src/libs/histogram.c:1136
+#: ../src/libs/histogram.c:1135
 msgid "set view to waveform"
 msgstr "встановити тип перегляду на форму хвиль"
 
-#: ../src/libs/histogram.c:1168
+#: ../src/libs/histogram.c:1167
 msgid "set view to AzBz"
 msgstr "встановити тип перегляду на AzBz"
 
-#: ../src/libs/histogram.c:1173
+#: ../src/libs/histogram.c:1172
 msgid "set view to u*v*"
 msgstr "встановити тип перегляду на u*v*"
 
-#: ../src/libs/histogram.c:1187
+#: ../src/libs/histogram.c:1186
 msgid "set mode to waveform"
 msgstr "встановити режим форми сигналу"
 
-#: ../src/libs/histogram.c:1197
+#: ../src/libs/histogram.c:1196
 msgid "set mode to vectorscope"
 msgstr "встановити режим вектороскопа"
 
-#: ../src/libs/histogram.c:1205
+#: ../src/libs/histogram.c:1204
 msgid "set mode to histogram"
 msgstr "встановити режим гістограми"
 
-#: ../src/libs/histogram.c:1289 ../src/libs/histogram.c:1325
+#: ../src/libs/histogram.c:1288 ../src/libs/histogram.c:1324
 #: ../src/libs/histogram.c:1631
 msgid "click to hide red channel"
 msgstr "приховати канал червоного"
 
-#: ../src/libs/histogram.c:1289 ../src/libs/histogram.c:1325
+#: ../src/libs/histogram.c:1288 ../src/libs/histogram.c:1324
 #: ../src/libs/histogram.c:1631
 msgid "click to show red channel"
 msgstr "показати канал червоного"
 
-#: ../src/libs/histogram.c:1297 ../src/libs/histogram.c:1323
+#: ../src/libs/histogram.c:1296 ../src/libs/histogram.c:1322
 #: ../src/libs/histogram.c:1638
 msgid "click to hide green channel"
 msgstr "приховати канал зеленого"
 
-#: ../src/libs/histogram.c:1297 ../src/libs/histogram.c:1323
+#: ../src/libs/histogram.c:1296 ../src/libs/histogram.c:1322
 #: ../src/libs/histogram.c:1638
 msgid "click to show green channel"
 msgstr "показати канал зеленого"
 
-#: ../src/libs/histogram.c:1305 ../src/libs/histogram.c:1324
+#: ../src/libs/histogram.c:1304 ../src/libs/histogram.c:1323
 #: ../src/libs/histogram.c:1644
 msgid "click to hide blue channel"
 msgstr "приховати канал синього"
 
-#: ../src/libs/histogram.c:1305 ../src/libs/histogram.c:1324
+#: ../src/libs/histogram.c:1304 ../src/libs/histogram.c:1323
 #: ../src/libs/histogram.c:1644
 msgid "click to show blue channel"
 msgstr "показати канал синього"
@@ -17900,7 +17928,7 @@ msgid "physically delete from disk immediately"
 msgstr "фізично видалити з диску відразу ж"
 
 #. delete
-#: ../src/libs/image.c:474 ../src/libs/modulegroups.c:3798
+#: ../src/libs/image.c:474 ../src/libs/modulegroups.c:3821
 #: ../src/libs/styles.c:861
 msgid "remove"
 msgstr "вилучити"
@@ -18148,40 +18176,72 @@ msgctxt "accel"
 msgid "ungroup"
 msgstr "розгрупувати"
 
-#: ../src/libs/import.c:175
+#: ../src/libs/import.c:199
 msgctxt "accel"
 msgid "copy & import from camera"
 msgstr "копіювати й імпортувати з камери"
 
-#: ../src/libs/import.c:176
+#: ../src/libs/import.c:200
 msgctxt "accel"
 msgid "tethered shoot"
 msgstr "дистанційна зйомка"
 
-#: ../src/libs/import.c:177
+#: ../src/libs/import.c:201
 msgctxt "accel"
 msgid "add to library"
 msgstr "додати до бібліотеки"
 
-#: ../src/libs/import.c:178
+#: ../src/libs/import.c:202
 msgctxt "accel"
 msgid "copy & import"
 msgstr "копіювати й імпортувати"
 
-#: ../src/libs/import.c:244
+#: ../src/libs/import.c:203
+msgctxt "accel"
+msgid "mount camera"
+msgstr "змонтувати камеру"
+
+#: ../src/libs/import.c:204
+msgctxt "accel"
+msgid "unmount camera"
+msgstr "розмонтувати камеру"
+
+#: ../src/libs/import.c:291
 #, c-format
 msgid "device \"%s\" connected on port \"%s\"."
 msgstr "пристрій \"%s\" приєднано до порту \"%s\"."
 
-#: ../src/libs/import.c:254 ../src/libs/import.c:1407
+#: ../src/libs/import.c:301 ../src/libs/import.c:1638
 msgid "copy & import from camera"
 msgstr "копіювати й імпортувати з камери"
 
-#: ../src/libs/import.c:261
+#: ../src/libs/import.c:308
 msgid "tethered shoot"
 msgstr "дистанційна зйомка"
 
-#: ../src/libs/import.c:678
+#: ../src/libs/import.c:312
+msgid "unmount camera"
+msgstr "розмонтувати камеру"
+
+#: ../src/libs/import.c:348
+msgid ""
+"camera is locked by another application\n"
+"make sure it is no longer mounted\n"
+"or quit the locking application"
+msgstr ""
+"камера заблокована іншою програмою\n"
+"переконайтеся, що вона більше не змонтована в операційній системі\n"
+"або закрийте блокуючу програму"
+
+#: ../src/libs/import.c:351
+msgid "tethering and importing is disabled for this camera"
+msgstr "дистанційне керування та імпорт для цієї камери вимкнені"
+
+#: ../src/libs/import.c:353
+msgid "mount camera"
+msgstr "змонтувати камеру"
+
+#: ../src/libs/import.c:743
 #, c-format
 msgid "%d image out of %d selected"
 msgid_plural "%d images out of %d selected"
@@ -18189,87 +18249,112 @@ msgstr[0] "вибрано %d зображення з %d"
 msgstr[1] "вибрано %d зображення з %d"
 msgstr[2] "вибрано %d зображень з %d"
 
-#: ../src/libs/import.c:1069
+#: ../src/libs/import.c:1091
+msgid "you can't delete the selected place"
+msgstr "ви не можете видалити вибране місце"
+
+#: ../src/libs/import.c:1191
+msgid "choose the root of the folder tree below"
+msgstr "виберіть корінь дерева папок нижче"
+
+#: ../src/libs/import.c:1194
+msgid "places"
+msgstr "місця"
+
+#: ../src/libs/import.c:1198
+msgid "restore all default places you have removed by right-click"
+msgstr ""
+"відновити всі місця за замовчуванням, які ви видалили, клікнувши правою "
+"кнопкою миші"
+
+#: ../src/libs/import.c:1203
+msgid ""
+"add a custom place\n"
+"\n"
+"right-click on a place to remove it"
+msgstr ""
+"додати власне місце\n"
+"\n"
+"клікніть правою кнопкою миші на місці, щоб видалити його"
+
+#: ../src/libs/import.c:1210
+msgid "you can add custom places using the plus icon"
+msgstr "ви можете додати власні місця за допомогою значка з плюсом"
+
+#: ../src/libs/import.c:1235
 msgid "select a folder to see the content"
 msgstr "виберіть каталог, щоб переглянути його вміст"
 
-#: ../src/libs/import.c:1072
+#: ../src/libs/import.c:1238
 msgid "folders"
 msgstr "каталоги"
 
-#: ../src/libs/import.c:1237
+#: ../src/libs/import.c:1305
+msgid "home"
+msgstr "домівка"
+
+#: ../src/libs/import.c:1315
+msgid "pictures"
+msgstr "зображення"
+
+#: ../src/libs/import.c:1468
 msgid "open folder"
 msgstr "відкрити каталог"
 
-#: ../src/libs/import.c:1300
+#: ../src/libs/import.c:1531
 msgid "mark already imported pictures"
 msgstr "позначає вже імпортовані зображення"
 
-#: ../src/libs/import.c:1324
+#: ../src/libs/import.c:1555
 msgid "modified"
 msgstr "змінено"
 
-#: ../src/libs/import.c:1329
+#: ../src/libs/import.c:1560
 msgid "file 'modified date/time', may be different from 'Exif date/time'"
 msgstr "'дата/час зміни файлу', може відрізнятись від 'дата/час із Exif'"
 
-#: ../src/libs/import.c:1341
+#: ../src/libs/import.c:1572
 msgid "show/hide thumbnails"
 msgstr "показати/приховати мініатюри"
 
 #. collapsible section
-#: ../src/libs/import.c:1377
+#: ../src/libs/import.c:1608
 msgid "naming rules"
 msgstr "правила іменування"
 
-#: ../src/libs/import.c:1405
+#: ../src/libs/import.c:1636
 msgid "add to library"
 msgstr "додати до бібліотеки"
 
-#: ../src/libs/import.c:1406
+#: ../src/libs/import.c:1637
 msgid "copy & import"
 msgstr "копіювати й імпортувати"
 
-#: ../src/libs/import.c:1410
-msgid ""
-"choose the root of the folder tree below\n"
-"try to choose a root folder that contains most/all of your photographs (in "
-"sub-folders)\n"
-"so that you don't need to change the root frequently\n"
-"e.g. set it to your 'pictures' or 'home' directory"
-msgstr ""
-"виберіть корінь дерева каталогів нижче\n"
-"спробуйте вибрати кореневий каталог, який містить більшість / усі ваші "
-"фотографії (у підкаталогах)\n"
-"так, щоб вам не потрібно було часто міняти корінь\n"
-"наприклад, встановіть його на свій каталог 'Зображення' чи на домашній "
-"каталог"
-
-#: ../src/libs/import.c:1449 ../src/libs/select.c:137
+#: ../src/libs/import.c:1675 ../src/libs/select.c:137
 msgid "select none"
 msgstr "скасувати вибір"
 
-#: ../src/libs/import.c:1455
+#: ../src/libs/import.c:1681
 msgid "select new"
 msgstr "вибрати нові"
 
-#: ../src/libs/import.c:1531
+#: ../src/libs/import.c:1726
 msgid "please wait while prefetching the list of images from camera..."
 msgstr "зачекайте, поки попередньо отримується список зображень з камери..."
 
-#: ../src/libs/import.c:1737
+#: ../src/libs/import.c:1943
 msgid "add to library..."
 msgstr "додати до бібліотеки..."
 
-#: ../src/libs/import.c:1738
+#: ../src/libs/import.c:1944
 msgid "add existing images to the library"
 msgstr "додати існуючі зображення до бібліотеки"
 
-#: ../src/libs/import.c:1745
+#: ../src/libs/import.c:1951
 msgid "copy & import..."
 msgstr "копіювати й імпортувати..."
 
-#: ../src/libs/import.c:1746
+#: ../src/libs/import.c:1952
 msgid ""
 "copy and optionally rename images before adding them to the library\n"
 "patterns can be defined to rename the images and specify the destination "
@@ -18280,7 +18365,7 @@ msgstr ""
 "каталог призначення та правило перейменування зображень задаються шаблонами"
 
 #. collapsible section
-#: ../src/libs/import.c:1772
+#: ../src/libs/import.c:1974
 msgid "parameters"
 msgstr "параметри"
 
@@ -18309,188 +18394,192 @@ msgstr "нічого зберігати"
 msgid "reset parameters"
 msgstr "скинути параметри"
 
-#: ../src/libs/live_view.c:135
+#: ../src/libs/live_view.c:143
 msgid "live view"
 msgstr "live view"
 
-#: ../src/libs/live_view.c:161
+#: ../src/libs/live_view.c:169
 msgctxt "accel"
 msgid "toggle live view"
 msgstr "переключити режим Live View"
 
-#: ../src/libs/live_view.c:162
+#: ../src/libs/live_view.c:170
 msgctxt "accel"
 msgid "zoom live view"
 msgstr "live view в масштабі 100%"
 
-#: ../src/libs/live_view.c:163
+#: ../src/libs/live_view.c:171
 msgctxt "accel"
 msgid "rotate 90 degrees CCW"
 msgstr "обертати на 90 градусів проти годинникової стрілки"
 
-#: ../src/libs/live_view.c:164
+#: ../src/libs/live_view.c:172
 msgctxt "accel"
 msgid "rotate 90 degrees CW"
 msgstr "обертати на 90 градусів за годинниковою стрілкою"
 
-#: ../src/libs/live_view.c:165
+#: ../src/libs/live_view.c:173
 msgctxt "accel"
 msgid "flip horizontally"
 msgstr "віддзеркалити за горизонталлю"
 
-#: ../src/libs/live_view.c:166
+#: ../src/libs/live_view.c:174
 msgctxt "accel"
 msgid "move focus point in (big steps)"
 msgstr "наблизити точку фокусування (великі кроки)"
 
-#: ../src/libs/live_view.c:167
+#: ../src/libs/live_view.c:175
 msgctxt "accel"
 msgid "move focus point in (small steps)"
 msgstr "наблизити точку фокусування (маленькі кроки)"
 
-#: ../src/libs/live_view.c:168
+#: ../src/libs/live_view.c:176
 msgctxt "accel"
 msgid "move focus point out (small steps)"
 msgstr "віддалити точку фокусування (маленькі кроки)"
 
-#: ../src/libs/live_view.c:169
+#: ../src/libs/live_view.c:177
 msgctxt "accel"
 msgid "move focus point out (big steps)"
 msgstr "віддалити точку фокусування (великі кроки)"
 
-#: ../src/libs/live_view.c:286
+#: ../src/libs/live_view.c:361
 msgid "toggle live view"
 msgstr "переключити live view"
 
-#: ../src/libs/live_view.c:287
+#: ../src/libs/live_view.c:362
 msgid "zoom live view"
 msgstr "live view в масштабі 100%"
 
-#: ../src/libs/live_view.c:288
+#: ../src/libs/live_view.c:363
 msgid "rotate 90 degrees ccw"
 msgstr "поворот на 90 градусів проти годинникової стрілки"
 
-#: ../src/libs/live_view.c:289
+#: ../src/libs/live_view.c:364
 msgid "rotate 90 degrees cw"
 msgstr "поворот на 90 градусів за годинниковою стрілкою"
 
-#: ../src/libs/live_view.c:290
+#: ../src/libs/live_view.c:365
 msgid "flip live view horizontally"
 msgstr "віддзеркалити Live View за горизонталлю"
 
-#: ../src/libs/live_view.c:316
+#: ../src/libs/live_view.c:393
 msgid "move focus point in (big steps)"
 msgstr "наблизити точку фокусування (великі кроки)"
 
-#: ../src/libs/live_view.c:317
+#: ../src/libs/live_view.c:394
 msgid "move focus point in (small steps)"
 msgstr "наблизити точку фокусування (маленькі кроки)"
 
-#: ../src/libs/live_view.c:318
+#: ../src/libs/live_view.c:395
+msgid "run autofocus"
+msgstr "запустити автофокус"
+
+#: ../src/libs/live_view.c:396
 msgid "move focus point out (small steps)"
 msgstr "віддалити точку фокусування (маленькі кроки)"
 
-#: ../src/libs/live_view.c:319
+#: ../src/libs/live_view.c:397
 msgid "move focus point out (big steps)"
 msgstr "віддалити точку фокусування (великі кроки)"
 
-#: ../src/libs/live_view.c:376
+#: ../src/libs/live_view.c:453
 msgid "overlay"
 msgstr "накладення"
 
-#: ../src/libs/live_view.c:378
+#: ../src/libs/live_view.c:455
 msgid "selected image"
 msgstr "вибране зображення"
 
-#: ../src/libs/live_view.c:379 ../src/libs/tools/filter.c:90
+#: ../src/libs/live_view.c:456 ../src/libs/tools/filter.c:90
 msgid "id"
 msgstr "id"
 
-#: ../src/libs/live_view.c:380
+#: ../src/libs/live_view.c:457
 msgid "overlay another image over the live view"
 msgstr "накладає інше зображення поверх live view"
 
-#: ../src/libs/live_view.c:385 ../src/libs/metadata_view.c:127
+#: ../src/libs/live_view.c:462 ../src/libs/metadata_view.c:123
 msgid "image id"
 msgstr "id зображення"
 
-#: ../src/libs/live_view.c:389
+#: ../src/libs/live_view.c:466
 msgid "enter image id of the overlay manually"
 msgstr "вкажіть вручну id зображення для накладення"
 
-#: ../src/libs/live_view.c:400
+#: ../src/libs/live_view.c:477
 msgid "overlay mode"
 msgstr "режим накладання"
 
-#: ../src/libs/live_view.c:402
+#: ../src/libs/live_view.c:479
 msgctxt "blendmode"
 msgid "xor"
 msgstr "xor"
 
-#: ../src/libs/live_view.c:403
+#: ../src/libs/live_view.c:480
 msgctxt "blendmode"
 msgid "add"
 msgstr "додавання"
 
-#: ../src/libs/live_view.c:404
+#: ../src/libs/live_view.c:481
 msgctxt "blendmode"
 msgid "saturate"
 msgstr "насиченість"
 
-#: ../src/libs/live_view.c:410
+#: ../src/libs/live_view.c:487
 msgctxt "blendmode"
 msgid "color dodge"
 msgstr "освітлення кольору"
 
-#: ../src/libs/live_view.c:411
+#: ../src/libs/live_view.c:488
 msgctxt "blendmode"
 msgid "color burn"
 msgstr "випалювання кольору"
 
-#: ../src/libs/live_view.c:412
+#: ../src/libs/live_view.c:489
 msgctxt "blendmode"
 msgid "hard light"
 msgstr "направлене світло"
 
-#: ../src/libs/live_view.c:413
+#: ../src/libs/live_view.c:490
 msgctxt "blendmode"
 msgid "soft light"
 msgstr "розсіяне світло"
 
-#: ../src/libs/live_view.c:415
+#: ../src/libs/live_view.c:492
 msgctxt "blendmode"
 msgid "exclusion"
 msgstr "виключення"
 
-#: ../src/libs/live_view.c:416
+#: ../src/libs/live_view.c:493
 msgctxt "blendmode"
 msgid "HSL hue"
 msgstr "HSL відтінок"
 
-#: ../src/libs/live_view.c:417
+#: ../src/libs/live_view.c:494
 msgctxt "blendmode"
 msgid "HSL saturation"
 msgstr "HSL насиченість"
 
-#: ../src/libs/live_view.c:418
+#: ../src/libs/live_view.c:495
 msgctxt "blendmode"
 msgid "HSL color"
 msgstr "HSL колір"
 
-#: ../src/libs/live_view.c:419
+#: ../src/libs/live_view.c:496
 msgctxt "blendmode"
 msgid "HSL luminosity"
 msgstr "HSL світність"
 
-#: ../src/libs/live_view.c:420
+#: ../src/libs/live_view.c:497
 msgid "mode of the overlay"
 msgstr "режим накладення"
 
-#: ../src/libs/live_view.c:426
+#: ../src/libs/live_view.c:503
 msgid "split line"
 msgstr "роздільна лінія"
 
-#: ../src/libs/live_view.c:429
+#: ../src/libs/live_view.c:506
 msgid "only draw part of the overlay"
 msgstr "малювати лише частину накладки"
 
@@ -18671,11 +18760,11 @@ msgstr "редактор метаданих"
 msgid "<leave unchanged>"
 msgstr "<залишити незмінним>"
 
-#: ../src/libs/metadata.c:444 ../src/libs/metadata_view.c:1018
+#: ../src/libs/metadata.c:444 ../src/libs/metadata_view.c:1225
 msgid "metadata settings"
 msgstr "налаштування метаданих"
 
-#: ../src/libs/metadata.c:492 ../src/libs/metadata_view.c:1062
+#: ../src/libs/metadata.c:492 ../src/libs/metadata_view.c:1269
 msgid "visible"
 msgstr "видимі"
 
@@ -18783,63 +18872,112 @@ msgid "all rights reserved."
 msgstr "всі права зберігаються."
 
 #. internal
-#: ../src/libs/metadata_view.c:126
+#: ../src/libs/metadata_view.c:122
 msgid "filmroll"
 msgstr "плівка"
 
-#: ../src/libs/metadata_view.c:128
+#: ../src/libs/metadata_view.c:124
 msgid "group id"
 msgstr "id групи"
 
-#: ../src/libs/metadata_view.c:130
+#: ../src/libs/metadata_view.c:126
 msgid "version"
 msgstr "версія"
 
-#: ../src/libs/metadata_view.c:131 ../src/libs/tools/filter.c:93
+#: ../src/libs/metadata_view.c:127 ../src/libs/tools/filter.c:93
 msgid "full path"
 msgstr "повний шлях"
 
-#: ../src/libs/metadata_view.c:138
+#: ../src/libs/metadata_view.c:133
 msgid "flags"
 msgstr "прапорці"
 
-#: ../src/libs/metadata_view.c:149
+#: ../src/libs/metadata_view.c:143
 msgid "focus distance"
 msgstr "дистанція фокусування"
 
-#: ../src/libs/metadata_view.c:151
+#: ../src/libs/metadata_view.c:145
 msgid "datetime"
 msgstr "дата і час"
 
-#: ../src/libs/metadata_view.c:153 ../src/libs/print_settings.c:1304
+#: ../src/libs/metadata_view.c:147 ../src/libs/print_settings.c:1304
 msgid "height"
 msgstr "висота"
 
-#: ../src/libs/metadata_view.c:154
+#: ../src/libs/metadata_view.c:148
 msgid "export width"
 msgstr "ширина експорту"
 
-#: ../src/libs/metadata_view.c:155
+#: ../src/libs/metadata_view.c:149
 msgid "export height"
 msgstr "висота експорту"
 
-#: ../src/libs/metadata_view.c:163
+#: ../src/libs/metadata_view.c:157
 msgid "longitude"
 msgstr "довгота"
 
-#: ../src/libs/metadata_view.c:164
+#: ../src/libs/metadata_view.c:158
 msgid "elevation"
 msgstr "висота"
 
-#: ../src/libs/metadata_view.c:168
+#: ../src/libs/metadata_view.c:162
 msgid "categories"
 msgstr "категорії"
 
-#: ../src/libs/metadata_view.c:175
+#: ../src/libs/metadata_view.c:169
 msgid "image information"
 msgstr "інформація про зображення"
 
-#: ../src/libs/metadata_view.c:390
+#: ../src/libs/metadata_view.c:357
+msgid "unused/deprecated"
+msgstr "не використовується/застарілий"
+
+#: ../src/libs/metadata_view.c:358
+msgid "ldr"
+msgstr "ldr"
+
+#: ../src/libs/metadata_view.c:360
+msgid "hdr"
+msgstr "hdr"
+
+#: ../src/libs/metadata_view.c:361
+msgid "marked for deletion"
+msgstr "позначено для видалення"
+
+#: ../src/libs/metadata_view.c:362
+msgid "auto-applying presets applied"
+msgstr "застосовано пресети автоматичного застосування"
+
+#: ../src/libs/metadata_view.c:363
+msgid "legacy flag. set for all new images"
+msgstr "застарілий прапорець. встановлюється для всіх нових зображень"
+
+#: ../src/libs/metadata_view.c:365
+msgid "has .txt"
+msgstr "має .txt"
+
+#: ../src/libs/metadata_view.c:366
+msgid "has .wav"
+msgstr "має .wav"
+
+#: ../src/libs/metadata_view.c:384
+#, c-format
+msgid "image has %d star"
+msgid_plural "image has %d stars"
+msgstr[0] "зображення має %d зірку"
+msgstr[1] "зображення має %d зірки"
+msgstr[2] "зображення має %d зірок"
+
+#: ../src/libs/metadata_view.c:466
+#, c-format
+msgid "loader: %s"
+msgstr "завантажувач: %s"
+
+#: ../src/libs/metadata_view.c:639
+msgid "<various values>"
+msgstr "<різні значення>"
+
+#: ../src/libs/metadata_view.c:652
 #, c-format
 msgid ""
 "double click to jump to film roll\n"
@@ -18848,57 +18986,17 @@ msgstr ""
 "подвійний клік для переходу до плівки\n"
 "%s"
 
-#: ../src/libs/metadata_view.c:443
-msgid "unused/deprecated"
-msgstr "не використовується/застарілий"
-
-#: ../src/libs/metadata_view.c:444
-msgid "ldr"
-msgstr "ldr"
-
-#: ../src/libs/metadata_view.c:446
-msgid "hdr"
-msgstr "hdr"
-
-#: ../src/libs/metadata_view.c:447
-msgid "marked for deletion"
-msgstr "позначено для видалення"
-
-#: ../src/libs/metadata_view.c:448
-msgid "auto-applying presets applied"
-msgstr "застосовано пресети автоматичного застосування"
-
-#: ../src/libs/metadata_view.c:449
-msgid "legacy flag. set for all new images"
-msgstr "застарілий прапорець. встановлюється для всіх нових зображень"
-
-#: ../src/libs/metadata_view.c:451
-msgid "has .txt"
-msgstr "має .txt"
-
-#: ../src/libs/metadata_view.c:452
-msgid "has .wav"
-msgstr "має .wav"
-
-#: ../src/libs/metadata_view.c:470
+#: ../src/libs/metadata_view.c:770
 #, c-format
-msgid "image has %d star"
-msgid_plural "image has %d stars"
-msgstr[0] "зображення має %d зірку"
-msgstr[1] "зображення має %d зірки"
-msgstr[2] "зображення має %d зірок"
+msgid "%.2f m"
+msgstr "%.2f м"
 
-#: ../src/libs/metadata_view.c:552
-#, c-format
-msgid "loader: %s"
-msgstr "завантажувач: %s"
-
-#: ../src/libs/metadata_view.c:857
+#: ../src/libs/metadata_view.c:1064
 msgctxt "accel"
 msgid "jump to film roll"
 msgstr "перейти до плівки"
 
-#: ../src/libs/metadata_view.c:1057
+#: ../src/libs/metadata_view.c:1264
 msgid ""
 "drag and drop one row at a time until you get the desired order\n"
 "untick to hide metadata which are not of interest for you\n"
@@ -18920,18 +19018,19 @@ msgstr "модулі: застарілі"
 msgid "last modified layout"
 msgstr "остання змінена розкладка"
 
-#: ../src/libs/modulegroups.c:207
+#: ../src/libs/modulegroups.c:206
 msgid "modulegroups"
 msgstr "групи модулів"
 
-#: ../src/libs/modulegroups.c:352 ../src/libs/modulegroups.c:371
-#: ../src/libs/modulegroups.c:2503 ../src/libs/modulegroups.c:2520
-#: ../src/libs/modulegroups.c:2530
+#: ../src/libs/modulegroups.c:355 ../src/libs/modulegroups.c:364
+#: ../src/libs/modulegroups.c:387 ../src/libs/modulegroups.c:399
+#: ../src/libs/modulegroups.c:2526 ../src/libs/modulegroups.c:2543
+#: ../src/libs/modulegroups.c:2553
 msgid "on-off"
 msgstr "вкл.-викл."
 
-#: ../src/libs/modulegroups.c:544 ../src/libs/modulegroups.c:547
-#: ../src/libs/modulegroups.c:652
+#: ../src/libs/modulegroups.c:568 ../src/libs/modulegroups.c:571
+#: ../src/libs/modulegroups.c:675
 msgid ""
 "this quick access widget is disabled as there are multiple instances of this "
 "module present. Please use the full module to access this widget..."
@@ -18939,7 +19038,7 @@ msgstr ""
 "цей віджет швидкого доступу вимкнено, оскільки для цього модуля існує кілька "
 "екземплярів. використовуйте повний модуль для доступу до цього віджета..."
 
-#: ../src/libs/modulegroups.c:659
+#: ../src/libs/modulegroups.c:682
 msgid ""
 "this quick access widget is disabled as it's hidden in the actual module "
 "configuration. Please use the full module to access this widget..."
@@ -18947,156 +19046,156 @@ msgstr ""
 "цей віджет швидкого доступу вимкнено, оскільки він прихований у конфігурації "
 "модуля. використовуйте повний модуль для доступу до цього віджета..."
 
-#: ../src/libs/modulegroups.c:665
+#: ../src/libs/modulegroups.c:688
 msgid "(some features may only be available in the full module interface)"
 msgstr "(деякі функції можуть бути доступні лише в інтерфейсі повного модуля)"
 
-#: ../src/libs/modulegroups.c:691
+#: ../src/libs/modulegroups.c:714
 #, c-format
 msgid "go to the full version of the %s module"
 msgstr "перейти до повної версії модуля %s"
 
-#: ../src/libs/modulegroups.c:1565 ../src/libs/modulegroups.c:1649
-#: ../src/libs/modulegroups.c:1682 ../src/libs/modulegroups.c:1733
-#: ../src/libs/modulegroups.c:1903
+#: ../src/libs/modulegroups.c:1588 ../src/libs/modulegroups.c:1672
+#: ../src/libs/modulegroups.c:1705 ../src/libs/modulegroups.c:1756
+#: ../src/libs/modulegroups.c:1926
 msgctxt "modulegroup"
 msgid "base"
 msgstr "базові"
 
-#: ../src/libs/modulegroups.c:1585
+#: ../src/libs/modulegroups.c:1608
 msgctxt "modulegroup"
 msgid "tone"
 msgstr "тонування"
 
-#: ../src/libs/modulegroups.c:1593 ../src/libs/modulegroups.c:1696
-#: ../src/libs/modulegroups.c:1743
+#: ../src/libs/modulegroups.c:1616 ../src/libs/modulegroups.c:1719
+#: ../src/libs/modulegroups.c:1766
 msgctxt "modulegroup"
 msgid "color"
 msgstr "колір"
 
-#: ../src/libs/modulegroups.c:1608 ../src/libs/modulegroups.c:1704
-#: ../src/libs/modulegroups.c:1748
+#: ../src/libs/modulegroups.c:1631 ../src/libs/modulegroups.c:1727
+#: ../src/libs/modulegroups.c:1771
 msgctxt "modulegroup"
 msgid "correct"
 msgstr "корекція"
 
-#: ../src/libs/modulegroups.c:1627 ../src/libs/modulegroups.c:1717
-#: ../src/libs/modulegroups.c:1761 ../src/libs/modulegroups.c:2394
+#: ../src/libs/modulegroups.c:1650 ../src/libs/modulegroups.c:1740
+#: ../src/libs/modulegroups.c:1784 ../src/libs/modulegroups.c:2417
 msgctxt "modulegroup"
 msgid "effect"
 msgstr "ефект"
 
-#: ../src/libs/modulegroups.c:1643
+#: ../src/libs/modulegroups.c:1666
 msgid "modules: all"
 msgstr "модулі: всі"
 
-#: ../src/libs/modulegroups.c:1661 ../src/libs/modulegroups.c:1810
+#: ../src/libs/modulegroups.c:1684 ../src/libs/modulegroups.c:1833
 msgctxt "modulegroup"
 msgid "grading"
 msgstr "кольорокорекція"
 
-#: ../src/libs/modulegroups.c:1669 ../src/libs/modulegroups.c:1829
-#: ../src/libs/modulegroups.c:2398
+#: ../src/libs/modulegroups.c:1692 ../src/libs/modulegroups.c:1852
+#: ../src/libs/modulegroups.c:2421
 msgctxt "modulegroup"
 msgid "effects"
 msgstr "ефекти"
 
-#: ../src/libs/modulegroups.c:1677
+#: ../src/libs/modulegroups.c:1700
 msgid "workflow: beginner"
 msgstr "робочий процес: початківець"
 
-#: ../src/libs/modulegroups.c:1727
+#: ../src/libs/modulegroups.c:1750
 msgid "workflow: display-referred"
 msgstr "робочий процес: на основі відображення"
 
-#: ../src/libs/modulegroups.c:1770
+#: ../src/libs/modulegroups.c:1793
 msgid "workflow: scene-referred"
 msgstr "робочий процес: на основі сцен"
 
-#: ../src/libs/modulegroups.c:1776
+#: ../src/libs/modulegroups.c:1799
 msgctxt "modulegroup"
 msgid "technical"
 msgstr "технічні"
 
-#: ../src/libs/modulegroups.c:1852
+#: ../src/libs/modulegroups.c:1875
 msgid "search only"
 msgstr "лише пошук"
 
-#: ../src/libs/modulegroups.c:1858 ../src/libs/modulegroups.c:2164
-#: ../src/libs/modulegroups.c:2659
+#: ../src/libs/modulegroups.c:1881 ../src/libs/modulegroups.c:2187
+#: ../src/libs/modulegroups.c:2682
 msgctxt "modulegroup"
 msgid "deprecated"
 msgstr "застарілі"
 
-#: ../src/libs/modulegroups.c:1879
+#: ../src/libs/modulegroups.c:1902
 msgid "previous config"
 msgstr "попередня конфігурація"
 
-#: ../src/libs/modulegroups.c:1880
+#: ../src/libs/modulegroups.c:1903
 msgid "previous layout"
 msgstr "попередня розкладка модулів"
 
-#: ../src/libs/modulegroups.c:1884
+#: ../src/libs/modulegroups.c:1907
 msgid "previous config with new layout"
 msgstr "попередня конфігурація з новою розкладкою"
 
-#: ../src/libs/modulegroups.c:2036 ../src/libs/modulegroups.c:2506
-#: ../src/libs/modulegroups.c:2562
+#: ../src/libs/modulegroups.c:2059 ../src/libs/modulegroups.c:2529
+#: ../src/libs/modulegroups.c:2585
 msgid "remove this widget"
 msgstr "видалити цей віджет"
 
-#: ../src/libs/modulegroups.c:2182 ../src/libs/modulegroups.c:2420
+#: ../src/libs/modulegroups.c:2205 ../src/libs/modulegroups.c:2443
 msgid "remove this module"
 msgstr "видалити цей модуль"
 
 #. does it belong to recommended modules ?
-#: ../src/libs/modulegroups.c:2389
+#: ../src/libs/modulegroups.c:2412
 msgid "base"
 msgstr "базові"
 
-#: ../src/libs/modulegroups.c:2392
+#: ../src/libs/modulegroups.c:2415
 msgid "tone"
 msgstr "тонові"
 
-#: ../src/libs/modulegroups.c:2395
+#: ../src/libs/modulegroups.c:2418
 msgid "technical"
 msgstr "технічні"
 
-#: ../src/libs/modulegroups.c:2396
+#: ../src/libs/modulegroups.c:2419
 msgid "grading"
 msgstr "грейдинг"
 
-#: ../src/libs/modulegroups.c:2402 ../src/libs/modulegroups.c:2410
+#: ../src/libs/modulegroups.c:2425 ../src/libs/modulegroups.c:2433
 msgid "add this module"
 msgstr "додати цей модуль"
 
 #. show the submenu with all the modules
-#: ../src/libs/modulegroups.c:2432 ../src/libs/modulegroups.c:2605
+#: ../src/libs/modulegroups.c:2455 ../src/libs/modulegroups.c:2628
 msgid "all available modules"
 msgstr "всі доступні модулі"
 
-#: ../src/libs/modulegroups.c:2440 ../src/libs/modulegroups.c:2613
+#: ../src/libs/modulegroups.c:2463 ../src/libs/modulegroups.c:2636
 msgid "add module"
 msgstr "додати модуль"
 
-#: ../src/libs/modulegroups.c:2445 ../src/libs/modulegroups.c:2618
+#: ../src/libs/modulegroups.c:2468 ../src/libs/modulegroups.c:2641
 msgid "remove module"
 msgstr "видалити модуль"
 
-#: ../src/libs/modulegroups.c:2523 ../src/libs/modulegroups.c:2532
-#: ../src/libs/modulegroups.c:2578 ../src/libs/modulegroups.c:2586
+#: ../src/libs/modulegroups.c:2546 ../src/libs/modulegroups.c:2555
+#: ../src/libs/modulegroups.c:2601 ../src/libs/modulegroups.c:2609
 msgid "add this widget"
 msgstr "додати цей віджет"
 
-#: ../src/libs/modulegroups.c:2762
+#: ../src/libs/modulegroups.c:2785
 msgid "quick access panel"
 msgstr "панель швидкого доступу"
 
-#: ../src/libs/modulegroups.c:2771
+#: ../src/libs/modulegroups.c:2794
 msgid "show only active modules"
 msgstr "показувати лише активні модулі"
 
-#: ../src/libs/modulegroups.c:2776
+#: ../src/libs/modulegroups.c:2799
 msgid ""
 "presets\n"
 "ctrl+click to manage"
@@ -19105,19 +19204,19 @@ msgstr ""
 "ctrl+клік – керувати"
 
 #. search box
-#: ../src/libs/modulegroups.c:2781
+#: ../src/libs/modulegroups.c:2804
 msgid "search module"
 msgstr "пошук модуля"
 
-#: ../src/libs/modulegroups.c:2787
+#: ../src/libs/modulegroups.c:2810
 msgid "search modules by name or tag"
 msgstr "пошук модуля по імені чи тегу"
 
-#: ../src/libs/modulegroups.c:2795
+#: ../src/libs/modulegroups.c:2818
 msgid "clear text"
 msgstr "очистити текст"
 
-#: ../src/libs/modulegroups.c:2804
+#: ../src/libs/modulegroups.c:2827
 msgid ""
 "the following modules are deprecated because they have internal design "
 "mistakes which can't be solved and alternative modules which solve them.\n"
@@ -19127,139 +19226,139 @@ msgstr ""
 "проектування, які неможливо вирішити, та альтернативи, які їх вирішують.\n"
 "їх буде видалено для нових редагувань у наступному випуску."
 
-#: ../src/libs/modulegroups.c:3046
+#: ../src/libs/modulegroups.c:3069
 msgid "basic icon"
 msgstr "базові"
 
-#: ../src/libs/modulegroups.c:3056
+#: ../src/libs/modulegroups.c:3079
 msgid "active icon"
 msgstr "активні"
 
-#: ../src/libs/modulegroups.c:3066
+#: ../src/libs/modulegroups.c:3089
 msgid "color icon"
 msgstr "корекція кольорів"
 
-#: ../src/libs/modulegroups.c:3076
+#: ../src/libs/modulegroups.c:3099
 msgid "correct icon"
 msgstr "коригування"
 
-#: ../src/libs/modulegroups.c:3086
+#: ../src/libs/modulegroups.c:3109
 msgid "effect icon"
 msgstr "ефекти"
 
-#: ../src/libs/modulegroups.c:3096
+#: ../src/libs/modulegroups.c:3119
 msgid "favorites icon"
 msgstr "улюблені"
 
-#: ../src/libs/modulegroups.c:3106
+#: ../src/libs/modulegroups.c:3129
 msgid "tone icon"
 msgstr "тонокорекція"
 
-#: ../src/libs/modulegroups.c:3116
+#: ../src/libs/modulegroups.c:3139
 msgid "grading icon"
 msgstr "грейдинг"
 
-#: ../src/libs/modulegroups.c:3126
+#: ../src/libs/modulegroups.c:3149
 msgid "technical icon"
 msgstr "технічні"
 
-#: ../src/libs/modulegroups.c:3159
+#: ../src/libs/modulegroups.c:3182
 msgid "quick access panel widgets"
 msgstr "віджети панелі швидкого доступу"
 
-#: ../src/libs/modulegroups.c:3161
+#: ../src/libs/modulegroups.c:3184
 msgid "quick access"
 msgstr "швидкий доступ"
 
-#: ../src/libs/modulegroups.c:3182
+#: ../src/libs/modulegroups.c:3205
 msgid "add widget to the quick access panel"
 msgstr "додати віджет до панелі швидкого доступу"
 
-#: ../src/libs/modulegroups.c:3214
+#: ../src/libs/modulegroups.c:3237
 msgid "group icon"
 msgstr "іконка групи"
 
-#: ../src/libs/modulegroups.c:3223
+#: ../src/libs/modulegroups.c:3246
 msgid "group name"
 msgstr "ім'я групи"
 
-#: ../src/libs/modulegroups.c:3234
+#: ../src/libs/modulegroups.c:3257
 msgid "remove group"
 msgstr "видалити групу"
 
-#: ../src/libs/modulegroups.c:3261
+#: ../src/libs/modulegroups.c:3284
 msgid "move group to the left"
 msgstr "перемістити групу вліво"
 
-#: ../src/libs/modulegroups.c:3270
+#: ../src/libs/modulegroups.c:3293
 msgid "add module to the group"
 msgstr "додати модуль до групи"
 
-#: ../src/libs/modulegroups.c:3282
+#: ../src/libs/modulegroups.c:3305
 msgid "move group to the right"
 msgstr "перемістити групу вправо"
 
-#: ../src/libs/modulegroups.c:3309 ../src/libs/modulegroups.c:3425
-#: ../src/libs/modulegroups.c:3807 ../src/libs/tagging.c:3082
+#: ../src/libs/modulegroups.c:3332 ../src/libs/modulegroups.c:3448
+#: ../src/libs/modulegroups.c:3830 ../src/libs/tagging.c:3082
 msgid "new"
 msgstr "новий"
 
-#: ../src/libs/modulegroups.c:3450
+#: ../src/libs/modulegroups.c:3473
 msgid "rename preset"
 msgstr "перейменувати пресет"
 
-#: ../src/libs/modulegroups.c:3457
+#: ../src/libs/modulegroups.c:3480
 msgid "new preset name :"
 msgstr "ім'я нового пресету :"
 
-#: ../src/libs/modulegroups.c:3458
+#: ../src/libs/modulegroups.c:3481
 msgid "a preset with this name already exists !"
 msgstr "пресет із цим іменем вже існує !"
 
-#: ../src/libs/modulegroups.c:3791
+#: ../src/libs/modulegroups.c:3814
 msgid "preset : "
 msgstr "пресет : "
 
-#: ../src/libs/modulegroups.c:3798
+#: ../src/libs/modulegroups.c:3821
 msgid "remove the preset"
 msgstr "видалити пресет"
 
-#: ../src/libs/modulegroups.c:3801
+#: ../src/libs/modulegroups.c:3824
 msgid "duplicate the preset"
 msgstr "зробити копію цього пресету"
 
-#: ../src/libs/modulegroups.c:3804
+#: ../src/libs/modulegroups.c:3827
 msgid "rename the preset"
 msgstr "перейменувати цей пресет"
 
-#: ../src/libs/modulegroups.c:3807
+#: ../src/libs/modulegroups.c:3830
 msgid "create a new empty preset"
 msgstr "створити новий порожній пресет"
 
-#: ../src/libs/modulegroups.c:3815
+#: ../src/libs/modulegroups.c:3838
 msgid "show search line"
 msgstr "показувати рядок пошуку"
 
-#: ../src/libs/modulegroups.c:3819
+#: ../src/libs/modulegroups.c:3842
 msgid "show quick access panel"
 msgstr "показати панель швидкого доступу"
 
-#: ../src/libs/modulegroups.c:3828
+#: ../src/libs/modulegroups.c:3851
 msgid "auto-apply this preset"
 msgstr "автозастосувати цей пресет"
 
-#: ../src/libs/modulegroups.c:3844
+#: ../src/libs/modulegroups.c:3867
 msgid "module groups"
 msgstr "групи модулів"
 
-#: ../src/libs/modulegroups.c:3862
+#: ../src/libs/modulegroups.c:3885
 msgid ""
 "this is a built-in read-only preset. duplicate it if you want to make changes"
 msgstr ""
 "це вбудований незмінний пресет. зробіть його дублікат, якщо хочете внести "
 "зміни"
 
-#: ../src/libs/modulegroups.c:3870
+#: ../src/libs/modulegroups.c:3893
 msgid "reset"
 msgstr "скинути"
 
@@ -20274,70 +20373,70 @@ msgstr ""
 msgid "show global preferences"
 msgstr "показати глобальні налаштування"
 
-#: ../src/libs/tools/global_toolbox.c:596
+#: ../src/libs/tools/global_toolbox.c:623
 #, c-format
 msgid "do you want to access `%s'?"
 msgstr "хочете отримати доступ до `%s'?"
 
-#: ../src/libs/tools/global_toolbox.c:601
+#: ../src/libs/tools/global_toolbox.c:628
 msgid "access the online usermanual?"
 msgstr "отримати доступ до онлайн-довідника?"
 
-#: ../src/libs/tools/global_toolbox.c:647
+#: ../src/libs/tools/global_toolbox.c:679
 msgid "help url opened in web browser"
 msgstr "URL довідки відкрито у веб-браузері"
 
-#: ../src/libs/tools/global_toolbox.c:651
+#: ../src/libs/tools/global_toolbox.c:683
 msgid "error while opening help url in web browser"
 msgstr "помилка під час відкриття URL-адреси довідки у веб-браузері"
 
-#: ../src/libs/tools/global_toolbox.c:662
+#: ../src/libs/tools/global_toolbox.c:694
 msgid "there is no help available for this element"
 msgstr "для цього елемента немає допомоги"
 
-#: ../src/libs/tools/global_toolbox.c:721
+#: ../src/libs/tools/global_toolbox.c:753
 msgctxt "accel"
 msgid "grouping"
 msgstr "групування"
 
-#: ../src/libs/tools/global_toolbox.c:722
+#: ../src/libs/tools/global_toolbox.c:754
 msgctxt "accel"
 msgid "preferences"
 msgstr "налаштування"
 
-#: ../src/libs/tools/global_toolbox.c:724
+#: ../src/libs/tools/global_toolbox.c:756
 msgctxt "accel"
 msgid "thumbnail overlays/no overlays"
 msgstr "інформація на мініатюрах/не показувати інформацію"
 
-#: ../src/libs/tools/global_toolbox.c:725
+#: ../src/libs/tools/global_toolbox.c:757
 msgctxt "accel"
 msgid "thumbnail overlays/overlays on mouse hover"
 msgstr "інформація на мініатюрах/інформація при наведенні миші"
 
-#: ../src/libs/tools/global_toolbox.c:726
+#: ../src/libs/tools/global_toolbox.c:758
 msgctxt "accel"
 msgid "thumbnail overlays/extended overlays on mouse hover"
 msgstr "інформація на мініатюрах/розширена інформація при наведенні миші"
 
-#: ../src/libs/tools/global_toolbox.c:727
+#: ../src/libs/tools/global_toolbox.c:759
 msgctxt "accel"
 msgid "thumbnail overlays/permanent overlays"
 msgstr "інформація на мініатюрах/постійна інформація"
 
-#: ../src/libs/tools/global_toolbox.c:728
+#: ../src/libs/tools/global_toolbox.c:760
 msgctxt "accel"
 msgid "thumbnail overlays/permanent extended overlays"
 msgstr "інформація на мініатюрах/постійна розширена інформація"
 
-#: ../src/libs/tools/global_toolbox.c:729
+#: ../src/libs/tools/global_toolbox.c:761
 msgctxt "accel"
 msgid "thumbnail overlays/permanent overlays extended on mouse hover"
 msgstr ""
 "інформація на мініатюрах/постійна інформація, що розширюється при наведенні "
 "миші"
 
-#: ../src/libs/tools/global_toolbox.c:730
+#: ../src/libs/tools/global_toolbox.c:762
 msgctxt "accel"
 msgid "thumbnail overlays/overlays block on mouse hover"
 msgstr "інформація на мініатюрах/тимчасовий блок інформації при наведенні миші"
@@ -20428,12 +20527,12 @@ msgstr "набір інструментів модуля"
 msgid "timeline"
 msgstr "шкала часу"
 
-#: ../src/libs/tools/timeline.c:1438
+#: ../src/libs/tools/timeline.c:1450
 msgctxt "accel"
 msgid "start selection"
 msgstr "розпочати вибір"
 
-#: ../src/libs/tools/timeline.c:1439
+#: ../src/libs/tools/timeline.c:1451
 msgctxt "accel"
 msgid "stop selection"
 msgstr "зупинити вибір"
@@ -20697,11 +20796,11 @@ msgstr ""
 "переключити перевірку охоплення\n"
 "права кнопка миші - опції профілів"
 
-#: ../src/views/darkroom.c:2409 ../src/views/lighttable.c:1326
+#: ../src/views/darkroom.c:2409 ../src/views/lighttable.c:1333
 msgid "display profile"
 msgstr "профіль відображення"
 
-#: ../src/views/darkroom.c:2410 ../src/views/lighttable.c:1329
+#: ../src/views/darkroom.c:2410 ../src/views/lighttable.c:1336
 msgid "preview display profile"
 msgstr "профіль попереднього перегляду"
 
@@ -20709,12 +20808,12 @@ msgstr "профіль попереднього перегляду"
 msgid "histogram profile"
 msgstr "профіль гістограми"
 
-#: ../src/views/darkroom.c:2476 ../src/views/lighttable.c:1365
+#: ../src/views/darkroom.c:2476 ../src/views/lighttable.c:1372
 #, c-format
 msgid "display ICC profiles in %s or %s"
 msgstr "ICC профілі дисплея в %s або %s"
 
-#: ../src/views/darkroom.c:2479 ../src/views/lighttable.c:1368
+#: ../src/views/darkroom.c:2479 ../src/views/lighttable.c:1375
 #, c-format
 msgid "preview display ICC profiles in %s or %s"
 msgstr "ICC профілі попереднього перегляду в %s або %s"
@@ -20745,195 +20844,195 @@ msgstr "колір перекриття"
 msgid "set overlay color"
 msgstr "встановити колір елементів, що перекривають зображення"
 
-#: ../src/views/darkroom.c:3840
+#: ../src/views/darkroom.c:3841
 msgid "keyboard shortcut slider precision: fine"
 msgstr "точність клавіатурного прискорювача повзунка: тонко"
 
-#: ../src/views/darkroom.c:3842
+#: ../src/views/darkroom.c:3843
 msgid "keyboard shortcut slider precision: normal"
 msgstr "точність клавіатурного прискорювача повзунка: нормально"
 
-#: ../src/views/darkroom.c:3844
+#: ../src/views/darkroom.c:3845
 msgid "keyboard shortcut slider precision: coarse"
 msgstr "точність клавіатурного прискорювача повзунка: грубо"
 
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:3881
+#: ../src/views/darkroom.c:3882
 msgctxt "accel"
 msgid "zoom close-up"
 msgstr "масштабування: масштаб 100% (і 200%)"
 
-#: ../src/views/darkroom.c:3882
+#: ../src/views/darkroom.c:3883
 msgctxt "accel"
 msgid "zoom fill"
 msgstr "масштабування: заповнити по ширині"
 
-#: ../src/views/darkroom.c:3883
+#: ../src/views/darkroom.c:3884
 msgctxt "accel"
 msgid "zoom fit"
 msgstr "масштабування: заповнити по висоті"
 
 #. zoom in/out
 #. zoom in/out/min/max
-#: ../src/views/darkroom.c:3886 ../src/views/lighttable.c:889
+#: ../src/views/darkroom.c:3887 ../src/views/lighttable.c:893
 msgctxt "accel"
 msgid "zoom in"
 msgstr "масштабування: збільшити"
 
-#: ../src/views/darkroom.c:3887 ../src/views/lighttable.c:891
+#: ../src/views/darkroom.c:3888 ../src/views/lighttable.c:895
 msgctxt "accel"
 msgid "zoom out"
 msgstr "масштабування: зменшити"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:3890
+#: ../src/views/darkroom.c:3891
 msgctxt "accel"
 msgid "image forward"
 msgstr "наступне зображення"
 
-#: ../src/views/darkroom.c:3891
+#: ../src/views/darkroom.c:3892
 msgctxt "accel"
 msgid "image back"
 msgstr "попереднє зображення"
 
 #. toggle ISO 12646 color assessment condition
-#: ../src/views/darkroom.c:3894
+#: ../src/views/darkroom.c:3895
 msgctxt "accel"
 msgid "color assessment"
 msgstr "оцінка кольорів"
 
 #. toggle raw overexposure indication
-#: ../src/views/darkroom.c:3897
+#: ../src/views/darkroom.c:3898
 msgctxt "accel"
 msgid "raw overexposed"
 msgstr "показати переекспоновані канали в raw"
 
 #. toggle overexposure indication
-#: ../src/views/darkroom.c:3900
+#: ../src/views/darkroom.c:3901
 msgctxt "accel"
 msgid "overexposed"
 msgstr "показати переекспоновані ділянки"
 
 #. cycle overlay colors
-#: ../src/views/darkroom.c:3903
+#: ../src/views/darkroom.c:3904
 msgctxt "accel"
 msgid "cycle overlay colors"
 msgstr "колір допоміжних ліній на зображенні"
 
 #. toggle softproofing
-#: ../src/views/darkroom.c:3906
+#: ../src/views/darkroom.c:3907
 msgctxt "accel"
 msgid "softproof"
 msgstr "екранна кольоропроба"
 
 #. toggle gamut check
-#: ../src/views/darkroom.c:3909
+#: ../src/views/darkroom.c:3910
 msgctxt "accel"
 msgid "gamut check"
 msgstr "перевірити охоплення"
 
 #. toggle visibility of drawn masks for current gui module
-#: ../src/views/darkroom.c:3912
+#: ../src/views/darkroom.c:3913
 msgctxt "accel"
 msgid "show drawn masks"
 msgstr "показати намальовані маски"
 
 #. brush size +/-
-#: ../src/views/darkroom.c:3915
+#: ../src/views/darkroom.c:3916
 msgctxt "accel"
 msgid "increase brush size"
 msgstr "збільшити розмір пензля"
 
-#: ../src/views/darkroom.c:3916
+#: ../src/views/darkroom.c:3917
 msgctxt "accel"
 msgid "decrease brush size"
 msgstr "зменшити розмір пензля"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:3919
+#: ../src/views/darkroom.c:3920
 msgctxt "accel"
 msgid "increase brush hardness"
 msgstr "збільшити жорсткість пензля"
 
-#: ../src/views/darkroom.c:3920
+#: ../src/views/darkroom.c:3921
 msgctxt "accel"
 msgid "decrease brush hardness"
 msgstr "зменшити жорсткість пензля"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:3923
+#: ../src/views/darkroom.c:3924
 msgctxt "accel"
 msgid "increase brush opacity"
 msgstr "збільшити непрозорість пензля"
 
-#: ../src/views/darkroom.c:3924
+#: ../src/views/darkroom.c:3925
 msgctxt "accel"
 msgid "decrease brush opacity"
 msgstr "зменшити непрозорість пензля"
 
 #. fullscreen view
-#: ../src/views/darkroom.c:3927
+#: ../src/views/darkroom.c:3928
 msgctxt "accel"
 msgid "full preview"
 msgstr "попередній перегляд на все вікно"
 
 #. undo/redo
-#: ../src/views/darkroom.c:3930 ../src/views/lighttable.c:881
+#: ../src/views/darkroom.c:3931 ../src/views/lighttable.c:885
 #: ../src/views/map.c:2072
 msgctxt "accel"
 msgid "undo"
 msgstr "скасувати"
 
-#: ../src/views/darkroom.c:3931 ../src/views/lighttable.c:882
+#: ../src/views/darkroom.c:3932 ../src/views/lighttable.c:886
 #: ../src/views/map.c:2073
 msgctxt "accel"
 msgid "redo"
 msgstr "повторити"
 
 #. add an option to allow skip mouse events while editing masks
-#: ../src/views/darkroom.c:3934
+#: ../src/views/darkroom.c:3935
 msgctxt "accel"
 msgid "allow to pan & zoom while editing masks"
 msgstr "дозволити панорамування і масштабування при редагуванні масок"
 
 #. set focus to the search modules text box
-#: ../src/views/darkroom.c:3937
+#: ../src/views/darkroom.c:3938
 msgctxt "accel"
 msgid "search modules"
 msgstr "пошук модулів"
 
 #. change the precision for adjusting sliders with keyboard shortcuts
-#: ../src/views/darkroom.c:3940
+#: ../src/views/darkroom.c:3941
 msgctxt "accel"
 msgid "change keyboard shortcut slider precision"
 msgstr "змінити точність керування повзунками з клавіатури"
 
-#: ../src/views/darkroom.c:4051
+#: ../src/views/darkroom.c:4052
 msgid "switch to lighttable"
 msgstr "перейти до світлого столу"
 
-#: ../src/views/darkroom.c:4052 ../src/views/lighttable.c:1027
+#: ../src/views/darkroom.c:4053 ../src/views/lighttable.c:1033
 msgid "zoom in the image"
 msgstr "масштабувати зображення, максимум - 100%"
 
-#: ../src/views/darkroom.c:4053
+#: ../src/views/darkroom.c:4054
 msgid "unbounded zoom in the image"
 msgstr "масштабувати зображення, максимум - 1600%"
 
-#: ../src/views/darkroom.c:4054
+#: ../src/views/darkroom.c:4055
 msgid "zoom to 100% 200% and back"
 msgstr "масштабувати до 100%, 200% і назад"
 
-#: ../src/views/darkroom.c:4056
+#: ../src/views/darkroom.c:4057
 msgid "[modules] expand module without closing others"
 msgstr "[модулі] розширити модуль, не закриваючи інші"
 
-#: ../src/views/darkroom.c:4058
+#: ../src/views/darkroom.c:4059
 msgid "[modules] change module position in pipe"
 msgstr "[модулі] змінити положення модуля в конвеєрі"
 
 #. workaround for GTK Quartz backend bug
-#: ../src/views/darkroom.c:4674 ../src/views/darkroom.c:4692
+#: ../src/views/darkroom.c:4707 ../src/views/darkroom.c:4725
 msgid "darktable - darkroom preview"
 msgstr "darktable - попередній перегляд зображення з темної кімнати"
 
@@ -20941,215 +21040,215 @@ msgstr "darktable - попередній перегляд зображення �
 msgid "good knight"
 msgstr "good knight"
 
-#: ../src/views/lighttable.c:399 ../src/views/slideshow.c:376
+#: ../src/views/lighttable.c:402 ../src/views/slideshow.c:376
 msgid "there are no images in this collection"
 msgstr "в цій колекції немає зображень"
 
-#: ../src/views/lighttable.c:403
+#: ../src/views/lighttable.c:406
 msgid "if you have not imported any images yet"
 msgstr "якщо ви ще не імпортували жодного зображення"
 
-#: ../src/views/lighttable.c:407
+#: ../src/views/lighttable.c:410
 msgid "you can do so in the import module"
 msgstr "ви можете зробити це в модулі імпорту"
 
-#: ../src/views/lighttable.c:415
+#: ../src/views/lighttable.c:418
 msgid "try to relax the filter settings in the top panel"
 msgstr "спробуйте послабити налаштування фільтра на верхній панелі"
 
-#: ../src/views/lighttable.c:424
+#: ../src/views/lighttable.c:427
 msgid "or add images in the collections module in the left panel"
 msgstr "або додати зображення в модулі колекції на лівій панелі"
 
 #. movement keys
-#: ../src/views/lighttable.c:852
+#: ../src/views/lighttable.c:856
 msgctxt "accel"
 msgid "move page up"
 msgstr "переміщення: на сторінку вгору"
 
-#: ../src/views/lighttable.c:853
+#: ../src/views/lighttable.c:857
 msgctxt "accel"
 msgid "move page down"
 msgstr "переміщення: на сторінку вниз"
 
-#: ../src/views/lighttable.c:854
+#: ../src/views/lighttable.c:858
 msgctxt "accel"
 msgid "move up"
 msgstr "переміщення: вгору"
 
-#: ../src/views/lighttable.c:855
+#: ../src/views/lighttable.c:859
 msgctxt "accel"
 msgid "move down"
 msgstr "переміщення: вниз"
 
-#: ../src/views/lighttable.c:856
+#: ../src/views/lighttable.c:860
 msgctxt "accel"
 msgid "move left"
 msgstr "переміщення: ліворуч"
 
-#: ../src/views/lighttable.c:857
+#: ../src/views/lighttable.c:861
 msgctxt "accel"
 msgid "move right"
 msgstr "переміщення: праворуч"
 
-#: ../src/views/lighttable.c:858
+#: ../src/views/lighttable.c:862
 msgctxt "accel"
 msgid "move start"
 msgstr "переміщення: на початок"
 
-#: ../src/views/lighttable.c:859
+#: ../src/views/lighttable.c:863
 msgctxt "accel"
 msgid "move end"
 msgstr "переміщення: в кінець"
 
 #. movement keys with selection
-#: ../src/views/lighttable.c:862
+#: ../src/views/lighttable.c:866
 msgctxt "accel"
 msgid "move page up and select"
 msgstr "переміщення: на сторінку вгору і вибрати"
 
-#: ../src/views/lighttable.c:863
+#: ../src/views/lighttable.c:867
 msgctxt "accel"
 msgid "move page down and select"
 msgstr "переміщення: на сторінку вниз і вибрати"
 
-#: ../src/views/lighttable.c:864
+#: ../src/views/lighttable.c:868
 msgctxt "accel"
 msgid "move up and select"
 msgstr "переміщення: вгору і вибрати"
 
-#: ../src/views/lighttable.c:865
+#: ../src/views/lighttable.c:869
 msgctxt "accel"
 msgid "move down and select"
 msgstr "переміщення: вниз і вибрати"
 
-#: ../src/views/lighttable.c:866
+#: ../src/views/lighttable.c:870
 msgctxt "accel"
 msgid "move left and select"
 msgstr "переміщення: ліворуч і вибрати"
 
-#: ../src/views/lighttable.c:867
+#: ../src/views/lighttable.c:871
 msgctxt "accel"
 msgid "move right and select"
 msgstr "переміщення: праворуч і вибрати"
 
-#: ../src/views/lighttable.c:868
+#: ../src/views/lighttable.c:872
 msgctxt "accel"
 msgid "move start and select"
 msgstr "переміщення: на початок і вибрати"
 
-#: ../src/views/lighttable.c:869
+#: ../src/views/lighttable.c:873
 msgctxt "accel"
 msgid "move end and select"
 msgstr "переміщення: в кінець і вибрати"
 
-#: ../src/views/lighttable.c:871
+#: ../src/views/lighttable.c:875
 msgctxt "accel"
 msgid "align images to grid"
 msgstr "вирівняти зображення за сіткою"
 
-#: ../src/views/lighttable.c:872
+#: ../src/views/lighttable.c:876
 msgctxt "accel"
 msgid "reset first image offset"
 msgstr "скинути зміщення першого зображення"
 
-#: ../src/views/lighttable.c:873
+#: ../src/views/lighttable.c:877
 msgctxt "accel"
 msgid "select toggle image"
 msgstr "додати чи прибрати зображення з вибірки"
 
-#: ../src/views/lighttable.c:874
+#: ../src/views/lighttable.c:878
 msgctxt "accel"
 msgid "select single image"
 msgstr "вибрати одне зображення"
 
 #. Preview key
-#: ../src/views/lighttable.c:877
+#: ../src/views/lighttable.c:881
 msgctxt "accel"
 msgid "preview"
 msgstr "попередній перегляд"
 
-#: ../src/views/lighttable.c:878
+#: ../src/views/lighttable.c:882
 msgctxt "accel"
 msgid "preview with focus detection"
 msgstr "попередній перегляд із виявленням фокусу"
 
 #. zoom for full culling & preview
-#: ../src/views/lighttable.c:885
+#: ../src/views/lighttable.c:889
 msgctxt "accel"
 msgid "preview zoom 100%"
 msgstr "попередній перегляд в масштабі 100%"
 
-#: ../src/views/lighttable.c:886
+#: ../src/views/lighttable.c:890
 msgctxt "accel"
 msgid "preview zoom fit"
 msgstr "попередній перегляд, заповнити область перегляду"
 
-#: ../src/views/lighttable.c:890
+#: ../src/views/lighttable.c:894
 msgctxt "accel"
 msgid "zoom max"
 msgstr "масштабування: максимум"
 
-#: ../src/views/lighttable.c:892
+#: ../src/views/lighttable.c:896
 msgctxt "accel"
 msgid "zoom min"
 msgstr "масштабування: мінімум"
 
-#: ../src/views/lighttable.c:1022
+#: ../src/views/lighttable.c:1028
 msgid "open image in darkroom"
 msgstr "відкрити зображення в темній кімнаті"
 
-#: ../src/views/lighttable.c:1026
+#: ../src/views/lighttable.c:1032
 msgid "switch to next/previous image"
 msgstr "перейти до наступного/попереднього зображення"
 
-#: ../src/views/lighttable.c:1029 ../src/views/lighttable.c:1051
+#: ../src/views/lighttable.c:1035 ../src/views/lighttable.c:1058
 #, no-c-format
 msgid "zoom to 100% and back"
 msgstr "масштабувати до 100% і назад"
 
-#: ../src/views/lighttable.c:1033 ../src/views/lighttable.c:1044
+#: ../src/views/lighttable.c:1039 ../src/views/lighttable.c:1051
 msgid "scroll the collection"
 msgstr "прокрутити колекцію"
 
-#: ../src/views/lighttable.c:1035
+#: ../src/views/lighttable.c:1041
 msgid "change number of images per row"
 msgstr "змінити кількість зображень на рядок"
 
-#: ../src/views/lighttable.c:1039
+#: ../src/views/lighttable.c:1045
 msgid "change image order"
 msgstr "змінити порядок зображень"
 
-#: ../src/views/lighttable.c:1045
+#: ../src/views/lighttable.c:1052
 msgid "zoom all the images"
 msgstr "масштабувати всі зображення"
 
-#: ../src/views/lighttable.c:1046
+#: ../src/views/lighttable.c:1053
 msgid "pan inside all the images"
 msgstr "панорамувати всередині всіх зображень"
 
-#: ../src/views/lighttable.c:1048
+#: ../src/views/lighttable.c:1055
 msgid "zoom current image"
 msgstr "масштабувати поточне зображення"
 
-#: ../src/views/lighttable.c:1049
+#: ../src/views/lighttable.c:1056
 msgid "pan inside current image"
 msgstr "панорамувати всередині поточного зображення"
 
-#: ../src/views/lighttable.c:1054
+#: ../src/views/lighttable.c:1061
 #, no-c-format
 msgid "zoom current image to 100% and back"
 msgstr "масштабувати поточне зображення до 100% і назад"
 
-#: ../src/views/lighttable.c:1058
+#: ../src/views/lighttable.c:1065
 msgid "zoom the main view"
 msgstr "масштабувати головне вікно"
 
-#: ../src/views/lighttable.c:1059
+#: ../src/views/lighttable.c:1066
 msgid "pan inside the main view"
 msgstr "панорамувати всередині головного вікна"
 
-#: ../src/views/lighttable.c:1289
+#: ../src/views/lighttable.c:1296
 msgid "set display profile"
 msgstr "встановити профіль відображення"
 
@@ -21224,7 +21323,7 @@ msgstr "камера"
 msgid "new session initiated '%s'"
 msgstr "розпочато новий сеанс '%s'"
 
-#: ../src/views/tethering.c:441
+#: ../src/views/tethering.c:448
 msgid "no camera with tethering support available for use..."
 msgstr "камер з підтримкою віддаленого керування не знайдено..."
 
@@ -21289,6 +21388,20 @@ msgstr "Прискорювач"
 #: ../src/views/view.c:1791
 msgid "Action"
 msgstr "Дія"
+
+#~ msgid ""
+#~ "choose the root of the folder tree below\n"
+#~ "try to choose a root folder that contains most/all of your photographs "
+#~ "(in sub-folders)\n"
+#~ "so that you don't need to change the root frequently\n"
+#~ "e.g. set it to your 'pictures' or 'home' directory"
+#~ msgstr ""
+#~ "виберіть корінь дерева каталогів нижче\n"
+#~ "спробуйте вибрати кореневий каталог, який містить більшість / усі ваші "
+#~ "фотографії (у підкаталогах)\n"
+#~ "так, щоб вам не потрібно було часто міняти корінь\n"
+#~ "наприклад, встановіть його на свій каталог 'Зображення' чи на домашній "
+#~ "каталог"
 
 #~ msgid "collect images"
 #~ msgstr "колекції зображень"


### PR DESCRIPTION
Translations of new and changed strings.

Better translation for "color cast". Prev one was the same as Adobe's translation, but it derived from the root word that basically means paint as a substance and is very unusual in the context of scene hues.
