### PR TITLE
display live samples in vectorscope

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -46,14 +46,6 @@ typedef enum dt_lib_colorpicker_model_t
   DT_LIB_COLORPICKER_MODEL_N // needs to be the lsat one
 } dt_lib_colorpicker_model_t;
 
-typedef enum dt_lib_colorpicker_statistic_t
-{
-  DT_LIB_COLORPICKER_STATISTIC_MEAN = 0,
-  DT_LIB_COLORPICKER_STATISTIC_MIN,
-  DT_LIB_COLORPICKER_STATISTIC_MAX,
-  DT_LIB_COLORPICKER_STATISTIC_N // needs to be the lsat one
-} dt_lib_colorpicker_statistic_t;
-
 const gchar *dt_lib_colorpicker_model_names[DT_LIB_COLORPICKER_MODEL_N] = {"RGB", "Lab", "LCh", "HSL", "Hex", "none"};
 const gchar *dt_lib_colorpicker_statistic_names[DT_LIB_COLORPICKER_STATISTIC_N] = {"mean", "min", "max"};
 
@@ -355,6 +347,7 @@ static void _statistic_changed(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_colorpicker_t *data = self->data;
   data->statistic = dt_bauhaus_combobox_get(widget);
+  darktable.lib->proxy.colorpicker.statistic = (int)data->statistic;
   dt_conf_set_string("ui_last/colorpicker_mode", dt_lib_colorpicker_statistic_names[data->statistic]);
 
   _update_picker_output(self);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -359,7 +359,8 @@ static void _statistic_changed(GtkWidget *widget, dt_lib_module_t *self)
 
   _update_picker_output(self);
   _update_samples_output(self);
-  dt_dev_invalidate_from_gui(darktable.develop);
+  if(darktable.lib->proxy.colorpicker.display_samples)
+      dt_dev_invalidate_from_gui(darktable.develop);
 }
 
 static void _color_mode_changed(GtkWidget *widget, dt_lib_module_t *self)
@@ -398,7 +399,10 @@ static gboolean _sample_enter_callback(GtkWidget *widget, GdkEvent *event, gpoin
   if(sample->size != DT_LIB_COLORPICKER_SIZE_NONE)
   {
     darktable.lib->proxy.colorpicker.selected_sample = sample;
-    dt_dev_invalidate_from_gui(darktable.develop);
+    if(darktable.lib->proxy.colorpicker.display_samples)
+      dt_dev_invalidate_from_gui(darktable.develop);
+   	else
+   	  dt_control_queue_redraw_center();
   }
 
   return FALSE;
@@ -411,7 +415,10 @@ static gboolean _sample_leave_callback(GtkWidget *widget, GdkEvent *event, gpoin
   if(darktable.lib->proxy.colorpicker.selected_sample)
   {
     darktable.lib->proxy.colorpicker.selected_sample = NULL;
-    dt_dev_invalidate_from_gui(darktable.develop);
+    if(darktable.lib->proxy.colorpicker.display_samples)
+      dt_dev_invalidate_from_gui(darktable.develop);
+   	else
+   	  dt_control_queue_redraw_center();
   }
 
   return FALSE;
@@ -526,7 +533,10 @@ static void _add_sample(GtkButton *widget, dt_lib_module_t *self)
 
   // Updating the display
   _update_samples_output(self);
-  dt_dev_invalidate_from_gui(darktable.develop);
+  if(darktable.lib->proxy.colorpicker.display_samples)
+      dt_dev_invalidate_from_gui(darktable.develop);
+   	else
+   	  dt_control_queue_redraw_center();
 }
 
 static void _display_samples_changed(GtkToggleButton *button, gpointer data)
@@ -674,7 +684,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget),
                      dt_ui_scroll_wrap(data->samples_container, 1, "plugins/darkroom/colorpicker/windowheight"), TRUE, TRUE, 0);
 
-  data->display_samples_check_box = gtk_check_button_new_with_label(_("display sample areas on image"));
+  data->display_samples_check_box = gtk_check_button_new_with_label(_("display samples on image/vectorscope"));
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(data->display_samples_check_box))),
                           PANGO_ELLIPSIZE_MIDDLE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box),

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -359,6 +359,7 @@ static void _statistic_changed(GtkWidget *widget, dt_lib_module_t *self)
 
   _update_picker_output(self);
   _update_samples_output(self);
