### PR TITLE
Update of preset scene-referred default blend mode in exposure module

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -276,7 +276,7 @@ void init_presets (dt_iop_module_so_t *self)
                                                          .deflicker_percentile = 50.0f,
                                                          .deflicker_target_level = -4.0f,
                                                          .compensate_exposure_bias = TRUE},
-                             sizeof(dt_iop_exposure_params_t), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
+                             sizeof(dt_iop_exposure_params_t), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
                             self->version(), FOR_RAW);


### PR DESCRIPTION
Inside the scene-referred default preset of the exposure module the blend mode should be set to RGB (scene) instead of RGB (display) 