### PR TITLE
censorize: remove extraneous call to make_noise

### DIFF
--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -233,9 +233,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     output = out;
 
-    if(noise != 0.f)
-      make_noise(output, noise, width, height);
-
     dt_gaussian_t *g = dt_gaussian_init(width, height, ch, RGBmax, RGBmin, sigma_2, 0);
     if(!g) return;
     dt_gaussian_blur_4c(g, input, output);


### PR DESCRIPTION
One of the calls of make_noise has its output immediately and completely overwritten, so remove it.

In double-checking that this was correct, discovered that successive runs give slightly different outputs because dt_gaussian_blur_4c has a
data race....

Timings with Blur1=30, Pixel=20, Blur2=5, Noise=1.0
```
Thr   Master     PR
1      1.233     0.934
2      0.643     0.493
4      0.340     0.262
8      0.190     0.150
16    0.120     0.099
32    0.129     0.113
```
(the slowdown at 32 threads is presumably due to the data race causing cacheline bouncing)