### PR TITLE
report separate memory requirements for CPU vs GPU to reduce CPU tiling

### DIFF
--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -85,21 +85,17 @@ size_t dt_gaussian_memory_use(const int width,    // width of input image
                               const int height,   // height of input image
                               const int channels) // channels per pixel
 {
-  size_t mem_use;
-#ifdef HAVE_OPENCL
-  mem_use = sizeof(float) * channels * (width + BLOCKSIZE) * (height + BLOCKSIZE) * 2;
-#else
-  mem_use = sizeof(float) * channels * width * height;
-#endif
-  return mem_use;
-}
-
-size_t dt_gaussian_memory_use_CPU(const int width,    // width of input image
-                                  const int height,   // height of input image
-                                  const int channels) // channels per pixel
-{
   return sizeof(float) * channels * width * height;
 }
+
+#ifdef HAVE_OPENCL
+size_t dt_gaussian_memory_use_cl(const int width,    // width of input image
+                                 const int height,   // height of input image
+                                 const int channels) // channels per pixel
+{
+  return sizeof(float) * channels * (width + BLOCKSIZE) * (height + BLOCKSIZE) * 2;
+}
+#endif /* HAVE_OPENCL */
 
 size_t dt_gaussian_singlebuffer_size(const int width,    // width of input image
                                      const int height,   // height of input image

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -94,6 +94,13 @@ size_t dt_gaussian_memory_use(const int width,    // width of input image
   return mem_use;
 }
 
+size_t dt_gaussian_memory_use_CPU(const int width,    // width of input image
+                                  const int height,   // height of input image
+                                  const int channels) // channels per pixel
+{
+  return sizeof(float) * channels * width * height;
+}
+
 size_t dt_gaussian_singlebuffer_size(const int width,    // width of input image
                                      const int height,   // height of input image
                                      const int channels) // channels per pixel

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -44,7 +44,9 @@ dt_gaussian_t *dt_gaussian_init(const int width, const int height, const int cha
                                 const float *min, const float sigma, const int order);
 
 size_t dt_gaussian_memory_use(const int width, const int height, const int channels);
-size_t dt_gaussian_memory_use_CPU(const int width, const int height, const int channels);
+#ifdef HAVE_OPENCL
+size_t dt_gaussian_memory_use_cl(const int width, const int height, const int channels);
+#endif
 
 size_t dt_gaussian_singlebuffer_size(const int width, const int height, const int channels);
 

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -44,6 +44,7 @@ dt_gaussian_t *dt_gaussian_init(const int width, const int height, const int cha
                                 const float *min, const float sigma, const int order);
 
 size_t dt_gaussian_memory_use(const int width, const int height, const int channels);
+size_t dt_gaussian_memory_use_CPU(const int width, const int height, const int channels);
 
 size_t dt_gaussian_singlebuffer_size(const int width, const int height, const int channels);
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -118,6 +118,9 @@ const dt_iop_roi_t *roi_out, dt_develop_tiling_t *tiling)
   const size_t basebuffer = width*height*channels*sizeof(float);
 
   tiling->factor = 2.0f + (float)dt_gaussian_memory_use(width, height, channels)/basebuffer;
+#ifdef HAVE_OPENCL
+  tiling->factor_cl = 2.0f + (float)dt_gaussian_memory_use_cl(width, height, channels)/basebuffer;
+#endif
   tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels)/basebuffer);
   tiling->overhead = 0;
   tiling->overlap = p->window;

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -353,8 +353,10 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use_CPU(width, height, channels) / basebuffer);
-    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+#ifdef HAVE_OPENCL
+    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use_cl(width, height, channels) / basebuffer);
+#endif
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
   tiling->overhead = 0;

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -353,7 +353,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use_CPU(width, height, channels) / basebuffer);
+    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
   tiling->overhead = 0;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -607,7 +607,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use_CPU(width, height, channels) / basebuffer);
+    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
 

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -607,8 +607,10 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use_CPU(width, height, channels) / basebuffer);
-    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
+#ifdef HAVE_OPENCL
+    tiling->factor_cl = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use_cl(width, height, channels) / basebuffer);
+#endif
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
 


### PR DESCRIPTION
Mitigates #5428.  Now that we have a mechanism for reporting memory requirements separately for the CPU and GPU code paths, take advantage of it.  Reporting the lower actual requrements for the CPU code path reduces tiling in low-memory situations and thus reduces the slowdown.

Additional memory savings are possible, but require more extensive changes that should wait until after 3.6.
