### PR TITLE
cleanup: use new dt_colormatrix_t type (Phase 1)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ FILE(GLOB SOURCE_FILES
   "common/locallaplacian.c"
   "common/locallaplaciancl.c"
   "common/l10n.c"
+  "common/matrices.c"
   "common/metadata.c"
   "common/metadata_export.c"
   "common/mipmap_cache.c"

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -36,13 +36,13 @@ typedef enum dt_adaptation_t
 // but coeffs are wrong in the above, so they come from :
 // http://www2.cmp.uea.ac.uk/Research/compvis/Papers/FinSuss_COL00.pdf
 // At any time, ensure XYZ_to_LMS is the exact matrice inverse of LMS_to_XYZ
-const float DT_ALIGNED_ARRAY XYZ_to_Bradford_LMS[3][4] = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
-                                                           { -0.7502f,  1.7135f,  0.0367f, 0.f },
-                                                           {  0.0389f, -0.0685f,  1.0296f, 0.f } };
+const dt_colormatrix_t XYZ_to_Bradford_LMS = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
+                                               { -0.7502f,  1.7135f,  0.0367f, 0.f },
+                                               {  0.0389f, -0.0685f,  1.0296f, 0.f } };
 
-const float DT_ALIGNED_ARRAY Bradford_LMS_to_XYZ[3][4] = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
-                                                           {  0.4323f,  0.5184f,  0.0493f, 0.f },
-                                                           { -0.0085f,  0.0400f,  0.9685f, 0.f } };
+const dt_colormatrix_t Bradford_LMS_to_XYZ = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
+                                               {  0.4323f,  0.5184f,  0.0493f, 0.f },
+                                               { -0.0085f,  0.0400f,  0.9685f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
@@ -66,13 +66,13 @@ static inline void convert_bradford_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_
 // modified LMS cone response for CAT16, from CIECAM16
 // reference : https://ntnuopen.ntnu.no/ntnu-xmlui/bitstream/handle/11250/2626317/CCIW-23.pdf?sequence=1
 // At any time, ensure XYZ_to_LMS is the exact matrice inverse of LMS_to_XYZ
-const float DT_ALIGNED_ARRAY XYZ_to_CAT16_LMS[3][4] = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
-                                                        { -0.250268f, 1.204414f,  0.045854f, 0.f },
-                                                        { -0.002079f, 0.048952f,  0.953127f, 0.f } };
+const dt_colormatrix_t XYZ_to_CAT16_LMS = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
+                                            { -0.250268f, 1.204414f,  0.045854f, 0.f },
+                                            { -0.002079f, 0.048952f,  0.953127f, 0.f } };
 
-const float DT_ALIGNED_ARRAY CAT16_LMS_to_XYZ[3][4] = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
-                                                        {  0.38752f ,  0.621447f, -0.008974f, 0.f },
-                                                        { -0.015841f, -0.034123f,  1.049964f, 0.f } };
+const dt_colormatrix_t CAT16_LMS_to_XYZ = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
+                                            {  0.38752f ,  0.621447f, -0.008974f, 0.f },
+                                            { -0.015841f, -0.034123f,  1.049964f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
@@ -350,22 +350,22 @@ static inline void XYZ_adapt_D50(const dt_aligned_pixel_t lms_in,
 
 /* Pre-solved matrices to adjust white point for triplets in CIE XYZ 1931 2° observer */
 
-const float DT_ALIGNED_ARRAY XYZ_D50_to_D65_CAT16[3][4]
+const dt_colormatrix_t XYZ_D50_to_D65_CAT16
     = { { 9.89466254e-01f, -4.00304626e-02f, 4.40530317e-02f, 0.f },
         { -5.40518733e-03f, 1.00666069e+00f, -1.75551955e-03f, 0.f },
         { -4.03920992e-04f, 1.50768030e-02f, 1.30210211e+00f, 0.f } };
 
-const float DT_ALIGNED_ARRAY XYZ_D50_to_D65_Bradford[3][4]
+const dt_colormatrix_t XYZ_D50_to_D65_Bradford
     = { { 0.95547342f, -0.02309845f, 0.06325924f, 0.f },
         { -0.02836971f, 1.00999540f, 0.02104144f, 0.f },
         { 0.01231401f, -0.02050765f, 1.33036593f, 0.f } };
 
-const float DT_ALIGNED_ARRAY XYZ_D65_to_D50_CAT16[3][4]
+const dt_colormatrix_t XYZ_D65_to_D50_CAT16
     = { { 1.01085433e+00f, 4.07086103e-02f, -3.41445825e-02f, 0.f },
         { 5.42814201e-03f, 9.93581926e-01f, 1.15592039e-03f, 0.f },
         { 2.50722468e-04f, -1.14918759e-02f, 7.67964947e-01f, 0.f } };
 
-const float DT_ALIGNED_ARRAY XYZ_D65_to_D50_Bradford[3][4]
+const dt_colormatrix_t XYZ_D65_to_D50_Bradford
     = { { 1.04792979f, 0.02294687f, -0.05019227f, 0.f },
         { 0.02962781f, 0.99043443f, -0.0170738f, 0.f },
         { -0.00924304f, 0.01505519f, 0.75187428f, 0.f } };

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -41,7 +41,7 @@ static inline void rgb_to_JzCzhz(const float *const rgb, float *const JzCzhz,
   if(profile)
   {
     dt_aligned_pixel_t XYZ_D50 = { 0.0f, 0.0f, 0.0f };
-    dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, profile->matrix_in, profile->lut_in, profile->unbounded_coeffs_in,
+    dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, profile->matrix_in_transposed, profile->lut_in, profile->unbounded_coeffs_in,
                                profile->lutsize, profile->nonlinearlut);
     dt_XYZ_D50_2_XYZ_D65(XYZ_D50, XYZ_D65);
   }

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -22,6 +22,7 @@
 #include "common/debug.h"
 #include "common/file_location.h"
 #include "common/math.h"
+#include "common/matrices.h"
 #include "common/srgb_tone_curve_values.h"
 #include "common/utility.h"
 #include "control/conf.h"
@@ -146,7 +147,7 @@ static const dt_colorspaces_color_profile_t *_get_profile(dt_colorspaces_t *self
                                                           const char *filename,
                                                           dt_colorspaces_profile_direction_t direction);
 
-static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
+static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, dt_colormatrix_t matrix, float *lutr, float *lutg,
                                                   float *lutb, const int lutsize, const int input)
 {
   // create an OpenCL processable matrix + tone curves from an cmsHPROFILE:
@@ -180,21 +181,16 @@ static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matri
 
   if(!red_curve || !green_curve || !blue_curve || !red_color || !green_color || !blue_color) return 2;
 
-  float matrix_tmp[9];
-  matrix_tmp[0] = red_color->X;
-  matrix_tmp[1] = green_color->X;
-  matrix_tmp[2] = blue_color->X;
-  matrix_tmp[3] = red_color->Y;
-  matrix_tmp[4] = green_color->Y;
-  matrix_tmp[5] = blue_color->Y;
-  matrix_tmp[6] = red_color->Z;
-  matrix_tmp[7] = green_color->Z;
-  matrix_tmp[8] = blue_color->Z;
+  dt_colormatrix_t matrix_tmp = { { red_color->X, green_color->X, blue_color->X },
+                                  { red_color->Y, green_color->Y, blue_color->Y },
+                                  { red_color->Z, green_color->Z,  blue_color->Z } };
 
   // some camera ICC profiles claim to have color locations for red, green and blue base colors defined,
   // but in fact these are all set to zero. we catch this case here.
   float sum = 0.0f;
-  for(int k = 0; k < 9; k++) sum += matrix_tmp[k];
+  for(int k1 = 0; k1 < 3; k1++)
+    for(int k2 = 0; k2 < 3; k2++)
+      sum += matrix_tmp[k1][k2];
   if(sum == 0.0f) return 3;
 
   if(input && lutr && lutg && lutb)
@@ -216,9 +212,10 @@ static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matri
   else
   {
     // invert profile->XYZ matrix for output profiles
-    float tmp[9];
-    memcpy(tmp, matrix_tmp, sizeof(float) * 9);
-    if(mat3inv(matrix_tmp, tmp)) return 3;
+    dt_colormatrix_t tmp;
+    memcpy(tmp, matrix_tmp, sizeof(dt_colormatrix_t));
+    if(mat3SSEinv(matrix_tmp, tmp))
+      return 3;
     // also need to reverse gamma, to apply reverse before matrix multiplication:
     cmsToneCurve *rev_red = cmsReverseToneCurveEx(0x8000, red_curve);
     cmsToneCurve *rev_green = cmsReverseToneCurveEx(0x8000, green_curve);
@@ -253,18 +250,19 @@ static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matri
     cmsFreeToneCurve(rev_blue);
   }
 
-  if(matrix) memcpy(matrix, matrix_tmp, sizeof(float) * 9);
+  if(matrix)
+    memcpy(matrix, matrix_tmp, sizeof(dt_colormatrix_t));
 
   return 0;
 }
 
-int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
+int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, dt_colormatrix_t matrix, float *lutr, float *lutg,
                                                  float *lutb, const int lutsize)
 {
   return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 1);
 }
 
