### PR TITLE
Fix various source comment typos

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2127,7 +2127,7 @@ Hierarchy :
       #thumb_bottom                                                  (GtkEventBox -- background of the bottom infos area)
         #thumb_bottom_label                                          (GtkLabel -- text of the bottom infos area, just with .dt_extended_overlay)
       #thumb_reject                                                  (GtkDarktableThumbnailBtn -- Reject icon)
-      #thumb_star                                                    (GtkDarktableThumbnailBtn -- Star icon, 5 occurences of this)
+      #thumb_star                                                    (GtkDarktableThumbnailBtn -- Star icon, 5 occurrences of this)
       #thumb_colorlabels                                             (GtkDarktableThumbnailBtn -- colorlabels icon, 1 icon with all labels)
       #thumb_localcopy                                               (GtkDarktableThumbnailBtn -- local copy triangle icon)
       #thumb_altered                                                 (GtkDarktableThumbnailBtn -- altered icon)

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -795,8 +795,8 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
             : high_quality;
 
   /* The pipeline might have out-of-bounds problems at the right and lower borders leading to
-     artefacts or mem access errors if ignored. (#3646)
-     It's very difficult to prepare the pipeline avoiding this **and** not introducing artefacts.
+     artifacts or mem access errors if ignored. (#3646)
+     It's very difficult to prepare the pipeline avoiding this **and** not introducing artifacts.
      But we can test for that situation and if there is an out-of-bounds problem we
      have basically two options:
      a) reduce the output image size by one for width & height.

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1156,7 +1156,7 @@ static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton 
 
     // note that a ctrl+click followed by a shift-click must keep the
     // toggle button active. But a single click must invert current
-    // toggle buttong.  That's why we check for request_mask_display
+    // toggle button.  That's why we check for request_mask_display
     // value below. But note that the toggle button state has not yet
     // been inverted by Gtk at this stage. So if a button must be ON
     // we ensure it is OFF now.

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -26,7 +26,7 @@
   As the DM using algorithms (like dual demosaicing, sharpening ...) are all pixel peeping we
   want the "original data" from the sensor to calculate it.
   (Calculating the mask from the modules roi might not detect such regions at all because of
-  scaling / rotating artefacts, some blurring earlier in the pipeline, color changes ...)
+  scaling / rotating artifacts, some blurring earlier in the pipeline, color changes ...)
 
   In all cases the user interface is pretty simple, we just pass a threshold value, which
   is in the range of -1.0 to 1.0 by an additional slider in the masks refinement section.
@@ -74,7 +74,7 @@
 
   Some additional comments:
   1. intentionally this details mask refinement has only been implemented for raws. Especially for compressed
-     inmages like jpegs or 8bit input the algo didn't work as good because of input precision and compression artefacts.
+     inmages like jpegs or 8bit input the algo didn't work as good because of input precision and compression artifacts.
   2. In the gui the slider is above the rest of the refinemt sliders to emphasize that blurring & feathering use the
      mask corrected by detail refinemnt.
   3. Of course credit goes to Ingo @heckflosse from rt team for the original idea. (in the rt world this is knowb

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -70,7 +70,7 @@ typedef struct dt_iop_borders_params_t
                                DEFAULT: "constant border" */
   int aspect_orient;        /* aspect ratio orientation
                                $DEFAULT: 0 $DESCRIPTION: "orientation" */
-  float size;               /* border width relative to overal frame width
+  float size;               /* border width relative to overall frame width
                                $MIN: 0.0 $MAX: 0.5 $DEFAULT: 0.1 $DESCRIPTION: "border size" */
   float pos_h;              /* picture horizontal position ratio into the final image
                                $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.5 $DESCRIPTION: "horizontal offset" */
@@ -120,7 +120,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     {
       float color[3]; // border color
       float aspect;   // aspect ratio of the outer frame w/h
-      float size;     // border width relative to overal frame width
+      float size;     // border width relative to overall frame width
     } dt_iop_borders_params_v1_t;
 
     dt_iop_borders_params_v1_t *o = (dt_iop_borders_params_v1_t *)old_params;
@@ -146,7 +146,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       float aspect;         // aspect ratio of the outer frame w/h
       char aspect_text[20]; // aspect ratio of the outer frame w/h (user string version)
       int aspect_orient;    // aspect ratio orientation
-      float size;           // border width relative to overal frame width
+      float size;           // border width relative to overall frame width
       float pos_h;          // picture horizontal position ratio into the final image
       char pos_h_text[20];  // picture horizontal position ratio into the final image (user string version)
       float pos_v;          // picture vertical position ratio into the final image

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -272,7 +272,7 @@ static inline void pixSort(float *a, float *b)
 
 /*
   We want to avoid the module being processed in case the provided size of data is too small resulting in
-  really bad artefacts. This is often the case while zooming in with the current dt pipeline.
+  really bad artifacts. This is often the case while zooming in with the current dt pipeline.
   There is no "maths background" so i chose this after a lot of testing.
 */
 #define CA_SIZE_MINIMUM (1600)

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -621,7 +621,7 @@ dt_omp_firstprivate(in, out, in_out, width, height, guide, ch) \
   // we do a weighted average between input and output, keeping more input if
   // the local averages are very different.
   // we use the same weight for all channels, as using different weights
