### PR TITLE
vectorscope appearance update

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -326,6 +326,7 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
                                              {0.f, 1.f, 0.f}, {0.f, 1.f, 1.f},
                                              {0.f, 0.f, 1.f}, {1.f, 0.f, 1.f} };
   float max_radius = 0.f;
+  const dt_lib_histogram_vectorscope_type_t vs_type = d->vectorscope_type;
   for(int k=0; k<6; k++)
   {
     dt_aligned_pixel_t delta;
@@ -338,8 +339,7 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
         rgb[ch] = vertex_rgb[k][ch] + delta[ch] * i;
       dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, vs_prof->matrix_in_transposed, vs_prof->lut_in,
                                  vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
-      // FIXME: keep d->vectorscope_type in local variable for speed?
-      if(d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
+      if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
       {
         dt_XYZ_to_xyY(XYZ_D50, intermed);
         dt_xyY_to_Luv(intermed, chromaticity);
@@ -349,16 +349,18 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
         dt_XYZ_D50_2_XYZ_D65(XYZ_D50, intermed);
         dt_XYZ_2_JzAzBz(intermed, chromaticity);
       }
-      // FIXME: log_scale these coords here rather than when drawing the hue ring
       d->hue_ring[k][i][0] = chromaticity[1];
       d->hue_ring[k][i][1] = chromaticity[2];
       max_radius = MAX(max_radius, hypotf(chromaticity[1], chromaticity[2]));
     }
   }
+  if(d->vectorscope_scale == DT_LIB_HISTOGRAM_SCALE_LOGARITHMIC)
+    for(int k=0; k<6; k++)
+      for(int i=0; i < VECTORSCOPE_HUES; i++)
+        log_scale(d, &d->hue_ring[k][i][0], &d->hue_ring[k][i][1], max_radius);
 
   // chromaticities for drawing both hue ring and grpah
   const int diam_px = d->vectorscope_diameter_px;
-  const dt_lib_histogram_vectorscope_type_t vs_type = d->vectorscope_type;
   const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px);
   // loop appears to be too small to benefit w/OpenMP
   // FIXME: is this still true? -- all this will only run once per colorspace change, so doesn't need to be extra-fast
@@ -853,8 +855,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       // note that hue_ring coords are calculated as float but converted here to double
       float x = d->hue_ring[n][h][0];
       float y = d->hue_ring[n][h][1];
-      // FIXME: do this in _lib_histogram_vectorscope_bkgd()
-      log_scale(d, &x, &y, vs_radius);
       cairo_line_to(cr, x*scale, y*scale);
     }
   cairo_close_path(cr);
@@ -866,8 +866,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   {
     float x = d->hue_ring[n][0][0];
     float y = d->hue_ring[n][0][1];
-    // FIXME: do this in _lib_histogram_vectorscope_bkgd()
-    log_scale(d, &x, &y, vs_radius);
     cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
     // FIXME: use vertex RGB colors instead of background?, with hard light effect?
     cairo_set_source(cr, bkgd_pat);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -824,7 +824,18 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     cairo_stroke(cr);
   }
 
-  // FIXME: draw hue ring as a mask on the background, then don't calculate hue ring colors
+  cairo_surface_t *bkgd_surface =
+    dt_cairo_image_surface_create_for_data(d->vectorscope_bkgd, CAIRO_FORMAT_RGB24,
+                                           diam_px, diam_px,
+                                           cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
+  cairo_pattern_t *bkgd_pat = cairo_pattern_create_for_surface(bkgd_surface);
+  // FIXME: is there an easier way to do this work?
+  cairo_matrix_t matrix;
+  cairo_matrix_init_translate(&matrix, 0.5*diam_px/darktable.gui->ppd, 0.5*diam_px/darktable.gui->ppd);
+  cairo_matrix_scale(&matrix, (double)diam_px / min_size / darktable.gui->ppd,
+                     (double)diam_px / min_size / darktable.gui->ppd);
+  cairo_pattern_set_matrix(bkgd_pat, &matrix);
+
   // FIXME: also add hue rings (monochrome/dotted) for input/work/output profiles
   // from Sobotka:
   // 1. The input encoding primaries. How dd the image start out life? What is valid data within that? What is invalid introduced by error of camera virtual primaries solving or math such as resampling an image such that negative lobes result?
@@ -833,31 +844,36 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // graticule: histogram profile hue ring
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  float x = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][0];
-  float y = d->hue_ring_coord[5][VECTORSCOPE_HUES-1][1];
-  log_scale(d, &x, &y, vs_radius);
   for(int n=0; n<6; n++)
-  {
     for(int h=0; h<VECTORSCOPE_HUES; h++)
     {
-      cairo_move_to(cr, x*scale, y*scale);
-      // FIXME: can we pre-make a pattern with the hues radiating out, and use it as the "ink" to draw the hue ring and -- if in false color mode -- the vectorscope? will this be faster then drawing lots of lines each with their own color? will it allow for drawing the hue ring with splines and calculating fewer points? -- we might need a color pattern of the colorspace, then masked once to increase saturation and once for alpha?
       // note that hue_ring_rgb and hue_ring_coord are calculated as float but converted here to double
-      cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 0.5);
-      x = d->hue_ring_coord[n][h][0];
-      y = d->hue_ring_coord[n][h][1];
+      //cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 0.5);
+      float x = d->hue_ring_coord[n][h][0];
+      float y = d->hue_ring_coord[n][h][1];
+      // FIXME: do this in _lib_histogram_vectorscope_bkgd()
       log_scale(d, &x, &y, vs_radius);
       cairo_line_to(cr, x*scale, y*scale);
-      cairo_stroke(cr);
-      if(h==0)
-      {
-        cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
-        cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 1.);
-        cairo_fill_preserve(cr);
-        set_color(cr, darktable.bauhaus->graph_grid);
-        cairo_stroke(cr);
-      }
     }
