### PR TITLE
ashift rework

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3124,6 +3124,13 @@
     <longdescription>this is just for remembering whether to show margins or not and remember it</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/ashift/expand_values</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>whether to show values</shortdescription>
+    <longdescription>this is just for remembering whether to show values or not</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/colorzones/bg_sat_factor</name>
     <type min="0.1" max="1.0">float</type>
     <default>0.5</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2899,6 +2899,13 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/ashift/near_delta_draw</name>
+    <type>float</type>
+    <default>5.0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/print/print/black_point_compensation</name>
     <type>bool</type>
     <default>true</default>

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1327,6 +1327,29 @@ void dtgtk_cairo_paint_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   FINISH
 }
 
+void dtgtk_cairo_paint_draw_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.1, 0.1);
+  cairo_line_to(cr, 0.1, 0.9);
+  cairo_line_to(cr, 0.9, 0.9);
+  cairo_line_to(cr, 0.9, 0.1);
+  cairo_line_to(cr, 0.1, 0.1);
+  cairo_stroke(cr);
+
+  cairo_arc(cr, 0.1, 0.1, 0.1, 0.0, 2 * M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.1, 0.9, 0.1, 0.0, 2 * M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.9, 0.9, 0.1, 0.0, 2 * M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.9, 0.1, 0.1, 0.0, 2 * M_PI);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1.05, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -105,6 +105,8 @@ void dtgtk_cairo_paint_refresh(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 void dtgtk_cairo_paint_perspective(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a get structure icon */
 void dtgtk_cairo_paint_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a drawn structure icon */
+void dtgtk_cairo_paint_draw_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a cancel X icon */
 void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint two boxes indicating portrait/landscape flip */

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4031,7 +4031,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
   if(wd < 1.0 || ht < 1.0) return 1;
 
   // if we start to draw a straightening line
-  if(which == 3)
+  if((g->lines_suppressed || g->lines == NULL) && which == 3)
   {
     dt_control_change_cursor(GDK_CROSSHAIR);
     g->straightening = TRUE;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -426,7 +426,6 @@ typedef struct dt_iop_ashift_gui_data_t
   GtkWidget *structure_auto;
   GtkWidget *structure_quad;
   GtkWidget *structure_lines;
-  GtkWidget *clean;
   GtkWidget *eye;
   GtkWidget *values_expander;
   GtkWidget *values_box;
@@ -4778,6 +4777,14 @@ static void _gui_update_structure_states(dt_iop_module_t *self, GtkWidget *widge
     if(widget != g->structure_auto) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->structure_auto), FALSE);
     if(widget) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
   }
+
+  // update fit buttons state
+  const gboolean enable = (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->structure_auto))
+                           || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->structure_quad))
+                           || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->structure_lines)));
+  gtk_widget_set_sensitive(g->fit_v, enable);
+  gtk_widget_set_sensitive(g->fit_h, enable);
+  gtk_widget_set_sensitive(g->fit_both, enable);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
@@ -5044,16 +5051,6 @@ static int _event_structure_auto_clicked(GtkWidget *widget, GdkEventButton *even
     return TRUE;
   }
   return FALSE;
-}
-
-static void _event_clean_button_clicked(GtkButton *button, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-  dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
-  (void)do_clean_structure(self, p, FALSE);
-  dt_iop_request_focus(self);
-  dt_control_queue_redraw_center();
 }
 
 static void _event_eye_button_toggled(GtkToggleButton *togglebutton, gpointer user_data)
@@ -5641,9 +5638,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_name(helpers, "section_label");
   gtk_box_pack_start(GTK_BOX(helpers), dt_ui_label_new(_("perspective helpers")), TRUE, TRUE, 0);
 
-  g->clean = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-  gtk_box_pack_start(GTK_BOX(helpers), g->clean, FALSE, TRUE, 0);
-
   g->eye = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye_toggle, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(helpers), g->eye, FALSE, TRUE, 0);
 
