### PR TITLE
MacOS: remap Control bit to Cmd for key accelerators

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -393,19 +393,29 @@ static inline void dt_unlock_image_pair(int32_t imgid1, int32_t imgid2) RELEASE(
   dt_pthread_mutex_unlock(&(darktable.db_image[imgid2 & (DT_IMAGE_DBLOCKS-1)]));
 }
 
+// on Macs, remap the GDK_CONTROL_MASK bit in the given modifier mask to be the bit for the Cmd key
+static inline const GdkModifierType dt_map_ctrl_bit_to_cmd(const GdkModifierType mask)
+{
+  if (mask & GDK_CONTROL_MASK)
+  {
+    GdkModifierType primary = gdk_keymap_get_modifier_mask(gdk_keymap_get_for_display(gdk_display_get_default()),
+                                                           GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR);
+    return (GdkModifierType)((mask & ~GDK_CONTROL_MASK) | primary);
+  }
+  return mask;
+}
+
 // check whether the specified mask of modifier keys exactly matches, among the set Shift+Control+(Alt/Meta).
-// ignores the state of any other shifting keys
+// ignores the state of any other shifting keys.
 static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
 {
   const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-//TODO: on Macs, remap the GDK_CONTROL_MASK bit in desired_modifier_mask to be the bit for the Cmd key
   return (state & modifiers) == desired_modifier_mask;
 }
 
 // check whether the given modifier state includes AT LEAST the specified mask of modifier keys
 static inline gboolean dt_modifiers_include(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
 {
-//TODO: on Macs, remap the GDK_CONTROL_MASK bit in desired_modifier_mask to be the bit for the Cmd key
   const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
   // check whether all modifier bits of interest are turned on
   return (state & (modifiers & desired_modifier_mask)) == desired_modifier_mask;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -882,9 +882,9 @@ static gboolean _event_grouping_release(GtkWidget *widget, GdkEventButton *event
   if(event->button == 1 && !thumb->moved)
   {
     //TODO: will succeed if either or *both* of Shift and Control are pressed.  Do we want this?
-    if(event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) // just add the whole group to the selection. TODO:
-                                                           // make this also work for collapsed groups.
+    if(dt_modifier_is(event->state, GDK_SHIFT_MASK) | dt_modifier_is(event->state, GDK_CONTROL_MASK))
     {
+      // just add the whole group to the selection. TODO: make this also work for collapsed groups.
       sqlite3_stmt *stmt;
       DT_DEBUG_SQLITE3_PREPARE_V2(
           dt_database_get(darktable.db),

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -157,7 +157,7 @@ void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierTyp
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
 
   dt_accel_path_global(accel_path, sizeof(accel_path), path);
-  gtk_accel_map_add_entry(accel_path, accel_key, mods);
+  gtk_accel_map_add_entry(accel_path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
 
   g_strlcpy(accel->path, accel_path, sizeof(accel->path));
   dt_accel_path_global_translated(accel_path, sizeof(accel_path), path);
@@ -175,7 +175,7 @@ void dt_accel_register_view(dt_view_t *self, const gchar *path, guint accel_key,
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
 
   dt_accel_path_view(accel_path, sizeof(accel_path), self->module_name, path);
-  gtk_accel_map_add_entry(accel_path, accel_key, mods);
+  gtk_accel_map_add_entry(accel_path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
 
   g_strlcpy(accel->path, accel_path, sizeof(accel->path));
   dt_accel_path_view_translated(accel_path, sizeof(accel_path), self, path);
@@ -193,7 +193,7 @@ void dt_accel_register_iop(dt_iop_module_so_t *so, gboolean local, const gchar *
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
 
   dt_accel_path_iop(accel->path, sizeof(accel->path), so->op, path);
-  gtk_accel_map_add_entry(accel->path, accel_key, mods);
+  gtk_accel_map_add_entry(accel->path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
   dt_accel_path_iop_translated(accel->translated_path, sizeof(accel->translated_path), so, path);
 
   g_strlcpy(accel->module, so->op, sizeof(accel->module));
@@ -210,7 +210,7 @@ void dt_accel_register_lib_as_view(gchar *view_name, const gchar *path, guint ac
   if (dt_accel_find_by_path(accel_path)) return; // return if nothing to add, to avoid multiple entries
 
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
-  gtk_accel_map_add_entry(accel_path, accel_key, mods);
+  gtk_accel_map_add_entry(accel_path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
   g_strlcpy(accel->path, accel_path, sizeof(accel->path));
 
   snprintf(accel_path, sizeof(accel_path), "<Darktable>/%s/%s/%s", C_("accel", "views"),
@@ -247,7 +247,7 @@ void dt_accel_register_lib_for_views(dt_lib_module_t *self, dt_view_type_flags_t
 
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
 
-  gtk_accel_map_add_entry(accel_path, accel_key, mods);
+  gtk_accel_map_add_entry(accel_path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
   g_strlcpy(accel->path, accel_path, sizeof(accel->path));
   dt_accel_path_lib_translated(accel_path, sizeof(accel_path), self, path);
   g_strlcpy(accel->translated_path, accel_path, sizeof(accel->translated_path));
@@ -351,7 +351,7 @@ void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType m
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
 
   dt_accel_path_lua(accel_path, sizeof(accel_path), path);
-  gtk_accel_map_add_entry(accel_path, accel_key, mods);
+  gtk_accel_map_add_entry(accel_path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
 
   g_strlcpy(accel->path, accel_path, sizeof(accel->path));
   dt_accel_path_lua_translated(accel_path, sizeof(accel_path), path);
@@ -370,7 +370,7 @@ void dt_accel_register_manual(const gchar *full_path, dt_view_type_flags_t views
   dt_accel_t *accel = (dt_accel_t *)g_malloc0(sizeof(dt_accel_t));
 
   dt_accel_path_manual(accel_path, sizeof(accel_path), full_path);
-  gtk_accel_map_add_entry(accel_path, accel_key, mods);
+  gtk_accel_map_add_entry(accel_path, accel_key, dt_map_ctrl_bit_to_cmd(mods));
 
   g_strlcpy(accel->path, accel_path, sizeof(accel->path));
   dt_accel_path_manual_translated(accel_path, sizeof(accel_path), full_path);

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -537,7 +537,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       {
         dt_bauhaus_slider_set(g->scale, new_scale);
 
-        if(which != GDK_CONTROL_MASK)
+        if(!dt_modifier_is(which, GDK_CONTROL_MASK))
         {
           float new_whratio = 2.0 - 1.0 / ratio;
           dt_bauhaus_slider_set(g->whratio, new_whratio);
@@ -569,7 +569,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
         const float new_scale = 100.0 * new_vignette_h / max;
         dt_bauhaus_slider_set(g->scale, new_scale);
 
-        if(which != GDK_CONTROL_MASK)
+        if(!dt_modifier_is(which, GDK_CONTROL_MASK))
         {
           const float new_whratio = 1.0 / ratio;
           dt_bauhaus_slider_set(g->whratio, new_whratio);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -269,7 +269,7 @@ static gboolean _key_pressed(GtkWidget *textview, GdkEventKey *event, dt_lib_mod
       case GDK_KEY_Return:
       case GDK_KEY_KP_Enter:
         // insert new line
-        event->state &= ~GDK_CONTROL_MASK;  //TODO: on Mac, remap Ctrl to Cmd key
+        event->state &= ~GDK_CONTROL_MASK;
       default:
         d->editing = TRUE;
     }


### PR DESCRIPTION
May fix #4384.  Will work for mouse actions including mask drawing even if #8078 does not.  I'll need someone with a Mac to test, as I've gone solely by what I could find in the Gdk documentation (at https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkModifierIntent)

For 3.8, since this would require documentation changes.
