### PR TITLE
distinguish on/off toggles when mouse hovering

### DIFF
--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -108,7 +108,7 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
       if(!(flags & CPF_BG_TRANSPARENT) || (flags & CPF_PRELIGHT))
         gtk_render_background(context, cr, startx, starty, cwidth, cheight);
     }
-    else if(!(flags & CPF_ACTIVE) || (flags & CPF_IGNORE_FG_STATE))
+    if(!(flags & CPF_ACTIVE) || (flags & CPF_IGNORE_FG_STATE))
       fg_color.alpha = CLAMP(fg_color.alpha / 2.0, 0.3, 1.0);
   }
   else if(!(flags & CPF_BG_TRANSPARENT))


### PR DESCRIPTION
dt toggle buttons show exactly the same whether active or inactive when the mouse is hovering over them ("prelight" style). This small change (re-?)introduces a small difference between the two states so that there is visual feedback to a click _while_ the mouse is still over the button (you don't have to move the mouse away to check if your click had an effect).

The buttons in the row of toggles in the darkroom do not always get reliably refreshed when their status changes. If someone has any idea why, or where to best resolve this, please let me know. The issue can be resolved by adding a bunch of gtk_widget_queue_draw calls to all the "clicked" event handlers, but a structural solution would be preferred to this whack-a-mole approach. Curiously, when the mouse is hovering over the button and it is toggled using a shortcut, it _does_ reliably update..