### PR TITLE
Adding HSV reading to color picker

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -41,12 +41,13 @@ typedef enum dt_lib_colorpicker_model_t
   DT_LIB_COLORPICKER_MODEL_LAB,
   DT_LIB_COLORPICKER_MODEL_LCH,
   DT_LIB_COLORPICKER_MODEL_HSL,
+  DT_LIB_COLORPICKER_MODEL_HSV,
   DT_LIB_COLORPICKER_MODEL_HEX,
   DT_LIB_COLORPICKER_MODEL_NONE,
   DT_LIB_COLORPICKER_MODEL_N // needs to be the lsat one
 } dt_lib_colorpicker_model_t;
 
-const gchar *dt_lib_colorpicker_model_names[DT_LIB_COLORPICKER_MODEL_N] = {"RGB", "Lab", "LCh", "HSL", "Hex", "none"};
+const gchar *dt_lib_colorpicker_model_names[DT_LIB_COLORPICKER_MODEL_N] = {"RGB", "Lab", "LCh", "HSL", "HSV", "Hex", "none"};
 const gchar *dt_lib_colorpicker_statistic_names[DT_LIB_COLORPICKER_STATISTIC_N] = {"mean", "min", "max"};
 
 typedef struct dt_lib_colorpicker_t
@@ -192,6 +193,11 @@ static void _update_sample_label(dt_lib_module_t *self, dt_colorpicker_sample_t 
 
     case DT_LIB_COLORPICKER_MODEL_HSL:
       dt_RGB_2_HSL(*rgb_hist, alt);
+      snprintf(text, sizeof(text), "%6.02f %6.02f %6.02f", alt[0] * 360.f, alt[1] * 100.f, alt[2] * 100.f);
+      break;
+
+    case DT_LIB_COLORPICKER_MODEL_HSV:
+      dt_RGB_2_HSV(*rgb_hist, alt);
       snprintf(text, sizeof(text), "%6.02f %6.02f %6.02f", alt[0] * 360.f, alt[1] * 100.f, alt[2] * 100.f);
       break;
 


### PR DESCRIPTION
This PR add HSV color reading to the (already long) list of modes for color picker.

![immagine](https://user-images.githubusercontent.com/43290988/131509568-293d7fe1-337a-4ef9-9245-30365d1af12c.png)

There are some online resources that use this model, among others (for example Adobe Color, where it is called HSB), so it could be useful