### PR TITLE
When try-enter fails make sure we select back the previous view.

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -297,8 +297,12 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
   if(new_view->try_enter)
   {
-    int error = new_view->try_enter(new_view);
-    if(error) return error;
+    const int error = new_view->try_enter(new_view);
+    if(error)
+    {
+      dt_view_manager_switch_by_view(vm, old_view);
+      return error;
+    }
   }
 
   /* cleanup current view before initialization of new  */


### PR DESCRIPTION
Selecting Print or Tethering view may fail, the first if there is no
picture selected and the later if there is no camera connected. In this
case the selected view in the drop-down top-right was not reset.

This PR fixes this and ensure that failing to swicth to the view will
reset to the previous one.