### PR TITLE
fix singlebuffer_limit tooltip

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -200,7 +200,7 @@
     <type min="2" max="64">int</type>
     <default>16</default>
     <shortdescription>minimum amount of memory (in MB) for a single buffer in tiling</shortdescription>
-    <longdescription>if set to a positive, non-zero value this variable defines the minimum amount of memory (in MB) that tiling should take for a single image buffer. has precedence over heuristics based on host_memory_limit (needs a restart).</longdescription>
+    <longdescription>minimum amount of memory (in MB) that tiling should take for a single image buffer (needs a restart).</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_memory_headroom</name>


### PR DESCRIPTION
Fixes #9176 

The tooltip was a bit misleading. Refactored tooltip to only say the valid part.