### PR TITLE
color picker: fix sample info tooltip

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -345,6 +345,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
   gtk_text_buffer_get_start_iter(buffer, &iter);
   gtk_text_buffer_insert_markup(buffer, &iter, tooltip_text, -1);
   gtk_tooltip_set_custom(tooltip, view);
+  gtk_widget_map(view); //added in order to fix #9908, probably a Gtk issue
 
   g_free(tooltip_text);
 

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -345,7 +345,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
   gtk_text_buffer_get_start_iter(buffer, &iter);
   gtk_text_buffer_insert_markup(buffer, &iter, tooltip_text, -1);
   gtk_tooltip_set_custom(tooltip, view);
-  gtk_widget_map(view); //added in order to fix #9908, probably a Gtk issue
+  gtk_widget_map(view); // FIXME: workaround added in order to fix #9908, probably a Gtk issue, remove when fixed upstream
 
   g_free(tooltip_text);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -960,6 +960,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
     GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(view));
     gtk_text_buffer_set_text(buffer, tooltip_text, -1);
     gtk_tooltip_set_custom(tooltip, view);
+    gtk_widget_map(view); // FIXME: workaround added in order to fix #9908, probably a Gtk issue, remove when fixed upstream
 
     int count_column1 = 0, count_column2 = 0;
     for(gchar *line = tooltip_text; *line; )


### PR DESCRIPTION
This fixes #9908, wrongly cropped sample info tooltip in color picker, happening in some circumstances (font size below a certain value). See more info in the linked issue.

![image](https://user-images.githubusercontent.com/43290988/131656076-ba833a33-ad2f-41a9-a3a6-24e945bced43.png)

It is most likely a workaround for a Gtk issue, for which we considering to file a bug.