### PR TITLE
Fixing xmp disabling regression (9776)

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -416,7 +416,7 @@ int main(int argc, char *arg[])
   m_arg[m_argc++] = "--library";
   m_arg[m_argc++] = ":memory:";
   m_arg[m_argc++] = "--conf";
-  m_arg[m_argc++] = "write_sidecar_files=FALSE";
+  m_arg[m_argc++] = "write_sidecar_files=never";
   for(; k < argc; k++) m_arg[m_argc++] = arg[k];
   m_arg[m_argc] = NULL;
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -293,23 +293,28 @@ void dt_image_film_roll(const dt_image_t *img, char *pathname, size_t pathname_l
 
 dt_imageio_write_xmp_t dt_image_get_xmp_mode()
 {
-  dt_imageio_write_xmp_t res = DT_WRITE_XMP_ALWAYS;
+  dt_imageio_write_xmp_t res = DT_WRITE_XMP_NEVER;
   const char *config = dt_conf_get_string_const("write_sidecar_files");
   if(config)
   {
     if(!strcmp(config, "after edit"))
       res = DT_WRITE_XMP_LAZY;
-    else if(!strcmp(config, "never"))
-      res = DT_WRITE_XMP_NEVER;
-    // migration path from boolean settings in <= 3.6, lazy mode were introduced in 3.8
-    else if(!strcmp(config, "FALSE"))
-    {
-      dt_conf_set_string("write_sidecar_files", "never");
-      res = DT_WRITE_XMP_NEVER;
-    }
+    else if(!strcmp(config, "on import"))
+      res = DT_WRITE_XMP_ALWAYS;
     else if(!strcmp(config, "TRUE"))
+    {
+      // migration path from boolean settings in <= 3.6, lazy mode was introduced in 3.8
+      // as scripts or tools might use FALSE we can only update TRUE in a safe way.
+      // This leaves others like "false" or "FALSE" as DT_WRITE_XMP_NEVER without conf string update
       dt_conf_set_string("write_sidecar_files", "on import");
+      res = DT_WRITE_XMP_ALWAYS;
+    }
   }
+  else
+  {
+    res = DT_WRITE_XMP_ALWAYS;
+    dt_conf_set_string("write_sidecar_files", "on import");
+  }  
   return res;
 }
 

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -211,7 +211,7 @@ int main(int argc, char *arg[])
   char **m_arg = malloc(sizeof(char *) * (3 + argc - k + 1));
   m_arg[m_argc++] = "darktable-generate-cache";
   m_arg[m_argc++] = "--conf";
-  m_arg[m_argc++] = "write_sidecar_files=FALSE";
+  m_arg[m_argc++] = "write_sidecar_files=never";
   for(; k < argc; k++) m_arg[m_argc++] = arg[k];
   m_arg[m_argc] = NULL;
 

--- a/src/tests/variables.c
+++ b/src/tests/variables.c
@@ -199,7 +199,7 @@ static const test_t test_real_paths = {
 
 int main(int argc, char* argv[])
 {
-  char *argv_override[] = {"darktable-test-variables", "--library", ":memory:", "--conf", "write_sidecar_files=FALSE", NULL};
+  char *argv_override[] = {"darktable-test-variables", "--library", ":memory:", "--conf", "write_sidecar_files=never", NULL};
   int argc_override = sizeof(argv_override) / sizeof(*argv_override) - 1;
 
   // init dt without gui and without data.db:

--- a/tools/regression_tests/src/lib/build.rb
+++ b/tools/regression_tests/src/lib/build.rb
@@ -49,7 +49,7 @@ class DTBuild
   #  command += " -d camsupport"
     command += " --conf plugins/imageio/format/tiff/bpp=16"
   #  command += " --conf plugins/imageio/format/jpeg/quality=100"
-    command += " --conf write_sidecar_files=false"
+    command += " --conf write_sidecar_files=never"
     run_cmd_test_file command, outfile
   end
 


### PR DESCRIPTION
The reported issue comes down to incorrect updating the conf data for "write-sidecar-files".

Some tools lic dt-cli, generate-cache called dt with the option set to "FALSE" or "false"
leading to an incorrect upgrade of the config options data. In this pr

1. make sure all cli tools use "never" as the correct parameter
2. only upgrade "TRUE" to "on import" and leave FALSE

Fixes #9776