### PR TITLE
don't request focus on preset apply or reset

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1857,9 +1857,6 @@ static void dt_iop_gui_reset_callback(GtkButton *button, GdkEventButton *event, 
     /* update ui to default params*/
     dt_iop_gui_update(module);
 
-    /* and give focus to the module*/
-    dt_iop_request_focus(module);
-
     dt_dev_add_history_item(module->dev, module, TRUE);
   }
 

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -917,7 +917,6 @@ static void _apply_preset(const gchar *name, dt_iop_module_t *module)
     if(!writeprotect) dt_gui_store_last_preset(name);
   }
   sqlite3_finalize(stmt);
-  dt_iop_request_focus(module);
   dt_iop_gui_update(module);
   dt_dev_add_history_item(darktable.develop, module, FALSE);
   gtk_widget_queue_draw(module->widget);


### PR DESCRIPTION
this confuse mosules which rely on gui_focus to change params like crop...
this manually revert  b8ae0cf which was here to fix issue #6090 but reading and testing the issue, I think that what happen is the correct behavior... (see my comment there)