@@ -5720,7 +5714,6 @@ void gui_init(struct dt_iop_module_t *self)
                                                    "ctrl+shift+click for a combination of both methods"));
   gtk_widget_set_tooltip_text(g->structure_quad, _("manually define perspective rectangle"));
   gtk_widget_set_tooltip_text(g->structure_lines, _("manually draw structure lines"));
-  gtk_widget_set_tooltip_text(g->clean, _("remove line structure information"));
   gtk_widget_set_tooltip_text(g->eye, _("toggle visibility of structure lines"));
 
   g_signal_connect(G_OBJECT(g->fit_v), "button-press-event", G_CALLBACK(_event_fit_v_button_clicked),
@@ -5735,7 +5728,6 @@ void gui_init(struct dt_iop_module_t *self)
                    (gpointer)self);
   g_signal_connect(G_OBJECT(g->structure_auto), "button-press-event", G_CALLBACK(_event_structure_auto_clicked),
                    (gpointer)self);
-  g_signal_connect(G_OBJECT(g->clean), "clicked", G_CALLBACK(_event_clean_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(g->eye), "toggled", G_CALLBACK(_event_eye_button_toggled), (gpointer)self);
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4774,19 +4774,10 @@ static int _event_structure_button_clicked(GtkWidget *widget, GdkEventButton *ev
 
   if(event->button == 1)
   {
-    _gui_update_structure_states(self, widget);
-
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
     dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
 
     do_clean_structure(self, p);
-
-    // if the button is unselcted, we don't go further
-    if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
-    {
-      dt_control_queue_redraw_center();
-      return TRUE;
-    }
 
     const int control = dt_modifiers_include(event->state, GDK_CONTROL_MASK);
     const int shift = dt_modifiers_include(event->state, GDK_SHIFT_MASK);
@@ -4801,6 +4792,20 @@ static int _event_structure_button_clicked(GtkWidget *widget, GdkEventButton *ev
       enhance = ASHIFT_ENHANCE_EDGES;
     else
       enhance = ASHIFT_ENHANCE_NONE;
+
+    // if the button is unselcted, we don't go further
+    if(enhance == ASHIFT_ENHANCE_NONE && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
+    {
+      _gui_update_structure_states(self, widget);
+      dt_control_queue_redraw_center();
+      return TRUE;
+    }
+    else
+    {
+      // force the button to be untoggled, so the update routine can enable it
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
+      _gui_update_structure_states(self, widget);
+    }
 
     dt_iop_request_focus(self);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -423,14 +423,14 @@ typedef struct dt_iop_ashift_gui_data_t
   GtkWidget *fit_v;
   GtkWidget *fit_h;
   GtkWidget *fit_both;
-  GtkWidget *structure;
+  GtkWidget *structure_auto;
+  GtkWidget *structure_quad;
+  GtkWidget *structure_lines;
   GtkWidget *clean;
   GtkWidget *eye;
   GtkWidget *values_expander;
   GtkWidget *values_box;
   GtkWidget *values_toggle;
-  GtkWidget *draw_structure;
-  GtkWidget *draw_direct_structure;
   gboolean values_expanded;
   gboolean straightening;
   float straighten_x;
@@ -4773,10 +4773,9 @@ static void _gui_update_structure_states(dt_iop_module_t *self, GtkWidget *widge
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
   else
   {
-    if(widget != g->draw_direct_structure)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->draw_direct_structure), FALSE);
-    if(widget != g->draw_structure) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->draw_structure), FALSE);
-    if(widget != g->structure) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->structure), FALSE);
+    if(widget != g->structure_lines) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->structure_lines), FALSE);
+    if(widget != g->structure_quad) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->structure_quad), FALSE);
+    if(widget != g->structure_auto) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->structure_auto), FALSE);
     if(widget) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
   }
 }
@@ -4983,7 +4982,7 @@ static int _event_fit_both_button_clicked(GtkWidget *widget, GdkEventButton *eve
   return FALSE;
 }
 
-static int _event_structure_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_structure_auto_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return FALSE;
@@ -5426,7 +5425,7 @@ static void _event_values_expander_click(GtkWidget *widget, GdkEventButton *e, g
                                !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->values_toggle)));
 }
 
