### PR TITLE
Windows UNC support: add copy/move operations and fixes

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -133,9 +133,16 @@ void dt_conf_set_string(const char *name, const char *val)
   if(dt_conf_set_if_not_overridden(name, str)) g_free(str);
 }
 
-void dt_conf_set_folder_from_file_chooser(const char *name, GtkWidget *chooser)
+void dt_conf_set_folder_from_file_chooser(const char *name, GtkFileChooser *chooser)
 {
-  gchar *folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(chooser));
+
+#ifdef WIN32
+  // Windows native file chooser does not need to save current folder
+  // moreover gtk_file_chooser_get_current_folder() does not work for Windows
+  if(GTK_IS_FILE_CHOOSER_NATIVE(chooser)) return;
+#endif
+
+  gchar *folder = gtk_file_chooser_get_current_folder(chooser);
   if(dt_conf_set_if_not_overridden(name, folder)) g_free(folder);
 }
 
@@ -310,12 +317,18 @@ const char *dt_conf_get_string_const(const char *name)
   return dt_conf_get_var(name);
 }
 
-gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser)
+gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *chooser)
 {
+
+#ifdef WIN32
+  // Windows native file chooser does not need to be manually set to current folder
+  if(GTK_IS_FILE_CHOOSER_NATIVE(chooser)) return TRUE;
+#endif
+
   const gchar *folder = dt_conf_get_string_const(name);
   if (folder)
   {
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser),folder);
+    gtk_file_chooser_set_current_folder(chooser, folder);
     return TRUE;
   }
   return FALSE;

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -77,7 +77,7 @@ void dt_conf_set_int64(const char *name, int64_t val);
 void dt_conf_set_float(const char *name, float val);
 void dt_conf_set_bool(const char *name, int val);
 void dt_conf_set_string(const char *name, const char *val);
-void dt_conf_set_folder_from_file_chooser(const char *name, GtkWidget *chooser);
+void dt_conf_set_folder_from_file_chooser(const char *name, GtkFileChooser *chooser);
 int dt_conf_get_int_fast(const char *name);
 int dt_conf_get_int(const char *name);
 int64_t dt_conf_get_int64_fast(const char *name);
@@ -93,7 +93,7 @@ int dt_conf_get_bool(const char *name);
 const char *dt_conf_get_string_const(const char *name);
 // get a freshly-allocated duplicate of the configuration string; safe to use even if calling dt_conf_set_string
 gchar *dt_conf_get_string(const char *name);
-gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkWidget *chooser);
+gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *chooser);
 gboolean dt_conf_is_equal(const char *name, const char *value);
 void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries);
 void dt_conf_cleanup(dt_conf_t *cf);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1676,21 +1676,16 @@ void dt_control_move_images()
     return;
   }
 
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_select as destination"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("open folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
 
-  dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", filechooser);
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", GTK_FILE_CHOOSER(filechooser));
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_folder_from_file_chooser("ui_last/copymove_path", filechooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/copymove_path", GTK_FILE_CHOOSER(filechooser));
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 
   if(!dir || !g_file_test(dir, G_FILE_TEST_IS_DIR)) goto abort;
 
@@ -1742,20 +1737,16 @@ void dt_control_copy_images()
     return;
   }
 
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_select as destination"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
-  dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", filechooser);
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("open folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
+
+  dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", GTK_FILE_CHOOSER(filechooser));
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    dt_conf_set_folder_from_file_chooser("ui_last/copymove_path", filechooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/copymove_path", GTK_FILE_CHOOSER(filechooser));
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 
   if(!dir || !g_file_test(dir, G_FILE_TEST_IS_DIR)) goto abort;
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1738,7 +1738,7 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
   dt_osx_disallow_fullscreen(chooser);
 #endif
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
-  dt_conf_get_folder_to_file_chooser("ui_last/export_path", chooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(chooser));
   gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc");
   if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
   {
@@ -1746,7 +1746,7 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
 
     _shortcuts_save(filename, id);
     g_free(filename);
-    dt_conf_set_folder_from_file_chooser("ui_last/export_path", chooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(chooser));
   }
   gtk_widget_destroy(chooser);
 }
@@ -1827,7 +1827,7 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(chooser);
 #endif
-  dt_conf_get_folder_to_file_chooser("ui_last/import_path", chooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc");
   if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
   {
@@ -1864,7 +1864,7 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
     _shortcuts_load(filename, from_id, to_id, wipe && from_id == DT_ALL_DEVICES);
 
     g_free(filename);
-    dt_conf_set_folder_from_file_chooser("ui_last/import_path", chooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   }
   gtk_widget_destroy(chooser);
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -980,7 +980,7 @@ static void import_preset(GtkButton *button, gpointer data)
   dt_osx_disallow_fullscreen(chooser);
 #endif
 
-  dt_conf_get_folder_to_file_chooser("ui_last/import_path", chooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(chooser), TRUE);
 
   GtkFileFilter *filter;
@@ -1006,7 +1006,7 @@ static void import_preset(GtkButton *button, gpointer data)
     gtk_tree_store_clear(tree_store);
     tree_insert_presets(tree_store);
 
-    dt_conf_set_folder_from_file_chooser("ui_last/import_path", chooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   }
   gtk_widget_destroy(chooser);
 }
@@ -1022,7 +1022,7 @@ static void export_preset(GtkButton *button, gpointer data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  dt_conf_get_folder_to_file_chooser("ui_last/export_path", filechooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
@@ -1053,7 +1053,7 @@ static void export_preset(GtkButton *button, gpointer data)
 
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "END TRANSACTION", NULL, NULL, NULL);
 
-    dt_conf_set_folder_from_file_chooser("ui_last/export_path", filechooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
 
     g_free(filedir);
   }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -367,7 +367,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(filechooser);
 #endif
-    dt_conf_get_folder_to_file_chooser("ui_last/export_path", filechooser);
+    dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
 
     // save if accepted
     if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
@@ -376,7 +376,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
       dt_presets_save_to_file(g->old_id, name, filedir);
       dt_control_log(_("preset %s was successfully exported"), name);
       g_free(filedir);
-      dt_conf_set_folder_from_file_chooser("ui_last/export_path", filechooser);
+      dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
     }
 
     gtk_widget_destroy(GTK_WIDGET(filechooser));

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -125,14 +125,14 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     {
       // handle situation where there's some problem with cache/film_id
       // i guess that's impossible, but better safe than sorry ;)
-      dt_conf_get_folder_to_file_chooser("ui_last/import_path", filechooser);
+      dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
     }
     dt_image_cache_read_release(darktable.image_cache, img);
   }
   else
   {
     // multiple images, use "last import" preference
-    dt_conf_get_folder_to_file_chooser("ui_last/import_path", filechooser);
+    dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
   }
 
   GtkFileFilter *filter;
@@ -172,7 +172,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     if(act_on_any)
     {
       //remember last import path if applying history to multiple images
-      dt_conf_set_folder_from_file_chooser("ui_last/import_path", filechooser);
+      dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
     }
     g_free(dtfilename);
   }

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -939,7 +939,7 @@ static void _choose_gpx_callback(GtkWidget *widget, dt_lib_module_t *self)
   dt_osx_disallow_fullscreen(filechooser);
 #endif
 
