### PR TITLE
geotagging: improve timezone entry

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1597,7 +1597,7 @@ static gboolean _timezone_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_l
     case GDK_KEY_Escape:
       gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
       return TRUE;
-    default:
+    default: ;
       dt_lib_geotagging_t *d = (dt_lib_geotagging_t *)self->data;
       gtk_label_set_text(GTK_LABEL (d->timezone_changed), " *");
       break;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1731,7 +1731,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->timezone = gtk_entry_new();
   gtk_widget_set_tooltip_text(d->timezone, _("start typing to show a list of permitted values and select your timezone.\npress enter to confirm, so that the asterisk * disappers"));
-  d->timezone_changed = dt_ui_label_new(_(""));
+  d->timezone_changed = dt_ui_label_new("");
 
   GtkWidget *timezone_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(timezone_box), d->timezone, TRUE, TRUE, 0);


### PR DESCRIPTION
fix #9702

- show indicator * as long as input field 'camera time zone' is not saved
- allow saving with tab-key and focus-out (in addition to return-key)
- show entry_completion before entering the first key (delete 'UTC')