### PR TITLE
cleanup: aligned pixel data type

### DIFF
--- a/src/chart/colorchart.c
+++ b/src/chart/colorchart.c
@@ -106,8 +106,8 @@ void checker_set_color(box_t *box, dt_colorspaces_color_profile_type_t color_spa
   box->color[1] = c1;
   box->color[2] = c2;
 
-  float DT_ALIGNED_PIXEL Lab[4] = { c0, c1, c2 };
-  float DT_ALIGNED_PIXEL XYZ[4] = { c0 * 0.01, c1 * 0.01, c2 * 0.01 };
+  dt_aligned_pixel_t Lab = { c0, c1, c2 };
+  dt_aligned_pixel_t XYZ = { c0 * 0.01, c1 * 0.01, c2 * 0.01 };
 
   switch(color_space)
   {

--- a/src/chart/colorchart.h
+++ b/src/chart/colorchart.h
@@ -40,8 +40,8 @@ typedef struct box_t
   float w, h;
   // color
   dt_colorspaces_color_profile_type_t color_space;
-  float color[3]; // either XYZ or Lab, depending on color_space
-  float rgb[3];   // color converted to sRGB for rough displaying of patches
+  dt_aligned_pixel_t color; // either XYZ or Lab, depending on color_space
+  dt_aligned_pixel_t rgb;   // color converted to sRGB for rough displaying of patches
 } box_t;
 
 typedef struct chart_t

--- a/src/chart/deltaE.c
+++ b/src/chart/deltaE.c
@@ -29,7 +29,7 @@
 #define RAD2DEG(rad) (rad * 180.0 / M_PI)
 
 // http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE76.html
-float dt_colorspaces_deltaE_1976(float Lab0[3], float Lab1[3])
+float dt_colorspaces_deltaE_1976(dt_aligned_pixel_t Lab0, dt_aligned_pixel_t Lab1)
 {
   float dE = 0.0;
   for(int i = 0; i < 3; i++)
@@ -41,7 +41,7 @@ float dt_colorspaces_deltaE_1976(float Lab0[3], float Lab1[3])
 }
 
 // http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html
-float dt_colorspaces_deltaE_2000(float Lab0[3], float Lab1[3])
+float dt_colorspaces_deltaE_2000(dt_aligned_pixel_t Lab0, dt_aligned_pixel_t Lab1)
 {
   float L_ip = (Lab0[0] + Lab1[0]) * 0.5;
   float C1 = sqrtf(Lab0[1] * Lab0[1] + Lab0[2] * Lab0[2]);

--- a/src/chart/deltaE.h
+++ b/src/chart/deltaE.h
@@ -18,8 +18,10 @@
 
 #pragma once
 
-float dt_colorspaces_deltaE_1976(float Lab0[3], float Lab1[3]);
-float dt_colorspaces_deltaE_2000(float Lab0[3], float Lab1[3]);
+#include "common/darktable.h"
+
+float dt_colorspaces_deltaE_1976(dt_aligned_pixel_t Lab0, dt_aligned_pixel_t Lab1);
+float dt_colorspaces_deltaE_2000(dt_aligned_pixel_t Lab0, dt_aligned_pixel_t Lab1);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/chart/dtcairo.c
+++ b/src/chart/dtcairo.c
@@ -196,7 +196,7 @@ cairo_surface_t *cairo_surface_create_from_xyz_data(const float *const image, co
     const float *iter = image + y * width * 3;
     for(int x = 0; x < width; x++, iter += 3)
     {
-      float DT_ALIGNED_PIXEL sRGB[4];
+      dt_aligned_pixel_t sRGB;
       int32_t pixel = 0;
       dt_XYZ_to_sRGB_clipped(iter, sRGB);
       for(int c = 0; c < 3; c++) pixel |= ((int)(sRGB[c] * 255) & 0xff) << (16 - c * 8);

--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -609,7 +609,7 @@ static void print_patches(dt_lut_t *self, FILE *fd, GList *patch_names)
       continue;
     }
 
-    float source_Lab[3] = { 0.0 }, reference_Lab[3] = { 0.0 };
+    dt_aligned_pixel_t source_Lab = { 0.0 }, reference_Lab = { 0.0 };
     get_Lab_from_box(source_patch, source_Lab);
     get_Lab_from_box(reference_patch, reference_Lab);
 
@@ -753,7 +753,7 @@ static void add_patches_to_array(dt_lut_t *self, GList *patch_names, int *N, int
       continue;
     }
 
-    float source_Lab[3] = { 0.0 }, reference_Lab[3] = { 0.0 };
+    dt_aligned_pixel_t source_Lab = { 0.0 }, reference_Lab = { 0.0 };
     get_Lab_from_box(source_patch, source_Lab);
     get_Lab_from_box(reference_patch, reference_Lab);
 
@@ -1371,7 +1371,7 @@ static void update_table(dt_lut_t *self)
     box_t *box = (box_t *)g_hash_table_lookup(self->chart->box_table, name);
     if(box)
     {
-      float Lab[3] = { 0.0 };
+      dt_aligned_pixel_t Lab = { 0.0 };
       char *s_Lab_in, *s_RGB_in, *s_deltaE_1976, *s_deltaE_2000;
       float deltaE_1976 = 0.0, deltaE_2000 = 0.0;
 
@@ -1380,7 +1380,7 @@ static void update_table(dt_lut_t *self)
       box_t *patch = (box_t *)g_hash_table_lookup(self->picked_source_patches, name);
       if(patch)
       {
-        float in_Lab[3] = { 0.0 };
+        dt_aligned_pixel_t in_Lab = { 0.0 };
         get_Lab_from_box(patch, in_Lab);
         s_RGB_in = g_strdup_printf("%d; %d; %d", (int)(patch->rgb[0] * 255 + 0.5),
                                    (int)(patch->rgb[1] * 255 + 0.5), (int)(patch->rgb[2] * 255 + 0.5));

--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -1018,7 +1018,7 @@ static void process_data(dt_lut_t *self, double *target_L, double *target_a, dou
   cx[num_tonecurve - 1] = cy[num_tonecurve - 1] = 100.0; // fix white
   for(int k = 1; k < num_tonecurve-1; k++)
   {
-    float DT_ALIGNED_PIXEL rgb[4], Lab[4] = { 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t rgb, Lab = { 0.0f, 0.0f, 0.0f };
     Lab[0] = grays[6*k+0];
     dt_Lab_to_prophotorgb(Lab, rgb);
     cx[k] = rgb[0];
@@ -1032,7 +1032,7 @@ static void process_data(dt_lut_t *self, double *target_L, double *target_a, dou
   // now unapply the curve:
   for(int k = 0; k < N; k++)
   {
-    float DT_ALIGNED_PIXEL rgb[4], Lab[4] = { 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t rgb, Lab = { 0.0f, 0.0f, 0.0f };
     Lab[0] = target_L[k];
     Lab[1] = target_a[k];
     Lab[2] = target_b[k];
@@ -1420,7 +1420,7 @@ static void get_Lab_from_box(box_t *box, float *Lab)
   {
     case DT_COLORSPACE_XYZ:
     {
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
       for(int i = 0; i < 3; i++) XYZ[i] = box->color[i] * 0.01;
       dt_XYZ_to_Lab(XYZ, Lab);
       break;
@@ -1467,7 +1467,7 @@ static void collect_source_patches_foreach(gpointer key, gpointer value, gpointe
 {
   dt_lut_t *self = (dt_lut_t *)user_data;
   box_t *box = (box_t *)value;
-  float DT_ALIGNED_PIXEL xyz[4] /*, lab[4], srgb[4]*/;
+  dt_aligned_pixel_t xyz;
 
   box_t *patch = find_patch(self->picked_source_patches, key);
 
@@ -1480,7 +1480,7 @@ static void collect_reference_patches_foreach(gpointer key, gpointer value, gpoi
 {
   dt_lut_t *self = (dt_lut_t *)user_data;
   box_t *patch = (box_t *)value;
-  float DT_ALIGNED_PIXEL xyz[4];
+  dt_aligned_pixel_t xyz;
 
   get_xyz_sample_from_image(&self->reference, self->reference.shrink, patch, xyz);
 

--- a/src/chart/thinplate.c
+++ b/src/chart/thinplate.c
@@ -73,8 +73,8 @@ static inline double compute_error(
     const double Lt = target[0][i];
     const double L0 = tonecurve_apply(c, Lt);
     const double L1 = tonecurve_apply(c, Lt + residual_L[i]);
-    float Lab0[3] = { L0, target[1][i], target[2][i] };
-    float Lab1[3] = { L1, target[1][i], target[2][i] };
+    dt_aligned_pixel_t Lab0 = { L0, target[1][i], target[2][i] };
+    dt_aligned_pixel_t Lab1 = { L1, target[1][i], target[2][i] };
     const double localerr = dt_colorspaces_deltaE_2000(Lab0, Lab1);
     err += localerr;
 #else
@@ -94,8 +94,8 @@ static inline double compute_error(
     const double Lt = target[0][i];
     const double L0 = tonecurve_apply(c, Lt);
     const double L1 = tonecurve_apply(c, Lt + residual_L[i]);
-    float Lab0[3] = {L0, target[1][i], target[2][i]};
-    float Lab1[3] = {L1, target[1][i], target[2][i]};
+    dt_aligned_pixel_t Lab0 = {L0, target[1][i], target[2][i]};
+    dt_aligned_pixel_t Lab1 = {L1, target[1][i], target[2][i]};
     err += dt_colorspaces_deltaE_2000(Lab0, Lab1);
 #else
     const double Lt = target[0][i];

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -215,7 +215,7 @@ void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in)
         // nearest neighbour splatting:
         const size_t grid_index = base + image_to_relgrid(b, i, L, &xf, &zf);
         // sum up payload here
-        const float contrib[4] =
+        const dt_aligned_pixel_t contrib =
         {
           (1.0f - xf) * (1.0f - yf) * 100.0f / sigma_s,	// precompute the contributions along the first two dimensions
           xf * (1.0f - yf) * 100.0f / sigma_s,

--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -375,7 +375,7 @@ static void blur_horizontal_4ch(float *const restrict buf, const size_t height, 
   for(int y = 0; y < height; y++)
   {
     float *const restrict scratch = dt_get_perthread(scanlines,padded_size);
-    float DT_ALIGNED_PIXEL L[4] = { 0, 0, 0, 0 };
+    dt_aligned_pixel_t L = { 0, 0, 0, 0 };
     size_t hits = 0;
     const size_t index = (size_t)4 * y * width;
     float *const restrict bufp = buf + index;
@@ -427,8 +427,8 @@ static void blur_horizontal_4ch(float *const restrict buf, const size_t height, 
 static void blur_horizontal_4ch_Kahan(float *const restrict buf, const size_t width,
                                       const size_t radius, float *const restrict scratch)
 {
-  float DT_ALIGNED_PIXEL L[4] = { 0, 0, 0, 0 };
-  float DT_ALIGNED_PIXEL comp[4] = { 0, 0, 0, 0 };
+  dt_aligned_pixel_t L = { 0, 0, 0, 0 };
+  dt_aligned_pixel_t comp = { 0, 0, 0, 0 };
   size_t hits = 0;
   // add up the left half of the window
   for (size_t x = 0; x < MIN(radius,width) ; x++)
@@ -817,7 +817,7 @@ static void blur_vertical_4wide(float *const restrict buf, const size_t height, 
   size_t mask = 1;
   for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
 
-  float DT_ALIGNED_PIXEL L[4] = { 0, 0, 0, 0 };
+  dt_aligned_pixel_t L = { 0, 0, 0, 0 };
   size_t hits = 0;
   // add up the left half of the window
   for (size_t y = 0; y < MIN(radius, height); y++)
@@ -876,8 +876,8 @@ static void blur_vertical_4wide_Kahan(float *const restrict buf, const size_t he
   size_t mask = 1;
   for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
 
-  float DT_ALIGNED_PIXEL L[4] = { 0, 0, 0, 0 };
-  float DT_ALIGNED_PIXEL comp[4] = { 0, 0, 0, 0 };
+  dt_aligned_pixel_t L = { 0, 0, 0, 0 };
+  dt_aligned_pixel_t comp = { 0, 0, 0, 0 };
   size_t hits = 0;
   // add up the left half of the window
   for (size_t y = 0; y < MIN(radius, height); y++)

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -187,10 +187,10 @@ static inline void convert_any_LMS_to_RGB(const float LMS[4], float RGB[4], dt_a
 #pragma omp declare simd uniform(origin_illuminant) \
   aligned(lms_in, lms_out, origin_illuminant:16)
 #endif
-static inline void bradford_adapt_D65(const float lms_in[4],
-                                      const float origin_illuminant[4],
+static inline void bradford_adapt_D65(const dt_aligned_pixel_t lms_in,
+                                      const dt_aligned_pixel_t origin_illuminant,
                                       const float p, const int full,
-                                      float lms_out[4])
+                                      dt_aligned_pixel_t lms_out)
 {
   // Bradford chromatic adaptation from origin to target D65 illuminant in LMS space
   // p = powf(origin_illuminant[2] / D65[2], 0.0834f) needs to be precomputed for performance,
@@ -198,13 +198,12 @@ static inline void bradford_adapt_D65(const float lms_in[4],
   // origin illuminant need also to be precomputed to LMS
 
   // Precomputed D65 primaries in Bradford LMS for camera WB adjustment
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.941238f, 1.040633f, 1.088932f, 0.f };
+  const dt_aligned_pixel_t D65 = { 0.941238f, 1.040633f, 1.088932f, 0.f };
 
-
-  float DT_ALIGNED_PIXEL temp[4] = { lms_in[0] / origin_illuminant[0],
-                                     lms_in[1] / origin_illuminant[1],
-                                     lms_in[2] / origin_illuminant[2],
-                                     0.f };
+  dt_aligned_pixel_t temp = { lms_in[0] / origin_illuminant[0],
+                              lms_in[1] / origin_illuminant[1],
+                              lms_in[2] / origin_illuminant[2],
+                              0.f };
 
   // use linear Bradford if B is negative
   if(full) temp[2] = (temp[2] > 0.f) ? powf(temp[2], p) : temp[2];
@@ -219,10 +218,10 @@ static inline void bradford_adapt_D65(const float lms_in[4],
 #pragma omp declare simd uniform(origin_illuminant) \
   aligned(lms_in, lms_out, origin_illuminant:16)
 #endif
-static inline void bradford_adapt_D50(const float lms_in[4],
-                                      const float origin_illuminant[4],
+static inline void bradford_adapt_D50(const dt_aligned_pixel_t lms_in,
+                                      const dt_aligned_pixel_t origin_illuminant,
                                       const float p, const int full,
-                                      float lms_out[4])
+                                      dt_aligned_pixel_t lms_out)
 {
   // Bradford chromatic adaptation from origin to target D50 illuminant in LMS space
   // p = powf(origin_illuminant[2] / D50[2], 0.0834f) needs to be precomputed for performance,
@@ -230,13 +229,12 @@ static inline void bradford_adapt_D50(const float lms_in[4],
   // origin illuminant need also to be precomputed to LMS
 
   // Precomputed D50 primaries in Bradford LMS for ICC transforms
-  const float DT_ALIGNED_PIXEL D50[4] = { 0.996078f, 1.020646f, 0.818155f, 0.f };
+  const dt_aligned_pixel_t D50 = { 0.996078f, 1.020646f, 0.818155f, 0.f };
 
-
-  float DT_ALIGNED_PIXEL temp[4] = { lms_in[0] / origin_illuminant[0],
-                                     lms_in[1] / origin_illuminant[1],
-                                     lms_in[2] / origin_illuminant[2],
-                                     0.f };
+  dt_aligned_pixel_t temp = { lms_in[0] / origin_illuminant[0],
+                              lms_in[1] / origin_illuminant[1],
+                              lms_in[2] / origin_illuminant[2],
+                              0.f };
 
   // use linear Bradford if B is negative
   if(full) temp[2] = (temp[2] > 0.f) ? powf(temp[2], p) : temp[2];
@@ -253,17 +251,16 @@ static inline void bradford_adapt_D50(const float lms_in[4],
 #pragma omp declare simd uniform(origin_illuminant) \
   aligned(lms_in, lms_out, origin_illuminant:16)
 #endif
-static inline void CAT16_adapt_D65(const float lms_in[4],
-                                      const float origin_illuminant[4],
-                                      const float D, const int full,
-                                      float lms_out[4])
+static inline void CAT16_adapt_D65(const dt_aligned_pixel_t lms_in,
+                                   const dt_aligned_pixel_t origin_illuminant,
+                                   const float D, const int full, dt_aligned_pixel_t lms_out)
 {
   // CAT16 chromatic adaptation from origin to target D65 illuminant in LMS space
   // D is the coefficient of adaptation, depending of the surround lighting
   // origin illuminant need also to be precomputed to LMS
 
   // Precomputed D65 primaries in CAT16 LMS for camera WB adjustment
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.97553267f, 1.01647859f, 1.0848344f, 0.f };
+  const dt_aligned_pixel_t D65 = { 0.97553267f, 1.01647859f, 1.0848344f, 0.f };
 
   if(full)
   {
@@ -284,17 +281,17 @@ static inline void CAT16_adapt_D65(const float lms_in[4],
 #pragma omp declare simd uniform(origin_illuminant) \
   aligned(lms_in, lms_out, origin_illuminant:16)
 #endif
-static inline void CAT16_adapt_D50(const float lms_in[4],
-                                      const float origin_illuminant[4],
+static inline void CAT16_adapt_D50(const dt_aligned_pixel_t lms_in,
+                                      const dt_aligned_pixel_t origin_illuminant,
                                       const float D, const int full,
-                                      float lms_out[4])
+                                      dt_aligned_pixel_t lms_out)
 {
   // CAT16 chromatic adaptation from origin to target D50 illuminant in LMS space
   // D is the coefficient of adaptation, depending of the surround lighting
   // origin illuminant need also to be precomputed to LMS
 
   // Precomputed D50 primaries in CAT16 LMS for ICC transforms
-  const float DT_ALIGNED_PIXEL D50[4] = { 0.994535f, 1.000997f, 0.833036f, 0.f };
+  const dt_aligned_pixel_t D50 = { 0.994535f, 1.000997f, 0.833036f, 0.f };
 
   if(full)
   {
@@ -316,15 +313,15 @@ static inline void CAT16_adapt_D50(const float lms_in[4],
 #pragma omp declare simd uniform(origin_illuminant) \
   aligned(lms_in, lms_out, origin_illuminant:16)
 #endif
-static inline void XYZ_adapt_D65(const float lms_in[4],
-                                      const float origin_illuminant[4],
-                                      float lms_out[4])
+static inline void XYZ_adapt_D65(const dt_aligned_pixel_t lms_in,
+                                 const dt_aligned_pixel_t origin_illuminant,
+                                 dt_aligned_pixel_t lms_out)
 {
   // XYZ chromatic adaptation from origin to target D65 illuminant in XYZ space
   // origin illuminant need also to be precomputed to XYZ
 
   // Precomputed D65 primaries in XYZ for camera WB adjustment
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.9504285453771807f, 1.0f, 1.0889003707981277f, 0.f };
+  const dt_aligned_pixel_t D65 = { 0.9504285453771807f, 1.0f, 1.0889003707981277f, 0.f };
 
   lms_out[0] = lms_in[0] * D65[0] / origin_illuminant[0];
   lms_out[1] = lms_in[1] * D65[1] / origin_illuminant[1];
@@ -335,15 +332,15 @@ static inline void XYZ_adapt_D65(const float lms_in[4],
 #pragma omp declare simd uniform(origin_illuminant) \
   aligned(lms_in, lms_out, origin_illuminant:16)
 #endif
-static inline void XYZ_adapt_D50(const float lms_in[4],
-                                      const float origin_illuminant[4],
-                                      float lms_out[4])
+static inline void XYZ_adapt_D50(const dt_aligned_pixel_t lms_in,
+                                 const dt_aligned_pixel_t origin_illuminant,
+                                 dt_aligned_pixel_t lms_out)
 {
   // XYZ chromatic adaptation from origin to target D65 illuminant in XYZ space
   // origin illuminant need also to be precomputed to XYZ
 
   // Precomputed D50 primaries in XYZ for camera WB adjustment
-  const float DT_ALIGNED_PIXEL D50[4] = { 0.9642119944211994f, 1.0f, 0.8251882845188288f, 0.f };
+  const dt_aligned_pixel_t D50 = { 0.9642119944211994f, 1.0f, 0.8251882845188288f, 0.f };
 
   lms_out[0] = lms_in[0] * D50[0] / origin_illuminant[0];
   lms_out[1] = lms_in[1] * D50[1] / origin_illuminant[1];

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -167,7 +167,7 @@ static inline void convert_any_XYZ_to_LMS(const float XYZ[4], float LMS[4], dt_a
 static inline void convert_any_LMS_to_RGB(const float LMS[4], float RGB[4], dt_adaptation_t kind)
 {
   // helper function switching internally to the proper conversion
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.f };
+  dt_aligned_pixel_t XYZ = { 0.f };
   convert_any_LMS_to_XYZ(LMS, XYZ, kind);
 
   // Fixme : convert to RGB display space instead of sRGB but first the display profile should be global in dt,

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -47,7 +47,7 @@ const float DT_ALIGNED_ARRAY Bradford_LMS_to_XYZ[3][4] = { {  0.9870f, -0.1471f,
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
 #endif
-static inline void convert_XYZ_to_bradford_LMS(const float XYZ[4], float LMS[4])
+static inline void convert_XYZ_to_bradford_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
   dot_product(XYZ, XYZ_to_Bradford_LMS, LMS);
@@ -56,7 +56,7 @@ static inline void convert_XYZ_to_bradford_LMS(const float XYZ[4], float LMS[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
 #endif
-static inline void convert_bradford_LMS_to_XYZ(const float LMS[4], float XYZ[4])
+static inline void convert_bradford_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
   dot_product(LMS, Bradford_LMS_to_XYZ, XYZ);
@@ -77,7 +77,7 @@ const float DT_ALIGNED_ARRAY CAT16_LMS_to_XYZ[3][4] = { {  1.862068f, -1.011255f
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
 #endif
-static inline void convert_XYZ_to_CAT16_LMS(const float XYZ[4], float LMS[4])
+static inline void convert_XYZ_to_CAT16_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
   dot_product(XYZ, XYZ_to_CAT16_LMS, LMS);
@@ -86,7 +86,7 @@ static inline void convert_XYZ_to_CAT16_LMS(const float XYZ[4], float LMS[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
 #endif
-static inline void convert_CAT16_LMS_to_XYZ(const float LMS[4], float XYZ[4])
+static inline void convert_CAT16_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
   dot_product(LMS, CAT16_LMS_to_XYZ, XYZ);
@@ -96,7 +96,8 @@ static inline void convert_CAT16_LMS_to_XYZ(const float LMS[4], float XYZ[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16) uniform(kind)
 #endif
-static inline void convert_any_LMS_to_XYZ(const float LMS[4], float XYZ[4], const dt_adaptation_t kind)
+static inline void convert_any_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ,
+                                          const dt_adaptation_t kind)
 {
   // helper function switching internally to the proper conversion
 
@@ -130,7 +131,7 @@ static inline void convert_any_LMS_to_XYZ(const float LMS[4], float XYZ[4], cons
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16) uniform(kind)
 #endif
-static inline void convert_any_XYZ_to_LMS(const float XYZ[4], float LMS[4], dt_adaptation_t kind)
+static inline void convert_any_XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS, dt_adaptation_t kind)
 {
   // helper function switching internally to the proper conversion
 
@@ -164,7 +165,7 @@ static inline void convert_any_XYZ_to_LMS(const float XYZ[4], float LMS[4], dt_a
 #ifdef _OPENMP
 #pragma omp declare simd aligned(RGB, LMS:16) uniform(kind)
 #endif
-static inline void convert_any_LMS_to_RGB(const float LMS[4], float RGB[4], dt_adaptation_t kind)
+static inline void convert_any_LMS_to_RGB(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB, dt_adaptation_t kind)
 {
   // helper function switching internally to the proper conversion
   dt_aligned_pixel_t XYZ = { 0.f };
@@ -372,7 +373,7 @@ const float DT_ALIGNED_ARRAY XYZ_D65_to_D50_Bradford[3][4]
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_in, XYZ_out:16)
 #endif
-static inline void XYZ_D50_to_D65(const float XYZ_in[4], float XYZ_out[4])
+static inline void XYZ_D50_to_D65(const dt_aligned_pixel_t XYZ_in, dt_aligned_pixel_t XYZ_out)
 {
   dot_product(XYZ_in, XYZ_D50_to_D65_CAT16, XYZ_out);
 }
@@ -380,7 +381,7 @@ static inline void XYZ_D50_to_D65(const float XYZ_in[4], float XYZ_out[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_in, XYZ_out:16)
 #endif
-static inline void XYZ_D65_to_D50(const float XYZ_in[4], float XYZ_out[4])
+static inline void XYZ_D65_to_D50(const dt_aligned_pixel_t XYZ_in, dt_aligned_pixel_t XYZ_out)
 {
   dot_product(XYZ_in, XYZ_D65_to_D50_CAT16, XYZ_out);
 }

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -63,7 +63,7 @@ static inline void _color_picker_rgb_or_lab(float *const avg, float *const min, 
 {
   for(size_t i = 0; i < width; i += 4)
   {
-    float pick[4] DT_ALIGNED_PIXEL = { pixels[i], pixels[i + 1], pixels[i + 2], 0.0f };
+    dt_aligned_pixel_t pick = { pixels[i], pixels[i + 1], pixels[i + 2], 0.0f };
     for(size_t k = 0; k < 4; k++)
     {
       avg[k] += w * pick[k];
@@ -81,7 +81,7 @@ static inline void _color_picker_lch(float *const avg, float *const min, float *
 {
   for(size_t i = 0; i < width; i += 4)
   {
-    float pick[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t pick;
     dt_Lab_2_LCH(pixels + i, pick);
     pick[3] = pick[2] < 0.5f ? pick[2] + 0.5f : pick[2] - 0.5f;
     for(size_t k = 0; k < 4; k++)
@@ -101,7 +101,7 @@ static inline void _color_picker_hsl(float *const avg, float *const min, float *
 {
   for(size_t i = 0; i < width; i += 4)
   {
-    float pick[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t pick;
     dt_RGB_2_HSL(pixels + i, pick);
     pick[3] = pick[0] < 0.5f ? pick[0] + 0.5f : pick[0] - 0.5f;
     for(size_t k = 0; k < 4; k++)
@@ -122,7 +122,7 @@ static inline void _color_picker_jzczhz(float *const avg, float *const min, floa
 {
   for(size_t i = 0; i < width; i += 4)
   {
-    float pick[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t pick;
     rgb_to_JzCzhz(pixels + i, pick, profile);
     pick[3] = pick[2] < 0.5f ? pick[2] + 0.5f : pick[2] - 0.5f;
     for(size_t k = 0; k < 4; k++)

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -35,12 +35,12 @@ static inline size_t _box_size(const int *const box)
 static inline void rgb_to_JzCzhz(const float *const rgb, float *const JzCzhz,
                                  const dt_iop_order_iccprofile_info_t *const profile)
 {
-  float XYZ_D65[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
-  float JzAzBz[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t XYZ_D65 = { 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t JzAzBz = { 0.0f, 0.0f, 0.0f };
 
   if(profile)
   {
-    float XYZ_D50[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t XYZ_D50 = { 0.0f, 0.0f, 0.0f };
     dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, profile->matrix_in, profile->lut_in, profile->unbounded_coeffs_in,
                                profile->lutsize, profile->nonlinearlut);
     dt_XYZ_D50_2_XYZ_D65(XYZ_D50, XYZ_D65);

--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -35,8 +35,8 @@ typedef enum dt_color_checker_targets
 // helper to deal with patch color
 typedef struct dt_color_checker_patch
 {
-  const char *name;     // mnemonic name for the patch
-  float Lab[3];         // reference color in CIE Lab
+  const char *name;        // mnemonic name for the patch
+  dt_aligned_pixel_t Lab;  // reference color in CIE Lab
 
   // (x, y) position of the patch center, relatively to the guides (white dots)
   // in ratio of the grid dimension along that axis

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1092,7 +1092,7 @@ error:
   g_free(utf8);
 }
 
-void rgb2hsl(const float rgb[3], float *h, float *s, float *l)
+void rgb2hsl(const dt_aligned_pixel_t rgb, float *h, float *s, float *l)
 {
   const float r = rgb[0], g = rgb[1], b = rgb[2];
   const float pmax = fmaxf(r, fmax(g, b));
@@ -1136,7 +1136,7 @@ static inline float hue2rgb(float m1, float m2, float hue)
     return hue < 4.0f ? (m1 + (m2 - m1) * (4.0f - hue)) : m1;
 }
 
-void hsl2rgb(float rgb[3], float h, float s, float l)
+void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l)
 {
   float m1, m2;
   if(s == 0)
@@ -2172,7 +2172,8 @@ int dt_colorspaces_conversion_matrices_rgb(const char *name,
   return TRUE;
 }
 
-void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int num, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], float coeffs[4])
+void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int num, double RGB_to_CAM[4][3],
+                                             double CAM_to_RGB[3][4], dt_aligned_pixel_t coeffs)
 {
   // Create the CAM to RGB with applied WB matrix
   double CAM_to_RGB_WB[3][4];

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -512,10 +512,10 @@ int dt_colorspaces_get_darktable_matrix(const char *makermodel, float *matrix)
                    coeff[0] * (1.0f - xr - yr), coeff[1] * (1.0f - xg - yg), coeff[2] * (1.0f - xb - yb) };
 
   // input whitepoint[] in XYZ with Y normalized to 1.0f
-  const float dn[3]
+  const dt_aligned_pixel_t dn
       = { preset->white[0] / (float)preset->white[1], 1.0f, preset->white[2] / (float)preset->white[1] };
   const float lam_rigg[9] = { 0.8951, 0.2664, -0.1614, -0.7502, 1.7135, 0.0367, 0.0389, -0.0685, 1.0296 };
-  const float d50[3] = { 0.9642, 1.0, 0.8249 };
+  const dt_aligned_pixel_t d50 = { 0.9642, 1.0, 0.8249 };
 
 
   // adapt to d50

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -501,8 +501,8 @@ int dt_colorspaces_get_darktable_matrix(const char *makermodel, float *matrix)
   float result[9];
   if(mat3inv(result, primaries)) return -1;
 
-  const float whitepoint[3] = { xn / yn, 1.0f, (1.0f - xn - yn) / yn };
-  float coeff[3];
+  const dt_aligned_pixel_t whitepoint = { xn / yn, 1.0f, (1.0f - xn - yn) / yn };
+  dt_aligned_pixel_t coeff;
 
   // get inverse primary whitepoint
   mat3mulv(coeff, result, whitepoint);
@@ -522,7 +522,7 @@ int dt_colorspaces_get_darktable_matrix(const char *makermodel, float *matrix)
   float chad_inv[9];
   if(mat3inv(chad_inv, lam_rigg)) return -1;
 
-  float cone_src_rgb[3], cone_dst_rgb[3];
+  dt_aligned_pixel_t cone_src_rgb, cone_dst_rgb;
   mat3mulv(cone_src_rgb, lam_rigg, dn);
   mat3mulv(cone_dst_rgb, lam_rigg, d50);
 
@@ -943,7 +943,7 @@ static void dt_colorspaces_create_cmatrix(float cmatrix[4][3], float mat[3][3])
 static cmsHPROFILE dt_colorspaces_create_xyzmatrix_profile(float mat[3][3])
 {
   // mat: cam -> xyz
-  float x[3], y[3];
+  dt_aligned_pixel_t x, y;
   for(int k = 0; k < 3; k++)
   {
     const float norm = mat[0][k] + mat[1][k] + mat[2][k];
@@ -2211,7 +2211,7 @@ void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4])
   for(int i = 0; i < num; i++)
   {
     float *in = &out[i*4];
-    float o[3] = {0.0f,0.0f,0.0f};
+    dt_aligned_pixel_t o = {0.0f,0.0f,0.0f};
     for(int c = 0; c < 3; c++)
       for(int k = 0; k < 4; k++)
         o[c] += CAM_to_RGB[c][k] * in[k];
@@ -2228,7 +2228,7 @@ void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3])
   for(int i = 0; i < num; i++)
   {
     float *in = &out[i*3];
-    float o[4] = {0.0f,0.0f,0.0f,0.0f};
+    dt_aligned_pixel_t o = {0.0f,0.0f,0.0f,0.0f};
     for(int c = 0; c < 4; c++)
       for(int k = 0; k < 3; k++)
         o[c] += RGB_to_CAM[c][k] * in[k];

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -206,8 +206,8 @@ void dt_colorspaces_get_profile_name(cmsHPROFILE p, const char *language, const 
 const char *dt_colorspaces_get_name(dt_colorspaces_color_profile_type_t type, const char *filename);
 
 /** common functions to change between colorspaces, used in iop modules */
-void rgb2hsl(const float rgb[3], float *h, float *s, float *l);
-void hsl2rgb(float rgb[3], float h, float s, float l);
+void rgb2hsl(const dt_aligned_pixel_t rgb, float *h, float *s, float *l);
+void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l);
 
 /** trigger updating the display profile from the system settings (x atom, colord, ...) */
 void dt_colorspaces_set_display_profile(const dt_colorspaces_color_profile_type_t profile_type);
@@ -235,7 +235,7 @@ int dt_colorspaces_conversion_matrices_xyz(const char *name, float in_XYZ_to_CAM
 int dt_colorspaces_conversion_matrices_rgb(const char *name, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], const float *embedded_matrix, double mul[4]);
 
 /** Applies CYGM WB coeffs to an image that's already been converted to RGB by dt_colorspaces_cygm_to_rgb */
-void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int num, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], float coeffs[4]);
+void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int num, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], dt_aligned_pixel_t coeffs);
 
 /** convert CYGM buffer to RGB */
 void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4]);

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -181,7 +181,7 @@ static inline void dt_apply_transposed_color_matrix(const float *const in, const
   // Use a temp variable to accumulate the results.  GCC8 will optimize away the memory accesses for the
   // temp array, while it writes the intermediate values to 'out' after each iteration if we don't use
   // the temp.  That cuts total memory bandwidth by a third.
-  float DT_ALIGNED_PIXEL result[4] = { 0.0f };
+  dt_aligned_pixel_t result = { 0.0f };
   for(int c = 0; c < 3; c++)
     for_each_channel(r)
     {
@@ -450,7 +450,7 @@ static inline void dt_XYZ_to_Rec709_D65(const float *const XYZ, float *const sRG
 static inline void dt_XYZ_to_sRGB(const float *const XYZ, float *const sRGB)
 {
   // XYZ -> linear sRGB
-  float DT_ALIGNED_PIXEL rgb[4];
+  dt_aligned_pixel_t rgb;
   dt_XYZ_to_Rec709_D50(XYZ, rgb);
   // linear sRGB -> gamma corrected sRGB
   for(size_t c = 0; c < 3; c++)
@@ -464,7 +464,7 @@ static inline void dt_XYZ_to_sRGB(const float *const XYZ, float *const sRGB)
 #endif
 static inline void dt_XYZ_to_sRGB_clipped(const float *const XYZ, float *const sRGB)
 {
-  float DT_ALIGNED_PIXEL result[4];
+  dt_aligned_pixel_t result;
   dt_XYZ_to_sRGB(XYZ, result);
 
   for(int i = 0; i < 3; i++) sRGB[i] = CLIP(result[i]);
@@ -492,7 +492,7 @@ static inline void dt_Rec709_to_XYZ_D50(const float *const DT_RESTRICT sRGB, flo
 #endif
 static inline void dt_sRGB_to_XYZ(const float *const sRGB, float *const XYZ)
 {
-  float DT_ALIGNED_PIXEL rgb[4] = { 0 };
+  dt_aligned_pixel_t rgb = { 0 };
   // gamma corrected sRGB -> linear sRGB
   for(int c = 0; c < 3; c++)
     rgb[c] = sRGB[c] <= 0.04045f ? sRGB[c] / 12.92f : powf((sRGB[c] + 0.055f) / (1.0f + 0.055f), 2.4f);
@@ -506,7 +506,7 @@ static inline void dt_sRGB_to_XYZ(const float *const sRGB, float *const XYZ)
 static inline void dt_XYZ_to_prophotorgb(const float *const XYZ, float *const rgb)
 {
   // transpose and pad the conversion matrix to enable vectorization
-  const float xyz_to_rgb_transpose[3][4] = {
+  const float xyz_to_rgb_transpose[3][4] DT_ALIGNED_PIXEL = {
     {  1.3459433f, -0.5445989f, 0.0000000f, 0.0f },
     { -0.2556075f,  1.5081673f, 0.0000000f, 0.0f },
     { -0.0511118f,  0.0205351f, 1.2118128f, 0.0f }
@@ -520,7 +520,7 @@ static inline void dt_XYZ_to_prophotorgb(const float *const XYZ, float *const rg
 static inline void dt_prophotorgb_to_XYZ(const float *const rgb, float *const XYZ)
 {
   // transpose and pad the conversion matrix to enable vectorization
-  const float rgb_to_xyz_transpose[3][4] = {
+  const float rgb_to_xyz_transpose[3][4] DT_ALIGNED_PIXEL = {
     // prophoto rgb
     { 0.7976749f, 0.2880402f, 0.0000000f, 0.0f },
     { 0.1351917f, 0.7118741f, 0.0000000f, 0.0f },
@@ -535,7 +535,7 @@ static inline void dt_prophotorgb_to_XYZ(const float *const rgb, float *const XY
 #endif
 static inline void dt_Lab_to_prophotorgb(const float *const Lab, float *const rgb)
 {
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ(Lab, XYZ);
   dt_XYZ_to_prophotorgb(XYZ, rgb);
 }
@@ -545,7 +545,7 @@ static inline void dt_Lab_to_prophotorgb(const float *const Lab, float *const rg
 #endif
 static inline void dt_prophotorgb_to_Lab(const float *const rgb, float *const Lab)
 {
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_prophotorgb_to_XYZ(rgb, XYZ);
   dt_XYZ_to_Lab(XYZ, Lab);
 }
@@ -807,8 +807,8 @@ static inline void dt_XYZ_2_JzAzBz(const float *const DT_RESTRICT XYZ_D65, float
       { 0.199076f,  1.096799f, -1.295875f, 0.0f },
   };
 
-  float XYZ[4] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f, 0.0f };
-  float LMS[4] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t LMS = { 0.0f, 0.0f, 0.0f, 0.0f };
 
   // XYZ -> X'Y'Z
   XYZ[0] = b * XYZ_D65[0] - (b - 1.0f) * XYZ_D65[2];
@@ -881,9 +881,9 @@ static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float 
       {  1.0f, -0.0960192420263190f, -0.8118918960560390f, 0.0f },
   };
 
-  float XYZ[4] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f, 0.0f };
-  float LMS[4] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f, 0.0f };
-  float IzAzBz[4] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t LMS = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t IzAzBz = { 0.0f, 0.0f, 0.0f, 0.0f };
 
   IzAzBz[0] = JzAzBz[0] + d0;
   IzAzBz[0] = fmaxf(IzAzBz[0] / (1.0f + d - d * IzAzBz[0]), 0.f);
@@ -935,7 +935,7 @@ static const float DT_ALIGNED_ARRAY LMS_2006_D65_to_XYZ_D65[3][4]
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, XYZ: 16)
 #endif
-static inline void XYZ_to_LMS(const float XYZ[4], float LMS[4])
+static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
   dot_product(XYZ, XYZ_D65_to_LMS_2006_D65, LMS);
 }
@@ -943,7 +943,7 @@ static inline void XYZ_to_LMS(const float XYZ[4], float LMS[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS: 16)
 #endif
-static inline void LMS_to_XYZ(const float LMS[4], float XYZ[4])
+static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
   dot_product(LMS, LMS_2006_D65_to_XYZ_D65, XYZ);
 }
@@ -968,7 +968,7 @@ static const float DT_ALIGNED_ARRAY LMS_D65_to_filmlightRGB_D65[3][4]
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
-static inline void gradingRGB_to_LMS(const float RGB[4], float LMS[4])
+static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t LMS)
 {
   dot_product(RGB, filmlightRGB_D65_to_LMS_D65, LMS);
 }
@@ -976,7 +976,7 @@ static inline void gradingRGB_to_LMS(const float RGB[4], float LMS[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
-static inline void LMS_to_gradingRGB(const float LMS[4], float RGB[4])
+static inline void LMS_to_gradingRGB(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB)
 {
   dot_product(LMS, LMS_D65_to_filmlightRGB_D65, RGB);
 }
@@ -989,18 +989,18 @@ static inline void LMS_to_gradingRGB(const float LMS[4], float RGB[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, Yrg: 16)
 #endif
-static inline void LMS_to_Yrg(const float LMS[4], float Yrg[4])
+static inline void LMS_to_Yrg(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t Yrg)
 {
   // compute luminance
   const float Y = 0.68990272f * LMS[0] + 0.34832189f * LMS[1];
 
   // normalize LMS
   const float a = LMS[0] + LMS[1] + LMS[2];
-  float DT_ALIGNED_PIXEL lms[4] = { 0.f };
+  dt_aligned_pixel_t lms = { 0.f };
   for_four_channels(c, aligned(LMS, lms : 16)) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
 
   // convert to Filmlight rgb (normalized)
-  float DT_ALIGNED_PIXEL rgb[4] = { 0.f };
+  dt_aligned_pixel_t rgb = { 0.f };
   LMS_to_gradingRGB(lms, rgb);
 
   Yrg[0] = Y;
@@ -1011,7 +1011,7 @@ static inline void LMS_to_Yrg(const float LMS[4], float Yrg[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Yrg, LMS: 16)
 #endif
-static inline void Yrg_to_LMS(const float Yrg[4], float LMS[4])
+static inline void Yrg_to_LMS(const dt_aligned_pixel_t Yrg, dt_aligned_pixel_t LMS)
 {
   const float Y = Yrg[0];
 
@@ -1019,10 +1019,10 @@ static inline void Yrg_to_LMS(const float Yrg[4], float LMS[4])
   const float r = Yrg[1];
   const float g = Yrg[2];
   const float b = 1.f - r - g;
-  const float rgb[4] = { r, g, b, 0.f };
+  const dt_aligned_pixel_t rgb = { r, g, b, 0.f };
 
   // convert to lms (normalized)
-  float DT_ALIGNED_PIXEL lms[4] = { 0.f };
+  dt_aligned_pixel_t lms = { 0.f };
   gradingRGB_to_LMS(rgb, lms);
 
   // denormalize to LMS
@@ -1038,9 +1038,9 @@ static inline void Yrg_to_LMS(const float Yrg[4], float LMS[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, Yrg: 16)
 #endif
-static inline void Yrg_to_Ych(const float Yrg[4], float Ych[4])
+static inline void Yrg_to_Ych(const dt_aligned_pixel_t Yrg, dt_aligned_pixel_t Ych)
 {
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  const dt_aligned_pixel_t D65 = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
   const float Y = Yrg[0];
   const float r = Yrg[1] - D65[0];
   const float g = Yrg[2] - D65[1];
@@ -1054,9 +1054,9 @@ static inline void Yrg_to_Ych(const float Yrg[4], float Ych[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, Yrg: 16)
 #endif
-static inline void Ych_to_Yrg(const float Ych[4], float Yrg[4])
+static inline void Ych_to_Yrg(const dt_aligned_pixel_t Ych, dt_aligned_pixel_t Yrg)
 {
-  const float DT_ALIGNED_PIXEL D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  const dt_aligned_pixel_t D65 = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
   const float Y = Ych[0];
   const float c = Ych[1];
   const float h = Ych[2];
@@ -1074,10 +1074,10 @@ static inline void Ych_to_Yrg(const float Ych[4], float Yrg[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, RGB: 16)
 #endif
-static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[4])
+static inline void Ych_to_gradingRGB(const dt_aligned_pixel_t Ych, dt_aligned_pixel_t RGB)
 {
-  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
-  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  dt_aligned_pixel_t Yrg = { 0.f };
+  dt_aligned_pixel_t LMS = { 0.f };
   Ych_to_Yrg(Ych, Yrg);
   Yrg_to_LMS(Yrg, LMS);
   LMS_to_gradingRGB(LMS, RGB);
@@ -1087,10 +1087,10 @@ static inline void Ych_to_gradingRGB(const float Ych[4], float RGB[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, RGB: 16)
 #endif
-static inline void gradingRGB_to_Ych(const float RGB[4], float Ych[4])
+static inline void gradingRGB_to_Ych(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t Ych)
 {
-  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
-  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  dt_aligned_pixel_t Yrg = { 0.f };
+  dt_aligned_pixel_t LMS = { 0.f };
   gradingRGB_to_LMS(RGB, LMS);
   LMS_to_Yrg(LMS, Yrg);
   Yrg_to_Ych(Yrg, Ych);
@@ -1100,11 +1100,11 @@ static inline void gradingRGB_to_Ych(const float RGB[4], float Ych[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, XYZ: 16)
 #endif
-static inline void XYZ_to_Ych(const float XYZ[4], float Ych[4])
+static inline void XYZ_to_Ych(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t Ych)
 {
   // WARNING: XYZ needs to be chroma-adapted to D65 before
-  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
-  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  dt_aligned_pixel_t Yrg = { 0.f };
+  dt_aligned_pixel_t LMS = { 0.f };
   XYZ_to_LMS(XYZ, LMS);
   LMS_to_Yrg(LMS, Yrg);
   Yrg_to_Ych(Yrg, Ych);
@@ -1114,11 +1114,11 @@ static inline void XYZ_to_Ych(const float XYZ[4], float Ych[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Ych, XYZ: 16)
 #endif
-static inline void Ych_to_XYZ(const float Ych[4], float XYZ[4])
+static inline void Ych_to_XYZ(const dt_aligned_pixel_t Ych, dt_aligned_pixel_t XYZ)
 {
   // WARNING: XYZ is output in D65
-  float DT_ALIGNED_PIXEL Yrg[4] = { 0.f };
-  float DT_ALIGNED_PIXEL LMS[4] = { 0.f };
+  dt_aligned_pixel_t Yrg = { 0.f };
+  dt_aligned_pixel_t LMS = { 0.f };
   Ych_to_Yrg(Ych, Yrg);
   Yrg_to_LMS(Yrg, LMS);
   LMS_to_XYZ(LMS, XYZ);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -142,6 +142,9 @@ typedef unsigned int u_int;
 /* Helper to force stack vectors to be aligned on 64 bits blocks to enable AVX2 */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
 
+// utility type to ease declaration of aligned small arrays to hold a pixel (and document their purpose)
+typedef DT_ALIGNED_PIXEL float dt_aligned_pixel_t[4];
+
 #ifndef _RELEASE
 #include "common/poison.h"
 #endif

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -28,9 +28,9 @@
 
 static inline void weight(const float *c1, const float *c2, const float sharpen, float *weight)
 {
-  float DT_ALIGNED_PIXEL square[4];
-  for(int c = 0; c < 3; c++) square[c] = c1[c] - c2[c];
-  for(int c = 0; c < 3; c++) square[c] = square[c] * square[c];
+  dt_aligned_pixel_t square;
+  for_each_channel(c) square[c] = c1[c] - c2[c];
+  for_each_channel(c) square[c] = square[c] * square[c];
 
   const float wl = dt_fast_expf(-sharpen * square[0]);
   const float wc = dt_fast_expf(-sharpen * (square[1] + square[2]));
@@ -358,9 +358,9 @@ void eaw_synthesize_sse2(float *const out, const float *const in, const float *c
 static inline float dn_weight(const float *c1, const float *c2, const float inv_sigma2)
 {
   // 3d distance based on color
-  float DT_ALIGNED_PIXEL sqr[4];
-  for(int c = 0; c < 3; c++) // don't use for_each_channel here, that substantially hurts performance by preventing
-  {                          // other vectorization
+  dt_aligned_pixel_t sqr;
+  for_each_channel(c)
+  {
     const float diff = c1[c] - c2[c];
     sqr[c] = diff * diff;
   }

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -69,10 +69,10 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
   do                                                                                                         \
   {                                                                                                          \
     const float f = filter[(ii)] * filter[(jj)];                                                             \
-    float DT_ALIGNED_PIXEL wp[4];                                                                            \
+    dt_aligned_pixel_t wp;                                                                                   \
     weight(px, px2, sharpen, wp);                                                                            \
-    float DT_ALIGNED_PIXEL w[4];                                                                             \
-    float DT_ALIGNED_PIXEL pd[4];                                                                            \
+    dt_aligned_pixel_t w;                                                                                    \
+    dt_aligned_pixel_t pd;                                                                                   \
     for_four_channels(c,aligned(px2))                                                                        \
     {                                                                                                        \
       w[c] = f * wp[c];                                                                                      \
@@ -96,8 +96,8 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
 #endif
 
 #define SUM_PIXEL_PROLOGUE                                                                                   \
-  float DT_ALIGNED_PIXEL sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };                                                \
-  float DT_ALIGNED_PIXEL wgt[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t sum = { 0.0f, 0.0f, 0.0f, 0.0f };                                                       \
+  dt_aligned_pixel_t wgt = { 0.0f, 0.0f, 0.0f, 0.0f };
 
 #if defined(__SSE2__)
 #define SUM_PIXEL_PROLOGUE_SSE                                                                               \
@@ -387,7 +387,7 @@ static inline float dn_weight_sse(const __m128 *c1, const __m128 *c2, const floa
 
 typedef struct _aligned_pixel {
   union {
-    float DT_ALIGNED_PIXEL v[4];
+    dt_aligned_pixel_t v;
 #ifdef __SSE2__
     __m128 sse;
 #endif
@@ -410,7 +410,7 @@ static inline _aligned_pixel add_float4(_aligned_pixel acc, _aligned_pixel newva
     const float f = filter[(ii)] * filter[(jj)];                                                             \
     const float wp = dn_weight(px, px2, inv_sigma2);                                                         \
     const float w = f * wp;                                                                                  \
-    float DT_ALIGNED_PIXEL pd[4];                                                                            \
+    dt_aligned_pixel_t pd;                                                                                   \
     for_each_channel(c,aligned(px2))                                                                         \
     {                                                                                                        \
       pd[c] = w * px2[c];                                                                                    \
@@ -461,7 +461,7 @@ static inline _aligned_pixel add_float4(_aligned_pixel acc, _aligned_pixel newva
 #endif
 
 void eaw_dn_decompose(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                      float sum_squared[4], const int scale, const float inv_sigma2,
+                      dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                       const int32_t width, const int32_t height)
 {
   const int mult = 1u << scale;
@@ -556,7 +556,7 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
 
 #if defined(__SSE2__)
 void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                                 float sum_squared[4], const int scale, const float inv_sigma2,
+                          dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                                  const int32_t width, const int32_t height)
 {
   const int mult = 1u << scale;

--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include "common/darktable.h"
 
 typedef void((*eaw_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
                                 const int scale, const float sharpen, const int32_t width, const int32_t height));
@@ -41,12 +42,12 @@ void eaw_synthesize_sse2(float *const restrict out, const float *const restrict 
                          const int32_t width, const int32_t height);
 
 typedef void((*eaw_dn_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                                   float sum_squared[4], const int scale, const float inv_sigma2,
+                                   dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                                    const int32_t width, const int32_t height));
 
 void eaw_dn_decompose(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                      float sum_squared[4], const int scale, const float inv_sigma2,
+                      dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                       const int32_t width, const int32_t height);
 void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                          float sum_squared[4], const int scale, const float inv_sigma2,
+                          dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                           const int32_t width, const int32_t height);

--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -111,8 +111,8 @@ dt_omp_firstprivate(guide, mask, in, Ndim) \
     maxmg = MAX(maxmg,pixelmg);
   }
 
-  float max[4] = {maxg, maxg2, maxm, maxmg};
-  float min[4] = {ming, ming2, minm, minmg};
+  dt_aligned_pixel_t max = {maxg, maxg2, maxm, maxmg};
+  dt_aligned_pixel_t min = {ming, ming2, minm, minmg};
   dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
   if(!g) return;
   dt_gaussian_blur_4c(g, in, out);

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -178,15 +178,9 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 #endif
   for(int i = 0; i < width; i++)
   {
-    float xp[4] = {0.0f};
-    float yb[4] = {0.0f};
-    float yp[4] = {0.0f};
-    float xc[4] = {0.0f};
-    float yc[4] = {0.0f};
-    float xn[4] = {0.0f};
-    float xa[4] = {0.0f};
-    float yn[4] = {0.0f};
-    float ya[4] = {0.0f};
+    dt_aligned_pixel_t xp = {0.0f};
+    dt_aligned_pixel_t yb = {0.0f};
+    dt_aligned_pixel_t yp = {0.0f};
 
     // forward filter
     for(int k = 0; k < ch; k++)
@@ -194,9 +188,14 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
       xp[k] = CLAMPF(in[(size_t)i * ch + k], Labmin[k], Labmax[k]);
       yb[k] = xp[k] * coefp;
       yp[k] = yb[k];
-      xc[k] = yc[k] = xn[k] = xa[k] = yn[k] = ya[k] = 0.0f;
     }
 
+    dt_aligned_pixel_t xc = {0.0f};
+    dt_aligned_pixel_t yc = {0.0f};
+    dt_aligned_pixel_t xn = {0.0f};
+    dt_aligned_pixel_t xa = {0.0f};
+    dt_aligned_pixel_t yn = {0.0f};
+    dt_aligned_pixel_t ya = {0.0f};
     for(int j = 0; j < height; j++)
     {
       size_t offset = ((size_t)j * width + i) * ch;
@@ -252,15 +251,9 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 #endif
   for(int j = 0; j < height; j++)
   {
-    float xp[4] = {0.0f};
-    float yb[4] = {0.0f};
-    float yp[4] = {0.0f};
-    float xc[4] = {0.0f};
-    float yc[4] = {0.0f};
-    float xn[4] = {0.0f};
-    float xa[4] = {0.0f};
-    float yn[4] = {0.0f};
-    float ya[4] = {0.0f};
+    dt_aligned_pixel_t xp = {0.0f};
+    dt_aligned_pixel_t yb = {0.0f};
+    dt_aligned_pixel_t yp = {0.0f};
 
     // forward filter
     for(int k = 0; k < ch; k++)
@@ -268,8 +261,14 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
       xp[k] = CLAMPF(temp[(size_t)j * width * ch + k], Labmin[k], Labmax[k]);
       yb[k] = xp[k] * coefp;
       yp[k] = yb[k];
-      xc[k] = yc[k] = xn[k] = xa[k] = yn[k] = ya[k] = 0.0f;
     }
+
+    dt_aligned_pixel_t xc = {0.0f};
+    dt_aligned_pixel_t yc = {0.0f};
+    dt_aligned_pixel_t xn = {0.0f};
+    dt_aligned_pixel_t xa = {0.0f};
+    dt_aligned_pixel_t yn = {0.0f};
+    dt_aligned_pixel_t ya = {0.0f};
 
     for(int i = 0; i < width; i++)
     {
@@ -625,8 +624,8 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
   const int bwidth = g->bwidth;
   const int bheight = g->bheight;
 
-  float Labmax[4] = { 0.0f };
-  float Labmin[4] = { 0.0f };
+  dt_aligned_pixel_t Labmax = { 0.0f };
+  dt_aligned_pixel_t Labmin = { 0.0f };
 
   for(int k = 0; k < MIN(channels, 4); k++)
   {

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -139,7 +139,7 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
     {
       size_t i = i_imgg - source.left;
       const float *pixel_ = get_color_pixel(imgg, i_imgg + (size_t)j_imgg * imgg.width);
-      float DT_ALIGNED_PIXEL pixel[4] =
+      dt_aligned_pixel_t pixel =
         { pixel_[0] * guide_weight, pixel_[1] * guide_weight, pixel_[2] * guide_weight, pixel_[3] * guide_weight };
       const float input = img.data[i_imgg + (size_t)j_imgg * img.width];
       meanpx[4*i+INP_MEAN] = input;

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -76,7 +76,8 @@ static void dt_heal_add(const float *const restrict first_buffer, const float *c
 }
 
 // define a custom reduction operation to handle a 3-vector of floats
-typedef struct _aligned_pixel { float DT_ALIGNED_PIXEL v[4]; } _aligned_pixel;
+// we can't return an array from a function, so wrap the array type in a struct
+typedef struct _aligned_pixel { dt_aligned_pixel_t v; } _aligned_pixel;
 #ifdef _OPENMP
 static inline _aligned_pixel add_float4(_aligned_pixel acc, _aligned_pixel newval)
 {
@@ -110,7 +111,7 @@ static float dt_heal_laplace_iteration(float *const restrict pixels, const float
     const size_t j4 = Aidx[i * 5 + 4];
     const float a = Adiag[i];
 
-    float DT_ALIGNED_PIXEL diff[4];
+    dt_aligned_pixel_t diff;
     for_each_channel(k,aligned(pixels))
     {
       diff[k] = w * (a * pixels[j0 + k] - (pixels[j1 + k] + pixels[j2 + k] + pixels[j3 + k] + pixels[j4 + k]));

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -272,7 +272,7 @@ inline static void histogram_helper_cs_Lab(const dt_dev_histogram_collection_par
 inline static void __attribute__((__unused__)) histogram_helper_cs_Lab_LCh_helper_process_pixel_float(
     const dt_dev_histogram_collection_params_t *const histogram_params, const float *pixel, uint32_t *histogram)
 {
-  float LCh[3];
+  dt_aligned_pixel_t LCh;
   dt_Lab_2_LCH(pixel, LCh);
   const uint32_t L = PS((LCh[0] / 100.f), histogram_params);
   const uint32_t C = PS((LCh[1] / (128.0f * sqrtf(2.0f))), histogram_params);

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -94,9 +94,9 @@ inline static void __attribute__((__unused__)) histogram_helper_cs_rgb_helper_pr
     const dt_dev_histogram_collection_params_t *const histogram_params, const float *pixel, uint32_t *histogram,
     const dt_iop_order_iccprofile_info_t *const profile_info)
 {
-  const float rgb[3] = { dt_ioppr_compensate_middle_grey(pixel[0], profile_info),
-      dt_ioppr_compensate_middle_grey(pixel[1], profile_info),
-      dt_ioppr_compensate_middle_grey(pixel[2], profile_info) };
+  const dt_aligned_pixel_t rgb = { dt_ioppr_compensate_middle_grey(pixel[0], profile_info),
+                                   dt_ioppr_compensate_middle_grey(pixel[1], profile_info),
+                                   dt_ioppr_compensate_middle_grey(pixel[2], profile_info) };
   const uint32_t R = PS(rgb[0], histogram_params);
   const uint32_t G = PS(rgb[1], histogram_params);
   const uint32_t B = PS(rgb[2], histogram_params);

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -180,7 +180,7 @@ static inline void CCT_to_xy_blackbody(const float t, float *x, float *y)
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void illuminant_xy_to_XYZ(const float x, const float y, float XYZ[3])
+static inline void illuminant_xy_to_XYZ(const float x, const float y, dt_aligned_pixel_t XYZ)
 {
   XYZ[0] = x / y;             // X
   XYZ[1] = 1.f;               // Y is always 1 by definition, for an illuminant
@@ -191,7 +191,7 @@ static inline void illuminant_xy_to_XYZ(const float x, const float y, float XYZ[
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void illuminant_xy_to_RGB(const float x, const float y, float RGB[4])
+static inline void illuminant_xy_to_RGB(const float x, const float y, dt_aligned_pixel_t RGB)
 {
   // Get an sRGB preview of current illuminant
   dt_aligned_pixel_t XYZ;
@@ -210,7 +210,7 @@ static inline void illuminant_xy_to_RGB(const float x, const float y, float RGB[
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void illuminant_CCT_to_RGB(const float t, float RGB[4])
+static inline void illuminant_CCT_to_RGB(const float t, dt_aligned_pixel_t RGB)
 {
   float x, y;
   if(t > 4000.f)
@@ -223,12 +223,13 @@ static inline void illuminant_CCT_to_RGB(const float t, float RGB[4])
 
 
 // Fetch image from pipeline and read EXIF for camera RAW WB coeffs
-static inline int find_temperature_from_raw_coeffs(const dt_image_t *img, const float custom_wb[4], float *chroma_x, float *chroma_y);
+static inline int find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_aligned_pixel_t custom_wb,
+                                                   float *chroma_x, float *chroma_y);
 
 
 static inline int illuminant_to_xy(const dt_illuminant_t illuminant, // primary type of illuminant
                                    const dt_image_t *img,            // image container
-                                   const float custom_wb[4],         // optional user-set WB coeffs
+                                   const dt_aligned_pixel_t custom_wb, // optional user-set WB coeffs
                                    float *x_out, float *y_out,       // chromaticity output
                                    const float t,                    // temperature in K, if needed
                                    const dt_illuminant_fluo_t fluo,  // sub-type of fluorescent illuminant, if needed
@@ -327,7 +328,8 @@ static inline int illuminant_to_xy(const dt_illuminant_t illuminant, // primary 
 }
 
 
-static inline void WB_coeffs_to_illuminant_xy(const float CAM_to_XYZ[4][3], const float WB[4], float *x, float *y)
+static inline void WB_coeffs_to_illuminant_xy(const float CAM_to_XYZ[4][3], const dt_aligned_pixel_t WB,
+                                              float *x, float *y)
 {
   // Find the illuminant chromaticity x y from RAW WB coeffs and camera input matrice
   dt_aligned_pixel_t XYZ, LMS;
@@ -390,7 +392,8 @@ static inline void matrice_pseudoinverse(float (*in)[3], float (*out)[3], int si
 }
 
 
-static int find_temperature_from_raw_coeffs(const dt_image_t *img, const float custom_wb[4], float *chroma_x, float *chroma_y)
+static int find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_aligned_pixel_t custom_wb,
+                                            float *chroma_x, float *chroma_y)
 {
   if(img == NULL) return FALSE;
   if(!dt_image_is_matrix_correction_supported(img)) return FALSE;

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -194,7 +194,7 @@ static inline void illuminant_xy_to_XYZ(const float x, const float y, float XYZ[
 static inline void illuminant_xy_to_RGB(const float x, const float y, float RGB[4])
 {
   // Get an sRGB preview of current illuminant
-  float DT_ALIGNED_PIXEL XYZ[4];
+  dt_aligned_pixel_t XYZ;
   illuminant_xy_to_XYZ(x, y, XYZ);
 
   // Fixme : convert to RGB display space instead of sRGB but first the display profile should be global in dt,
@@ -330,8 +330,7 @@ static inline int illuminant_to_xy(const dt_illuminant_t illuminant, // primary 
 static inline void WB_coeffs_to_illuminant_xy(const float CAM_to_XYZ[4][3], const float WB[4], float *x, float *y)
 {
   // Find the illuminant chromaticity x y from RAW WB coeffs and camera input matrice
-  float XYZ[4];
-  float LMS[4];
+  dt_aligned_pixel_t XYZ, LMS;
   // Simulate white point, aka convert (1, 1, 1) in camera space to XYZ
   // warning : we multiply the transpose of CAM_to_XYZ  since the pseudoinverse transposes it
   XYZ[0] = CAM_to_XYZ[0][0] / WB[0] + CAM_to_XYZ[1][0] / WB[1] + CAM_to_XYZ[2][0] / WB[2];
@@ -406,10 +405,7 @@ static int find_temperature_from_raw_coeffs(const dt_image_t *img, const float c
   if(!has_valid_coeffs) return FALSE;
 
   // Get white balance camera factors
-  float WB[4] = { img->wb_coeffs[0],
-                  img->wb_coeffs[1],
-                  img->wb_coeffs[2],
-                  img->wb_coeffs[3] };
+  dt_aligned_pixel_t WB = { img->wb_coeffs[0], img->wb_coeffs[1], img->wb_coeffs[2], img->wb_coeffs[3] };
 
   // Adapt the camera coeffs with custom white balance if provided
   // this can deal with WB coeffs that don't use the input matrix reference

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -359,7 +359,7 @@ static inline void WB_coeffs_to_illuminant_xy(const float CAM_to_XYZ[4][3], cons
 
 static inline void matrice_pseudoinverse(float (*in)[3], float (*out)[3], int size)
 {
-  float work[3][6];
+  float DT_ALIGNED_ARRAY work[3][6];
 
   for(int i = 0; i < 3; i++)
   {

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -340,7 +340,7 @@ static inline void WB_coeffs_to_illuminant_xy(const float CAM_to_XYZ[4][3], cons
   XYZ[2] = CAM_to_XYZ[0][2] / WB[0] + CAM_to_XYZ[1][2] / WB[1] + CAM_to_XYZ[2][2] / WB[2];
 
   // Matrices white point is D65. We need to convert it for darktable's pipe (D50)
-  static const float DT_ALIGNED_PIXEL D65[4] = { 0.941238f, 1.040633f, 1.088932f, 0.f };
+  static const dt_aligned_pixel_t D65 = { 0.941238f, 1.040633f, 1.088932f, 0.f };
   const float p = powf(1.088932f / 0.818155f, 0.0834f);
 
   convert_XYZ_to_bradford_LMS(XYZ, LMS);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -244,7 +244,7 @@ typedef struct dt_image_t
   float pixel_aspect_ratio;
 
   /* White balance coeffs from the raw */
-  float wb_coeffs[4];
+  dt_aligned_pixel_t wb_coeffs;
 
   /* DefaultUserCrop */
   float usercrop[4];

--- a/src/common/image_compression.c
+++ b/src/common/image_compression.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "common/image_compression.h"
+#include "common/darktable.h"
 
 #include <math.h>
 #include <stdio.h>
@@ -32,7 +33,7 @@ void dt_image_uncompress(const uint8_t *in, float *out, const int32_t width, con
 {
   dt_image_float_int_t L[16];
   float chrom[4][3];
-  const float fac[3] = { 4., 2., 4. };
+  const dt_aligned_pixel_t fac = { 4., 2., 4. };
   uint16_t L16[16];
   int32_t n_zeroes, Lbias;
   uint8_t r[4], b[4];
@@ -93,7 +94,7 @@ void dt_image_compress(const float *in, uint8_t *out, const int32_t width, const
       Lmin = 0x7fff;
       for(int q = 0; q < 4; q++)
       {
-        float chrom[3] = { 0, 0, 0 };
+        dt_aligned_pixel_t chrom = { 0, 0, 0 };
         for(int pj = 0; pj < 2; pj++)
         {
           for(int pi = 0; pi < 2; pi++)

--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -77,7 +77,7 @@ static inline void dt_imageio_dng_write_tiff_header(
     float f, float iso, uint32_t filter,
     const uint8_t xtrans[6][6],
     const float whitelevel,
-    const float wb_coeffs[3],
+    const dt_aligned_pixel_t wb_coeffs,
     const char camera_makermodel[128])
 {
   const uint32_t channels = 1;
@@ -206,7 +206,7 @@ static inline void dt_imageio_write_dng(
     const int ht, void *exif, const int exif_len, const uint32_t filter,
     const uint8_t xtrans[6][6],
     const float whitelevel,
-    const float wb_coeffs[3],
+    const dt_aligned_pixel_t wb_coeffs,
     const char camera_model[24])
 {
   FILE *f = g_fopen(filename, "wb");

--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -85,7 +85,7 @@ static inline void dt_imageio_dng_write_tiff_header(
   // uint32_t exif_offs;
   uint8_t buf[1024];
   uint8_t cnt = 0;
-  float coeff[3];
+  dt_aligned_pixel_t coeff;
   float XYZ_CAM[12];
   // this matrix is generic for XYZ->sRGB / D65
   int m[9] = { 3240454, -1537138, -498531, -969266, 1876010, 41556, 55643, -204025, 1057225 };

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -819,10 +819,10 @@ static void dt_interpolation_compute_pixel4c_plain(const struct dt_interpolation
     in = in - (itor->width - 1) * (4 + linestride);
 
     // Apply the kernel
-    float pixel[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t pixel = { 0.0f, 0.0f, 0.0f, 0.0f };
     for(int i = 0; i < 2 * itor->width; i++)
     {
-      float h[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      dt_aligned_pixel_t h = { 0.0f, 0.0f, 0.0f, 0.0f };
       for(int j = 0; j < 2 * itor->width; j++)
       {
         for(int c = 0; c < 3; c++) h[c] += kernelh[j] * in[j * 4 + c];
@@ -853,11 +853,11 @@ static void dt_interpolation_compute_pixel4c_plain(const struct dt_interpolation
     prepare_tap_boundaries(&ytap_first, &ytap_last, bordermode, 2 * itor->width, iy, height);
 
     // Apply the kernel
-    float pixel[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t pixel = { 0.0f, 0.0f, 0.0f, 0.0f };
     for(int i = ytap_first; i < ytap_last; i++)
     {
       const int clip_y = clip(iy + i, 0, height - 1, bordermode);
-      float h[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      dt_aligned_pixel_t h = { 0.0f, 0.0f, 0.0f, 0.0f };
       for(int j = xtap_first; j < xtap_last; j++)
       {
         const int clip_x = clip(ix + j, 0, width - 1, bordermode);

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1480,7 +1480,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
       debug_extra("output %p [% 4d % 4d]\n", out, ox, oy);
 
       // This will hold the resulting pixel
-      DT_ALIGNED_PIXEL float vs[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      dt_aligned_pixel_t vs = { 0.0f, 0.0f, 0.0f, 0.0f };
 
       // Number of horizontal samples contributing to the output
       int hl = hlength[hlidx++]; // H(orizontal) L(ength)
@@ -1490,7 +1490,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
         // This is our input line
         size_t baseidx_vindex = (size_t)vindex[viidx++] * in_stride_floats;
 
-        DT_ALIGNED_PIXEL float vhs[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t vhs = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         for(int ix = 0; ix < hl; ix++)
         {
@@ -1498,7 +1498,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
           const size_t baseidx = baseidx_vindex + (size_t)hindex[hiidx++] * 4;
           const float htap = hkernel[hkidx++];
           // Convince gcc 10 to vectorize
-          DT_ALIGNED_PIXEL float tmp[4] = { in[baseidx], in[baseidx+1], in[baseidx+2], in[baseidx+3] };
+          dt_aligned_pixel_t tmp = { in[baseidx], in[baseidx+1], in[baseidx+2], in[baseidx+3] };
           for_each_channel(c, aligned(tmp,vhs:16)) vhs[c] += tmp[c] * htap;
         }
 

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -377,7 +377,7 @@ static inline void _transform_rgb_to_lab_matrix(const float *const restrict imag
     for(size_t y = 0; y < stride; y += ch)
     {
       float *const restrict in = __builtin_assume_aligned(image_out + y, 16);
-      float xyz[4] DT_ALIGNED_PIXEL; // already inited in _ioppr_linear_rgb_matrix_to_xyz()
+      dt_aligned_pixel_t xyz; // inited in _ioppr_linear_rgb_matrix_to_xyz()
       _ioppr_linear_rgb_matrix_to_xyz(in, xyz, matrix);
       dt_XYZ_to_Lab(xyz, in);
     }
@@ -394,7 +394,7 @@ static inline void _transform_rgb_to_lab_matrix(const float *const restrict imag
       const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
       float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
 
-      float xyz[4] DT_ALIGNED_PIXEL; // already inited in _ioppr_linear_rgb_matrix_to_xyz()
+      dt_aligned_pixel_t xyz; // inited in _ioppr_linear_rgb_matrix_to_xyz()
       _ioppr_linear_rgb_matrix_to_xyz(in, xyz, matrix);
       dt_XYZ_to_Lab(xyz, out);
     }
@@ -420,7 +420,7 @@ static inline void _transform_lab_to_rgb_matrix(const float *const restrict imag
     const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
     float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
 
-    float xyz[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t xyz;
     dt_Lab_to_XYZ(in, xyz);
     _ioppr_xyz_to_linear_rgb_matrix(xyz, out, matrix);
   }
@@ -469,8 +469,8 @@ static inline void _transform_matrix_rgb(const float *const restrict image_in,
     {
       const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
       float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
-      float rgb[4] DT_ALIGNED_PIXEL;
-      float temp[4] DT_ALIGNED_PIXEL = { 0.f };
+      dt_aligned_pixel_t rgb;
+      dt_aligned_pixel_t temp = { 0.f };
 
       // linearize if non-linear input
       for(size_t c = 0; c < 3; c++)

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -282,9 +282,11 @@ static inline int _init_unbounded_coeffs(float *const lutr, float *const lutg, f
     // omit luts marked as linear (negative as marker)
     if(lut[k][0] >= 0.0f)
     {
-      const float x[4] DT_ALIGNED_PIXEL = { 0.7f, 0.8f, 0.9f, 1.0f };
-      const float y[4] DT_ALIGNED_PIXEL = { extrapolate_lut(lut[k], x[0], lutsize), extrapolate_lut(lut[k], x[1], lutsize), extrapolate_lut(lut[k], x[2], lutsize),
-                                            extrapolate_lut(lut[k], x[3], lutsize) };
+      const dt_aligned_pixel_t x = { 0.7f, 0.8f, 0.9f, 1.0f };
+      const dt_aligned_pixel_t y = { extrapolate_lut(lut[k], x[0], lutsize),
+                                     extrapolate_lut(lut[k], x[1], lutsize),
+                                     extrapolate_lut(lut[k], x[2], lutsize),
+                                     extrapolate_lut(lut[k], x[3], lutsize) };
       dt_iop_estimate_exp(x, y, 4, unbounded_coeffs[k]);
 
       nonlinearlut++;
@@ -676,7 +678,7 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
 
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]) && profile_info->nonlinearlut)
   {
-    const float rgb[4] = { 0.1842f, 0.1842f, 0.1842f };
+    const dt_aligned_pixel_t rgb = { 0.1842f, 0.1842f, 0.1842f };
     profile_info->grey = dt_ioppr_get_rgb_matrix_luminance(rgb, profile_info->matrix_in, profile_info->lut_in, profile_info->unbounded_coeffs_in, profile_info->lutsize, profile_info->nonlinearlut);
   }
 

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -347,7 +347,7 @@ static inline void dt_ioppr_xyz_to_rgb_matrix(const float xyz[4], float rgb[4],
 {
   if(nonlinearlut)
   {
-    float linear_rgb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t linear_rgb;
     _ioppr_xyz_to_linear_rgb_matrix(xyz, linear_rgb, matrix_out);
     _apply_trc(linear_rgb, rgb, lut_out, unbounded_coeffs_out, lutsize);
   }

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -241,7 +241,7 @@ static inline float eval_exp(const float coeff[3], const float x)
   aligned(lut:64) \
   uniform(rgb_in, rgb_out, unbounded_coeffs, lut)
 #endif
-static inline void _apply_trc(const float rgb_in[3], float rgb_out[3],
+static inline void _apply_trc(const dt_aligned_pixel_t rgb_in, dt_aligned_pixel_t rgb_out,
                               float *const lut[3],
                               const float unbounded_coeffs[3][3],
                               const int lutsize)
@@ -260,7 +260,7 @@ static inline void _apply_trc(const float rgb_in[3], float rgb_out[3],
   aligned(xyz, rgb, matrix:16) \
   uniform(xyz, rgb, matrix)
 #endif
-static inline void _ioppr_linear_rgb_matrix_to_xyz(const float rgb[4], float xyz[4],
+static inline void _ioppr_linear_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t xyz,
                                                    const float matrix[9])
 {
   for(size_t c = 0; c < 3; c++) xyz[c] = 0.0f;
@@ -276,7 +276,7 @@ static inline void _ioppr_linear_rgb_matrix_to_xyz(const float rgb[4], float xyz
   aligned(xyz, rgb, matrix:16) \
   uniform(xyz, rgb, matrix)
 #endif
-static inline void _ioppr_xyz_to_linear_rgb_matrix(const float xyz[4], float rgb[4],
+static inline void _ioppr_xyz_to_linear_rgb_matrix(const dt_aligned_pixel_t xyz, dt_aligned_pixel_t rgb,
                                                    const float matrix[9])
 {
   for(size_t c = 0; c < 3; c++) rgb[c] = 0.0f;
@@ -293,7 +293,7 @@ static inline void _ioppr_xyz_to_linear_rgb_matrix(const float xyz[4], float rgb
   aligned(lut_in:64) \
   uniform(rgb, matrix_in, lut_in, unbounded_coeffs_in)
 #endif
-static inline float dt_ioppr_get_rgb_matrix_luminance(const float rgb[4],
+static inline float dt_ioppr_get_rgb_matrix_luminance(const dt_aligned_pixel_t rgb,
                                                       const float matrix_in[9], float *const lut_in[3],
                                                       const float unbounded_coeffs_in[3][3],
                                                       const int lutsize, const int nonlinearlut)

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -302,7 +302,7 @@ static inline float dt_ioppr_get_rgb_matrix_luminance(const float rgb[4],
 
   if(nonlinearlut)
   {
-    float linear_rgb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t linear_rgb;
     _apply_trc(rgb, linear_rgb, lut_in, unbounded_coeffs_in, lutsize);
     luminance = matrix_in[3] * linear_rgb[0] + matrix_in[4] * linear_rgb[1] + matrix_in[5] * linear_rgb[2];
   }
@@ -319,14 +319,14 @@ static inline float dt_ioppr_get_rgb_matrix_luminance(const float rgb[4],
   aligned(lut_in:64) \
   uniform(rgb, xyz, matrix_in, lut_in, unbounded_coeffs_in)
 #endif
-static inline void dt_ioppr_rgb_matrix_to_xyz(const float rgb[4], float xyz[4],
+static inline void dt_ioppr_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t xyz,
                                               const float matrix_in[9], float *const lut_in[3],
                                               const float unbounded_coeffs_in[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
   if(nonlinearlut)
   {
-    float linear_rgb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t linear_rgb;
     _apply_trc(rgb, linear_rgb, lut_in, unbounded_coeffs_in, lutsize);
     _ioppr_linear_rgb_matrix_to_xyz(linear_rgb, xyz, matrix_in);
   }
@@ -340,7 +340,7 @@ static inline void dt_ioppr_rgb_matrix_to_xyz(const float rgb[4], float xyz[4],
   aligned(lut_out:64) \
   uniform(rgb, xyz, matrix_out, lut_out, unbounded_coeffs_out)
 #endif
-static inline void dt_ioppr_xyz_to_rgb_matrix(const float xyz[4], float rgb[4],
+static inline void dt_ioppr_xyz_to_rgb_matrix(const dt_aligned_pixel_t xyz, dt_aligned_pixel_t rgb,
                                               const float matrix_out[9], float *const lut_out[3],
                                               const float unbounded_coeffs_out[3][3],
                                               const int lutsize, const int nonlinearlut)
@@ -362,17 +362,17 @@ static inline void dt_ioppr_xyz_to_rgb_matrix(const float xyz[4], float rgb[4],
   aligned(lut_out:64) \
   uniform(lab, rgb, matrix_out, lut_out, unbounded_coeffs_out)
 #endif
-static inline void dt_ioppr_lab_to_rgb_matrix(const float lab[4], float rgb[4],
+static inline void dt_ioppr_lab_to_rgb_matrix(const dt_aligned_pixel_t lab, dt_aligned_pixel_t rgb,
                                               const float matrix_out[9], float *const lut_out[3],
                                               const float unbounded_coeffs_out[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
-  float xyz[4] DT_ALIGNED_PIXEL = { 0.f };
+  dt_aligned_pixel_t xyz;
   dt_Lab_to_XYZ(lab, xyz);
 
   if(nonlinearlut)
   {
-    float linear_rgb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t linear_rgb;
     _ioppr_xyz_to_linear_rgb_matrix(xyz, linear_rgb, matrix_out);
     _apply_trc(linear_rgb, rgb, lut_out, unbounded_coeffs_out, lutsize);
   }
@@ -388,12 +388,12 @@ static inline void dt_ioppr_lab_to_rgb_matrix(const float lab[4], float rgb[4],
   aligned(lut_in:64) \
   uniform(rgb, lab, matrix_in, lut_in, unbounded_coeffs_in)
 #endif
-static inline void dt_ioppr_rgb_matrix_to_lab(const float rgb[3], float lab[3],
+static inline void dt_ioppr_rgb_matrix_to_lab(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t lab,
                                               const float matrix_in[9], float *const lut_in[3],
                                               const float unbounded_coeffs_in[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
-  float xyz[4] DT_ALIGNED_PIXEL = { 0.f };
+  dt_aligned_pixel_t xyz = { 0.f };
   dt_ioppr_rgb_matrix_to_xyz(rgb, xyz, matrix_in, lut_in, unbounded_coeffs_in, lutsize, nonlinearlut);
   dt_XYZ_to_Lab(xyz, lab);
 }
@@ -409,8 +409,8 @@ static inline float dt_ioppr_get_profile_info_middle_grey(const dt_iop_order_icc
 static inline float dt_ioppr_compensate_middle_grey(const float x, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   // we transform the curve nodes from the image colorspace to lab
-  float lab[4] DT_ALIGNED_PIXEL = { 0.0f };
-  const float rgb[4] DT_ALIGNED_PIXEL = { x, x, x };
+  dt_aligned_pixel_t lab = { 0.0f };
+  const dt_aligned_pixel_t rgb = { x, x, x };
   dt_ioppr_rgb_matrix_to_lab(rgb, lab, profile_info->matrix_in, profile_info->lut_in, profile_info->unbounded_coeffs_in, profile_info->lutsize, profile_info->nonlinearlut);
   return lab[0] * .01f;
 }
@@ -421,8 +421,8 @@ static inline float dt_ioppr_compensate_middle_grey(const float x, const dt_iop_
 static inline float dt_ioppr_uncompensate_middle_grey(const float x, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   // we transform the curve nodes from lab to the image colorspace
-  const float lab[4] DT_ALIGNED_PIXEL = { x * 100.f, 0.0f, 0.0f };
-  float rgb[4] DT_ALIGNED_PIXEL = { 0.0f };
+  const dt_aligned_pixel_t lab = { x * 100.f, 0.0f, 0.0f };
+  dt_aligned_pixel_t rgb = { 0.0f };
 
   dt_ioppr_lab_to_rgb_matrix(lab, rgb, profile_info->matrix_out, profile_info->lut_out, profile_info->unbounded_coeffs_out, profile_info->lutsize, profile_info->nonlinearlut);
   return rgb[0];

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -169,7 +169,7 @@ static inline void gauss_expand(
 #if defined(__SSE2__)
 static inline __m128 convolve14641_vert(const float *in, const int wd)
 {
-  float four[4] = { 4.f, 4.f, 4.f, 4.f };
+  const dt_aligned_pixel_t four = { 4.f, 4.f, 4.f, 4.f };
   __m128 r0 = _mm_loadu_ps(in);
   __m128 r1 = _mm_loadu_ps(in + wd);
   __m128 r2 = _mm_loadu_ps(in + 2*wd);

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -24,6 +24,7 @@
 #ifdef __SSE__
 #include <xmmintrin.h>
 #endif
+#include "common/darktable.h"
 
 // work around missing standard math.h symbols
 /** ln(10) */
@@ -190,7 +191,7 @@ static inline float scalar_product(const float v_1[4], const float v_2[4])
 #ifdef _OPENMP
 #pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
 #endif
-static inline void dot_product(const float v_in[4], const float M[3][4], float v_out[4])
+static inline void dot_product(const dt_aligned_pixel_t v_in, const float M[3][4], dt_aligned_pixel_t v_out)
 {
   // specialized 3×4 dot products of 4×1 RGB-alpha pixels
   #ifdef _OPENMP

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -172,7 +172,7 @@ static inline void mul_mat_vec_2(const float *m, const float *p, float *o)
 #ifdef _OPENMP
 #pragma omp declare simd uniform(v_2) aligned(v_1, v_2:16)
 #endif
-static inline float scalar_product(const float v_1[4], const float v_2[4])
+static inline float scalar_product(const dt_aligned_pixel_t v_1, const dt_aligned_pixel_t v_2)
 {
   // specialized 3×1 dot products 2 4×1 RGB-alpha pixels.
   // v_2 needs to be uniform along loop increments, e.g. independent from current pixel values

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -148,7 +148,7 @@ static float compute_center_pixel_norm(const float center_weight, const int radi
 // compute the channel-normed squared difference between two pixels
 static inline float pixel_difference(const float* const pix1, const float* pix2, const float norm[4])
 {
-  float DT_ALIGNED_PIXEL sum[4] = { 0.f, 0.f, 0.f, 0.f };
+  dt_aligned_pixel_t sum = { 0.f, 0.f, 0.f, 0.f };
   for_each_channel(i, aligned(sum:16))
   {
     const float diff = pix1[i] - pix2[i];

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -146,7 +146,7 @@ static float compute_center_pixel_norm(const float center_weight, const int radi
 }
 
 // compute the channel-normed squared difference between two pixels
-static inline float pixel_difference(const float* const pix1, const float* pix2, const float norm[4])
+static inline float pixel_difference(const float* const pix1, const float* pix2, const dt_aligned_pixel_t norm)
 {
   dt_aligned_pixel_t sum = { 0.f, 0.f, 0.f, 0.f };
   for_each_channel(i, aligned(sum:16))
@@ -186,7 +186,7 @@ static inline __m128 channel_difference_sse2(const float* const pix1, const floa
 
 #if defined(__SSE2__)
 // compute the channel-normed squared difference between two pixels
-static inline float pixel_difference_sse2(const float* const pix1, const float* pix2, const float norm[4])
+static inline float pixel_difference_sse2(const float* const pix1, const float* pix2, const dt_aligned_pixel_t norm)
 {
   const __m128 px1 = _mm_load_ps(pix1);
   const __m128 px2 = _mm_load_ps(pix2);

--- a/src/common/noiseprofiles.h
+++ b/src/common/noiseprofiles.h
@@ -28,8 +28,8 @@ typedef struct dt_noiseprofile_t
   char *maker;
   char *model;
   int iso;
-  float a[3]; // poissonian part
-  float b[3]; // gaussian part
+  float a[4]; // poissonian part; use 4 instead of 3 elements to aid vectorization
+  float b[4]; // gaussian part
 }
 dt_noiseprofile_t;
 

--- a/src/common/noiseprofiles.h
+++ b/src/common/noiseprofiles.h
@@ -28,8 +28,8 @@ typedef struct dt_noiseprofile_t
   char *maker;
   char *model;
   int iso;
-  float a[4]; // poissonian part; use 4 instead of 3 elements to aid vectorization
-  float b[4]; // gaussian part
+  dt_aligned_pixel_t a; // poissonian part; use 4 aligned instead of 3 elements to aid vectorization
+  dt_aligned_pixel_t b; // gaussian part
 }
 dt_noiseprofile_t;
 

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -280,7 +280,7 @@ typedef struct dt_control_merge_hdr_t
 
   float whitelevel;
   float epsw;
-  float wb_coeffs[3];
+  dt_aligned_pixel_t wb_coeffs;
   char camera_makermodel[128];
 
   // 0 - ok; 1 - errors, abort

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1474,9 +1474,9 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     dt_develop_blend_params_t *bp = module->blend_params;
 
     const int tab = data->tab;
-    float raw_min[4] DT_ALIGNED_PIXEL, raw_max[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t raw_min, raw_max;
     float picker_min[8] DT_ALIGNED_PIXEL, picker_max[8] DT_ALIGNED_PIXEL;
-    float picker_values[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t picker_values;
 
     const int in_out = ((dt_key_modifier_state() == GDK_CONTROL_MASK) && data->output_channels_shown) ? 1 : 0;
 

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -352,7 +352,7 @@ void dt_develop_blendif_lab_make_mask(struct dt_dev_pixelpipe_iop_t *piece, cons
 #endif
 static inline void _blend_Lab_scale(const float *i, float *o)
 {
-  const float DT_ALIGNED_PIXEL scale[4] = { 1/100.0f, 1/128.0f, 1/128.0f, 1.0f };
+  const dt_aligned_pixel_t scale = { 1/100.0f, 1/128.0f, 1/128.0f, 1.0f };
   for_each_channel(c)
     o[c] = i[c] * scale[c];
 }
@@ -362,7 +362,7 @@ static inline void _blend_Lab_scale(const float *i, float *o)
 #endif
 static inline void _blend_Lab_rescale(const float *i, float *o)
 {
-  const float DT_ALIGNED_PIXEL scale[4] = { 100.0f, 128.0f, 128.0f, 1.0f };
+  const dt_aligned_pixel_t scale = { 100.0f, 128.0f, 128.0f, 1.0f };
   for_each_channel(c)
     o[c] = i[c] * scale[c];
 }
@@ -1519,8 +1519,8 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
   {
     _blend_row_func *const blend = _choose_blend_func(d->blend_mode);
     // minimum and maximum values after scaling !!!
-    const float min[4] DT_ALIGNED_PIXEL = { 0.0f, -1.0f, -1.0f, 0.0f };
-    const float max[4] DT_ALIGNED_PIXEL = { 1.0f, 1.0f, 1.0f, 1.0f };
+    const dt_aligned_pixel_t min = { 0.0f, -1.0f, -1.0f, 0.0f };
+    const dt_aligned_pixel_t max = { 1.0f, 1.0f, 1.0f, 1.0f };
 
     float *tmp_buffer = dt_alloc_align_float(owidth * oheight * DT_BLENDIF_LAB_CH);
     if (tmp_buffer != NULL)

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -143,7 +143,7 @@ static inline void _blendif_lch(const float *const restrict pixels, float *const
   const float c_scale = 1.0f / (128.0f * sqrtf(2.0f));
   for(size_t x = 0, j = 0; x < stride; x++, j += DT_BLENDIF_LAB_CH)
   {
-    float LCH[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t LCH;
     dt_Lab_2_LCH(pixels + j, LCH);
     float factor = 1.0f;
     factor *= _blendif_compute_factor(LCH[1] * c_scale, invert_mask[0], parameters);
@@ -380,8 +380,7 @@ static void _blend_normal_bounded(const float *const restrict a, const float *co
   {
     size_t j = i * DT_BLENDIF_LAB_CH;
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -407,8 +406,7 @@ static void _blend_normal_unbounded(const float *const restrict a, const float *
   {
     size_t j = i * DT_BLENDIF_LAB_CH;
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -432,8 +430,7 @@ static void _blend_lighten(const float *const restrict a, const float *const res
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -461,8 +458,7 @@ static void _blend_darken(const float *const restrict a, const float *const rest
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -490,8 +486,7 @@ static void _blend_multiply(const float *const restrict a, const float *const re
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -519,8 +514,7 @@ static void _blend_average(const float *const restrict a, const float *const res
   {
     size_t j = i * DT_BLENDIF_LAB_CH;
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -545,8 +539,7 @@ static void _blend_add(const float *const restrict a, const float *const restric
   {
     size_t j = i * DT_BLENDIF_LAB_CH;
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -571,8 +564,7 @@ static void _blend_subtract(const float *const restrict a, const float *const re
   {
     size_t j = i * DT_BLENDIF_LAB_CH;
     float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -597,8 +589,7 @@ static void _blend_difference(const float *const restrict a, const float *const 
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -628,8 +619,7 @@ static void _blend_difference2(const float *const restrict a, const float *const
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -658,8 +648,7 @@ static void _blend_screen(const float *const restrict a, const float *const rest
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -695,8 +684,7 @@ static void _blend_overlay(const float *const restrict a, const float *const res
   {
     const float local_opacity = mask[i];
     const float local_opacity2 = local_opacity * local_opacity;
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(&a[j], ta);
     _blend_Lab_scale(&b[j], tb);
@@ -735,8 +723,7 @@ static void _blend_softlight(const float *const restrict a, const float *const r
   {
     const float local_opacity = mask[i];
     const float local_opacity2 = local_opacity * local_opacity;
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -774,8 +761,7 @@ static void _blend_hardlight(const float *const restrict a, const float *const r
   {
     const float local_opacity = mask[i];
     const float local_opacity2 = local_opacity * local_opacity;
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -814,8 +800,7 @@ static void _blend_vividlight(const float *const restrict a, const float *const 
   {
     const float local_opacity = mask[i];
     const float local_opacity2 = local_opacity * local_opacity;
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -854,8 +839,7 @@ static void _blend_linearlight(const float *const restrict a, const float *const
   {
     const float local_opacity = mask[i];
     const float local_opacity2 = local_opacity * local_opacity;
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -890,8 +874,7 @@ static void _blend_pinlight(const float *const restrict a, const float *const re
   {
     const float local_opacity = mask[i];
     const float local_opacity2 = local_opacity * local_opacity;
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -928,8 +911,7 @@ static void _blend_lightness(const float *const restrict a, const float *const r
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -956,10 +938,8 @@ static void _blend_chromaticity(const float *const restrict a, const float *cons
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
-    float tta[4] DT_ALIGNED_PIXEL;
-    float ttb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _blend_Lab_scale(a + j, ta);
     _CLAMP_XYZ(ta, min, max);
@@ -991,10 +971,8 @@ static void _blend_hue(const float *const restrict a, const float *const restric
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
-    float tta[4] DT_ALIGNED_PIXEL;
-    float ttb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _blend_Lab_scale(a + j, ta);
     _CLAMP_XYZ(ta, min, max);
@@ -1029,10 +1007,8 @@ static void _blend_color(const float *const restrict a, const float *const restr
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
-    float tta[4] DT_ALIGNED_PIXEL;
-    float ttb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _blend_Lab_scale(a + j, ta);
     _CLAMP_XYZ(ta, min, max);
@@ -1068,10 +1044,8 @@ static void _blend_coloradjust(const float *const restrict a, const float *const
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
-    float tta[4] DT_ALIGNED_PIXEL;
-    float ttb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _blend_Lab_scale(a + j, ta);
     _CLAMP_XYZ(ta, min, max);
@@ -1107,8 +1081,7 @@ static void _blend_Lab_lightness(const float *const restrict a, const float *con
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -1133,8 +1106,7 @@ static void _blend_Lab_a(const float *const restrict a, const float *const restr
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -1159,8 +1131,7 @@ static void _blend_Lab_b(const float *const restrict a, const float *const restr
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -1186,8 +1157,7 @@ static void _blend_Lab_color(const float *const restrict a, const float *const r
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
     float local_opacity = mask[i];
-    float ta[4] DT_ALIGNED_PIXEL;
-    float tb[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     _blend_Lab_scale(a + j, ta);
     _blend_Lab_scale(b + j, tb);
@@ -1382,7 +1352,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       const float factor = 1.0f / (128.0f * sqrtf(2.0f) * exp2f(boost_factors[DEVELOP_BLENDIF_C_in]));
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
       {
-        float LCH[4] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t LCH;
         dt_Lab_2_LCH(a + j, LCH);
         const float c = clamp_simd(LCH[1] * factor);
         _display_channel_value(b + j, c, mask[i]);
@@ -1394,7 +1364,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       const float factor = 1.0f / (128.0f * sqrtf(2.0f) * exp2f(boost_factors[DEVELOP_BLENDIF_C_out]));
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
       {
-        float LCH[4] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t LCH;
         dt_Lab_2_LCH(b + j, LCH);
         const float c = clamp_simd(LCH[1] * factor);
         _display_channel_value(b + j, c, mask[i]);
@@ -1405,7 +1375,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factor for hues
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
       {
-        float LCH[4] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t LCH;
         dt_Lab_2_LCH(a + j, LCH);
         const float c = clamp_simd(LCH[2]);
         _display_channel_value(b + j, c, mask[i]);
@@ -1415,7 +1385,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factor for hues
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
       {
-        float LCH[4] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t LCH;
         dt_Lab_2_LCH(b + j, LCH);
         const float c = clamp_simd(LCH[2]);
         _display_channel_value(b + j, c, mask[i]);
@@ -1494,7 +1464,7 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
 #endif
       for(size_t j = 0; j < buffsize; j += DT_BLENDIF_LAB_CH)
       {
-        float pixel[4] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t pixel;
         for_each_channel(c,aligned(b))
           pixel[c] = b[j+c];
         dt_ioppr_rgb_matrix_to_lab(pixel, b + j, profile->matrix_in, profile->lut_in,
@@ -1509,7 +1479,7 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
 #endif
       for(size_t j = 0; j < buffsize; j += DT_BLENDIF_LAB_CH)
       {
-        float XYZ[4] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t XYZ;
         dt_Rec709_to_XYZ_D50(b + j, XYZ);
         dt_XYZ_to_Lab(XYZ, b + j);
       }

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -172,7 +172,7 @@ static inline void _blendif_hsl(const float *const restrict pixels, float *const
 {
   for(size_t x = 0, j = 0; x < stride; x++, j += DT_BLENDIF_RGB_CH)
   {
-    float HSL[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t HSL;
     dt_RGB_2_HSL(pixels + j, HSL);
     float factor = 1.0f;
     for(size_t i = 0; i < 3; i++)
@@ -732,10 +732,8 @@ static void _blend_lightness(const float *const restrict a, const float *const r
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
-    float tta[3] DT_ALIGNED_PIXEL;
-    float ttb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _PX_COPY(a + j, ta);
     _PX_COPY(b + j, tb);
@@ -767,10 +765,8 @@ static void _blend_chromaticity(const float *const restrict a, const float *cons
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
-    float tta[3] DT_ALIGNED_PIXEL;
-    float ttb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _PX_COPY(a + j, ta);
     _PX_COPY(b + j, tb);
@@ -802,10 +798,8 @@ static void _blend_hue(const float *const restrict a, const float *const restric
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
-    float tta[3] DT_ALIGNED_PIXEL;
-    float ttb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _PX_COPY(a + j, ta);
     _PX_COPY(b + j, tb);
@@ -840,10 +834,8 @@ static void _blend_color(const float *const restrict a, const float *const restr
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
-    float tta[3] DT_ALIGNED_PIXEL;
-    float ttb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _PX_COPY(a + j, ta);
     _PX_COPY(b + j, tb);
@@ -879,10 +871,8 @@ static void _blend_coloradjust(const float *const restrict a, const float *const
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
-    float tta[3] DT_ALIGNED_PIXEL;
-    float ttb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
+    dt_aligned_pixel_t tta, ttb;
 
     _PX_COPY(a + j, ta);
     _PX_COPY(b + j, tb);
@@ -918,8 +908,7 @@ static void _blend_HSV_value(const float *const restrict a, const float *const r
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     dt_RGB_2_HSV(a + j, ta);
     dt_RGB_2_HSV(b + j, tb);
@@ -946,8 +935,7 @@ static void _blend_HSV_color(const float *const restrict a, const float *const r
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
     const float local_opacity = mask[i];
-    float ta[3] DT_ALIGNED_PIXEL;
-    float tb[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t ta, tb;
 
     dt_RGB_2_HSV(a + j, ta);
     dt_RGB_2_HSV(b + j, tb);
@@ -1239,7 +1227,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float HSL[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t HSL;
         dt_RGB_2_HSL(a + j, HSL);
         const float c = clamp_simd(HSL[0]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -1250,7 +1238,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float HSL[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t HSL;
         dt_RGB_2_HSL(b + j, HSL);
         const float c = clamp_simd(HSL[0]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -1261,7 +1249,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float HSL[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t HSL;
         dt_RGB_2_HSL(a + j, HSL);
         const float c = clamp_simd(HSL[1]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -1272,7 +1260,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float HSL[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t HSL;
         dt_RGB_2_HSL(b + j, HSL);
         const float c = clamp_simd(HSL[1]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -1283,7 +1271,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float HSL[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t HSL;
         dt_RGB_2_HSL(a + j, HSL);
         const float c = clamp_simd(HSL[2]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -1294,7 +1282,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factors for HSL
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float HSL[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t HSL;
         dt_RGB_2_HSL(b + j, HSL);
         const float c = clamp_simd(HSL[2]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -141,9 +141,9 @@ static inline void _blendif_jzczhz(const float *const restrict pixels, float *co
 {
   for(size_t x = 0, j = 0; x < stride; x++, j += DT_BLENDIF_RGB_CH)
   {
-    float XYZ_D65[3] DT_ALIGNED_PIXEL;
-    float JzAzBz[3] DT_ALIGNED_PIXEL;
-    float JzCzhz[3] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t XYZ_D65;
+    dt_aligned_pixel_t JzAzBz;
+    dt_aligned_pixel_t JzCzhz;
 
     // use the matrix_out of the hacked profile for blending to use the
     // conversion from RGB to XYZ D65 (instead of XYZ D50)
@@ -749,11 +749,11 @@ static inline float _rgb_luminance(const float *const restrict rgb,
 static inline void _rgb_to_JzCzhz(const float *const restrict rgb, float *const restrict JzCzhz,
                                   const dt_iop_order_iccprofile_info_t *const restrict profile)
 {
-  float JzAzBz[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t JzAzBz = { 0.0f, 0.0f, 0.0f };
 
   if(profile)
   {
-    float XYZ_D65[3] DT_ALIGNED_PIXEL = { 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t XYZ_D65 = { 0.0f, 0.0f, 0.0f };
     // use the matrix_out of the hacked profile for blending to use the
     // conversion from RGB to XYZ D65 (instead of XYZ D50)
     dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D65, profile->matrix_out, profile->lut_in, profile->unbounded_coeffs_in,
@@ -873,7 +873,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Jz_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t JzCzhz;
         _rgb_to_JzCzhz(a + j, JzCzhz, profile);
         const float c = clamp_simd(JzCzhz[0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -886,7 +886,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Jz_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t JzCzhz;
         _rgb_to_JzCzhz(b + j, JzCzhz, profile);
         const float c = clamp_simd(JzCzhz[0] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -899,7 +899,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Cz_in]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t JzCzhz;
         _rgb_to_JzCzhz(a + j, JzCzhz, profile);
         const float c = clamp_simd(JzCzhz[1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -912,7 +912,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       const float factor = 1.0f / exp2f(boost_factors[DEVELOP_BLENDIF_Cz_out]);
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t JzCzhz;
         _rgb_to_JzCzhz(b + j, JzCzhz, profile);
         const float c = clamp_simd(JzCzhz[1] * factor);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -924,7 +924,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factor for hues
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t JzCzhz;
         _rgb_to_JzCzhz(a + j, JzCzhz, profile);
         const float c = clamp_simd(JzCzhz[2]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;
@@ -935,7 +935,7 @@ static void _display_channel(const float *const restrict a, float *const restric
       // no boost factor for hues
       for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
       {
-        float JzCzhz[3] DT_ALIGNED_PIXEL;
+        dt_aligned_pixel_t JzCzhz;
         _rgb_to_JzCzhz(b + j, JzCzhz, profile);
         const float c = clamp_simd(JzCzhz[2]);
         for(int k = 0; k < DT_BLENDIF_RGB_BCH; k++) b[j + k] = c;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -279,7 +279,7 @@ typedef struct dt_develop_t
 
     // is the WB module using D65 illuminant and not doing full chromatic adaptation ?
     gboolean wb_is_D65;
-    float wb_coeffs[4];
+    dt_aligned_pixel_t wb_coeffs;
 
   } proxy;
 

--- a/src/develop/format.h
+++ b/src/develop/format.h
@@ -20,6 +20,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "common/darktable.h"
 
 struct dt_dev_pixelpipe_iop_t;
 struct dt_dev_pixelpipe_t;
@@ -51,11 +52,11 @@ typedef struct dt_iop_buffer_dsc_t
   struct
   {
     int enabled;
-    float coeffs[4];
+    dt_aligned_pixel_t coeffs;
   } temperature;
 
   /** sensor saturation, propagated through the operations */
-  float processed_maximum[4];
+  dt_aligned_pixel_t processed_maximum;
 
   /** colorspace of the image */
   int cst;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -213,9 +213,9 @@ typedef struct dt_iop_module_t
   /** single point to pick if in point mode */
   float color_picker_point[2];
   /** place to store the picked color of module input. */
-  float picked_color[4], picked_color_min[4], picked_color_max[4];
+  dt_aligned_pixel_t picked_color, picked_color_min, picked_color_max;
   /** place to store the picked color of module output (before blending). */
-  float picked_output_color[4], picked_output_color_min[4], picked_output_color_max[4];
+  dt_aligned_pixel_t picked_output_color, picked_output_color_min, picked_output_color_max;
   /** pointer to pre-module histogram data; if available: histogram_bins_count bins with 4 channels each */
   uint32_t *histogram;
   /** stats of captured histogram */

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -282,7 +282,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *cons
 
     for(int x = 0; x < roi_out->width; x++)
     {
-      float col[4] = { 0, 0, 0, 0 };
+      dt_aligned_pixel_t col = { 0, 0, 0, 0 };
 
       const float fx = (x + roi_out->x) * px_footprint;
       int px = (int)fx & ~1;
@@ -291,7 +291,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *cons
 
       const int maxi = MIN(((roi_in->width - 5) & ~1u) + rggbx, px + 2 * samples);
 
-      float p[4];
+      dt_aligned_pixel_t p;
       float num = 0;
 
       // upper left 2x2 block of sampling region
@@ -704,7 +704,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in
 
     for(int x = 0; x < roi_out->width; x++)
     {
-      float col[4] = { 0, 0, 0, 0 };
+      dt_aligned_pixel_t col = { 0, 0, 0, 0 };
 
       const float fx = (x + roi_out->x) * px_footprint;
       int px = (int)fx & ~1;

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -713,7 +713,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in
 
       const int maxi = MIN(((roi_in->width - 5) & ~1u) + rggbx, px + 2 * samples);
 
-      float p[3];
+      dt_aligned_pixel_t p;
       float num = 0;
 
       // upper left 2x2 block of sampling region
@@ -874,7 +874,7 @@ void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out, const float *
 
     for(int x = 0; x < roi_out->width; x++, outc += 4)
     {
-      float col[3] = { 0.0f };
+      dt_aligned_pixel_t col = { 0.0f };
       int num = 0;
       const int px = CLAMPS((int)round((x + roi_out->x - 0.5f) * px_footprint), 0, roi_in->width - 3);
       const int xmax = MIN(roi_in->width - 3, px + 3 * samples);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -432,7 +432,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
 /** luminance mask support */
 void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
 void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
-void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float wb[3]);
+void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *const tmp, const int width,
+                                  const int height, const dt_aligned_pixel_t wb);
 void dt_masks_calc_detail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
 
 /** return the list of possible mouse actions */

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -42,7 +42,7 @@
   telling a) we want a DM and b) we want it from either demosaic or from rawprepare.
   If such a flag has not been previously set we will force a pipeline reprocessing.
   
-  gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode, const float wb[3]);
+  gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode, const dt_aligned_pixel_t wb);
   or it's _cl equivalent write a preliminary mask holding signal-change values for every pixel.
   These mask values are calculated as
   a) get Y0 for every pixel
@@ -188,7 +188,8 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
   dt_masks_extend_border(out, width, height, 4);
 }
 
-void dt_masks_calc_rawdetail_mask(float *const restrict src, float *const restrict mask, float *const restrict tmp, const int width, const int height, const float wb[3])
+void dt_masks_calc_rawdetail_mask(float *const restrict src, float *const restrict mask, float *const restrict tmp,
+                                  const int width, const int height, const dt_aligned_pixel_t wb)
 {
   const int msize = width * height;
 #ifdef _OPENMP

--- a/src/develop/noise_generator.h
+++ b/src/develop/noise_generator.h
@@ -140,7 +140,7 @@ static inline float dt_noise_generator(const dt_noise_distribution_t distributio
 #endif
 static inline void uniform_noise_simd(const float mu[3], const float sigma[3], uint32_t state[4], float out[3])
 {
-  const float DT_ALIGNED_ARRAY noise[3] = { xoshiro128plus(state), xoshiro128plus(state), xoshiro128plus(state) };
+  const dt_aligned_pixel_t noise = { xoshiro128plus(state), xoshiro128plus(state), xoshiro128plus(state) };
 
   #pragma unroll
   for(size_t c = 0; c < 3; c++)
@@ -158,8 +158,8 @@ static inline void gaussian_noise_simd(const float mu[3], const float sigma[3], 
   // flip needs to be flipped every next iteration
   // reference : https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
 
-  float DT_ALIGNED_ARRAY u1[3] = { 0.f };
-  float DT_ALIGNED_ARRAY u2[3] = { 0.f };
+  dt_aligned_pixel_t u1 = { 0.f };
+  dt_aligned_pixel_t u2 = { 0.f };
 
   #pragma unroll
   for(size_t c = 0; c < 3; c++)
@@ -169,7 +169,7 @@ static inline void gaussian_noise_simd(const float mu[3], const float sigma[3], 
   for(size_t c = 0; c < 3; c++)
     u2[c] = xoshiro128plus(state);
 
-  float DT_ALIGNED_ARRAY noise[3] = { 0.f };
+  dt_aligned_pixel_t noise = { 0.f };
 
   #pragma unroll
   for(size_t c = 0; c < 3; c++)
@@ -189,8 +189,8 @@ static inline void gaussian_noise_simd(const float mu[3], const float sigma[3], 
 static inline void poisson_noise_simd(const float mu[3], const float sigma[3], const int flip[3], uint32_t state[4], float out[3])
 {
   // create poissonian noise - It's just gaussian noise with Anscombe transform applied
-  float DT_ALIGNED_ARRAY u1[3] = { 0.f };
-  float DT_ALIGNED_ARRAY u2[3] = { 0.f };
+  dt_aligned_pixel_t u1 = { 0.f };
+  dt_aligned_pixel_t u2 = { 0.f };
 
   #pragma unroll
   for(size_t c = 0; c < 3; c++)
@@ -199,7 +199,7 @@ static inline void poisson_noise_simd(const float mu[3], const float sigma[3], c
     u2[c] = xoshiro128plus(state);
   }
 
-  float DT_ALIGNED_ARRAY noise[3] = { 0.f };
+  dt_aligned_pixel_t noise = { 0.f };
 
   #pragma unroll
   for(size_t c = 0; c < 3; c++)
@@ -209,7 +209,7 @@ static inline void poisson_noise_simd(const float mu[3], const float sigma[3], c
   }
 
   // now we have gaussian noise, then apply Anscombe transform to get poissonian one
-  float DT_ALIGNED_ARRAY r[3] = { 0.f };
+  dt_aligned_pixel_t r = { 0.f };
 
   #pragma unroll
   for(size_t c = 0; c < 3; c++)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -672,7 +672,7 @@ static void pixelpipe_picker(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
     return;
   }
 
-  float min[4] DT_ALIGNED_PIXEL, max[4] DT_ALIGNED_PIXEL, avg[4] DT_ALIGNED_PIXEL;
+  dt_aligned_pixel_t min, max, avg;
   for(int k = 0; k < 4; k++)
   {
     min[k] = INFINITY;
@@ -757,7 +757,7 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_dev_pixel
   box[2] = region[0];
   box[3] = region[1];
 
-  float min[4] DT_ALIGNED_PIXEL, max[4] DT_ALIGNED_PIXEL, avg[4] DT_ALIGNED_PIXEL;
+  dt_aligned_pixel_t min, max, avg;
   for(int k = 0; k < 4; k++)
   {
     min[k] = INFINITY;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -788,9 +788,9 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
                                        float *pick_color_rgb_mean, float *pick_color_lab_min,
                                        float *pick_color_lab_max, float *pick_color_lab_mean)
 {
-  float picked_color_rgb_min[3] = { 0.0f };
-  float picked_color_rgb_max[3] = { 0.0f };
-  float picked_color_rgb_mean[3] = { 0.0f };
+  dt_aligned_pixel_t picked_color_rgb_min = { 0.0f };
+  dt_aligned_pixel_t picked_color_rgb_max = { 0.0f };
+  dt_aligned_pixel_t picked_color_rgb_mean = { 0.0f };
 
   for(int k = 0; k < 3; k++) picked_color_rgb_min[k] = FLT_MAX;
   for(int k = 0; k < 3; k++) picked_color_rgb_max[k] = FLT_MIN;
@@ -805,7 +805,7 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
   point[0] = MIN(roi_in->width - 1, MAX(0, pick_point[0] * roi_in->width));
   point[1] = MIN(roi_in->height - 1, MAX(0, pick_point[1] * roi_in->height));
 
-  float rgb[3] = { 0.0f };
+  dt_aligned_pixel_t rgb = { 0.0f };
 
   const float w = 1.0 / ((box[3] - box[1] + 1) * (box[2] - box[0] + 1));
 
@@ -2099,8 +2099,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       if((*out_format)->datatype == TYPE_FLOAT && (*out_format)->channels == 4)
       {
         int hasinf = 0, hasnan = 0;
-        float min[3] = { FLT_MAX };
-        float max[3] = { FLT_MIN };
+        dt_aligned_pixel_t min = { FLT_MAX };
+        dt_aligned_pixel_t max = { FLT_MIN };
 
         for(int k = 0; k < 4 * roi_out->width * roi_out->height; k++)
         {
@@ -2612,7 +2612,9 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const
   p->rawdetail_mask_data = mask;
   memcpy(&p->rawdetail_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
-  float wb[3] = {piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+  dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0],
+                            piece->pipe->dsc.temperature.coeffs[1],
+                            piece->pipe->dsc.temperature.coeffs[2] };
   if((p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) == DT_DEV_DETAIL_MASK_RAWPREPARE)
   {
     wb[0] = wb[1] = wb[2] = 1.0f;
@@ -2653,7 +2655,9 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   if(tmp == NULL) goto error;
   {
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;
-    float wb[3] = {piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+    dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0],
+                              piece->pipe->dsc.temperature.coeffs[1],
+                              piece->pipe->dsc.temperature.coeffs[2] };
     if((p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) == DT_DEV_DETAIL_MASK_RAWPREPARE)
     {
       wb[0] = wb[1] = wb[2] = 1.0f;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -719,10 +719,9 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   }
 
   /* store processed_maximum to be re-used and aggregated */
-  float processed_maximum_saved[4];
-  float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
-
+  dt_aligned_pixel_t processed_maximum_saved;
+  dt_aligned_pixel_t processed_maximum_new = { 1.0f };
+  for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* iterate over tiles */
   for(size_t tx = 0; tx < tiles_x; tx++)
@@ -989,9 +988,9 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
 
 
   /* store processed_maximum to be re-used and aggregated */
-  float processed_maximum_saved[4];
-  float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
+  dt_aligned_pixel_t processed_maximum_saved;
+  dt_aligned_pixel_t processed_maximum_new = { 1.0f };
+  for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* iterate over tiles */
   for(size_t tx = 0; tx < tiles_x; tx++)
@@ -1328,9 +1327,9 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
            tiles_x, tiles_y, width, height, overlap);
 
   /* store processed_maximum to be re-used and aggregated */
-  float processed_maximum_saved[4];
-  float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
+  dt_aligned_pixel_t processed_maximum_saved;
+  dt_aligned_pixel_t processed_maximum_new = { 1.0f };
+  for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* reserve pinned input and output memory for host<->device data transfer */
   if(use_pinned_memory)
@@ -1710,9 +1709,9 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
 
 
   /* store processed_maximum to be re-used and aggregated */
-  float processed_maximum_saved[4];
-  float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
+  dt_aligned_pixel_t processed_maximum_saved;
+  dt_aligned_pixel_t processed_maximum_new = { 1.0f };
+  for_four_channels(k) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* reserve pinned input and output memory for host<->device data transfer */
   if(use_pinned_memory)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1329,7 +1329,7 @@ static int detail_enhance(const float *const in, float *const out, const int wid
 #endif
   for(size_t index = 0; index < 4*npixels; index += 4)
   {
-    float XYZ[3];
+    dt_aligned_pixel_t XYZ;
     dt_Lab_to_XYZ(out + index, XYZ);
     XYZ_to_sRGB(XYZ, out + index);
   }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1302,7 +1302,7 @@ static int detail_enhance(const float *const in, float *const out, const int wid
 #endif
   for(size_t index = 0; index < 4*npixels; index += 4)
   {
-    float DT_ALIGNED_PIXEL XYZ[4];
+    dt_aligned_pixel_t XYZ;
     sRGB_to_XYZ(in + index, XYZ);
     dt_XYZ_to_Lab(XYZ, out + index);
   }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -258,8 +258,8 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
                              const eaw_synthesize_t synthesize)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
-  float DT_ALIGNED_PIXEL thrs[MAX_NUM_SCALES][4];
-  float DT_ALIGNED_PIXEL boost[MAX_NUM_SCALES][4];
+  dt_aligned_pixel_t thrs[MAX_NUM_SCALES];
+  dt_aligned_pixel_t boost[MAX_NUM_SCALES];
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
   const int max_mult = 1u << (max_scale - 1);
@@ -350,8 +350,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
-  float thrs[MAX_NUM_SCALES][4];
-  float boost[MAX_NUM_SCALES][4];
+  dt_aligned_pixel_t thrs[MAX_NUM_SCALES];
+  dt_aligned_pixel_t boost[MAX_NUM_SCALES];
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
 
@@ -487,8 +487,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
-  float thrs[MAX_NUM_SCALES][4];
-  float boost[MAX_NUM_SCALES][4];
+  dt_aligned_pixel_t thrs[MAX_NUM_SCALES];
+  dt_aligned_pixel_t boost[MAX_NUM_SCALES];
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
 
@@ -631,8 +631,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
                      struct dt_develop_tiling_t *tiling)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
-  float thrs[MAX_NUM_SCALES][4];
-  float boost[MAX_NUM_SCALES][4];
+  dt_aligned_pixel_t thrs[MAX_NUM_SCALES];
+  dt_aligned_pixel_t boost[MAX_NUM_SCALES];
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
   const int max_filter_radius = 2 * (1 << max_scale); // 2 * 2^max_scale

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -380,8 +380,8 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
 struct border_positions_t
 {
-  float DT_ALIGNED_PIXEL bcolor[4];
-  float DT_ALIGNED_PIXEL flcolor[4];
+  dt_aligned_pixel_t bcolor;
+  dt_aligned_pixel_t flcolor;
   int border_top;		// 0..bt is rows of top border outside the frameline
   int fl_top;			//bt..ft is the top frameline
   int image_top;		//ft..it is the top border inside the frameline

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -400,7 +400,7 @@ struct border_positions_t
 };
 
 // this will be called from inside an OpenMP parallel section, so no need to parallelize further
-static inline void set_pixels(float *buf, const float color[4], const int npixels)
+static inline void set_pixels(float *buf, const dt_aligned_pixel_t color, const int npixels)
 {
   for (int i = 0; i < npixels; i++)
   {

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -257,8 +257,8 @@ static void get_manifolds(const float* const restrict in, const size_t width, co
   float *const restrict blurred_manifold_higher = dt_alloc_align_float(width * height * 4);
   float *const restrict blurred_manifold_lower = dt_alloc_align_float(width * height * 4);
 
-  float max[4] = {INFINITY, INFINITY, INFINITY, INFINITY};
-  float min[4] = {-INFINITY, -INFINITY, -INFINITY, 0.0f};
+  dt_aligned_pixel_t max = {INFINITY, INFINITY, INFINITY, INFINITY};
+  dt_aligned_pixel_t min = {-INFINITY, -INFINITY, -INFINITY, 0.0f};
   // start with a larger blur to estimate the manifolds if we refine them
   // later on
   const float blur_size = refine_manifolds ? sigma2 : sigma;
@@ -603,8 +603,8 @@ static void reduce_artifacts(const float* const restrict in,
   }
 
   float *const restrict blurred_in_out = dt_alloc_align_float(width * height * 4);
-  float max[4] = {INFINITY, INFINITY, INFINITY, INFINITY};
-  float min[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+  dt_aligned_pixel_t max = {INFINITY, INFINITY, INFINITY, INFINITY};
+  dt_aligned_pixel_t min = {0.0f, 0.0f, 0.0f, 0.0f};
   dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
   if(!g) return;
   dt_gaussian_blur_4c(g, in_out, blurred_in_out);

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -156,7 +156,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
   const float noise = data->noise / scale;
 
-  float RGBmax[4], RGBmin[4];
+  dt_aligned_pixel_t RGBmax, RGBmin;
   for(int k = 0; k < 4; k++)
   {
     RGBmax[k] = INFINITY;
@@ -207,7 +207,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         const point_t box[5] = { tl, { br.x, tl.y }, cc, { tl.x, br.y }, br };
 
         // find the average color over the big pixel
-        float DT_ALIGNED_PIXEL RGB[4] = { 0.f };
+        dt_aligned_pixel_t RGB = { 0.f };
         for(size_t k = 0; k < 5; k++)
         {
           const float *const restrict pix_in = __builtin_assume_aligned(input + (width * box[k].y + box[k].x) * 4, 16);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -170,7 +170,7 @@ typedef struct dt_iop_channelmixer_rbg_data_t
   float DT_ALIGNED_PIXEL saturation[CHANNEL_SIZE];
   float DT_ALIGNED_PIXEL lightness[CHANNEL_SIZE];
   float DT_ALIGNED_PIXEL grey[CHANNEL_SIZE];
-  float DT_ALIGNED_PIXEL illuminant[4]; // XYZ coordinates of illuminant
+  dt_aligned_pixel_t illuminant; // XYZ coordinates of illuminant
   float p, gamut;
   int apply_grey;
   int clip;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -524,7 +524,8 @@ static inline void upscale_vector(float vector[4], const float scaling)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(input, output:16) uniform(compression, clip)
 #endif
-static inline void gamut_mapping(const float input[4], const float compression, const int clip, float output[4])
+static inline void gamut_mapping(const dt_aligned_pixel_t input, const float compression, const int clip,
+                                 dt_aligned_pixel_t output)
 {
   // Get the sum XYZ
   const float sum = input[0] + input[1] + input[2];
@@ -533,10 +534,10 @@ static inline void gamut_mapping(const float input[4], const float compression, 
   if(sum > 0.f && Y > 0.f)
   {
     // Convert to xyY
-    float xyY[4] DT_ALIGNED_PIXEL = { input[0] / sum, input[1] / sum , Y, 0.0f };
+    dt_aligned_pixel_t xyY = { input[0] / sum, input[1] / sum , Y, 0.0f };
 
     // Convert to uvY
-    float uvY[4] DT_ALIGNED_PIXEL;
+    dt_aligned_pixel_t uvY;
     dt_xyY_to_uvY(xyY, uvY);
 
     // Get the chromaticity difference with white point uv
@@ -585,8 +586,9 @@ static inline void gamut_mapping(const float input[4], const float compression, 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(input, output, saturation, lightness:16) uniform(saturation, lightness)
 #endif
-static inline void luma_chroma(const float input[4], const float saturation[4], const float lightness[4],
-                               float output[4], const dt_iop_channelmixer_rgb_version_t version)
+static inline void luma_chroma(const dt_aligned_pixel_t input, const dt_aligned_pixel_t saturation,
+                               const dt_aligned_pixel_t lightness, dt_aligned_pixel_t output,
+                               const dt_iop_channelmixer_rgb_version_t version)
 {
   // Compute euclidean norm
   float norm = euclidean_norm(input);
@@ -660,8 +662,8 @@ static inline void loop_switch(const float *const restrict in, float *const rest
   for(size_t k = 0; k < height * width * 4; k += 4)
   {
     // intermediate temp buffers
-    float DT_ALIGNED_PIXEL temp_one[4];
-    float DT_ALIGNED_PIXEL temp_two[4];
+    dt_aligned_pixel_t temp_one;
+    dt_aligned_pixel_t temp_two;
 
     for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; c++)
       temp_two[c] = (clip) ? fmaxf(in[k + c], 0.0f) : in[k + c];
@@ -888,8 +890,8 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
     for(size_t j = 0; j < width; j++)
     {
       const size_t index = (i * width + j) * ch;
-      float DT_ALIGNED_PIXEL RGB[4];
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t RGB;
+      dt_aligned_pixel_t XYZ;
 
       // Clip negatives
       for_each_channel(c,aligned(in))
@@ -914,7 +916,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
     }
 
   float elements = 0.f;
-  float xyY[4] = { 0.f };
+  dt_aligned_pixel_t xyY = { 0.f };
 
   if(illuminant == DT_ILLUMINANT_DETECT_SURFACES)
   {
@@ -938,7 +940,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
           central_average[c] = fmaxf(central_average[c], 0.0f);
         }
 
-        float var[4] = { 0.f };
+        dt_aligned_pixel_t var = { 0.f };
 
         // compute patch-wise variance
         // If variance = 0, we are on a flat surface and want to discard that patch.
@@ -1177,8 +1179,8 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
   for(size_t k = 0; k < checker->patches; k++)
   {
     // Convert to Lab
-    float DT_ALIGNED_PIXEL Lab_test[4];
-    float DT_ALIGNED_PIXEL XYZ_test[4];
+    dt_aligned_pixel_t Lab_test;
+    dt_aligned_pixel_t XYZ_test;
 
     // If exposure was normalized, denormalized it before
     for(size_t c = 0; c < 4; c++) XYZ_test[c] = patches[k * 4 + c];
@@ -1374,7 +1376,7 @@ static const extraction_result_t _extract_patches(const float *const restrict in
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] /= (float)num_elem;
 
     // Convert to XYZ
-    float XYZ[4] = { 0 };
+    dt_aligned_pixel_t XYZ = { 0 };
     dot_product(patches + k * 4, RGB_to_XYZ, XYZ);
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] = XYZ[c];
   }
@@ -1382,14 +1384,14 @@ static const extraction_result_t _extract_patches(const float *const restrict in
   /* match global exposure */
   // white exposure depends on camera settings and raw white point,
   // we want our profile to be independent from that
-  float XYZ_white_ref[4];
+  dt_aligned_pixel_t XYZ_white_ref;
   float *XYZ_white_test = patches + g->checker->white * 4;
   dt_Lab_to_XYZ(g->checker->values[g->checker->white].Lab, XYZ_white_ref);
   const float exposure = XYZ_white_ref[1] / XYZ_white_test[1];
 
   // black point is evaluated by rawspeed on each picture using the dark pixels
   // we want our profile to be also independent from its discrepancies
-  float XYZ_black_ref[4];
+  dt_aligned_pixel_t XYZ_black_ref;
   float *XYZ_black_test = patches + g->checker->black * 4;
   dt_Lab_to_XYZ(g->checker->values[g->checker->black].Lab, XYZ_black_ref);
   float black = 0.f;
@@ -1430,15 +1432,15 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   /* find the scene illuminant */
 
   // find reference grey patch
-  float XYZ_grey_ref[4];
+  dt_aligned_pixel_t XYZ_grey_ref;
   dt_Lab_to_XYZ(g->checker->values[g->checker->middle_grey].Lab, XYZ_grey_ref);
 
   // find test grey patch
-  float DT_ALIGNED_PIXEL XYZ_grey_test[4];
+  dt_aligned_pixel_t XYZ_grey_test;
   for(size_t c = 0; c < 3; c++) XYZ_grey_test[c] = patches[g->checker->middle_grey * 4 + c];
 
   // compute reference illuminant
-  float DT_ALIGNED_PIXEL D50_XYZ[4];
+  dt_aligned_pixel_t D50_XYZ;
   illuminant_xy_to_XYZ(0.34567f, 0.35850f, D50_XYZ);
 
   // normalize luminances - note : illuminant is normalized by definition
@@ -1451,17 +1453,17 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   }
 
   // convert XYZ to LMS
-  float DT_ALIGNED_PIXEL LMS_grey_ref[4], LMS_grey_test[4], D50_LMS[4];
+  dt_aligned_pixel_t LMS_grey_ref, LMS_grey_test, D50_LMS;
   convert_any_XYZ_to_LMS(XYZ_grey_ref, LMS_grey_ref, kind);
   convert_any_XYZ_to_LMS(XYZ_grey_test, LMS_grey_test, kind);
   convert_any_XYZ_to_LMS(D50_XYZ, D50_LMS, kind);
 
   // solve the equation to find the scene illuminant
-  float DT_ALIGNED_PIXEL illuminant[4] = { 0.0f };
+  dt_aligned_pixel_t illuminant = { 0.0f };
   for(size_t c = 0; c < 3; c++) illuminant[c] = D50_LMS[c] * LMS_grey_test[c] / LMS_grey_ref[c];
 
   // convert back the illuminant to XYZ then xyY
-  float DT_ALIGNED_PIXEL illuminant_XYZ[4], illuminant_xyY[4] = { .0f };
+  dt_aligned_pixel_t illuminant_XYZ, illuminant_xyY = { .0f };
   convert_any_LMS_to_XYZ(illuminant, illuminant_XYZ, kind);
   const float Y_illu = illuminant_XYZ[1];
   for(size_t c = 0; c < 3; c++) illuminant_XYZ[c] /= Y_illu;
@@ -1484,10 +1486,10 @@ void extract_color_checker(const float *const restrict in, float *const restrict
     const float Y = sample[1];
     downscale_vector(sample, Y);
 
-    float LMS[4];
+    dt_aligned_pixel_t LMS;
     convert_any_XYZ_to_LMS(sample, LMS, kind);
 
-    float temp[4];
+    dt_aligned_pixel_t temp;
 
     switch(kind)
     {
@@ -1536,11 +1538,11 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   for(size_t k = 0; k < g->checker->patches; k++)
   {
     float *const sample = patches + k * 4;
-    float LMS_test[4];
+    dt_aligned_pixel_t LMS_test;
     convert_any_XYZ_to_LMS(sample, LMS_test, kind);
 
     float *const reference = g->checker->values[k].Lab;
-    float XYZ_ref[4], LMS_ref[4];
+    dt_aligned_pixel_t XYZ_ref, LMS_ref;
     dt_Lab_to_XYZ(reference, XYZ_ref);
     convert_any_XYZ_to_LMS(XYZ_ref, LMS_ref, kind);
 
@@ -1628,8 +1630,8 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   for(size_t k = 0; k < g->checker->patches; k++)
   {
     float *const sample = patches + k * 4;
-    float LMS_test[4];
-    float temp[4] = { 0.f };
+    dt_aligned_pixel_t LMS_test;
+    dt_aligned_pixel_t temp = { 0.f };
 
     // Restore the original exposure of the patch
     for(size_t c = 0; c < 3; c++) temp[c] = sample[c];
@@ -1843,13 +1845,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     // is changed later, we get no notification of the change here, so we can't update the defaults.
     // So we need to re-run the detection at runtime…
     float x, y;
-    float custom_wb[4];
+    dt_aligned_pixel_t custom_wb;
     get_white_balance_coeff(self, custom_wb);
 
     if(find_temperature_from_raw_coeffs(&(self->dev->image_storage), custom_wb, &(x), &(y)))
     {
       // Convert illuminant from xyY to XYZ
-      float XYZ[4];
+      dt_aligned_pixel_t XYZ;
       illuminant_xy_to_XYZ(x, y, XYZ);
 
       // Convert illuminant from XYZ to Bradford modified LMS
@@ -1944,13 +1946,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     // is changed later, we get no notification of the change here, so we can't update the defaults.
     // So we need to re-run the detection at runtime…
     float x, y;
-    float custom_wb[4];
+    dt_aligned_pixel_t custom_wb;
     get_white_balance_coeff(self, custom_wb);
 
     if(find_temperature_from_raw_coeffs(&(self->dev->image_storage), custom_wb, &(x), &(y)))
     {
       // Convert illuminant from xyY to XYZ
-      float XYZ[4];
+      dt_aligned_pixel_t XYZ;
       illuminant_xy_to_XYZ(x, y, XYZ);
 
       // Convert illuminant from XYZ to Bradford modified LMS
@@ -2445,7 +2447,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
 
-    float RGB[4];
+    dt_aligned_pixel_t RGB;
     dt_ioppr_lab_to_rgb_matrix(g->checker->values[k].Lab, RGB, work_profile->matrix_out, work_profile->lut_out,
                                work_profile->unbounded_coeffs_out, work_profile->lutsize,
                                work_profile->nonlinearlut);
@@ -2731,7 +2733,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // find x y coordinates of illuminant for CIE 1931 2° observer
   float x = p->x;
   float y = p->y;
-  float custom_wb[4];
+  dt_aligned_pixel_t custom_wb;
   get_white_balance_coeff(self, custom_wb);
   illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb, &x, &y, p->temperature, p->illum_fluo, p->illum_led);
 
@@ -2742,7 +2744,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->illuminant_type = p->illuminant;
 
   // Convert illuminant from xyY to XYZ
-  float XYZ[4];
+  dt_aligned_pixel_t XYZ;
   illuminant_xy_to_XYZ(x, y, XYZ);
 
   // Convert illuminant from XYZ to Bradford modified LMS
@@ -2971,7 +2973,8 @@ static void update_xy_color(dt_iop_module_t *self)
 }
 
 static void _convert_GUI_colors(dt_iop_channelmixer_rgb_params_t *p,
-                                const struct dt_iop_order_iccprofile_info_t *const work_profile, const float LMS[4], float RGB[4])
+                                const struct dt_iop_order_iccprofile_info_t *const work_profile,
+                                const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB)
 {
   if(p->adaptation != DT_ADAPTATION_RGB)
   {
@@ -2980,7 +2983,7 @@ static void _convert_GUI_colors(dt_iop_channelmixer_rgb_params_t *p,
   }
   else
   {
-    float DT_ALIGNED_PIXEL XYZ[4];
+    dt_aligned_pixel_t XYZ;
     if(work_profile)
     {
       dt_ioppr_rgb_matrix_to_xyz(LMS, XYZ, work_profile->matrix_in, work_profile->lut_in,
@@ -3027,8 +3030,8 @@ static void update_R_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float RR = RR_min + stop * RR_range;
     const float stop_R = RR + RGB[1] + RGB[2];
-    const float LMS[4] = { 0.5f * stop_R, 0.5f, 0.5f };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f * stop_R, 0.5f, 0.5f };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_red_R, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3042,8 +3045,8 @@ static void update_R_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float RG = RG_min + stop * RG_range;
     const float stop_R = RGB[0] + RG + RGB[2];
-    const float LMS[4] = { 0.5f * stop_R, 0.5f, 0.5f };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f * stop_R, 0.5f, 0.5f };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_red_G, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3057,8 +3060,8 @@ static void update_R_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float RB = RB_min + stop * RB_range;
     const float stop_R = RGB[0] + RGB[1] + RB;
-    const float LMS[4] = { 0.5f * stop_R, 0.5f, 0.5f };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f * stop_R, 0.5f, 0.5f };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_red_B, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3093,8 +3096,8 @@ static void update_B_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float BR = BR_min + stop * BR_range;
     const float stop_B = BR + RGB[1] + RGB[2];
-    const float LMS[4] = { 0.5f, 0.5f, 0.5f * stop_B };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f, 0.5f, 0.5f * stop_B };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_blue_R, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3108,8 +3111,8 @@ static void update_B_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float BG = BG_min + stop * BG_range;
     const float stop_B = RGB[0] + BG + RGB[2];
-    const float LMS[4] = { 0.5f , 0.5f, 0.5f * stop_B };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f , 0.5f, 0.5f * stop_B };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_blue_G, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3123,8 +3126,8 @@ static void update_B_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float BB = BB_min + stop * BB_range;
     const float stop_B = RGB[0] + RGB[1] + BB;
-    const float LMS[4] = { 0.5f, 0.5f, 0.5f * stop_B , 0.f};
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f, 0.5f, 0.5f * stop_B , 0.f};
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_blue_B, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3158,8 +3161,8 @@ static void update_G_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float GR = GR_min + stop * GR_range;
     const float stop_G = GR + RGB[1] + RGB[2];
-    const float LMS[4] = { 0.5f , 0.5f * stop_G, 0.5f };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f , 0.5f * stop_G, 0.5f };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_green_R, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3173,8 +3176,8 @@ static void update_G_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float GG = GG_min + stop * GG_range;
     const float stop_G = RGB[0] + GG + RGB[2];
-    const float LMS[4] = { 0.5f, 0.5f * stop_G, 0.5f };
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f, 0.5f * stop_G, 0.5f };
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_green_G, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3188,8 +3191,8 @@ static void update_G_colors(dt_iop_module_t *self)
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float GB = GB_min + stop * GB_range;
     const float stop_G = RGB[0] + RGB[1] + GB;
-    const float LMS[4] = { 0.5f, 0.5f * stop_G , 0.5f};
-    float RGB_t[4] = { 0.5f };
+    const dt_aligned_pixel_t LMS = { 0.5f, 0.5f * stop_G , 0.5f};
+    dt_aligned_pixel_t RGB_t = { 0.5f };
     _convert_GUI_colors(p, work_profile, LMS, RGB_t);
     dt_bauhaus_slider_set_stop(g->scale_green_B, stop, RGB_t[0], RGB_t[1], RGB_t[2]);
   }
@@ -3226,8 +3229,8 @@ static gboolean illuminant_color_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   // Paint illuminant color - we need to recompute it in full in case camera RAW is chosen
   float x = p->x;
   float y = p->y;
-  float RGB[4] = { 0 };
-  float custom_wb[4];
+  dt_aligned_pixel_t RGB = { 0 };
+  dt_aligned_pixel_t custom_wb;
   get_white_balance_coeff(self, custom_wb);
   illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb,
                    &x, &y, p->temperature, p->illum_fluo, p->illum_led);
@@ -3252,7 +3255,7 @@ static void update_approx_cct(dt_iop_module_t *self)
 
   float x = p->x;
   float y = p->y;
-  float custom_wb[4];
+  dt_aligned_pixel_t custom_wb;
   get_white_balance_coeff(self, custom_wb);
   illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb, &x, &y, p->temperature, p->illum_fluo, p->illum_led);
 
@@ -3466,7 +3469,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   const dt_image_t *img = &module->dev->image_storage;
 
-  float custom_wb[4];
+  dt_aligned_pixel_t custom_wb;
   if(!CAT_already_applied
      && is_modern
      && !get_white_balance_coeff(module, custom_wb))
@@ -3524,7 +3527,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     if(p->illuminant == DT_ILLUMINANT_CAMERA)
     {
       // Get camera WB and update illuminant
-      float custom_wb[4];
+      dt_aligned_pixel_t custom_wb;
       get_white_balance_coeff(self, custom_wb);
       const int found = find_temperature_from_raw_coeffs(&(self->dev->image_storage), custom_wb, &(p->x), &(p->y));
       check_if_close_to_daylight(p->x, p->y, &(p->temperature), NULL, &(p->adaptation));
@@ -3639,7 +3642,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   repack_3x3_to_3xSSE(work_profile->matrix_in, RGB_to_XYZ);
 
   // Convert to XYZ
-  float XYZ[4] = { 0 };
+  dt_aligned_pixel_t XYZ = { 0 };
   dot_product(RGB, RGB_to_XYZ, XYZ);
 
   // Convert to xyY
@@ -3758,7 +3761,7 @@ void gui_init(struct dt_iop_module_t *self)
   {
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float t = min_temp + stop * (max_temp - min_temp);
-    float RGB[4] = { 0 };
+    dt_aligned_pixel_t RGB = { 0 };
     illuminant_CCT_to_RGB(t, RGB);
     dt_bauhaus_slider_set_stop(g->temperature, stop, RGB[0], RGB[1], RGB[2]);
   }

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2595,8 +2595,8 @@ static void commit_profile_callback(GtkWidget *widget, GdkEventButton *event, gp
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
   dt_bauhaus_slider_set(g->temperature, p->temperature);
 
-  float xyY[3] = { p->x, p->y, 1.f };
-  float Lch[3] = { 0 };
+  dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
+  dt_aligned_pixel_t Lch = { 0 };
   dt_xyY_to_Lch(xyY, Lch);
   dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
   dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);
@@ -2646,8 +2646,8 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
   dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
 
-  const float xyY[3] = { p->x, p->y, 1.f };
-  float Lch[3];
+  const dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
+  dt_aligned_pixel_t Lch;
   dt_xyY_to_Lch(xyY, Lch);
   dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
   dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);
@@ -2935,10 +2935,10 @@ static void update_xy_color(dt_iop_module_t *self)
   {
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float x = x_min + stop * x_range;
-    float RGB[4];
+    dt_aligned_pixel_t RGB;
 
-    const float Lch[3] = { 100.f, 50.f, x / 180.f * M_PI };
-    float xyY[3] = { 0 };
+    const dt_aligned_pixel_t Lch = { 100.f, 50.f, x / 180.f * M_PI };
+    dt_aligned_pixel_t xyY = { 0 };
     dt_Lch_to_xyY(Lch, xyY);
     illuminant_xy_to_RGB(xyY[0], xyY[1], RGB);
     dt_bauhaus_slider_set_stop(g->illum_x, stop, RGB[0], RGB[1], RGB[2]);
@@ -2949,11 +2949,11 @@ static void update_xy_color(dt_iop_module_t *self)
   {
     const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
     const float y = (y_min + stop * y_range) / 2.0f;
-    float RGB[4] = { 0 };
+    dt_aligned_pixel_t RGB = { 0 };
 
     // Find current hue
-    float xyY[3] = { p->x, p->y, 1.f };
-    float Lch[3] = { 0 };
+    dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
+    dt_aligned_pixel_t Lch = { 0 };
     dt_xyY_to_Lch(xyY, Lch);
 
     // Replace chroma by current step
@@ -3008,7 +3008,7 @@ static void update_R_colors(dt_iop_module_t *self)
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, self->dev->pipe);
 
   // scale params if needed
-  float RGB[3] = { p->red[0], p->red[1], p->red[2] };
+  dt_aligned_pixel_t RGB = { p->red[0], p->red[1], p->red[2] };
 
   if(p->normalize_R)
   {
@@ -3074,7 +3074,7 @@ static void update_B_colors(dt_iop_module_t *self)
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, self->dev->pipe);
 
   // scale params if needed
-  float RGB[3] = { p->blue[0], p->blue[1], p->blue[2] };
+  dt_aligned_pixel_t RGB = { p->blue[0], p->blue[1], p->blue[2] };
 
   if(p->normalize_B)
   {
@@ -3139,7 +3139,7 @@ static void update_G_colors(dt_iop_module_t *self)
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, self->dev->pipe);
 
   // scale params if needed
-  float RGB[3] = { p->green[0], p->green[1], p->green[2] };
+  dt_aligned_pixel_t RGB = { p->green[0], p->green[1], p->green[2] };
 
   if(p->normalize_G)
   {
@@ -3306,12 +3306,12 @@ static void illum_xy_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
 
-  float Lch[3] = { 0 };
+  dt_aligned_pixel_t Lch = { 0 };
   Lch[0] = 100.f;
   Lch[2] = dt_bauhaus_slider_get(g->illum_x) / 180. * M_PI;
   Lch[1] = dt_bauhaus_slider_get(g->illum_y);
 
-  float xyY[3] = { 0 };
+  dt_aligned_pixel_t xyY = { 0 };
   dt_Lch_to_xyY(Lch, xyY);
   p->x = xyY[0];
   p->y = xyY[1];
@@ -3486,8 +3486,8 @@ void reload_defaults(dt_iop_module_t *module)
   dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)module->gui_data;
   if(g)
   {
-    const float xyY[3] = { d->x, d->y, 1.f };
-    float Lch[3] = { 0 };
+    const dt_aligned_pixel_t xyY = { d->x, d->y, 1.f };
+    dt_aligned_pixel_t Lch = { 0 };
     dt_xyY_to_Lch(xyY, Lch);
 
     dt_bauhaus_slider_set_default(g->illum_x, Lch[2] / M_PI * 180.f);
@@ -3566,8 +3566,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
     // force-update all the illuminant sliders in case something above changed them
     // notice the hue/chroma of the illuminant has to be computed on-the-fly anyway
-    float xyY[3] = { p->x, p->y, 1.f };
-    float Lch[3];
+    dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
+    dt_aligned_pixel_t Lch;
     dt_xyY_to_Lch(xyY, Lch);
 
     // If the chroma is zero then there is not a meaningful hue angle. In this case
@@ -3658,8 +3658,8 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
   dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
 
-  const float xyY[3] = { p->x, p->y, 1.f };
-  float Lch[3] = { 0 };
+  const dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
+  dt_aligned_pixel_t Lch = { 0 };
   dt_xyY_to_Lch(xyY, Lch);
   dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
   dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -646,7 +646,8 @@ static inline void luma_chroma(const float input[4], const float saturation[4], 
 static inline void loop_switch(const float *const restrict in, float *const restrict out,
                                const size_t width, const size_t height, const size_t ch,
                                const float XYZ_to_RGB[3][4], const float RGB_to_XYZ[3][4], const float MIX[3][4],
-                               const float illuminant[4], const float saturation[4], const float lightness[4], const float grey[4],
+                               const dt_aligned_pixel_t illuminant, const dt_aligned_pixel_t saturation,
+                               const dt_aligned_pixel_t lightness, const dt_aligned_pixel_t grey,
                                const float p, const float gamut, const int clip, const int apply_grey,
                                const dt_adaptation_t kind,
                                const dt_iop_channelmixer_rgb_version_t version)
@@ -860,7 +861,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
 
 static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_t illuminant,
                                   const size_t width, const size_t height, const size_t ch,
-                                  const float RGB_to_XYZ[3][4], float xyz[4])
+                                  const float RGB_to_XYZ[3][4], dt_aligned_pixel_t xyz)
 {
   /**
    * Detect the chromaticity of the illuminant based on the grey edges hypothesis.

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -455,7 +455,7 @@ void init_presets(dt_iop_module_so_t *self)
 }
 
 
-static int get_white_balance_coeff(struct dt_iop_module_t *self, float custom_wb[4])
+static int get_white_balance_coeff(struct dt_iop_module_t *self, dt_aligned_pixel_t custom_wb)
 {
   // Init output with a no-op
   for(size_t k = 0; k < 4; k++) custom_wb[k] = 1.f;
@@ -494,7 +494,7 @@ static int get_white_balance_coeff(struct dt_iop_module_t *self, float custom_wb
 #ifdef _OPENMP
 #pragma omp declare simd aligned(vector:16)
 #endif
-static inline float euclidean_norm(const float vector[4])
+static inline float euclidean_norm(const dt_aligned_pixel_t vector)
 {
   return fmaxf(sqrtf(sqf(vector[0]) + sqf(vector[1]) + sqf(vector[2])), NORM_MIN);
 }
@@ -503,7 +503,7 @@ static inline float euclidean_norm(const float vector[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(vector:16)
 #endif
-static inline void downscale_vector(float vector[4], const float scaling)
+static inline void downscale_vector(dt_aligned_pixel_t vector, const float scaling)
 {
   // check zero or NaN
   const int valid = (scaling > NORM_MIN) && !isnan(scaling);
@@ -514,7 +514,7 @@ static inline void downscale_vector(float vector[4], const float scaling)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(vector:16)
 #endif
-static inline void upscale_vector(float vector[4], const float scaling)
+static inline void upscale_vector(dt_aligned_pixel_t vector, const float scaling)
 {
   const int valid = (scaling > NORM_MIN) && !isnan(scaling);
   for(size_t c = 0; c < 3; c++) vector[c] = (valid) ? vector[c] * (scaling + NORM_MIN) : vector[c] * NORM_MIN;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -602,7 +602,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
     const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
-    float k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
+    float DT_ALIGNED_PIXEL k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
     const float kxa = d->kxa * rx, kxb = d->kxb * rx, kxc = d->kxc * rx, kxd = d->kxd * rx;
     const float kya = d->kya * ry, kyb = d->kyb * ry, kyc = d->kyc * ry, kyd = d->kyd * ry;
     float ma, mb, md, me, mg, mh;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -310,10 +310,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = piece->colors;
 
   // these are RGB values!
-  const float gain[3] = { d->gain[CHANNEL_RED] * d->gain[CHANNEL_FACTOR],
-                          d->gain[CHANNEL_GREEN] * d->gain[CHANNEL_FACTOR],
-                          d->gain[CHANNEL_BLUE] * d->gain[CHANNEL_FACTOR] },
-              contrast = (d->contrast != 0.0f) ? 1.0f / d->contrast : 1000000.0f,
+  const dt_aligned_pixel_t gain = { d->gain[CHANNEL_RED] * d->gain[CHANNEL_FACTOR],
+                                    d->gain[CHANNEL_GREEN] * d->gain[CHANNEL_FACTOR],
+                                    d->gain[CHANNEL_BLUE] * d->gain[CHANNEL_FACTOR] };
+  const float contrast = (d->contrast != 0.0f) ? 1.0f / d->contrast : 1000000.0f,
               grey = d->grey / 100.0f;
 
   // For neutral parameters, skip the computations doing x^1 or (x-a)*1 + a to save time
@@ -914,7 +914,7 @@ static inline void set_HSL_sliders(GtkWidget *hue, GtkWidget *sat, float RGB[4])
   * Only the RGB values are saved and used in the computations.
   * The HSL sliders are merely an interface.
   */
-  float RGB_norm[3] = { (RGB[CHANNEL_RED] / 2.0f), (RGB[CHANNEL_GREEN] / 2.0f), (RGB[CHANNEL_BLUE] / 2.0f) };
+  dt_aligned_pixel_t RGB_norm = { (RGB[CHANNEL_RED] / 2.0f), (RGB[CHANNEL_GREEN] / 2.0f), (RGB[CHANNEL_BLUE] / 2.0f) };
 
   float h, s, l;
   rgb2hsl(RGB_norm, &h, &s, &l);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -326,15 +326,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case LEGACY:
     {
       // these are RGB values!
-      const float lift[3] = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
-                              2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
-                              2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
-                 gamma[3] = { d->gamma[CHANNEL_RED] * d->gamma[CHANNEL_FACTOR],
-                              d->gamma[CHANNEL_GREEN] * d->gamma[CHANNEL_FACTOR],
-                              d->gamma[CHANNEL_BLUE] * d->gamma[CHANNEL_FACTOR] },
-             gamma_inv[3] = { (gamma[0] != 0.0) ? 1.0 / gamma[0] : 1000000.0,
-                              (gamma[1] != 0.0) ? 1.0 / gamma[1] : 1000000.0,
-                              (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
+      const dt_aligned_pixel_t lift = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
+                                        2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
+                                        2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
+                              gamma = { d->gamma[CHANNEL_RED] * d->gamma[CHANNEL_FACTOR],
+                                        d->gamma[CHANNEL_GREEN] * d->gamma[CHANNEL_FACTOR],
+                                        d->gamma[CHANNEL_BLUE] * d->gamma[CHANNEL_FACTOR] },
+                          gamma_inv = { (gamma[0] != 0.0) ? 1.0 / gamma[0] : 1000000.0,
+                                        (gamma[1] != 0.0) ? 1.0 / gamma[1] : 1000000.0,
+                                        (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
@@ -350,11 +350,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
         // transform the pixel to sRGB:
         // Lab -> XYZ
-        float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+        dt_aligned_pixel_t XYZ = { 0.0f };
         dt_Lab_to_XYZ(in, XYZ);
 
         // XYZ -> sRGB
-        float DT_ALIGNED_PIXEL rgb[4] = { 0.0f };
+        dt_aligned_pixel_t rgb = { 0.0f };
         dt_XYZ_to_sRGB(XYZ, rgb);
 
         // do the calculation in RGB space
@@ -377,15 +377,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case LIFT_GAMMA_GAIN:
     {
       // these are RGB values!
-      const float lift[3] = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
-                              2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
-                              2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
-                 gamma[3] = { d->gamma[CHANNEL_RED] * d->gamma[CHANNEL_FACTOR],
-                              d->gamma[CHANNEL_GREEN] * d->gamma[CHANNEL_FACTOR],
-                              d->gamma[CHANNEL_BLUE] * d->gamma[CHANNEL_FACTOR] },
-             gamma_inv[3] = { (gamma[0] != 0.0) ? 1.0 / gamma[0] : 1000000.0,
-                              (gamma[1] != 0.0) ? 1.0 / gamma[1] : 1000000.0,
-                              (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
+      const dt_aligned_pixel_t lift = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
+                                        2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
+                                        2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
+                              gamma = { d->gamma[CHANNEL_RED] * d->gamma[CHANNEL_FACTOR],
+                                        d->gamma[CHANNEL_GREEN] * d->gamma[CHANNEL_FACTOR],
+                                        d->gamma[CHANNEL_BLUE] * d->gamma[CHANNEL_FACTOR] },
+                          gamma_inv = { (gamma[0] != 0.0) ? 1.0 / gamma[0] : 1000000.0,
+                                        (gamma[1] != 0.0) ? 1.0 / gamma[1] : 1000000.0,
+                                        (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
@@ -402,11 +402,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
         // transform the pixel to sRGB:
         // Lab -> XYZ
-        float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+        dt_aligned_pixel_t XYZ = { 0.0f };
         dt_Lab_to_XYZ(in, XYZ);
 
         // XYZ -> sRGB
-        float DT_ALIGNED_PIXEL rgb[4] = { 0.0f };
+        dt_aligned_pixel_t rgb = { 0.0f };
         dt_XYZ_to_prophotorgb(XYZ, rgb);
 
         float luma = XYZ[1]; // the Y channel is the relative luminance
@@ -449,12 +449,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     {
       // these are RGB values!
 
-      const float lift[3] = { ( d->lift[CHANNEL_RED] + d->lift[CHANNEL_FACTOR] - 2.0f),
-                              ( d->lift[CHANNEL_GREEN] + d->lift[CHANNEL_FACTOR] - 2.0f),
-                              ( d->lift[CHANNEL_BLUE] + d->lift[CHANNEL_FACTOR] - 2.0f)},
-                 gamma[3] = { (2.0f - d->gamma[CHANNEL_RED]) * (2.0f - d->gamma[CHANNEL_FACTOR]),
-                              (2.0f - d->gamma[CHANNEL_GREEN]) * (2.0f - d->gamma[CHANNEL_FACTOR]),
-                              (2.0f - d->gamma[CHANNEL_BLUE]) * (2.0f - d->gamma[CHANNEL_FACTOR])};
+      const dt_aligned_pixel_t lift = { ( d->lift[CHANNEL_RED] + d->lift[CHANNEL_FACTOR] - 2.0f),
+                                        ( d->lift[CHANNEL_GREEN] + d->lift[CHANNEL_FACTOR] - 2.0f),
+                                        ( d->lift[CHANNEL_BLUE] + d->lift[CHANNEL_FACTOR] - 2.0f)},
+                              gamma = { (2.0f - d->gamma[CHANNEL_RED]) * (2.0f - d->gamma[CHANNEL_FACTOR]),
+                                        (2.0f - d->gamma[CHANNEL_GREEN]) * (2.0f - d->gamma[CHANNEL_FACTOR]),
+                                        (2.0f - d->gamma[CHANNEL_BLUE]) * (2.0f - d->gamma[CHANNEL_FACTOR])};
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
@@ -471,11 +471,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
         // transform the pixel to RGB:
         // Lab -> XYZ
-        float DT_ALIGNED_PIXEL XYZ[4];
+        dt_aligned_pixel_t XYZ;
         dt_Lab_to_XYZ(in, XYZ);
 
         // XYZ -> RGB
-        float DT_ALIGNED_PIXEL rgb[4];
+        dt_aligned_pixel_t rgb;
         dt_XYZ_to_prophotorgb(XYZ, rgb);
 
         float luma = XYZ[1]; // the Y channel is the RGB luminance
@@ -877,7 +877,7 @@ error:
 
 static inline void update_saturation_slider_color(GtkWidget *slider, float hue)
 {
-  float DT_ALIGNED_PIXEL rgb[4];
+  dt_aligned_pixel_t rgb;
   if(hue != -1)
   {
     hsl2rgb(rgb, hue, 1.0, 0.5);
@@ -891,7 +891,7 @@ static inline void update_saturation_slider_color(GtkWidget *slider, float hue)
 static inline void set_RGB_sliders(GtkWidget *R, GtkWidget *G, GtkWidget *B, float hsl[3], float *p, int mode)
 {
 
-  float DT_ALIGNED_PIXEL rgb[4] = { 0.0f };
+  dt_aligned_pixel_t rgb = { 0.0f };
   hsl2rgb(rgb, hsl[0], hsl[1], hsl[2]);
 
   if(hsl[0] != -1)
@@ -958,21 +958,21 @@ static void apply_autogrey(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
-  float DT_ALIGNED_PIXEL rgb[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
+  dt_aligned_pixel_t rgb = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
   dt_XYZ_to_prophotorgb((const float *)XYZ, rgb);
 
-  const float lift[3]
+  const dt_aligned_pixel_t lift
       = { (p->lift[CHANNEL_RED] + p->lift[CHANNEL_FACTOR] - 2.0f),
           (p->lift[CHANNEL_GREEN] + p->lift[CHANNEL_FACTOR] - 2.0f),
           (p->lift[CHANNEL_BLUE] + p->lift[CHANNEL_FACTOR] - 2.0f) },
-      gamma[3]
+      gamma
       = { p->gamma[CHANNEL_RED] * p->gamma[CHANNEL_FACTOR],
           p->gamma[CHANNEL_GREEN] * p->gamma[CHANNEL_FACTOR],
           p->gamma[CHANNEL_BLUE] * p->gamma[CHANNEL_FACTOR] },
-      gain[3] = { p->gain[CHANNEL_RED] * p->gain[CHANNEL_FACTOR], p->gain[CHANNEL_GREEN] * p->gain[CHANNEL_FACTOR],
-                  p->gain[CHANNEL_BLUE] * p->gain[CHANNEL_FACTOR] };
+      gain = { p->gain[CHANNEL_RED] * p->gain[CHANNEL_FACTOR], p->gain[CHANNEL_GREEN] * p->gain[CHANNEL_FACTOR],
+               p->gain[CHANNEL_BLUE] * p->gain[CHANNEL_FACTOR] };
 
   for(int c = 0; c < 3; c++)
   {
@@ -997,9 +997,9 @@ static void apply_lift_neutralize(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
-  float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+  dt_aligned_pixel_t RGB = { 0.0f };
   dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
 // Save the patch color for the optimization
@@ -1036,9 +1036,9 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
-  float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+  dt_aligned_pixel_t RGB = { 0.0f };
   dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
 // Save the patch color for the optimization
@@ -1075,9 +1075,9 @@ static void apply_gain_neutralize(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
-  float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+  dt_aligned_pixel_t RGB = { 0.0f };
   dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
 // Save the patch color for the optimization
@@ -1114,13 +1114,13 @@ static void apply_lift_auto(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color_min, XYZ);
 
   g->luma_patches[LIFT] = XYZ[1];
   g->luma_patches_flags[LIFT] = USER_SELECTED;
 
-  float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+  dt_aligned_pixel_t RGB = { 0.0f };
   dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
   p->lift[CHANNEL_FACTOR] = -p->gain[CHANNEL_FACTOR] * XYZ[1] + 1.0f;
@@ -1138,13 +1138,13 @@ static void apply_gamma_auto(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
 
   g->luma_patches[GAMMA] = XYZ[1];
   g->luma_patches_flags[GAMMA] = USER_SELECTED;
 
-  float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+  dt_aligned_pixel_t RGB = { 0.0f };
   dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
   p->gamma[CHANNEL_FACTOR]
@@ -1163,13 +1163,13 @@ static void apply_gain_auto(dt_iop_module_t *self)
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color_max, XYZ);
 
   g->luma_patches[GAIN] = XYZ[1];
   g->luma_patches_flags[GAIN] = USER_SELECTED;
 
-  float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+  dt_aligned_pixel_t RGB = { 0.0f };
   dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
   p->gain[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR] / (XYZ[1]);
@@ -1193,9 +1193,9 @@ static void apply_autocolor(dt_iop_module_t *self)
      * Some color patches were not picked by the user. Take a
      * picture-wide patch for these.
      */
-    float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+    dt_aligned_pixel_t XYZ = { 0.0f };
     dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
-    float DT_ALIGNED_PIXEL RGB[4] = { 0.0f };
+    dt_aligned_pixel_t RGB = { 0.0f };
     dt_XYZ_to_prophotorgb((const float *)XYZ, RGB);
 
     // Save the patch color for the optimization
@@ -1310,21 +1310,21 @@ static void apply_autoluma(dt_iop_module_t *self)
    */
   if(g->luma_patches_flags[LIFT] == INVALID)
   {
-    float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+    dt_aligned_pixel_t XYZ = { 0.0f };
     dt_Lab_to_XYZ((const float *)self->picked_color_min, XYZ);
     g->luma_patches[LIFT] = XYZ[1];
     g->luma_patches_flags[LIFT] = AUTO_SELECTED;
   }
   if(g->luma_patches_flags[GAMMA] == INVALID)
   {
-    float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+    dt_aligned_pixel_t XYZ = { 0.0f };
     dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
     g->luma_patches[GAMMA] = XYZ[1];
     g->luma_patches_flags[GAMMA] = AUTO_SELECTED;
   }
   if(g->luma_patches_flags[GAIN] == INVALID)
   {
-    float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+    dt_aligned_pixel_t XYZ = { 0.0f };
     dt_Lab_to_XYZ((const float *)self->picked_color_max, XYZ);
     g->luma_patches[GAIN] = XYZ[1];
     g->luma_patches_flags[GAIN] = AUTO_SELECTED;
@@ -1412,7 +1412,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     case SLOPE_OFFSET_POWER:
     {
       // Correct the luminance in RGB parameters so we don't affect it
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
 
       dt_prophotorgb_to_XYZ((const float *)&p->lift[CHANNEL_RED], XYZ);
       d->lift[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR];
@@ -1451,7 +1451,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     case LIFT_GAMMA_GAIN:
     {
       // Correct the luminance in RGB parameters so we don't affect it
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
       dt_prophotorgb_to_XYZ((const float *)&p->lift[CHANNEL_RED], XYZ);
       d->lift[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR];
       d->lift[CHANNEL_RED] = (p->lift[CHANNEL_RED] - XYZ[1]) + 1.f;
@@ -1673,7 +1673,7 @@ static gboolean dt_iop_area_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t
 
       double hue = angle / (2.0 * M_PI);
 
-      float DT_ALIGNED_PIXEL rgb[4];
+      dt_aligned_pixel_t rgb;
       hsl2rgb(rgb, hue, 1.0, 0.5);
 
       *p++ = (((int)floor(rgb[0] * 255 + 0.5) << 16) | ((int)floor(rgb[1] * 255 + 0.5) << 8)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1219,9 +1219,9 @@ static void apply_autocolor(dt_iop_module_t *self)
   dt_iop_color_picker_reset(self, TRUE);
 
   // Build the CDL-corrected samples (after the factors)
-  float samples_lift[3] = { 0.f };
-  float samples_gamma[3] = { 0.f };
-  float samples_gain[3] = { 0.f };
+  dt_aligned_pixel_t samples_lift = { 0.f };
+  dt_aligned_pixel_t samples_gamma = { 0.f };
+  dt_aligned_pixel_t samples_gain = { 0.f };
 
   for (int c = 0; c < 3; ++c)
   {
@@ -1231,8 +1231,8 @@ static void apply_autocolor(dt_iop_module_t *self)
   }
 
   // Get the average patches luma value (= neutral grey equivalents) after the CDL factors
-  float DT_ALIGNED_PIXEL greys[4] = { 0.0 };
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0 };
+  dt_aligned_pixel_t greys = { 0.0 };
+  dt_aligned_pixel_t XYZ = { 0.0 };
   dt_prophotorgb_to_XYZ((const float *)samples_lift, (float *)XYZ);
   greys[0] = XYZ[1];
   dt_prophotorgb_to_XYZ((const float *)samples_gamma, (float *)XYZ);
@@ -1241,9 +1241,9 @@ static void apply_autocolor(dt_iop_module_t *self)
   greys[2] = XYZ[1];
 
   // Get the current params
-  float RGB_lift[3] = { p->lift[CHANNEL_RED] - 1.0f, p->lift[CHANNEL_GREEN] - 1.0f, p->lift[CHANNEL_BLUE] - 1.0f };
-  float RGB_gamma[3] = { p->gamma[CHANNEL_RED], p->gamma[CHANNEL_GREEN], p->gamma[CHANNEL_BLUE] };
-  float RGB_gain[3] = { p->gain[CHANNEL_RED], p->gain[CHANNEL_GREEN], p->gain[CHANNEL_BLUE] };
+  dt_aligned_pixel_t RGB_lift = { p->lift[CHANNEL_RED] - 1.0f, p->lift[CHANNEL_GREEN] - 1.0f, p->lift[CHANNEL_BLUE] - 1.0f };
+  dt_aligned_pixel_t RGB_gamma = { p->gamma[CHANNEL_RED], p->gamma[CHANNEL_GREEN], p->gamma[CHANNEL_BLUE] };
+  dt_aligned_pixel_t RGB_gain = { p->gain[CHANNEL_RED], p->gain[CHANNEL_GREEN], p->gain[CHANNEL_BLUE] };
 
   /** Optimization loop :
   * We try to find the CDL curves that neutralize the 3 input color patches, while not affecting the overall lightness.

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -621,7 +621,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     // Gamut-clip in Yrg at constant hue and luminance
     // e.g. find the max chroma value that fits in gamut at the current hue
-    const float D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+    const dt_aligned_pixel_t D65 = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
     float max_c = Ych[1];
     const float cos_h = cosf(Ych[2]);
     const float sin_h = sinf(Ych[2]);
@@ -736,7 +736,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
             {  1.0f, -0.0960192420263190f, -0.8118918960560390f, 0.0f } };
 
     // Do a test conversion to L'M'S'
-    const float IzAzBz[4] = { Iz, JC[1] * cos_H, JC[1] * sin_H, 0.f };
+    const dt_aligned_pixel_t IzAzBz = { Iz, JC[1] * cos_H, JC[1] * sin_H, 0.f };
     dot_product(IzAzBz, AI, LMS);
 
     // Clip chroma
@@ -1007,8 +1007,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->hue_angle = M_PI * p->hue_angle / 180.f;
 
   // measure the grading RGB of a pure white
-  const float Ych_norm[4] = { 1.f, 0.f, 0.f, 0.f };
-  float RGB_norm[4] = { 0.f };
+  const dt_aligned_pixel_t Ych_norm = { 1.f, 0.f, 0.f, 0.f };
+  dt_aligned_pixel_t RGB_norm = { 0.f };
   Ych_to_gradingRGB(Ych_norm, RGB_norm);
 
   // global
@@ -1084,13 +1084,11 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       for(size_t g = 0; g < STEPS; g++)
         for(size_t b = 0; b < STEPS; b++)
         {
-          const float DT_ALIGNED_PIXEL rgb[4] = { (float)r / (float)(STEPS - 1),
-                                                  (float)g / (float)(STEPS - 1),
-                                                  (float)b / (float)(STEPS - 1),
-                                                  0.f };
-          float DT_ALIGNED_PIXEL XYZ[4] = { 0.f };
-          float DT_ALIGNED_PIXEL Jab[4] = { 0.f };
-          float DT_ALIGNED_PIXEL Jch[4] = { 0.f };
+          const dt_aligned_pixel_t rgb = { (float)r / (float)(STEPS - 1), (float)g / (float)(STEPS - 1),
+                                           (float)b / (float)(STEPS - 1), 0.f };
+          dt_aligned_pixel_t XYZ = { 0.f };
+          dt_aligned_pixel_t Jab = { 0.f };
+          dt_aligned_pixel_t Jch = { 0.f };
 
           dot_product(rgb, input_matrix, XYZ); // Go to D50 pipeline RGB to D65 XYZ in one step
           dt_XYZ_2_JzAzBz(XYZ, Jab);           // this one expects D65 XYZ

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1136,13 +1136,14 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float RGB[4], float Ych[4])
+void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_aligned_pixel_t RGB,
+                     dt_aligned_pixel_t Ych)
 {
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   if(work_profile == NULL) return; // no point
 
-  float DT_ALIGNED_ARRAY XYZ_D50[4] = { 0.f };
-  float DT_ALIGNED_ARRAY XYZ_D65[4] = { 0.f };
+  dt_aligned_pixel_t XYZ_D50 = { 0.f };
+  dt_aligned_pixel_t XYZ_D65 = { 0.f };
 
   dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, work_profile->matrix_in, work_profile->lut_in,
                              work_profile->unbounded_coeffs_in, work_profile->lutsize,

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -141,8 +141,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 #pragma omp declare simd aligned(in,out:64) aligned(slope,offset,low,high)
 #endif
 static inline void clamped_scaling(float *const restrict out, const float *const restrict in,
-                                   const float slope[4], const float offset[4],
-                                   const float low[4], const float high[4])
+                                   const dt_aligned_pixel_t slope, const dt_aligned_pixel_t offset,
+                                   const dt_aligned_pixel_t low, const dt_aligned_pixel_t high)
 {
   for_each_channel(c,dt_omp_nontemporal(out))
     out[c] = CLAMPS(in[c] * slope[c] + offset[c], low[c], high[c]);
@@ -165,10 +165,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *const restrict out = DT_IS_ALIGNED((float *const)ovoid);
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
 
-  const float DT_ALIGNED_PIXEL slope[4] = { 1.0f, d->a_steepness, d->b_steepness, 1.0f };
-  const float DT_ALIGNED_PIXEL offset[4] = { 0.0f, d->a_offset, d->b_offset, 0.0f };
-  const float DT_ALIGNED_PIXEL lowlimit[4] = { -INFINITY, -128.0f, -128.0f, -INFINITY };
-  const float DT_ALIGNED_PIXEL highlimit[4] = { INFINITY, 128.0f, 128.0f, INFINITY };
+  const dt_aligned_pixel_t slope = { 1.0f, d->a_steepness, d->b_steepness, 1.0f };
+  const dt_aligned_pixel_t offset = { 0.0f, d->a_offset, d->b_offset, 0.0f };
+  const dt_aligned_pixel_t lowlimit = { -INFINITY, -128.0f, -128.0f, -INFINITY };
+  const dt_aligned_pixel_t highlimit = { INFINITY, 128.0f, 128.0f, INFINITY };
 
   if(d->unbound)
   {

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -680,7 +680,7 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   {
     const float *in = (const float *)ivoid + (size_t)ch * j * roi_out->width;
     float *out = (float *)ovoid + (size_t)ch * j * roi_out->width;
-    float cam[3];
+    dt_aligned_pixel_t cam;
 
     for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
     {
@@ -696,7 +696,7 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
       if(!clipping)
       {
-        float DT_ALIGNED_PIXEL _xyz[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t _xyz = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         for(int c = 0; c < 3; c++)
         {
@@ -711,7 +711,7 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
       }
       else
       {
-        float DT_ALIGNED_PIXEL nRGB[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t nRGB = { 0.0f, 0.0f, 0.0f, 0.0f };
         for(int c = 0; c < 3; c++)
         {
           nRGB[c] = 0.0f;
@@ -721,13 +721,13 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
           }
         }
 
-        float DT_ALIGNED_PIXEL cRGB[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t cRGB = { 0.0f, 0.0f, 0.0f, 0.0f };
         for(int c = 0; c < 3; c++)
         {
           cRGB[c] = CLAMP(nRGB[c], 0.0f, 1.0f);
         }
 
-        float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t XYZ = { 0.0f, 0.0f, 0.0f, 0.0f };
         for(int c = 0; c < 3; c++)
         {
           XYZ[c] = 0.0f;
@@ -762,7 +762,7 @@ static void process_cmatrix_fastpath_simple(struct dt_iop_module_t *self, dt_dev
     float *in = (float *)ivoid + (size_t)ch * k;
     float *out = (float *)ovoid + (size_t)ch * k;
 
-    float DT_ALIGNED_PIXEL _xyz[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t _xyz = { 0.0f, 0.0f, 0.0f, 0.0f };
 
     for(int c = 0; c < 3; c++)
     {
@@ -796,7 +796,7 @@ static void process_cmatrix_fastpath_clipping(struct dt_iop_module_t *self, dt_d
     float *in = (float *)ivoid + (size_t)ch * k;
     float *out = (float *)ovoid + (size_t)ch * k;
 
-    float DT_ALIGNED_PIXEL nRGB[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t nRGB = { 0.0f, 0.0f, 0.0f, 0.0f };
     for(int c = 0; c < 3; c++)
     {
       nRGB[c] = 0.0f;
@@ -806,13 +806,13 @@ static void process_cmatrix_fastpath_clipping(struct dt_iop_module_t *self, dt_d
       }
     }
 
-    float DT_ALIGNED_PIXEL cRGB[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t cRGB = { 0.0f, 0.0f, 0.0f, 0.0f };
     for(int c = 0; c < 3; c++)
     {
       cRGB[c] = CLAMP(nRGB[c], 0.0f, 1.0f);
     }
 
-    float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_aligned_pixel_t XYZ = { 0.0f, 0.0f, 0.0f, 0.0f };
     for(int c = 0; c < 3; c++)
     {
       XYZ[c] = 0.0f;
@@ -862,7 +862,7 @@ static void process_cmatrix_proper(struct dt_iop_module_t *self, dt_dev_pixelpip
   {
     const float *in = (const float *)ivoid + (size_t)ch * j * roi_out->width;
     float *out = (float *)ovoid + (size_t)ch * j * roi_out->width;
-    float cam[3];
+    dt_aligned_pixel_t cam;
 
     for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
     {
@@ -876,7 +876,7 @@ static void process_cmatrix_proper(struct dt_iop_module_t *self, dt_dev_pixelpip
 
       if(!clipping)
       {
-        float DT_ALIGNED_PIXEL _xyz[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t _xyz = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         for(int c = 0; c < 3; c++)
         {
@@ -891,7 +891,7 @@ static void process_cmatrix_proper(struct dt_iop_module_t *self, dt_dev_pixelpip
       }
       else
       {
-        float DT_ALIGNED_PIXEL nRGB[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t nRGB = { 0.0f, 0.0f, 0.0f, 0.0f };
         for(int c = 0; c < 3; c++)
         {
           nRGB[c] = 0.0f;
@@ -901,13 +901,13 @@ static void process_cmatrix_proper(struct dt_iop_module_t *self, dt_dev_pixelpip
           }
         }
 
-        float DT_ALIGNED_PIXEL cRGB[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t cRGB = { 0.0f, 0.0f, 0.0f, 0.0f };
         for(int c = 0; c < 3; c++)
         {
           cRGB[c] = CLAMP(nRGB[c], 0.0f, 1.0f);
         }
 
-        float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t XYZ = { 0.0f, 0.0f, 0.0f, 0.0f };
         for(int c = 0; c < 3; c++)
         {
           XYZ[c] = 0.0f;
@@ -1095,7 +1095,7 @@ static void process_sse2_cmatrix_bm(struct dt_iop_module_t *self, dt_dev_pixelpi
 
     float *buf_in = in + (size_t)ch * roi_in->width * j;
     float *buf_out = out + (size_t)ch * roi_out->width * j;
-    float cam[3];
+    dt_aligned_pixel_t cam;
     const __m128 cm0 = _mm_set_ps(0.0f, cmat[6], cmat[3], cmat[0]);
     const __m128 cm1 = _mm_set_ps(0.0f, cmat[7], cmat[4], cmat[1]);
     const __m128 cm2 = _mm_set_ps(0.0f, cmat[8], cmat[5], cmat[2]);
@@ -1265,7 +1265,7 @@ static void process_sse2_cmatrix_proper(struct dt_iop_module_t *self, dt_dev_pix
 
     float *buf_in = in + (size_t)ch * roi_in->width * j;
     float *buf_out = out + (size_t)ch * roi_out->width * j;
-    float cam[3];
+    dt_aligned_pixel_t cam;
     const __m128 cm0 = _mm_set_ps(0.0f, cmat[6], cmat[3], cmat[0]);
     const __m128 cm1 = _mm_set_ps(0.0f, cmat[7], cmat[4], cmat[1]);
     const __m128 cm2 = _mm_set_ps(0.0f, cmat[8], cmat[5], cmat[2]);

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -219,7 +219,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 static inline void update_saturation_slider_end_color(GtkWidget *slider, float hue)
 {
-  float rgb[3];
+  dt_aligned_pixel_t rgb;
   hsl2rgb(rgb, hue, 1.0, 0.5);
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -243,8 +243,8 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
   // convert picker RGB 2 HSL
   float H = .0f, S = .0f, L = .0f;
-  float DT_ALIGNED_PIXEL XYZ[4];
-  float DT_ALIGNED_PIXEL rgb[4];
+  dt_aligned_pixel_t XYZ;
+  dt_aligned_pixel_t rgb;
   dt_Lab_to_XYZ(self->picked_color, XYZ);
   dt_XYZ_to_sRGB(XYZ, rgb);
   rgb2hsl(rgb, &H, &S, &L);
@@ -279,9 +279,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_colorize_data_t *d = (dt_iop_colorize_data_t *)piece->data;
 
   /* create Lab */
-  float DT_ALIGNED_PIXEL rgb[4] = { 0 };
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0 };
-  float DT_ALIGNED_PIXEL Lab[4] = { 0 };
+  dt_aligned_pixel_t rgb = { 0 };
+  dt_aligned_pixel_t XYZ = { 0 };
+  dt_aligned_pixel_t Lab = { 0 };
   hsl2rgb(rgb, p->hue, p->saturation, p->lightness / 100.0);
 
   if(p->version == 1)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -344,7 +344,7 @@ static void kmeans(const float *col, const int width, const int height, const in
       for(int k = 0; k < n; k++)
       {
         const float L = col[4 * (width * j + i)];
-        const float Lab[3] = { L, col[4 * (width * j + i) + 1], col[4 * (width * j + i) + 2] };
+        const dt_aligned_pixel_t Lab = { L, col[4 * (width * j + i) + 1], col[4 * (width * j + i) + 2] };
         // determine dist to mean_out
         const int c = get_cluster(Lab, n, mean_out);
 #ifdef _OPENMP
@@ -543,7 +543,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       for(size_t j = 0; j < 4*npixels; j += 4)
       {
         const float L = in[j];
-        const float Lab[3] = { L, in[j + 1], in[j + 2] };
+        const dt_aligned_pixel_t Lab = { L, in[j + 1], in[j + 2] };
 
         // transfer back scaled and blurred delta L to output L
         out[j] = 2.0f * (out[j] - 50.0f) + L;

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -424,7 +424,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #endif
     for(size_t k = 0; k < (size_t)ch * npixels; k += ch)
     {
-      float xyz[3];
+      dt_aligned_pixel_t xyz;
       dt_Lab_to_XYZ(in + k, xyz);
 
       for(int c = 0; c < 3; c++)

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -195,9 +195,9 @@ typedef struct dt_iop_colorreconstruct_bilateral_t
 
 static inline float hue_conversion(const float HSL_Hue)
 {
-  float DT_ALIGNED_PIXEL rgb[4] = { 0 };
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0 };
-  float DT_ALIGNED_PIXEL Lab[4] = { 0 };
+  dt_aligned_pixel_t rgb = { 0 };
+  dt_aligned_pixel_t XYZ = { 0 };
+  dt_aligned_pixel_t Lab = { 0 };
 
   hsl2rgb(rgb, HSL_Hue, 1.0f, 0.5f);
 

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -603,7 +603,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float sigma_s = fmax(data->spatial, 1.0f) / scale;
   const float hue = hue_conversion(data->hue); // convert to LCH hue which better fits to Lab colorspace
 
-  const float params[4] = { hue, M_PI*M_PI/8, 0.0f, 0.0f };
+  const dt_aligned_pixel_t params = { hue, M_PI*M_PI/8, 0.0f, 0.0f };
 
   dt_iop_colorreconstruct_bilateral_t *b;
   dt_iop_colorreconstruct_bilateral_frozen_t *can = NULL;

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -282,7 +282,7 @@ static void kmeans(const float *col, const dt_iop_roi_t *const roi, const int n,
       for(int k = 0; k < n; k++)
       {
         const float L = col[3 * (roi->width * j + i)];
-        const float Lab[3] = { L, col[3 * (roi->width * j + i) + 1], col[3 * (roi->width * j + i) + 2] };
+        const dt_aligned_pixel_t Lab = { L, col[3 * (roi->width * j + i) + 1], col[3 * (roi->width * j + i) + 2] };
         // determine dist to mean_out
         const int c = get_cluster(Lab, n, mean_out);
 #ifdef _OPENMP
@@ -411,7 +411,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       for(int i = 0; i < roi_out->width; i++)
       {
         const float L = in[j];
-        const float Lab[3] = { L, in[j + 1], in[j + 2] };
+        const dt_aligned_pixel_t Lab = { L, in[j + 1], in[j + 2] };
 // a, b: subtract mean, scale nvar/var, add nmean
 #if 0 // single cluster, gives color banding
         const int ki = get_cluster(in + j, data->n, mean);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -786,9 +786,9 @@ static int _select_base_display_color(dt_iop_module_t *self, float *picked_color
                                  || self->picked_color_max[0] < 0.0f || self->picked_color[0] == 0.0f);
   if(!select_by_picker)
   {
-    float DT_ALIGNED_PIXEL rgb[4] = { 0.0f, 0.3f, 0.7f };
-    float DT_ALIGNED_PIXEL xyz[4];
-    float DT_ALIGNED_PIXEL lab[4];
+    dt_aligned_pixel_t rgb = { 0.0f, 0.3f, 0.7f };
+    dt_aligned_pixel_t xyz;
+    dt_aligned_pixel_t lab;
     dt_sRGB_to_XYZ(rgb, xyz);
     dt_XYZ_to_Lab(xyz, lab);
     dt_Lab_2_LCH(lab, picked_color);
@@ -826,7 +826,7 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           = dt_ioppr_get_histogram_profile_info(self->dev);
       const dt_iop_order_iccprofile_info_t *const work_profile
           = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
-      float DT_ALIGNED_PIXEL pick_mean[4], pick_min[4], pick_max[4];
+      dt_aligned_pixel_t pick_mean, pick_min, pick_max;
       int converted_cst;
 
       if(work_profile && histogram_profile)

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -397,7 +397,7 @@ void process_display(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece
     float *in = (float *)ivoid + ch * k;
     float *out = (float *)ovoid + ch * k;
 
-    float LCh[3];
+    dt_aligned_pixel_t LCh;
 
     dt_Lab_2_LCH(in, LCh);
 
@@ -442,7 +442,7 @@ void process_v1(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, con
     float *in = (float *)ivoid + ch * k;
     float *out = (float *)ovoid + ch * k;
 
-    float LCh[3];
+    dt_aligned_pixel_t LCh;
 
     dt_Lab_2_LCH(in, LCh);
 
@@ -959,7 +959,7 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
 #define DT_COLORZONES_CELLSJ 36
 
 #define COLORZONES_DRAW_BACKGROUD_BOX                                                                             \
-  float Lab[3];                                                                                                   \
+  dt_aligned_pixel_t Lab;                                                                                         \
   dt_LCH_2_Lab(LCh, Lab);                                                                                         \
   const float L0 = Lab[0];                                                                                        \
   /* gamut mapping magic from iop/exposure.c: */                                                                  \
@@ -972,8 +972,8 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
   Lab[1] *= Lab[0] / L0 * clip2;                                                                                  \
   Lab[2] *= Lab[0] / L0 * clip2;                                                                                  \
                                                                                                                   \
-  float DT_ALIGNED_PIXEL xyz[4];                                                                                  \
-  float DT_ALIGNED_PIXEL rgb[4];                                                                                  \
+  dt_aligned_pixel_t xyz;                                                                                         \
+  dt_aligned_pixel_t rgb;                                                                                         \
   dt_Lab_to_XYZ(Lab, xyz);                                                                                        \
   dt_XYZ_to_sRGB(xyz, rgb);                                                                                       \
                                                                                                                   \
@@ -993,7 +993,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
   {
     for(int i = 0; i < cellsi; i++)
     {
-      float LCh[3] = { 0 };
+      dt_aligned_pixel_t LCh = { 0 };
 
       const float jj = _mouse_to_curve(1.0f - ((float)j - .5f) / (float)(cellsj - 1), c->zoom_factor, c->offset_y);
       const float jjh
@@ -1162,7 +1162,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
   // if color picker is active we use it as base color
   // otherwise we use a light blue
   // we will work on LCh
-  float picked_color[3], picker_min[3], picker_max[3];
+  dt_aligned_pixel_t picked_color, picker_min, picker_max;
   const int select_by_picker = _select_base_display_color(self, picked_color, picker_min, picker_max);
 
   cairo_set_antialias(cr, CAIRO_ANTIALIAS_NONE);
@@ -1455,7 +1455,7 @@ static gboolean _bottom_area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_i
   // if color picker is active we use it as base color
   // otherwise we use a light blue
   // we will work on LCh
-  float picked_color[3], picker_min[3], picker_max[3];
+  dt_aligned_pixel_t picked_color, picker_min, picker_max;
   _select_base_display_color(self, picked_color, picker_min, picker_max);
   const float normalize_C = (128.f * sqrtf(2.f));
 
@@ -1468,7 +1468,7 @@ static gboolean _bottom_area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_i
     const float ii = _mouse_to_curve(((float)i + .5f) / (float)(cellsi - 1), c->zoom_factor, c->offset_x);
     const float iih = _mouse_to_curve((float)i / (float)(cellsi - 1), c->zoom_factor, c->offset_x);
 
-    float LCh[3];
+    dt_aligned_pixel_t LCh;
 
     switch(p.channel)
     {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2098,7 +2098,7 @@ static void xtrans_fdc_interpolate(struct dt_iop_module_t *self, float *out, con
           float complex C18m = qmat[7] * modulator[6];
           qmat[0] = *(i_src + row * TS + col) - C2m - C3m - C5m - C6m - 2.0f * C7m - C12m - C18m;
           // get the rgb components from fdc
-          float rgbpix[3] = { 0.f, 0.f, 0.f };
+          dt_aligned_pixel_t rgbpix = { 0.f, 0.f, 0.f };
           // multiply with the inverse matrix of M
           for(int color = 0; color < 3; color++)
             for(int c = 0; c < 8; c++)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2144,7 +2144,7 @@ static void xtrans_fdc_interpolate(struct dt_iop_module_t *self, float *out, con
               avg[3]++;
             }
           }
-          float rgbpix[3];
+          dt_aligned_pixel_t rgbpix;
           for(int c = 0; c < 3; c++) rgbpix[c] = avg[c] / avg[3];
           // preserve all components of Markesteijn for this pixel
           const float y = 0.2627f * rgbpix[0] + 0.6780f * rgbpix[1] + 0.0593f * rgbpix[2];
@@ -2716,7 +2716,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
     {
       // also prefetch direct nbs top/bottom
       const int c = FC(j, i, filters);
-      float color[4] = { buf[0], buf[1], buf[2], buf[3] };
+      dt_aligned_pixel_t color = { buf[0], buf[1], buf[2], buf[3] };
 
       // fill all four pixels with correctly interpolated stuff: r/b for green1/2
       // b for r and r for b

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1062,7 +1062,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
             else if(hm[d] > hm[d + 4])
               hm[d + 4] = 0;
           }
-          float avg[4] = { 0.0f };
+          dt_aligned_pixel_t avg = { 0.0f };
           for(int d = 0; d < ndir; d++)
           {
             if(hm[d] >= maxval)
@@ -2135,7 +2135,7 @@ static void xtrans_fdc_interpolate(struct dt_iop_module_t *self, float *out, con
               hm[d + 4] = 0;
           }
 
-          float avg[4] = { 0.f };
+          dt_aligned_pixel_t avg = { 0.f };
           for(int d = 0; d < ndir; d++)
           {
             if(hm[d] >= maxval)
@@ -2221,7 +2221,7 @@ static void lin_interpolate(float *out, const float *const in, const dt_iop_roi_
   for(int row = 0; row < roi_out->height; row++)
     for(int col = 0; col < roi_out->width; col++)
     {
-      float sum[4] = { 0.0f };
+      dt_aligned_pixel_t sum = { 0.0f };
       uint8_t count[4] = { 0 };
       if(col == 1 && row >= 1 && row < roi_out->height - 1) col = roi_out->width - 1;
       // average all the adjoining pixels inside image by color
@@ -2301,7 +2301,7 @@ static void lin_interpolate(float *out, const float *const in, const dt_iop_roi_
     const float *buf_in = in + roi_in->width * row + 1;
     for(int col = 1; col < roi_out->width - 1; col++)
     {
-      float sum[4] = { 0.0f };
+      dt_aligned_pixel_t sum = { 0.0f };
       int *ip = &(lookup[row % size][col % size][0]);
       // for each adjoining pixel not of this pixel's color, sum up its weighted values
       for(int i = *ip++; i--; ip += 3) sum[ip[2]] += buf_in[ip[0]] * ip[1];
@@ -2461,7 +2461,7 @@ static void vng_interpolate(float *out, const float *const in,
         continue;
       }
       const float thold = gmin + (gmax * 0.5f);
-      float sum[4] = { 0.0f };
+      dt_aligned_pixel_t sum = { 0.0f };
       const int color = fcol(row + roi_in->y, col + roi_in->x, filters4, xtrans);
       int num = 0;
       for(g = 0; g < 8; g++, ip += 2) /* Average the neighbors */
@@ -2650,7 +2650,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
     for(int i = 3; i < roi_out->width - 3; i++)
     {
       const int c = FC(j, i, filters);
-      float color[4];
+      dt_aligned_pixel_t color;
       const float pc = buf_in[0];
       // if(__builtin_expect(c == 0 || c == 2, 1))
       if(c == 0 || c == 2)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -949,11 +949,11 @@ static inline void backtransform_v2(float *const buf, const int wd, const int ht
 static inline void precondition_Y0U0V0(const float *const in, float *const buf, const int wd, const int ht,
                                        const float a, const float p[4], const float b, const float toY0U0V0[3][4])
 {
-  const float DT_ALIGNED_PIXEL expon[4] = { -p[0] / 2 + 1, -p[1] / 2 + 1, -p[2] / 2 + 1, 1.0f };
-  const float DT_ALIGNED_PIXEL scale[4] = { 2.0f / ((-p[0] + 2) * sqrtf(a)),
-                                            2.0f / ((-p[1] + 2) * sqrtf(a)),
-                                            2.0f / ((-p[2] + 2) * sqrtf(a)),
-                                            1.0f };
+  const dt_aligned_pixel_t expon = { -p[0] / 2 + 1, -p[1] / 2 + 1, -p[2] / 2 + 1, 1.0f };
+  const dt_aligned_pixel_t scale = { 2.0f / ((-p[0] + 2) * sqrtf(a)),
+                                     2.0f / ((-p[1] + 2) * sqrtf(a)),
+                                     2.0f / ((-p[2] + 2) * sqrtf(a)),
+                                     1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(buf, ht, in, wd, b, toY0U0V0) \
@@ -979,18 +979,19 @@ static inline void precondition_Y0U0V0(const float *const in, float *const buf, 
   }
 }
 
-static inline void backtransform_Y0U0V0(float *const buf, const int wd, const int ht, const float a, const float p[4],
-                                        const float b, const float bias, const float wb[4], const float toRGB[3][4])
+static inline void backtransform_Y0U0V0(float *const buf, const int wd, const int ht, const float a,
+                                        const dt_aligned_pixel_t p, const float b, const float bias,
+                                        const dt_aligned_pixel_t wb, const float toRGB[3][4])
 {
-  const float DT_ALIGNED_PIXEL bias_wb[4] = { bias * wb[0], bias * wb[1], bias * wb[2], 0.0f };
-  const float DT_ALIGNED_PIXEL expon[4] = {  1.0f / (1.0f - p[0] / 2.0f),
-                                             1.0f / (1.0f - p[1] / 2.0f),
-                                             1.0f / (1.0f - p[2] / 2.0f),
-                                             1.0f };
-  const float DT_ALIGNED_PIXEL scale[4] = { (sqrtf(a) * (2.0f - p[0])) / 4.0f,
-                                            (sqrtf(a) * (2.0f - p[1])) / 4.0f,
-                                            (sqrtf(a) * (2.0f - p[2])) / 4.0f,
-                                            1.0f };
+  const dt_aligned_pixel_t bias_wb = { bias * wb[0], bias * wb[1], bias * wb[2], 0.0f };
+  const dt_aligned_pixel_t expon = {  1.0f / (1.0f - p[0] / 2.0f),
+                                      1.0f / (1.0f - p[1] / 2.0f),
+                                      1.0f / (1.0f - p[2] / 2.0f),
+                                      1.0f };
+  const dt_aligned_pixel_t scale = { (sqrtf(a) * (2.0f - p[0])) / 4.0f,
+                                     (sqrtf(a) * (2.0f - p[1])) / 4.0f,
+                                     (sqrtf(a) * (2.0f - p[2])) / 4.0f,
+                                     1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(buf, ht, wd, b, bias_wb, toRGB, expon, scale)  \

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -373,7 +373,7 @@ static void process_floyd_steinberg(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   const float f = levels - 1;
   const float rf = 1.0 / f;
-  float DT_ALIGNED_PIXEL err[4];
+  dt_aligned_pixel_t err;
 
   // dither without error diffusion on very tiny images
   if(width < 3 || height < 3)

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -111,7 +111,8 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
   {
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    const float wb[3] = {piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+    const dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1],
+                                    piece->pipe->dsc.temperature.coeffs[2] };
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &detail);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &high_image);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -407,10 +407,10 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     float *in = ((float *)ivoid) + k;
     float *out = ((float *)ovoid) + k;
 
-    float DT_ALIGNED_PIXEL XYZ[4];
+    dt_aligned_pixel_t XYZ;
     dt_Lab_to_XYZ(in, XYZ);
 
-    float DT_ALIGNED_PIXEL rgb[4] = { 0.0f };
+    dt_aligned_pixel_t rgb = { 0.0f };
     dt_XYZ_to_prophotorgb(XYZ, rgb);
 
     float concavity, luma;
@@ -429,7 +429,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     if (preserve_color)
     {
       int index;
-      float ratios[4];
+      dt_aligned_pixel_t ratios;
       float max = fmaxf(fmaxf(rgb[0], rgb[1]), rgb[2]);
 
       // Save the ratios
@@ -590,7 +590,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
       concavity = _mm_set1_ps(data->grad_2[(int)CLAMP(XYZ[1] * 0x10000ul, 0, 0xffff)]);
 
       // Unpack SSE vector to regular array
-      float rgb_unpack[4];
+      dt_aligned_pixel_t rgb_unpack;
 
       // Filmic S curve
       for (int c = 0; c < 4; ++c)
@@ -700,7 +700,7 @@ static void apply_auto_grey(dt_iop_module_t *self)
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
 
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ(self->picked_color, XYZ);
 
   const float grey = XYZ[1];
@@ -727,7 +727,7 @@ static void apply_auto_black(dt_iop_module_t *self)
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
 
   const float noise = powf(2.0f, -16.0f);
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
 
   // Black
   dt_Lab_to_XYZ(self->picked_color_min, XYZ);
@@ -755,7 +755,7 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
 
   const float noise = powf(2.0f, -16.0f);
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
 
   // White
   dt_Lab_to_XYZ(self->picked_color_max, XYZ);
@@ -814,7 +814,7 @@ static void apply_autotune(dt_iop_module_t *self)
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
 
   const float noise = powf(2.0f, -16.0f);
-  float DT_ALIGNED_PIXEL XYZ[4] = { 0.0f };
+  dt_aligned_pixel_t XYZ = { 0.0f };
 
   // Grey
   dt_Lab_to_XYZ(self->picked_color, XYZ);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -564,7 +564,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 #ifdef _OPENMP
 #pragma omp declare simd aligned(pixel:16)
 #endif
-static inline float pixel_rgb_norm_power(const float pixel[4])
+static inline float pixel_rgb_norm_power(const dt_aligned_pixel_t pixel)
 {
   // weird norm sort of perceptual. This is black magic really, but it looks good.
   // the full norm is (R^3 + G^3 + B^3) / (R^2 + G^2 + B^2) and it should be in ]0; +infinity[
@@ -588,7 +588,7 @@ static inline float pixel_rgb_norm_power(const float pixel[4])
 #ifdef _OPENMP
 #pragma omp declare simd aligned(pixel : 16) uniform(variant, work_profile)
 #endif
-static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_methods_type_t variant,
+static inline float get_pixel_norm(const dt_aligned_pixel_t pixel, const dt_iop_filmicrgb_methods_type_t variant,
                                    const dt_iop_order_iccprofile_info_t *const work_profile)
 {
   // a newly added norm should satisfy the condition that it is linear with respect to grey pixels:

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -143,7 +143,7 @@ typedef enum dt_iop_filmicrgb_reconstruction_type_t
 
 typedef struct dt_iop_filmic_rgb_spline_t
 {
-  float DT_ALIGNED_PIXEL M1[4], M2[4], M3[4], M4[4], M5[4]; // factors for the interpolation polynom
+  dt_aligned_pixel_t M1, M2, M3, M4, M5;                    // factors for the interpolation polynom
   float latitude_min, latitude_max;                         // bounds of the latitude == linear part by design
   float y[5];                                               // controls nodes
   float x[5];                                               // controls nodes
@@ -1163,7 +1163,7 @@ static inline void filmic_split_v1(const float *const restrict in, float *const 
   {
     const float *const restrict pix_in = in + k;
     float *const restrict pix_out = out + k;
-    float DT_ALIGNED_ARRAY temp[4];
+    dt_aligned_pixel_t temp;
 
     // Log tone-mapping
     for(int c = 0; c < 3; c++)
@@ -1205,7 +1205,7 @@ static inline void filmic_split_v2_v3(const float *const restrict in, float *con
   {
     const float *const restrict pix_in = in + k;
     float *const restrict pix_out = out + k;
-    float DT_ALIGNED_ARRAY temp[4];
+    dt_aligned_pixel_t temp;
 
     // Log tone-mapping
     for(int c = 0; c < 3; c++)
@@ -1247,7 +1247,7 @@ static inline void filmic_chroma_v1(const float *const restrict in, float *const
     const float *const restrict pix_in = in + k;
     float *const restrict pix_out = out + k;
 
-    float DT_ALIGNED_ARRAY ratios[4] = { 0.0f };
+    dt_aligned_pixel_t ratios = { 0.0f };
     float norm = fmaxf(get_pixel_norm(pix_in, variant, work_profile), NORM_MIN);
 
     // Save the ratios
@@ -1308,7 +1308,7 @@ static inline void filmic_chroma_v2_v3(const float *const restrict in, float *co
     float norm = fmaxf(get_pixel_norm(pix_in, variant, work_profile), NORM_MIN);
 
     // Save the ratios
-    float DT_ALIGNED_ARRAY ratios[4] = { 0.0f };
+    dt_aligned_pixel_t ratios = { 0.0f };
 
     for_each_channel(c,aligned(pix_in))
       ratios[c] = pix_in[c] / norm;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -868,7 +868,6 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
     }
 }
 
-
 inline static void wavelets_reconstruct_RGB(const float *const restrict HF, const float *const restrict LF,
                                             const float *const restrict texture, const float *const restrict mask,
                                             float *const restrict reconstructed, const size_t width,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -662,8 +662,9 @@ static inline float exp_tonemapping_v2(const float x, const float grey, const fl
 #ifdef _OPENMP
 #pragma omp declare simd aligned(M1, M2, M3, M4 : 16) uniform(M1, M2, M3, M4, M5, latitude_min, latitude_max)
 #endif
-static inline float filmic_spline(const float x, const float M1[4], const float M2[4], const float M3[4],
-                                  const float M4[4], const float M5[4], const float latitude_min,
+static inline float filmic_spline(const float x, const dt_aligned_pixel_t M1, const dt_aligned_pixel_t M2,
+                                  const dt_aligned_pixel_t M3, const dt_aligned_pixel_t M4,
+                                  const dt_aligned_pixel_t M5, const float latitude_min,
                                   const float latitude_max, const dt_iop_filmicrgb_curve_type_t type[2])
 {
   // if type polynomial :

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -851,8 +851,8 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
       const size_t index = idx * 4;
       const float weight = mask[idx];
       const float *const restrict pix_in = __builtin_assume_aligned(in + index, 16);
-      float DT_ALIGNED_ARRAY noise[4] = { 0.f };
-      float DT_ALIGNED_ARRAY sigma[4] = { 0.f };
+      dt_aligned_pixel_t noise = { 0.f };
+      dt_aligned_pixel_t sigma = { 0.f };
       const int DT_ALIGNED_ARRAY flip[4] = { TRUE, FALSE, TRUE, FALSE };
 
       for_each_channel(c,aligned(pix_in))

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -429,7 +429,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
 
 static inline void update_saturation_slider_end_color(GtkWidget *slider, float hue)
 {
-  float rgb[3];
+  dt_aligned_pixel_t rgb;
   hsl2rgb(rgb, hue, 1.0, 0.5);
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -317,7 +317,7 @@ static inline void interpolate_color_xtrans(const void *const ivoid, void *const
                           { 1,  0, -3},
                           { 2,  3,  0}};
   // record ratios of color transitions 0:unused, 1:RG, 2:RB, and 3:GB
-  float ratios[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+  dt_aligned_pixel_t ratios = {1.0f, 1.0f, 1.0f, 1.0f};
 
   // passes are 0:+x, 1:-x, 2:+y, 3:-y
   // dims are 0:traverse a row, 1:traverse a column

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -607,7 +607,7 @@ static void process_lch_bayer(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
             H *= ratio;
           }
 
-          float RGB[3] = { 0.0f, 0.0f, 0.0f };
+          dt_aligned_pixel_t RGB = { 0.0f, 0.0f, 0.0f };
 
           /*
            * backtransform proof, sage:
@@ -708,9 +708,9 @@ static void process_lch_xtrans(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
         if(clipped)
         {
-          float mean[3] = { 0.0f, 0.0f, 0.0f };
+          dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f };
+          dt_aligned_pixel_t RGBmax = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
           int cnt[3] = { 0, 0, 0 };
-          float RGBmax[3] = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
 
           for(int jj = -1; jj <= 1; jj++)
           {
@@ -747,7 +747,7 @@ static void process_lch_xtrans(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
             H *= ratio;
           }
 
-          float RGB[3] = { 0.0f, 0.0f, 0.0f };
+          dt_aligned_pixel_t RGB = { 0.0f, 0.0f, 0.0f };
 
           RGB[0] = L - H / 6.0f + C / SQRT12;
           RGB[1] = L - H / 6.0f - C / SQRT12;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -229,7 +229,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const float *const m = piece->pipe->dsc.processed_maximum;
 
-  const float film_rgb_f[4]
+  const dt_aligned_pixel_t film_rgb_f
       = { d->color[0] * m[0], d->color[1] * m[1], d->color[2] * m[2], d->color[3] * m[3] };
 
   // FIXME: it could be wise to make this a NOP when picking colors. not sure about that though.
@@ -313,7 +313,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   const float *const m = piece->pipe->dsc.processed_maximum;
 
-  const float film_rgb_f[4]
+  const dt_aligned_pixel_t film_rgb_f
       = { d->color[0] * m[0], d->color[1] * m[1], d->color[2] * m[2], d->color[3] * m[3] };
 
   // FIXME: it could be wise to make this a NOP when picking colors. not sure about that though.

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -163,7 +163,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   if(img->flags & DT_IMAGE_4BAYER)
   {
     dt_aligned_pixel_t rgb;
-    for(int k = 0; k < 4; k++) rgb[k] = p->color[k];
+    for_four_channels(k) rgb[k] = p->color[k];
 
     dt_colorspaces_cygm_to_rgb(rgb, 1, g->CAM_to_RGB);
 
@@ -177,16 +177,16 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
-  static float old[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+  static dt_aligned_pixel_t old = { 0.0f, 0.0f, 0.0f, 0.0f };
 
   const float *grayrgb = self->picked_color;
 
   if(grayrgb[0] == old[0] && grayrgb[1] == old[1] && grayrgb[2] == old[2] && grayrgb[3] == old[3]) return;
 
-  for(int k = 0; k < 4; k++) old[k] = grayrgb[k];
+  for_four_channels(k) old[k] = grayrgb[k];
 
   dt_iop_invert_params_t *p = self->params;
-  for(int k = 0; k < 4; k++) p->color[k] = grayrgb[k];
+  for_four_channels(k) p->color[k] = grayrgb[k];
 
   ++darktable.gui->reset;
   gui_update_from_coeffs(self);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -162,7 +162,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   const dt_image_t *img = &self->dev->image_storage;
   if(img->flags & DT_IMAGE_4BAYER)
   {
-    float rgb[4];
+    dt_aligned_pixel_t rgb;
     for(int k = 0; k < 4; k++) rgb[k] = p->color[k];
 
     dt_colorspaces_cygm_to_rgb(rgb, 1, g->CAM_to_RGB);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -467,7 +467,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   cl_int err = -999;
   int kernel = -1;
 
-  float film_rgb_f[4] = { d->color[0], d->color[1], d->color[2], d->color[3] };
+  dt_aligned_pixel_t film_rgb_f = { d->color[0], d->color[1], d->color[2], d->color[3] };
 
   if(filters)
   {

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -190,7 +190,7 @@ static void dt_iop_levels_compute_levels_automatic(dt_dev_pixelpipe_iop_t *piece
 
   uint32_t total = piece->histogram_stats.pixels;
 
-  float thr[3];
+  dt_aligned_pixel_t thr;
   for(int k = 0; k < 3; k++)
   {
     thr[k] = (float)total * d->percentiles[k] / 100.0f;
@@ -256,7 +256,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
      && self->picked_color_max[0] >= 0.0f
      && mean_picked_color != c->last_picked_color)
   {
-    float previous_color[3];
+    dt_aligned_pixel_t previous_color;
     previous_color[0] = p->levels[0];
     previous_color[1] = p->levels[1];
     previous_color[2] = p->levels[2];

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -129,8 +129,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float threshold = 0.01f;
 
   // scotopic white, blue saturated
-  float Lab_sw[3] = { 100.0f, 0, -d->blueness };
-  float XYZ_sw[3];
+  dt_aligned_pixel_t Lab_sw = { 100.0f, 0, -d->blueness };
+  dt_aligned_pixel_t XYZ_sw;
 
   dt_Lab_to_XYZ(Lab_sw, XYZ_sw);
 
@@ -197,8 +197,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int height = roi_out->height;
 
   // scotopic white, blue saturated
-  float Lab_sw[3] = { 100.0f, 0.0f, -d->blueness };
-  float XYZ_sw[4];
+  dt_aligned_pixel_t Lab_sw = { 100.0f, 0.0f, -d->blueness };
+  dt_aligned_pixel_t XYZ_sw;
 
   dt_Lab_to_XYZ(Lab_sw, XYZ_sw);
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -144,7 +144,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     float *in = (float *)i + ch * k;
     float *out = (float *)o + ch * k;
-    float DT_ALIGNED_PIXEL XYZ[4], XYZ_s[4];
+    dt_aligned_pixel_t XYZ, XYZ_s;
     float V;
     float w;
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -217,7 +217,7 @@ void correct_pixel_trilinear(const float *const in, float *const out,
 
     int rgbi[3], i, j;
     float tmp[6];
-    float rgbd[3];
+    dt_aligned_pixel_t rgbd;
 
     for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
 
@@ -294,7 +294,7 @@ void correct_pixel_tetrahedral(const float *const in, float *const out,
     float *const output = ((float *const)out) + k;
 
     int rgbi[3];
-    float rgbd[3];
+    dt_aligned_pixel_t rgbd;
     for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
 
     rgbd[0] = input[0] * (float)(level - 1);
@@ -382,7 +382,7 @@ void correct_pixel_pyramid(const float *const in, float *const out,
     float *const output = ((float *const)out) + k;
 
     int rgbi[3];
-    float rgbd[3];
+    dt_aligned_pixel_t rgbd;
     for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
 
     rgbd[0] = input[0] * (float)(level - 1);

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -107,9 +107,9 @@ typedef struct dt_iop_negadoctor_params_t
 
 typedef struct dt_iop_negadoctor_data_t
 {
-  float DT_ALIGNED_PIXEL Dmin[4];         // color of film substrate
-  float DT_ALIGNED_PIXEL wb_high[4];      // white balance RGB coeffs / Dmax
-  float DT_ALIGNED_PIXEL offset[4];       // inversion offset
+  dt_aligned_pixel_t Dmin;                // color of film substrate
+  dt_aligned_pixel_t wb_high;             // white balance RGB coeffs / Dmax
+  dt_aligned_pixel_t offset;              // inversion offset
   float black;                            // display black level
   float gamma;                            // display gamma
   float soft_clip;                        // highlights roll-off
@@ -184,9 +184,9 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     typedef struct dt_iop_negadoctor_params_v1_t
     {
       dt_iop_negadoctor_filmstock_t film_stock;
-      float DT_ALIGNED_PIXEL Dmin[4];         // color of film substrate
-      float DT_ALIGNED_PIXEL wb_high[4];      // white balance RGB coeffs (illuminant)
-      float DT_ALIGNED_PIXEL wb_low[4];       // white balance RGB offsets (base light)
+      dt_aligned_pixel_t Dmin;                // color of film substrate
+      dt_aligned_pixel_t wb_high;             // white balance RGB coeffs (illuminant)
+      dt_aligned_pixel_t wb_low;              // white balance RGB offsets (base light)
       float D_max;                            // max density of film
       float offset;                           // inversion offset
       float black;                            // display black level

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -510,7 +510,7 @@ static void WB_low_picker_update(dt_iop_module_t *self)
   GdkRGBA color;
   color.alpha = 1.0f;
 
-  float WB_low_invert[3];
+  dt_aligned_pixel_t WB_low_invert;
   for(size_t c = 0; c < 3; ++c) WB_low_invert[c] = 2.0f - p->wb_low[c];
   const float WB_low_max = v_maxf(WB_low_invert);
   for(size_t c = 0; c < 3; ++c) WB_low_invert[c] /= WB_low_max;
@@ -533,10 +533,7 @@ static void WB_low_picker_callback(GtkColorButton *widget, dt_iop_module_t *self
   GdkRGBA c;
   gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(widget), &c);
 
-  float RGB[3];
-  RGB[0] = 2.0f - c.red;
-  RGB[1] = 2.0f - c.green;
-  RGB[2] = 2.0f - c.blue;
+  dt_aligned_pixel_t RGB = { 2.0f - c.red, 2.0f - c.green, 2.0f - c.blue };
 
   float RGB_min = v_minf(RGB);
   for(size_t k = 0; k < 3; k++) p->wb_low[k] = RGB[k] / RGB_min;
@@ -561,7 +558,7 @@ static void WB_high_picker_update(dt_iop_module_t *self)
   GdkRGBA color;
   color.alpha = 1.0f;
 
-  float WB_high_invert[3];
+  dt_aligned_pixel_t WB_high_invert;
   for(size_t c = 0; c < 3; ++c) WB_high_invert[c] = 2.0f - p->wb_high[c];
   const float WB_high_max = v_maxf(WB_high_invert);
   for(size_t c = 0; c < 3; ++c) WB_high_invert[c] /= WB_high_max;
@@ -584,11 +581,7 @@ static void WB_high_picker_callback(GtkColorButton *widget, dt_iop_module_t *sel
   GdkRGBA c;
   gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(widget), &c);
 
-  float RGB[3];
-  RGB[0] = 2.0f - c.red;
-  RGB[1] = 2.0f - c.green;
-  RGB[2] = 2.0f - c.blue;
-
+  dt_aligned_pixel_t RGB = { 2.0f - c.red, 2.0f - c.green, 2.0f - c.blue };
   float RGB_min = v_minf(RGB);
   for(size_t k = 0; k < 3; k++) p->wb_high[k] = RGB[k] / RGB_min;
 
@@ -633,7 +626,7 @@ static void apply_auto_Dmax(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  float RGB[3];
+  dt_aligned_pixel_t RGB;
   for(int c = 0; c < 3; c++)
   {
     RGB[c] = log10f(p->Dmin[c] / fmaxf(self->picked_color_min[c], THRESHOLD));
@@ -657,7 +650,7 @@ static void apply_auto_offset(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  float RGB[3];
+  dt_aligned_pixel_t RGB;
   for(int c = 0; c < 3; c++)
     RGB[c] = log10f(p->Dmin[c] / fmaxf(self->picked_color_max[c], THRESHOLD)) / p->D_max;
 
@@ -680,7 +673,7 @@ static void apply_auto_WB_low(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  float RGB_min[3];
+  dt_aligned_pixel_t RGB_min;
   for(int c = 0; c < 3; c++)
     RGB_min[c] = log10f(p->Dmin[c] / fmaxf(self->picked_color[c], THRESHOLD)) / p->D_max;
 
@@ -706,7 +699,7 @@ static void apply_auto_WB_high(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  float RGB_min[3];
+  dt_aligned_pixel_t RGB_min;
   for(int c = 0; c < 3; c++)
     RGB_min[c] = fabsf(-1.0f / (p->offset * p->wb_low[c] - log10f(p->Dmin[c] / fmaxf(self->picked_color[c], THRESHOLD)) / p->D_max));
 
@@ -732,7 +725,7 @@ static void apply_auto_black(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  float RGB[3];
+  dt_aligned_pixel_t RGB;
   for(int c = 0; c < 3; c++)
   {
     RGB[c] = -log10f(p->Dmin[c] / fmaxf(self->picked_color_max[c], THRESHOLD));
@@ -758,7 +751,7 @@ static void apply_auto_exposure(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  float RGB[3];
+  dt_aligned_pixel_t RGB;
   for(int c = 0; c < 3; c++)
   {
     RGB[c] = -log10f(p->Dmin[c] / fmaxf(self->picked_color_min[c], THRESHOLD));

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -227,7 +227,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float max_L = 120.0f, max_C = 512.0f;
   const float nL = 1.0f / max_L, nC = 1.0f / max_C;
   const float nL2 = nL * nL, nC2 = nC * nC;
-  const float weight[4] = { d->luma, d->chroma, d->chroma, 1.0f };
+  const dt_aligned_pixel_t weight = { d->luma, d->chroma, d->chroma, 1.0f };
 
   const int devid = piece->pipe->devid;
   cl_mem dev_U2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 4 * width * height);

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -418,7 +418,7 @@ static void process_cpu(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
   // adjust to Lab, make L more important
   float max_L = 120.0f, max_C = 512.0f;
   float nL = 1.0f / max_L, nC = 1.0f / max_C;
-  const float norm2[4] = { nL * nL, nC * nC, nC * nC, 1.0f };
+  const dt_aligned_pixel_t norm2 = { nL * nL, nC * nC, nC * nC, 1.0f };
 
   // faster but less accurate processing by skipping half the patches on previews and thumbnails
   int decimate = (piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW || piece->pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -219,7 +219,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       // luminance is ok, so check for saturation
       else
       {
-        float DT_ALIGNED_ARRAY saturation[4] = { 0.f };
+        dt_aligned_pixel_t saturation = { 0.f };
 
         for_each_channel(c,aligned(saturation, img_tmp : 64))
         {
@@ -298,7 +298,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                                                 work_profile->lutsize, work_profile->nonlinearlut);
       if(luminance < upper && luminance > lower)
       {
-        float DT_ALIGNED_ARRAY saturation[4] = { 0.f };
+        dt_aligned_pixel_t saturation = { 0.f };
 
         for_each_channel(c,aligned(saturation, img_tmp : 64))
         {

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -166,7 +166,7 @@ static void rcd_ppg_border(float *const out, const float *const in, const int wi
       if(i == width) break;
 
       const int c = FC(j, i, filters);
-      float color[4];
+      dt_aligned_pixel_t color;
       const float pc = fmaxf(0.0f, buf_in[0]);
       if(c == 0 || c == 2)
       {
@@ -230,7 +230,7 @@ static void rcd_ppg_border(float *const out, const float *const in, const int wi
         buf = out + (size_t)4 * (width * j + i);
       }
       const int c = FC(j, i, filters);
-      float color[4] = { buf[0], buf[1], buf[2], buf[3] };
+      dt_aligned_pixel_t color = { buf[0], buf[1], buf[2], buf[3] };
       const int linesize = 4 * width;
       // fill all four pixels with correctly interpolated stuff: r/b for green1/2
       // b for r and r for b

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2874,7 +2874,7 @@ static void rt_process_stats(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 #endif
   for(int i = 0; i < size; i += ch)
   {
-    float Lab[3] = { 0 };
+    dt_aligned_pixel_t Lab = { 0 };
 
     if(work_profile)
     {
@@ -2884,7 +2884,7 @@ static void rt_process_stats(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     }
     else
     {
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
       dt_linearRGB_to_XYZ(img_src + i, XYZ);
       dt_XYZ_to_Lab(XYZ, Lab);
     }
@@ -3430,7 +3430,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
           else if(algo == DT_IOP_RETOUCH_FILL)
           {
             // add a brightness to the color so it can be fine-adjusted by the user
-            float DT_ALIGNED_PIXEL fill_color[4];
+            dt_aligned_pixel_t fill_color;
 
             if(p->rt_forms[index].fill_mode == DT_IOP_RETOUCH_FILL_ERASE)
             {
@@ -3535,10 +3535,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   // decompose it
   dwt_decompose(dwt_p, rt_process_forms);
 
-  float levels[3] = { 0.f };
-  levels[0] = p->preview_levels[0];
-  levels[1] = p->preview_levels[1];
-  levels[2] = p->preview_levels[2];
+  dt_aligned_pixel_t levels = { p->preview_levels[0], p->preview_levels[1], p->preview_levels[2] };
 
   // process auto levels
   if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL)
@@ -4247,7 +4244,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
           else if(algo == DT_IOP_RETOUCH_FILL)
           {
             // add a brightness to the color so it can be fine-adjusted by the user
-            float fill_color[3];
+            dt_aligned_pixel_t fill_color;
 
             if(p->rt_forms[index].fill_mode == DT_IOP_RETOUCH_FILL_ERASE)
             {
@@ -4378,10 +4375,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dwt_decompose_cl(dwt_p, rt_process_forms_cl);
   if(err != CL_SUCCESS) goto cleanup;
 
-  float levels[3] = { 0.f };
-  levels[0] = p->preview_levels[0];
-  levels[1] = p->preview_levels[1];
-  levels[2] = p->preview_levels[2];
+  dt_aligned_pixel_t levels = { p->preview_levels[0], p->preview_levels[1], p->preview_levels[2] };
 
   // process auto levels
   if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2806,7 +2806,7 @@ static void image_rgb2lab(float *img_src, const int width, const int height, con
 #endif
   for(int i = 0; i < stride; i += ch)
   {
-    float DT_ALIGNED_PIXEL XYZ[4];
+    dt_aligned_pixel_t XYZ;
 
     dt_linearRGB_to_XYZ(img_src + i, XYZ);
     dt_XYZ_to_Lab(XYZ, img_src + i);
@@ -2847,7 +2847,7 @@ static void image_lab2rgb(float *img_src, const int width, const int height, con
 #endif
   for(int i = 0; i < stride; i += ch)
   {
-    float DT_ALIGNED_PIXEL XYZ[4];
+    dt_aligned_pixel_t XYZ;
 
     dt_Lab_to_XYZ(img_src + i, XYZ);
     dt_XYZ_to_linearRGB(XYZ, img_src + i);
@@ -2933,7 +2933,7 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
     }
     else
     {
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
 
       dt_linearRGB_to_XYZ(img_src + i, XYZ);
       dt_XYZ_to_Lab(XYZ, img_src + i);
@@ -2962,7 +2962,7 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
     }
     else
     {
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
 
       dt_Lab_to_XYZ(img_src + i, XYZ);
       dt_XYZ_to_linearRGB(XYZ, img_src + i);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -873,7 +873,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
       const dt_iop_order_iccprofile_info_t *const work_profile
           = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
 
-      float DT_ALIGNED_PIXEL picker_mean[4], picker_min[4], picker_max[4];
+      dt_aligned_pixel_t picker_mean, picker_min, picker_max;
 
       // the global live samples ...
       GSList *samples = darktable.lib->proxy.colorpicker.live_samples;

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -780,7 +780,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
      && self->picked_color_max[0] >= 0.0f
      && mean_picked_color != c->last_picked_color)
   {
-    float previous_color[3];
+    dt_aligned_pixel_t previous_color;
     previous_color[0] = p->levels[channel][0];
     previous_color[1] = p->levels[channel][1];
     previous_color[2] = p->levels[channel][2];

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1260,9 +1260,9 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     }
   }
 
-  const float mult[3] = { 1.f / (d->params.levels[0][2] - d->params.levels[0][0]),
-                          1.f / (d->params.levels[1][2] - d->params.levels[1][0]),
-                          1.f / (d->params.levels[2][2] - d->params.levels[2][0]) };
+  const dt_aligned_pixel_t mult = { 1.f / (d->params.levels[0][2] - d->params.levels[0][0]),
+                                    1.f / (d->params.levels[1][2] - d->params.levels[1][0]),
+                                    1.f / (d->params.levels[2][2] - d->params.levels[2][0]) };
 
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
   const float *const restrict in = (const float*)ivoid;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -331,8 +331,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(data->shadhi_algo == SHADHI_ALGO_GAUSSIAN)
   {
-    float Labmax[4] = { 100.0f, 128.0f, 128.0f, 1.0f };
-    float Labmin[4] = { 0.0f, -128.0f, -128.0f, 0.0f };
+    dt_aligned_pixel_t Labmax = { 100.0f, 128.0f, 128.0f, 1.0f };
+    dt_aligned_pixel_t Labmin = { 0.0f, -128.0f, -128.0f, 0.0f };
 
     if(unbound_mask)
     {
@@ -501,8 +501,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   if(d->shadhi_algo == SHADHI_ALGO_GAUSSIAN)
   {
-    float Labmax[4] = { 100.0f, 128.0f, 128.0f, 1.0f };
-    float Labmin[4] = { 0.0f, -128.0f, -128.0f, 0.0f };
+    dt_aligned_pixel_t Labmax = { 100.0f, 128.0f, 128.0f, 1.0f };
+    dt_aligned_pixel_t Labmin = { 0.0f, -128.0f, -128.0f, 0.0f };
 
     if(unbound_mask)
     {

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -378,7 +378,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #endif
   for(size_t j = 0; j < (size_t)width * height * ch; j += ch)
   {
-    float ta[3], tb[3];
+    dt_aligned_pixel_t ta, tb;
     _Lab_scale(&in[j], ta);
     // invert and desaturate the blurred output pixel
     out[j + 0] = 100.0f - out[j + 0];

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -359,8 +359,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_bilateral_free(b);
   }
 
-  const float max[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
-  const float min[4] = { 0.0f, -1.0f, -1.0f, 0.0f };
+  const dt_aligned_pixel_t max = { 1.0f, 1.0f, 1.0f, 1.0f };
+  const dt_aligned_pixel_t min = { 0.0f, -1.0f, -1.0f, 0.0f };
   const float lmin = 0.0f;
   const float lmax = max[0] + fabsf(min[0]);
   const float halfmax = lmax / 2.0;

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -339,7 +339,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // do the bulk of the row four at a time
     for(int i = 0; i < width; i += 4)
     {
-      float DT_ALIGNED_PIXEL sum[4] = { 0.0f };
+      dt_aligned_pixel_t sum = { 0.0f };
       for(int k = start_row; k <= end_row; k++)
       {
         const int k_adj = k - (j-rad);
@@ -357,7 +357,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       for(int k = start_row; k <= end_row; k++)
       {
         const int k_adj = k - (j-rad);
-        temp_buf[i] += mat[k_adj] * in[4*(k*width+i)];
+        sum += mat[k_adj] * in[4*(k*width+i)];
       }
       temp_buf[i] = sum;
     }

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -265,7 +265,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 static inline void update_colorpicker_color(GtkWidget *colorpicker, float hue, float sat)
 {
-  float rgb[3];
+  dt_aligned_pixel_t rgb;
   hsl2rgb(rgb, hue, sat, 0.5);
 
   GdkRGBA color = (GdkRGBA){.red = rgb[0], .green = rgb[1], .blue = rgb[2], .alpha = 1.0 };
@@ -274,7 +274,7 @@ static inline void update_colorpicker_color(GtkWidget *colorpicker, float hue, f
 
 static inline void update_saturation_slider_end_color(GtkWidget *slider, float hue)
 {
-  float rgb[3];
+  dt_aligned_pixel_t rgb;
   hsl2rgb(rgb, hue, 1.0, 0.5);
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }
@@ -284,7 +284,7 @@ static inline void update_balance_slider_colors(
     float shadow_hue,
     float highlight_hue)
 {
-  float rgb[3];
+  dt_aligned_pixel_t rgb;
   if(shadow_hue != -1)
   {
     hsl2rgb(rgb, shadow_hue, 1.0, 0.5);
@@ -336,7 +336,8 @@ static void colorpick_callback(GtkColorButton *widget, dt_iop_module_t *self)
 
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
 
-  float color[3], h, s, l;
+  dt_aligned_pixel_t color;
+  float h, s, l;
 
   GdkRGBA c;
   gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(widget), &c);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -175,7 +175,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     rgb2hsl(in+k, &h, &s, &l);
     if(l < data->balance - compress)
     {
-      float DT_ALIGNED_PIXEL mixrgb[4];
+      dt_aligned_pixel_t mixrgb;
       hsl2rgb(mixrgb, data->shadow_hue, data->shadow_saturation, l);
 
       const float ra = CLIP((data->balance - compress - l) * 2.0f);
@@ -186,7 +186,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else if(l > data->balance + compress)
     {
-      float DT_ALIGNED_PIXEL mixrgb[4];
+      dt_aligned_pixel_t mixrgb;
       hsl2rgb(mixrgb, data->highlight_hue, data->highlight_saturation, l);
 
       const float ra = CLIP((l - (data->balance + compress)) * 2.0f);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1062,10 +1062,10 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
 
       const cmsCIEXYZ cmsXYZ_temp = temperature_tint_to_XYZ(K,cur_tint);
       const cmsCIEXYZ cmsXYZ_tint = temperature_tint_to_XYZ(cur_temp, tint);
-      float DT_ALIGNED_PIXEL XYZ_temp[4] = {cmsXYZ_temp.X, cmsXYZ_temp.Y, cmsXYZ_temp.Z};
-      float DT_ALIGNED_PIXEL XYZ_tint[4] = {cmsXYZ_tint.X, cmsXYZ_tint.Y, cmsXYZ_tint.Z};
-      float DT_ALIGNED_PIXEL sRGB_temp[4];
-      float DT_ALIGNED_PIXEL sRGB_tint[4];
+      dt_aligned_pixel_t XYZ_temp = {cmsXYZ_temp.X, cmsXYZ_temp.Y, cmsXYZ_temp.Z};
+      dt_aligned_pixel_t XYZ_tint = {cmsXYZ_tint.X, cmsXYZ_tint.Y, cmsXYZ_tint.Z};
+      dt_aligned_pixel_t sRGB_temp;
+      dt_aligned_pixel_t sRGB_tint;
 
       dt_XYZ_to_Rec709_D65(XYZ_temp, sRGB_temp);
       dt_XYZ_to_Rec709_D65(XYZ_tint, sRGB_tint);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1028,8 +1028,10 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       coeffs_tint[3] /= coeffs_tint[1];
       coeffs_tint[1] = 1.0;
 
-      float sRGB_K[3] = { dayligh_white[0]*coeffs_K[0], dayligh_white[1]*coeffs_K[1], dayligh_white[2]*coeffs_K[2] };
-      float sRGB_tint[3] = {cur_white[0]*coeffs_tint[0], cur_white[1]*coeffs_tint[1], cur_white[2]*coeffs_tint[2]};
+      dt_aligned_pixel_t sRGB_K = { dayligh_white[0]*coeffs_K[0], dayligh_white[1]*coeffs_K[1],
+                                    dayligh_white[2]*coeffs_K[2] };
+      dt_aligned_pixel_t sRGB_tint = {cur_white[0]*coeffs_tint[0], cur_white[1]*coeffs_tint[1],
+                                      cur_white[2]*coeffs_tint[2]};
       const float maxsRGB_K = fmaxf(fmaxf(sRGB_K[0], sRGB_K[1]), sRGB_K[2]);
       const float maxsRGB_tint = fmaxf(fmaxf(sRGB_tint[0], sRGB_tint[1]),sRGB_tint[2]);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -523,10 +523,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         const size_t p = (size_t)j * width + i;
         out[p] = in[p] * d_coeffs[FC(offset_j, i + roi_out->x, filters)];
       }
-      const float DT_ALIGNED_PIXEL coeffs[4] = { d_coeffs[FC(offset_j, i + roi_out->x, filters)],
-                                                 d_coeffs[FC(offset_j, i + roi_out->x + 1,filters)],
-                                                 d_coeffs[FC(offset_j, i + roi_out->x + 2, filters)],
-                                                 d_coeffs[FC(offset_j, i + roi_out->x + 3, filters)] };
+      const dt_aligned_pixel_t coeffs = { d_coeffs[FC(offset_j, i + roi_out->x, filters)],
+                                          d_coeffs[FC(offset_j, i + roi_out->x + 1,filters)],
+                                          d_coeffs[FC(offset_j, i + roi_out->x + 2, filters)],
+                                          d_coeffs[FC(offset_j, i + roi_out->x + 3, filters)] };
       // process sensels four at a time
       for(; i < (width & ~3); i += 4)
       {

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1404,7 +1404,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   {
     float *raw_mean, *raw_min, *raw_max;
     float *raw_mean_output;
-    float picker_mean[3], picker_min[3], picker_max[3];
+    dt_aligned_pixel_t picker_mean, picker_min, picker_max;
     const gboolean is_linear = darktable.lib->proxy.histogram.is_linear;
 
     raw_mean = gd->picked_color;

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -445,7 +445,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else if(autoscale_ab == DT_S_SCALE_AUTOMATIC_XYZ)
     {
-      float DT_ALIGNED_PIXEL XYZ[4];
+      dt_aligned_pixel_t XYZ;
       dt_Lab_to_XYZ(in + k, XYZ);
       for(int c=0;c<3;c++)
         XYZ[c] = (XYZ[c] < xm_L) ? d->table[ch_L][CLAMP((int)(XYZ[c] * 0x10000ul), 0, 0xffff)]
@@ -454,7 +454,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else if(autoscale_ab == DT_S_SCALE_AUTOMATIC_RGB)
     {
-      float DT_ALIGNED_PIXEL rgb[4] = {0, 0, 0};
+      dt_aligned_pixel_t rgb = {0, 0, 0};
       dt_Lab_to_prophotorgb(in + k, rgb);
       if(d->preserve_colors == DT_RGB_NORM_NONE)
       {
@@ -694,8 +694,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // derive curve for XYZ:
     for(int k=0;k<0x10000;k++)
     {
-      float DT_ALIGNED_PIXEL XYZ[4] = {k/(float)0x10000, k/(float)0x10000, k/(float)0x10000};
-      float DT_ALIGNED_PIXEL Lab[4] = {0.0};
+      dt_aligned_pixel_t XYZ = {k/(float)0x10000, k/(float)0x10000, k/(float)0x10000};
+      dt_aligned_pixel_t Lab = {0.0};
       dt_XYZ_to_Lab(XYZ, Lab);
       Lab[0] = d->table[ch_L][CLAMP((int)(Lab[0]/100.0f * 0x10000), 0, 0xffff)];
       dt_Lab_to_XYZ(Lab, XYZ);
@@ -707,8 +707,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // derive curve for rgb:
     for(int k=0;k<0x10000;k++)
     {
-      float DT_ALIGNED_PIXEL rgb[4] = {k/(float)0x10000, k/(float)0x10000, k/(float)0x10000};
-      float DT_ALIGNED_PIXEL Lab[4] = {0.0};
+      dt_aligned_pixel_t rgb = {k/(float)0x10000, k/(float)0x10000, k/(float)0x10000};
+      dt_aligned_pixel_t Lab = {0.0};
       dt_prophotorgb_to_Lab(rgb, Lab);
       Lab[0] = d->table[ch_L][CLAMP((int)(Lab[0]/100.0f * 0x10000), 0, 0xffff)];
       dt_Lab_to_prophotorgb(Lab, rgb);

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -124,7 +124,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float sw = sqrtf((in[k + 1] * in[k + 1]) + (in[k + 2] * in[k + 2])) / 256.0f;
     const float ls = 1.0f - ((amount * sw) * .25f);
     const float ss = 1.0f + (amount * sw);
-    const float weights[4] = { ls, ss, ss, 1.0f };
+    const dt_aligned_pixel_t weights = { ls, ss, ss, 1.0f };
 #ifdef _OPENMP
 #pragma omp simd aligned(in, out : 16)
 #endif

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -192,7 +192,7 @@ static void _update_sample_label(dt_colorpicker_sample_t *sample)
 
   // Setting the output label
   char text[128] = { 0 };
-  float alt[3] = { 0 };
+  dt_aligned_pixel_t alt = { 0 };
 
   switch(model)
   {

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -98,8 +98,8 @@ static inline gboolean _convert_color_space(const GdkRGBA *restrict sample, GdkR
   dt_iop_order_iccprofile_info_t *histogram_profile = dt_ioppr_get_histogram_profile_info(darktable.develop);
   dt_iop_order_iccprofile_info_t *display_profile = dt_ioppr_get_pipe_output_profile_info(darktable.develop->pipe);
 
-  float RGB[3] = { sample->red, sample->green, sample->blue };
-  float XYZ[3];
+  dt_aligned_pixel_t RGB = { sample->red, sample->green, sample->blue };
+  dt_aligned_pixel_t XYZ;
 
   if(!(histogram_profile && display_profile)) return TRUE; // no need to paint, color will be wrong
 
@@ -300,7 +300,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
     const float *picked_rgb = (i == 0) ? sample->picked_color_rgb_mean :
                               (i == 1) ? sample->picked_color_rgb_min
                                        : sample->picked_color_rgb_max;
-    float rgb[3];
+    dt_aligned_pixel_t rgb;
     for(size_t c = 0; c < 3; c++) rgb[c] = picked_rgb[c];
 
     GdkRGBA color_in = { rgb[0], rgb[1], rgb[2], 1.f };

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -34,13 +34,13 @@ typedef struct dt_colorpicker_sample_t
   int locked;
 
   /** The actual picked colors */
-  float picked_color_rgb_mean[3];
-  float picked_color_rgb_min[3];
-  float picked_color_rgb_max[3];
+  dt_aligned_pixel_t picked_color_rgb_mean;
+  dt_aligned_pixel_t picked_color_rgb_min;
+  dt_aligned_pixel_t picked_color_rgb_max;
 
-  float picked_color_lab_mean[3];
-  float picked_color_lab_min[3];
-  float picked_color_lab_max[3];
+  dt_aligned_pixel_t picked_color_lab_mean;
+  dt_aligned_pixel_t picked_color_lab_min;
+  dt_aligned_pixel_t picked_color_lab_max;
 
   /** The GUI elements */
   GtkWidget *container;

--- a/tools/noise/noiseprofile.c
+++ b/tools/noise/noiseprofile.c
@@ -343,10 +343,10 @@ int main(int argc, char *arg[])
       for(int k=0;k<3;k++) std[i][k] *= max;
   // output variance per brightness level:
   // fprintf(stdout, "# bin std_r std_g std_b hist_r hist_g hist_b cdf_r cdf_g cdf_b\n");
-  float sum[3] = {0.0f};
+  dt_aligned_pixel_t sum = {0.0f};
   for(int i=0;i<N;i++)
     for(int k=0;k<3;k++) sum[k] += std[i][k];
-  float cdf[3] = {0.0f};
+  dt_aligned_pixel_t cdf = {0.0f};
   for(int i=0;i<N;i++)
   {
     fprintf(stdout, "%f %f %f %f %f %f %f %f %f %f\n", i/(float)N, std[i][0], std[i][1], std[i][2],

--- a/tools/noise/noiseprofile.c
+++ b/tools/noise/noiseprofile.c
@@ -164,7 +164,8 @@ int main(int argc, char *arg[])
   // correction requested?
   if(argc >= 9 && !strcmp(arg[2], "-c"))
   {
-    const float a[3] = {atof(arg[3]), atof(arg[4]), atof(arg[5])}, b[3] = {atof(arg[6]), atof(arg[7]), atof(arg[8])};
+    const dt_aligned_pixel_t a = { atof(arg[3]), atof(arg[4]), atof(arg[5]) },
+                             b = { atof(arg[6]), atof(arg[7]), atof(arg[8]) };
     // const float m[3] = {1, 1, 1};
     //   2.0f*sqrt(a[0]*1.0f+b[0])/a[0],
     //   2.0f*sqrt(a[1]*1.0f+b[1])/a[1],


### PR DESCRIPTION
Add a new type `dt_aligned_pixel_t` and switch all of the various occurences of float[3] and float[4] which represent single full-color pixels to use the new type instead.

Advantages:
- better self-documentation of the variable/parameter's usage
- having the alignment information as part of the type means it propagates into functions even in the absence of OpenMP directives (so the compiler can do a better job of optimization when OpenMP is disabled, and we don't need to remember to add the directives in the first place).

The code has been verified to produce integration-test output matching master (though master itself has some cases dramatically differing from the expected output).  Timings are unchanged from master, as at this point nearly all occurrences which could affect vectorization in the current code have already been converted to aligned float[4].

Planned follow-ups (in separate PRs):
- change three-iteration `for` loops to `for_each_channel` for vectorization
- new type `dt_boundingbox_t` for float[4] containing a pair of (x,y) coordinates representing a rectangle in the image
- new type `dt_colormatrix_t` which will hold an SSE-padded 3x3 matrix, replacing current float[9], float[3][3], float[3][4], and float[4][3].  Then ensure that all of the various matrix-multiplication code vectorizes.