-  dt_conf_get_folder_to_file_chooser("ui_last/gpx_last_directory", filechooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/gpx_last_directory", GTK_FILE_CHOOSER(filechooser));
 
   GtkFileFilter *filter;
   filter = GTK_FILE_FILTER(gtk_file_filter_new());
@@ -964,7 +964,7 @@ static void _choose_gpx_callback(GtkWidget *widget, dt_lib_module_t *self)
   }
   if(res == GTK_RESPONSE_OK)
   {
-    dt_conf_set_folder_from_file_chooser("ui_last/gpx_last_directory", filechooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/gpx_last_directory", GTK_FILE_CHOOSER(filechooser));
 
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1544,7 +1544,7 @@ static void _lib_import_select_folder(GtkWidget *widget, dt_lib_module_t *self)
       _("open folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
 
   // run the native dialog
-  dt_conf_get_folder_to_file_chooser("ui_last/import_last_place", GTK_WIDGET(filechooser));
+  dt_conf_get_folder_to_file_chooser("ui_last/import_last_place", GTK_FILE_CHOOSER(filechooser));
   if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     char *dirname = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -396,7 +396,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  dt_conf_get_folder_to_file_chooser("ui_last/export_path", filechooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
   if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
@@ -513,7 +513,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
       }
       dt_control_log(_("style %s was successfully exported"), (char*)style->data);
     }
-    dt_conf_set_folder_from_file_chooser("ui_last/export_path", filechooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
     g_free(filedir);
   }
   gtk_widget_destroy(filechooser);
@@ -533,7 +533,7 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(filechooser);
 #endif
-  dt_conf_get_folder_to_file_chooser("ui_last/import_path", filechooser);
+  dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), TRUE);
 
   GtkFileFilter *filter;
@@ -694,7 +694,7 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
 
     dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
     _gui_styles_update_view(d);
-    dt_conf_set_folder_from_file_chooser("ui_last/import_path", filechooser);
+    dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
   }
   gtk_widget_destroy(filechooser);
 }


### PR DESCRIPTION
This PR contains an extended support to Windows UNC paths introduced with #9774, plus fixes.
That basically means migrating `GtkFileChooser` dialogs to `GtkFileChooserNative`. In fact this is recommended by Gtk also in Linux because it works in case of FlatPacks or similar.
I have now implemented native dialogs for image copy / move operations.

However native dialogs have their quirks:
I had to define two new helper functions `dt_conf_set_folder_from_file_chooser_native()` and `dt_conf_get_folder_to_file_chooser_native()`, in addition to the existing `dt_conf_set_folder_from_file_chooser()` and `dt_conf_get_folder_to_file_chooser()`, for two reasons:
1) type casting from `GtkFileChooserNative` to `GtkFileChooser` is allowed, but going through `GtkWidget` generates a Glib-Critical at run time
2) unfortunately the behaviour of the native dialogs is different in Windows and Linux. In Windows, we don't need to manually set the default folder as the dialog is able to propose a smart choice, while this is still needed in Linux. Moreover, for some misterious reasons, `gtk_file_chooser_get_current_folder()` does not really work for Windows native dialogs, as it always returns the default folder set manually with `gtk_file_chooser_set_current_folder()`, irrespective of what is done in the dialog.
So I have been forced to separate code paths per OS and it is better to do this in the helper functions

If this setup works, I can continue the migration to native dialog for the remaining cases (file choosers for presets, styles, LUTs etc.)

@parafin We need some testing for MAC OS, to understand how the native dialog behaves