### PR TITLE
ignore window state changes during shortcut

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2811,7 +2811,6 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
     break;
   case GDK_GRAB_BROKEN:
     if(event->grab_broken.implicit) break;
-  case GDK_WINDOW_STATE:
     event->focus_change.in = FALSE; // fall through to GDK_FOCUS_CHANGE
   case GDK_FOCUS_CHANGE: // dialog boxes and switch to other app release grab
     if(event->focus_change.in)


### PR DESCRIPTION
There may no longer be a need to cancel a shortcut sequence grab when the window state changes and  this seemed to be causing reliability problems for me and I'm wondering if it could also be the cause of #9655 