### PR TITLE
Lazy xmp writing (v3)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -281,10 +281,16 @@
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">
     <name>write_sidecar_files</name>
-    <type>bool</type>
-    <default>true</default>
+    <type>
+      <enum>
+        <option>never</option>
+        <option>after edit</option>
+        <option>on import</option>
+      </enum>
+    </type>
+    <default>on import</default>
     <shortdescription>write sidecar file for each image</shortdescription>
-    <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.</longdescription>
+    <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be written\n never\n on import: immediately after importing into the database\n after first edit: after any user change on the image</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="xmp">
     <name>compress_xmp_tags</name>

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -538,7 +538,7 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       }
     }
 
-    if(dt_conf_get_bool("write_sidecar_files") ||
+    if((dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER) ||
        dt_conf_get_bool("ui_last/import_last_tags_imported"))
     {
       GList *tags = NULL;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -291,10 +291,32 @@ void dt_image_film_roll(const dt_image_t *img, char *pathname, size_t pathname_l
   pathname[pathname_len - 1] = '\0';
 }
 
+dt_imageio_write_xmp_t dt_image_get_xmp_mode()
+{
+  dt_imageio_write_xmp_t res = DT_WRITE_XMP_ALWAYS;
+  const char *config = dt_conf_get_string_const("write_sidecar_files");
+  if(config)
+  {
+    if(!strcmp(config, "after edit"))
+      res = DT_WRITE_XMP_LAZY;
+    else if(!strcmp(config, "never"))
+      res = DT_WRITE_XMP_NEVER;
+    // migration path from boolean settings in <= 3.6, lazy mode were introduced in 3.8
+    else if(!strcmp(config, "FALSE"))
+    {
+      dt_conf_set_string("write_sidecar_files", "never");
+      res = DT_WRITE_XMP_NEVER;
+    }
+    else if(!strcmp(config, "TRUE"))
+      dt_conf_set_string("write_sidecar_files", "on import");
+  }
+  return res;
+}
+
 gboolean dt_image_safe_remove(const int32_t imgid)
 {
   // always safe to remove if we do not have .xmp
-  if(!dt_conf_get_bool("write_sidecar_files")) return TRUE;
+  if(dt_image_get_xmp_mode() == DT_WRITE_XMP_NEVER) return TRUE;
 
   // check whether the original file is accessible
   char pathname[PATH_MAX] = { 0 };
@@ -1378,6 +1400,7 @@ static int _image_read_duplicates(const uint32_t id, const char *filename, const
 static uint32_t _image_import_internal(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs,
                                        gboolean lua_locking, gboolean raise_signals)
 {
+  const dt_imageio_write_xmp_t xmp_mode = dt_image_get_xmp_mode(); 
   char *normalized_filename = dt_util_normalize_path(filename);
   if(!normalized_filename || !dt_util_test_image_file(normalized_filename))
   {
@@ -1604,9 +1627,10 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   if((res != 0) && (nb_xmp == 0))
   {
     // Search for Lightroom sidecar file, import tags if found
-    dt_lightroom_import(id, NULL, TRUE);
+    const gboolean lr_xmp = dt_lightroom_import(id, NULL, TRUE);
     // Make sure that lightroom xmp data (label in particular) are saved in dt xmp
-    dt_image_write_sidecar_file(id);
+    if(lr_xmp)
+      dt_image_write_sidecar_file(id);
   }
 
   // add a tag with the file extension
@@ -1621,7 +1645,8 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   dt_mipmap_cache_remove(darktable.mipmap_cache, id);
 
   //synch database entries to xmp
-  dt_image_synch_all_xmp(normalized_filename);
+  if(xmp_mode == DT_WRITE_XMP_ALWAYS)
+    dt_image_synch_all_xmp(normalized_filename);
 
   g_free(imgfname);
   g_free(basename);
@@ -2387,7 +2412,7 @@ void dt_image_write_sidecar_file(const int32_t imgid)
 {
   // TODO: compute hash and don't write if not needed!
   // write .xmp file
-  if(imgid > 0 && dt_conf_get_bool("write_sidecar_files"))
+  if((imgid > 0) && (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER))
   {
     char filename[PATH_MAX] = { 0 };
 
@@ -2427,7 +2452,7 @@ void dt_image_write_sidecar_file(const int32_t imgid)
 void dt_image_synch_xmps(const GList *img)
 {
   if(!img) return;
-  if(dt_conf_get_bool("write_sidecar_files"))
+  if(dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER)
   {
     for(const GList *imgs = img; imgs; imgs = g_list_next(imgs))
     {
@@ -2451,7 +2476,7 @@ void dt_image_synch_xmp(const int selected)
 
 void dt_image_synch_all_xmp(const gchar *pathname)
 {
-  if(dt_conf_get_bool("write_sidecar_files"))
+  if(dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER)
   {
     sqlite3_stmt *stmt;
     gchar *imgfname = g_path_get_basename(pathname);
@@ -2480,8 +2505,7 @@ void dt_image_synch_all_xmp(const gchar *pathname)
 void dt_image_local_copy_synch(void)
 {
   // nothing to do if not creating .xmp
-  if(!dt_conf_get_bool("write_sidecar_files")) return;
-
+  if(dt_image_get_xmp_mode() == DT_WRITE_XMP_NEVER) return;
   sqlite3_stmt *stmt;
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT id FROM main.images WHERE flags&?1=?1", -1,

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -928,7 +928,7 @@ void dt_image_set_aspect_ratio_if_different(const int32_t imgid, const float asp
       dt_image_cache_read_release(darktable.image_cache, image);
       dt_image_t *wimage = dt_image_cache_get(darktable.image_cache, imgid, 'w');
       wimage->aspect_ratio = aspect_ratio;
-      dt_image_cache_write_release(darktable.image_cache, wimage, DT_IMAGE_CACHE_SAFE);
+      dt_image_cache_write_release(darktable.image_cache, wimage, DT_IMAGE_CACHE_RELAXED);
     }
     else
       dt_image_cache_read_release(darktable.image_cache, image);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -37,6 +37,13 @@ typedef enum dt_imageio_retval_t
   DT_IMAGEIO_CACHE_FULL      // dt's caches are full :(
 } dt_imageio_retval_t;
 
+typedef enum dt_imageio_write_xmp_t
+{
+  DT_WRITE_XMP_NEVER = 0,
+  DT_WRITE_XMP_LAZY = 1,
+  DT_WRITE_XMP_ALWAYS = 2
+} dt_imageio_write_xmp_t;
+
 typedef enum
 {
   // the first 0x7 in flags are reserved for star ratings.
@@ -402,6 +409,8 @@ void dt_image_write_sidecar_file(const int32_t imgid);
 void dt_image_synch_xmp(const int selected);
 void dt_image_synch_xmps(const GList *img);
 void dt_image_synch_all_xmp(const gchar *pathname);
+/** get the mode xmp sidecars are written */
+dt_imageio_write_xmp_t dt_image_get_xmp_mode();
 
 // add an offset to the exif_datetime_taken field
 void dt_image_add_time_offset(const int32_t imgid, const long int offset);

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -614,7 +614,7 @@ void dt_metadata_set_import(const int imgid, const char *key, const char *value)
 
   if(keyid != -1) // known key
   {
-    gboolean imported = dt_conf_get_bool("write_sidecar_files");
+    gboolean imported = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
     if(!imported && dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL)
     {
       const gchar *name = dt_metadata_get_name(keyid);

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -60,7 +60,7 @@ GList *dt_control_crawler_run()
 {
   sqlite3_stmt *stmt, *inner_stmt;
   GList *result = NULL;
-  gboolean look_for_xmp = dt_conf_get_bool("write_sidecar_files");
+  gboolean look_for_xmp = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
 
   sqlite3_prepare_v2(dt_database_get(darktable.db),
                      "SELECT i.id, write_timestamp, version, folder || '" G_DIR_SEPARATOR_S "' || filename, flags "

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2037,9 +2037,11 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
       flags = flags | (auto_apply_modules ? DT_HISTORY_HASH_AUTO : DT_HISTORY_HASH_BASIC);
     }
     dt_history_hash_write_from_history(imgid, flags);
-    // As we have a proper history right now and this is first_run we write the xmp now
+    // As we have a proper history right now and this is first_run we possibly write the xmp now
     dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
-    dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+    // depending on the xmp_writing mode we either us safe or relaxed
+    const gboolean always = (dt_image_get_xmp_mode() == DT_WRITE_XMP_ALWAYS);
+    dt_image_cache_write_release(darktable.image_cache, image, always ? DT_IMAGE_CACHE_SAFE : DT_IMAGE_CACHE_RELAXED);
   }
   else if(legacy_params)
   {

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -1063,7 +1063,7 @@ static inline float round5(double x)
   return round(x * 100000.f) / 100000.f;
 }
 
-void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
+gboolean dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
 {
   gboolean refresh_needed = FALSE;
   char imported[256] = { 0 };
@@ -1075,7 +1075,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   if(!pathname)
   {
     if(!iauto) dt_control_log(_("cannot find lightroom XMP!"));
-    return;
+    return FALSE;
   }
 
   // Load LR xmp
@@ -1090,7 +1090,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   if(doc == NULL)
   {
     g_free(pathname);
-    return;
+    return FALSE ;
   }
 
   // Enter first node, xmpmeta
@@ -1101,14 +1101,14 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   {
     g_free(pathname);
     xmlFreeDoc(doc);
-    return;
+    return FALSE;
   }
 
   if(xmlStrcmp(entryNode->name, (const xmlChar *)"xmpmeta"))
   {
     if(!iauto) dt_control_log(_("`%s' not a lightroom XMP!"), pathname);
     g_free(pathname);
-    return;
+    return FALSE;
   }
 
   // Check that this is really a Lightroom document
@@ -1119,7 +1119,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
   {
     g_free(pathname);
     xmlFreeDoc(doc);
-    return;
+    return FALSE;
   }
 
   xmlXPathRegisterNs(xpathCtx, BAD_CAST "stEvt", BAD_CAST "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#");
@@ -1132,7 +1132,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
     xmlXPathFreeContext(xpathCtx);
     g_free(pathname);
     xmlFreeDoc(doc);
-    return;
+    return FALSE;
   }
 
   xmlNodeSetPtr xnodes = xpathObj->nodesetval;
@@ -1150,7 +1150,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
       xmlFree(value);
       if(!iauto) dt_control_log(_("`%s' not a lightroom XMP!"), pathname);
       g_free(pathname);
-      return;
+      return FALSE;
     }
     xmlFree(value);
   }
@@ -1559,6 +1559,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
     }
   }
+  return TRUE;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/lightroom.h
+++ b/src/develop/lightroom.h
@@ -24,7 +24,7 @@
    When called from lightable : dev == NULL, in this case only the tags are imported
    When called from darkroom  : dev != NULL, in this case only develop data are imported
 */
-void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto);
+gboolean dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto);
 
 /* returns NULL if not found, or g_strdup'ed pathname, the caller should g_free it. */
 char *dt_get_lightroom_xmp(int imgid);

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -144,7 +144,7 @@ static void _import_tags_changed(GtkWidget *widget, dt_import_metadata_t *metada
 
 static void _update_layout(dt_import_metadata_t *metadata)
 {
-  const gboolean write_xmp = dt_conf_get_bool("write_sidecar_files");
+  const gboolean write_xmp = (dt_image_get_xmp_mode() != DT_WRITE_XMP_NEVER);
   GtkWidget *w = gtk_grid_get_child_at(GTK_GRID(metadata->grid), 2, DT_META_META_HEADER);
   gtk_widget_set_visible(w, !write_xmp);
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)


### PR DESCRIPTION
After discussions and better understanding on my side how currently xmp files writing is managed
here is a third try.

**What does this pr want to achieve?**
Currently sidecar files are either written or not. Here a third mode is introduced: "after edit".
For the user this would mean we have three modes now

1. never      - sidecars will never be written (was the off option)

2. on import  - sidecars will always be written, (was the on option and will stay default)

3. after edit - sidecars will be written only if the user has done "any edit" on the image
                may that be changing any module, tag, metadata, geo location ...
                The user should be aware, that xmps will **not** be written while importing
                (even if there are modules activated automatically, metadata added, presets
                applied, tags set ...) until **any** further edit on the image has been done.
                So another import to darktable might have a different output if there is a
                different preset.

Basically this works as @phweyland had suggested, we don't check for any condition while writing
the sidecar but use the existing checks and make sure here, that sidecars will not be written in
- `_image_import_internal` and
- `dt_dev_read_history_ext` while in firstrun mode.

Further checks were necessary in darkrooms `dt_dev_change_image` and `leave`.
In both cases we look for unsynced mipmaps and if found we currently write a sidecar.
If there has been no edit so far this can be avoided in lazy mode, otherwise a sidecar would
be written whenever we open an image in darkroom to view it (even with out any edits).

Further tested showed written xmps because of `dt_image_set_aspect_ratio_if_different` fighting
with two problems: a) orientation is not checked correctly so 3/2 vs 2/3 as an example. b) For
some camera raws the number of pixels removed in rawprepare exceeds the margin of 0.1.

Anyway, the updated ratio does not need to be reflected in the sidecars at all.

For further discussion about my first two bad attempts and @phweyland commenting/suggesting
see #9568 and #9538. After more thinking the two lazy options are really not necessary.

Won't be available for the next days so lot's of time to review and maybe test.