### PR TITLE
minimize copying of configuration/preference strings

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1937,7 +1937,7 @@ int dt_collection_serialize(char *buf, int bufsize)
   return 0;
 }
 
-void dt_collection_deserialize(char *buf)
+void dt_collection_deserialize(const char *buf)
 {
   int num_rules = 0;
   sscanf(buf, "%d", &num_rules);

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1926,14 +1926,13 @@ int dt_collection_serialize(char *buf, int bufsize)
     buf += c;
     bufsize -= c;
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", k);
-    gchar *str = dt_conf_get_string(confname);
+    const char *str = dt_conf_get_conststring(confname);
     if(str && (str[0] != '\0'))
       c = snprintf(buf, bufsize, "%s$", str);
     else
       c = snprintf(buf, bufsize, "%%$");
     buf += c;
     bufsize -= c;
-    g_free(str);
   }
   return 0;
 }

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1926,7 +1926,7 @@ int dt_collection_serialize(char *buf, int bufsize)
     buf += c;
     bufsize -= c;
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", k);
-    const char *str = dt_conf_get_conststring(confname);
+    const char *str = dt_conf_get_string_const(confname);
     if(str && (str[0] != '\0'))
       c = snprintf(buf, bufsize, "%s$", str);
     else

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -258,7 +258,7 @@ void dt_collection_hint_message(const dt_collection_t *collection);
 int dt_collection_image_offset(int imgid);
 
 /* serialize and deserialize into a string. */
-void dt_collection_deserialize(char *buf);
+void dt_collection_deserialize(const char *buf);
 int dt_collection_serialize(char *buf, int bufsize);
 
 /* splits an input string into a number part and an optional operator part */

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1494,13 +1494,13 @@ dt_colorspaces_t *dt_colorspaces_init()
   res->display2_type = dt_conf_get_int("ui_last/color/display2_type");
   res->softproof_type = dt_conf_get_int("ui_last/color/softproof_type");
   res->histogram_type = dt_conf_get_int("ui_last/color/histogram_type");
-  const char *tmp = dt_conf_get_conststring("ui_last/color/display_filename");
+  const char *tmp = dt_conf_get_string_const("ui_last/color/display_filename");
   g_strlcpy(res->display_filename, tmp, sizeof(res->display_filename));
-  tmp = dt_conf_get_conststring("ui_last/color/display2_filename");
+  tmp = dt_conf_get_string_const("ui_last/color/display2_filename");
   g_strlcpy(res->display2_filename, tmp, sizeof(res->display2_filename));
-  tmp = dt_conf_get_conststring("ui_last/color/softproof_filename");
+  tmp = dt_conf_get_string_const("ui_last/color/softproof_filename");
   g_strlcpy(res->softproof_filename, tmp, sizeof(res->softproof_filename));
-  tmp = dt_conf_get_conststring("ui_last/color/histogram_filename");
+  tmp = dt_conf_get_string_const("ui_last/color/histogram_filename");
   g_strlcpy(res->histogram_filename, tmp, sizeof(res->histogram_filename));
   res->display_intent = dt_conf_get_int("ui_last/color/display_intent");
   res->display2_intent = dt_conf_get_int("ui_last/color/display2_intent");
