### PR TITLE
Fix typos

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1392,7 +1392,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     // Next section is to recover old edits where all modules with default parameters were not
     // recorded in the db nor in the .XMP.
     //
-    // One crutial point is the white-balance which has automatic default based on the camera
+    // One crucial point is the white-balance which has automatic default based on the camera
     // and depends on the chroma-adaptation. In modern mode the default won't be the same used
     // in legacy mode and if the white-balance is not found on the history one will be added by
     // default using current defaults. But if we are in modern chromatic adaptation the default

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -23,7 +23,7 @@
   They contain threshold weighed values of pixel-wise local signal changes so they can be
   understood as "areas with or without local detail". 
   
-  As the DM using algoritms (like dual demosaicing, sharpening ...) are all pixel peeping we
+  As the DM using algorithms (like dual demosaicing, sharpening ...) are all pixel peeping we
   want the "original data" from the sensor to calculate it.
   (Calculating the mask from the modules roi might not detect such regions at all because of
   scaling / rotating artefacts, some blurring earlier in the pipeline, color changes ...)

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -717,7 +717,7 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
     if(w) gtk_widget_set_sensitive(w, FALSE);
   }
 
-  // put focus on cancel button if 2 first entry desactivated
+  // put focus on cancel button if 2 first entries deactivated
   if(!allow_desc_change && !allow_name_change)
   {
     GtkWidget *w = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_CANCEL);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -824,7 +824,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_restore(cr);
 }
 
-// FIXME: have different drawable for each scope in a stack -- simplifies this function from being a swath of conditionals -- then esentially draw callbacks _lib_histogram_draw_waveform, _lib_histogram_draw_rgb_parade, etc.
+// FIXME: have different drawable for each scope in a stack -- simplifies this function from being a swath of conditionals -- then essentially draw callbacks _lib_histogram_draw_waveform, _lib_histogram_draw_rgb_parade, etc.
 // FIXME: if exposure change regions are separate widgets, then we could have a menu to swap in different overlay widgets (sort of like basic adjustments) to adjust other things about the image, e.g. tone equalizer, color balance, etc.
 static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -75,12 +75,12 @@ static GList* _get_custom_places();
 
 typedef enum dt_import_cols_t
 {
-  DT_IMPORT_SEL_THUMB = 0,      // active / deactive thumbnails
+  DT_IMPORT_SEL_THUMB = 0,      // active / inactive thumbnails
   DT_IMPORT_THUMB,              // thumbnail
   DT_IMPORT_UI_FILENAME,        // displayed filename
   DT_IMPORT_FILENAME,           // filename
   DT_IMPORT_UI_DATETIME,        // displayed datetime
-  DT_IMPORT_UI_EXISTS,          // wether the picture is already imported
+  DT_IMPORT_UI_EXISTS,          // whether the picture is already imported
   DT_IMPORT_DATETIME,           // file datetime
   DT_IMPORT_NUM_COLS
 } dt_import_cols_t;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -597,7 +597,7 @@ static void _main_do_event(GdkEvent *event, gpointer data)
           dt_print(DT_DEBUG_CONTROL, "[context help] opening `%s'\n", help_url);
           char *base_url = _get_base_url();
 
-          // in case of a standard release, happend the dt version to the url
+          // in case of a standard release, append the dt version to the url
           if(!dt_is_dev_version())
           {
             char *ver = dt_version_major_minor();

--- a/src/lua/widget/widget.c
+++ b/src/lua/widget/widget.c
@@ -242,7 +242,7 @@ static int visible_member(lua_State *L)
     if(value)
     {
       gtk_widget_show(widget->widget);
-      // enable gtk_widget_show_all() in case it was diabled by 
+      // enable gtk_widget_show_all() in case it was disabled by 
       // setting a widget to hidden
       gtk_widget_set_no_show_all(widget->widget, FALSE);
     }


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,./src/external,./src/common,./data/pswp -L ba,bloc,dinamic,hist,ist,inout,uint,ue,webp`