### PR TITLE
crop + c&r : sanitize crop datas for processing

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1315,10 +1315,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   else
   {
-    d->cx = p->cx;
-    d->cy = p->cy;
-    d->cw = fabsf(p->cw);
-    d->ch = fabsf(p->ch);
+    d->cx = CLAMPF(p->cx, 0.0f, 0.9f);
+    d->cy = CLAMPF(p->cy, 0.0f, 0.9f);
+    d->cw = CLAMPF(fabsf(p->cw), 0.1f, 1.0f);
+    d->ch = CLAMPF(fabsf(p->ch), 0.1f, 1.0f);
   }
 }
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -373,10 +373,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   else
   {
-    d->cx = p->cx;
-    d->cy = p->cy;
-    d->cw = p->cw;
-    d->ch = p->ch;
+    d->cx = CLAMPF(p->cx, 0.0f, 0.9f);
+    d->cy = CLAMPF(p->cy, 0.0f, 0.9f);
+    d->cw = CLAMPF(p->cw, 0.1f, 1.0f);
+    d->ch = CLAMPF(p->ch, 0.1f, 1.0f);
   }
 }
 


### PR DESCRIPTION
this is a "light" version of #9133 with only the critical fix : this avoid dt to crash.
imho this is safe to be merged at this stage for 3.6 because anyway, if values are out the the sanitized range, c&r can't handle that and so will crash !

This doesn't fix all the gui part : that means that in the (very uncommon) case where this happens, user will need to reset c&r module to default to be able to define a new crop. This part is fixed in #9133 and will be postponed for 3.8