### PR TITLE
perspective : don't try to crop if image is nor ready

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2445,6 +2445,9 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
 {
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
 
+  // if sizes are not ready (module disabled), just ignore this
+  if(g->buf_width == 0 || g->buf_height == 0) return;
+
   // skip if fitting is still running
   if(g->fitting) return;
 


### PR DESCRIPTION
this fix #7818 this fix #9214

when the module has not been yet been enabled, changing the crop setting directly fail because no sizes are stored in gui_data. This just ensure that the crop value is not reset so the module can use it later when the perspective values will be set