@@ -1825,8 +1825,8 @@ void dt_colorspaces_set_display_profile(const dt_colorspaces_color_profile_type_
 #if defined USE_COLORDGTK
   gboolean use_colord = TRUE;
   const char *display_profile_source = (profile_type == DT_COLORSPACE_DISPLAY2)
-                                      ? dt_conf_get_conststring("ui_last/display2_profile_source")
-                                      : dt_conf_get_conststring("ui_last/display_profile_source");
+                                      ? dt_conf_get_string_const("ui_last/display2_profile_source")
+                                      : dt_conf_get_string_const("ui_last/display_profile_source");
   if(display_profile_source)
   {
     if(!strcmp(display_profile_source, "xatom"))

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1494,18 +1494,14 @@ dt_colorspaces_t *dt_colorspaces_init()
   res->display2_type = dt_conf_get_int("ui_last/color/display2_type");
   res->softproof_type = dt_conf_get_int("ui_last/color/softproof_type");
   res->histogram_type = dt_conf_get_int("ui_last/color/histogram_type");
-  char *tmp = dt_conf_get_string("ui_last/color/display_filename");
+  const char *tmp = dt_conf_get_conststring("ui_last/color/display_filename");
   g_strlcpy(res->display_filename, tmp, sizeof(res->display_filename));
-  g_free(tmp);
-  tmp = dt_conf_get_string("ui_last/color/display2_filename");
+  tmp = dt_conf_get_conststring("ui_last/color/display2_filename");
   g_strlcpy(res->display2_filename, tmp, sizeof(res->display2_filename));
-  g_free(tmp);
-  tmp = dt_conf_get_string("ui_last/color/softproof_filename");
+  tmp = dt_conf_get_conststring("ui_last/color/softproof_filename");
   g_strlcpy(res->softproof_filename, tmp, sizeof(res->softproof_filename));
-  g_free(tmp);
-  tmp = dt_conf_get_string("ui_last/color/histogram_filename");
+  tmp = dt_conf_get_conststring("ui_last/color/histogram_filename");
   g_strlcpy(res->histogram_filename, tmp, sizeof(res->histogram_filename));
-  g_free(tmp);
   res->display_intent = dt_conf_get_int("ui_last/color/display_intent");
   res->display2_intent = dt_conf_get_int("ui_last/color/display2_intent");
   res->softproof_intent = dt_conf_get_int("ui_last/color/softproof_intent");
@@ -1828,16 +1824,15 @@ void dt_colorspaces_set_display_profile(const dt_colorspaces_color_profile_type_
   gboolean use_xatom = TRUE;
 #if defined USE_COLORDGTK
   gboolean use_colord = TRUE;
-  gchar *display_profile_source = (profile_type == DT_COLORSPACE_DISPLAY2)
-                                      ? dt_conf_get_string("ui_last/display2_profile_source")
-                                      : dt_conf_get_string("ui_last/display_profile_source");
+  const char *display_profile_source = (profile_type == DT_COLORSPACE_DISPLAY2)
+                                      ? dt_conf_get_conststring("ui_last/display2_profile_source")
+                                      : dt_conf_get_conststring("ui_last/display_profile_source");
   if(display_profile_source)
   {
     if(!strcmp(display_profile_source, "xatom"))
       use_colord = FALSE;
     else if(!strcmp(display_profile_source, "colord"))
       use_xatom = FALSE;
-    g_free(display_profile_source);
   }
 #endif
 

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1425,9 +1425,7 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     // insert an history_hash entry for all images which have an history
     // note that images without history don't get hash and are considered as basic
     sqlite3_stmt *h_stmt;
-    char *workflow = dt_conf_get_string("plugins/darkroom/workflow");
-    const gboolean basecurve_auto_apply = strcmp(workflow, "display-referred") == 0;
-    g_free(workflow);
+    const gboolean basecurve_auto_apply = dt_conf_is_equal("plugins/darkroom/workflow", "display-referred");
     const gboolean sharpen_auto_apply = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
     char *query = g_strdup_printf(
                             "SELECT id, CASE WHEN imgid IS NULL THEN 0 ELSE 1 END as altered "
@@ -3572,7 +3570,7 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
 
   char *later_info = NULL;
   char *size_info = g_format_size(size);
-  char *config = dt_conf_get_string("database/maintenance_check");
+  const char *config = dt_conf_get_conststring("database/maintenance_check");
   if((closing_time && (!g_strcmp0(config, "on both"))) || !g_strcmp0(config, "on startup"))
   {
     later_info = _("click later to be asked on next startup");
@@ -3585,7 +3583,6 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
   {
     later_info = _("click later to be asked next time when closing darktable");
   }
-
 
   char *label_text = g_markup_printf_escaped(_("the database could use some maintenance\n"
                                                  "\n"
@@ -3616,13 +3613,12 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db, const gbo
   if(_is_mem_db(db))
     return FALSE;
 
-  char *config = dt_conf_get_string("database/maintenance_check");
+  const char *config = dt_conf_get_conststring("database/maintenance_check");
 
   if(!g_strcmp0(config, "never"))
   {
     // early bail out on "never"
     dt_print(DT_DEBUG_SQL, "[db maintenance] please consider enabling database maintenance.\n");
-    g_free(config);
     return FALSE;
   }
 
@@ -3640,7 +3636,6 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db, const gbo
       check_for_maintenance = TRUE;
     }
     // if the config was "never", check_for_vacuum is false.
-    g_free(config);
   }
 
   if(!check_for_maintenance)
@@ -3811,19 +3806,17 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   if(_is_mem_db(db))
     return FALSE;
 
-  char *config = dt_conf_get_string("database/create_snapshot");
+  const char *config = dt_conf_get_conststring("database/create_snapshot");
   if(!g_strcmp0(config, "never"))
   {
     // early bail out on "never"
     dt_print(DT_DEBUG_SQL, "[db backup] please consider enabling database snapshots.\n");
-    g_free(config);
     return FALSE;
   }
   if(!g_strcmp0(config, "on close"))
   {
     // early bail out on "on close"
     dt_print(DT_DEBUG_SQL, "[db backup] performing unconditional snapshot.\n");
-    g_free(config);
     return TRUE;
   }
 
@@ -3846,10 +3839,8 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   {
     // early bail out on "invalid value"
     dt_print(DT_DEBUG_SQL, "[db backup] invalid timespan requirement expecting never/on close/once a [day/week/month], got %s.\n", config);
-    g_free(config);
     return TRUE;
   }
-  g_free(config);
 
   //we're in trouble zone - we have to determine when was the last snapshot done (including version upgrade snapshot) :/
   //this could be easy if we wrote date of last successful backup to config, but that's not really an option since

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3570,7 +3570,7 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
 
   char *later_info = NULL;
   char *size_info = g_format_size(size);
-  const char *config = dt_conf_get_conststring("database/maintenance_check");
+  const char *config = dt_conf_get_string_const("database/maintenance_check");
   if((closing_time && (!g_strcmp0(config, "on both"))) || !g_strcmp0(config, "on startup"))
   {
     later_info = _("click later to be asked on next startup");
@@ -3613,7 +3613,7 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db, const gbo
   if(_is_mem_db(db))
     return FALSE;
 
-  const char *config = dt_conf_get_conststring("database/maintenance_check");
+  const char *config = dt_conf_get_string_const("database/maintenance_check");
 
   if(!g_strcmp0(config, "never"))
   {
@@ -3806,7 +3806,7 @@ gboolean dt_database_maybe_snapshot(const struct dt_database_t *db)
   if(_is_mem_db(db))
     return FALSE;
 
-  const char *config = dt_conf_get_conststring("database/create_snapshot");
+  const char *config = dt_conf_get_string_const("database/create_snapshot");
   if(!g_strcmp0(config, "never"))
   {
     // early bail out on "never"

--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -287,7 +287,7 @@ void dt_imageio_cleanup(dt_imageio_t *iio)
 dt_imageio_module_format_t *dt_imageio_get_format()
 {
   dt_imageio_t *iio = darktable.imageio;
-  const char *format_name = dt_conf_get_conststring("plugins/lighttable/export/format_name");
+  const char *format_name = dt_conf_get_string_const("plugins/lighttable/export/format_name");
   dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(format_name);
   // if the format from the config isn't available default to jpeg, if that's not available either just use
   // the first we have
@@ -299,7 +299,7 @@ dt_imageio_module_format_t *dt_imageio_get_format()
 dt_imageio_module_storage_t *dt_imageio_get_storage()
 {
   dt_imageio_t *iio = darktable.imageio;
-  const char *storage_name = dt_conf_get_conststring("plugins/lighttable/export/storage_name");
+  const char *storage_name = dt_conf_get_string_const("plugins/lighttable/export/storage_name");
   dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(storage_name);
   // if the storage from the config isn't available default to disk, if that's not available either just use
   // the first we have

--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -287,9 +287,8 @@ void dt_imageio_cleanup(dt_imageio_t *iio)
 dt_imageio_module_format_t *dt_imageio_get_format()
 {
   dt_imageio_t *iio = darktable.imageio;
-  gchar *format_name = dt_conf_get_string("plugins/lighttable/export/format_name");
+  const char *format_name = dt_conf_get_conststring("plugins/lighttable/export/format_name");
   dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(format_name);
-  g_free(format_name);
   // if the format from the config isn't available default to jpeg, if that's not available either just use
   // the first we have
   if(!format) format = dt_imageio_get_format_by_name("jpeg");
@@ -300,9 +299,8 @@ dt_imageio_module_format_t *dt_imageio_get_format()
 dt_imageio_module_storage_t *dt_imageio_get_storage()
 {
   dt_imageio_t *iio = darktable.imageio;
-  gchar *storage_name = dt_conf_get_string("plugins/lighttable/export/storage_name");
+  const char *storage_name = dt_conf_get_conststring("plugins/lighttable/export/storage_name");
   dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(storage_name);
-  g_free(storage_name);
   // if the storage from the config isn't available default to disk, if that's not available either just use
   // the first we have
   if(!storage) storage = dt_imageio_get_storage_by_name("disk");

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -101,15 +101,11 @@ static void _import_session_migrate_old_config()
 }
 
 
-static char *_import_session_path_pattern()
+static gchar *_import_session_path_pattern()
 {
-  char *res;
-  char *base;
-  char *sub;
-
-  res = NULL;
-  base = dt_conf_get_string("session/base_directory_pattern");
-  sub = dt_conf_get_string("session/sub_directory_pattern");
+  gchar *res = NULL;
+  const char *base = dt_conf_get_conststring("session/base_directory_pattern");
+  const char *sub = dt_conf_get_conststring("session/sub_directory_pattern");
 
   if(!sub || !base)
   {
@@ -124,17 +120,13 @@ static char *_import_session_path_pattern()
 #endif
 
 bail_out:
-  g_free(base);
-  g_free(sub);
   return res;
 }
 
 
 static char *_import_session_filename_pattern()
 {
-  char *name;
-
-  name = dt_conf_get_string("session/filename_pattern");
+  gchar *name = dt_conf_get_string("session/filename_pattern");
   if(!name)
   {
     fprintf(stderr, "[import_session] No name configured...\n");
@@ -248,7 +240,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
 {
   const char *path;
   char *fname, *previous_fname;
-  char *pattern;
+  gchar *pattern;
   gchar *result_fname;
 
   /* expand next filename */
@@ -309,7 +301,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
 
 static const char *_import_session_path(struct dt_import_session_t *self, gboolean current)
 {
-  char *pattern;
+  gchar *pattern;
   char *new_path;
   const gboolean currentok = dt_util_test_writable_dir(self->current_path);
   fprintf(stderr, " _import_session_path testing `%s' %i", self->current_path, currentok);

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -104,8 +104,8 @@ static void _import_session_migrate_old_config()
 static gchar *_import_session_path_pattern()
 {
   gchar *res = NULL;
-  const char *base = dt_conf_get_conststring("session/base_directory_pattern");
-  const char *sub = dt_conf_get_conststring("session/sub_directory_pattern");
+  const char *base = dt_conf_get_string_const("session/base_directory_pattern");
+  const char *sub = dt_conf_get_string_const("session/sub_directory_pattern");
 
   if(!sub || !base)
   {

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1102,7 +1102,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
   if(type == DT_INTERPOLATION_USERPREF)
   {
     // Find user preferred interpolation method
-    const char *uipref = dt_conf_get_conststring("plugins/lighttable/export/pixel_interpolator");
+    const char *uipref = dt_conf_get_string_const("plugins/lighttable/export/pixel_interpolator");
     for(int i = DT_INTERPOLATION_FIRST; uipref && i < DT_INTERPOLATION_LAST; i++)
     {
       if(!strcmp(uipref, dt_interpolator[i].name))
@@ -1120,7 +1120,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
   else if(type == DT_INTERPOLATION_USERPREF_WARP)
   {
     // Find user preferred interpolation method
-    const char *uipref = dt_conf_get_conststring("plugins/lighttable/export/pixel_interpolator_warp");
+    const char *uipref = dt_conf_get_string_const("plugins/lighttable/export/pixel_interpolator_warp");
     for(int i = DT_INTERPOLATION_FIRST; uipref && i < DT_INTERPOLATION_LAST; i++)
     {
       if(!strcmp(uipref, dt_interpolator[i].name))

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1102,7 +1102,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
   if(type == DT_INTERPOLATION_USERPREF)
   {
     // Find user preferred interpolation method
-    gchar *uipref = dt_conf_get_string("plugins/lighttable/export/pixel_interpolator");
+    const char *uipref = dt_conf_get_conststring("plugins/lighttable/export/pixel_interpolator");
     for(int i = DT_INTERPOLATION_FIRST; uipref && i < DT_INTERPOLATION_LAST; i++)
     {
       if(!strcmp(uipref, dt_interpolator[i].name))
@@ -1112,7 +1112,6 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
         break;
       }
     }
-    g_free(uipref);
 
     /* In the case the search failed (!uipref or name not found),
      * prepare later search pass with default fallback */
@@ -1121,7 +1120,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
   else if(type == DT_INTERPOLATION_USERPREF_WARP)
   {
     // Find user preferred interpolation method
-    gchar *uipref = dt_conf_get_string("plugins/lighttable/export/pixel_interpolator_warp");
+    const char *uipref = dt_conf_get_conststring("plugins/lighttable/export/pixel_interpolator_warp");
     for(int i = DT_INTERPOLATION_FIRST; uipref && i < DT_INTERPOLATION_LAST; i++)
     {
       if(!strcmp(uipref, dt_interpolator[i].name))
@@ -1131,7 +1130,6 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
         break;
       }
     }
-    g_free(uipref);
 
     /* In the case the search failed (!uipref or name not found),
      * prepare later search pass with default fallback */

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -690,7 +690,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
   // and new image not yet loaded or whose history has been reset.
   if(!iop_order_list)
   {
-    const char *workflow = dt_conf_get_conststring("plugins/darkroom/workflow");
+    const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
     dt_iop_order_t iop_order_version = strcmp(workflow, "display-referred") == 0 ? DT_IOP_ORDER_LEGACY : DT_IOP_ORDER_V30;
 
     if(iop_order_version == DT_IOP_ORDER_LEGACY)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -690,9 +690,8 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
   // and new image not yet loaded or whose history has been reset.
   if(!iop_order_list)
   {
-    char *workflow = dt_conf_get_string("plugins/darkroom/workflow");
+    const char *workflow = dt_conf_get_conststring("plugins/darkroom/workflow");
     dt_iop_order_t iop_order_version = strcmp(workflow, "display-referred") == 0 ? DT_IOP_ORDER_LEGACY : DT_IOP_ORDER_V30;
-    g_free(workflow);
 
     if(iop_order_version == DT_IOP_ORDER_LEGACY)
       iop_order_list = _table_to_list(legacy_order);

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -297,7 +297,7 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
   result->selected = -1;
   result->sys_default = -1;
 
-  char *ui_lang = dt_conf_get_string("ui_last/gui_language");
+  gchar *ui_lang = dt_conf_get_string("ui_last/gui_language");
   const char *old_env = g_getenv("LANGUAGE");
 
 #if defined(_WIN32)

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -31,7 +31,7 @@ const char formula_keyword[] = "plugins/lighttable/export/metadata_formula";
 
 uint32_t dt_lib_export_metadata_get_conf_flags(void)
 {
-  const char *metadata_flags = dt_conf_get_conststring(flags_keyword);
+  const char *metadata_flags = dt_conf_get_string_const(flags_keyword);
   const int32_t flags = strtol(metadata_flags, NULL, 16);
   return flags;
 }

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -31,9 +31,8 @@ const char formula_keyword[] = "plugins/lighttable/export/metadata_formula";
 
 uint32_t dt_lib_export_metadata_get_conf_flags(void)
 {
-  char *metadata_flags = dt_conf_get_string(flags_keyword);
+  const char *metadata_flags = dt_conf_get_conststring(flags_keyword);
   const int32_t flags = strtol(metadata_flags, NULL, 16);
-  g_free(metadata_flags);
   return flags;
 }
 
@@ -47,7 +46,7 @@ char *dt_lib_export_metadata_get_conf(void)
     char *conf_keyword = g_strdup_printf("%s%d", formula_keyword, i);
     while (dt_conf_key_exists(conf_keyword))
     {
-      char *nameformula = dt_conf_get_string(conf_keyword);
+      gchar *nameformula = dt_conf_get_string(conf_keyword);
       g_free(conf_keyword);
       if(nameformula[0])
       {

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -967,7 +967,7 @@ dt_mipmap_size_t dt_mipmap_cache_get_matching_size(const dt_mipmap_cache_t *cach
   return best;
 }
 
-dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(char *value)
+dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value)
 {
   if(strcmp(value, "always") == 0) return DT_MIPMAP_0;
   if(strcmp(value, "small") == 0)  return DT_MIPMAP_1;
@@ -1181,9 +1181,8 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
   const int incompatible = !strncmp(cimg->exif_maker, "Phase One", 9);
   dt_image_cache_read_release(darktable.image_cache, cimg);
 
-  char *min = dt_conf_get_string("plugins/lighttable/thumbnail_raw_min_level");
+  const char *min = dt_conf_get_conststring("plugins/lighttable/thumbnail_raw_min_level");
   const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
-  g_free(min);
   const gboolean use_embedded = (size <= min_s);
 
   if(!altered && use_embedded && !incompatible)

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1181,7 +1181,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
   const int incompatible = !strncmp(cimg->exif_maker, "Phase One", 9);
   dt_image_cache_read_release(darktable.image_cache, cimg);
 
-  const char *min = dt_conf_get_conststring("plugins/lighttable/thumbnail_raw_min_level");
+  const char *min = dt_conf_get_string_const("plugins/lighttable/thumbnail_raw_min_level");
   const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
   const gboolean use_embedded = (size <= min_s);
 

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -166,7 +166,7 @@ dt_colorspaces_color_profile_type_t dt_mipmap_cache_get_colorspace();
 void dt_mipmap_cache_copy_thumbnails(const dt_mipmap_cache_t *cache, const uint32_t dst_imgid, const uint32_t src_imgid);
 
 // return the mipmap corresponding to text value saved in prefs
-dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(char *value);
+dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -526,7 +526,6 @@ end:
 
 void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics)
 {
-  char *str;
   dt_pthread_mutex_init(&cl->lock, NULL);
   cl->inited = 0;
   cl->enabled = 0;
@@ -577,28 +576,24 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl related configuration options:\n");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] \n");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl: %d\n", dt_conf_get_bool("opencl"));
-  str = dt_conf_get_string("opencl_scheduling_profile");
+  const char *str = dt_conf_get_conststring("opencl_scheduling_profile");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_scheduling_profile: '%s'\n", str);
-  g_free(str);
-  str = dt_conf_get_string("opencl_library");
+  str = dt_conf_get_conststring("opencl_library");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_library: '%s'\n", str);
-  g_free(str);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_memory_requirement: %d\n",
            dt_conf_get_int("opencl_memory_requirement"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_memory_headroom: %d\n",
            dt_conf_get_int("opencl_memory_headroom"));
-  str = dt_conf_get_string("opencl_device_priority");
+  str = dt_conf_get_conststring("opencl_device_priority");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_device_priority: '%s'\n", str);
-  g_free(str);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_mandatory_timeout: %d\n",
            dt_conf_get_int("opencl_mandatory_timeout"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_size_roundup: %d\n",
            dt_conf_get_int("opencl_size_roundup"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_async_pixelpipe: %d\n",
            dt_conf_get_bool("opencl_async_pixelpipe"));
-  str = dt_conf_get_string("opencl_synch_cache");
+  str = dt_conf_get_conststring("opencl_synch_cache");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_synch_cache: %s\n", str);
-  g_free(str);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_number_event_handles: %d\n",
            dt_conf_get_int("opencl_number_event_handles"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_micro_nap: %d\n", dt_conf_get_int("opencl_micro_nap"));
@@ -614,14 +609,13 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] \n");
 
   // look for explicit definition of opencl_runtime library in preferences
-  char *library = dt_conf_get_string("opencl_library");
+  const char *library = dt_conf_get_conststring("opencl_library");
 
   // dynamically load opencl runtime
   if((cl->dlocl = dt_dlopencl_init(library)) == NULL)
   {
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_init] no working opencl library found. Continue with opencl disabled\n");
-    g_free(library);
     goto finally;
   }
   else
@@ -629,7 +623,6 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
     dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl library '%s' found on your system and loaded\n",
              cl->dlocl->library);
   }
-  g_free(library);
 
   cl_int err;
   all_platforms = malloc(sizeof(cl_platform_id) * DT_OPENCL_MAX_PLATFORMS);
@@ -772,7 +765,7 @@ finally:
 
     char checksum[64];
     snprintf(checksum, sizeof(checksum), "%u", cl->crc);
-    char *oldchecksum = dt_conf_get_string("opencl_checksum");
+    const char *oldchecksum = dt_conf_get_conststring("opencl_checksum");
 
     // check if the configuration (OpenCL device setup) has changed, indicated by checksum != oldchecksum
     if(strcasecmp(oldchecksum, "OFF") != 0 && strcmp(oldchecksum, checksum) != 0)
@@ -821,7 +814,6 @@ finally:
         dt_control_log(_("opencl scheduling profile set to default."));
       }
     }
-    g_free(oldchecksum);
 
     // apply config settings for scheduling profile: sets device priorities and pixelpipe synchronization timeout
     dt_opencl_scheduling_profile_t profile = dt_opencl_get_scheduling_profile();
@@ -2521,9 +2513,8 @@ int dt_opencl_update_settings(void)
 
   if(darktable.opencl->scheduling_profile != profile)
   {
-    char *pstr = dt_conf_get_string("opencl_scheduling_profile");
+    const char *pstr = dt_conf_get_conststring("opencl_scheduling_profile");
     dt_print(DT_DEBUG_OPENCL, "[opencl_update_scheduling_profile] scheduling profile set to %s\n", pstr);
-    g_free(pstr);
     dt_opencl_apply_scheduling_profile(profile);
   }
 
@@ -2531,9 +2522,8 @@ int dt_opencl_update_settings(void)
 
   if(darktable.opencl->sync_cache != sync)
   {
-    char *pstr = dt_conf_get_string("opencl_synch_cache");
+    const char *pstr = dt_conf_get_conststring("opencl_synch_cache");
     dt_print(DT_DEBUG_OPENCL, "[opencl_update_synch_cache] sync cache set to %s\n", pstr);
-    g_free(pstr);
     darktable.opencl->sync_cache = sync;
   }
 
@@ -2543,7 +2533,7 @@ int dt_opencl_update_settings(void)
 /** read scheduling profile for config variables */
 static dt_opencl_scheduling_profile_t dt_opencl_get_scheduling_profile(void)
 {
-  char *pstr = dt_conf_get_string("opencl_scheduling_profile");
+  const char *pstr = dt_conf_get_conststring("opencl_scheduling_profile");
   if(!pstr) return OPENCL_PROFILE_DEFAULT;
 
   dt_opencl_scheduling_profile_t profile = OPENCL_PROFILE_DEFAULT;
@@ -2553,15 +2543,13 @@ static dt_opencl_scheduling_profile_t dt_opencl_get_scheduling_profile(void)
   else if(!strcmp(pstr, "very fast GPU"))
     profile = OPENCL_PROFILE_VERYFAST_GPU;
 
-  g_free(pstr);
-
   return profile;
 }
 
 /** read config of when/if to synch to cache */
 static dt_opencl_sync_cache_t dt_opencl_get_sync_cache(void)
 {
-  char *pstr = dt_conf_get_string("opencl_synch_cache");
+  const char *pstr = dt_conf_get_conststring("opencl_synch_cache");
   if(!pstr) return OPENCL_SYNC_ACTIVE_MODULE;
 
   dt_opencl_sync_cache_t sync = OPENCL_SYNC_ACTIVE_MODULE;
@@ -2570,8 +2558,6 @@ static dt_opencl_sync_cache_t dt_opencl_get_sync_cache(void)
     sync = OPENCL_SYNC_TRUE;
   else if(!strcmp(pstr, "false"))
     sync = OPENCL_SYNC_FALSE;
-
-  g_free(pstr);
 
   return sync;
 }
@@ -2586,8 +2572,6 @@ static void dt_opencl_set_synchronization_timeout(int value)
 /** adjust opencl subsystem according to scheduling profile */
 static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t profile)
 {
-  char *str;
-
   dt_pthread_mutex_lock(&darktable.opencl->lock);
   darktable.opencl->scheduling_profile = profile;
 
@@ -2603,9 +2587,7 @@ static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t pr
       break;
     case OPENCL_PROFILE_DEFAULT:
     default:
-      str = dt_conf_get_string("opencl_device_priority");
-      dt_opencl_update_priorities(str);
-      g_free(str);
+      dt_opencl_update_priorities(dt_conf_get_conststring("opencl_device_priority"));
       dt_opencl_set_synchronization_timeout(dt_conf_get_int("pixelpipe_synchronization_timeout"));
       break;
   }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -576,15 +576,15 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl related configuration options:\n");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] \n");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl: %d\n", dt_conf_get_bool("opencl"));
-  const char *str = dt_conf_get_conststring("opencl_scheduling_profile");
+  const char *str = dt_conf_get_string_const("opencl_scheduling_profile");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_scheduling_profile: '%s'\n", str);
-  str = dt_conf_get_conststring("opencl_library");
+  str = dt_conf_get_string_const("opencl_library");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_library: '%s'\n", str);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_memory_requirement: %d\n",
            dt_conf_get_int("opencl_memory_requirement"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_memory_headroom: %d\n",
            dt_conf_get_int("opencl_memory_headroom"));
-  str = dt_conf_get_conststring("opencl_device_priority");
+  str = dt_conf_get_string_const("opencl_device_priority");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_device_priority: '%s'\n", str);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_mandatory_timeout: %d\n",
            dt_conf_get_int("opencl_mandatory_timeout"));
@@ -592,7 +592,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
            dt_conf_get_int("opencl_size_roundup"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_async_pixelpipe: %d\n",
            dt_conf_get_bool("opencl_async_pixelpipe"));
-  str = dt_conf_get_conststring("opencl_synch_cache");
+  str = dt_conf_get_string_const("opencl_synch_cache");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_synch_cache: %s\n", str);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_number_event_handles: %d\n",
            dt_conf_get_int("opencl_number_event_handles"));
@@ -609,7 +609,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] \n");
 
   // look for explicit definition of opencl_runtime library in preferences
-  const char *library = dt_conf_get_conststring("opencl_library");
+  const char *library = dt_conf_get_string_const("opencl_library");
 
   // dynamically load opencl runtime
   if((cl->dlocl = dt_dlopencl_init(library)) == NULL)
@@ -765,7 +765,7 @@ finally:
 
     char checksum[64];
     snprintf(checksum, sizeof(checksum), "%u", cl->crc);
-    const char *oldchecksum = dt_conf_get_conststring("opencl_checksum");
+    const char *oldchecksum = dt_conf_get_string_const("opencl_checksum");
 
     // check if the configuration (OpenCL device setup) has changed, indicated by checksum != oldchecksum
     if(strcasecmp(oldchecksum, "OFF") != 0 && strcmp(oldchecksum, checksum) != 0)
@@ -2513,7 +2513,7 @@ int dt_opencl_update_settings(void)
 
   if(darktable.opencl->scheduling_profile != profile)
   {
-    const char *pstr = dt_conf_get_conststring("opencl_scheduling_profile");
+    const char *pstr = dt_conf_get_string_const("opencl_scheduling_profile");
     dt_print(DT_DEBUG_OPENCL, "[opencl_update_scheduling_profile] scheduling profile set to %s\n", pstr);
     dt_opencl_apply_scheduling_profile(profile);
   }
@@ -2522,7 +2522,7 @@ int dt_opencl_update_settings(void)
 
   if(darktable.opencl->sync_cache != sync)
   {
-    const char *pstr = dt_conf_get_conststring("opencl_synch_cache");
+    const char *pstr = dt_conf_get_string_const("opencl_synch_cache");
     dt_print(DT_DEBUG_OPENCL, "[opencl_update_synch_cache] sync cache set to %s\n", pstr);
     darktable.opencl->sync_cache = sync;
   }
@@ -2533,7 +2533,7 @@ int dt_opencl_update_settings(void)
 /** read scheduling profile for config variables */
 static dt_opencl_scheduling_profile_t dt_opencl_get_scheduling_profile(void)
 {
-  const char *pstr = dt_conf_get_conststring("opencl_scheduling_profile");
+  const char *pstr = dt_conf_get_string_const("opencl_scheduling_profile");
   if(!pstr) return OPENCL_PROFILE_DEFAULT;
 
   dt_opencl_scheduling_profile_t profile = OPENCL_PROFILE_DEFAULT;
@@ -2549,7 +2549,7 @@ static dt_opencl_scheduling_profile_t dt_opencl_get_scheduling_profile(void)
 /** read config of when/if to synch to cache */
 static dt_opencl_sync_cache_t dt_opencl_get_sync_cache(void)
 {
-  const char *pstr = dt_conf_get_conststring("opencl_synch_cache");
+  const char *pstr = dt_conf_get_string_const("opencl_synch_cache");
   if(!pstr) return OPENCL_SYNC_ACTIVE_MODULE;
 
   dt_opencl_sync_cache_t sync = OPENCL_SYNC_ACTIVE_MODULE;
@@ -2587,7 +2587,7 @@ static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t pr
       break;
     case OPENCL_PROFILE_DEFAULT:
     default:
-      dt_opencl_update_priorities(dt_conf_get_conststring("opencl_device_priority"));
+      dt_opencl_update_priorities(dt_conf_get_string_const("opencl_device_priority"));
       dt_opencl_set_synchronization_timeout(dt_conf_get_int("pixelpipe_synchronization_timeout"));
       break;
   }

--- a/src/common/pwstorage/pwstorage.c
+++ b/src/common/pwstorage/pwstorage.c
@@ -50,7 +50,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 
   if(pwstorage == NULL) return NULL;
 
-  gchar *_backend_str = dt_conf_get_string("plugins/pwstorage/pwstorage_backend");
+  const char *_backend_str = dt_conf_get_conststring("plugins/pwstorage/pwstorage_backend");
   gint _backend = PW_STORAGE_BACKEND_NONE;
 
   if(strcmp(_backend_str, "auto") == 0)
@@ -83,8 +83,6 @@ const dt_pwstorage_t *dt_pwstorage_new()
     dt_control_log(_("GNOME Keyring backend is no longer supported. configure a different one"));
     _backend = PW_STORAGE_BACKEND_NONE;
   }
-
-  g_free(_backend_str);
 
   switch(_backend)
   {

--- a/src/common/pwstorage/pwstorage.c
+++ b/src/common/pwstorage/pwstorage.c
@@ -50,7 +50,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 
   if(pwstorage == NULL) return NULL;
 
-  const char *_backend_str = dt_conf_get_conststring("plugins/pwstorage/pwstorage_backend");
+  const char *_backend_str = dt_conf_get_string_const("plugins/pwstorage/pwstorage_backend");
   gint _backend = PW_STORAGE_BACKEND_NONE;
 
   if(strcmp(_backend_str, "auto") == 0)

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -305,13 +305,17 @@ gchar *dt_conf_get_string(const char *name)
   return g_strdup(str);
 }
 
+const char *dt_conf_get_conststring(const char *name)
+{
+  return dt_conf_get_var(name);
+}
+
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser)
 {
-  gchar *folder = dt_conf_get_string(name);
+  const gchar *folder = dt_conf_get_conststring(name);
   if (folder)
   {
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser),folder);
-    g_free(folder);
     return TRUE;
   }
   return FALSE;

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -305,14 +305,14 @@ gchar *dt_conf_get_string(const char *name)
   return g_strdup(str);
 }
 
-const char *dt_conf_get_conststring(const char *name)
+const char *dt_conf_get_string_const(const char *name)
 {
   return dt_conf_get_var(name);
 }
 
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser)
 {
-  const gchar *folder = dt_conf_get_conststring(name);
+  const gchar *folder = dt_conf_get_string_const(name);
   if (folder)
   {
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser),folder);

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -90,7 +90,7 @@ float dt_conf_get_and_sanitize_float(const char *name, float min, float max);
 int dt_conf_get_bool(const char *name);
 // get the configuration string without duplicating it; the returned string will be invalidated by any
 // subsequent dt_conf_set_string call
-const char *dt_conf_get_conststring(const char *name);
+const char *dt_conf_get_string_const(const char *name);
 // get a freshly-allocated duplicate of the configuration string; safe to use even if calling dt_conf_set_string
 gchar *dt_conf_get_string(const char *name);
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser);

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -88,6 +88,10 @@ int dt_conf_get_and_sanitize_int(const char *name, int min, int max);
 int64_t dt_conf_get_and_sanitize_int64(const char *name, int64_t min, int64_t max);
 float dt_conf_get_and_sanitize_float(const char *name, float min, float max);
 int dt_conf_get_bool(const char *name);
+// get the configuration string without duplicating it; the returned string will be invalidated by any
+// subsequent dt_conf_set_string call
+const char *dt_conf_get_conststring(const char *name);
+// get a freshly-allocated duplicate of the configuration string; safe to use even if calling dt_conf_set_string
 gchar *dt_conf_get_string(const char *name);
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser);
 gboolean dt_conf_is_equal(const char *name, const char *value);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -359,7 +359,7 @@ dt_job_t *dt_camera_import_job_create(GList *images, struct dt_camera_t *camera,
 
   /* initialize import session for camera import job */
   if(time_override != 0) dt_import_session_set_time(params->shared.session, time_override);
-  const char *jobcode = dt_conf_get_conststring("ui_last/import_jobcode");
+  const char *jobcode = dt_conf_get_string_const("ui_last/import_jobcode");
   dt_import_session_set_name(params->shared.session, jobcode);
 
   params->fraction = 0;

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -359,9 +359,8 @@ dt_job_t *dt_camera_import_job_create(GList *images, struct dt_camera_t *camera,
 
   /* initialize import session for camera import job */
   if(time_override != 0) dt_import_session_set_time(params->shared.session, time_override);
-  char *jobcode = dt_conf_get_string("ui_last/import_jobcode");
+  const char *jobcode = dt_conf_get_conststring("ui_last/import_jobcode");
   dt_import_session_set_name(params->shared.session, jobcode);
-  g_free(jobcode);
 
   params->fraction = 0;
   params->images = images;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -88,9 +88,7 @@ static inline dt_develop_blend_colorspace_t _blend_default_module_blend_colorspa
 
 dt_develop_blend_colorspace_t dt_develop_blend_default_module_blend_colorspace(dt_iop_module_t *module)
 {
-  gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
-  const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
-  g_free(workflow);
+  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
   return _blend_default_module_blend_colorspace(module, is_scene_referred);
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -200,7 +200,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
 
 float dt_dev_get_preview_downsampling()
 {
-  const char *preview_downsample = dt_conf_get_conststring("preview_downsampling");
+  const char *preview_downsample = dt_conf_get_string_const("preview_downsampling");
   const float downsample = (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
         : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
         : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
@@ -1432,7 +1432,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     return FALSE;
   }
 
-  const char *workflow = dt_conf_get_conststring("plugins/darkroom/workflow");
+  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
   const gboolean is_workflow_none = strcmp(workflow, "none") == 0;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -200,12 +200,11 @@ void dt_dev_cleanup(dt_develop_t *dev)
 
 float dt_dev_get_preview_downsampling()
 {
-  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+  const char *preview_downsample = dt_conf_get_conststring("preview_downsampling");
   const float downsample = (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
         : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
         : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
         : 0.25f;
-  g_free(preview_downsample);
   return downsample;
 }
 
@@ -1433,11 +1432,10 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     return FALSE;
   }
 
-  gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
+  const char *workflow = dt_conf_get_conststring("plugins/darkroom/workflow");
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
   const gboolean is_workflow_none = strcmp(workflow, "none") == 0;
-  g_free(workflow);
 
   //  Add scene-referred workflow
   //  Note that we cannot use a preset for FilmicRGB as the default values are

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2219,7 +2219,7 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
      event->detail == GDK_NOTIFY_INFERIOR ||
      event->mode != GDK_CROSSING_NORMAL)) return TRUE;
 
-  const char *config = dt_conf_get_conststring("darkroom/ui/hide_header_buttons");
+  const char *config = dt_conf_get_string_const("darkroom/ui/hide_header_buttons");
 
   gboolean dynamic = FALSE;
   double opacity = 1.0;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2219,7 +2219,7 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
      event->detail == GDK_NOTIFY_INFERIOR ||
      event->mode != GDK_CROSSING_NORMAL)) return TRUE;
 
-  gchar *config = dt_conf_get_string("darkroom/ui/hide_header_buttons");
+  const char *config = dt_conf_get_conststring("darkroom/ui/hide_header_buttons");
 
   gboolean dynamic = FALSE;
   double opacity = 1.0;
@@ -2236,8 +2236,6 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
     ;
   else
     dynamic = TRUE;
-
-  g_free(config);
 
   GList *children = gtk_container_get_children(GTK_CONTAINER(header));
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1288,7 +1288,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       }
 
       gui->pressure_sensitivity = DT_MASKS_PRESSURE_OFF;
-      char *psens = dt_conf_get_string("pressure_sensitivity");
+      const char *psens = dt_conf_get_conststring("pressure_sensitivity");
       if(psens)
       {
         if(!strcmp(psens, "hardness (absolute)"))
@@ -1301,7 +1301,6 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
           gui->pressure_sensitivity = DT_MASKS_PRESSURE_OPACITY_REL;
         else if(!strcmp(psens, "brush size (relative)"))
           gui->pressure_sensitivity = DT_MASKS_PRESSURE_BRUSHSIZE_REL;
-        g_free(psens);
       }
 
       dt_control_queue_redraw_center();
@@ -1635,14 +1634,13 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
       }
 
       float factor = 0.01f;
-      char *smoothing = dt_conf_get_string("brush_smoothing");
+      const char *smoothing = dt_conf_get_conststring("brush_smoothing");
       if(!strcmp(smoothing, "low"))
         factor = 0.0025f;
       else if(!strcmp(smoothing, "medium"))
         factor = 0.01f;
       else if(!strcmp(smoothing, "high"))
         factor = 0.04f;
-      g_free(smoothing);
 
       // accuracy level for node elimination, dependent on brush size
       const float epsilon2 = factor * MAX(BORDER_MIN, masks_border) * MAX(BORDER_MIN, masks_border);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1288,7 +1288,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       }
 
       gui->pressure_sensitivity = DT_MASKS_PRESSURE_OFF;
-      const char *psens = dt_conf_get_conststring("pressure_sensitivity");
+      const char *psens = dt_conf_get_string_const("pressure_sensitivity");
       if(psens)
       {
         if(!strcmp(psens, "hardness (absolute)"))
@@ -1634,7 +1634,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
       }
 
       float factor = 0.01f;
-      const char *smoothing = dt_conf_get_conststring("brush_smoothing");
+      const char *smoothing = dt_conf_get_string_const("brush_smoothing");
       if(!strcmp(smoothing, "low"))
         factor = 0.0025f;
       else if(!strcmp(smoothing, "medium"))

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1721,7 +1721,7 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   if(thumb->container == DT_THUMBNAIL_CONTAINER_LIGHTTABLE)
   {
     // we get the corresponding size
-    gchar *txt = dt_conf_get_string("plugins/lighttable/thumbnail_sizes");
+    const char *txt = dt_conf_get_conststring("plugins/lighttable/thumbnail_sizes");
     gchar **ts = g_strsplit(txt, "|", -1);
     int i = 0;
     while(ts[i])
@@ -1731,7 +1731,6 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
       i++;
     }
     g_strfreev(ts);
-    g_free(txt);
 
     gchar *cl = g_strdup_printf("dt_thumbnails_%d", i);
     GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_image);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1721,7 +1721,7 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   if(thumb->container == DT_THUMBNAIL_CONTAINER_LIGHTTABLE)
   {
     // we get the corresponding size
-    const char *txt = dt_conf_get_conststring("plugins/lighttable/thumbnail_sizes");
+    const char *txt = dt_conf_get_string_const("plugins/lighttable/thumbnail_sizes");
     gchar **ts = g_strsplit(txt, "|", -1);
     int i = 0;
     while(ts[i])

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -79,7 +79,7 @@ static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
   // we get the size delimitations to differentiate sizes categories
   // one we set as many categories as we want (this can be useful if
   // we want to finetune css very precisely)
-  gchar *txt = dt_conf_get_string("plugins/lighttable/thumbnail_sizes");
+  const char *txt = dt_conf_get_conststring("plugins/lighttable/thumbnail_sizes");
   gchar **ts = g_strsplit(txt, "|", -1);
   int i = 0;
   while(ts[i])
@@ -89,7 +89,6 @@ static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
     i++;
   }
   g_strfreev(ts);
-  g_free(txt);
   return i;
 }
 
@@ -1150,12 +1149,10 @@ static void _thumbtable_restore_scrollbars(dt_thumbtable_t *table)
 static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 {
   // we get "new values"
-  gchar *hq = dt_conf_get_string("plugins/lighttable/thumbnail_hq_min_level");
+  const char *hq = dt_conf_get_conststring("plugins/lighttable/thumbnail_hq_min_level");
   dt_mipmap_size_t hql = dt_mipmap_cache_get_min_mip_from_pref(hq);
-  g_free(hq);
-  gchar *embedded = dt_conf_get_string("plugins/lighttable/thumbnail_raw_min_level");
+  const char *embedded = dt_conf_get_conststring("plugins/lighttable/thumbnail_raw_min_level");
   dt_mipmap_size_t embeddedl = dt_mipmap_cache_get_min_mip_from_pref(embedded);
-  g_free(embedded);
 
   int min_level = 8;
   int max_level = 0;
@@ -1771,12 +1768,10 @@ dt_thumbtable_t *dt_thumbtable_new()
   dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
 
   // get thumb generation pref for reference in case of change
-  gchar *tx = dt_conf_get_string("plugins/lighttable/thumbnail_hq_min_level");
+  const char *tx = dt_conf_get_conststring("plugins/lighttable/thumbnail_hq_min_level");
   table->pref_hq = dt_mipmap_cache_get_min_mip_from_pref(tx);
-  g_free(tx);
-  tx = dt_conf_get_string("plugins/lighttable/thumbnail_raw_min_level");
+  tx = dt_conf_get_conststring("plugins/lighttable/thumbnail_raw_min_level");
   table->pref_embedded = dt_mipmap_cache_get_min_mip_from_pref(tx);
-  g_free(tx);
 
   // set css name and class
   gtk_widget_set_name(table->widget, "thumbtable_filemanager");

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -79,7 +79,7 @@ static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
   // we get the size delimitations to differentiate sizes categories
   // one we set as many categories as we want (this can be useful if
   // we want to finetune css very precisely)
-  const char *txt = dt_conf_get_conststring("plugins/lighttable/thumbnail_sizes");
+  const char *txt = dt_conf_get_string_const("plugins/lighttable/thumbnail_sizes");
   gchar **ts = g_strsplit(txt, "|", -1);
   int i = 0;
   while(ts[i])
@@ -1149,9 +1149,9 @@ static void _thumbtable_restore_scrollbars(dt_thumbtable_t *table)
 static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 {
   // we get "new values"
-  const char *hq = dt_conf_get_conststring("plugins/lighttable/thumbnail_hq_min_level");
+  const char *hq = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
   dt_mipmap_size_t hql = dt_mipmap_cache_get_min_mip_from_pref(hq);
-  const char *embedded = dt_conf_get_conststring("plugins/lighttable/thumbnail_raw_min_level");
+  const char *embedded = dt_conf_get_string_const("plugins/lighttable/thumbnail_raw_min_level");
   dt_mipmap_size_t embeddedl = dt_mipmap_cache_get_min_mip_from_pref(embedded);
 
   int min_level = 8;
@@ -1768,9 +1768,9 @@ dt_thumbtable_t *dt_thumbtable_new()
   dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
 
   // get thumb generation pref for reference in case of change
-  const char *tx = dt_conf_get_conststring("plugins/lighttable/thumbnail_hq_min_level");
+  const char *tx = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
   table->pref_hq = dt_mipmap_cache_get_min_mip_from_pref(tx);
-  tx = dt_conf_get_conststring("plugins/lighttable/thumbnail_raw_min_level");
+  tx = dt_conf_get_string_const("plugins/lighttable/thumbnail_raw_min_level");
   table->pref_embedded = dt_mipmap_cache_get_min_mip_from_pref(tx);
 
   // set css name and class

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -187,9 +187,8 @@ static gboolean toggle_tooltip_visibility(GtkAccelGroup *accel_group, GObject *a
     dt_control_log(_("tooltip visibility can only be toggled if compositing is enabled in your window manager"));
   }
 
-  gchar *theme = dt_conf_get_string("ui_last/theme");
+  const char *theme = dt_conf_get_conststring("ui_last/theme");
   dt_gui_load_theme(theme);
-  g_free(theme);
   dt_bauhaus_load_theme();
 
   return TRUE;
@@ -1130,11 +1129,10 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_loc_get_sharedir(sharedir, sizeof(sharedir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  gchar *css_theme = dt_conf_get_string("ui_last/theme");
+  const char *css_theme = dt_conf_get_conststring("ui_last/theme");
   if(css_theme)
   {
     g_strlcpy(gui->gtkrc, css_theme, sizeof(gui->gtkrc));
-    g_free(css_theme);
   }
   else
     g_snprintf(gui->gtkrc, sizeof(gui->gtkrc), "darktable");

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -187,7 +187,7 @@ static gboolean toggle_tooltip_visibility(GtkAccelGroup *accel_group, GObject *a
     dt_control_log(_("tooltip visibility can only be toggled if compositing is enabled in your window manager"));
   }
 
-  const char *theme = dt_conf_get_conststring("ui_last/theme");
+  const char *theme = dt_conf_get_string_const("ui_last/theme");
   dt_gui_load_theme(theme);
   dt_bauhaus_load_theme();
 
@@ -1129,7 +1129,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_loc_get_sharedir(sharedir, sizeof(sharedir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  const char *css_theme = dt_conf_get_conststring("ui_last/theme");
+  const char *css_theme = dt_conf_get_string_const("ui_last/theme");
   if(css_theme)
   {
     g_strlcpy(gui->gtkrc, css_theme, sizeof(gui->gtkrc));

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -443,7 +443,7 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
 
     GtkWidget *metadata_entry = gtk_entry_new();
     setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
-    const char *str = dt_conf_get_conststring(setting);
+    const char *str = dt_conf_get_string_const(setting);
     _set_up_entry(metadata_entry, str, metadata_name, i + DT_META_META_VALUE, metadata);
     g_free(setting);
     g_signal_connect(GTK_ENTRY(metadata_entry), "changed",
@@ -471,7 +471,7 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
 
   GtkWidget *entry = gtk_entry_new();
   gtk_widget_set_visible(entry, TRUE);
-  const char *str = dt_conf_get_conststring("ui_last/import_last_tags");
+  const char *str = dt_conf_get_string_const("ui_last/import_last_tags");
   _set_up_entry(entry, str, "tags", DT_META_TAGS_VALUE, metadata);
   gtk_widget_set_tooltip_text(entry, _("comma separated list of tags"));
   g_signal_connect(GTK_ENTRY(entry), "changed",
@@ -523,7 +523,7 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
     GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + DT_META_META_VALUE);
     const gchar *metadata_name = dt_metadata_get_name_by_display_order(i);
     gchar *setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
-    const char *meta = dt_conf_get_conststring(setting);
+    const char *meta = dt_conf_get_string_const(setting);
     g_signal_handlers_block_by_func(w, _import_metadata_changed, metadata);
     gtk_entry_set_text(GTK_ENTRY(w), meta);
     g_signal_handlers_unblock_by_func(w, _import_metadata_changed, metadata);
@@ -538,7 +538,7 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
   }
 
   GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_VALUE);
-  const char *tags = dt_conf_get_conststring("ui_last/import_last_tags");
+  const char *tags = dt_conf_get_string_const("ui_last/import_last_tags");
   g_signal_handlers_block_by_func(w, _import_tags_changed, metadata);
   gtk_entry_set_text(GTK_ENTRY(w), tags);
   g_signal_handlers_unblock_by_func(w, _import_tags_changed, metadata);

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -443,9 +443,8 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
 
     GtkWidget *metadata_entry = gtk_entry_new();
     setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
-    gchar *str = dt_conf_get_string(setting);
+    const char *str = dt_conf_get_conststring(setting);
     _set_up_entry(metadata_entry, str, metadata_name, i + DT_META_META_VALUE, metadata);
-    g_free(str);
     g_free(setting);
     g_signal_connect(GTK_ENTRY(metadata_entry), "changed",
                      G_CALLBACK(_import_metadata_changed), metadata);
@@ -472,10 +471,9 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
 
   GtkWidget *entry = gtk_entry_new();
   gtk_widget_set_visible(entry, TRUE);
-  gchar *str = dt_conf_get_string("ui_last/import_last_tags");
+  const char *str = dt_conf_get_conststring("ui_last/import_last_tags");
   _set_up_entry(entry, str, "tags", DT_META_TAGS_VALUE, metadata);
   gtk_widget_set_tooltip_text(entry, _("comma separated list of tags"));
-  g_free(str);
   g_signal_connect(GTK_ENTRY(entry), "changed",
                    G_CALLBACK(_import_tags_changed), metadata);
   g_signal_connect(GTK_EVENT_BOX(labelev), "button-press-event",
@@ -525,11 +523,10 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
     GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + DT_META_META_VALUE);
     const gchar *metadata_name = dt_metadata_get_name_by_display_order(i);
     gchar *setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
-    char *meta = dt_conf_get_string(setting);
+    const char *meta = dt_conf_get_conststring(setting);
     g_signal_handlers_block_by_func(w, _import_metadata_changed, metadata);
     gtk_entry_set_text(GTK_ENTRY(w), meta);
     g_signal_handlers_unblock_by_func(w, _import_metadata_changed, metadata);
-    g_free(meta);
     g_free(setting);
     w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, i + DT_META_META_VALUE);
     setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", metadata_name);
@@ -541,11 +538,10 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
   }
 
   GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, DT_META_TAGS_VALUE);
-  char *tags = dt_conf_get_string("ui_last/import_last_tags");
+  const char *tags = dt_conf_get_conststring("ui_last/import_last_tags");
   g_signal_handlers_block_by_func(w, _import_tags_changed, metadata);
   gtk_entry_set_text(GTK_ENTRY(w), tags);
   g_signal_handlers_unblock_by_func(w, _import_tags_changed, metadata);
-  g_free(tags);
   w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_TAGS_VALUE);
   const gboolean imported = dt_conf_get_bool("ui_last/import_last_tags_imported");
   g_signal_handlers_block_by_func(w, _import_metadata_toggled, metadata);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -164,7 +164,7 @@ static void load_themes(void)
 
 static void reload_ui_last_theme(void)
 {
-  const char *theme = dt_conf_get_conststring("ui_last/theme");
+  const char *theme = dt_conf_get_string_const("ui_last/theme");
   dt_gui_load_theme(theme);
   dt_bauhaus_load_theme();
 }
@@ -1508,7 +1508,7 @@ _gui_preferences_string_reset(GtkWidget *label, GdkEventButton *event, GtkWidget
 void dt_gui_preferences_string_update(GtkWidget *widget)
 {
   const char *key = gtk_widget_get_name(widget);
-  const char *str = dt_conf_get_conststring(key);
+  const char *str = dt_conf_get_string_const(key);
   gtk_entry_set_text(GTK_ENTRY(widget), str);
 }
 
@@ -1522,7 +1522,7 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
 
   GtkWidget *w = gtk_entry_new();
-  const char *str = dt_conf_get_conststring(key);
+  const char *str = dt_conf_get_string_const(key);
   gtk_entry_set_text(GTK_ENTRY(w), str);
   gtk_widget_set_hexpand(w, TRUE);
   gtk_widget_set_name(w, key);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -164,9 +164,8 @@ static void load_themes(void)
 
 static void reload_ui_last_theme(void)
 {
-  gchar *theme = dt_conf_get_string("ui_last/theme");
+  const char *theme = dt_conf_get_conststring("ui_last/theme");
   dt_gui_load_theme(theme);
-  g_free(theme);
   dt_bauhaus_load_theme();
 }
 
@@ -1509,9 +1508,8 @@ _gui_preferences_string_reset(GtkWidget *label, GdkEventButton *event, GtkWidget
 void dt_gui_preferences_string_update(GtkWidget *widget)
 {
   const char *key = gtk_widget_get_name(widget);
-  char *str = dt_conf_get_string(key);
+  const char *str = dt_conf_get_conststring(key);
   gtk_entry_set_text(GTK_ENTRY(widget), str);
-  g_free(str);
 }
 
 GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint col,
@@ -1524,9 +1522,8 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint
   gtk_container_add(GTK_CONTAINER(labelev), w_label);
 
   GtkWidget *w = gtk_entry_new();
-  gchar *str = dt_conf_get_string(key);
+  const char *str = dt_conf_get_conststring(key);
   gtk_entry_set_text(GTK_ENTRY(w), str);
-  g_free(str);
   gtk_widget_set_hexpand(w, TRUE);
   gtk_widget_set_name(w, key);
 

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -918,7 +918,7 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
 {
   dt_image_t *image = &module->dev->image_storage;
 
-  const char *workflow = dt_conf_get_conststring("plugins/darkroom/workflow");
+  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -918,11 +918,10 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
 {
   dt_image_t *image = &module->dev->image_storage;
 
-  gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
+  const char *workflow = dt_conf_get_conststring("plugins/darkroom/workflow");
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);
-  g_free(workflow);
 
   char query[2024];
   snprintf(query, sizeof(query),

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -611,7 +611,7 @@ void *get_params(dt_imageio_module_format_t *self)
     return NULL;
   }
 
-  const char *bpp = dt_conf_get_conststring("plugins/imageio/format/avif/bpp");
+  const char *bpp = dt_conf_get_string_const("plugins/imageio/format/avif/bpp");
   d->bit_depth = atoi(bpp);
   if(d->bit_depth < 8 || d->bit_depth > 12)
   {

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -611,9 +611,8 @@ void *get_params(dt_imageio_module_format_t *self)
     return NULL;
   }
 
-  gchar * bpp = dt_conf_get_string("plugins/imageio/format/avif/bpp");
+  const char *bpp = dt_conf_get_conststring("plugins/imageio/format/avif/bpp");
   d->bit_depth = atoi(bpp);
-  g_free(bpp);
   if(d->bit_depth < 8 || d->bit_depth > 12)
   {
       d->bit_depth = 8;

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -582,7 +582,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_grid_attach(grid, GTK_WIDGET(d->title), 1, line, 1, 1);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title), _("enter the title of the pdf"));
-  const char *str = dt_conf_get_conststring("plugins/imageio/format/pdf/title");
+  const char *str = dt_conf_get_string_const("plugins/imageio/format/pdf/title");
   if(str)
   {
     gtk_entry_set_text(GTK_ENTRY(d->title), str);
@@ -628,7 +628,7 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->border));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->border), _("empty space around the pdf\n"
                                                        "format: size + unit\nexamples: 10 mm, 1 inch"));
-  str = dt_conf_get_conststring("plugins/imageio/format/pdf/border");
+  str = dt_conf_get_string_const("plugins/imageio/format/pdf/border");
   if(str)
   {
     gtk_entry_set_text(GTK_ENTRY(d->border), str);
@@ -761,13 +761,13 @@ void *get_params(dt_imageio_module_format_t *self)
 
   if(d)
   {
-    const char *text = dt_conf_get_conststring("plugins/imageio/format/pdf/title");
+    const char *text = dt_conf_get_string_const("plugins/imageio/format/pdf/title");
     g_strlcpy(d->params.title, text, sizeof(d->params.title));
 
-    text = dt_conf_get_conststring("plugins/imageio/format/pdf/border");
+    text = dt_conf_get_string_const("plugins/imageio/format/pdf/border");
     g_strlcpy(d->params.border, text, sizeof(d->params.border));
 
-    text = dt_conf_get_conststring("plugins/imageio/format/pdf/size");
+    text = dt_conf_get_string_const("plugins/imageio/format/pdf/size");
     g_strlcpy(d->params.size, text, sizeof(d->params.size));
 
     d->params.bpp = dt_conf_get_int("plugins/imageio/format/pdf/bpp");

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -582,11 +582,10 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_grid_attach(grid, GTK_WIDGET(d->title), 1, line, 1, 1);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title), _("enter the title of the pdf"));
-  gchar *str = dt_conf_get_string("plugins/imageio/format/pdf/title");
+  const char *str = dt_conf_get_conststring("plugins/imageio/format/pdf/title");
   if(str)
   {
     gtk_entry_set_text(GTK_ENTRY(d->title), str);
-    g_free(str);
   }
   g_signal_connect(G_OBJECT(d->title), "changed", G_CALLBACK(title_changed_callback), self);
 
@@ -602,9 +601,9 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_tooltip_text(d->size, _("paper size of the pdf\neither one from the list or "
                                          "\"<width> [unit] x <height> <unit>\n"
                                          "example: 210 mm x 2.97 cm"));
-  str = dt_conf_get_string("plugins/imageio/format/pdf/size");
-  _set_paper_size(self, str);
-  g_free(str);
+  gchar *size_str = dt_conf_get_string("plugins/imageio/format/pdf/size");
+  _set_paper_size(self, size_str);
+  g_free(size_str);
 
   // orientation
 
@@ -629,11 +628,10 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->border));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->border), _("empty space around the pdf\n"
                                                        "format: size + unit\nexamples: 10 mm, 1 inch"));
-  str = dt_conf_get_string("plugins/imageio/format/pdf/border");
+  str = dt_conf_get_conststring("plugins/imageio/format/pdf/border");
   if(str)
   {
     gtk_entry_set_text(GTK_ENTRY(d->border), str);
-    g_free(str);
   }
   g_signal_connect(G_OBJECT(d->border), "changed", G_CALLBACK(border_changed_callback), self);
 
@@ -763,17 +761,14 @@ void *get_params(dt_imageio_module_format_t *self)
 
   if(d)
   {
-    gchar *text = dt_conf_get_string("plugins/imageio/format/pdf/title");
+    const char *text = dt_conf_get_conststring("plugins/imageio/format/pdf/title");
     g_strlcpy(d->params.title, text, sizeof(d->params.title));
-    g_free(text);
 
-    text = dt_conf_get_string("plugins/imageio/format/pdf/border");
+    text = dt_conf_get_conststring("plugins/imageio/format/pdf/border");
     g_strlcpy(d->params.border, text, sizeof(d->params.border));
-    g_free(text);
 
-    text = dt_conf_get_string("plugins/imageio/format/pdf/size");
+    text = dt_conf_get_conststring("plugins/imageio/format/pdf/size");
     g_strlcpy(d->params.size, text, sizeof(d->params.size));
-    g_free(text);
 
     d->params.bpp = dt_conf_get_int("plugins/imageio/format/pdf/bpp");
     d->params.compression = dt_conf_get_int("plugins/imageio/format/pdf/compression");

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -421,7 +421,7 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_t *d = (dt_imageio_png_t *)calloc(1, sizeof(dt_imageio_png_t));
-  const char *bpp = dt_conf_get_conststring("plugins/imageio/format/png/bpp");
+  const char *bpp = dt_conf_get_string_const("plugins/imageio/format/png/bpp");
   d->bpp = atoi(bpp);
   if(d->bpp != 8 && d->bpp != 16)
     d->bpp = 8;
@@ -510,7 +510,7 @@ void gui_init(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_gui_t *gui = (dt_imageio_png_gui_t *)malloc(sizeof(dt_imageio_png_gui_t));
   self->gui_data = (void *)gui;
-  const char *conf_bpp = dt_conf_get_conststring("plugins/imageio/format/png/bpp");
+  const char *conf_bpp = dt_conf_get_string_const("plugins/imageio/format/png/bpp");
   int bpp = atoi(conf_bpp);
 
   // PNG compression level might actually be zero!

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -421,9 +421,8 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_t *d = (dt_imageio_png_t *)calloc(1, sizeof(dt_imageio_png_t));
-  gchar *bpp = dt_conf_get_string("plugins/imageio/format/png/bpp");
+  const char *bpp = dt_conf_get_conststring("plugins/imageio/format/png/bpp");
   d->bpp = atoi(bpp);
-  g_free(bpp);
   if(d->bpp != 8 && d->bpp != 16)
     d->bpp = 8;
 
@@ -511,9 +510,8 @@ void gui_init(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_gui_t *gui = (dt_imageio_png_gui_t *)malloc(sizeof(dt_imageio_png_gui_t));
   self->gui_data = (void *)gui;
-  gchar *conf_bpp = dt_conf_get_string("plugins/imageio/format/png/bpp");
+  const char *conf_bpp = dt_conf_get_conststring("plugins/imageio/format/png/bpp");
   int bpp = atoi(conf_bpp);
-  g_free(conf_bpp);
 
   // PNG compression level might actually be zero!
   int compression = 5;

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -631,9 +631,8 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_tiff_t *d = (dt_imageio_tiff_t *)calloc(1, sizeof(dt_imageio_tiff_t));
-  gchar *bpp = dt_conf_get_string("plugins/imageio/format/tiff/bpp");
+  const char *bpp = dt_conf_get_conststring("plugins/imageio/format/tiff/bpp");
   d->bpp = atoi(bpp);
-  g_free(bpp);
   if(d->bpp == 16)
     d->bpp = 16;
   else if(d->bpp == 32)

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -631,7 +631,7 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_tiff_t *d = (dt_imageio_tiff_t *)calloc(1, sizeof(dt_imageio_tiff_t));
-  const char *bpp = dt_conf_get_conststring("plugins/imageio/format/tiff/bpp");
+  const char *bpp = dt_conf_get_string_const("plugins/imageio/format/tiff/bpp");
   d->bpp = atoi(bpp);
   if(d->bpp == 16)
     d->bpp = 16;

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -230,9 +230,8 @@ void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_xcf_t *d = (dt_imageio_xcf_t *)calloc(1, sizeof(dt_imageio_xcf_t));
 
-  gchar *conf_bpp = dt_conf_get_string("plugins/imageio/format/xcf/bpp");
+  const char *conf_bpp = dt_conf_get_conststring("plugins/imageio/format/xcf/bpp");
   d->bpp = atoi(conf_bpp);
-  g_free(conf_bpp);
   if(d->bpp != 16 && d->bpp != 32)
     d->bpp = 8;
 
@@ -330,9 +329,8 @@ void gui_init(dt_imageio_module_format_t *self)
   int bpp = 32;
   if(dt_conf_key_exists("plugins/imageio/format/xcf/bpp"))
   {
-    gchar *conf_bpp = dt_conf_get_string("plugins/imageio/format/xcf/bpp");
+    const char *conf_bpp = dt_conf_get_conststring("plugins/imageio/format/xcf/bpp");
     bpp = atoi(conf_bpp);
-    g_free(conf_bpp);
   }
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -230,7 +230,7 @@ void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_xcf_t *d = (dt_imageio_xcf_t *)calloc(1, sizeof(dt_imageio_xcf_t));
 
-  const char *conf_bpp = dt_conf_get_conststring("plugins/imageio/format/xcf/bpp");
+  const char *conf_bpp = dt_conf_get_string_const("plugins/imageio/format/xcf/bpp");
   d->bpp = atoi(conf_bpp);
   if(d->bpp != 16 && d->bpp != 32)
     d->bpp = 8;
@@ -329,7 +329,7 @@ void gui_init(dt_imageio_module_format_t *self)
   int bpp = 32;
   if(dt_conf_key_exists("plugins/imageio/format/xcf/bpp"))
   {
-    const char *conf_bpp = dt_conf_get_conststring("plugins/imageio/format/xcf/bpp");
+    const char *conf_bpp = dt_conf_get_string_const("plugins/imageio/format/xcf/bpp");
     bpp = atoi(conf_bpp);
   }
 

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -171,7 +171,7 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   widget = gtk_entry_new();
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  const char *dir = dt_conf_get_conststring("plugins/imageio/storage/disk/file_directory");
+  const char *dir = dt_conf_get_string_const("plugins/imageio/storage/disk/file_directory");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
@@ -361,7 +361,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)calloc(1, sizeof(dt_imageio_disk_t));
 
-  const char *text = dt_conf_get_conststring("plugins/imageio/storage/disk/file_directory");
+  const char *text = dt_conf_get_string_const("plugins/imageio/storage/disk/file_directory");
   g_strlcpy(d->filename, text, sizeof(d->filename));
 
   d->onsave_action = dt_conf_get_int("plugins/imageio/storage/disk/overwrite");

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -171,12 +171,11 @@ void gui_init(dt_imageio_module_storage_t *self)
 
   widget = gtk_entry_new();
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  gchar *dir = dt_conf_get_string("plugins/imageio/storage/disk/file_directory");
+  const char *dir = dt_conf_get_conststring("plugins/imageio/storage/disk/file_directory");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
     gtk_editable_set_position(GTK_EDITABLE(widget), strlen(dir));
-    g_free(dir);
   }
 
   dt_gtkentry_setup_completion(GTK_ENTRY(widget), dt_gtkentry_get_default_path_compl_list());
@@ -362,9 +361,8 @@ void *get_params(dt_imageio_module_storage_t *self)
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)calloc(1, sizeof(dt_imageio_disk_t));
 
-  char *text = dt_conf_get_string("plugins/imageio/storage/disk/file_directory");
+  const char *text = dt_conf_get_conststring("plugins/imageio/storage/disk/file_directory");
   g_strlcpy(d->filename, text, sizeof(d->filename));
-  g_free(text);
 
   d->onsave_action = dt_conf_get_int("plugins/imageio/storage/disk/overwrite");
 

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -157,7 +157,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   widget = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(widget), 0);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  const char *dir = dt_conf_get_conststring("plugins/imageio/storage/gallery/file_directory");
+  const char *dir = dt_conf_get_string_const("plugins/imageio/storage/gallery/file_directory");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
@@ -189,7 +189,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(d->title_entry), TRUE, TRUE, 0);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title_entry));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title_entry), _("enter the title of the website"));
-  dir = dt_conf_get_conststring("plugins/imageio/storage/gallery/title");
+  dir = dt_conf_get_string_const("plugins/imageio/storage/gallery/title");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(d->title_entry), dir);
@@ -567,10 +567,10 @@ void *get_params(dt_imageio_module_storage_t *self)
   d->l = NULL;
   dt_variables_params_init(&d->vp);
 