-static int _event_draw_structure_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_structure_quad_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
@@ -5484,7 +5483,7 @@ static int _event_draw_structure_clicked(GtkWidget *widget, GdkEventButton *even
   return TRUE;
 }
 
-static int _event_draw_direct_structure_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_structure_lines_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
@@ -5657,17 +5656,17 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_grid_attach(auto_grid, dt_ui_label_new(_("structure")), 0, 0, 1, 1);
 
-  g->draw_direct_structure = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->draw_direct_structure), TRUE);
-  gtk_grid_attach(auto_grid, g->draw_direct_structure, 1, 0, 1, 1);
+  g->structure_lines = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_hexpand(GTK_WIDGET(g->structure_lines), TRUE);
+  gtk_grid_attach(auto_grid, g->structure_lines, 1, 0, 1, 1);
 
-  g->draw_structure = dtgtk_togglebutton_new(dtgtk_cairo_paint_draw_structure, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->draw_structure), TRUE);
-  gtk_grid_attach(auto_grid, g->draw_structure, 2, 0, 1, 1);
+  g->structure_quad = dtgtk_togglebutton_new(dtgtk_cairo_paint_draw_structure, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_hexpand(GTK_WIDGET(g->structure_quad), TRUE);
+  gtk_grid_attach(auto_grid, g->structure_quad, 2, 0, 1, 1);
 
-  g->structure = dtgtk_togglebutton_new(dtgtk_cairo_paint_structure, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->structure), TRUE);
-  gtk_grid_attach(auto_grid, g->structure, 3, 0, 1, 1);
+  g->structure_auto = dtgtk_togglebutton_new(dtgtk_cairo_paint_structure, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_hexpand(GTK_WIDGET(g->structure_auto), TRUE);
+  gtk_grid_attach(auto_grid, g->structure_auto, 3, 0, 1, 1);
 
   gtk_grid_attach(auto_grid, dt_ui_label_new(_("fit")), 0, 1, 1, 1);
 
@@ -5715,12 +5714,12 @@ void gui_init(struct dt_iop_module_t *self)
                                              "ctrl+click to only fit rotation\n"
                                              "shift+click to only fit lens shift\n"
                                              "ctrl+shift+click to only fit rotation and lens shift"));
-  gtk_widget_set_tooltip_text(g->structure, _("automatically analyse line structure in image\n"
-                                              "ctrl+click for an additional edge enhancement\n"
-                                              "shift+click for an additional detail enhancement\n"
-                                              "ctrl+shift+click for a combination of both methods"));
-  gtk_widget_set_tooltip_text(g->draw_structure, _("manually define perspective rectangle"));
-  gtk_widget_set_tooltip_text(g->draw_direct_structure, _("manually draw structure lines"));
+  gtk_widget_set_tooltip_text(g->structure_auto, _("automatically analyse line structure in image\n"
+                                                   "ctrl+click for an additional edge enhancement\n"
+                                                   "shift+click for an additional detail enhancement\n"
+                                                   "ctrl+shift+click for a combination of both methods"));
+  gtk_widget_set_tooltip_text(g->structure_quad, _("manually define perspective rectangle"));
+  gtk_widget_set_tooltip_text(g->structure_lines, _("manually draw structure lines"));
   gtk_widget_set_tooltip_text(g->clean, _("remove line structure information"));
   gtk_widget_set_tooltip_text(g->eye, _("toggle visibility of structure lines"));
 
@@ -5730,11 +5729,11 @@ void gui_init(struct dt_iop_module_t *self)
                    (gpointer)self);
   g_signal_connect(G_OBJECT(g->fit_both), "button-press-event", G_CALLBACK(_event_fit_both_button_clicked),
                    (gpointer)self);
