### PR TITLE
Fix Windows import

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -288,9 +288,10 @@ gboolean dt_util_test_image_file(const char *filename)
   // utf8 paths will not work in this context for no reason 
   // that I can figure out, but converting utf8 to utf16 works
   // fine.
-  
+
   wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
   if(_wstati64(wfilename, &stats)) return FALSE;
+  g_free(wfilename);
 #else
   struct stat stats;
   if(stat(filename, &stats)) return FALSE;

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -290,8 +290,11 @@ gboolean dt_util_test_image_file(const char *filename)
   // fine.
 
   wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
-  if(_wstati64(wfilename, &stats)) return FALSE;
-  g_free(wfilename);
+  if(int result = _wstati64(wfilename, &stats))
+  {
+    g_free(wfilename);
+    if(result) return FALSE;
+  } 
 #else
   struct stat stats;
   if(stat(filename, &stats)) return FALSE;

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -283,7 +283,14 @@ gboolean dt_util_test_image_file(const char *filename)
   if(g_access(filename, R_OK)) return FALSE;
 #ifdef _WIN32
   struct _stati64 stats;
-  if(_stati64(filename, &stats)) return FALSE;
+
+  // the code this replaced used utf8 paths with no problem
+  // utf8 paths will not work in this context for no reason 
+  // that I can figure out, but converting utf8 to utf16 works
+  // fine.
+  
+  wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
+  if(_wstati64(wfilename, &stats)) return FALSE;
 #else
   struct stat stats;
   if(stat(filename, &stats)) return FALSE;

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -290,7 +290,7 @@ gboolean dt_util_test_image_file(const char *filename)
   // fine.
 
   wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
-  int result = _wstati64(wfilename, &stats);
+  const int result = _wstati64(wfilename, &stats);
   g_free(wfilename);
   if(result) return FALSE; // there was an error
  #else

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -290,12 +290,10 @@ gboolean dt_util_test_image_file(const char *filename)
   // fine.
 
   wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
-  if(int result = _wstati64(wfilename, &stats))
-  {
-    g_free(wfilename);
-    if(result) return FALSE;
-  } 
-#else
+  int result = _wstati64(wfilename, &stats);
+  g_free(wfilename);
+  if(result) return FALSE; // there was an error
+ #else
   struct stat stats;
   if(stat(filename, &stats)) return FALSE;
 #endif


### PR DESCRIPTION
Changed file check to use utf16 pathname instead of utf8.  Fixes #9475. Fixes #9436