### PR TITLE
remove unnecessary memset

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1306,7 +1306,6 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       }
       else if(dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format))
       {
-        memset(*output, 0, bufsize);
         if(roi_in.scale == 1.0f)
         {
           // fast branch for 1:1 pixel copies.


### PR DESCRIPTION
The ROI buffer cleared by the memset is immediately overwritten in its entirety, so delete the memset call.

Saves nearly 1% pixelpipe processing time without changing output.
