### PR TITLE
diffuse: remove unnecessary trigonometry

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -112,9 +112,9 @@ inline void rotation_matrix_isophote(const float4 c2,
   //  [ a12, a22 ]]
   // taken from https://www.researchgate.net/publication/220663968
   // c dampens the gradient direction
-  a[0][0] = clamp(cos_theta2 + c2 * sin_theta2, 0.f, 1.f);
-  a[1][1] = clamp(c2 * cos_theta2 + sin_theta2, 0.f, 1.f);
-  a[0][1] = a[1][0] = clamp((c2 - 1.0f) * cos_theta_sin_theta, 0.f, 1.f);
+  a[0][0] = cos_theta2 + c2 * sin_theta2;
+  a[1][1] = c2 * cos_theta2 + sin_theta2;
+  a[0][1] = a[1][0] = (c2 - 1.0f) * cos_theta_sin_theta;
 }
 
 inline void rotation_matrix_gradient(const float4 c2,
@@ -127,9 +127,9 @@ inline void rotation_matrix_gradient(const float4 c2,
   //  [ a12, a22 ]]
   // based on https://www.researchgate.net/publication/220663968 and inverted
   // c dampens the isophote direction
-  a[0][0] = clamp(c2 * cos_theta2 + sin_theta2, 0.f, 1.f);
-  a[1][1] = clamp(cos_theta2 + c2 * sin_theta2, 0.f, 1.f);
-  a[0][1] = a[1][0] = clamp((1.0f - c2) * cos_theta_sin_theta, 0.f, 1.f);
+  a[0][0] = c2 * cos_theta2 + sin_theta2;
+  a[1][1] = cos_theta2 + c2 * sin_theta2;
+  a[0][1] = a[1][0] = (1.0f - c2) * cos_theta_sin_theta;
 }
 
 

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -257,13 +257,10 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     const float4 magnitude_grad = hypot(gradient[0], gradient[1]);
     const float4 magnitude_lapl = hypot(laplacian[0], laplacian[1]);
 
-    const float4 theta_grad = atan2(gradient[1], gradient[0]);
-    const float4 theta_lapl = atan2(laplacian[1], laplacian[0]);
-
-    const float4 cos_theta_grad = native_cos(theta_grad);
-    const float4 cos_theta_lapl = native_cos(theta_lapl);
-    const float4 sin_theta_grad = native_sin(theta_grad);
-    const float4 sin_theta_lapl = native_sin(theta_lapl);
+    const float4 cos_theta_grad = gradient[0] / magnitude_grad;
+    const float4 cos_theta_lapl = laplacian[0] / magnitude_lapl;
+    const float4 sin_theta_grad = gradient[1] / magnitude_grad;
+    const float4 sin_theta_lapl = laplacian[1] / magnitude_lapl;
 
     const float4 cos_theta_grad_sq = sqf(cos_theta_grad);
     const float4 sin_theta_grad_sq = sqf(sin_theta_grad);

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -223,6 +223,8 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
 
   const char opacity = (has_mask) ? read_imageui(mask, sampleri, (int2)(x, y)).x : 1;
 
+  const float4 regularization_factor = regularization * current_radius_square / 9.f;
+
   float4 out;
 
   if(opacity)
@@ -298,8 +300,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     // This allows to keep the scene-referred variance roughly constant
     // regardless of the wavelet scale where we compute it.
     // Prevents large scale halos when deblurring.
-    variance /= 9.f / current_radius_square;
-    variance = variance_threshold + native_sqrt(variance * regularization);
+    variance = variance_threshold + native_sqrt(variance * regularization_factor);
 
     // compute the update
     float4 acc = (float4)0.f;

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -251,7 +251,6 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
       }
 
     // build the local anisotropic convolution filters for gradients and laplacians
