### PR TITLE
let action list grab focus (so search works)

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1433,11 +1433,11 @@ static gboolean _action_view_click(GtkWidget *widget, GdkEventButton *event, gpo
       {
         gtk_tree_selection_unselect_path(selection, path);
         gtk_tree_view_collapse_row(view, path);
-
-        return TRUE;
       }
       else
         gtk_tree_selection_select_path(selection, path);
+
+      gtk_widget_grab_focus(widget);
     }
     else
       gtk_tree_selection_unselect_all(selection);
@@ -2692,9 +2692,9 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
   switch(event->type)
   {
   case GDK_KEY_PRESS:
-    if(event->key.is_modifier || 
-       event->key.keyval == GDK_KEY_VoidSymbol || 
-       event->key.keyval == GDK_KEY_Meta_L || event->key.keyval == GDK_KEY_Meta_R || 
+    if(event->key.is_modifier ||
+       event->key.keyval == GDK_KEY_VoidSymbol ||
+       event->key.keyval == GDK_KEY_Meta_L || event->key.keyval == GDK_KEY_Meta_R ||
        event->key.keyval == GDK_KEY_ISO_Level3_Shift) return FALSE;
 
     _sc.mods = event->key.state;


### PR DESCRIPTION
#9434 prevented the action treeview from grabbing focus, which caused incremental search to stop working.

"fixes" #9598