-  const char *text = dt_conf_get_conststring("plugins/imageio/storage/gallery/file_directory");
+  const char *text = dt_conf_get_string_const("plugins/imageio/storage/gallery/file_directory");
   g_strlcpy(d->filename, text, sizeof(d->filename));
 
-  text = dt_conf_get_conststring("plugins/imageio/storage/gallery/title");
+  text = dt_conf_get_string_const("plugins/imageio/storage/gallery/title");
   g_strlcpy(d->title, text, sizeof(d->title));
 
   return d;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -157,11 +157,10 @@ void gui_init(dt_imageio_module_storage_t *self)
   widget = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(widget), 0);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  gchar *dir = dt_conf_get_string("plugins/imageio/storage/gallery/file_directory");
+  const char *dir = dt_conf_get_conststring("plugins/imageio/storage/gallery/file_directory");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
-    g_free(dir);
   }
   d->entry = GTK_ENTRY(widget);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->entry));
@@ -190,11 +189,10 @@ void gui_init(dt_imageio_module_storage_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(d->title_entry), TRUE, TRUE, 0);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title_entry));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title_entry), _("enter the title of the website"));
-  dir = dt_conf_get_string("plugins/imageio/storage/gallery/title");
+  dir = dt_conf_get_conststring("plugins/imageio/storage/gallery/title");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(d->title_entry), dir);
-    g_free(dir);
   }
   g_signal_connect(G_OBJECT(d->title_entry), "changed", G_CALLBACK(title_changed_callback), self);
 }
