### PR TITLE
simplify preferences content

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -147,7 +147,7 @@
     <default>5</default>
     <shortdescription>waiting time between each picture in slideshow</shortdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="other">
+  <dtconfig>
     <name>ui_last/no_april1st</name>
     <type>bool</type>
     <default>true</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -153,21 +153,21 @@
     <default>true</default>
     <shortdescription>do not show april 1st game</shortdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu" restart="true">
+  <dtconfig prefs="processing" section="cpugpu" restart="true">
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
     <default>(1024 * 1024 * 512)</default>
     <shortdescription>memory in megabytes to use for thumbnail cache</shortdescription>
     <longdescription>this controls how much memory is going to be used for thumbnails and other buffers (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu">
+  <dtconfig prefs="processing" section="cpugpu">
     <name>cache_disk_backend</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>enable disk backend for thumbnail cache</shortdescription>
     <longdescription>if enabled, write thumbnails to disk (.cache/darktable/) when evicted from the memory cache. note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again. it's safe though to delete these manually, if you want. light table performance will be increased greatly when browsing a lot. to generate all thumbnails of your entire collection offline, run 'darktable-generate-cache'.</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu">
+  <dtconfig prefs="processing" section="cpugpu">
     <name>cache_disk_backend_full</name>
     <type>bool</type>
     <default>false</default>
@@ -181,14 +181,14 @@
     <shortdescription>color manage cached thumbnails</shortdescription>
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu" restart="true">
+  <dtconfig prefs="processing" section="cpugpu" restart="true">
     <name>host_memory_limit</name>
     <type>int</type>
     <default>1500</default>
     <shortdescription>host memory limit (in MB) for tiling</shortdescription>
     <longdescription>this variable controls the maximum amount of memory (in MB) a module may use during image processing. lower values will force memory hungry modules to process image with increasing number of tiles. setting this to 0 will omit any limit. values below 500 will be treated as 500 (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu" restart="true">
+  <dtconfig prefs="processing" section="cpugpu" restart="true">
     <name>singlebuffer_limit</name>
     <type min="2" max="64">int</type>
     <default>16</default>
@@ -332,14 +332,14 @@
     <shortdescription>tags case sensitivity</shortdescription>
     <longdescription>tags case sensitivity. without the Sqlite ICU extension, insensivity works only for the 26 latin letters</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu" capability="opencl">
+  <dtconfig prefs="processing" section="cpugpu" capability="opencl">
     <name>opencl</name>
     <type>bool</type>
     <default>${DEFCONFIG_OPENCL}</default>
     <shortdescription>activate OpenCL support</shortdescription>
     <longdescription>if found, use OpenCL runtime on your system for improved processing speed. can be switched on and off at any time.</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu" capability="opencl">
+  <dtconfig prefs="processing" section="cpugpu" capability="opencl">
     <name>opencl_scheduling_profile</name>
     <type>
       <enum>
@@ -1972,7 +1972,7 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>plugins/lighttable/export/force_lcms2</name>
     <type>bool</type>
     <default>false</default>
@@ -2102,7 +2102,7 @@
     <shortdescription>show loading screen between images</shortdescription>
     <longdescription>show gray loading screen when navigating between images in the darkroom\ndisable to just show a toast message</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>plugins/lighttable/export/pixel_interpolator_warp</name>
     <type>
       <enum>
@@ -2115,7 +2115,7 @@
     <shortdescription>pixel interpolator (warp)</shortdescription>
     <longdescription>pixel interpolator used in modules for rotation, lens correction, liquify, cropping and final scaling (bilinear, bicubic, lanczos2).</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>plugins/lighttable/export/pixel_interpolator</name>
     <type>
       <enum>
@@ -2877,14 +2877,14 @@
     <shortdescription>executable for playing audio files</shortdescription>
     <longdescription>this external program is used to play audio files some cameras record to keep notes for images</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing" restart="true">
+  <dtconfig prefs="processing" section="general" restart="true">
     <name>plugins/darkroom/lut3d/def_path</name>
     <type>dir</type>
     <default></default>
     <shortdescription>3D lut root folder</shortdescription>
     <longdescription>this folder (and sub-folders) contains Lut files used by lut3d modules. (need a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/workflow</name>
     <type>
       <enum>
@@ -2897,7 +2897,7 @@
     <shortdescription>auto-apply pixel workflow defaults</shortdescription>
     <longdescription>scene-referred workflow is based on linear modules and will auto-apply filmic and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve and the legacy module pipe order.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/chromatic-adaptation</name>
     <type>
       <enum>
@@ -2909,28 +2909,28 @@
     <shortdescription>auto-apply chromatic adaptation defaults</shortdescription>
     <longdescription>legacy performs a basic chromatic adaptation using only the white balance module\nmodern uses a combination of white balance module and color calibration module, with improved color science for chromatic adaptation.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing" restart="true">
+  <dtconfig prefs="processing" section="general" restart="true">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>auto-apply per camera basecurve presets</shortdescription>
     <longdescription>use the per-camera basecurve by default instead of the generic manufacturer one if there is one available (needs a restart).\nthis option is taken into account when the \"auto-apply pixel workflow defaults\" is set to \"display-referred\".\nto prevent auto-apply basecurve presets \"auto-apply pixel workflow defaults\" should be set to \"none\"</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/sharpen/auto_apply</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>auto-apply sharpen</shortdescription>
     <longdescription>this added sharpen is not recommended on cameras without a low-pass filter. you should disable this option if you use one of those more recent cameras or sharpen your images with other means.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" section="general">
     <name>ui/detect_mono_exif</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>detect monochrome previews</shortdescription>
     <longdescription>many monochrome images can be identified via exif and preview data. beware: this slows down imports and reading exif data</longdescription>
  </dtconfig>
- <dtconfig prefs="processing">
+ <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/show_warnings</name>
     <type>bool</type>
     <default>true</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -709,7 +709,7 @@
   <dtconfig>
     <name>ui_last/shortcuts_dialog_height</name>
     <type>int</type>
-    <default>750</default>
+    <default>700</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>
@@ -723,7 +723,7 @@
   <dtconfig>
     <name>ui_last/preferences_dialog_height</name>
     <type>int</type>
-    <default>750</default>
+    <default>700</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -393,49 +393,49 @@
     <shortdescription>assumed maximum sane number of tiles</shortdescription>
     <longdescription>if during tiling this number is exceeded darktable assumes that tiling is not possible and falls back to untiled processing - with all system memory limits taking full effect. in case you want to process huge images you may want to increase this number.</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>ask_before_remove</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before removing images from the library</shortdescription>
     <longdescription>always ask the user before any image is removed from the library</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>ask_before_delete</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before deleting images from disk</shortdescription>
     <longdescription>always ask the user before any image file is deleted</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>ask_before_discard</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before discarding history stack</shortdescription>
     <longdescription>always ask the user before history stack is discarded on any image</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>send_to_trash</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>try to use trash when deleting images</shortdescription>
     <longdescription>send files to trash instead of permanently deleting files on system that supports it</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>ask_before_move</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before moving images from film roll folder</shortdescription>
     <longdescription>always ask the user before any image file is moved.</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>ask_before_copy</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before copying images to new film roll folder</shortdescription>
     <longdescription>always ask the user before any image file is copied.</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>ask_before_rmdir</name>
     <type>bool</type>
     <default>false</default>
@@ -1595,7 +1595,7 @@
     <shortdescription>show the export module in the darkroom view (as well as in lighttable)</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>plugins/lighttable/tagging/ask_before_delete_tag</name>
     <type>bool</type>
     <default>true</default>
@@ -1700,21 +1700,21 @@
     <shortdescription>height of the metadata version name field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>plugins/lighttable/style/ask_before_delete_style</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before deleting a style</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>plugins/lighttable/preset/ask_before_delete_preset</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before deleting a preset</shortdescription>
     <longdescription>will ask for confirmation before deleting or overwriting a preset</longdescription>
   </dtconfig>
-  <dtconfig prefs="security">
+  <dtconfig prefs="security" section="general">
     <name>plugins/lighttable/export/ask_before_export_overwrite</name>
     <type>bool</type>
     <default>true</default>
@@ -2404,7 +2404,7 @@
     <shortdescription>XCF bit depth (bpp)</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="misc" section="other">
+  <dtconfig prefs="security" section="other">
     <name>plugins/pwstorage/pwstorage_backend</name>
     <type>
       <enum>
@@ -2870,7 +2870,7 @@
     <shortdescription>look for updated xmp files on startup</shortdescription>
     <longdescription>check file modification times of all xmp files on startup to check if any got updated in the meantime</longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="other">
+  <dtconfig prefs="security" section="other">
     <name>plugins/lighttable/audio_player</name>
     <type>string</type>
     <default>${DEFCONFIG_AUDIOPLAYER}</default>

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -579,10 +579,8 @@ void dt_gui_preferences_show()
   init_tab_import(_preferences_dialog, stack);
   init_tab_lighttable(_preferences_dialog, stack);
   init_tab_darkroom(_preferences_dialog, stack);
-  init_tab_other_views(_preferences_dialog, stack);
   init_tab_processing(_preferences_dialog, stack);
   init_tab_security(_preferences_dialog, stack);
-  //init_tab_cpugpu(_preferences_dialog, stack);
   init_tab_storage(_preferences_dialog, stack);
   init_tab_misc(_preferences_dialog, stack);
   init_tab_accels(stack);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -582,7 +582,7 @@ void dt_gui_preferences_show()
   init_tab_other_views(_preferences_dialog, stack);
   init_tab_processing(_preferences_dialog, stack);
   init_tab_security(_preferences_dialog, stack);
-  init_tab_cpugpu(_preferences_dialog, stack);
+  //init_tab_cpugpu(_preferences_dialog, stack);
   init_tab_storage(_preferences_dialog, stack);
   init_tab_misc(_preferences_dialog, stack);
   init_tab_accels(stack);

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -293,7 +293,34 @@ gboolean restart_required = FALSE;
 
   <xsl:text>&#xA;static void&#xA;init_tab_security</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("security"), _("security"));&#xA;</xsl:text>
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security']">
+  <!-- general (confirmations) section -->
+  <xsl:text>
+    {
+      GtkWidget *seclabel = gtk_label_new(_("general"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+    }
+  </xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security' and @section='general']">
+    <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+  <!--<xsl:value-of select="$tab_end" />-->
+
+  <!-- others section -->
+  <xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("other"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+  </xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security' and @section='other']">
     <xsl:apply-templates select="." mode="tab_block"/>
   </xsl:for-each>
   <xsl:value-of select="$tab_end" />
@@ -385,23 +412,9 @@ gboolean restart_required = FALSE;
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='accel']">
     <xsl:apply-templates select="." mode="tab_block"/>
   </xsl:for-each>
-
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("other"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='other']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
   <xsl:value-of select="$tab_end" />
 
-        <!-- import -->
+  <!-- import -->
 
   <xsl:text>&#xA;static void&#xA;init_tab_import</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("import"), _("import"));&#xA;</xsl:text>
 

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -246,40 +246,6 @@ gboolean restart_required = FALSE;
 
   <xsl:value-of select="$tab_end" />
 
-  <!-- other views -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_other_views</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("other views"), _("other views"));&#xA;</xsl:text>
-
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("map / geolocalization"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='otherviews' and @section='geoloc']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- slideshow section -->
-  <xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("slideshow"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='otherviews' and @section='slideshow']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-  <xsl:value-of select="$tab_end" />
-
   <!-- processing -->
 
   <xsl:text>&#xA;static void&#xA;init_tab_processing</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("processing"), _("processing"));&#xA;</xsl:text>
@@ -335,7 +301,6 @@ gboolean restart_required = FALSE;
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security' and @section='general']">
     <xsl:apply-templates select="." mode="tab_block"/>
   </xsl:for-each>
-  <!--<xsl:value-of select="$tab_end" />-->
 
   <!-- others section -->
   <xsl:text>
@@ -427,6 +392,37 @@ gboolean restart_required = FALSE;
 </xsl:text>
 
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='accel']">
+    <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+
+  <!-- other views -->
+
+  <xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("map / geolocalization view"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+  </xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='otherviews' and @section='geoloc']">
+    <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+
+  <!-- slideshow section -->
+  <xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("slideshow view"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='otherviews' and @section='slideshow']">
     <xsl:apply-templates select="." mode="tab_block"/>
   </xsl:for-each>
   <xsl:value-of select="$tab_end" />

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -284,8 +284,36 @@ gboolean restart_required = FALSE;
 
   <xsl:text>&#xA;static void&#xA;init_tab_processing</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("processing"), _("processing"));&#xA;</xsl:text>
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing']">
+  <xsl:text>
+    {
+      GtkWidget *seclabel = gtk_label_new(_("image processing"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+    }
+  </xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing' and @section='general']">
     <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+
+  <!-- cpu/gpu/memory -->
+
+  <xsl:text>
+    {
+      GtkWidget *seclabel = gtk_label_new(_("cpu / gpu / memory"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+    }
+  </xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing' and @section='cpugpu']">
+    <xsl:if test="name != 'opencl' or $HAVE_OPENCL=1">
+      <xsl:apply-templates select="." mode="tab_block"/>
+    </xsl:if>
   </xsl:for-each>
   <xsl:value-of select="$tab_end" />
 
@@ -322,17 +350,6 @@ gboolean restart_required = FALSE;
 
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security' and @section='other']">
     <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-  <xsl:value-of select="$tab_end" />
-
-  <!-- cpu/gpu/memory -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_cpugpu</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_stack_add_titled(GTK_STACK(stack), scroll, _("cpu / gpu / memory"), _("cpu / gpu / memory"));&#xA;</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='cpugpu']">
-    <xsl:if test="name != 'opencl' or $HAVE_OPENCL=1">
-      <xsl:apply-templates select="." mode="tab_block"/>
-    </xsl:if>
   </xsl:for-each>
   <xsl:value-of select="$tab_end" />
 


### PR DESCRIPTION
Fixes #7050

- [x] Remove april 1st game in miscellaneous tab and only let that setting in darktablerc file (keep as deactivated by default)
- [x] Move pass storage backend and playing audio files in security tab
- [x] Split security tab in 2 sections : "general" for actual settings in that tab and "other" one for 2 settings moved from misc tab
- [x] Move then settings in other views in miscellaneous tab (with section name "[view name] view")
- [x] Merged processing and cpu/gpu/memory tabs together under "processing" tab name. Actual settings in processing have  like "processing images" section name

This completes @Nilvus' list as seen in https://github.com/darktable-org/darktable/issues/7050#issuecomment-864553493

this makes settings window somehow needing less space for me :)