### PR TITLE
Check if Sony Exif tag for focus distance has valid information

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -914,11 +914,11 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     {
       const float focus_position = pos->toFloat();
 
-      if (FIND_EXIF_TAG("Exif.Photo.FocalLengthIn35mmFilm")) {
-          const float focal_length_35mm = pos->toFloat();
+      if (FIND_EXIF_TAG("Exif.Photo.FocalLengthIn35mmFilm") && focus_position) {
+        const float focal_length_35mm = pos->toFloat();
 
-          /* http://u88.n24.queensu.ca/exiftool/forum/index.php/topic,3688.msg29653.html#msg29653 */
-          img->exif_focus_distance = (pow(2, focus_position / 16 - 5) + 1) * focal_length_35mm / 1000;
+        /* http://u88.n24.queensu.ca/exiftool/forum/index.php/topic,3688.msg29653.html#msg29653 */
+        img->exif_focus_distance = (pow(2, focus_position / 16 - 5) + 1) * focal_length_35mm / 1000;
       }
     }
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -914,7 +914,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     {
       const float focus_position = pos->toFloat();
 
-      if (FIND_EXIF_TAG("Exif.Photo.FocalLengthIn35mmFilm") && focus_position) {
+      if (focus_position && FIND_EXIF_TAG("Exif.Photo.FocalLengthIn35mmFilm")) {
         const float focal_length_35mm = pos->toFloat();
 
         /* http://u88.n24.queensu.ca/exiftool/forum/index.php/topic,3688.msg29653.html#msg29653 */


### PR DESCRIPTION
Many Sony cameras does not record into Exif tag "Exif.Sony2Fp.FocusPosition2" valid information. When calculating the actual focusing distance according to the formula, we received incorrect information in this case. The value of this tag should be checked for non-zero value.

In addition, fix indent width to comply with coding style.
