### PR TITLE
cleanup: prefer g_strdup_printf over dt_util_dstrcat

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1680,6 +1680,14 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
   }
 }
 
+static gchar *_build_label(const dt_bauhaus_widget_t *w)
+{
+  if(w->show_extended_label && w->section)
+    return g_strdup_printf("%s - %s", w->section, w->label);
+  else
+    return g_strdup(w->label);
+}
+
 static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_bauhaus_widget_t *w = darktable.bauhaus->current;
@@ -1791,11 +1799,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       float label_width = width - darktable.bauhaus->quad_width - INNER_PADDING * 2.0 - value_width;
       if(label_width > 0)
       {
-        gchar *lb = NULL;
-        if(w->show_extended_label && w->section)
-          lb = dt_util_dstrcat(NULL, "%s - %s", w->section, w->label);
-        else
-          lb = g_strdup(w->label);
+        gchar *lb = _build_label(w);
         show_pango_text(w, context, cr, lb, 0, 0, label_width, FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE, FALSE);
         g_free(lb);
       }
@@ -1867,11 +1871,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       if(show_box_label)
       {
         set_color(cr, text_color);
-        gchar *lb = NULL;
-        if(w->show_extended_label && w->section)
-          lb = dt_util_dstrcat(NULL, "%s - %s", w->section, w->label);
-        else
-          lb = g_strdup(w->label);
+        gchar *lb = _build_label(w);
         show_pango_text(w, context, cr, lb, INNER_PADDING, darktable.bauhaus->widget_space,
                         wd - INNER_PADDING - darktable.bauhaus->quad_width - first_label_width, FALSE, FALSE,
                         PANGO_ELLIPSIZE_END, FALSE, TRUE);
@@ -1981,11 +1981,7 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
       const float available_width = width - darktable.bauhaus->quad_width - INNER_PADDING;
 
       //calculate total widths of label and combobox
-      gchar *label_text = NULL;
-      if(w->show_extended_label && w->section)
-        label_text = dt_util_dstrcat(NULL, "%s - %s", w->section, w->label);
-      else
-        label_text = g_strdup(w->label);
+      gchar *label_text = _build_label(w);
       const float label_width
           = show_pango_text(w, context, cr, label_text, 0, 0, 0, FALSE, TRUE, PANGO_ELLIPSIZE_END, FALSE, TRUE);
       const float combo_width
@@ -2049,11 +2045,7 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
         g_free(text);
       }
       // label on top of marker:
-      gchar *label_text = NULL;
-      if(w->show_extended_label && w->section)
-        label_text = dt_util_dstrcat(NULL, "%s - %s", w->section, w->label);
-      else
-        label_text = g_strdup(w->label);
+      gchar *label_text = _build_label(w);
       set_color(cr, *text_color);
       float label_width = width - darktable.bauhaus->quad_width - INNER_PADDING - value_width;
       if(label_width > 0)

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -217,7 +217,7 @@ int dt_collection_update(const dt_collection_t *collection)
     /* add default filters */
     if(collection->params.filter_flags & COLLECTION_FILTER_FILM_ID)
     {
-      wq = dt_util_dstrcat(wq, "%s (film_id = %d)", and_operator(&and_term), collection->params.film_id);
+      wq = g_strdup_printf("%s (film_id = %d)", and_operator(&and_term), collection->params.film_id);
     }
     // DON'T SELECT IMAGES MARKED TO BE DELETED.
     wq = dt_util_dstrcat(wq, " %s (flags & %d) != %d",
@@ -243,9 +243,16 @@ int dt_collection_update(const dt_collection_t *collection)
                            rejected_check);
 
     if(collection->params.filter_flags & COLLECTION_FILTER_ALTERED)
-      wq = dt_util_dstrcat(wq, " %s id IN (SELECT imgid FROM main.images, main.history_hash WHERE imgid=mi.id AND history_hash.imgid=id AND (basic_hash IS NULL OR current_hash != basic_hash) AND (auto_hash IS NULL OR current_hash != auto_hash))", and_operator(&and_term));
+      wq = dt_util_dstrcat(wq, " %s id IN (SELECT imgid FROM main.images, main.history_hash "
+                                           "WHERE imgid=mi.id AND history_hash.imgid=id AND "
+                                           " (basic_hash IS NULL OR current_hash != basic_hash) AND "
+                                           " (auto_hash IS NULL OR current_hash != auto_hash))",
+                           and_operator(&and_term));
     else if(collection->params.filter_flags & COLLECTION_FILTER_UNALTERED)
-      wq = dt_util_dstrcat(wq, " %s id IN (SELECT imgid FROM main.images, main.history_hash WHERE imgid=mi.id AND history_hash.imgid=id AND (current_hash == basic_hash OR current_hash == auto_hash))", and_operator(&and_term));
+      wq = dt_util_dstrcat(wq, " %s id IN (SELECT imgid FROM main.images, main.history_hash "
+                                           "WHERE imgid=mi.id AND history_hash.imgid=id AND "
+                                           " (current_hash == basic_hash OR current_hash == auto_hash))",
+                           and_operator(&and_term));
 
     /* add where ext if wanted */
     if((collection->params.query_flags & COLLECTION_QUERY_USE_WHERE_EXT))
@@ -254,7 +261,7 @@ int dt_collection_update(const dt_collection_t *collection)
     g_free(rejected_check);
   }
   else
-    wq = dt_util_dstrcat(wq, "%s", where_ext);
+    wq = g_strdup(where_ext);
 
   g_free(where_ext);
 
@@ -1052,7 +1059,7 @@ GList *dt_collection_get(const dt_collection_t *collection, int limit, gboolean 
     if(selected)
       q = g_strdup_printf("SELECT id FROM main.selected_images AS s JOIN (%s) AS mi WHERE mi.id = s.imgid LIMIT -1, ?3", query);
     else
-      q = g_strdup_printf("%s", query);
+      q = g_strdup(query);
 
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), q, -1, &stmt, NULL);
 

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -555,7 +555,7 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection, int e
   else
     complete_string = g_strjoinv(complete_string, ((dt_collection_t *)collection)->where_ext);
 
-  gchar *where_ext = dt_strdup_printf("(1=1%s)", complete_string);
+  gchar *where_ext = g_strdup_printf("(1=1%s)", complete_string);
   g_free(complete_string);
 
   return where_ext;
@@ -2014,7 +2014,7 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
       }
       // 2. search the first imgid not in the list but AFTER the list (or in a gap inside the list)
       // we need to be carefull that some images in the list may not be present on screen (collapsed groups)