+  cairo_close_path(cr);
+  cairo_set_source(cr, bkgd_pat);
+  // FIXME: this should be drawn with 50% alpha to make it dimmer, as should the faded out vectorscope on point sample -- make a second RGBA32 buffer which is 50% alpha? -- or paint this to a temporary surface then composite it over at 50%?
+  cairo_stroke(cr);
+
+  // draw primary/secondary nodes
+  for(int n=0; n<6; n++)
+  {
+    float x = d->hue_ring_coord[n][0][0];
+    float y = d->hue_ring_coord[n][0][1];
+    // FIXME: do this in _lib_histogram_vectorscope_bkgd()
+    log_scale(d, &x, &y, vs_radius);
+    cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
+    // FIXME: mask bkgd instead of setting color?
+    // FIXME: if do have colors here, are they just vertex_rgb?
+    cairo_set_source_rgba(cr, d->hue_ring_rgb[n][0][0], d->hue_ring_rgb[n][0][1], d->hue_ring_rgb[n][0][2], 1.);
+    cairo_fill_preserve(cr);
+    set_color(cr, darktable.bauhaus->graph_grid);
+    cairo_stroke(cr);
   }
 
   // vectorscope graph
@@ -867,20 +883,8 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     dt_cairo_image_surface_create_for_data(d->vectorscope_graph, CAIRO_FORMAT_A8,
                                            diam_px, diam_px,
                                            cairo_format_stride_for_width(CAIRO_FORMAT_A8, diam_px));
-  cairo_surface_t *bkgd_surface =
-    dt_cairo_image_surface_create_for_data(d->vectorscope_bkgd, CAIRO_FORMAT_RGB24,
-                                           diam_px, diam_px,
-                                           cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
-
   cairo_pattern_t *graph_pat = cairo_pattern_create_for_surface(graph_surface);
-  cairo_pattern_t *bkgd_pat = cairo_pattern_create_for_surface(bkgd_surface);
-  // FIXME: is there an easier way to do this work?
-  cairo_matrix_t matrix;
-  cairo_matrix_init_translate(&matrix, 0.5*diam_px/darktable.gui->ppd, 0.5*diam_px/darktable.gui->ppd);
-  cairo_matrix_scale(&matrix, (double)diam_px / min_size / darktable.gui->ppd,
-                     (double)diam_px / min_size / darktable.gui->ppd);
   cairo_pattern_set_matrix(graph_pat, &matrix);
-  cairo_pattern_set_matrix(bkgd_pat, &matrix);
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_set_source(cr, bkgd_pat);
 #if 0

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -44,7 +44,7 @@
 // FIXME: why does the blue curve in to the center point? is this a color processing bug or a relic of a luminance of that primary
 // FIXME: do fewer points and splines?
 // FIXME: do more points so that the PQ in Linear Prophoto in Luv look better?
-#define VECTORSCOPE_HUES 48
+#define VECTORSCOPE_HUES 32
 #define VECTORSCOPE_BASE_LOG 30
 
 DT_MODULE(1)
@@ -365,9 +365,11 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
         dt_XYZ_D50_2_XYZ_D65(XYZ_D50, XYZ_D65);
         dt_XYZ_2_JzAzBz(XYZ_D65, chromaticity);
       }
+      // FIXME: the median of chromaticity[0] could be used if we do another pass to color the background image
       d->hue_ring[k][i][0] = chromaticity[1];
       d->hue_ring[k][i][1] = chromaticity[2];
-      max_radius = MAX(max_radius, dt_fast_hypotf(chromaticity[1], chromaticity[2]));
+      const float h = dt_fast_hypotf(chromaticity[1], chromaticity[2]);
+      max_radius = MAX(max_radius, h);
 
       // FIXME: make a series of triangles painted on background, rather than using mesh pattern?
       if(!(k==0 && i==0))
@@ -375,17 +377,26 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
         cairo_mesh_pattern_begin_patch(p);
         cairo_mesh_pattern_move_to(p, 0., 0.);
         cairo_mesh_pattern_line_to(p, px, py);
+        // FIXME: hack
+        // For blue in ProPhoto there is a very small chroma, and
+        // hence a very small radius sector would be drawn. Also as
+        // this starts with bright red/yellow this evens out sector
+        // radii for other colors.
+        // FIXME: green really is the brightest, so should start with that to really see benefit here, though current setup does work
+        chromaticity[1] *= max_radius / h;
+        chromaticity[2] *= max_radius / h;
         cairo_mesh_pattern_line_to(p, chromaticity[1], chromaticity[2]);
         // define 4th point so it isn't degenerate and can make the two radial edges have different colors w/out gradients, gradient only across the far edge of triangle
         cairo_mesh_pattern_line_to(p, 0., 0.);
         if(0) cairo_mesh_pattern_set_corner_color_rgb(p, 0, prgb[0], prgb[1], prgb[2]);
-  #if 1
+#if 1
         cairo_mesh_pattern_set_corner_color_rgb(p, 0, prgb[0], prgb[1], prgb[2]);
         cairo_mesh_pattern_set_corner_color_rgb(p, 1, prgb[0], prgb[1], prgb[2]);
-  #else
+#else
+        // debug without gradients
         cairo_mesh_pattern_set_corner_color_rgb(p, 0, rgb[0], rgb[1], rgb[2]);
         cairo_mesh_pattern_set_corner_color_rgb(p, 1, rgb[0], rgb[1], rgb[2]);
-  #endif
+#endif
         cairo_mesh_pattern_set_corner_color_rgb(p, 2, rgb[0], rgb[1], rgb[2]);
         cairo_mesh_pattern_set_corner_color_rgb(p, 3, rgb[0], rgb[1], rgb[2]);
         cairo_mesh_pattern_end_patch(p);
