### PR TITLE
print: skip areas not populated with an image.

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -378,23 +378,29 @@ static void _create_pdf(dt_job_t *job, dt_images_box imgs, const float width, co
   if (*printer_profile)
     icc_id = dt_pdf_add_icc(pdf, printer_profile);
 */
+  int32_t count = 0;
+
   for(int k=0; k<imgs.count; k++)
   {
     const int resolution = params->prt.printer.resolution;
     const dt_image_box *box = &imgs.box[k];
 
-    pdf_image[k] =
-      dt_pdf_add_image(pdf, (uint8_t *)box->buf, box->exp_width, box->exp_height,
-                       8, icc_id, 0.0);
+    if(box->imgid > -1)
+    {
+      pdf_image[count] =
+        dt_pdf_add_image(pdf, (uint8_t *)box->buf, box->exp_width, box->exp_height,
+                         8, icc_id, 0.0);
 
-    //  PDF bounding-box has origin on bottom-left
-    pdf_image[k]->bb_x      = dt_pdf_pixel_to_point(box->print.x, resolution);
-    pdf_image[k]->bb_y      = dt_pdf_pixel_to_point(box->print.y, resolution);
-    pdf_image[k]->bb_width  = dt_pdf_pixel_to_point(box->print.width, resolution);
-    pdf_image[k]->bb_height = dt_pdf_pixel_to_point(box->print.height, resolution);
+      //  PDF bounding-box has origin on bottom-left
+      pdf_image[count]->bb_x      = dt_pdf_pixel_to_point(box->print.x, resolution);
+      pdf_image[count]->bb_y      = dt_pdf_pixel_to_point(box->print.y, resolution);
+      pdf_image[count]->bb_width  = dt_pdf_pixel_to_point(box->print.width, resolution);
+      pdf_image[count]->bb_height = dt_pdf_pixel_to_point(box->print.height, resolution);
+      count++;
+    }
   }
 
-  params->pdf_page = dt_pdf_add_page(pdf, pdf_image, imgs.count);
+  params->pdf_page = dt_pdf_add_page(pdf, pdf_image, count);
   dt_pdf_finish(pdf, &params->pdf_page, 1);
 
   // now releases all the buf
@@ -471,8 +477,9 @@ static int _print_job_run(dt_job_t *job)
 
   for(int k=0; k<params->imgs.count; k++)
   {
-    if(_export_and_setup_pos(job, &params->imgs.box[k], k))
-      return 1;
+    if(params->imgs.box[k].imgid > -1)
+      if(_export_and_setup_pos(job, &params->imgs.box[k], k))
+        return 1;
   }
 
   if(dt_control_job_get_state(job) == DT_JOB_STATE_CANCELLED) return 0;
@@ -512,8 +519,9 @@ static int _print_job_run(dt_job_t *job)
 
   for(int k=0; k<params->imgs.count; k++)
   {
-    if(dt_tag_attach(tagid, params->imgs.box[k].imgid, FALSE, FALSE))
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    if(params->imgs.box[k].imgid > -1)
+      if(dt_tag_attach(tagid, params->imgs.box[k].imgid, FALSE, FALSE))
+        DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
     /* register print timestamp in cache */
     dt_image_cache_set_print_timestamp(darktable.image_cache, params->imgs.box[k].imgid);


### PR DESCRIPTION
Fixes #9435.