### PR TITLE
Use American spelling of localization

### DIFF
--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -252,7 +252,7 @@ gboolean restart_required = FALSE;
 
 <xsl:text>
    {
-      GtkWidget *seclabel = gtk_label_new(_("map / geolocalisation"));
+      GtkWidget *seclabel = gtk_label_new(_("map / geolocalization"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
       gtk_widget_set_name(lbox, "pref_section");


### PR DESCRIPTION
To be more precise, this is Oxford English Dictionary spelling. So, this is not a non-British version, but rather internationally acceptable.
