### PR TITLE
Introducing a LMMSE demosaicer

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -211,6 +211,7 @@ src/iop/defringe.c
 src/iop/demosaic.c
 src/iop/denoiseprofile.c
 src/iop/dither.c
+src/iop/dual_demosaic.c
 src/iop/equalizer.c
 src/iop/exposure.c
 src/iop/filmic.c
@@ -229,6 +230,7 @@ src/iop/invert.c
 src/iop/lens.cc
 src/iop/levels.c
 src/iop/liquify.c
+src/iop/lmmse_demosaic.c
 src/iop/lowlight.c
 src/iop/lowpass.c
 src/iop/lut3d.c
@@ -241,6 +243,7 @@ src/iop/profile_gamma.c
 src/iop/rawdenoise.c
 src/iop/rawoverexposed.c
 src/iop/rawprepare.c
+src/iop/rcd_demosaic.c
 src/iop/relight.c
 src/iop/retouch.c
 src/iop/rgbcurve.c

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -109,7 +109,8 @@ typedef enum dt_iop_demosaic_lmmse_t
   LMMSE_REFINE_0 = 0,   // $DESCRIPTION: "basic"
   LMMSE_REFINE_1 = 1,   // $DESCRIPTION: "median"
   LMMSE_REFINE_2 = 2,   // $DESCRIPTION: "3x median"
-  LMMSE_REFINE_3 = 3,   // $DESCRIPTION: "refine + 3x median"
+  LMMSE_REFINE_3 = 3,   // $DESCRIPTION: "refine & medians"
+  LMMSE_REFINE_4 = 4,   // $DESCRIPTION: "2x refine + medians"
 } dt_iop_demosaic_lmmse_t;
 
 typedef struct dt_iop_demosaic_params_t

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5347,7 +5347,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     else
       tiling->factor += smooth;                        // + smooth
     tiling->maxbuf = 1.0f;
-    tiling->factor += 5;
+    tiling->overhead = sizeof(float) * LMMSE_GRP * LMMSE_GRP * 6 * MAX(1, darktable.num_openmp_threads);
     tiling->xalign = 2;
     tiling->yalign = 2;
     tiling->overlap = 10;
@@ -5380,6 +5380,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   }
   return;
 }
+#undef RCD_TILESIZE
+#undef LMMSE_GRP
 
 void init_global(dt_iop_module_so_t *module)
 {
@@ -5569,7 +5571,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
       break;
     case DT_IOP_DEMOSAIC_LMMSE:
       piece->process_cl_ready = 0;
-      piece->process_tiling_ready = 0;
       break;
     case DT_IOP_DEMOSAIC_RCD_VNG:
       piece->process_cl_ready = 1;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3062,7 +3062,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
             gd->lmmse_gamma_out[j] = (x <= 0.031746) ? x / 17.0 : exp(log((x + 0.044445) / 1.044445) * 2.4);
           }
         }
-        lmmse_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, data->lmmse_refine, gd->lmmse_gamma_in, gd->lmmse_gamma_out);
+        lmmse_demosaic(piece, tmp, in, &roo, &roi, piece->pipe->dsc.filters, data->lmmse_refine, gd->lmmse_gamma_in, gd->lmmse_gamma_out);
       }
       else if((demosaicing_method & ~DEMOSAIC_DUAL) != DT_IOP_DEMOSAIC_AMAZE)
         demosaic_ppg(tmp, in, &roo, &roi, piece->pipe->dsc.filters,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -46,6 +46,7 @@
 #include <time.h>
 
 #include "rcd_demosaic.c"
+#include "lmmse_demosaic.c"
 
 DT_MODULE_INTROSPECTION(4, dt_iop_demosaic_params_t)
 
@@ -60,6 +61,7 @@ typedef enum dt_iop_demosaic_method_t
   DT_IOP_DEMOSAIC_AMAZE = 1, // $DESCRIPTION: "AMaZE"
   DT_IOP_DEMOSAIC_VNG4 = 2,  // $DESCRIPTION: "VNG4"
   DT_IOP_DEMOSAIC_RCD = 5,   // $DESCRIPTION: "RCD"
+  DT_IOP_DEMOSAIC_LMMSE = 6, // $DESCRIPTION: "LMMSE" 
   DT_IOP_DEMOSAIC_RCD_VNG = DEMOSAIC_DUAL | DT_IOP_DEMOSAIC_RCD, // $DESCRIPTION: "RCD + VNG4"
   DT_IOP_DEMOSAIC_AMAZE_VNG = DEMOSAIC_DUAL | DT_IOP_DEMOSAIC_AMAZE, // $DESCRIPTION: "AMaZE + VNG4"
   DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME = 3, // $DESCRIPTION: "passthrough (monochrome)"
@@ -102,13 +104,21 @@ typedef enum dt_iop_demosaic_smooth_t
   DEMOSAIC_SMOOTH_5 = 5,   // $DESCRIPTION: "five times"
 } dt_iop_demosaic_smooth_t;
 
+typedef enum dt_iop_demosaic_lmmse_t
+{
+  LMMSE_REFINE_0 = 0,   // $DESCRIPTION: "basic"
+  LMMSE_REFINE_1 = 1,   // $DESCRIPTION: "median"
+  LMMSE_REFINE_2 = 2,   // $DESCRIPTION: "3x median"
+  LMMSE_REFINE_3 = 3,   // $DESCRIPTION: "3x median + refine"
+} dt_iop_demosaic_lmmse_t;
+
 typedef struct dt_iop_demosaic_params_t
 {
   dt_iop_demosaic_greeneq_t green_eq; // $DEFAULT: DT_IOP_GREEN_EQ_NO $DESCRIPTION: "match greens"
   float median_thrs; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "edge threshold"
   dt_iop_demosaic_smooth_t color_smoothing; // $DEFAULT: DEMOSAIC_SMOOTH_OFF $DESCRIPTION: "color smoothing"
   dt_iop_demosaic_method_t demosaicing_method; // $DEFAULT: DT_IOP_DEMOSAIC_RCD $DESCRIPTION: "demosaicing method"
-  uint32_t yet_unused_data_specific_to_demosaicing_method;
+  dt_iop_demosaic_lmmse_t lmmse_refine; // $DEFAULT: LMMSE_REFINE_1 $DESCRIPTION: "lmmse refinement"
   float dual_thrs; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.20 $DESCRIPTION: "switch dual threshold"
 } dt_iop_demosaic_params_t;
 
