### PR TITLE
Fix error font size

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -480,7 +480,7 @@ void expose(
 
     if(dev->image_invalid_cnt)
     {
-      fontsize = DT_PIXEL_APPLY_DPI(20);
+      fontsize = DT_PIXEL_APPLY_DPI(16);
       load_txt = dt_util_dstrcat(
           NULL,
           _("darktable could not load `%s', switching to lighttable now.\n\n"


### PR DESCRIPTION
Fix #9313 

This message needs to remain a little higher than other but maybe it was too big. Should be safe as a fix for 3.6!