### PR TITLE
macOS: fix button-press on "by scale" in "export selected"

### DIFF
--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -438,7 +438,7 @@ static void _scale_changed(GtkEntry *spin, dt_lib_export_t *d)
 static void _width_changed(GtkEditable *entry, gpointer user_data);
 static void _height_changed(GtkEditable *entry, gpointer user_data);
 
-static void _scale_mdlclick(GtkEntry *spin, GdkEventButton *event, dt_lib_export_t *d)
+static gboolean _scale_mdlclick(GtkEntry *spin, GdkEventButton *event, dt_lib_export_t *d)
 {
   if (event->button == 2)
   {
@@ -451,6 +451,7 @@ static void _scale_mdlclick(GtkEntry *spin, GdkEventButton *event, dt_lib_export
   {
     _scale_changed(spin, d);
   }
+  return FALSE;
 }
 
 static void _widht_mdlclick(GtkEntry *spin, GdkEventButton *event, gpointer user_data)


### PR DESCRIPTION
Entry widget wasn't accepting input on macOS. `Button-press-event` wasn't propagating properly and changing the handler to return false allows the event to propagate further. [(gtk)](https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html) 

I don't know why width and height are working without this fix or why other OSs work differently.

Fix #7898