### PR TITLE
Make Tests runnable on Windows

### DIFF
--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -27,6 +27,23 @@ macro(_detach_debuginfo target dest)
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES $<TARGET_FILE_NAME:${target}>.dbg)
 endmacro()
 
+
+#-------------------------------------------------------------------------------
+# _copy_required_library(<target> <library>)
+#
+# Helper function to copy required library (specified by target) alongside the 
+# target binary. 
+# 
+# This is required as Win doesn't have a RPATH
+#-------------------------------------------------------------------------------
+function(_copy_required_library target library)
+  message( STATUS "WIN32: Adding post-build step to copy required lib alongside target binary")
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${library}> $<TARGET_FILE_DIR:${target}>
+  )
+endfunction()
+
+
 function(InstallDependencyFiles)
 
 if (WIN32 AND NOT BUILD_MSYS2_INSTALL)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,4 +3,12 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/../")
 add_executable(darktable-test-variables variables.c)
 target_link_libraries(darktable-test-variables lib_darktable)
 
+if(WIN32)
+    # This tester sets up a darktable instance (of sorts). Hence it expects libraries at ../lib/darktable
+    # Easiest way to comply with this on Windows: Put tester executable in same directory as darktable executable
+    set_target_properties(darktable-test-variables PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${DARKTABLE_BINDIR}
+    )
+endif(WIN32)
+
 add_subdirectory(unittests)

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -7,4 +7,5 @@ add_cmocka_test(test_sample
 # Windows: main-method requires the wrapper provided by lib-darktable
 if(WIN32)
     target_link_libraries(test_sample PRIVATE lib_darktable)
+    _copy_required_library(test_sample lib_darktable)
 endif(WIN32)

--- a/src/tests/unittests/iop/CMakeLists.txt
+++ b/src/tests/unittests/iop/CMakeLists.txt
@@ -6,7 +6,4 @@ add_cmocka_mock_test(test_filmicrgb
 # Windows: libs have to be copied next to the executable
 if(WIN32)
     _copy_required_library(test_filmicrgb lib_darktable)
-    #add_custom_command(TARGET test_filmicrgb POST_BUILD
-    #    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:lib_darktable> $<TARGET_FILE_DIR:test_filmicrgb>
-    #)
 endif(WIN32)

--- a/src/tests/unittests/iop/CMakeLists.txt
+++ b/src/tests/unittests/iop/CMakeLists.txt
@@ -2,3 +2,11 @@ add_cmocka_mock_test(test_filmicrgb
                      SOURCES test_filmicrgb.c ../util/testimg.c
                      LINK_LIBRARIES lib_darktable cmocka
                      MOCKS dt_iop_color_picker_reset)
+
+# Windows: libs have to be copied next to the executable
+if(WIN32)
+    _copy_required_library(test_filmicrgb lib_darktable)
+    #add_custom_command(TARGET test_filmicrgb POST_BUILD
+    #    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:lib_darktable> $<TARGET_FILE_DIR:test_filmicrgb>
+    #)
+endif(WIN32)


### PR DESCRIPTION
In order to execute the testcases, some extra measures have to be taken:
- variable-test: move exec to ${DARKTABLE_BINDIR}
 (it launches a darktable instance and requires libraries at a certain relative path: `../lib/darktable/<libs>`
- unit-test: copy libdarktable along

With this PR, all tests can be successfully executed
- `make test` will run all unittests
- `darktable-test-variables` has to be executed from ${DARKTABLE_BINDIR} - this might conflict with linux, s.th. there needs to be a case-switch when running tests. **This remains open**

Background: Windows does not "magically" find libraries, and does not implement RPATH. So, libraries have to be put where they are expected (next to the executable, that is)

This is a follow-up of #9765