### PR TITLE
don't crash when importing invalid style files

### DIFF
--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -562,7 +562,14 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
       /* extract name from xml file */
       gchar *bname = "";
       xmlDoc *document = xmlReadFile((char*)filename->data, NULL, 0);
-      xmlNode *root = xmlDocGetRootElement(document);
+      xmlNode *root = NULL;
+      if(document != NULL)
+        root = xmlDocGetRootElement(document);
+
+      if(document == NULL || root == NULL){
+        dt_print(DT_DEBUG_CONTROL, "[styles] file %s is not a style file\n", (char*)filename->data);
+        continue;
+      }
 
       for(xmlNode *node = root->children->children; node; node = node->next)
       {


### PR DESCRIPTION
While browsing old issues I noticed that while crash when importing presets was fixed, the same wasn't done with styles.

This essentially fixes crashes when users try to import incorrect style files (eg empty/malformed)