### PR TITLE
Show slider units in gui where units are known/meaningful

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3095,14 +3095,14 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     bd->feathering_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 250.0, 0.1, 0.0, 1);
     dt_bauhaus_widget_set_label(bd->feathering_radius_slider, N_("blend"), N_("feathering radius"));
-    dt_bauhaus_slider_set_format(bd->feathering_radius_slider, "%.1f");
+    dt_bauhaus_slider_set_format(bd->feathering_radius_slider, "%.1f px");
     gtk_widget_set_tooltip_text(bd->feathering_radius_slider, _("spatial radius of feathering"));
     g_signal_connect(G_OBJECT(bd->feathering_radius_slider), "value-changed",
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->feathering_radius);
 
     bd->blur_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0.1, 0.0, 1);
     dt_bauhaus_widget_set_label(bd->blur_radius_slider, N_("blend"), N_("mask blur"));
-    dt_bauhaus_slider_set_format(bd->blur_radius_slider, "%.1f");
+    dt_bauhaus_slider_set_format(bd->blur_radius_slider, "%.1f px");
     gtk_widget_set_tooltip_text(bd->blur_radius_slider, _("radius for gaussian blur of blend mask"));
     g_signal_connect(G_OBJECT(bd->blur_radius_slider), "value-changed",
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->blur_radius);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3109,6 +3109,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     bd->brightness_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
     dt_bauhaus_widget_set_label(bd->brightness_slider, N_("blend"), N_("mask opacity"));
+    dt_bauhaus_slider_set_factor(bd->brightness_slider, 100.0f);
+    dt_bauhaus_slider_set_format(bd->brightness_slider, "%+.0f%%");
     dt_bauhaus_slider_set_format(bd->brightness_slider, "%.2f");
     gtk_widget_set_tooltip_text(bd->brightness_slider, _("shifts and tilts the tone curve of the blend mask to adjust its "
                                                          "brightness without affecting fully transparent/fully opaque "

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3081,7 +3081,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
     dt_bauhaus_widget_set_label(bd->details_slider, N_("blend"), N_("details threshold"));
-    dt_bauhaus_slider_set_format(bd->details_slider, "%.2f");
+    dt_bauhaus_slider_set_factor(bd->details_slider, 100.0f);
+    dt_bauhaus_slider_set_format(bd->details_slider, "%.0f%%");
     gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask (using raw data), "
                                                       "\npositive values selects areas with strong details, "
                                                       "\nnegative values select flat areas"));

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3101,7 +3101,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                      G_CALLBACK(dt_iop_slider_float_callback), &module->blend_params->feathering_radius);
 
     bd->blur_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0.1, 0.0, 1);