@@ -569,13 +567,11 @@ void *get_params(dt_imageio_module_storage_t *self)
   d->l = NULL;
   dt_variables_params_init(&d->vp);
 
-  char *text = dt_conf_get_string("plugins/imageio/storage/gallery/file_directory");
+  const char *text = dt_conf_get_conststring("plugins/imageio/storage/gallery/file_directory");
   g_strlcpy(d->filename, text, sizeof(d->filename));
-  g_free(text);
 
-  text = dt_conf_get_string("plugins/imageio/storage/gallery/title");
+  text = dt_conf_get_conststring("plugins/imageio/storage/gallery/title");
   g_strlcpy(d->title, text, sizeof(d->title));
-  g_free(text);
 
   return d;
 }

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -156,11 +156,10 @@ void gui_init(dt_imageio_module_storage_t *self)
   widget = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(widget), 0);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  gchar *dir = dt_conf_get_string("plugins/imageio/storage/latex/file_directory");
+  const char *dir = dt_conf_get_conststring("plugins/imageio/storage/latex/file_directory");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
-    g_free(dir);
   }
   d->entry = GTK_ENTRY(widget);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->entry));
@@ -192,11 +191,10 @@ void gui_init(dt_imageio_module_storage_t *self)
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title_entry));
   // TODO: support title, author, subject, keywords (collect tags?)
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title_entry), _("enter the title of the book"));
-  dir = dt_conf_get_string("plugins/imageio/storage/latex/title");
+  dir = dt_conf_get_conststring("plugins/imageio/storage/latex/title");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(d->title_entry), dir);
-    g_free(dir);
   }
   g_signal_connect(G_OBJECT(d->title_entry), "changed", G_CALLBACK(title_changed_callback), self);
 }
@@ -428,13 +426,11 @@ void *get_params(dt_imageio_module_storage_t *self)
   d->l = NULL;
   dt_variables_params_init(&d->vp);
 
-  char *text = dt_conf_get_string("plugins/imageio/storage/latex/file_directory");
+  const char *text = dt_conf_get_conststring("plugins/imageio/storage/latex/file_directory");
   g_strlcpy(d->filename, text, sizeof(d->filename));
-  g_free(text);
 
-  text = dt_conf_get_string("plugins/imageio/storage/latex/title");
+  text = dt_conf_get_conststring("plugins/imageio/storage/latex/title");
   g_strlcpy(d->title, text, sizeof(d->title));
-  g_free(text);
 
   return d;
 }

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -156,7 +156,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   widget = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(widget), 0);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
-  const char *dir = dt_conf_get_conststring("plugins/imageio/storage/latex/file_directory");
+  const char *dir = dt_conf_get_string_const("plugins/imageio/storage/latex/file_directory");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
@@ -191,7 +191,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->title_entry));
   // TODO: support title, author, subject, keywords (collect tags?)
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->title_entry), _("enter the title of the book"));
-  dir = dt_conf_get_conststring("plugins/imageio/storage/latex/title");
+  dir = dt_conf_get_string_const("plugins/imageio/storage/latex/title");
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(d->title_entry), dir);
@@ -426,10 +426,10 @@ void *get_params(dt_imageio_module_storage_t *self)
   d->l = NULL;
   dt_variables_params_init(&d->vp);
 
