### PR TITLE
[performance] scale up performance to 2021 reality

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1586,7 +1586,19 @@ void dt_configure_performance()
 
   fprintf(stderr, "[defaults] found a %zu-bit system with %zu kb ram and %zu cores (%d atom based)\n",
           bits, mem, threads, atom_cores);
-  if(mem >= (8lu << 20) && threads > 4 && atom_cores == 0)
+  if(mem >= (16lu << 20) && threads > 6 && atom_cores == 0)
+  {
+    // CONFIG 0: at least 16GB RAM, and more than 6 CPU cores, no atom
+    // But respect if user has set higher values manually earlier
+    fprintf(stderr, "[defaults] setting ultra high quality defaults\n");
+    // if machine has at least 16GB RAM, use all of the total memory size leaving 4GB "breathing room"
+    dt_conf_set_int("host_memory_limit", MAX((mem - (4lu << 20)) >> 11, dt_conf_get_int("host_memory_limit")));
+    dt_conf_set_int("singlebuffer_limit", MAX(64, dt_conf_get_int("singlebuffer_limit")));
+    if(demosaic_quality == NULL || !strcmp(demosaic_quality, "always bilinear (fast)"))
+      dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
+    dt_conf_set_bool("ui/performance", FALSE);
+  }
+  else if(mem >= (8lu << 20) && threads > 4 && atom_cores == 0)
   {
     // CONFIG 1: at least 8GB RAM, and more than 4 CPU cores, no atom
     // But respect if user has set higher values manually earlier
@@ -1594,7 +1606,7 @@ void dt_configure_performance()
 
     // if machine has at least 8GB RAM, use half of the total memory size
     dt_conf_set_int("host_memory_limit", MAX(mem >> 11, dt_conf_get_int("host_memory_limit")));
-    dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
+    dt_conf_set_int("singlebuffer_limit", MAX(32, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL || !strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
     dt_conf_set_bool("ui/performance", FALSE);
@@ -1633,6 +1645,23 @@ void dt_configure_performance()
   }
 
   g_free(demosaic_quality);
+
+  char cachedir[PATH_MAX] = { 0 };
+  guint64 freecache = 0;
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+  GFile *gfile = g_file_new_for_path(cachedir);
+  GFileInfo *gfileinfo = g_file_query_filesystem_info(gfile, G_FILE_ATTRIBUTE_FILESYSTEM_FREE, NULL, NULL);
+  if(gfileinfo != NULL)
+    freecache = g_file_info_get_attribute_uint64(gfileinfo, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
+  g_object_unref(gfile);
+  g_object_unref(gfileinfo);
+
+  // set cache_memory to half of freediskspace - 4gb (eg 1gb cache_mem in case of 6gb free space)
+  if(freecache > (6lu << 20))
+    dt_conf_set_int64("cache_memory", (freecache - (4lu << 20))/2);
+
+  // enable cache_disk_backend_full when user has over 8gb free diskspace
+  dt_conf_set_bool("cache_disk_backend_full", freecache > (8lu << 20));
 
   // store the current performance configure version as the last completed
   // that would prevent further execution of previous performance configuration run

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -153,7 +153,7 @@ typedef unsigned int u_int;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 1
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 2
 
 // every module has to define this:
 #ifdef _DEBUG

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -944,7 +944,7 @@ static enum _dt_delete_status delete_file_from_disk(const char *filename, gboole
           send_to_trash,
           filename_display == NULL ? filename : filename_display,
           gerror == NULL ? NULL : gerror->message);
-
+      g_object_unref(gfileinfo);
       if (send_to_trash && res == _DT_DELETE_DIALOG_CHOICE_DELETE)
       {
         // Loop again, this time delete instead of trashing


### PR DESCRIPTION
Fixes #5328

This should address all points of #5328 :)

To note:
1. creates new performance configuration (as to update users current one)
2. for beefy machines (over 16G ram and over 6 cores) sets max mem to ALL mem minus 4GB (eg 12GB on 16GB machnie)
3. Tiles have been scalled up (64MB for biggest config and then 32, 16 and to 8MB for lowest)
4. Instead of default 512MB for on disk cache - uses half a disk space lowered by 4GB for those who have minimum of 6GB of free space, leaving 512 for those below that (eg will set 1GB cache when there's 6GB free) (note: mipmap cache still will limit that to 8GB MAX)
5. enables full preview disk cache when disk freespace is bigger than 8GB.

additrionally fixes tiny mem leak :)