### PR TITLE
crop + c&r : fix max-size compute on quick focus in-out

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1331,6 +1331,8 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
     dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
   }
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
+  // force max size to be recomputed
+  g->clip_max_pipe_hash = 0;
 }
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -389,6 +389,8 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
     dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
   }
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
+  // force max size to be recomputed
+  g->clip_max_pipe_hash = 0;
 }
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)


### PR DESCRIPTION
this fix #9171

the isuue can still be reproduced, but this is now very hard (here, I need to do multiple double-click on the crop&rotate header to focus in-out extremely quickly... certainly not a common usecase !)
So there's certainly something else that can be done, but I've not managed to find it.

Considering that it just enforce some computations already done in usual cases, I would say it's quite safe...