### PR TITLE
fix variable autocompletion removing one char more

### DIFF
--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -37,8 +37,6 @@ static gboolean on_match_select(GtkEntryCompletion *widget, GtkTreeModel *model,
   gchar *s = gtk_editable_get_chars(e, 0, -1);
   gint cur_pos = gtk_editable_get_position(e);
   gint p = cur_pos;
-  gchar *end;
-  gint del_end_pos = -1;
 
   GValue value = {
     0,
@@ -54,22 +52,11 @@ static gboolean on_match_select(GtkEntryCompletion *widget, GtkTreeModel *model,
     }
   }
 
-  end = s + cur_pos;
-
-  if(end)
-  {
-    del_end_pos = end - s + 1;
-  }
-  else
-  {
-    del_end_pos = cur_pos;
-  }
-
   size_t text_len = strlen(varname) + 2;
   gchar *addtext = (gchar *)g_malloc(text_len);
   snprintf(addtext, text_len, "%s)", varname);
 
-  gtk_editable_delete_text(e, p, del_end_pos);
+  gtk_editable_delete_text(e, p, cur_pos);
   gtk_editable_insert_text(e, addtext, -1, &p);
   gtk_editable_set_position(e, p);
   g_value_unset(&value);


### PR DESCRIPTION
This PR will fix a small annoying bug in gtk entry variable auto completion.

Currently, when using auto completion and selecting a variable from the pop up list, one character more than needed is removed.
This is visible if you are in the middle of a string.
For example, if I am here, with the cursor between the two slashes
![image](https://user-images.githubusercontent.com/43290988/130665975-039cc686-02fd-4410-b5fc-27b99728b69a.png)

If I start typing $(, the pop up list will appear, and if I choose for example $(YEAR), this will be the result
![image](https://user-images.githubusercontent.com/43290988/130665861-d494425b-3cd5-47d9-9800-886b3258cf5a.png)
The second slash has been deleted.
