### PR TITLE
improve and add toasts for shortcuts

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2957,7 +2957,10 @@ static float _action_process_slider(gpointer target, dt_action_element_t element
         fprintf(stderr, "[_action_process_slider] unknown shortcut effect (%d) for slider\n", effect);
         break;
       }
-      dt_accel_widget_toast(widget);
+
+      gchar *text = dt_bauhaus_slider_get_text(widget);
+      dt_action_widget_toast(bhw->module, widget, text);
+      g_free(text);
 
       break;
     case DT_ACTION_ELEMENT_BUTTON:
@@ -3067,7 +3070,9 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
       break;
     }
 
-    dt_accel_widget_toast(widget);
+    gchar *text = g_strdup_printf("\n%s", dt_bauhaus_combobox_get_text(widget));
+    dt_action_widget_toast(w->module, widget, text);
+    g_free(text);
   }
 
   GList *e = w->data.combobox.entries;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3225,6 +3225,11 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
     }
   }
 
+  gchar *text = g_strdup_printf("%s, %s", dt_action_def_iop.elements[element].name,
+                                dt_action_def_iop.elements[element].effects[effect]);
+  dt_action_widget_toast(target, NULL, text);
+  g_free(text);
+
   return 0;
 }
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -183,7 +183,7 @@ void dt_accel_rename_global(const gchar *path, const gchar *new_path);
 void dt_accel_rename_lua(const gchar *path, const gchar *new_path);
 
 // UX miscellaneous functions
-void dt_accel_widget_toast(GtkWidget *widget);
+void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *text);
 
 // Get the scale multiplier for adjusting sliders with shortcuts
 float dt_accel_get_slider_scale_multiplier();

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2997,6 +2997,9 @@ static float _action_process_tabs(gpointer target, dt_action_element_t element, 
 
   const int c = gtk_notebook_get_current_page(notebook);
 
+  dt_action_widget_toast(NULL, GTK_WIDGET(notebook),
+                         gtk_notebook_get_tab_label_text(notebook, gtk_notebook_get_nth_page(notebook, c)));
+
   return -1 - c + (c == element ? DT_VALUE_PATTERN_ACTIVE : 0);
 }
 


### PR DESCRIPTION
More types of widget now show the impact of a pressed shortcut.

If no mapping or fallback exists for a key, a toast is used (top of screen) rather than a message in the middle of the screen (that doesn't disappear when the correct shortcut is found).

fixes #9484