### PR TITLE
refactor: encapsulate getting/setting folders in preferences

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -133,6 +133,12 @@ void dt_conf_set_string(const char *name, const char *val)
   if(dt_conf_set_if_not_overridden(name, str)) g_free(str);
 }
 
+void dt_conf_set_folder_from_file_chooser(const char *name, GtkWidget *chooser)
+{
+  gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(chooser));
+  if(dt_conf_set_if_not_overridden(name, folder)) g_free(folder);
+}
+
 int dt_conf_get_int_fast(const char *name)
 {
   const char *str = dt_conf_get_var(name);

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -305,6 +305,18 @@ gchar *dt_conf_get_string(const char *name)
   return g_strdup(str);
 }
 
+gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser)
+{
+  gchar *folder = dt_conf_get_string(name);
+  if (folder)
+  {
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser),folder);
+    g_free(folder);
+    return TRUE;
+  }
+  return FALSE;
+}
+
 gboolean dt_conf_is_equal(const char *name, const char *value)
 {
   const char *str = dt_conf_get_var(name);

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -89,6 +89,7 @@ int64_t dt_conf_get_and_sanitize_int64(const char *name, int64_t min, int64_t ma
 float dt_conf_get_and_sanitize_float(const char *name, float min, float max);
 int dt_conf_get_bool(const char *name);
 gchar *dt_conf_get_string(const char *name);
+gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser);
 gboolean dt_conf_is_equal(const char *name, const char *value);
 void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries);
 void dt_conf_cleanup(dt_conf_t *cf);

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -25,6 +25,7 @@
 #include "common/dtpthread.h"
 
 #include <glib.h>
+#include <gtk/gtk.h>
 #include <inttypes.h>
 
 typedef enum dt_confgen_type_t
@@ -76,6 +77,7 @@ void dt_conf_set_int64(const char *name, int64_t val);
 void dt_conf_set_float(const char *name, float val);
 void dt_conf_set_bool(const char *name, int val);
 void dt_conf_set_string(const char *name, const char *val);
+void dt_conf_set_folder_from_file_chooser(const char *name, GtkWidget *chooser);
 int dt_conf_get_int_fast(const char *name);
 int dt_conf_get_int(const char *name);
 int64_t dt_conf_get_int64_fast(const char *name);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1690,9 +1690,7 @@ void dt_control_move_images()
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/copymove_path", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/copymove_path", filechooser);
   }
   gtk_widget_destroy(filechooser);
 
@@ -1763,9 +1761,7 @@ void dt_control_copy_images()
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/copymove_path", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/copymove_path", filechooser);
   }
   gtk_widget_destroy(filechooser);
 

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1679,13 +1679,7 @@ void dt_control_move_images()
   dt_osx_disallow_fullscreen(filechooser);
 #endif
 
-  gchar *copymove_path = dt_conf_get_string("ui_last/copymove_path");
-  if(copymove_path != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), copymove_path);
-    g_free(copymove_path);
-  }
-
+  dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", filechooser);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
@@ -1750,13 +1744,7 @@ void dt_control_copy_images()
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  gchar *copymove_path = dt_conf_get_string("ui_last/copymove_path");
-  if(copymove_path != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), copymove_path);
-    g_free(copymove_path);
-  }
-
+  dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", filechooser);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1011,12 +1011,7 @@ static void import_export(GtkButton *button, gpointer data)
     dt_osx_disallow_fullscreen(chooser);
 #endif
     gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
-    gchar *exported_path = dt_conf_get_string("ui_last/export_path");
-    if(exported_path != NULL)
-    {
-      gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), exported_path);
-      g_free(exported_path);
-    }
+    dt_conf_get_folder_to_file_chooser("ui_last/export_path", chooser);
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "keyboardrc");
     if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
     {
@@ -1037,12 +1032,7 @@ static void import_export(GtkButton *button, gpointer data)
     dt_osx_disallow_fullscreen(chooser);
 #endif
 
-    gchar *import_path = dt_conf_get_string("ui_last/import_path");
-    if(import_path != NULL)
-    {
-      gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), import_path);
-      g_free(import_path);
-    }
+    dt_conf_get_folder_to_file_chooser("ui_last/import_path", chooser);
     if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
     {
       gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
@@ -1126,12 +1116,7 @@ static void import_preset(GtkButton *button, gpointer data)
   dt_osx_disallow_fullscreen(chooser);
 #endif
 
-  gchar *import_path = dt_conf_get_string("ui_last/import_path");
-  if(import_path != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), import_path);
-    g_free(import_path);
-  }
+  dt_conf_get_folder_to_file_chooser("ui_last/import_path", chooser);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(chooser), TRUE);
 
   GtkFileFilter *filter;
@@ -1171,12 +1156,7 @@ static void export_preset(GtkButton *button, gpointer data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  gchar *import_path = dt_conf_get_string("ui_last/export_path");
-  if(import_path != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), import_path);
-    g_free(import_path);
-  }
+  dt_conf_get_folder_to_file_chooser("ui_last/export_path", filechooser);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1023,9 +1023,7 @@ static void import_export(GtkButton *button, gpointer data)
       gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
       gtk_accel_map_save(filename);
       g_free(filename);
-      gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(chooser));
-      dt_conf_set_string("ui_last/export_path", folder);
-      g_free(folder);
+      dt_conf_set_folder_from_file_chooser("ui_last/export_path", chooser);
     }
     gtk_widget_destroy(chooser);
   }
@@ -1058,9 +1056,7 @@ static void import_export(GtkButton *button, gpointer data)
         snprintf(accelpath, sizeof(accelpath), "%s/keyboardrc", confdir);
         gtk_accel_map_save(accelpath);
 
