### PR TITLE
variables.c: add substitutable variables for image dimensions

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -44,6 +44,10 @@ typedef struct dt_variables_data_t
   /* export settings for image maximum width and height taken from GUI */
   int max_width;
   int max_height;
+  int sensor_width;
+  int sensor_height;
+  int export_width;
+  int export_height;
 
   char *homedir;
   char *pictures_folder;
@@ -141,6 +145,13 @@ static void init_expansion(dt_variables_params_t *params, gboolean iterate)
     if(!isnan(img->geoloc.elevation)) params->data->elevation = img->geoloc.elevation;
 
     params->data->flags = img->flags;
+
+    params->data->max_height = img->p_height;
+    params->data->max_width = img->p_width;
+    params->data->sensor_height = img->height;
+    params->data->sensor_width = img->width;
+    params->data->export_height = img->final_height;
+    params->data->export_width = img->final_width;
 
     if(params->img == NULL) dt_image_cache_read_release(darktable.image_cache, img);
   }
@@ -468,6 +479,14 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup_printf("%d", params->data->max_width);
   else if(has_prefix(variable, "MAX_HEIGHT"))
     result = g_strdup_printf("%d", params->data->max_height);
+  else if(has_prefix(variable, "SENSOR_WIDTH"))
+    result = g_strdup_printf("%d", params->data->sensor_width);
+  else if(has_prefix(variable, "SENSOR_HEIGHT"))
+    result = g_strdup_printf("%d", params->data->sensor_height);
+  else if(has_prefix(variable, "EXPORT_WIDTH"))
+    result = g_strdup_printf("%d", params->data->export_width);
+  else if(has_prefix(variable, "EXPORT_HEIGHT"))
+    result = g_strdup_printf("%d", params->data->export_height);
   else if (has_prefix(variable, "CATEGORY"))
   {
     // CATEGORY should be followed by n [0,9] and "(category)". category can contain 0 or more '|'


### PR DESCRIPTION
Adds $(SENSOR_HEIGHT) and $(SENSOR_WIDTH) for the absolute pixel dimensions of the sensor, implements the existing stubs for $(MAX_WIDTH) and $(MAX_HEIGHT) to represent the raw image size, and adds $(EXPORT_HEIGHT) and $(EXPORT_WIDTH) for the post-cropping final image size.

Note that there is a race condition for the export sizes when using them in the watermark module due to the evaluation of those values in the middle of the pixelpipe.  Changing cropping generally leaves the substituted value unchanged until something causes a full pixelpipe run (e.g. switch to lighttable and back), but exporting seems to reliably pick up the current value.

Fixes #8476.  Needs documentation update in `special_topics/variables` provided by https://github.com/darktable-org/dtdocs/pull/294
