### PR TITLE
fix translation of key_pressed_accel

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2870,7 +2870,7 @@ void dt_action_define_key_pressed_accel(dt_action_t *action, const gchar *path, 
 {
   dt_action_t *new_action = calloc(1, sizeof(dt_action_t));
   new_action->id = path_without_symbols(path);
-  new_action->label = g_strdup(Q_(path));
+  new_action->label = g_strdup(g_dpgettext2(NULL, "accel", path));
   new_action->type = DT_ACTION_TYPE_KEY_PRESSED;
   new_action->target = key;
   new_action->owner = action;


### PR DESCRIPTION
fixes #9454

Thanks @TurboGit for pointing this out. I must have inadvertently "fixed" the translation at some point.

Justs FYI, this was always meant as a stop gap solution to support the current approach to handle these shortcuts in the views.

To properly integrate this in the Input NG framework, to allow multiple shortcuts, also from other devices, those key_pressed routines need to be changed to proper actions.

It also makes sense to treat the pairs of arrow keys (and page up/down) as Moves, so that they can be combined with any other shortcut. And _that_ requires another extension, namely implicit shortcuts (that don't require a key press, just a Move or mouse click) that apply to the focused or under-cursor widget. That would then work for the central area, but also for say sliders and would allow setting the speed of a slider when using scroll wheel directly over it (rather than _only_ if you use a shortcut as now).