### PR TITLE
Add default values to plugins/lighttable/collect/num_rules and plugins/lighttable/collect/string0

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1353,7 +1353,7 @@
   <dtconfig>
     <name>plugins/lighttable/collect/num_rules</name>
     <type>int</type>
-    <default>0</default>
+    <default>1</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>
@@ -1367,7 +1367,7 @@
   <dtconfig>
     <name>plugins/lighttable/collect/string0</name>
     <type>string</type>
-    <default/>
+    <default>%</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>


### PR DESCRIPTION
These two configuration variables had wrong default values. As a result, when darktable is initialized (reset of the darktablerc file), the window of the "recent collections" module is empty and the module does not record the last visited collections.
This PR fixes the bug by adding the right default values in the file data/darktableconfig.xml.in