@@ -410,11 +421,7 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
   cairo_mesh_pattern_end_patch(p);
 
   const int diam_px = d->vectorscope_diameter_px;
-  // multiplying as hack to extend out the pattern slightly as
-  // CAIRO_EXTEND_PAD doesn't help for mesh patterns and it's likely
-  // that there will be rays from center slightly off from the corner
-  // which will cause undrawn areas otherwise
-  const double pattern_max_radius = hypotf(diam_px, diam_px) * 1.1;
+  const double pattern_max_radius = hypotf(diam_px, diam_px);
   cairo_matrix_t matrix;
   cairo_matrix_init_scale(&matrix, max_radius / pattern_max_radius, max_radius / pattern_max_radius);
   cairo_matrix_translate(&matrix, -0.5 * (diam_px-1), -0.5 * (diam_px-1));

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -100,8 +100,7 @@ typedef struct dt_lib_histogram_t
   uint8_t *waveform_img[3];           // image per RGB channel
   int waveform_bins, waveform_tones, waveform_max_bins;
   // FIXME: make dt_lib_histogram_vectorscope_t for all this data?
-  uint8_t *vectorscope_graph;
-  uint8_t *vectorscope_bkgd;
+  uint8_t *vectorscope_graph, *vectorscope_bkgd, *vectorscope_bkgd_dim;
   float vectorscope_pt[2];            // point colorpicker position
   int vectorscope_diameter_px;
   // FIXME: These arrays could instead be alloc'd/free'd. Would the only concern about making dt_lib_histogram_t large so long be if it were stored in the DB?
@@ -374,7 +373,6 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
   for(size_t y = 0; y < diam_px; y++)
     for(size_t x = 0; x < diam_px; x++)
     {
-      uint8_t *const restrict px = d->vectorscope_bkgd + y * stride + x * 4U;
       // FIXME: should be / (diam_px-1)? same in other places?
       float a = max_radius * 2.0f * (x / (float)(diam_px-1) - 0.5f);
       float b = max_radius * 2.0f * (y / (float)(diam_px-1) - 0.5f);
@@ -404,9 +402,14 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
       }
       // FIXME: a custom matrix could do this flip and write directly to pixel buffer
       dt_XYZ_to_Rec709_D50(XYZ_D50, RGB);
+      uint8_t *const restrict px = d->vectorscope_bkgd + y * stride + x * 4U;
+      uint8_t *const restrict px_dim = d->vectorscope_bkgd_dim + y * stride + x * 4U;
       // BGR/RGB flip is for pixelpipe vs. Cairo color?
       for(int ch=0; ch<3; ch++)
+      {
         px[2U-ch] = CLAMP((int)(RGB[ch] * 255.0f), 0, 255);
+        px_dim[2U-ch] = px[2U-ch] / 2;
+      }
     }
 
   d->vectorscope_radius = max_radius;
@@ -824,17 +827,24 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     cairo_stroke(cr);
   }
 
+  // FIXME: these different background patterns are hacky -- could try to do something clever and have one buffer which has 50% alpha and lives as both RGB24 (full) and ARGB32 (dim)
   cairo_surface_t *bkgd_surface =
     dt_cairo_image_surface_create_for_data(d->vectorscope_bkgd, CAIRO_FORMAT_RGB24,
                                            diam_px, diam_px,
                                            cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
+  cairo_surface_t *bkgd_dim_surface =
+    dt_cairo_image_surface_create_for_data(d->vectorscope_bkgd_dim, CAIRO_FORMAT_RGB24,
+                                           diam_px, diam_px,
+                                           cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
   cairo_pattern_t *bkgd_pat = cairo_pattern_create_for_surface(bkgd_surface);
+  cairo_pattern_t *bkgd_dim_pat = cairo_pattern_create_for_surface(bkgd_dim_surface);
   // FIXME: is there an easier way to do this work?
   cairo_matrix_t matrix;
   cairo_matrix_init_translate(&matrix, 0.5*diam_px/darktable.gui->ppd, 0.5*diam_px/darktable.gui->ppd);
   cairo_matrix_scale(&matrix, (double)diam_px / min_size / darktable.gui->ppd,
                      (double)diam_px / min_size / darktable.gui->ppd);
   cairo_pattern_set_matrix(bkgd_pat, &matrix);
+  cairo_pattern_set_matrix(bkgd_dim_pat, &matrix);
 
   // FIXME: also add hue rings (monochrome/dotted) for input/work/output profiles
   // from Sobotka:
@@ -844,6 +854,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // graticule: histogram profile hue ring
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
+  cairo_set_source(cr, bkgd_dim_pat);
   for(int n=0; n<6; n++)
     for(int h=0; h<VECTORSCOPE_HUES; h++)
     {
@@ -856,7 +867,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       cairo_line_to(cr, x*scale, y*scale);
     }
   cairo_close_path(cr);
-  cairo_set_source(cr, bkgd_pat);
   // FIXME: this should be drawn with 50% alpha to make it dimmer, as should the faded out vectorscope on point sample -- make a second RGBA32 buffer which is 50% alpha? -- or paint this to a temporary surface then composite it over at 50%?
   cairo_stroke(cr);
 
@@ -886,26 +896,21 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_pattern_t *graph_pat = cairo_pattern_create_for_surface(graph_surface);
   cairo_pattern_set_matrix(graph_pat, &matrix);
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  cairo_set_source(cr, bkgd_pat);
+  cairo_set_source(cr, isnan(d->vectorscope_pt[0]) ? bkgd_pat : bkgd_dim_pat);
 #if 0
   // for debugging background color
   cairo_paint(cr);
 #else
   cairo_mask(cr, graph_pat);
+  //cairo_mask_surface(cr, graph_surface, 0., 0.);
   cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.6);
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, isnan(d->vectorscope_pt[0]) ? 0.6 : 0.3);
   cairo_mask(cr, graph_pat);
 #endif
