### PR TITLE
select area color picker with right-click

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -156,7 +156,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
   const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
-  const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK);
+  const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK) || e->button == 3;
   dt_iop_color_picker_kind_t kind = self->kind;
 
   _iop_color_picker_reset(module->picker);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -17,6 +17,7 @@
 */
 
 #include "gui/color_picker_proxy.h"
+#include "libs/colorpicker.h"
 #include "bauhaus/bauhaus.h"
 #include "libs/lib.h"
 #include "control/control.h"
@@ -161,7 +162,8 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
 
   _iop_color_picker_reset(module->picker);
 
-  if (module->picker != self || (ctrl_key_pressed && kind == DT_COLOR_PICKER_POINT_AREA))
+  if (module->picker != self || (kind == DT_COLOR_PICKER_POINT_AREA &&
+      (ctrl_key_pressed ^ (darktable.lib->proxy.colorpicker.size == DT_COLORPICKER_SIZE_BOX))))
   {
     module->picker = self;
 

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -638,7 +638,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(picker_row), data->color_mode_selector, TRUE, TRUE, 0);
 
   data->picker_button = dt_color_picker_new(NULL, DT_COLOR_PICKER_POINT_AREA, picker_row);
-  gtk_widget_set_tooltip_text(data->picker_button, _("turn on color picker\nctrl+click to select an area"));
+  gtk_widget_set_tooltip_text(data->picker_button, _("turn on color picker\nctrl+click or right-click to select an area"));
   gtk_widget_set_name(GTK_WIDGET(data->picker_button), "color-picker-button");
   g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), data);
 


### PR DESCRIPTION
Also allow right click on a color picker button to select area mode (in additon to ctrl-click). Does not work on bauhaus quads.

I have not updated tooltips all over the place, just in the lib, because it is a non-essential feature and those who like it can probably extrapolate.

fixes #7525