### PR TITLE
improve search fields and some buttons alignement

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1277,6 +1277,11 @@ dialog scrollbar
   margin-right: 0.35em;
 }
 
+#preferences_box #shortcut_controls entry
+{
+  min-width: 15em;
+}
+
 #preferences_box #shortcut_controls button
 {
   margin-left: 0.21em;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -694,9 +694,9 @@ spinbutton>button
   margin-right: 0.5em;
 }
 
-#search-box image.left
+.search image.left
 {
-  padding-right: 0.5em;
+  padding: 0 0.35em 0 0.21em;
 }
 
 /*-------------------
@@ -1272,15 +1272,19 @@ dialog scrollbar
   margin: 0.35em 1.05em 1.05em 1.05em;
 }
 
-#preferences_box #shortcut_controls
+#preferences_box #shortcut_controls .search
 {
-  margin-left: 0.35em;
+  margin-right: 0.35em;
 }
 
-#preferences_box #shortcut_controls button,
+#preferences_box #shortcut_controls button
+{
+  margin-left: 0.21em;
+}
+
 #preferences_box #preset_controls button
 {
-margin: 0 0.14em;
+  margin-right: 0.21em;
 }
 
 /*--------------------------------


### PR DESCRIPTION
I didn't have time to review #9712 as requested by @elstoc. His proposal is good and was needed. Anyway, I've also seen that new search fields in shortcut view by @dterrahe needed some CSS tweaks. I so see that same padding was needed for those search box, so better use .search to apply to all search fields. I also find a way to have a better (I hope) balanced padding around search image inside search entry. See:

before:
![2021-08-03_23-18](https://user-images.githubusercontent.com/45535283/128087622-9b71c692-ea3a-490e-9e97-16751883b5ea.png) ![2021-08-03_23-18_1](https://user-images.githubusercontent.com/45535283/128087631-0e986342-04de-4175-ac69-35f63790d01f.png)

after:
![2021-08-03_23-12](https://user-images.githubusercontent.com/45535283/128086978-5efa5abb-f0b3-4337-a58b-5cbc99893c10.png) ![2021-08-03_23-13](https://user-images.githubusercontent.com/45535283/128086984-bd84cc06-b52d-4e34-8914-9c0d0ee9eab8.png)

I also improve some buttons alignment regardless main view above them in shortcuts and presets view in preferences window.

See:

before:
![2021-08-03_23-15](https://user-images.githubusercontent.com/45535283/128087265-37c79245-cfa9-44ef-a5ce-4196bf348250.png)

after:
![2021-08-03_23-01](https://user-images.githubusercontent.com/45535283/128087292-704780fd-bf63-4c81-8436-0e54da708f97.png)