-    dt_bauhaus_widget_set_label(bd->blur_radius_slider, N_("blend"), N_("mask blur"));
+    dt_bauhaus_widget_set_label(bd->blur_radius_slider, N_("blend"), N_("blurring radius"));
     dt_bauhaus_slider_set_format(bd->blur_radius_slider, "%.1f px");
     gtk_widget_set_tooltip_text(bd->blur_radius_slider, _("radius for gaussian blur of blend mask"));
     g_signal_connect(G_OBJECT(bd->blur_radius_slider), "value-changed",
@@ -3111,7 +3111,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     dt_bauhaus_widget_set_label(bd->brightness_slider, N_("blend"), N_("mask opacity"));
     dt_bauhaus_slider_set_factor(bd->brightness_slider, 100.0f);
     dt_bauhaus_slider_set_format(bd->brightness_slider, "%+.0f%%");
-    dt_bauhaus_slider_set_format(bd->brightness_slider, "%.2f");
     gtk_widget_set_tooltip_text(bd->brightness_slider, _("shifts and tilts the tone curve of the blend mask to adjust its "
                                                          "brightness without affecting fully transparent/fully opaque "
                                                          "regions"));

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3118,7 +3118,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     bd->contrast_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
     dt_bauhaus_widget_set_label(bd->contrast_slider, N_("blend"), N_("mask contrast"));
-    dt_bauhaus_slider_set_format(bd->contrast_slider, "%.2f");
+    dt_bauhaus_slider_set_factor(bd->contrast_slider, 100.0f);
+    dt_bauhaus_slider_set_format(bd->contrast_slider, "%+.0f%%");
     gtk_widget_set_tooltip_text(bd->contrast_slider, _("gives the tone curve of the blend mask an s-like shape to "
                                                        "adjust its contrast"));
     g_signal_connect(G_OBJECT(bd->contrast_slider), "value-changed",

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -360,6 +360,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue, _("select the hue tone"));
 
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
+  dt_bauhaus_slider_set_factor(g->saturation, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation, "%.0f%%");
   dt_bauhaus_slider_set_stop(g->saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(g->saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   gtk_widget_set_tooltip_text(g->saturation, _("select the saturation shadow tone"));

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -348,6 +348,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->hue = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, dt_bauhaus_slider_from_params(self, N_("hue")));
   dt_bauhaus_slider_set_feedback(g->hue, 0);
+  dt_bauhaus_slider_set_factor(g->hue, 360.0f);
+  dt_bauhaus_slider_set_format(g->hue, "%.2f°");
   dt_bauhaus_slider_set_stop(g->hue, 0.0f  , 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.322f, 0.0f, 1.0f, 0.0f);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1288,6 +1288,8 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->range, 0.1f);
   g->precedence = dt_bauhaus_combobox_from_params(self, N_("precedence"));
   g->hue = dt_bauhaus_slider_from_params(self, N_("hue"));
+  dt_bauhaus_slider_set_factor(g->hue, 360.0f);
+  dt_bauhaus_slider_set_format(g->hue, "%.2f°");
   dt_bauhaus_slider_set_feedback(g->hue, 0);
   dt_bauhaus_slider_set_stop(g->hue, 0.0f,   1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1115,6 +1115,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->hue = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, dt_bauhaus_slider_from_params(self, "hue"));
   dt_bauhaus_slider_set_feedback(g->hue, 0);
+  dt_bauhaus_slider_set_factor(g->hue, 360.0f);
+  dt_bauhaus_slider_set_format(g->hue, "%.2f°");
   dt_bauhaus_slider_set_stop(g->hue, 0.0f, 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.322f, 0.0f, 1.0f, 0.0f);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1127,6 +1127,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue, _("select the hue tone of filter"));
 
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
+  dt_bauhaus_slider_set_factor(g->saturation, 100.0f);
+  dt_bauhaus_slider_set_format(g->saturation, "%.0f%%");
   dt_bauhaus_slider_set_stop(g->saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(g->saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   gtk_widget_set_tooltip_text(g->saturation, _("select the saturation of filter"));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2336,6 +2336,8 @@ void gui_init(dt_iop_module_t *self)
 
   g->sl_fill_brightness = dt_bauhaus_slider_from_params(self, "fill_brightness");
   dt_bauhaus_slider_set_digits(g->sl_fill_brightness, 4);
+  dt_bauhaus_slider_set_factor(g->sl_fill_brightness, 100.0f);
+  dt_bauhaus_slider_set_format(g->sl_fill_brightness, "%+.2f%%");
   gtk_widget_set_tooltip_text(g->sl_fill_brightness,
                               _("adjusts color brightness to fine-tune it. works with erase as well"));
 
@@ -2347,11 +2349,14 @@ void gui_init(dt_iop_module_t *self)
 
   g->sl_blur_radius = dt_bauhaus_slider_from_params(self, "blur_radius");
   dt_bauhaus_slider_set_step(g->sl_blur_radius, 0.1);
+  dt_bauhaus_slider_set_format(g->sl_blur_radius, "%.1f px");
   gtk_widget_set_tooltip_text(g->sl_blur_radius, _("radius of the selected blur type"));
 
   // mask opacity
   g->sl_mask_opacity = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.05, 1., 3);
   dt_bauhaus_widget_set_label(g->sl_mask_opacity, NULL, N_("mask opacity"));
+  dt_bauhaus_slider_set_factor(g->sl_mask_opacity, 100.0f);
+  dt_bauhaus_slider_set_format(g->sl_mask_opacity, "%.2f%%");
   gtk_widget_set_tooltip_text(g->sl_mask_opacity, _("set the opacity on the selected shape"));
   g_signal_connect(G_OBJECT(g->sl_mask_opacity), "value-changed", G_CALLBACK(rt_mask_opacity_callback), self);
 


### PR DESCRIPTION
Fixes #8980
Fixes #8913

For hues since 0..1 is already in proper size al we need is to multiply by 360 to get degrees,

Other places required some touch ups.

For reasoning see https://github.com/darktable-org/darktable/issues/8980#issuecomment-842307675