-      gchar *query = g_strdup_print( "SELECT imgid"
+      gchar *query = g_strdup_printf("SELECT imgid"
                                      " FROM memory.collected_images"
                                      " WHERE imgid NOT IN (%s)"
                                      "  AND rowid > (SELECT rowid"
@@ -2259,8 +2259,7 @@ int64_t dt_collection_get_image_position(const int32_t image_id, const int32_t t
   if (image_id >= 0)
   {
     sqlite3_stmt *stmt = NULL;
-    gchar *image_pos_query = g_strdup_printf(
-          image_pos_query,
+    gchar *image_pos_query = g_strdup(
           tagid ? "SELECT position FROM main.tagged_images WHERE imgid = ?1 AND tagid = ?2"
                 : "SELECT position FROM main.images WHERE id = ?1");
 

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -167,7 +167,7 @@ void dt_collection_memory_update()
                         NULL, NULL, NULL);
 
   // 2. insert collected images into the temporary table
-  gchar *ins_query = dt_util_dstrcat(NULL, "INSERT INTO memory.collected_images (imgid) %s", query);
+  gchar *ins_query = g_strdup_printf("INSERT INTO memory.collected_images (imgid) %s", query);
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), ins_query, -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, 0);
@@ -555,7 +555,7 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection, int e
   else
     complete_string = g_strjoinv(complete_string, ((dt_collection_t *)collection)->where_ext);
 
-  gchar *where_ext = dt_util_dstrcat(NULL, "(1=1%s)", complete_string);
+  gchar *where_ext = dt_strdup_printf("(1=1%s)", complete_string);
   g_free(complete_string);
 
   return where_ext;
@@ -618,11 +618,9 @@ static void _collection_update_aspect_ratio(const dt_collection_t *collection)
   {
     const float MAX_TIME = 7.0;
     const gchar *where_ext = dt_collection_get_extended_where(collection, -1);
-    gchar *query = NULL;
     sqlite3_stmt *stmt = NULL;
 
-    query = dt_util_dstrcat
-      (query,
+    gchar *query = g_strdup_printf(
        "SELECT id"
        " FROM main.images"
        " WHERE %s AND (aspect_ratio=0.0 OR aspect_ratio IS NULL)", where_ext);
@@ -711,7 +709,7 @@ const char *dt_collection_name(dt_collection_properties_t prop)
         if(type != DT_METADATA_TYPE_INTERNAL)
         {
           const char *name = (gchar *)dt_metadata_get_name_by_display_order(i);
-          char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+          char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
           const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
           free(setting);
           if(!hidden) col_name = _(name);
@@ -724,7 +722,6 @@ const char *dt_collection_name(dt_collection_properties_t prop)
 
 gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
 {
-  gchar *sq = NULL;
   gchar *second_order = NULL;/*string for previous sorting criteria as second order sorting criteria*/
 
   switch(collection->params.sort_second_order)/*build ORDER BY string for second order*/
@@ -747,60 +744,61 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
           case DT_COLLECTION_SORT_PRINT_TIMESTAMP:  colname = "print_timestamp" ; break ;
           default: colname = "";
         }
-      second_order = dt_util_dstrcat(NULL, "%s %s", colname, (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("%s %s", colname, (collection->params.descending ? "DESC" : ""));
       break;
       }
 
     case DT_COLLECTION_SORT_RATING:
-      second_order = dt_util_dstrcat(NULL, "CASE WHEN flags & 8 = 8 THEN -1 ELSE flags & 7 END %s", (collection->params.descending ? "" : "DESC"));
+      second_order = g_strdup_printf("CASE WHEN flags & 8 = 8 THEN -1 ELSE flags & 7 END %s", (collection->params.descending ? "" : "DESC"));
       break;
 
     case DT_COLLECTION_SORT_FILENAME:
-      second_order = dt_util_dstrcat(NULL, "filename %s", (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("filename %s", (collection->params.descending ? "DESC" : ""));
       break;
 
     case DT_COLLECTION_SORT_ID:
-      second_order = dt_util_dstrcat(NULL, "mi.id %s", (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("mi.id %s", (collection->params.descending ? "DESC" : ""));
       break;
 
     case DT_COLLECTION_SORT_COLOR:
-      second_order = dt_util_dstrcat(NULL, "color %s", (collection->params.descending ? "" : "DESC"));
+      second_order = g_strdup_printf("color %s", (collection->params.descending ? "" : "DESC"));
       break;
 
     case DT_COLLECTION_SORT_GROUP:
-      second_order = dt_util_dstrcat(NULL, "group_id %s, mi.id-group_id != 0", (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("group_id %s, mi.id-group_id != 0", (collection->params.descending ? "DESC" : ""));
       break;
 
     case DT_COLLECTION_SORT_PATH:
-      second_order = dt_util_dstrcat(NULL, "folder %s, filename %s", (collection->params.descending ? "DESC" : ""), (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("folder %s, filename %s", (collection->params.descending ? "DESC" : ""), (collection->params.descending ? "DESC" : ""));
       break;
 
     case DT_COLLECTION_SORT_CUSTOM_ORDER:
-      second_order = dt_util_dstrcat(NULL, "position %s", (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("position %s", (collection->params.descending ? "DESC" : ""));
       break;
 
      case DT_COLLECTION_SORT_TITLE:
      case DT_COLLECTION_SORT_DESCRIPTION:/*same sorting for TITLE and DESCRIPTION -> Fall through*/
-       second_order = dt_util_dstrcat(NULL, "m.value %s", (collection->params.descending ? "DESC" : ""));
+       second_order = g_strdup_printf("m.value %s", (collection->params.descending ? "DESC" : ""));
        break;
 
     case DT_COLLECTION_SORT_ASPECT_RATIO:
-      second_order = dt_util_dstrcat(NULL, "aspect_ratio %s", (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("aspect_ratio %s", (collection->params.descending ? "DESC" : ""));
       break;
 
     case DT_COLLECTION_SORT_SHUFFLE:
       /* do not remember shuffle for second order */
-      if(!second_order) second_order = dt_util_dstrcat(NULL, "filename %s", (collection->params.descending ? "DESC" : ""));/*only set if not yet initialized*/
+      if(!second_order) second_order = g_strdup_printf("filename %s", (collection->params.descending ? "DESC" : ""));/*only set if not yet initialized*/
       break;
 
     case DT_COLLECTION_SORT_NONE:/*fall through for default*/
     default:
       // shouldn't happen
-      second_order = dt_util_dstrcat(NULL, "filename %s", (collection->params.descending ? "DESC" : ""));
+      second_order = g_strdup_printf("filename %s", (collection->params.descending ? "DESC" : ""));
       break;
   }
 
 
+  gchar *sq = NULL;
   if(collection->params.descending)
   {
     switch(collection->params.sort)
@@ -823,60 +821,60 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
           case DT_COLLECTION_SORT_PRINT_TIMESTAMP:  colname = "print_timestamp" ; break ;
           default: colname = "";
         }
-        sq = dt_util_dstrcat(sq, "ORDER BY %s DESC, %s, filename DESC, version DESC", colname, second_order);
+        sq = g_strdup_printf("ORDER BY %s DESC, %s, filename DESC, version DESC", colname, second_order);
         break;
         }
 
       case DT_COLLECTION_SORT_RATING:
-        sq = dt_util_dstrcat(sq, "ORDER BY CASE WHEN flags & 8 = 8 THEN -1 ELSE flags & 7 END, %s, filename DESC, version DESC", second_order);
+        sq = g_strdup_printf("ORDER BY CASE WHEN flags & 8 = 8 THEN -1 ELSE flags & 7 END, %s, filename DESC, version DESC", second_order);
         break;
 
       case DT_COLLECTION_SORT_FILENAME:
-        sq = dt_util_dstrcat(sq, "ORDER BY filename DESC, %s, version DESC", second_order);
+        sq = g_strdup_printf("ORDER BY filename DESC, %s, version DESC", second_order);
         break;
 
       case DT_COLLECTION_SORT_ID:
-        sq = dt_util_dstrcat(sq, "ORDER BY mi.id DESC"); /* makes no sense to consider second order here since ID is unique ;) */
+        sq = g_strdup_printf("ORDER BY mi.id DESC"); /* makes no sense to consider second order here since ID is unique ;) */
         break;
 
       case DT_COLLECTION_SORT_COLOR:
-        sq = dt_util_dstrcat(sq, "ORDER BY color, %s, filename DESC, version DESC", second_order);
+        sq = g_strdup_printf("ORDER BY color, %s, filename DESC, version DESC", second_order);
         break;
 
       case DT_COLLECTION_SORT_GROUP:
-        sq = dt_util_dstrcat(sq, "ORDER BY group_id DESC, %s, mi.id-group_id != 0, mi.id DESC", second_order);
+        sq = g_strdup_printf("ORDER BY group_id DESC, %s, mi.id-group_id != 0, mi.id DESC", second_order);
         break;
 
       case DT_COLLECTION_SORT_PATH:
-        sq = dt_util_dstrcat(sq, "ORDER BY folder DESC, filename DESC, %s, version DESC", second_order);
+        sq = g_strdup_printf("ORDER BY folder DESC, filename DESC, %s, version DESC", second_order);
         break;
 
       case DT_COLLECTION_SORT_CUSTOM_ORDER:
-        sq = dt_util_dstrcat(sq, "ORDER BY position DESC, %s, filename DESC, version DESC", second_order);
+        sq = g_strdup_printf("ORDER BY position DESC, %s, filename DESC, version DESC", second_order);
         break;
 
       case DT_COLLECTION_SORT_TITLE:
-        sq = dt_util_dstrcat(sq, "ORDER BY m.value DESC, filename DESC, version DESC");
+        sq = g_strdup_printf("ORDER BY m.value DESC, filename DESC, version DESC");
         break;
 
       case DT_COLLECTION_SORT_DESCRIPTION:
-        sq = dt_util_dstrcat(sq, "ORDER BY m.value DESC, filename DESC, version DESC");
+        sq = g_strdup_printf("ORDER BY m.value DESC, filename DESC, version DESC");
         break;
 
       case DT_COLLECTION_SORT_ASPECT_RATIO:
-        sq = dt_util_dstrcat(sq, "ORDER BY aspect_ratio DESC, %s, filename DESC, version DESC", second_order);
+        sq = g_strdup_printf("ORDER BY aspect_ratio DESC, %s, filename DESC, version DESC", second_order);
         break;
 
 
       case DT_COLLECTION_SORT_SHUFFLE:
-        sq = dt_util_dstrcat(sq, "ORDER BY RANDOM()"); /* do not consider second order for shuffle */
+        sq = g_strdup("ORDER BY RANDOM()"); /* do not consider second order for shuffle */
         /* do not remember shuffle for second order */
         break;
 
       case DT_COLLECTION_SORT_NONE:
       default:/*fall through for default*/
         // shouldn't happen
-        sq = dt_util_dstrcat(sq, "ORDER BY mi.id DESC");
+        sq = g_strdup("ORDER BY mi.id DESC");
         break;
     }
   }
@@ -902,59 +900,59 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
           case DT_COLLECTION_SORT_PRINT_TIMESTAMP:  colname = "print_timestamp" ; break ;
           default: colname = "";
         }
-        sq = dt_util_dstrcat(sq, "ORDER BY %s, %s, filename, version", colname, second_order);
+        sq = g_strdup_printf("ORDER BY %s, %s, filename, version", colname, second_order);
         break;
         }
 
       case DT_COLLECTION_SORT_RATING:
-        sq = dt_util_dstrcat(sq, "ORDER BY CASE WHEN flags & 8 = 8 THEN -1 ELSE flags & 7 END DESC, %s, filename, version", second_order);
+        sq = g_strdup_printf("ORDER BY CASE WHEN flags & 8 = 8 THEN -1 ELSE flags & 7 END DESC, %s, filename, version", second_order);
         break;
 
       case DT_COLLECTION_SORT_FILENAME:
-        sq = dt_util_dstrcat(sq, "ORDER BY filename, %s, version", second_order);
+        sq = g_strdup_printf("ORDER BY filename, %s, version", second_order);
         break;
 
       case DT_COLLECTION_SORT_ID:
-        sq = dt_util_dstrcat(sq, "ORDER BY mi.id"); /* makes no sense to consider second order here since ID is unique ;) */
+        sq = g_strdup_printf("ORDER BY mi.id"); /* makes no sense to consider second order here since ID is unique ;) */
         break;
 
       case DT_COLLECTION_SORT_COLOR:
-        sq = dt_util_dstrcat(sq, "ORDER BY color DESC, %s, filename, version", second_order);
+        sq = g_strdup_printf("ORDER BY color DESC, %s, filename, version", second_order);
         break;
 
       case DT_COLLECTION_SORT_GROUP:
-        sq = dt_util_dstrcat(sq, "ORDER BY group_id, %s, mi.id-group_id != 0, mi.id", second_order);
+        sq = g_strdup_printf("ORDER BY group_id, %s, mi.id-group_id != 0, mi.id", second_order);
         break;
 
       case DT_COLLECTION_SORT_PATH:
-        sq = dt_util_dstrcat(sq, "ORDER BY folder, filename, %s, version", second_order);
+        sq = g_strdup_printf("ORDER BY folder, filename, %s, version", second_order);
         break;
 
       case DT_COLLECTION_SORT_CUSTOM_ORDER:
-        sq = dt_util_dstrcat(sq, "ORDER BY position, %s, filename, version", second_order);
+        sq = g_strdup_printf("ORDER BY position, %s, filename, version", second_order);
         break;
 
       case DT_COLLECTION_SORT_TITLE:
-        sq = dt_util_dstrcat(sq, "ORDER BY m.value, filename, version");
+        sq = g_strdup_printf("ORDER BY m.value, filename, version");
         break;
 
       case DT_COLLECTION_SORT_DESCRIPTION:
-        sq = dt_util_dstrcat(sq, "ORDER BY m.value, filename, version");
+        sq = g_strdup_printf("ORDER BY m.value, filename, version");
         break;
 
       case DT_COLLECTION_SORT_ASPECT_RATIO:
-        sq = dt_util_dstrcat(sq, "ORDER BY aspect_ratio, %s, filename, version", second_order);
+        sq = g_strdup_printf("ORDER BY aspect_ratio, %s, filename, version", second_order);
         break;
 
       case DT_COLLECTION_SORT_SHUFFLE:
-        sq = dt_util_dstrcat(sq, "ORDER BY RANDOM()"); /* do not consider second order for shuffle */
+        sq = g_strdup("ORDER BY RANDOM()"); /* do not consider second order for shuffle */
         /* do not remember shuffle for second order */
         break;
 
       case DT_COLLECTION_SORT_NONE:
       default:/*fall through for default*/
         // shouldn't happen
-        sq = dt_util_dstrcat(sq, "ORDER BY mi.id");
+        sq = g_strdup("ORDER BY mi.id");
         break;
     }
   }
@@ -1001,11 +999,11 @@ static uint32_t _dt_collection_compute_count(const dt_collection_t *collection, 
   if((collection->params.query_flags & COLLECTION_QUERY_USE_ONLY_WHERE_EXT))
   {
     gchar *where_ext = dt_collection_get_extended_where(collection, -1);
-    count_query = dt_util_dstrcat(NULL, "SELECT COUNT(DISTINCT main.images.id) FROM main.images AS mi %s", where_ext);
+    count_query = g_strdup_printf("SELECT COUNT(DISTINCT main.images.id) FROM main.images AS mi %s", where_ext);
     g_free(where_ext);
   }
   else
-    count_query = dt_util_dstrcat(count_query, "SELECT COUNT(DISTINCT mi.id) %s", fq);
+    count_query = g_strdup_printf("SELECT COUNT(DISTINCT mi.id) %s", fq);
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), count_query, -1, &stmt, NULL);
   if((collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
@@ -1320,14 +1318,14 @@ void dt_collection_split_operator_exposure(const gchar *input, char **number1, c
     gchar *n1 = g_match_info_fetch(match_info, 2);
 
     if(strstr(g_match_info_fetch(match_info, 1), "1/") != NULL)
-      *number1 = dt_util_dstrcat(NULL, "1.0/%s", n1);
+      *number1 = g_strdup_printf("1.0/%s", n1);
     else
       *number1 = n1;
 
     gchar *n2 = g_match_info_fetch(match_info, 5);
 
     if(strstr(g_match_info_fetch(match_info, 4), "1/") != NULL)
-      *number2 = dt_util_dstrcat(NULL, "1.0/%s", n2);
+      *number2 = g_strdup_printf("1.0/%s", n2);
     else
       *number2 = n2;
 
@@ -1351,7 +1349,7 @@ void dt_collection_split_operator_exposure(const gchar *input, char **number1, c
     gchar *n1 = g_match_info_fetch(match_info, 3);
 
     if(strstr(g_match_info_fetch(match_info, 2), "1/") != NULL)
-      *number1 = dt_util_dstrcat(NULL, "1.0/%s", n1);
+      *number1 = g_strdup_printf("1.0/%s", n1);
     else
       *number1 = n1;
 
@@ -1428,8 +1426,6 @@ void dt_collection_get_makermodels(const gchar *filter, GList **sanitized, GList
 
 gchar *dt_collection_get_makermodel(const char *exif_maker, const char *exif_model)
 {
-  gchar *makermodel = NULL;
-
   char maker[64];
   char model[64];
   char alias[64];
@@ -1440,9 +1436,7 @@ gchar *dt_collection_get_makermodel(const char *exif_maker, const char *exif_mod
                                 alias, sizeof(alias));
 
   // Create the makermodel by concatenation
-
-  makermodel = dt_util_dstrcat(makermodel, "%s %s", maker, model);
-
+  gchar *makermodel = g_strdup_printf("%s %s", maker, model);
   return makermodel;
 }
 
@@ -1527,7 +1521,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
               "AND (auto_hash IS NULL OR current_hash != auto_hash) "
             : "";
         const char *condition2 = (strcmp(escaped_text, _("basic")) == 0) ? "not" : "";
-        query = dt_util_dstrcat(query, "(id %s IN (SELECT imgid FROM main.history_hash %s)) ",
+        query = g_strdup_printf("(id %s IN (SELECT imgid FROM main.history_hash %s)) ",
                                 condition2, condition);
       }
       break;
@@ -1784,7 +1778,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     }
 
     case DT_COLLECTION_PROP_DAY:
-    // query = dt_util_dstrcat(NULL, "(datetime_taken like '%%%s%%')", escaped_text);
+    // query = g_strdup_printf("(datetime_taken like '%%%s%%')", escaped_text);
     // break;
 
     case DT_COLLECTION_PROP_TIME:
@@ -1835,18 +1829,18 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       if(strcmp(operator, "[]") == 0)
       {
         if(number1 && number2)
-          query = dt_util_dstrcat(query, "((strftime('%%Y:%%m:%%d:%%H:%%M:%%S', %s, 'unixepoch', 'localtime') >= '%s')"
-                                           "AND (strftime('%%Y:%%m:%%d:%%H:%%M:%%S', %s, 'unixepoch', 'localtime') <= '%s'))",
+          query = g_strdup_printf("((strftime('%%Y:%%m:%%d:%%H:%%M:%%S', %s, 'unixepoch', 'localtime') >= '%s')"
+                                  "AND (strftime('%%Y:%%m:%%d:%%H:%%M:%%S', %s, 'unixepoch', 'localtime') <= '%s'))",
                                   colname, number1, colname, number2);
       }
       else if((strcmp(operator, "=") == 0 || strcmp(operator, "") == 0) && number1)
-        query = dt_util_dstrcat(query, "(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') LIKE '%s')", colname, number1);
+        query = g_strdup_printf("(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') LIKE '%s')", colname, number1);
       else if(strcmp(operator, "<>") == 0 && number1)
-        query = dt_util_dstrcat(query, "(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') NOT LIKE '%s')", colname, number1);
+        query = g_strdup_printf("(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') NOT LIKE '%s')", colname, number1);
       else if(number1)
-        query = dt_util_dstrcat(query, "(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') %s '%s')", colname, operator, number1);
+        query = g_strdup_printf("(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') %s '%s')", colname, operator, number1);
       else
-        query = dt_util_dstrcat(query, "(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') LIKE '%%%s%%')", colname, escaped_text);
+        query = g_strdup_printf("(strftime('%%Y:%%m:%%d %%H:%%M:%%S', %s, 'unixepoch', 'localtime') LIKE '%%%s%%')", colname, escaped_text);
 
       g_free(operator);
       g_free(number1);
@@ -1855,14 +1849,14 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     break;
 
     case DT_COLLECTION_PROP_GROUPING: // grouping
-      query = dt_util_dstrcat(query, "(id %s group_id)", (strcmp(escaped_text, _("group leaders")) == 0) ? "=" : "!=");
+      query = g_strdup_printf("(id %s group_id)", (strcmp(escaped_text, _("group leaders")) == 0) ? "=" : "!=");
       break;
 
     case DT_COLLECTION_PROP_MODULE: // dev module
       {
-        query = dt_util_dstrcat(query, "(id IN (SELECT imgid AS id FROM main.history AS h "
-                                       "JOIN memory.darktable_iop_names AS m ON m.operation = h.operation "
-                                       "WHERE h.enabled = 1 AND m.name LIKE '%s'))", escaped_text);
+        query = g_strdup_printf("(id IN (SELECT imgid AS id FROM main.history AS h "
+                                "JOIN memory.darktable_iop_names AS m ON m.operation = h.operation "
+                                "WHERE h.enabled = 1 AND m.name LIKE '%s'))", escaped_text);
       }
       break;
 
@@ -2020,8 +2014,7 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
       }
       // 2. search the first imgid not in the list but AFTER the list (or in a gap inside the list)
       // we need to be carefull that some images in the list may not be present on screen (collapsed groups)
-      gchar *query = dt_util_dstrcat(NULL,
-                                     "SELECT imgid"
+      gchar *query = g_strdup_print( "SELECT imgid"
                                      " FROM memory.collected_images"
                                      " WHERE imgid NOT IN (%s)"
                                      "  AND rowid > (SELECT rowid"
@@ -2041,8 +2034,7 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
       // 3. if next is still unvalid, let's try to find the first untouched image BEFORE the list
       if(next < 0)
       {
-        query = dt_util_dstrcat(NULL,
-                                "SELECT imgid"
+        query = g_strdup_printf("SELECT imgid"
                                 " FROM memory.collected_images"
                                 " WHERE imgid NOT IN (%s)"
                                 "   AND rowid < (SELECT rowid"
@@ -2116,11 +2108,9 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
   // remove from selected images where not in this query.
   sqlite3_stmt *stmt = NULL;
   const gchar *cquery = dt_collection_get_query_no_group(collection);
-  gchar *complete_query = NULL;
   if(cquery && cquery[0] != '\0')
   {
-    complete_query
-        = dt_util_dstrcat(complete_query, "DELETE FROM main.selected_images WHERE imgid NOT IN (%s)", cquery);
+    gchar *complete_query = g_strdup_printf("DELETE FROM main.selected_images WHERE imgid NOT IN (%s)", cquery);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), complete_query, -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, 0);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, -1);
@@ -2269,8 +2259,7 @@ int64_t dt_collection_get_image_position(const int32_t image_id, const int32_t t
   if (image_id >= 0)
   {
     sqlite3_stmt *stmt = NULL;
-    gchar *image_pos_query = NULL;
-    image_pos_query = dt_util_dstrcat(
+    gchar *image_pos_query = g_strdup_printf(
           image_pos_query,
           tagid ? "SELECT position FROM main.tagged_images WHERE imgid = ?1 AND tagid = ?2"
                 : "SELECT position FROM main.images WHERE id = ?1");

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1429,8 +1429,7 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     const gboolean basecurve_auto_apply = strcmp(workflow, "display-referred") == 0;
     g_free(workflow);
     const gboolean sharpen_auto_apply = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
-    char *query = NULL;
-    query = dt_util_dstrcat(query,
+    char *query = g_strdup_printf(
                             "SELECT id, CASE WHEN imgid IS NULL THEN 0 ELSE 1 END as altered "
                             // first, images which are both in images and history (avoids history orphans)
                             "FROM (SELECT DISTINCT id FROM main.images JOIN main.history ON imgid = id) "

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -629,7 +629,7 @@ static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const
     }
 
     if(!skip_modules)
-      skip_modules = dt_util_dstrcat(skip_modules, "'@'");
+      skip_modules = g_strdup("'@'");
 
     gchar *query = g_strdup_printf
       ("INSERT INTO main.history "
@@ -1401,7 +1401,7 @@ void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_ha
     char *conflict = NULL;
     if(type & DT_HISTORY_HASH_BASIC)
     {
-      fields = dt_util_dstrcat(fields, "%s,", "basic_hash");
+      fields = g_strdup_printf("%s,", "basic_hash");
       values = g_strdup("?2,");
       conflict = g_strdup("basic_hash=?2,");
     }
@@ -1426,11 +1426,11 @@ void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_ha
     {
       sqlite3_stmt *stmt;
 #ifdef HAVE_SQLITE_324_OR_NEWER
-      char *query = dt_util_dstrcat(NULL, "INSERT INTO main.history_hash"
-                                          " (imgid, %s) VALUES (?1, %s)"
-                                          " ON CONFLICT (imgid)"
-                                          " DO UPDATE SET %s",
-                                          fields, values, conflict);
+      char *query = g_strdup_printf("INSERT INTO main.history_hash"
+                                    " (imgid, %s) VALUES (?1, %s)"
+                                    " ON CONFLICT (imgid)"
+                                    " DO UPDATE SET %s",
+                                    fields, values, conflict);
 #else
       char *query = NULL;
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -1441,17 +1441,17 @@ void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_ha
       if(sqlite3_step(stmt) == SQLITE_ROW)
       {
         sqlite3_finalize(stmt);
-        query = dt_util_dstrcat(NULL, "UPDATE main.history_hash"
-                                      " SET %s"
-                                      " WHERE imgid = ?1",
-                                      conflict);
+        query = g_strdup_printf("UPDATE main.history_hash"
+                                " SET %s"
+                                " WHERE imgid = ?1",
+                                conflict);
       }
       else
       {
         sqlite3_finalize(stmt);
-        query = dt_util_dstrcat(NULL, "INSERT INTO main.history_hash"
-                                      " (imgid, %s) VALUES (?1, %s)",
-                                      fields, values);
+        query = g_strdup_printf("INSERT INTO main.history_hash"
+                                " (imgid, %s) VALUES (?1, %s)",
+                                fields, values);
       }
 #endif
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -1568,8 +1568,7 @@ dt_history_hash_t dt_history_hash_get_status(const int32_t imgid)
   dt_history_hash_t status = 0;
   if(imgid == -1) return status;
   sqlite3_stmt *stmt;
-  char *query = dt_util_dstrcat(NULL,
-                                "SELECT CASE"
+  char *query = g_strdup_printf("SELECT CASE"
                                 "  WHEN basic_hash == current_hash THEN %d"
                                 "  WHEN auto_hash == current_hash THEN %d"
                                 "  WHEN (basic_hash IS NULL OR current_hash != basic_hash) AND"

--- a/src/common/iop_group.c
+++ b/src/common/iop_group.c
@@ -32,7 +32,7 @@ static int _group_number(int group_id)
 
 int dt_iop_get_group(const dt_iop_module_t *module)
 {
-  gchar *key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/modulegroup", module->op);
+  gchar *key = g_strdup_printf("plugins/darkroom/%s/modulegroup", module->op);
   int prefs = dt_conf_get_int(key);
 
   /* if zero, not found, record it */
@@ -44,7 +44,7 @@ int dt_iop_get_group(const dt_iop_module_t *module)
   }
   else
   {
-    gchar *g_key = dt_util_dstrcat(NULL, "plugins/darkroom/group_order/%d", prefs);
+    gchar *g_key = g_strdup_printf("plugins/darkroom/group_order/%d", prefs);
     prefs = dt_conf_get_int(g_key);
 
     prefs = 1 << (prefs - 1);

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -168,7 +168,7 @@ void dt_metadata_init()
   {
     const int type = dt_metadata_get_type(i);
     const char *name = (gchar *)dt_metadata_get_name(i);
-    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+    char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
     if(!dt_conf_key_exists(setting))
     {
       // per default should be imported - ignored if "write_sidecar_files" set
@@ -264,9 +264,8 @@ static void _bulk_remove_metadata(const int img, const gchar *metadata_list)
 {
   if(img > 0 && metadata_list)
   {
-    char *query = NULL;
     sqlite3_stmt *stmt;
-    query = dt_util_dstrcat(query, "DELETE FROM main.meta_data WHERE id = %d AND key IN (%s)", img, metadata_list);
+    gchar *query = g_strdup_printf("DELETE FROM main.meta_data WHERE id = %d AND key IN (%s)", img, metadata_list);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -278,9 +277,8 @@ static void _bulk_add_metadata(gchar *metadata_list)
 {
   if(metadata_list)
   {
-    char *query = NULL;
     sqlite3_stmt *stmt;
-    query = dt_util_dstrcat(query, "INSERT INTO main.meta_data (id, key, value) VALUES %s", metadata_list);
+    gchar *query = g_strdup_printf("INSERT INTO main.meta_data (id, key, value) VALUES %s", metadata_list);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -328,8 +326,8 @@ GList *dt_metadata_get_list_id(const int id)
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const gchar *value = (const char *)sqlite3_column_text(stmt, 1);
-    const gchar *ckey = dt_util_dstrcat(NULL, "%d", sqlite3_column_int(stmt, 0));
-    const gchar *cvalue = g_strdup(value ? value : ""); // to avoid NULL value
+    gchar *ckey = g_strdup_printf("%d", sqlite3_column_int(stmt, 0));
+    gchar *cvalue = g_strdup(value ? value : ""); // to avoid NULL value
     metadata = g_list_append(metadata, (gpointer)ckey);
     metadata = g_list_append(metadata, (gpointer)cvalue);
   }
@@ -589,7 +587,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
       GList *undo = NULL;
       if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
 
-      const gchar *ckey = dt_util_dstrcat(NULL, "%d", keyid);
+      const gchar *ckey = g_strdup_printf("%d", keyid);
       const gchar *cvalue = _cleanup_metadata_value(value);
       GList *metadata = NULL;
       metadata = g_list_append(metadata, (gpointer)ckey);
@@ -620,7 +618,7 @@ void dt_metadata_set_import(const int imgid, const char *key, const char *value)
     if(!imported && dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL)
     {
       const gchar *name = dt_metadata_get_name(keyid);
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       imported = dt_conf_get_int(setting) & DT_METADATA_FLAG_IMPORTED;
       g_free(setting);
     }
@@ -632,7 +630,7 @@ void dt_metadata_set_import(const int imgid, const char *key, const char *value)
       {
         GList *undo = NULL;
 
-        const gchar *ckey = dt_util_dstrcat(NULL, "%d", keyid);
+        const gchar *ckey = g_strdup_printf("%d", keyid);
         const gchar *cvalue = _cleanup_metadata_value(value);
         GList *metadata = NULL;
         metadata = g_list_append(metadata, (gpointer)ckey);
@@ -657,7 +655,7 @@ void dt_metadata_set_list(const GList *imgs, GList *key_value, const gboolean un
     const int keyid = dt_metadata_get_keyid(key);
     if(keyid != -1) // known key
     {
-      const gchar *ckey = dt_util_dstrcat(NULL, "%d", keyid);
+      const gchar *ckey = g_strdup_printf("%d", keyid);
       kv = g_list_next(kv);
       const gchar *value = (const gchar *)kv->data;
       kv = g_list_next(kv);
@@ -700,13 +698,13 @@ void dt_metadata_clear(const GList *imgs, const gboolean undo_on)
     if(dt_metadata_get_type(i) != DT_METADATA_TYPE_INTERNAL)
     {
       const gchar *name = dt_metadata_get_name(i);
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
       g_free(setting);
       if(!hidden)
       {
         // caution: metadata is a simple list here
-        metadata = g_list_prepend(metadata, dt_util_dstrcat(NULL, "%d", i));
+        metadata = g_list_prepend(metadata, g_strdup_printf("%d", i));
       }
     }
   }

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -44,7 +44,7 @@ char *dt_lib_export_metadata_get_conf(void)
   {
     metadata_presets = dt_conf_get_string(flags_keyword);
     int i = 0;
-    char *conf_keyword = dt_util_dstrcat(NULL,"%s%d", formula_keyword, i);
+    char *conf_keyword = g_strdup_printf("%s%d", formula_keyword, i);
     while (dt_conf_key_exists(conf_keyword))
     {
       char *nameformula = dt_conf_get_string(conf_keyword);
@@ -61,13 +61,13 @@ char *dt_lib_export_metadata_get_conf(void)
       }
       g_free(nameformula);
       i++;
-      conf_keyword = dt_util_dstrcat(NULL,"%s%d", formula_keyword, i);
+      conf_keyword = g_strdup_printf("%s%d", formula_keyword, i);
     }
     g_free(conf_keyword);
   }
   else
   {
-    metadata_presets = dt_util_dstrcat(NULL, "%x", dt_lib_export_metadata_default_flags());
+    metadata_presets = g_strdup_printf("%x", dt_lib_export_metadata_default_flags());
   }
   return metadata_presets;
 }
@@ -92,8 +92,8 @@ void dt_lib_export_metadata_set_conf(const char *metadata_presets)
         tags = g_list_next(tags);
         if (!tags) break;
         const char *formula = (char *)tags->data;
-        nameformula = dt_util_dstrcat(NULL,"%s;%s", tagname, formula);
-        conf_keyword = dt_util_dstrcat(NULL,"%s%d", formula_keyword, i);
+        nameformula = g_strdup_printf("%s;%s", tagname, formula);
+        conf_keyword = g_strdup_printf("%s%d", formula_keyword, i);
         dt_conf_set_string(conf_keyword, nameformula);
         g_free(nameformula);
         g_free(conf_keyword);
@@ -105,13 +105,13 @@ void dt_lib_export_metadata_set_conf(const char *metadata_presets)
   g_list_free_full(list, g_free);
 
   // clean up deprecated formulas
-  conf_keyword = dt_util_dstrcat(NULL,"%s%d", formula_keyword, i);
+  conf_keyword = g_strdup_printf("%s%d", formula_keyword, i);
   while (dt_conf_key_exists(conf_keyword))
   {
     dt_conf_set_string(conf_keyword, "");
     g_free(conf_keyword);
     i++;
-    conf_keyword = dt_util_dstrcat(NULL,"%s%d", formula_keyword, i);
+    conf_keyword = g_strdup_printf("%s%d", formula_keyword, i);
   }
   g_free(conf_keyword);
 }

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -76,9 +76,8 @@ static void _bulk_remove_tags(const int img, const gchar *tag_list)
 {
   if(img > 0 && tag_list)
   {
-    char *query = NULL;
     sqlite3_stmt *stmt;
-    query = dt_util_dstrcat(query, "DELETE FROM main.tagged_images WHERE imgid = %d AND tagid IN (%s)", img, tag_list);
+    gchar *query = g_strdup_printf("DELETE FROM main.tagged_images WHERE imgid = %d AND tagid IN (%s)", img, tag_list);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -90,9 +89,8 @@ static void _bulk_add_tags(const gchar *tag_list)
 {
   if(tag_list)
   {
-    char *query = NULL;
     sqlite3_stmt *stmt;
-    query = dt_util_dstrcat(query, "INSERT INTO main.tagged_images (imgid, tagid, position) VALUES %s", tag_list);
+    gchar *query = g_strdup_printf("INSERT INTO main.tagged_images (imgid, tagid, position) VALUES %s", tag_list);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -243,15 +241,13 @@ void dt_tag_delete_tag_batch(const char *flatlist)
 {
   sqlite3_stmt *stmt;
 
-  char *query = NULL;
-  query = dt_util_dstrcat(query, "DELETE FROM data.tags WHERE id IN (%s)", flatlist);
+  gchar *query = g_strdup_printf("DELETE FROM data.tags WHERE id IN (%s)", flatlist);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
   g_free(query);
 
-  query = NULL;
-  query = dt_util_dstrcat(query, "DELETE FROM main.tagged_images WHERE tagid IN (%s)", flatlist);
+  query = g_strdup_printf("DELETE FROM main.tagged_images WHERE tagid IN (%s)", flatlist);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
@@ -607,7 +603,7 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
   char *images = NULL;
   if(imgid > 0)
   {
-    images = dt_util_dstrcat(NULL, "%d", imgid);
+    images = g_strdup_printf("%d", imgid);
     nb_selected = 1;
   }
   else
@@ -615,8 +611,7 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
     // we get the query used to retrieve the list of select images
     images = dt_selection_get_list_query(darktable.selection, FALSE, FALSE);
     // and we retrieve the number of image in the selection
-    gchar *query = dt_util_dstrcat(NULL,
-                                   "SELECT COUNT(*)"
+    gchar *query = g_strdup_printf("SELECT COUNT(*)"
                                    " FROM (%s)",
                                    images);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -627,8 +622,7 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
   uint32_t count = 0;
   if(images)
   {
-    char *query = NULL;
-    query = dt_util_dstrcat(query,
+    gchar *query = g_strdup_printf(
                             "SELECT DISTINCT I.tagid, T.name, T.flags, T.synonyms,"
                             " COUNT(DISTINCT I.imgid) AS inb"
                             " FROM main.tagged_images AS I"
@@ -670,8 +664,7 @@ static uint32_t _tag_get_attached_export(const gint imgid, GList **result)
   if(!(imgid > 0)) return 0;
 
   sqlite3_stmt *stmt;
-  char *query = NULL;
-  query = dt_util_dstrcat(query,
+  gchar *query = g_strdup_printf(
                           "SELECT DISTINCT T.id, T.name, T.flags, T.synonyms"
                           // all tags
                           " FROM data.tags AS T"
@@ -827,7 +820,7 @@ static GList *_tag_get_tags(const gint imgid, const dt_tag_type_t type)
   GList *tags = NULL;
   char *images = NULL;
   if(imgid > 0)
-    images = dt_util_dstrcat(NULL, "%d", imgid);
+    images = g_strdup_printf("%d", imgid);
   else
   {
     // we get the query used to retrieve the list of select images
@@ -1023,8 +1016,7 @@ GList *dt_tag_get_images_from_list(const GList *img, const gint tagid)
 
     sqlite3_stmt *stmt;
 
-    char *query = NULL;
-    query = dt_util_dstrcat(query,
+    gchar *query = g_strdup_printf(
                             "SELECT imgid FROM main.tagged_images"
                             " WHERE tagid = %d AND imgid IN (%s)",
                             tagid, images);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2670,7 +2670,7 @@ void dt_iop_set_darktable_iop_table()
   if(module_list)
   {
     module_list[strlen(module_list) - 1] = '\0';
-    char *query = dt_util_dstrcat(NULL, "INSERT INTO memory.darktable_iop_names (operation, name) VALUES %s", module_list);
+    gchar *query = g_strdup_printf("INSERT INTO memory.darktable_iop_names (operation, name) VALUES %s", module_list);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -54,8 +54,7 @@ static void _list_remove_thumb(gpointer user_data)
 static int _get_selection_count()
 {
   int nb = 0;
-  gchar *query = dt_util_dstrcat(
-      NULL,
+  gchar *query = g_strdup(  //TODO: since this is a fixed string, do we need to copy?
       "SELECT count(*) FROM main.selected_images AS s, memory.collected_images as m WHERE s.imgid = m.imgid");
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -77,7 +76,7 @@ static int _thumb_get_imgid(int rowid)
 {
   int id = -1;
   sqlite3_stmt *stmt;
-  gchar *query = dt_util_dstrcat(NULL, "SELECT imgid FROM memory.collected_images WHERE rowid=%d", rowid);
+  gchar *query = g_strdup_printf("SELECT imgid FROM memory.collected_images WHERE rowid=%d", rowid);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -92,7 +91,7 @@ static int _thumb_get_rowid(int imgid)
 {
   int id = -1;
   sqlite3_stmt *stmt;
-  gchar *query = dt_util_dstrcat(NULL, "SELECT rowid FROM memory.collected_images WHERE imgid=%d", imgid);
+  gchar *query = g_strdup_printf("SELECT rowid FROM memory.collected_images WHERE imgid=%d", imgid);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -199,8 +198,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
     if(table->navigate_inside_selection)
     {
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(NULL,
-                                     "SELECT m.rowid FROM memory.collected_images as m, main.selected_images as s "
+      gchar *query = g_strdup_printf("SELECT m.rowid FROM memory.collected_images as m, main.selected_images as s "
                                      "WHERE m.imgid=s.imgid AND m.rowid<=%d "
                                      "ORDER BY m.rowid DESC LIMIT 1 OFFSET %d",
                                      table->offset, -1 * move);
@@ -214,8 +212,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
         // if we are here, that means we don't have enough space to move as wanted. So we move to first position
         g_free(query);
         sqlite3_finalize(stmt);
-        query
-            = dt_util_dstrcat(NULL, "SELECT m.rowid FROM memory.collected_images as m, main.selected_images as s "
+        query = g_strdup_printf("SELECT m.rowid FROM memory.collected_images as m, main.selected_images as s "
                                     "WHERE m.imgid=s.imgid "
                                     "ORDER BY m.rowid LIMIT 1");
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -247,8 +244,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
     if(table->navigate_inside_selection)
     {
       sqlite3_stmt *stmt;
-      gchar *query
-          = dt_util_dstrcat(NULL,
+      gchar *query = g_strdup_printf(
                             "SELECT COUNT(m.rowid) FROM memory.collected_images as m, main.selected_images as s "
                             "WHERE m.imgid=s.imgid AND m.rowid>%d",
                             table->offset);
@@ -264,8 +260,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
       if(nb_after >= table->thumbs_count)
       {
         const int delta = MIN(nb_after + 1 - table->thumbs_count, move);
-        query = dt_util_dstrcat(NULL,
-                                "SELECT m.rowid FROM memory.collected_images as m, main.selected_images as s "
+        query = g_strdup_printf("SELECT m.rowid FROM memory.collected_images as m, main.selected_images as s "
                                 "WHERE m.imgid=s.imgid AND m.rowid>=%d "
                                 "ORDER BY m.rowid LIMIT 1 OFFSET %d",
                                 table->offset, delta);
@@ -287,8 +282,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
     else
     {
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(NULL,
-                                     "SELECT COUNT(m.rowid) FROM memory.collected_images as m "
+      gchar *query = g_strdup_printf("SELECT COUNT(m.rowid) FROM memory.collected_images as m "
                                      "WHERE m.rowid>%d",
                                      table->offset);
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -1061,8 +1055,7 @@ static void _thumbs_prefetch(dt_culling_t *table)
   dt_thumbnail_t *last = (dt_thumbnail_t *)g_list_last(table->list)->data;
   if(table->navigate_inside_selection)
   {
-    query
-        = dt_util_dstrcat(NULL,
+    query = g_strdup_printf(
                           "SELECT m.imgid "
                           "FROM memory.collected_images AS m, main.selected_images AS s "
                           "WHERE m.imgid = s.imgid"
@@ -1073,8 +1066,7 @@ static void _thumbs_prefetch(dt_culling_t *table)
   }
   else
   {
-    query
-        = dt_util_dstrcat(NULL,
+    query = g_strdup_printf(
                           "SELECT m.imgid "
                           "FROM memory.collected_images AS m "
                           "WHERE m.rowid > (SELECT mm.rowid FROM memory.collected_images AS mm WHERE mm.imgid=%d) "
@@ -1095,8 +1087,7 @@ static void _thumbs_prefetch(dt_culling_t *table)
   dt_thumbnail_t *prev = (dt_thumbnail_t *)(table->list)->data;
   if(table->navigate_inside_selection)
   {
-    query
-        = dt_util_dstrcat(NULL,
+    query = g_strdup_printf(
                           "SELECT m.imgid "
                           "FROM memory.collected_images AS m, main.selected_images AS s "
                           "WHERE m.imgid = s.imgid"
@@ -1107,8 +1098,7 @@ static void _thumbs_prefetch(dt_culling_t *table)
   }
   else
   {
-    query
-        = dt_util_dstrcat(NULL,
+    query = g_strdup_printf(
                           "SELECT m.imgid "
                           "FROM memory.collected_images AS m "
                           "WHERE m.rowid < (SELECT mm.rowid FROM memory.collected_images AS mm WHERE mm.imgid=%d) "
@@ -1132,8 +1122,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
 
   if(table->navigate_inside_selection)
   {
-    query = dt_util_dstrcat(NULL,
-                            "SELECT m.rowid, m.imgid, b.aspect_ratio "
+    query = g_strdup_printf("SELECT m.rowid, m.imgid, b.aspect_ratio "
                             "FROM memory.collected_images AS m, main.selected_images AS s, images AS b "
                             "WHERE m.imgid = b.id AND m.imgid = s.imgid AND m.rowid >= %d "
                             "ORDER BY m.rowid "
@@ -1142,8 +1131,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
   }
   else
   {
-    query = dt_util_dstrcat(NULL,
-                            "SELECT m.rowid, m.imgid, b.aspect_ratio "
+    query = g_strdup_printf("SELECT m.rowid, m.imgid, b.aspect_ratio "
                             "FROM (SELECT rowid, imgid "
                             "FROM memory.collected_images "
                             "WHERE rowid < %d + %d "
@@ -1232,8 +1220,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
      && g_list_shorter_than(newlist, _get_selection_count()))
   {
     const int nb = table->thumbs_count - g_list_length(newlist);
-    query = dt_util_dstrcat(NULL,
-                            "SELECT m.rowid, m.imgid, b.aspect_ratio "
+    query = g_strdup_printf("SELECT m.rowid, m.imgid, b.aspect_ratio "
                             "FROM memory.collected_images AS m, main.selected_images AS s, images AS b "
                             "WHERE m.imgid = b.id AND m.imgid = s.imgid AND m.rowid < %d "
                             "ORDER BY m.rowid DESC "

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -807,19 +807,19 @@ static gchar *_thumbs_get_overlays_class(dt_thumbnail_overlay_t over)
   switch(over)
   {
     case DT_THUMBNAIL_OVERLAYS_NONE:
-      return dt_util_dstrcat(NULL, "dt_overlays_none");
+      return g_strdup("dt_overlays_none");
     case DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED:
-      return dt_util_dstrcat(NULL, "dt_overlays_hover_extended");
+      return g_strdup("dt_overlays_hover_extended");
     case DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL:
-      return dt_util_dstrcat(NULL, "dt_overlays_always");
+      return g_strdup("dt_overlays_always");
     case DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED:
-      return dt_util_dstrcat(NULL, "dt_overlays_always_extended");
+      return g_strdup("dt_overlays_always_extended");
     case DT_THUMBNAIL_OVERLAYS_MIXED:
-      return dt_util_dstrcat(NULL, "dt_overlays_mixed");
+      return g_strdup("dt_overlays_mixed");
     case DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK:
-      return dt_util_dstrcat(NULL, "dt_overlays_hover_block");
+      return g_strdup("dt_overlays_hover_block");
     default:
-      return dt_util_dstrcat(NULL, "dt_overlays_hover");
+      return g_strdup("dt_overlays_hover");
   }
 }
 
@@ -843,7 +843,7 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
     gtk_style_context_add_class(context, "dt_culling");
 
   // overlays
-  gchar *otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", table->mode);
+  gchar *otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", table->mode);
   table->overlays = dt_conf_get_int(otxt);
   g_free(otxt);
 
@@ -851,7 +851,7 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   gtk_style_context_add_class(context, cl0);
   free(cl0);
 
-  otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
+  otxt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
   table->overlays_block_timeout = 2;
   if(!dt_conf_key_exists(otxt))
     table->overlays_block_timeout = dt_conf_get_int("plugins/lighttable/overlay_timeout");
@@ -859,7 +859,7 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
     table->overlays_block_timeout = dt_conf_get_int(otxt);
   g_free(otxt);
 
-  otxt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/culling/%d", table->mode);
+  otxt = g_strdup_printf("plugins/lighttable/tooltips/culling/%d", table->mode);
   table->show_tooltips = dt_conf_get_bool(otxt);
   g_free(otxt);
 
@@ -993,8 +993,7 @@ void dt_culling_init(dt_culling_t *table, int offset)
 
   // is first_id inside selection ?
   gboolean inside = FALSE;
-  query = dt_util_dstrcat(NULL,
-                          "SELECT col.imgid "
+  query = g_strdup_printf("SELECT col.imgid "
                           "FROM memory.collected_images AS col, main.selected_images AS sel "
                           "WHERE col.imgid=sel.imgid AND col.imgid=%d",
                           first_id);
@@ -1720,7 +1719,7 @@ void dt_culling_zoom_fit(dt_culling_t *table)
 void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over)
 {
   if(!table) return;
-  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", table->mode);
+  gchar *txt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", table->mode);
   dt_conf_set_int(txt, over);
   g_free(txt);
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
@@ -1730,7 +1729,7 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
   gtk_style_context_remove_class(context, cl0);
   gtk_style_context_add_class(context, cl1);
 
-  txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
+  txt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
   int timeout = 2;
   if(!dt_conf_key_exists(txt))
     timeout = dt_conf_get_int("plugins/lighttable/overlay_timeout");
@@ -1738,7 +1737,7 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
     timeout = dt_conf_get_int(txt);
   g_free(txt);
 
-  txt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/culling/%d", table->mode);
+  txt = g_strdup_printf("plugins/lighttable/tooltips/culling/%d", table->mode);
   table->show_tooltips = dt_conf_get_bool(txt);
   g_free(txt);
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -89,13 +89,13 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
 
   // the group leader
   if(thumb->imgid == thumb->groupid)
-    tt = dt_util_dstrcat(tt, "\n<b>%s (%s)</b>", _("current"), _("leader"));
+    tt = g_strdup_printf("\n<b>%s (%s)</b>", _("current"), _("leader"));
   else
   {
     const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->groupid, 'r');
     if(img)
     {
-      tt = dt_util_dstrcat(tt, "\n<b>%s (%s)</b>", img->filename, _("leader"));
+      tt = g_strdup_printf("\n<b>%s (%s)</b>", img->filename, _("leader"));
       dt_image_cache_read_release(darktable.image_cache, img);
     }
   }
@@ -126,7 +126,7 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
   sqlite3_finalize(stmt);
 
   // and the number of grouped images
-  gchar *ttf = dt_util_dstrcat(NULL, "%d %s\n%s", nb, _("grouped images"), tt);
+  gchar *ttf = g_strdup_printf("%d %s\n%s", nb, _("grouped images"), tt);
   g_free(tt);
 
   // let's apply the tooltip
@@ -272,11 +272,10 @@ static void _thumb_write_extension(dt_thumbnail_t *thumb)
 {
   // fill the file extension label
   const char *ext = thumb->filename + strlen(thumb->filename);
-  gchar *ext2 = NULL;
   while(ext > thumb->filename && *ext != '.') ext--;
   ext++;
   gchar *uext = dt_view_extend_modes_str(ext, thumb->is_hdr, thumb->is_bw, thumb->is_bw_flow);
-  ext2 = dt_util_dstrcat(ext2, "%s", uext);
+  gchar *ext2 = g_strdup_printf("%s", uext);
   gtk_label_set_text(GTK_LABEL(thumb->w_ext), ext2);
   g_free(uext);
   g_free(ext2);
@@ -675,7 +674,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       }
       else
       {
-        gchar *z = dt_util_dstrcat(NULL, "%.0f%%", thumb->zoom * 100.0 / thumb->zoom_100);
+        gchar *z = g_strdup_printf("%.0f%%", thumb->zoom * 100.0 / thumb->zoom_100);
         gtk_label_set_text(GTK_LABEL(thumb->w_zoom), z);
         g_free(z);
       }
@@ -1736,7 +1735,7 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
     g_strfreev(ts);
     g_free(txt);
 
-    gchar *cl = dt_util_dstrcat(NULL, "dt_thumbnails_%d", i);
+    gchar *cl = g_strdup_printf("dt_thumbnails_%d", i);
     GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_image);
     if(!gtk_style_context_has_class(context, cl))
     {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1271,7 +1271,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     if(thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED
        || thumb->over == DT_THUMBNAIL_OVERLAYS_MIXED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
     {
-      gchar *lb = dt_util_dstrcat(NULL, "%s", thumb->info_line);
+      gchar *lb = g_strdup(thumb->info_line);
       thumb->w_bottom = gtk_label_new(NULL);
       gtk_label_set_markup(GTK_LABEL(thumb->w_bottom), lb);
       g_free(lb);
@@ -1972,7 +1972,7 @@ void dt_thumbnail_reload_infos(dt_thumbnail_t *thumb)
   gchar *lb = NULL;
   if(thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED
      || thumb->over == DT_THUMBNAIL_OVERLAYS_MIXED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
-    lb = dt_util_dstrcat(NULL, "%s", thumb->info_line);
+    lb = g_strdup(thumb->info_line);
 
   // we set the text
   gtk_label_set_markup(GTK_LABEL(thumb->w_bottom), lb);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -57,19 +57,19 @@ static gchar *_thumbs_get_overlays_class(dt_thumbnail_overlay_t over)
   switch(over)
   {
     case DT_THUMBNAIL_OVERLAYS_NONE:
-      return dt_util_dstrcat(NULL, "dt_overlays_none");
+      return g_strdup("dt_overlays_none");
     case DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED:
-      return dt_util_dstrcat(NULL, "dt_overlays_hover_extended");
+      return g_strdup("dt_overlays_hover_extended");
     case DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL:
-      return dt_util_dstrcat(NULL, "dt_overlays_always");
+      return g_strdup("dt_overlays_always");
     case DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED:
-      return dt_util_dstrcat(NULL, "dt_overlays_always_extended");
+      return g_strdup("dt_overlays_always_extended");
     case DT_THUMBNAIL_OVERLAYS_MIXED:
-      return dt_util_dstrcat(NULL, "dt_overlays_mixed");
+      return g_strdup("dt_overlays_mixed");
     case DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK:
-      return dt_util_dstrcat(NULL, "dt_overlays_hover_block");
+      return g_strdup("dt_overlays_hover_block");
     default:
-      return dt_util_dstrcat(NULL, "dt_overlays_hover");
+      return g_strdup("dt_overlays_hover");
   }
 }
 
@@ -99,8 +99,8 @@ static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
   int ns = _thumbs_get_prefs_size(table);
 
   // we change the class that indicate the thumb size
-  gchar *c0 = dt_util_dstrcat(NULL, "dt_thumbnails_%d", table->prefs_size);
-  gchar *c1 = dt_util_dstrcat(NULL, "dt_thumbnails_%d", ns);
+  gchar *c0 = g_strdup_printf("dt_thumbnails_%d", table->prefs_size);
+  gchar *c1 = g_strdup_printf("dt_thumbnails_%d", ns);
   GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
   gtk_style_context_remove_class(context, c0);
   gtk_style_context_add_class(context, c1);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -109,10 +109,10 @@ static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
   table->prefs_size = ns;
 
   // we change the overlay mode
-  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/%d/%d", table->mode, ns);
+  gchar *txt = g_strdup_printf("plugins/lighttable/overlays/%d/%d", table->mode, ns);
   dt_thumbnail_overlay_t over = dt_conf_get_int(txt);
   g_free(txt);
-  txt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/%d/%d", table->mode, ns);
+  txt = g_strdup_printf("plugins/lighttable/tooltips/%d/%d", table->mode, ns);
   table->show_tooltips = dt_conf_get_bool(txt);
   g_free(txt);
 
@@ -124,7 +124,7 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
 {
   if(!table) return;
   // we ensure the tooltips change in any cases
-  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/%d/%d", table->mode, table->prefs_size);
+  gchar *txt = g_strdup_printf("plugins/lighttable/tooltips/%d/%d", table->mode, table->prefs_size);
   dt_conf_set_bool(txt, table->show_tooltips);
   g_free(txt);
   for(const GList *l = table->list; l; l = g_list_next(l))
@@ -135,7 +135,7 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
   }
 
   if(over == table->overlays) return;
-  txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/%d/%d", table->mode, table->prefs_size);
+  txt = g_strdup_printf("plugins/lighttable/overlays/%d/%d", table->mode, table->prefs_size);
   dt_conf_set_int(txt, over);
   g_free(txt);
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
@@ -145,7 +145,7 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
   gtk_style_context_remove_class(context, cl0);
   gtk_style_context_add_class(context, cl1);
 
-  txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
+  txt = g_strdup_printf("plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
   int timeout = 2;
   if(!dt_conf_key_exists(txt))
     timeout = dt_conf_get_int("plugins/lighttable/overlay_timeout");
@@ -173,8 +173,7 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
 void dt_thumbtable_set_overlays_block_timeout(dt_thumbtable_t *table, const int timeout)
 {
   if(!table) return;
-  gchar *txt
-      = dt_util_dstrcat(NULL, "plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
+  gchar *txt = g_strdup_printf("plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
   dt_conf_set_int(txt, timeout);
   g_free(txt);
 
@@ -219,7 +218,7 @@ static int _thumb_get_imgid(int rowid)
 {
   int id = -1;
   sqlite3_stmt *stmt;
-  gchar *query = dt_util_dstrcat(NULL, "SELECT imgid FROM memory.collected_images WHERE rowid=%d", rowid);
+  gchar *query = g_strdup_printf("SELECT imgid FROM memory.collected_images WHERE rowid=%d", rowid);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -234,7 +233,7 @@ static int _thumb_get_rowid(int imgid)
 {
   int id = -1;
   sqlite3_stmt *stmt;
-  gchar *query = dt_util_dstrcat(NULL, "SELECT rowid FROM memory.collected_images WHERE imgid=%d", imgid);
+  gchar *query = g_strdup_printf("SELECT rowid FROM memory.collected_images WHERE imgid=%d", imgid);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -521,8 +520,7 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
     int space = first->y;
     if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP) space = first->x;
     const int nb_to_load = space / table->thumb_size + (space % table->thumb_size != 0);
-    gchar *query = dt_util_dstrcat
-      (NULL,
+    gchar *query = g_strdup_printf(
        "SELECT rowid, imgid"
        " FROM memory.collected_images"
        " WHERE rowid<%d"
@@ -576,8 +574,7 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
     if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
       space = table->view_width - (last->x + table->thumb_size);
     const int nb_to_load = space / table->thumb_size + (space % table->thumb_size != 0);
-    gchar *query = dt_util_dstrcat
-      (NULL,
+    gchar *query = g_strdup_printf(
        "SELECT rowid, imgid"
        " FROM memory.collected_images"
        " WHERE rowid>%d"
@@ -1178,8 +1175,7 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
     GtkWidget *dialog;
     GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-    gchar *txt
-        = dt_util_dstrcat(NULL, _("you have changed the settings related to how thumbnails are generated.\n"));
+    gchar *txt = g_strdup(_("you have changed the settings related to how thumbnails are generated.\n"));
     if(max_level >= DT_MIPMAP_8 && min_level == DT_MIPMAP_0)
       txt = dt_util_dstrcat(txt, _("all cached thumbnails need to be invalidated.\n\n"));
     else if(max_level >= DT_MIPMAP_8)
@@ -1429,8 +1425,7 @@ static void _dt_collection_changed_callback(gpointer instance, dt_collection_cha
         if(table->navigate_inside_selection)
         {
           sqlite3_stmt *stmt;
-          gchar *query = dt_util_dstrcat(
-              NULL,
+          gchar *query = g_strdup_printf(
               "SELECT m.imgid"
               " FROM memory.collected_images AS m, main.selected_images AS s"
               " WHERE m.imgid=s.imgid"
@@ -1447,8 +1442,7 @@ static void _dt_collection_changed_callback(gpointer instance, dt_collection_cha
             // no select image after, search before
             g_free(query);
             sqlite3_finalize(stmt);
-            query = dt_util_dstrcat(
-                NULL,
+            query = g_strdup_printf(
                 "SELECT m.imgid"
                 " FROM memory.collected_images AS m, main.selected_images AS s"
                 " WHERE m.imgid=s.imgid"
@@ -1966,7 +1960,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
     GList *newlist = NULL;
     int nbnew = 0;
     gchar *query
-        = dt_util_dstrcat(NULL, "SELECT rowid, imgid FROM memory.collected_images WHERE rowid>=%d LIMIT %d",
+        = g_strdup_printf("SELECT rowid, imgid FROM memory.collected_images WHERE rowid>=%d LIMIT %d",
                           offset, table->rows * table->thumbs_per_row - empty_start);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     while(sqlite3_step(stmt) == SQLITE_ROW)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -257,14 +257,16 @@ static gchar *_panels_get_view_path(char *suffix)
     g_snprintf(lay, sizeof(lay), "%d/", dt_view_darkroom_get_layout(darktable.view_manager));
   }
 
-  return dt_util_dstrcat(NULL, "%s/ui/%s%s", cv->module_name, lay, suffix);
+  return g_strdup_printf("%s/ui/%s%s", cv->module_name, lay, suffix);
 }
 
 static gchar *_panels_get_panel_path(dt_ui_panel_t panel, char *suffix)
 {
   gchar *v = _panels_get_view_path("");
   if(!v) return NULL;
-  return dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffix);
+  gchar *path = dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffix);
+  g_free(v);
+  return path;
 }
 
 static gboolean _panel_is_visible(dt_ui_panel_t panel)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2754,9 +2754,9 @@ void dt_gui_load_theme(const char *theme)
   {
     //font name can only use period as decimal separator
     //but printf format strings use comma for some locales, so replace comma with period
-    gchar *font_size = dt_util_dstrcat(NULL, _("%.1f"), dt_conf_get_float("font_size"));
+    gchar *font_size = g_strdup_printf(_("%.1f"), dt_conf_get_float("font_size"));
     gchar *font_size_updated = dt_util_str_replace(font_size, ",", ".");
-    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %s"), font_size_updated);
+    gchar *font_name = g_strdup_printf(_("Sans %s"), font_size_updated);
     g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
     g_free(font_size_updated);
     g_free(font_size);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -264,9 +264,7 @@ static gchar *_panels_get_panel_path(dt_ui_panel_t panel, char *suffix)
 {
   gchar *v = _panels_get_view_path("");
   if(!v) return NULL;
-  gchar *path = dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffix);
-  g_free(v);
-  return path;
+  return dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffix);
 }
 
 static gboolean _panel_is_visible(dt_ui_panel_t panel)

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -55,7 +55,7 @@ static void _metadata_save(GtkWidget *widget, dt_import_metadata_t *metadata)
   const int i = dt_metadata_get_keyid_by_name(name);
   if(i != -1)
   {
-    char *setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", name);
+    char *setting = g_strdup_printf("ui_last/import_last_%s", name);
     dt_conf_set_string(setting, gtk_entry_get_text(GTK_ENTRY(widget)));
     g_free(setting);
   }
@@ -120,7 +120,7 @@ static void _import_metadata_toggled(GtkWidget *widget, dt_import_metadata_t *me
     const int i = dt_metadata_get_keyid_by_name(name);
     if(i != -1)
     {
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       const gboolean imported = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
       const uint32_t flag = dt_conf_get_int(setting);
       dt_conf_set_int(setting, imported ? flag | DT_METADATA_FLAG_IMPORTED : flag & ~DT_METADATA_FLAG_IMPORTED);
@@ -151,7 +151,7 @@ static void _update_layout(dt_import_metadata_t *metadata)
   {
     const gboolean internal = dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL;
     const gchar *metadata_name = (gchar *)dt_metadata_get_name_by_display_order(i);
-    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
+    char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", metadata_name);
     const gboolean visible = !internal & !(dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN);
     g_free(setting);
     for(int j = 0; j < 3; j++)
@@ -434,7 +434,7 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
     const gchar *metadata_name = (gchar *)dt_metadata_get_name_by_display_order(i);
-    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
+    gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", metadata_name);
     const uint32_t flag = dt_conf_get_int(setting);
     g_free(setting);
 
@@ -442,7 +442,7 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
     labelev = _set_up_label(metadata_label, GTK_ALIGN_START, i + DT_META_META_VALUE, metadata);
 
     GtkWidget *metadata_entry = gtk_entry_new();
-    setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
+    setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
     gchar *str = dt_conf_get_string(setting);
     _set_up_entry(metadata_entry, str, metadata_name, i + DT_META_META_VALUE, metadata);
     g_free(str);
@@ -524,7 +524,7 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
   {
     GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 1, i + DT_META_META_VALUE);
     const gchar *metadata_name = dt_metadata_get_name_by_display_order(i);
-    char *setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
+    gchar *setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
     char *meta = dt_conf_get_string(setting);
     g_signal_handlers_block_by_func(w, _import_metadata_changed, metadata);
     gtk_entry_set_text(GTK_ENTRY(w), meta);
@@ -532,7 +532,7 @@ void dt_import_metadata_update(dt_import_metadata_t *metadata)
     g_free(meta);
     g_free(setting);
     w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, i + DT_META_META_VALUE);
-    setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
+    setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", metadata_name);
     const uint32_t flag = dt_conf_get_int(setting);
     g_signal_handlers_block_by_func(w, _import_metadata_toggled, metadata);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), flag & DT_METADATA_FLAG_IMPORTED);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -270,8 +270,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
     if(g->old_id >= 0)
     {
       // we update presets values
-      query = dt_util_dstrcat(query,
-                              "UPDATE data.presets "
+      query = g_strdup_printf("UPDATE data.presets "
                               "SET"
                               " name=?1, description=?2,"
                               " model=?3, maker=?4, lens=?5, iso_min=?6, iso_max=?7, exposure_min=?8,"
@@ -284,8 +283,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
     else
     {
       // we create a new preset
-      query = dt_util_dstrcat(query,
-                              "INSERT INTO data.presets"
+      query = g_strdup_printf("INSERT INTO data.presets"
                               " (name, description, "
                               "  model, maker, lens, iso_min, iso_max, exposure_min, exposure_max, aperture_min,"
                               "  aperture_max, focal_length_min, focal_length_max, autoapply,"
@@ -1150,7 +1148,7 @@ static void _menuitem_manage_quick_presets(GtkMenuItem *menuitem, gpointer data)
         const char *name = (char *)sqlite3_column_text(stmt, 0);
         gchar *presetname = g_markup_escape_text(name, -1);
         // is this preset part of the list ?
-        gchar *txt = dt_util_dstrcat(NULL, "ꬹ%s|%sꬹ", iop->op, name);
+        gchar *txt = g_strdup_printf("ꬹ%s|%sꬹ", iop->op, name);
         const gboolean inlist = (config && strstr(config, txt));
         g_free(txt);
         gtk_tree_store_append(treestore, &child, &toplevel);
@@ -1228,14 +1226,14 @@ void dt_gui_favorite_presets_menu_show()
         if(retrieve_list)
         {
           // we only show it if module is in favorite
-          gchar *key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/favorite", iop->so->op);
+          gchar *key = g_strdup_printf("plugins/darkroom/%s/favorite", iop->so->op);
           const gboolean fav = dt_conf_get_bool(key);
           g_free(key);
           if(fav) config = dt_util_dstrcat(config, "ꬹ%s|%sꬹ", iop->so->op, name);
         }
 
         // check that this preset is in the config list
-        gchar *txt = dt_util_dstrcat(NULL, "ꬹ%s|%sꬹ", iop->so->op, name);
+        gchar *txt = g_strdup_printf("ꬹ%s|%sꬹ", iop->so->op, name);
         if(config && strstr(config, txt))
         {
           GtkMenuItem *mi = (GtkMenuItem *)gtk_menu_item_new_with_label(name);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2179,18 +2179,18 @@ void gui_init(dt_iop_module_t *self)
       G_CALLBACK(rt_select_algorithm_callback), TRUE, 0, 0, dtgtk_cairo_paint_tool_heal, hbox_algo);
 
   // overwrite tooltip ourself to handle shift+click
-  gchar *tt2 = dt_util_dstrcat(NULL, "%s\n%s", _("ctrl+click to change tool for current form"),
+  gchar *tt2 = g_strdup_printf("%s\n%s", _("ctrl+click to change tool for current form"),
                                _("shift+click to set the tool as default"));
-  gchar *tt = dt_util_dstrcat(NULL, "%s\n%s", _("activate blur tool"), tt2);
+  gchar *tt = g_strdup_printf("%s\n%s", _("activate blur tool"), tt2);
   gtk_widget_set_tooltip_text(g->bt_blur, tt);
   g_free(tt);
-  tt = dt_util_dstrcat(NULL, "%s\n%s", _("activate fill tool"), tt2);
+  tt = g_strdup_printf("%s\n%s", _("activate fill tool"), tt2);
   gtk_widget_set_tooltip_text(g->bt_fill, tt);
   g_free(tt);
-  tt = dt_util_dstrcat(NULL, "%s\n%s", _("activate cloning tool"), tt2);
+  tt = g_strdup_printf("%s\n%s", _("activate cloning tool"), tt2);
   gtk_widget_set_tooltip_text(g->bt_clone, tt);
   g_free(tt);
-  tt = dt_util_dstrcat(NULL, "%s\n%s", _("activate healing tool"), tt2);
+  tt = g_strdup_printf("%s\n%s", _("activate healing tool"), tt2);
   gtk_widget_set_tooltip_text(g->bt_heal, tt);
   g_free(tt);
   g_free(tt2);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -452,8 +452,7 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
     {
       gchar *old = NULL;
 
-      gchar *q_tree_path = NULL;
-      q_tree_path = dt_util_dstrcat(q_tree_path, "%s%%", tree_path);
+      gchar *q_tree_path = g_strdup_printf("%s%%", tree_path);
       query = "SELECT id, folder FROM main.film_rolls WHERE folder LIKE ?1";
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
       DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, q_tree_path, -1, SQLITE_TRANSIENT);
@@ -466,8 +465,7 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
         id = sqlite3_column_int(stmt, 0);
         old = (gchar *)sqlite3_column_text(stmt, 1);
 
-        query = NULL;
-        query = dt_util_dstrcat(query, "UPDATE main.film_rolls SET folder=?1 WHERE id=?2");
+        query = g_strdup("UPDATE main.film_rolls SET folder=?1 WHERE id=?2");
 
         gchar trailing[1024] = { 0 };
         gchar final[1024] = { 0 };
@@ -538,8 +536,7 @@ static void view_popup_menu_onRemove(GtkWidget *menuitem, gpointer userdata)
     /* Clean selected images, and add to the table those which are going to be deleted */
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.selected_images", NULL, NULL, NULL);
 
-    fullq = dt_util_dstrcat(fullq,
-                            "INSERT INTO main.selected_images"
+    fullq = g_strdup_printf("INSERT INTO main.selected_images"
                             " SELECT id"
                             " FROM main.images"
                             " WHERE film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s%%')",
@@ -987,16 +984,12 @@ static void tree_set_visibility(GtkTreeModel *model, gpointer data)
 static void _lib_folders_update_collection(const gchar *filmroll)
 {
 
-  gchar *complete_query = NULL;
-
   // remove from selected images where not in this query.
   sqlite3_stmt *stmt = NULL;
   const gchar *cquery = dt_collection_get_query(darktable.collection);
-  // complete_query = NULL;
   if(cquery && cquery[0] != '\0')
   {
-    complete_query
-        = dt_util_dstrcat(complete_query,
+    gchar *complete_query = g_strdup_printf(
                           "DELETE FROM main.selected_images WHERE imgid NOT IN (%s)",
                           cquery);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), complete_query, -1, &stmt, NULL);
@@ -1634,9 +1627,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
     {
       case DT_COLLECTION_PROP_CAMERA:; // camera
         int index = 0;
-        gchar *makermodel_query = NULL;
-        makermodel_query = dt_util_dstrcat(makermodel_query, "SELECT maker, model, COUNT(*) AS count "
-                "FROM main.images AS mi WHERE %s GROUP BY maker, model", where_ext);
+        gchar *makermodel_query = g_strdup_printf("SELECT maker, model, COUNT(*) AS count "
+                                                  "FROM main.images AS mi WHERE %s GROUP BY maker, model", where_ext);
 
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                 makermodel_query,
@@ -1837,7 +1829,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
         {
           const int keyid = dt_metadata_get_keyid_by_display_order(property - DT_COLLECTION_PROP_METADATA);
           const char *name = (gchar *)dt_metadata_get_name(keyid);
-          char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+          char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
           const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
           g_free(setting);
           if(!hidden)
@@ -2791,7 +2783,7 @@ static void _populate_collect_combo(GtkWidget *w)
     {
       const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
       const gchar *name = dt_metadata_get_name(keyid);
-      gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
       g_free(setting);
       const int meta_type = dt_metadata_get_type(keyid);
@@ -3189,7 +3181,7 @@ void init(struct dt_lib_module_t *self)
     if(dt_metadata_get_type(i) != DT_METADATA_TYPE_INTERNAL)
     {
       const char *name = dt_metadata_get_name(i);
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
       g_free(setting);
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1874,7 +1874,7 @@ void *legacy_params(dt_lib_module_t *self, const void *const old_params, const s
     //  - old rest
 
     const gboolean omit = dt_conf_get_bool("omit_tag_hierarchy");
-    char *flags = dt_util_dstrcat(NULL, "%x", dt_lib_export_metadata_default_flags() | (omit ? DT_META_OMIT_HIERARCHY : 0));
+    gchar *flags = g_strdup_printf("%x", dt_lib_export_metadata_default_flags() | (omit ? DT_META_OMIT_HIERARCHY : 0));
     const int flags_size = strlen(flags) + 1;
     const size_t new_params_size = old_params_size + flags_size;
     void *new_params = calloc(1, new_params_size);

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -448,7 +448,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
                     (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(omithierarchy)) ? DT_META_OMIT_HIERARCHY : 0)
                     );
 
-    newlist = dt_util_dstrcat(NULL,"%x", newflags);
+    newlist = g_strdup_printf("%x", newflags);
     GtkTreeIter iter;
     gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(d->liststore), &iter);
     while(valid)

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -275,7 +275,7 @@ static gchar *_datetime_tooltip(GDateTime *start, GDateTime *end, GTimeZone *tz)
   gchar *dtel = _utc_timeval_to_localtime_text(end, tz, FALSE);
   gchar *dtsu = _utc_timeval_to_utc_text(start, FALSE);
   gchar *dteu = _utc_timeval_to_utc_text(end, FALSE);
-  gchar *res = dt_util_dstrcat(NULL, "%s -> %s LT\n%s -> %s UTC", dtsl, dtel, dtsu, dteu);
+  gchar *res = g_strdup_printf("%s -> %s LT\n%s -> %s UTC", dtsl, dtel, dtsu, dteu);
   g_free(dtsl);
   g_free(dtel);
   g_free(dtsu);
@@ -362,7 +362,7 @@ static void _update_nb_images(dt_lib_module_t *self)
     valid = gtk_tree_model_iter_next(model, &iter);
   }
   d->map.nb_imgs = nb_imgs;
-  gchar *nb = dt_util_dstrcat(NULL, "%d/%d", nb_imgs, d->nb_imgs);
+  gchar *nb = g_strdup_printf("%d/%d", nb_imgs, d->nb_imgs);
   gtk_label_set_text(GTK_LABEL(d->map.nb_imgs_label), nb);
   g_free(nb);
 }
@@ -856,10 +856,10 @@ static void _preview_gpx_file(GtkWidget *widget, dt_lib_module_t *self)
     _set_up_label(t->name, GTK_ALIGN_START, grid, 0, line, PANGO_ELLIPSIZE_NONE);
     _set_up_label(dts, GTK_ALIGN_START, grid, 1, line, PANGO_ELLIPSIZE_NONE);
     _set_up_label(dte, GTK_ALIGN_START, grid, 2, line, PANGO_ELLIPSIZE_NONE);
-    char *nb = dt_util_dstrcat(NULL, "%d", t->nb_trkpt);
+    char *nb = g_strdup_printf("%d", t->nb_trkpt);
     _set_up_label(nb, GTK_ALIGN_CENTER, grid, 3, line, PANGO_ELLIPSIZE_NONE);
     g_free(nb);
-    nb = dt_util_dstrcat(NULL, "%d", nb_imgs);
+    nb = g_strdup_printf("%d", nb_imgs);
     _set_up_label(nb, GTK_ALIGN_CENTER, grid, 4, line, PANGO_ELLIPSIZE_NONE);
     g_free(nb);
     line++;
@@ -868,10 +868,10 @@ static void _preview_gpx_file(GtkWidget *widget, dt_lib_module_t *self)
     g_free(dte);
   }
 
-  char *nb = dt_util_dstrcat(NULL, "%d", total_pts);
+  char *nb = g_strdup_printf("%d", total_pts);
   _set_up_label(nb, GTK_ALIGN_CENTER, grid, 3, line, PANGO_ELLIPSIZE_NONE);
   g_free(nb);
-  nb = dt_util_dstrcat(NULL, "%d / %d", total_imgs, d->nb_imgs);
+  nb = g_strdup_printf("%d / %d", total_imgs, d->nb_imgs);
   _set_up_label(nb, GTK_ALIGN_CENTER, grid, 4, line, PANGO_ELLIPSIZE_NONE);
   g_free(nb);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1209,7 +1209,7 @@ static void _set_places_list(GtkWidget *places_paned, dt_lib_module_t* self)
   gtk_widget_set_tooltip_text(places_header, _("choose the root of the folder tree below"));
 
   GtkWidget *places_label = gtk_label_new(NULL);
-  gchar *markup = dt_util_dstrcat(NULL, "<b>  %s</b>",_("places"));
+  gchar *markup = g_strdup_printf("<b>  %s</b>",_("places"));
   gtk_label_set_markup(GTK_LABEL(places_label), markup);
   g_free(markup);
   gtk_box_pack_start(GTK_BOX(places_header), places_label, FALSE, FALSE, 0);
@@ -1437,7 +1437,7 @@ static void _add_custom_place(const gchar *folder, dt_lib_module_t* self)
 
   if(!g_strrstr(current_folders, folder))
   {
-    gchar *place = dt_util_dstrcat(NULL, "%s%s,", current_folders, folder);
+    gchar *place = g_strdup_printf("%s%s,", current_folders, folder);
     dt_conf_set_string("ui_last/import_custom_places", place);
     g_free(place);
 
@@ -1468,7 +1468,7 @@ static void _remove_place(const gchar *folder, GtkTreeIter iter, dt_lib_module_t
     dt_conf_set_bool("ui_last/import_dialog_show_mounted", FALSE);
   if(type == DT_TYPE_CUSTOM)
   {
-    gchar *pattern = dt_util_dstrcat(NULL, "%s,", folder);
+    gchar *pattern = g_strdup_printf("%s,", folder);
     gchar *place = dt_util_str_replace(current_folders, pattern, "");
     dt_conf_set_string("ui_last/import_custom_places", place);
     g_free(pattern);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -2114,11 +2114,11 @@ static void _set_default_preferences(dt_lib_module_t *self)
     if(dt_metadata_get_type(i) != DT_METADATA_TYPE_INTERNAL)
     {
       const char *metadata_name = dt_metadata_get_name(i);
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
+      char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", metadata_name);
       const uint32_t flag = (dt_conf_get_int(setting) | DT_METADATA_FLAG_IMPORTED);
       dt_conf_set_int(setting, flag);
       g_free(setting);
-      setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
+      setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
       dt_conf_set_string(setting, "");
       g_free(setting);
     }
@@ -2156,12 +2156,12 @@ static char *_get_current_configuration(dt_lib_module_t *self)
     if(dt_metadata_get_type_by_display_order(i) != DT_METADATA_TYPE_INTERNAL)
     {
       const char *metadata_name = dt_metadata_get_name_by_display_order(i);
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag",
-                                      metadata_name);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag",
+                                       metadata_name);
       const gboolean imported = dt_conf_get_int(setting) & DT_METADATA_FLAG_IMPORTED;
       g_free(setting);
 
-      setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
+      setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
       char *metadata_value = dt_conf_get_string(setting);
       pref = dt_util_dstrcat(pref, "%s=%d%s,", metadata_name, imported ? 1 : 0, metadata_value);
       g_free(setting);
@@ -2214,13 +2214,13 @@ static void _apply_preferences(const char *pref, dt_lib_module_t *self)
       // metadata
       const int j = dt_metadata_get_keyid_by_name(metadata_name);
       if(j == -1) continue;
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", metadata_name);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", metadata_name);
       const uint32_t flag = (dt_conf_get_int(setting) & ~DT_METADATA_FLAG_IMPORTED) |
                             ((value[0] == '1') ? DT_METADATA_FLAG_IMPORTED : 0);
       dt_conf_set_int(setting, flag);
       g_free(setting);
       value++;
-      setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", metadata_name);
+      setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
       dt_conf_set_string(setting, value);
       g_free(setting);
     }

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -385,7 +385,7 @@ gchar *dt_lib_presets_duplicate(const gchar *preset, const gchar *module_name, i
   while(ko)
   {
     i++;
-    gchar *tx = dt_util_dstrcat(NULL, "%s_%d", preset, i);
+    gchar *tx = g_strdup_printf("%s_%d", preset, i);
     DT_DEBUG_SQLITE3_PREPARE_V2(
         dt_database_get(darktable.db),
         "SELECT name"
@@ -398,7 +398,7 @@ gchar *dt_lib_presets_duplicate(const gchar *preset, const gchar *module_name, i
     sqlite3_finalize(stmt);
     g_free(tx);
   }
-  gchar *nname = dt_util_dstrcat(NULL, "%s_%d", preset, i);
+  gchar *nname = g_strdup_printf("%s_%d", preset, i);
 
   // and we duplicate the entry
   DT_DEBUG_SQLITE3_PREPARE_V2(
@@ -469,7 +469,7 @@ gboolean dt_lib_presets_apply(const gchar *preset, const gchar *module_name, int
         dt_lib_module_t *module = (dt_lib_module_t *)it->data;
         if(!strncmp(module->plugin_name, module_name, 128))
         {
-          gchar *tx = dt_util_dstrcat(NULL, "plugins/darkroom/%s/last_preset", module_name);
+          gchar *tx = g_strdup_printf("plugins/darkroom/%s/last_preset", module_name);
           dt_conf_set_string(tx, preset);
           g_free(tx);
           res = module->set_params(module, blob, length);
@@ -1234,7 +1234,7 @@ static gchar *_get_lib_view_path(dt_lib_module_t *module, char *suffix)
     g_snprintf(lay, sizeof(lay), "%d/", dt_view_darkroom_get_layout(darktable.view_manager));
   }
 
-  return dt_util_dstrcat(NULL, "plugins/%s/%s%s%s", cv->module_name, lay, module->plugin_name, suffix);
+  return g_strdup_printf("plugins/%s/%s%s%s", cv->module_name, lay, module->plugin_name, suffix);
 }
 
 gboolean dt_lib_is_visible(dt_lib_module_t *module)

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -364,7 +364,7 @@ static gboolean _lib_location_search(gpointer user_data)
 
   /* build the query url */
   search_url = dt_conf_get_string("plugins/map/geotagging_search_url");
-  query = dt_util_dstrcat(query, search_url, text, LIMIT_RESULT);
+  query = g_strdup_printf(search_url, text, LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();
   if(!curl) goto bail_out;

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -310,7 +310,7 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   while(dt_map_location_name_exists(new_name))
   {
     g_free(new_name);
-    new_name = dt_util_dstrcat(NULL,"%s %d", name, i);
+    new_name = g_strdup_printf("%s %d", name, i);
     i++;
   }
 
@@ -763,7 +763,7 @@ static gboolean _set_location_collection(dt_lib_module_t *self)
   {
     char *name;
     gtk_tree_model_get(model, &iter, DT_MAP_LOCATION_COL_PATH, &name, -1);
-    char *collection = dt_util_dstrcat(NULL, "1:0:%d:%s|%s$",
+    char *collection = g_strdup_printf("1:0:%d:%s|%s$",
                                        DT_COLLECTION_PROP_GEOTAGGING,
                                        _("tagged"), name);
     dt_collection_deserialize(collection);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -169,8 +169,7 @@ static void _update(dt_lib_module_t *self)
   if(images)
   {
     sqlite3_stmt *stmt;
-    char *query = NULL;
-    query = dt_util_dstrcat(query,
+    gchar *query = g_strdup_printf(
                             "SELECT key, value, COUNT(id) AS ct FROM main.meta_data"
                             " WHERE id IN (%s)"
                             " GROUP BY key, value ORDER BY value",
@@ -335,7 +334,7 @@ static void _update_layout(dt_lib_module_t *self)
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
     const gchar *name = dt_metadata_get_name_by_display_order(i);
-    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+    gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
     const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
     g_free(setting);
     const int type = dt_metadata_get_type_by_display_order(i);
@@ -466,7 +465,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
     if(type != DT_METADATA_TYPE_INTERNAL)
     {
       name[i] = (gchar *)dt_metadata_get_name_by_display_order(i);
-      char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name[i]);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name[i]);
       const uint32_t flag = dt_conf_get_int(setting);
       g_free(setting);
       visible[i] = !(flag & DT_METADATA_FLAG_HIDDEN);
@@ -551,7 +550,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
                          -1);
       if(i < DT_METADATA_NUMBER)
       {
-        char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name[i]);
+        gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name[i]);
         uint32_t flag = dt_conf_get_int(setting);
         if(new_visible !=  visible[i])
         {
@@ -635,7 +634,7 @@ static gboolean _click_on_textview(GtkWidget *textview, GdkEventButton *event, d
   gtk_widget_get_allocation(GTK_WIDGET(d->swindow[i]), &metadata_allocation);
   // popup height
   const gchar *name = dt_metadata_get_name_by_display_order(i);
-  gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_text_height", name);
+  gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_text_height", name);
   const gint height = dt_conf_get_int(setting) * 5;
   g_free(setting);
 
@@ -740,7 +739,7 @@ void gui_init(dt_lib_module_t *self)
                                 "italic", "style", PANGO_STYLE_ITALIC, NULL);
 
     const char *name = (char *)dt_metadata_get_name_by_display_order(i);
-    d->setting_name[i] = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_text_height", name);
+    d->setting_name[i] = g_strdup_printf("plugins/lighttable/metadata/%s_text_height", name);
 
     GtkWidget *swindow = dt_ui_scroll_wrap(GTK_WIDGET(textview), 100, d->setting_name[i]);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -507,8 +507,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     {
       images = dt_view_get_images_to_act_on_query(FALSE);
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(NULL,
-                                     "SELECT id, COUNT(id) "
+      gchar *query = g_strdup_printf("SELECT id, COUNT(id) "
                                      "FROM main.images "
                                      "WHERE id IN (%s)",
                                      images);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -539,7 +539,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
   {
     if(!images) images = dt_view_get_images_to_act_on_query(FALSE);
     sqlite3_stmt *stmt = NULL;
-    gchar *query = dt_util_dstrcat(NULL, "SELECT COUNT(DISTINCT film_id), "
+    gchar *query = g_strdup_printf("SELECT COUNT(DISTINCT film_id), "
                                          "2, " //id always different
                                          "COUNT(DISTINCT group_id), "
                                          "COUNT(DISTINCT filename), "
@@ -582,9 +582,13 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
 
     sqlite3_stmt *stmt_tags = NULL;
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                dt_util_dstrcat(NULL, "SELECT flags, COUNT(DISTINCT imgid) FROM main.tagged_images JOIN data.tags ON data.tags.id = main.tagged_images.tagid AND name NOT LIKE 'darktable|%%' WHERE imgid in (%s) GROUP BY tagid", images),
-                                -1, &stmt_tags, NULL);
+    gchar *tag_query = g_strdup_printf("SELECT flags, COUNT(DISTINCT imgid) "
+                                       "FROM main.tagged_images "
+                                       "JOIN data.tags "
+                                       "ON data.tags.id = main.tagged_images.tagid AND name NOT LIKE 'darktable|%%' "
+                                       "WHERE imgid in (%s) GROUP BY tagid", images);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), tag_query, -1, &stmt_tags, NULL);
+    g_free(tag_query);
     g_free(query);
 
     if(sqlite3_step(stmt) == SQLITE_ROW)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -334,9 +334,9 @@ static void _basics_init_item(dt_lib_modulegroups_basic_item_t *item)
     else
     {
       if(g_strv_length(elems) > 2)
-        item->widget_name = dt_util_dstrcat(NULL, "%s - %s", _(elems[1]), _(elems[2]));
+        item->widget_name = g_strdup_printf("%s - %s", _(elems[1]), _(elems[2]));
       else if(g_strv_length(elems) > 1)
-        item->widget_name = dt_util_dstrcat(NULL, "%s", _(elems[1]));
+        item->widget_name = g_strdup_printf("%s", _(elems[1]));
       else
       {
         item->widget_name = g_strdup(_("on-off"));

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -618,7 +618,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     }
     else
     {
-      gchar *txt = dt_util_dstrcat(NULL, "%s (%s)\n\n%s%s%s", item->widget_name, item->module->name(),
+      gchar *txt = g_strdup_printf("%s (%s)\n\n%s%s%s", item->widget_name, item->module->name(),
                                    item->tooltip ? item->tooltip : "", item->tooltip ? "\n\n" : "",
                                    _("(some features may only be available in the full module interface)"));
       gtk_widget_set_tooltip_text(item->widget, txt);
@@ -646,7 +646,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     // we create the link to the full iop
     GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, CPF_STYLE_FLAT, NULL);
     gtk_widget_show(wbt);
-    gchar *tt = dt_util_dstrcat(NULL, _("go to the full version of the %s module"), item->module->name());
+    gchar *tt = g_strdup_printf(_("go to the full version of the %s module"), item->module->name());
     gtk_widget_set_tooltip_text(wbt, tt);
     gtk_widget_set_name(wbt, "basics-link");
     gtk_widget_set_valign(wbt, GTK_ALIGN_CENTER);
@@ -1186,10 +1186,10 @@ static gchar *_preset_retrieve_old_layout_updated()
       {
         // get previous visibility values
         const int group = module->default_group();
-        gchar *key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/visible", module->op);
+        gchar *key = g_strdup_printf("plugins/darkroom/%s/visible", module->op);
         const gboolean visi = dt_conf_get_bool(key);
         g_free(key);
-        key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/favorite", module->op);
+        key = g_strdup_printf("plugins/darkroom/%s/favorite", module->op);
         const gboolean fav = dt_conf_get_bool(key);
         g_free(key);
 
@@ -1242,7 +1242,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
 
       if(!dt_iop_so_is_hidden(module) && !(module->flags() & IOP_FLAGS_DEPRECATED))
       {
-        gchar *search = dt_util_dstrcat(NULL, "|%s|", module->op);
+        gchar *search = g_strdup_printf("|%s|", module->op);
         gchar *key;
 
         // get previous visibility values
@@ -1264,7 +1264,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
         }
         else if(i > 0)
         {
-          key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/modulegroup", module->op);
+          key = g_strdup_printf("plugins/darkroom/%s/modulegroup", module->op);
           group = dt_conf_get_int(key);
           g_free(key);
         }
@@ -1274,7 +1274,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
           visi = (strstr(list, search) != NULL);
         else
         {
-          key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/visible", module->op);
+          key = g_strdup_printf("plugins/darkroom/%s/visible", module->op);
           visi = dt_conf_get_bool(key);
           g_free(key);
         }
@@ -1284,7 +1284,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
           fav = (strstr(list_fav, search) != NULL);
         else if(i == 0)
         {
-          key = dt_util_dstrcat(NULL, "plugins/darkroom/%s/favorite", module->op);
+          key = g_strdup_printf("plugins/darkroom/%s/favorite", module->op);
           fav = dt_conf_get_bool(key);
           g_free(key);
         }
@@ -1476,16 +1476,14 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
 #define SNQA()                                                                                                    \
   {                                                                                                               \
     g_free(tx);                                                                                                   \
-    tx = NULL;                                                                                                    \
-    tx = dt_util_dstrcat(tx, "1ꬹ0||");                                                                          \
+    tx = g_strdup("1ꬹ0||");                                                                                       \
   }
 
 // start quick access
 #define SQA()                                                                                                     \
   {                                                                                                               \
     g_free(tx);                                                                                                   \
-    tx = NULL;                                                                                                    \
-    tx = dt_util_dstrcat(tx, "1ꬹ1||");                                                                          \
+    tx = g_strdup_printf("1ꬹ1||");                                                                                \
     if(is_modern)                                                                                                 \
     {                                                                                                             \
       AM("channelmixerrgb/temperature");                                                                          \
@@ -1992,7 +1990,7 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
         {
           GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
           gtk_widget_set_name(hb, "modulegroups-iop-header");
-          gchar *lbn = dt_util_dstrcat(NULL, "%s\n    %s", module->name(), item->widget_name);
+          gchar *lbn = g_strdup_printf("%s\n    %s", module->name(), item->widget_name);
           GtkWidget *lb = gtk_label_new(lbn);
           gtk_label_set_ellipsize(GTK_LABEL(lb), PANGO_ELLIPSIZE_END);
           gtk_label_set_xalign(GTK_LABEL(lb), 0.0);
@@ -2063,7 +2061,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 
   _preset_from_string(self, (char *)params, FALSE);
 
-  gchar *tx = dt_util_dstrcat(NULL, "plugins/darkroom/%s/last_preset", self->plugin_name);
+  gchar *tx = g_strdup_printf("plugins/darkroom/%s/last_preset", self->plugin_name);
 
   gchar *value = dt_conf_get_string(tx);
   dt_conf_set_string("plugins/darkroom/modulegroups_preset", value);
@@ -2537,7 +2535,6 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions, dt_lib_module_t
             g_signal_connect(G_OBJECT(item_top), "activate", callback, self);
             gtk_menu_shell_append(GTK_MENU_SHELL(base_menu), item_top);
           }
-
           g_free(delimited_id);
         }
         g_free(action_id);
@@ -3377,7 +3374,7 @@ static void _manage_editor_preset_action(GtkWidget *btn, dt_lib_module_t *self)
   else if(btn == d->presets_btn_new)
     new_name = g_strdup(_("new"));
   else if(btn == d->presets_btn_dup)
-    new_name = dt_util_dstrcat(NULL, "%s_1", d->edit_preset);
+    new_name = g_strdup_printf("%s_1", d->edit_preset);
   else
     return;
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -322,9 +322,9 @@ static void _basics_init_item(dt_lib_modulegroups_basic_item_t *item)
     {
       DtBauhausWidget *bw = DT_BAUHAUS_WIDGET(item->widget);
       if(g_strv_length(elems) > 2)
-        item->widget_name = dt_util_dstrcat(NULL, "%s - %s", _(elems[1]), bw->label);
+        item->widget_name = g_strdup_printf("%s - %s", _(elems[1]), bw->label);
       else if(g_strv_length(elems) > 1)
-        item->widget_name = dt_util_dstrcat(NULL, "%s", bw->label);
+        item->widget_name = g_strdup_printf("%s", bw->label);
       else
       {
         item->widget_name = g_strdup(_("on-off"));

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2004,8 +2004,7 @@ static void _pop_menu_dictionary_goto_tag_collection(GtkWidget *menuitem, dt_lib
     if (count)
     {
       if (!d->collection[0]) dt_collection_serialize(d->collection, 4096);
-      char *tag_collection = NULL;
-      tag_collection = dt_util_dstrcat(tag_collection, "1:0:%d:%s$", DT_COLLECTION_PROP_TAG, path);
+      gchar *tag_collection = g_strdup_printf("1:0:%d:%s$", DT_COLLECTION_PROP_TAG, path);
       dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
       dt_collection_deserialize(tag_collection);
       dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
@@ -2277,7 +2276,7 @@ static gboolean _row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean
       {
         if ((flags & DT_TF_PRIVATE) || (synonyms && synonyms[0]))
         {
-          char *text = dt_util_dstrcat(NULL, _("%s"), tagname);
+          gchar *text = g_strdup_printf(_("%s"), tagname);
           text = dt_util_dstrcat(text, " %s\n", (flags & DT_TF_PRIVATE) ? _("(private)") : "");
           text = dt_util_dstrcat(text, "synonyms: %s", (synonyms && synonyms[0]) ? synonyms : " - ");
           gtk_tooltip_set_text(tooltip, text);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -141,10 +141,10 @@ static void _overlays_toggle_culling_button(GtkWidget *w, gpointer user_data)
 
   dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
   if(dt_view_lighttable_preview_state(darktable.view_manager)) cmode = DT_CULLING_MODE_PREVIEW;
-  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", cmode);
+  gchar *txt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", cmode);
   dt_conf_set_int(txt, over);
   g_free(txt);
-  txt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/culling/%d", cmode);
+  txt = g_strdup_printf("plugins/lighttable/tooltips/culling/%d", cmode);
   dt_conf_set_bool(txt, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_culling_tt)));
   g_free(txt);
   dt_view_lighttable_culling_preview_reload_overlays(darktable.view_manager);
@@ -176,7 +176,7 @@ static void _overlays_timeout_changed(GtkWidget *w, gpointer user_data)
   {
     dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
     if(dt_view_lighttable_preview_state(darktable.view_manager)) cmode = DT_CULLING_MODE_PREVIEW;
-    gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling_block_timeout/%d", cmode);
+    gchar *txt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", cmode);
     dt_conf_set_int(txt, val);
     g_free(txt);
 
@@ -220,7 +220,7 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   if(thumbs_state)
   {
     // we write the label with the size category
-    gchar *txt = dt_util_dstrcat(NULL, "%s %d (%d %s)", _("thumbnails overlays for size"),
+    gchar *txt = g_strdup_printf("%s %d (%d %s)", _("thumbnails overlays for size"),
                                  dt_ui_thumbtable(darktable.gui->ui)->prefs_size,
                                  dt_ui_thumbtable(darktable.gui->ui)->thumb_size, _("px"));
     gtk_label_set_text(GTK_LABEL(d->over_label), txt);
@@ -287,11 +287,11 @@ static void _overlays_show_popup(dt_lib_module_t *self)
       gtk_label_set_text(GTK_LABEL(d->over_culling_label), _("preview overlays"));
 
     // we get and set the current value
-    gchar *otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", cmode);
+    gchar *otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", cmode);
     dt_thumbnail_overlay_t mode = dt_conf_get_int(otxt);
     g_free(otxt);
 
-    otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling_block_timeout/%d", cmode);
+    otxt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", cmode);
     int timeout = 2;
     if(!dt_conf_key_exists(otxt))
       timeout = dt_conf_get_int("plugins/lighttable/overlay_timeout");
@@ -325,7 +325,7 @@ static void _overlays_show_popup(dt_lib_module_t *self)
       gtk_widget_set_tooltip_text(d->over_culling_timeout, _("timeout only available for block overlay"));
     }
 
-    otxt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/culling/%d", cmode);
+    otxt = g_strdup_printf("plugins/lighttable/tooltips/culling/%d", cmode);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_tt), dt_conf_get_bool(otxt));
     g_free(otxt);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -481,8 +481,7 @@ void expose(
     if(dev->image_invalid_cnt)
     {
       fontsize = DT_PIXEL_APPLY_DPI(16);
-      load_txt = dt_util_dstrcat(
-          NULL,
+      load_txt = g_strdup_printf(
           _("darktable could not load `%s', switching to lighttable now.\n\n"
             "please check that the camera model that produced the image is supported in darktable\n"
             "(list of supported cameras is at https://www.darktable.org/resources/camera-support/).\n"
@@ -499,7 +498,7 @@ void expose(
     {
       fontsize = DT_PIXEL_APPLY_DPI(14);
       if(dt_conf_get_bool("darkroom/ui/loading_screen"))
-        load_txt = dt_util_dstrcat(NULL, C_("darkroom", "loading `%s' ..."), dev->image_storage.filename);
+        load_txt = g_strdup_printf(C_("darkroom", "loading `%s' ..."), dev->image_storage.filename);
       else
         load_txt = g_strdup(dev->image_storage.filename);
     }
@@ -1118,9 +1117,9 @@ static void dt_dev_jump_image(dt_develop_t *dev, int diff, gboolean by_key)
 
   // we new offset and imgid after the jump
   sqlite3_stmt *stmt;
-  gchar *query = dt_util_dstrcat(NULL, "SELECT rowid, imgid "
-                                          "FROM memory.collected_images "
-                                          "WHERE rowid=(SELECT rowid FROM memory.collected_images WHERE imgid=%d)+%d",
+  gchar *query = g_strdup_printf("SELECT rowid, imgid "
+                                 "FROM memory.collected_images "
+                                 "WHERE rowid=(SELECT rowid FROM memory.collected_images WHERE imgid=%d)+%d",
                                  imgid, diff);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   if(sqlite3_step(stmt) == SQLITE_ROW)
@@ -1141,7 +1140,7 @@ static void dt_dev_jump_image(dt_develop_t *dev, int diff, gboolean by_key)
     // in this case, let's use the image before current offset
     new_offset = MAX(1, dt_ui_thumbtable(darktable.gui->ui)->offset - 1);
     sqlite3_stmt *stmt2;
-    gchar *query2 = dt_util_dstrcat(NULL, "SELECT imgid FROM memory.collected_images WHERE rowid=%d", new_offset);
+    gchar *query2 = g_strdup_printf("SELECT imgid FROM memory.collected_images WHERE rowid=%d", new_offset);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query2, -1, &stmt2, NULL);
     if(sqlite3_step(stmt2) == SQLITE_ROW)
     {

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -199,7 +199,7 @@ static void _lighttable_check_layout(dt_view_t *self)
     {
       int id = lib->thumbtable_offset;
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(NULL, "SELECT rowid FROM memory.collected_images WHERE imgid=%d",
+      gchar *query = g_strdup_printf("SELECT rowid FROM memory.collected_images WHERE imgid=%d",
                                      dt_conf_get_int("plugins/lighttable/culling_last_id"));
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
       if(sqlite3_step(stmt) == SQLITE_ROW)
@@ -274,11 +274,11 @@ static void _culling_preview_reload_overlays(dt_view_t *self)
   dt_library_t *lib = (dt_library_t *)self->data;
 
   // change overlays if needed for culling and preview
-  gchar *otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", DT_CULLING_MODE_CULLING);
+  gchar *otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", DT_CULLING_MODE_CULLING);
   dt_thumbnail_overlay_t over = dt_conf_get_int(otxt);
   dt_culling_set_overlays_mode(lib->culling, over);
   g_free(otxt);
-  otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", DT_CULLING_MODE_PREVIEW);
+  otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", DT_CULLING_MODE_PREVIEW);
   over = dt_conf_get_int(otxt);
   dt_culling_set_overlays_mode(lib->preview, over);
   g_free(otxt);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2502,8 +2502,7 @@ static gboolean _view_map_center_on_image_list(dt_view_t *self, const char* tabl
   double min_latitude = INFINITY;
   int count = 0;
 
-  char *query = dt_util_dstrcat(NULL,
-                                "SELECT MIN(latitude), MAX(latitude),"
+  gchar *query = g_strdup_printf("SELECT MIN(latitude), MAX(latitude),"
                                 "       MIN(longitude), MAX(longitude), COUNT(*)"
                                 " FROM main.images AS i "
                                 " JOIN %s AS l ON l.imgid = i.id "

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -431,7 +431,7 @@ void enter(dt_view_t *self)
   if(imgid > 0)
   {
     sqlite3_stmt *stmt;
-    gchar *query = dt_util_dstrcat(NULL, "SELECT rowid FROM memory.collected_images WHERE imgid=%d", imgid);
+    gchar *query = g_strdup_printf("SELECT rowid FROM memory.collected_images WHERE imgid=%d", imgid);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     if(sqlite3_step(stmt) == SQLITE_ROW)
     {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1508,10 +1508,7 @@ GSList *dt_mouse_action_create_format(GSList *actions, dt_mouse_action_type_t ty
 
 static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
 {
-  gchar *accel_label = gtk_accelerator_get_label(ma->key.accel_key, ma->key.accel_mods);
-  gchar *atxt = dt_util_dstrcat(NULL, "%s", accel_label);
-  g_free(accel_label);
-
+  gchar *atxt = gtk_accelerator_get_label(ma->key.accel_key, ma->key.accel_mods);
   if(strcmp(atxt, ""))
     atxt = dt_util_dstrcat(atxt, "+");
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -684,8 +684,7 @@ static void _images_to_act_on_insert_in_list(GList **list, const int imgid, gboo
     else
     {
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(
-          NULL,
+      gchar *query = g_strdup_printf(
           "SELECT id"
           "  FROM main.images"
           "  WHERE group_id = %d AND id IN (%s)",
@@ -765,7 +764,7 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
     {
       // column 1,2
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(NULL, "SELECT imgid FROM main.selected_images WHERE imgid=%d", mouseover);
+      gchar *query = g_strdup_printf("SELECT imgid FROM main.selected_images WHERE imgid=%d", mouseover);
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
       if(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
       {
@@ -873,7 +872,7 @@ gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible)
     {
       // column 1,2
       sqlite3_stmt *stmt;
-      gchar *query = dt_util_dstrcat(NULL, "SELECT imgid FROM main.selected_images WHERE imgid =%d", mouseover);
+      gchar *query = g_strdup_printf("SELECT imgid FROM main.selected_images WHERE imgid =%d", mouseover);
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
       if(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
       {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -935,10 +935,11 @@ gchar *dt_view_get_images_to_act_on_query(const gboolean only_visible)
   }
   if(images)
   {
+    // remove trailing comma
     images[strlen(images) - 1] = '\0';
   }
   else
-    images = dt_util_dstrcat(NULL, " ");
+    images = g_strdup(" ");
   return images;
 }
 


### PR DESCRIPTION
Replace uses of `dt_util_dstrcat(NULL, ...)` with `g_strdup_printf(...)` to avoid the extra overhead of the former and better self-document the operation.  Note that a fair number of replaced occurrences have a variable as the first arg, but that variable is known to always be NULL at that point.

Also did a slight bit of deduplication in bauhaus.c.
