### PR TITLE
Unify formating of strings across modules

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1757,7 +1757,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
   const gchar **short_label = (p->mode == SLOPE_OFFSET_POWER) ? short_label_ops : short_label_lgg;
   const gchar *long_label[]
      = { N_("shadows : lift / offset"),
-         N_("mid-tones : gamma / power"),
+         N_("midtones : gamma / power"),
          N_("highlights : gain / slope") };
 
   gchar *layout = dt_conf_get_string("plugins/darkroom/colorbalance/layout");
@@ -1782,7 +1782,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
   }
   else
   {
-    gtk_label_set_text(GTK_LABEL(g->main_label), _("shadows / mid-tones / highlights"));
+    gtk_label_set_text(GTK_LABEL(g->main_label), _("shadows / midtones / highlights"));
 
     GtkWidget *label[3];
     for(int i=0; i<3; i++)
@@ -2078,7 +2078,7 @@ void gui_init(dt_iop_module_t *self)
         N_("factor of blue for gain/slope") };
 
   ADD_BLOCK(0, lift,  N_("shadows"), lift_messages, 0.05f,  5.0f)
-  ADD_BLOCK(1, gamma, N_("mid-tones"), gamma_messages, 0.5f, 20.0f)
+  ADD_BLOCK(1, gamma, N_("midtones"), gamma_messages, 0.5f, 20.0f)
   ADD_BLOCK(2, gain,  N_("highlights"), gain_messages,  0.5f, 25.0f)
   _configure_slider_blocks(NULL, self);
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1327,31 +1327,31 @@ void gui_init(struct dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, g->combobox_patch);
 
   g->scale_L = dt_bauhaus_slider_new_with_range(self, -100.0, 200.0, 1.0, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_L, _("lightness offset"));
+  gtk_widget_set_tooltip_text(g->scale_L, _("scale lightness in Lab space\nlower values darken target color while higher brighten it"));
   dt_bauhaus_widget_set_label(g->scale_L, NULL, N_("lightness"));
 
   g->scale_a = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_a, _("chroma offset green/red"));
-  dt_bauhaus_widget_set_label(g->scale_a, NULL, N_("green/red"));
+  gtk_widget_set_tooltip_text(g->scale_a, _("scale target color in Lab a dimmension\nlower values shift target color towards greens while higher shift towards magentas"));
+  dt_bauhaus_widget_set_label(g->scale_a, NULL, N_("green-magenta offset"));
   dt_bauhaus_slider_set_stop(g->scale_a, 0.0, 0.0, 1.0, 0.2);
   dt_bauhaus_slider_set_stop(g->scale_a, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_a, 1.0, 1.0, 0.0, 0.2);
 
   g->scale_b = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_b, _("chroma offset blue/yellow"));
-  dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue/yellow"));
+  gtk_widget_set_tooltip_text(g->scale_b, _("scale target color in Lab b dimmension\nlower values shift target color towards blues while higher shift towards yellows"));
+  dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue-yellow offset"));
   dt_bauhaus_slider_set_stop(g->scale_b, 0.0, 0.0, 0.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 1.0, 1.0, 1.0, 0.0);
 
   g->scale_C = dt_bauhaus_slider_new_with_range(self, -128.0, 128.0, 1.0f, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_C, _("saturation offset"));
+  gtk_widget_set_tooltip_text(g->scale_C, _("scale target color saturation\nscales a and b values of target color in Lab simultaneously\nlower values scale towards lower saturation while higher scale towards higher saturation"));
   dt_bauhaus_widget_set_label(g->scale_C, NULL, N_("saturation"));
 
   g->absolute_target = 0;
   g->combobox_target = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->combobox_target, 0, N_("target color"));
