### PR TITLE
Fix crash in orientation module when resetting orientation

### DIFF
--- a/src/dtgtk/resetlabel.c
+++ b/src/dtgtk/resetlabel.c
@@ -36,7 +36,7 @@ static gboolean _reset_label_callback(GtkDarktableResetLabel *label, GdkEventBut
   {
     memcpy(((char *)label->module->params) + label->offset,
            ((char *)label->module->default_params) + label->offset, label->size);
-    label->module->gui_update(label->module);
+    if(label->module->gui_update) label->module->gui_update(label->module);
     dt_dev_add_history_item(darktable.develop, label->module, FALSE);
     return TRUE;
   }


### PR DESCRIPTION
Fixes a crash that occurs if the module that initiated the callback does not contain the gui_update function.

This applies to the orientation module, so this PR specifically fixes a crash in this module which existed since darktable 3.4.
