### PR TITLE
cacorrectrgb: better handling of noisy pixels

### DIFF
--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -245,7 +245,7 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
   }
 }
 
-#define DT_CACORRECTRGB_MAX_EV_DIFF 3.0f
+#define DT_CACORRECTRGB_MAX_EV_DIFF 2.0f
 static void get_manifolds(const float* const restrict in, const size_t width, const size_t height,
                           const size_t ch, const float sigma, const float sigma2,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
@@ -279,17 +279,30 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
   {
     const float pixelg = fmaxf(in[k * 4 + guide], 1E-6f);
     const float avg = blurred_in[k * 4 + guide];
-    const float weighth = (pixelg >= avg);
-    const float weightl = (pixelg <= avg);
+    float weighth = (pixelg >= avg);
+    float weightl = (pixelg <= avg);
+    float logdiffs[2];
     for(size_t kc = 0; kc <= 1; kc++)
     {
       const size_t c = (kc + guide + 1) % 3;
       const float pixel = fmaxf(in[k * 4 + c], 1E-6f);
-      // we limit log diff to 3EV maximum as higher range may be due to
-      // noise and may result in artefacts
-      const float log_diff = fminf(fmaxf(log2f(pixel / pixelg), -DT_CACORRECTRGB_MAX_EV_DIFF), DT_CACORRECTRGB_MAX_EV_DIFF);
-      manifold_higher[k * 4 + c] = log_diff * weighth;
-      manifold_lower[k * 4 + c] = log_diff * weightl;
+      float log_diff = log2f(pixel / pixelg);
+      logdiffs[kc] = log_diff;
+    }
+    // regularization of logdiff to avoid too many problems with noise:
+    // we lower the weights of pixels with too high logdiff
+    float maxlogdiff = fmaxf(fabsf(logdiffs[0]), fabsf(logdiffs[1]));
+    if(maxlogdiff > DT_CACORRECTRGB_MAX_EV_DIFF)
+    {
+      float correction_weight = DT_CACORRECTRGB_MAX_EV_DIFF / maxlogdiff;
+      weightl *= correction_weight;
+      weighth *= correction_weight;
+    }
+    for(size_t kc = 0; kc <= 1; kc++)
+    {
+      const size_t c = (kc + guide + 1) % 3;
+      manifold_higher[k * 4 + c] = logdiffs[kc] * weighth;
+      manifold_lower[k * 4 + c] = logdiffs[kc] * weightl;
     }
     manifold_higher[k * 4 + guide] = pixelg * weighth;
     manifold_lower[k * 4 + guide] = pixelg * weightl;
@@ -398,12 +411,26 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
 
       if(pixelg > avgg)
       {
+        float logdiffs[2];
         for(size_t kc = 0; kc <= 1; kc++)
         {
           const size_t c = (guide + kc + 1) % 3;
           const float pixel = fmaxf(in[k * 4 + c], 1E-6f);
-          const float log_diff = fminf(fmaxf(log2f(pixel) - pixelg, -DT_CACORRECTRGB_MAX_EV_DIFF), DT_CACORRECTRGB_MAX_EV_DIFF);
-          manifold_higher[k * 4 + c] = log_diff * w;
+          const float log_diff = log2f(pixel) - pixelg;
+          logdiffs[kc] = log_diff;
+        }
+        // regularization of logdiff to avoid too many problems with noise:
+        // we lower the weights of pixels with too high logdiff
+        float maxlogdiff = fmaxf(fabsf(logdiffs[0]), fabsf(logdiffs[1]));
+        if(maxlogdiff > DT_CACORRECTRGB_MAX_EV_DIFF)
+        {
+          float correction_weight = DT_CACORRECTRGB_MAX_EV_DIFF / maxlogdiff;
+          w *= correction_weight;
+        }
+        for(size_t kc = 0; kc <= 1; kc++)
+        {
+          const size_t c = (kc + guide + 1) % 3;
+          manifold_higher[k * 4 + c] = logdiffs[kc] * w;
         }
         manifold_higher[k * 4 + guide] = fmaxf(in[k * 4 + guide], 0.0f) * w;
         manifold_higher[k * 4 + 3] = w;
@@ -416,12 +443,26 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
       }
       else
       {
+        float logdiffs[2];
         for(size_t kc = 0; kc <= 1; kc++)
         {
           const size_t c = (guide + kc + 1) % 3;
           const float pixel = fmaxf(in[k * 4 + c], 1E-6f);
-          const float log_diff = fminf(fmaxf(log2f(pixel) - pixelg, -DT_CACORRECTRGB_MAX_EV_DIFF), DT_CACORRECTRGB_MAX_EV_DIFF);
-          manifold_lower[k * 4 + c] = log_diff * w;
+          const float log_diff = log2f(pixel) - pixelg;
+          logdiffs[kc] = log_diff;
+        }
+        // regularization of logdiff to avoid too many problems with noise:
+        // we lower the weights of pixels with too high logdiff
+        float maxlogdiff = fmaxf(fabsf(logdiffs[0]), fabsf(logdiffs[1]));
+        if(maxlogdiff > DT_CACORRECTRGB_MAX_EV_DIFF)
+        {
+          float correction_weight = DT_CACORRECTRGB_MAX_EV_DIFF / maxlogdiff;
+          w *= correction_weight;
+        }
+        for(size_t kc = 0; kc <= 1; kc++)
+        {
+          const size_t c = (kc + guide + 1) % 3;
+          manifold_lower[k * 4 + c] = logdiffs[kc] * w;
         }
         manifold_lower[k * 4 + guide] = fmaxf(in[k * 4 + guide], 0.0f) * w;
         manifold_lower[k * 4 + 3] = w;


### PR DESCRIPTION
Original problem:
noisy pixels that have value very close to 0 resulted in very high log
difference, which messed up the algorithm result sometimes, especially
with small radius.

Previous method ( #9115 ):
clamp log difference to avoid having a log difference higher than a
given threshold.

Problem with this method:
We may have images with colors that give higher log difference than the
threshold. In this case, it will desaturate and produce hue shifts on
these colors. (though, the 3EV threshold seemed to be quite safe in
practice).
To see the issue, take a very saturated image and set the threshold in the code to 1EV.

New method:
Lower the weights of pixels that have very high log differences, so that
they don't influence too much the manifold computation.
Advantage: if the image has very saturated colors, no problem, the
manifolds will still be correct, as we don't clamp anything.
We lower the weights only if log differences are higher than 2EVs,
and do so in a way that keeps the value in manifold lower than 2
(in absolute).
Value in the manifold will be:
- original log difference value if it is higher than -2 and lower than 2
- -2 if log difference is smaller than -2
- 2 if log difference is higher than 2
Value in the weight is computed such that value in manifold divided by
the weight is equal to the original value.