### PR TITLE
Lua: add darkroom-image-loaded event and clear_snapshots() function

### DIFF
--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -342,21 +342,6 @@ int mouse_moved(dt_lib_module_t *self, double x, double y, double pressure, int 
   return 0;
 }
 
-void _internal_gui_reset(dt_lib_module_t *self)
-{
-  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
-  d->num_snapshots = 0;
-  d->snapshot_image = NULL;
-
-  for(uint32_t k = 0; k < d->size; k++)
-  {
-    gtk_widget_hide(d->snapshot[k].button);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->snapshot[k].button), FALSE);
-  }
-
-  dt_control_queue_redraw_center();
-}
-
 void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
@@ -686,15 +671,7 @@ static int lua_take_snapshot(lua_State *L)
 static int lua_clear_snapshots(lua_State *L)
 {
   dt_lib_module_t *self = lua_touserdata(L, lua_upvalueindex(1));
-  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
-  d->num_snapshots = 0;
-  d->snapshot_image = NULL;
-
-  for(uint32_t k = 0; k < d->size; k++)
-  {
-    gtk_widget_hide(d->snapshot[k].button);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->snapshot[k].button), FALSE);
-  }
+  gui_reset(self);
   return 0;
 }
 

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -342,6 +342,21 @@ int mouse_moved(dt_lib_module_t *self, double x, double y, double pressure, int 
   return 0;
 }
 
+void _internal_gui_reset(dt_lib_module_t *self)
+{
+  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+  d->num_snapshots = 0;
+  d->snapshot_image = NULL;
+
+  for(uint32_t k = 0; k < d->size; k++)
+  {
+    gtk_widget_hide(d->snapshot[k].button);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->snapshot[k].button), FALSE);
+  }
+
+  dt_control_queue_redraw_center();
+}
+
 void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
@@ -668,6 +683,21 @@ static int lua_take_snapshot(lua_State *L)
   return 0;
 }
 
+static int lua_clear_snapshots(lua_State *L)
+{
+  dt_lib_module_t *self = lua_touserdata(L, lua_upvalueindex(1));
+  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+  d->num_snapshots = 0;
+  d->snapshot_image = NULL;
+
+  for(uint32_t k = 0; k < d->size; k++)
+  {
+    gtk_widget_hide(d->snapshot[k].button);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->snapshot[k].button), FALSE);
+  }
+  return 0;
+}
+
 typedef int dt_lua_snapshot_t;
 static int selected_member(lua_State *L)
 {
@@ -771,6 +801,11 @@ void init(struct dt_lib_module_t *self)
   dt_lua_gtk_wrap(L);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, my_type, "take_snapshot");
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, lua_clear_snapshots, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "clear_snapshots");
   lua_pushcfunction(L, snapshots_length);
   lua_pushcfunction(L, number_member);
   dt_lua_type_register_number_const_type(L, my_type);


### PR DESCRIPTION
Added "darkroom-image-loaded event that fires when an image is loaded into darkroom mode.  The image is returned to the event handler when the event fires.  Needed to build a solution to #2315.  Also needed (along with some other events that don't exist yet) to implement responsive cache updating (lua script to keep mipmap cache up to date by catching image changes and updating the cache in the lua thread).

Added function clear_snapshots() to remove the list of snapshots.  While testing the script to automatically generate a snapshot when an image was loaded in darkroom, I ended up with a string of snapshots named "exposure(11)".  The newest was always at the top, but for this function having that list didn't really make sense so I added a function to clear the list before taking the snapshot.

To test:  add the attached test_darkroom_trigger.lua script to your scripts and enable it.  Open an image in darkroom view and it will automatically create a snapshot.  Each time you change images, the snapshot list will be cleared and a new snapshot created.