### PR TITLE
fix wrong preset name

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -351,41 +351,41 @@ void init_presets(dt_iop_module_so_t *self)
   * in legacy channel mixer that don't even say in which RGB space they are supposed to be applied.
   */
 
-  // Ilford HP5 +
+  // ILFORD HP5 +
   // https://www.ilfordphoto.com/amfile/file/download/file/1903/product/695/
   p.grey[0] = 0.25304098f;
   p.grey[1] = 0.25958747f;
   p.grey[2] = 0.48737156f;
 
-  dt_gui_presets_add_generic(_("B&W : Ilford HP5+"), self->op,
+  dt_gui_presets_add_generic(_("B&W : ILFORD HP5+"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-  // Ilford Delta 100
+  // ILFORD Delta 100
   // https://www.ilfordphoto.com/amfile/file/download/file/3/product/681/
   p.grey[0] = 0.24552374f;
   p.grey[1] = 0.25366007f;
   p.grey[2] = 0.50081619f;
 
-  dt_gui_presets_add_generic(_("B&W : Ilford Delta 100"), self->op,
+  dt_gui_presets_add_generic(_("B&W : ILFORD DELTA 100"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-  // Ilford Delta 400 and 3200 - they have the same curve
+  // ILFORD Delta 400 and 3200 - they have the same curve
   // https://www.ilfordphoto.com/amfile/file/download/file/1915/product/685/
   // https://www.ilfordphoto.com/amfile/file/download/file/1913/product/683/
   p.grey[0] = 0.24376712f;
   p.grey[1] = 0.23613559f;
   p.grey[2] = 0.52009729f;
 
-  dt_gui_presets_add_generic(_("B&W : Ilford Delta 400 - 3200"), self->op,
+  dt_gui_presets_add_generic(_("B&W : ILFORD DELTA 400 - 3200"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-  // Ilford FP 2
+  // ILFORD FP4+
   // https://www.ilfordphoto.com/amfile/file/download/file/1919/product/690/
   p.grey[0] = 0.24149085f;
   p.grey[1] = 0.22149272f;
   p.grey[2] = 0.53701643f;
 
-  dt_gui_presets_add_generic(_("B&W : Ilford FP2"), self->op,
+  dt_gui_presets_add_generic(_("B&W : ILFORD FP4+"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Fuji Acros 100


### PR DESCRIPTION
Fix #8369

As this don't need any translation, maybe this could be added for 3.6, even if we are on string freeze? Anyway, no big deal if it's of course for 3.6.1 or 3.8 as it's a really minor issue.