### PR TITLE
diffuse: speedup B-spline wavelet decomposition

### DIFF
--- a/src/common/bspline.h
+++ b/src/common/bspline.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include "common/darktable.h"
+#include "common/dwt.h"
+
+// B spline filter
+#define BSPLINE_FSIZE 5
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(buf, indices, result:64)
+#endif
+inline static void sparse_scalar_product(const float *const buf, const size_t indices[BSPLINE_FSIZE], float result[4])
+{
+  // scalar product of 2 3×5 vectors stored as RGB planes and B-spline filter,
+  // e.g. RRRRR - GGGGG - BBBBB
+
+  const float DT_ALIGNED_ARRAY filter[BSPLINE_FSIZE] =
+                        { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+
+  #ifdef _OPENMP
+  #pragma omp simd
+  #endif
+  for(size_t c = 0; c < 4; ++c)
+  {
+    float acc = 0.0f;
+    for(size_t k = 0; k < BSPLINE_FSIZE; ++k)
+      acc += filter[k] * buf[indices[k] + c];
+    result[c] = fmaxf(acc, 0.f);
+  }
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out:64) aligned(tempbuf:16)
+#endif
+inline static void blur_2D_Bspline(const float *const restrict in, float *const restrict out,
+                                   float *const restrict tempbuf,
+                                   const size_t width, const size_t height, const int mult)
+{
+  // À-trous B-spline interpolation/blur shifted by mult
+  #ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+    dt_omp_firstprivate(width, height, mult)  \
+    dt_omp_sharedconst(out, in, tempbuf) \
+    schedule(simd:static)
+  #endif
+  for(size_t row = 0; row < height; row++)
+  {
+    // get a thread-private one-row temporary buffer
+    float *const temp = tempbuf + 4 * width * dt_get_thread_num();
+    // interleave the order in which we process the rows so that we minimize cache misses
+    const size_t i = dwt_interleave_rows(row, height, mult);
+    // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
+    size_t DT_ALIGNED_ARRAY indices[BSPLINE_FSIZE] = { 0 };
+    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
+    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
+    // over the row
+    for(size_t ii = 0; ii < BSPLINE_FSIZE; ++ii)
+    {
+      const size_t r = CLAMP(mult * (int)(ii - (BSPLINE_FSIZE - 1) / 2) + (int)i, (int)0, (int)height - 1);
+      indices[ii] = 4 * r * width;
+    }
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the vertical blur of the current pixel and store it in the temp buffer for the row
+      sparse_scalar_product(in + j * 4, indices, temp + j * 4);
+    }
+    // Convolve B-spline filter horizontally over current row
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the array indices of the pixels of interest; since the offsets will change near the ends of
+      // the row, we need to recompute for each pixel
+      for(size_t jj = 0; jj < BSPLINE_FSIZE; ++jj)
+      {
+        const size_t col = CLAMP(mult * (int)(jj - (BSPLINE_FSIZE - 1) / 2) + (int)j, (int)0, (int)width - 1);
+        indices[jj] = 4 * col;
+      }
+      // Compute the horizontal blur of the already vertically-blurred pixel and store the result at the proper
+      //  row/column location in the output buffer
+      sparse_scalar_product(temp, indices, out + (i * width + j) * 4);
+    }
+  }
+}
+
+
+inline static void decompose_2D_Bspline(const float *const restrict in, float *const restrict HF,
+                                        float *const restrict LF,
+                                        const size_t width, const size_t height, const int mult)
+{
+  size_t padded_size;
+  float *tempbuf = dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
+  // Blur and compute the decimated wavelet at once
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+    dt_omp_firstprivate(width, height, in, LF, HF, mult, tempbuf, padded_size) \
+    schedule(simd: static)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    // get a thread-private one-row temporary buffer
+    float *restrict const temp = dt_get_perthread(tempbuf, padded_size);
+    // interleave the order in which we process the rows so that we minimize cache misses
+    const size_t i = dwt_interleave_rows(row, height, mult);
+    // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
+    size_t DT_ALIGNED_ARRAY indices[BSPLINE_FSIZE] = { 0 };
+    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
+    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
+    // over the row
+    for(size_t ii = 0; ii < BSPLINE_FSIZE; ++ii)
+    {
+      const size_t r = CLAMP(mult * (int)(ii - (BSPLINE_FSIZE - 1) / 2) + (int)i, (int)0, (int)height - 1);
+      indices[ii] = 4 * r * width;
+    }
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the vertical blur of the current pixel and store it in the temp buffer for the row
+      sparse_scalar_product(in + j * 4, indices, temp + j * 4);
+    }
+    // Convolve B-spline filter horizontally over current row
+    for(size_t j = 0; j < width; j++)
+    {
+      // Compute the array indices of the pixels of interest; since the offsets will change near the ends of
+      // the row, we need to recompute for each pixel
+      for(size_t jj = 0; jj < BSPLINE_FSIZE; ++jj)
+      {
+        const size_t col = CLAMP(mult * (int)(jj - (BSPLINE_FSIZE - 1) / 2) + (int)j, (int)0, (int)width - 1);
+        indices[jj] = 4 * col;
+      }
+      size_t index = 4U * (i * width + j);
+      // Compute the horizontal blur of the already vertically-blurred pixel and store the result at the proper
+      //  row/column location in the LF output buffer
+      sparse_scalar_product(temp, indices, LF + index);
+      // compute the HF component by subtracting the LF from the original input
+      for_each_channel(c)
+        HF[index + c] = in[index + c] - LF[index + c];
+    }
+  }
+  dt_free_align(tempbuf);
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/bspline.h
+++ b/src/common/bspline.h
@@ -30,6 +30,8 @@ static inline void _bspline_vertical_pass(const float *const restrict in, float 
                                           size_t row, size_t width, size_t height, int mult)
 {
   size_t DT_ALIGNED_ARRAY indices[BSPLINE_FSIZE];
+  // compute the index offsets of the pixels of interest; since the offsets are the same for the entire row,
+  // we only need to do this once and can then process the entire row
   indices[0] = 4 * width * MAX((int)row - 2 * mult, 0);
   indices[1] = 4 * width * MAX((int)row - mult, 0);
   indices[2] = 4 * width * row;
@@ -82,9 +84,6 @@ inline static void blur_2D_Bspline(const float *const restrict in, float *const 
     // interleave the order in which we process the rows so that we minimize cache misses
     const size_t i = dwt_interleave_rows(row, height, mult);
     // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
-    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
-    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
-    // over the row
     _bspline_vertical_pass(in, temp, i, width, height, mult);
     // Convolve B-spline filter horizontally over current row
     for(size_t j = 0; j < width; j++)
@@ -115,9 +114,6 @@ inline static void decompose_2D_Bspline(const float *const DT_ALIGNED_PIXEL rest
     // interleave the order in which we process the rows so that we minimize cache misses
     const size_t i = dwt_interleave_rows(row, height, mult);
     // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur
-    // Start by computing the array indices of the pixels of interest; the offsets from the current pixel stay
-    // unchanged over the entire row, so we can compute once and just offset the base address while iterating
-    // over the row
     _bspline_vertical_pass(in, temp, i, width, height, mult);
     // Convolve B-spline filter horizontally over current row
     for(size_t j = 0; j < width; j++)

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -759,6 +759,9 @@ static inline gint wavelets_process(const float *const restrict in, float *const
   // there is a paper from a guy we know that explains it : https://jo.dreggn.org/home/2010_atrous.pdf
   // the wavelets decomposition here is the same as the equalizer/atrous module,
   float *restrict residual; // will store the temp buffer containing the last step of blur
+  // allocate a one-row temporary buffer for the decomposition
+  size_t padded_size;
+  float *const DT_ALIGNED_ARRAY tempbuf = dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
   for(int s = 0; s < scales; ++s)
   {
     /* fprintf(stdout, "Wavelet decompose : scale %i\n", s); */
@@ -783,7 +786,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
       buffer_out = LF_odd;
     }
 
-    decompose_2D_Bspline(buffer_in, HF[s], buffer_out, width, height, mult);
+    decompose_2D_Bspline(buffer_in, HF[s], buffer_out, width, height, mult, tempbuf, padded_size);
 
     residual = buffer_out;
 
@@ -796,6 +799,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
     dump_PFM(name, buffer_out, width, height);
 #endif
   }
+  dt_free_align(tempbuf);
 
   // will store the temp buffer NOT containing the last step of blur
   float *restrict temp = (residual == LF_even) ? LF_odd : LF_even;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -379,9 +379,6 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("inpaint highlights"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
-// B spline filter
-#define FSIZE 5
-
 // The B spline best approximate a Gaussian of standard deviation :
 // see https://eng.aurelienpierre.com/2021/03/rotation-invariant-laplacian-for-2d-grids/
 #define B_SPLINE_SIGMA 1.0553651328015339f


### PR DESCRIPTION
Improve cache behavior and reduce computation by using two passes over the image instead of computing the full 25-element kernel for each pixel.  Carefully tweaked to ensure auto-vectorization by the compiler.

This PR can be applied independently of #9515, but unlike the other PR, this one does marginally change the output do to different rounding as a result of decomposing the B-spline convolution.  The two PRs together reduce run time on integration test 0086 from 0.587 to 0.312 seconds (0.053 seconds gained from this PR  out of about 0.147 used by the wavelet decomposition).

Since both filmicrgb and diffuse use nearly identical B-spline blur functions, this PR also refactors them into a new common file as well as factoring out common code between the two functions.
