### PR TITLE
diffuse: avoid division by zero

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -312,6 +312,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     // regardless of the wavelet scale where we compute it.
     // Prevents large scale halos when deblurring.
     variance = variance_threshold + native_sqrt(variance * regularization_factor);
+    variance = fmax(variance, (float4)1e-6f);
 
     // compute the update
     float4 acc = (float4)0.f;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -784,6 +784,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
         for_each_channel(c, aligned(variance))
         {
           variance[c] = variance_threshold + sqrtf(variance[c] * regularization_factor);
+          variance[c] = MAX(variance[c], 1e-6f);
         }
         // compute the update
         dt_aligned_pixel_t acc = { 0.f };


### PR DESCRIPTION
Ensure the variance / regularization value is always greater than zero. Otherwise we may end up dividing by zero later when this value is used as the divisor.