### PR TITLE
[crawler] use dt internal path normalization

### DIFF
--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -104,7 +104,7 @@ GList *dt_control_crawler_run()
 
       struct stat statbuf;
       // on Windows the encoding might not be UTF8
-      gchar *xmp_path_locale = g_locale_from_utf8(xmp_path, -1, NULL, NULL, NULL);
+      gchar *xmp_path_locale = dt_util_normalize_path(xmp_path);
       const int stat_res = stat(xmp_path_locale, &statbuf);
       g_free(xmp_path_locale);
       if(stat_res == -1) continue; // TODO: shall we report these?


### PR DESCRIPTION
Fixes #9333

The problem with `g_locale_from_utf8` is that it errors out conversion of path names on linux for some reason.

Since crawler uses paths it's natural to use dt's own internal tried and true `dt_util_normalize_path` :)

should also work on windows (with caveats of `dt_util_normalize_path` on windows, but so far nobody complained about them:) )