### PR TITLE
colorbalancergb: optimization, improve vectorization

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -361,42 +361,37 @@ static inline float4 sRGB_to_XYZ(float4 sRGB)
 
 static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
 {
-  const float4 M[3] = { { 0.41478972f, 0.579999f, 0.0146480f, 0.0f },
-                        { -0.2015100f, 1.120649f, 0.0531008f, 0.0f },
-                        { -0.0166008f, 0.264800f, 0.6684799f, 0.0f } };
-
+  const float4 K[3] = {
+    { 0.674207838e-4f, 0.38279934e-4f, -0.047570458e-4f, 0.f },
+    { 0.14928416e-4f,  0.73962834e-4f,  0.0833273e-4f,   0.f },
+    { 0.07094108e-4f,  0.174768e-4f,    0.67097002e-4f,  0.f },
+  };
   const float4 A[3] = { { 0.5f, 0.5f, 0.0f, 0.0f },
                         { 3.524000f, -4.066708f, 0.542708f, 0.0f },
                         { 0.199076f, 1.096799f, -1.295875f, 0.0f } };
 
   float4 temp1, temp2;
-  // XYZ -> X'Y'Z
-  temp1.x = 1.15f * XYZ_D65.x - 0.15f * XYZ_D65.z;
-  temp1.y = 0.66f * XYZ_D65.y + 0.34f * XYZ_D65.x;
-  temp1.z = XYZ_D65.z;
+  // XYZ -> LMS
+  temp1.x = dot(K[0], XYZ_D65);
+  temp1.y = dot(K[1], XYZ_D65);
+  temp1.z = dot(K[2], XYZ_D65);
   temp1.w = 0.f;
-  // X'Y'Z -> LMS
-  temp2.x = dot(M[0], temp1);
-  temp2.y = dot(M[1], temp1);
-  temp2.z = dot(M[2], temp1);
-  temp2.w = 0.f;
   // LMS -> L'M'S'
-  temp2 = native_powr(fmax(temp2 / 10000.f, 0.0f), 0.159301758f);
-  temp2 = native_powr((0.8359375f + 18.8515625f * temp2) / (1.0f + 18.6875f * temp2), 134.034375f);
+  temp1 = native_powr(fmax(temp1, 0.0f), 0.159301758f);
+  temp1 = native_powr((0.8359375f + 18.8515625f * temp1) / (1.0f + 18.6875f * temp1), 134.034375f);
   // L'M'S' -> Izazbz
-  temp1.x = dot(A[0], temp2);
-  temp1.y = dot(A[1], temp2);
-  temp1.z = dot(A[2], temp2);
+  temp2.x = dot(A[0], temp1);
+  temp2.y = dot(A[1], temp1);
+  temp2.z = dot(A[2], temp1);
+  temp2.w = 0.f;
   // Iz -> Jz
-  temp1.x = fmax(0.44f * temp1.x / (1.0f - 0.56f * temp1.x) - 1.6295499532821566e-11f, 0.f);
-  return temp1;
+  temp2.x = fmax(0.44f * temp2.x / (1.0f - 0.56f * temp2.x) - 1.6295499532821566e-11f, 0.f);
+  return temp2;
 }
 
 
 static inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
 {
-  const float b = 1.15f;
-  const float g = 0.66f;
   const float c1 = 0.8359375f; // 3424 / 2^12
   const float c2 = 18.8515625f; // 2413 / 2^7
   const float c3 = 18.6875f; // 2392 / 2^7
@@ -404,18 +399,21 @@ static inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
   const float p_inv = 1.0f / 134.034375f; // 1.7 x 2523 / 2^5
   const float d = -0.56f;
   const float d0 = 1.6295499532821566e-11f;
-  const float4 MI[3] = { {  1.9242264357876067f, -1.0047923125953657f,  0.0376514040306180f, 0.0f },
-                         {  0.3503167620949991f,  0.7264811939316552f, -0.0653844229480850f, 0.0f },
-                         { -0.0909828109828475f, -0.3127282905230739f,  1.5227665613052603f, 0.0f } };
+  const float4 KI[3] = {
+    {  1.6613730558e4f, -0.9145230923e4f,  0.2313620767e4f, 0.f },
+    { -0.325075874e4f,   1.5718470384e4f, -0.2182538319e4f, 0.f },
+    { -0.090982811e4f,  -0.3127282905e4f,  1.5227665613e4f, 0.f },
+  };
   const float4 AI[3] = { {  1.0f,  0.1386050432715393f,  0.0580473161561189f, 0.0f },
                          {  1.0f, -0.1386050432715393f, -0.0580473161561189f, 0.0f },
                          {  1.0f, -0.0960192420263190f, -0.8118918960560390f, 0.0f } };
 
-  float4 XYZ, LMS, IzAzBz;
+  float4 XYZ_D65, LMS, IzAzBz;
   // Jz -> Iz
   IzAzBz = JzAzBz;
   IzAzBz.x += d0;
   IzAzBz.x = fmax(IzAzBz.x / (1.0f + d - d * IzAzBz.x), 0.f);
+  IzAzBz.w = 0.f;
   // IzAzBz -> L'M'S'
   LMS.x = dot(AI[0], IzAzBz);
   LMS.y = dot(AI[1], IzAzBz);
@@ -423,17 +421,11 @@ static inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
   LMS.w = 0.f;
   // L'M'S' -> LMS
   LMS = native_powr(fmax(LMS, 0.0f), p_inv);
-  LMS = 10000.f * native_powr(fmax((c1 - LMS) / (c3 * LMS - c2), 0.0f), n_inv);
-  // LMS -> X'Y'Z
-  XYZ.x = dot(MI[0], LMS);
-  XYZ.y = dot(MI[1], LMS);
-  XYZ.z = dot(MI[2], LMS);
-  XYZ.w = 0.f;
-  // X'Y'Z -> XYZ_D65
-  float4 XYZ_D65;
-  XYZ_D65.x = (XYZ.x + (b - 1.0f) * XYZ.z) / b;
-  XYZ_D65.y = (XYZ.y + (g - 1.0f) * XYZ_D65.x) / g;
-  XYZ_D65.z = XYZ.z;
+  LMS = native_powr(fmax((c1 - LMS) / (c3 * LMS - c2), 0.0f), n_inv);
+  // LMS -> XYZ_D65
+  XYZ_D65.x = dot(KI[0], LMS);
+  XYZ_D65.y = dot(KI[1], LMS);
+  XYZ_D65.z = dot(KI[2], LMS);
   XYZ_D65.w = JzAzBz.w;
   return XYZ_D65;
 }

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -350,20 +350,20 @@ static inline void XYZ_adapt_D50(const dt_aligned_pixel_t lms_in,
 
 /* Pre-solved matrices to adjust white point for triplets in CIE XYZ 1931 2° observer */
 
-const dt_colormatrix_t XYZ_D50_to_D65_CAT16
-    = { { 9.89466254e-01f, -4.00304626e-02f, 4.40530317e-02f, 0.f },
-        { -5.40518733e-03f, 1.00666069e+00f, -1.75551955e-03f, 0.f },
-        { -4.03920992e-04f, 1.50768030e-02f, 1.30210211e+00f, 0.f } };
+const dt_colormatrix_t XYZ_D50_to_D65_CAT16_transposed
+    = { {  9.89466254e-01f, -5.40518733e-03f, -4.03920992e-04f, 0.f },
+        { -4.00304626e-02f,  1.00666069e+00f,  1.50768030e-02f, 0.f },
+        {  4.40530317e-02f, -1.75551955e-03f,  1.30210211e+00f, 0.f } };
 
 const dt_colormatrix_t XYZ_D50_to_D65_Bradford
     = { { 0.95547342f, -0.02309845f, 0.06325924f, 0.f },
         { -0.02836971f, 1.00999540f, 0.02104144f, 0.f },
         { 0.01231401f, -0.02050765f, 1.33036593f, 0.f } };
 
-const dt_colormatrix_t XYZ_D65_to_D50_CAT16
-    = { { 1.01085433e+00f, 4.07086103e-02f, -3.41445825e-02f, 0.f },
-        { 5.42814201e-03f, 9.93581926e-01f, 1.15592039e-03f, 0.f },
-        { 2.50722468e-04f, -1.14918759e-02f, 7.67964947e-01f, 0.f } };
+const dt_colormatrix_t XYZ_D65_to_D50_CAT16_transposed
+    = { {  1.01085433e+00f, 5.42814201e-03f,  2.50722468e-04f, 0.f },
+        {  4.07086103e-02f, 9.93581926e-01f, -1.14918759e-02f, 0.f },
+        { -3.41445825e-02f, 1.15592039e-03f,  7.67964947e-01f, 0.f } };
 
 const dt_colormatrix_t XYZ_D65_to_D50_Bradford
     = { { 1.04792979f, 0.02294687f, -0.05019227f, 0.f },
@@ -375,7 +375,7 @@ const dt_colormatrix_t XYZ_D65_to_D50_Bradford
 #endif
 static inline void XYZ_D50_to_D65(const dt_aligned_pixel_t XYZ_in, dt_aligned_pixel_t XYZ_out)
 {
-  dot_product(XYZ_in, XYZ_D50_to_D65_CAT16, XYZ_out);
+  dt_apply_transposed_color_matrix(XYZ_in, XYZ_D50_to_D65_CAT16_transposed, XYZ_out);
 }
 
 #ifdef _OPENMP
@@ -383,5 +383,5 @@ static inline void XYZ_D50_to_D65(const dt_aligned_pixel_t XYZ_in, dt_aligned_pi
 #endif
 static inline void XYZ_D65_to_D50(const dt_aligned_pixel_t XYZ_in, dt_aligned_pixel_t XYZ_out)
 {
-  dot_product(XYZ_in, XYZ_D65_to_D50_CAT16, XYZ_out);
+  dt_apply_transposed_color_matrix(XYZ_in, XYZ_D65_to_D50_CAT16_transposed, XYZ_out);
 }

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1022,15 +1022,15 @@ static inline void dt_JzAzBz_2_XYZ(const dt_aligned_pixel_t JzAzBz, dt_aligned_p
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-static const dt_colormatrix_t XYZ_D65_to_LMS_2006_D65
-    = { { 0.257085f, 0.859943f, -0.031061f, 0.f },
-        { -0.394427f, 1.175800f, 0.106423f, 0.f },
-        { 0.064856f, -0.076250f, 0.559067f, 0.f } };
+static const dt_colormatrix_t XYZ_D65_to_LMS_2006_D65_transposed
+    = { {  0.257085f, -0.394427f,  0.064856f, 0.f },
+        {  0.859943f,  1.175800f, -0.076250f, 0.f },
+        { -0.031061f,  0.106423f,  0.559067f, 0.f } };
 
-static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65
-    = { { 1.80794659f, -1.29971660f, 0.34785879f, 0.f },
-        { 0.61783960f, 0.39595453f, -0.04104687f, 0.f },
-        { -0.12546960f, 0.20478038f, 1.74274183f, 0.f } };
+static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65_transposed
+    = { {  1.80794659f,  0.61783960f, -0.12546960f, 0.f },
+        { -1.29971660f,  0.39595453f,  0.20478038f, 0.f },
+        {  0.34785879f, -0.04104687f,  1.74274183f, 0.f } };
 
 
 #ifdef _OPENMP
@@ -1038,7 +1038,7 @@ static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65
 #endif
 static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
-  dot_product(XYZ, XYZ_D65_to_LMS_2006_D65, LMS);
+  dt_apply_transposed_color_matrix(XYZ, XYZ_D65_to_LMS_2006_D65_transposed, LMS);
 }
 
 #ifdef _OPENMP
@@ -1046,7 +1046,7 @@ static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t L
 #endif
 static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
-  dot_product(LMS, LMS_2006_D65_to_XYZ_D65, XYZ);
+  dt_apply_transposed_color_matrix(LMS, LMS_2006_D65_to_XYZ_D65_transposed, XYZ);
 }
 
 /*
@@ -1056,22 +1056,22 @@ static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t X
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-static const dt_colormatrix_t filmlightRGB_D65_to_LMS_D65
-    = { { 0.95f, 0.38f, 0.00f, 0.f },
-        { 0.05f, 0.62f, 0.03f, 0.f },
-        { 0.00f, 0.00f, 0.97f, 0.f } };
+static const dt_colormatrix_t filmlightRGB_D65_to_LMS_D65_transposed
+    = { { 0.95f, 0.05f, 0.00f, 0.f },
+        { 0.38f, 0.62f, 0.00f, 0.f },
+        { 0.00f, 0.03f, 0.97f, 0.f } };
 
-static const dt_colormatrix_t LMS_D65_to_filmlightRGB_D65
-    = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
-        { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
-        {         0.f,          0.f,  1.03092784f, 0.f } };
+static const dt_colormatrix_t LMS_D65_to_filmlightRGB_D65_transposed
+    = { {  1.0877193f,  -0.0877193f,  0.f,         0.f },
+        { -0.66666667f,  1.66666667f, 0.f,         0.f },
+        {  0.02061856f, -0.05154639f, 1.03092784f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
 static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t LMS)
 {
-  dot_product(RGB, filmlightRGB_D65_to_LMS_D65, LMS);
+  dt_apply_transposed_color_matrix(RGB, filmlightRGB_D65_to_LMS_D65_transposed, LMS);
 }
 
 #ifdef _OPENMP
@@ -1079,7 +1079,7 @@ static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pi
 #endif
 static inline void LMS_to_gradingRGB(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB)
 {
-  dot_product(LMS, LMS_D65_to_filmlightRGB_D65, RGB);
+  dt_apply_transposed_color_matrix(LMS, LMS_D65_to_filmlightRGB_D65_transposed, RGB);
 }
 
 

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1097,11 +1097,11 @@ static inline void LMS_to_Yrg(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t Y
 
   // normalize LMS
   const float a = LMS[0] + LMS[1] + LMS[2];
-  dt_aligned_pixel_t lms = { 0.f };
+  dt_aligned_pixel_t lms;
   for_each_channel(c, aligned(LMS, lms : 16)) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
 
   // convert to Filmlight rgb (normalized)
-  dt_aligned_pixel_t rgb = { 0.f };
+  dt_aligned_pixel_t rgb;
   LMS_to_gradingRGB(lms, rgb);
 
   Yrg[0] = Y;
@@ -1123,7 +1123,7 @@ static inline void Yrg_to_LMS(const dt_aligned_pixel_t Yrg, dt_aligned_pixel_t L
   const dt_aligned_pixel_t rgb = { r, g, b, 0.f };
 
   // convert to lms (normalized)
-  dt_aligned_pixel_t lms = { 0.f };
+  dt_aligned_pixel_t lms;
   gradingRGB_to_LMS(rgb, lms);
 
   // denormalize to LMS

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -937,7 +937,7 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
   for(int i = 0; i < 3; i++)
   {
     LMS[i] = M[i][0] * XYZ[0] + M[i][1] * XYZ[1] + M[i][2] * XYZ[2];
-    LMS[i] = powf(fmaxf(LMS[i] / 10000.f, 0.0f), n);
+    LMS[i] = powf(MAX(LMS[i] / 10000.f, 0.0f), n);
     LMS[i] = powf((c1 + c2 * LMS[i]) / (1.0f + c3 * LMS[i]), p);
   }
 
@@ -945,7 +945,7 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
   for_each_channel(c)
     JzAzBz[c] = A_transposed[0][c] * LMS[0] + A_transposed[1][c] * LMS[1] + A_transposed[2][c] * LMS[2];
   // Iz -> Jz
-  JzAzBz[0] = fmaxf(((1.0f + d) * JzAzBz[0]) / (1.0f + d * JzAzBz[0]) - d0, 0.f);
+  JzAzBz[0] = MAX(((1.0f + d) * JzAzBz[0]) / (1.0f + d * JzAzBz[0]) - d0, 0.f);
 }
 
 #ifdef _OPENMP
@@ -999,7 +999,7 @@ static inline void dt_JzAzBz_2_XYZ(const dt_aligned_pixel_t JzAzBz, dt_aligned_p
   dt_aligned_pixel_t IzAzBz = { 0.0f, 0.0f, 0.0f, 0.0f };
 
   IzAzBz[0] = JzAzBz[0] + d0;
-  IzAzBz[0] = fmaxf(IzAzBz[0] / (1.0f + d - d * IzAzBz[0]), 0.f);
+  IzAzBz[0] = MAX(IzAzBz[0] / (1.0f + d - d * IzAzBz[0]), 0.f);
   IzAzBz[1] = JzAzBz[1];
   IzAzBz[2] = JzAzBz[2];
 
@@ -1010,8 +1010,8 @@ static inline void dt_JzAzBz_2_XYZ(const dt_aligned_pixel_t JzAzBz, dt_aligned_p
   for(int i = 0; i < 3; i++)
   {
     LMS[i] = AI[i][0] * IzAzBz[0] + AI[i][1] * IzAzBz[1] + AI[i][2] * IzAzBz[2];
-    LMS[i] = powf(fmaxf(LMS[i], 0.0f), p_inv);
-    LMS[i] = 10000.f * powf(fmaxf((c1 - LMS[i]) / (c3 * LMS[i] - c2), 0.0f), n_inv);
+    LMS[i] = powf(MAX(LMS[i], 0.0f), p_inv);
+    LMS[i] = 10000.f * powf(MAX((c1 - LMS[i]) / (c3 * LMS[i] - c2), 0.0f), n_inv);
   }
 
   // LMS -> X'Y'Z

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1110,7 +1110,7 @@ static inline void LMS_to_Yrg(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t Y
   // normalize LMS
   const float a = LMS[0] + LMS[1] + LMS[2];
   dt_aligned_pixel_t lms = { 0.f };
-  for_four_channels(c, aligned(LMS, lms : 16)) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
+  for_each_channel(c, aligned(LMS, lms : 16)) lms[c] = (a == 0.f) ? 0.f : LMS[c] / a;
 
   // convert to Filmlight rgb (normalized)
   dt_aligned_pixel_t rgb = { 0.f };
@@ -1141,7 +1141,7 @@ static inline void Yrg_to_LMS(const dt_aligned_pixel_t Yrg, dt_aligned_pixel_t L
   // denormalize to LMS
   const float denom = (0.68990272f * lms[0] + 0.34832189f * lms[1]);
   const float a = (denom == 0.f) ? 0.f : Y / denom;
-  for_four_channels(c, aligned(lms, LMS:16)) LMS[c] = lms[c] * a;
+  for_each_channel(c, aligned(lms, LMS:16)) LMS[c] = lms[c] * a;
 }
 
 /*

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -73,6 +73,13 @@ typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
   for (size_t _var = 0; _var < 4; _var++)
 #endif
 
+// A macro for loops which process all the three (color) channels of a pixel, when the loop body is not
+// vectorizable. Examples include some math library calls such as powf(), logf() (at least when
+// the -ffinite-math-only optimization is disabled). This can be used in such cases to save the fourth
+// unnecessary iteration.
+#define for_three_channels(_var) \
+  for (size_t _var = 0; _var < 3; _var++)
+
 // transpose a padded 3x3 matrix
 static inline void transpose_3xSSE(const dt_colormatrix_t input, dt_colormatrix_t output)
 {

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -535,7 +535,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_aligned_pixel_t Yrg = { 0.f };
 
     // clip pipeline RGB
-    for_four_channels(c, aligned(pix_in:16)) RGB[c] = fmaxf(pix_in[c], 0.0f);
+    for_each_channel(c, aligned(pix_in:16)) RGB[c] = fmaxf(pix_in[c], 0.0f);
 
     // go to CIE 2006 LMS D65
     dot_product(RGB, input_matrix, LMS);
@@ -610,7 +610,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     LMS_to_gradingRGB(LMS, RGB);
 
     // Color balance
-    for_four_channels(c, aligned(RGB, opacities, opacities_comp, global, shadows, midtones, highlights:16))
+    for_each_channel(c, aligned(RGB, opacities, opacities_comp, global, shadows, midtones, highlights:16))
     {
       // global : offset
       RGB[c] += global[c];
@@ -733,24 +733,24 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       dt_aligned_pixel_t color;
       if(i % checker_1 < i % checker_2)
       {
-        if(j % checker_1 < j % checker_2) for_four_channels(c) color[c] = d->checker_color_2[c];
-        else for_four_channels(c) color[c] = d->checker_color_1[c];
+        if(j % checker_1 < j % checker_2) for_each_channel(c) color[c] = d->checker_color_2[c];
+        else for_each_channel(c) color[c] = d->checker_color_1[c];
       }
       else
       {
-        if(j % checker_1 < j % checker_2) for_four_channels(c) color[c] = d->checker_color_1[c];
-        else for_four_channels(c) color[c] = d->checker_color_2[c];
+        if(j % checker_1 < j % checker_2) for_each_channel(c) color[c] = d->checker_color_1[c];
+        else for_each_channel(c) color[c] = d->checker_color_2[c];
       }
 
       float opacity = opacities[g->mask_type];
       const float opacity_comp = 1.0f - opacity;
 
-      for_four_channels(c, aligned(pix_out, color:16)) pix_out[c] = opacity_comp * color[c] + opacity * fmaxf(pix_out[c], 0.f);
+      for_each_channel(c, aligned(pix_out, color:16)) pix_out[c] = opacity_comp * color[c] + opacity * fmaxf(pix_out[c], 0.f);
       pix_out[3] = 1.0f; // alpha is opaque, we need to preview it
     }
     else
     {
-      for_four_channels(c, aligned(pix_out:16)) pix_out[c] = fmaxf(pix_out[c], 0.f);
+      for_each_channel(c, aligned(pix_out:16)) pix_out[c] = fmaxf(pix_out[c], 0.f);
       pix_out[3] = pix_in[3]; // alpha copy
     }
   }

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -416,35 +416,22 @@ static inline float lookup_gamut(const float *const gamut_lut, const float x)
   // WARNING : x should be between [-pi ; pi ], which is the default output of atan2 anyway
 
   // convert in LUT coordinate
-  const float x_test = (LUT_ELEM - 1) * (x + M_PI_F) / (2.f * M_PI_F);
-
-  // find the 2 closest integer coordinates (next/previous)
-  float x_prev = floorf(x_test);
-  float x_next = ceilf(x_test);
+  const float angle = x + DT_M_PI_F;
+  const float x_test = angle * (LUT_ELEM - 1) / (2.f * DT_M_PI_F);
+  const float x_prev = fmaxf(floorf(x_test), 0.f);
 
   // get the 2 closest LUT elements at integer coordinates
   // cycle on the hue ring if out of bounds
-  int xi = (int)x_prev;
-  if(xi < 0) xi = LUT_ELEM - 1;
-  else if(xi > LUT_ELEM - 1) xi = 0;
-
-  int xii = (int)x_next;
-  if(xii < 0) xii = LUT_ELEM - 1;
-  else if(xii > LUT_ELEM - 1) xii = 0;
+  const size_t xi = x_prev;
+  const size_t xii = xi == LUT_ELEM - 1 ? 0 : xi + 1;
 
   // fetch the corresponding y values
   const float y_prev = gamut_lut[xi];
   const float y_next = gamut_lut[xii];
 
-  // assume that we are exactly on an integer LUT element
-  float out = y_prev;
+  const float delta_x = x_test - x_prev;
 
-  if(x_next != x_prev)
-    // we are between 2 LUT elements : do linear interpolation
-    // actually, we only add the slope term on the previous one
-    out += (x_test - x_prev) * (y_next - y_prev) / (x_next - x_prev);
-
-  return out;
+  return (1.f - delta_x) * y_prev + delta_x * y_next;
 }
 
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -520,10 +520,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float *const restrict pix_in = __builtin_assume_aligned(in + k, 16);
     float *const restrict pix_out = __builtin_assume_aligned(out + k, 16);
 
-    dt_aligned_pixel_t XYZ_D65 = { 0.f };
-    dt_aligned_pixel_t LMS = { 0.f };
-    dt_aligned_pixel_t RGB = { 0.f };
-    dt_aligned_pixel_t Yrg = { 0.f };
+    dt_aligned_pixel_t XYZ_D65, LMS, RGB, Yrg, Jab;
 
     // clip pipeline RGB
     for_each_channel(c, aligned(pix_in:16)) RGB[c] = MAX(pix_in[c], 0.0f);
@@ -642,7 +639,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     LMS_to_XYZ(LMS, XYZ_D65);
 
     // Perceptual color adjustments
-    dt_aligned_pixel_t Jab = { 0.f };
     dt_XYZ_2_JzAzBz(XYZ_D65, Jab);
 
     // Convert to JCh


### PR DESCRIPTION
In an effort to speed up Color balance RGB, I took on a couple of low-hanging fixes / improvements to the pixel loop in `process()`, hoping it would allow modern compilers to vectorize the code. Currently Color balance RGB takes a significant portion of time compared to other modules typically present in a scene-referred workflow (on CPU) – 2.3 seconds compared to a total processing time of 3.6 seconds. GPU version is fine as-is.

```
$ darktable-cli images/mire1.cr2 0083-colorbalancergb/colorbalancergb.xmp output.png --core -d perf --disable-opencl
output file already exists, it will get renamed
1.724157 [dev] took 0.161 secs (0.139 CPU) to load the image.
1.851654 [export] creating pixelpipe took 0.124 secs (0.387 CPU)
1.851755 [dev_pixelpipe] took 0.000 secs (0.000 CPU) initing base buffer [export]
1.865977 [dev_pixelpipe] took 0.014 secs (0.032 CPU) processed `raw black/white point' on CPU, blended on CPU [export]
1.880293 [dev_pixelpipe] took 0.014 secs (0.027 CPU) processed `white balance' on CPU, blended on CPU [export]
1.885870 [dev_pixelpipe] took 0.006 secs (0.021 CPU) processed `highlight reconstruction' on CPU, blended on CPU [export]
2.027324 [dev_pixelpipe] took 0.141 secs (0.497 CPU) processed `demosaic' on CPU, blended on CPU [export]
2.062370 [dev_pixelpipe] took 0.035 secs (0.065 CPU) processed `exposure' on CPU, blended on CPU [export]
2.097796 [dev_pixelpipe] took 0.035 secs (0.134 CPU) processed `input color profile' on CPU, blended on CPU [export]
image colorspace transform Lab-->RGB took 0.046 secs (0.168 CPU) [channelmixerrgb ]
2.692354 [dev_pixelpipe] took 0.595 secs (2.314 CPU) processed `color calibration' on CPU, blended on CPU [export]
4.989018 [dev_pixelpipe] took 2.297 secs (9.015 CPU) processed `color balance rgb' on CPU, blended on CPU [export]
5.319613 [dev_pixelpipe] took 0.331 secs (1.271 CPU) processed `filmic rgb' on CPU, blended on CPU [export]
image colorspace transform RGB-->Lab took 0.036 secs (0.136 CPU) [colorout ]
5.427945 [dev_pixelpipe] took 0.108 secs (0.414 CPU) processed `output color profile' on CPU, blended on CPU [export]
5.489746 [dev_pixelpipe] took 0.062 secs (0.233 CPU) processed `display encoding' on CPU, blended on CPU [export]
5.489868 [dev_process_export] pixel pipeline processing took 3.638 secs (14.032 CPU)
```

Here's roughly what was done so far:

* Remove roundtrip `Yrg -> Ych -> test conversion to Yrg -> actual conversion to Yrg`. Instead perform hue rotation by linear algebra in `Yrg` and eliminate the test conversion in the gamut mapping phase. Usage of trigonometric functions is entirely eliminated in this phase of the calculations.
* Also eliminate explicit computation of sines and cosines elsewhere. This is nice since there is a potentially faster way to get the angles and also it should be easier to auto-vectorize (no need to call a vector math library)
* Remove branching from the gamut lookup routine (which is essentially a linear interpolation of a look-up table with wrapping at the edges). simplifying the control flow
* Replace `hypotf(x, y)` by `sqrtf(x*x + y*y)` – we don't need `hypotf()`'s handling of overflow here, and we avoid a slow library call – `sqrtf()` can probably be calculated using native instructions

These are all worthwhile changes alone, in my opinion, and are included here as separate commits. They make the code a bit faster, although nothing drastic (proper measurements to be done). However, as I was aiming at getting the whole pixel loop to an auto-vectorizable state, I also replaced the remaining calls to `atan2f()` by a custom branchless polynomial approximation. According to experiments in godbolt, neither GCC nor Clang seem to auto-vectorize `atan2f()` calls even if linking with a vector math library (`libmvec`, in a recent Clang version use `-fveclib=libmvec`).

With clang I'm indeed able to get the pixel loop auto-vectorized – well, almost. Two things that are preventing auto-vectorization are the lookup `opacities[g->mask_type]` in mask drawing, and the gamut LUT lookup. If I replace these with some dummy assignment, the loop auto-vectorizes and executes quite a bit faster than the non-vectorized version (a factor of 2-3). These dummy changes are included in the last commit along with notes. However, I couldn't find a way so far to convince Clang that there's no pointer aliasing taking place here (vectorization is failing with message `cannot identify array bounds`). @ralfbrown has done a bunch of nice work regarding auto-vectorization recently – would you like to have a look at this?

There's also the challenge of choosing a good optimization strategy. I'm not sure trying to get the whole loop to auto-vectorize is the best strategy – after all there are some operations in the loop that are naturally vectorized within one pixel: several `for_four_channels()` loops and `dot_product()`s at least. In other parts, individual channels of `Yrg` and `JzAzBz` are processed in a scalar-like manner and would benefit from vectorization, processing several pixels at a time. In principle the pixel loop could be split in several parts with different vectorization accordingly, but then one would have to allocate memory to store the `opacities[]` array that is calculated early in the processing.

Any help and comments are appreciated here. :)