-  g_signal_connect(G_OBJECT(g->draw_structure), "button-press-event", G_CALLBACK(_event_draw_structure_clicked),
+  g_signal_connect(G_OBJECT(g->structure_quad), "button-press-event", G_CALLBACK(_event_structure_quad_clicked),
                    (gpointer)self);
-  g_signal_connect(G_OBJECT(g->draw_direct_structure), "button-press-event",
-                   G_CALLBACK(_event_draw_direct_structure_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->structure), "button-press-event", G_CALLBACK(_event_structure_button_clicked),
+  g_signal_connect(G_OBJECT(g->structure_lines), "button-press-event", G_CALLBACK(_event_structure_lines_clicked),
+                   (gpointer)self);
+  g_signal_connect(G_OBJECT(g->structure_auto), "button-press-event", G_CALLBACK(_event_structure_auto_clicked),
                    (gpointer)self);
   g_signal_connect(G_OBJECT(g->clean), "clicked", G_CALLBACK(_event_clean_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(g->eye), "toggled", G_CALLBACK(_event_eye_button_toggled), (gpointer)self);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -402,7 +402,6 @@ typedef struct dt_iop_ashift_gui_data_t
   GtkWidget *values_expander;
   GtkWidget *values_box;
   GtkWidget *values_toggle;
-  GtkGrid *auto_grid;
   GtkWidget *draw_structure;
   GtkWidget *draw_direct_structure;
   gboolean values_expanded;
@@ -5209,48 +5208,53 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(g->values_box), g->specifics, TRUE, TRUE, 0);
 
-  g->auto_grid = GTK_GRID(gtk_grid_new());
-  gtk_grid_set_row_spacing(g->auto_grid, 2 * DT_BAUHAUS_SPACE);
-  gtk_grid_set_column_spacing(g->auto_grid, DT_PIXEL_APPLY_DPI(10));
+  GtkWidget *helpers = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_name(helpers, "section_label");
+  gtk_box_pack_start(GTK_BOX(helpers), dt_ui_label_new(_("perspective helpers")), TRUE, TRUE, 0);
 
-  gtk_grid_attach(g->auto_grid, dt_ui_label_new(_("fit")), 0, 0, 1, 1);
+  g->clean = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+  gtk_box_pack_start(GTK_BOX(helpers), g->clean, FALSE, TRUE, 0);
 
-  g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->fit_v), TRUE);
-  gtk_grid_attach(g->auto_grid, g->fit_v, 2, 0, 1, 1);
+  g->eye = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye_toggle, CPF_STYLE_FLAT, NULL);
+  gtk_box_pack_start(GTK_BOX(helpers), g->eye, FALSE, TRUE, 0);
 
-  g->fit_h = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->fit_h), TRUE);
-  gtk_grid_attach(g->auto_grid, g->fit_h, 3, 0, 1, 1);
+  gtk_widget_show_all(helpers);
+  gtk_box_pack_start(GTK_BOX(g->values_box), helpers, TRUE, TRUE, 0);
 
-  g->fit_both = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->fit_both), TRUE);
-  gtk_grid_attach(g->auto_grid, g->fit_both, 4, 0, 1, 1);
+  GtkGrid *auto_grid = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_row_spacing(auto_grid, 2 * DT_BAUHAUS_SPACE);
+  gtk_grid_set_column_spacing(auto_grid, DT_PIXEL_APPLY_DPI(10));
 
-  gtk_grid_attach(g->auto_grid, dt_ui_label_new(_("structure")), 0, 1, 1, 1);
+  gtk_grid_attach(auto_grid, dt_ui_label_new(_("structure")), 0, 0, 1, 1);
 
   g->draw_direct_structure = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->draw_direct_structure), TRUE);
-  gtk_grid_attach(g->auto_grid, g->draw_direct_structure, 1, 1, 1, 1);
+  gtk_grid_attach(auto_grid, g->draw_direct_structure, 1, 0, 1, 1);
 
   g->draw_structure = dtgtk_togglebutton_new(dtgtk_cairo_paint_draw_structure, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->draw_structure), TRUE);
-  gtk_grid_attach(g->auto_grid, g->draw_structure, 2, 1, 1, 1);
+  gtk_grid_attach(auto_grid, g->draw_structure, 2, 0, 1, 1);
 
   g->structure = dtgtk_button_new(dtgtk_cairo_paint_structure, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->structure), TRUE);
