### PR TITLE
add type dt_boundingbox_t to hold a pair of point coordinates

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -244,6 +244,8 @@ struct dt_undo_t;
 struct dt_colorspaces_t;
 struct dt_l10n_t;
 
+typedef float dt_boundingbox_t[4];  //(x,y) of upperleft, then (x,y) of lowerright
+
 typedef enum dt_debug_thread_t
 {
   // powers of two, masking

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -693,7 +693,7 @@ static bool dt_check_usercrop(Exiv2::ExifData &exifData, dt_image_t *img)
   Exiv2::ExifData::const_iterator pos = exifData.findKey(Exiv2::ExifKey("Exif.SubImage1.0xc7b5"));
   if(pos != exifData.end() && pos->count() == 4 && pos->size())
   {
-    float crop[4];
+    dt_boundingbox_t crop;
     for(int i = 0; i < 4; i++) crop[i] = pos->toFloat(i);
     if (((crop[0]>0)||(crop[1]>0)||(crop[2]<1)||(crop[3]<1))&&(crop[2]-crop[0]>0.05f)&&(crop[3]-crop[1]>0.05f))
     {

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -247,7 +247,7 @@ typedef struct dt_image_t
   dt_aligned_pixel_t wb_coeffs;
 
   /* DefaultUserCrop */
-  float usercrop[4];
+  dt_boundingbox_t usercrop;
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -209,7 +209,7 @@ typedef struct dt_iop_module_t
   /** color picker proxy */
   struct dt_iop_color_picker_t *picker;
   /** bounding box in which the mean color is requested. */
-  float color_picker_box[4];
+  dt_boundingbox_t color_picker_box;
   /** single point to pick if in point mode */
   float color_picker_point[2];
   /** place to store the picked color of module input. */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -602,7 +602,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   // position
   if(module->color_picker_point[0] < 0 || module->color_picker_point[1] < 0) return 1;
 
-  float fbox[4] = { 0.0f };
+  dt_boundingbox_t fbox = { 0.0f };
 
   // get absolute pixel coordinates in final preview image
   if(darktable.lib->proxy.colorpicker.size)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -37,7 +37,7 @@ typedef struct dt_iop_color_picker_t
   /** used to avoid recursion when a parameter is modified in the apply() */
   GtkWidget *colorpick;
   float pick_pos[2]; // last picker positions (max 9 picker per module)
-  float pick_box[4]; // last picker areas (max 9 picker per module)
+  dt_boundingbox_t pick_box; // last picker areas (max 9 picker per module)
 } dt_iop_color_picker_t;
 
 static gboolean _iop_record_point_area(dt_iop_color_picker_t *self)
@@ -78,7 +78,7 @@ static void _iop_get_point(dt_iop_color_picker_t *self, float *pos)
   }
 }
 
