### PR TITLE
fix hold key regressions and modifier only fallbacks

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -129,7 +129,7 @@ void dt_control_init(dt_control_t *s)
   dt_action_t *ac = dt_action_define(&s->actions_global, NULL, N_("show accels window"), NULL, &dt_action_def_accels_show);
   dt_accel_register_shortcut(ac, NULL, 0, DT_ACTION_EFFECT_HOLD, GDK_KEY_h, 0);
 
-  dt_action_define(&s->actions_global, NULL, N_("modifiers"), NULL, &dt_action_def_modifiers);
+  s->actions_modifiers = dt_action_define(&s->actions_global, NULL, N_("modifiers"), NULL, &dt_action_def_modifiers);
 
   memset(s->vimkey, 0, sizeof(s->vimkey));
   s->vimkey_cnt = 0;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -135,7 +135,7 @@ typedef struct dt_control_t
 {
   gboolean accel_initialising;
 
-  dt_action_t *actions, actions_global, actions_views, actions_thumb, actions_libs, actions_iops, actions_blend, actions_lua, actions_fallbacks;
+  dt_action_t *actions, actions_global, actions_views, actions_thumb, actions_libs, actions_iops, actions_blend, actions_lua, actions_fallbacks, *actions_modifiers;
 
   GHashTable *widgets;
   GSequence *shortcuts;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -663,7 +663,7 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
   {
     dt_shortcut_t *s = g_sequence_get(iter);
     if(s->action == action &&
-       (darktable.control->element == -1 ||
+       (!def || darktable.control->element == -1 ||
         s->element == darktable.control->element ||
         (s->element == DT_ACTION_ELEMENT_DEFAULT && has_fallbacks)))
     {


### PR DESCRIPTION
 fixes #9752

Switch off special treatment of hold shortcuts (like W or Ctrl-W for preview) while defining new shortcut (either in dialog or visually). This does logically result in emulated modifiers (on MIDI for example) not being treated as such while defining new shortcuts. So if midi key A is defined as ctrl modifier, the keyboard will need to be used to define ctrl+midi key B, even though afterwards A+B together will trigger the shortcut.

Also fixes hold shortcuts in combination with modifiers; only in the case where the hold shortcut actually is an emulated _modifier_ are other modifiers ignored (so you can do shift+ctrl+alt).

Third fix is for defining fallbacks; when defining a fallback shortcut, you can use _just_ modifiers (shift+, or shift+ctrl+alt+). You don't _have_ to (but _can_) combine them with moves or clicks. You _cannot_ combine them with normal key presses (because that would be the base shortcut that you are defining a fallback for).