### PR TITLE
mask indicator tooltip to show the source module for raster mask

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2343,7 +2343,8 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
       fprintf(stderr, "unknown mask mode '%d' in module '%s'", mm, module->op);
     gchar *str1 = g_strconcat(_("this module has a"), " ", type, NULL);
     if(raster)
-      tooltip = g_strdup(str1);
+      tooltip = g_strconcat(str1, "\n", _("as in module"), " ",
+                            dt_history_item_get_name(module->raster_mask.sink.source), NULL);
     else
       tooltip = g_strconcat(str1, "\n", _("click to display (module must be activated first)"), NULL);
     gtk_widget_set_tooltip_text(module->mask_indicator, tooltip);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2343,7 +2343,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
       fprintf(stderr, "unknown mask mode '%d' in module '%s'", mm, module->op);
     gchar *str1 = g_strconcat(_("this module has a"), " ", type, NULL);
     if(raster)
-      tooltip = g_strconcat(str1, "\n", _("as in module"), " ",
+      tooltip = g_strconcat(str1, "\n", _("taken from module"), " ",
                             dt_history_item_get_name(module->raster_mask.sink.source), NULL);
     else
       tooltip = g_strconcat(str1, "\n", _("click to display (module must be activated first)"), NULL);


### PR DESCRIPTION
With this PR the tooltip for the mask indicator, in case of raster mask, will show which is the soruce module.
This can be useful when checking masks with collapsed modules. Previously we had to expand the module to find out the mask source

![immagine](https://user-images.githubusercontent.com/43290988/127348955-348fbde9-7b8c-4312-b0d9-5160bb1d719a.png)