-        gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(chooser));
-        dt_conf_set_string("ui_last/import_path", folder);
-        g_free(folder);
+        dt_conf_set_folder_from_file_chooser("ui_last/import_path", chooser);
       }
       g_free(filename);
     }
@@ -1161,9 +1157,7 @@ static void import_preset(GtkButton *button, gpointer data)
     gtk_tree_store_clear(tree_store);
     tree_insert_presets(tree_store);
 
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(chooser));
-    dt_conf_set_string("ui_last/import_path", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/import_path", chooser);
   }
   gtk_widget_destroy(chooser);
 }
@@ -1213,9 +1207,7 @@ static void export_preset(GtkButton *button, gpointer data)
 
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "END TRANSACTION", NULL, NULL, NULL);
 
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/export_path", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/export_path", filechooser);
 
     g_free(filedir);
   }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -368,12 +368,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(filechooser);
 #endif
-    gchar *import_path = dt_conf_get_string("ui_last/export_path");
-    if(import_path != NULL)
-    {
-      gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), import_path);
-      g_free(import_path);
-    }
+    dt_conf_get_folder_to_file_chooser("ui_last/export_path", filechooser);
 
     // save if accepted
     if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -382,9 +382,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
       dt_presets_save_to_file(g->old_id, name, filedir);
       dt_control_log(_("preset %s was successfully exported"), name);
       g_free(filedir);
-      gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-      dt_conf_set_string("ui_last/export_path", folder);
-      g_free(folder);
+      dt_conf_set_folder_from_file_chooser("ui_last/export_path", filechooser);
     }
 
     gtk_widget_destroy(GTK_WIDGET(filechooser));

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -182,9 +182,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     if(act_on_any)
     {
       //remember last import path if applying history to multiple images
-      gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-      dt_conf_set_string("ui_last/import_path", folder);
-      g_free(folder);
+      dt_conf_set_folder_from_file_chooser("ui_last/import_path", filechooser);
     }
     g_free(dtfilename);
   }

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -125,24 +125,14 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     {
       // handle situation where there's some problem with cache/film_id
       // i guess that's impossible, but better safe than sorry ;)
-      gchar *import_path = dt_conf_get_string("ui_last/import_path");
-      if(import_path != NULL)
-      {
-        gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), import_path);
-        g_free(import_path);
-      }
+      dt_conf_get_folder_to_file_chooser("ui_last/import_path", filechooser);
     }
     dt_image_cache_read_release(darktable.image_cache, img);
   }
   else
   {
     // multiple images, use "last import" preference
-    gchar *import_path = dt_conf_get_string("ui_last/import_path");
-    if(import_path != NULL)
-    {
-      gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), import_path);
-      g_free(import_path);
-    }
+    dt_conf_get_folder_to_file_chooser("ui_last/import_path", filechooser);
   }
 
   GtkFileFilter *filter;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -968,9 +968,7 @@ static void _choose_gpx_callback(GtkWidget *widget, dt_lib_module_t *self)
   }
   if(res == GTK_RESPONSE_OK)
   {
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/gpx_last_directory", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/gpx_last_directory", filechooser);
 
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -938,12 +938,7 @@ static void _choose_gpx_callback(GtkWidget *widget, dt_lib_module_t *self)
   dt_osx_disallow_fullscreen(filechooser);
 #endif
 
-  char *last_directory = dt_conf_get_string("ui_last/gpx_last_directory");
-  if(last_directory != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), last_directory);
-    g_free(last_directory);
-  }
+  dt_conf_get_folder_to_file_chooser("ui_last/gpx_last_directory", filechooser);
 
   GtkFileFilter *filter;
   filter = GTK_FILE_FILTER(gtk_file_filter_new());

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1496,9 +1496,7 @@ static void _lib_import_select_folder(GtkWidget *widget, dt_lib_module_t *self)
 #endif
 
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
-
-  const gchar *last_place = dt_conf_get_string("ui_last/import_last_place");
-  gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), last_place);
+  dt_conf_get_folder_to_file_chooser("ui_last/import_last_place", filechooser);
 
   // run the dialog
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -518,9 +518,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
       }
       dt_control_log(_("style %s was successfully exported"), (char*)style->data);
     }
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/export_path", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/export_path", filechooser);
     g_free(filedir);
   }
   gtk_widget_destroy(filechooser);
@@ -707,9 +705,7 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
 
     dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
     _gui_styles_update_view(d);
-    gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_string("ui_last/import_path", folder);
-    g_free(folder);
+    dt_conf_set_folder_from_file_chooser("ui_last/import_path", filechooser);
   }
   gtk_widget_destroy(filechooser);
 }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -396,12 +396,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  gchar *import_path = dt_conf_get_string("ui_last/export_path");
-  if(import_path != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), import_path);
-    g_free(import_path);
-  }
+  dt_conf_get_folder_to_file_chooser("ui_last/export_path", filechooser);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
@@ -538,13 +533,7 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  gchar *import_path = dt_conf_get_string("ui_last/import_path");
-  if(import_path != NULL)
-  {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), import_path);
-    g_free(import_path);
-  }
-
+  dt_conf_get_folder_to_file_chooser("ui_last/import_path", filechooser);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   GtkFileFilter *filter;


### PR DESCRIPTION
This patch introduces new functions `dt_conf_set_folder_from_file_chooser` and `dt_conf_get_folder_to_file_chooser`.  The former ensures that the user doesn't forget to free the result of `gtk_file_chooser_get_current_folder` and has the beneficial side effect of avoiding a
string copy as well.  The latter eliminates the need for boilerplate code.