### PR TITLE
Selecting the best illuminant for dng images

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -75,8 +75,6 @@ extern "C" {
 #include "develop/masks.h"
 }
 
-#include "external/adobe_coeff.c"
-
 #define DT_XMP_EXIF_VERSION 4
 
 // persistent list of exiv2 tags. set up in dt_init()
@@ -157,6 +155,45 @@ static void _get_xmp_tags(const char *prefix, GList **taglist)
       char *tag = dt_util_dstrcat(NULL, "Xmp.%s.%s,%s", prefix, pl[i].name_, _get_exiv2_type(pl[i].typeId_));
       *taglist = g_list_prepend(*taglist, tag);
     }
+  }
+}
+static int _illu_to_temp(dt_dng_illuminant_t illu)
+{
+  switch(illu)
+  {
+    case DT_LS_StandardLightA:
+    case DT_LS_Tungsten:
+      return 2850;
+    case DT_LS_ISOStudioTungsten:
+      return 3200;
+    case DT_LS_D50:
+      return 5000;
+    case DT_LS_D55:
+    case DT_LS_Daylight:
+    case DT_LS_FineWeather:
+    case DT_LS_Flash:
+    case DT_LS_StandardLightB:
+      return 5500;
+    case DT_LS_D65:
+    case DT_LS_StandardLightC:
+    case DT_LS_CloudyWeather:
+      return 6500;
+    case DT_LS_D75:
+    case DT_LS_Shade:
+      return 7500;
+    case DT_LS_DaylightFluorescent:
+      return (5700 + 7100) / 2;
+    case DT_LS_DayWhiteFluorescent:
+      return (4600 + 5500) / 2;
+    case DT_LS_CoolWhiteFluorescent:
+    case DT_LS_Fluorescent:
+      return (3800 + 4500) / 2;
+    case DT_LS_WhiteFluorescent:
+      return (3250 + 3800) / 2;
+    case DT_LS_WarmWhiteFluorescent:
+      return (2600 + 3250) / 2;
+    default:
+      return 0;
   }
 }
 
@@ -1093,103 +1130,116 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
     // read embedded color matrix as used in DNGs
     {
-      int illu1 = -1, illu2 = -1, illu = -1; // -1: not found, otherwise the detected CalibrationIlluminant
-      float colmatrix[12];
+      float colmatrix[3][12];
+      colmatrix[0][0] = colmatrix[1][0] = colmatrix[2][0] = NAN;
+      dt_dng_illuminant_t illu[3] = { DT_LS_Unknown, DT_LS_Unknown, DT_LS_Unknown };
       img->d65_color_matrix[0] = NAN; // make sure for later testing
+
+      // Maybe there is a predefined camera matrix in adobe_coeff?
+      // fallback later via `find_temperature_from_raw_coeffs` if there is no valid illuminant
+
       // The correction matrices are taken from
       // http://www.brucelindbloom.com - chromatic Adaption.
       // using Bradford method: found Illuminant -> D65
       const float correctmat[7][9] = {
         { 0.9555766, -0.0230393, 0.0631636, -0.0282895, 1.0099416, 0.0210077, 0.0122982, -0.0204830,
-          1.3299098 }, // 23 = D50
+          1.3299098 }, // D50
         { 0.9726856, -0.0135482, 0.0361731, -0.0167463, 1.0049102, 0.0120598, 0.0070026, -0.0116372,
-          1.1869548 }, // 20 = D55
+          1.1869548 }, // D55
         { 1.0206905, 0.0091588, -0.0228796, 0.0115005, 0.9984917, -0.0076762, -0.0043619, 0.0072053,
-          0.8853432 }, // 22 = D75
+          0.8853432 }, // D75
         { 0.8446965, -0.1179225, 0.3948108, -0.1366303, 1.1041226, 0.1291718, 0.0798489, -0.1348999,
-          3.1924009 }, // 17 = Standard light A
+          3.1924009 }, // Standard light A
         { 0.9415037, -0.0321240, 0.0584672, -0.0428238, 1.0250998, 0.0203309, 0.0101511, -0.0161170,
-          1.2847354 }, // 18 = Standard light B
+          1.2847354 }, // Standard light B
         { 0.9904476, -0.0071683, -0.0116156, -0.0123712, 1.0155950, -0.0029282, -0.0035635, 0.0067697,
-          0.9181569 }, // 19 = Standard light C
+          0.9181569 }, //  Standard light C
         { 0.9212269, -0.0449128, 0.1211620, -0.0553723, 1.0277243, 0.0403563, 0.0235086, -0.0391019,
-          1.6390644 }  // F2 = cool white
+          1.6390644 }  // CoolWhiteFluorescent
       };
 
