### PR TITLE
highlights: remove SSE code path

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -22,9 +22,6 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__SSE__)
-#include <xmmintrin.h>
-#endif
 #include "bauhaus/bauhaus.h"
 #include "common/opencl.h"
 #include "control/control.h"
@@ -770,9 +767,9 @@ static void process_lch_xtrans(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 #undef SQRT3
 #undef SQRT12
 
-static void process_clip_plain(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                               const float clip)
+static void process_clip(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         const float clip)
 {
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
@@ -803,65 +800,6 @@ static void process_clip_plain(dt_dev_pixelpipe_iop_t *piece, const void *const 
       out[k] = MIN(clip, in[k]);
     }
   }
-}
-
-#if defined(__SSE__)
-static void process_clip_sse2(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                              const float clip)
-{
-  if(piece->pipe->dsc.filters)
-  { // raw mosaic
-    const __m128 clipm = _mm_set1_ps(clip);
-    const size_t n = (size_t)roi_out->height * roi_out->width;
-    float *const out = (float *)ovoid;
-    float *const in = (float *)ivoid;
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(clipm, in, n, out) \
-    schedule(static)
-#endif
-    for(size_t j = 0; j < (n & ~3u); j += 4) _mm_stream_ps(out + j, _mm_min_ps(clipm, _mm_load_ps(in + j)));
-    _mm_sfence();
-    // lets see if there's a non-multiple of four rest to process:
-    if(n & 3)
-      for(size_t j = n & ~3u; j < n; j++) out[j] = MIN(clip, in[j]);
-  }
-  else
-  {
-    const __m128 clipm = _mm_set1_ps(clip);
-    const int ch = piece->colors;
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-    dt_omp_firstprivate(ch, clipm, ivoid, ovoid, roi_in, roi_out) \
-    schedule(static)
-#endif
-    for(int j = 0; j < roi_out->height; j++)
-    {
-      float *out = (float *)ovoid + (size_t)ch * roi_out->width * j;
-      float *in = (float *)ivoid + (size_t)ch * roi_in->width * j;
-      for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
-      {
-        _mm_stream_ps(out, _mm_min_ps(clipm, _mm_set_ps(in[3], in[2], in[1], in[0])));
-      }
-    }
-    _mm_sfence();
-  }
-}
-#endif
-
-static void process_clip(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         const float clip)
-{
-  if(darktable.codepath.OPENMP_SIMD) process_clip_plain(piece, ivoid, ovoid, roi_in, roi_out, clip);
-#if defined(__SSE__)
-  else if(darktable.codepath.SSE2)
-    process_clip_sse2(piece, ivoid, ovoid, roi_in, roi_out, clip);
-#endif
-  else
-    dt_unreachable_codepath();
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,


### PR DESCRIPTION
A check of generated code shows that `process_clip_plain` vectorizes very nicely, and a quick benchmark showed it to be 7 times as fast as 'process_clip_sse2` -- 0.14 ms versus 0.96 ms (the nontemporal stores from the _mm_stream_ps seem to hurt here).