@@ -121,6 +131,7 @@ typedef struct dt_iop_demosaic_gui_data_t
   GtkWidget *demosaic_method_xtrans;
   GtkWidget *dual_thrs;
   GtkWidget *dual_mask;
+  GtkWidget *lmmse_refine;
   gint show_mask;
 } dt_iop_demosaic_gui_data_t;
 
@@ -176,6 +187,8 @@ typedef struct dt_iop_demosaic_global_data_t
   int kernel_rcd_border_redblue;
   int kernel_rcd_border_green;
   int kernel_write_blended_dual;
+  float *lmmse_gamma_in;
+  float *lmmse_gamma_out;
 } dt_iop_demosaic_global_data_t;
 
 typedef struct dt_iop_demosaic_data_t
@@ -183,7 +196,7 @@ typedef struct dt_iop_demosaic_data_t
   uint32_t green_eq;
   uint32_t color_smoothing;
   uint32_t demosaicing_method;
-  uint32_t yet_unused_data_specific_to_demosaicing_method;
+  uint32_t lmmse_refine;
   float median_thrs;
   double CAM_to_RGB[3][4];
   float dual_thrs;
@@ -238,7 +251,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     float median_thrs;
     uint32_t color_smoothing;
     dt_iop_demosaic_method_t demosaicing_method;
-    uint32_t yet_unused_data_specific_to_demosaicing_method;
+    dt_iop_demosaic_lmmse_t lmmse_refine;
   } dt_iop_demosaic_params_v3_t;
 
   if(old_version == 3 && new_version == 4)
@@ -258,7 +271,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->median_thrs = o->median_thrs;
     n->color_smoothing = 0;
     n->demosaicing_method = DT_IOP_DEMOSAIC_PPG;
-    n->yet_unused_data_specific_to_demosaicing_method = 0;
+    n->lmmse_refine = LMMSE_REFINE_1;
     return 0;
   }
   return 1;
@@ -299,6 +312,9 @@ static const char* method2string(dt_iop_demosaic_method_t method)
       break;
     case DT_IOP_DEMOSAIC_RCD:
       string = "RCD";
+      break;
+    case DT_IOP_DEMOSAIC_LMMSE:
+      string = "LMMSE";
       break;
     case DT_IOP_DEMOSAIC_RCD_VNG:
       string = "RCD + VNG4";
@@ -2936,6 +2952,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
+  dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
 
   const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
   int demosaicing_method = data->demosaicing_method;
@@ -3027,6 +3044,24 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       else if((demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_RCD)
       {
         rcd_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters);
+      }
+      else if(demosaicing_method == DT_IOP_DEMOSAIC_LMMSE)
+      {
+        if(gd->lmmse_gamma_in == NULL)
+        {
+          gd->lmmse_gamma_in = dt_alloc_align_float(65536);
+          gd->lmmse_gamma_out = dt_alloc_align_float(65536);
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+          for(int j = 0; j < 65536; j++)
+          {
+            const double x = (double)j / 65535.0;
+            gd->lmmse_gamma_in[j]  = (x <= 0.001867) ? x * 17.0 : 1.044445 * exp(log(x) / 2.4) - 0.044445;
+            gd->lmmse_gamma_out[j] = (x <= 0.031746) ? x / 17.0 : exp(log((x + 0.044445) / 1.044445) * 2.4);
+          }
+        }
+        lmmse_demosaic(piece, tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, data->lmmse_refine, gd->lmmse_gamma_in, gd->lmmse_gamma_out);
       }
       else if((demosaicing_method & ~DEMOSAIC_DUAL) != DT_IOP_DEMOSAIC_AMAZE)
         demosaic_ppg(tmp, in, &roo, &roi, piece->pipe->dsc.filters,
@@ -5301,6 +5336,21 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     tiling->yalign = 2;
     tiling->overlap = 10;
   }
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_LMMSE)
+  {
+    tiling->factor = 1.0f + ioratio;
+    if(full_scale_demosaicing && unscaled)
+      tiling->factor += fmax(1.0f + greeneq, smooth);  // + tmp + geeneq | + smooth
+    else if(full_scale_demosaicing)
+      tiling->factor += fmax(2.0f + greeneq, smooth);  // + tmp + aux + greeneq | + smooth
+    else
+      tiling->factor += smooth;                        // + smooth
+    tiling->maxbuf = 1.0f;
+    tiling->factor += 5;
+    tiling->xalign = 2;
+    tiling->yalign = 2;
+    tiling->overlap = 10;
+  }
   else
   {
     // VNG
@@ -5393,6 +5443,8 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_rcd_border_redblue = dt_opencl_create_kernel(rcd, "rcd_border_redblue");
   gd->kernel_rcd_border_green = dt_opencl_create_kernel(rcd, "rcd_border_green");
   gd->kernel_write_blended_dual  = dt_opencl_create_kernel(rcd, "write_blended_dual");  
+  gd->lmmse_gamma_in = NULL;
+  gd->lmmse_gamma_out = NULL;
 }
 
 void cleanup_global(dt_iop_module_so_t *module)
@@ -5447,6 +5499,8 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_rcd_border_redblue);
   dt_opencl_free_kernel(gd->kernel_rcd_border_green);
   dt_opencl_free_kernel(gd->kernel_write_blended_dual);  
+  dt_free_align(gd->lmmse_gamma_in);
+  dt_free_align(gd->lmmse_gamma_out);
   free(module->data);
   module->data = NULL;
 }
