### PR TITLE
 Apply a style in overwrite & duplicate mode must not remove history of originals

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -593,7 +593,7 @@ gboolean dt_styles_create_from_image(const char *name, const char *description,
 void dt_styles_apply_to_list(const char *name, const GList *list, gboolean duplicate)
 {
   gboolean selected = FALSE;
-
+fprintf(stderr," we are here");
   /* write current history changes so nothing gets lost,
      do that only in the darkroom as there is nothing to be saved
      when in the lighttable (and it would write over current history stack) */
@@ -601,16 +601,16 @@ void dt_styles_apply_to_list(const char *name, const GList *list, gboolean dupli
   if(cv->view(cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
 
   const int mode = dt_conf_get_int("plugins/lighttable/style/applymode");
+  const gboolean is_overwrite = (mode == DT_STYLE_HISTORY_OVERWRITE);
 
   /* for each selected image apply style */
   dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
 
-  const gboolean is_overwrite = mode == (DT_STYLE_HISTORY_OVERWRITE);
   dt_undo_lt_history_t *hist = NULL;
 
   for(const GList *l = list; l; l = g_list_next(l))
   {
-    const int imgid = GPOINTER_TO_INT(l->data);
+    const int32_t imgid = GPOINTER_TO_INT(l->data);
     if(is_overwrite)
     {
       hist = dt_history_snapshot_item_init();
@@ -618,10 +618,10 @@ void dt_styles_apply_to_list(const char *name, const GList *list, gboolean dupli
       dt_history_snapshot_undo_create(hist->imgid, &hist->before, &hist->before_history_end);
 
       dt_undo_disable_next(darktable.undo);
-      dt_history_delete_on_image_ext(imgid, FALSE);
+      if(!duplicate) dt_history_delete_on_image_ext(imgid, FALSE);
     }
 
-    dt_styles_apply_to_image(name, duplicate, imgid);
+    dt_styles_apply_to_image(name, duplicate, is_overwrite, imgid);
 
     if(is_overwrite)
     {
@@ -666,18 +666,19 @@ void dt_multiple_styles_apply_to_list(GList *styles, const GList *list, gboolean
   }
 
   const int mode = dt_conf_get_int("plugins/lighttable/style/applymode");
+  const gboolean is_overwrite = (mode == DT_STYLE_HISTORY_OVERWRITE);
 
   /* for each selected image apply style */
   dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
   for(const GList *l = list; l; l = g_list_next(l))
   {
-    const int imgid = GPOINTER_TO_INT(l->data);
-    if(mode == DT_STYLE_HISTORY_OVERWRITE)
+    const int32_t imgid = GPOINTER_TO_INT(l->data);
+    if(is_overwrite && !duplicate)
       dt_history_delete_on_image_ext(imgid, FALSE);
 
     for (GList *style = styles; style; style = g_list_next(style))
     {
-      dt_styles_apply_to_image((char*)style->data, duplicate, imgid);
+      dt_styles_apply_to_image((char*)style->data, duplicate, is_overwrite, imgid);
     }
   }
   dt_undo_end_group(darktable.undo);
@@ -802,7 +803,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, 
   }
 }
 
-void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const int32_t imgid)
+void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const gboolean overwrite, const int32_t imgid)
 {
   int id = 0;
   sqlite3_stmt *stmt;
@@ -815,7 +816,12 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
     {
       newimgid = dt_image_duplicate(imgid);
       if(newimgid != -1)
-        dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL, TRUE, TRUE);
+      {
+        if(overwrite)
+          dt_history_delete_on_image_ext(newimgid, FALSE);
+        else
+          dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL, TRUE, TRUE);
+      }
     }
     else
       newimgid = imgid;

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -593,7 +593,7 @@ gboolean dt_styles_create_from_image(const char *name, const char *description,
 void dt_styles_apply_to_list(const char *name, const GList *list, gboolean duplicate)
 {
   gboolean selected = FALSE;
-fprintf(stderr," we are here");
+
   /* write current history changes so nothing gets lost,
      do that only in the darkroom as there is nothing to be saved
      when in the lighttable (and it would write over current history stack) */

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -85,8 +85,8 @@ void dt_multiple_styles_apply_to_list(GList *styles, const GList *list, gboolean
 /** applies the item style to dev->history */
 void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, GList **modules_used, const gboolean append);
 
-/** applies the style to image by imgid*/
-void dt_styles_apply_to_image(const char *name, const gboolean dulpicate, const int32_t imgid);
+/** applies the style to image by imgid, takes care of overwrite and duplicate modes */
+void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const gboolean overwrite, const int32_t imgid);
 
 /** delete a style by name */
 void dt_styles_delete_by_name_adv(const char *name, const gboolean raise);

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -259,7 +259,7 @@ int dt_lua_style_apply(lua_State *L)
     luaA_to(L, dt_style_t, &style, 1);
     luaA_to(L, dt_lua_image_t, &imgid, 2);
   }
-  dt_styles_apply_to_image(style.name, FALSE, imgid);
+  dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   return 1;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1266,7 +1266,7 @@ static void _darkroom_ui_apply_style_activate_callback(gchar *name)
   dt_dev_undo_start_record(darktable.develop);
 
   /* apply style on image and reload*/
-  dt_styles_apply_to_image(name, FALSE, darktable.develop->image_storage.id);
+  dt_styles_apply_to_image(name, FALSE, FALSE, darktable.develop->image_storage.id);
   dt_dev_reload_image(darktable.develop, darktable.develop->image_storage.id);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);


### PR DESCRIPTION
Fixes #7352

Has been due to deleting history of the source image whenever overwrite mode was used.

To make this an easy go the definition of

`void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const gboolean overwrite, const int32_t imgid);`

now also gets the overwrite mode so it can decide on all combinattion of duplicate & overwrite what to do with an existing history.