### PR TITLE
Canonical path to env is /usr/bin/env

### DIFF
--- a/src/tests/benchmark/darktable-bench
+++ b/src/tests/benchmark/darktable-bench
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Canonical path to env in modern Linux distros and *nix-derived systems (like *BSDs and macOS) is /usr/bin/env.
In most of these systems script with /bin/env in shebang line will refuse to run with diagnostics:
`bad interpreter: No such file or directory`

