### PR TITLE
Cleanup size_t & related alloc code

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -432,7 +432,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
   // check if blend is disabled
   if(!(mask_mode & DEVELOP_MASK_ENABLED)) return;
 
-  const int ch = piece->colors;           // the number of channels in the buffer
+  const size_t ch = piece->colors;           // the number of channels in the buffer
   const int xoffs = roi_out->x - roi_in->x;
   const int yoffs = roi_out->y - roi_in->y;
   const int iwidth = roi_in->width;
@@ -589,8 +589,8 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
         const float guide_weight = cst == iop_cs_rgb ? 100.0f : 1.0f;
         float *restrict guide = (float *restrict)ivoid;
         if(!rois_equal)
-          guide = _develop_blend_process_copy_region(guide, iwidth * ch, xoffs * ch, yoffs * ch,
-                                                     owidth * ch, oheight * ch);
+          guide = _develop_blend_process_copy_region(guide, ch * iwidth, ch * xoffs, ch * yoffs,
+                                                     ch * owidth, ch * oheight);
         if(guide)
           _develop_blend_process_feather(guide, mask, owidth, oheight, ch, guide_weight,
                                          d->feathering_radius, roi_out->scale / piece->iscale);
@@ -687,13 +687,13 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
   const int owidth  = roi_in->width;
   const int oheight = roi_in->height;
 
-  lum = dt_alloc_align_float(iwidth * iheight);
+  lum = dt_alloc_align_float((size_t)iwidth * iheight);
   if(lum == NULL) goto error;
   tmp = dt_opencl_alloc_device(devid, iwidth, iheight, sizeof(float));
   if(tmp == NULL) goto error;
-  out = dt_opencl_alloc_device_buffer(devid, iwidth * iheight * sizeof(float));
+  out = dt_opencl_alloc_device_buffer(devid, sizeof(float) * iwidth * iheight);
   if(out == NULL) goto error;
