### PR TITLE
Fix retouch

### DIFF
--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3193,9 +3193,8 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
                          dt_iop_roi_t *const roi_mask_scaled, const float opacity, const int blur_type,
                          const float blur_radius, dt_dev_pixelpipe_iop_t *piece, const int use_sse)
 {
-  if(fabsf(blur_radius) <= 0.1f) return;
-
-  const float sigma = blur_radius * roi_in->scale / piece->iscale;
+  const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
+  const float sigma = blur_radius / scale;
 
   float *img_dest = NULL;
 
@@ -3920,9 +3919,8 @@ static cl_int retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *c
 {
   cl_int err = CL_SUCCESS;
 
-  if(fabsf(blur_radius) <= 0.1f) return err;
-
-  const float sigma = blur_radius * roi_layer->scale / piece->iscale;
+  const float scale = fmaxf(piece->iscale / roi_layer->scale, 1.f);
+  const float sigma = blur_radius / scale;
   const int ch = 4;
 
   const cl_mem dev_dest =

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3480,6 +3480,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 
   const int gui_active = (self->dev) ? (self == self->dev->gui_module) : 0;
   const int display_wavelet_scale = (g && gui_active) ? g->display_wavelet_scale : 0;
+  const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
 
   // we will do all the clone, heal, etc on the input image,
   // this way the source for one algorithm can be the destination from a previous one
@@ -3501,7 +3502,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   dwt_p = dt_dwt_init(in_retouch, roi_rt->width, roi_rt->height, 4, p->num_scales,
                       (!display_wavelet_scale || (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) != DT_DEV_PIXELPIPE_FULL) ? 0 : p->curr_scale,
                       p->merge_from_scale, &usr_data,
-                      roi_in->scale / piece->iscale, use_sse);
+                      1.f / scale, use_sse);
   if(dwt_p == NULL) goto cleanup;
 
   // check if this module should expose mask.
@@ -4292,6 +4293,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   const int gui_active = (self->dev) ? (self == self->dev->gui_module) : 0;
   const int display_wavelet_scale = (g && gui_active) ? g->display_wavelet_scale : 0;
+  const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
 
   // we will do all the clone, heal, etc on the input image,
   // this way the source for one algorithm can be the destination from a previous one
@@ -4325,7 +4327,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                          (!display_wavelet_scale
                           || (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) != DT_DEV_PIXELPIPE_FULL) ? 0 : p->curr_scale,
                          p->merge_from_scale, &usr_data,
-                         roi_in->scale / piece->iscale);
+                         1.f / scale);
   if(dwt_p == NULL)
   {
     fprintf(stderr, "process_internal: error initializing wavelet decompose\n");

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3548,22 +3548,16 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     {
       g->preview_auto_levels = -1;
 
-      dt_iop_gui_leave_critical_section(self);
-
       levels[0] = levels[1] = levels[2] = 0;
       rt_process_stats(self, piece, in_retouch, roi_rt->width, roi_rt->height, 4, levels);
       rt_clamp_minmax(levels, levels);
 
       for(int i = 0; i < 3; i++) g->preview_levels[i] = levels[i];
 
-      dt_iop_gui_enter_critical_section(self);
       g->preview_auto_levels = 2;
-      dt_iop_gui_leave_critical_section(self);
     }
-    else
-    {
-      dt_iop_gui_leave_critical_section(self);
-    }
+
+    dt_iop_gui_leave_critical_section(self);
   }
 
   // if user wants to preview a detail scale adjust levels
@@ -4391,8 +4385,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     {
       g->preview_auto_levels = -1;
 
-      dt_iop_gui_leave_critical_section(self);
-
       levels[0] = levels[1] = levels[2] = 0;
       err = rt_process_stats_cl(self, piece, devid, in_retouch, roi_rt->width, roi_rt->height, levels);
       if(err != CL_SUCCESS) goto cleanup;
@@ -4401,14 +4393,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
       for(int i = 0; i < 3; i++) g->preview_levels[i] = levels[i];
 
-      dt_iop_gui_enter_critical_section(self);
       g->preview_auto_levels = 2;
-      dt_iop_gui_leave_critical_section(self);
     }
-    else
-    {
-      dt_iop_gui_leave_critical_section(self);
-    }
+    dt_iop_gui_leave_critical_section(self);
   }
 
   // if user wants to preview a detail scale adjust levels


### PR DESCRIPTION
This PR attempts to fix various inconsistencies in retouch module in order to troubleshoot a particular problem describe at the end (not yet solved).

bac5bbb aims at fixing preview inconsistencies occuring when refreshing the preview (in wavelet scale preview mode). Basically, from one refresh to another, the preview could be full white, full black and sometimes properly showing the details in the current wavelet scale. 

The next commits try to prevent oversampling the blurring radius, consistently with all the other spatial filters (this issue was already corrected in low pass, contrast equalizer, etc.). When the zoom level of the preview is > 100 %, the pixel pipe is still scaled at 100% and the preview is only upscaled before drawing the GUI, so the blurring radius scaling should always be bounded at 100%.

The problem at hand is an inconsistency of the preview, when using split-frequency gaussian blurring on the 4th scale.

Here is the preview at 1:1 (100%) :
![Screenshot_20210723_154941](https://user-images.githubusercontent.com/2779157/126792173-e66d2d02-6c53-4a77-a52d-496790bcf4d8.jpg)

Same preview at 50%:
![Screenshot_20210723_155059](https://user-images.githubusercontent.com/2779157/126792213-9c67daca-6462-4ee6-9ddc-b2e3594ea7ce.jpg)

Same preview between 25-33% (fit screen):
![Screenshot_20210723_155133](https://user-images.githubusercontent.com/2779157/126792256-aadce1c5-a38b-4569-98c5-1c3dfa1c39a5.jpg)

Here is the mask incriminated:
![Screenshot_20210723_155228](https://user-images.githubusercontent.com/2779157/126792292-3d0aad7f-31cf-402d-aa7a-d466cafcc614.jpg)

The current wavelet scale preview at 1:1:
![Screenshot_20210723_155340](https://user-images.githubusercontent.com/2779157/126792320-e25806d3-5337-41bc-a085-3fdf8cb8af5d.jpg)

The current wavelet scale preview at 25-33%:
![Screenshot_20210723_155420](https://user-images.githubusercontent.com/2779157/126792360-f2edc739-36da-4b7f-8d02-8b579b80c373.jpg)

So, I see 2 possible causes:
1. mismatch in the mask locality (the blur is sampled in the wrong region),
2. scaling issue in the wavelet decomposition (the current scale is too coarse once rescaled for zoom)
