### PR TITLE
Fix inaccurate message about Exiv2 version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,7 +410,7 @@ if (USE_ISOBMFF)
       message(STATUS "Exiv2 >= 0.27.4 found, but was not compiled with ISOBMFF support (CR3, AVIF, HEIF)")
     endif()
   else()
-    message(STATUS "Exiv2 <= 0.27.4 found, no support for ISOBMFF files (CR3, AVIF, HEIF)")
+    message(STATUS "Exiv2 < 0.27.4 found, no support for ISOBMFF files (CR3, AVIF, HEIF)")
   endif()
 endif()
 


### PR DESCRIPTION
This is a purely cosmetic fix, but let's not confuse the user with inaccurate information.