### PR TITLE
Fixing color picker crashes with monochrome images

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -600,6 +600,8 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const p
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);
   else if(dsc->channels == 4u && image_cst == iop_cs_rgb && (picker_cst == iop_cs_HSL || picker_cst == iop_cs_JzCzhz))
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);
+  else if(dsc->channels == 4u) // This is a fallback, better than crashing as happens with monochromes
+    color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);
   else if(dsc->channels == 1u && dsc->filters != 0u && dsc->filters != 9u)
     color_picker_helper_bayer(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
   else if(dsc->channels == 1u && dsc->filters == 9u)


### PR DESCRIPTION
True monochrome images have a iop_cs_RAW image_cst as they are processed in rawprepare.

This is not handled by `dt_color_picker_helper` and thus might lead to crashes. Can be triggered by
open a monochrome in darkroom with empty history, open exposure module and click on the picker box.

Ran into this while working on the monochrome workflow.