### PR TITLE
Fix build of unittests on Windows

### DIFF
--- a/packaging/windows/BUILD.md
+++ b/packaging/windows/BUILD.md
@@ -25,6 +25,11 @@ How to make a darktable windows installer (64 bit only):
     $ pacman -S mingw-w64-x86_64-gmic
     ```
 
+* Optional: Install libraries required for [testing](../../src/tests/unittests/README.md)
+    ```
+    $ pacman -S mingw-w64-x86_64-cmocka
+    ```
+
 * For gphoto2:
     * You need to restart the MINGW64 or MSYS terminal to have CAMLIBS and IOLIBS environment variables properly set for LIBGPHOTO are available.
     * make sure they aren't pointing into your normal windows installation in case you already have darktable installed. You can check them with:

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -3,3 +3,8 @@ add_subdirectory(iop)
 add_cmocka_test(test_sample
                 SOURCES test_sample.c
                 LINK_LIBRARIES cmocka)
+
+# Windows: main-method requires the wrapper provided by lib-darktable
+if(WIN32)
+    target_link_libraries(test_sample PRIVATE lib_darktable)
+endif(WIN32)

--- a/src/tests/unittests/iop/test_filmicrgb.c
+++ b/src/tests/unittests/iop/test_filmicrgb.c
@@ -35,6 +35,10 @@
 
 #include "iop/filmicrgb.c"
 
+#ifdef _WIN32
+#include "win/main_wrapper.h"
+#endif
+
 /*
  * DEFINITIONS
  */
@@ -499,11 +503,10 @@ static void test_linear_saturation(void **state)
   testimg_free(ti);
 }
 
-
 /*
  * MAIN FUNCTION
  */
-int main()
+int main(int argc, char* argv[])
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_name),

--- a/src/tests/unittests/test_sample.c
+++ b/src/tests/unittests/test_sample.c
@@ -23,12 +23,16 @@
 
 #include <cmocka.h>
 
+#ifdef _WIN32
+#include "win/main_wrapper.h"
+#endif
+
 static void test_sample(void **state)
 {
   // most efficient test: does just nothing :-)
 }
 
-int main()
+int main(int argc, char* argv[])
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_sample)

--- a/src/tests/variables.c
+++ b/src/tests/variables.c
@@ -3,6 +3,10 @@
 
 #include <stdio.h>
 
+#ifdef _WIN32
+#include "win/main_wrapper.h"
+#endif
+
 typedef struct test_case_t
 {
   char *input, *expected_result;
@@ -193,13 +197,13 @@ static const test_t test_real_paths = {
     printf("%d / %d tests failed\n\n", n_failed, n_tests);\
 }
 
-int main()
+int main(int argc, char* argv[])
 {
-  char *argv[] = {"darktable-test-variables", "--library", ":memory:", "--conf", "write_sidecar_files=FALSE", NULL};
-  int argc = sizeof(argv) / sizeof(*argv) - 1;
+  char *argv_override[] = {"darktable-test-variables", "--library", ":memory:", "--conf", "write_sidecar_files=FALSE", NULL};
+  int argc_override = sizeof(argv_override) / sizeof(*argv_override) - 1;
 
   // init dt without gui and without data.db:
-  if(dt_init(argc, argv, FALSE, FALSE, NULL)) exit(1);
+  if(dt_init(argc_override, argv_override, FALSE, FALSE, NULL)) exit(1);
 
   int n_tests_overall = 0, n_failed_overall = 0, n_test_functions = 0, n_test_functions_failed = 0;
 


### PR DESCRIPTION
This PR fixes #9757 

Basically, it adds the Windows main-wrapper of lib_darktable to all test suites