### PR TITLE
add permanent search entries for shortcuts dialog

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1640,7 +1640,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_tree_view_set_search_column(shortcuts_view, 0); // fake column for _search_func
   gtk_tree_view_set_search_equal_func(shortcuts_view, _search_func, shortcuts_view, NULL);
   GtkWidget *search_shortcuts = gtk_search_entry_new();
-  gtk_entry_set_placeholder_text(GTK_ENTRY(search_shortcuts), _("search shortcuts"));
+  gtk_entry_set_placeholder_text(GTK_ENTRY(search_shortcuts), _("search shortcuts list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_shortcuts), "incrementally search the list of shortcuts\npress up or down keys to cycle through matches");
   g_signal_connect(G_OBJECT(search_shortcuts), "stop-search", G_CALLBACK(_stop_search), shortcuts_view);
   gtk_tree_view_set_search_entry(shortcuts_view, GTK_ENTRY(search_shortcuts));
@@ -1730,7 +1730,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_tree_view_set_search_column(actions_view, 1); // fake column for _search_func
   gtk_tree_view_set_search_equal_func(actions_view, _search_func, actions_view, NULL);
   GtkWidget *search_actions = gtk_search_entry_new();
-  gtk_entry_set_placeholder_text(GTK_ENTRY(search_actions), _("search actions"));
+  gtk_entry_set_placeholder_text(GTK_ENTRY(search_actions), _("search actions list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_actions), "incrementally search the list of actions\npress up or down keys to cycle through matches");
   g_signal_connect(G_OBJECT(search_actions), "stop-search", G_CALLBACK(_stop_search), actions_view);
   gtk_tree_view_set_search_entry(actions_view, GTK_ENTRY(search_actions));

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1450,11 +1450,11 @@ static gboolean _action_view_click(GtkWidget *widget, GdkEventButton *event, gpo
       {
         gtk_tree_selection_unselect_path(selection, path);
         gtk_tree_view_collapse_row(view, path);
-
-        return TRUE;
       }
       else
         gtk_tree_selection_select_path(selection, path);
+
+      gtk_widget_grab_focus(widget);
     }
     else
       gtk_tree_selection_unselect_all(selection);


### PR DESCRIPTION
Searches can be started by beginning to type while one of the search entries or one of the treeviews has focus. In the latter case, the focus will move the appropriate search entry. Pressing Esc will move it (back) to a treeview (and clear the search). Pressing down/up moves to next/previous match.

Very much inspired by the requests and all the attempts by @elstoc. Thank you! This version doesn't require pressing Ctrl-F to start an incremental search (which is important to me, since that's what I've been used to in lists and dropdowns for decades). Please let me know if I missed any misbehaviors that disturb _your_ habits.

Will need some love from @Nilvus to get consistent spacing both when used in preferences and as a stand-alone shortcuts dialog. 

fixes #9598
fixes #9378 