-    // we use the low freq layer all the type as it is less likely to be nosy
     float4 gradient[2], laplacian[2];
     find_gradient(neighbour_pixel_LF, gradient);
     find_gradient(neighbour_pixel_HF, laplacian);

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -103,7 +103,7 @@ inline float4 sqf(const float4 in)
 }
 
 inline void rotation_matrix_isophote(const float4 c2,
-                                     const float4 cos_theta, const float4 sin_theta,
+                                     const float4 cos_theta_sin_theta,
                                      const float4 cos_theta2, const float4 sin_theta2,
                                      float4 a[2][2])
 {
@@ -114,11 +114,11 @@ inline void rotation_matrix_isophote(const float4 c2,
   // c dampens the gradient direction
   a[0][0] = clamp(cos_theta2 + c2 * sin_theta2, 0.f, 1.f);
   a[1][1] = clamp(c2 * cos_theta2 + sin_theta2, 0.f, 1.f);
-  a[0][1] = a[1][0] = clamp((c2 - 1.0f) * cos_theta * sin_theta, 0.f, 1.f);
+  a[0][1] = a[1][0] = clamp((c2 - 1.0f) * cos_theta_sin_theta, 0.f, 1.f);
 }
 
 inline void rotation_matrix_gradient(const float4 c2,
-                                     const float4 cos_theta, const float4 sin_theta,
+                                     const float4 cos_theta_sin_theta,
                                      const float4 cos_theta2, const float4 sin_theta2,
                                      float4 a[2][2])
 {
@@ -129,7 +129,7 @@ inline void rotation_matrix_gradient(const float4 c2,
   // c dampens the isophote direction
   a[0][0] = clamp(c2 * cos_theta2 + sin_theta2, 0.f, 1.f);
   a[1][1] = clamp(cos_theta2 + c2 * sin_theta2, 0.f, 1.f);
-  a[0][1] = a[1][0] = clamp((1.0f - c2) * cos_theta * sin_theta, 0.f, 1.f);
+  a[0][1] = a[1][0] = clamp((1.0f - c2) * cos_theta_sin_theta, 0.f, 1.f);
 }
 
 
@@ -173,7 +173,7 @@ inline void isotrope_laplacian(float4 kern[9])
 
 
 inline void compute_kern(const float4 c2,
-                           const float4 cos_theta, const float4 sin_theta,
+                           const float4 cos_theta_sin_theta,
                            const float4 cos_theta2, const float4 sin_theta2,
                            const dt_isotropy_t isotropy_type,
                            float4 kern[9])
@@ -191,14 +191,14 @@ inline void compute_kern(const float4 c2,
     case(DT_ISOTROPY_ISOPHOTE):
     {
       float4 a[2][2] = { { (float4)0.f } };
-      rotation_matrix_isophote(c2, cos_theta, sin_theta, cos_theta2, sin_theta2, a);
+      rotation_matrix_isophote(c2, cos_theta_sin_theta, cos_theta2, sin_theta2, a);
       build_matrix(a, kern);
       break;
     }
     case(DT_ISOTROPY_GRADIENT):
     {
       float4 a[2][2] = { { (float4)0.f } };
-      rotation_matrix_gradient(c2, cos_theta, sin_theta, cos_theta2, sin_theta2, a);
+      rotation_matrix_gradient(c2, cos_theta_sin_theta, cos_theta2, sin_theta2, a);
       build_matrix(a, kern);
       break;
     }
@@ -256,18 +256,30 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     find_gradient(neighbour_pixel_LF, gradient);
     find_gradient(neighbour_pixel_HF, laplacian);
 
-    const float4 magnitude_grad = hypot(gradient[0], gradient[1]);
-    const float4 magnitude_lapl = hypot(laplacian[0], laplacian[1]);
+    const float4 magnitude_grad = native_sqrt(sqf(gradient[0]) + sqf(gradient[1]));
+    // Compute cos(arg(grad)) = dx / hypot - force arg(grad) = 0 if hypot == 0
+    gradient[0] = (magnitude_grad != 0.f) ? gradient[0] / magnitude_grad
+                                          : 1.f; // cos(0)
+    // Compute sin (arg(grad))= dy / hypot - force arg(grad) = 0 if hypot == 0
+    gradient[1] = (magnitude_grad != 0.f) ? gradient[1] / magnitude_grad
+                                          : 0.f; // sin(0)
+    // Warning : now gradient[2] = { cos(arg(grad)) , sin(arg(grad)) }
 
-    const float4 cos_theta_grad = gradient[0] / magnitude_grad;
-    const float4 cos_theta_lapl = laplacian[0] / magnitude_lapl;
-    const float4 sin_theta_grad = gradient[1] / magnitude_grad;
-    const float4 sin_theta_lapl = laplacian[1] / magnitude_lapl;
+    const float4 magnitude_lapl = native_sqrt(sqf(laplacian[0]) + sqf(laplacian[1]));
+    // Compute cos(arg(lapl)) = dx / hypot - force arg(lapl) = 0 if hypot == 0
+    laplacian[0] = (magnitude_lapl != 0.f) ? laplacian[0] / magnitude_lapl
+                                           : 1.f; // cos(0)
+    // Compute sin (arg(lapl))= dy / hypot - force arg(lapl) = 0 if hypot == 0
+    laplacian[1] = (magnitude_lapl != 0.f) ? laplacian[1] / magnitude_lapl
+                                           : 0.f; // sin(0)
+    // Warning : now laplacian[2] = { cos(arg(lapl)) , sin(arg(lapl)) }
 
-    const float4 cos_theta_grad_sq = sqf(cos_theta_grad);
-    const float4 sin_theta_grad_sq = sqf(sin_theta_grad);
-    const float4 cos_theta_lapl_sq = sqf(cos_theta_lapl);
-    const float4 sin_theta_lapl_sq = sqf(sin_theta_lapl);
+    const float4 cos_theta_grad_sq = sqf(gradient[0]);
+    const float4 sin_theta_grad_sq = sqf(gradient[1]);
+    const float4 cos_theta_sin_theta_grad = gradient[0] * gradient[1];
+    const float4 cos_theta_lapl_sq = sqf(laplacian[0]);
+    const float4 sin_theta_lapl_sq = sqf(laplacian[1]);
+    const float4 cos_theta_sin_theta_lapl = laplacian[0] * laplacian[1];
 
     // c² in https://www.researchgate.net/publication/220663968
     // warning : in c2[s], s is the order of the derivative
@@ -277,10 +289,10 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
                            native_exp(-magnitude_lapl * anisotropy.w) };
 
     float4 kern_first[9], kern_second[9], kern_third[9], kern_fourth[9];
-    compute_kern(c2[0], cos_theta_grad, sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.x, kern_first);
-    compute_kern(c2[1], cos_theta_lapl, sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.y, kern_second);
-    compute_kern(c2[2], cos_theta_grad, sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.z, kern_third);
-    compute_kern(c2[3], cos_theta_lapl, sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.w, kern_fourth);
+    compute_kern(c2[0], cos_theta_sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.x, kern_first);
+    compute_kern(c2[1], cos_theta_sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.y, kern_second);
+    compute_kern(c2[2], cos_theta_sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.z, kern_third);
+    compute_kern(c2[3], cos_theta_sin_theta_lapl, cos_theta_lapl_sq, sin_theta_lapl_sq, isotropy_type.w, kern_fourth);
 
     // convolve filters and compute the variance and the regularization term
     float4 derivatives[4] = { (float4)0.f };

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -269,10 +269,10 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
 
     // c² in https://www.researchgate.net/publication/220663968
     // warning : in c2[s], s is the order of the derivative
-    const float4 c2[4] = { native_exp(-magnitude_grad / anisotropy.x),
-                           native_exp(-magnitude_lapl / anisotropy.y),
-                           native_exp(-magnitude_grad / anisotropy.z),
-                           native_exp(-magnitude_lapl / anisotropy.w) };
+    const float4 c2[4] = { native_exp(-magnitude_grad * anisotropy.x),
+                           native_exp(-magnitude_lapl * anisotropy.y),
+                           native_exp(-magnitude_grad * anisotropy.z),
+                           native_exp(-magnitude_lapl * anisotropy.w) };
 
     float4 kern_first[9], kern_second[9], kern_third[9], kern_fourth[9];
     compute_kern(c2[0], cos_theta_grad, sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type.x, kern_first);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -699,8 +699,9 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           const float cos_theta_sin_theta_lapl = laplacian[0] * laplacian[1];
 
           // c² in https://www.researchgate.net/publication/220663968
-          const float c2[4] = { expf(-magnitude_grad * anisotropy[0]), expf(-magnitude_lapl * anisotropy[1]),
-                                expf(-magnitude_grad * anisotropy[2]), expf(-magnitude_lapl * anisotropy[3]) };
+          const float c2[4]
+              = { dt_fast_expf(-magnitude_grad * anisotropy[0]), dt_fast_expf(-magnitude_lapl * anisotropy[1]),
+                  dt_fast_expf(-magnitude_grad * anisotropy[2]), dt_fast_expf(-magnitude_lapl * anisotropy[3]) };
 
           float DT_ALIGNED_ARRAY kern_first[9], kern_second[9], kern_third[9], kern_fourth[9];
           compute_kernel(c2[0], cos_theta_sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type[0],

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -509,9 +509,9 @@ static inline void rotation_matrix_isophote(const float c2, const float cos_thet
   //  [ a12, a22 ]]
   // taken from https://www.researchgate.net/publication/220663968
   // c dampens the gradient direction
-  a[0][0] = clamp_simd(cos_theta2 + c2 * sin_theta2);
-  a[1][1] = clamp_simd(c2 * cos_theta2 + sin_theta2);
-  a[0][1] = a[1][0] = clamp_simd((c2 - 1.0f) * cos_theta_sin_theta);
+  a[0][0] = cos_theta2 + c2 * sin_theta2;
+  a[1][1] = c2 * cos_theta2 + sin_theta2;
+  a[0][1] = a[1][0] = (c2 - 1.0f) * cos_theta_sin_theta;
 }
 
 #ifdef _OPENMP
@@ -525,9 +525,9 @@ static inline void rotation_matrix_gradient(const float c2, const float cos_thet
   //  [ a12, a22 ]]
   // based on https://www.researchgate.net/publication/220663968 and inverted
   // c dampens the isophote direction
-  a[0][0] = clamp_simd(c2 * cos_theta2 + sin_theta2);
-  a[1][1] = clamp_simd(cos_theta2 + c2 * sin_theta2);
-  a[0][1] = a[1][0] = clamp_simd((1.0f - c2) * cos_theta_sin_theta);
+  a[0][0] = c2 * cos_theta2 + sin_theta2;
+  a[1][1] = cos_theta2 + c2 * sin_theta2;
+  a[0][1] = a[1][0] = (1.0f - c2) * cos_theta_sin_theta;
 }
 
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -635,11 +635,13 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
   const float *const restrict LF = DT_IS_ALIGNED(low_freq);
   const float *const restrict HF = DT_IS_ALIGNED(high_freq);
 
+  const float regularization_factor = regularization * current_radius_square / 9.f;
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none)                                                                            \
-    dt_omp_firstprivate(out, mask, HF, LF, height, width, ABCD, has_mask, variance_threshold,      \
-                        anisotropy, regularization, mult, strength, isotropy_type, current_radius_square) \
-                        schedule(simd:static) collapse(2)
+    dt_omp_firstprivate(out, mask, HF, LF, height, width, ABCD, has_mask, variance_threshold, anisotropy,         \
+                        regularization_factor, mult, strength, isotropy_type) schedule(simd                       \
+                                                                                       : static) collapse(2)
 #endif
   for(size_t i = 0; i < height; ++i)
     for(size_t j = 0; j < width; ++j)
@@ -720,8 +722,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           // This allows to keep the scene-referred variance roughly constant
           // regardless of the wavelet scale where we compute it.
           // Prevents large scale halos when deblurring.
-          variance /= 9.f / current_radius_square;
-          variance = variance_threshold + sqrtf(variance * regularization);
+          variance = variance_threshold + sqrtf(variance * regularization_factor);
 
           // compute the update
           float acc = 0.f;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -696,10 +696,8 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           const float sin_theta_lapl_sq = sqf(sin_theta_lapl);
 
           // c² in https://www.researchgate.net/publication/220663968
-          const float c2[4] = { expf(-magnitude_grad / anisotropy[0]),
-                                expf(-magnitude_lapl / anisotropy[1]),
-                                expf(-magnitude_grad / anisotropy[2]),
-                                expf(-magnitude_lapl / anisotropy[3]) };
+          const float c2[4] = { expf(-magnitude_grad * anisotropy[0]), expf(-magnitude_lapl * anisotropy[1]),
+                                expf(-magnitude_grad * anisotropy[2]), expf(-magnitude_lapl * anisotropy[3]) };
 
           float DT_ALIGNED_ARRAY kern_first[9], kern_second[9], kern_third[9], kern_fourth[9];
           compute_kernel(c2[0], cos_theta_grad, sin_theta_grad, cos_theta_grad_sq, sin_theta_grad_sq, isotropy_type[0], kern_first);
@@ -745,12 +743,10 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
 
 static inline float compute_anisotropy_factor(const float user_param)
 {
-  // compute the K param in c evaluation from https://www.researchgate.net/publication/220663968
+  // compute the inverse of the K param in c evaluation from
+  // https://www.researchgate.net/publication/220663968
   // but in a perceptually-even way, for better GUI interaction
-  if(user_param == 0.f)
-    return FLT_MAX;
-  else
-    return 1.f / sqf(user_param);
+  return sqf(user_param);
 }
 
 #if DEBUG_DUMP_PFM

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -672,7 +672,6 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
             aligned(anisotropy, isotropy_type, ABCD :16))
         {
           // build the local anisotropic convolution filters for gradients and laplacians
-          // we use the low freq layer all the type as it is less likely to be nosy
           float gradient[2], laplacian[2]; // x, y for each channel
           find_gradient(neighbour_pixel_LF, c, gradient);
           find_gradient(neighbour_pixel_HF, c, laplacian);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -685,13 +685,10 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           const float magnitude_grad = hypotf(gradient[0], gradient[1]);
           const float magnitude_lapl = hypotf(laplacian[0], laplacian[1]);
 
-          const float theta_grad = atan2f(gradient[1], gradient[0]);
-          const float theta_lapl = atan2f(laplacian[1], laplacian[0]);
-
-          const float cos_theta_grad = cosf(theta_grad);
-          const float cos_theta_lapl = cosf(theta_lapl);
-          const float sin_theta_grad = sinf(theta_grad);
-          const float sin_theta_lapl = sinf(theta_lapl);
+          const float cos_theta_grad = gradient[0] / magnitude_grad;
+          const float cos_theta_lapl = laplacian[0] / magnitude_lapl;
+          const float sin_theta_grad = gradient[1] / magnitude_grad;
+          const float sin_theta_lapl = laplacian[1] / magnitude_lapl;
 
           const float cos_theta_grad_sq = sqf(cos_theta_grad);
           const float sin_theta_grad_sq = sqf(sin_theta_grad);


### PR DESCRIPTION
The trigonometric calculations in the heat equation calculation are easy to replace by simpler FLOPs. This should make for a nice performance gain at least on the CPU (seems to me this is the case). How to measure it in a reproducible manner? @ralfbrown I recall seeing some performance measurements in your optimization PRs – how did you come up with those?

In separate commits there are also a couple of further optimizations (mainly removal of divisions) but these are not likely as significant.

Test report with the patch applied:
```
Test 0086-diffuse
      Image mire1.cr2
      CPU & GPU version differ by 42566 pixels
      CPU vs. GPU report :
      ----------------------------------
      Max dE                   : 3.29131
      Avg dE                   : 0.00643
      Std dE                   : 0.05739
      ----------------------------------
      Pixels below avg + 0 std : 98.48 %
      Pixels below avg + 1 std : 98.49 %
      Pixels below avg + 3 std : 98.60 %
      Pixels below avg + 6 std : 99.02 %
      Pixels below avg + 9 std : 99.66 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
 
      Expected CPU vs. current CPU report :
      ----------------------------------
      Max dE                   : 4.14407
      Avg dE                   : 0.01192
      Std dE                   : 0.08298
      ----------------------------------
      Pixels below avg + 0 std : 97.43 %
      Pixels below avg + 1 std : 97.45 %
      Pixels below avg + 3 std : 97.82 %
      Pixels below avg + 6 std : 99.25 %
      Pixels below avg + 9 std : 99.75 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
 
  OK

Total test 1
Errors     0
```
Without the patch:
```
Test 0086-diffuse
      Image mire1.cr2
      CPU & GPU version differ by 98923 pixels
      CPU vs. GPU report :
      ----------------------------------
      Max dE                   : 4.93617
      Avg dE                   : 0.01611
      Std dE                   : 0.09499
      ----------------------------------
      Pixels below avg + 0 std : 96.46 %
      Pixels below avg + 1 std : 96.54 %
      Pixels below avg + 3 std : 97.24 %
      Pixels below avg + 6 std : 99.23 %
      Pixels below avg + 9 std : 99.81 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
 
      Expected CPU vs. current CPU report :
      ----------------------------------
      Max dE                   : 1.18492
      Avg dE                   : 0.00057
      Std dE                   : 0.01768
      ----------------------------------
      Pixels below avg + 0 std : 99.88 %
      Pixels below avg + 1 std : 99.88 %
      Pixels below avg + 3 std : 99.88 %
      Pixels below avg + 6 std : 99.88 %
      Pixels below avg + 9 std : 99.88 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
 
  OK

Total test 1
Errors     0
```
There's some difference caused by this patch but I think the end result is more accurately since we save a roundtrip via `atan -> sin` and `atan -> cos` which are always approximations. @aurelienpierre will have the final word, though.

PS. I'm going to read through the literature for this module and see if there are more optimizations to make (although this was the only low-hanging one I spotted so far). Similar trigonometry optimizations seem to be available for Color balance RGB, but I'll look at them later because the module is already quite fast.