### PR TITLE
Fix a couple of module input and output colorspace descriptions

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -137,7 +137,7 @@ const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("add or remove local contrast, sharpness, acutance"),
                                       _("corrective and creative"),
-                                      _("linear, RGB, scene-referred"),
+                                      _("linear, Lab, scene-referred"),
                                       _("frequential, RGB"),
                                       _("linear, Lab, scene-referred"));
 }

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -169,9 +169,9 @@ const char *description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("affect color, brightness and contrast"),
                                       _("corrective or creative"),
-                                      _("linear, Lab, scene-referred"),
+                                      _("linear, RGB, scene-referred"),
                                       _("non-linear, RGB"),
-                                      _("non-linear, Lab, scene-referred"));
+                                      _("non-linear, RGB, scene-referred"));
 }
 
 int flags()

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -89,9 +89,9 @@ const char *description(struct dt_iop_module_t *self)
   return dt_iop_set_description(self, _("convert pipeline reference RGB to any display RGB\n"
                                         "using color profiles to remap RGB values"),
                                       _("mandatory"),
-                                      _("linear or non-linear, RGB or Lab, display-referred"),
+                                      _("linear or non-linear, Lab, display-referred"),
                                       _("defined by profile"),
-                                      _("non-linear, RGB, display-referred"));
+                                      _("non-linear, RGB or Lab, display-referred"));
 }
 
 


### PR DESCRIPTION
Based on `default_colorspace()`, `input_colorspace()` and `output_colorspace()` defined in the modules.

* Contrast equalizer defines Lab as the input and output colorspace (via `default_colorspace()`)
* Color balance RGB takes RGB in and puts RGB out
* Colorout takes Lab in and outputs RGB or Lab (depending on the chosen profile?)