@@ -5462,7 +5516,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   d->color_smoothing = p->color_smoothing;
   d->median_thrs = p->median_thrs;
   d->dual_thrs = p->dual_thrs;
-
+  d->lmmse_refine = p->lmmse_refine;
   dt_iop_demosaic_method_t use_method = p->demosaicing_method;
   const gboolean xmethod = use_method & DEMOSAIC_XTRANS;
   const gboolean bayer   = (self->dev->image_storage.buf_dsc.filters != 9u);
@@ -5511,6 +5565,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
       break;
     case DT_IOP_DEMOSAIC_RCD:
       piece->process_cl_ready = 1;
+      break;
+    case DT_IOP_DEMOSAIC_LMMSE:
+      piece->process_cl_ready = 0;
+      piece->process_tiling_ready = 0;
       break;
     case DT_IOP_DEMOSAIC_RCD_VNG:
       piece->process_cl_ready = 1;
@@ -5586,6 +5644,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   const gboolean isppg = (use_method == DT_IOP_DEMOSAIC_PPG);
   const gboolean isdual = (use_method & DEMOSAIC_DUAL);
+  const gboolean islmmse = (p->demosaicing_method == DT_IOP_DEMOSAIC_LMMSE);
   const gboolean passing = ((use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
                             (use_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR) ||
                             (use_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
@@ -5603,9 +5662,12 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_widget_set_visible(g->color_smoothing, !passing && !isdual);
   gtk_widget_set_visible(g->dual_mask, isdual);
   gtk_widget_set_visible(g->dual_thrs, isdual);
+  gtk_widget_set_visible(g->lmmse_refine, islmmse);
+
   dt_bauhaus_slider_set(g->median_thrs, p->median_thrs);
   dt_bauhaus_combobox_set(g->color_smoothing, p->color_smoothing);
   dt_bauhaus_combobox_set(g->greeneq, p->green_eq);
+  dt_bauhaus_combobox_set(g->lmmse_refine, p->lmmse_refine);
   dt_bauhaus_slider_set(g->dual_thrs, p->dual_thrs);
 
   g->show_mask = FALSE;
@@ -5653,6 +5715,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   const gboolean bayer = (self->dev->image_storage.buf_dsc.filters != 9u);
   const gboolean isppg = (p->demosaicing_method == DT_IOP_DEMOSAIC_PPG);
   const gboolean isdual = (p->demosaicing_method & DEMOSAIC_DUAL);
+  const gboolean islmmse = (p->demosaicing_method == DT_IOP_DEMOSAIC_LMMSE);
   const gboolean passing = ((p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR) ||
                             (p->demosaicing_method == DT_IOP_DEMOSAIC_PASSTHR_MONOX) ||
@@ -5670,6 +5733,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_visible(g->color_smoothing, !passing && !isdual);
   gtk_widget_set_visible(g->dual_mask, isdual);
   gtk_widget_set_visible(g->dual_thrs, isdual);
+  gtk_widget_set_visible(g->lmmse_refine, islmmse);
 
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, self->dev->image_storage.id, 'w');
   int changed = img->flags & DT_IMAGE_MONOCHROME_BAYER;
@@ -5705,11 +5769,11 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->demosaic_method_bayer = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, 8);
-  gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("bayer sensor demosaicing method, PPG and RCD are fast, AMaZE is slow.\ndual demosaicers double processing time."));
+  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, 9);
+  gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\nFor high ISO images LMMSE is suited best.\ndual demosaicers double processing time."));
 
   g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<8;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
