### PR TITLE
Fixing module->trouble widget

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1816,8 +1816,16 @@ void dt_iop_gui_update(dt_iop_module_t *module)
   {
     if(module->gui_data)
     {
-      if(module->params && module->gui_update) module->gui_update(module);
-
+      if(module->params && module->gui_update)
+      {
+        if(module->widget && dt_conf_get_bool("plugins/darkroom/show_warnings"))
+        {
+          GtkWidget *label_widget = dt_gui_container_first_child(GTK_CONTAINER(gtk_widget_get_parent(module->widget)));
+          if(!g_strcmp0(gtk_widget_get_name(label_widget), "iop-plugin-warning")) gtk_widget_destroy(label_widget);
+          module->has_trouble = FALSE;
+        }
+        module->gui_update(module);
+      }
       dt_iop_gui_update_blending(module);
       dt_iop_gui_update_expanded(module);
     }


### PR DESCRIPTION
There is a very lenghty issue #9497, this comes down to:

If we have setup a module trouble widget this is left over when directly changing the image in darkroom.

Why does this happen?
For some modules we have more than one top widget depending on image status like being raw. So there might be
a remaining warning widged. This should cleared in any case we do `dt_iop_gui_update` to ensure proper widgets.

Fixes #9497