-int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
+int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, dt_colormatrix_t matrix, float *lutr, float *lutg,
                                                   float *lutb, const int lutsize)
 {
   return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 0);
@@ -920,7 +918,7 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_output_profile(const in
 static void dt_colorspaces_create_cmatrix(float cmatrix[4][3], float mat[3][3])
 {
   // sRGB D65, the linear part:
-  const dt_colormatrix_t rgb_to_xyz = { { 0.4124564f, 0.3575761f, 0.1804375f, 0.0f },
+  static const dt_colormatrix_t rgb_to_xyz = { { 0.4124564f, 0.3575761f, 0.1804375f, 0.0f },
                                         { 0.2126729f, 0.7151522f, 0.0721750f, 0.0f },
                                         { 0.0193339f, 0.1191920f, 0.9503041f, 0.0f } };
 
@@ -938,7 +936,7 @@ static void dt_colorspaces_create_cmatrix(float cmatrix[4][3], float mat[3][3])
 }
 #endif
 
-static cmsHPROFILE dt_colorspaces_create_xyzmatrix_profile(float mat[3][3])
+static cmsHPROFILE dt_colorspaces_create_xyzmatrix_profile(const float mat[3][3])
 {
   // mat: cam -> xyz
   dt_aligned_pixel_t x, y;

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -514,7 +514,7 @@ int dt_colorspaces_get_darktable_matrix(const char *makermodel, float *matrix)
   // input whitepoint[] in XYZ with Y normalized to 1.0f
   const dt_aligned_pixel_t dn
       = { preset->white[0] / (float)preset->white[1], 1.0f, preset->white[2] / (float)preset->white[1] };
-  const float lam_rigg[9] = { 0.8951, 0.2664, -0.1614, -0.7502, 1.7135, 0.0367, 0.0389, -0.0685, 1.0296 };
+  static const float lam_rigg[9] = { 0.8951f, 0.2664f, -0.1614f, -0.7502f, 1.7135f, 0.0367f, 0.0389f, -0.0685f, 1.0296f };
 
   // adapt to d50
   float chad_inv[9];

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -922,9 +922,9 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_output_profile(const in
 static void dt_colorspaces_create_cmatrix(float cmatrix[4][3], float mat[3][3])
 {
   // sRGB D65, the linear part:
-  const float rgb_to_xyz[3][3] = { { 0.4124564, 0.3575761, 0.1804375 },
-                                   { 0.2126729, 0.7151522, 0.0721750 },
-                                   { 0.0193339, 0.1191920, 0.9503041 } };
+  const dt_colormatrix_t rgb_to_xyz = { { 0.4124564f, 0.3575761f, 0.1804375f, 0.0f },
+                                        { 0.2126729f, 0.7151522f, 0.0721750f, 0.0f },
+                                        { 0.0193339f, 0.1191920f, 0.9503041f, 0.0f } };
 
   for(int c = 0; c < 3; c++)
   {

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -515,8 +515,6 @@ int dt_colorspaces_get_darktable_matrix(const char *makermodel, float *matrix)
   const dt_aligned_pixel_t dn
       = { preset->white[0] / (float)preset->white[1], 1.0f, preset->white[2] / (float)preset->white[1] };
   const float lam_rigg[9] = { 0.8951, 0.2664, -0.1614, -0.7502, 1.7135, 0.0367, 0.0389, -0.0685, 1.0296 };
-  const dt_aligned_pixel_t d50 = { 0.9642, 1.0, 0.8249 };
-
 
   // adapt to d50
   float chad_inv[9];

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -191,11 +191,11 @@ void dt_colorspaces_cleanup_profile(cmsHPROFILE p);
 
 /** extracts tonecurves and color matrix prof to XYZ from a given input profile, returns 0 on success (curves
  * and matrix are inverted for input) */
-int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
+int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, dt_colormatrix_t matrix, float *lutr, float *lutg,
                                                  float *lutb, const int lutsize);
 
 /** extracts tonecurves and color matrix prof to XYZ from a given output profile, returns 0 on success. */
-int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
+int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, dt_colormatrix_t matrix, float *lutr, float *lutg,
                                                   float *lutb, const int lutsize);
 
 /** wrapper to get the name from a color profile. this tries to handle character encodings. */

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -439,7 +439,7 @@ static inline void dt_XYZ_to_Rec709_D65(const dt_aligned_pixel_t XYZ, dt_aligned
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, sRGB)
 #endif
-static inline void dt_XYZ_to_sRGB(const float *const XYZ, float *const sRGB)
+static inline void dt_XYZ_to_sRGB(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t sRGB)
 {
   // XYZ -> linear sRGB
   dt_aligned_pixel_t rgb;
@@ -454,12 +454,13 @@ static inline void dt_XYZ_to_sRGB(const float *const XYZ, float *const sRGB)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, sRGB)
 #endif
-static inline void dt_XYZ_to_sRGB_clipped(const float *const XYZ, float *const sRGB)
+static inline void dt_XYZ_to_sRGB_clipped(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t sRGB)
 {
   dt_aligned_pixel_t result;
   dt_XYZ_to_sRGB(XYZ, result);
 
-  for(int i = 0; i < 3; i++) sRGB[i] = CLIP(result[i]);
+  for_each_channel(c)
+    sRGB[c] = CLIP(result[c]);
 }
 
 
@@ -482,7 +483,7 @@ static inline void dt_Rec709_to_XYZ_D50(const dt_aligned_pixel_t sRGB, dt_aligne
 #ifdef _OPENMP
 #pragma omp declare simd aligned(sRGB, XYZ)
 #endif
-static inline void dt_sRGB_to_XYZ(const float *const sRGB, float *const XYZ)
+static inline void dt_sRGB_to_XYZ(const dt_aligned_pixel_t sRGB, dt_aligned_pixel_t XYZ)
 {
   dt_aligned_pixel_t rgb = { 0 };
   // gamma corrected sRGB -> linear sRGB
@@ -584,7 +585,7 @@ static inline void dt_XYZ_to_linearRGB(const dt_aligned_pixel_t XYZ, dt_aligned_
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Lab, rgb)
 #endif
-static inline void dt_Lab_to_prophotorgb(const float *const Lab, float *const rgb)
+static inline void dt_Lab_to_prophotorgb(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t rgb)
 {
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ(Lab, XYZ);
@@ -594,7 +595,7 @@ static inline void dt_Lab_to_prophotorgb(const float *const Lab, float *const rg
 #ifdef _OPENMP
 #pragma omp declare simd aligned(rgb, Lab)
 #endif
-static inline void dt_prophotorgb_to_Lab(const float *const rgb, float *const Lab)
+static inline void dt_prophotorgb_to_Lab(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t Lab)
 {
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_prophotorgb_to_XYZ(rgb, XYZ);
@@ -605,7 +606,7 @@ static inline void dt_prophotorgb_to_Lab(const float *const rgb, float *const La
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline float _dt_RGB_2_Hue(const float *const DT_RESTRICT RGB, const float max, const float delta)
+static inline float _dt_RGB_2_Hue(const dt_aligned_pixel_t RGB, const float max, const float delta)
 {
   float hue;
   if(RGB[0] == max)
@@ -624,7 +625,7 @@ static inline float _dt_RGB_2_Hue(const float *const DT_RESTRICT RGB, const floa
 #ifdef _OPENMP
 #pragma omp declare simd aligned(RGB: 16)
 #endif
-static inline void _dt_Hue_2_RGB(float *const DT_RESTRICT RGB, const float H, const float C, const float min)
+static inline void _dt_Hue_2_RGB(dt_aligned_pixel_t RGB, const float H, const float C, const float min)
 {
   const float h = H * 6.0f;
   const float i = floorf(h);
@@ -676,7 +677,7 @@ static inline void _dt_Hue_2_RGB(float *const DT_RESTRICT RGB, const float H, co
 #ifdef _OPENMP
 #pragma omp declare simd aligned(RGB, HSL: 16)
 #endif
-static inline void dt_RGB_2_HSL(const float *const DT_RESTRICT RGB, float *const DT_RESTRICT HSL)
+static inline void dt_RGB_2_HSL(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t HSL)
 {
   const float min = fminf(RGB[0], fminf(RGB[1], RGB[2]));
   const float max = fmaxf(RGB[0], fmaxf(RGB[1], RGB[2]));
@@ -707,7 +708,7 @@ static inline void dt_RGB_2_HSL(const float *const DT_RESTRICT RGB, float *const
 #ifdef _OPENMP
 #pragma omp declare simd aligned(HSL, RGB: 16)
 #endif
-static inline void dt_HSL_2_RGB(const float *const DT_RESTRICT HSL, float *const DT_RESTRICT RGB)
+static inline void dt_HSL_2_RGB(const dt_aligned_pixel_t HSL, dt_aligned_pixel_t RGB)
 {
   // almost straight from https://en.wikipedia.org/wiki/HSL_and_HSV
   const float L = HSL[2];
@@ -724,7 +725,7 @@ static inline void dt_HSL_2_RGB(const float *const DT_RESTRICT HSL, float *const
 #ifdef _OPENMP
 #pragma omp declare simd aligned(RGB, HSV: 16)
 #endif
-static inline void dt_RGB_2_HSV(const float *const DT_RESTRICT RGB, float *const DT_RESTRICT HSV)
+static inline void dt_RGB_2_HSV(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t HSV)
 {
   const float min = fminf(RGB[0], fminf(RGB[1], RGB[2]));
   const float max = fmaxf(RGB[0], fmaxf(RGB[1], RGB[2]));
@@ -752,7 +753,7 @@ static inline void dt_RGB_2_HSV(const float *const DT_RESTRICT RGB, float *const
 #ifdef _OPENMP
 #pragma omp declare simd aligned(HSV, RGB: 16)
 #endif
-static inline void dt_HSV_2_RGB(const float *const DT_RESTRICT HSV, float *const DT_RESTRICT RGB)
+static inline void dt_HSV_2_RGB(const dt_aligned_pixel_t HSV, dt_aligned_pixel_t RGB)
 {
   // almost straight from https://en.wikipedia.org/wiki/HSL_and_HSV
   const float C = HSV[1] * HSV[2];
@@ -764,7 +765,7 @@ static inline void dt_HSV_2_RGB(const float *const DT_RESTRICT HSV, float *const
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void dt_Lab_2_LCH(const float *const Lab, float *const LCH)
+static inline void dt_Lab_2_LCH(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t LCH)
 {
   float var_H = atan2f(Lab[2], Lab[1]);
 
@@ -782,14 +783,14 @@ static inline void dt_Lab_2_LCH(const float *const Lab, float *const LCH)
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void dt_LCH_2_Lab(const float *const LCH, float *const Lab)
+static inline void dt_LCH_2_Lab(const dt_aligned_pixel_t LCH, dt_aligned_pixel_t Lab)
 {
   Lab[0] = LCH[0];
   Lab[1] = cosf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
   Lab[2] = sinf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
 }
 
-static inline float dt_camera_rgb_luminance(const float *const rgb)
+static inline float dt_camera_rgb_luminance(const dt_aligned_pixel_t rgb)
 {
   return (rgb[0] * 0.2225045f + rgb[1] * 0.7168786f + rgb[2] * 0.0606169f);
 }
@@ -798,7 +799,7 @@ static inline float dt_camera_rgb_luminance(const float *const rgb)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_D50, XYZ_D65: 16)
 #endif
-static inline void dt_XYZ_D50_2_XYZ_D65(const float *const DT_RESTRICT XYZ_D50, float *const DT_RESTRICT XYZ_D65)
+static inline void dt_XYZ_D50_2_XYZ_D65(const dt_aligned_pixel_t XYZ_D50, dt_aligned_pixel_t XYZ_D65)
 {
   // Bradford adaptation matrix from http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
   const dt_colormatrix_t M = {
@@ -813,7 +814,7 @@ static inline void dt_XYZ_D50_2_XYZ_D65(const float *const DT_RESTRICT XYZ_D50, 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_D50, XYZ_D65: 16)
 #endif
-static inline void dt_XYZ_D65_2_XYZ_D50(const float *const DT_RESTRICT XYZ_D65, float *const DT_RESTRICT XYZ_D50)
+static inline void dt_XYZ_D65_2_XYZ_D50(const dt_aligned_pixel_t XYZ_D65, dt_aligned_pixel_t XYZ_D50)
 {
   // Bradford adaptation matrix from http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
   const dt_colormatrix_t M = {
@@ -836,7 +837,7 @@ static inline void dt_XYZ_D65_2_XYZ_D50(const float *const DT_RESTRICT XYZ_D65, 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_D65, JzAzBz: 16)
 #endif
-static inline void dt_XYZ_2_JzAzBz(const float *const DT_RESTRICT XYZ_D65, float *const DT_RESTRICT JzAzBz)
+static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_pixel_t JzAzBz)
 {
   const float b = 1.15f;
   const float g = 0.66f;
@@ -889,7 +890,7 @@ static inline void dt_XYZ_2_JzAzBz(const float *const DT_RESTRICT XYZ_D65, float
 #ifdef _OPENMP
 #pragma omp declare simd aligned(JzAzBz, JzCzhz: 16)
 #endif
-static inline void dt_JzAzBz_2_JzCzhz(const float *const DT_RESTRICT JzAzBz, float *const DT_RESTRICT JzCzhz)
+static inline void dt_JzAzBz_2_JzCzhz(const dt_aligned_pixel_t JzAzBz, dt_aligned_pixel_t JzCzhz)
 {
   float var_H = atan2f(JzAzBz[2], JzAzBz[1]) / (2.0f * DT_M_PI_F);
   JzCzhz[0] = JzAzBz[0];
@@ -900,7 +901,7 @@ static inline void dt_JzAzBz_2_JzCzhz(const float *const DT_RESTRICT JzAzBz, flo
 #ifdef _OPENMP
 #pragma omp declare simd aligned(JzCzhz, JzAzBz: 16)
 #endif
-static inline void dt_JzCzhz_2_JzAzBz(const float *const DT_RESTRICT JzCzhz, float *const DT_RESTRICT JzAzBz)
+static inline void dt_JzCzhz_2_JzAzBz(const dt_aligned_pixel_t JzCzhz, dt_aligned_pixel_t JzAzBz)
 {
   JzAzBz[0] = JzCzhz[0];
   JzAzBz[1] = cosf(2.0f * DT_M_PI_F * JzCzhz[2]) * JzCzhz[1];
@@ -910,7 +911,7 @@ static inline void dt_JzCzhz_2_JzAzBz(const float *const DT_RESTRICT JzCzhz, flo
 #ifdef _OPENMP
 #pragma omp declare simd aligned(JzAzBz, XYZ_D65: 16)
 #endif
-static inline void dt_JzAzBz_2_XYZ(const float *const DT_RESTRICT JzAzBz, float *const DT_RESTRICT XYZ_D65)
+static inline void dt_JzAzBz_2_XYZ(const dt_aligned_pixel_t JzAzBz, dt_aligned_pixel_t XYZ_D65)
 {
   const float b = 1.15f;
   const float g = 0.66f;

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -116,28 +116,6 @@ static inline void transpose_3x3_to_3xSSE(const float input[9], dt_colormatrix_t
 }
 
 // convert a 3x3 matrix into the padded format optimized for vectorization
-static inline void repack_3x3_to_3xSSE(const float input[9], dt_colormatrix_t output)
-{
-  output[0][0] = input[0];
-  output[0][1] = input[1];
-  output[0][2] = input[2];
-  output[0][3] = 0.0f;
-
-  output[1][0] = input[3];
-  output[1][1] = input[4];
-  output[1][2] = input[5];
-  output[1][3] = 0.0f;
-
-  output[2][0] = input[6];
-  output[2][1] = input[7];
-  output[2][2] = input[8];
-  output[2][3] = 0.0f;
-
-  for_four_channels(c, aligned(output))
-    output[3][c] = 0.0f;
-}
-
-// convert a 3x3 matrix into the padded format optimized for vectorization
 static inline void repack_double3x3_to_3xSSE(const double input[9], dt_colormatrix_t output)
 {
   output[0][0] = input[0];

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -35,6 +35,49 @@ typedef DT_ALIGNED_PIXEL float dt_aligned_pixel_t[4];
 // a 3x3 matrix, padded to permit SSE instructions to be used for multiplication and addition
 typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
 
+// convert a 3x3 matrix into the padded format optimized for vectorization
+static inline void repack_3x3_to_3xSSE(const float input[9], dt_colormatrix_t output)
+{
+  output[0][0] = input[0];
+  output[0][1] = input[1];
+  output[0][2] = input[2];
+  output[0][3] = 0.0f;
+
+  output[1][0] = input[3];
+  output[1][1] = input[4];
+  output[1][2] = input[5];
+  output[1][3] = 0.0f;
+
+  output[2][0] = input[6];
+  output[2][1] = input[7];
+  output[2][2] = input[8];
+  output[2][3] = 0.0f;
+
+  for(size_t c = 0; c < 4; c++)
+    output[3][c] = 0.0f;
+}
+
+// convert a 3x3 matrix into the padded format optimized for vectorization
+static inline void repack_double3x3_to_3xSSE(const double input[9], dt_colormatrix_t output)
+{
+  output[0][0] = input[0];
+  output[0][1] = input[1];
+  output[0][2] = input[2];
+  output[0][3] = 0.0f;
+
+  output[1][0] = input[3];
+  output[1][1] = input[4];
+  output[1][2] = input[5];
+  output[1][3] = 0.0f;
+
+  output[2][0] = input[6];
+  output[2][1] = input[7];
+  output[2][2] = input[8];
+  output[2][3] = 0.0f;
+
+  for(size_t c = 0; c < 4; c++)
+    output[3][c] = 0.0f;
+}
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -71,6 +71,28 @@ typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
   for (size_t _var = 0; _var < 4; _var++)
 #endif
 
+// transpose and pad a 3x3 matrix into the padded format optimized for vectorization
+static inline void transpose_3x3_to_3xSSE(const float input[9], dt_colormatrix_t output)
+{
+  output[0][0] = input[0];
+  output[0][1] = input[3];
+  output[0][2] = input[6];
+  output[0][3] = 0.0f;
+
+  output[1][0] = input[1];
+  output[1][1] = input[4];
+  output[1][2] = input[7];
+  output[1][3] = 0.0f;
+
+  output[2][0] = input[2];
+  output[2][1] = input[5];
+  output[2][2] = input[8];
+  output[2][3] = 0.0f;
+
+  for_four_channels(c, aligned(output))
+    output[3][c] = 0.0f;
+}
+
 // convert a 3x3 matrix into the padded format optimized for vectorization
 static inline void repack_3x3_to_3xSSE(const float input[9], dt_colormatrix_t output)
 {

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -71,6 +71,28 @@ typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
   for (size_t _var = 0; _var < 4; _var++)
 #endif
 
+// transpose a padded 3x3 matrix
+static inline void transpose_3xSSE(const dt_colormatrix_t input, dt_colormatrix_t output)
+{
+  output[0][0] = input[0][0];
+  output[0][1] = input[1][0];
+  output[0][2] = input[2][0];
+  output[0][3] = 0.0f;
+
+  output[1][0] = input[0][1];
+  output[1][1] = input[1][1];
+  output[1][2] = input[2][1];
+  output[1][3] = 0.0f;
+
+  output[2][0] = input[0][2];
+  output[2][1] = input[1][2];
+  output[2][2] = input[2][2];
+  output[2][3] = 0.0f;
+
+  for_four_channels(c, aligned(output))
+    output[3][c] = 0.0f;
+}
+
 // transpose and pad a 3x3 matrix into the padded format optimized for vectorization
 static inline void transpose_3x3_to_3xSSE(const float input[9], dt_colormatrix_t output)
 {
@@ -135,6 +157,20 @@ static inline void repack_double3x3_to_3xSSE(const double input[9], dt_colormatr
 
   for(size_t c = 0; c < 4; c++)
     output[3][c] = 0.0f;
+}
+
+// convert a 3x3 matrix into the padded format optimized for vectorization
+static inline void pack_3xSSE_to_3x3(const dt_colormatrix_t input, float output[9])
+{
+  output[0] = input[0][0];
+  output[1] = input[0][1];
+  output[2] = input[0][2];
+  output[3] = input[1][0];
+  output[4] = input[1][1];
+  output[5] = input[1][2];
+  output[6] = input[2][0];
+  output[7] = input[2][1];
+  output[8] = input[2][2];
 }
 
 // vectorized multiplication of padded 3x3 matrices

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -820,7 +820,7 @@ dt_ioppr_set_pipe_input_profile_info(struct dt_develop_t *dev,
                                      const dt_colorspaces_color_profile_type_t type,
                                      const char *filename,
                                      const int intent,
-                                     const float matrix_in[9])
+                                     const dt_colormatrix_t matrix_in)
 {
   dt_iop_order_iccprofile_info_t *profile_info = dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
 

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -263,7 +263,7 @@ static inline void _apply_trc(const dt_aligned_pixel_t rgb_in, dt_aligned_pixel_
 static inline void _ioppr_linear_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t xyz,
                                                    const float matrix[9])
 {
-  for(size_t c = 0; c < 3; c++) xyz[c] = 0.0f;
+  for_each_channel(c) xyz[c] = 0.0f;
 
   for(size_t c = 0; c < 3; c++)
     for(size_t i = 0; i < 3; i++)
@@ -279,7 +279,7 @@ static inline void _ioppr_linear_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb,
 static inline void _ioppr_xyz_to_linear_rgb_matrix(const dt_aligned_pixel_t xyz, dt_aligned_pixel_t rgb,
                                                    const float matrix[9])
 {
-  for(size_t c = 0; c < 3; c++) rgb[c] = 0.0f;
+  for_each_channel(c) rgb[c] = 0.0f;
 
   for(size_t c = 0; c < 3; c++)
     for(size_t i = 0; i < 3; i++)

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -105,7 +105,7 @@ dt_ioppr_set_pipe_input_profile_info(struct dt_develop_t *dev,
                                      struct dt_dev_pixelpipe_t *pipe,
                                      const dt_colorspaces_color_profile_type_t type,
                                      const char *filename,
-                                     const int intent, const float matrix_in[9]);
+                                     const int intent, const dt_colormatrix_t matrix_in);
 
 dt_iop_order_iccprofile_info_t *
 dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -53,6 +53,8 @@ typedef struct dt_iop_order_iccprofile_info_t
   float unbounded_coeffs_out[3][3] DT_ALIGNED_PIXEL;
   int nonlinearlut;
   float grey;
+  dt_colormatrix_t matrix_in_transposed;  // same as matrix_in, but stored such as to permit vectorization
+  dt_colormatrix_t matrix_out_transposed; // same as matrix_out, but stored such as to permit vectorization
 } dt_iop_order_iccprofile_info_t;
 
 #undef DT_IOPPR_COLOR_ICC_LEN
@@ -209,7 +211,7 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
                                                const char *message);
 #endif
 
-/** the following must have the matrix_in and matrix out generated */
+/** the following must have the matrix_in and matrix_out generated */
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(lut:64)
@@ -254,39 +256,6 @@ static inline void _apply_trc(const dt_aligned_pixel_t rgb_in, dt_aligned_pixel_
   }
 }
 
-
-#ifdef _OPENMP
-#pragma omp declare simd \
-  aligned(xyz, rgb, matrix:16) \
-  uniform(xyz, rgb, matrix)
-#endif
-static inline void _ioppr_linear_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t xyz,
-                                                   const float matrix[9])
-{
-  for_each_channel(c) xyz[c] = 0.0f;
-
-  for(size_t c = 0; c < 3; c++)
-    for(size_t i = 0; i < 3; i++)
-      xyz[c] += matrix[3 * c + i] * rgb[i];
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd \
-  aligned(xyz, rgb, matrix:16) \
-  uniform(xyz, rgb, matrix)
-#endif
-static inline void _ioppr_xyz_to_linear_rgb_matrix(const dt_aligned_pixel_t xyz, dt_aligned_pixel_t rgb,
-                                                   const float matrix[9])
-{
-  for_each_channel(c) rgb[c] = 0.0f;
-
-  for(size_t c = 0; c < 3; c++)
-    for(size_t i = 0; i < 3; i++)
-      rgb[c] += matrix[3 * c + i] * xyz[i];
-}
-
-
 #ifdef _OPENMP
 #pragma omp declare simd \
   aligned(rgb, matrix_in, unbounded_coeffs_in:16) \
@@ -315,12 +284,12 @@ static inline float dt_ioppr_get_rgb_matrix_luminance(const dt_aligned_pixel_t r
 
 #ifdef _OPENMP
 #pragma omp declare simd \
-  aligned(rgb, xyz, matrix_in, unbounded_coeffs_in:16) \
+  aligned(unbounded_coeffs_in:16) \
   aligned(lut_in:64) \
-  uniform(rgb, xyz, matrix_in, lut_in, unbounded_coeffs_in)
+  uniform(lut_in, unbounded_coeffs_in)
 #endif
 static inline void dt_ioppr_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t xyz,
-                                              const float matrix_in[9], float *const lut_in[3],
+                                              const dt_colormatrix_t matrix_in_transposed, float *const lut_in[3],
                                               const float unbounded_coeffs_in[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
@@ -328,42 +297,42 @@ static inline void dt_ioppr_rgb_matrix_to_xyz(const dt_aligned_pixel_t rgb, dt_a
   {
     dt_aligned_pixel_t linear_rgb;
     _apply_trc(rgb, linear_rgb, lut_in, unbounded_coeffs_in, lutsize);
-    _ioppr_linear_rgb_matrix_to_xyz(linear_rgb, xyz, matrix_in);
+    dt_apply_transposed_color_matrix(linear_rgb, matrix_in_transposed, xyz);
   }
   else
-    _ioppr_linear_rgb_matrix_to_xyz(rgb, xyz, matrix_in);
+    dt_apply_transposed_color_matrix(rgb, matrix_in_transposed, xyz);
 }
 
 #ifdef _OPENMP
 #pragma omp declare simd \
-  aligned(rgb, xyz, matrix_out, unbounded_coeffs_out:16) \
+  aligned(unbounded_coeffs_out:16) \
   aligned(lut_out:64) \
-  uniform(rgb, xyz, matrix_out, lut_out, unbounded_coeffs_out)
+  uniform(lut_out, unbounded_coeffs_out)
 #endif
 static inline void dt_ioppr_xyz_to_rgb_matrix(const dt_aligned_pixel_t xyz, dt_aligned_pixel_t rgb,
-                                              const float matrix_out[9], float *const lut_out[3],
+                                              const dt_colormatrix_t matrix_out_transposed, float *const lut_out[3],
                                               const float unbounded_coeffs_out[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
   if(nonlinearlut)
   {
     dt_aligned_pixel_t linear_rgb;
-    _ioppr_xyz_to_linear_rgb_matrix(xyz, linear_rgb, matrix_out);
+    dt_apply_transposed_color_matrix(xyz, matrix_out_transposed, linear_rgb);
     _apply_trc(linear_rgb, rgb, lut_out, unbounded_coeffs_out, lutsize);
   }
   else
-    _ioppr_xyz_to_linear_rgb_matrix(xyz, rgb, matrix_out);
+    dt_apply_transposed_color_matrix(xyz, matrix_out_transposed, rgb);
 }
 
 
 #ifdef _OPENMP
 #pragma omp declare simd \
-  aligned(lab, rgb, matrix_out, unbounded_coeffs_out:16) \
+  aligned(unbounded_coeffs_out:16) \
   aligned(lut_out:64) \
-  uniform(lab, rgb, matrix_out, lut_out, unbounded_coeffs_out)
+  uniform(lut_out, unbounded_coeffs_out)
 #endif
 static inline void dt_ioppr_lab_to_rgb_matrix(const dt_aligned_pixel_t lab, dt_aligned_pixel_t rgb,
-                                              const float matrix_out[9], float *const lut_out[3],
+                                              const dt_colormatrix_t matrix_out_transposed, float *const lut_out[3],
                                               const float unbounded_coeffs_out[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
@@ -373,28 +342,28 @@ static inline void dt_ioppr_lab_to_rgb_matrix(const dt_aligned_pixel_t lab, dt_a
   if(nonlinearlut)
   {
     dt_aligned_pixel_t linear_rgb;
-    _ioppr_xyz_to_linear_rgb_matrix(xyz, linear_rgb, matrix_out);
+    dt_apply_transposed_color_matrix(xyz, matrix_out_transposed, linear_rgb);
     _apply_trc(linear_rgb, rgb, lut_out, unbounded_coeffs_out, lutsize);
   }
   else
   {
-    _ioppr_xyz_to_linear_rgb_matrix(xyz, rgb, matrix_out);
+    dt_apply_transposed_color_matrix(xyz, matrix_out_transposed, rgb);
   }
 }
 
 #ifdef _OPENMP
 #pragma omp declare simd \
-  aligned(lab, rgb, matrix_in, unbounded_coeffs_in:16) \
+  aligned(unbounded_coeffs_in:16) \
   aligned(lut_in:64) \
-  uniform(rgb, lab, matrix_in, lut_in, unbounded_coeffs_in)
+  uniform(lut_in, unbounded_coeffs_in)
 #endif
 static inline void dt_ioppr_rgb_matrix_to_lab(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t lab,
-                                              const float matrix_in[9], float *const lut_in[3],
+                                              const dt_colormatrix_t matrix_in_transposed, float *const lut_in[3],
                                               const float unbounded_coeffs_in[3][3],
                                               const int lutsize, const int nonlinearlut)
 {
   dt_aligned_pixel_t xyz = { 0.f };
-  dt_ioppr_rgb_matrix_to_xyz(rgb, xyz, matrix_in, lut_in, unbounded_coeffs_in, lutsize, nonlinearlut);
+  dt_ioppr_rgb_matrix_to_xyz(rgb, xyz, matrix_in_transposed, lut_in, unbounded_coeffs_in, lutsize, nonlinearlut);
   dt_XYZ_to_Lab(xyz, lab);
 }
 
@@ -411,7 +380,8 @@ static inline float dt_ioppr_compensate_middle_grey(const float x, const dt_iop_
   // we transform the curve nodes from the image colorspace to lab
   dt_aligned_pixel_t lab = { 0.0f };
   const dt_aligned_pixel_t rgb = { x, x, x };
-  dt_ioppr_rgb_matrix_to_lab(rgb, lab, profile_info->matrix_in, profile_info->lut_in, profile_info->unbounded_coeffs_in, profile_info->lutsize, profile_info->nonlinearlut);
+  dt_ioppr_rgb_matrix_to_lab(rgb, lab, profile_info->matrix_in_transposed, profile_info->lut_in,
+                             profile_info->unbounded_coeffs_in, profile_info->lutsize, profile_info->nonlinearlut);
   return lab[0] * .01f;
 }
 
@@ -424,7 +394,8 @@ static inline float dt_ioppr_uncompensate_middle_grey(const float x, const dt_io
   const dt_aligned_pixel_t lab = { x * 100.f, 0.0f, 0.0f };
   dt_aligned_pixel_t rgb = { 0.0f };
 
-  dt_ioppr_lab_to_rgb_matrix(lab, rgb, profile_info->matrix_out, profile_info->lut_out, profile_info->unbounded_coeffs_out, profile_info->lutsize, profile_info->nonlinearlut);
+  dt_ioppr_lab_to_rgb_matrix(lab, rgb, profile_info->matrix_out_transposed, profile_info->lut_out,
+                             profile_info->unbounded_coeffs_out, profile_info->lutsize, profile_info->nonlinearlut);
   return rgb[0];
 }
 

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -44,8 +44,8 @@ typedef struct dt_iop_order_iccprofile_info_t
   dt_colorspaces_color_profile_type_t type;
   char filename[DT_IOPPR_COLOR_ICC_LEN];
   dt_iop_color_intent_t intent;
-  float matrix_in[9] DT_ALIGNED_PIXEL; // don't align on more than 16 bits or OpenCL will fail
-  float matrix_out[9] DT_ALIGNED_PIXEL;
+  dt_colormatrix_t matrix_in; // don't align on more than 16 bits or OpenCL will fail
+  dt_colormatrix_t matrix_out;
   int lutsize;
   float *lut_in[3];
   float *lut_out[3];
@@ -263,7 +263,7 @@ static inline void _apply_trc(const dt_aligned_pixel_t rgb_in, dt_aligned_pixel_
   uniform(rgb, matrix_in, lut_in, unbounded_coeffs_in)
 #endif
 static inline float dt_ioppr_get_rgb_matrix_luminance(const dt_aligned_pixel_t rgb,
-                                                      const float matrix_in[9], float *const lut_in[3],
+                                                      const dt_colormatrix_t matrix_in, float *const lut_in[3],
                                                       const float unbounded_coeffs_in[3][3],
                                                       const int lutsize, const int nonlinearlut)
 {
@@ -273,10 +273,10 @@ static inline float dt_ioppr_get_rgb_matrix_luminance(const dt_aligned_pixel_t r
   {
     dt_aligned_pixel_t linear_rgb;
     _apply_trc(rgb, linear_rgb, lut_in, unbounded_coeffs_in, lutsize);
-    luminance = matrix_in[3] * linear_rgb[0] + matrix_in[4] * linear_rgb[1] + matrix_in[5] * linear_rgb[2];
+    luminance = matrix_in[1][0] * linear_rgb[0] + matrix_in[1][1] * linear_rgb[1] + matrix_in[1][2] * linear_rgb[2];
   }
   else
-    luminance = matrix_in[3] * rgb[0] + matrix_in[4] * rgb[1] + matrix_in[5] * rgb[2];
+    luminance = matrix_in[1][0] * rgb[0] + matrix_in[1][1] * rgb[1] + matrix_in[1][2] * rgb[2];
 
   return luminance;
 }

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -191,7 +191,7 @@ static inline float scalar_product(const dt_aligned_pixel_t v_1, const dt_aligne
 #ifdef _OPENMP
 #pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
 #endif
-static inline void dot_product(const dt_aligned_pixel_t v_in, const float M[3][4], dt_aligned_pixel_t v_out)
+static inline void dot_product(const dt_aligned_pixel_t v_in, const dt_colormatrix_t M, dt_aligned_pixel_t v_out)
 {
   // specialized 3×4 dot products of 4×1 RGB-alpha pixels
   #ifdef _OPENMP

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -160,6 +160,26 @@ static inline void mat3mul(float *const __restrict__ dest, const float *const __
   }
 }
 
+// multiply two padded 3x3 matrices
+// dest needs to be different from m1 and m2
+// dest = m1 * m2 in this order
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
+static inline void mat3SSEmul(dt_colormatrix_t dest, const dt_colormatrix_t m1, const dt_colormatrix_t m2)
+{
+  for(int k = 0; k < 3; k++)
+  {
+    for(int i = 0; i < 3; i++)
+    {
+      float x = 0.0f;
+      for(int j = 0; j < 3; j++)
+        x += m1[k][j] * m2[j][i];
+      dest[k][i] = x;
+    }
+  }
+}
+
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif

--- a/src/common/matrices.c
+++ b/src/common/matrices.c
@@ -19,11 +19,11 @@
 #include "common/math.h"
 #include "common/matrices.h"
 
-/** inverts the given 3x3 matrix */
-int mat3inv(float *const dst, const float *const src)
+/** inverts the given padded 3x3 matrix */
+int mat3SSEinv(dt_colormatrix_t dst, const dt_colormatrix_t src)
 {
-#define A(y, x) src[(y - 1) * 3 + (x - 1)]
-#define B(y, x) dst[(y - 1) * 3 + (x - 1)]
+#define A(y, x) src[(y - 1)][(x - 1)]
+#define B(y, x) dst[(y - 1)][(x - 1)]
 
   const float det = A(1, 1) * (A(3, 3) * A(2, 2) - A(3, 2) * A(2, 3))
                     - A(2, 1) * (A(3, 3) * A(1, 2) - A(3, 2) * A(1, 3))

--- a/src/common/matrices.h
+++ b/src/common/matrices.h
@@ -1,0 +1,28 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/dttypes.h"
+
+// inverts the given padded 3x3 matrix
+int mat3SSEinv(dt_colormatrix_t dst, const dt_colormatrix_t src);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -222,8 +222,8 @@ int dt_develop_blendif_init_masking_profile(struct dt_dev_pixelpipe_iop_t *piece
     {
       float sum = 0.0f;
       for(size_t i = 0; i < 3; i++)
-        sum += M[y][i] * profile->matrix_in[x + i * 3];
-      blending_profile->matrix_out[y * 3 + x] = sum;
+        sum += M[y][i] * profile->matrix_in[i][x];
+      blending_profile->matrix_out[y][x] = sum;
     }
   }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -204,7 +204,7 @@ int dt_develop_blendif_init_masking_profile(struct dt_dev_pixelpipe_iop_t *piece
                                             dt_develop_blend_colorspace_t cst)
 {
   // Bradford adaptation matrix from http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
-  const float M[3][4] DT_ALIGNED_ARRAY = {
+  const dt_colormatrix_t M = {
       {  0.9555766f, -0.0230393f,  0.0631636f, 0.0f },
       { -0.0282895f,  1.0099416f,  0.0210077f, 0.0f },
       {  0.0122982f, -0.0204830f,  1.3299098f, 0.0f },

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -1467,7 +1467,7 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
         dt_aligned_pixel_t pixel;
         for_each_channel(c,aligned(b))
           pixel[c] = b[j+c];
-        dt_ioppr_rgb_matrix_to_lab(pixel, b + j, profile->matrix_in, profile->lut_in,
+        dt_ioppr_rgb_matrix_to_lab(pixel, b + j, profile->matrix_in_transposed, profile->lut_in,
                                    profile->unbounded_coeffs_in, profile->lutsize, profile->nonlinearlut);
       }
     }

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -147,7 +147,7 @@ static inline void _blendif_jzczhz(const float *const restrict pixels, float *co
 
     // use the matrix_out of the hacked profile for blending to use the
     // conversion from RGB to XYZ D65 (instead of XYZ D50)
-    dt_ioppr_rgb_matrix_to_xyz(pixels + j, XYZ_D65, profile->matrix_out, profile->lut_in,
+    dt_ioppr_rgb_matrix_to_xyz(pixels + j, XYZ_D65, profile->matrix_out_transposed, profile->lut_in,
                                profile->unbounded_coeffs_in, profile->lutsize, profile->nonlinearlut);
 
     dt_XYZ_2_JzAzBz(XYZ_D65, JzAzBz);
@@ -756,7 +756,7 @@ static inline void _rgb_to_JzCzhz(const float *const restrict rgb, float *const 
     dt_aligned_pixel_t XYZ_D65 = { 0.0f, 0.0f, 0.0f };
     // use the matrix_out of the hacked profile for blending to use the
     // conversion from RGB to XYZ D65 (instead of XYZ D50)
-    dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D65, profile->matrix_out, profile->lut_in, profile->unbounded_coeffs_in,
+    dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D65, profile->matrix_out_transposed, profile->lut_in, profile->unbounded_coeffs_in,
                                profile->lutsize, profile->nonlinearlut);
     dt_XYZ_2_JzAzBz(XYZ_D65, JzAzBz);
   }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -976,7 +976,7 @@ static inline void mat4inv(const float X[][4], float R[][4])
             / det;
 }
 
-static void mat4mulv(float *dst, float mat[][4], const float *const v)
+static void mat4mulv(float dst[4], const float mat[4][4], const float v[4])
 {
   for(int k = 0; k < 4; k++)
   {
@@ -986,7 +986,7 @@ static void mat4mulv(float *dst, float mat[][4], const float *const v)
   }
 }
 
-void dt_iop_estimate_cubic(const float *const x, const float *const y, float *a)
+void dt_iop_estimate_cubic(const float x[4], const float y[4], float a[4])
 {
   // we want to fit a spline
   // [y]   [x^3 x^2 x^1 1] [a^3]

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -104,7 +104,7 @@ void dt_iop_RGB_to_YCbCr(const float *rgb, float *yuv);
 
 /** takes four points (x,y) in two arrays and fills the cubic coefficients a, such that y = [X] * a, where
   * [X] is the matrix containing all x^3 x^2 x^1 x^0 lines for all four x. */
-void dt_iop_estimate_cubic(const float *const x, const float *const y, float *a);
+void dt_iop_estimate_cubic(const float x[4], const float y[4], float a[4]);
 
 /** evaluates the cubic fit, i.e. returns y = a^t [x^3 x^2 x^1 1] */
 static inline float dt_iop_eval_cubic(const float *const a, const float x)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2426,7 +2426,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
 
     dt_aligned_pixel_t RGB;
-    dt_ioppr_lab_to_rgb_matrix(g->checker->values[k].Lab, RGB, work_profile->matrix_out, work_profile->lut_out,
+    dt_ioppr_lab_to_rgb_matrix(g->checker->values[k].Lab, RGB, work_profile->matrix_out_transposed, work_profile->lut_out,
                                work_profile->unbounded_coeffs_out, work_profile->lutsize,
                                work_profile->nonlinearlut);
 
@@ -2964,7 +2964,7 @@ static void _convert_GUI_colors(dt_iop_channelmixer_rgb_params_t *p,
     dt_aligned_pixel_t XYZ;
     if(work_profile)
     {
-      dt_ioppr_rgb_matrix_to_xyz(LMS, XYZ, work_profile->matrix_in, work_profile->lut_in,
+      dt_ioppr_rgb_matrix_to_xyz(LMS, XYZ, work_profile->matrix_in_transposed, work_profile->lut_in,
                                   work_profile->unbounded_coeffs_in, work_profile->lutsize,
                                   work_profile->nonlinearlut);
       dt_XYZ_to_Rec709_D65(XYZ, RGB);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1112,7 +1112,7 @@ void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
   dt_aligned_pixel_t XYZ_D50 = { 0.f };
   dt_aligned_pixel_t XYZ_D65 = { 0.f };
 
-  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, work_profile->matrix_in, work_profile->lut_in,
+  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, work_profile->matrix_in_transposed, work_profile->lut_in,
                              work_profile->unbounded_coeffs_in, work_profile->lutsize,
                              work_profile->nonlinearlut);
   XYZ_D50_to_D65(XYZ_D50, XYZ_D65);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -368,26 +368,6 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("add basic colorfulness"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
-/* Custom matrix handling for speed */
-static inline void repack_3x3_to_3xSSE(const float input[9], dt_colormatrix_t output)
-{
-  // Repack a 3×3 array/matrice into a 3×1 SSE2 vector to enable SSE4/AVX/AVX2 dot products
-  output[0][0] = input[0];
-  output[0][1] = input[1];
-  output[0][2] = input[2];
-  output[0][3] = 0.0f;
-
-  output[1][0] = input[3];
-  output[1][1] = input[4];
-  output[1][2] = input[5];
-  output[1][3] = 0.0f;
-
-  output[2][0] = input[6];
-  output[2][1] = input[7];
-  output[2][2] = input[8];
-  output[2][3] = 0.0f;
-}
-
 
 static void mat3mul4(float *restrict dst, const float *const restrict m1, const float *const restrict m2)
 {

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1704,9 +1704,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
   // commit color profiles to pipeline
   dt_ioppr_set_pipe_work_profile_info(self->dev, piece->pipe, d->type_work, d->filename_work, DT_INTENT_PERCEPTUAL);
-  float cmatrix[9];
-  pack_3xSSE_to_3x3(d->cmatrix, cmatrix);
-  dt_ioppr_set_pipe_input_profile_info(self->dev, piece->pipe, d->type, d->filename, p->intent, cmatrix);
+  dt_ioppr_set_pipe_input_profile_info(self->dev, piece->pipe, d->type, d->filename, p->intent, d->cmatrix);
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -21,6 +21,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/colorspaces_inline_conversions.h"
+#include "common/dttypes.h"
 #include "common/file_location.h"
 #include "common/imagebuf.h"
 #include "common/iop_profile.h"
@@ -55,7 +56,7 @@ typedef struct dt_iop_colorout_data_t
   dt_colorspaces_color_profile_type_t type;
   dt_colorspaces_color_mode_t mode;
   float lut[3][LUT_SAMPLES];
-  float cmatrix[9];
+  dt_colormatrix_t cmatrix;
   cmsHTRANSFORM *xform;
   float unbounded_coeffs[3][3]; // for extrapolation of shaper curves
 } dt_iop_colorout_data_t;
@@ -302,7 +303,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
 
-  dev_m = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 9, d->cmatrix);
+  float cmatrix[9];
+  pack_3xSSE_to_3x3(d->cmatrix, cmatrix);
+  dev_m = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 9, cmatrix);
   if(dev_m == NULL) goto error;
   dev_r = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
   if(dev_r == NULL) goto error;
@@ -350,7 +353,7 @@ static void process_fastpath_apply_tonecurves(struct dt_iop_module_t *self, dt_d
 {
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
 
-  if(!isnan(d->cmatrix[0]))
+  if(!isnan(d->cmatrix[0][0]))
   {
     const size_t npixels = (size_t)roi_out->width * roi_out->height;
     float *const restrict out = (float *const)ovoid;
@@ -410,11 +413,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, piece->colors);
   }
-  else if(!isnan(d->cmatrix[0]))
+  else if(!isnan(d->cmatrix[0][0]))
   {
     const float *const restrict in = (const float *const)ivoid;
     dt_colormatrix_t cmatrix;
-    transpose_3x3_to_3xSSE(d->cmatrix, cmatrix);
+    transpose_3xSSE(d->cmatrix, cmatrix);
 
 // fprintf(stderr,"Using cmatrix codepath\n");
 // convert to rgb using matrix
@@ -483,13 +486,12 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   {
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, ch);
   }
-  else if(!isnan(d->cmatrix[0]))
+  else if(!isnan(d->cmatrix[0][0]))
   {
     const float *const restrict in = (const float *const)ivoid;
-    const float *const restrict cmatrix = d->cmatrix;
-    const __m128 m0 = _mm_set_ps(0.0f, cmatrix[6], cmatrix[3], cmatrix[0]);
-    const __m128 m1 = _mm_set_ps(0.0f, cmatrix[7], cmatrix[4], cmatrix[1]);
-    const __m128 m2 = _mm_set_ps(0.0f, cmatrix[8], cmatrix[5], cmatrix[2]);
+    const __m128 m0 = _mm_set_ps(0.0f, d->cmatrix[2][0], d->cmatrix[1][0], d->cmatrix[0][0]);
+    const __m128 m1 = _mm_set_ps(0.0f, d->cmatrix[2][1], d->cmatrix[1][1], d->cmatrix[0][1]);
+    const __m128 m2 = _mm_set_ps(0.0f, d->cmatrix[2][2], d->cmatrix[1][2], d->cmatrix[0][2]);
 // fprintf(stderr,"Using cmatrix codepath\n");
 // convert to rgb using matrix
 #ifdef _OPENMP
@@ -594,7 +596,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     cmsDeleteTransform(d->xform);
     d->xform = NULL;
   }
-  d->cmatrix[0] = NAN;
+  d->cmatrix[0][0] = NAN;
   d->lut[0][0] = -1.0f;
   d->lut[1][0] = -1.0f;
   d->lut[2][0] = -1.0f;
@@ -723,14 +725,14 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
      || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
                                                       LUT_SAMPLES))
   {
-    d->cmatrix[0] = NAN;
+    d->cmatrix[0][0] = NAN;
     piece->process_cl_ready = 0;
     d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,
                                           out_intent, INTENT_RELATIVE_COLORIMETRIC, transformFlags);
   }
 
   // user selected a non-supported output profile, check that:
-  if(!d->xform && isnan(d->cmatrix[0]))
+  if(!d->xform && isnan(d->cmatrix[0][0]))
   {
     dt_control_log(_("unsupported output profile has been replaced by sRGB!"));
     fprintf(stderr, "unsupported output profile `%s' has been replaced by sRGB!\n", out_profile->name);
@@ -740,7 +742,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
        || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
                                                         LUT_SAMPLES))
     {
-      d->cmatrix[0] = NAN;
+      d->cmatrix[0][0] = NAN;
       piece->process_cl_ready = 0;
 
       d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2821,7 +2821,7 @@ static void rt_process_stats(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 
     if(work_profile)
     {
-      dt_ioppr_rgb_matrix_to_lab(img_src + i, Lab, work_profile->matrix_in,
+      dt_ioppr_rgb_matrix_to_lab(img_src + i, Lab, work_profile->matrix_in_transposed,
                                   work_profile->lut_in, work_profile->unbounded_coeffs_in,
                                   work_profile->lutsize, work_profile->nonlinearlut);
     }
@@ -2870,7 +2870,7 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
   {
     if(work_profile)
     {
-      dt_ioppr_rgb_matrix_to_lab(img_src + i, img_src + i, work_profile->matrix_in,
+      dt_ioppr_rgb_matrix_to_lab(img_src + i, img_src + i, work_profile->matrix_in_transposed,
                                   work_profile->lut_in, work_profile->unbounded_coeffs_in,
                                   work_profile->lutsize, work_profile->nonlinearlut);
     }
@@ -2899,7 +2899,7 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
 
     if(work_profile)
     {
-      dt_ioppr_lab_to_rgb_matrix(img_src + i, img_src + i, work_profile->matrix_out,
+      dt_ioppr_lab_to_rgb_matrix(img_src + i, img_src + i, work_profile->matrix_out_transposed,
                                  work_profile->lut_out, work_profile->unbounded_coeffs_out,
                                  work_profile->lutsize, work_profile->nonlinearlut);;
     }

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2715,63 +2715,6 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 // process
 //--------------------------------------------------------------------------------------------------
 
-#ifdef __SSE2__
-/** uses D50 white point. */
-// see http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html for the transformation matrices
-static inline __m128 dt_XYZ_to_RGB_sse2(__m128 XYZ)
-{
-  // XYZ -> sRGB matrix, D65
-  const __m128 xyz_to_srgb_0 = _mm_setr_ps(3.1338561f, -0.9787684f, 0.0719453f, 0.0f);
-  const __m128 xyz_to_srgb_1 = _mm_setr_ps(-1.6168667f, 1.9161415f, -0.2289914f, 0.0f);
-  const __m128 xyz_to_srgb_2 = _mm_setr_ps(-0.4906146f, 0.0334540f, 1.4052427f, 0.0f);
-
-  __m128 rgb
-      = _mm_add_ps(_mm_mul_ps(xyz_to_srgb_0, _mm_shuffle_ps(XYZ, XYZ, _MM_SHUFFLE(0, 0, 0, 0))),
-                   _mm_add_ps(_mm_mul_ps(xyz_to_srgb_1, _mm_shuffle_ps(XYZ, XYZ, _MM_SHUFFLE(1, 1, 1, 1))),
-                              _mm_mul_ps(xyz_to_srgb_2, _mm_shuffle_ps(XYZ, XYZ, _MM_SHUFFLE(2, 2, 2, 2)))));
-
-  return rgb;
-}
-
-static inline __m128 dt_RGB_to_XYZ_sse2(__m128 rgb)
-{
-  // sRGB -> XYZ matrix, D65
-  const __m128 srgb_to_xyz_0 = _mm_setr_ps(0.4360747f, 0.2225045f, 0.0139322f, 0.0f);
-  const __m128 srgb_to_xyz_1 = _mm_setr_ps(0.3850649f, 0.7168786f, 0.0971045f, 0.0f);
-  const __m128 srgb_to_xyz_2 = _mm_setr_ps(0.1430804f, 0.0606169f, 0.7141733f, 0.0f);
-
-  __m128 XYZ
-      = _mm_add_ps(_mm_mul_ps(srgb_to_xyz_0, _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(0, 0, 0, 0))),
-                   _mm_add_ps(_mm_mul_ps(srgb_to_xyz_1, _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(1, 1, 1, 1))),
-                              _mm_mul_ps(srgb_to_xyz_2, _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(2, 2, 2, 2)))));
-  return XYZ;
-}
-#endif
-
-static inline void dt_linearRGB_to_XYZ(const float *const linearRGB, float *XYZ)
-{
-  const float srgb_to_xyz[3][3] = { { 0.4360747, 0.3850649, 0.1430804 },
-                                    { 0.2225045, 0.7168786, 0.0606169 },
-                                    { 0.0139322, 0.0971045, 0.7141733 } };
-
-  // sRGB -> XYZ
-  XYZ[0] = XYZ[1] = XYZ[2] = 0.0;
-  for(int r = 0; r < 3; r++)
-    for(int c = 0; c < 3; c++) XYZ[r] += srgb_to_xyz[r][c] * linearRGB[c];
-}
-
-static inline void dt_XYZ_to_linearRGB(const float *const XYZ, float *linearRGB)
-{
-  const float xyz_to_srgb_matrix[3][3] = { { 3.1338561, -1.6168667, -0.4906146 },
-                                           { -0.9787684, 1.9161415, 0.0334540 },
-                                           { 0.0719453, -0.2289914, 1.4052427 } };
-
-  // XYZ -> sRGB
-  linearRGB[0] = linearRGB[1] = linearRGB[2] = 0.f;
-  for(int r = 0; r < 3; r++)
-    for(int c = 0; c < 3; c++) linearRGB[r] += xyz_to_srgb_matrix[r][c] * XYZ[c];
-}
-
 static void image_rgb2lab(float *img_src, const int width, const int height, const int ch, const int use_sse)
 {
   const int stride = width * height * ch;

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -104,12 +104,12 @@ static inline gboolean _convert_color_space(const GdkRGBA *restrict sample, GdkR
   if(!(histogram_profile && display_profile)) return TRUE; // no need to paint, color will be wrong
 
   // convert from histogram RGB to XYZ
-  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ, histogram_profile->matrix_in, histogram_profile->lut_in,
+  dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ, histogram_profile->matrix_in_transposed, histogram_profile->lut_in,
                              histogram_profile->unbounded_coeffs_in, histogram_profile->lutsize,
                              histogram_profile->nonlinearlut);
 
   // convert from XYZ to display RGB
-  dt_ioppr_xyz_to_rgb_matrix(XYZ, RGB, display_profile->matrix_out, display_profile->lut_out,
+  dt_ioppr_xyz_to_rgb_matrix(XYZ, RGB, display_profile->matrix_out_transposed, display_profile->lut_out,
                              display_profile->unbounded_coeffs_out, display_profile->lutsize,
                              display_profile->nonlinearlut);
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -301,7 +301,7 @@ static void _lib_histogram_hue_ring(dt_lib_histogram_t *d, const dt_iop_order_ic
       dt_aligned_pixel_t rgb, XYZ_D50, intermed, chromaticity;
       for_each_channel(ch,aligned(vertex_rgb,delta,rgb:16))
         rgb[ch] = vertex_rgb[k][ch] + delta[ch] * i;
-      dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, vs_prof->matrix_in, vs_prof->lut_in,
+      dt_ioppr_rgb_matrix_to_xyz(rgb, XYZ_D50, vs_prof->matrix_in_transposed, vs_prof->lut_in,
                                  vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
       // Try to represent hue in profile colorspace. Values may be
       // outside [0,1] but cairo_set_source_rgba will clamp. Compare
@@ -426,7 +426,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
             RGB[ch] += px[4U * (yy * roi->width + xx) + ch] * 0.25f;
 
       // this goes to the PCS which has standard illuminant D50
-      dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, vs_prof->matrix_in, vs_prof->lut_in,
+      dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, vs_prof->matrix_in_transposed, vs_prof->lut_in,
                                  vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
       // NOTE: see for comparison/reference rgb_to_JzCzhz() in color_picker.c
       if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -354,7 +354,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   const int diam_px = d->vectorscope_diameter_px;
   const dt_lib_histogram_vectorscope_type_t vs_type = d->vectorscope_type;
 
-  if(!vs_prof || isnan(vs_prof->matrix_in[0]))
+  if(!vs_prof || isnan(vs_prof->matrix_in[0][0]))
   {
     fprintf(stderr, "[histogram] unsupported vectorscope profile %i %s, it will be replaced with linear rec2020\n", vs_prof->type, vs_prof->filename);
     vs_prof = dt_ioppr_add_profile_info_to_list(darktable.develop, DT_COLORSPACE_LIN_REC2020, "", DT_INTENT_RELATIVE_COLORIMETRIC);


### PR DESCRIPTION
The current codebase uses a variety of data types for 3x3 color matrices: float[9], float[3][3], float[4][3], and float[3][4].  Only the last of these is properly organized to permit auto-vectorization.  This PR converts as many of those as is easily done to a new type `dt_colormatrix_t` which ensures proper padding and alignment for vectorization and improves self-documentation of the variables.  A future Phase 2 will address the remaining instances of color matrices which this PR has not converted.

Verified to produce the same results on the integration tests as master.
