### PR TITLE
vectorscope: add RYB option

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -482,14 +482,22 @@ static inline void dt_Rec709_to_XYZ_D50(const dt_aligned_pixel_t sRGB, dt_aligne
 
 
 #ifdef _OPENMP
+#pragma omp declare simd aligned(sRGB, RGB)
+#endif
+static inline void dt_sRGB_to_linear_sRGB(const dt_aligned_pixel_t sRGB, dt_aligned_pixel_t RGB)
+{
+  // gamma corrected sRGB -> linear sRGB
+  for(int c = 0; c < 3; c++)
+    RGB[c] = sRGB[c] <= 0.04045f ? sRGB[c] / 12.92f : powf((sRGB[c] + 0.055f) / (1.0f + 0.055f), 2.4f);
+}
+
+#ifdef _OPENMP
 #pragma omp declare simd aligned(sRGB, XYZ)
 #endif
 static inline void dt_sRGB_to_XYZ(const dt_aligned_pixel_t sRGB, dt_aligned_pixel_t XYZ)
 {
   dt_aligned_pixel_t rgb = { 0 };
-  // gamma corrected sRGB -> linear sRGB
-  for(int c = 0; c < 3; c++)
-    rgb[c] = sRGB[c] <= 0.04045f ? sRGB[c] / 12.92f : powf((sRGB[c] + 0.055f) / (1.0f + 0.055f), 2.4f);
+  dt_sRGB_to_linear_sRGB(sRGB, rgb);
   // linear sRGB -> XYZ
   dt_Rec709_to_XYZ_D50(rgb, XYZ);
 }

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -772,6 +772,34 @@ static inline void dt_HSV_2_RGB(const dt_aligned_pixel_t HSV, dt_aligned_pixel_t
 
 
 #ifdef _OPENMP
+#pragma omp declare simd aligned(RGB, HCV: 16)
+#endif
+static inline void dt_RGB_2_HCV(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t HCV)
+{
+  const float min = fminf(RGB[0], fminf(RGB[1], RGB[2]));
+  const float max = fmaxf(RGB[0], fmaxf(RGB[1], RGB[2]));
+  const float delta = max - min;
+
+  const float V = max;
+  float C, H;
+
+  if(fabsf(max) > 1e-6f && fabsf(delta) > 1e-6f)
+  {
+    C = delta;
+    H = _dt_RGB_2_Hue(RGB, max, delta);
+  }
+  else
+  {
+    C = 0.0f;
+    H = 0.0f;
+  }
+
+  HCV[0] = H;
+  HCV[1] = C;
+  HCV[2] = V;
+}
+
+#ifdef _OPENMP
 #pragma omp declare simd
 #endif
 static inline void dt_Lab_2_LCH(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t LCH)

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1199,6 +1199,33 @@ void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   FINISH
 }
 
+void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // FIXME: change icon to "RYB"
+
+  cairo_move_to(cr, 0.0, 0.7);
+  cairo_line_to(cr, 0.0, 0.2);
+  cairo_curve_to(cr, 0.5, 0.25, -0.2, 0.45, 0.45, 0.7);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.5, 0.5);
+  cairo_line_to(cr, 1.0, 0.0);
+  cairo_stroke(cr);
+  cairo_move_to(cr, 0.75, 0.25);
+  cairo_line_to(cr, 0.4, 0.0);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.55, 1.0);
+  cairo_line_to(cr, 0.55, 0.5);
+  cairo_curve_to(cr, 1.0, 0.55, 1.0, 0.7, 0.55, 0.75);
+  cairo_curve_to(cr, 1.3, 0.8, 1.3, 0.95, 0.4, 1.0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -205,6 +205,8 @@ void dtgtk_cairo_paint_rgb_parade(cairo_t *cr, gint x, gint y, gint w, gint h, g
 void dtgtk_cairo_paint_luv(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint JzAzBz icon */
 void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint RYB icon */
+void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -542,9 +542,7 @@ static  void _get_chromaticity(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t 
   else
   {
     dt_aligned_pixel_t RYB, rgb, HCV;
-    // gamma corrected sRGB -> linear sRGB
-    for_each_channel(ch, aligned(rgb, RGB:16))
-      rgb[ch] = RGB[ch] <= 0.04045f ? RGB[ch] / 12.92f : powf((RGB[ch] + 0.055f) / (1.0f + 0.055f), 2.4f);
+    dt_sRGB_to_linear_sRGB(RGB, rgb);
     _rgb2ryb(rgb, RYB, rgb2ryb_ypp);
     dt_RGB_2_HCV(RYB, HCV);
     const float alpha = 2.0 * M_PI * HCV[0];
@@ -1060,8 +1058,8 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   cairo_set_operator(cr, CAIRO_OPERATOR_HARD_LIGHT);
   cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.55);
   cairo_mask(cr, graph_pat);
-  cairo_pattern_destroy(bkgd_pat);
 
+  cairo_pattern_destroy(bkgd_pat);
   cairo_surface_destroy(bkgd_surface);
   cairo_pattern_destroy(graph_pat);
   cairo_surface_destroy(graph_surface);


### PR DESCRIPTION
fixes #9847. See this FR for more details.

This is inspired by "[Paint Inspired Color Mixing and Compositing for Visualization](http://vis.computer.org/vis2004/DVD/infovis/papers/gossett.pdf)" - Gossett.
As the Gossett model is not reversible, we keep his cube hues and use them to transpose the rgb <-> ryb data by spline interpolation.
This model compensates the orange expansion by compressing from green to red unlike the model proposed by Junichi SUGITA & Tokiichiro TAKAHASHI, in "[Computational RYB Color Model and its Applications](https://danielhaim.com/research/downloads/Computational%20RYB%20Color%20Model%20and%20its%20Applications.pdf)", which compresses mainly the cyan colors. This latest is also reversible and is used in the G'MIC functions.

As we talk of colors harmony I'm embarrassed by the color wash of the presented graph. Example:
![image](https://user-images.githubusercontent.com/23012047/131264431-a54cf32c-b6c6-4dab-982c-b2ece8f74abf.png)
compared to:
![image](https://user-images.githubusercontent.com/23012047/131264439-4d0d7225-db8f-4e77-8e78-b28b21c06246.png)
In the first image, it's impossible to identify the blue... The second image is far more aligned on the real colors of the image.
Thoughts ?




