### PR TITLE
add device cname to debugging output

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -323,6 +323,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   if(darktable.unmuted & DT_DEBUG_OPENCL)
   {
     printf("[opencl_init] device %d: %s \n", k, infostr);
+    printf("     CANONICAL_NAME:           %s\n", cname);
     printf("     GLOBAL_MEM_SIZE:          %.0fMB\n", (double)cl->dev[dev].max_global_mem / 1024.0 / 1024.0);
     (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(infoint), &infoint, NULL);
     printf("     MAX_WORK_GROUP_SIZE:      %zu\n", infoint);


### PR DESCRIPTION
When trying to sniff out what's going on in #5317 I noticed that while device canonical name is computed and used when checking priority list, it isn't shown to user and so it might lead to some confusion when cname gets a bit unexpected value.

also... i think the cname is a bit wonky. So adding this info might be 1st step in debugging any device priority problems.

(note: device numbers in priorities work normally)