### PR TITLE
Fix internal lua build

### DIFF
--- a/src/external/lua/CMakeLists.txt
+++ b/src/external/lua/CMakeLists.txt
@@ -21,7 +21,6 @@ set(LUA_SOURCES
 	"src/lzio.c"
 	"src/lauxlib.c"
 	"src/lbaselib.c"
-	"src/lbitlib.c"
 	"src/lcorolib.c"
 	"src/ldblib.c"
 	"src/liolib.c"


### PR DESCRIPTION
Removed unneeded src/lbitlib.c.  Fixes #9530 