### PR TITLE
cleanup: remove extraneous memset() calls

### DIFF
--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -148,14 +148,12 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   b->numslices = darktable.num_openmp_threads;
   b->sliceheight = (height + b->numslices - 1) / b->numslices;
   b->slicerows = (b->size_y + b->numslices - 1) / b->numslices + 2;
-  b->buf = dt_alloc_align_float(b->size_x * b->size_z * b->numslices * b->slicerows);
-  if (b->buf)
-  {
-    memset(b->buf, 0, sizeof(float) * b->size_x * b->size_z * b->numslices * b->slicerows);
-  }
-  else
+  b->buf = dt_calloc_align_float(b->size_x * b->size_z * b->numslices * b->slicerows);
+  if (!b->buf)
   {
     fprintf(stderr,"[bilateral] unable to allocate buffer for %lux%lux%lu grid\n",b->size_x,b->size_y,b->size_z);
+    free(b);
+    return NULL;
   }
   dt_print(DT_DEBUG_DEV, "[bilateral] created grid [%ld %ld %ld] with sigma (%f %f) (%f %f)\n",
            b->size_x, b->size_y, b->size_z, b->sigma_s, sigma_s, b->sigma_r, sigma_r);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -349,6 +349,12 @@ static inline float *dt_alloc_align_float(size_t pixels)
 {
   return (float*)__builtin_assume_aligned(dt_alloc_align(64, pixels * sizeof(float)), 64);
 }
+static inline float *dt_calloc_align_float(size_t pixels)
+{
+  float *const buf = (float*)dt_alloc_align(64, pixels * sizeof(float));
+  if(buf) memset(buf, 0, pixels * sizeof(float));
+  return (float*)__builtin_assume_aligned(buf, 64);
+}
 size_t dt_round_size(const size_t size, const size_t alignment);
 size_t dt_round_size_sse(const size_t size);
 

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -88,13 +88,13 @@ gboolean dt_iop_alloc_image_buffers(struct dt_iop_module_t *const module,
     if (size & DT_IMGSZ_PERTHREAD)
     {
       *bufptr = dt_alloc_perthread_float(nfloats,paddedsize);
-      if (size & DT_IMGSZ_CLEARBUF)
+      if ((size & DT_IMGSZ_CLEARBUF) && *bufptr)
         memset(*bufptr, 0, *paddedsize * dt_get_num_threads() * sizeof(float));
     }
     else
     {
       *bufptr = dt_alloc_align_float(nfloats);
-      if (size & DT_IMGSZ_CLEARBUF)
+      if ((size & DT_IMGSZ_CLEARBUF) && *bufptr)
         memset(*bufptr, 0, nfloats * sizeof(float));
     }
     if (!*bufptr)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2657,8 +2657,8 @@ static int _brush_get_area(const dt_iop_module_t *const module, const dt_dev_pix
 }
 
 /** we write a falloff segment */
-static void _brush_falloff(float **buffer, int *p0, int *p1, int posx, int posy, int bw, float hardness,
-                           float density)
+static void _brush_falloff(float *const restrict buffer, int p0[2], int p1[2], int posx, int posy, int bw,
+                           float hardness, float density)
 {
   // segment length
   const int l = sqrt((p1[0] - p0[0]) * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
@@ -2674,13 +2674,13 @@ static void _brush_falloff(float **buffer, int *p0, int *p1, int posx, int posy,
     const int x = (int)((float)i * lx / (float)l) + p0[0] - posx;
     const int y = (int)((float)i * ly / (float)l) + p0[1] - posy;
     const float op = density * ((i <= solid) ? 1.0f : 1.0 - (float)(i - solid) / (float)soft);
-    (*buffer)[y * bw + x] = MAX((*buffer)[y * bw + x], op);
+    buffer[y * bw + x] = MAX(buffer[y * bw + x], op);
     if(x > 0)
-      (*buffer)[y * bw + x - 1]
-          = MAX((*buffer)[y * bw + x - 1], op); // this one is to avoid gap due to int rounding
+      buffer[y * bw + x - 1]
+          = MAX(buffer[y * bw + x - 1], op); // this one is to avoid gap due to int rounding
     if(y > 0)
-      (*buffer)[(y - 1) * bw + x]
-          = MAX((*buffer)[(y - 1) * bw + x], op); // this one is to avoid gap due to int rounding
+      buffer[(y - 1) * bw + x]
+          = MAX(buffer[(y - 1) * bw + x], op); // this one is to avoid gap due to int rounding
   }
 }
 
@@ -2728,7 +2728,6 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
     dt_free_align(payload);
     return 0;
   }
-  memset(*buffer, 0, sizeof(float) * bufsize);
 
   // now we fill the falloff
   int p0[2], p1[2];
@@ -2740,7 +2739,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
     p1[0] = border[i * 2];
     p1[1] = border[i * 2 + 1];
 
-    _brush_falloff(buffer, p0, p1, *posx, *posy, *width, payload[i * 2], payload[i * 2 + 1]);
+    _brush_falloff(*buffer, p0, p1, *posx, *posy, *width, payload[i * 2], payload[i * 2 + 1]);
   }
 
   dt_free_align(points);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1815,7 +1815,6 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
     dt_free_align(points);
     return 0;
   }