-      if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant1")) illu1 = pos->toLong();
-      if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant2")) illu2 = pos->toLong();
+      if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant1")) illu[0] = (dt_dng_illuminant_t) pos->toLong();
       Exiv2::ExifData::const_iterator cm1_pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.ColorMatrix1"));
+      if((illu[0] != DT_LS_Unknown) && (cm1_pos->count() == 9) && (cm1_pos != exifData.end()))
+      {
+        for(int i = 0; i < 9; i++) colmatrix[0][i] = cm1_pos->toFloat(i);      
+      }
+      else
+        illu[0] = DT_LS_Unknown;
+
+      if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant2")) illu[1] = (dt_dng_illuminant_t) pos->toLong();
       Exiv2::ExifData::const_iterator cm2_pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.ColorMatrix2"));
+      if((illu[1] != DT_LS_Unknown) && (cm2_pos->count() == 9) && (cm2_pos != exifData.end()))
+      {
+        for(int i = 0; i < 9; i++) colmatrix[1][i] = cm2_pos->toFloat(i);      
+      }
+      else
+        illu[1] = DT_LS_Unknown;
+      // So far the Exif.Image.CalibrationIlluminant3 tag and friends have not been implemented and there are no images to test
 
-      // Which is the wanted colormatrix?
-      // If we have D65 in Illuminant1 we use it; otherwise we prefer Illuminant2 because it's the higher
-      // color temperature and thus closer to D65
-      if(illu1 == 21 && cm1_pos != exifData.end() && cm1_pos->count() == 9 && cm1_pos->size())
+      int sel_illu = -1;
+      int sel_temp = 0;
+      const int D65temp = _illu_to_temp(DT_LS_D65);
+      // Which illuminant will be used for the color matrix?
+      // if there is none defined we just leave the matrix marked as undefined
+      // otherwise we take the one closest >= D65
+      for(int i = 0; i < 3; i++)
       {
-        for(int i = 0; i < 9; i++) colmatrix[i] = cm1_pos->toFloat(i);
-        illu = illu1;
-      }
-      else if(illu2 != -1 && cm2_pos != exifData.end() && cm2_pos->count() == 9 && cm2_pos->size())
-      {
-        for(int i = 0; i < 9; i++) colmatrix[i] = cm2_pos->toFloat(i);
-        illu = illu2;
-      }
-      else if(illu1 != -1 && cm1_pos != exifData.end() && cm1_pos->count() == 9 && cm1_pos->size())
-      {
-        for(int i = 0; i < 9; i++) colmatrix[i] = cm1_pos->toFloat(i);
-        illu = illu1;
-      }
-      // In a few cases we only have one color matrix; it should not be corrected
-      if(illu == -1 && cm1_pos != exifData.end() && cm1_pos->count() == 9 && cm1_pos->size())
-      {
-        for(int i = 0; i < 9; i++) colmatrix[i] = cm1_pos->toFloat(i);
-        illu = 0;
+        if((illu[i] != DT_LS_Unknown) && (_illu_to_temp(illu[i]) > sel_temp) && (sel_temp < D65temp)) 
+        {
+          sel_illu = i;
+          sel_temp = _illu_to_temp(illu[i]);
+        }
       }
 