-static void _iop_get_area(dt_iop_color_picker_t *self, float *box)
+static void _iop_get_area(dt_iop_color_picker_t *self, dt_boundingbox_t box)
 {
   if(!isnan(self->pick_box[0]) && !isnan(self->pick_box[1]))
   {
@@ -184,7 +184,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
     }
     if(kind == DT_COLOR_PICKER_AREA)
     {
-      float box[4];
+      dt_boundingbox_t box;
       _iop_get_area(self, box);
       dt_lib_colorpicker_set_box_area(darktable.lib, box);
       self->pick_pos[0] = NAN; // trigger difference on first apply

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2849,7 +2849,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float scale = roi_in->scale / pr_d;
 
     // origin of image and opposite corner as reference points
-    float points[4] = { 0.0f, 0.0f, (float)piece->buf_in.width, (float)piece->buf_in.height };
+    dt_boundingbox_t points = { 0.0f, 0.0f, (float)piece->buf_in.width, (float)piece->buf_in.height };
     float ivec[2] = { points[2] - points[0], points[3] - points[1] };
     float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
@@ -2983,7 +2983,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     const float scale = roi_in->scale / pr_d;
 
     // origin of image and opposite corner as reference points
-    float points[4] = { 0.0f, 0.0f, (float)piece->buf_in.width, (float)piece->buf_in.height };
+    dt_boundingbox_t points = { 0.0f, 0.0f, (float)piece->buf_in.width, (float)piece->buf_in.height };
     float ivec[2] = { points[2] - points[0], points[3] - points[1] };
     float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
@@ -3205,7 +3205,7 @@ static uint64_t get_lines_hash(const dt_iop_ashift_line_t *lines, const int line
   uint64_t hash = 5381;
   for(int n = 0; n < lines_count; n++)
   {
-    float v[4] = { lines[n].p1[0], lines[n].p1[1], lines[n].p2[0], lines[n].p2[1] };
+    const dt_boundingbox_t v = { lines[n].p1[0], lines[n].p1[1], lines[n].p2[0], lines[n].p2[1] };
     union {
         float f;
         uint32_t u;
@@ -3735,7 +3735,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
   {
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
 
-    float pts[4] = { pzx, pzy, 1.0f, 1.0f };
+    dt_boundingbox_t pts = { pzx, pzy, 1.0f, 1.0f };
     dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
 
@@ -3825,7 +3825,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
       dt_control_change_cursor(GDK_HAND1);
       g->adjust_crop = TRUE;
 
-      float pts[4] = { pzx, pzy, 1.0f, 1.0f };
+      dt_boundingbox_t pts = { pzx, pzy, 1.0f, 1.0f };
       dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->iop_order,
                                         DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -62,7 +62,7 @@ typedef struct dt_iop_basicadj_gui_data_t
   int call_auto_exposure;                       // should we calculate exposure automatically?
   int draw_selected_region;                     // are we drawing the selected region?
   float posx_from, posx_to, posy_from, posy_to; // coordinates of the area
-  float box_cood[4];                            // normalized coordinates
+  dt_boundingbox_t box_cood;                    // normalized coordinates
   int button_down;                              // user pressed the mouse button?
 
   GtkWidget *bt_auto_levels;
@@ -1211,7 +1211,7 @@ static void _get_selected_area(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   {
     const int width = roi_in->width;
     const int height = roi_in->height;
-    float box_cood[4] = { g->box_cood[0], g->box_cood[1], g->box_cood[2], g->box_cood[3] };
+    dt_boundingbox_t box_cood = { g->box_cood[0], g->box_cood[1], g->box_cood[2], g->box_cood[3] };
 
     box_cood[0] *= piece->pipe->iwidth;
     box_cood[1] *= piece->pipe->iheight;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -265,7 +265,7 @@ typedef struct dt_iop_clipping_data_t
   uint32_t flags;           // flipping flags
   uint32_t flip;            // flipped output buffer so more area would fit.
 
-  float k_space[4]; // space for the "destination" rectangle of the keystone quadrilatere
+  dt_boundingbox_t k_space; // space for the "destination" rectangle of the keystone quadrilateral
   float kxa, kya, kxb, kyb, kxc, kyc, kxd,
       kyd; // point of the "source" quadrilatere (modified if keystone is not "full")
   float a, b, d, e, g, h; // value of the transformation matrix (c=f=0 && i=1)
@@ -353,7 +353,7 @@ static int gui_has_focus(struct dt_iop_module_t *self)
           && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS);
 }
 
-static void keystone_get_matrix(float *k_space, float kxa, float kxb, float kxc, float kxd, float kya,
+static void keystone_get_matrix(const dt_boundingbox_t k_space, float kxa, float kxb, float kxc, float kxd, float kya,
                                 float kyb, float kyc, float kyd, float *a, float *b, float *d, float *e,
                                 float *g, float *h)
 {
@@ -389,8 +389,8 @@ static void keystone_get_matrix(float *k_space, float kxa, float kxb, float kxc,
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void keystone_backtransform(float *i, float *k_space, float a, float b, float d, float e, float g,
-                                          float h, float kxa, float kya)
+static inline void keystone_backtransform(float *i, const dt_boundingbox_t k_space, float a, float b, float d,
+                                          float e, float g, float h, float kxa, float kya)
 {
   const float xx = i[0] - k_space[0];
   const float yy = i[1] - k_space[1];
@@ -404,8 +404,8 @@ static inline void keystone_backtransform(float *i, float *k_space, float a, flo
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void keystone_transform(float *i, float *k_space, float a, float b, float d, float e, float g, float h,
-                                      float kxa, float kya)
+static inline void keystone_transform(float *i, const dt_boundingbox_t k_space, float a, float b, float d,
+                                      float e, float g, float h, float kxa, float kya)
 {
   const float xx = i[0] - kxa;
   const float yy = i[1] - kya;
@@ -465,7 +465,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   const float rx = piece->buf_in.width;
   const float ry = piece->buf_in.height;
 
-  float DT_ALIGNED_PIXEL k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
+  const dt_boundingbox_t k_space = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
   const float kxa = d->kxa * rx, kxb = d->kxb * rx, kxc = d->kxc * rx, kxd = d->kxd * rx;
   const float kya = d->kya * ry, kyb = d->kyb * ry, kyc = d->kyc * ry, kyd = d->kyd * ry;
   float ma = 0, mb = 0, md = 0, me = 0, mg = 0, mh = 0;
@@ -535,7 +535,7 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   const float rx = piece->buf_in.width;
   const float ry = piece->buf_in.height;
 
-  float DT_ALIGNED_PIXEL k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
+  const dt_boundingbox_t k_space = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
   const float kxa = d->kxa * rx, kxb = d->kxb * rx, kxc = d->kxc * rx, kxd = d->kxd * rx;
   const float kya = d->kya * ry, kyb = d->kyb * ry, kyc = d->kyc * ry, kyd = d->kyd * ry;
   float ma, mb, md, me, mg, mh;
@@ -602,7 +602,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
     const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
-    float DT_ALIGNED_PIXEL k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
+    const dt_boundingbox_t k_space = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
     const float kxa = d->kxa * rx, kxb = d->kxb * rx, kxc = d->kxc * rx, kxd = d->kxd * rx;
     const float kya = d->kya * ry, kyb = d->kyb * ry, kyc = d->kyc * ry, kyd = d->kyd * ry;
     float ma, mb, md, me, mg, mh;
@@ -612,7 +612,8 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(in, kxa, kya, out, roi_in, roi_out) \
-    shared(d, interpolation, k_space, ma, mb, md, me, mg, mh) \
+    dt_omp_sharedconst(k_space)                             \
+    shared(d, interpolation, ma, mb, md, me, mg, mh) \
     schedule(static)
 #endif
     // (slow) point-by-point transformation.
@@ -787,11 +788,11 @@ void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t 
     *roi_out = *roi_in;
     // set roi_out values with rotation and keystone
     // initial corners pos
-    float corn_x[4] = { 0.0f, roi_in->width, roi_in->width, 0.0f };
-    float corn_y[4] = { 0.0f, 0.0f, roi_in->height, roi_in->height };
+    dt_boundingbox_t corn_x = { 0.0f, roi_in->width, roi_in->width, 0.0f };
+    dt_boundingbox_t corn_y = { 0.0f, 0.0f, roi_in->height, roi_in->height };
     // destination corner points
-    float corn_out_x[4] = { 0.0f };
-    float corn_out_y[4] = { 0.0f };
+    dt_boundingbox_t corn_out_x = { 0.0f };
+    dt_boundingbox_t corn_out_y = { 0.0f };
 
     // we don't test image flip as autocrop is not completely ok...
     d->flip = 0;
@@ -894,10 +895,10 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   const float so = roi_out->scale;
   const float kw = piece->buf_in.width * so, kh = piece->buf_in.height * so;
   const float roi_out_x = roi_out->x - d->enlarge_x * so, roi_out_y = roi_out->y - d->enlarge_y * so;
-  float p[2], o[2],
-      aabb[4] = { roi_out_x + d->cix * so, roi_out_y + d->ciy * so, roi_out_x + d->cix * so + roi_out->width,
+  float p[2], o[2];
+  dt_boundingbox_t aabb = { roi_out_x + d->cix * so, roi_out_y + d->ciy * so, roi_out_x + d->cix * so + roi_out->width,
                   roi_out_y + d->ciy * so + roi_out->height };
-  float aabb_in[4] = { INFINITY, INFINITY, -INFINITY, -INFINITY };
+  dt_boundingbox_t aabb_in = { INFINITY, INFINITY, -INFINITY, -INFINITY };
   for(int c = 0; c < 4; c++)
   {
     // get corner points of roi_out
@@ -979,7 +980,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
     const float rx = piece->buf_in.width * roi_in->scale;
     const float ry = piece->buf_in.height * roi_in->scale;
-    float k_space[4] = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
+    const dt_boundingbox_t k_space = { d->k_space[0] * rx, d->k_space[1] * ry, d->k_space[2] * rx, d->k_space[3] * ry };
     const float kxa = d->kxa * rx, kxb = d->kxb * rx, kxc = d->kxc * rx, kxd = d->kxd * rx;
     const float kya = d->kya * ry, kyb = d->kyb * ry, kyc = d->kyc * ry, kyd = d->kyd * ry;
     float ma, mb, md, me, mg, mh;
@@ -989,7 +990,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(ch, ch_width, ivoid, kxa, kya, ovoid, roi_in, roi_out) \
-    shared(d, interpolation, k_space, ma, mb, md, me, mg, mh) \
+    dt_omp_sharedconst(k_space) \
+    shared(d, interpolation, ma, mb, md, me, mg, mh) \
     schedule(static)
 #endif
     // (slow) point-by-point transformation.
@@ -1089,16 +1091,16 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     float m[4] = { d->m[0], d->m[1], d->m[2], d->m[3] };
 
     float k_sizes[2] = { piece->buf_in.width * roi_in->scale, piece->buf_in.height * roi_in->scale };
-    float k_space[4] = { d->k_space[0] * k_sizes[0], d->k_space[1] * k_sizes[1], d->k_space[2] * k_sizes[0],
-                         d->k_space[3] * k_sizes[1] };
-    if(d->k_apply == 0) k_space[2] = 0.0f;
+    const dt_boundingbox_t k_space = { d->k_space[0] * k_sizes[0], d->k_space[1] * k_sizes[1],
+                                       d->k_apply ? d->k_space[2] * k_sizes[0] : 0.0f,
+                                       d->k_space[3] * k_sizes[1] };
     float ma, mb, md, me, mg, mh;
     keystone_get_matrix(k_space, d->kxa * k_sizes[0], d->kxb * k_sizes[0], d->kxc * k_sizes[0],
                         d->kxd * k_sizes[0], d->kya * k_sizes[1], d->kyb * k_sizes[1], d->kyc * k_sizes[1],
                         d->kyd * k_sizes[1], &ma, &mb, &md, &me, &mg, &mh);
-    float ka[2] = { d->kxa * k_sizes[0], d->kya * k_sizes[1] };
-    float maa[4] = { ma, mb, md, me };
-    float mbb[2] = { mg, mh };
+    const float ka[2] = { d->kxa * k_sizes[0], d->kya * k_sizes[1] };
+    const float maa[4] = { ma, mb, md, me };
+    const float mbb[2] = { mg, mh };
 
     size_t sizes[3];
 
@@ -3137,7 +3139,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
   if(g->straightening)
   {
     // adjust the line with possible current angle and flip on this module
-    float pts[4] = { x, y, g->button_down_x, g->button_down_y };
+    dt_boundingbox_t pts = { x, y, g->button_down_x, g->button_down_y };
     dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
 
     float dx = pts[0] - pts[2];

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -188,7 +188,7 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
   // we want value in iop space
   const float wd = self->dev->preview_pipe->backbuf_width;
   const float ht = self->dev->preview_pipe->backbuf_height;
-  float points[4] = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
+  dt_boundingbox_t points = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
   if(dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->iop_order,
                                        DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -302,7 +302,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
   // we get the extremities of the line
   const float v = (-rotation / 180) * M_PI;
   const float sinv = sinf(v);
-  float pts[4];
+  dt_boundingbox_t pts;
 
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
   if(!piece) return 0;

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -176,7 +176,9 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
 
 #if 0
-  float pts[4] = {(float)(roi_out->x) / roi_in->scale, (float)(roi_out->y) / roi_in->scale, (float)(roi_out->x + roi_out->width) / roi_in->scale, (float)(roi_out->y + roi_out->height) / roi_in->scale};
+  const float in_scale = roi_in->scale;
+  dt_boundingbox_t pts = {(float)(roi_out->x) / in_scale, (float)(roi_out->y) / in_scale,
+                          (float)(roi_out->x + roi_out->width) / in_scale, (float)(roi_out->y + roi_out->height) / in_scale};
   printf("in  %f %f %f %f\n", pts[0], pts[1], pts[2], pts[3]);
   dt_dev_distort_backtransform_plus(dev, dev->pipe, 0, priority, pts, 2);
   printf("out %f %f %f %f\n\n", pts[0], pts[1], pts[2], pts[3]);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -750,7 +750,7 @@ static int rt_masks_point_calc_delta(dt_iop_module_t *self, dt_dev_pixelpipe_iop
 {
   // if distort_mode==1 we don't scale at the right place, hence false positions if there's distortion before this
   // module. we keep it for backward compatibility only. all new forms have distort_mode==2
-  float points[4];
+  dt_boundingbox_t points;
   if(distort_mode == 1)
   {
     rt_masks_point_denormalize(piece, roi, target, 1, points);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -72,7 +72,7 @@ typedef struct dt_iop_rgblevels_gui_data_t
   int call_auto_levels;                         // should we calculate levels automatically?
   int draw_selected_region;                     // are we drawing the selected region?
   float posx_from, posx_to, posy_from, posy_to; // coordinates of the area
-  float box_cood[4];                            // normalized coordinates
+  dt_boundingbox_t box_cood;                    // normalized coordinates
   int button_down;                              // user pressed the mouse button?
 
   double mouse_x, mouse_y;
@@ -1105,7 +1105,7 @@ static void _get_selected_area(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   {
     const int width = roi_in->width;
     const int height = roi_in->height;
-    float box_cood[4] = { g->box_cood[0], g->box_cood[1], g->box_cood[2], g->box_cood[3] };
+    dt_boundingbox_t box_cood = { g->box_cood[0], g->box_cood[1], g->box_cood[2], g->box_cood[3] };
 
     box_cood[0] *= piece->pipe->iwidth;
     box_cood[1] *= piece->pipe->iheight;

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -238,9 +238,9 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
   const float scale = roi_in->scale / piece->iscale;
 
-  float aabb[4] = { roi_out->x, roi_out->y, roi_out->x + roi_out->width, roi_out->y + roi_out->height };
+  dt_boundingbox_t aabb = { roi_out->x, roi_out->y, roi_out->x + roi_out->width, roi_out->y + roi_out->height };
 
-  float aabb_in[4] = { INFINITY, INFINITY, -INFINITY, -INFINITY };
+  dt_boundingbox_t aabb_in = { INFINITY, INFINITY, -INFINITY, -INFINITY };
 
   for(int c = 0; c < 4; c++)
   {

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -478,7 +478,7 @@ static int masks_point_calc_delta(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
                                   const dt_iop_roi_t *roi, const float *target, const float *source, int *dx,
                                   int *dy)
 {
-  float points[4];
+  dt_boundingbox_t points;
   masks_point_denormalize(piece, roi, target, 1, points);
   masks_point_denormalize(piece, roi, source, 1, points + 2);
 
@@ -563,7 +563,7 @@ void _process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
       {
         dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)form->points->data;
 
-        float points[4];
+        dt_boundingbox_t points;
         masks_point_denormalize(piece, roi_in, circle->center, 1, points);
         masks_point_denormalize(piece, roi_in, form->source, 1, points + 2);
 

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -29,7 +29,7 @@ typedef struct dt_colorpicker_sample_t
 {
   /** The sample area or point */
   float point[2];
-  float box[4];
+  dt_boundingbox_t box;
   int size;
   int locked;
 


### PR DESCRIPTION
...and convert uses of float[4] representing such a bounding box.

Followup to #9617.