-  gtk_grid_attach(g->auto_grid, g->structure, 3, 1, 1, 1);
+  gtk_grid_attach(auto_grid, g->structure, 3, 0, 1, 1);
 
-  g->clean = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->clean), TRUE);
-  gtk_grid_attach(g->auto_grid, g->clean, 4, 1, 1, 1);
+  gtk_grid_attach(auto_grid, dt_ui_label_new(_("fit")), 0, 1, 1, 1);
 
-  g->eye = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye_toggle, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_hexpand(GTK_WIDGET(g->eye), TRUE);
-  gtk_grid_attach(g->auto_grid, g->eye, 5, 1, 1, 1);
+  g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
+  gtk_widget_set_hexpand(GTK_WIDGET(g->fit_v), TRUE);
+  gtk_grid_attach(auto_grid, g->fit_v, 1, 1, 1, 1);
 
-  gtk_widget_show_all(GTK_WIDGET(g->auto_grid));
-  gtk_box_pack_start(GTK_BOX(g->values_box), GTK_WIDGET(g->auto_grid), TRUE, TRUE, 0);
+  g->fit_h = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
+  gtk_widget_set_hexpand(GTK_WIDGET(g->fit_h), TRUE);
+  gtk_grid_attach(auto_grid, g->fit_h, 2, 1, 1, 1);
+
+  g->fit_both = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
+  gtk_widget_set_hexpand(GTK_WIDGET(g->fit_both), TRUE);
+  gtk_grid_attach(auto_grid, g->fit_both, 3, 1, 1, 1);
+
+  gtk_widget_show_all(GTK_WIDGET(auto_grid));
+  gtk_box_pack_start(GTK_BOX(g->values_box), GTK_WIDGET(auto_grid), TRUE, TRUE, 0);
 
   self->widget = main_box;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4469,7 +4469,7 @@ static void cropmode_callback(GtkWidget *widget, gpointer user_data)
   swap_shadow_crop_box(p,g);
 }
 
-static int fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return FALSE;
@@ -4521,7 +4521,7 @@ static int fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
   return FALSE;
 }
 
-static int fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return FALSE;
@@ -4573,7 +4573,7 @@ static int fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
   return FALSE;
 }
 
-static int fit_both_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_fit_both_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return FALSE;
@@ -4642,7 +4642,7 @@ static void _gui_update_structure_states(dt_iop_module_t *self, GtkWidget *widge
   }
 }
 
-static int structure_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_structure_button_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return FALSE;
@@ -4699,7 +4699,7 @@ static int structure_button_clicked(GtkWidget *widget, GdkEventButton *event, gp
   return FALSE;
 }
 
-static void clean_button_clicked(GtkButton *button, gpointer user_data)
+static void _event_clean_button_clicked(GtkButton *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
@@ -4709,7 +4709,7 @@ static void clean_button_clicked(GtkButton *button, gpointer user_data)
   dt_control_queue_redraw_center();
 }
 
-static void eye_button_toggled(GtkToggleButton *togglebutton, gpointer user_data)
+static void _event_eye_button_toggled(GtkToggleButton *togglebutton, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
@@ -4730,7 +4730,7 @@ static void eye_button_toggled(GtkToggleButton *togglebutton, gpointer user_data
 // routine that is called after preview image has been processed. we use it
 // to perform structure collection or fitting in case those have been triggered while
 // the module had not yet been enabled
-static void process_after_preview_callback(gpointer instance, gpointer user_data)
+static void _event_process_after_preview_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
@@ -4964,7 +4964,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 }
 
 // adjust labels of lens shift parameters according to flip status of image
-static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
+static gboolean _event_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 {
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
   if(darktable.gui->reset) return FALSE;
@@ -5071,7 +5071,7 @@ static void _event_values_expander_click(GtkWidget *widget, GdkEventButton *e, g
                                !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->values_toggle)));
 }
 
