### PR TITLE
[CI] Fix mac & windows ci to stop it from exploding on us

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,10 +344,10 @@ jobs:
           - btype: Debug
             compiler: { compiler: GNU,  CC: gcc,   CXX: g++ }
             target: skiptest
-            generator: Ninja
+            generator: MSYS Makefiles
         generator:
           - MSYS Makefiles
-          - Ninja
+          #- Ninja # do enable if confirmed that ninja is innocent in libxcf case
     defaults:
       run:
         shell: msys2 {0}
@@ -477,7 +477,8 @@ jobs:
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
-      GENERATOR: Ninja
+      #GENERATOR: Ninja
+      GENERATOR: Unix Makefiles
       TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,8 +490,8 @@ jobs:
           brew unlink python@3.8
           brew unlink gcc@9
           sudo rm '/usr/local/bin/2to3'
-          brew link --overwrite python@3.9 # workaround introduced 30.12.2021, replace asap.
-          brew upgrade --ignore-pinned
+          brew link --overwrite python@3.9 # workaround introduced 30.12.2020, replace asap.
+          # brew upgrade --ignore-pinned # workaround introduced 18.07.2021, replace asap
           brew tap Homebrew/bundle
           cd src/.ci 
           brew bundle --verbose


### PR DESCRIPTION
Fixes #9560 

This temporarly disables `brew upgrade`. Reasoning is: github keeps mac images relatively up2date while brew upgrade doesn't have non-interactive option of "just going with it" or "force link overwrites". This imo should be addressed by brew team, but oh well.

~sidenote: mac ci can still fail, but it's on XCF lib and i don't have mac to investigate that one.~

//edit: Ninja was to blame.
Now both mac and win use makefiles and things work. TADA.