### PR TITLE
cleanup: g_strdup_printf("%s", ...) -> g_strdup(...)

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2751,7 +2751,7 @@ void ask_for_upgrade(const gchar *dbname, const gboolean has_gui)
 
 void dt_database_backup(const char *filename)
 {
-  char *version = g_strdup_printf("%s", darktable_package_version);
+  char *version = g_strdup(darktable_package_version);
   int k = 0;
   // get plain version (no commit id)
   while(version[k])

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -123,7 +123,7 @@ void dt_conf_set_float(const char *name, float val)
 
 void dt_conf_set_bool(const char *name, int val)
 {
-  char *str = g_strdup_printf("%s", val ? "TRUE" : "FALSE");
+  char *str = g_strdup(val ? "TRUE" : "FALSE");
   if(dt_conf_set_if_not_overridden(name, str)) g_free(str);
 }
 
@@ -369,7 +369,7 @@ static char *_sanitize_confgen(const char *name, const char *value)
     case DT_BOOL:
     {
       if(strcasecmp(value, "true") && strcasecmp(value, "false"))
-        result = g_strdup_printf("%s", dt_confgen_get(name, DT_DEFAULT));
+        result = g_strdup(dt_confgen_get(name, DT_DEFAULT));
       else
         result = g_strdup(value);
     }
@@ -378,7 +378,7 @@ static char *_sanitize_confgen(const char *name, const char *value)
     {
       char *v = g_strdup_printf("[%s]", value);
       if(!strstr(item->enum_values, v))
-        result = g_strdup_printf("%s", dt_confgen_get(name, DT_DEFAULT));
+        result = g_strdup(dt_confgen_get(name, DT_DEFAULT));
       else
         result = g_strdup(value);
       g_free(v);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2574,7 +2574,7 @@ gchar *dt_history_item_get_name(const struct dt_iop_module_t *module)
   gchar *label;
   /* create a history button and add to box */
   if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
-    label = g_strdup_printf("%s", module->name());
+    label = g_strdup(module->name());
   else
     label = g_strdup_printf("%s %s", module->name(), module->multi_name);
   return label;
@@ -2585,7 +2585,7 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
   gchar *label;
   /* create a history button and add to box */
   if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
-    label = g_strdup_printf("%s", module->name());
+    label = g_strdup(module->name());
   else
     label = g_markup_printf_escaped("%s <span size=\"smaller\">%s</span>", module->name(), module->multi_name);
   return label;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3072,7 +3072,7 @@ char *dt_iop_warning_message(const char *message)
   if(dt_conf_get_bool("plugins/darkroom/show_warnings"))
     return g_strdup_printf("<span foreground='red'>⚠</span> %s", message);
   else
-    return g_strdup_printf("%s", message);
+    return g_strdup(message);
 }
 
 char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, const char *purpose, const char *input, const char *process,

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -275,10 +275,8 @@ static void _thumb_write_extension(dt_thumbnail_t *thumb)
   while(ext > thumb->filename && *ext != '.') ext--;
   ext++;
   gchar *uext = dt_view_extend_modes_str(ext, thumb->is_hdr, thumb->is_bw, thumb->is_bw_flow);
-  gchar *ext2 = g_strdup_printf("%s", uext);
-  gtk_label_set_text(GTK_LABEL(thumb->w_ext), ext2);
+  gtk_label_set_text(GTK_LABEL(thumb->w_ext), uext);
   g_free(uext);
-  g_free(ext2);
 }
 
 static gboolean _event_cursor_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1391,7 +1391,7 @@ static void _dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int3
     if(isdefault)
       label = g_strdup_printf("%s %s", name, _("(default)"));
     else
-      label = g_strdup_printf("%s", name);
+      label = g_strdup(name);
     mi = gtk_menu_item_new_with_label(label);
     g_free(label);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1067,7 +1067,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
     const dt_dev_history_item_t *hitem = (dt_dev_history_item_t *)(history->data);
     gchar *label;
     if(!hitem->multi_name[0] || strcmp(hitem->multi_name, "0") == 0)
-      label = g_strdup_printf("%s", hitem->module->name());
+      label = g_strdup(hitem->module->name());
     else
       label = g_strdup_printf("%s %s", hitem->module->name(), hitem->multi_name);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -324,7 +324,7 @@ static void _basics_init_item(dt_lib_modulegroups_basic_item_t *item)
       if(g_strv_length(elems) > 2)
         item->widget_name = g_strdup_printf("%s - %s", _(elems[1]), bw->label);
       else if(g_strv_length(elems) > 1)
-        item->widget_name = g_strdup_printf("%s", bw->label);
+        item->widget_name = g_strdup(bw->label);
       else
       {
         item->widget_name = g_strdup(_("on-off"));
@@ -336,7 +336,7 @@ static void _basics_init_item(dt_lib_modulegroups_basic_item_t *item)
       if(g_strv_length(elems) > 2)
         item->widget_name = g_strdup_printf("%s - %s", _(elems[1]), _(elems[2]));
       else if(g_strv_length(elems) > 1)
-        item->widget_name = g_strdup_printf("%s", _(elems[1]));
+        item->widget_name = g_strdup(_(elems[1]));
       else
       {
         item->widget_name = g_strdup(_("on-off"));


### PR DESCRIPTION
Use the faster `g_strdup` where the existing `g_strdup_printf` is merely duplicating the input string.
Also eliminates an unnecessary copy in thumbnail.c.