+      if((sel_illu > -1) && (darktable.unmuted & DT_DEBUG_IMAGEIO))
+      {
+        fprintf(stderr, "[exif] `%s` dng illuminant %i (%i°) selected from ", img->filename, illu[sel_illu], _illu_to_temp(illu[sel_illu]));
+        for(int i = 0; i < 3; i++)
+          if(illu[i] != DT_LS_Unknown) fprintf(stderr," -- [%i] %i (%i°)", i + 1, illu[i], _illu_to_temp(illu[i]));
+        fprintf(stderr, "\n");
+      }
 
       // Take the found CalibrationIlluminant / ColorMatrix pair.
-      // D65 or default: just copy. Otherwise multiply by the specific correction matrix.
-      if(illu != -1)
+      // D65: just copy. Otherwise multiply by the specific correction matrix.
+      if(sel_illu > -1)
       {
        // If no supported Illuminant is found it's better NOT to use the found matrix.
        // The colorin module will write an error message and use a fallback matrix
        // instead of showing wrong colors.
-        switch(illu)
+        switch(illu[sel_illu])
         {
-          case 23:
-            mat3mul(img->d65_color_matrix, correctmat[0], colmatrix);
+          case DT_LS_D50:
+            mat3mul(img->d65_color_matrix, correctmat[0], colmatrix[sel_illu]);
             break;
-          case 20:
-            mat3mul(img->d65_color_matrix, correctmat[1], colmatrix);
+          case DT_LS_D55:
+            mat3mul(img->d65_color_matrix, correctmat[1], colmatrix[sel_illu]);
             break;
-          case 22:
-            mat3mul(img->d65_color_matrix, correctmat[2], colmatrix);
+          case DT_LS_Shade:
+          case DT_LS_D75:
+            mat3mul(img->d65_color_matrix, correctmat[2], colmatrix[sel_illu]);
             break;
-          case 17:
-            mat3mul(img->d65_color_matrix, correctmat[3], colmatrix);
+          case DT_LS_Tungsten:
+          case DT_LS_StandardLightA:
+            mat3mul(img->d65_color_matrix, correctmat[3], colmatrix[sel_illu]);
             break;
-          case 18:
-            mat3mul(img->d65_color_matrix, correctmat[4], colmatrix);
+          case DT_LS_StandardLightB:
+            mat3mul(img->d65_color_matrix, correctmat[4], colmatrix[sel_illu]);
             break;
-          case 19:
-            mat3mul(img->d65_color_matrix, correctmat[5], colmatrix);
+          case DT_LS_StandardLightC:
+            mat3mul(img->d65_color_matrix, correctmat[5], colmatrix[sel_illu]);
             break;
-          case 3:
-            mat3mul(img->d65_color_matrix, correctmat[3], colmatrix);
+          case DT_LS_CoolWhiteFluorescent:
+            mat3mul(img->d65_color_matrix, correctmat[6], colmatrix[sel_illu]);
             break;
-          case 14:
-            mat3mul(img->d65_color_matrix, correctmat[6], colmatrix);
+          case DT_LS_D65:
+            for(int i = 0; i < 9; i++) img->d65_color_matrix[i] = colmatrix[sel_illu][i];
             break;
+            
           default:
-            for(int i = 0; i < 9; i++) img->d65_color_matrix[i] = colmatrix[i];
+            fprintf(stderr,"[exif] did not find a proper dng correction matrix for illuminant %i\n", illu[sel_illu]);
             break;
         }
-        // Maybe there is a predefined camera matrix in adobe_coeff?
-        // This is tested to possibly override the matrix.
-        colmatrix[0] = NAN;
-        dt_dcraw_adobe_coeff(img->camera_model, (float(*)[12])colmatrix);
-        if(!isnan(colmatrix[0]))
-          for(int i = 0; i < 9; i++) img->d65_color_matrix[i] = colmatrix[i];
       }
     }
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1176,7 +1176,16 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       else
         illu[1] = DT_LS_Unknown;
       // So far the Exif.Image.CalibrationIlluminant3 tag and friends have not been implemented and there are no images to test
