### PR TITLE
Fix Potential integer overflow in image pfm/pnm image loading

### DIFF
--- a/src/common/imageio_pfm.c
+++ b/src/common/imageio_pfm.c
@@ -22,6 +22,7 @@
 #include "common/imageio_pfm.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,8 +51,17 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
     cols = 1;
   else
     goto error_corrupt;
-  ret = fscanf(f, "%d %d %f%*[^\n]", &img->width, &img->height, &scale_factor);
+  char width_string[10] = { 0 };
+  char height_string[10] = { 0 };
+  char scale_factor_string[64] = { 0 };
+  ret = fscanf(f, "%9s %9s %63s%*[^\n]", width_string, height_string, scale_factor_string);
   if(ret != 3) goto error_corrupt;
+  errno = 0;
+  img->width = strtol(width_string, NULL, 0);
+  img->height = strtol(height_string, NULL, 0);
+  scale_factor = g_ascii_strtod(scale_factor_string, NULL);
+  if(errno != 0) goto error_corrupt;
+  if(img->width <= 0 || img->height <= 0 ) goto error_corrupt;
   ret = fread(&ret, sizeof(char), 1, f);
   if(ret != 1) goto error_corrupt;
   ret = 0;
@@ -84,6 +94,7 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
             = buf[4 * (img->width * j + i) + 0] = v.f;
       }
   float *line = (float *)calloc(4 * img->width, sizeof(float));
+  if(line == NULL) goto error_cache_full;
   for(size_t j = 0; j < img->height / 2; j++)
   {
     memcpy(line, buf + img->width * j * 4, sizeof(float) * 4 * img->width);

--- a/src/common/imageio_pnm.c
+++ b/src/common/imageio_pnm.c
@@ -22,6 +22,7 @@
 #include "common/imageio_pfm.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -205,8 +206,15 @@ dt_imageio_retval_t dt_imageio_open_pnm(dt_image_t *img, const char *filename, d
   ret = fscanf(f, "%c%c ", head, head + 1);
   if(ret != 2 || head[0] != 'P') goto end;
 
-  ret = fscanf(f, "%d %d ", &img->width, &img->height);
+  char width_string[10] = { 0 };
+  char height_string[10] = { 0 };
+  ret = fscanf(f, "%9s %9s ", width_string, height_string);
   if(ret != 2) goto end;
+
+  errno = 0;
+  img->width = strtol(width_string, NULL, 0);
+  img->height = strtol(height_string, NULL, 0);
+  if(errno != 0 || img->width <= 0 || img->height <= 0) goto end;
 
   img->buf_dsc.channels = 4;
   img->buf_dsc.datatype = TYPE_FLOAT;


### PR DESCRIPTION
Fixes #9827 and similar fscanf problem in pnm

generally if image is corrupted/crafted to overflow, instead of crashing should just return `DT_IMAGEIO_FILE_CORRUPTED`