### PR TITLE
module-search: add some padding after search icon

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -694,6 +694,11 @@ spinbutton>button
   margin-right: 0.5em;
 }
 
+#search-box image.left
+{
+  padding-right: 0.5em;
+}
+
 /*-------------------
   - Scope/Histogram -
   -------------------*/


### PR DESCRIPTION
Before:
![Screenshot_2021-08-02_23-55-27](https://user-images.githubusercontent.com/9555491/127933698-fb3dfafd-b77e-426c-a6f8-2a41b4ff6f90.png) ![Screenshot_2021-08-02_23-55-47](https://user-images.githubusercontent.com/9555491/127933703-e2f2b9b8-e737-429d-8562-f1e4819c100f.png)

After:
![Screenshot_2021-08-02_23-56-16](https://user-images.githubusercontent.com/9555491/127933712-70b37cde-93ec-40d2-80a2-b8509a916ced.png) ![Screenshot_2021-08-02_23-56-33](https://user-images.githubusercontent.com/9555491/127933718-aae19713-4cad-4a8f-8069-ee3f1f4cae99.png)