-  const char *text = dt_conf_get_conststring("plugins/imageio/storage/latex/file_directory");
+  const char *text = dt_conf_get_string_const("plugins/imageio/storage/latex/file_directory");
   g_strlcpy(d->filename, text, sizeof(d->filename));
 
-  text = dt_conf_get_conststring("plugins/imageio/storage/latex/title");
+  text = dt_conf_get_string_const("plugins/imageio/storage/latex/title");
   g_strlcpy(d->title, text, sizeof(d->title));
 
   return d;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1892,7 +1892,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->controls, _("color-grading mapping method"));
   g_signal_connect(G_OBJECT(g->controls), "value-changed", G_CALLBACK(controls_callback), self);
 
-  const char *mode = dt_conf_get_conststring("plugins/darkroom/colorbalance/controls");
+  const char *mode = dt_conf_get_string_const("plugins/darkroom/colorbalance/controls");
   dt_bauhaus_combobox_set(g->controls, !g_strcmp0(mode, "RGBL") ? RGBL :
                                        !g_strcmp0(mode, "BOTH") ? BOTH : HSL);
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1892,10 +1892,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->controls, _("color-grading mapping method"));
   g_signal_connect(G_OBJECT(g->controls), "value-changed", G_CALLBACK(controls_callback), self);
 
-  gchar *mode = dt_conf_get_string("plugins/darkroom/colorbalance/controls");
+  const char *mode = dt_conf_get_conststring("plugins/darkroom/colorbalance/controls");
   dt_bauhaus_combobox_set(g->controls, !g_strcmp0(mode, "RGBL") ? RGBL :
                                        !g_strcmp0(mode, "BOTH") ? BOTH : HSL);
-  g_free(mode);
 
   g->master_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2856,7 +2856,7 @@ static int get_thumb_quality(int width, int height)
 {
   // we check if we need ultra-high quality thumbnail for this size
   const int level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
-  const char *min = dt_conf_get_conststring("plugins/lighttable/thumbnail_hq_min_level");
+  const char *min = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
   const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
 
   return (level >= min_s);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2841,14 +2841,13 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 static int get_quality()
 {
   int qual = 1;
-  gchar *quality = dt_conf_get_string("plugins/darkroom/demosaic/quality");
+  const char *quality = dt_conf_get_string("plugins/darkroom/demosaic/quality");
   if(quality)
   {
     if(!strcmp(quality, "always bilinear (fast)"))
       qual = 0;
     else if(!strcmp(quality, "full (possibly slow)"))
       qual = 2;
-    g_free(quality);
   }
   return qual;
 }
@@ -2856,11 +2855,9 @@ static int get_quality()
 static int get_thumb_quality(int width, int height)
 {
   // we check if we need ultra-high quality thumbnail for this size
-  char *min = dt_conf_get_string("plugins/lighttable/thumbnail_hq_min_level");
-
   const int level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
+  const char *min = dt_conf_get_conststring("plugins/lighttable/thumbnail_hq_min_level");
   const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
-  g_free(min);
 
   return (level >= min_s);
 }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2544,9 +2544,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   module->default_enabled = FALSE;
 
-  gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
-  const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
-  g_free(workflow);
+  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
 
   if(dt_image_is_matrix_correction_supported(&module->dev->image_storage) && is_scene_referred)
   {

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1911,7 +1911,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
 
-  const char *config = dt_conf_get_conststring("plugins/darkroom/temperature/colored_sliders");
+  const char *config = dt_conf_get_string_const("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
 
@@ -1937,7 +1937,7 @@ void gui_init(struct dt_iop_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
                             G_CALLBACK(_develop_ui_pipe_finished_callback), self);
 
-  const char *config = dt_conf_get_conststring("plugins/darkroom/temperature/colored_sliders");
+  const char *config = dt_conf_get_string_const("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
   g->expand_coeffs = dt_conf_get_bool("plugins/darkroom/temperature/expand_coefficients");

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1911,10 +1911,9 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
 
-  gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
+  const char *config = dt_conf_get_conststring("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
-  g_free(config);
 
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
   gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
@@ -1938,11 +1937,10 @@ void gui_init(struct dt_iop_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
                             G_CALLBACK(_develop_ui_pipe_finished_callback), self);
 
-  gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
+  const char *config = dt_conf_get_conststring("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
   g->expand_coeffs = dt_conf_get_bool("plugins/darkroom/temperature/expand_coefficients");
-  g_free(config);
 
   const int feedback = g->colored_sliders ? 0 : 1;
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1169,23 +1169,21 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_entry_set_width_chars(GTK_ENTRY(g->text), 1);
   gtk_widget_set_tooltip_text(g->text, _("text string, tag:\n$(WATERMARK_TEXT)"));
   dt_gui_key_accel_block_on_focus_connect(g->text);
-  gchar *str = dt_conf_get_string("plugins/darkroom/watermark/text");
+  const char *str = dt_conf_get_conststring("plugins/darkroom/watermark/text");
   gtk_entry_set_text(GTK_ENTRY(g->text), str);
-  g_free(str);
 
   gtk_grid_attach(grid, label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(grid, g->text, label, GTK_POS_RIGHT, 2, 1);
 
   // Text font
   label = dtgtk_reset_label_new(_("font"), self, &p->font, sizeof(p->font));
-  str = dt_conf_get_string("plugins/darkroom/watermark/font");
+  str = dt_conf_get_conststring("plugins/darkroom/watermark/font");
   g->fontsel = gtk_font_button_new_with_font(str==NULL?"DejaVu Sans 10":str);
   GtkWidget *child = dt_gui_container_first_child(GTK_CONTAINER(gtk_bin_get_child(GTK_BIN(g->fontsel))));
   gtk_label_set_ellipsize(GTK_LABEL(child), PANGO_ELLIPSIZE_MIDDLE);
   gtk_widget_set_tooltip_text(g->fontsel, _("text font, tags:\n$(WATERMARK_FONT_FAMILY)\n"
                                             "$(WATERMARK_FONT_STYLE)\n$(WATERMARK_FONT_WEIGHT)"));
   gtk_font_button_set_show_size (GTK_FONT_BUTTON(g->fontsel), FALSE);
-  g_free(str);
 
   gtk_grid_attach(grid, label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(grid, g->fontsel, label, GTK_POS_RIGHT, 2, 1);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1169,7 +1169,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_entry_set_width_chars(GTK_ENTRY(g->text), 1);
   gtk_widget_set_tooltip_text(g->text, _("text string, tag:\n$(WATERMARK_TEXT)"));
   dt_gui_key_accel_block_on_focus_connect(g->text);
-  const char *str = dt_conf_get_conststring("plugins/darkroom/watermark/text");
+  const char *str = dt_conf_get_string_const("plugins/darkroom/watermark/text");
   gtk_entry_set_text(GTK_ENTRY(g->text), str);
 
   gtk_grid_attach(grid, label, 0, line++, 1, 1);
@@ -1177,7 +1177,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Text font
   label = dtgtk_reset_label_new(_("font"), self, &p->font, sizeof(p->font));
-  str = dt_conf_get_conststring("plugins/darkroom/watermark/font");
+  str = dt_conf_get_string_const("plugins/darkroom/watermark/font");
   g->fontsel = gtk_font_button_new_with_font(str==NULL?"DejaVu Sans 10":str);
   GtkWidget *child = dt_gui_container_first_child(GTK_CONTAINER(gtk_bin_get_child(GTK_BIN(g->fontsel))));
   gtk_label_set_ellipsize(GTK_LABEL(child), PANGO_ELLIPSIZE_MIDDLE);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -330,7 +330,7 @@ static void _lib_collect_update_params(dt_lib_collect_t *d)
 
     /* get string */
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", i);
-    const char *string = dt_conf_get_conststring(confname);
+    const char *string = dt_conf_get_string_const(confname);
     if(string != NULL)
     {
       g_strlcpy(p->rule[i].string, string, PARAM_STRING_SIZE);
@@ -1851,7 +1851,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
         // filmroll
         {
           gchar *order_by = NULL;
-          const char *filmroll_sort = dt_conf_get_conststring("plugins/collect/filmroll_sort");
+          const char *filmroll_sort = dt_conf_get_string_const("plugins/collect/filmroll_sort");
           if(strcmp(filmroll_sort, "id") == 0)
             order_by = g_strdup("film_rolls_id DESC");
           else
@@ -2121,7 +2121,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/item%1d", i);
     _combo_set_active_collection(d->rule[i].combo, dt_conf_get_int(confname));
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", i);
-    const char *text = dt_conf_get_conststring(confname);
+    const char *text = dt_conf_get_string_const(confname);
     if(text)
     {
       g_signal_handlers_block_matched(d->rule[i].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
@@ -2952,7 +2952,7 @@ void gui_init(dt_lib_module_t *self)
 
   if(_combo_get_active_collection(d->rule[0].combo) == DT_COLLECTION_PROP_TAG)
   {
-    const char *tag = dt_conf_get_conststring("plugins/lighttable/collect/string0");
+    const char *tag = dt_conf_get_string_const("plugins/lighttable/collect/string0");
     dt_collection_set_tag_id((dt_collection_t *)darktable.collection, dt_tag_get_tag_id_by_name(tag));
   }
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -330,11 +330,10 @@ static void _lib_collect_update_params(dt_lib_collect_t *d)
 
     /* get string */
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", i);
-    gchar *string = dt_conf_get_string(confname);
+    const char *string = dt_conf_get_conststring(confname);
     if(string != NULL)
     {
       g_strlcpy(p->rule[i].string, string, PARAM_STRING_SIZE);
-      g_free(string);
     }
 
     // fprintf(stderr,"[%i] %d,%d,%s\n",i, p->rule[i].item, p->rule[i].mode,  p->rule[i].string);
@@ -1852,7 +1851,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
         // filmroll
         {
           gchar *order_by = NULL;
-          gchar *filmroll_sort = dt_conf_get_string("plugins/collect/filmroll_sort");
+          const char *filmroll_sort = dt_conf_get_conststring("plugins/collect/filmroll_sort");
           if(strcmp(filmroll_sort, "id") == 0)
             order_by = g_strdup("film_rolls_id DESC");
           else
@@ -1860,7 +1859,6 @@ static void list_view(dt_lib_collect_rule_t *dr)
               order_by = g_strdup("folder DESC");
             else
               order_by = g_strdup("folder");
-          g_free(filmroll_sort);
 
           g_snprintf(query, sizeof(query),
                      "SELECT folder, film_rolls_id, COUNT(*) AS count"
@@ -2123,14 +2121,13 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/item%1d", i);
     _combo_set_active_collection(d->rule[i].combo, dt_conf_get_int(confname));
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", i);
-    gchar *text = dt_conf_get_string(confname);
+    const char *text = dt_conf_get_conststring(confname);
     if(text)
     {
       g_signal_handlers_block_matched(d->rule[i].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
       gtk_entry_set_text(GTK_ENTRY(d->rule[i].text), text);
       gtk_editable_set_position(GTK_EDITABLE(d->rule[i].text), -1);
       g_signal_handlers_unblock_matched(d->rule[i].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
-      g_free(text);
       d->rule[i].typing = FALSE;
     }
 
@@ -2955,7 +2952,7 @@ void gui_init(dt_lib_module_t *self)
 
   if(_combo_get_active_collection(d->rule[0].combo) == DT_COLLECTION_PROP_TAG)
   {
-    gchar *tag = dt_conf_get_string("plugins/lighttable/collect/string0");
+    const char *tag = dt_conf_get_conststring("plugins/lighttable/collect/string0");
     dt_collection_set_tag_id((dt_collection_t *)darktable.collection, dt_tag_get_tag_id_by_name(tag));
   }
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -182,13 +182,10 @@ static void _update(dt_lib_module_t *self)
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   const gboolean has_act_on = imgs != NULL;
 
-  char *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
-  char *storage_name = dt_conf_get_string(CONFIG_PREFIX "storage_name");
+  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
+  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
   const int format_index = dt_imageio_get_index_of_format(dt_imageio_get_format_by_name(format_name));
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(storage_name));
-
-  g_free(format_name);
-  g_free(storage_name);
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->export_button), has_act_on && format_index != -1 && storage_index != -1);
 }
@@ -289,13 +286,10 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
 
   // get the format_name and storage_name settings which are plug-ins name and not necessary what is displayed on the combobox.
   // note that we cannot take directly the combobox entry index as depending on the storage some format are not listed.
-  char *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
-  char *storage_name = dt_conf_get_string(CONFIG_PREFIX "storage_name");
+  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
+  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
   const int format_index = dt_imageio_get_index_of_format(dt_imageio_get_format_by_name(format_name));
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(storage_name));
-
-  g_free(format_name);
-  g_free(storage_name);
 
   if(format_index == -1)
   {
@@ -341,12 +335,11 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   const gboolean upscale = dt_conf_get_bool(CONFIG_PREFIX "upscale");
   const gboolean high_quality = dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing");
   const gboolean export_masks = dt_conf_get_bool(CONFIG_PREFIX "export_masks");
-  char *tmp = dt_conf_get_string(CONFIG_PREFIX "style");
   const gboolean style_append = dt_conf_get_bool(CONFIG_PREFIX "style_append");
+  const char *tmp = dt_conf_get_conststring(CONFIG_PREFIX "style");
   if(tmp)
   {
     g_strlcpy(style, tmp, sizeof(style));
-    g_free(tmp);
   }
 
   // if upscale is activated and only one dimension is 0 we adjust it to ensure
@@ -378,7 +371,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   g_free(icc_filename);
 
   _scale_optim();
-  gtk_entry_set_text(GTK_ENTRY(d->scale), dt_conf_get_string(CONFIG_PREFIX "resizing_factor"));
+  gtk_entry_set_text(GTK_ENTRY(d->scale), dt_conf_get_conststring(CONFIG_PREFIX "resizing_factor"));
 }
 
 static void _scale_changed(GtkEntry *spin, dt_lib_export_t *d)
@@ -695,13 +688,11 @@ static void _format_changed(GtkWidget *widget, dt_lib_export_t *d)
 
 static void _get_max_output_dimension(dt_lib_export_t *d, uint32_t *width, uint32_t *height)
 {
-  gchar *storage_name = dt_conf_get_string(CONFIG_PREFIX "storage_name");
+  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
   dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(storage_name);
-  g_free(storage_name);
 
-  char *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
+  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
   dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(format_name);
-  g_free(format_name);
 
   if(storage && format)
   {
@@ -797,9 +788,8 @@ static void set_storage_by_name(dt_lib_export_t *d, const char *name)
   _update_formats_combobox(d);
 
   // Lets try to set selected format if fail select first in list..
-  gchar *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
+  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
   const dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(format_name);
-  g_free(format_name);
 
   if(format == NULL
      || dt_bauhaus_combobox_set_from_text(d->format, format->name()) == FALSE)
@@ -1036,9 +1026,8 @@ static void _update_formats_combobox(dt_lib_export_t *d)
   dt_bauhaus_combobox_clear(d->format);
 
   // Get current selected storage
-  gchar *storage_name = dt_conf_get_string(CONFIG_PREFIX "storage_name");
+  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
   dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(storage_name);
-  g_free(storage_name);
 
   // Add supported formats to combobox
   gboolean empty = TRUE;
@@ -1203,9 +1192,8 @@ void gui_init(dt_lib_module_t *self)
   d->print_dpi = gtk_entry_new();
   gtk_widget_set_tooltip_text(d->print_dpi, _("resolution in dot per inch"));
   gtk_entry_set_width_chars(GTK_ENTRY(d->print_dpi), 4);
-  char *dpi = dt_conf_get_string(CONFIG_PREFIX "print_dpi");
+  const char *dpi = dt_conf_get_conststring(CONFIG_PREFIX "print_dpi");
   gtk_entry_set_text(GTK_ENTRY(d->print_dpi), dpi);
-  g_free(dpi);
 
   dt_gui_key_accel_block_on_focus_connect(d->print_width);
   dt_gui_key_accel_block_on_focus_connect(d->print_height);
@@ -1252,7 +1240,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->scale = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(d->scale), 5);
-  gtk_entry_set_text (GTK_ENTRY(d->scale), dt_conf_get_string(CONFIG_PREFIX "resizing_factor"));
+  gtk_entry_set_text (GTK_ENTRY(d->scale), dt_conf_get_conststring(CONFIG_PREFIX "resizing_factor"));
   gtk_widget_set_tooltip_text(d->scale, _("it can be an integer, decimal number or simple fraction.\n"
                                           "zero or empty values are equal to 1.\n"
                                           "click middle mouse button to reset to 1."));
@@ -1431,12 +1419,10 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show_all(self->widget);
   gtk_widget_set_no_show_all(self->widget, TRUE);
 
-  gchar* setting = dt_conf_get_string(CONFIG_PREFIX "width");
+  const char* setting = dt_conf_get_conststring(CONFIG_PREFIX "width");
   gtk_entry_set_text(GTK_ENTRY(d->width), setting);
-  g_free(setting);
-  setting = dt_conf_get_string(CONFIG_PREFIX "height");
+  setting = dt_conf_get_conststring(CONFIG_PREFIX "height");
   gtk_entry_set_text(GTK_ENTRY(d->height), setting);
-  g_free(setting);
   dt_bauhaus_combobox_set(d->dimensions_type, dt_conf_get_int(CONFIG_PREFIX "dimensions_type"));
 
   const gboolean is_scaling = dt_conf_is_equal(CONFIG_PREFIX "resizing", "scaling");
@@ -1458,9 +1444,8 @@ void gui_init(dt_lib_module_t *self)
   _print_size_update_display(d);
 
   // Set storage
-  setting = dt_conf_get_string(CONFIG_PREFIX "storage_name");
+  setting = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(setting));
-  g_free(setting);
   dt_bauhaus_combobox_set(d->storage, storage_index);
 
   dt_bauhaus_combobox_set(d->upscale, dt_conf_get_bool(CONFIG_PREFIX "upscale") ? 1 : 0);
@@ -1493,8 +1478,7 @@ void gui_init(dt_lib_module_t *self)
   // style
   // set it to none if the var is not set or the style doesn't exist anymore
   gboolean rc = FALSE;
-  setting = NULL;
-  setting = dt_conf_get_string(CONFIG_PREFIX "style");
+  setting = dt_conf_get_conststring(CONFIG_PREFIX "style");
   if(setting != NULL && strlen(setting) > 0)
   {
     rc = dt_bauhaus_combobox_set_from_text(d->style, setting);
@@ -1503,7 +1487,6 @@ void gui_init(dt_lib_module_t *self)
   }
   else
     dt_bauhaus_combobox_set(d->style, 0);
-  g_free(setting);
 
   // style mode to overwrite as it was the initial behavior
   dt_bauhaus_combobox_set(d->style_mode, dt_conf_get_bool(CONFIG_PREFIX "style_append"));

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -182,8 +182,8 @@ static void _update(dt_lib_module_t *self)
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
   const gboolean has_act_on = imgs != NULL;
 
-  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
-  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
+  const char *format_name = dt_conf_get_string_const(CONFIG_PREFIX "format_name");
+  const char *storage_name = dt_conf_get_string_const(CONFIG_PREFIX "storage_name");
   const int format_index = dt_imageio_get_index_of_format(dt_imageio_get_format_by_name(format_name));
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(storage_name));
 
@@ -286,8 +286,8 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
 
   // get the format_name and storage_name settings which are plug-ins name and not necessary what is displayed on the combobox.
   // note that we cannot take directly the combobox entry index as depending on the storage some format are not listed.
-  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
-  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
+  const char *format_name = dt_conf_get_string_const(CONFIG_PREFIX "format_name");
+  const char *storage_name = dt_conf_get_string_const(CONFIG_PREFIX "storage_name");
   const int format_index = dt_imageio_get_index_of_format(dt_imageio_get_format_by_name(format_name));
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(storage_name));
 
@@ -336,7 +336,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   const gboolean high_quality = dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing");
   const gboolean export_masks = dt_conf_get_bool(CONFIG_PREFIX "export_masks");
   const gboolean style_append = dt_conf_get_bool(CONFIG_PREFIX "style_append");
-  const char *tmp = dt_conf_get_conststring(CONFIG_PREFIX "style");
+  const char *tmp = dt_conf_get_string_const(CONFIG_PREFIX "style");
   if(tmp)
   {
     g_strlcpy(style, tmp, sizeof(style));
@@ -371,7 +371,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   g_free(icc_filename);
 
   _scale_optim();
-  gtk_entry_set_text(GTK_ENTRY(d->scale), dt_conf_get_conststring(CONFIG_PREFIX "resizing_factor"));
+  gtk_entry_set_text(GTK_ENTRY(d->scale), dt_conf_get_string_const(CONFIG_PREFIX "resizing_factor"));
 }
 
 static void _scale_changed(GtkEntry *spin, dt_lib_export_t *d)
@@ -688,10 +688,10 @@ static void _format_changed(GtkWidget *widget, dt_lib_export_t *d)
 
 static void _get_max_output_dimension(dt_lib_export_t *d, uint32_t *width, uint32_t *height)
 {
-  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
+  const char *storage_name = dt_conf_get_string_const(CONFIG_PREFIX "storage_name");
   dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(storage_name);
 
-  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
+  const char *format_name = dt_conf_get_string_const(CONFIG_PREFIX "format_name");
   dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(format_name);
 
   if(storage && format)
@@ -788,7 +788,7 @@ static void set_storage_by_name(dt_lib_export_t *d, const char *name)
   _update_formats_combobox(d);
 
   // Lets try to set selected format if fail select first in list..
-  const char *format_name = dt_conf_get_conststring(CONFIG_PREFIX "format_name");
+  const char *format_name = dt_conf_get_string_const(CONFIG_PREFIX "format_name");
   const dt_imageio_module_format_t *format = dt_imageio_get_format_by_name(format_name);
 
   if(format == NULL
@@ -1026,7 +1026,7 @@ static void _update_formats_combobox(dt_lib_export_t *d)
   dt_bauhaus_combobox_clear(d->format);
 
   // Get current selected storage
-  const char *storage_name = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
+  const char *storage_name = dt_conf_get_string_const(CONFIG_PREFIX "storage_name");
   dt_imageio_module_storage_t *storage = dt_imageio_get_storage_by_name(storage_name);
 
   // Add supported formats to combobox
@@ -1192,7 +1192,7 @@ void gui_init(dt_lib_module_t *self)
   d->print_dpi = gtk_entry_new();
   gtk_widget_set_tooltip_text(d->print_dpi, _("resolution in dot per inch"));
   gtk_entry_set_width_chars(GTK_ENTRY(d->print_dpi), 4);
-  const char *dpi = dt_conf_get_conststring(CONFIG_PREFIX "print_dpi");
+  const char *dpi = dt_conf_get_string_const(CONFIG_PREFIX "print_dpi");
   gtk_entry_set_text(GTK_ENTRY(d->print_dpi), dpi);
 
   dt_gui_key_accel_block_on_focus_connect(d->print_width);
@@ -1240,7 +1240,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->scale = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(d->scale), 5);
-  gtk_entry_set_text (GTK_ENTRY(d->scale), dt_conf_get_conststring(CONFIG_PREFIX "resizing_factor"));
+  gtk_entry_set_text (GTK_ENTRY(d->scale), dt_conf_get_string_const(CONFIG_PREFIX "resizing_factor"));
   gtk_widget_set_tooltip_text(d->scale, _("it can be an integer, decimal number or simple fraction.\n"
                                           "zero or empty values are equal to 1.\n"
                                           "click middle mouse button to reset to 1."));
@@ -1419,9 +1419,9 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show_all(self->widget);
   gtk_widget_set_no_show_all(self->widget, TRUE);
 
-  const char* setting = dt_conf_get_conststring(CONFIG_PREFIX "width");
+  const char* setting = dt_conf_get_string_const(CONFIG_PREFIX "width");
   gtk_entry_set_text(GTK_ENTRY(d->width), setting);
-  setting = dt_conf_get_conststring(CONFIG_PREFIX "height");
+  setting = dt_conf_get_string_const(CONFIG_PREFIX "height");
   gtk_entry_set_text(GTK_ENTRY(d->height), setting);
   dt_bauhaus_combobox_set(d->dimensions_type, dt_conf_get_int(CONFIG_PREFIX "dimensions_type"));
 
@@ -1444,7 +1444,7 @@ void gui_init(dt_lib_module_t *self)
   _print_size_update_display(d);
 
   // Set storage
-  setting = dt_conf_get_conststring(CONFIG_PREFIX "storage_name");
+  setting = dt_conf_get_string_const(CONFIG_PREFIX "storage_name");
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(setting));
   dt_bauhaus_combobox_set(d->storage, storage_index);
 
@@ -1478,7 +1478,7 @@ void gui_init(dt_lib_module_t *self)
   // style
   // set it to none if the var is not set or the style doesn't exist anymore
   gboolean rc = FALSE;
-  setting = dt_conf_get_conststring(CONFIG_PREFIX "style");
+  setting = dt_conf_get_string_const(CONFIG_PREFIX "style");
   if(setting != NULL && strlen(setting) > 0)
   {
     rc = dt_bauhaus_combobox_set_from_text(d->style, setting);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1511,27 +1511,27 @@ void gui_init(dt_lib_module_t *self)
   d->green = dt_conf_get_bool("plugins/darkroom/histogram/show_green");
   d->blue = dt_conf_get_bool("plugins/darkroom/histogram/show_blue");
 
-  const char *str = dt_conf_get_conststring("plugins/darkroom/histogram/mode");
+  const char *str = dt_conf_get_string_const("plugins/darkroom/histogram/mode");
   for(dt_lib_histogram_scope_type_t i=0; i<DT_LIB_HISTOGRAM_SCOPE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_scope_type_names[i]) == 0)
       d->scope_type = i;
 
-  str = dt_conf_get_conststring("plugins/darkroom/histogram/histogram");
+  str = dt_conf_get_string_const("plugins/darkroom/histogram/histogram");
   for(dt_lib_histogram_scale_t i=0; i<DT_LIB_HISTOGRAM_SCALE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_scale_names[i]) == 0)
       d->histogram_scale = i;
 
-  str = dt_conf_get_conststring("plugins/darkroom/histogram/waveform");
+  str = dt_conf_get_string_const("plugins/darkroom/histogram/waveform");
   for(dt_lib_histogram_waveform_type_t i=0; i<DT_LIB_HISTOGRAM_WAVEFORM_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_waveform_type_names[i]) == 0)
       d->waveform_type = i;
 
-  str = dt_conf_get_conststring("plugins/darkroom/histogram/vectorscope");
+  str = dt_conf_get_string_const("plugins/darkroom/histogram/vectorscope");
   for(dt_lib_histogram_vectorscope_type_t i=0; i<DT_LIB_HISTOGRAM_VECTORSCOPE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_vectorscope_type_names[i]) == 0)
       d->vectorscope_type = i;
 
-  str = dt_conf_get_conststring("plugins/darkroom/histogram/vectorscope/scale");
+  str = dt_conf_get_string_const("plugins/darkroom/histogram/vectorscope/scale");
   for(dt_lib_histogram_scale_t i=0; i<DT_LIB_HISTOGRAM_SCALE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_scale_names[i]) == 0)
       d->vectorscope_scale = i;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1511,35 +1511,30 @@ void gui_init(dt_lib_module_t *self)
   d->green = dt_conf_get_bool("plugins/darkroom/histogram/show_green");
   d->blue = dt_conf_get_bool("plugins/darkroom/histogram/show_blue");
 
-  gchar *str = dt_conf_get_string("plugins/darkroom/histogram/mode");
+  const char *str = dt_conf_get_conststring("plugins/darkroom/histogram/mode");
   for(dt_lib_histogram_scope_type_t i=0; i<DT_LIB_HISTOGRAM_SCOPE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_scope_type_names[i]) == 0)
       d->scope_type = i;
-  g_free(str);
 
-  str = dt_conf_get_string("plugins/darkroom/histogram/histogram");
+  str = dt_conf_get_conststring("plugins/darkroom/histogram/histogram");
   for(dt_lib_histogram_scale_t i=0; i<DT_LIB_HISTOGRAM_SCALE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_scale_names[i]) == 0)
       d->histogram_scale = i;
-  g_free(str);
 
-  str = dt_conf_get_string("plugins/darkroom/histogram/waveform");
+  str = dt_conf_get_conststring("plugins/darkroom/histogram/waveform");
   for(dt_lib_histogram_waveform_type_t i=0; i<DT_LIB_HISTOGRAM_WAVEFORM_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_waveform_type_names[i]) == 0)
       d->waveform_type = i;
-  g_free(str);
 
-  str = dt_conf_get_string("plugins/darkroom/histogram/vectorscope");
+  str = dt_conf_get_conststring("plugins/darkroom/histogram/vectorscope");
   for(dt_lib_histogram_vectorscope_type_t i=0; i<DT_LIB_HISTOGRAM_VECTORSCOPE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_vectorscope_type_names[i]) == 0)
       d->vectorscope_type = i;
-  g_free(str);
 
-  str = dt_conf_get_string("plugins/darkroom/histogram/vectorscope/scale");
+  str = dt_conf_get_conststring("plugins/darkroom/histogram/vectorscope/scale");
   for(dt_lib_histogram_scale_t i=0; i<DT_LIB_HISTOGRAM_SCALE_N; i++)
     if(g_strcmp0(str, dt_lib_histogram_scale_names[i]) == 0)
       d->vectorscope_scale = i;
-  g_free(str);
 
   int a = dt_conf_get_int("plugins/darkroom/histogram/vectorscope/angle");
   d->vectorscope_angle = a * M_PI / 180.0;

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -568,7 +568,7 @@ static void _thumb_set_in_listview(GtkTreeModel *model, GtkTreeIter *iter,
   else
 #endif
   {
-    const char *folder = dt_conf_get_conststring("ui_last/import_last_directory");
+    const char *folder = dt_conf_get_string_const("ui_last/import_last_directory");
     char *fullname = g_build_filename(folder, filename, NULL);
     pixbuf = thumb_sel ? _import_get_thumbnail(fullname) : d->from.eye;
     g_free(fullname);
@@ -1100,7 +1100,7 @@ static gboolean _places_button_press(GtkWidget *view, GdkEventButton *event, dt_
     // right-click: delete / hide place (if not selected)
     else if(button_pressed == 3)
     {
-      if(g_strcmp0(folder_path, dt_conf_get_conststring("ui_last/import_last_place")))
+      if(g_strcmp0(folder_path, dt_conf_get_string_const("ui_last/import_last_place")))
         _remove_place(folder_path, iter, self);
       else
         dt_toast_log(_("you can't delete the selected place"));
@@ -1315,7 +1315,7 @@ static void _update_places_list(dt_lib_module_t* self)
 
   GtkTreeIter iter, current_iter;
   d->placesSelection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->placesView));
-  const char *last_place = dt_conf_get_conststring("ui_last/import_last_place");
+  const char *last_place = dt_conf_get_string_const("ui_last/import_last_place");
   char *current_place = "";
 
   if(dt_conf_get_bool("ui_last/import_dialog_show_home"))
@@ -1409,7 +1409,7 @@ static void _update_folders_list(dt_lib_module_t* self)
   g_object_ref(model);
   gtk_tree_view_set_model(d->from.folderview, NULL);
   gtk_tree_store_clear(GTK_TREE_STORE(model));
-  const char *last_place = dt_conf_get_conststring("ui_last/import_last_place");
+  const char *last_place = dt_conf_get_string_const("ui_last/import_last_place");
   char *folder = dt_conf_get_string("ui_last/import_last_directory");
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
                                        GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
@@ -1431,7 +1431,7 @@ static void _update_folders_list(dt_lib_module_t* self)
 static void _add_custom_place(const gchar *folder, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const char *current_folders = dt_conf_get_conststring("ui_last/import_custom_places");
+  const char *current_folders = dt_conf_get_string_const("ui_last/import_custom_places");
   GtkTreeIter iter;
 
   if(!g_strrstr(current_folders, folder))
@@ -1455,7 +1455,7 @@ static void _add_custom_place(const gchar *folder, dt_lib_module_t* self)
 static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const char *current_folders = dt_conf_get_conststring("ui_last/import_custom_places");
+  const char *current_folders = dt_conf_get_string_const("ui_last/import_custom_places");
   int type = 0;
   gtk_tree_model_get(GTK_TREE_MODEL(d->placesModel), &iter, DT_PLACES_TYPE, &type, -1);
 
@@ -2145,7 +2145,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
     }
     else if(_pref[i].type == DT_STRING)
     {
-      const char *s = dt_conf_get_conststring(_pref[i].key);
+      const char *s = dt_conf_get_string_const(_pref[i].key);
       pref = dt_util_dstrcat(pref, "%s=%s,", _pref[i].name, s);
     }
   }
@@ -2161,14 +2161,14 @@ static char *_get_current_configuration(dt_lib_module_t *self)
       g_free(setting);
 
       setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
-      const char *metadata_value = dt_conf_get_conststring(setting);
+      const char *metadata_value = dt_conf_get_string_const(setting);
       pref = dt_util_dstrcat(pref, "%s=%d%s,", metadata_name, imported ? 1 : 0, metadata_value);
       g_free(setting);
     }
   }
   // must be the last (comma separated list)
   const gboolean imported = dt_conf_get_bool("ui_last/import_last_tags_imported");
