### PR TITLE
colorbalancergb gamut mapping : better fix for #9095

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -755,7 +755,7 @@ inline float lookup_gamut(read_only image2d_t gamut_lut, const float x)
   // WARNING : x should be between [-pi ; pi ], which is the default output of atan2 anyway
 
   // convert in LUT coordinate
-  const float x_test = (x + M_PI_F) / (2.f * M_PI_F);
+  const float x_test = (LUT_ELEM - 1) * (x + M_PI_F) / (2.f * M_PI_F);
 
   // find the 2 closest integer coordinates (next/previous)
   float x_prev = floor(x_test);
@@ -948,7 +948,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
   // Gamut mapping
   const float out_max_sat_h = lookup_gamut(gamut_lut, h);
   float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : 0.f;
-  sat = soft_clip(sat, 0.9f * out_max_sat_h, out_max_sat_h);
+  sat = soft_clip(sat, 0.8f * out_max_sat_h, out_max_sat_h);
   const float max_C_at_sat = JC[0] * sat;
   const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : 0.f;
   JC[0] = (JC[0] + max_J_at_sat) / 2.f;

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1098,9 +1098,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
           Jch[2] = atan2f(Jab[2], Jab[1]);
 
           const size_t index = roundf((LUT_ELEM - 1) * (Jch[2] + M_PI_F) / (2.f * M_PI_F));
-          // The 6.f factor is an ugly hack to prevent false-positives in gamut detection.
-          // we shouldn't need it, which means there is a well-hidden bug somewhere.
-          // for the time being, this will prevent gamut clipping of valid colors
           const float saturation = (Jch[0] > 0.f) ? Jch[1] / Jch[0] : 0.f;
           LUT[index] = fmaxf(saturation, LUT[index]);
         }

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -42,7 +42,7 @@
 //#include <gtk/gtk.h>
 #include <stdlib.h>
 #define LUT_ELEM 360     // gamut LUT number of elements: resolution of 1°
-#define STEPS 92         // so we test 72×72×72 combinations of RGB in [0; 1] to build the gamut LUT
+#define STEPS 92         // so we test 92×92×92 combinations of RGB in [0; 1] to build the gamut LUT
 
 // Filmlight Yrg puts red at 330°, while usual HSL wheels put it at 360/0°
 // so shift in GUI only it to not confuse people. User params are always degrees,

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -445,7 +445,7 @@ static inline float soft_clip(const float x, const float soft_threshold, const f
 
 
 
-inline float lookup_gamut(const float *const gamut_lut, const float x)
+static inline float lookup_gamut(const float *const gamut_lut, const float x)
 {
   // WARNING : x should be between [-pi ; pi ], which is the default output of atan2 anyway
 


### PR DESCRIPTION
Fix #9095 

Before this, with global chroma = +100% :
![sRGB-primary-blue-continuous_03](https://user-images.githubusercontent.com/2779157/121781944-78b46f80-cba7-11eb-80a6-d6df9bc973ac.jpg)

After this patch:
![sRGB-primary-blue-continuous_01](https://user-images.githubusercontent.com/2779157/121781948-7fdb7d80-cba7-11eb-8ff5-6ccefc6cd25e.jpg)

Before this, with saturation = +50% :
![sRGB-primary-blue-continuous_04](https://user-images.githubusercontent.com/2779157/121781957-8ec23000-cba7-11eb-9661-821039a6ea9f.jpg)

After this patch:
![sRGB-primary-blue-continuous_02](https://user-images.githubusercontent.com/2779157/121781964-9aadf200-cba7-11eb-9cc9-67c0cd01cda8.jpg)

I have also changed the way the gamut LUT is used : previously, it used a nearest neighbour approach, now it does a linear interpolation, leading to better smoothness for quickly varying hues.

Notice the hue shift toward red in the yellow section. It shouldn't be there. I'm still trying to figure out where it comes from.