### PR TITLE
Fix crash in lua import filter

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2189,14 +2189,17 @@ static GList *_apply_lua_filter(GList *images)
     g_list_free_full(images, g_free);
     // recreate list of images
     images = NULL;
-   for(int i = 1; i < image_count; i++)
+    for(int i = 1; i < image_count; i++)
     {
-      /* uses 'key' (at index -2) and 'value' (at index -1) */
+      //get entry I from table at index -1.  Push the result on the stack
       lua_geti(L, -1, i);
-      void *filename = strdup(luaL_checkstring(L, -1));
+      if(lua_isstring(L, -1)) //images to ignore are set to nil
+      {
+        void *filename = strdup(luaL_checkstring(L, -1));
+        images = g_list_prepend(images, filename);
+      }
       lua_pop(L, 1);
-      images = g_list_prepend(images, filename);
-    }
+   }
   }
 
   lua_pop(L, 1); // remove the table again from the stack

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -265,10 +265,14 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
     images = NULL;
     for(int i = 1; i < image_count; i++)
     {
+      //get entry I from table at index -1.  Push the result on the stack
       lua_geti(L, -1, i);
-      void *filename = strdup(luaL_checkstring(L, -1));
+      if(lua_isstring(L, -1)) //images to ignore are set to nil
+      {
+        void *filename = strdup(luaL_checkstring(L, -1));
+        images = g_list_prepend(images, filename);
+      }
       lua_pop(L, 1);
-      images = g_list_prepend(images, filename);
     }
   }
 


### PR DESCRIPTION
The lua import filters set the the filename of the images to ignore to nil, so added a check to ensure the value retrieved from the table is a string before trying to process it.  Fixes #9649.