-  const char *tags_value = dt_conf_get_conststring("ui_last/import_last_tags");
+  const char *tags_value = dt_conf_get_string_const("ui_last/import_last_tags");
   pref = dt_util_dstrcat(pref, "%s=%d%s,", "tags", imported ? 1 : 0, tags_value);
   if(pref && *pref) pref[strlen(pref) - 1] = '\0';
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1480,7 +1480,7 @@ static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t
 static GList* _get_custom_places()
 {
   GList *places = NULL;
-  char *saved = dt_conf_get_string("ui_last/import_custom_places");
+  gchar *saved = dt_conf_get_string("ui_last/import_custom_places");
   const int nb_saved = saved[0] ? dt_util_str_occurence(saved, ",") + 1 : 0;
   char *folders = saved;
 
@@ -1496,6 +1496,7 @@ static GList* _get_custom_places()
         folders = next + 1;
     }
   }
+  g_free(saved);
   return places;
 }
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -568,10 +568,9 @@ static void _thumb_set_in_listview(GtkTreeModel *model, GtkTreeIter *iter,
   else
 #endif
   {
-    char *folder = dt_conf_get_string("ui_last/import_last_directory");
+    const char *folder = dt_conf_get_conststring("ui_last/import_last_directory");
     char *fullname = g_build_filename(folder, filename, NULL);
     pixbuf = thumb_sel ? _import_get_thumbnail(fullname) : d->from.eye;
-    g_free(folder);
     g_free(fullname);
   }
   gtk_list_store_set(d->from.store, iter, DT_IMPORT_SEL_THUMB, thumb_sel,
@@ -1101,7 +1100,7 @@ static gboolean _places_button_press(GtkWidget *view, GdkEventButton *event, dt_
     // right-click: delete / hide place (if not selected)
     else if(button_pressed == 3)
     {
-      if(g_strcmp0(folder_path, dt_conf_get_string("ui_last/import_last_place")))
+      if(g_strcmp0(folder_path, dt_conf_get_conststring("ui_last/import_last_place")))
         _remove_place(folder_path, iter, self);
       else
         dt_toast_log(_("you can't delete the selected place"));
@@ -1316,8 +1315,8 @@ static void _update_places_list(dt_lib_module_t* self)
 
   GtkTreeIter iter, current_iter;
   d->placesSelection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->placesView));
-  const gchar *last_place = dt_conf_get_string("ui_last/import_last_place");
-  gchar *current_place = g_strdup("");
+  const char *last_place = dt_conf_get_conststring("ui_last/import_last_place");
+  char *current_place = "";
 
   if(dt_conf_get_bool("ui_last/import_dialog_show_home"))
   {
@@ -1410,7 +1409,7 @@ static void _update_folders_list(dt_lib_module_t* self)
   g_object_ref(model);
   gtk_tree_view_set_model(d->from.folderview, NULL);
   gtk_tree_store_clear(GTK_TREE_STORE(model));
-  const gchar *last_place = dt_conf_get_string("ui_last/import_last_place");
+  const char *last_place = dt_conf_get_conststring("ui_last/import_last_place");
   char *folder = dt_conf_get_string("ui_last/import_last_directory");
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
                                        GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
@@ -1432,7 +1431,7 @@ static void _update_folders_list(dt_lib_module_t* self)
 static void _add_custom_place(const gchar *folder, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const gchar *current_folders = dt_conf_get_string("ui_last/import_custom_places");
+  const char *current_folders = dt_conf_get_conststring("ui_last/import_custom_places");
   GtkTreeIter iter;
 
   if(!g_strrstr(current_folders, folder))
@@ -1456,7 +1455,7 @@ static void _add_custom_place(const gchar *folder, dt_lib_module_t* self)
 static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
-  const gchar *current_folders = dt_conf_get_string("ui_last/import_custom_places");
+  const char *current_folders = dt_conf_get_conststring("ui_last/import_custom_places");
   int type = 0;
   gtk_tree_model_get(GTK_TREE_MODEL(d->placesModel), &iter, DT_PLACES_TYPE, &type, -1);
 
@@ -2145,9 +2144,8 @@ static char *_get_current_configuration(dt_lib_module_t *self)
     }
     else if(_pref[i].type == DT_STRING)
     {
-      char *s = dt_conf_get_string(_pref[i].key);
+      const char *s = dt_conf_get_conststring(_pref[i].key);
       pref = dt_util_dstrcat(pref, "%s=%s,", _pref[i].name, s);
-      g_free(s);
     }
   }
 
@@ -2162,17 +2160,15 @@ static char *_get_current_configuration(dt_lib_module_t *self)
       g_free(setting);
 
       setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
-      char *metadata_value = dt_conf_get_string(setting);
+      const char *metadata_value = dt_conf_get_conststring(setting);
       pref = dt_util_dstrcat(pref, "%s=%d%s,", metadata_name, imported ? 1 : 0, metadata_value);
       g_free(setting);
-      g_free(metadata_value);
     }
   }
   // must be the last (comma separated list)
   const gboolean imported = dt_conf_get_bool("ui_last/import_last_tags_imported");