+  for(int i=0;i<9;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
   gtk_widget_set_tooltip_text(g->demosaic_method_xtrans, _("xtrans sensor demosaicing method, Markesteijn 3-pass and frequency domain chroma are slow.\ndual demosaicers double processing time."));
 
   g->median_thrs = dt_bauhaus_slider_from_params(self, "median_thrs");
@@ -5728,6 +5792,9 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_toggle(g->dual_mask, TRUE);
   g_signal_connect(G_OBJECT(g->dual_mask), "quad-pressed", G_CALLBACK(show_mask_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->dual_mask, FALSE, FALSE, 0);
+
+  g->lmmse_refine = dt_bauhaus_combobox_from_params(self, "lmmse_refine");
+  gtk_widget_set_tooltip_text(g->lmmse_refine, _("LMMSE refinement steps. the median steps avarage the output,\nrefine adds some recalculation of red & blue channels."));
 
   g->color_smoothing = dt_bauhaus_combobox_from_params(self, "color_smoothing");
   gtk_widget_set_tooltip_text(g->color_smoothing, _("how many color smoothing median steps after demosaicing"));

--- a/src/iop/lmmse_demosaic.c
+++ b/src/iop/lmmse_demosaic.c
@@ -32,9 +32,9 @@
 /* about performance tested with 45mpix images (AMaZE is 0.45 here)
                       untiled           tiled
    basic:             0.5               0.15
-   median:            0.6 (default)     0.23
-   3xmedian:          0.8               0.40
-   3xmed + 2xrefine:  1.2               0.75
+   median:            0.6 (default)     0.25
+   3xmedian:          0.8               0.42
+   3xmed + 2xrefine:  1.2               0.80
 */
 
 /* Why tiling?
@@ -487,7 +487,7 @@ static void lmmse_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict 
           }
 
           // red/blue at GREEN pixel locations & red/blue and green at BLUE/RED pixel locations
-          for(int rr = 0; rr < last_rr / 3; rr++)
+          for(int rr = 0; rr < last_rr - 1; rr++)
           {
             rix[0] = qix[0] + rr * LMMSE_GRP;
             rix[1] = qix[1] + rr * LMMSE_GRP;

--- a/src/iop/lmmse_demosaic.c
+++ b/src/iop/lmmse_demosaic.c
@@ -44,17 +44,19 @@
    As the borders are calculated with reduced precision due to the algo there is an overlapping
    area which is not used for the internal tiles. 
 */
+#ifndef LMMSE_GRP
+  #define LMMSE_GRP 136
+#endif
 
 #ifdef __GNUC__
   #pragma GCC push_options
   #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno")
 #endif
 
-#define LMMSE_TILESIZE 128
 #define LMMSE_OVERLAP 8
 #define BORDER_AROUND 4
+#define LMMSE_TILESIZE (LMMSE_GRP - 2 * BORDER_AROUND)
 #define LMMSE_TILEVALID (LMMSE_TILESIZE - 2 * LMMSE_OVERLAP)
-#define LMMSE_GRP (LMMSE_TILESIZE + 2 * BORDER_AROUND)
 #define w1 (LMMSE_GRP)
 #define w2 (LMMSE_GRP * 2)
 #define w3 (LMMSE_GRP * 3)
@@ -601,7 +603,6 @@ static void lmmse_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict 
 #undef LMMSE_OVERLAP
 #undef BORDER_AROUND
 #undef LMMSE_TILEVALID
-#undef LMMSE_GRP
 #undef w1
 #undef w2
 #undef w3

--- a/src/iop/lmmse_demosaic.c
+++ b/src/iop/lmmse_demosaic.c
@@ -1,0 +1,602 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+    The lmmse code base used for the darktable port has been taken from rawtherapee derived librtprocess.
+    Adaption for dt and tiling - hanno schwalm 06/2021
+
+    LSMME demosaicing algorithm
+    L. Zhang and X. Wu,
+    Color demozaicing via directional Linear Minimum Mean Square-error Estimation,
+    IEEE Trans. on Image Processing, vol. 14, pp. 2167-2178, Dec. 2005.
+
+    Adapted to RawTherapee by Jacques Desmis 3/2013
+    Improved speed and reduced memory consumption by Ingo Weyrich 2/2015
+*/
+
+/* about performance tested with 45mpix images (AMaZE is 0.45 here)
+   basic:         0.5
+   median:        0.6 (default)
+   3xmedian:      0.8
+   3xmed +refine: 1.2
+*/
+
+#ifdef __GNUC__
+  #pragma GCC push_options
+  #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "fp-contract=fast", "no-math-errno")
+#endif
+
+#define LMMSE_TILESIZE 128
+#define LMMSE_OVERLAP 8
+#define BORDER_AROUND 4
+#define LMMSE_TILEVALID (LMMSE_TILESIZE - 2 * LMMSE_OVERLAP)
+
+static INLINE float limf(float x, float min, float max)
+{
+  return fmaxf(min, fminf(x, max));
+}
+
+static INLINE float median3f(float x0, float x1, float x2)
+{
+  return fmaxf(fminf(x0,x1), fminf(x2, fmaxf(x0,x1))); 
+}
+
+static INLINE float median9f(float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7, float a8)
+{
+  float tmp;
+  tmp = fminf(a1, a2);
+  a2  = fmaxf(a1, a2);
+  a1  = tmp;
+  tmp = fminf(a4, a5);
+  a5  = fmaxf(a4, a5);
+  a4  = tmp;
+  tmp = fminf(a7, a8);
+  a8  = fmaxf(a7, a8);
+  a7  = tmp;
+  tmp = fminf(a0, a1);
+  a1  = fmaxf(a0, a1);
+  a0  = tmp;
+  tmp = fminf(a3, a4);
+  a4  = fmaxf(a3, a4);
+  a3  = tmp;
+  tmp = fminf(a6, a7);
+  a7  = fmaxf(a6, a7);
+  a6  = tmp;
+  tmp = fminf(a1, a2);
+  a2  = fmaxf(a1, a2);
+  a1  = tmp;
+  tmp = fminf(a4, a5);
+  a5  = fminf(a4, a5);
+  a4  = tmp;
+  tmp = fminf(a7, a8);
+  a8  = fmaxf(a7, a8);
+  a3  = fmaxf(a0, a3);
+  a5  = fminf(a5, a8);
+  a7  = fmaxf(a4, tmp);
+  tmp = fminf(a4, tmp);
+  a6  = fmaxf(a3, a6);
+  a4  = fmaxf(a1, tmp);
+  a2  = fminf(a2, a5);
+  a4  = fminf(a4, a7);
+  tmp = fminf(a4, a2);
+  a2  = fmaxf(a4, a2);
+  a4  = fmaxf(a6, tmp);
+  return fminf(a4, a2);
+}
+
+static INLINE float calc_gamma(float val, float *table)
+{
+  const float index = val * 65535.0f;
+  const int idx = (int)index;
+  if(index < 0.0f)      return 0.0f;
+  if(index > 65534.99f) return 1.0f;
+
+  const float diff = index - (float)idx;
+  const float p1 = table[idx];
+  const float p2 = table[idx+1] - p1;
+  return (p1 + p2 * diff);
+}
+
+/*
+   Refinement based on EECI demosaicing algorithm by L. Chang and Y.P. Tan
+   Paul Lee
+   Adapted for RawTherapee - Jacques Desmis 04/2013
+*/
+
+#define c1 4
+#define c2 8
+
+#ifdef _OPENMP
+  #pragma omp declare simd aligned(out)
+#endif
+static void refinement(const int width, const int height, float *const restrict out, const uint32_t filters, const float scaler)
+{
+  const int r1 = 4 * width;
+  const int r2 = 8 * width;
+  const float magic = (0.5f * scaler) / 65535.0f; 
+  for(int b = 0; b < 2; b++)
+  {
+#ifdef _OPENMP
+  #pragma omp parallel
+#endif
+    {
+      // Reinforce interpolated green pixels on RED/BLUE pixel locations
+#ifdef _OPENMP
+      #pragma omp for
+#endif
+      for(int row = 2; row < height - 2; row++)
+      {
+        for(int col = 2 + (FC(row, 2, filters) & 1), c = FC(row, col, filters); col < width - 2; col += 2)
+        {
+          float *rgb = &out[4 * (width * row + col)];
+          const float dL = 1.0f / (1.0f + fabsf(rgb[c - c2] - rgb[c]) + fabsf(rgb[1 + c1] - rgb[1 - c1]));
+          const float dR = 1.0f / (1.0f + fabsf(rgb[c + c2] - rgb[c]) + fabsf(rgb[1 + c1] - rgb[1 - c1]));
+          const float dU = 1.0f / (1.0f + fabsf(rgb[c - r2] - rgb[c]) + fabsf(rgb[1 + r1] - rgb[1 - r1]));
+          const float dD = 1.0f / (1.0f + fabsf(rgb[c + r2] - rgb[c]) + fabsf(rgb[1 + r1] - rgb[1 - r1]));
+          const float v0 = (rgb[c] + magic + ((rgb[1 - c1] - rgb[c - c1]) * dL + (rgb[1 + c1] - rgb[c + c1]) * dR + (rgb[1 - r1] - rgb[c - r1]) * dU + (rgb[1 + r1] - rgb[c + r1]) * dD ) / (dL + dR + dU + dD));
+          rgb[1] = fmaxf(0.0f, v0);
+        }
+      }
+
+      // Reinforce interpolated red/blue pixels on GREEN pixel locations
+#ifdef _OPENMP
+      #pragma omp for
+#endif
+      for(int row = 2; row < height - 2; row++)
+      {
+        for(int col = 2 + (FC(row, 3, filters) & 1), c = FC(row, col + 1, filters); col < width - 2; col += 2)
+        {
+          float *rgb = &out[4 * (width * row + col)];
+          for(int i = 0; i < 2; c = 2 - c, i++)
+          {
+            const float dL = 1.0f / (1.0f + fabsf(rgb[1 - c2] - rgb[1]) + fabsf(rgb[c + c1] - rgb[c - c1]));
+            const float dR = 1.0f / (1.0f + fabsf(rgb[1 + c2] - rgb[1]) + fabsf(rgb[c + c1] - rgb[c - c1]));
+            const float dU = 1.0f / (1.0f + fabsf(rgb[1 - r2] - rgb[1]) + fabsf(rgb[c + r1] - rgb[c - r1]));
+            const float dD = 1.0f / (1.0f + fabsf(rgb[1 + r2] - rgb[1]) + fabsf(rgb[c + r1] - rgb[c - r1]));
+            const float v0 = (rgb[1] + magic - ((rgb[1 - c1] - rgb[c - c1]) * dL + (rgb[1 + c1] - rgb[c + c1]) * dR + (rgb[1 - r1] - rgb[c - r1]) * dU + (rgb[1 + r1] - rgb[c + r1]) * dD ) / (dL + dR + dU + dD));
+            rgb[c] = fmaxf(0.0f, v0);
+          }
+        }
+      }
+      // Reinforce integrated red/blue pixels on BLUE/RED pixel locations
+#ifdef _OPENMP
+      #pragma omp for
+#endif
+      for(int row = 2; row < height - 2; row++)
+      {
+        for(int col = 2 + (FC(row, 2, filters) & 1), c = 2 - FC(row, col, filters); col < width - 2; col += 2)
+        {
+          float *rgb = &out[4 * (width * row + col)];
+          const int d = 2 - c;
+          const float dL = 1.0f / (1.0f + fabsf(rgb[d - c2] - rgb[d]) + fabsf(rgb[1 + c1] - rgb[1 - c1]));
+          const float dR = 1.0f / (1.0f + fabsf(rgb[d + c2] - rgb[d]) + fabsf(rgb[1 + c1] - rgb[1 - c1]));
+          const float dU = 1.0f / (1.0f + fabsf(rgb[d - r2] - rgb[d]) + fabsf(rgb[1 + r1] - rgb[1 - r1]));
+          const float dD = 1.0f / (1.0f + fabsf(rgb[d + r2] - rgb[d]) + fabsf(rgb[1 + r1] - rgb[1 - r1]));
+          const float v0 = (rgb[1] + magic - ((rgb[1 - c1] - rgb[c - c1]) * dL + (rgb[1 + c1] - rgb[c + c1]) * dR + (rgb[1 - r1] - rgb[c - r1]) * dU + (rgb[1 + r1] - rgb[c + r1]) * dD ) / (dL + dR + dU + dD));
+          rgb[c] = fmaxf(0.0f, v0);
+        }
+      }
+    }
+  }
+}
+#undef c1
+#undef c2
+
+#ifdef _OPENMP
+  #pragma omp declare simd aligned(in, out, gamma_in, gamma_out)
+#endif
+static void lmmse_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict out, const float *const restrict in, dt_iop_roi_t *const roi_out,
+                                   const dt_iop_roi_t *const roi_in, const uint32_t filters, const uint32_t mode, float *const restrict gamma_in, float *const restrict gamma_out)
+{
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+
+  if((width < 16) || (height < 16))
+  {
+    dt_control_log(_("[lmmse_demosaic] too small area"));
+    return;
+  }
+  const int grp_height = height + 2 * BORDER_AROUND;
+  const int grp_width = width + 2 * BORDER_AROUND;
+  const int w1 = grp_width;
+  const int w2 = 2 * w1;
+  const int w3 = 3 * w1;
+  const int w4 = 4 * w1;
+
+  float h0 = 1.0f;
+  float h1 = expf( -1.0f / 8.0f);
+  float h2 = expf( -4.0f / 8.0f);
+  float h3 = expf( -9.0f / 8.0f);
+  float h4 = expf(-16.0f / 8.0f);
+  float hs = h0 + 2.0f * (h1 + h2 + h3 + h4);
+  h0 /= hs;
+  h1 /= hs;
+  h2 /= hs;
+  h3 /= hs;
+  h4 /= hs;
+
+  // median filter iterations
+  int iter = (mode < 2) ? mode : 3;
+  // refinement steps
+  const gboolean refine = mode > 2;
+ 
+  float *rix[5];
+  float *qix[5];
+  float *buffer = dt_alloc_align_float(grp_height * grp_width * 5);
+
+  if(!buffer)
+  {
+    dt_free_align(buffer);
+    dt_control_log(_("[lmmse_demosaic] can't allocate buffer"));
+    fprintf(stderr, "[lmmse_demosaic] can't allocate buffer\n");
+    return;
+  }
+
+  qix[0] = buffer;
+  for(int i = 1; i < 5; i++)
+  {
+    qix[i] = qix[i - 1] + grp_height * grp_width;
+  }
+
+  memset(buffer, 0, sizeof(float) * grp_height * grp_width * 5);
+
+  const float scaler = fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+  const float revscaler = 1.0f / scaler;
+
+#ifdef _OPENMP
+    #pragma omp parallel private(rix)
+#endif
+  {
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+    for(int rrr = BORDER_AROUND; rrr < grp_height - BORDER_AROUND; rrr++)
+    {
+      for(int ccc = BORDER_AROUND, row = rrr - BORDER_AROUND; ccc < grp_width - BORDER_AROUND; ccc++)
+      {
+        float *rix0 = qix[4] + rrr * grp_width + ccc;
+        rix0[0] = calc_gamma(revscaler * in[row * width + ccc - BORDER_AROUND], gamma_in);
+      }
+    }
+
+    // G-R(B)
+#ifdef _OPENMP
+    #pragma omp for schedule(dynamic,16)
+#endif
+    for(int rr = 2; rr < grp_height - 2; rr++)
+    {
+      // G-R(B) at R(B) location
+      for(int cc = 2 + (FC(rr, 2, filters) & 1); cc < grp_width - 2; cc += 2)
+      {
+        rix[4] = qix[4] + rr * grp_width + cc;
+        float v0 = 0.0625f * (rix[4][-w1 - 1] + rix[4][-w1 + 1] + rix[4][w1 - 1] + rix[4][w1 + 1]) + 0.25f * rix[4][0];
+        // horizontal
+        rix[0] = qix[0] + rr * grp_width + cc;
+        rix[0][0] = -0.25f * (rix[4][ -2] + rix[4][ 2]) + 0.5f * (rix[4][ -1] + rix[4][0] + rix[4][ 1]);
+        float Y = v0 + 0.5f * rix[0][0];
+
+        rix[0][0] = (rix[4][0] > 1.75f * Y) ? median3f(rix[0][0], rix[4][ -1], rix[4][ 1]) : limf(rix[0][0], 0.0f, 1.0f);
+        rix[0][0] -= rix[4][0];
+        // vertical
+        rix[1] = qix[1] + rr * grp_width + cc;
+        rix[1][0] = -0.25f * (rix[4][-w2] + rix[4][w2]) + 0.5f * (rix[4][-w1] + rix[4][0] + rix[4][w1]);
+        Y = v0 + 0.5f * rix[1][0];
+
+        rix[1][0] = (rix[4][0] > 1.75f * Y) ? median3f(rix[1][0], rix[4][-w1], rix[4][w1]) : limf(rix[1][0], 0.0f, 1.0f);
+        rix[1][0] -= rix[4][0];
+      }
+
+      // G-R(B) at G location
+      for(int ccc = 2 + (FC(rr, 3, filters) & 1); ccc < grp_width - 2; ccc += 2)
+      {
+        rix[0] = qix[0] + rr * grp_width + ccc;
+        rix[1] = qix[1] + rr * grp_width + ccc;
+        rix[4] = qix[4] + rr * grp_width + ccc;
+        rix[0][0] = 0.25f * (rix[4][ -2] + rix[4][ 2]) - 0.5f * (rix[4][ -1] + rix[4][0] + rix[4][ 1]);
+        rix[1][0] = 0.25f * (rix[4][-w2] + rix[4][w2]) - 0.5f * (rix[4][-w1] + rix[4][0] + rix[4][w1]);
+        rix[0][0] = limf(rix[0][0], -1.0f, 0.0f) + rix[4][0];
+        rix[1][0] = limf(rix[1][0], -1.0f, 0.0f) + rix[4][0];
+      }
+    }
+
+    // apply low pass filter on differential colors
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+    for (int rr = 4; rr < grp_height - 4; rr++)
+    {
+      for(int cc = 4; cc < grp_width - 4; cc++)
+      {
+        rix[0] = qix[0] + rr * grp_width + cc;
+        rix[2] = qix[2] + rr * grp_width + cc;
+        rix[2][0] = h0 * rix[0][0] + h1 * (rix[0][ -1] + rix[0][ 1]) + h2 * (rix[0][ -2] + rix[0][ 2]) + h3 * (rix[0][ -3] + rix[0][ 3]) + h4 * (rix[0][ -4] + rix[0][ 4]);
+        rix[1] = qix[1] + rr * grp_width + cc;
+        rix[3] = qix[3] + rr * grp_width + cc;
+        rix[3][0] = h0 * rix[1][0] + h1 * (rix[1][-w1] + rix[1][w1]) + h2 * (rix[1][-w2] + rix[1][w2]) + h3 * (rix[1][-w3] + rix[1][w3]) + h4 * (rix[1][-w4] + rix[1][w4]);
+      }
+    }
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+    for(int rr = 4; rr < grp_height - 4; rr++)
+    {
+      for(int cc = 4 + (FC(rr, 4, filters) & 1); cc < grp_width - 4; cc += 2)
+      {
+        rix[0] = qix[0] + rr * grp_width + cc;
+        rix[1] = qix[1] + rr * grp_width + cc;
+        rix[2] = qix[2] + rr * grp_width + cc;
+        rix[3] = qix[3] + rr * grp_width + cc;
+        rix[4] = qix[4] + rr * grp_width + cc;
+        // horizontal
+        float p1 = rix[2][-4];
+        float p2 = rix[2][-3];
+        float p3 = rix[2][-2];
+        float p4 = rix[2][-1];
+        float p5 = rix[2][ 0];
+        float p6 = rix[2][ 1];
+        float p7 = rix[2][ 2];
+        float p8 = rix[2][ 3];
+        float p9 = rix[2][ 4];
+        float mu = (p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9) / 9.0f;
+        float vx = 1e-7f + sqrf(p1 - mu) + sqrf(p2 - mu) + sqrf(p3 - mu) + sqrf(p4 - mu) + sqrf(p5 - mu) + sqrf(p6 - mu) + sqrf(p7 - mu) + sqrf(p8 - mu) + sqrf(p9 - mu);
+        p1 -= rix[0][-4];
+        p2 -= rix[0][-3];
+        p3 -= rix[0][-2];
+        p4 -= rix[0][-1];
+        p5 -= rix[0][ 0];
+        p6 -= rix[0][ 1];
+        p7 -= rix[0][ 2];
+        p8 -= rix[0][ 3];
+        p9 -= rix[0][ 4];
+        float vn = 1e-7f + sqrf(p1) + sqrf(p2) + sqrf(p3) + sqrf(p4) + sqrf(p5) + sqrf(p6) + sqrf(p7) + sqrf(p8) + sqrf(p9);
+        float xh = (rix[0][0] * vx + rix[2][0] * vn) / (vx + vn);
+        float vh = vx * vn / (vx + vn);
+
+        // vertical
+        p1 = rix[3][-w4];
+        p2 = rix[3][-w3];
+        p3 = rix[3][-w2];
+        p4 = rix[3][-w1];
+        p5 = rix[3][  0];
+        p6 = rix[3][ w1];
+        p7 = rix[3][ w2];
+        p8 = rix[3][ w3];
+        p9 = rix[3][ w4];
+        mu = (p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9) / 9.0f;
+        vx = 1e-7f + sqrf(p1 - mu) + sqrf(p2 - mu) + sqrf(p3 - mu) + sqrf(p4 - mu) + sqrf(p5 - mu) + sqrf(p6 - mu) + sqrf(p7 - mu) + sqrf(p8 - mu) + sqrf(p9 - mu);
+        p1 -= rix[1][-w4];
+        p2 -= rix[1][-w3];
+        p3 -= rix[1][-w2];
+        p4 -= rix[1][-w1];
+        p5 -= rix[1][  0];
+        p6 -= rix[1][ w1];
+        p7 -= rix[1][ w2];
+        p8 -= rix[1][ w3];
+        p9 -= rix[1][ w4];
+        vn = 1e-7f + sqrf(p1) + sqrf(p2) + sqrf(p3) + sqrf(p4) + sqrf(p5) + sqrf(p6) + sqrf(p7) + sqrf(p8) + sqrf(p9);
+        float xv = (rix[1][0] * vx + rix[3][0] * vn) / (vx + vn);
+        float vv = vx * vn / (vx + vn);
+        // interpolated G-R(B)
+        rix[4][0] = (xh * vv + xv * vh) / (vh + vv);
+      }
+    }
+
+    // copy CFA values
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+    for(int rr = 0; rr < grp_height; rr++)
+    {
+      for(int cc = 0, row_in = rr - BORDER_AROUND, col_in = cc - BORDER_AROUND; cc < grp_width; cc++, col_in++)
+      {
+        const int c = FC(rr, cc, filters);
+        rix[c] = qix[c] + rr * grp_width + cc;
+
+        rix[c][0] = ((row_in >= 0) && (row_in < height) && (col_in >= 0) && (col_in < width)) ? calc_gamma(revscaler * in[row_in * width + col_in], gamma_in) : 0.0f;
+
+        if(c != 1)
+        {
+          rix[1] = qix[1] + rr * grp_width + cc;
+          rix[4] = qix[4] + rr * grp_width + cc;
+          rix[1][0] = rix[c][0] + rix[4][0];
+        }
+      }
+    }
+
+    // bilinear interpolation for R/B
+    // interpolate R/B at G location
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+    for(int rr = 1; rr < grp_height - 1; rr++)
+    {
+      for(int cc = 1 + (FC(rr, 2, filters) & 1), c = FC(rr, cc + 1, filters); cc < grp_width - 1; cc += 2)
+      {
+        rix[c] = qix[c] + rr * grp_width + cc;
+        rix[1] = qix[1] + rr * grp_width + cc;
+        rix[c][0] = rix[1][0] + 0.5f * (rix[c][ -1] - rix[1][ -1] + rix[c][ 1] - rix[1][ 1]);
+        c = 2 - c;
+        rix[c] = qix[c] + rr * grp_width + cc;
+        rix[c][0] = rix[1][0] + 0.5f * (rix[c][-w1] - rix[1][-w1] + rix[c][w1] - rix[1][w1]);
+        c = 2 - c;
+      }
+    }
+
+    // interpolate R/B at B/R location
+#ifdef _OPENMP
+    #pragma omp for
+#endif
+    for(int rr = 1; rr < grp_height - 1; rr++)
+    {
+      for(int cc = 1 + (FC(rr, 1, filters) & 1), c = 2 - FC(rr, cc, filters); cc < grp_width - 1; cc += 2)
+      {
+        rix[c] = qix[c] + rr * grp_width + cc;
+        rix[1] = qix[1] + rr * grp_width + cc;
+        rix[c][0] = rix[1][0] + 0.25f * (rix[c][-w1] - rix[1][-w1] + rix[c][ -1] - rix[1][ -1] + rix[c][  1] - rix[1][  1] + rix[c][ w1] - rix[1][ w1]);
+      }
+    }
+  } // End of parallelization 1
+
+  // median filter/
+  for(int pass = 0; pass < iter; pass++)
+  {
+    // Apply 3x3 median filter
+    // Compute median(R-G) and median(B-G)
+#ifdef _OPENMP
+    #pragma omp parallel for private(rix)
+#endif
+    for(int rr = 1; rr < grp_height - 1; rr++)
+    {
+      for(int c = 0; c < 3; c += 2)
+      {
+        const int d = c + 3 - (c == 0 ? 0 : 1);
+        for(int cc = 1; cc < grp_width - 1; cc++)
+        {
+          rix[d] = qix[d] + rr * grp_width + cc;
+          rix[c] = qix[c] + rr * grp_width + cc;
+          rix[1] = qix[1] + rr * grp_width + cc;
+          // Assign 3x3 differential color values
+          rix[d][0] = median9f(rix[c][-w1-1] - rix[1][-w1-1], rix[c][-w1  ] - rix[1][-w1  ], rix[c][-w1+1] - rix[1][-w1+1],
+                               rix[c][   -1] - rix[1][   -1], rix[c][    0] - rix[1][    0], rix[c][    1] - rix[1][    1],
+                               rix[c][ w1-1] - rix[1][ w1-1], rix[c][ w1  ] - rix[1][ w1  ], rix[c][ w1+1] - rix[1][ w1+1]);
+        }
+      }
+    }
+
+    // red/blue at GREEN pixel locations & red/blue and green at BLUE/RED pixel locations
+#ifdef _OPENMP
+    #pragma omp parallel for private (rix)
+#endif
+    for(int rr = 0; rr < grp_height; rr++)
+    {
+      rix[0] = qix[0] + rr * grp_width;
+      rix[1] = qix[1] + rr * grp_width;
+      rix[2] = qix[2] + rr * grp_width;
+      rix[3] = qix[3] + rr * grp_width;
+      rix[4] = qix[4] + rr * grp_width;
+      int c0 = FC(rr, 0, filters);
+      int c1 = FC(rr, 1, filters);
+
+      if(c0 == 1)
+      {
+        c1 = 2 - c1;
+        const int d = c1 + 3 - (c1 == 0 ? 0 : 1);
+        int cc;
+
+        for(cc = 0; cc < grp_width - 1; cc += 2)
+        {
+          rix[0][0] = rix[1][0] + rix[3][0];
+          rix[2][0] = rix[1][0] + rix[4][0];
+          rix[0]++;
+          rix[1]++;
+          rix[2]++;
+          rix[3]++;
+          rix[4]++;
+          rix[c1][0] = rix[1][0] + rix[d][0];
+          rix[1][0] = 0.5f * (rix[0][0] - rix[3][0] + rix[2][0] - rix[4][0]);
+          rix[0]++;
+          rix[1]++;
+          rix[2]++;
+          rix[3]++;
+          rix[4]++;
+        }
+
+        if(cc < grp_width)
+        { // remaining pixel, only if width is odd
+          rix[0][0] = rix[1][0] + rix[3][0];
+          rix[2][0] = rix[1][0] + rix[4][0];
+        }
+      }
+      else
+      {
+        c0 = 2 - c0;
+        const int d = c0 + 3 - (c0 == 0 ? 0 : 1);
+        int cc;
+
+        for(cc = 0; cc < grp_width - 1; cc += 2)
+        {
+          rix[c0][0] = rix[1][0] + rix[d][0];
+          rix[1][0] = 0.5f * (rix[0][0] - rix[3][0] + rix[2][0] - rix[4][0]);
+          rix[0]++;
+          rix[1]++;
+          rix[2]++;
+          rix[3]++;
+          rix[4]++;
+          rix[0][0] = rix[1][0] + rix[3][0];
+          rix[2][0] = rix[1][0] + rix[4][0];
+          rix[0]++;
+          rix[1]++;
+          rix[2]++;
+          rix[3]++;
+          rix[4]++;
+        }
+
+        if(cc < grp_width)
+        { // remaining pixel, only if width is odd
+          rix[c0][0] = rix[1][0] + rix[d][0];
+          rix[1][0] = 0.5f * (rix[0][0] - rix[3][0] + rix[2][0] - rix[4][0]);
+        }
+      }
+    }
+  }
+
+  // write result to out
+#ifdef _OPENMP
+  #pragma omp parallel for
+#endif
+  for(int row = 0; row < height; row++)
+  {
+    for(int col = 0, rr = row + BORDER_AROUND; col < width; col++)
+    {
+      const int cc = col + BORDER_AROUND;
+      const int c = FC(row, col, filters);
+      const int oidx = 4 * (row * width + col);
+      for(int i = 0; i < 3; i++)
+      {
+        if(i != c)
+        {
+          float *rix0 = qix[i] + rr * grp_width + cc;
+          out[oidx + i] = fmaxf(0.0f, scaler * calc_gamma(rix0[0], gamma_out));
+        }
+        else
+        {
+          out[oidx + i] = fmaxf(0.0f, in[row * width + col]);
+        }
+      }
+      out[oidx + 3] = 0.0f;
+    }
+  }
+
+  if(refine)
+  {
+    refinement(width, height, out, filters, scaler);
+  }
+
+  dt_free_align(buffer);
+}
+
+// revert specific aggressive optimizing
+#ifdef __GNUC__
+  #pragma GCC pop_options
+#endif
+
+#undef LMMSE_TILESIZE
+#undef LMMSE_OVERLAP
+#undef BORDER_AROUND
+#undef LMMSE_TILEVALID
+


### PR DESCRIPTION
[last edit 21/07/01]

Currently we clearly miss a demosaicer better suited for high ISO / noisy images.

There are a number of papers analysing image quality and S/N ratios, LMMSE is one of the algorithms with good results and a performance suited for realtime use as we require for dt.

LMMSE also handles raw moire patterns much better than PPG, RCD or AMaZE

The code for this dt adaption has been taken from rawtherapee/librtprocess, the algorithm is unchanged as i took that as the reference but has been tuned for performance quite a lot.

- no SSE specific code path. We can make sure for finite math in all sections of the code and thus can make use of aggressive compiler flags resulting in almost identical performance.
- the gamma correction is always used.
- internal tiling has been implemented for reduced memory footprint and thus improved performance as most data is kept in cpu cache.
- the original code used a lot of indirect pointers, this has been changed also for performance
- no OpenCL code yet. I am not sure if it's worth the effort as lmmse is likely not for general use ...
 

The performance is good now, for LMMSE default settings it is >2 times faster than AMaZE and just 70% of RCD cpu code.