-static int _event_draw_structure_click(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_draw_structure_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
@@ -5122,7 +5122,7 @@ static int _event_draw_structure_click(GtkWidget *widget, GdkEventButton *event,
   return TRUE;
 }
 
-static int _event_draw_direct_structure_click(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static int _event_draw_direct_structure_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
@@ -5358,26 +5358,30 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->clean, _("remove line structure information"));
   gtk_widget_set_tooltip_text(g->eye, _("toggle visibility of structure lines"));
 
-  g_signal_connect(G_OBJECT(g->fit_v), "button-press-event", G_CALLBACK(fit_v_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->fit_h), "button-press-event", G_CALLBACK(fit_h_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->fit_both), "button-press-event", G_CALLBACK(fit_both_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->draw_structure), "button-press-event", G_CALLBACK(_event_draw_structure_click),
+  g_signal_connect(G_OBJECT(g->fit_v), "button-press-event", G_CALLBACK(_event_fit_v_button_clicked),
+                   (gpointer)self);
+  g_signal_connect(G_OBJECT(g->fit_h), "button-press-event", G_CALLBACK(_event_fit_h_button_clicked),
+                   (gpointer)self);
+  g_signal_connect(G_OBJECT(g->fit_both), "button-press-event", G_CALLBACK(_event_fit_both_button_clicked),
+                   (gpointer)self);
+  g_signal_connect(G_OBJECT(g->draw_structure), "button-press-event", G_CALLBACK(_event_draw_structure_clicked),
                    (gpointer)self);
   g_signal_connect(G_OBJECT(g->draw_direct_structure), "button-press-event",
-                   G_CALLBACK(_event_draw_direct_structure_click), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->structure), "button-press-event", G_CALLBACK(structure_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->clean), "clicked", G_CALLBACK(clean_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(g->eye), "toggled", G_CALLBACK(eye_button_toggled), (gpointer)self);
-  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
+                   G_CALLBACK(_event_draw_direct_structure_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(g->structure), "button-press-event", G_CALLBACK(_event_structure_button_clicked),
+                   (gpointer)self);
+  g_signal_connect(G_OBJECT(g->clean), "clicked", G_CALLBACK(_event_clean_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(g->eye), "toggled", G_CALLBACK(_event_eye_button_toggled), (gpointer)self);
+  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
 
   /* add signal handler for preview pipe finish to redraw the overlay */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                            G_CALLBACK(process_after_preview_callback), self);
+                                  G_CALLBACK(_event_process_after_preview_callback), self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(process_after_preview_callback), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_process_after_preview_callback), self);
 
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
   free(g->lines);


### PR DESCRIPTION
This is the last part of the c&r "rewrite" #8834

This handle rotation and keystone directly in perspective module : 
- UI rewrite to advertise rotation, as it will certainly be the most used feature...
- rename the module as "rotation and perspective"
- port the c&r feature "straightening drawing line"
- change the rotation slider max bound (available by typing numbers) to -180/180
- allow to choose between 3 perspective modes : none/auto/drawn
- "hide" detailed values under an expander, like what is done in crop module

**currently the "drawing perspective" mode is not done at all** : just the icons are here ! @aurelienpierre : if you have time to look into it, it would be great :) (I have no idea how to translate c&r implementation, which is done in a "big" weird matrix into vertical/horizontal lenshift and shear values, as it's done for automatic mode here)

some screenshots : 
default UI : 
![Capture d’écran_2021-07-08_11-54-41](https://user-images.githubusercontent.com/1818223/124904777-a2658880-dfe5-11eb-8651-6f78cbcdbf20.png)
with perspective : 
![Capture d’écran_2021-07-08_11-55-14](https://user-images.githubusercontent.com/1818223/124904832-b315fe80-dfe5-11eb-99d7-04ffd5d09b52.png)
![Capture d’écran_2021-07-08_11-58-34](https://user-images.githubusercontent.com/1818223/124904844-b5785880-dfe5-11eb-86a2-03ab7de30979.png)
![Capture d’écran_2021-07-08_11-58-55](https://user-images.githubusercontent.com/1818223/124904851-b7dab280-dfe5-11eb-9fbb-7e0a81cd5a26.png)