-
+#if EXIV2_MINOR_VERSION >= 24
+      if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant3")) illu[2] = (dt_dng_illuminant_t) pos->toLong();
+      Exiv2::ExifData::const_iterator cm3_pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.ColorMatrix3"));
+      if((illu[2] != DT_LS_Unknown) && (cm3_pos != exifData.end()) && (cm3_pos->count() == 9))
+      {
+        for(int i = 0; i < 9; i++) colmatrix[2][i] = cm3_pos->toFloat(i);      
+      }
+      else
+        illu[2] = DT_LS_Unknown;
+#endif
       int sel_illu = -1;
       int sel_temp = 0;
       const int D65temp = _illu_to_temp(DT_LS_D65);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1160,7 +1160,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
       if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant1")) illu[0] = (dt_dng_illuminant_t) pos->toLong();
       Exiv2::ExifData::const_iterator cm1_pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.ColorMatrix1"));
-      if((illu[0] != DT_LS_Unknown) && (cm1_pos->count() == 9) && (cm1_pos != exifData.end()))
+      if((illu[0] != DT_LS_Unknown) && (cm1_pos != exifData.end()) && (cm1_pos->count() == 9))
       {
         for(int i = 0; i < 9; i++) colmatrix[0][i] = cm1_pos->toFloat(i);      
       }
@@ -1169,7 +1169,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
       if(FIND_EXIF_TAG("Exif.Image.CalibrationIlluminant2")) illu[1] = (dt_dng_illuminant_t) pos->toLong();
       Exiv2::ExifData::const_iterator cm2_pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.ColorMatrix2"));
-      if((illu[1] != DT_LS_Unknown) && (cm2_pos->count() == 9) && (cm2_pos != exifData.end()))
+      if((illu[1] != DT_LS_Unknown) && (cm2_pos != exifData.end()) && (cm2_pos->count() == 9))
       {
         for(int i = 0; i < 9; i++) colmatrix[1][i] = cm2_pos->toFloat(i);      
       }

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -26,6 +26,33 @@
 extern "C" {
 #endif
 
+typedef enum dt_dng_illuminant_t // from adobes dng_sdk
+{
+	DT_LS_Unknown              =  0,
+	DT_LS_Daylight             =  1,
+	DT_LS_Fluorescent          =  2,
+	DT_LS_Tungsten             =  3,
+	DT_LS_Flash                =  4,
+	DT_LS_FineWeather          =  9,
+	DT_LS_CloudyWeather        = 10,
+	DT_LS_Shade                = 11,
+	DT_LS_DaylightFluorescent  = 12, // D  5700 - 7100K
+	DT_LS_DayWhiteFluorescent  = 13, // N  4600 - 5500K
+	DT_LS_CoolWhiteFluorescent = 14, // W  3800 - 4500K
+	DT_LS_WhiteFluorescent     = 15, // WW 3250 - 3800K
+	DT_LS_WarmWhiteFluorescent = 16, // L  2600 - 3250K
+	DT_LS_StandardLightA       = 17,
+	DT_LS_StandardLightB       = 18,
+	DT_LS_StandardLightC       = 19,
+	DT_LS_D55                  = 20,
+	DT_LS_D65                  = 21,
+	DT_LS_D75                  = 22,
+	DT_LS_D50                  = 23,
+	DT_LS_ISOStudioTungsten    = 24,
+	DT_LS_Other                = 255
+} dt_dng_illuminant_t;
+
+
 /** set the list of available tags from Exvi2 */
 void dt_exif_set_exiv2_taglist();
 


### PR DESCRIPTION
Until now we assumed an order of illuminants tags for dng images. This assumption does not
hold so we need to define the selection otherwise.

Here we look for Exif.Image.CalibrationIlluminant1/2 and look for the one with the highest
temperature as long as that is not > D65.

Also preparations have been done to add Exif.Image.CalibrationIlluminant3 defined in dng v. 1.6,
this has not been implemented yet as there are no test images so far and current exiv2 does not
implement them.

Also the fallback to use the adobe coeffs was not correct, here we look for dng tags and only if we don't have such
the fallback is taken later.

Fixes #9223
Edit: Fixes #9268
Also see #9212 

@kmilos indeed this sort of fix does not break old edits, it only changes the matrix if re-reading exif data. 