### PR TITLE
More robust image and xmp file testing

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2546,11 +2546,11 @@ void dt_database_show_error(const dt_database_t *db)
         int status = 0;
 
         char *lck_filename = g_strconcat(lck_dirname, "/data.db.lock", NULL);
-        if(access(lck_filename, F_OK) != -1)
+        if(g_access(lck_filename, F_OK) != -1)
           status += remove(lck_filename);
 
         lck_filename = g_strconcat(lck_dirname, "/library.db.lock", NULL);
-        if(access(lck_filename, F_OK) != -1)
+        if(g_access(lck_filename, F_OK) != -1)
           status += remove(lck_filename);
 
         if(status==0)
@@ -3474,14 +3474,14 @@ static void _database_delete_mipmaps_files()
 
   snprintf(mipmapfilename, sizeof(mipmapfilename), "%s/mipmaps", cachedir);
 
-  if(access(mipmapfilename, F_OK) != -1)
+  if(g_access(mipmapfilename, F_OK) != -1)
   {
     fprintf(stderr, "[mipmap_cache] dropping old version file: %s\n", mipmapfilename);
     g_unlink(mipmapfilename);
 
     snprintf(mipmapfilename, sizeof(mipmapfilename), "%s/mipmaps.fallback", cachedir);
 
-    if(access(mipmapfilename, F_OK) != -1) g_unlink(mipmapfilename);
+    if(g_access(mipmapfilename, F_OK) != -1) g_unlink(mipmapfilename);
   }
 }
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1379,9 +1379,7 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
                                        gboolean lua_locking, gboolean raise_signals)
 {
   char *normalized_filename = dt_util_normalize_path(filename);
-  if(!normalized_filename
-     || !g_file_test(normalized_filename, G_FILE_TEST_IS_REGULAR)
-     || dt_util_get_file_size(normalized_filename) == 0)
+  if(!normalized_filename || !dt_util_test_image_file(normalized_filename))
   {
     g_free(normalized_filename);
     return 0;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1249,9 +1249,9 @@ GList* dt_image_find_duplicates(const char* filename)
   // concatenate filename and sidecar extension
   g_strlcpy(pattern,  filename, sizeof(pattern));
   g_strlcpy(pattern + fn_len, xmp, sizeof(pattern) - fn_len);
-  if (access(pattern, R_OK) == 0)
+  if(dt_util_test_image_file(pattern))
   {
-    // the default sidecar exists and is readable, so add it to the list
+    // the default sidecar exists, is readable and is a regular file with lenght > 0, so add it to the list
     files = g_list_prepend(files, g_strdup(pattern));
   }
 

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -291,7 +291,7 @@ gboolean dt_util_test_image_file(const char *filename)
 
   const gboolean regular = (S_ISREG(stats.st_mode)) != 0;
   const gboolean size_ok = stats.st_size > 0;
-  return regular & size_ok;
+  return regular && size_ok;
 }
 
 gboolean dt_util_is_dir_empty(const char *dirname)

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -278,17 +278,20 @@ size_t dt_utf8_strlcpy(char *dest, const char *src, size_t n)
   return s - src;
 }
 
-off_t dt_util_get_file_size(const char *filename)
+gboolean dt_util_test_image_file(const char *filename)
 {
+  if(g_access(filename, R_OK)) return FALSE;
 #ifdef _WIN32
-  struct _stati64 st;
-  if(_stati64(filename, &st) == 0) return st.st_size;
+  struct _stati64 stats;
+  if(_stati64(filename, &stats)) return FALSE;
 #else
-  struct stat st;
-  if(stat(filename, &st) == 0) return st.st_size;
+  struct stat stats;
+  if(stat(filename, &stats)) return FALSE;
 #endif
 
-  return -1;
+  const gboolean regular = (S_ISREG(stats.st_mode)) != 0;
+  const gboolean size_ok = stats.st_size > 0;
+  return regular & size_ok;
 }
 
 gboolean dt_util_is_dir_empty(const char *dirname)

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -37,8 +37,8 @@ GList *dt_util_glist_uniq(GList *items);
 /** fixes the given path by replacing a possible tilde with the correct home directory */
 gchar *dt_util_fix_path(const gchar *path);
 size_t dt_utf8_strlcpy(char *dest, const char *src, size_t n);
-/** get the size of a file in bytes */
-off_t dt_util_get_file_size(const char *filename);
+/** returns true if a file is regular, has read access and a filesize > 0 */
+gboolean dt_util_test_image_file(const char *filename);
 /** returns true if dirname is empty */
 gboolean dt_util_is_dir_empty(const char *dirname);
 /** returns a valid UTF-8 string for the given char array. has to be freed with g_free(). */

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -104,8 +104,8 @@ static int generate_thumbnail_cache(const dt_mipmap_size_t min_mip, const dt_mip
       char filename[PATH_MAX] = { 0 };
       snprintf(filename, sizeof(filename), "%s.d/%d/%d.jpg", darktable.mipmap_cache->cachedir, k, imgid);
 
-      // if the thumbnail is already on disc - do nothing
-      if(!access(filename, R_OK)) continue;
+      // if a valid thumbnail file is already on disc - do nothing
+      if(dt_util_test_image_file(filename)) continue;
 
       // else, generate thumbnail and store in mipmap cache.
       dt_mipmap_buffer_t buf;

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -244,7 +244,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
   // set max_width and max_height values to expand them afterwards in darktable variables
   dt_variables_set_max_width_height(d->vp, fdata->max_width, fdata->max_height);
-  int fail = 0;
+  gboolean fail = FALSE;
   // we're potentially called in parallel. have sequence number synchronized:
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
   {
@@ -285,14 +285,14 @@ try_again:
     {
       fprintf(stderr, "[imageio_storage_disk] could not create directory: `%s'!\n", output_dir);
       dt_control_log(_("could not create directory `%s'!"), output_dir);
-      fail = 1;
+      fail = TRUE;
       goto failed;
     }
     if(g_access(output_dir, W_OK | X_OK) != 0)
     {
       fprintf(stderr, "[imageio_storage_disk] could not write to directory: `%s'!\n", output_dir);
       dt_control_log(_("could not write to directory `%s'!"), output_dir);
-      fail = 1;
+      fail = TRUE;
       goto failed;
     }
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1558,7 +1558,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
   char *composed = g_build_filename(lutfolder, p->filepath, NULL);
-  if (strlen(p->filepath) == 0 || access(composed, F_OK) == -1)
+  if (strlen(p->filepath) == 0 || g_access(composed, F_OK) == -1)
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), lutfolder);
   else
     gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(filechooser), composed);


### PR DESCRIPTION
As @HansBull has been pretty silent in #8623 i open this.

Fixes #8598
Likely Fixes #9112

- Basically uses `g_access` instead of `access` as other file accessing calls also use the g_ variant.
- introduces `gboolean dt_util_test_image_file(const char *filename)` and removes redundant `off_t dt_util_get_file_size`. This new calls tests for "regular and readable file have a size of at least 1" as a quick safety and plausability check.
- `gboolean dt_util_test_image_file(const char *filename)` is used while importing files, looking for duplicates (.xmp) and for existing thumbs in generate cache.

@cryptomilk requested the check to get a stat and do all three mentioned tests on that struct, unfortunately i couldn't find out a portable way to do that for g_access.
