### PR TITLE
iop order: add pipe default pipe order for v3.0 JPEG

### DIFF
--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -133,7 +133,8 @@ typedef enum dt_iop_order_t
   DT_IOP_ORDER_CUSTOM  = 0, // a customr order (re-ordering the pipe)
   DT_IOP_ORDER_LEGACY  = 1, // up to dt 2.6.3
   DT_IOP_ORDER_V30     = 2, // starts with dt 3.0
-  DT_IOP_ORDER_LAST    = 3
+  DT_IOP_ORDER_V30_JPG = 3, // same as previous but tuned for non-linear input
+  DT_IOP_ORDER_LAST    = 4
 } dt_iop_order_t;
 
 typedef struct dt_iop_order_entry_t

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -117,6 +117,11 @@ void update(dt_lib_module_t *self)
     d->current_mode = kind;
     gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_V30)));
   }
+  else if(kind == DT_IOP_ORDER_V30_JPG)
+  {
+    d->current_mode = kind;
+    gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_V30_JPG)));
+  }
 }
 
 static void _image_loaded_callback(gpointer instance, gpointer user_data)
@@ -190,7 +195,12 @@ void init_presets(dt_lib_module_t *self)
 
   list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30);
   params = dt_ioppr_serialize_iop_order_list(list, &size);
-  dt_lib_presets_add(_("v3.0 (default)"), self->plugin_name, self->version(), (const char *)params, (int32_t)size,
+  dt_lib_presets_add(_("v3.0 for RAW input (default)"), self->plugin_name, self->version(), (const char *)params, (int32_t)size,
+                     TRUE);
+
+  list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30_JPG);
+  params = dt_ioppr_serialize_iop_order_list(list, &size);
+  dt_lib_presets_add(_("v3.0 for JPEG/non-RAW input"), self->plugin_name, self->version(), (const char *)params, (int32_t)size,
                      TRUE);
   free(params);
 }


### PR DESCRIPTION
I have been told that many Fuji users prefer to edit OOC JPEGs rathen than RAWs.
The default v3.0 pipe order assumes linear (RAW) input. For non-linear input, many modules need to be moved after colorin (which removes EOTF/gamma) to get linear RGB in.

This introduces a very similar order as the default v3.0 but tuned for JPEG input.