### PR TITLE
add a few more shortcut toasts

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3223,12 +3223,12 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
       if(module->presets_button) presets_popup_callback(NULL, module);
       break;
     }
-  }
 
-  gchar *text = g_strdup_printf("%s, %s", dt_action_def_iop.elements[element].name,
-                                dt_action_def_iop.elements[element].effects[effect]);
-  dt_action_widget_toast(target, NULL, text);
-  g_free(text);
+    gchar *text = g_strdup_printf("%s, %s", dt_action_def_iop.elements[element].name,
+                                  dt_action_def_iop.elements[element].effects[effect]);
+    dt_action_widget_toast(target, NULL, text);
+    g_free(text);
+  }
 
   return 0;
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2363,7 +2363,7 @@ static float process_mapping(float move_size)
 
         return_value = definition->process(action_target, fsc.element, effect, move_size);
       }
-      else
+      else if(move_size)
         dt_action_widget_toast(fsc.action, action_target, "not active");
     }
   }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2969,8 +2969,9 @@ static float _action_process_tabs(gpointer target, dt_action_element_t element, 
 
   const int c = gtk_notebook_get_current_page(notebook);
 
-  dt_action_widget_toast(NULL, GTK_WIDGET(notebook),
-                         gtk_notebook_get_tab_label_text(notebook, gtk_notebook_get_nth_page(notebook, c)));
+  if(move_size)
+    dt_action_widget_toast(NULL, GTK_WIDGET(notebook),
+                           gtk_notebook_get_tab_label_text(notebook, gtk_notebook_get_nth_page(notebook, c)));
 
   return -1 - c + (c == element ? DT_VALUE_PATTERN_ACTIVE : 0);
 }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2311,6 +2311,17 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_control_queue_redraw_widget(self->widget);
 }
 
+const dt_action_element_def_t _action_elements_zones[]
+  = { { N_("red"    ), dt_action_effect_value },
+      { N_("orange" ), dt_action_effect_value },
+      { N_("yellow" ), dt_action_effect_value },
+      { N_("green"  ), dt_action_effect_value },
+      { N_("aqua"   ), dt_action_effect_value },
+      { N_("blue"   ), dt_action_effect_value },
+      { N_("purple" ), dt_action_effect_value },
+      { N_("magenta"), dt_action_effect_value },
+      { NULL } };
+
 static float _action_process_zones(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
   dt_iop_module_t *self = g_object_get_data(G_OBJECT(target), "iop-instance");
@@ -2357,23 +2368,16 @@ static float _action_process_zones(gpointer target, dt_action_element_t element,
       fprintf(stderr, "[_action_process_zones] unknown shortcut effect (%d) for color zones\n", effect);
       break;
     }
+
+    gchar *text = g_strdup_printf("%s %+.2f", _action_elements_zones[element].name, return_value * 2. - 1.);
+    dt_action_widget_toast(DT_ACTION(self), target, text);
+    g_free(text);
   }
 
   return return_value + DT_VALUE_PATTERN_PLUS_MINUS;
 }
 
-const dt_action_element_def_t _action_elements_zones[]
-  = { { N_("red"    ), dt_action_effect_value },
-      { N_("orange" ), dt_action_effect_value },
-      { N_("yellow" ), dt_action_effect_value },
-      { N_("green"  ), dt_action_effect_value },
-      { N_("aqua"   ), dt_action_effect_value },
-      { N_("blue"   ), dt_action_effect_value },
-      { N_("purple" ), dt_action_effect_value },
-      { N_("magenta"), dt_action_effect_value },
-      { NULL } };
-
-const dt_action_def_t dt_action_def_zones
+const dt_action_def_t _action_def_zones
   = { N_("color zones"),
       _action_process_zones,
       _action_elements_zones };
@@ -2514,7 +2518,7 @@ void gui_init(struct dt_iop_module_t *self)
                                            | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                                            | darktable.gui->scroll_mask);
   g_object_set_data(G_OBJECT(c->area), "iop-instance", self);
-  dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(c->area), &dt_action_def_zones);
+  dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(c->area), &_action_def_zones);
   gtk_widget_set_can_focus(GTK_WIDGET(c->area), TRUE);
   g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(_area_draw_callback), self);
   g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(_area_button_press_callback), self);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -944,6 +944,12 @@ void change_image(struct dt_iop_module_t *self)
   g->button_down = 0;
 }
 
+const dt_action_element_def_t _action_elements_levels[]
+  = { { N_("black"), dt_action_effect_value },
+      { N_("grey" ), dt_action_effect_value },
+      { N_("white"), dt_action_effect_value },
+      { NULL } };
+
 static float _action_process(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
   dt_iop_module_t *self = g_object_get_data(G_OBJECT(target), "iop-instance");
@@ -977,18 +983,16 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
       fprintf(stderr, "[_action_process_tabs] unknown shortcut effect (%d) for levels\n", effect);
       break;
     }
+
+    gchar *text = g_strdup_printf("%s %.2f", _action_elements_levels[element].name, p->levels[c->channel][element]);
+    dt_action_widget_toast(DT_ACTION(self), target, text);
+    g_free(text);
   }
 
   return p->levels[c->channel][element];
 }
 
-const dt_action_element_def_t _action_elements_levels[]
-  = { { N_("black"), dt_action_effect_value },
-      { N_("grey" ), dt_action_effect_value },
-      { N_("white"), dt_action_effect_value },
-      { NULL } };
-
-const dt_action_def_t dt_action_def_levels
+const dt_action_def_t _action_def_levels
   = { N_("levels"),
       _action_process,
       _action_elements_levels };
@@ -1020,7 +1024,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->area), TRUE, TRUE, 0);
 
   g_object_set_data(G_OBJECT(c->area), "iop-instance", self);
-  dt_action_define_iop(self, NULL, N_("levels"), GTK_WIDGET(c->area), &dt_action_def_levels);
+  dt_action_define_iop(self, NULL, N_("levels"), GTK_WIDGET(c->area), &_action_def_levels);
 
   gtk_widget_set_tooltip_text(GTK_WIDGET(c->area),_("drag handles to set black, gray, and white points. "
                                                     "operates on L channel."));


### PR DESCRIPTION
For color zones and rgb levels.

Also fixes stuck toast when midi knob assigned to hidden widget or notebook tab.