### PR TITLE
Fix duplicate UI issue

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -614,7 +614,17 @@ spinbutton>button
 /* Set duplicate module space in darkroom */
 #left .duplicate-ui .text-button
 {
-  margin-top: 0.28em;
+  margin-top: 0.5em;
+}
+
+#left .duplicate-ui grid > label
+{
+  margin-top: 1em;
+}
+
+#left .duplicate-ui entry
+{
+  margin: 1.25em 0 1.25em 0.5em;
 }
 
 /* Set modules name header */
@@ -2262,7 +2272,7 @@ Details :
 }
 
 /* Set top margin on active image in filmstrip */
-#thumb_main:active #thumb_back
+#thumbtable_filmstrip #thumb_main:active #thumb_back
 {
   border-top: 0.105em solid @border_color;
 }


### PR DESCRIPTION
Seems that duplicate UI had been broken (maybe by me some times ago with some CSS changes). This fix the UI.

Before (actual master and seems that this issue is in darktable 3.6 ; I see that since a post in darktable.fr forum this day):

![2021-08-31_22-23](https://user-images.githubusercontent.com/45535283/131571314-4973bb48-4db4-43eb-82e0-2a165c0261ca.png)

After:

![2021-08-31_22-20](https://user-images.githubusercontent.com/45535283/131571331-20ed573a-5ff4-4d3c-92b1-cecfa32bd310.png)

So for darktable 3.6.1.