-  char *tags_value = dt_conf_get_string("ui_last/import_last_tags");
+  const char *tags_value = dt_conf_get_conststring("ui_last/import_last_tags");
   pref = dt_util_dstrcat(pref, "%s=%d%s,", "tags", imported ? 1 : 0, tags_value);
-  g_free(tags_value);
   if(pref && *pref) pref[strlen(pref) - 1] = '\0';
 
   return pref;

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -352,7 +352,7 @@ static gboolean _lib_location_search(gpointer user_data)
 
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_location_t *lib = (dt_lib_location_t *)self->data;
-  gchar *query = NULL, *text = NULL, *search_url = NULL;
+  gchar *query = NULL, *text = NULL;
 
   /* get escaped search text */
   text = g_uri_escape_string(gtk_entry_get_text(lib->search), NULL, FALSE);
@@ -363,7 +363,7 @@ static gboolean _lib_location_search(gpointer user_data)
   clear_search(lib);
 
   /* build the query url */
-  search_url = dt_conf_get_string("plugins/map/geotagging_search_url");
+  const char *search_url = dt_conf_get_conststring("plugins/map/geotagging_search_url");
   query = g_strdup_printf(search_url, text, LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();
@@ -410,7 +410,6 @@ bail_out:
 
   g_free(text);
   g_free(query);
-  g_free(search_url);
 
   if(ctx) g_markup_parse_context_free(ctx);
 

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -363,7 +363,7 @@ static gboolean _lib_location_search(gpointer user_data)
   clear_search(lib);
 
   /* build the query url */
-  const char *search_url = dt_conf_get_conststring("plugins/map/geotagging_search_url");
+  const char *search_url = dt_conf_get_string_const("plugins/map/geotagging_search_url");
   query = g_strdup_printf(search_url, text, LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -114,7 +114,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(d->map_source_dropdown), renderer, FALSE);
   gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(d->map_source_dropdown), renderer, "text", 0, NULL);
 
-  gchar *map_source = dt_conf_get_string("plugins/map/map_source");
+  const char *map_source = dt_conf_get_conststring("plugins/map/map_source");
   int selection = OSM_GPS_MAP_SOURCE_OPENSTREETMAP - 1, entry = 0;
   GtkTreeIter iter;
   for(int i = 1; i < OSM_GPS_MAP_SOURCE_LAST; i++)
@@ -132,7 +132,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(hbox, d->map_source_dropdown, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(d->map_source_dropdown), "changed", G_CALLBACK(_map_source_changed), NULL);
   g_object_unref(model);
-  g_free(map_source);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
@@ -178,7 +177,7 @@ static gboolean _thumbnail_change(GtkAccelGroup *accel_group, GObject *accelerat
 {
   dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)self->data;
 
-  char *str = dt_conf_get_string("plugins/map/images_thumbnail");
+  const char *str = dt_conf_get_conststring("plugins/map/images_thumbnail");
   if(!g_strcmp0(str, "thumbnail"))
     dt_conf_set_string("plugins/map/images_thumbnail", "count");
   else if(!g_strcmp0(str, "count"))
@@ -186,7 +185,6 @@ static gboolean _thumbnail_change(GtkAccelGroup *accel_group, GObject *accelerat
   else
     dt_conf_set_string("plugins/map/images_thumbnail", "thumbnail");
   dt_gui_preferences_enum_update(d->images_thumb);
-  g_free(str);
 
   return TRUE;
 }

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -114,7 +114,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(d->map_source_dropdown), renderer, FALSE);
   gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(d->map_source_dropdown), renderer, "text", 0, NULL);
 
-  const char *map_source = dt_conf_get_conststring("plugins/map/map_source");
+  const char *map_source = dt_conf_get_string_const("plugins/map/map_source");
   int selection = OSM_GPS_MAP_SOURCE_OPENSTREETMAP - 1, entry = 0;
   GtkTreeIter iter;
   for(int i = 1; i < OSM_GPS_MAP_SOURCE_LAST; i++)
@@ -177,7 +177,7 @@ static gboolean _thumbnail_change(GtkAccelGroup *accel_group, GObject *accelerat
 {
   dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)self->data;
 
-  const char *str = dt_conf_get_conststring("plugins/map/images_thumbnail");
+  const char *str = dt_conf_get_string_const("plugins/map/images_thumbnail");
   if(!g_strcmp0(str, "thumbnail"))
     dt_conf_set_string("plugins/map/images_thumbnail", "count");
   else if(!g_strcmp0(str, "count"))

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1405,7 +1405,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show_all(d->grid);
   gtk_widget_set_no_show_all(d->grid, TRUE);
   _lib_metadata_setup_grid(self);
-  const char *pref = dt_conf_get_conststring("plugins/lighttable/metadata_view/visible");
+  const char *pref = dt_conf_get_string_const("plugins/lighttable/metadata_view/visible");
   if(!strlen(pref))
     _display_default(self);
   _apply_preferences(pref, self);
@@ -1579,7 +1579,7 @@ static int lua_register_info(lua_State *L)
       lua_pop(L, 1);
     }
     // apply again preferences because it's already done
-    const char *pref = dt_conf_get_conststring("plugins/lighttable/metadata_view/visible");
+    const char *pref = dt_conf_get_string_const("plugins/lighttable/metadata_view/visible");
     _apply_preferences(pref, self);
   }
   return 0;

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1405,11 +1405,10 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show_all(d->grid);
   gtk_widget_set_no_show_all(d->grid, TRUE);
   _lib_metadata_setup_grid(self);
-  char *pref = dt_conf_get_string("plugins/lighttable/metadata_view/visible");
+  const char *pref = dt_conf_get_conststring("plugins/lighttable/metadata_view/visible");
   if(!strlen(pref))
     _display_default(self);
   _apply_preferences(pref, self);
-  g_free(pref);
 
   /* lets signup for mouse over image change signals */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
@@ -1580,9 +1579,8 @@ static int lua_register_info(lua_State *L)
       lua_pop(L, 1);
     }
     // apply again preferences because it's already done
-    char *pref = dt_conf_get_string("plugins/lighttable/metadata_view/visible");
+    const char *pref = dt_conf_get_conststring("plugins/lighttable/metadata_view/visible");
     _apply_preferences(pref, self);
-    g_free(pref);
   }
   return 0;
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1117,7 +1117,7 @@ static uint32_t _lib_modulegroups_get(dt_lib_module_t *self)
 static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref(gchar **ret)
 {
   // show the search box ?
-  gchar *show_text_entry = dt_conf_get_string("plugins/darkroom/search_iop_by_text");
+  const char *show_text_entry = dt_conf_get_conststring("plugins/darkroom/search_iop_by_text");
   dt_lib_modulegroup_iop_visibility_type_t val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
 
   if(strcmp(show_text_entry, "show search text") == 0)
@@ -1138,7 +1138,6 @@ static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref
     *ret = dt_util_dstrcat(*ret, "1");
     val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
   }
-  g_free(show_text_entry);
   return val;
 }
 
@@ -2087,7 +2086,7 @@ static void _manage_editor_save(dt_lib_module_t *self)
   g_free(params);
 
   // update groups
-  gchar *preset = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
+  const char *preset = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
   if(g_strcmp0(preset, d->edit_preset) == 0)
   {
     // and we update the gui
@@ -2095,7 +2094,6 @@ static void _manage_editor_save(dt_lib_module_t *self)
       dt_lib_presets_apply((gchar *)C_("modulegroup", FALLBACK_PRESET_NAME),
                            self->plugin_name, self->version());
   }
-  g_free(preset);
 }
 
 static void _manage_editor_module_remove(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)
@@ -3645,14 +3643,13 @@ static void _manage_preset_delete(GtkWidget *widget, dt_lib_module_t *self)
     // if the deleted preset was the one currently in use, load default preset
     if(dt_conf_key_exists("plugins/darkroom/modulegroups_preset"))
     {
-      gchar *cur = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
+      const char *cur = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
       if(g_strcmp0(cur, d->edit_preset) == 0)
       {
         dt_conf_set_string("plugins/darkroom/modulegroups_preset", C_("modulegroup", FALLBACK_PRESET_NAME));
         dt_lib_presets_apply((gchar *)C_("modulegroup", FALLBACK_PRESET_NAME),
                              self->plugin_name, self->version());
       }
-      g_free(cur);
     }
 
     // reload presets list
@@ -3828,9 +3825,8 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_widget_show_all(vb_main);
 
   // and we select the current one
-  gchar *preset = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
+  const char *preset = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
   _manage_editor_load(preset, self);
-  g_free(preset);
 
   gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(d->dialog))), vb_main);
 
@@ -3865,10 +3861,9 @@ void view_enter(dt_lib_module_t *self, dt_view_t *old_view, dt_view_t *new_view)
     dt_gui_key_accel_block_on_focus_connect(d->text_entry);
 
     // and we initialize the buttons too
-    gchar *preset = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
+    const char *preset = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
     if(!dt_lib_presets_apply(preset, self->plugin_name, self->version()))
       dt_lib_presets_apply(_(FALLBACK_PRESET_NAME), self->plugin_name, self->version());
-    g_free(preset);
 
     // and set the current group
     d->current = dt_conf_get_int("plugins/darkroom/groups");

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1117,7 +1117,7 @@ static uint32_t _lib_modulegroups_get(dt_lib_module_t *self)
 static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref(gchar **ret)
 {
   // show the search box ?
-  const char *show_text_entry = dt_conf_get_conststring("plugins/darkroom/search_iop_by_text");
+  const char *show_text_entry = dt_conf_get_string_const("plugins/darkroom/search_iop_by_text");
   dt_lib_modulegroup_iop_visibility_type_t val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
 
   if(strcmp(show_text_entry, "show search text") == 0)
@@ -2086,7 +2086,7 @@ static void _manage_editor_save(dt_lib_module_t *self)
   g_free(params);
 
   // update groups
-  const char *preset = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
+  const char *preset = dt_conf_get_string_const("plugins/darkroom/modulegroups_preset");
   if(g_strcmp0(preset, d->edit_preset) == 0)
   {
     // and we update the gui
@@ -3643,7 +3643,7 @@ static void _manage_preset_delete(GtkWidget *widget, dt_lib_module_t *self)
     // if the deleted preset was the one currently in use, load default preset
     if(dt_conf_key_exists("plugins/darkroom/modulegroups_preset"))
     {
-      const char *cur = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
+      const char *cur = dt_conf_get_string_const("plugins/darkroom/modulegroups_preset");
       if(g_strcmp0(cur, d->edit_preset) == 0)
       {
         dt_conf_set_string("plugins/darkroom/modulegroups_preset", C_("modulegroup", FALLBACK_PRESET_NAME));
@@ -3825,7 +3825,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_widget_show_all(vb_main);
 
   // and we select the current one
-  const char *preset = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
+  const char *preset = dt_conf_get_string_const("plugins/darkroom/modulegroups_preset");
   _manage_editor_load(preset, self);
 
   gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(d->dialog))), vb_main);
@@ -3861,7 +3861,7 @@ void view_enter(dt_lib_module_t *self, dt_view_t *old_view, dt_view_t *new_view)
     dt_gui_key_accel_block_on_focus_connect(d->text_entry);
 
     // and we initialize the buttons too
-    const char *preset = dt_conf_get_conststring("plugins/darkroom/modulegroups_preset");
+    const char *preset = dt_conf_get_string_const("plugins/darkroom/modulegroups_preset");
     if(!dt_lib_presets_apply(preset, self->plugin_name, self->version()))
       dt_lib_presets_apply(_(FALLBACK_PRESET_NAME), self->plugin_name, self->version());
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -708,7 +708,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   dt_conf_set_string("plugins/print/print/printer", printer_name);
 
-  char *default_paper = dt_conf_get_string("plugins/print/print/paper");
+  const char *default_paper = dt_conf_get_conststring("plugins/print/print/paper");
 
   // next add corresponding papers
 
@@ -746,11 +746,9 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
   if(paper)
     memcpy(&ps->prt.paper, paper, sizeof(dt_paper_info_t));
 
-  g_free (default_paper);
-
   // next add corresponding supported media
 
-  char *default_medium = dt_conf_get_string("plugins/print/print/medium");
+  const char *default_medium = dt_conf_get_conststring("plugins/print/print/medium");
 
   // first clear current list
 
@@ -2154,7 +2152,7 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->pprofile), TRUE, TRUE, 0);
   int printer_profile_type = dt_conf_get_int("plugins/print/printer/icctype");
-  gchar *printer_profile = dt_conf_get_string("plugins/print/printer/iccprofile");
+  const char *printer_profile = dt_conf_get_conststring("plugins/print/printer/iccprofile");
   combo_idx = -1;
   n = 0;
 
@@ -2177,8 +2175,6 @@ void gui_init(dt_lib_module_t *self)
       }
     }
   }
-
-  g_free (printer_profile);
 
   // profile not found, maybe a profile has been removed? revert to none
   if(combo_idx == -1)
@@ -2480,7 +2476,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->profile, _("image settings"));
 
   const int icctype = dt_conf_get_int("plugins/print/print/icctype");
-  gchar *iccprofile = dt_conf_get_string("plugins/print/print/iccprofile");
+  const gchar *iccprofile = dt_conf_get_conststring("plugins/print/print/iccprofile");
   combo_idx = -1;
   n = 0;
 
@@ -2508,7 +2504,6 @@ void gui_init(dt_lib_module_t *self)
     d->v_iccprofile = g_strdup("");
     combo_idx = 0;
   }
-  g_free (iccprofile);
 
   dt_bauhaus_combobox_set(d->profile, combo_idx);
 
@@ -2542,7 +2537,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->style, _("none"));
 
   GList *styles = dt_styles_get_list("");
-  gchar *current_style = dt_conf_get_string("plugins/print/print/style");
+  const char *current_style = dt_conf_get_conststring("plugins/print/print/style");
   combo_idx = -1; n=0;
 
   for(const GList *st_iter = styles; st_iter; st_iter = g_list_next(st_iter))
@@ -2557,7 +2552,6 @@ void gui_init(dt_lib_module_t *self)
       combo_idx=n;
     }
   }
-  g_free(current_style);
   g_list_free_full(styles, dt_style_free);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->style), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(d->style, _("temporary style to use while printing"));

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -708,7 +708,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   dt_conf_set_string("plugins/print/print/printer", printer_name);
 
-  const char *default_paper = dt_conf_get_conststring("plugins/print/print/paper");
+  const char *default_paper = dt_conf_get_string_const("plugins/print/print/paper");
 
   // next add corresponding papers
 
@@ -748,7 +748,7 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   // next add corresponding supported media
 
-  const char *default_medium = dt_conf_get_conststring("plugins/print/print/medium");
+  const char *default_medium = dt_conf_get_string_const("plugins/print/print/medium");
 
   // first clear current list
 
@@ -784,8 +784,6 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   if(medium)
     memcpy(&ps->prt.medium, medium, sizeof(dt_medium_info_t));
-
-  g_free (default_medium);
 
   dt_view_print_settings(darktable.view_manager, &ps->prt, &ps->imgs);
 }
@@ -2152,7 +2150,7 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->pprofile), TRUE, TRUE, 0);
   int printer_profile_type = dt_conf_get_int("plugins/print/printer/icctype");
-  const char *printer_profile = dt_conf_get_conststring("plugins/print/printer/iccprofile");
+  const char *printer_profile = dt_conf_get_string_const("plugins/print/printer/iccprofile");
   combo_idx = -1;
   n = 0;
 
@@ -2476,7 +2474,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->profile, _("image settings"));
 
   const int icctype = dt_conf_get_int("plugins/print/print/icctype");
-  const gchar *iccprofile = dt_conf_get_conststring("plugins/print/print/iccprofile");
+  const gchar *iccprofile = dt_conf_get_string_const("plugins/print/print/iccprofile");
   combo_idx = -1;
   n = 0;
 
@@ -2537,7 +2535,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->style, _("none"));
 
   GList *styles = dt_styles_get_list("");
