### PR TITLE
Fix inaccurate wording (should be cropping, not clipping)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2106,7 +2106,7 @@
     </type>
     <default>bicubic</default>
     <shortdescription>pixel interpolator (warp)</shortdescription>
-    <longdescription>pixel interpolator used in modules for rotation, lens correction, liquify, clipping and final scaling (bilinear, bicubic, lanczos2).</longdescription>
+    <longdescription>pixel interpolator used in modules for rotation, lens correction, liquify, cropping and final scaling (bilinear, bicubic, lanczos2).</longdescription>
   </dtconfig>
   <dtconfig prefs="processing">
     <name>plugins/lighttable/export/pixel_interpolator</name>


### PR DESCRIPTION
The word clipping in darktable is used exclusively in the context of colors (like 'highlight clipping' or 'gamut clipping'). What was meant here is cropping, obviously.
