### PR TITLE
copy & import: secure filename is set before variables expansion

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2084,9 +2084,9 @@ static int _control_import_image_copy(const char *filename,
 
   if(have_exif_time)
     dt_import_session_set_exif_time(session, exif_time);
+  dt_import_session_set_filename(session, basename);
   const char *output_path = dt_import_session_path(session, FALSE);
   const gboolean use_filename = dt_conf_get_bool("session/use_filename");
-  dt_import_session_set_filename(session, basename);
   const char *fname = dt_import_session_filename(session, use_filename);
 
   char *output = g_build_filename(output_path, fname, NULL);


### PR DESCRIPTION
This PR fixes #9863 by reversing the order of two calls inside `_control_import_image_copy()` in `control_jobs.c`.
This will make sure that filename is set and can be used for variable expansion, for example for `$(FILE_EXTENSION)`