### PR TITLE
Fix module header actions

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1798,6 +1798,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
     }
     _iop_gui_update_label(module);
     dt_iop_gui_set_enable_button(module);
+    dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
   }
   --darktable.gui->reset;
 }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1858,6 +1858,9 @@ static void _preset_popup_position(GtkMenu *menu, gint *x, gint *y, gboolean *pu
 
 static void presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
 {
+  const gboolean disabled = !module->default_enabled && module->hide_enable_button;
+  if(disabled) return;
+
   dt_gui_presets_popup_menu_show_for_module(module);
 
 #if GTK_CHECK_VERSION(3, 22, 0)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -440,20 +440,20 @@ static gboolean _header_enter_notify_callback(GtkWidget *eventbox, GdkEventCross
   return FALSE;
 }
 
-static gboolean _header_motion_notify_show_callback(GtkWidget *eventbox, GdkEventCrossing *event, GtkWidget *header)
+static gboolean _header_motion_notify_show_callback(GtkWidget *eventbox, GdkEventCrossing *event, dt_iop_module_t *module)
 {
   darktable.control->element = DT_ACTION_ELEMENT_SHOW;
-  return dt_iop_show_hide_header_buttons(header, event, TRUE, FALSE);
+  return dt_iop_show_hide_header_buttons(module, event, TRUE, FALSE);
 }
 
-static gboolean _header_motion_notify_hide_callback(GtkWidget *eventbox, GdkEventCrossing *event, GtkWidget *header)
+static gboolean _header_motion_notify_hide_callback(GtkWidget *eventbox, GdkEventCrossing *event, dt_iop_module_t *module)
 {
-  return dt_iop_show_hide_header_buttons(header, event, FALSE, FALSE);
+  return dt_iop_show_hide_header_buttons(module, event, FALSE, FALSE);
 }
 
-static gboolean _header_menu_deactivate_callback(GtkMenuShell *menushell, GtkWidget *header)
+static gboolean _header_menu_deactivate_callback(GtkMenuShell *menushell, dt_iop_module_t *module)
 {
-  return dt_iop_show_hide_header_buttons(header, NULL, FALSE, FALSE);
+  return dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
 }
 
 static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
@@ -845,7 +845,7 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
   {
     g_signal_handlers_disconnect_by_func(entry, G_CALLBACK(_rename_module_key_press), module);
     gtk_widget_destroy(entry);
-    dt_iop_show_hide_header_buttons(module->header, NULL, TRUE, FALSE); // after removing entry
+    dt_iop_show_hide_header_buttons(module, NULL, TRUE, FALSE); // after removing entry
     dt_iop_gui_update_header(module);
     dt_masks_group_update_name(module);
     return TRUE;
@@ -893,7 +893,7 @@ static void _iop_gui_rename_module(dt_iop_module_t *module)
   g_signal_connect(entry, "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
 
-  dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, TRUE); // before adding entry
+  dt_iop_show_hide_header_buttons(module, NULL, FALSE, TRUE); // before adding entry
   gtk_box_pack_start(GTK_BOX(module->header), entry, TRUE, TRUE, 0);
   gtk_widget_show(entry);
   gtk_widget_grab_focus(entry);
@@ -956,7 +956,7 @@ static void dt_iop_gui_multiinstance_callback(GtkButton *button, GdkEventButton 
   g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(dt_iop_gui_rename_callback), module);
   gtk_menu_shell_append(menu, item);
 
-  g_signal_connect(G_OBJECT(menu), "deactivate", G_CALLBACK(_header_menu_deactivate_callback), module->header);
+  g_signal_connect(G_OBJECT(menu), "deactivate", G_CALLBACK(_header_menu_deactivate_callback), module);
 
   dt_gui_menu_popup(GTK_MENU(menu), GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
 
@@ -1811,6 +1811,10 @@ void dt_iop_gui_reset(dt_iop_module_t *module)
 
 static void dt_iop_gui_reset_callback(GtkButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
+  // never use the callback if module is always disabled
+  const gboolean disabled = !module->default_enabled && module->hide_enable_button;
+  if(disabled) return;
+
   //Ctrl is used to apply any auto-presets to the current module
   //If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
   if(!(event && dt_modifier_is(event->state, GDK_CONTROL_MASK)) || !dt_gui_presets_autoapply_for_module(module))
@@ -1856,7 +1860,7 @@ static void presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
   dt_gui_presets_popup_menu_show_for_module(module);
 
 #if GTK_CHECK_VERSION(3, 22, 0)
-  g_signal_connect(G_OBJECT(darktable.gui->presets_popup_menu), "deactivate", G_CALLBACK(_header_menu_deactivate_callback), module->header);
+  g_signal_connect(G_OBJECT(darktable.gui->presets_popup_menu), "deactivate", G_CALLBACK(_header_menu_deactivate_callback), module);
 
   dt_gui_menu_popup(darktable.gui->presets_popup_menu, GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
 #else
@@ -2184,9 +2188,10 @@ static void header_size_callback(GtkWidget *widget, GdkRectangle *allocation, Gt
   if(header_allocation.width > 1) gtk_widget_size_allocate(header, &header_allocation);
 }
 
-gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide)
+gboolean dt_iop_show_hide_header_buttons(dt_iop_module_t *module, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide)
 {
   // check if Entry widget for module name edit exists
+  GtkWidget *header = module->header;
   GtkWidget *focused = gtk_container_get_focus_child(GTK_CONTAINER(header));
   if(focused && GTK_IS_ENTRY(focused)) return TRUE;
 
@@ -2212,6 +2217,8 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
   else
     dynamic = TRUE;
 
+  const gboolean disabled = !module->default_enabled && module->hide_enable_button;
+
   GList *children = gtk_container_get_children(GTK_CONTAINER(header));
 
   GList *button;
@@ -2220,7 +2227,7 @@ gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *ev
       button = g_list_previous(button))
   {
     gtk_widget_set_no_show_all(GTK_WIDGET(button->data), TRUE);
-    gtk_widget_set_visible(GTK_WIDGET(button->data), show_buttons && !always_hide);
+    gtk_widget_set_visible(GTK_WIDGET(button->data), show_buttons && !always_hide && !disabled);
     gtk_widget_set_opacity(GTK_WIDGET(button->data), opacity);
   }
   if(GTK_IS_DRAWING_AREA(button->data))
@@ -2282,7 +2289,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
     {
       gtk_widget_destroy(module->mask_indicator);
       module->mask_indicator = NULL;
-      dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, FALSE);
+      dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
     }
     else
       gtk_widget_set_sensitive(module->mask_indicator, !raster && module->enabled);
@@ -2312,7 +2319,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
     }
     g_list_free(children);
 
-    dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, FALSE);
+    dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
   }
 
   if(module->mask_indicator)
