### PR TITLE
flag preview shortcuts as handled by lighttable

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -719,9 +719,9 @@ int key_pressed(dt_view_t *self, guint key, guint state)
       }
 
       _preview_enter(self, FALSE, focus, mouse_over_id);
-      return 1;
+      return TRUE;
     }
-    return 0;
+    return TRUE;
   }
 
   // navigation accels for thumbtable layouts


### PR DESCRIPTION
fixes #9381

Input NG hasn't fully replaced legacy key handling in the key_pressed and key_released methods of several views yet. So it first checks if keys are handled there and if not processes them. In the case of #9381, the lighttable receives repeating W keys. The first one switches to preview mode. The second does nothing (because we already are in preview mode). Key_pressed incorrectly returns that the key was not handled (i.e. needs to be handled elsewhere). So now Input NG tries to handle it as well, causing problems.

Handling of the preview key has other existing problems (not regressions). Try pressing W (preview switches on) , then press shift and release W (without releasing shift). You are now stuck in preview mode. This could more commonly cause problems for ctrl-W except for the fact that both releasing Ctrl-W and W by itself exit preview mode. If normal Preview (without focus detect) was mapped to Shift-W the stuck preview issue would probably crop up more often.