+  dt_dev_invalidate_from_gui(darktable.develop);
 }
 
 static void _color_mode_changed(GtkWidget *widget, dt_lib_module_t *self)
@@ -397,7 +398,7 @@ static gboolean _sample_enter_callback(GtkWidget *widget, GdkEvent *event, gpoin
   if(sample->size != DT_LIB_COLORPICKER_SIZE_NONE)
   {
     darktable.lib->proxy.colorpicker.selected_sample = sample;
-    dt_control_queue_redraw_center();
+    dt_dev_invalidate_from_gui(darktable.develop);
   }
 
   return FALSE;
@@ -410,7 +411,7 @@ static gboolean _sample_leave_callback(GtkWidget *widget, GdkEvent *event, gpoin
   if(darktable.lib->proxy.colorpicker.selected_sample)
   {
     darktable.lib->proxy.colorpicker.selected_sample = NULL;
-    dt_control_queue_redraw_center();
+    dt_dev_invalidate_from_gui(darktable.develop);
   }
 
   return FALSE;
@@ -525,7 +526,7 @@ static void _add_sample(GtkButton *widget, dt_lib_module_t *self)
 
   // Updating the display
   _update_samples_output(self);
-  dt_control_queue_redraw_center();
+  dt_dev_invalidate_from_gui(darktable.develop);
 }
 
 static void _display_samples_changed(GtkToggleButton *button, gpointer data)
@@ -742,7 +743,10 @@ void gui_reset(dt_lib_module_t *self)
   // Resetting GUI elements
   dt_bauhaus_combobox_set(data->statistic_selector, 0);
   dt_bauhaus_combobox_set(data->color_mode_selector, 0);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box), FALSE);
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box)))
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box), FALSE);
+  else
+    dt_dev_invalidate_from_gui(darktable.develop);
 
   // redraw without a picker
   dt_control_queue_redraw_center();

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -71,6 +71,15 @@ typedef struct dt_colorpicker_sample_t
   GdkRGBA rgb_display;
 } dt_colorpicker_sample_t;
 
+typedef enum dt_lib_colorpicker_statistic_t
+{
+  DT_LIB_COLORPICKER_STATISTIC_MEAN = 0,
+  DT_LIB_COLORPICKER_STATISTIC_MIN,
+  DT_LIB_COLORPICKER_STATISTIC_MAX,
+  DT_LIB_COLORPICKER_STATISTIC_N // needs to be the lsat one
+} dt_lib_colorpicker_statistic_t;
+
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1059,6 +1059,13 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 
+  // overlay central circle
+  set_color(cr, darktable.bauhaus->graph_grid);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5));
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, 0., 0., DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
+  cairo_fill(cr);
+
   if(!isnan(d->vectorscope_pt[0]))
   {
     // point sample
@@ -1092,13 +1099,6 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       pos++;
     }
   }
-
-  // overlay central circle
-  set_color(cr, darktable.bauhaus->graph_grid);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5));
-  cairo_new_sub_path(cr);
-  cairo_arc(cr, 0., 0., DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
-  cairo_fill(cr);
 
   cairo_restore(cr);
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -580,8 +580,8 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
         dt_atomic_add_int(binned + out_y * diam_px + out_x, 1);
     }
 
-  //find live sample position
-  if(d->vectorscope_samples)
+  // if live simple visualized, find their position
+  if(d->vectorscope_samples && darktable.lib->proxy.colorpicker.display_samples)
   {
     g_slist_free_full((GSList *)d->vectorscope_samples, free);
     d->vectorscope_samples = NULL;
@@ -1000,7 +1000,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_pattern_set_matrix(graph_pat, &matrix);
 
   cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
-  if(!isnan(d->vectorscope_pt[0]) || d->vectorscope_samples)
+  if(!isnan(d->vectorscope_pt[0]) || (d->vectorscope_samples && darktable.lib->proxy.colorpicker.display_samples))
     cairo_push_group(cr);
   cairo_set_source(cr, bkgd_pat);
   cairo_mask(cr, graph_pat);
@@ -1013,7 +1013,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_pattern_destroy(graph_pat);
   cairo_surface_destroy(graph_surface);
 
-  if(!isnan(d->vectorscope_pt[0]) || d->vectorscope_samples)
+  if(!isnan(d->vectorscope_pt[0]) || (d->vectorscope_samples && darktable.lib->proxy.colorpicker.display_samples))
   {
     cairo_pop_group_to_source(cr);
     cairo_paint_with_alpha(cr, 0.5);
@@ -1031,7 +1031,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   }
 
    // live samples
-  if(d->vectorscope_samples)
+  if(d->vectorscope_samples && darktable.lib->proxy.colorpicker.display_samples)
   {
     GSList *samples = d->vectorscope_samples;
     float *sample_xy = NULL;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1059,11 +1059,10 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   }
 
   // overlay central circle
-  set_color(cr, darktable.bauhaus->graph_overlay);
-  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
+  set_color(cr, darktable.bauhaus->graph_grid);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5));
   cairo_new_sub_path(cr);
