### PR TITLE
use gtk check menus to indicate choosen preset/blendmode

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1831,7 +1831,7 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 button:hover,
 #add-color-button:hover,
 menuitem:hover,
-menuitem:hover > *,
+menuitem:hover > *:not(check),
 combobox window *:hover,
 radiobutton:hover label,
 #control-button:hover,
@@ -1930,9 +1930,11 @@ button:disabled,
 }
 
 /* Treeviews and filechoosers states */
-treeview check /* set specific background color about check buttons in treeviews like copy/paste dialog window */
+treeview check, /* set specific background color about check buttons like in copy/paste dialog window */
+menuitem check
 {
   background-color: @field_selected_bg;
+  border-color: @field_selected_bg;
 }
 
 treeview:not(#lutname) *:hover:not(check),
@@ -1960,17 +1962,17 @@ filechooser *:selected
   color: @field_selected_fg;
 }
 
-treeview check:selected
+treeview check:selected,
+menuitem check:selected
 {
   background-color: @button_bg;
   border-color: @plugin_bg_color;
 }
 
-treeview check:hover
+treeview check:hover,
+menuitem check:hover
 {
-  background-color: @bauhaus_bg_hover;
   color: @field_hover_fg;
-  border-color: @selected_bg_color;
 }
 
 filechooser checkbutton:checked
@@ -2638,7 +2640,7 @@ Details :
 }
 
 /* Set active menu items: needed for some Pango issues not rendering synthetic bold for all OS */
-.active-menu-item *
+.active-menu-item label
 {
-    font-weight: bold;
+  font-weight: bold;
 }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1725,24 +1725,33 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     // should not be activated for RGB modules before colorin and after colorout)
     if(module_cst == DEVELOP_BLEND_CS_LAB)
     {
-      mi = gtk_menu_item_new_with_label(_("Lab"));
+      mi = gtk_check_menu_item_new_with_label(_("Lab"));
       if(module_blend_cst == DEVELOP_BLEND_CS_LAB)
+      {
+        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
         gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+      }
       g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_LAB), NULL);
       g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     }
 
-    mi = gtk_menu_item_new_with_label(_("RGB (display)"));
+    mi = gtk_check_menu_item_new_with_label(_("RGB (display)"));
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_DISPLAY)
+    {
+      gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
       gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+    }
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_DISPLAY), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
-    mi = gtk_menu_item_new_with_label(_("RGB (scene)"));
+    mi = gtk_check_menu_item_new_with_label(_("RGB (scene)"));
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_SCENE)
+    {
+      gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
       gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+    }
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_SCENE), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1393,7 +1393,7 @@ static void _dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int3
       label = g_strdup_printf("%s %s", name, _("(default)"));
     else
       label = g_strdup(name);
-    mi = gtk_menu_item_new_with_label(label);
+    mi = gtk_check_menu_item_new_with_label(label);
     g_free(label);
 
     if(module
@@ -1404,6 +1404,7 @@ static void _dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int3
       active_preset = cnt;
       writeprotect = sqlite3_column_int(stmt, 2);
       gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+      gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
     }
 
     if(isdisabled)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -474,7 +474,8 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo)
     {
       active_preset = cnt;
       selected_writeprotect = writeprotect;
-      mi = gtk_menu_item_new_with_label(name);
+      mi = gtk_check_menu_item_new_with_label(name);
+      gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
       gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
     }
     else


### PR DESCRIPTION
Fixes #3843

This PR makes use of gtk's native check menu functionality.

This makes choosen preset or blending mode stand out more in case the bold doesn't do it's job properly ;)

The way to get of squares in non-choosen menu items would be to use normal menu item for not choosen thingie, but i guess it's fine as is.