### PR TITLE
Better wording when can not load image

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -485,7 +485,9 @@ void expose(
           NULL,
           _("darktable could not load `%s', switching to lighttable now.\n\n"
             "please check that the camera model that produced the image is supported in darktable\n"
-            "(list of supported cameras is at https://www.darktable.org/resources/camera-support/)."),
+            "(list of supported cameras is at https://www.darktable.org/resources/camera-support/).\n"
+            "if you are sure that the camera model is supported, please consider opening an issue\n"
+            "at https://github.com/darktable-org/darktable"),
           dev->image_storage.filename);
       if(dev->image_invalid_cnt > 400)
       {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -484,8 +484,8 @@ void expose(
       load_txt = dt_util_dstrcat(
           NULL,
           _("darktable could not load `%s', switching to lighttable now.\n\n"
-            "please check the image (use exiv2 or exiftool) for corrupted data. if the image seems to\n"
-            "be intact, please consider opening an issue at https://github.com/darktable-org/darktable."),
+            "please check that the camera model that produced the image is supported in darktable\n"
+            "(list of supported cameras is at https://www.darktable.org/resources/camera-support/)."),
           dev->image_storage.filename);
       if(dev->image_invalid_cnt > 400)
       {


### PR DESCRIPTION
In my experience, I've never seen image files that would be so corrupted that it prevented the decoder from showing them.

I'm sure the vast majority of times a user sees this message is when he/she tries to open an image file from a camera that is not yet supported.

Since the deadline fot string freeze  is so close, I offer my version of this toast message quickly and I'm sure it can be improved. But, IMHO, it is better not to leave the original text.