-  memset(*buffer, 0, sizeof(float) * w * h);
 
   // we populate the buffer
   const int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
@@ -1957,9 +1956,6 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
   const int grid = CLAMP((10.0f * roi->scale + 2.0f) / 3.0f, 1, 4); // scale dependent resolution
   const int gw = (w + grid - 1) / grid + 1;  // grid dimension of total roi
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
-
-  // initialize output buffer with zero
-  memset(buffer, 0, sizeof(float) * w * h);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -593,12 +593,9 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
   const int height = roi->height;
   const size_t npixels = (size_t)width * height;
 
-  // we need to allocate a temporary buffer for intermediate creation of individual shapes
-  float *const restrict bufs = dt_alloc_align_float(npixels);
+  // we need to allocate a zeroed temporary buffer for intermediate creation of individual shapes
+  float *const restrict bufs = dt_calloc_align_float(npixels);
   if(bufs == NULL) return 0;
-
-  // empty the output buffer
-  memset(buffer, 0, sizeof(float) * npixels);
 
   // and we get all masks
   for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))

--- a/src/iop/equalizer_eaw.h
+++ b/src/iop/equalizer_eaw.h
@@ -34,9 +34,13 @@ static void dt_iop_equalizer_wtf(float *const buf, float **weight_a, const int l
   const int wd = (int)(1 + (width >> (l - 1))), ht = (int)(1 + (height >> (l - 1)));
   int ch = 0;
   // store weights for luma channel only, chroma uses same basis.
-  memset(weight_a[l], 0, sizeof(float) * wd * ht);
   for(int j = 0; j < ht - 1; j++)
+  {
     for(int i = 0; i < wd - 1; i++) weight_a[l][(size_t)j * wd + i] = gbuf(buf, i << (l - 1), j << (l - 1));
+    weight_a[l][j * wd + (wd - 1)] = 0.0f; // zero out right-most column
+  }
+  for(int i = 0; i < wd; i++) // zero out the bottom row
+    weight_a[l][(ht-1) * wd + i] = 0.0f;
 
   const int step = 1 << l;
   const int st = step / 2;


### PR DESCRIPTION
Following up on a recent removal of an unnecessary call to clear a buffer which gets written in its entirety anyway, I checked through the other occurrences of memset in the codebase, and found several more that proved to be extraneous.

I also added a new function `dt_calloc_align_float` which does the memset internally instead of requiring the caller to do so (and to remember to check for a NULL return from the allocation).  In one instance, that also resulted in a potential memory leak being fixed.

