### PR TITLE
diffuse: caching and vectorization speedups

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -214,6 +214,9 @@ static inline float dt_log2f(const float f)
 
 // fast approximation of expf()
 /****** if you change this function, you need to make the same change in data/kernels/{basecurve,basic}.cl ***/
+#ifdef _OPENMP
+#pragma omp declare simd 
+#endif
 static inline float dt_fast_expf(const float x)
 {
   // meant for the range [-100.0f, 0.0f]. largest error ~ -0.06 at 0.0f.
@@ -230,6 +233,30 @@ static inline float dt_fast_expf(const float x)
   } u;
   u.k = k0 > 0 ? k0 : 0;
   return u.f;
+}
+
+static inline void dt_fast_expf_4wide(const float x[4], float result[4])
+{
+  // meant for the range [-100.0f, 0.0f]. largest error ~ -0.06 at 0.0f.
+  // will get _a_lot_ worse for x > 0.0f (9000 at 10.0f)..
+  const int i1 = 0x3f800000u;
+  // e^x, the comment would be 2^x
+  const int i2 = 0x402DF854u; // 0x40000000u;
+  // const int k = CLAMPS(i1 + x * (i2 - i1), 0x0u, 0x7fffffffu);
+  // without max clamping (doesn't work for large x, but is faster):
+  union {
+      float f;
+      int k;
+  } u[4];
+#ifdef _OPENMP
+#pragma omp simd aligned(x, result)
+#endif
+  for(size_t c = 0; c < 4; c++)
+  {
+    const int k0 = i1 + (int)(x[c] * (i2 - i1));
+    u[c].k = k0 > 0 ? k0 : 0;
+    result[c] = u[c].f;
+  }
 }
 
 #if defined(__SSE2__)

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -212,6 +212,11 @@ static inline float dt_log2f(const float f)
 #endif
 }
 
+union float_int {
+  float f;
+  int k;
+};
+
 // fast approximation of expf()
 /****** if you change this function, you need to make the same change in data/kernels/{basecurve,basic}.cl ***/
 #ifdef _OPENMP
@@ -227,10 +232,7 @@ static inline float dt_fast_expf(const float x)
   // const int k = CLAMPS(i1 + x * (i2 - i1), 0x0u, 0x7fffffffu);
   // without max clamping (doesn't work for large x, but is faster):
   const int k0 = i1 + x * (i2 - i1);
-  union {
-      float f;
-      int k;
-  } u;
+  union float_int u;
   u.k = k0 > 0 ? k0 : 0;
   return u.f;
 }
@@ -244,10 +246,7 @@ static inline void dt_fast_expf_4wide(const float x[4], float result[4])
   const int i2 = 0x402DF854u; // 0x40000000u;
   // const int k = CLAMPS(i1 + x * (i2 - i1), 0x0u, 0x7fffffffu);
   // without max clamping (doesn't work for large x, but is faster):
-  union {
-      float f;
-      int k;
-  } u[4];
+  union float_int u[4];
 #ifdef _OPENMP
 #pragma omp simd aligned(x, result)
 #endif

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -716,8 +716,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           cos_theta_sin_theta_lapl[c] = laplacian[0][c] * laplacian[1][c];
         }
 
-        for_four_channels(c, aligned(neighbour_pixel_LF, neighbour_pixel_HF, out, LF, HF : 64) \
-            aligned(anisotropy, isotropy_type, ABCD :16))
+        for(size_t c = 0; c < 3; c++) // the body of this loop can't vectorize, so don't compute the fourth channel
         {
           // c² in https://www.researchgate.net/publication/220663968
           const float c2[4]


### PR DESCRIPTION
Now that @flannelhead has sped up  the trig in `heat_PDE_diffusion` in #9453, it's my turn to speed up the rest....
The changes in this PR speed up the diffuse module on the 0086 integration test from 0.587 to 0.418 seconds running on a 32-core Threadripper.

The big inner per-pixel loop was not vectorizing at all.  Splitting off some of the beginning of the body using four-element arrays instead of a simple variable yields some speedup from vectorization, but the bulk of the body can't vectorize due to data-dependent branching.  That means computing the fourth channel is simply wasted effort, so I changed the `for_four_channels` to a three-iteration standard for loop.  That produced the majority of the speedup.

BTW, I noticed that there are definitions for `find_gradient` and `find_laplacian`, but only the former is called (to fill in both the `gradient` and `laplacian` variables).  Is that correct?
