### PR TITLE
toneeq: visualize cursor on focus, activate on scroll

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2275,11 +2275,12 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     correction = log2f(pixel_correction(exposure_in, g->factors, g->sigma));
     exposure_out = exposure_in + correction;
     luminance_out = exp2f(exposure_out);
-    if(isnan(correction) || isnan(exposure_in)) return; // something went wrong
   }
 
   dt_iop_gui_leave_critical_section(self);
-
+  
+  if(isnan(correction) || isnan(exposure_in)) return; // something went wrong
+ 
   // Rescale and shift Cairo drawing coordinates
   const float wd = dev->preview_pipe->backbuf_width;
   const float ht = dev->preview_pipe->backbuf_height;


### PR DESCRIPTION
This PR fixes #9834 by allowing the special cursor of Tone Equalizer to show up (with a dummy text, as luminance mask is not ready yet) when module is focused and expanded, but not necessarily activated, for uniformity with other modules.
Also, mouse scroll on centre image will activate the module, as per help text.

![immagine](https://user-images.githubusercontent.com/43290988/130265178-9901c1b0-403d-4215-8e6e-c43a7e1cba7b.png)
