### PR TITLE
histogram: add vertical waveform

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2627,6 +2627,7 @@
       <enum>
         <option>histogram</option>
         <option>waveform</option>
+        <option>rgb parade</option>
         <option>vectorscope</option>
       </enum>
     </type>
@@ -2643,6 +2644,18 @@
       </enum>
     </type>
     <default>logarithmic</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/histogram/orient</name>
+    <type>
+      <enum>
+        <option>horizontal</option>
+        <option>vertical</option>
+      </enum>
+    </type>
+    <default>horizontal</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -203,9 +203,9 @@ static inline void dt_draw_semilog_y_grid(cairo_t *cr, const int num, const int 
 
 
 static inline void dt_draw_waveform_lines(cairo_t *cr, const int left, const int top, const int right,
-                                          const int bottom)
+                                          const int bottom, const gboolean horizontal)
 {
-  //   float width = right - left;
+  float width = right - left;
   const float height = bottom - top;
   const int num = 9, middle = 5, white = 1;
   // FIXME: should this vary with ppd?
@@ -219,7 +219,10 @@ static inline void dt_draw_waveform_lines(cairo_t *cr, const int left, const int
   {
     cairo_set_dash(cr, &dashes, k == white || k == middle, 0);
     cairo_set_line_width(cr, k == white ? wd * 3 : k == middle ? wd * 2 : wd);
-    dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
+    if(horizontal)
+      dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
+    else
+      dt_draw_line(cr, right - k / (float)num * width, top, right - k / (float)num * width, bottom);
     cairo_stroke(cr);
   }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1347,6 +1347,7 @@ static void _scope_view_clicked(GtkWidget *button, dt_lib_histogram_t *d)
       d->scope_orient = (d->scope_orient + 1) % DT_LIB_HISTOGRAM_ORIENT_N;
       dt_conf_set_string("plugins/darkroom/histogram/orient",
                          dt_lib_histogram_orient_names[d->scope_orient]);
+      d->waveform_bins = 0;
       _scope_orient_update(d);
       break;
     case DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE:

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -207,7 +207,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
 
   // Note that, with current constants, the input buffer is from the
   // preview pixelpipe and should be <= 1440x900x4. The output buffer
-  // will be <= 360x128x3. Hence process works with a relatively small
+  // will be <= 360x160x3. Hence process works with a relatively small
   // quantity of data.
   size_t bin_pad;
   uint32_t *const restrict partial_binned = dt_calloc_perthread(3U * num_bins * num_tones, sizeof(uint32_t), &bin_pad);
@@ -1674,13 +1674,13 @@ void gui_init(dt_lib_module_t *self)
   d->waveform_bins = 0;
   // Should be at least 100 (approx. # of tones the eye can see) and
   // multiple of 16 (for optimization), larger #'s will make a more
-  // detailed scope display at cost of CPU usage.
+  // detailed scope display at cost of a bit of CPU/memory.
   // 175 rows is the default histogram widget height. It's OK if the
   // widget height changes from this, as the width will almost always
   // be scaled. 175 rows is reasonable CPU usage and represents plenty
   // of tonal gradation. 256 would match the # of bins in a regular
   // histogram.
-  d->waveform_tones = 128;
+  d->waveform_tones = 160;
   // FIXME: combine waveform_8bit and vectorscope_graph, as only ever use one or the other
   // FIXME: keep alignment instead via single alloc via dt_alloc_perthread()?
   const size_t bytes_hori = d->waveform_tones * cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_max_bins);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -227,11 +227,8 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
       // FIXME: use for_each_channel?
       for(size_t ch = 0; ch < 3; ch++)
       {
-        // FIXME: instead of doing this math, apply a transform when drawing?
-        const float v = (8.0f / 9.0f) * px[ch];
         const size_t bin = (orient == DT_LIB_HISTOGRAM_ORIENT_HORI ? x : y) / samples_per_bin;
-        // FIXME: faster to flip tone in next loop or on display?
-        const size_t tone = (orient == DT_LIB_HISTOGRAM_ORIENT_HORI ? 1.0f-v : v) * (num_tones-1);
+        const size_t tone = (8.0f / 9.0f) * px[ch] * (num_tones-1);
         // NOTE: this clamps NAN and < 0 to 0, but clips > 1
         if(tone <= num_tones-1)
           dt_atomic_add_int(binned + (ch * num_bins + bin) * num_tones + tone, 1);
@@ -699,7 +696,16 @@ static void _lib_histogram_draw_waveform(dt_lib_histogram_t *d, cairo_t *cr,
 
   // scale and write to output buffer
   cairo_save(cr);
-  cairo_scale(cr, (float)width/img_width, (float)height/img_height);
+  if(d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_HORI)
+  {
+    // y=0 is at bottom of widget
+    cairo_translate(cr, 0., height);
+    cairo_scale(cr, (float)width/img_width, (float)-height/img_height);
+  }
+  else
+  {
+    cairo_scale(cr, (float)width/img_width, (float)height/img_height);
+  }
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_set_source_surface(cr, cst, 0., 0.);
   cairo_paint(cr);
@@ -744,7 +750,16 @@ static void _lib_histogram_draw_rgb_parade(dt_lib_histogram_t *d, cairo_t *cr, i
   cairo_destroy(crt);
 
   cairo_save(cr);
-  cairo_scale(cr, (float)width/img_width, (float)height/img_height);
+  if(d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_HORI)
+  {
+    // y=0 is at bottom of widget
+    cairo_translate(cr, 0., height);
+    cairo_scale(cr, (float)width/img_width, (float)-height/img_height);
+  }
+  else
+  {
+    cairo_scale(cr, (float)width/img_width, (float)height/img_height);
+  }
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_set_source_surface(cr, cst, 0., 0.);
   cairo_paint(cr);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -227,7 +227,15 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
       const size_t bin = (orient == DT_LIB_HISTOGRAM_ORIENT_HORI ? x : y) / samples_per_bin;
       size_t tone[4] DT_ALIGNED_PIXEL;
       for_each_channel(ch,aligned(px,tone:16))
-        tone[ch] = MIN((8.0f / 9.0f) * px[4U * (x + roi->crop_x) + ch], 1.0f) * (num_tones-1);
+      {
+        // 1.0 is at 8/9 of the height!
+        const float v = (8.0f / 9.0f) * px[4U * (x + roi->crop_x) + ch];
+        // Using ceilf brings everything <= 0 to bottom tone,
+        // everything > 1.0f/(num_tones-1) to top tone. Note that
+        // don't need to clamp to >= 0 as assigning a negative value
+        // to size_t (or any unsigned integer) results in 0.
+        tone[ch] = ceilf(MIN(v, 1.0f) * (num_tones-1));
+      }
       for(size_t ch = 0; ch < 3; ch++)
         binned[num_tones * (ch * num_bins + bin) + tone[ch]]++;
     }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -210,8 +210,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   // will be <= 360x128x3. Hence process works with a relatively small
   // quantity of data.
   size_t bin_pad;
-  // FIXME: should be uint32_t or int?
-  int *const restrict partial_binned = dt_calloc_perthread(3U * num_bins * num_tones, sizeof(int), &bin_pad);
+  uint32_t *const restrict partial_binned = dt_calloc_perthread(3U * num_bins * num_tones, sizeof(uint32_t), &bin_pad);
 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) \
@@ -222,7 +221,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   {
     const float *const restrict px = DT_IS_ALIGNED((const float *const restrict)input +
                                                    4U * ((y + roi->crop_y) * roi->width));
-    int *const restrict binned = dt_get_perthread(partial_binned, bin_pad);
+    uint32_t *const restrict binned = dt_get_perthread(partial_binned, bin_pad);
     for(size_t x=0; x<sample_width; x++)
     {
       const size_t bin = (orient == DT_LIB_HISTOGRAM_ORIENT_HORI ? x : y) / samples_per_bin;
@@ -261,10 +260,10 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
       for(size_t tone = 0; tone < num_tones; tone++)
       {
         uint8_t *const restrict wf_img = DT_IS_ALIGNED((uint8_t *const restrict)d->waveform_img[ch]);
-        int acc = 0;
+        uint32_t acc = 0;
         for(size_t n = 0; n < nthreads; n++)
         {
-          int *const restrict binned = dt_get_bythread(partial_binned, bin_pad, n);
+          uint32_t *const restrict binned = dt_get_bythread(partial_binned, bin_pad, n);
           acc += binned[num_tones * (ch * num_bins + bin) + tone];
         }
         const float linear = MIN(1.f, scale * acc);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -251,7 +251,11 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   const float scale = brightness / ((DT_LIB_HISTOGRAM_ORIENT_HORI ? sample_height : sample_width) * samples_per_bin);
   size_t nthreads = dt_get_num_threads();
 
-  // too small (3 * 360 * 128 * nthreads max iterations) to need threads
+#if defined(_OPENMP)
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(d, partial_binned, bin_pad, wf_img_stride, num_bins, num_tones, orient, lut, lutmax, scale, nthreads) \
+  schedule(static) collapse(3)
+#endif
   for(size_t ch = 0; ch < 3; ch++)
     for(size_t bin = 0; bin < num_bins; bin++)
       for(size_t tone = 0; tone < num_tones; tone++)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -247,7 +247,7 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d, const f
   // NOTE: if constant is decreased, will brighten output
   // FIXME: instead of using an area-beased scale, figure out max bin count and scale to that?
   const float brightness = num_tones / 40.0f;
-  const float scale = brightness / ((DT_LIB_HISTOGRAM_ORIENT_HORI ? sample_height : sample_width) * samples_per_bin);
+  const float scale = brightness / ((orient == DT_LIB_HISTOGRAM_ORIENT_HORI ? sample_height : sample_width) * samples_per_bin);
   size_t nthreads = dt_get_num_threads();
 
 #if defined(_OPENMP)


### PR DESCRIPTION
This adds a "vertical" waveform and RGB parade option.

For extant "horizontal" waveform, x-axis relates spatially to the image x-axis and y-axis represents luminance. For "vertical", y-axis relates spatially to the image y-axis and x-axis represents luminance. In both variations, the luminance of each graph point represents the quantity of pixels of the position/luminance which that point refers to.

Prior to this PR, there was a "waveform" scope type, which allowed for toggling between "waveform" and "rgb parade" views. With this PR, there are now "waveform" and "rgb parade" scope types. Each can be toggled between horizontal and vertical views.

The revised code should be equivalent or better performance compared to the prior code. Tested on this computer, times in seconds median/mean:

action | prior | this PR
------ | ----- | -------
process horizontal | 0.052/0.048 | 0.032/0.038
process vertical | n/a | 0.049/0.048
draw horizontal | 0.009/0.010 | 0.009/0.010
draw vertical | n/a | 0.009/0.010

The new code does use more memory. Prior code used a 738K intermediate buffer which was always allocated. This PR uses a 675K buffer per CPU, only allocated/used during waveform process. This is similar to how the "regular" histogram processing is implemented. It would be possible to switch back to a CPU-invariant memory allocation using `dt_atomic_int`, without much slowdown, if the extra memory use was a concern.

This PR reduces the number of tone gradations in the waveform from 175 to 160. This should be visually indistinguishable, but may be helpful for optimization as it is a multiple of 16.

Here is a "horizontal" waveform, which should be very similar to the current waveform:

![image](https://user-images.githubusercontent.com/2311860/120911367-0991c500-c655-11eb-90a4-a4ebfc4a84c3.png)

Here is the "vertical" variant for the same image:

![image](https://user-images.githubusercontent.com/2311860/120911375-20381c00-c655-11eb-97ec-759121ba3591.png)

Here is a "horizontal" RGB parade (with exposure change region highlit):

![image](https://user-images.githubusercontent.com/2311860/120911392-3cd45400-c655-11eb-897e-11d225a05468.png)

And the "vertical" RGB parade variant:

![image](https://user-images.githubusercontent.com/2311860/120911406-4f4e8d80-c655-11eb-825b-2ed6f83bdb52.png)

What with there now being four "primary" scope modes (histogram, waveform, rgb parade, vectorscope), for usability it might be better to alter the "mode" switcher button to some sort of drop-down, or perhaps allow shift-clicking it to move backwards through modes. With this PR, it can get annoying to cycle through the modes to find the right mode. Alternately, a keyboard shortcut to call up a particular mode could be nice (current shortcuts cycle modes).

Note that this PR and #9052 probably would not apply cleanly on top of each other, but it should be relatively easy to make them work with each other. For now, as both this PR and that are made with an eye to v3.8, it seems good to just make them easy to apply to the current code.

Closes #3005.