### PR TITLE
fix compatibility with Xcode 11.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,12 +460,17 @@ jobs:
           retention-days: 1
 
   macOS:
-    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.target }}
+    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}
     needs: Linux-minimal
-    runs-on: macos-latest
+    runs-on: ${{ matrix.build.os }}
     strategy:
       fail-fast: true
       matrix:
+        build:
+          - { os: macos-10.15, xcode: 11.3.1 }
+          - { os: macos-10.15, xcode: 11.7 }
+          - { os: macos-10.15, xcode: 12.4 }
+          - { os: macos-11,    xcode: 12.5.1 }
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ RelWithDebInfo ]
@@ -473,6 +478,7 @@ jobs:
           - skiptest
           - nofeatures
     env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
       SRC_DIR: ${{ github.workspace }}/src

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -470,7 +470,7 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
 
   _aligned_pixel sum_sq = { .v = { 0.0f } };
 
-#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
+#if !(defined(__apple_build_version__) && __apple_build_version__ < 11030000) //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(detail, filter, height, in, inv_sigma2, mult, boundary, out, width) \
@@ -567,7 +567,7 @@ void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict
 
   _aligned_pixel sum_sq = { .v = { 0.0f } };
 
-#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
+#if !(defined(__apple_build_version__) && __apple_build_version__ < 11030000) //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(detail, filter, height, in, inv_sigma2, mult, boundary, out, width) \

--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -470,11 +470,13 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
 
   _aligned_pixel sum_sq = { .v = { 0.0f } };
 
+#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(detail, filter, height, in, inv_sigma2, mult, boundary, out, width) \
   reduction(vsum: sum_sq) \
   schedule(static)
+#endif
 #endif
   for(int rowid = 0; rowid < height; rowid++)
   {
@@ -565,11 +567,13 @@ void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict
 
   _aligned_pixel sum_sq = { .v = { 0.0f } };
 
+#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(detail, filter, height, in, inv_sigma2, mult, boundary, out, width) \
   reduction(vsum: sum_sq) \
   schedule(static)
+#endif
 #endif
   for(int rowid = 0; rowid < height; rowid++)
   {

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -95,7 +95,7 @@ static float dt_heal_laplace_iteration(float *const restrict pixels, const float
 {
   _aligned_pixel err = { { 0.f } };
 
-#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
+#if !(defined(__apple_build_version__) && __apple_build_version__ < 11030000) //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(Adiag, Aidx, w, nmask_from, nmask_to) \

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -95,12 +95,14 @@ static float dt_heal_laplace_iteration(float *const restrict pixels, const float
 {
   _aligned_pixel err = { { 0.f } };
 
+#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(Adiag, Aidx, w, nmask_from, nmask_to) \
   dt_omp_sharedconst(pixels) \
   schedule(static) \
   reduction(vsum : err)
+#endif
 #endif
   for(int i = nmask_from; i < nmask_to; i++)
   {

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -564,7 +564,7 @@ static inline float CCT_reverse_lookup(const float x, const float y)
 
   struct pair min_radius = { FLT_MAX, 0.0f };
 
-#ifndef __APPLE__ //makes Xcode 11.3.1 compiler crash
+#if !(defined(__apple_build_version__) && __apple_build_version__ < 11030000) //makes Xcode 11.3.1 compiler crash
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(x, y, T_min, T_range, LUT_samples) reduction(pairmin:min_radius)\


### PR DESCRIPTION
Compilation results in segfault on my macOS 10.14 and XCode 11.3.1.
Pinging @ralfbrown since it is his changes: maybe you can figure out a workaround to keep those OpenMP pragmas on macOS.
Also added this type of build to CI to catch these things earlier.