@@ -2362,14 +2369,14 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   /* setup the header box */
   g_signal_connect(G_OBJECT(header_evb), "button-press-event", G_CALLBACK(_iop_plugin_header_button_press), module);
   gtk_widget_add_events(header_evb, GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(header_evb), "enter-notify-event", G_CALLBACK(_header_motion_notify_show_callback), header);
-  g_signal_connect(G_OBJECT(header_evb), "leave-notify-event", G_CALLBACK(_header_motion_notify_hide_callback), header);
+  g_signal_connect(G_OBJECT(header_evb), "enter-notify-event", G_CALLBACK(_header_motion_notify_show_callback), module);
+  g_signal_connect(G_OBJECT(header_evb), "leave-notify-event", G_CALLBACK(_header_motion_notify_hide_callback), module);
 
   /* connect mouse button callbacks for focus and presets */
   g_signal_connect(G_OBJECT(body_evb), "button-press-event", G_CALLBACK(_iop_plugin_body_button_press), module);
   gtk_widget_add_events(body_evb, GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(body_evb), "enter-notify-event", G_CALLBACK(_header_motion_notify_show_callback), header);
-  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event", G_CALLBACK(_header_motion_notify_hide_callback), header);
+  g_signal_connect(G_OBJECT(body_evb), "enter-notify-event", G_CALLBACK(_header_motion_notify_show_callback), module);
+  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event", G_CALLBACK(_header_motion_notify_hide_callback), module);
 
   /*
    * initialize the header widgets
@@ -2491,7 +2498,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   if(module->connect_key_accels) module->connect_key_accels(module);
 
   dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
-  dt_iop_show_hide_header_buttons(header, NULL, FALSE, FALSE);
+  dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
 }
 
 GtkWidget *dt_iop_gui_get_widget(dt_iop_module_t *module)

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -467,7 +467,7 @@ void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
 void dt_iop_cancel_history_update(dt_iop_module_t *module);
 
 /** (un)hide iop module header right side buttons */
-gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
+gboolean dt_iop_show_hide_header_buttons(dt_iop_module_t *module, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
 
 /** add/remove mask indicator to iop module header */
 void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5652,6 +5652,8 @@ void reload_defaults(dt_iop_module_t *module)
   module->hide_enable_button = 1;
 
   module->default_enabled = dt_image_is_raw(&module->dev->image_storage);
+  if(module->widget)
+    gtk_stack_set_visible_child_name(GTK_STACK(module->widget), module->default_enabled ? "raw" : "non_raw");
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)


### PR DESCRIPTION
Currently the actions defined in the module's headerbar (duplicate, reset to default and presets selection) are all active even if the module can't be applied. Best example is demosaic on a non-raw file.

This pr redefines `gboolean dt_iop_show_hide_header_buttons(dt_iop_module_t *module, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide)` to make it possible to test for an always-off module. 

In effect:
1. if a module is always off the icons in the headerbar won't be visible
2. the callbacks also test always-off to avoid action taken on shortcut.

the demosaic missed proper init of headerbar so when we change developed image in darkroom it won't be reset properly.