### PR TITLE
add shortcut tooltips and visual mapping to more widgets

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1523,6 +1523,7 @@ static void init_widgets(dt_gui_gtk_t *gui)
   // Initializing the top border
   widget = gtk_drawing_area_new();
   gui->widgets.top_border = widget;
+  dt_action_define(&darktable.control->actions_global, NULL, "toggle top panel", widget, NULL);
   gtk_box_pack_start(GTK_BOX(container), widget, FALSE, TRUE, 0);
   gtk_widget_set_size_request(widget, -1, DT_PIXEL_APPLY_DPI(10));
   gtk_widget_set_app_paintable(widget, TRUE);
@@ -1538,6 +1539,7 @@ static void init_widgets(dt_gui_gtk_t *gui)
   // Initializing the bottom border
   widget = gtk_drawing_area_new();
   gui->widgets.bottom_border = widget;
+  dt_action_define(&darktable.control->actions_global, NULL, "toggle bottom panel", widget, NULL);
   gtk_box_pack_start(GTK_BOX(container), widget, FALSE, TRUE, 0);
   gtk_widget_set_size_request(widget, -1, DT_PIXEL_APPLY_DPI(10));
   gtk_widget_set_app_paintable(widget, TRUE);
@@ -1571,6 +1573,7 @@ static void init_main_table(GtkWidget *container)
   // Adding the left border
   widget = gtk_drawing_area_new();
   darktable.gui->widgets.left_border = widget;
+  dt_action_define(&darktable.control->actions_global, NULL, "toggle left panel", widget, NULL);
 
   gtk_widget_set_size_request(widget, DT_PIXEL_APPLY_DPI(10), -1);
   gtk_widget_set_app_paintable(widget, TRUE);
@@ -1584,6 +1587,7 @@ static void init_main_table(GtkWidget *container)
   // Adding the right border
   widget = gtk_drawing_area_new();
   darktable.gui->widgets.right_border = widget;
+  dt_action_define(&darktable.control->actions_global, NULL, "toggle right panel", widget, NULL);
 
   gtk_widget_set_size_request(widget, DT_PIXEL_APPLY_DPI(10), -1);
   gtk_widget_set_app_paintable(widget, TRUE);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1719,6 +1719,8 @@ void gui_init(dt_lib_module_t *self)
   // shows the scope, scale, and has draggable areas
   d->scope_draw = gtk_drawing_area_new();
   gtk_widget_set_tooltip_text(d->scope_draw, _("ctrl+scroll to change display height"));
+  dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, "histogram", "hide histogram", d->scope_draw, NULL);
+  gtk_widget_set_events(d->scope_draw, GDK_ENTER_NOTIFY_MASK);
 
   // a row of control buttons
   d->button_box = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
@@ -1737,8 +1739,10 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: this could be a combobox to allow for more types and not to have to swap the icon on click
   // icons will be filled in by _scope_type_update()
   d->scope_type_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, "histogram", "switch histogram mode", d->scope_type_button, NULL);
   gtk_box_pack_start(GTK_BOX(d->button_box), d->scope_type_button, FALSE, FALSE, 0);
   d->scope_view_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
+  dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, "histogram", "switch histogram type", d->scope_view_button, NULL);
   gtk_box_pack_start(GTK_BOX(d->button_box), d->scope_view_button, FALSE, FALSE, 0);
 
   // the red togglebutton turns into colorspace button in vectorscope

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2741,6 +2741,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* search box */
   d->text_entry = gtk_search_entry_new();
+  dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, NULL, "search modules", d->text_entry, NULL);
   gtk_entry_set_placeholder_text(GTK_ENTRY(d->text_entry), _("search modules by name or tag"));
   g_signal_connect(G_OBJECT(d->text_entry), "search-changed", G_CALLBACK(_text_entry_changed_callback), self);
   g_signal_connect(G_OBJECT(d->text_entry), "stop-search", G_CALLBACK(_stop_search), NULL);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -135,6 +135,8 @@ void gui_init(dt_lib_module_t *self)
   /* set size of navigation draw area */
   gtk_widget_set_size_request(self->widget, -1, 175);
   gtk_widget_set_name(GTK_WIDGET(self->widget), "navigation-module");
+  dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, NULL, "hide navigation thumbnail", self->widget, NULL);
+  gtk_widget_set_events(self->widget, GDK_ENTER_NOTIFY_MASK);
 
   /* connect a redraw callback to control draw all and preview pipe finish signals */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -256,6 +256,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->layout_box, TRUE, TRUE, 0);
 
   d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
+                   "toggle filemanager layout", d->layout_filemanager, NULL);
   dt_gui_add_help_link(d->layout_filemanager, dt_get_help_url("layout_filemanager"));
   gtk_widget_set_tooltip_text(d->layout_filemanager, _("click to enter filemanager layout."));
   g_signal_connect(G_OBJECT(d->layout_filemanager), "button-release-event",
@@ -263,6 +265,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_filemanager, TRUE, TRUE, 0);
 
   d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
+                   "toggle zoomable lighttable layout", d->layout_zoomable, NULL);
   dt_gui_add_help_link(d->layout_zoomable, dt_get_help_url("layout_zoomable"));
   gtk_widget_set_tooltip_text(d->layout_zoomable, _("click to enter zoomable lighttable layout."));
   g_signal_connect(G_OBJECT(d->layout_zoomable), "button-release-event",
@@ -270,6 +274,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_zoomable, TRUE, TRUE, 0);
 
   d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
+                   "toggle culling mode", d->layout_culling_fix, NULL);
   dt_gui_add_help_link(d->layout_culling_fix, dt_get_help_url("layout_culling"));
   g_signal_connect(G_OBJECT(d->layout_culling_fix), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
@@ -277,12 +283,16 @@ void gui_init(dt_lib_module_t *self)
 
   d->layout_culling_dynamic
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
+                   "toggle culling dynamic mode", d->layout_culling_dynamic, NULL);
   dt_gui_add_help_link(d->layout_culling_dynamic, dt_get_help_url("layout_culling"));
   g_signal_connect(G_OBJECT(d->layout_culling_dynamic), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_dynamic, TRUE, TRUE, 0);
 
   d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
+                   "toggle sticky preview mode", d->layout_preview, NULL);
   dt_gui_add_help_link(d->layout_preview, dt_get_help_url("layout_preview"));
   g_signal_connect(G_OBJECT(d->layout_preview), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);

--- a/src/libs/tools/viewswitcher.c
+++ b/src/libs/tools/viewswitcher.c
@@ -24,6 +24,7 @@
 #include "develop/develop.h"
 #include "dtgtk/button.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
 
@@ -119,6 +120,10 @@ void gui_init(dt_lib_module_t *self)
       GtkWidget *w = _lib_viewswitcher_create_label(view);
       gtk_box_pack_start(GTK_BOX(self->widget), w, FALSE, FALSE, 0);
       d->labels = g_list_append(d->labels, gtk_bin_get_child(GTK_BIN(w)));
+
+      gchar *id = g_strdup_printf("%s %s", view->module_name, "view");
+      dt_action_define(&darktable.control->actions_global, NULL, id, w, NULL);
+      g_free(id);
 
       /* create space if more views */
       if(view_iter->next != NULL)


### PR DESCRIPTION
lighttable/darkroom view switch buttons
side/top/bottom panel collapse arrows
lighttable layout/culling/zoom buttons
modules search

fixes #9448