### PR TITLE
Fix "inline" usage in OpenCL kernels

### DIFF
--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -15,7 +15,7 @@ macro (testcompile_opencl_kernel IN)
 
   add_custom_command(
     OUTPUT  ${TOUCH}
-    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.1 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
+    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
     COMMAND ${CMAKE_COMMAND} -E touch ${TOUCH} # will be empty!
     DEPENDS ${IN}
     COMMENT "Test-compiling OpenCL program ${KERNAME}"

--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -331,8 +331,8 @@ blendif_factor_rgb_hsl(const float4 input, const float4 output,
 }
 
 
-inline float4 rgb_to_JzCzhz(float4 rgb, constant dt_colorspaces_iccprofile_info_cl_t *profile_info,
-                            read_only image2d_t profile_lut, const int use_work_profile)
+static inline float4 rgb_to_JzCzhz(float4 rgb, constant dt_colorspaces_iccprofile_info_cl_t *profile_info,
+                                   read_only image2d_t profile_lut, const int use_work_profile)
 {
   float4 xyz = rgb;
   if(use_work_profile != 0)

--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -43,17 +43,17 @@ typedef enum dt_adaptation_t
 #define FALSE 0
 #define NORM_MIN 1e-6f
 
-inline float sqf(const float x)
+static inline float sqf(const float x)
 {
   return x * x;
 }
 
-inline float euclidean_norm(const float4 input)
+static inline float euclidean_norm(const float4 input)
 {
   return fmax(native_sqrt(sqf(input.x) + sqf(input.y) + sqf(input.z)), NORM_MIN);
 }
 
-inline float4 gamut_mapping(const float4 input, const float compression, const int clip)
+static inline float4 gamut_mapping(const float4 input, const float compression, const int clip)
 {
   // Get the sum XYZ
   float sum = input.x + input.y + input.z;
@@ -100,8 +100,8 @@ inline float4 gamut_mapping(const float4 input, const float compression, const i
   return dt_xyY_to_XYZ(xyY);
 }
 
-inline float4 luma_chroma(const float4 input, const float4 saturation, const float4 lightness,
-                          const dt_iop_channelmixer_rgb_version_t version)
+static inline float4 luma_chroma(const float4 input, const float4 saturation, const float4 lightness,
+                                 const dt_iop_channelmixer_rgb_version_t version)
 {
   float4 output;
 
@@ -199,22 +199,23 @@ inline float4 luma_chroma(const float4 input, const float4 saturation, const flo
   }})
 
 
-inline void downscale_vector(float4 *const vector, const float scaling)
+static inline void downscale_vector(float4 *const vector, const float scaling)
 {
   const int valid = (scaling > NORM_MIN) && !isnan(scaling);
   *vector /= (valid) ? (scaling + NORM_MIN) : NORM_MIN;
 }
 
-inline void upscale_vector(float4 *const vector, const float scaling)
+static inline void upscale_vector(float4 *const vector, const float scaling)
 {
   const int valid = (scaling > NORM_MIN) && !isnan(scaling);
   *vector *= (valid) ? (scaling + NORM_MIN) : NORM_MIN;
 }
 
-inline float4 chroma_adapt_bradford(const float4 RGB,
-                                    constant const float *const RGB_to_XYZ,
-                                    constant const float *const MIX, const float4 illuminant, const float p,
-                                    const int full)
+static inline float4 chroma_adapt_bradford(const float4 RGB,
+                                           constant const float *const RGB_to_XYZ,
+                                           constant const float *const MIX,
+                                           const float4 illuminant, const float p,
+                                           const int full)
 {
   // Convert from RGB to XYZ
   const float4 XYZ = matrix_product_float4(RGB, RGB_to_XYZ);
@@ -234,10 +235,11 @@ inline float4 chroma_adapt_bradford(const float4 RGB,
   return convert_bradford_LMS_to_XYZ(LMS_mixed);
 };
 
-inline float4 chroma_adapt_CAT16(const float4 RGB,
-                                 constant const float *const RGB_to_XYZ,
-                                 constant const float *const MIX, const float4 illuminant, const float p,
-                                 const int full)
+static inline float4 chroma_adapt_CAT16(const float4 RGB,
+                                        constant const float *const RGB_to_XYZ,
+                                        constant const float *const MIX,
+                                        const float4 illuminant, const float p,
+                                        const int full)
 {
   // Convert from RGB to XYZ
   const float4 XYZ = matrix_product_float4(RGB, RGB_to_XYZ);
@@ -257,9 +259,9 @@ inline float4 chroma_adapt_CAT16(const float4 RGB,
   return convert_CAT16_LMS_to_XYZ(LMS_mixed);
 }
 
-inline float4 chroma_adapt_XYZ(const float4 RGB,
-                               constant const float *const RGB_to_XYZ,
-                               constant const float *const MIX, const float4 illuminant)
+static inline float4 chroma_adapt_XYZ(const float4 RGB,
+                                      constant const float *const RGB_to_XYZ,
+                                      constant const float *const MIX, const float4 illuminant)
 {
   // Convert from RGB to XYZ
   float4 XYZ_mixed = matrix_product_float4(RGB, RGB_to_XYZ);
@@ -274,7 +276,7 @@ inline float4 chroma_adapt_XYZ(const float4 RGB,
   return matrix_product_float4(XYZ_mixed, MIX);
 }
 
-inline float4 chroma_adapt_RGB(const float4 RGB,
+static inline float4 chroma_adapt_RGB(const float4 RGB,
                                constant const float *const RGB_to_XYZ,
                                constant const float *const MIX)
 {

--- a/data/kernels/color_conversion.h
+++ b/data/kernels/color_conversion.h
@@ -43,8 +43,9 @@ typedef struct dt_colorspaces_iccprofile_info_cl_t
   float grey;
 } dt_colorspaces_iccprofile_info_cl_t;
 
-inline float lerp_lookup_unbounded(const float x, read_only image2d_t lut,
-                                   constant const float *const unbounded_coeffs, const int n_lut, const int lutsize)
+static inline float lerp_lookup_unbounded(const float x, read_only image2d_t lut,
+                                          constant const float *const unbounded_coeffs,
+                                          const int n_lut, const int lutsize)
 {
   // in case the tone curve is marked as linear, return the fast
   // path to linear unbounded (does not clip x at 1)
@@ -66,14 +67,14 @@ inline float lerp_lookup_unbounded(const float x, read_only image2d_t lut,
   else return x;
 }
 
-inline float lookup(read_only image2d_t lut, const float x)
+static inline float lookup(read_only image2d_t lut, const float x)
 {
   const int xi = clamp((int)(x * 0x10000ul), 0, 0xffff);
   const int2 p = (int2)((xi & 0xff), (xi >> 8));
   return read_imagef(lut, sampleri, p).x;
 }
 
-inline float lookup_unbounded(read_only image2d_t lut, const float x, constant const float *const a)
+static inline float lookup_unbounded(read_only image2d_t lut, const float x, constant const float *const a)
 {
   // in case the tone curve is marked as linear, return the fast
   // path to linear unbounded (does not clip x at 1)
@@ -90,8 +91,9 @@ inline float lookup_unbounded(read_only image2d_t lut, const float x, constant c
   else return x;
 }
 
-inline float4 apply_trc_in(const float4 rgb_in, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                           read_only image2d_t lut)
+static inline float4 apply_trc_in(const float4 rgb_in,
+                                  constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                  read_only image2d_t lut)
 {
   const float R = lerp_lookup_unbounded(rgb_in.x, lut, profile_info->unbounded_coeffs_in[0], 0, profile_info->lutsize);
   const float G = lerp_lookup_unbounded(rgb_in.y, lut, profile_info->unbounded_coeffs_in[1], 1, profile_info->lutsize);
@@ -100,8 +102,9 @@ inline float4 apply_trc_in(const float4 rgb_in, constant const dt_colorspaces_ic
   return (float4)(R, G, B, a);
 }
 
-inline float4 apply_trc_out(const float4 rgb_in, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                            read_only image2d_t lut)
+static inline float4 apply_trc_out(const float4 rgb_in,
+                                   constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                   read_only image2d_t lut)
 {
   const float R = lerp_lookup_unbounded(rgb_in.x, lut, profile_info->unbounded_coeffs_out[0], 3, profile_info->lutsize);
   const float G = lerp_lookup_unbounded(rgb_in.y, lut, profile_info->unbounded_coeffs_out[1], 4, profile_info->lutsize);
@@ -110,8 +113,9 @@ inline float4 apply_trc_out(const float4 rgb_in, constant const dt_colorspaces_i
   return (float4)(R, G, B, a);
 }
 
-inline float get_rgb_matrix_luminance(const float4 rgb, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                      constant const float *const matrix, read_only image2d_t lut)
+static inline float get_rgb_matrix_luminance(const float4 rgb,
+                                             constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                             constant const float *const matrix, read_only image2d_t lut)
 {
   float luminance = 0.f;
 
@@ -128,8 +132,9 @@ inline float get_rgb_matrix_luminance(const float4 rgb, constant const dt_colors
   return luminance;
 }
 
-inline float4 rgb_matrix_to_xyz(const float4 rgb, constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                constant const float *const matrix, read_only image2d_t lut)
+static inline float4 rgb_matrix_to_xyz(const float4 rgb,
+                                       constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                       constant const float *const matrix, read_only image2d_t lut)
 {
   float4 out;
   if(profile_info->nonlinearlut)
@@ -144,7 +149,7 @@ inline float4 rgb_matrix_to_xyz(const float4 rgb, constant const dt_colorspaces_
   return out;
 }
 
-inline float dt_camera_rgb_luminance(const float4 rgb)
+static inline float dt_camera_rgb_luminance(const float4 rgb)
 {
   const float4 coeffs = { 0.2225045f, 0.7168786f, 0.0606169f, 0.0f };
   return dot(rgb, coeffs);

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -21,7 +21,7 @@
 
 #include "common.h"
 
-inline float4 matrix_dot(const float4 vector, const float4 matrix[3])
+static inline float4 matrix_dot(const float4 vector, const float4 matrix[3])
 {
   float4 output;
   const float4 vector_copy = { vector.x, vector.y, vector.z, 0.f };
@@ -33,7 +33,7 @@ inline float4 matrix_dot(const float4 vector, const float4 matrix[3])
 }
 
 
-inline float4 matrix_product(const float4 xyz, constant const float *const matrix)
+static inline float4 matrix_product(const float4 xyz, constant const float *const matrix)
 {
   const float R = matrix[0] * xyz.x + matrix[1] * xyz.y + matrix[2] * xyz.z;
   const float G = matrix[3] * xyz.x + matrix[4] * xyz.y + matrix[5] * xyz.z;
@@ -43,7 +43,7 @@ inline float4 matrix_product(const float4 xyz, constant const float *const matri
 }
 
 // same as above but with 4×float padded matrix
-inline float4 matrix_product_float4(const float4 xyz, constant const float *const matrix)
+static inline float4 matrix_product_float4(const float4 xyz, constant const float *const matrix)
 {
   const float R = matrix[0] * xyz.x + matrix[1] * xyz.y + matrix[2]  * xyz.z;
   const float G = matrix[4] * xyz.x + matrix[5] * xyz.y + matrix[6]  * xyz.z;
@@ -52,7 +52,7 @@ inline float4 matrix_product_float4(const float4 xyz, constant const float *cons
   return (float4)(R, G, B, a);
 }
 
-inline float4 Lab_2_LCH(float4 Lab)
+static inline float4 Lab_2_LCH(float4 Lab)
 {
   float H = atan2(Lab.z, Lab.y);
 
@@ -65,7 +65,7 @@ inline float4 Lab_2_LCH(float4 Lab)
 }
 
 
-inline float4 LCH_2_Lab(float4 LCH)
+static inline float4 LCH_2_Lab(float4 LCH)
 {
   const float L = LCH.x;
   const float a = cos(2.0f*M_PI_F*LCH.z) * LCH.y;
@@ -75,7 +75,7 @@ inline float4 LCH_2_Lab(float4 LCH)
 }
 
 
-inline float4 lab_f(float4 x)
+static inline float4 lab_f(float4 x)
 {
   const float4 epsilon = 216.0f / 24389.0f;
   const float4 kappa = 24389.0f / 27.0f;
@@ -83,7 +83,7 @@ inline float4 lab_f(float4 x)
 }
 
 
-inline float4 XYZ_to_Lab(float4 xyz)
+static inline float4 XYZ_to_Lab(float4 xyz)
 {
   float4 lab;
   const float4 d50 = (float4)(0.9642f, 1.0f, 0.8249f, 1.0f);
@@ -96,7 +96,7 @@ inline float4 XYZ_to_Lab(float4 xyz)
 }
 
 
-inline float4 lab_f_inv(float4 x)
+static inline float4 lab_f_inv(float4 x)
 {
   const float4 epsilon = 0.206896551f;
   const float4 kappa   = 24389.0f / 27.0f;
@@ -104,7 +104,7 @@ inline float4 lab_f_inv(float4 x)
 }
 
 
-inline float4 Lab_to_XYZ(float4 Lab)
+static inline float4 Lab_to_XYZ(float4 Lab)
 {
   const float4 d50 = (float4)(0.9642f, 1.0f, 0.8249f, 0.0f);
   float4 f;
@@ -114,7 +114,7 @@ inline float4 Lab_to_XYZ(float4 Lab)
   return d50 * lab_f_inv(f);
 }
 
-inline float4 prophotorgb_to_XYZ(float4 rgb)
+static inline float4 prophotorgb_to_XYZ(float4 rgb)
 {
   const float rgb_to_xyz[3][3] = { // prophoto rgb
     {0.7976749f, 0.1351917f, 0.0313534f},
@@ -134,7 +134,7 @@ inline float4 prophotorgb_to_XYZ(float4 rgb)
   return XYZ;
 }
 
-inline float4 XYZ_to_prophotorgb(float4 XYZ)
+static inline float4 XYZ_to_prophotorgb(float4 XYZ)
 {
   const float xyz_to_rgb[3][3] = { // prophoto rgb d50
     { 1.3459433f, -0.2556075f, -0.0511118f},
@@ -154,19 +154,19 @@ inline float4 XYZ_to_prophotorgb(float4 XYZ)
   return rgb;
 }
 
-inline float4 Lab_to_prophotorgb(float4 Lab)
+static inline float4 Lab_to_prophotorgb(float4 Lab)
 {
   const float4 XYZ = Lab_to_XYZ(Lab);
   return XYZ_to_prophotorgb(XYZ);
 }
 
-inline float4 prophotorgb_to_Lab(float4 rgb)
+static inline float4 prophotorgb_to_Lab(float4 rgb)
 {
   const float4 XYZ = prophotorgb_to_XYZ(rgb);
   return XYZ_to_Lab(XYZ);
 }
 
-inline float4 RGB_2_HSL(const float4 RGB)
+static inline float4 RGB_2_HSL(const float4 RGB)
 {
   float H, S, L;
 
@@ -208,7 +208,7 @@ inline float4 RGB_2_HSL(const float4 RGB)
 
 
 
-inline float Hue_2_RGB(float v1, float v2, float vH)
+static inline float Hue_2_RGB(float v1, float v2, float vH)
 {
   if (vH < 0.0f) vH += 1.0f;
   if (vH > 1.0f) vH -= 1.0f;
@@ -220,7 +220,7 @@ inline float Hue_2_RGB(float v1, float v2, float vH)
 
 
 
-inline float4 HSL_2_RGB(const float4 HSL)
+static inline float4 HSL_2_RGB(const float4 HSL)
 {
   float R, G, B;
 
@@ -250,7 +250,7 @@ inline float4 HSL_2_RGB(const float4 HSL)
   return (float4)(R, G, B, HSL.w);
 }
 
-inline float4 RGB_2_HSV(const float4 RGB)
+static inline float4 RGB_2_HSV(const float4 RGB)
 {
   float4 HSV;
 
@@ -287,7 +287,7 @@ inline float4 RGB_2_HSV(const float4 RGB)
   return HSV;
 }
 
-inline float4 HSV_2_RGB(const float4 HSV)
+static inline float4 HSV_2_RGB(const float4 HSV)
 {
   float4 RGB;
 
@@ -332,7 +332,7 @@ inline float4 HSV_2_RGB(const float4 HSV)
 
 
 // XYZ -> sRGB matrix, D65
-inline float4 XYZ_to_sRGB(float4 XYZ)
+static inline float4 XYZ_to_sRGB(float4 XYZ)
 {
   float4 sRGB;
 
@@ -346,7 +346,7 @@ inline float4 XYZ_to_sRGB(float4 XYZ)
 
 
 // sRGB -> XYZ matrix, D65
-inline float4 sRGB_to_XYZ(float4 sRGB)
+static inline float4 sRGB_to_XYZ(float4 sRGB)
 {
   float4 XYZ;
 
@@ -359,7 +359,7 @@ inline float4 sRGB_to_XYZ(float4 sRGB)
 }
 
 
-inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
+static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
 {
   const float4 M[3] = { { 0.41478972f, 0.579999f, 0.0146480f, 0.0f },
                         { -0.2015100f, 1.120649f, 0.0531008f, 0.0f },
@@ -393,7 +393,7 @@ inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
 }
 
 
-inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
+static inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
 {
   const float b = 1.15f;
   const float g = 0.66f;
@@ -439,7 +439,7 @@ inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
 }
 
 
-inline float4 JzAzBz_to_JzCzhz(float4 JzAzBz)
+static inline float4 JzAzBz_to_JzCzhz(float4 JzAzBz)
 {
   const float h = atan2(JzAzBz.z, JzAzBz.y) / (2.0f * M_PI_F);
   float4 JzCzhz;
@@ -459,7 +459,7 @@ inline float4 JzAzBz_to_JzCzhz(float4 JzAzBz)
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-inline float4 XYZ_to_LMS(const float4 XYZ)
+static inline float4 XYZ_to_LMS(const float4 XYZ)
 {
   const float4 XYZ_D65_to_LMS_2006_D65[3]
     = { { 0.257085f, 0.859943f, -0.031061f, 0.f },
@@ -470,7 +470,7 @@ inline float4 XYZ_to_LMS(const float4 XYZ)
 }
 
 
-inline float4 LMS_to_XYZ(const float4 LMS)
+static inline float4 LMS_to_XYZ(const float4 LMS)
 {
   const float4 LMS_2006_D65_to_XYZ_D65[3]
     = { { 1.80794659f, -1.29971660f, 0.34785879f, 0.f },
@@ -488,7 +488,7 @@ inline float4 LMS_to_XYZ(const float4 LMS)
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-inline float4 gradingRGB_to_LMS(const float4 RGB)
+static inline float4 gradingRGB_to_LMS(const float4 RGB)
 {
   const float4 filmlightRGB_D65_to_LMS_D65[3]
     = { { 0.95f, 0.38f, 0.00f, 0.f },
@@ -498,7 +498,7 @@ inline float4 gradingRGB_to_LMS(const float4 RGB)
   return matrix_dot(RGB, filmlightRGB_D65_to_LMS_D65);
 }
 
-inline float4 LMS_to_gradingRGB(const float4 LMS)
+static inline float4 LMS_to_gradingRGB(const float4 LMS)
 {
   const float4 LMS_D65_to_filmlightRGB_D65[3]
     = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
@@ -513,7 +513,7 @@ inline float4 LMS_to_gradingRGB(const float4 LMS)
 * Re-express the Filmlight RGB triplet as Yrg luminance/chromacity coordinates
 */
 
-inline float4 LMS_to_Yrg(const float4 LMS)
+static inline float4 LMS_to_Yrg(const float4 LMS)
 {
   // compute luminance
   const float Y = 0.68990272f * LMS.x + 0.34832189f * LMS.y;
@@ -529,7 +529,7 @@ inline float4 LMS_to_Yrg(const float4 LMS)
 }
 
 
-inline float4 Yrg_to_LMS(const float4 Yrg)
+static inline float4 Yrg_to_LMS(const float4 Yrg)
 {
   const float Y = Yrg.x;
 
@@ -553,7 +553,7 @@ inline float4 Yrg_to_LMS(const float4 Yrg)
 * Re-express Filmlight Yrg in polar coordinates Ych
 */
 
-inline float4 Yrg_to_Ych(const float4 Yrg)
+static inline float4 Yrg_to_Ych(const float4 Yrg)
 {
   const float D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
   const float Y = Yrg.x;
@@ -565,7 +565,7 @@ inline float4 Yrg_to_Ych(const float4 Yrg)
 }
 
 
-inline float4 Ych_to_Yrg(const float4 Ych)
+static inline float4 Ych_to_Yrg(const float4 Ych)
 {
   const float D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
   const float Y = Ych.x;
@@ -577,7 +577,7 @@ inline float4 Ych_to_Yrg(const float4 Ych)
 }
 
 
-inline float4 dt_xyY_to_uvY(const float4 xyY)
+static inline float4 dt_xyY_to_uvY(const float4 xyY)
 {
   // This is the linear part of the chromaticity transform from CIE L*u*v* e.g. u'v'.
   // See https://en.wikipedia.org/wiki/CIELUV
@@ -595,7 +595,7 @@ inline float4 dt_xyY_to_uvY(const float4 xyY)
 }
 
 
-inline float4 dt_uvY_to_xyY(const float4 uvY)
+static inline float4 dt_uvY_to_xyY(const float4 uvY)
 {
   // This is the linear part of chromaticity transform from CIE L*u*v* e.g. u'v'.
   // See https://en.wikipedia.org/wiki/CIELUV
@@ -612,7 +612,7 @@ inline float4 dt_uvY_to_xyY(const float4 uvY)
   return xyY;
 }
 
-inline float4 dt_xyY_to_XYZ(const float4 xyY)
+static inline float4 dt_xyY_to_XYZ(const float4 xyY)
 {
   float4 XYZ;
   XYZ.x = xyY.z * xyY.x / xyY.y;
@@ -624,7 +624,7 @@ inline float4 dt_xyY_to_XYZ(const float4 xyY)
 
 // port src/common/chromatic_adaptation.h
 
-inline float4 convert_XYZ_to_bradford_LMS(const float4 XYZ)
+static inline float4 convert_XYZ_to_bradford_LMS(const float4 XYZ)
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
   const float4 XYZ_to_Bradford_LMS[3] = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
@@ -634,7 +634,7 @@ inline float4 convert_XYZ_to_bradford_LMS(const float4 XYZ)
   return matrix_dot(XYZ, XYZ_to_Bradford_LMS);
 }
 
-inline float4 convert_bradford_LMS_to_XYZ(const float4 LMS)
+static inline float4 convert_bradford_LMS_to_XYZ(const float4 LMS)
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
   const float4 Bradford_LMS_to_XYZ[3] = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
@@ -644,7 +644,7 @@ inline float4 convert_bradford_LMS_to_XYZ(const float4 LMS)
   return matrix_dot(LMS, Bradford_LMS_to_XYZ);
 }
 
-inline float4 convert_XYZ_to_CAT16_LMS(const float4 XYZ)
+static inline float4 convert_XYZ_to_CAT16_LMS(const float4 XYZ)
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
   const float4 XYZ_to_CAT16_LMS[3] = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
@@ -654,7 +654,7 @@ inline float4 convert_XYZ_to_CAT16_LMS(const float4 XYZ)
   return matrix_dot(XYZ, XYZ_to_CAT16_LMS);
 }
 
-inline float4 convert_CAT16_LMS_to_XYZ(const float4 LMS)
+static inline float4 convert_CAT16_LMS_to_XYZ(const float4 LMS)
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
   const float4 CAT16_LMS_to_XYZ[3] = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
@@ -664,9 +664,9 @@ inline float4 convert_CAT16_LMS_to_XYZ(const float4 LMS)
   return matrix_dot(LMS, CAT16_LMS_to_XYZ);
 }
 
-inline void bradford_adapt_D50(float4 *lms_in,
-                               const float4 origin_illuminant,
-                               const float p, const int full)
+static inline void bradford_adapt_D50(float4 *lms_in,
+                                      const float4 origin_illuminant,
+                                      const float p, const int full)
 {
   // Bradford chromatic adaptation from origin to target D50 illuminant in LMS space
   // p = powf(origin_illuminant[2] / D50[2], 0.0834f) needs to be precomputed for performance,
@@ -689,9 +689,9 @@ inline void bradford_adapt_D50(float4 *lms_in,
     *lms_in *= D50 / origin_illuminant;
 }
 
-inline void CAT16_adapt_D50(float4 *lms_in,
-                            const float4 origin_illuminant,
-                            const float D, const int full)
+static inline void CAT16_adapt_D50(float4 *lms_in,
+                                   const float4 origin_illuminant,
+                                   const float D, const int full)
 {
   // CAT16 chromatic adaptation from origin to target D50 illuminant in LMS space
   // D is the coefficient of adaptation, depending of the surround lighting
@@ -704,8 +704,8 @@ inline void CAT16_adapt_D50(float4 *lms_in,
   else *lms_in *= (D * D50 / origin_illuminant + 1.f - D);
 }
 
-inline void XYZ_adapt_D50(float4 *lms_in,
-                          const float4 origin_illuminant)
+static inline void XYZ_adapt_D50(float4 *lms_in,
+                                 const float4 origin_illuminant)
 {
   // XYZ chromatic adaptation from origin to target D65 illuminant in XYZ space
   // origin illuminant need also to be precomputed to XYZ

--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -32,14 +32,14 @@ constant sampler_t samplerc =  CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP  
 #define ICLAMP(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
 
 
-inline int
+static inline int
 FC(const int row, const int col, const unsigned int filters)
 {
   return filters >> ((((row) << 1 & 14) + ((col) & 1)) << 1) & 3;
 }
 
 
-inline int
+static inline int
 FCxtrans(const int row, const int col, global const unsigned char (*const xtrans)[6])
 {
   return xtrans[row % 6][col % 6];

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -18,12 +18,12 @@
 
 #include "common.h"
 
-inline float sqrf(float a)
+static inline float sqrf(float a)
 {
   return (a * a);
 }
 
-inline float calcBlendFactor(float val, float threshold)
+static inline float calcBlendFactor(float val, float threshold)
 {
     // sigmoid function
     // result is in ]0;1] range

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -722,15 +722,15 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
 }
 
 
-inline float sqf(const float x)
+static inline float sqf(const float x)
 {
   return x * x;
 }
 
 
-inline float4 opacity_masks(const float x,
-                            const float shadows_weight, const float highlights_weight,
-                            const float midtones_weight, const float mask_grey_fulcrum)
+static inline float4 opacity_masks(const float x,
+                                   const float shadows_weight, const float highlights_weight,
+                                   const float midtones_weight, const float mask_grey_fulcrum)
 {
   float4 output;
   const float x_offset = (x - mask_grey_fulcrum);
@@ -750,7 +750,7 @@ inline float4 opacity_masks(const float x,
 
 #define LUT_ELEM 360 // gamut LUT number of elements: resolution of 1°
 
-inline float lookup_gamut(read_only image2d_t gamut_lut, const float x)
+static inline float lookup_gamut(read_only image2d_t gamut_lut, const float x)
 {
   // WARNING : x should be between [-pi ; pi ], which is the default output of atan2 anyway
 
@@ -787,7 +787,7 @@ inline float lookup_gamut(read_only image2d_t gamut_lut, const float x)
 }
 
 
-inline float soft_clip(const float x, const float soft_threshold, const float hard_threshold)
+static inline float soft_clip(const float x, const float soft_threshold, const float hard_threshold)
 {
   // use an exponential soft clipping above soft_threshold
   // hard threshold must be > soft threshold

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -24,7 +24,7 @@
 #define INVERSE_SQRT_3 0.5773502691896258f
 
 // In case the OpenCL driver doesn't have a dot method
-inline float vdot(const float4 vec1, const float4 vec2)
+static inline float vdot(const float4 vec1, const float4 vec2)
 {
     return vec1.x * vec2.x + vec1.y * vec2.y + vec1.z * vec2.z;
 }
@@ -148,7 +148,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
 
 
 /* Norms */
-inline float pixel_rgb_norm_power(const float4 pixel)
+static inline float pixel_rgb_norm_power(const float4 pixel)
 {
   // weird norm sort of perceptual. This is black magic really, but it looks good.
   const float4 RGB = fabs(pixel);
@@ -157,16 +157,16 @@ inline float pixel_rgb_norm_power(const float4 pixel)
   return (RGB_cubic.x + RGB_cubic.y + RGB_cubic.z) / fmax(RGB_square.x + RGB_square.y + RGB_square.z, 1e-12f);
 }
 
-inline float pixel_rgb_norm_euclidean(const float4 pixel)
+static inline float pixel_rgb_norm_euclidean(const float4 pixel)
 {
   const float4 RGB = pixel;
   const float4 RGB_square = RGB * RGB;
   return native_sqrt(RGB_square.x + RGB_square.y + RGB_square.z);
 }
 
-inline float get_pixel_norm(const float4 pixel, const dt_iop_filmicrgb_methods_type_t variant,
-                            constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                            read_only image2d_t lut, const int use_work_profile)
+static inline float get_pixel_norm(const float4 pixel, const dt_iop_filmicrgb_methods_type_t variant,
+                                   constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                   read_only image2d_t lut, const int use_work_profile)
 {
   switch(variant)
   {
@@ -195,7 +195,7 @@ inline float get_pixel_norm(const float4 pixel, const dt_iop_filmicrgb_methods_t
 
 /* Saturation */
 
-inline float filmic_desaturate_v1(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
+static inline float filmic_desaturate_v1(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
 {
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
@@ -207,7 +207,7 @@ inline float filmic_desaturate_v1(const float x, const float sigma_toe, const fl
 }
 
 
-inline float filmic_desaturate_v2(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
+static inline float filmic_desaturate_v2(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
 {
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
@@ -219,16 +219,16 @@ inline float filmic_desaturate_v2(const float x, const float sigma_toe, const fl
 }
 
 
-inline float4 linear_saturation(const float4 x, const float luminance, const float saturation)
+static inline float4 linear_saturation(const float4 x, const float luminance, const float saturation)
 {
   return (float4)luminance + (float4)saturation * (x - (float4)luminance);
 }
 
 
-inline float filmic_spline(const float x,
-                           const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
-                           const float latitude_min, const float latitude_max,
-                           const dt_iop_filmicrgb_curve_type_t type[2])
+static inline float filmic_spline(const float x,
+                                  const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
+                                  const float latitude_min, const float latitude_max,
+                                  const dt_iop_filmicrgb_curve_type_t type[2])
 {
   // if type polynomial :
   // y = M5 * x⁴ + M4 * x³ + M3 * x² + M2 * x¹ + M1 * x⁰
@@ -292,29 +292,29 @@ inline float filmic_spline(const float x,
 #define NORM_MIN 1.52587890625e-05f // norm can't be < to 2^(-16)
 
 
-inline float log_tonemapping_v1(const float x,
-                                const float grey, const float black,
-                                const float dynamic_range)
+static inline float log_tonemapping_v1(const float x,
+                                       const float grey, const float black,
+                                       const float dynamic_range)
 {
   const float temp = (native_log2(x / grey) - black) / dynamic_range;
   return clamp(temp, NORM_MIN, 1.f);
 }
 
-inline float log_tonemapping_v2(const float x,
-                                const float grey, const float black,
-                                const float dynamic_range)
+static inline float log_tonemapping_v2(const float x,
+                                       const float grey, const float black,
+                                       const float dynamic_range)
 {
   return clamp((native_log2(x / grey) - black) / dynamic_range, 0.f, 1.f);
 }
 
-inline float4 filmic_split_v1(const float4 i,
-                              const float dynamic_range, const float black_exposure, const float grey_value,
-                              constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                              read_only image2d_t lut, const int use_work_profile,
-                              const float sigma_toe, const float sigma_shoulder, const float saturation,
-                              const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
-                              const float latitude_min, const float latitude_max, const float output_power,
-                              const dt_iop_filmicrgb_curve_type_t type[2])
+static inline float4 filmic_split_v1(const float4 i,
+                                     const float dynamic_range, const float black_exposure, const float grey_value,
+                                     constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                     read_only image2d_t lut, const int use_work_profile,
+                                     const float sigma_toe, const float sigma_shoulder, const float saturation,
+                                     const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
+                                     const float latitude_min, const float latitude_max, const float output_power,
+                                     const dt_iop_filmicrgb_curve_type_t type[2])
 {
   float4 o;
 
@@ -344,14 +344,14 @@ inline float4 filmic_split_v1(const float4 i,
   return o;
 }
 
-inline float4 filmic_split_v2_v3(const float4 i,
-                                 const float dynamic_range, const float black_exposure, const float grey_value,
-                                 constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                 read_only image2d_t lut, const int use_work_profile,
-                                 const float sigma_toe, const float sigma_shoulder, const float saturation,
-                                 const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
-                                 const float latitude_min, const float latitude_max, const float output_power,
-                                 const dt_iop_filmicrgb_curve_type_t type[2])
+static inline float4 filmic_split_v2_v3(const float4 i,
+                                        const float dynamic_range, const float black_exposure, const float grey_value,
+                                        constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                        read_only image2d_t lut, const int use_work_profile,
+                                        const float sigma_toe, const float sigma_shoulder, const float saturation,
+                                        const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
+                                        const float latitude_min, const float latitude_max, const float output_power,
+                                        const dt_iop_filmicrgb_curve_type_t type[2])
 {
   float4 o;
 
@@ -430,15 +430,15 @@ filmicrgb_split (read_only image2d_t in, write_only image2d_t out,
 }
 
 
-inline float4 filmic_chroma_v1(const float4 i,
-                               const float dynamic_range, const float black_exposure, const float grey_value,
-                               constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                               read_only image2d_t lut, const int use_work_profile,
-                               const float sigma_toe, const float sigma_shoulder, const float saturation,
-                               const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
-                               const float latitude_min, const float latitude_max, const float output_power,
-                               const dt_iop_filmicrgb_methods_type_t variant,
-                               const dt_iop_filmicrgb_curve_type_t type[2])
+static inline float4 filmic_chroma_v1(const float4 i,
+                                      const float dynamic_range, const float black_exposure, const float grey_value,
+                                      constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                      read_only image2d_t lut, const int use_work_profile,
+                                      const float sigma_toe, const float sigma_shoulder, const float saturation,
+                                      const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
+                                      const float latitude_min, const float latitude_max, const float output_power,
+                                      const dt_iop_filmicrgb_methods_type_t variant,
+                                      const dt_iop_filmicrgb_curve_type_t type[2])
 {
   float norm = fmax(get_pixel_norm(i, variant, profile_info, lut, use_work_profile), NORM_MIN);
 
@@ -471,16 +471,16 @@ inline float4 filmic_chroma_v1(const float4 i,
 }
 
 
-inline float4 filmic_chroma_v2_v3(const float4 i,
-                                  const float dynamic_range, const float black_exposure, const float grey_value,
-                                  constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
-                                  read_only image2d_t lut, const int use_work_profile,
-                                  const float sigma_toe, const float sigma_shoulder, const float saturation,
-                                  const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
-                                  const float latitude_min, const float latitude_max, const float output_power,
-                                  const dt_iop_filmicrgb_methods_type_t variant,
-                                  const dt_iop_filmicrgb_colorscience_type_t colorscience_version,
-                                  const dt_iop_filmicrgb_curve_type_t type[2])
+static inline float4 filmic_chroma_v2_v3(const float4 i,
+                                         const float dynamic_range, const float black_exposure, const float grey_value,
+                                         constant const dt_colorspaces_iccprofile_info_cl_t *const profile_info,
+                                         read_only image2d_t lut, const int use_work_profile,
+                                         const float sigma_toe, const float sigma_shoulder, const float saturation,
+                                         const float4 M1, const float4 M2, const float4 M3, const float4 M4, const float4 M5,
+                                         const float latitude_min, const float latitude_max, const float output_power,
+                                         const dt_iop_filmicrgb_methods_type_t variant,
+                                         const dt_iop_filmicrgb_colorscience_type_t colorscience_version,
+                                         const dt_iop_filmicrgb_curve_type_t type[2])
 {
   float norm = fmax(get_pixel_norm(i, variant, profile_info, lut, use_work_profile), NORM_MIN);
 
@@ -708,14 +708,14 @@ kernel void blur_2D_Bspline_horizontal(read_only image2d_t in, write_only image2
   write_imagef(out, (int2)(x, y), fmax(accumulator, 0.f));
 }
 
-inline float fmaxabsf(const float a, const float b)
+static inline float fmaxabsf(const float a, const float b)
 {
   // Find the max in absolute value and return it with its sign
   return (fabs(a) > fabs(b) && !isnan(a)) ? a :
                                           (isnan(b)) ? 0.f : b;
 }
 
-inline float fminabsf(const float a, const float b)
+static inline float fminabsf(const float a, const float b)
 {
   // Find the min in absolute value and return it with its sign
   return (fabs(a) < fabs(b) && !isnan(a)) ? a :

--- a/data/kernels/noise_generator.h
+++ b/data/kernels/noise_generator.h
@@ -27,7 +27,7 @@ typedef enum dt_noise_distribution_t
 } dt_noise_distribution_t;
 
 
-inline unsigned int splitmix32(const unsigned long seed)
+static inline unsigned int splitmix32(const unsigned long seed)
 {
   // fast random number generator
   // reference : https://gist.github.com/imneme/6179748664e88ef3c34860f44309fc71
@@ -38,13 +38,13 @@ inline unsigned int splitmix32(const unsigned long seed)
 
 
 
-inline unsigned rol32(const unsigned int x, const int k)
+static inline unsigned rol32(const unsigned int x, const int k)
 {
   return (x << k) | (x >> (32 - k));
 }
 
 
-inline float xoshiro128plus(uint state[4])
+static inline float xoshiro128plus(uint state[4])
 {
   // fast random number generator
   // reference : http://prng.di.unimi.it/
@@ -63,14 +63,14 @@ inline float xoshiro128plus(uint state[4])
 }
 
 
-inline float4 uniform_noise_simd(const float4 mu, const float4 sigma, uint state[4])
+static inline float4 uniform_noise_simd(const float4 mu, const float4 sigma, uint state[4])
 {
   const float4 noise = { xoshiro128plus(state), xoshiro128plus(state), xoshiro128plus(state), 0.f };
   return mu + 2.0f * (noise - 0.5f) * sigma;
 }
 
 
-inline float4 gaussian_noise_simd(const float4 mu, const float4 sigma, uint state[4])
+static inline float4 gaussian_noise_simd(const float4 mu, const float4 sigma, uint state[4])
 {
   // Create gaussian noise centered in mu of standard deviation sigma
   // state should be initialized with xoshiro256_init() before calling and private in thread
@@ -99,7 +99,7 @@ inline float4 gaussian_noise_simd(const float4 mu, const float4 sigma, uint stat
 }
 
 
-inline float4 poisson_noise_simd(const float4 mu, const float4 sigma, uint state[4])
+static inline float4 poisson_noise_simd(const float4 mu, const float4 sigma, uint state[4])
 {
   // create poissonian noise - It's just gaussian noise with Anscombe transform applied
   float4 u1, u2;
@@ -127,9 +127,9 @@ inline float4 poisson_noise_simd(const float4 mu, const float4 sigma, uint state
 }
 
 
-inline float4 dt_noise_generator_simd(const dt_noise_distribution_t distribution,
-                                      const float4 mu, const float4 param,
-                                      uint state[4])
+static inline float4 dt_noise_generator_simd(const dt_noise_distribution_t distribution,
+                                             const float4 mu, const float4 param,
+                                             uint state[4])
 {
   // vector version
 

--- a/data/kernels/rgb_norms.h
+++ b/data/kernels/rgb_norms.h
@@ -27,7 +27,7 @@
    DT_RGB_NORM_POWER = 6
  } dt_iop_rgb_norms_t;
 
-inline float
+static inline float
 dt_rgb_norm(const float4 in, const int norm, const int work_profile,
   constant dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut)
 {


### PR DESCRIPTION
The darktable OpenCL kernel code uses `inline` for many of its functions. When `inline` is used under OpenCL/C99 semantics, no out-of-line version of the function is generated by the compiler. However, OpenCL compilers are free to choose whether or not to actually inline the code as an optimization, or instead call the function. In the latter case, if the linker cannot find the out-of-line function, an error will result.

Several users of darktable have encountered such an error. For example:

- #8831
- [Reddit post](https://www.reddit.com/r/DarkTable/comments/mw7okf/darktable_v341_fails_to_compile_filmic_module/)

In these cases, the cause of the problem has been misattributed to bad OpenCL drivers, and left unresolved. The real cause of the problem is unsound usage of `inline` in the darktable code.

This problem with `inline` can be addressed in a few different ways:
1. Eliminate usage of `inline` in the OpenCL code,
2. Add an additional `extern inline` function definition for each inlined function, or
3. Change each `inline` to `static inline`, so that the compiler never generates or calls an external symbol.

In this PR, I've chosen the third approach. It keeps the optimization-oriented intention of `inline` in the code, and is safe as long as each of darktable's OpenCL programs continue to be compiled from a single `*.cl` file. However, using `static inline` will break compatibility with any OpenCL versions prior to 1.2.

I've tested these changes successfully with a variety of OpenCL compilers, including the recent AMDGPU-Pro OpenCL stack, which is particularly strict about `inline`. 

fix #8831