### PR TITLE
performance: fast hypotf()

### DIFF
--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -45,8 +45,8 @@ static inline float laplacian(const float *const image, const size_t index[8])
 {
   // Compute the magnitude of the gradient over the principal directions,
   // then again over the diagonal directions, and average both.
-  const float l1 = hypotf(image[index[4]] - image[index[3]], image[index[6]] - image[index[1]]);
-  const float l2 = hypotf(image[index[7]] - image[index[0]], image[index[5]] - image[index[2]]);
+  const float l1 = dt_fast_hypotf(image[index[4]] - image[index[3]], image[index[6]] - image[index[1]]);
+  const float l2 = dt_fast_hypotf(image[index[7]] - image[index[0]], image[index[5]] - image[index[2]]);
   //const float div = fabsf(image[index[3]] + image[index[4]] + image[index[1]] + image[index[6]] - 4.0f * image[index[3] + 1]) + 1.0f;
 
   // we assume the gradients follow an hyper-laplacian distributions in natural images,

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -588,7 +588,7 @@ static inline float CCT_reverse_lookup(const float x, const float y)
       CCT_to_xy_blackbody(T, &x_bb, &y_bb);
 
     // Compute distance between current planckian chromaticity and input
-    const pair radius_tmp = { hypotf((x_bb - x), (y_bb - y)), T };
+    const pair radius_tmp = { dt_fast_hypotf((x_bb - x), (y_bb - y)), T };
 
     // If we found a smaller radius, save it
     min_radius = pair_min(min_radius, radius_tmp);

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -244,7 +244,7 @@ union float_int {
 #endif
 static inline float dt_fast_hypotf(const float x, const float y)
 {
-  return sqrtf(x * x + y + y);
+  return sqrtf(x * x + y * y);
 }
 
 // fast approximation of expf()

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -238,6 +238,15 @@ union float_int {
   int k;
 };
 
+// a faster, vectorizable version of hypotf() when we know that there won't be overflow, NaNs, or infinities
+#ifdef _OPENMP
+#pragma omp declare simd 
+#endif
+static inline float dt_fast_hypotf(const float x, const float y)
+{
+  return sqrtf(x * x + y + y);
+}
+
 // fast approximation of expf()
 /****** if you change this function, you need to make the same change in data/kernels/{basecurve,basic}.cl ***/
 #ifdef _OPENMP

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -980,12 +980,12 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     const float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
 
-    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
 
     float pts2[8] = { xref, yref, x , y, xref+10.0f, yref, xref, yref+10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if (check_angle < 0)
@@ -1230,12 +1230,12 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
 
     const float pts[8] = { xref, yref, x, y, 0, 0, gui->dx, gui->dy };
 
-    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
 
     float pts2[8] = { xref, yref, x, y, xref + 10.0f, yref, xref, yref + 10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if(check_angle < 0)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -260,7 +260,7 @@ static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, fl
   // in the correct direction as dragged. We test for this by checking the
   // angle between two vectors that should be 90 degrees apart. If the angle
   // is -90 degrees, then the image is flipped.
-  float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2(pts[5] - pts[1], pts[4] - pts[0]);
+  float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2f(pts[5] - pts[1], pts[4] - pts[0]);
   // Normalize to the range -180 to 180 degrees
   check_angle = atan2f(sinf(check_angle), cosf(check_angle));
   if(check_angle < 0.0f) rot -= M_PI;
@@ -359,7 +359,7 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
 
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if (check_angle < 0)
@@ -521,7 +521,7 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     float pts2[8] = { xref, yref, x, y, xref + 10.0f, yref, xref, yref + 10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if(check_angle < 0.0f)

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -191,7 +191,7 @@ static inline void create_lens_kernel(float *const restrict buffer,
       const float y = (float)(j - 1) / radius - 1;
 
       // get current radial distance from kernel center
-      const float r = hypotf(x, y);
+      const float r = dt_fast_hypotf(x, y);
 
       // get the radial distance at current angle of the shape envelope
       const float M = cosf((2.f * asinf(k) + M_PI_F * m) / (2.f * n))

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -908,7 +908,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
 
       // Shift the chromaticity plane so the D50 point (target) becomes the origin
       const float D50[2] = { 0.34567f, 0.35850f };
-      const float norm = hypotf(D50[0], D50[1]);
+      const float norm = dt_fast_hypotf(D50[0], D50[1]);
 
       temp[index    ] = (XYZ[0] - D50[0]) / norm;
       temp[index + 1] = (XYZ[1] - D50[1]) / norm;
@@ -1022,7 +1022,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
   }
 
   const float D50[2] = { 0.34567f, 0.35850 };
-  const float norm_D50 = hypotf(D50[0], D50[1]);
+  const float norm_D50 = dt_fast_hypotf(D50[0], D50[1]);
 
   for(size_t c = 0; c < 2; c++)
     xyz[c] = norm_D50 * (xyY[c] / elements) + D50[c];
@@ -1114,14 +1114,14 @@ static void check_if_close_to_daylight(const float x, const float y, float *temp
   xy_to_uv(xy_test, uv_test);
 
   // Compute the error between the reference illuminant and the test illuminant derivated from the CCT with daylight model
-  const float delta_daylight = hypotf((uv_test[0] - uv_ref[0]), (uv_test[1] - uv_ref[1]));
+  const float delta_daylight = dt_fast_hypotf((uv_test[0] - uv_ref[0]), (uv_test[1] - uv_ref[1]));
 
   // Compute the test chromaticity from the blackbody model
   illuminant_to_xy(DT_ILLUMINANT_BB, NULL, NULL, &xy_test[0], &xy_test[1], t, DT_ILLUMINANT_FLUO_LAST, DT_ILLUMINANT_LED_LAST);
   xy_to_uv(xy_test, uv_test);
 
   // Compute the error between the reference illuminant and the test illuminant derivated from the CCT with black body model
-  const float delta_bb = hypotf((uv_test[0] - uv_ref[0]), (uv_test[1] - uv_ref[1]));
+  const float delta_bb = dt_fast_hypotf((uv_test[0] - uv_ref[0]), (uv_test[1] - uv_ref[1]));
 
   // Check the error between original and test chromaticity
   if(delta_bb < 0.005f || delta_daylight < 0.005f)
@@ -1173,8 +1173,8 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
     // note : it will only be luck if I didn't mess-up the computation somewhere
     const float DL = Lab_ref[0] - Lab_test[0];
     const float L_avg = (Lab_ref[0] + Lab_test[0]) / 2.f;
-    const float C_ref = hypotf(Lab_ref[1], Lab_ref[2]);
-    const float C_test = hypotf(Lab_test[1], Lab_test[2]);
+    const float C_ref = dt_fast_hypotf(Lab_ref[1], Lab_ref[2]);
+    const float C_test = dt_fast_hypotf(Lab_test[1], Lab_test[2]);
     const float C_avg = (C_ref + C_test) / 2.f;
     float C_avg_7 = C_avg * C_avg; // C_avg²
     C_avg_7 *= C_avg_7;            // C_avg⁴
@@ -1183,8 +1183,8 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
     const float C_avg_7_ratio_sqrt = sqrtf(C_avg_7 / (C_avg_7 + 6103515625.f)); // 25⁷ = 6103515625
     const float a_ref_prime = Lab_ref[1] * (1.f + 0.5f * (1.f - C_avg_7_ratio_sqrt));
     const float a_test_prime = Lab_test[1] * (1.f + 0.5f * (1.f - C_avg_7_ratio_sqrt));
-    const float C_ref_prime = hypotf(a_ref_prime, Lab_ref[2]);
-    const float C_test_prime = hypotf(a_test_prime, Lab_test[2]);
+    const float C_ref_prime = dt_fast_hypotf(a_ref_prime, Lab_ref[2]);
+    const float C_test_prime = dt_fast_hypotf(a_test_prime, Lab_test[2]);
     const float DC_prime = C_ref_prime - C_test_prime;
     const float C_avg_prime = (C_ref_prime + C_test_prime) / 2.f;
     float h_ref_prime = atan2f(Lab_ref[2], a_ref_prime);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -642,7 +642,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_XYZ_2_JzAzBz(XYZ_D65, Jab);
 
     // Convert to JCh
-    float JC[2] = { Jab[0], hypotf(Jab[1], Jab[2]) };               // brightness/chroma vector
+    float JC[2] = { Jab[0], dt_fast_hypotf(Jab[1], Jab[2]) };   // brightness/chroma vector
     const float h = atan2f(Jab[2], Jab[1]);  // hue : (a, b) angle
 
     // Project JC onto S, the saturation eigenvector, with orthogonal vector O.
@@ -1044,7 +1044,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
           dot_product(rgb, input_matrix, XYZ); // Go to D50 pipeline RGB to D65 XYZ in one step
           dt_XYZ_2_JzAzBz(XYZ, Jab);           // this one expects D65 XYZ
           Jch[0] = Jab[0];
-          Jch[1] = hypotf(Jab[2], Jab[1]);
+          Jch[1] = dt_fast_hypotf(Jab[2], Jab[1]);
           Jch[2] = atan2f(Jab[2], Jab[1]);
 
           const size_t index = roundf((LUT_ELEM - 1) * (Jch[2] + M_PI_F) / (2.f * M_PI_F));

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -354,7 +354,7 @@ static void _lib_histogram_hue_ring(dt_lib_histogram_t *d, const dt_iop_order_ic
 static inline float baselog(float x, float bound)
 {
   // FIXME: use dt's fastlog()?
-  return log1pf((VECTORSCOPE_BASE_LOG - 1.f) * x / bound) / log(VECTORSCOPE_BASE_LOG) * bound;
+  return log1pf((VECTORSCOPE_BASE_LOG - 1.f) * x / bound) / logf(VECTORSCOPE_BASE_LOG) * bound;
 }
 
 static inline void log_scale(const dt_lib_histogram_t *d, float *x, float *y, float r)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -361,7 +361,7 @@ static inline void log_scale(const dt_lib_histogram_t *d, float *x, float *y, fl
 {
   if(d->vectorscope_scale == DT_LIB_HISTOGRAM_SCALE_LOGARITHMIC)
   {
-    const float h = hypotf(*x,*y);
+    const float h = dt_fast_hypotf(*x,*y);
     const float s = baselog(h, r);
     *x *= s / h;
     *y *= s / h;
@@ -518,7 +518,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
 
       const float intensity = lut[(int)(MIN(1.f, b[0]) * lutmax)];
       dt_aligned_pixel_t XYZ_D50, RGB;
-      const float h = hypotf(b[1], b[2]);
+      const float h = dt_fast_hypotf(b[1], b[2]);
 
       // FIXME: look into alternative ways to render this. From Sobotka: "Makes me wonder if full emission mixtures using the GL alpha transparency adding might help for visibility? I’d expect maximum volume of values add to display referred maximum white, while lower density volume of values are more visible and loosely representative of the mixture?"
       if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)


### PR DESCRIPTION
Add a `dt_fast_hypotf` which runs in half the time of GCC library's `hypotf`.  It generates the same result but doesn't handle denormals/overflow/infinity/NaN (which we don't care about anyway).  Since hypotf isn't exactly a big fraction of dt's overall CPU usage, it would take extra timing code on just the loops where the replacement was made to see a speedup.

Also a tiny bit of cleanup, replacing double versions of called functions with float versions.

Aside: This started as me trying to be clever and computing sinf(a) from `a` and cosf(a) to avoid a second trigonometric function call, only to find that the folks behind GCCs optimizer were even more clever -- it detects that we're using both sinf(a) and cosf(a) and replaces the two by a single call to sincosf() which takes exactly the same time as either `sinf` or `cosf`.
