### PR TITLE
cleanup: use dt_aligned_pixel_t for formal args

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -185,9 +185,9 @@ static void blur_horizontal_2ch(float *const restrict buf, const int height, con
 // Put the to-be-vectorized loop into a function by itself to nudge the compiler into actually vectorizing...
 // With optimization enabled, this gets inlined and interleaved with other instructions as though it had been
 // written in place, so we get a net win from better vectorization.
-static void load_add_4wide(float *const restrict out, float *const restrict accum, const float *const restrict values)
+static void load_add_4wide(float *const restrict out, dt_aligned_pixel_t accum, const float *const restrict values)
 {
-  for_four_channels(c,aligned(accum))
+  for_four_channels(c,aligned(accum, out))
   {
     const float v = values[c];
     accum[c] += v;
@@ -195,7 +195,7 @@ static void load_add_4wide(float *const restrict out, float *const restrict accu
   }
 }
 
-static void sub_4wide(float *const restrict accum, const float *const restrict values)
+static void sub_4wide(float *const restrict accum, const dt_aligned_pixel_t values)
 {
   for_four_channels(c,aligned(accum))
     accum[c] -= values[c];
@@ -204,10 +204,10 @@ static void sub_4wide(float *const restrict accum, const float *const restrict v
 // Put the to-be-vectorized loop into a function by itself to nudge the compiler into actually vectorizing...
 // With optimization enabled, this gets inlined and interleaved with other instructions as though it had been
 // written in place, so we get a net win from better vectorization.
-static void load_add_4wide_Kahan(float *const restrict out, float *const restrict accum,
+static void load_add_4wide_Kahan(float *const restrict out, dt_aligned_pixel_t accum,
                                  const float *const restrict values, float *const restrict comp)
 {
-  for_four_channels(c,aligned(accum,comp))
+  for_four_channels(c,aligned(accum, comp, out))
   {
     const float v = values[c];
     out[c] = v;
@@ -219,7 +219,7 @@ static void load_add_4wide_Kahan(float *const restrict out, float *const restric
   }
 }
 
-static void sub_4wide_Kahan(float *const restrict accum, const float *const restrict values,
+static void sub_4wide_Kahan(float *const restrict accum, const dt_aligned_pixel_t values,
                             float *const restrict comp)
 {
   for_four_channels(c,aligned(accum,comp,values))
@@ -232,7 +232,7 @@ static void sub_4wide_Kahan(float *const restrict accum, const float *const rest
   }
 }
 
-static void store_scaled_4wide(float *const restrict out, const float *const restrict in, const float scale)
+static void store_scaled_4wide(float *const restrict out, const dt_aligned_pixel_t in, const float scale)
 {
   for_four_channels(c,aligned(in))
     out[c] = in[c] / scale;

--- a/src/common/bspline.h
+++ b/src/common/bspline.h
@@ -10,8 +10,8 @@
 #ifdef _OPENMP
 #pragma omp declare simd aligned(buf, indices, result:64)
 #endif
-static inline void sparse_scalar_product(const float *const restrict buf, const size_t indices[BSPLINE_FSIZE],
-                                         float *const restrict result)
+static inline void sparse_scalar_product(const dt_aligned_pixel_t buf, const size_t indices[BSPLINE_FSIZE],
+                                         dt_aligned_pixel_t result)
 {
   // scalar product of 2 3×5 vectors stored as RGB planes and B-spline filter,
   // e.g. RRRRR - GGGGG - BBBBB

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -32,7 +32,7 @@ static inline size_t _box_size(const int *const box)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(rgb, JzCzhz: 16) uniform(profile)
 #endif
-static inline void rgb_to_JzCzhz(const float *const rgb, float *const JzCzhz,
+static inline void rgb_to_JzCzhz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t JzCzhz,
                                  const dt_iop_order_iccprofile_info_t *const profile)
 {
   dt_aligned_pixel_t XYZ_D65 = { 0.0f, 0.0f, 0.0f };
@@ -136,8 +136,8 @@ static inline void _color_picker_jzczhz(float *const avg, float *const min, floa
 
 static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                         const dt_iop_roi_t *const roi, const int *const box,
-                                        float *const picked_color, float *const picked_color_min,
-                                        float *const picked_color_max, const dt_iop_colorspace_type_t cst_to,
+                                        dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                                        dt_aligned_pixel_t picked_color_max, const dt_iop_colorspace_type_t cst_to,
                                         const dt_iop_order_iccprofile_info_t *const profile)
 {
   const int width = roi->width;
@@ -186,8 +186,8 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *const dsc, co
 
 static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                              const dt_iop_roi_t *const roi, const int *const box,
-                                             float *const picked_color, float *const picked_color_min,
-                                             float *const picked_color_max, const dt_iop_colorspace_type_t cst_to,
+                                             dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                                             dt_aligned_pixel_t picked_color_max, const dt_iop_colorspace_type_t cst_to,
                                              const dt_iop_order_iccprofile_info_t *const profile)
 {
   const int width = roi->width;
@@ -314,8 +314,8 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const ds
 }
 
 static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
-                                    const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                                    float *const picked_color_min, float *const picked_color_max,
+                                    const dt_iop_roi_t *roi, const int *const box, dt_aligned_pixel_t picked_color,
+                                    dt_aligned_pixel_t picked_color_min, dt_aligned_pixel_t picked_color_max,
                                     const dt_iop_colorspace_type_t cst_to,
                                     const dt_iop_order_iccprofile_info_t *const profile)
 {
@@ -331,8 +331,8 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float 
 
 static void color_picker_helper_bayer_seq(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                           const dt_iop_roi_t *const roi, const int *const box,
-                                          float *const picked_color, float *const picked_color_min,
-                                          float *const picked_color_max)
+                                          dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                                          dt_aligned_pixel_t picked_color_max)
 {
   const int width = roi->width;
   const uint32_t filters = dsc->filters;
@@ -365,8 +365,8 @@ static void color_picker_helper_bayer_seq(const dt_iop_buffer_dsc_t *const dsc, 
 
 static void color_picker_helper_bayer_parallel(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                                const dt_iop_roi_t *const roi, const int *const box,
-                                               float *const picked_color, float *const picked_color_min,
-                                               float *const picked_color_max)
+                                               dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                                               dt_aligned_pixel_t picked_color_max)
 {
   const int width = roi->width;
   const uint32_t filters = dsc->filters;
@@ -445,8 +445,8 @@ static void color_picker_helper_bayer_parallel(const dt_iop_buffer_dsc_t *const 
 }
 
 static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
-                                      const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                                      float *const picked_color_min, float *const picked_color_max)
+                                      const dt_iop_roi_t *roi, const int *const box, dt_aligned_pixel_t picked_color,
+                                      dt_aligned_pixel_t picked_color_min, dt_aligned_pixel_t picked_color_max)
 {
   const size_t size = _box_size(box);
 
@@ -459,8 +459,8 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *dsc, const floa
 
 static void color_picker_helper_xtrans_seq(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                            const dt_iop_roi_t *const roi, const int *const box,
-                                           float *const picked_color, float *const picked_color_min,
-                                           float *const picked_color_max)
+                                           dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                                           dt_aligned_pixel_t picked_color_max)
 {
   const int width = roi->width;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])dsc->xtrans;
@@ -494,8 +494,8 @@ static void color_picker_helper_xtrans_seq(const dt_iop_buffer_dsc_t *const dsc,
 
 static void color_picker_helper_xtrans_parallel(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                                 const dt_iop_roi_t *const roi, const int *const box,
-                                                float *const picked_color, float *const picked_color_min,
-                                                float *const picked_color_max)
+                                                dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                                                dt_aligned_pixel_t picked_color_max)
 {
   const int width = roi->width;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])dsc->xtrans;
@@ -575,8 +575,8 @@ static void color_picker_helper_xtrans_parallel(const dt_iop_buffer_dsc_t *const
 }
 
 static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
-                                       const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                                       float *const picked_color_min, float *const picked_color_max)
+                                       const dt_iop_roi_t *roi, const int *const box, dt_aligned_pixel_t picked_color,
+                                       dt_aligned_pixel_t picked_color_min, dt_aligned_pixel_t picked_color_max)
 {
   const size_t size = _box_size(box);
 
@@ -589,8 +589,8 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *dsc, const flo
 
 // picked_color, picked_color_min and picked_color_max should be aligned
 void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
-                            const int *const box, float *const picked_color, float *const picked_color_min,
-                            float *const picked_color_max, const dt_iop_colorspace_type_t image_cst,
+                            const int *const box, dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
+                            dt_aligned_pixel_t picked_color_max, const dt_iop_colorspace_type_t image_cst,
                             const dt_iop_colorspace_type_t picker_cst,
                             const dt_iop_order_iccprofile_info_t *const profile)
 {

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -58,7 +58,7 @@ static inline void rgb_to_JzCzhz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_
 #ifdef _OPENMP
 #pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width, w)
 #endif
-static inline void _color_picker_rgb_or_lab(float *const avg, float *const min, float *const max,
+static inline void _color_picker_rgb_or_lab(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
                                             const float *const pixels, const float w, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -76,7 +76,7 @@ static inline void _color_picker_rgb_or_lab(float *const avg, float *const min, 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width, w)
 #endif
-static inline void _color_picker_lch(float *const avg, float *const min, float *const max,
+static inline void _color_picker_lch(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
                                      const float *const pixels, const float w, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -96,7 +96,7 @@ static inline void _color_picker_lch(float *const avg, float *const min, float *
 #ifdef _OPENMP
 #pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width, w)
 #endif
-static inline void _color_picker_hsl(float *const avg, float *const min, float *const max,
+static inline void _color_picker_hsl(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
                                      const float *const pixels, const float w, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -116,7 +116,7 @@ static inline void _color_picker_hsl(float *const avg, float *const min, float *
 #ifdef _OPENMP
 #pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width, w, profile)
 #endif
-static inline void _color_picker_jzczhz(float *const avg, float *const min, float *const max,
+static inline void _color_picker_jzczhz(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
                                         const float *const pixels, const float w, const size_t width,
                                         const dt_iop_order_iccprofile_info_t *const profile)
 {

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -25,8 +25,8 @@ struct dt_iop_roi_t;
 enum dt_iop_colorspace_type_t;
 
 void dt_color_picker_helper(const struct dt_iop_buffer_dsc_t *dsc, const float *const pixel,
-                            const struct dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                            float *const picked_color_min, float *const picked_color_max,
+                            const struct dt_iop_roi_t *roi, const int *const box, dt_aligned_pixel_t picked_color,
+                            dt_aligned_pixel_t picked_color_min, dt_aligned_pixel_t picked_color_max,
                             const enum dt_iop_colorspace_type_t image_cst,
                             const enum dt_iop_colorspace_type_t picker_cst,
                             const dt_iop_order_iccprofile_info_t *const profile);

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -26,7 +26,7 @@
 #include <xmmintrin.h>
 #endif
 
-static inline void weight(const float *c1, const float *c2, const float sharpen, float *weight)
+static inline void weight(const float *c1, const float *c2, const float sharpen, dt_aligned_pixel_t weight)
 {
   dt_aligned_pixel_t square;
   for_each_channel(c) square[c] = c1[c] - c2[c];

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -39,7 +39,7 @@
 
 typedef void(_blend_row_func)(const float *const restrict a, const float *const restrict b,
                               float *const restrict out, const float *const restrict mask, const size_t stride,
-                              const float *const restrict min, const float *const restrict max);
+                              const dt_aligned_pixel_t min, const dt_aligned_pixel_t max);
 
 
 #ifdef _OPENMP
@@ -53,8 +53,7 @@ static inline float _CLAMP(const float x, const float min, const float max)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, min, max: 16)
 #endif
-static inline void _CLAMP_XYZ(float *const restrict XYZ, const float *const restrict min,
-                              const float *const restrict max)
+static inline void _CLAMP_XYZ(dt_aligned_pixel_t XYZ, const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for_each_channel(i) XYZ[i] = fminf(fmaxf(XYZ[i], min[i]), max[i]);
 }
@@ -374,7 +373,7 @@ static inline void _blend_Lab_rescale(const float *i, float *o)
 #endif
 static void _blend_normal_bounded(const float *const restrict a, const float *const restrict b,
                                   float *const restrict out, const float *const restrict mask, const size_t stride,
-                                  const float *const restrict min, const float *const restrict max)
+                                  const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -400,7 +399,7 @@ static void _blend_normal_bounded(const float *const restrict a, const float *co
 static void _blend_normal_unbounded(const float *const restrict a, const float *const restrict b,
                                     float *const restrict out,
                                     const float *const restrict mask, const size_t stride,
-                                    const float *const restrict min, const float *const restrict max)
+                                    const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -425,7 +424,7 @@ static void _blend_normal_unbounded(const float *const restrict a, const float *
 #endif
 static void _blend_lighten(const float *const restrict a, const float *const restrict b,
                            float *const restrict out, const float *const restrict mask, const size_t stride,
-                           const float *const restrict min, const float *const restrict max)
+                           const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -453,7 +452,7 @@ static void _blend_lighten(const float *const restrict a, const float *const res
 #endif
 static void _blend_darken(const float *const restrict a, const float *const restrict b,
                           float *const restrict out, const float *const restrict mask, const size_t stride,
-                          const float *const restrict min, const float *const restrict max)
+                          const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -481,7 +480,7 @@ static void _blend_darken(const float *const restrict a, const float *const rest
 #endif
 static void _blend_multiply(const float *const restrict a, const float *const restrict b,
                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                            const float *const restrict min, const float *const restrict max)
+                            const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -508,7 +507,7 @@ static void _blend_multiply(const float *const restrict a, const float *const re
 #endif
 static void _blend_average(const float *const restrict a, const float *const restrict b,
                            float *const restrict out, const float *const restrict mask, const size_t stride,
-                           const float *const restrict min, const float *const restrict max)
+                           const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -533,7 +532,7 @@ static void _blend_average(const float *const restrict a, const float *const res
 #endif
 static void _blend_add(const float *const restrict a, const float *const restrict b,
                        float *const restrict out, const float *const restrict mask, const size_t stride,
-                       const float *const restrict min, const float *const restrict max)
+                       const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -558,7 +557,7 @@ static void _blend_add(const float *const restrict a, const float *const restric
 #endif
 static void _blend_subtract(const float *const restrict a, const float *const restrict b,
                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                            const float *const restrict min, const float *const restrict max)
+                            const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -584,7 +583,7 @@ static void _blend_subtract(const float *const restrict a, const float *const re
 #endif
 static void _blend_difference(const float *const restrict a, const float *const restrict b,
                               float *const restrict out, const float *const restrict mask, const size_t stride,
-                              const float *const restrict min, const float *const restrict max)
+                              const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -614,7 +613,7 @@ static void _blend_difference(const float *const restrict a, const float *const 
 #endif
 static void _blend_difference2(const float *const restrict a, const float *const restrict b,
                                float *const restrict out, const float *const restrict mask, const size_t stride,
-                               const float *const restrict min, const float *const restrict max)
+                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -643,7 +642,7 @@ static void _blend_difference2(const float *const restrict a, const float *const
 #endif
 static void _blend_screen(const float *const restrict a, const float *const restrict b,
                           float *const restrict out, const float *const restrict mask, const size_t stride,
-                          const float *const restrict min, const float *const restrict max)
+                          const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -678,7 +677,7 @@ static void _blend_screen(const float *const restrict a, const float *const rest
 #endif
 static void _blend_overlay(const float *const restrict a, const float *const restrict b,
                            float *const restrict out, const float *const restrict mask, const size_t stride,
-                           const float *const restrict min, const float *const restrict max)
+                           const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -717,7 +716,7 @@ static void _blend_overlay(const float *const restrict a, const float *const res
 #endif
 static void _blend_softlight(const float *const restrict a, const float *const restrict b,
                              float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const float *const restrict min, const float *const restrict max)
+                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -755,7 +754,7 @@ static void _blend_softlight(const float *const restrict a, const float *const r
 #endif
 static void _blend_hardlight(const float *const restrict a, const float *const restrict b,
                              float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const float *const restrict min, const float *const restrict max)
+                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -794,7 +793,7 @@ static void _blend_hardlight(const float *const restrict a, const float *const r
 #endif
 static void _blend_vividlight(const float *const restrict a, const float *const restrict b,
                               float *const restrict out, const float *const restrict mask, const size_t stride,
-                              const float *const restrict min, const float *const restrict max)
+                              const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -833,7 +832,7 @@ static void _blend_vividlight(const float *const restrict a, const float *const 
 #endif
 static void _blend_linearlight(const float *const restrict a, const float *const restrict b,
                                float *const restrict out, const float *const restrict mask, const size_t stride,
-                               const float *const restrict min, const float *const restrict max)
+                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -868,7 +867,7 @@ static void _blend_linearlight(const float *const restrict a, const float *const
 #endif
 static void _blend_pinlight(const float *const restrict a, const float *const restrict b,
                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                            const float *const restrict min, const float *const restrict max)
+                            const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -906,7 +905,7 @@ static void _blend_pinlight(const float *const restrict a, const float *const re
 #endif
 static void _blend_lightness(const float *const restrict a, const float *const restrict b,
                              float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const float *const restrict min, const float *const restrict max)
+                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -933,7 +932,7 @@ static void _blend_lightness(const float *const restrict a, const float *const r
 #endif
 static void _blend_chromaticity(const float *const restrict a, const float *const restrict b,
                                 float *const restrict out, const float *const restrict mask, const size_t stride,
-                                const float *const restrict min, const float *const restrict max)
+                                const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -966,7 +965,7 @@ static void _blend_chromaticity(const float *const restrict a, const float *cons
 #endif
 static void _blend_hue(const float *const restrict a, const float *const restrict b,
                        float *const restrict out, const float *const restrict mask, const size_t stride,
-                       const float *const restrict min, const float *const restrict max)
+                       const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1002,7 +1001,7 @@ static void _blend_hue(const float *const restrict a, const float *const restric
 #endif
 static void _blend_color(const float *const restrict a, const float *const restrict b,
                          float *const restrict out, const float *const restrict mask, const size_t stride,
-                         const float *const restrict min, const float *const restrict max)
+                         const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1039,7 +1038,7 @@ static void _blend_color(const float *const restrict a, const float *const restr
 #endif
 static void _blend_coloradjust(const float *const restrict a, const float *const restrict b,
                                float *const restrict out, const float *const restrict mask, const size_t stride,
-                               const float *const restrict min, const float *const restrict max)
+                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1076,7 +1075,7 @@ static void _blend_coloradjust(const float *const restrict a, const float *const
 #endif
 static void _blend_Lab_lightness(const float *const restrict a, const float *const restrict b,
                                  float *const restrict out, const float *const restrict mask, const size_t stride,
-                                 const float *const restrict min, const float *const restrict max)
+                                 const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1101,7 +1100,7 @@ static void _blend_Lab_lightness(const float *const restrict a, const float *con
 #endif
 static void _blend_Lab_a(const float *const restrict a, const float *const restrict b,
                          float *const restrict out, const float *const restrict mask, const size_t stride,
-                         const float *const restrict min, const float *const restrict max)
+                         const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1126,7 +1125,7 @@ static void _blend_Lab_a(const float *const restrict a, const float *const restr
 #endif
 static void _blend_Lab_b(const float *const restrict a, const float *const restrict b,
                          float *const restrict out, const float *const restrict mask, const size_t stride,
-                         const float *const restrict min, const float *const restrict max)
+                         const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1152,7 +1151,7 @@ static void _blend_Lab_b(const float *const restrict a, const float *const restr
 #endif
 static void _blend_Lab_color(const float *const restrict a, const float *const restrict b,
                              float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const float *const restrict min, const float *const restrict max)
+                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1270,7 +1269,7 @@ static _blend_row_func *_choose_blend_func(const unsigned int blend_mode)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(out:16)
 #endif
-static inline void _display_channel_value(float *const restrict out, const float value, const float mask)
+static inline void _display_channel_value(dt_aligned_pixel_t out, const float value, const float mask)
 {
   out[0] = value;
   out[1] = value;

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -746,7 +746,7 @@ static inline float _rgb_luminance(const float *const restrict rgb,
 #ifdef _OPENMP
 #pragma omp declare simd aligned(rgb, JzCzhz: 16) uniform(profile)
 #endif
-static inline void _rgb_to_JzCzhz(const float *const restrict rgb, float *const restrict JzCzhz,
+static inline void _rgb_to_JzCzhz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t JzCzhz,
                                   const dt_iop_order_iccprofile_info_t *const restrict profile)
 {
   dt_aligned_pixel_t JzAzBz = { 0.0f, 0.0f, 0.0f };

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -895,14 +895,14 @@ void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out, const float *
   }
 }
 
-void dt_iop_RGB_to_YCbCr(const float *rgb, float *yuv)
+void dt_iop_RGB_to_YCbCr(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t yuv)
 {
   yuv[0] = 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2];
   yuv[1] = -0.147 * rgb[0] - 0.289 * rgb[1] + 0.437 * rgb[2];
   yuv[2] = 0.615 * rgb[0] - 0.515 * rgb[1] - 0.100 * rgb[2];
 }
 
-void dt_iop_YCbCr_to_RGB(const float *yuv, float *rgb)
+void dt_iop_YCbCr_to_RGB(const dt_aligned_pixel_t yuv, dt_aligned_pixel_t rgb)
 {
   rgb[0] = yuv[0] + 1.140 * yuv[2];
   rgb[1] = yuv[0] - 0.394 * yuv[1] - 0.581 * yuv[2];

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -99,8 +99,8 @@ void dt_iop_clip_and_zoom_8(const uint8_t *i, int32_t ix, int32_t iy, int32_t iw
                             int32_t ibh, uint8_t *o, int32_t ox, int32_t oy, int32_t ow, int32_t oh,
                             int32_t obw, int32_t obh);
 
-void dt_iop_YCbCr_to_RGB(const float *yuv, float *rgb);
-void dt_iop_RGB_to_YCbCr(const float *rgb, float *yuv);
+void dt_iop_YCbCr_to_RGB(const dt_aligned_pixel_t yuv, dt_aligned_pixel_t rgb);
+void dt_iop_RGB_to_YCbCr(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t yuv);
 
 /** takes four points (x,y) in two arrays and fills the cubic coefficients a, such that y = [X] * a, where
   * [X] is the matrix containing all x^3 x^2 x^1 x^0 lines for all four x. */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -586,8 +586,8 @@ static void histogram_collect_cl(int devid, dt_dev_pixelpipe_iop_t *piece, cl_me
 #endif
 
 // helper for color picking
-static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *roi, float *picked_color,
-                                   float *picked_color_min, float *picked_color_max,
+static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *roi, dt_aligned_pixel_t picked_color,
+                                   dt_aligned_pixel_t picked_color_min, dt_aligned_pixel_t picked_color_max,
                                    dt_pixelpipe_picker_source_t picker_source, int *box)
 {
   const float wd = darktable.develop->preview_pipe->backbuf_width;
@@ -784,9 +784,10 @@ error:
 static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_roi_t *roi_in,
                                        cmsHTRANSFORM xform_rgb2lab, cmsHTRANSFORM xform_rgb2rgb,
                                        const float *const pick_box, const float *const pick_point,
-                                       const int pick_size, float *pick_color_rgb_min, float *pick_color_rgb_max,
-                                       float *pick_color_rgb_mean, float *pick_color_lab_min,
-                                       float *pick_color_lab_max, float *pick_color_lab_mean)
+                                       const int pick_size, dt_aligned_pixel_t pick_color_rgb_min,
+                                       dt_aligned_pixel_t pick_color_rgb_max, dt_aligned_pixel_t pick_color_rgb_mean,
+                                       dt_aligned_pixel_t pick_color_lab_min, dt_aligned_pixel_t pick_color_lab_max,
+                                       dt_aligned_pixel_t pick_color_lab_mean)
 {
   dt_aligned_pixel_t picked_color_rgb_min = { 0.0f };
   dt_aligned_pixel_t picked_color_rgb_max = { 0.0f };

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1266,7 +1266,7 @@ error:
 }
 
 // XYZ -> sRGB matrix
-static void XYZ_to_sRGB(const float *XYZ, float *sRGB)
+static void XYZ_to_sRGB(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t sRGB)
 {
   sRGB[0] =  3.1338561f * XYZ[0] - 1.6168667f * XYZ[1] - 0.4906146f * XYZ[2];
   sRGB[1] = -0.9787684f * XYZ[0] + 1.9161415f * XYZ[1] + 0.0334540f * XYZ[2];
@@ -1274,7 +1274,7 @@ static void XYZ_to_sRGB(const float *XYZ, float *sRGB)
 }
 
 // sRGB -> XYZ matrix
-static void sRGB_to_XYZ(const float *sRGB, float *XYZ)
+static void sRGB_to_XYZ(const dt_aligned_pixel_t sRGB, dt_aligned_pixel_t XYZ)
 {
   XYZ[0] = 0.4360747f * sRGB[0] + 0.3850649f * sRGB[1] + 0.1430804f * sRGB[2];
   XYZ[1] = 0.2225045f * sRGB[0] + 0.7168786f * sRGB[1] + 0.0606169f * sRGB[2];


### PR DESCRIPTION
To give the compiler better information and make future maintenance easier, replace float* function args by `dt_aligned_pixel_t` where appropriate.
