### PR TITLE
split-toning: display hues in degrees

### DIFF
--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -509,10 +509,14 @@ void gui_init(struct dt_iop_module_t *self)
   ++darktable.bauhaus->skip_accel;
   GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->shadow_hue_gslider = dt_bauhaus_slider_from_params(self, "shadow_hue");
+  dt_bauhaus_slider_set_factor(g->shadow_hue_gslider, 360.0f);
+  dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "%.2f°");
   g->shadow_sat_gslider = dt_bauhaus_slider_from_params(self, "shadow_saturation");
 
   GtkWidget *highlights_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->highlight_hue_gslider = dt_bauhaus_slider_from_params(self, "highlight_hue");
+  dt_bauhaus_slider_set_factor(g->highlight_hue_gslider, 360.0f);
+  dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "%.2f°");
   g->highlight_sat_gslider = dt_bauhaus_slider_from_params(self, "highlight_saturation");
   --darktable.bauhaus->skip_accel;
 


### PR DESCRIPTION
In module split-toning, this PR changes the hue visualization scale from 0..1 to 0°..360°, for uniformity with most other modules

![image](https://user-images.githubusercontent.com/43290988/129899506-2a72d02c-b298-454b-ba7b-f5ac989eda6a.png)
