### PR TITLE
avoid duplicate free of Dbus connection

### DIFF
--- a/src/common/dbus.c
+++ b/src/common/dbus.c
@@ -199,7 +199,8 @@ void dt_dbus_destroy(const dt_dbus_t *dbus)
 {
   g_bus_unown_name(dbus->owner_id);
   g_dbus_node_info_unref(dbus->introspection_data);
-  g_object_unref(G_OBJECT(dbus->dbus_connection));
+  if(dbus->dbus_connection)
+    g_object_unref(G_OBJECT(dbus->dbus_connection));
 
   g_free((dt_dbus_t *)dbus);
 }

--- a/src/control/progress.c
+++ b/src/control/progress.c
@@ -222,6 +222,7 @@ static void global_progress_end(dt_control_t *control, dt_progress_t *progress)
     }
 
     g_object_unref(G_OBJECT(darktable.dbus->dbus_connection));
+    darktable.dbus->dbus_connection = NULL;
   }
 
 #endif // HAVE_UNITY
@@ -281,6 +282,7 @@ void dt_control_progress_init(struct dt_control_t *control)
     }
 
     g_object_unref(G_OBJECT(darktable.dbus->dbus_connection));
+    darktable.dbus->dbus_connection = NULL;
   }
 
 #endif // HAVE_UNITY


### PR DESCRIPTION
Recent versions of dt were spitting out a Glib-GObject-WARNING and a Glib-GObject-CRITICAL message on shutdown.  Those proved to be coming from unref'ing an object pointer which had already been unref'ed and freed.  This commit fixes that double free.
