### PR TITLE
duplicate : fix output_width/height copying

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -999,7 +999,7 @@ static int32_t _image_duplicate_with_version_ext(const int32_t imgid, const int3
      "   position, aspect_ratio, exposure_bias, import_timestamp)"
      " SELECT NULL, group_id, film_id, width, height, filename, maker, model, lens,"
      "       exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
-     "       flags, width, height, crop, raw_parameters, raw_denoise_threshold,"
+     "       flags, output_width, output_height, crop, raw_parameters, raw_denoise_threshold,"
      "       raw_auto_bright_threshold, raw_black, raw_maximum,"
      "       license, sha1sum, orientation, histogram, lightmap,"
      "       longitude, latitude, altitude, color_matrix, colorspace, NULL, NULL, 0, ?1,"


### PR DESCRIPTION
this fix #9198

That was tricky... The fixed code was obviously wrong and the result was that newly copied image may get wrong output sizes, but don't ask me how this is related to hdpi things...