### PR TITLE
Fix dual demosaic mask display

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5723,16 +5723,29 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
-static void show_mask_callback(GtkWidget *slider, gpointer user_data)
+static void show_mask_callback(GtkWidget *togglebutton, dt_iop_module_t *self)
 {
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
+  dt_iop_request_focus(self);
+
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+
   g->show_mask = !(g->show_mask);
   dt_bauhaus_widget_set_quad_active(g->dual_mask, g->show_mask);
-  dt_bauhaus_widget_set_quad_toggle(g->dual_mask, g->show_mask);
   dt_dev_reprocess_center(self->dev);
+}
+
+void gui_focus(struct dt_iop_module_t *self, gboolean in)
+{
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+  if(!in)
+  {
+    const gboolean was_mask = g->show_mask;
+    g->show_mask = FALSE;  
+    dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->dual_mask), FALSE);
+    if(was_mask) dt_dev_reprocess_center(self->dev);
+  }
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -109,7 +109,8 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
 
   const float contrastf = slider2contrast(data->dual_thrs);
-  if(showmask) piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
+  if(showmask)
+    piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   {
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -65,6 +65,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
 
   if(dual_mask)
   {
+    piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(blend, rgb_data, vng_image, width, height) \
@@ -108,6 +109,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->global_data;
 
   const float contrastf = slider2contrast(data->dual_thrs);
+  if(showmask) piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   {
     size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };


### PR DESCRIPTION
There were some issues regarding the way the dual demosaicer mask was displayed.

1. The mask button was not correctly displayed switching on/off
2. When closing the module header (loosing focus) the mask display should always be switched off for a better UI
3. modules following in the pipeline should not change the mask display (i learned that from toneequal.c)