### PR TITLE
guides : optionnally show a widget in distort modules to auto-show guides

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1192,6 +1192,13 @@
     <shortdescription>hide built-in presets for processing modules</shortdescription>
     <longdescription>hides built-in presets of processing modules in both presets and favourites menu.</longdescription>
   </dtconfig>
+    <dtconfig prefs="darkroom" section="modules">
+    <name>plugins/darkroom/show_guides_in_ui</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show the auto_apply guides widget in modules UI</shortdescription>
+    <longdescription>show the auto_apply guides widget in modules UI</longdescription>
+  </dtconfig>
   <dtconfig prefs="lighttable" section="general">
     <name>plugins/lighttable/hide_default_presets</name>
     <type>bool</type>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -506,6 +506,17 @@ spinbutton>button
   padding: 0 0.84em;
 }
 
+#guides_module_combobox
+{
+  padding-left: 0.84em;
+  padding-right: 0.84em;
+}
+#guides_menu_warning
+{
+  font-weight: bold;
+  background-color: @really_dark_bg_color;
+}
+
 /* icon buttons in modules main body */
 #iop-plugin-ui-main #dt-button,
 #iop-plugin-ui-main #dt-toggle-button,

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1823,6 +1823,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
     }
     _iop_gui_update_label(module);
     dt_iop_gui_set_enable_button(module);
+    dt_guides_update_module_widget(module);
   }
   --darktable.gui->reset;
 }
@@ -2499,6 +2500,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
 
   /* add the blending ui if supported */
   gtk_box_pack_start(GTK_BOX(iopw), module->widget, TRUE, TRUE, 0);
+  dt_guides_init_module_widget(iopw, module);
   dt_iop_gui_init_blending(iopw, module);
   gtk_widget_set_name(module->widget, "iop-plugin-ui-main");
   dt_gui_add_help_link(module->widget, dt_get_help_url(module->op));

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -280,8 +280,9 @@ typedef struct dt_iop_module_t
   GtkWidget *fusion_slider;
 
   GSList *widget_list;
-  /** show/hide guide button */
+  /** show/hide guide button and combobox */
   GtkWidget *guides_toggle;
+  GtkWidget *guides_combo;
   /** list of closures: show, enable/disable */
   GSList *accel_closures;
   GSList *accel_closures_local;

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -42,7 +42,7 @@ void dt_guides_cleanup(GList *guides);
 void dt_guides_add_guide(const char *name, dt_guides_draw_callback draw, dt_guides_widget_callback widget, void *user_data, GDestroyNotify free);
 
 // show the popup to setup the guides
-void dt_guides_show_popup(GtkWidget *button);
+void dt_guides_show_popup(GtkWidget *button, gboolean warning);
 
 // draw the guide on screen
 void dt_guides_draw(cairo_t *cr, const float left, const float top, const float width, const float height,
@@ -54,6 +54,10 @@ void dt_guides_button_toggled();
 
 // show the menuitem for modules
 void dt_guides_add_module_menuitem(void *menu, struct dt_iop_module_t *module);
+
+// show the line in UI modules
+void dt_guides_init_module_widget(GtkWidget *box, struct dt_iop_module_t *module);
+void dt_guides_update_module_widget(struct dt_iop_module_t *module);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1472,7 +1472,7 @@ static gboolean _guides_quickbutton_pressed(GtkWidget *widget, GdkEvent *event, 
   const GdkEventButton *e = (GdkEventButton *)event;
   if(e->button == 3)
   {
-    dt_guides_show_popup(widget);
+    dt_guides_show_popup(widget, FALSE);
     return TRUE;
   }
   else


### PR DESCRIPTION
this fix #9490

quick solution to fix discoverability and ability to switch between guides inside a module.
this is redundant with the hamburger menu checkbox
for those who don't to see the combobox, there's a preference to hide them

@elstoc @Nilvus : can you have a try ? thanks !