### PR TITLE
test picker event to prevent crash

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -157,7 +157,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
   const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
-  const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK) || e->button == 3;
+  const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK) || (e != NULL && e->button == 3);
   dt_iop_color_picker_kind_t kind = self->kind;
 
   _iop_color_picker_reset(module->picker);


### PR DESCRIPTION
fixes #9468
fixes #9470
fixes #9480

This fixes a sloppy bug introduced with #9441. Sorry.

Many thanks to @davidvj, @todd-prior and @s7habo for reporting and to @wpferguson for copying me in.