### PR TITLE
partially revert 3202ff6 to fix #9380

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -875,6 +875,7 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
 
   if(ended)
   {
+    g_signal_handlers_disconnect_by_func(entry, G_CALLBACK(_rename_module_key_press), module);
     gtk_widget_destroy(entry);
     dt_iop_show_hide_header_buttons(module->header, NULL, TRUE, FALSE); // after removing entry
     dt_iop_gui_update_header(module);


### PR DESCRIPTION
Disconnecting the key press callback before destroying the entry is still needed. I don't know why.

An "easy cleanup" not properly tested...

fixes #9380 