### PR TITLE
fix patch size tooltip in denoise profiled

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3680,7 +3680,7 @@ void gui_init(dt_iop_module_t *self)
                                                        "denoise chroma and luma separately."));
   gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match.\n"
                                            "increase for more sharpness on strong edges, and better denoising of smooth areas.\n"
-                                           "if details are oversmoothed, reduce this value or increase the details slider."));
+                                           "if details are oversmoothed, reduce this value or increase the central pixel weight slider."));
   gtk_widget_set_tooltip_text(g->nbhood, _("emergency use only: radius of the neighbourhood to search patches in. "
                                            "increase for better denoising performance, but watch the long runtimes! "
                                            "large radii can be very slow. you have been warned"));


### PR DESCRIPTION
Fixes #9118

Over the commits to denoise profiled module, central pixel weight lost reference to details and so the tooltip from patch size lost it's meaning.

This corrects the tooltip to reference correct slider