### PR TITLE
order or skip midi devices

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3226,4 +3226,11 @@
     <shortdescription>height of the collect list</shortdescription>
     <longdescription>maximum height the collect list in lighttable will grow to before scrolling</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/midi/devices</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription>order or exclude midi devices</shortdescription>
+    <longdescription>comma-separated list of device name fragments that if matched load midi device at id given by location in list or if preceded by - prevent matching devices from loading</longdescription>
+  </dtconfig>
 </dtconfiglist>


### PR DESCRIPTION
fixes #9445

This helps if you have two midi devices and you want them always assigned the same number, so that your configuration doesn't get used by the wrong device. 

For example, if you have an X-Touch Mini and an Arturia Beatstep, add a line in darktablerc with the format:

`plugins/midi/devices=MINI,BeatStep,-
`

(this stops any further midi devices from loading after those two. If you want other devices added after them, in "random" order, just don't specify the `,-` at the end)

You can also just skip loading one particular device (or a list of them) with something like this:

`plugins/midi/devices=-BeatStep
`

@MStraeten would you please test and report if this solution works for you?