-  //cairo_mask_surface(cr, graph_surface, 0., 0.);
-  // FIXME: how will handle fading background for point sample? draw to another surface?
-  /*
-  if(isnan(d->vectorscope_pt[0]))
-    cairo_paint(cr);
-  else
-    cairo_paint_with_alpha(cr, 0.5);
-  */
   cairo_pattern_destroy(bkgd_pat);
   cairo_surface_destroy(bkgd_surface);
+  cairo_pattern_destroy(bkgd_dim_pat);
+  cairo_surface_destroy(bkgd_dim_surface);
   cairo_pattern_destroy(graph_pat);
   cairo_surface_destroy(graph_surface);
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
@@ -1726,6 +1731,8 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: note that the background can be lower resolution than the graph -- test/compare?
   d->vectorscope_bkgd = dt_alloc_align(64, sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
                                        cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
+  d->vectorscope_bkgd_dim = dt_alloc_align(64, sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
+                                           cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
   d->hue_ring_prof = NULL;
   d->hue_ring_scale = DT_LIB_HISTOGRAM_SCALE_N;
   d->hue_ring_colorspace = DT_LIB_HISTOGRAM_VECTORSCOPE_N;
@@ -1883,6 +1890,8 @@ void gui_cleanup(dt_lib_module_t *self)
   for(int ch=0; ch<3; ch++)
     dt_free_align(d->waveform_img[ch]);
   dt_free_align(d->vectorscope_graph);
+  dt_free_align(d->vectorscope_bkgd);
+  dt_free_align(d->vectorscope_bkgd_dim);
   dt_pthread_mutex_destroy(&d->lock);
 
   g_free(self->data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -40,11 +40,12 @@
 
 #define HISTOGRAM_BINS 256
 // # of gradations between each primary/secondary to draw the hue ring
-// this is tuned to most degenerate case -- curve to blue primary in Luv in linear ProPhoto RGB
-// FIXME: why does the blue curve in to the center point? is this a color processing bug or a relic of a luminance of that primary
-// FIXME: do fewer points and splines?
-// FIXME: do more points so that the PQ in Linear Prophoto in Luv look better?
-#define VECTORSCOPE_HUES 64
+// this is tuned to most degenerate cases: curve to blue primary in
+// Luv in linear ProPhoto RGB and the widely spaced gradations of the
+// PQ P3 RGB colorspace. This could be lowered to 32 with little
+// visible consequence.
+// FIXME: why does the blue curve in to the center point? is this a color processing bug, a relic of a luminance of that primary, or have to do with ProPhoto's imaginary blue primary?
+#define VECTORSCOPE_HUES 48
 #define VECTORSCOPE_BASE_LOG 30
 
 DT_MODULE(1)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -585,7 +585,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   uint8_t *const graph = d->vectorscope_graph;
 
   // FIXME: should count the max bin size, and vary the scale such that it is always 1?
-  const float gain = 1.f / 75.f;
+  const float gain = 1.f / 30.f;
   const float scale = gain * (diam_px * diam_px) / (sample_width * sample_height);
 
   // loop appears to be too small to benefit w/OpenMP
@@ -933,7 +933,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_set_source(cr, bkgd_pat);
   cairo_mask(cr, graph_pat);
   cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.55);
   cairo_mask(cr, graph_pat);
   cairo_pattern_destroy(graph_pat);
   cairo_surface_destroy(graph_surface);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -935,8 +935,12 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
   cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.55);
   cairo_mask(cr, graph_pat);
+
+  cairo_pattern_destroy(bkgd_pat);
+  cairo_surface_destroy(bkgd_surface);
   cairo_pattern_destroy(graph_pat);
   cairo_surface_destroy(graph_surface);
+
   if(!isnan(d->vectorscope_pt[0]))
   {
     cairo_pop_group_to_source(cr);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -337,7 +337,8 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
   // NOTE: As ProPhoto's blue primary is very dark (and imaginary), it
   // maps to a very small radius in CIELuv.
   cairo_pattern_t *p = cairo_pattern_create_mesh();
-  dt_aligned_pixel_t prev_rgb_display, first_rgb_display;
+  // initialize to make gcc-7 happy
+  dt_aligned_pixel_t prev_rgb_display = { 0.f }, first_rgb_display = { 0.f };
   double px = 0., py= 0.;
 
   for(int k=0; k<6; k++)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -42,6 +42,7 @@
 // # of gradations between each primary/secondary to draw the hue ring
 // this is tuned to most degenerate case -- curve to blue primary in Luv in linear ProPhoto RGB
 // FIXME: why does the blue curve in to the center point? is this a color processing bug or a relic of a luminance of that primary
+// FIXME: do fewer points and splines
 #define VECTORSCOPE_HUES 48
 #define VECTORSCOPE_BASE_LOG 30
 
@@ -99,7 +100,7 @@ typedef struct dt_lib_histogram_t
   uint8_t *waveform_img[3];           // image per RGB channel
   int waveform_bins, waveform_tones, waveform_max_bins;
   // FIXME: make dt_lib_histogram_vectorscope_t for all this data?
-  uint8_t *vectorscope_graph, *vectorscope_bkgd, *vectorscope_bkgd_dim;
+  uint8_t *vectorscope_graph, *vectorscope_bkgd;
   float vectorscope_pt[2];            // point colorpicker position
   int vectorscope_diameter_px;
   float hue_ring[6][VECTORSCOPE_HUES][2] DT_ALIGNED_ARRAY;
@@ -398,13 +399,9 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
       // FIXME: a custom matrix could do this flip and write directly to pixel buffer
       dt_XYZ_to_Rec709_D50(XYZ_D50, RGB);
       uint8_t *const restrict px = d->vectorscope_bkgd + y * stride + x * 4U;
-      uint8_t *const restrict px_dim = d->vectorscope_bkgd_dim + y * stride + x * 4U;
       // BGR/RGB flip is for pixelpipe vs. Cairo color?
       for(int ch=0; ch<3; ch++)
-      {
         px[2U-ch] = CLAMP((int)(RGB[ch] * 255.0f), 0, 255);
-        px_dim[2U-ch] = px[2U-ch] / 2;
-      }
     }
 
   d->vectorscope_radius = max_radius;
@@ -822,24 +819,17 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     cairo_stroke(cr);
   }
 
