### PR TITLE
New feature: lazy xmp files writing

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -287,6 +287,13 @@
     <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">
+    <name>lazy_sidecar_files</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>write sidecar file for each image in lazy mode</shortdescription>
+    <longdescription>sidecar file will only be written if the user has modified the image after import and presets have been applied.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="storage" section="xmp">
     <name>compress_xmp_tags</name>
     <type>
       <enum>

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -538,7 +538,7 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       }
     }
 
-    if(dt_conf_get_bool("write_sidecar_files") ||
+    if((dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER) ||
        dt_conf_get_bool("ui_last/import_last_tags_imported"))
     {
       GList *tags = NULL;
@@ -3171,12 +3171,13 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
     if(preset_applied > 0)
     {
       img->flags |= DT_IMAGE_AUTO_PRESETS_APPLIED;
+      img->flags |= DT_IMAGE_MODS;
     }
     else
     {
       // not found for old or buggy xmp where it was found but history was 0
       img->flags &= ~DT_IMAGE_AUTO_PRESETS_APPLIED;
-
+      img->flags &= ~DT_IMAGE_MODS;
       if(preset_applied < 0)
       {
         fprintf(stderr,"[exif] dt_exif_xmp_read for %s, id %i found auto_presets_applied but there was no history\n",filename,img->id);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -51,7 +51,7 @@ static void _remove_preset_flag(const int imgid)
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
   // clear flag
-  image->flags &= ~DT_IMAGE_AUTO_PRESETS_APPLIED;
+  image->flags &= ~(DT_IMAGE_AUTO_PRESETS_APPLIED | DT_IMAGE_MODS);
 
   // write through to sql+xmp
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -37,6 +37,13 @@ typedef enum dt_imageio_retval_t
   DT_IMAGEIO_CACHE_FULL      // dt's caches are full :(
 } dt_imageio_retval_t;
 
+typedef enum dt_imageio_write_xmp_t
+{
+  DT_WRITE_XMP_NEVER = 0,
+  DT_WRITE_XMP_LAZY = 1,
+  DT_WRITE_XMP_ALWAYS = 2
+} dt_imageio_write_xmp_t;
+
 typedef enum
 {
   // the first 0x7 in flags are reserved for star ratings.
@@ -87,6 +94,8 @@ typedef enum
   DT_IMAGE_MONOCHROME_BAYER = 1 << 19,
   // image has a flag set to use the monochrome workflow in the modules supporting it
   DT_IMAGE_MONOCHROME_WORKFLOW = 1 << 20,
+  // image has been changed by the user
+  DT_IMAGE_MODS = 1 << 21,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t
@@ -290,6 +299,8 @@ void dt_image_path_append_version_no_db(int version, char *pathname, size_t path
 void dt_image_path_append_version(const int32_t imgid, char *pathname, size_t pathname_len);
 /** prints a one-line exif information string. */
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len);
+/** get the mode xmp sidecars are written */
+dt_imageio_write_xmp_t dt_image_get_xmp_mode();
 /* set rating to img flags */
 void dt_image_set_xmp_rating(dt_image_t *img, const int rating);
 /* get rating from img flags */

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -614,7 +614,7 @@ void dt_metadata_set_import(const int imgid, const char *key, const char *value)
 
   if(keyid != -1) // known key
   {
-    gboolean imported = dt_conf_get_bool("write_sidecar_files");
+    gboolean imported = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
     if(!imported && dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL)
     {
       const gchar *name = dt_metadata_get_name(keyid);

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -60,7 +60,7 @@ GList *dt_control_crawler_run()
 {
   sqlite3_stmt *stmt, *inner_stmt;
   GList *result = NULL;
-  gboolean look_for_xmp = dt_conf_get_bool("write_sidecar_files");
+  gboolean look_for_xmp = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
 
   sqlite3_prepare_v2(dt_database_get(darktable.db),
                      "SELECT i.id, write_timestamp, version, folder || '" G_DIR_SEPARATOR_S "' || filename, flags "

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -1063,7 +1063,7 @@ static inline float round5(double x)
   return round(x * 100000.f) / 100000.f;
 }
 
-void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
+gboolean dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
 {
   gboolean refresh_needed = FALSE;
   char imported[256] = { 0 };
@@ -1075,7 +1075,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   if(!pathname)
   {
     if(!iauto) dt_control_log(_("cannot find lightroom XMP!"));
-    return;
+    return FALSE;
   }
 
   // Load LR xmp
@@ -1090,7 +1090,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   if(doc == NULL)
   {
     g_free(pathname);
-    return;
+    return FALSE;
   }
 
   // Enter first node, xmpmeta
@@ -1101,14 +1101,14 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   {
     g_free(pathname);
     xmlFreeDoc(doc);
-    return;
+    return FALSE;
   }
 
   if(xmlStrcmp(entryNode->name, (const xmlChar *)"xmpmeta"))
   {
     if(!iauto) dt_control_log(_("`%s' not a lightroom XMP!"), pathname);
     g_free(pathname);
-    return;
+    return FALSE;
   }
 
   // Check that this is really a Lightroom document
@@ -1119,7 +1119,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   {
     g_free(pathname);
     xmlFreeDoc(doc);
-    return;
+    return FALSE;
   }
 
   xmlXPathRegisterNs(xpathCtx, BAD_CAST "stEvt", BAD_CAST "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#");
@@ -1132,7 +1132,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
     xmlXPathFreeContext(xpathCtx);
     g_free(pathname);
     xmlFreeDoc(doc);
-    return;
+    return FALSE;
   }
 
   xmlNodeSetPtr xnodes = xpathObj->nodesetval;
@@ -1150,7 +1150,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
       xmlFree(value);
       if(!iauto) dt_control_log(_("`%s' not a lightroom XMP!"), pathname);
       g_free(pathname);
-      return;
+      return TRUE;
     }
     xmlFree(value);
   }
@@ -1559,6 +1559,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
     }
   }
+  return TRUE;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/lightroom.h
+++ b/src/develop/lightroom.h
@@ -24,7 +24,7 @@
    When called from lightable : dev == NULL, in this case only the tags are imported
    When called from darkroom  : dev != NULL, in this case only develop data are imported
 */
-void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto);
+gboolean dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto);
 
 /* returns NULL if not found, or g_strdup'ed pathname, the caller should g_free it. */
 char *dt_get_lightroom_xmp(int imgid);

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -144,7 +144,7 @@ static void _import_tags_changed(GtkWidget *widget, dt_import_metadata_t *metada
 
 static void _update_layout(dt_import_metadata_t *metadata)
 {
-  const gboolean write_xmp = dt_conf_get_bool("write_sidecar_files");
+  const gboolean write_xmp = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
   GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_META_HEADER);
   gtk_widget_set_visible(w, !write_xmp);
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)


### PR DESCRIPTION
As has been discussed in below mentioned issues it would be good to write sidecars only **after** the user did some
developing work on the image avoiding xmp file "pollution" and at least on slow drives would also mean better performance.

How does this pr work?

1. There is a new config option (default is off) switching on lazy-writing mode. After making that option true, sidecars
   should only be written after "work".

2. A new bit 'DT_IMAGE_MODS' in 'dt_image_flags_t' has been introduced, this bitmask flag is the reference for an image
   being edited.

The DT_IMAGE_MODS flags is cleared after importing and presets being applied. So that stage is the reference for an image
being **not** edited so in lazy mode there will be no sidecar written.

What conditions should set the flag?
- any history added afterwards
- any xmp file found while importing (it could not include this flag being set)
- any lightroom tags found
- monochrome setting

There are some conditions not supported yet:
  flip, rating, written tags

Anything else?

Not sure how to handle duplicates. If a file has been changed already we will have an xmp and so has the duplicate.
What if i duplicate an un-edited image? Currently we will have two sidecars. Personally i think we should keep that
behavior.

Fixes #4450
Fixes #2832