### PR TITLE
avoid thumbtable shortcuts clashes

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -737,7 +737,7 @@ void find_views(dt_shortcut_t *s)
     else if(owner == &darktable.control->actions_thumb)
     {
       s->views = DT_VIEW_DARKROOM | DT_VIEW_MAP | DT_VIEW_TETHERING | DT_VIEW_PRINT;
-      if(!strstr(s->action->id,"history"))
+      if(!strcmp(s->action->id,"rating") || !strcmp(s->action->id,"color label"))
         s->views |= DT_VIEW_LIGHTTABLE; // lighttable has copy/paste history shortcuts in separate lib
     }
     else


### PR DESCRIPTION
fixes https://github.com/dterrahe/darktable/issues/22

#8078 like for like enabled some identical thumbtable shortcuts in lighttable that were duplicates of module shortcuts (whereas others were always explicitly not duplicated). Because of the stricter clash detection in inputng, those duplicate shortcuts were automatically removed (for all views). I think this PR removes all duplicates in lighttable.

Even though this restores previous behavior (fixes a clear regression) I'm not sure this should be the long term fix. Visually remapping shortcuts in the select module doesn't change them in thumbtable and therefore other views will still use the original shortcuts (unless overwritten) and they can only be remapped using the dialog. This may have been intentional, because the darkroom has more use for shortcuts so you might want to move the tumbtable ones out of the way to make space. But with NG I don't think that is needed anymore and I would prefer the (configuration) consistency. This might be achievable, I think, by adding the select and history stack modules to all views (albeit _hidden_) so that their shortcuts will be active everywhere. All the passthrough mappings in tumbtable would then not be needed anymore).