-  const char *current_style = dt_conf_get_conststring("plugins/print/print/style");
+  const char *current_style = dt_conf_get_string_const("plugins/print/print/style");
   combo_idx = -1; n=0;
 
   for(const GList *st_iter = styles; st_iter; st_iter = g_list_next(st_iter))

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -72,7 +72,7 @@ int position()
 static gboolean _goto_previous(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                GdkModifierType modifier, gpointer data)
 {
-  const char *line = dt_conf_get_conststring("plugins/lighttable/recentcollect/line1");
+  const char *line = dt_conf_get_string_const("plugins/lighttable/recentcollect/line1");
   if(line)
   {
     dt_collection_deserialize(line);
@@ -162,7 +162,7 @@ static void _button_pressed(GtkButton *button, gpointer user_data)
   if(n < 0) return;
   char confname[200];
   snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", n);
-  const char *line = dt_conf_get_conststring(confname);
+  const char *line = dt_conf_get_string_const(confname);
   if(line)
   {
     dt_collection_deserialize(line);
@@ -205,7 +205,7 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
   {
     // is it already in the current list?
     snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
-    const char *line = dt_conf_get_conststring(confname);
+    const char *line = dt_conf_get_string_const(confname);
     if(!line) continue;
     if(!strcmp(line, buf))
     {
@@ -257,7 +257,7 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
   {
     char str[2048] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
-    const char *line2 = dt_conf_get_conststring(confname);
+    const char *line2 = dt_conf_get_string_const(confname);
     if(line2 && line2[0] != '\0') pretty_print(line2, str, sizeof(str));
     gtk_widget_set_tooltip_text(d->item[k].button, str);
     gtk_button_set_label(GTK_BUTTON(d->item[k].button), str);

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -72,11 +72,10 @@ int position()
 static gboolean _goto_previous(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                GdkModifierType modifier, gpointer data)
 {
-  gchar *line = dt_conf_get_string("plugins/lighttable/recentcollect/line1");
+  const char *line = dt_conf_get_conststring("plugins/lighttable/recentcollect/line1");
   if(line)
   {
     dt_collection_deserialize(line);
-    g_free(line);
   }
   return TRUE;
 }
@@ -93,7 +92,7 @@ void connect_key_accels(dt_lib_module_t *self)
 }
 
 
-static void pretty_print(char *buf, char *out, size_t outsize)
+static void pretty_print(const char *buf, char *out, size_t outsize)
 {
   memset(out, 0, outsize);
 
@@ -163,11 +162,10 @@ static void _button_pressed(GtkButton *button, gpointer user_data)
   if(n < 0) return;
   char confname[200];
   snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", n);
-  gchar *line = dt_conf_get_string(confname);
+  const char *line = dt_conf_get_conststring(confname);
   if(line)
   {
     dt_collection_deserialize(line);
-    g_free(line);
     // position will be updated when the list of recent collections is.
     // that way it'll also catch cases when this is triggered by a signal,
     // not only our button press here.
@@ -207,17 +205,15 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
   {
     // is it already in the current list?
     snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
-    gchar *line = dt_conf_get_string(confname);
+    const char *line = dt_conf_get_conststring(confname);
     if(!line) continue;
     if(!strcmp(line, buf))
     {
       snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", k);
       new_pos = dt_conf_get_int(confname);
       n = k;
-      g_free(line);
       break;
     }
-    g_free(line);
   }
   if(n < 0)
   {
@@ -261,9 +257,8 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
   {
     char str[2048] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
-    gchar *line2 = dt_conf_get_string(confname);
+    const char *line2 = dt_conf_get_conststring(confname);
     if(line2 && line2[0] != '\0') pretty_print(line2, str, sizeof(str));
-    g_free(line2);
     gtk_widget_set_tooltip_text(d->item[k].button, str);
     gtk_button_set_label(GTK_BUTTON(d->item[k].button), str);
     GtkWidget *child = gtk_bin_get_child(GTK_BIN(d->item[k].button));

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -114,9 +114,8 @@ void gui_init(dt_lib_module_t *self)
 
   g_signal_connect(G_OBJECT(lib->gui.button1), "clicked", G_CALLBACK(create_callback), self);
 
-  gchar *str = dt_conf_get_string("plugins/session/jobcode");
+  const char *str = dt_conf_get_conststring("plugins/session/jobcode");
   gtk_entry_set_text(lib->gui.entry1, str);
-  g_free(str);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -114,7 +114,7 @@ void gui_init(dt_lib_module_t *self)
 
   g_signal_connect(G_OBJECT(lib->gui.button1), "clicked", G_CALLBACK(create_callback), self);
 
-  const char *str = dt_conf_get_conststring("plugins/session/jobcode");
+  const char *str = dt_conf_get_string_const("plugins/session/jobcode");
   gtk_entry_set_text(lib->gui.entry1, str);
 }
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2295,7 +2295,7 @@ static gboolean _row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean
 
 static void _import_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
-  const char *last_dirname = dt_conf_get_conststring("plugins/lighttable/tagging/last_import_export_location");
+  const char *last_dirname = dt_conf_get_string_const("plugins/lighttable/tagging/last_import_export_location");
   if(!last_dirname || !*last_dirname)
   {
     last_dirname = g_get_home_dir();
@@ -2334,7 +2334,7 @@ static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   GDateTime *now = g_date_time_new_now_local();
   char *export_filename = g_date_time_format(now, "darktable_tags_%F_%R.txt");
-  const char *last_dirname = dt_conf_get_conststring("plugins/lighttable/tagging/last_import_export_location");
+  const char *last_dirname = dt_conf_get_string_const("plugins/lighttable/tagging/last_import_export_location");
   if(!last_dirname || !*last_dirname)
   {
     last_dirname = g_get_home_dir();

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2295,11 +2295,10 @@ static gboolean _row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean
 
 static void _import_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
-  char *last_dirname = dt_conf_get_string("plugins/lighttable/tagging/last_import_export_location");
+  const char *last_dirname = dt_conf_get_conststring("plugins/lighttable/tagging/last_import_export_location");
   if(!last_dirname || !*last_dirname)
   {
-    g_free(last_dirname);
-    last_dirname = g_strdup(g_get_home_dir());
+    last_dirname = g_get_home_dir();
   }
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
@@ -2327,7 +2326,6 @@ static void _import_button_clicked(GtkButton *button, dt_lib_module_t *self)
     g_free(dirname);
   }
 
-  g_free(last_dirname);
   gtk_widget_destroy(filechooser);
   _init_treeview(self, 1);
 }
@@ -2336,11 +2334,10 @@ static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   GDateTime *now = g_date_time_new_now_local();
   char *export_filename = g_date_time_format(now, "darktable_tags_%F_%R.txt");
-  char *last_dirname = dt_conf_get_string("plugins/lighttable/tagging/last_import_export_location");
+  const char *last_dirname = dt_conf_get_conststring("plugins/lighttable/tagging/last_import_export_location");
   if(!last_dirname || !*last_dirname)
   {
-    g_free(last_dirname);
-    last_dirname = g_strdup(g_get_home_dir());
+    last_dirname = g_get_home_dir();
   }
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
@@ -2370,7 +2367,6 @@ static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
   }
 
   g_date_time_unref(now);
-  g_free(last_dirname);
   g_free(export_filename);
   gtk_widget_destroy(filechooser);
 }

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -57,7 +57,7 @@ const char **views(dt_lib_module_t *self)
 
 uint32_t container(dt_lib_module_t *self)
 {
-  gchar *pos = dt_conf_get_string("plugins/darkroom/image_infos_position");
+  const char *pos = dt_conf_get_conststring("plugins/darkroom/image_infos_position");
   dt_ui_container_t cont = DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER; // default value
 
   if(g_strcmp0(pos, "top left") == 0)
@@ -67,7 +67,6 @@ uint32_t container(dt_lib_module_t *self)
   else if(g_strcmp0(pos, "top center") == 0)
     cont = DT_UI_CONTAINER_PANEL_CENTER_TOP_CENTER;
 
-  g_free(pos);
   return cont;
 }
 

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -57,7 +57,7 @@ const char **views(dt_lib_module_t *self)
 
 uint32_t container(dt_lib_module_t *self)
 {
-  const char *pos = dt_conf_get_conststring("plugins/darkroom/image_infos_position");
+  const char *pos = dt_conf_get_string_const("plugins/darkroom/image_infos_position");
   dt_ui_container_t cont = DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER; // default value
 
   if(g_strcmp0(pos, "top left") == 0)

--- a/src/lua/format.c
+++ b/src/lua/format.c
@@ -162,10 +162,9 @@ static int write_image(lua_State *L)
   gboolean export_masks = dt_conf_get_bool("plugins/lighttable/export/export_masks");
   // TODO: expose icc overwrites to the user!
   dt_colorspaces_color_profile_type_t icc_type = dt_conf_get_int("plugins/lighttable/export/icctype");
-  gchar *icc_filename = dt_conf_get_string("plugins/lighttable/export/iccprofile");
+  const char *icc_filename = dt_conf_get_conststring("plugins/lighttable/export/iccprofile");
   gboolean result = dt_imageio_export(imgid, filename, format, fdata, high_quality, upscale, FALSE, export_masks,
                                       icc_type, icc_filename, DT_INTENT_LAST, NULL, NULL, 1, 1, NULL);
-  g_free(icc_filename);
   dt_lua_lock();
   lua_pushboolean(L, result);
   format->free_params(format, fdata);

--- a/src/lua/format.c
+++ b/src/lua/format.c
@@ -162,7 +162,7 @@ static int write_image(lua_State *L)
   gboolean export_masks = dt_conf_get_bool("plugins/lighttable/export/export_masks");
   // TODO: expose icc overwrites to the user!
   dt_colorspaces_color_profile_type_t icc_type = dt_conf_get_int("plugins/lighttable/export/icctype");
-  const char *icc_filename = dt_conf_get_conststring("plugins/lighttable/export/iccprofile");
+  const char *icc_filename = dt_conf_get_string_const("plugins/lighttable/export/iccprofile");
   gboolean result = dt_imageio_export(imgid, filename, format, fdata, high_quality, upscale, FALSE, export_masks,
                                       icc_type, icc_filename, DT_INTENT_LAST, NULL, NULL, 1, 1, NULL);
   dt_lua_lock();

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -188,30 +188,26 @@ static int read_pref(lua_State *L)
   {
     case pref_enum:
     {
-      char *str = dt_conf_get_string(pref_name);
+      const char *str = dt_conf_get_conststring(pref_name);
       lua_pushstring(L, str);
-      g_free(str);
       break;
     }
     case pref_dir:
     {
-      char *str = dt_conf_get_string(pref_name);
+      const char *str = dt_conf_get_conststring(pref_name);
       lua_pushstring(L, str);
-      g_free(str);
       break;
     }
     case pref_file:
     {
-      char *str = dt_conf_get_string(pref_name);
+      const char *str = dt_conf_get_conststring(pref_name);
       lua_pushstring(L, str);
-      g_free(str);
       break;
     }
     case pref_string:
     {
-      char *str = dt_conf_get_string(pref_name);
+      const char *str = dt_conf_get_conststring(pref_name);
       lua_pushstring(L, str);
-      g_free(str);
       break;
     }
     case pref_bool:
@@ -225,9 +221,8 @@ static int read_pref(lua_State *L)
       break;
     case pref_lua:
     {
-      char *str = dt_conf_get_string(pref_name);
+      const char *str = dt_conf_get_conststring(pref_name);
       lua_pushstring(L, str);
-      g_free(str);
       break;
     }
   }
@@ -476,7 +471,7 @@ static gboolean reset_widget_lua(GtkWidget *label, GdkEventButton *event, pref_e
   {
     char pref_name[1024];
     get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-    char *old_str = dt_conf_get_string(pref_name);
+    gchar *old_str = dt_conf_get_string(pref_name);
     dt_conf_set_string(pref_name, cur_elt->type_data.lua_data.default_value);
     dt_lua_lock_silent();
     lua_State * L = darktable.lua_state.state;
@@ -487,7 +482,7 @@ static gboolean reset_widget_lua(GtkWidget *label, GdkEventButton *event, pref_e
     lua_call(L,3,0);
     dt_lua_unlock();
     dt_conf_set_string(pref_name, old_str);
-    free(old_str);
+    g_free(old_str);
     return TRUE;
   }
   return FALSE;
@@ -501,7 +496,7 @@ static void update_widget_enum(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_enum), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_enum), cur_elt);
   gtk_combo_box_set_active(GTK_COMBO_BOX(cur_elt->widget), 0);
-  char*value = dt_conf_get_string(pref_name);
+  const char *value = dt_conf_get_conststring(pref_name);
   do {
     char * active_entry = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(cur_elt->widget));
     if(!active_entry)
@@ -521,7 +516,6 @@ static void update_widget_enum(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
       g_free(active_entry);
     }
   } while(true);
-  g_free(value);
 }
 
 
@@ -529,9 +523,8 @@ static void update_widget_dir(pref_element* cur_elt,GtkWidget* dialog,GtkWidget*
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  gchar *str = dt_conf_get_string(pref_name);
+  const char *str = dt_conf_get_conststring(pref_name);
   gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(cur_elt->widget), str);
-  g_free(str);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_dir), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_dir), cur_elt);
 }
@@ -541,9 +534,8 @@ static void update_widget_file(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  gchar *str = dt_conf_get_string(pref_name);
+  const char *str = dt_conf_get_conststring(pref_name);
   gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(cur_elt->widget), str);
-  g_free(str);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_file), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_file), cur_elt);
 }
@@ -555,9 +547,8 @@ static void update_widget_string(pref_element* cur_elt,GtkWidget* dialog,GtkWidg
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_string), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_string), cur_elt);
-  char* str = dt_conf_get_string(pref_name);
+  const char *str = dt_conf_get_conststring(pref_name);
   gtk_entry_set_text(GTK_ENTRY(cur_elt->widget), str);
-  g_free(str);
 }
 
 

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -188,25 +188,25 @@ static int read_pref(lua_State *L)
   {
     case pref_enum:
     {
-      const char *str = dt_conf_get_conststring(pref_name);
+      const char *str = dt_conf_get_string_const(pref_name);
       lua_pushstring(L, str);
       break;
     }
     case pref_dir:
     {
-      const char *str = dt_conf_get_conststring(pref_name);
+      const char *str = dt_conf_get_string_const(pref_name);
       lua_pushstring(L, str);
       break;
     }
     case pref_file:
     {
-      const char *str = dt_conf_get_conststring(pref_name);
+      const char *str = dt_conf_get_string_const(pref_name);
       lua_pushstring(L, str);
       break;
     }
     case pref_string:
     {
-      const char *str = dt_conf_get_conststring(pref_name);
+      const char *str = dt_conf_get_string_const(pref_name);
       lua_pushstring(L, str);
       break;
     }
@@ -221,7 +221,7 @@ static int read_pref(lua_State *L)
       break;
     case pref_lua:
     {
-      const char *str = dt_conf_get_conststring(pref_name);
+      const char *str = dt_conf_get_string_const(pref_name);
       lua_pushstring(L, str);
       break;
     }
@@ -496,7 +496,7 @@ static void update_widget_enum(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_enum), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_enum), cur_elt);
   gtk_combo_box_set_active(GTK_COMBO_BOX(cur_elt->widget), 0);
-  const char *value = dt_conf_get_conststring(pref_name);
+  const char *value = dt_conf_get_string_const(pref_name);
   do {
     char * active_entry = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(cur_elt->widget));
     if(!active_entry)
@@ -523,7 +523,7 @@ static void update_widget_dir(pref_element* cur_elt,GtkWidget* dialog,GtkWidget*
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  const char *str = dt_conf_get_conststring(pref_name);
+  const char *str = dt_conf_get_string_const(pref_name);
   gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(cur_elt->widget), str);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_dir), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_dir), cur_elt);
@@ -534,7 +534,7 @@ static void update_widget_file(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
 {
   char pref_name[1024];
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
-  const char *str = dt_conf_get_conststring(pref_name);
+  const char *str = dt_conf_get_string_const(pref_name);
   gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(cur_elt->widget), str);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_file), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_file), cur_elt);
@@ -547,7 +547,7 @@ static void update_widget_string(pref_element* cur_elt,GtkWidget* dialog,GtkWidg
   get_pref_name(pref_name, sizeof(pref_name), cur_elt->script, cur_elt->name);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_string), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_string), cur_elt);
-  const char *str = dt_conf_get_conststring(pref_name);
+  const char *str = dt_conf_get_string_const(pref_name);
   gtk_entry_set_text(GTK_ENTRY(cur_elt->widget), str);
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2968,7 +2968,7 @@ void enter(dt_view_t *self)
   dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), dev->image_storage.id, TRUE);
 
   // get last active plugin:
-  gchar *active_plugin = dt_conf_get_string("plugins/darkroom/active");
+  const char *active_plugin = dt_conf_get_conststring("plugins/darkroom/active");
   if(active_plugin)
   {
     for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
@@ -2976,7 +2976,6 @@ void enter(dt_view_t *self)
       dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
       if(!strcmp(module->op, active_plugin)) dt_iop_request_focus(module);
     }
-    g_free(active_plugin);
   }
 
   // update module multishow state now modules are loaded

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2968,7 +2968,7 @@ void enter(dt_view_t *self)
   dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), dev->image_storage.id, TRUE);
 
   // get last active plugin:
-  const char *active_plugin = dt_conf_get_conststring("plugins/darkroom/active");
+  const char *active_plugin = dt_conf_get_string_const("plugins/darkroom/active");
   if(active_plugin)
   {
     for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -655,7 +655,7 @@ void init(dt_view_t *self)
 
     OsmGpsMapSource_t map_source
         = OSM_GPS_MAP_SOURCE_OPENSTREETMAP; // open street map should be a nice default ...
-    gchar *old_map_source = dt_conf_get_string("plugins/map/map_source");
+    const char *old_map_source = dt_conf_get_conststring("plugins/map/map_source");
     if(old_map_source && old_map_source[0] != '\0')
     {
       // find the number of the stored map_source
@@ -671,7 +671,6 @@ void init(dt_view_t *self)
     }
     else
       dt_conf_set_string("plugins/map/map_source", osm_gps_map_source_get_friendly_name(map_source));
-    g_free(old_map_source);
 
     lib->map_source = map_source;
 
@@ -2715,10 +2714,9 @@ static gboolean _view_map_prefs_changed(dt_map_t *lib)
   gboolean filter_images_drawn = dt_conf_get_bool("plugins/map/filter_images_drawn");
   if(lib->filter_images_drawn != filter_images_drawn) prefs_changed = TRUE;
 
-  char *thumbnail = dt_conf_get_string("plugins/map/images_thumbnail");
+  const char *thumbnail = dt_conf_get_conststring("plugins/map/images_thumbnail");
   lib->thumbnail = !g_strcmp0(thumbnail, "thumbnail") ? DT_MAP_THUMB_THUMB :
                    !g_strcmp0(thumbnail, "count") ? DT_MAP_THUMB_COUNT : DT_MAP_THUMB_NONE;
-  g_free(thumbnail);
 
   return prefs_changed;
 }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -655,7 +655,7 @@ void init(dt_view_t *self)
 
     OsmGpsMapSource_t map_source
         = OSM_GPS_MAP_SOURCE_OPENSTREETMAP; // open street map should be a nice default ...
-    const char *old_map_source = dt_conf_get_conststring("plugins/map/map_source");
+    const char *old_map_source = dt_conf_get_string_const("plugins/map/map_source");
     if(old_map_source && old_map_source[0] != '\0')
     {
       // find the number of the stored map_source
@@ -2714,7 +2714,7 @@ static gboolean _view_map_prefs_changed(dt_map_t *lib)
   gboolean filter_images_drawn = dt_conf_get_bool("plugins/map/filter_images_drawn");
   if(lib->filter_images_drawn != filter_images_drawn) prefs_changed = TRUE;
 
-  const char *thumbnail = dt_conf_get_conststring("plugins/map/images_thumbnail");
+  const char *thumbnail = dt_conf_get_string_const("plugins/map/images_thumbnail");
   lib->thumbnail = !g_strcmp0(thumbnail, "thumbnail") ? DT_MAP_THUMB_THUMB :
                    !g_strcmp0(thumbnail, "count") ? DT_MAP_THUMB_COUNT : DT_MAP_THUMB_NONE;
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -511,11 +511,10 @@ void enter(dt_view_t *self)
   /* initialize a session */
   lib->session = dt_import_session_new();
 
-  char *tmp = dt_conf_get_string("plugins/session/jobcode");
+  const char *tmp = dt_conf_get_conststring("plugins/session/jobcode");
   if(tmp != NULL)
   {
     _capture_view_set_jobcode(self, tmp);
-    g_free(tmp);
   }
 
   /* connect signal for mipmap update for a redraw */

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -511,7 +511,7 @@ void enter(dt_view_t *self)
   /* initialize a session */
   lib->session = dt_import_session_new();
 
-  const char *tmp = dt_conf_get_conststring("plugins/session/jobcode");
+  const char *tmp = dt_conf_get_string_const("plugins/session/jobcode");
   if(tmp != NULL)
   {
     _capture_view_set_jobcode(self, tmp);


### PR DESCRIPTION
Add a new utility function `dt_conf_get_conststring` and replace uses of `dt_conf_get_string` by the new function where possible.  This fixes a few memory leaks and eliminates lots of instances of string copying and the associated memory allocation/deallocation.
