### PR TITLE
secure refresh in color zones when "select by" changes

### DIFF
--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2171,6 +2171,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   {
     _reset_parameters(p, p->channel, p->splines_version);
     if(g->display_mask) _reset_display_selection(self);
+    gtk_widget_queue_draw(GTK_WIDGET(g->area));
   }
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2172,6 +2172,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     _reset_parameters(p, p->channel, p->splines_version);
     if(g->display_mask) _reset_display_selection(self);
     gtk_widget_queue_draw(GTK_WIDGET(g->area));
+    gtk_widget_queue_draw(GTK_WIDGET(g->bottom_area));
   }
 }
 


### PR DESCRIPTION
This PR fixes a GUI refresh issue in color zones.
Currently the drawing area and its histogram is not updated immediately when "select by" is changed, but only when entering the drawing are with mouse.
Actually, for mysterious reasons, the drawing area it is updated for the first two times "select by" is changed, but no more.
