### PR TITLE
Copy & Import in Windows: more robust detection of film roll name

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -244,7 +244,14 @@ const char *dt_image_film_roll_name(const char *path)
   int count = 0;
   while(folder > path)
   {
+
+#ifdef _WIN32
+    // in Windows, both \ and / can be folder separator
+    if(*folder == G_DIR_SEPARATOR || *folder == '/')
+#else
     if(*folder == G_DIR_SEPARATOR)
+#endif
+
       if(++count >= numparts)
       {
         ++folder;


### PR DESCRIPTION
This simple PR makes the detection fo the film roll name more robust in Windows.
In fact, although Windows file system, DT's copy&import and variable expansion accepts both \ (escaped of course) and / as folder separator, the function dt_image_film_roll_name() in image.c only expects \ as separator and it messes up the film roll name  if / is used.
This PR makes it possible to use both, like follows

![immagine](https://user-images.githubusercontent.com/43290988/131906982-f0ace0dd-dcf7-4e18-9364-e4f06b7cceec.png)

![immagine](https://user-images.githubusercontent.com/43290988/131907036-ba250323-fc33-4785-b85c-ec0bdb14a4a1.png)

This fixes #9905 (for a great extent) and other repetitive complaints by Windows users