-  // FIXME: these different background patterns are hacky -- could try to do something clever and have one buffer which has 50% alpha and lives as both RGB24 (full) and ARGB32 (dim)
   cairo_surface_t *bkgd_surface =
     dt_cairo_image_surface_create_for_data(d->vectorscope_bkgd, CAIRO_FORMAT_RGB24,
                                            diam_px, diam_px,
                                            cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
-  cairo_surface_t *bkgd_dim_surface =
-    dt_cairo_image_surface_create_for_data(d->vectorscope_bkgd_dim, CAIRO_FORMAT_RGB24,
-                                           diam_px, diam_px,
-                                           cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
   cairo_pattern_t *bkgd_pat = cairo_pattern_create_for_surface(bkgd_surface);
-  cairo_pattern_t *bkgd_dim_pat = cairo_pattern_create_for_surface(bkgd_dim_surface);
   // FIXME: is there an easier way to do this work?
   cairo_matrix_t matrix;
   cairo_matrix_init_translate(&matrix, 0.5*diam_px/darktable.gui->ppd, 0.5*diam_px/darktable.gui->ppd);
   cairo_matrix_scale(&matrix, (double)diam_px / min_size / darktable.gui->ppd,
                      (double)diam_px / min_size / darktable.gui->ppd);
   cairo_pattern_set_matrix(bkgd_pat, &matrix);
-  cairo_pattern_set_matrix(bkgd_dim_pat, &matrix);
 
   // FIXME: also add hue rings (monochrome/dotted) for input/work/output profiles
   // from Sobotka:
@@ -849,7 +839,8 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // graticule: histogram profile hue ring
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  cairo_set_source(cr, bkgd_dim_pat);
+  cairo_push_group(cr);
+  cairo_set_source(cr, bkgd_pat);
   for(int n=0; n<6; n++)
     for(int h=0; h<VECTORSCOPE_HUES; h++)
     {
@@ -860,9 +851,11 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
     }
   cairo_close_path(cr);
   cairo_stroke(cr);
+  cairo_pop_group_to_source(cr);
+  cairo_paint_with_alpha(cr, 0.4);
 
   // primary/secondary nodes
-  double vertex_rgb[6][4] DT_ALIGNED_PIXEL = {{1.0, 0.2, 0.2}, {1.0, 1.0, 0.2},
+  double vertex_rgb[6][3] DT_ALIGNED_PIXEL = {{1.0, 0.2, 0.2}, {1.0, 1.0, 0.2},
                                               {0.2, 1.0, 0.2}, {0.2, 1.0, 1.0},
                                               {0.2, 0.2, 1.0}, {1.0, 0.2, 1.0} };
   for(int n=0; n<6; n++)
@@ -886,7 +879,9 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_pattern_t *graph_pat = cairo_pattern_create_for_surface(graph_surface);
   cairo_pattern_set_matrix(graph_pat, &matrix);
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  cairo_set_source(cr, isnan(d->vectorscope_pt[0]) ? bkgd_pat : bkgd_dim_pat);
+  if(!isnan(d->vectorscope_pt[0]))
+    cairo_push_group(cr);
+  cairo_set_source(cr, bkgd_pat);
 #if 0
   // for debugging background color
   cairo_paint(cr);
@@ -894,15 +889,19 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_mask(cr, graph_pat);
   //cairo_mask_surface(cr, graph_surface, 0., 0.);
   cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, isnan(d->vectorscope_pt[0]) ? 0.6 : 0.3);
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.6);
   cairo_mask(cr, graph_pat);
 #endif
   cairo_pattern_destroy(bkgd_pat);
   cairo_surface_destroy(bkgd_surface);
-  cairo_pattern_destroy(bkgd_dim_pat);
-  cairo_surface_destroy(bkgd_dim_surface);
   cairo_pattern_destroy(graph_pat);
   cairo_surface_destroy(graph_surface);
+  if(!isnan(d->vectorscope_pt[0]))
+  {
+    cairo_pop_group_to_source(cr);
+    cairo_paint_with_alpha(cr, 0.5);
+  }
+
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 
   if(!isnan(d->vectorscope_pt[0]))
@@ -1721,8 +1720,6 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: note that the background can be lower resolution than the graph -- test/compare?
   d->vectorscope_bkgd = dt_alloc_align(64, sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
                                        cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
-  d->vectorscope_bkgd_dim = dt_alloc_align(64, sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
-                                           cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
   d->hue_ring_prof = NULL;
   d->hue_ring_scale = DT_LIB_HISTOGRAM_SCALE_N;
   d->hue_ring_colorspace = DT_LIB_HISTOGRAM_VECTORSCOPE_N;
@@ -1881,7 +1878,6 @@ void gui_cleanup(dt_lib_module_t *self)
     dt_free_align(d->waveform_img[ch]);
   dt_free_align(d->vectorscope_graph);
   dt_free_align(d->vectorscope_bkgd);
-  dt_free_align(d->vectorscope_bkgd_dim);
   dt_pthread_mutex_destroy(&d->lock);
 
   g_free(self->data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -862,7 +862,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // vectorscope graph
   // FIXME: use cairo_pattern_set_filter()?
-  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   // FIXME: use cairo_pattern_set_extend() with CAIRO_EXTEND_PAD?
   cairo_surface_t *graph_surface =
     dt_cairo_image_surface_create_for_data(d->vectorscope_graph, CAIRO_FORMAT_A8,
@@ -873,7 +872,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
                                            diam_px, diam_px,
                                            cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, diam_px));
 
-  // FIXME: do one pass in color with bkgd, one pass with hard light with gray
   cairo_pattern_t *graph_pat = cairo_pattern_create_for_surface(graph_surface);
   cairo_pattern_t *bkgd_pat = cairo_pattern_create_for_surface(bkgd_surface);
   // FIXME: is there an easier way to do this work?
@@ -883,9 +881,17 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
                      (double)diam_px / min_size / darktable.gui->ppd);
   cairo_pattern_set_matrix(graph_pat, &matrix);
   cairo_pattern_set_matrix(bkgd_pat, &matrix);
+  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_set_source(cr, bkgd_pat);
-  //cairo_paint(cr);
+#if 0
+  // for debugging background color
+  cairo_paint(cr);
+#else
   cairo_mask(cr, graph_pat);
+  cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.6);
+  cairo_mask(cr, graph_pat);
+#endif
   //cairo_mask_surface(cr, graph_surface, 0., 0.);
   // FIXME: how will handle fading background for point sample? draw to another surface?
   /*

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -374,30 +374,33 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
       float b = max_radius * 2.0f * (y / (float)(diam_px-1) - 0.5f);
       // FIXME: should we be doing log_scale of [-1,1] rather than [-max_diam,max_diam]?
       log_scale(d, &a, &b, max_radius);
-      dt_aligned_pixel_t XYZ_D50, RGB;
+      dt_aligned_pixel_t RGB;
       // FIXME: look at how hue controls on colorbalance rgb are drawn -- what lightness level -- use similar math
       if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
       {
         const dt_aligned_pixel_t Luv = {65.0f, a, b};
-        dt_aligned_pixel_t xyY;
+        dt_aligned_pixel_t xyY, XYZ_D50;
         dt_Luv_to_xyY(Luv, xyY);
         // FIXME: do have to worry about chromatic adaptation? this assumes that the histogram profile white point is the same as PCS whitepoint (D50) -- if we have a D65 whitepoint profile, how does the result change if we adapt to D65 then convert to L*u*v* with a D65 whitepoint?
         dt_xyY_to_XYZ(xyY, XYZ_D50);
+        dt_XYZ_to_Rec709_D50(XYZ_D50, RGB);
       }
       else if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_JZAZBZ)
       {
         const dt_aligned_pixel_t JzAzBz = {0.008f, a, b};
-        // FIXME: can optimize the XYZ_D65 -> RGB conversion by pre-multiplying matrix?
         dt_aligned_pixel_t XYZ_D65;
         dt_JzAzBz_2_XYZ(JzAzBz, XYZ_D65);
-        dt_XYZ_D65_2_XYZ_D50(XYZ_D65, XYZ_D50);
+        dt_XYZ_to_Rec709_D65(XYZ_D65, RGB);
       }
       else
       {
         dt_unreachable_codepath();
       }
-      // FIXME: a custom matrix could do this flip and write directly to pixel buffer
-      dt_XYZ_to_Rec709_D50(XYZ_D50, RGB);
+      // FIXME: convert to RGB display space instead of sRGB
+      // conversion cribbed from colorbalancergb
+      // normalize with hue-preserving method (sort-of) to prevent gamut-clipping in sRGB
+      const float max_RGB = MAX(MAX(RGB[0], RGB[1]), RGB[2]);
+      for(size_t c = 0; c < 3; c++) RGB[c] = powf(RGB[c] / max_RGB, 1.f / 2.2f);
       uint8_t *const restrict px = d->vectorscope_bkgd + y * stride + x * 4U;
       // BGR/RGB flip is for pixelpipe vs. Cairo color?
       for(int ch=0; ch<3; ch++)
@@ -786,6 +789,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   cairo_save(cr);
 
+#if 1
   // background
   cairo_pattern_t *p = cairo_pattern_create_radial(0.5 * width, 0.5 * height, 0.5 * min_size,
                                                    0.5 * width, 0.5 * height, 0.5 * hypot(min_size, min_size));
@@ -795,6 +799,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_set_source(cr, p);
   cairo_fill(cr);
   cairo_pattern_destroy(p);
+#endif
 
   // FIXME: the areas to left/right of the scope could have some data (primaries, whitepoint, scale, etc.)
   cairo_translate(cr, width / 2., height / 2.);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -369,19 +369,17 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
   for(size_t y = 0; y < diam_px; y++)
     for(size_t x = 0; x < diam_px; x++)
     {
-      float a = 2.0f * (x / (float)(diam_px-1) - 0.5f);
-      float b = 2.0f * (y / (float)(diam_px-1) - 0.5f);
+      float a = x / (float)(diam_px-1) - 0.5f;
+      float b = y / (float)(diam_px-1) - 0.5f;
       const float f = max_radius / dt_fast_hypotf(a,b);
       // FIXME: hacky, really want to go to hue ring edge rather than max_radius
       // FIXME: or set radius by hand, to 0.4 for Luv, 0.8 for JzAzBz
-      a *= f;
-      b *= f;
       dt_aligned_pixel_t RGB;
       // FIXME: the L and Jz values are set by visual experimentation to give good saturation in graph, including center and primary/secondary nodes -- is there a better way?
       if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
       {
         // uv values can get huge at corners in logarithmic scale, so clamp to avoid weird colors
-        const dt_aligned_pixel_t Luv = {70.0f, a, b};
+        const dt_aligned_pixel_t Luv = {70.0f, a*f, b*f};
         dt_aligned_pixel_t xyY, XYZ_D50;
         dt_Luv_to_xyY(Luv, xyY);
         // FIXME: do have to worry about chromatic adaptation? this assumes that the histogram profile white point is the same as PCS whitepoint (D50) -- if we have a D65 whitepoint profile, how does the result change if we adapt to D65 then convert to L*u*v* with a D65 whitepoint?
@@ -390,7 +388,7 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
       }
       else if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_JZAZBZ)
       {
-        const dt_aligned_pixel_t JzAzBz = {0.01f, a, b};
+        const dt_aligned_pixel_t JzAzBz = {0.01f, a*f, b*f};
         dt_aligned_pixel_t XYZ_D65;
         dt_JzAzBz_2_XYZ(JzAzBz, XYZ_D65);
         dt_XYZ_to_Rec709_D65(XYZ_D65, RGB);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -40,10 +40,9 @@
 
 #define HISTOGRAM_BINS 256
 // # of gradations between each primary/secondary to draw the hue ring
-// Note that this is gradations of CIE 1931 xy, when converted to
-// RGB (or perceptual space), the spacing will be different
-// FIXME: would fewer gradations still produce a nice hue ring? are this many gradations (32 * 6 = 192) slow to draw on the scope?
-#define VECTORSCOPE_HUES 32
+// this is tuned to most degenerate case -- curve to blue primary in Luv in linear ProPhoto RGB
+// FIXME: why does the blue curve in to the center point? is this a color processing bug or a relic of a luminance of that primary
+#define VECTORSCOPE_HUES 48
 #define VECTORSCOPE_BASE_LOG 30
 
 DT_MODULE(1)
@@ -103,9 +102,7 @@ typedef struct dt_lib_histogram_t
   uint8_t *vectorscope_graph, *vectorscope_bkgd, *vectorscope_bkgd_dim;
   float vectorscope_pt[2];            // point colorpicker position
   int vectorscope_diameter_px;
-  // FIXME: These arrays could instead be alloc'd/free'd. Would the only concern about making dt_lib_histogram_t large so long be if it were stored in the DB?
-  float hue_ring_rgb[6][VECTORSCOPE_HUES][4] DT_ALIGNED_ARRAY;
-  float hue_ring_coord[6][VECTORSCOPE_HUES][2] DT_ALIGNED_ARRAY;
+  float hue_ring[6][VECTORSCOPE_HUES][2] DT_ALIGNED_ARRAY;
   const dt_iop_order_iccprofile_info_t *hue_ring_prof;
   dt_lib_histogram_scale_t hue_ring_scale;
   dt_lib_histogram_vectorscope_type_t hue_ring_colorspace;
@@ -341,10 +338,6 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
         rgb[ch] = vertex_rgb[k][ch] + delta[ch] * i;
       dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, vs_prof->matrix_in_transposed, vs_prof->lut_in,
                                  vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
-      // Try to represent hue in profile colorspace. Values may be
-      // outside [0,1] but cairo_set_source_rgba will clamp. Compare
-      // to illuminant_xy_to_RGB.
-      dt_XYZ_to_Rec709_D50(XYZ_D50, d->hue_ring_rgb[k][i]);
       // FIXME: keep d->vectorscope_type in local variable for speed?
       if(d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
       {
@@ -357,9 +350,8 @@ static void _lib_histogram_vectorscope_bkgd(dt_lib_histogram_t *d, const dt_iop_
         dt_XYZ_2_JzAzBz(intermed, chromaticity);
       }
       // FIXME: log_scale these coords here rather than when drawing the hue ring
-      d->hue_ring_coord[k][i][0] = chromaticity[1];
-      d->hue_ring_coord[k][i][1] = chromaticity[2];
-      // FIXME: max radius isn't log scaled?
+      d->hue_ring[k][i][0] = chromaticity[1];
+      d->hue_ring[k][i][1] = chromaticity[2];
       max_radius = MAX(max_radius, hypotf(chromaticity[1], chromaticity[2]));
     }
   }
@@ -858,10 +850,9 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   for(int n=0; n<6; n++)
     for(int h=0; h<VECTORSCOPE_HUES; h++)
     {
-      // note that hue_ring_rgb and hue_ring_coord are calculated as float but converted here to double
-      //cairo_set_source_rgba(cr, d->hue_ring_rgb[n][h][0], d->hue_ring_rgb[n][h][1], d->hue_ring_rgb[n][h][2], 0.5);
-      float x = d->hue_ring_coord[n][h][0];
-      float y = d->hue_ring_coord[n][h][1];
+      // note that hue_ring coords are calculated as float but converted here to double
+      float x = d->hue_ring[n][h][0];
+      float y = d->hue_ring[n][h][1];
       // FIXME: do this in _lib_histogram_vectorscope_bkgd()
       log_scale(d, &x, &y, vs_radius);
       cairo_line_to(cr, x*scale, y*scale);
@@ -873,14 +864,13 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   // draw primary/secondary nodes
   for(int n=0; n<6; n++)
   {
-    float x = d->hue_ring_coord[n][0][0];
-    float y = d->hue_ring_coord[n][0][1];
+    float x = d->hue_ring[n][0][0];
+    float y = d->hue_ring[n][0][1];
     // FIXME: do this in _lib_histogram_vectorscope_bkgd()
     log_scale(d, &x, &y, vs_radius);
     cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
-    // FIXME: mask bkgd instead of setting color?
-    // FIXME: if do have colors here, are they just vertex_rgb?
-    cairo_set_source_rgba(cr, d->hue_ring_rgb[n][0][0], d->hue_ring_rgb[n][0][1], d->hue_ring_rgb[n][0][2], 1.);
+    // FIXME: use vertex RGB colors instead of background?, with hard light effect?
+    cairo_set_source(cr, bkgd_pat);
     cairo_fill_preserve(cr);
     set_color(cr, darktable.bauhaus->graph_grid);
     cairo_stroke(cr);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -290,6 +290,7 @@ static inline float baselog(float x, float bound)
 
 static inline void log_scale(const dt_lib_histogram_t *d, float *x, float *y, float r)
 {
+  // FIXME: test for this in caller rather than here?
   if(d->vectorscope_scale == DT_LIB_HISTOGRAM_SCALE_LOGARITHMIC)
   {
     const float h = dt_fast_hypotf(*x,*y);
@@ -858,17 +859,18 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       cairo_line_to(cr, x*scale, y*scale);
     }
   cairo_close_path(cr);
-  // FIXME: this should be drawn with 50% alpha to make it dimmer, as should the faded out vectorscope on point sample -- make a second RGBA32 buffer which is 50% alpha? -- or paint this to a temporary surface then composite it over at 50%?
   cairo_stroke(cr);
 
-  // draw primary/secondary nodes
+  // primary/secondary nodes
+  double vertex_rgb[6][4] DT_ALIGNED_PIXEL = {{1.0, 0.2, 0.2}, {1.0, 1.0, 0.2},
+                                              {0.2, 1.0, 0.2}, {0.2, 1.0, 1.0},
+                                              {0.2, 0.2, 1.0}, {1.0, 0.2, 1.0} };
   for(int n=0; n<6; n++)
   {
     float x = d->hue_ring[n][0][0];
     float y = d->hue_ring[n][0][1];
     cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
-    // FIXME: use vertex RGB colors instead of background?, with hard light effect?
-    cairo_set_source(cr, bkgd_pat);
+    cairo_set_source_rgb(cr, vertex_rgb[n][0], vertex_rgb[n][1],  vertex_rgb[n][2]);
     cairo_fill_preserve(cr);
     set_color(cr, darktable.bauhaus->graph_grid);
     cairo_stroke(cr);


### PR DESCRIPTION
## Summary

Draw graph once in color (chromaticity represented by each graph point), then overlay in white "hard light" to give more of a sense of volume. Do this work in RGB via Cairo, rather than in CIELUV or JzAzBz.

The graph colors are a bit more true to the image colors, and hence much less saturated than with current code. Transition from blank areas of graph to those with just a bit of data is smoother (prior code had a noticeable minimum graph density if there was any data).

This is a comparable change to #9052 for waveform & rgb parade.

## Underlying code changes

- Precalculate the color for each vectorscope graph point for the current histogram profile, log/linear scale, and colorspace (CIELUV or JzAzBz). Then when processing the image, only calculate the count of pixels per graph point.
- Use Cairo to draw to combine the precalculated color with the single-channel data of current image. This simplifies image processing code, and lets the drawing code control the appearance of the scope.
- As there is now precalculated color data, use that to determine the hue ring and primary/secondary color nodes, rather than calculating their color separately.

## Memory

The new processing code requires approx. 144K more memory. (Prior code allocated a 576K buffer to hold the graph. Code in this PR allocates a 576K buffer to hold the background image and 144K buffer to hold the graph.)

It uses `cairo_push_group()` on draw, which will allocate an extra temporary buffer for the widget (350 x 175 px default, lodpi 239K, hidpi 957K).

## Timing comparisons

In seconds, mean/median:

work | colorspace | prior to this PR | with this PR
---- | ---------- | ---------------- | ------------
process | CIELUV | 0.024/0.024 | 0.023/0.024
process (changed profile/scale/colorspace) | CIELUV | n/a (same as above) | 0.026/0.024
draw | CIELUV | 0.011/0.011 | 0.013/0.013
process | JzAzBz | 0.032/0.032 | 0.031/0.031
process (changed profile/scale/colorspace) | JzAzBz | n/a (same as above) | 0.50/0.050
draw | JzAzBz | 0.011/0.011 | 0.014/0.013

Hence the precalculation makes normal updates to the scope be slightly faster, but this is offset by slower drawing of the graph due to more work in Cairo. Changes to pofile/scale/colorspace (rare) are slower as they do a lot of color math to generate a background color image. The prior code avoided a lot of this color math by only doing it for parts of the graph which actually had data. (That also meant that images with many different chromaticities would process a bit more slowly.)

## output comparison

### less saturated image

#### before this PR

![image](https://user-images.githubusercontent.com/2311860/121416227-8e6f2e00-c936-11eb-8ec2-adf59eba7ade.png)

#### after this PR

![image](https://user-images.githubusercontent.com/2311860/121414653-e0af4f80-c934-11eb-9bba-8b059fa5afec.png)

### more saturated image

#### before this PR

![image](https://user-images.githubusercontent.com/2311860/121416071-6384da00-c936-11eb-81be-0c77e6542e3a.png)

#### after this PR

![image](https://user-images.githubusercontent.com/2311860/121415951-43551b00-c936-11eb-85f3-35efd7d0d1d7.png)

## Notes

I'm putting this out there well in advance of v3.8. The underlying code looks more maintainable/sane to me, and the output is more controllable/reasonable.

This code is slightly slower in some cases, and uses more memory. If the intense color of the prior output is appealing, it would probably be possible to tweak this code to exaggerate the color more.

I still want to do more work to the vectorscope. I'd like to improve the processing speed so that it is more comparable to other scopes (histogram and waveform). Right now it is only acceptably fast by processing the preview at 1/4 resolution. I'd like the code to be fast enough to be able to process at the same resolution as with the other scopes.