-  blur = dt_opencl_alloc_device_buffer(devid, iwidth * iheight * sizeof(float));
+  blur = dt_opencl_alloc_device_buffer(devid, sizeof(float) * iwidth * iheight);
   if(blur == NULL) goto error;
 
   {

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -1495,10 +1495,10 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
     const dt_aligned_pixel_t min = { 0.0f, -1.0f, -1.0f, 0.0f };
     const dt_aligned_pixel_t max = { 1.0f, 1.0f, 1.0f, 1.0f };
 
-    float *tmp_buffer = dt_alloc_align_float(owidth * oheight * DT_BLENDIF_LAB_CH);
+    float *tmp_buffer = dt_alloc_align_float((size_t)(owidth) * oheight * DT_BLENDIF_LAB_CH);
     if (tmp_buffer != NULL)
     {
-      dt_iop_image_copy(tmp_buffer, b, owidth * oheight * DT_BLENDIF_LAB_CH);
+      dt_iop_image_copy(tmp_buffer, b, (size_t)(owidth) * oheight * DT_BLENDIF_LAB_CH);
       if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
       {
 #ifdef _OPENMP

--- a/src/develop/blends/blendif_raw.c
+++ b/src/develop/blends/blendif_raw.c
@@ -416,10 +416,10 @@ void dt_develop_blendif_raw_blend(struct dt_dev_pixelpipe_iop_t *piece,
   {
     _blend_row_func *const blend = _choose_blend_func(d->blend_mode);
 
-    float *tmp_buffer = dt_alloc_align_float(owidth * oheight);
+    float *tmp_buffer = dt_alloc_align_float((size_t)owidth * oheight);
     if (tmp_buffer != NULL)
     {
-      dt_iop_image_copy(tmp_buffer, b, owidth * oheight);
+      dt_iop_image_copy(tmp_buffer, b, (size_t)owidth * oheight);
       if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
       {
 #ifdef _OPENMP

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -1357,10 +1357,10 @@ void dt_develop_blendif_rgb_hsl_blend(struct dt_dev_pixelpipe_iop_t *piece,
   {
     _blend_row_func *const blend = _choose_blend_func(d->blend_mode);
 
-    float *tmp_buffer = dt_alloc_align_float(owidth * oheight * DT_BLENDIF_RGB_CH);
+    float *tmp_buffer = dt_alloc_align_float((size_t)owidth * oheight * DT_BLENDIF_RGB_CH);
     if (tmp_buffer != NULL)
     {
-      dt_iop_image_copy(tmp_buffer, b, owidth * oheight * DT_BLENDIF_RGB_CH);
+      dt_iop_image_copy(tmp_buffer, b, (size_t)owidth * oheight * DT_BLENDIF_RGB_CH);
       if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
       {
 #ifdef _OPENMP

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -1009,10 +1009,10 @@ void dt_develop_blendif_rgb_jzczhz_blend(struct dt_dev_pixelpipe_iop_t *piece, c
     const float p = exp2f(d->blend_parameter);
     _blend_row_func *const blend = _choose_blend_func(d->blend_mode);
 
-    float *tmp_buffer = dt_alloc_align_float(owidth * oheight * DT_BLENDIF_RGB_CH);
+    float *tmp_buffer = dt_alloc_align_float((size_t)owidth * oheight * DT_BLENDIF_RGB_CH);
     if (tmp_buffer != NULL)
     {
-      dt_iop_image_copy(tmp_buffer, b, owidth * oheight * DT_BLENDIF_RGB_CH);
+      dt_iop_image_copy(tmp_buffer, b, (size_t)owidth * oheight * DT_BLENDIF_RGB_CH);
       if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
       {
 #ifdef _OPENMP

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1900,7 +1900,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
 
   float *const bufptr = *buffer;
 
-  _fill_mask(h*w, bufptr, points, center, a, b, ta, tb, alpha, 0);
+  _fill_mask((size_t)(h)*w, bufptr, points, center, a, b, ta, tb, alpha, 0);
 
   dt_free_align(points);
 
@@ -2085,7 +2085,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   // we calculate the mask values at the transformed points;
   // re-use the points array for results; this requires out_scale==1 to double the offsets at which they are stored
-  _fill_mask(bbh*bbw, points, points, center, a, b, ta, tb, alpha, 1);
+  _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1664,7 +1664,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             // we abuse the empty output buffer on host for intermediate storage of data in
             // pixelpipe_picker_cl()
-            const size_t outbufsize = roi_out->width * roi_out->height * bpp;
+            const size_t outbufsize = bpp * roi_out->width * roi_out->height;
 
             pixelpipe_picker_cl(pipe->devid, module, piece, &piece->dsc_in, cl_mem_input, &roi_in,
                                 module->picked_color, module->picked_color_min, module->picked_color_max,
@@ -2653,7 +2653,7 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   if(mask == NULL) goto error;
   out = dt_opencl_alloc_device(devid, width, height, sizeof(float));
   if(out == NULL) goto error;
-  tmp = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
+  tmp = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
   if(tmp == NULL) goto error;
   {
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -200,9 +200,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       const float *in = ((float *)ivoid) + (size_t)ch * roi_out->width * j;
       float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
       for(int i = 0; i < rad; i++)
-        for_each_channel(c) out[ch * i + c] = in[ch * i + c];
+        for_each_channel(c) out[(size_t)ch * i + c] = in[(size_t)ch * i + c];
       for(int i = roi_out->width - rad; i < roi_out->width; i++)
-        for_each_channel(c) out[ch * i + c] = in[ch * i + c];
+        for_each_channel(c) out[(size_t)ch * i + c] = in[(size_t)ch * i + c];
     }
   }
   else
@@ -246,7 +246,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         float DT_ALIGNED_PIXEL val[4];
         lattice.slice(val, index);
         for_each_channel(k)
-	   out[ch*i + k] = val[k] / val[3];
+	   out[(size_t)ch*i + k] = val[k] / val[3];
       }
     }
   }

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -761,7 +761,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   if(!g->img_cached)
   {
-    g->img = dt_alloc_align(64, allocation.width * allocation.width * 4 * sizeof(unsigned char));
+    g->img = dt_alloc_align(64, sizeof(unsigned char) * 4 * allocation.width * allocation.width);
     g->img_width = allocation.width;
     g->img_cached = TRUE;
     build_gui_kernel(g->img, g->img_width, g->img_width, p);

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -337,7 +337,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(avoidshift)
   {
-    const size_t buffsize = h_width * h_height;
+    const size_t buffsize = (size_t)(h_width) * h_height;
     redfactor = dt_alloc_align_float(buffsize);
     memset(redfactor, 0, sizeof(float) * buffsize);
     bluefactor = dt_alloc_align_float(buffsize);
@@ -360,7 +360,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   double fitparams[2][2][16];
 
   // temporary array to store simple interpolation of G
-  float *Gtmp = dt_alloc_align_float(height * width);
+  float *Gtmp = dt_alloc_align_float((size_t)(height) * width);
   memset(Gtmp, 0, sizeof(float) * height * width);
 
   // temporary array to avoid race conflicts, only every second pixel needs to be saved here

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3484,21 +3484,21 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dt_opencl_release_mem_object(dev_tmp);
     dev_tmp = NULL;
 
-    cfa = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    cfa = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(cfa == NULL) goto error;
-    VH_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    VH_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(VH_dir == NULL) goto error;
-    PQ_dir = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    PQ_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(PQ_dir == NULL) goto error;
-    VP_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    VP_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(VP_diff == NULL) goto error;
-    HQ_diff = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    HQ_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(HQ_diff == NULL) goto error;
-    rgb0 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    rgb0 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(rgb0 == NULL) goto error;
-    rgb1 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    rgb1 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(rgb1 == NULL) goto error;
-    rgb2 = dt_opencl_alloc_device_buffer(devid, roi_in->width * roi_in->height * sizeof(float));
+    rgb2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
     if(rgb2 == NULL) goto error;
 
     {
@@ -5221,8 +5221,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dev_aux = dev_out;
 
   // here we have work to be done only for dual demosaicers
-  blend = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
-  details = dt_opencl_alloc_device_buffer(devid, width * height * sizeof(float));
+  blend = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
+  details = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
   low_image = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if((blend == NULL) || (low_image == NULL) || (details == NULL)) goto finish;
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -991,7 +991,7 @@ static inline void inpaint_mask(float *const restrict inpainted, const float *co
       const uint32_t i = k / width;
       const uint32_t j = k - i;
       uint32_t DT_ALIGNED_ARRAY state[4]
-          = { splitmix32(j + 1), splitmix32((j + 1) * (i + 3)),
+          = { splitmix32(j + 1), splitmix32((uint64_t)(j + 1) * (i + 3)),
               splitmix32(1337), splitmix32(666) };
       xoshiro128plus(state);
       xoshiro128plus(state);
@@ -1020,13 +1020,13 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   float *restrict in = DT_IS_ALIGNED((float *const restrict)ivoid);
   float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);
 
-  float *const restrict temp1 = dt_alloc_align_float(roi_out->width * roi_out->height * 4);
-  float *const restrict temp2 = dt_alloc_align_float(roi_out->width * roi_out->height * 4);
+  float *const restrict temp1 = dt_alloc_align_float((size_t)(4) * roi_out->width * roi_out->height);
+  float *const restrict temp2 = dt_alloc_align_float((size_t)(4) * roi_out->width * roi_out->height);
 
   float *restrict temp_in = NULL;
   float *restrict temp_out = NULL;
 
-  uint8_t *const restrict mask = dt_alloc_align(64, roi_out->width * roi_out->height * sizeof(uint8_t));
+  uint8_t *const restrict mask = dt_alloc_align(64, sizeof(uint8_t) * roi_out->width * roi_out->height);
 
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
   const float final_radius = (data->radius + data->radius_center) * 2.f / scale;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1454,14 +1454,14 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     }
   }
 
-  float *const restrict reconstructed = dt_alloc_align_float(4 * roi_out->width * roi_out->height);
+  float *const restrict reconstructed = dt_alloc_align_float((size_t)(4) * roi_out->width * roi_out->height);
   const gboolean run_fast = (piece->pipe->type & DT_DEV_PIXELPIPE_FAST) == DT_DEV_PIXELPIPE_FAST;
 
   // if fast mode is not in use
   if(!run_fast && recover_highlights && mask && reconstructed)
   {
     // init the blown areas with noise to create particles
-    float *const restrict inpainted =  dt_alloc_align_float(4 * roi_out->width * roi_out->height);
+    float *const restrict inpainted =  dt_alloc_align_float((size_t)(4) * roi_out->width * roi_out->height);
     inpaint_noise(in, mask, inpainted, data->noise_level / scale, data->reconstruct_threshold, data->noise_distribution,
                   roi_out->width, roi_out->height);
 
@@ -1475,7 +1475,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     if(data->high_quality_reconstruction > 0 && success_1)
     {
       float *const restrict norms = dt_alloc_align_float((size_t)roi_out->width * roi_out->height);
-      float *const restrict ratios = dt_alloc_align_float(4 * roi_out->width * roi_out->height);
+      float *const restrict ratios = dt_alloc_align_float((size_t)(4) * roi_out->width * roi_out->height);
 
       // reconstruct highlights PASS 2 on ratios
       if(norms && ratios)

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -328,7 +328,7 @@ static void wavelet_denoise_xtrans(const float *const restrict in, float *const 
     for (size_t col = 0; col < width; col++)
     {
       fimg[col] = 0.5f;
-      fimg[(height-1)*width + col] = 0.5f;
+      fimg[(size_t)(height-1)*width + col] = 0.5f;
     }
     const size_t nthreads = darktable.num_openmp_threads; // go direct, dt_get_num_threads() always returns numprocs
     const size_t chunksize = (height + nthreads - 1) / nthreads;

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -296,7 +296,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   const float *const restrict in = (const float *const)ivoid;
   float *const restrict out = (float *const)ovoid;
-  const size_t npixels = roi_out->width * roi_out->height;
+  const size_t npixels = (size_t)(roi_out->width) * roi_out->height;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1392,7 +1392,7 @@ static void _update_places_list(dt_lib_module_t* self)
   }
 
   // add folders added by user
-  GList *places = _get_custom_places(self);
+  GList *places = _get_custom_places();
 
   for (GList *places_iter = places; places_iter; places_iter = places_iter->next)
   {
@@ -1512,7 +1512,7 @@ static GList* _get_custom_places()
   GList *places = NULL;
   gchar *saved = dt_conf_get_string("ui_last/import_custom_places");
   const int nb_saved = saved[0] ? dt_util_str_occurence(saved, ",") + 1 : 0;
-  char *folders = saved;
+  gchar *folders = g_strdup(saved);
 
   for(int i = 0; i < nb_saved; i++)
   {
@@ -1526,7 +1526,7 @@ static GList* _get_custom_places()
         folders = next + 1;
     }
   }
-//  g_free(saved);  // we can't free the string here, because the returned list points into it
+  g_free(saved);
   return places;
 }
 


### PR DESCRIPTION
This is just pretty much 1:1 with current code, but with `size_t` elems making sure that stuff doesn't overflow int before being handed to allocs or similar.