### PR TITLE
OSX: add BMFF support for macports exiv2 0.27.4

### DIFF
--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -32,6 +32,8 @@ How to make disk image with darktable application bundle (64 bit Intel only):
      $ curl -Lo ~/ports/lang/libomp/Portfile https://github.com/macports/macports-ports/raw/589fc380ea8b74771fc4ec1de607ddbddf22cb70/lang/libomp/Portfile
      $ curl -Lo ~/ports/lang/libomp/files/reviews.llvm.org_D88252.diff https://github.com/macports/macports-ports/raw/589fc380ea8b74771fc4ec1de607ddbddf22cb70/lang/libomp/files/reviews.llvm.org_D88252.diff
      $ curl -Lo ~/ports/lang/libomp/files/patch-libomp-use-gettid-on-Leopard.diff https://github.com/macports/macports-ports/raw/589fc380ea8b74771fc4ec1de607ddbddf22cb70/lang/libomp/files/patch-libomp-use-gettid-on-Leopard.diff
+     $ cp -R "$(port dir exiv2)" ~/ports/graphics
+     $ curl -L https://raw.github.com/darktable-org/darktable/master/packaging/macosx/exiv2-BMFF.patch | patch -d ~/ports -p0
     then append this line:
      patchfiles-append patch.diff
     to ~/ports/*/*/Portfile files you just copied (except for pugixml, gmic and libomp) and run:

--- a/packaging/macosx/exiv2-BMFF.patch
+++ b/packaging/macosx/exiv2-BMFF.patch
@@ -1,0 +1,10 @@
+--- graphics/exiv2/Portfile	2021-06-25 17:36:56.000000000 +0200
++++ graphics/exiv2/Portfile	2021-07-04 20:52:36.000000000 +0200
+@@ -46,6 +46,7 @@
+ patchfiles-append   patch-remove-no-format-overflow.diff
+ 
+ configure.args-append \
++                    -DEXIV2_ENABLE_BMFF=On \
+                     -DIconv_INCLUDE_DIR=${prefix}/include \
+                     -DIconv_LIBRARY=${prefix}/lib/libiconv.dylib \
+                     -DZLIB_ROOT=${prefix}


### PR DESCRIPTION
by default exiv2 0.27.4 is configured without BMFF support.
in addition to #8751 macports portfile needs to be patched to add BMFF support to the configuration

Be aware: if BMFF support is enabled it's possible to import cr3 files even these can't be processed until cr3 support arrives in rawspeed. 