### PR TITLE
[ci] switch nightly from llvm to gcc in hopes of alleviating some issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         btype: [Release]
         compiler: 
-          - { compiler: LLVM,  CC: clang,   CXX: clang++ }
+          - { compiler: GNU,  CC: gcc,   CXX: g++ }
         eco: [-DBINARY_PACKAGE_BUILD=ON]
         target: [skiptest]
     defaults:


### PR DESCRIPTION
Fixes #8994 

On nightly CI I've set up llvm as compiller originally, however normally everybody builds windows packages with gcc. Now nightlies are compilled with GCC and do not crash

I think the reason for crash has something to do with openmp on llvm not agreeing with stuff. Didn't manage to debug it but I can confirm that build from this run: https://github.com/johnny-bit/darktable/actions/runs/1120564743 works flawlessly :)