-  gtk_widget_set_tooltip_text(g->combobox_target, _("control target color of the patches via relative offsets or via absolute Lab values"));
+  gtk_widget_set_tooltip_text(g->combobox_target, _("control target color of the patches\nrelative - target color is relative from the patch original color\nabsolute - target color is absolute Lab value"));
   dt_bauhaus_combobox_add(g->combobox_target, _("relative"));
   dt_bauhaus_combobox_add(g->combobox_target, _("absolute"));
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1327,25 +1327,25 @@ void gui_init(struct dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, g->combobox_patch);
 
   g->scale_L = dt_bauhaus_slider_new_with_range(self, -100.0, 200.0, 1.0, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_L, _("scale lightness in Lab space\nlower values darken target color while higher brighten it"));
+  gtk_widget_set_tooltip_text(g->scale_L, _("adjust target color Lab 'L' channel\nlower values darken target color while higher brighten it"));
   dt_bauhaus_widget_set_label(g->scale_L, NULL, N_("lightness"));
 
   g->scale_a = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_a, _("scale target color in Lab a dimmension\nlower values shift target color towards greens while higher shift towards magentas"));
+  gtk_widget_set_tooltip_text(g->scale_a, _("adjust target color Lab 'a' channel\nlower values shift target color towards greens while higher shift towards magentas"));
   dt_bauhaus_widget_set_label(g->scale_a, NULL, N_("green-magenta offset"));
   dt_bauhaus_slider_set_stop(g->scale_a, 0.0, 0.0, 1.0, 0.2);
   dt_bauhaus_slider_set_stop(g->scale_a, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_a, 1.0, 1.0, 0.0, 0.2);
 
   g->scale_b = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_b, _("scale target color in Lab b dimmension\nlower values shift target color towards blues while higher shift towards yellows"));
+  gtk_widget_set_tooltip_text(g->scale_b, _("adjust target color Lab 'b' channel\nlower values shift target color towards blues while higher shift towards yellows"));
   dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue-yellow offset"));
   dt_bauhaus_slider_set_stop(g->scale_b, 0.0, 0.0, 0.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 1.0, 1.0, 1.0, 0.0);
 
   g->scale_C = dt_bauhaus_slider_new_with_range(self, -128.0, 128.0, 1.0f, 0.0f, 2);
-  gtk_widget_set_tooltip_text(g->scale_C, _("scale target color saturation\nscales a and b values of target color in Lab simultaneously\nlower values scale towards lower saturation while higher scale towards higher saturation"));
+  gtk_widget_set_tooltip_text(g->scale_C, _("adjust target color saturation\adjusts 'a' and 'b' channels of target color in Lab space simultaneously\nlower values scale towards lower saturation while higher scale towards higher saturation"));
   dt_bauhaus_widget_set_label(g->scale_C, NULL, N_("saturation"));
 
   g->absolute_target = 0;

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1653,7 +1653,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->contrast, NULL, N_("contrast"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
-                                             "affects mostly the mid-tones"));
+                                             "affects mostly the midtones"));
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
 
   // latitude slider
@@ -1664,7 +1664,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->latitude_stops, _("width of the linear domain in the middle of the curve.\n"
                                                    "increase to get more contrast at the extreme luminances.\n"
-                                                   "this has no effect on mid-tones."));
+                                                   "this has no effect on midtones."));
   g_signal_connect(G_OBJECT(g->latitude_stops), "value-changed", G_CALLBACK(latitude_stops_callback), self);
 
   // balance slider

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -168,9 +168,9 @@ typedef struct dt_iop_filmicrgb_params_t
   float white_point_source;    // $MIN: 0 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
   float reconstruct_threshold; // $MIN: -6.0 $MAX: 6.0 $DEFAULT: +3.0 $DESCRIPTION: "threshold"
   float reconstruct_feather;   // $MIN: 0.25 $MAX: 6.0 $DEFAULT: 3.0 $DESCRIPTION: "transition"
