### PR TITLE
Fix double free on lua event destruction

### DIFF
--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -593,7 +593,7 @@ static int register_shortcut_event(lua_State *L)
   // 5 is the action to perform (checked)
   // 6 is the key itself
 
-  // duplicate the key for use elsewhere
+  // duplicate the key for use elsewhere - do not free as it's in use elsewhere
   char *tmp = strdup(luaL_checkstring(L, 6));
 
   // register the event
@@ -604,9 +604,6 @@ static int register_shortcut_event(lua_State *L)
 
   // set up the accelerator path
   dt_accel_connect_lua(tmp, g_cclosure_new(G_CALLBACK(shortcut_callback), tmp, closure_destroy));
-
-  // free temporary buffer
-  free(tmp);
 
   return result;
 }

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -621,7 +621,7 @@ static int destroy_shortcut_event(lua_State *L)
   // get the key from the index
   lua_getfield(L, 2, luaL_checkstring(L, 3));
 
-  // duplicate the key for use elsewhere
+  // duplicate the key for use elsewhere - do not free, destroyed elsewhere
   char *tmp = strdup(luaL_checkstring(L, -1));
 
   // remove the key from the stack
@@ -632,9 +632,6 @@ static int destroy_shortcut_event(lua_State *L)
 
   // remove the accelerator from the lua shortcuts
   dt_accel_deregister_lua(tmp);
-
-  // free temporary buffer
-  free(tmp);
 
   return result;
 }


### PR DESCRIPTION
Partially revert #9080.  Freeing the strdup tmp variable during event destruction results in a double free and a crash.

Sorry @TurboGit, @rabauke my test wasn't good enough to catch this.  I'll update it :)