### PR TITLE
bugfix: ensure proper init of brush/path stamps

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2721,7 +2721,8 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
-  *buffer = dt_alloc_align_float(bufsize);
+  // ensure that the buffer is zeroed, as the below code only fills in pixels in the falloff region
+  *buffer = dt_calloc_align_float(bufsize);
   if(*buffer == NULL)
   {
     dt_free_align(points);
@@ -2797,6 +2798,8 @@ static inline void _brush_falloff_roi(float *buffer, const int *p0, const int *p
   }
 }
 
+// build a stamp which can be combined with other shapes in the same group
+// prerequisite: 'buffer' is all zeros
 static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
                                dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
 {
@@ -2869,9 +2872,6 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev
     dt_free_align(payload);
     return 1;
   }
-
-  // empty the output buffer
-  dt_iop_image_fill(buffer, 0.0f, width, height, 1);
 
   // now we fill the falloff
 #ifdef _OPENMP

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2363,7 +2363,8 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
-  float *const restrict bufptr = *buffer = dt_alloc_align_float(bufsize);
+  // ensure that the buffer is zeroed, as the following code only actually sets the path+falloff pixels
+  float *const restrict bufptr = *buffer = dt_calloc_align_float(bufsize);
   if(*buffer == NULL)
   {
     dt_free_align(points);
@@ -2719,6 +2720,8 @@ static void _path_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh)
   }
 }
 
+// build a stamp which can be combined with other shapes in the same group
+// prerequisite: 'buffer' is all zeros
 static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
                               dt_masks_form_t *const form,
                               const dt_iop_roi_t *roi, float *buffer)
@@ -2858,9 +2861,6 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
-
-  // empty the output buffer
-  dt_iop_image_fill(buffer, 0.0f, width, height, 1);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {


### PR DESCRIPTION
A previous cleanup erroneously removed `memset` calls to clear the buffers for retouch brush and path shapes, which prove to actually be needed.  In contrast, the `dt_iop_image_fill` calls in the `XX_get_mask_roi` functions are no longer needed now that the group code ensures the buffer passed in is all zeros.

This commit adds back the necessary buffer clearing (by using `dt_calloc_align_float`) and eliminates the extraneous `dt_iop_image_fill` calls.

Fixes #9797.  Fixes #9695.