-  float reconstruct_bloom_vs_details; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "bloom/reconstruct"
-  float reconstruct_grey_vs_color; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "gray/colorful details"
-  float reconstruct_structure_vs_texture; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION: "structure/texture"
+  float reconstruct_bloom_vs_details; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "bloom ↔ reconstruct"
+  float reconstruct_grey_vs_color; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "gray ↔ colorful details"
+  float reconstruct_structure_vs_texture; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION: "structure ↔ texture"
   float security_factor;                  // $MIN: -50 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "dynamic range scaling"
   float grey_point_target;                // $MIN: 1 $MAX: 50 $DEFAULT: 18.45 $DESCRIPTION: "target middle gray"
   float black_point_target; // $MIN: 0.000 $MAX: 20.000 $DEFAULT: 0.01517634 $DESCRIPTION: "target black luminance"
@@ -179,7 +179,7 @@ typedef struct dt_iop_filmicrgb_params_t
   float latitude;           // $MIN: 0.01 $MAX: 100 $DEFAULT: 33.0
   float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.35
   float saturation;         // $MIN: -50 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "extreme luminance saturation"
-  float balance;            // $MIN: -50 $MAX: 50 $DEFAULT: 0.0 $DESCRIPTION: "shadows/highlights balance"
+  float balance;            // $MIN: -50 $MAX: 50 $DEFAULT: 0.0 $DESCRIPTION: "shadows ↔ highlights balance"
   float noise_level;        // $MIN: 0.0 $MAX: 6.0 $DEFAULT: 0.2f $DESCRIPTION: "add noise in highlights"
   dt_iop_filmicrgb_methods_type_t preserve_color; // $DEFAULT: DT_FILMIC_METHOD_POWER_NORM $DESCRIPTION: "preserve chrominance"
   dt_iop_filmicrgb_colorscience_type_t version; // $DEFAULT: DT_FILMIC_COLORSCIENCE_V3 $DESCRIPTION: "color science"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3782,7 +3782,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->contrast, 3);
   dt_bauhaus_slider_set_step(g->contrast, .01);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
-                                             "affects mostly the mid-tones"));
+                                             "affects mostly the midtones"));
 
   // brightness slider
   g->output_power = dt_bauhaus_slider_from_params(self, "output_power");
@@ -3798,7 +3798,7 @@ void gui_init(dt_iop_module_t *self)
                                 "in percent of the dynamic range (white exposure - black exposure).\n"
                                 "increase to get more contrast and less desaturation at extreme luminances,\n"
                                 "decrease otherwise. no desaturation happens in the latitude range.\n"
-                                "this has no effect on mid-tones."));
+                                "this has no effect on midtones."));
 
   g->balance = dt_bauhaus_slider_from_params(self, "balance");
   dt_bauhaus_slider_set_format(g->balance, "%.2f %%");
@@ -3959,7 +3959,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     if(p->version == DT_FILMIC_COLORSCIENCE_V1)
       dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
     else if(p->version == DT_FILMIC_COLORSCIENCE_V2 || p->version == DT_FILMIC_COLORSCIENCE_V3)
-      dt_bauhaus_widget_set_label(g->saturation, NULL, N_("middle tones saturation"));
+      dt_bauhaus_widget_set_label(g->saturation, NULL, N_("midtones saturation"));
   }
 
   if(!w || w == g->reconstruct_bloom_vs_details)

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -43,7 +43,7 @@ DT_MODULE_INTROSPECTION(2, dt_iop_velvia_params_t)
 typedef struct dt_iop_velvia_params_t
 {
   float strength; // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 25.0
-  float bias;     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 1.0 $DESCRIPTION: "mid-tones bias"
+  float bias;     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 1.0 $DESCRIPTION: "midtones bias"
 } dt_iop_velvia_params_t;
 
 /* legacy version 1 params */


### PR DESCRIPTION
Fixes #5660 

- make sure to use single spelling - `midtones` for all things dealing with middle tones
- explain color look up table and update labels
- use UTF-8 arrows for labels in filmic