### PR TITLE
use dt_modifier_is to check for Control-key pressed

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -882,9 +882,9 @@ static gboolean _event_grouping_release(GtkWidget *widget, GdkEventButton *event
   if(event->button == 1 && !thumb->moved)
   {
     //TODO: will succeed if either or *both* of Shift and Control are pressed.  Do we want this?
-    if(event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) // just add the whole group to the selection. TODO:
-                                                           // make this also work for collapsed groups.
+    if(dt_modifier_is(event->state, GDK_SHIFT_MASK) | dt_modifier_is(event->state, GDK_CONTROL_MASK))
     {
+      // just add the whole group to the selection. TODO: make this also work for collapsed groups.
       sqlite3_stmt *stmt;
       DT_DEBUG_SQLITE3_PREPARE_V2(
           dt_database_get(darktable.db),

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -537,7 +537,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       {
         dt_bauhaus_slider_set(g->scale, new_scale);
 
-        if(which != GDK_CONTROL_MASK)
+        if(!dt_modifier_is(which, GDK_CONTROL_MASK))
         {
           float new_whratio = 2.0 - 1.0 / ratio;
           dt_bauhaus_slider_set(g->whratio, new_whratio);
@@ -569,7 +569,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
         const float new_scale = 100.0 * new_vignette_h / max;
         dt_bauhaus_slider_set(g->scale, new_scale);
 
-        if(which != GDK_CONTROL_MASK)
+        if(!dt_modifier_is(which, GDK_CONTROL_MASK))
         {
           const float new_whratio = 1.0 / ratio;
           dt_bauhaus_slider_set(g->whratio, new_whratio);


### PR DESCRIPTION
This is the bug-fix portion of #9277.  Use `dt_modifier_is` to check for modifier keys so that any remapping can be done centrally.

