### PR TITLE
new debug option --enforce-tiling

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -131,6 +131,7 @@ static int usage(const char *argv0)
 #endif
   printf(">\n");
   printf("  --datadir <data directory>\n");
+  printf("  --enforce-tiling\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
@@ -620,7 +621,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
         if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted = 0xffffffff; // enable all debug information
+          darktable.unmuted = 0xffffffff & ~DT_DEBUG_TILING; // enable all debug information except the enforce-tiling flag
         else if(!strcmp(argv[k + 1], "cache"))
           darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
         else if(!strcmp(argv[k + 1], "control"))
@@ -800,6 +801,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifdef HAVE_OPENCL
         exclude_opencl = TRUE;
 #endif
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--enforce-tiling"))
+      {
+        darktable.unmuted |= DT_DEBUG_TILING;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--"))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -266,6 +266,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_SIGNAL         = 1 << 20,
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
+  DT_DEBUG_TILING         = 1 << 23,
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1112,11 +1112,14 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
 
   const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
   const size_t bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
+
+  const gboolean needs_tiling = (piece->process_tiling_ready &&
+     !dt_tiling_piece_fits_host_memory(MAX(roi_in->width, roi_out->width),
+                                       MAX(roi_in->height, roi_out->height), MAX(in_bpp, bpp),
+                                          tiling->factor, tiling->overhead));
+  
   /* process module on cpu. use tiling if needed and possible. */
-  if(piece->process_tiling_ready
-     && !dt_tiling_piece_fits_host_memory(MAX(roi_in->width, roi_out->width),
-                                          MAX(roi_in->height, roi_out->height), MAX(in_bpp, bpp),
-                                          tiling->factor, tiling->overhead))
+  if(needs_tiling || (darktable.unmuted & DT_DEBUG_TILING))
   {
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);


### PR DESCRIPTION
We want a runtime option to switch on tiling even on systems with lots of cpu/gpu memory for easier
reproducing and debugging of tiling issues.

This pr introduces the --enforce-tiling option

- setting a bit flag in unmuted
- reduces effective available memory at runtime depending on the bit flag
- "enforces" tiling in the pixelpipe