### PR TITLE
fix focus peaking

### DIFF
--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -81,19 +81,18 @@ static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
                                    uint8_t *const restrict image,
                                    const int buf_width, const int buf_height)
 {
-  float *const restrict luma =  dt_alloc_sse_ps((size_t)buf_width * buf_height);
+  float *const restrict luma = dt_alloc_align_float((size_t)buf_width * buf_height);
   uint8_t *const restrict focus_peaking = dt_alloc_align(64, sizeof(uint8_t) * buf_width * buf_height * 4);
 
+  const size_t npixels = (size_t)buf_height * buf_width;
   // Create a luma buffer as the euclidian norm of RGB channels
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(image, luma, buf_height, buf_width) \
-schedule(static) collapse(2) aligned(image, luma:64)
+#pragma omp parallel for simd default(none)             \
+  dt_omp_firstprivate(image, luma, npixels)             \
+  schedule(static) aligned(image, luma:64)
 #endif
-  for(size_t j = 0; j < buf_height; j++)
-    for(size_t i = 0; i < buf_width; i++)
+  for(size_t index = 0; index < npixels; index++)
     {
-      const size_t index = j * buf_width + i;
       const size_t index_RGB = index * 4;
 
       // remove gamma 2.2 and take the square is equivalent to this:
@@ -108,32 +107,38 @@ schedule(static) collapse(2) aligned(image, luma:64)
   fast_surface_blur(luma, buf_width, buf_height, 12, 0.00001f, 4, DT_GF_BLENDING_LINEAR, 1, 0.0f, exp2f(-8.0f), 1.0f);
 
   // Compute the gradients magnitudes
-  float *const restrict luma_ds =  dt_alloc_sse_ps((size_t)buf_width * buf_height);
+  float *const restrict luma_ds =  dt_alloc_align_float((size_t)buf_width * buf_height);
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
 dt_omp_firstprivate(luma, luma_ds, buf_height, buf_width) \
 schedule(static) collapse(2) aligned(luma_ds, luma:64)
 #endif
-  for(size_t i = 2; i < buf_height - 2; ++i)
-    for(size_t j = 2; j < buf_width - 2; ++j)
+  for(size_t i = 0; i < buf_height; ++i)
+    for(size_t j = 0; j < buf_width; ++j)
     {
-      size_t index_close[8];
-      get_indices(i, j, buf_width, buf_height, 1, index_close);
+      size_t index = i * buf_width + j;
+      if (i < 2 || i >= buf_height - 2 || j < 2 || j > buf_width -2)
+        // ensure defined value for borders
+        luma_ds[index] = 0.0f;
+      else
+      {
+        size_t index_close[8];
+        get_indices(i, j, buf_width, buf_height, 1, index_close);
 
-      size_t index_far[8];
-      get_indices(i, j, buf_width, buf_height, 2, index_far);
+        size_t index_far[8];
+        get_indices(i, j, buf_width, buf_height, 2, index_far);
 
-      // Computing the gradient on the closest neighbours gives us the rate of variation, but doesn't say if we are
-      // looking at local contrast or optical sharpness.
-      // so we compute again the gradient on neighbours a bit further.
-      // if both gradients have the same magnitude, it means we have no sharpness but just a big step in intensity,
-      // aka local contrast. If the closest is higher than the farthest, is means we have indeed a sharp something,
-      // either noise or edge. To mitigate that, we just subtract half the farthest gradient but add a noise threshold
-      luma_ds[i * buf_width + j] = laplacian(luma, index_close) - 0.67f * (laplacian(luma, index_far) - 0.00390625f);
+        // Computing the gradient on the closest neighbours gives us the rate of variation, but doesn't say if we are
+        // looking at local contrast or optical sharpness.
+        // so we compute again the gradient on neighbours a bit further.
+        // if both gradients have the same magnitude, it means we have no sharpness but just a big step in intensity,
+        // aka local contrast. If the closest is higher than the farthest, is means we have indeed a sharp something,
+        // either noise or edge. To mitigate that, we just subtract half the farthest gradient but add a noise threshold
+        luma_ds[index] = laplacian(luma, index_close) - 0.67f * (laplacian(luma, index_far) - 0.00390625f);
+      }
     }
 
   // Anti-aliasing
-//  box_average(luma_ds, buf_width, buf_height, 1, 2);
   dt_box_mean(luma_ds, buf_height, buf_width, 1, 2, 1);
 
   // Compute the gradient mean over the picture
@@ -175,103 +180,40 @@ schedule(static) collapse(2) aligned(focus_peaking, luma_ds:64) reduction(+:sigm
 
   // Prepare the focus-peaking image overlay
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(focus_peaking, luma_ds, buf_height, buf_width, six_sigma, four_sigma, two_sigma, sigma) \
-schedule(static) collapse(2) aligned(focus_peaking, luma_ds:64)
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(focus_peaking, luma_ds, buf_height, buf_width, six_sigma, four_sigma, two_sigma) \
+  schedule(static) collapse(2)
 #endif
-  for(size_t i = 2; i < buf_height - 2; ++i)
-    for(size_t j = 2; j < buf_width - 2; ++j)
+  for(size_t i = 0; i < buf_height; ++i)
+    for(size_t j = 0; j < buf_width; ++j)
     {
+      static const uint8_t yellow[4] = { 0/*B*/, 255/*G*/, 255/*R*/, 255/*alpha*/ };
+      static const uint8_t green[4] = { 0, 255, 0, 255 };
+      static const uint8_t blue[4] = { 255, 0, 0, 255 };
+
       const size_t index = (i * buf_width + j) * 4;
       const float TV = luma_ds[index / 4];
 
       if(TV > six_sigma)
       {
         // Very sharp : paint yellow, BGR = (0, 255, 255)
-        focus_peaking[index + 0] = 0;
-        focus_peaking[index + 1] = 255;
-        focus_peaking[index + 2] = 255;
-
-        // alpha channel
-        focus_peaking[index + 3] = 255;
+        for_four_channels(c) focus_peaking[index + c] = yellow[c];
       }
       else if(TV > four_sigma)
       {
         // Mediun sharp : paint green, BGR = (0, 255, 0)
-        focus_peaking[index + 0] = 0;
-        focus_peaking[index + 1] = 255;
-        focus_peaking[index + 2] = 0;
-
-        // alpha channel
-        focus_peaking[index + 3] = 255;
+        for_four_channels(c) focus_peaking[index + c] = green[c];
       }
       else if(TV > two_sigma)
       {
         // Little sharp : paint blue, BGR = (255, 0, 0)
-        focus_peaking[index + 0] = 255;
-        focus_peaking[index + 1] = 0;
-        focus_peaking[index + 2] = 0;
-
-        // alpha channel
-        focus_peaking[index + 3] = 255;
+        for_four_channels(c) focus_peaking[index + c] = blue[c];
       }
       else
       {
         // Not sharp enough : paint 0
-        focus_peaking[index + 3] = focus_peaking[index + 2] = focus_peaking[index + 1] = focus_peaking[index] = 0;
+        for_four_channels(c) focus_peaking[index + c] = 0;
       }
-    }
-
-  // deal with image borders : top rows
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(focus_peaking, buf_height, buf_width) \
-schedule(static) collapse(2) aligned(focus_peaking:64)
-#endif
-  for(size_t i = 0; i < 4; ++i)
-    for(size_t j = 2; j < buf_width - 2; ++j)
-    {
-      const size_t index = (i * buf_width + j) * 4;
-      focus_peaking[index + 3] = focus_peaking[index + 2] = focus_peaking[index + 1] = focus_peaking[index] = 0;
-    }
-
-  // deal with image borders : left columns
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(focus_peaking, buf_height, buf_width) \
-schedule(static) collapse(2) aligned(focus_peaking:64)
-#endif
-  for(size_t i = 0; i < buf_height; ++i)
-    for(size_t j = 0; j < 4; ++j)
-    {
-      const size_t index = (i * buf_width + j) * 4;
-      focus_peaking[index + 3] = focus_peaking[index + 2] = focus_peaking[index + 1] = focus_peaking[index] = 0;
-    }
-
-  // deal with image borders : right columns
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(focus_peaking, buf_height, buf_width) \
-schedule(static) collapse(2) aligned(focus_peaking:64)
-#endif
-  for(size_t i = 0; i < buf_height; ++i)
-    for(size_t j = buf_width - 5; j < buf_width; ++j)
-    {
-      const size_t index = (i * buf_width + j) * 4;
-      focus_peaking[index + 3] = focus_peaking[index + 2] = focus_peaking[index + 1] = focus_peaking[index] = 0;
-    }
-
-  // deal with image borders : bottom rows
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(focus_peaking, buf_height, buf_width) \
-schedule(static) collapse(2) aligned(focus_peaking:64)
-#endif
-  for(size_t i = buf_height - 5; i < buf_height; ++i)
-    for(size_t j = 0; j < buf_width; ++j)
-    {
-      const size_t index = (i * buf_width + j) * 4;
-      focus_peaking[index + 3] = focus_peaking[index + 2] = focus_peaking[index + 1] = focus_peaking[index] = 0;
     }
 
   // draw the focus peaking overlay


### PR DESCRIPTION
Current master shows random border pixels (mostly yellow and usually on right/bottom) and random yellow blobs for focus peaking on very small thumbnails (toggle on and off quickly to see them).  This PR fixes those, should speed up the code by eliminating four parallelized loops, and hopefully eliminates some vectorization warnings from LLVM/Xcode.

Also did a bit of code cleanup.