-  cairo_arc(cr, 0., 0., DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
+  cairo_arc(cr, 0., 0., DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
   cairo_fill(cr);
 
   cairo_restore(cr);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -601,22 +601,25 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       pos++;
 
       //find coordinates
-      const int statistic = dt_conf_get_int("ui_last/colorpicker_mode");
+      const dt_lib_colorpicker_statistic_t statistic = darktable.lib->proxy.colorpicker.statistic;
       dt_aligned_pixel_t RGB = {0.f}, XYZ_D50, chromaticity;
       for(int k = 0; k < 3; k++)
       {
         switch(statistic)
         {
-          case 0:
+          case DT_LIB_COLORPICKER_STATISTIC_MEAN:
             RGB[k] = sample->picked_color_rgb_mean[k];
             break;
 
-          case 1:
+          case DT_LIB_COLORPICKER_STATISTIC_MIN:
             RGB[k] = sample->picked_color_rgb_min[k];
             break;
 
-          default:
+          case DT_LIB_COLORPICKER_STATISTIC_MAX:
             RGB[k] = sample->picked_color_rgb_max[k];
+            break;
+          default:
+            fprintf(stderr, "[histogram] unsupported color picker statistics %i\n", statistic);
             break;
         }
       }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1060,10 +1060,11 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 
   // overlay central circle
   set_color(cr, darktable.bauhaus->graph_overlay);
+  cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5));
   cairo_new_sub_path(cr);
-  cairo_arc(cr, 0., 0., DT_PIXEL_APPLY_DPI(3.), 0., M_PI * 2.);
-  cairo_stroke(cr);
+  cairo_arc(cr, 0., 0., DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
+  cairo_fill(cr);
 
   cairo_restore(cr);
 }

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -55,6 +55,7 @@ typedef struct dt_lib_t
       struct dt_colorpicker_sample_t *selected_sample;
       gboolean display_samples;
       gboolean restrict_histogram;
+      int statistic;
       void (*update_panel)(struct dt_lib_module_t *self);
       void (*update_samples)(struct dt_lib_module_t *self);
       void (*set_sample_box_area)(struct dt_lib_module_t *self, const dt_boundingbox_t size);


### PR DESCRIPTION
This PR fixes #9798, by displaying live samples in global color picker with markers in the vectorscope.
ATM lives samples are always displayed, there is no option to prevent that, as I don't think that would be useful.
When there are live samples, colors in the vectorscope are dimmed, just like for the point sample when "restrict histogram to selection" is activated (to increase visibility)
Samples are shown with a square marker and will honor the statistics (mean / min / max) chosen in the color picker.
Hovering the live sample in color picker highlights the corrisponding marker in the vectorscope, by drawing a bigger and brighter square.
All the graphic choices can be adjusted of course, feedback is welcome.

I am aware of the colorpicker / vectorscope rework by @dtorop, so if needed this PR can wait and be rebased later.

Examples:

without live samples
![immagine](https://user-images.githubusercontent.com/43290988/130389426-5eea2b70-57a9-4641-bace-168e1536fb0c.png)

with live samples (the one in the bottom is highlighted)
![immagine](https://user-images.githubusercontent.com/43290988/130389478-d4c14d31-65b6-47d8-9ffe-c7119608df15.png)

BTW, I find this feature useful for color grading, working with palettes (combined with the png support in watermark) or for matching colors in a photoshoot among different cameras or light conditions