### PR TITLE
New feature: lazy xmp files writing (V. 2)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -284,12 +284,12 @@
     <type>
       <enum>
         <option>never</option>
-        <option>very lazy</option>
-        <option>lazy</option>
-        <option>always</option>
+        <option>after first manual edit</option>
+        <option>after first edit</option>
+        <option>on import</option>
       </enum>
     </type>
-    <default>always</default>
+    <default>on import</default>
     <shortdescription>write sidecar file for each image</shortdescription>
     <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.\nFor descriptions of 'lazy' and 'very_lazy' look up in the manual</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -281,10 +281,17 @@
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">
     <name>write_sidecar_files</name>
-    <type>bool</type>
-    <default>true</default>
+    <type>
+      <enum>
+        <option>never</option>
+        <option>very lazy</option>
+        <option>lazy</option>
+        <option>always</option>
+      </enum>
+    </type>
+    <default>always</default>
     <shortdescription>write sidecar file for each image</shortdescription>
-    <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.</longdescription>
+    <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.\nFor descriptions of 'lazy' and 'very_lazy' look up in the manual</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">
     <name>compress_xmp_tags</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -291,7 +291,7 @@
     </type>
     <default>on import</default>
     <shortdescription>write sidecar file for each image</shortdescription>
-    <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.\nFor descriptions of 'lazy' and 'very_lazy' look up in the manual</longdescription>
+    <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be written\n never\n on import: immediately after importing into the database\n after first manual edit: any edit after all defined presets had been applied\n after first edit: any edit after mandatory modules had been applied</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">
     <name>compress_xmp_tags</name>

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -538,7 +538,7 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       }
     }
 
-    if(dt_conf_get_bool("write_sidecar_files") ||
+    if((dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER) ||
        dt_conf_get_bool("ui_last/import_last_tags_imported"))
     {
       GList *tags = NULL;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -297,15 +297,20 @@ dt_imageio_write_xmp_t dt_image_get_xmp_mode()
   const char *config = dt_conf_get_string_const("write_sidecar_files");
   if(config)
   {
-    if(!strcmp(config, "very lazy"))
+    if(!strcmp(config, "after first manual edit"))
       res = DT_WRITE_XMP_VERY_LAZY;
-    if(!strcmp(config, "lazy"))
+    else if(!strcmp(config, "after first edit"))
       res = DT_WRITE_XMP_LAZY;
     else if(!strcmp(config, "never"))
       res = DT_WRITE_XMP_NEVER;
     // migration path from boolean settings in <= 3.6, lazy mode were introduced in 3.8
     else if(!strcmp(config, "FALSE"))
+    {
+      dt_conf_set_string("write_sidecar_files", "never");
       res = DT_WRITE_XMP_NEVER;
+    }
+    else if(!strcmp(config, "TRUE"))
+      dt_conf_set_string("write_sidecar_files", "on import");
   }
   return res;
 }

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2424,10 +2424,10 @@ static gboolean _enforce_xmp_writing(const int32_t imgid)
 
   if(!writing)
   {
-    // now check for geolocalisation, force write XMP if present
+    // now check for duplicates and geolocalisation, force write XMP if present
     sqlite3_stmt *stmt_2;
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-      "SELECT COUNT(*) FROM main.images WHERE id = ?1 AND longitude IS NOT NULL AND latitude IS NOT NULL", -1, &stmt_2, NULL); 
+      "SELECT COUNT(*) FROM main.images WHERE id = ?1 AND ((longitude IS NOT NULL AND latitude IS NOT NULL) OR (max_version > 0))", -1, &stmt_2, NULL); 
     DT_DEBUG_SQLITE3_BIND_INT(stmt_2, 1, imgid);
     if(sqlite3_step(stmt_2) == SQLITE_ROW)
     {

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -37,6 +37,14 @@ typedef enum dt_imageio_retval_t
   DT_IMAGEIO_CACHE_FULL      // dt's caches are full :(
 } dt_imageio_retval_t;
 
+typedef enum dt_imageio_write_xmp_t
+{
+  DT_WRITE_XMP_NEVER = 0,
+  DT_WRITE_XMP_VERY_LAZY = 1,
+  DT_WRITE_XMP_LAZY = 2,
+  DT_WRITE_XMP_ALWAYS = 3
+} dt_imageio_write_xmp_t;
+
 typedef enum
 {
   // the first 0x7 in flags are reserved for star ratings.
@@ -290,6 +298,8 @@ void dt_image_path_append_version_no_db(int version, char *pathname, size_t path
 void dt_image_path_append_version(const int32_t imgid, char *pathname, size_t pathname_len);
 /** prints a one-line exif information string. */
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len);
+/** get the mode xmp sidecars are written */
+dt_imageio_write_xmp_t dt_image_get_xmp_mode();
 /* set rating to img flags */
 void dt_image_set_xmp_rating(dt_image_t *img, const int rating);
 /* get rating from img flags */

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -614,7 +614,7 @@ void dt_metadata_set_import(const int imgid, const char *key, const char *value)
 
   if(keyid != -1) // known key
   {
-    gboolean imported = dt_conf_get_bool("write_sidecar_files");
+    gboolean imported = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
     if(!imported && dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL)
     {
       const gchar *name = dt_metadata_get_name(keyid);

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -60,7 +60,7 @@ GList *dt_control_crawler_run()
 {
   sqlite3_stmt *stmt, *inner_stmt;
   GList *result = NULL;
-  gboolean look_for_xmp = dt_conf_get_bool("write_sidecar_files");
+  gboolean look_for_xmp = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
 
   sqlite3_prepare_v2(dt_database_get(darktable.db),
                      "SELECT i.id, write_timestamp, version, folder || '" G_DIR_SEPARATOR_S "' || filename, flags "

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -144,7 +144,7 @@ static void _import_tags_changed(GtkWidget *widget, dt_import_metadata_t *metada
 
 static void _update_layout(dt_import_metadata_t *metadata)
 {
-  const gboolean write_xmp = dt_conf_get_bool("write_sidecar_files");
+  const gboolean write_xmp = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
   GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_META_HEADER);
   gtk_widget_set_visible(w, !write_xmp);
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)


### PR DESCRIPTION
Second attempt to implement this following discussion in #9538

The sidecar xmp files must be written if
a) there has been a change in developed history after import or
b) any tag, geolocation, color flag or metadata has been added in any way.

So far we have the options "never" and "always" write the sidecar file, via this pr we switch between 4 options, the two we have already and two lazy modes: "lazy" and "very lazy" selected in the preferences menu.

In both lazy modes we check for tags, metadata, colors ... in
a) "very lazy" we compare history to what we have after import including all presets applied, in
b) "lazy" we compare history to status after switching on mandatory modules

This is implemented as suggested using the history hashes.

In image.h we define the xmp-writing modes and a new function `dt_image_get_xmp_mode()` returning the selected mode
via preferences.

All work is done in `dt_image_write_sidecar_file`, if one of the lazy modes is used we test via `dt_history_hash_get_status(imgid)` if we can possibly ignore writing the sidecar file and make sure there is no tag ... forcing us to do so.

Only for the lazy modes there is a performance penalty by database searches, this can likely be ignored as we avoid
writing the sidecar file.

Tested here for some days ...

1) Please review & test
2) Anything i missed?
EDIT removed debugging output 3) for testing the lazy modes try '-d imageio' reporting what is tested and results, the verbose stuff probably should
be removed before possibly getting merged.

Fixes #4450
Fixes #2832