### PR TITLE
use g_strcmp0 in widget warn mechanism to prevent crash on null

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -223,7 +223,7 @@ void _display_module_trouble_message_callback(gpointer instance,
   if(module && module->has_trouble && module->widget)
   {
     label_widget = dt_gui_container_first_child(GTK_CONTAINER(gtk_widget_get_parent(module->widget)));
-    if(strcmp(gtk_widget_get_name(label_widget), "iop-plugin-warning"))
+    if(g_strcmp0(gtk_widget_get_name(label_widget), "iop-plugin-warning"))
       label_widget = NULL;
   }
 


### PR DESCRIPTION
While browsing issues I stumbled on #8073 

While the issue is fixed the one possible crash is when for some super odd reason `dt_gui_container_first_child` returns null then `gtk_widget_get_name` will return null and we'll be comparing null with string which will result in crash.

`gtk_widget_get_name` guarantees that if you pass widget to it, you'll get not null string so I think it's safe to just check if label_widget isn't null.