### PR TITLE
update warning messages when using non-default codepath settings

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -329,7 +329,7 @@ static void dt_codepaths_init()
 #endif
   {
     darktable.codepath.OPENMP_SIMD = 1;
-    fprintf(stderr, "[dt_codepaths_init] will be using HIGHLY EXPERIMENTAL plain OpenMP SIMD codepath.\n");
+    fprintf(stderr, "[dt_codepaths_init] will be using experimental plain OpenMP SIMD codepath.\n");
   }
 
 #if defined(__SSE__)
@@ -338,7 +338,7 @@ static void dt_codepaths_init()
   {
     fprintf(stderr, "[dt_codepaths_init] SSE2-optimized codepath is disabled or unavailable.\n");
     fprintf(stderr,
-            "[dt_codepaths_init] expect a LOT of functionality to be broken. you have been warned.\n");
+            "[dt_codepaths_init] some functionality may be broken. you have been warned.\n");
   }
 }
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -334,12 +334,10 @@ static void dt_codepaths_init()
 
 #if defined(__SSE__)
   if(darktable.codepath._no_intrinsics)
-#endif
   {
     fprintf(stderr, "[dt_codepaths_init] SSE2-optimized codepath is disabled or unavailable.\n");
-    fprintf(stderr,
-            "[dt_codepaths_init] some functionality may be broken. you have been warned.\n");
   }
+#endif
 }
 
 int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load_data, lua_State *L)


### PR DESCRIPTION
Tone down the startup message when forcing OpenMP from "HIGHLY EXPERIMENTAL" to "experimental" and when SSE is disabled from "expect a lot to be broken" to "some functionality may be broken".  We've been using OpenMP code paths as the default for new code for a while now and have been removing SSE code paths as they are found to be slower.

Today's removal of some SSE code paths reminded me that I had wanted to propose this change months ago.
