### PR TITLE
More robust dt_import_session_path checks

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -316,11 +316,10 @@ gboolean _dt_test_writable_dir(const char *path)
   return TRUE;
 }
 
-const char *dt_import_session_path(struct dt_import_session_t *self, gboolean current)
+static const char *_import_session_path(struct dt_import_session_t *self, gboolean current)
 {
   char *pattern;
   char *new_path;
-
   const gboolean currentok = _dt_test_writable_dir(self->current_path);
 
   if(current && self->current_path != NULL)
@@ -349,18 +348,28 @@ const char *dt_import_session_path(struct dt_import_session_t *self, gboolean cu
     if(currentok) return self->current_path;
   }
 
-
   if(!currentok) self->current_path = NULL;
   /* we need to initialize a new filmroll for the new path */
   if(_import_session_initialize_filmroll(self, new_path) != 0)
   {
     g_free(new_path);
-    fprintf(stderr, "[import_session] Failed to get session path.\n");
     return NULL;
   }
-
   return self->current_path;
 }
+
+const char *dt_import_session_path(struct dt_import_session_t *self, gboolean current)
+{
+  const char *path = _import_session_path(self, current);
+  if(path == NULL)
+  {
+    fprintf(stderr, "[import_session] Failed to get session path.\n");
+    dt_control_log(_("requested session path not available."
+                     "device not mounted?"));
+  }
+  return path;  
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -307,26 +307,11 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
   return self->current_filename;
 }
 
-gboolean _dt_test_writable_dir(const char *path)
-{
-  if(path == NULL) return FALSE;
-#ifdef _WIN32
-  struct _stati64 stats;
-  if(_stati64(path, &stats)) return FALSE;
-#else
-  struct stat stats;
-  if(stat(path, &stats)) return FALSE;
-#endif
-  if(S_ISDIR(stats.st_mode) == 0) return FALSE;  
-  if(g_access(path, W_OK | X_OK) != 0) return FALSE;
-  return TRUE;
-}
-
 static const char *_import_session_path(struct dt_import_session_t *self, gboolean current)
 {
   char *pattern;
   char *new_path;
-  const gboolean currentok = _dt_test_writable_dir(self->current_path);
+  const gboolean currentok = dt_util_test_writable_dir(self->current_path);
   fprintf(stderr, " _import_session_path testing `%s' %i", self->current_path, currentok);
 
   if(current && self->current_path != NULL)

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -294,6 +294,22 @@ gboolean dt_util_test_image_file(const char *filename)
   return regular && size_ok;
 }
 
+gboolean dt_util_test_writable_dir(const char *path)
+{
+  if(path == NULL) return FALSE;
+#ifdef _WIN32
+  struct _stati64 stats;
+  if(_stati64(path, &stats)) return FALSE;
+#else
+  struct stat stats;
+  if(stat(path, &stats)) return FALSE;
+#endif
+  if(S_ISDIR(stats.st_mode) == 0) return FALSE;  
+  if(g_access(path, W_OK | X_OK) != 0) return FALSE;
+  return TRUE;
+}
+
+
 gboolean dt_util_is_dir_empty(const char *dirname)
 {
   int n = 0;

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -39,6 +39,8 @@ gchar *dt_util_fix_path(const gchar *path);
 size_t dt_utf8_strlcpy(char *dest, const char *src, size_t n);
 /** returns true if a file is regular, has read access and a filesize > 0 */
 gboolean dt_util_test_image_file(const char *filename);
+/** returns true if the path represents a directory with write access */
+gboolean dt_util_test_writable_dir(const char *path);
 /** returns true if dirname is empty */
 gboolean dt_util_is_dir_empty(const char *dirname);
 /** returns a valid UTF-8 string for the given char array. has to be freed with g_free(). */


### PR DESCRIPTION
checks for a writable existing directory when finding the path. Also checks for that before trying to
keep the current session path as that might be not ok any more.

Likely Fixes #8938

As i don't use import sessions often i might have overseen something in my tests, please check and confirm.