### PR TITLE
iop: initialize variable in `dsvd()`

### DIFF
--- a/src/iop/svd.h
+++ b/src/iop/svd.h
@@ -72,7 +72,7 @@ static inline int dsvd(
   double c, f, h, s, x, y, z;
   double anorm = 0.0, g = 0.0, scale = 0.0;
   double *rv1 = malloc(n * sizeof(double));
-  int l;
+  int l = 0;
 
   /* Householder reduction to bidiagonal form */
   for (int i = 0; i < n; i++)


### PR DESCRIPTION
This won't matter unless n is 0, but it fixes building on GCC 11.1:

```
In file included from /home/me/darktable/src/chart/thinplate.c:28:
/home/me/darktable/src/chart/thinplate.c: In function ‘thinplate_match’:
/home/me/darktable/src/iop/svd.h:75:7: error: ‘l’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   75 |   int l;
      |       ^
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
```