-  // introduces artefacts in practice.
+  // introduces artifacts in practice.
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
 dt_omp_firstprivate(in, out, blurred_in_out, width, height, guide, safety, ch) \

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5766,7 +5766,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->dual_mask, FALSE, FALSE, 0);
 
   g->lmmse_refine = dt_bauhaus_combobox_from_params(self, "lmmse_refine");
-  gtk_widget_set_tooltip_text(g->lmmse_refine, _("LMMSE refinement steps. the median steps avarage the output,\nrefine adds some recalculation of red & blue channels."));
+  gtk_widget_set_tooltip_text(g->lmmse_refine, _("LMMSE refinement steps. the median steps average the output,\nrefine adds some recalculation of red & blue channels."));
 
   g->color_smoothing = dt_bauhaus_combobox_from_params(self, "color_smoothing");
   gtk_widget_set_tooltip_text(g->color_smoothing, _("how many color smoothing median steps after demosaicing"));

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1489,6 +1489,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->threshold,
                               _("luminance threshold for the mask.\n"
                                 "0. disables the luminance masking and applies the module on the whole image.\n"
-                                "any higher value excludes pixels whith luminance lower than the threshold.\n"
+                                "any higher value excludes pixels with luminance lower than the threshold.\n"
                                 "this can be used to inpaint highlights."));
 }

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -226,7 +226,7 @@ DEFAULT(dt_introspection_field_t *, get_introspection_linear, void);
 DEFAULT(void *, get_p, const void *param, const char *name);
 DEFAULT(dt_introspection_field_t *, get_f, const char *name);
 
-// optionnal preference entry to add at the bottom of the preset menu
+// optional preference entry to add at the bottom of the preset menu
 OPTIONAL(void, set_preferences, void *menu, struct dt_iop_module_t *self);
 
 #ifdef FULL_API_H

--- a/src/iop/lmmse_demosaic.c
+++ b/src/iop/lmmse_demosaic.c
@@ -18,7 +18,7 @@
 
 /*
     The lmmse code base used for the darktable port has been taken from rawtherapee derived librtprocess.
-    Adaption for dt and tiling - hanno schwalm 06/2021
+    Adapt for dt and tiling - hanno schwalm 06/2021
 
     LSMME demosaicing algorithm
     L. Zhang and X. Wu,
@@ -196,7 +196,7 @@ static void lmmse_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict 
         const int tileRows = MIN(rowEnd - rowStart, LMMSE_TILESIZE);
         const int tileCols = MIN(colEnd - colStart, LMMSE_TILESIZE);
 
-        // index limit; normally is LMMSE_GRP but maybe missing bottom lines or right colums for outermost  tile
+        // index limit; normally is LMMSE_GRP but maybe missing bottom lines or right columns for outermost tile
         const int last_rr = tileRows + 2 * BORDER_AROUND;
         const int last_cc = tileCols + 2 * BORDER_AROUND;
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -593,7 +593,7 @@ void gui_update(dt_iop_module_t *self)
   const gboolean is_monochrome = (self->dev->image_storage.flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) != 0;
   if(is_monochrome)
   {
-    // we might have to deal with old edits, so get avarage first
+    // we might have to deal with old edits, so get average first
     int av = 2; // for rounding
     for(int i = 0; i < 4; i++)
       av += p->raw_black_level_separate[i];

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -586,8 +586,8 @@ static int sanity_check(dt_iop_module_t *self)
 
   if(position_self < position_min && self->enabled)
   {
-    dt_control_log(_("tone equalizer needs to be after distorsion modules in the pipeline – disabled"));
-    fprintf(stdout, "tone equalizer needs to be after distorsion modules in the pipeline – disabled\n");
+    dt_control_log(_("tone equalizer needs to be after distortion modules in the pipeline – disabled"));
+    fprintf(stdout, "tone equalizer needs to be after distortion modules in the pipeline – disabled\n");
     self->enabled = 0;
     dt_dev_add_history_item(darktable.develop, self, FALSE);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3757,7 +3757,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(vb), hb2, FALSE, TRUE, 2);
   gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, TRUE, 2);
 
-  // presets settings (search + quick acces)
+  // presets settings (search + quick access)
   vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   d->edit_search_cb = gtk_check_button_new_with_label(_("show search line"));
   gtk_widget_set_name(d->edit_search_cb, "modulegroups_editor_setting");

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2727,7 +2727,7 @@ static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkTreeView *tree = GTK_TREE_VIEW(widget);
-  // disable the deault handler
+  // disable the default handler
   g_signal_stop_emission_by_name(tree, "drag-data-received");
   gboolean success = FALSE;
 

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1457,7 +1457,7 @@ static void _view_map_changed_callback(OsmGpsMap *map, dt_view_t *self)
     return;
   }
 
-  // "changed" event can be high frequence. As calculation is heavy we don't to repeat it.
+  // "changed" event can be high frequency. As calculation is heavy we don't to repeat it.
   if(!lib->time_out)
   {
     g_timeout_add(100, _view_map_changed_callback_wait, self);

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -226,7 +226,7 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr,
   cairo_rectangle (cr, px, py, pwidth, pheight);
   cairo_fill (cr);
 
-  // record the screen page dimention. this will be used to compute the actual
+  // record the screen page dimension. this will be used to compute the actual
   // layout of the areas placed over the page.
 
   dt_printing_setup_display(prt->imgs,


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,./src/external,./src/common,./data/pswp -L ba,bloc,dinamic,hist,ist,inout,uint,ue,webp`