### PR TITLE
run import of commandline  args as background job

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -58,6 +58,7 @@
 #include "control/control.h"
 #include "control/crawler.h"
 #include "control/jobs/control_jobs.h"
+#include "control/jobs/film_jobs.h"
 #include "control/signal.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
@@ -1231,28 +1232,15 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifndef MAC_INTEGRATION
     // load image(s) specified on cmdline.
     // this has to happen after lua is initialized as image import can run lua code
-    // If only one image is listed, attempt to load it in darkroom
-    int last_id = 0;
-    gboolean only_single_images = TRUE;
-    int loaded_images = 0;
-
-    for(int i = 1; i < argc; i++)
+    if (argc == 2)
     {
-      gboolean single_image = FALSE;
-      if(argv[i] == NULL || *argv[i] == '\0') continue;
-      int new_id = dt_load_from_string(argv[i], FALSE, &single_image);
-      if(new_id > 0)
-      {
-        last_id = new_id;
-        loaded_images++;
-        if(!single_image) only_single_images = FALSE;
-      }
+      // If only one image is listed, attempt to load it in darkroom
+      (void)dt_load_from_string(argv[1], TRUE, NULL);
     }
-
-    if(loaded_images == 1 && only_single_images)
+    else
     {
-      dt_control_set_mouse_over_id(last_id);
-      dt_ctl_switch_mode_to("darkroom");
+      // when multiple names are given, fire up a background job to import them
+      dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_BG, dt_pathlist_import_create(argc,argv));
     }
 #endif
   }

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -83,7 +83,7 @@ static int32_t _pathlist_import_run(dt_job_t *job)
 {
   dt_film_import1_t *params = dt_control_job_get_params(job);
   _film_import1(job, NULL, params->imagelist); // import the specified images, creating filmrolls as needed
-  g_list_free_full(params->imagelist, g_free);
+  params->imagelist = NULL;  // the import will have freed the image list
 
   // notify the user via the window manager
   dt_ui_notify_user();
@@ -93,7 +93,6 @@ static int32_t _pathlist_import_run(dt_job_t *job)
 static void _pathlist_import_cleanup(void *p)
 {
   dt_film_import1_t *params = p;
-  g_list_free_full(params->imagelist, g_free);
   free(params);
 }
 
@@ -359,7 +358,7 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
   dt_control_queue_redraw_center();
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, film->id);
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, film ? film->id : cfr->id);
 
   //QUESTION: should this come after _apply_filmroll_gpx, since that can change geotags again?
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, all_imgs, 0);

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -231,7 +231,7 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
   // first, gather all images to import if not already given
   if (!images)
   {
-    gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
+    const gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
 
     images = _film_recursive_get_files(film->dirname, recursive, &images);
     if(images == NULL)

--- a/src/control/jobs/film_jobs.h
+++ b/src/control/jobs/film_jobs.h
@@ -23,6 +23,7 @@
 #include <inttypes.h>
 
 dt_job_t *dt_film_import1_create(dt_film_t *film);
+dt_job_t *dt_pathlist_import_create(int argc, char *argv[]);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
When a large number of paths are given on the commandline, it can take a while to import them.  This patch moves the import into a background job when multiple paths are specified, so that the UI can display immediately without having to wait for the imports to complete.

If only a single file is specified on the command line, it is imported synchronously and dt switches to darkroom mode just as before.  Multiple args are assumed to result in multiple files imported, so dt stays in lighttable mode.

If the user quits dt while the import is still in progress, the import completes before dt actually exits (the UI closes immediately).  The user should be warned not to kill the remaining process or try to restart dt until it finishes.

Fixes #5799.
