### PR TITLE
fixes for LLVM vectorization warnings

### DIFF
--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -85,9 +85,9 @@ static inline void eigf_variance_analysis(const float *const restrict guide, // 
   float minmg = 10000000.0f;
   float maxmg = 0.0f;
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(guide, mask, in, Ndim) \
-  schedule(simd:static) aligned(guide, mask, in:64) \
+  schedule(simd:static) \
   reduction(max:maxg, maxm, maxg2, maxmg)\
   reduction(min:ming, minm, ming2, minmg)
 #endif
@@ -148,9 +148,9 @@ static inline void eigf_variance_analysis_no_mask(const float *const restrict gu
   float ming2 = 10000000.0f;
   float maxg2 = 0.0f;
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(guide, in, Ndim) \
-  schedule(simd:static) aligned(guide, in:64) \
+  schedule(simd:static) \
   reduction(max:maxg, maxg2)\
   reduction(min:ming, ming2)
 #endif

--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -101,14 +101,14 @@ dt_omp_firstprivate(guide, mask, in, Ndim) \
     in[k * 4 + 1] = pixelg2;
     in[k * 4 + 2] = pixelm;
     in[k * 4 + 3] = pixelmg;
-    if(pixelg < ming) ming = pixelg;
-    if(pixelg > maxg) maxg = pixelg;
-    if(pixelm < minm) minm = pixelm;
-    if(pixelm > maxm) maxm = pixelm;
-    if(pixelg2 < ming2) ming2 = pixelg2;
-    if(pixelg2 > maxg2) maxg2 = pixelg2;
-    if(pixelmg < minmg) minmg = pixelmg;
-    if(pixelmg > maxmg) maxmg = pixelmg;
+    ming = MIN(ming,pixelg);
+    maxg = MAX(maxg,pixelg);
+    minm = MIN(minm,pixelm);
+    maxm = MAX(maxm,pixelm);
+    ming2 = MIN(ming2,pixelg2);
+    maxg2 = MAX(maxg2,pixelg2);
+    minmg = MIN(minmg,pixelmg);
+    maxmg = MAX(maxmg,pixelmg);
   }
 
   float max[4] = {maxg, maxg2, maxm, maxmg};
@@ -160,10 +160,10 @@ dt_omp_firstprivate(guide, in, Ndim) \
     const float pixelg2 = pixelg * pixelg;
     in[2 * k] = pixelg;
     in[2 * k + 1] = pixelg2;
-    if(pixelg < ming) ming = pixelg;
-    if(pixelg > maxg) maxg = pixelg;
-    if(pixelg2 < ming2) ming2 = pixelg2;
-    if(pixelg2 > maxg2) maxg2 = pixelg2;
+    ming = MIN(ming,pixelg);
+    maxg = MAX(maxg,pixelg);
+    ming2 = MIN(ming2,pixelg2);
+    maxg2 = MAX(maxg2,pixelg2);
   }
 
   float max[2] = {maxg, maxg2};

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -109,9 +109,9 @@ static inline void interpolate_bilinear(const float *const restrict in, const si
 {
   // Fast vectorized bilinear interpolation on ch channels
 #ifdef _OPENMP
-#pragma omp parallel for simd collapse(2) default(none) \
-  schedule(simd:static) aligned(in, out:64) \
-  dt_omp_firstprivate(in, out, width_out, height_out, width_in, height_in, ch)
+#pragma omp parallel for collapse(2) default(none) \
+  dt_omp_firstprivate(in, out, width_out, height_out, width_in, height_in, ch) \
+  schedule(simd:static)
 #endif
   for(size_t i = 0; i < height_out; i++)
   {
@@ -153,7 +153,7 @@ static inline void interpolate_bilinear(const float *const restrict in, const si
       // Interpolate over ch layers
       float *const pixel_out = (float *)out + (i * width_out + j) * ch;
 
-#pragma unroll
+//#pragma unroll //LLVM warns it can't unroll -- presumably because 'ch' is not a constant
       for(size_t c = 0; c < ch; c++)
       {
         pixel_out[c] = Dy_prev * (Q_SW[c] * Dx_next + Q_SE[c] * Dx_prev) +

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -39,7 +39,7 @@ static inline uint8_t float_to_uint8(const float i)
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(image:64) uniform(image)
+#pragma omp declare simd aligned(image, index:64) uniform(image)
 #endif
 static inline float laplacian(const float *const image, const size_t index[8])
 {
@@ -109,9 +109,9 @@ static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
   // Compute the gradients magnitudes
   float *const restrict luma_ds =  dt_alloc_align_float((size_t)buf_width * buf_height);
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(luma, luma_ds, buf_height, buf_width) \
-schedule(static) collapse(2) aligned(luma_ds, luma:64)
+schedule(static) collapse(2)
 #endif
   for(size_t i = 0; i < buf_height; ++i)
     for(size_t j = 0; j < buf_width; ++j)
@@ -122,10 +122,10 @@ schedule(static) collapse(2) aligned(luma_ds, luma:64)
         luma_ds[index] = 0.0f;
       else
       {
-        size_t index_close[8];
+        size_t DT_ALIGNED_ARRAY index_close[8];
         get_indices(i, j, buf_width, buf_height, 1, index_close);
 
-        size_t index_far[8];
+        size_t DT_ALIGNED_ARRAY index_far[8];
         get_indices(i, j, buf_width, buf_height, 2, index_far);
 
         // Computing the gradient on the closest neighbours gives us the rate of variation, but doesn't say if we are

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -1489,15 +1489,14 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
     if(profile)
     {
 #ifdef _OPENMP
-#pragma omp parallel for simd schedule(static) default(none) aligned(b:64) \
+#pragma omp parallel for schedule(static) default(none) \
   dt_omp_firstprivate(b, buffsize, profile)
 #endif
       for(size_t j = 0; j < buffsize; j += DT_BLENDIF_LAB_CH)
       {
         float pixel[4] DT_ALIGNED_PIXEL;
-        pixel[0] = b[j + 0];
-        pixel[1] = b[j + 1];
-        pixel[2] = b[j + 2];
+        for_each_channel(c,aligned(b))
+          pixel[c] = b[j+c];
         dt_ioppr_rgb_matrix_to_lab(pixel, b + j, profile->matrix_in, profile->lut_in,
                                    profile->unbounded_coeffs_in, profile->lutsize, profile->nonlinearlut);
       }

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -114,6 +114,9 @@ void dt_masks_extend_border(float *mask, const int width, const int height, cons
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(src, out : 64)
+#endif
 void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, const int width, const int height, const float sigma)
 {
   // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here
@@ -151,10 +154,10 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
   const int w3 = 3*width;
   const int w4 = 4*width;
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(src, out) \
   dt_omp_sharedconst(c42, c41, c40, c33, c32, c31, c30, c22, c21, c20, c11, c10, c00, w1, w2, w3, w4, width, height) \
-  schedule(simd:static) aligned(src, out : 64)
+  schedule(simd:static)
  #endif
   for(int row = 4; row < height - 4; row++)
   {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -653,9 +653,9 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
 
 //  gboolean in_frame = FALSE;
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none)                                                                       \
+#pragma omp parallel for default(none)                                                                       \
     dt_omp_firstprivate(nthreads, pts, pts_count, count, cosv, sinv, xstart, xdelta, curvature, scale, x, y, wd,  \
-                        ht, c_padded_size, points) schedule(static) if(count > 100) aligned(points : 64)
+                        ht, c_padded_size, points) schedule(static) if(count > 100)
 #endif
   for(int i = 3; i < count; i++)
   {

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -193,9 +193,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 static void normalize_manifolds(const float *const restrict blurred_in, float *const restrict blurred_manifold_lower, float *const restrict blurred_manifold_higher, const size_t width, const size_t height, const dt_iop_cacorrectrgb_guide_channel_t guide)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher, width, height, guide) \
-  schedule(simd:static) aligned(blurred_in, blurred_manifold_lower, blurred_manifold_higher:64)
+  schedule(simd:static)
 #endif
   for(size_t k = 0; k < width * height; k++)
   {
@@ -225,7 +225,7 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
       // we make a smooth transition between full manifold at
       // weighth = 0.05f to full average at weighth = 0.01f
       const float w = (weighth - 0.01f) / (0.05f - 0.01f);
-      for(size_t c = 0; c < 3; c++)
+      for_each_channel(c,aligned(blurred_manifold_higher,blurred_in))
       {
         blurred_manifold_higher[k * 4 + c] = w * blurred_manifold_higher[k * 4 + c]
                                            + (1.0f - w) * blurred_in[k * 4 + c];
@@ -236,7 +236,7 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
       // we make a smooth transition between full manifold at
       // weightl = 0.05f to full average at weightl = 0.01f
       const float w = (weightl - 0.01f) / (0.05f - 0.01f);
-      for(size_t c = 0; c < 3; c++)
+      for_each_channel(c,aligned(blurred_manifold_lower,blurred_in))
       {
         blurred_manifold_lower[k * 4 + c] = w * blurred_manifold_lower[k * 4 + c]
                                           + (1.0f - w) * blurred_in[k * 4 + c];
@@ -247,15 +247,15 @@ dt_omp_firstprivate(blurred_in, blurred_manifold_lower, blurred_manifold_higher,
 
 #define DT_CACORRECTRGB_MAX_EV_DIFF 2.0f
 static void get_manifolds(const float* const restrict in, const size_t width, const size_t height,
-                          const size_t ch, const float sigma, const float sigma2,
+                          const float sigma, const float sigma2,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
                           float* const restrict manifolds, gboolean refine_manifolds)
 {
-  float *const restrict blurred_in = dt_alloc_align_float(width * height * ch);
-  float *const restrict manifold_higher = dt_alloc_align_float(width * height * ch);
-  float *const restrict manifold_lower = dt_alloc_align_float(width * height * ch);
-  float *const restrict blurred_manifold_higher = dt_alloc_align_float(width * height * ch);
-  float *const restrict blurred_manifold_lower = dt_alloc_align_float(width * height * ch);
+  float *const restrict blurred_in = dt_alloc_align_float(width * height * 4);
+  float *const restrict manifold_higher = dt_alloc_align_float(width * height * 4);
+  float *const restrict manifold_lower = dt_alloc_align_float(width * height * 4);
+  float *const restrict blurred_manifold_higher = dt_alloc_align_float(width * height * 4);
+  float *const restrict blurred_manifold_lower = dt_alloc_align_float(width * height * 4);
 
   float max[4] = {INFINITY, INFINITY, INFINITY, INFINITY};
   float min[4] = {-INFINITY, -INFINITY, -INFINITY, 0.0f};
@@ -271,9 +271,9 @@ static void get_manifolds(const float* const restrict in, const size_t width, co
   // lower manifold is the blur of all pixels that are below average
   // we use the guide channel to categorize the pixels as above or below average
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, height, guide) \
-  schedule(simd:static) aligned(in, blurred_in, manifold_lower, manifold_higher:64)
+  schedule(simd:static)
 #endif
   for(size_t k = 0; k < width * height; k++)
   {
@@ -340,9 +340,9 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
     // improve result especially on very degraded images
     // we use a blur of normal size for this step
   #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, blurred_manifold_lower, blurred_manifold_higher, width, height, guide) \
-    schedule(simd:static) aligned(in, blurred_in, manifold_lower, manifold_higher, blurred_manifold_lower, blurred_manifold_higher:64)
+    schedule(simd:static)
   #endif
     for(size_t k = 0; k < width * height; k++)
     {
@@ -436,7 +436,7 @@ dt_omp_firstprivate(in, blurred_in, manifold_lower, manifold_higher, width, heig
         manifold_higher[k * 4 + 3] = w;
         // manifold_lower still contains the values from first iteration
         // -> reset it.
-        for(size_t c = 0; c < 4; c++)
+        for_four_channels(c)
         {
           manifold_lower[k * 4 + c] = 0.0f;
         }
@@ -506,17 +506,16 @@ dt_omp_firstprivate(manifolds, blurred_manifold_lower, blurred_manifold_higher, 
 
 static void apply_correction(const float* const restrict in,
                           const float* const restrict manifolds,
-                          const size_t width, const size_t height,
-                          const size_t ch, const float sigma,
+                          const size_t width, const size_t height, const float sigma,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
                           const dt_iop_cacorrectrgb_mode_t mode,
                           float* const restrict out)
 
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
-  schedule(simd:static) aligned(in, manifolds, out)
+  schedule(simd:static)
 #endif
   for(size_t k = 0; k < width * height; k++)
   {
@@ -579,8 +578,7 @@ dt_omp_firstprivate(in, width, height, guide, manifolds, out, sigma, mode) \
 }
 
 static void reduce_artifacts(const float* const restrict in,
-                          const size_t width, const size_t height,
-                          const size_t ch, const float sigma,
+                          const size_t width, const size_t height, const float sigma,
                           const dt_iop_cacorrectrgb_guide_channel_t guide,
                           const float safety,
                           float* const restrict out)
@@ -588,23 +586,23 @@ static void reduce_artifacts(const float* const restrict in,
 {
   // in_out contains the 2 guided channels of in, and the 2 guided channels of out
   // it allows to blur all channels in one 4-channel gaussian blur instead of 2
-  float *const restrict in_out = dt_alloc_align_float(width * height * ch);
+  float *const restrict DT_ALIGNED_PIXEL in_out = dt_alloc_align_float(width * height * 4);
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, out, in_out, width, height, guide, ch) \
-  schedule(simd:static) aligned(in, out, in_out:64)
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(in, out, in_out, width, height, guide)        \
+  schedule(simd:static)
 #endif
   for(size_t k = 0; k < width * height; k++)
   {
     for(size_t kc = 0; kc <= 1; kc++)
     {
       const size_t c = (guide + kc + 1) % 3;
-      in_out[k * ch + kc * 2 + 0] = in[k * 4 + c];
-      in_out[k * ch + kc * 2 + 1] = out[k * 4 + c];
+      in_out[k * 4 + kc * 2 + 0] = in[k * 4 + c];
+      in_out[k * 4 + kc * 2 + 1] = out[k * 4 + c];
     }
   }
 
-  float *const restrict blurred_in_out = dt_alloc_align_float(width * height * ch);
+  float *const restrict blurred_in_out = dt_alloc_align_float(width * height * 4);
   float max[4] = {INFINITY, INFINITY, INFINITY, INFINITY};
   float min[4] = {0.0f, 0.0f, 0.0f, 0.0f};
   dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
@@ -624,7 +622,7 @@ dt_omp_firstprivate(in, out, in_out, width, height, guide, ch) \
   // introduces artefacts in practice.
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety, ch) \
+dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety) \
   schedule(simd:static) aligned(in, out, blurred_in_out:64)
 #endif
   for(size_t k = 0; k < width * height; k++)
@@ -632,14 +630,14 @@ dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety, ch) \
     float w = 1.0f;
     for(size_t kc = 0; kc <= 1; kc++)
     {
-      const float avg_in = log2f(fmaxf(blurred_in_out[k * ch + kc * 2 + 0], 1E-6f));
-      const float avg_out = log2f(fmaxf(blurred_in_out[k * ch + kc * 2 + 1], 1E-6f));
+      const float avg_in = log2f(fmaxf(blurred_in_out[k * 4 + kc * 2 + 0], 1E-6f));
+      const float avg_out = log2f(fmaxf(blurred_in_out[k * 4 + kc * 2 + 1], 1E-6f));
       w *= expf(-fmaxf(fabsf(avg_out - avg_in), 0.01f) * safety);
     }
     for(size_t kc = 0; kc <= 1; kc++)
     {
       const size_t c = (guide + kc + 1) % 3;
-      out[k * ch + c] = fmaxf(1.0f - w, 0.0f) * fmaxf(in[k * ch + c], 0.0f) + w * fmaxf(out[k * ch + c], 0.0f);
+      out[k * 4 + c] = fmaxf(1.0f - w, 0.0f) * fmaxf(in[k * 4 + c], 0.0f) + w * fmaxf(out[k * 4 + c], 0.0f);
     }
   }
   dt_free_align(blurred_in_out);
@@ -658,7 +656,7 @@ static void reduce_chromatic_aberrations(const float* const restrict in,
   const float downsize = fminf(3.0f, sigma);
   const size_t ds_width = width / downsize;
   const size_t ds_height = height / downsize;
-  float *const restrict ds_in = dt_alloc_align_float(ds_width * ds_height * ch);
+  float *const restrict ds_in = dt_alloc_align_float(ds_width * ds_height * 4);
   // we use only one variable for both higher and lower manifolds in order
   // to save time by doing only one bilinear interpolation instead of 2.
   float *const restrict ds_manifolds = dt_alloc_align_float(ds_width * ds_height * 6);
@@ -666,7 +664,7 @@ static void reduce_chromatic_aberrations(const float* const restrict in,
   interpolate_bilinear(in, width, height, ds_in, ds_width, ds_height, 4);
 
   // Compute manifolds
-  get_manifolds(ds_in, ds_width, ds_height, ch, sigma / downsize, sigma2 / downsize, guide, ds_manifolds, refine_manifolds);
+  get_manifolds(ds_in, ds_width, ds_height, sigma / downsize, sigma2 / downsize, guide, ds_manifolds, refine_manifolds);
   dt_free_align(ds_in);
 
   // upscale manifolds
@@ -674,15 +672,19 @@ static void reduce_chromatic_aberrations(const float* const restrict in,
   interpolate_bilinear(ds_manifolds, ds_width, ds_height, manifolds, width, height, 6);
   dt_free_align(ds_manifolds);
 
-  apply_correction(in, manifolds, width, height, ch, sigma, guide, mode, out);
+  apply_correction(in, manifolds, width, height, sigma, guide, mode, out);
   dt_free_align(manifolds);
 
-  reduce_artifacts(in, width, height, ch, sigma, guide, safety, out);
+  reduce_artifacts(in, width, height, sigma, guide, safety, out);
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
+  if (!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return; // ivoid has been copied to ovoid and the module's trouble flag has been set
+
   dt_iop_cacorrectrgb_params_t *d = (dt_iop_cacorrectrgb_params_t *)piece->data;
   // used to adjuste blur level depending on size. Don't amplify noise if magnified > 100%
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
@@ -693,12 +695,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float* out = (float*)ovoid;
   const float sigma = fmaxf(d->radius / scale, 1.0f);
   const float sigma2 = fmaxf(d->radius * d->radius / scale, 1.0f);
-
-  if(ch != 4)
-  {
-    memcpy(out, in, width * height * ch * sizeof(float));
-    return;
-  }
 
   // whether to be very conservative in preserving the original image, or to
   // keep algorithm result even if it overshoots

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -621,9 +621,9 @@ static void reduce_artifacts(const float* const restrict in,
   // we use the same weight for all channels, as using different weights
   // introduces artefacts in practice.
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
 dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety) \
-  schedule(simd:static) aligned(in, out, blurred_in_out:64)
+  schedule(simd:static)
 #endif
   for(size_t k = 0; k < width * height; k++)
   {

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -186,9 +186,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const size_t pixels_y = height / (2 * pixel_radius);
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
   dt_omp_firstprivate(width, height, ch, input, output, pixel_radius, pixels_y, pixels_x) \
-  aligned(input, output:64) \
   schedule(simd:static) collapse(2)
 #endif
     for(size_t j = 0; j < pixels_y + 1; j++)
@@ -212,7 +211,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         for(size_t k = 0; k < 5; k++)
         {
           const float *const restrict pix_in = __builtin_assume_aligned(input + (width * box[k].y + box[k].x) * 4, 16);
-          for(size_t c = 0; c < 4; c++) RGB[c] += pix_in[c] / 5.f;
+          for_four_channels(c)
+            RGB[c] += pix_in[c] / 5.f;
         }
 
         // paint the big pixel with solid color == average
@@ -220,7 +220,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           for(size_t ii = tl.x; ii < br.x; ii++)
           {
             float *const restrict pix_out = __builtin_assume_aligned(output + (jj * width + ii) * 4, 16);
-            for(size_t c = 0; c < 4; c++) pix_out[c] = RGB[c];
+            for_four_channels(c)
+              pix_out[c] = RGB[c];
           }
       }
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -762,6 +762,11 @@ static inline void loop_switch(const float *const restrict in, float *const rest
         for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) temp_one[c] = temp_two[c];
         break;
       }
+      default:
+      {
+        for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) temp_one[c] = temp_two[c];
+        break;
+      }
     }
 
     /* FROM HERE WE ARE MANDATORILY IN XYZ - DATA IS IN temp_one */

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -913,7 +913,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
   {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) reduction(+:xyY, elements) \
-  dt_omp_firstprivate(width, height, temp) \
+  dt_omp_firstprivate(width, height, temp, ch) \
   schedule(simd:static)
 #endif
     for(size_t i = 2 * OFF; i < height - 4 * OFF; i += OFF)
@@ -981,7 +981,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
   {
     #ifdef _OPENMP
 #pragma omp parallel for default(none) reduction(+:xyY, elements) \
-  dt_omp_firstprivate(width, height, temp) \
+  dt_omp_firstprivate(width, height, temp, ch) \
   schedule(simd:static)
 #endif
     for(size_t i = 2 * OFF; i < height - 4 * OFF; i += OFF)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -873,10 +873,9 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
 
    // Convert RGB to xy
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
   dt_omp_firstprivate(width, height, ch, in, temp, RGB_to_XYZ) \
-  aligned(in, temp, RGB_to_XYZ:64) collapse(2)\
-  schedule(simd:static)
+  collapse(2) schedule(simd:static)
 #endif
   for(size_t i = 0; i < height; i++)
     for(size_t j = 0; j < width; j++)
@@ -886,7 +885,8 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
       float DT_ALIGNED_PIXEL XYZ[4];
 
       // Clip negatives
-      for(size_t c = 0; c < 3; c++) RGB[c] = fmaxf(in[index + c], 0.0f);
+      for_each_channel(c,aligned(in))
+        RGB[c] = fmaxf(in[index + c], 0.0f);
 
       // Convert to XYZ
       dot_product(RGB, RGB_to_XYZ, XYZ);
@@ -912,9 +912,8 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
   if(illuminant == DT_ILLUMINANT_DETECT_SURFACES)
   {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) reduction(+:xyY, elements) \
-  dt_omp_firstprivate(width, height, ch, temp) \
-  aligned(temp:64) \
+#pragma omp parallel for default(none) reduction(+:xyY, elements) \
+  dt_omp_firstprivate(width, height, temp) \
   schedule(simd:static)
 #endif
     for(size_t i = 2 * OFF; i < height - 4 * OFF; i += OFF)
@@ -981,9 +980,8 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
   else if(illuminant == DT_ILLUMINANT_DETECT_EDGES)
   {
     #ifdef _OPENMP
-#pragma omp parallel for simd default(none) reduction(+:xyY, elements) \
-  dt_omp_firstprivate(width, height, ch, temp) \
-  aligned(temp:64) \
+#pragma omp parallel for default(none) reduction(+:xyY, elements) \
+  dt_omp_firstprivate(width, height, temp) \
   schedule(simd:static)
 #endif
     for(size_t i = 2 * OFF; i < height - 4 * OFF; i += OFF)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -640,7 +640,9 @@ static inline void luma_chroma(const float input[4], const float saturation[4], 
   }
 }
 
-
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out, XYZ_to_RGB, RGB_to_XYZ, MIX : 64) aligned(illuminant, saturation, lightness, grey:16)
+#endif
 static inline void loop_switch(const float *const restrict in, float *const restrict out,
                                const size_t width, const size_t height, const size_t ch,
                                const float XYZ_to_RGB[3][4], const float RGB_to_XYZ[3][4], const float MIX[3][4],
@@ -650,9 +652,8 @@ static inline void loop_switch(const float *const restrict in, float *const rest
                                const dt_iop_channelmixer_rgb_version_t version)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
   dt_omp_firstprivate(width, height, ch, in, out, XYZ_to_RGB, RGB_to_XYZ, MIX, illuminant, saturation, lightness, grey, p, gamut, clip, apply_grey, kind, version) \
-  aligned(in, out, XYZ_to_RGB, RGB_to_XYZ, MIX:64) aligned(illuminant, saturation, lightness, grey:16)\
   schedule(simd:static)
 #endif
   for(size_t k = 0; k < height * width * 4; k += 4)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -473,9 +473,9 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
     keystone_get_matrix(k_space, kxa, kxb, kxc, kxd, kya, kyb, kyc, kyd, &ma, &mb, &md, &me, &mg, &mh);
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
     dt_omp_firstprivate(points_count, points, d, factor, k_space, ma, mb, md, me, mg, mh, kxa, kya) \
-    schedule(static) if(points_count > 100) aligned(points:64) aligned(k_space:16)
+    schedule(static) if(points_count > 100)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1346,7 +1346,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   const size_t checker_2 = 2 * checker_1;
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
   dt_omp_firstprivate(data, graph_height, line_height, checker_1, checker_2) \
   schedule(static) collapse(2)
 #endif

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -230,9 +230,8 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   if (d->unbound)
   {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
   dt_omp_firstprivate(in, out, offset, npixels, scale) \
-  aligned(in, out : 64) \
   schedule(static)
 #endif
     for(int j = 0; j < 4 * npixels; j += 4)
@@ -243,9 +242,8 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   else
   {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
   dt_omp_firstprivate(in, out, max, min, offset, npixels, scale) \
-  aligned(in, out : 64) \
   schedule(static)
 #endif
     for(int j = 0; j < 4 * npixels; j += 4)

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -201,9 +201,9 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   if (d->orientation == 0) return 1;
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
     dt_omp_firstprivate(points_count, points, d, piece) \
-    schedule(static) if(points_count > 100) aligned(points:64)
+    schedule(static) if(points_count > 500)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -233,9 +233,9 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   if (d->orientation == 0) return 1;
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
     dt_omp_firstprivate(points_count, points, d, piece) \
-    schedule(static) if(points_count > 100) aligned(points:64)
+    schedule(static) if(points_count > 500)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
   {

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -231,7 +231,7 @@ static void _channel_display_false_color(const float *const restrict in, uint8_t
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_HSL_H:
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) schedule(static) aligned(in, out: 64) aligned(mask_color: 16) \
+#pragma omp parallel for default(none) schedule(static) \
     dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
 #endif
       for(size_t j = 0; j < buffsize; j += 4)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1288,9 +1288,9 @@ static int _distort_xtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
     dt_omp_firstprivate(points_count, points, scale) \
-    schedule(static) if(points_count > 100) aligned(points:64) \
+    schedule(simd:static) if(points_count > 100)          \
     reduction(min:xmin, ymin) reduction(max:xmax, ymax)
 #endif
   for(size_t i = 0; i < points_count * 2; i += 2)
@@ -1336,9 +1336,9 @@ static int _distort_xtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
     // apply distortion to all points (this is a simple displacement given by a vector at this same point in the map)
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
+#pragma omp parallel for default(none) \
     dt_omp_firstprivate(points_count, points, scale, extent, map, map_size, y_last, x_last) \
-    schedule(static) if(points_count > 100) aligned(points:64)
+    schedule(static) if(points_count > 100)
 #endif
     for(size_t i = 0; i < points_count; i++)
     {


### PR DESCRIPTION
Trying to eliminate the warnings LLVM and Xcode generate in various files when unable to vectorize a loop.  These seem to be primarily the result of demanding vectorization with "#pragma omp parallel for simd" on loops whose bodies can't possibly be vectorized.

Did some additional vectorization-related code cleanup while touching the files anyway.

Although the full integration test suite reports 30 tests above threshold (including 0083 with dramatic differences from expected.png), the results match between master and this PR. so the changes happened in previous code updates.  BTW, there's a bug in `run.sh` that prevents it from counting any test as having failed no matter how large the dE -- now that it pipes the output of `deltae` through `tee`, the retrieved exit code is that from `tee`, which is always zero....  I made a q&d fix by removing the logfile output.

