### PR TITLE
report separate memory requirements for CPU vs GPU to reduce CPU tiling

### DIFF
--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -353,7 +353,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor = 1.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
   tiling->overhead = 0;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -607,7 +607,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor = 1.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
 


### PR DESCRIPTION
Mitigates #5428.  We now have a way for `tiliing_callback` to report separate memory requirements for CPU and GPU code paths, so take advantage of that to report the smaller requirement of the CPU code to reduce tiling in Shadows&Highlights and Lowpass modules.

A further reduction is still possible, but that requires more extensive changes which should wait until after 3.6.
