### PR TITLE
Update osx Build instructions for lua support

### DIFF
--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -38,7 +38,7 @@ How to make disk image with darktable application bundle (64 bit Intel only):
      $ portindex ~/ports
     Add "file:///Users/<username>/ports" (change <username> to your actual login) to /opt/local/etc/macports/sources.conf before [default] line.
     Install required dependencies:
-     $ sudo port install git exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg libsoup openexr json-glib flickcurl GraphicsMagick openjpeg lua webp libsecret pugixml osm-gps-map adwaita-icon-theme tango-icon-theme intltool iso-codes libomp gmic
+     $ sudo port install git exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg libsoup openexr json-glib flickcurl GraphicsMagick openjpeg  webp libsecret pugixml osm-gps-map adwaita-icon-theme tango-icon-theme intltool iso-codes libomp gmic
      $ sudo port select --set python2 python27
     Clone darktable git repository (in this example into ~/src):
      $ mkdir ~/src

--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -51,7 +51,7 @@ How to make disk image with darktable application bundle (64 bit Intel only):
     Finally build and install darktable:
      $ mkdir build
      $ cd build
-     $ cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_OBJCXX_FLAGS=-stdlib=libc++ -DOpenMP_C_INCLUDE_DIR=/opt/local/include/libomp -DOpenMP_CXX_INCLUDE_DIR=/opt/local/include/libomp -DCMAKE_LIBRARY_PATH=/opt/local/lib/libomp -DBINARY_PACKAGE_BUILD=ON -DRAWSPEED_ENABLE_LTO=ON -DBUILD_CURVE_TOOLS=ON -DBUILD_NOISE_TOOLS=ON
+     $ cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_OBJCXX_FLAGS=-stdlib=libc++ -DOpenMP_C_INCLUDE_DIR=/opt/local/include/libomp -DOpenMP_CXX_INCLUDE_DIR=/opt/local/include/libomp -DCMAKE_LIBRARY_PATH=/opt/local/lib/libomp -DBINARY_PACKAGE_BUILD=ON -DRAWSPEED_ENABLE_LTO=ON -DBUILD_CURVE_TOOLS=ON -DBUILD_NOISE_TOOLS=ON -DDONT_USE_INTERNAL_LUA=OFF 
      $ make
      $ sudo make install
     After this darktable will be installed in /usr/local directory and can be started by typing the following command in terminal:


### PR DESCRIPTION
macports doesn't contain lua 5.4 support yet - a pull request for this dated in 2020 never was merged and closed later.
To be able to use lua scripts the option -DDONT_USE_INTERNAL_LUA=OFF needs to be added to the cmake instructions.