### PR TITLE
InputNG: add keyboard shortcut icon

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2854,66 +2854,57 @@ void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 {
   PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, .07);
-
-  //arrow
-  cairo_move_to(cr, .65, .35);
-  cairo_line_to(cr, 1., 0.);
-  cairo_stroke(cr);
-  cairo_move_to(cr, .75, 0.);
-  cairo_line_to(cr, 1., 0.);
-  cairo_line_to(cr, 1., .25);
-  cairo_stroke(cr);
-
   //keyboard outline
   cairo_set_line_width(cr, .05);
   cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
 
-  cairo_move_to(cr, .5, .271);
-  cairo_line_to(cr, .1, .271);
-  cairo_line_to(cr, .1, .728);
-  cairo_line_to(cr, .9, .728);
-  cairo_line_to(cr, .9, .500);
+  cairo_move_to(cr, .9, .27);
+  cairo_line_to(cr, .1, .27);
+  cairo_line_to(cr, .1, .73);
+  cairo_line_to(cr, .9, .73);
+  cairo_line_to(cr, .9, .27);
 
   cairo_stroke(cr);
 
   //keyboard buttons
 
-  cairo_set_line_width(cr, .04);
+  const double cr_linewidth=.04;
+  const int toprow_keycount = 7;
+
+  cairo_set_line_width(cr, cr_linewidth);
   cairo_set_line_join(cr, CAIRO_LINE_JOIN_MITER);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
-  //top row
-  cairo_move_to(cr, .23, .386);
-  cairo_line_to(cr, .257, .386);
+  const double kheight = .73-.27;
+  const double kwidth = .9 - .1;
+  const double rspace = (kheight - cr_linewidth*3.)/4.;
+  const double keylength = (kwidth-(cr_linewidth*2.0))/((double)toprow_keycount+((double)toprow_keycount/0.9));
+  const double keyspace = keylength / 0.9;
+  const double spacelength = kwidth / 2.0;
 
-  cairo_move_to(cr, .33, .386);
-  cairo_line_to(cr, .357, .386);
+  // top row
+  double keyrowwidth = keylength * toprow_keycount + keyspace*(toprow_keycount-1);
+  double rowstartpos = .1 + (kwidth - keyrowwidth)/2;
+  for(int i=0; i < 7; i++)
+  {
+    cairo_move_to(cr, rowstartpos + i*(keylength+keyspace), .27+rspace+cr_linewidth);
+    cairo_line_to(cr, rowstartpos + i*(keylength+keyspace)+keylength, .27+rspace+cr_linewidth);
+  }
 
-  cairo_move_to(cr, .43, .386);
-  cairo_line_to(cr, .457, .386);
+  // middle row
+  keyrowwidth = keylength * (toprow_keycount-1) + keyspace*(toprow_keycount-2);
+  rowstartpos = .1 + (kwidth - keyrowwidth)/2;
+  for(int i=0; i < 6; i++)
+  {
+    cairo_move_to(cr, rowstartpos + i*(keylength+keyspace), .27+(rspace+cr_linewidth)*2);
+    cairo_line_to(cr, rowstartpos + i*(keylength+keyspace)+keylength, .27+(rspace+cr_linewidth)*2);
+  }
 
-  cairo_move_to(cr, .53, .386);
-  cairo_line_to(cr, .557, .386);
-
-  //middle row
-
-  cairo_move_to(cr, .293, .486);
-  cairo_line_to(cr, .320, .486);
-
-  cairo_move_to(cr, .393, .486);
-  cairo_line_to(cr, .420, .486);
-
-  cairo_move_to(cr, .493, .486);
-  cairo_line_to(cr, .520, .486);
-
-  cairo_move_to(cr, .593, .486);
-  cairo_line_to(cr, .620, .486);
-
-  //bottom (spacebar) row
-
-  cairo_move_to(cr, .314, .586);
-  cairo_line_to(cr, .687, .586);
+  // 3rd (space) row
+  keyrowwidth = spacelength;
+  rowstartpos = .1 + (kwidth - keyrowwidth)/2;
+  cairo_move_to(cr, rowstartpos , .27+(rspace+cr_linewidth)*3);
+  cairo_line_to(cr, rowstartpos + spacelength, .27+(rspace+cr_linewidth)*3);
 
   cairo_stroke(cr);
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2852,7 +2852,7 @@ void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 
 void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 0, 0)
+  PREAMBLE(1.15, 0, 0)
 
   //keyboard outline
   cairo_set_line_width(cr, .05);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2850,6 +2850,76 @@ void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   FINISH
 }
 
+void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_set_line_width(cr, .07);
+
+  //arrow
+  cairo_move_to(cr, .65, .35);
+  cairo_line_to(cr, 1., 0.);
+  cairo_stroke(cr);
+  cairo_move_to(cr, .75, 0.);
+  cairo_line_to(cr, 1., 0.);
+  cairo_line_to(cr, 1., .25);
+  cairo_stroke(cr);
+
+  //keyboard outline
+  cairo_set_line_width(cr, .05);
+  cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+
+  cairo_move_to(cr, .5, .271);
+  cairo_line_to(cr, .1, .271);
+  cairo_line_to(cr, .1, .728);
+  cairo_line_to(cr, .9, .728);
+  cairo_line_to(cr, .9, .500);
+
+  cairo_stroke(cr);
+
+  //keyboard buttons
+
+  cairo_set_line_width(cr, .04);
+  cairo_set_line_join(cr, CAIRO_LINE_JOIN_MITER);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+
+  //top row
+  cairo_move_to(cr, .23, .386);
+  cairo_line_to(cr, .257, .386);
+
+  cairo_move_to(cr, .33, .386);
+  cairo_line_to(cr, .357, .386);
+
+  cairo_move_to(cr, .43, .386);
+  cairo_line_to(cr, .457, .386);
+
+  cairo_move_to(cr, .53, .386);
+  cairo_line_to(cr, .557, .386);
+
+  //middle row
+
+  cairo_move_to(cr, .293, .486);
+  cairo_line_to(cr, .320, .486);
+
+  cairo_move_to(cr, .393, .486);
+  cairo_line_to(cr, .420, .486);
+
+  cairo_move_to(cr, .493, .486);
+  cairo_line_to(cr, .520, .486);
+
+  cairo_move_to(cr, .593, .486);
+  cairo_line_to(cr, .620, .486);
+
+  //bottom (spacebar) row
+
+  cairo_move_to(cr, .314, .586);
+  cairo_line_to(cr, .687, .586);
+
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -306,6 +306,10 @@ void dtgtk_cairo_paint_lt_mode_fullpreview(cairo_t *cr, gint x, gint y, gint w, 
 /** Paint a link icon for basic adjustments */
 void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
+
+/** Paint a shortcut icon for input ng */
+void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -494,7 +494,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(d->help_button, dt_get_help_url("global_toolbox_help"));
 
   /* create the preference button */
-  d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_bracket, CPF_STYLE_FLAT, NULL);
+  d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), d->keymap_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->keymap_button, _("define shortcuts\n"
                                                   "hover over a widget and press keys with mouse click and scroll or move combinations\n"


### PR DESCRIPTION
ref #9483

this proposes an icon that looks like in the screenshot below

![obraz](https://user-images.githubusercontent.com/10687765/127740955-db10107a-4bcf-449e-b1f6-51f63f3d4156.png)

I think the cairo code (and the icon) needs some tweaks but IMO it's rather good for conveying what it does :)

// EDIT:

new, arrowless look:

![obraz](https://user-images.githubusercontent.com/10687765/127779722-2d6f05e7-fcb0-4d59-9a26-ac8da526e6ee.png)
