### PR TITLE
color picker: misc. improvements

### DIFF
--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -243,8 +243,8 @@ typedef enum dt_signal_t
   DT_SIGNAL_CONTROL_TOAST_REDRAW,
 
   /** \brief This signal is raised when new color picker data are available in the pixelpipe.
-    1 module (NULL if primary picker)
-    2 piece (NULL if primary picker)
+    1 module
+    2 piece
     no returned value
   */
   DT_SIGNAL_CONTROL_PICKERDATA_READY,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -606,7 +606,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   dt_boundingbox_t fbox = { 0.0f };
 
   // get absolute pixel coordinates in final preview image
-  if(sample && sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
+  if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
   {
     for(int k = 0; k < 4; k += 2) fbox[k] = sample->box[k] * wd;
     for(int k = 1; k < 4; k += 2) fbox[k] = sample->box[k] * ht;
@@ -635,7 +635,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   box[2] = fmaxf(fbox[0], fbox[2]);
   box[3] = fmaxf(fbox[1], fbox[3]);
 
-  if(darktable.lib->proxy.colorpicker.primary_sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
+  if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
   {
     // if we are sampling one point, make sure that we actually sample it.
     for(int k = 2; k < 4; k++) box[k] += 1;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -905,10 +905,10 @@ static gboolean _request_color_pick(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
 {
   // Does the current active module need a picker?
   return
-    // there is an active picker widget
-    darktable.lib->proxy.colorpicker.picker_proxy
     // pick from preview pipe to get pixels outside the viewport
-    && dev->gui_attached && pipe == dev->preview_pipe
+    dev->gui_attached && pipe == dev->preview_pipe
+    // there is an active picker widget
+    && darktable.lib->proxy.colorpicker.picker_proxy
     // only modules with focus can pick
     && module == dev->gui_module
     // and they are enabled

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2048,10 +2048,7 @@ post_process_collect_info:
       const gboolean primary_picker_active = darktable.lib->proxy.colorpicker.primary_sample
         && darktable.lib->proxy.colorpicker.primary_sample->size != DT_LIB_COLORPICKER_SIZE_NONE;
       if(primary_picker_active || darktable.lib->proxy.colorpicker.live_samples)
-      {
         _pixelpipe_pick_samples(dev, module, (const float *const )input, &roi_in, primary_picker_active);
-        DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PICKERDATA_READY, NULL, NULL);
-      }
     }
 
     // 4) final histogram:

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -62,17 +62,13 @@
 gboolean dt_iop_color_picker_is_visible(const dt_develop_t *dev)
 {
   dt_iop_color_picker_t *proxy = darktable.lib->proxy.colorpicker.picker_proxy;
-  dt_colorpicker_sample_t *sample = darktable.lib->proxy.colorpicker.primary_sample;
 
   const gboolean module_picker = dev->gui_module
     && dev->gui_module->enabled
     && dev->gui_module->request_color_pick != DT_REQUEST_COLORPICK_OFF
-    && sample && sample->size != DT_LIB_COLORPICKER_SIZE_NONE
     && proxy && proxy->module == dev->gui_module;
 
-  const gboolean primary_picker = sample
-    && sample->size != DT_LIB_COLORPICKER_SIZE_NONE
-    && proxy && !proxy->module;
+  const gboolean primary_picker = proxy && !proxy->module;
 
   return module_picker || primary_picker;
 }
@@ -130,7 +126,6 @@ void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
     {
       _iop_color_picker_reset(picker);
       darktable.lib->proxy.colorpicker.picker_proxy = NULL;
-      darktable.lib->proxy.colorpicker.primary_sample->size = DT_LIB_COLORPICKER_SIZE_NONE;
       if(module)
         module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
     }
@@ -222,7 +217,6 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   }
   else
   {
-    darktable.lib->proxy.colorpicker.primary_sample->size = DT_LIB_COLORPICKER_SIZE_NONE;
     darktable.lib->proxy.colorpicker.picker_proxy = NULL;
     _iop_color_picker_reset(self);
     if(module)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -25,11 +25,11 @@
 #include "develop/blend.h"
 
 /*
-  The color_picker_proxy code links the UI colorpicker buttons in
-  iops (and the colorpicker lib) with the rest of the implementation
-  (selecting/drawing colorpicker area in center view, reading color
-  value from preview pipe, and displaying results in the colorpicker
-  lib).
+  The color_picker_proxy code is an interface which links the UI
+  colorpicker buttons in iops (and the colorpicker lib) with the rest
+  of the implementation (selecting/drawing colorpicker area in center
+  view, reading color value from preview pipe, and displaying results
+  in the colorpicker lib).
 
   From the iop (or lib) POV, all that is necessary is to instantiate
   color picker(s) via dt_color_picker_new() or
@@ -302,6 +302,7 @@ static void _iop_color_picker_preview_pipe_callback(gpointer instance, gpointer 
   // about changed value as regardless we want to handle the new
   // sample
   if(!picker->module)
+    // FIXME: s/_iop_record_point_area/_record_point_area/ if this is called for primary picker as well
     _iop_record_point_area(picker);
 
   // pixelpipe may have run because sample area changed or an iop,
@@ -309,13 +310,15 @@ static void _iop_color_picker_preview_pipe_callback(gpointer instance, gpointer 
   // provide swatch color for a point sample overlay
   darktable.lib->proxy.colorpicker.update_panel(darktable.lib->proxy.colorpicker.module);
   darktable.lib->proxy.colorpicker.update_samples(darktable.lib->proxy.colorpicker.module);
+  // FIXME: debug signal sequence -- what if the preview pipe finishes after the full pixelpipe completes and DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED triggers a redraw of center view -- debug by adding a pause in preview pipe -- do we want to trigger a center view redraw here on point picker so the swatch fills in?
 }
 
 void dt_iop_color_picker_init(void)
 {
+  // we have incoming iop picker data
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PICKERDATA_READY,
                                   G_CALLBACK(_iop_color_picker_pickerdata_ready_callback), NULL);
-  // FIXME: how do we know that this is called before we redraw the center view?
+  // we have new primary picker data as preview pipe has run to conclusion
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
                                   G_CALLBACK(_iop_color_picker_preview_pipe_callback), NULL);
 }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -299,7 +299,11 @@ static void _iop_color_picker_signal_callback(gpointer instance, dt_iop_module_t
       // FIXME: redraw picker widget from here if the mouse has moved?
       _iop_record_point_area(picker);
       if(picker->changed)
+      {
         dt_control_queue_redraw_center();
+        darktable.lib->proxy.colorpicker.update_panel(darktable.lib->proxy.colorpicker.module);
+        darktable.lib->proxy.colorpicker.update_samples(darktable.lib->proxy.colorpicker.module);
+      }
     }
   }
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -307,6 +307,7 @@ static void _iop_color_picker_preview_pipe_callback(gpointer instance, gpointer 
   // FIXME: debug signal sequence -- what if the preview pipe finishes after the full pixelpipe completes and DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED triggers a redraw of center view -- debug by adding a pause in preview pipe -- do we want to trigger a center view redraw here on point picker so the swatch fills in?
 }
 
+// FIXME: s/dt_iop_color_picker_init/dt_color_picker_proxy_init/
 void dt_iop_color_picker_init(void)
 {
   // we have incoming iop picker data
@@ -317,6 +318,7 @@ void dt_iop_color_picker_init(void)
                                   G_CALLBACK(_iop_color_picker_preview_pipe_callback), NULL);
 }
 
+// FIXME: s/dt_iop_color_picker_cleanup/dt_color_picker_proxy_cleanup/
 void dt_iop_color_picker_cleanup(void)
 {
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_iop_color_picker_pickerdata_ready_callback), NULL);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -73,7 +73,7 @@ gboolean dt_iop_color_picker_is_visible(const dt_develop_t *dev)
   return module_picker || primary_picker;
 }
 
-static gboolean _iop_record_point_area(dt_iop_color_picker_t *self)
+static gboolean _record_point_area(dt_iop_color_picker_t *self)
 {
   const dt_colorpicker_sample_t *const sample = darktable.lib->proxy.colorpicker.primary_sample;
   gboolean changed = self->changed;
@@ -102,7 +102,7 @@ static gboolean _iop_record_point_area(dt_iop_color_picker_t *self)
   return changed;
 }
 
-static void _iop_color_picker_reset(dt_iop_color_picker_t *picker)
+static void _color_picker_reset(dt_iop_color_picker_t *picker)
 {
   if(picker)
   {
@@ -124,7 +124,7 @@ void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
   {
     if(!keep || (strcmp(gtk_widget_get_name(picker->colorpick), "keep-active") != 0))
     {
-      _iop_color_picker_reset(picker);
+      _color_picker_reset(picker);
       darktable.lib->proxy.colorpicker.picker_proxy = NULL;
       if(module)
         module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
@@ -132,8 +132,8 @@ void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
   }
 }
 
-static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
-                             dt_iop_color_picker_kind_t kind, GtkWidget *button)
+static void _init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
+                         dt_iop_color_picker_kind_t kind, GtkWidget *button)
 {
   // module is NULL if primary colorpicker
   picker->module     = module;
@@ -149,10 +149,10 @@ static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *mod
   picker->pick_box[0] = picker->pick_box[1] = 1.0f - area;
   picker->pick_box[2] = picker->pick_box[3] = area;
 
-  _iop_color_picker_reset(picker);
+  _color_picker_reset(picker);
 }
 
-static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
+static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
 {
   // module is NULL if primary colorpicker
   dt_iop_module_t *module = self->module;
@@ -162,7 +162,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   dt_iop_color_picker_t *prior_picker = darktable.lib->proxy.colorpicker.picker_proxy;
   if(prior_picker && prior_picker != self)
   {
-    _iop_color_picker_reset(prior_picker);
+    _color_picker_reset(prior_picker);
     if(prior_picker->module)
       prior_picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   }
@@ -218,7 +218,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   else
   {
     darktable.lib->proxy.colorpicker.picker_proxy = NULL;
-    _iop_color_picker_reset(self);
+    _color_picker_reset(self);
     if(module)
     {
       module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
@@ -236,9 +236,9 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   return TRUE;
 }
 
-static void _iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
+static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
 {
-  _iop_color_picker_callback_button_press(button, NULL, self);
+  _color_picker_callback_button_press(button, NULL, self);
 }
 
 void dt_iop_color_picker_set_cst(dt_iop_module_t *module, const dt_iop_colorspace_type_t picker_cst)
@@ -267,19 +267,17 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance, dt_io
 {
   // an iop colorpicker receives new data from the pixelpipe
   dt_iop_color_picker_t *picker = darktable.lib->proxy.colorpicker.picker_proxy;
-  dt_develop_t *dev = module->dev;
-  if(!picker || !dev) return;
+  if(!picker) return;
 
   // Invalidate the cache to ensure it will be fully recomputed.
   // modules between colorin & colorout may need the work_profile
   // to work properly. This will force colorin to be run and it
   // will set the work_profile if needed.
-  // FIXME: can use piece for this instead of dev?
-  dev->preview_pipe->changed |= DT_DEV_PIPE_REMOVE;
-  dev->preview_pipe->cache_obsolete = 1;
+  piece->pipe->changed |= DT_DEV_PIPE_REMOVE;
+  piece->pipe->cache_obsolete = 1;
 
   // iops only need new picker data if the pointer has moved
-  if(_iop_record_point_area(picker))
+  if(_record_point_area(picker))
   {
     if(!module->blend_data || !blend_color_picker_apply(module, picker->colorpick, piece))
       if(module->color_picker_apply)
@@ -287,7 +285,7 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance, dt_io
   }
 }
 
-static void _iop_color_picker_preview_pipe_callback(gpointer instance, gpointer user_data)
+static void _color_picker_proxy_preview_pipe_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_color_picker_t *picker = darktable.lib->proxy.colorpicker.picker_proxy;
   if(!picker) return;
@@ -296,19 +294,16 @@ static void _iop_color_picker_preview_pipe_callback(gpointer instance, gpointer 
   // about changed value as regardless we want to handle the new
   // sample
   if(!picker->module)
-    // FIXME: s/_iop_record_point_area/_record_point_area/ if this is called for primary picker as well
-    _iop_record_point_area(picker);
+    _record_point_area(picker);
 
   // pixelpipe may have run because sample area changed or an iop,
   // regardless we want to the colorpicker lib, which also can
   // provide swatch color for a point sample overlay
   darktable.lib->proxy.colorpicker.update_panel(darktable.lib->proxy.colorpicker.module);
   darktable.lib->proxy.colorpicker.update_samples(darktable.lib->proxy.colorpicker.module);
-  // FIXME: shouldn't we request a center view update here as we have new picker data from preview pipe to display?
-  // FIXME: debug signal sequence -- what if the preview pipe finishes after the full pixelpipe completes and DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED triggers a redraw of center view -- debug by adding a pause in preview pipe -- do we want to trigger a center view redraw here on point picker so the swatch fills in?
+  // FIXME: It appears that DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED -- which redraws the center view -- isn't called until all the DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED signal handlers are called. Hence the UI will always update once the picker data updates. But I'm not clear how this is guaranteed to be so.
 }
 
-// FIXME: s/dt_iop_color_picker_init/dt_color_picker_proxy_init/
 void dt_iop_color_picker_init(void)
 {
   // we have incoming iop picker data
@@ -316,14 +311,13 @@ void dt_iop_color_picker_init(void)
                                   G_CALLBACK(_iop_color_picker_pickerdata_ready_callback), NULL);
   // we have new primary picker data as preview pipe has run to conclusion
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_iop_color_picker_preview_pipe_callback), NULL);
+                                  G_CALLBACK(_color_picker_proxy_preview_pipe_callback), NULL);
 }
 
-// FIXME: s/dt_iop_color_picker_cleanup/dt_color_picker_proxy_cleanup/
 void dt_iop_color_picker_cleanup(void)
 {
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_iop_color_picker_pickerdata_ready_callback), NULL);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_iop_color_picker_preview_pipe_callback), NULL);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_color_picker_proxy_preview_pipe_callback), NULL);
 }
 
 static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
@@ -334,11 +328,11 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   if(w == NULL || GTK_IS_BOX(w))
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    _iop_init_picker(color_picker, module, kind, button);
+    _init_picker(color_picker, module, kind, button);
     if(init_cst)
       color_picker->picker_cst = cst;
     g_signal_connect_data(G_OBJECT(button), "button-press-event",
-                          G_CALLBACK(_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
+                          G_CALLBACK(_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
     if (w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
 
     return button;
@@ -347,11 +341,11 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   {
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
-    _iop_init_picker(color_picker, module, kind, w);
+    _init_picker(color_picker, module, kind, w);
     if(init_cst)
       color_picker->picker_cst = cst;
     g_signal_connect_data(G_OBJECT(w), "quad-pressed",
-                          G_CALLBACK(_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
+                          G_CALLBACK(_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
 
     return w;
   }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -295,8 +295,12 @@ static void _iop_color_picker_signal_callback(gpointer instance, dt_iop_module_t
   else
   {
     if(picker && !picker->module)
+    {
       // FIXME: redraw picker widget from here if the mouse has moved?
       _iop_record_point_area(picker);
+      if(picker->changed)
+        dt_control_queue_redraw_center();
+    }
   }
 
   picker->changed = FALSE;

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -127,6 +127,7 @@ void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
     {
       _iop_color_picker_reset(picker);
       darktable.lib->proxy.colorpicker.picker_proxy = NULL;
+      darktable.lib->proxy.colorpicker.primary_sample->size = DT_LIB_COLORPICKER_SIZE_NONE;
       if(module)
         module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
     }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -304,6 +304,7 @@ static void _iop_color_picker_preview_pipe_callback(gpointer instance, gpointer 
   // provide swatch color for a point sample overlay
   darktable.lib->proxy.colorpicker.update_panel(darktable.lib->proxy.colorpicker.module);
   darktable.lib->proxy.colorpicker.update_samples(darktable.lib->proxy.colorpicker.module);
+  // FIXME: shouldn't we request a center view update here as we have new picker data from preview pipe to display?
   // FIXME: debug signal sequence -- what if the preview pipe finishes after the full pixelpipe completes and DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED triggers a redraw of center view -- debug by adding a pause in preview pipe -- do we want to trigger a center view redraw here on point picker so the swatch fills in?
 }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -697,12 +697,6 @@ static gboolean draw(GtkWidget *da, cairo_t *cr, gpointer user_data)
     cairo_paint(cr);
   }
 
-  if(darktable.lib->proxy.colorpicker.module)
-  {
-    darktable.lib->proxy.colorpicker.update_panel(darktable.lib->proxy.colorpicker.module);
-    darktable.lib->proxy.colorpicker.update_samples(darktable.lib->proxy.colorpicker.module);
-  }
-
   return TRUE;
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -843,9 +843,9 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           // this functions need a 4c image
           for(int k = 0; k < 3; k++)
           {
-            pick_mean[k] = sample->picked_color_rgb_mean[k];
-            pick_min[k] = sample->picked_color_rgb_min[k];
-            pick_max[k] = sample->picked_color_rgb_max[k];
+            pick_mean[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MEAN][k];
+            pick_min[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MIN][k];
+            pick_max[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MAX][k];
           }
           pick_mean[3] = pick_min[3] = pick_max[3] = 1.f;
 

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -889,9 +889,9 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
             // this functions need a 4c image
             for(int k = 0; k < 3; k++)
             {
-              picker_mean[k] = sample->picked_color_rgb_mean[k];
-              picker_min[k] = sample->picked_color_rgb_min[k];
-              picker_max[k] = sample->picked_color_rgb_max[k];
+              picker_mean[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MEAN][k];
+              picker_min[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MIN][k];
+              picker_max[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MAX][k];
             }
             picker_mean[3] = picker_min[3] = picker_max[3] = 1.f;
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1443,9 +1443,9 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       {
         dt_colorpicker_sample_t *sample = samples->data;
 
-        picker_scale(sample->picked_color_lab_mean, picker_mean);
-        picker_scale(sample->picked_color_lab_min, picker_min);
-        picker_scale(sample->picked_color_lab_max, picker_max);
+        picker_scale(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MEAN], picker_mean);
+        picker_scale(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MIN], picker_min);
+        picker_scale(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MAX], picker_max);
 
         // Convert abcissa to log coordinates if needed
         picker_min[ch] = to_log(picker_min[ch], c->loglogscale, ch, c->semilog, 0);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -529,7 +529,6 @@ void gui_init(dt_lib_module_t *self)
   // Initializing proxy functions and data
   darktable.lib->proxy.colorpicker.module = self;
   darktable.lib->proxy.colorpicker.display_samples = dt_conf_get_bool("ui_last/colorpicker_display_samples");
-  // FIXME: should s/primary_sample/current_sample/
   darktable.lib->proxy.colorpicker.primary_sample = &data->primary_sample;
   darktable.lib->proxy.colorpicker.picker_proxy = NULL;
   darktable.lib->proxy.colorpicker.live_samples = NULL;

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -138,17 +138,10 @@ static gboolean _sample_draw_callback(GtkWidget *widget, cairo_t *cr, dt_colorpi
 static void _update_sample_label(dt_lib_module_t *self, dt_colorpicker_sample_t *sample)
 {
   dt_lib_colorpicker_t *data = self->data;
-  // initialize to placate compiler warnings
-  const dt_aligned_pixel_t *rgb_disp = NULL, *rgb_hist = NULL, *lab = NULL;
+  const dt_aligned_pixel_t *rgb_disp, *rgb_hist, *lab;
 
   switch(data->statistic)
   {
-    case DT_LIB_COLORPICKER_STATISTIC_MEAN:
-      rgb_disp = &sample->picked_color_display_rgb_mean;
-      rgb_hist = &sample->picked_color_rgb_mean;
-      lab      = &sample->picked_color_lab_mean;
-      break;
-
     case DT_LIB_COLORPICKER_STATISTIC_MIN:
       rgb_disp = &sample->picked_color_display_rgb_min;
       rgb_hist = &sample->picked_color_rgb_min;
@@ -161,8 +154,12 @@ static void _update_sample_label(dt_lib_module_t *self, dt_colorpicker_sample_t 
       lab      = &sample->picked_color_lab_max;
       break;
 
-    case DT_LIB_COLORPICKER_STATISTIC_N:
-      dt_unreachable_codepath();
+    default:
+    case DT_LIB_COLORPICKER_STATISTIC_MEAN:
+      rgb_disp = &sample->picked_color_display_rgb_mean;
+      rgb_hist = &sample->picked_color_rgb_mean;
+      lab      = &sample->picked_color_lab_mean;
+      break;
   }
 
   // output swatch
@@ -207,12 +204,10 @@ static void _update_sample_label(dt_lib_module_t *self, dt_colorpicker_sample_t 
       snprintf(text, sizeof(text), "0x%02X%02X%02X", sample->rgb_vals[0], sample->rgb_vals[1], sample->rgb_vals[2]);
       break;
 
+    default:
     case DT_LIB_COLORPICKER_MODEL_NONE:
       snprintf(text, sizeof(text), "◎");
       break;
-
-    case DT_LIB_COLORPICKER_MODEL_N:
-      dt_unreachable_codepath();
   }
 
   if(g_strcmp0(gtk_label_get_text(GTK_LABEL(sample->output_label)), text))

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -269,7 +269,8 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
   gchar **sample_parts = g_malloc0_n(12, sizeof(char*));
 
   sample_parts[3] = g_strdup_printf("%22s(0x%02X%02X%02X)\n<big><b>%14s</b></big>", " ",
-                                    sample->label_rgb[0], sample->label_rgb[1], sample->label_rgb[2], _("RGB"));
+                                    CLAMP(sample->label_rgb[0], 0, 255), CLAMP(sample->label_rgb[1], 0, 255),
+                                    CLAMP(sample->label_rgb[2], 0, 255), _("RGB"));
   sample_parts[7] = g_strdup_printf("\n<big><b>%14s</b></big>", _("Lab"));
 
   for(int i = 0; i < DT_LIB_COLORPICKER_STATISTIC_N; i++)

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -23,11 +23,8 @@
 
 typedef enum dt_lib_colorpicker_size_t
 {
-  // FIXME: rejigger so that NONE is first, and test for NONE case throughout
   DT_LIB_COLORPICKER_SIZE_POINT = 0,
   DT_LIB_COLORPICKER_SIZE_BOX,
-  // FIXME: instead just set proxy to NULL to signal there is no picker?
-  DT_LIB_COLORPICKER_SIZE_NONE
 } dt_lib_colorpicker_size_t;
 
 /** The struct for primary and live color picker samples */
@@ -40,7 +37,7 @@ typedef struct dt_colorpicker_sample_t
   float point[2];
   dt_boundingbox_t box;
   dt_lib_colorpicker_size_t size;
-  // NOTE: locked only applies to live samples
+  // NOTE: only applies to live samples
   gboolean locked;
 
   /** The actual picked colors */

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -27,6 +27,14 @@ typedef enum dt_lib_colorpicker_size_t
   DT_LIB_COLORPICKER_SIZE_BOX,
 } dt_lib_colorpicker_size_t;
 
+typedef enum dt_lib_colorpicker_statistic_t
+{
+  DT_LIB_COLORPICKER_STATISTIC_MEAN = 0,
+  DT_LIB_COLORPICKER_STATISTIC_MIN,
+  DT_LIB_COLORPICKER_STATISTIC_MAX,
+  DT_LIB_COLORPICKER_STATISTIC_N // needs to be the last one
+} dt_lib_colorpicker_statistic_t;
+
 /** The struct for primary and live color picker samples */
 typedef struct dt_colorpicker_sample_t
 {
@@ -41,41 +49,22 @@ typedef struct dt_colorpicker_sample_t
   gboolean locked;
 
   /** The actual picked colors */
-  // FIXME: make these instead "dt_aligned_pixel_t picked_color_display[dt_lib_colorpicker_statistic_t] and reference into them that way -- will simplify a bunch of code in which case picked_color_rgb_* -> picked_color_scope_rgb[]
-  // in display profile, as picked from preview pixelpipe
-  dt_aligned_pixel_t picked_color_display_rgb_mean;
-  dt_aligned_pixel_t picked_color_display_rgb_min;
-  dt_aligned_pixel_t picked_color_display_rgb_max;
-
-  // converted display profile -> histogram profile
-  dt_aligned_pixel_t picked_color_rgb_mean;
-  dt_aligned_pixel_t picked_color_rgb_min;
-  dt_aligned_pixel_t picked_color_rgb_max;
-
-  // converted display profile -> Lab
-  dt_aligned_pixel_t picked_color_lab_mean;
-  dt_aligned_pixel_t picked_color_lab_min;
-  dt_aligned_pixel_t picked_color_lab_max;
-
-  // mean, min, or max color for tooltip in histogram profile
-  int rgb_vals[4];
+  // picked color in display profile, as picked from preview pixelpipe
+  dt_aligned_pixel_t display[DT_LIB_COLORPICKER_STATISTIC_N];
+  // picked color converted display profile -> histogram profile
+  dt_aligned_pixel_t scope[DT_LIB_COLORPICKER_STATISTIC_N];
+  // picked color converted display profile -> Lab
+  dt_aligned_pixel_t lab[DT_LIB_COLORPICKER_STATISTIC_N];
+  // in scope profile with current statistic
+  int label_rgb[4];
+  // in display profile with current statistic
+  GdkRGBA swatch;
 
   /** The GUI elements */
   GtkWidget *container;
   GtkWidget *color_patch;
   GtkWidget *output_label;
-
-  // sample in current mode (mean/min/max) in display and histogram colorspace
-  GdkRGBA rgb_display;
 } dt_colorpicker_sample_t;
-
-typedef enum dt_lib_colorpicker_statistic_t
-{
-  DT_LIB_COLORPICKER_STATISTIC_MEAN = 0,
-  DT_LIB_COLORPICKER_STATISTIC_MIN,
-  DT_LIB_COLORPICKER_STATISTIC_MAX,
-  DT_LIB_COLORPICKER_STATISTIC_N // needs to be the lsat one
-} dt_lib_colorpicker_statistic_t;
 
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -35,6 +35,8 @@ typedef enum dt_lib_colorpicker_statistic_t
   DT_LIB_COLORPICKER_STATISTIC_N // needs to be the last one
 } dt_lib_colorpicker_statistic_t;
 
+typedef dt_aligned_pixel_t lib_colorpicker_sample_statistics[DT_LIB_COLORPICKER_STATISTIC_N];
+
 /** The struct for primary and live color picker samples */
 typedef struct dt_colorpicker_sample_t
 {
@@ -50,11 +52,11 @@ typedef struct dt_colorpicker_sample_t
 
   /** The actual picked colors */
   // picked color in display profile, as picked from preview pixelpipe
-  dt_aligned_pixel_t display[DT_LIB_COLORPICKER_STATISTIC_N];
+  lib_colorpicker_sample_statistics display;
   // picked color converted display profile -> histogram profile
-  dt_aligned_pixel_t scope[DT_LIB_COLORPICKER_STATISTIC_N];
+  lib_colorpicker_sample_statistics scope;
   // picked color converted display profile -> Lab
-  dt_aligned_pixel_t lab[DT_LIB_COLORPICKER_STATISTIC_N];
+  lib_colorpicker_sample_statistics lab;
   // in scope profile with current statistic
   int label_rgb[4];
   // in display profile with current statistic

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -26,7 +26,7 @@ typedef enum dt_lib_colorpicker_size_t
   // FIXME: rejigger so that NONE is first, and test for NONE case throughout
   DT_LIB_COLORPICKER_SIZE_POINT = 0,
   DT_LIB_COLORPICKER_SIZE_BOX,
-  // FIXME: instead just set picker to NULL for activate IOP?
+  // FIXME: instead just set proxy to NULL to signal there is no picker?
   DT_LIB_COLORPICKER_SIZE_NONE
 } dt_lib_colorpicker_size_t;
 
@@ -44,6 +44,7 @@ typedef struct dt_colorpicker_sample_t
   gboolean locked;
 
   /** The actual picked colors */
+  // FIXME: make these instead "dt_aligned_pixel_t picked_color_display[dt_lib_colorpicker_statistic_t] and reference into them that way -- will simplify a bunch of code in which case picked_color_rgb_* -> picked_color_scope_rgb[]
   // in display profile, as picked from preview pixelpipe
   dt_aligned_pixel_t picked_color_display_rgb_mean;
   dt_aligned_pixel_t picked_color_display_rgb_min;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -744,6 +744,8 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     dt_iop_color_picker_t *proxy = darktable.lib->proxy.colorpicker.picker_proxy;
     if(sample && sample->size != DT_LIB_COLORPICKER_SIZE_NONE && proxy && !proxy->module)
     {
+      // FIXME: for histogram process whole image, then pull point sample #'s from primary_picker->picked_color_rgb_mean (point) or _mean, _min, _max (as in rgb curve) and draw them as an overlay
+      // FIXME: for waveform point sample, could process whole image, then do an overlay of the point sample from primary_picker->picked_color_rgb_mean as red/green/blue dots (or short lines) at appropriate position at the horizontal/vertical position of sample
       if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
       {
         roi.crop_x = MIN(width, MAX(0, sample->box[0] * width));

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -574,26 +574,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
 
   // find position of the primary sample
   sample = darktable.lib->proxy.colorpicker.primary_sample;
-  for(int k = 0; k < 3; k++)
-  {
-    switch(statistic)
-    {
-      case DT_LIB_COLORPICKER_STATISTIC_MEAN:
-        RGB[k] = sample->picked_color_rgb_mean[k];
-        break;
-
-      case DT_LIB_COLORPICKER_STATISTIC_MIN:
-        RGB[k] = sample->picked_color_rgb_min[k];
-        break;
-
-      case DT_LIB_COLORPICKER_STATISTIC_MAX:
-        RGB[k] = sample->picked_color_rgb_max[k];
-        break;
-      default:
-        fprintf(stderr, "[histogram] unsupported color picker statistics %i\n", statistic);
-        break;
-    }
-  }
+  memcpy(RGB, sample->scope[statistic], sizeof(dt_aligned_pixel_t));
 
   dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, vs_prof->matrix_in_transposed, vs_prof->lut_in,
                              vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
@@ -635,27 +616,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
       pos++;
 
       //find coordinates
-      for(int k = 0; k < 3; k++)
-      {
-        switch(statistic)
-        {
-          case DT_LIB_COLORPICKER_STATISTIC_MEAN:
-            RGB[k] = sample->picked_color_rgb_mean[k];
-            break;
-
-          case DT_LIB_COLORPICKER_STATISTIC_MIN:
-            RGB[k] = sample->picked_color_rgb_min[k];
-            break;
-
-          case DT_LIB_COLORPICKER_STATISTIC_MAX:
-            RGB[k] = sample->picked_color_rgb_max[k];
-            break;
-          default:
-            fprintf(stderr, "[histogram] unsupported color picker statistics %i\n", statistic);
-            break;
-        }
-      }
-
+      memcpy(RGB, sample->scope[statistic], sizeof(dt_aligned_pixel_t));
       dt_ioppr_rgb_matrix_to_xyz(RGB, XYZ_D50, vs_prof->matrix_in_transposed, vs_prof->lut_in,
                                  vs_prof->unbounded_coeffs_in, vs_prof->lutsize, vs_prof->nonlinearlut);
       if(vs_type == DT_LIB_HISTOGRAM_VECTORSCOPE_CIELUV)
@@ -744,8 +705,8 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     dt_iop_color_picker_t *proxy = darktable.lib->proxy.colorpicker.picker_proxy;
     if(proxy && !proxy->module)
     {
-      // FIXME: for histogram process whole image, then pull point sample #'s from primary_picker->picked_color_rgb_mean (point) or _mean, _min, _max (as in rgb curve) and draw them as an overlay
-      // FIXME: for waveform point sample, could process whole image, then do an overlay of the point sample from primary_picker->picked_color_rgb_mean as red/green/blue dots (or short lines) at appropriate position at the horizontal/vertical position of sample
+      // FIXME: for histogram process whole image, then pull point sample #'s from primary_picker->scope_mean (point) or _mean, _min, _max (as in rgb curve) and draw them as an overlay
+      // FIXME: for waveform point sample, could process whole image, then do an overlay of the point sample from primary_picker->scope_mean as red/green/blue dots (or short lines) at appropriate position at the horizontal/vertical position of sample
       if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
       {
         roi.crop_x = MIN(width, MAX(0, sample->box[0] * width));

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -742,7 +742,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
   {
     const dt_colorpicker_sample_t *const sample = darktable.lib->proxy.colorpicker.primary_sample;
     dt_iop_color_picker_t *proxy = darktable.lib->proxy.colorpicker.picker_proxy;
-    if(sample && sample->size != DT_LIB_COLORPICKER_SIZE_NONE && proxy && !proxy->module)
+    if(proxy && !proxy->module)
     {
       // FIXME: for histogram process whole image, then pull point sample #'s from primary_picker->picked_color_rgb_mean (point) or _mean, _min, _max (as in rgb curve) and draw them as an overlay
       // FIXME: for waveform point sample, could process whole image, then do an overlay of the point sample from primary_picker->picked_color_rgb_mean as red/green/blue dots (or short lines) at appropriate position at the horizontal/vertical position of sample

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3328,10 +3328,10 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
       }
       else if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
       {
-        // FIXME: get rid of this code when 400% zoom rendering is fixed for hidpi
         // slight optimization: at higher zoom levels in particular,
         // no need to update unless are sampling a different preview
         // pipe pixel
+        // FIXME: get rid of this code when 400% zoom rendering is fixed for hidpi
         // FIXME: this makes less sense for an iop which may transform coordinates
         const float wd = (float)dev->preview_pipe->backbuf_width;
         const float ht = (float)dev->preview_pipe->backbuf_height;
@@ -3341,9 +3341,11 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
         const int cur_x = sample->point[0] * wd, cur_y = sample->point[1] * ht;
         if(prior_x != cur_x || prior_y != cur_y)
         {
+          // FIXME: this is a common enough idiom that it could be a function in proxy?
           if(darktable.lib->proxy.colorpicker.picker_proxy->module)
             dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
           else
+            // FIXME: if the primary picker has moved and the preview pixelpipe is valid, we don't have to rerun pixelpipe (even if cached), we could just calculate new picker results somewhere, e.g. in the proxy -- same goes for when user clicks on a new sample point, essentially could call _iop_record_point_area() and if it is
             dt_dev_invalidate_from_gui(darktable.develop);
         }
       }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -397,7 +397,6 @@ static void _darkroom_pickers_draw(dt_view_t *self, cairo_t *cri,
 
     // draw the actual color sampled
     // FIXME: if an area sample is selected, when selected should fill it with colorpicker color?
-    // FIXME: is this overlay always drawn after the current preview has been calculated?
     if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
     {
       if(sample == selected_sample)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3479,7 +3479,6 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
           gboolean on_corner_prev_box = TRUE;
           // initialized to calm gcc-11
           float opposite_x = 0.f, opposite_y = 0.f;
-          dt_cursor_t cursor = GDK_FLEUR;
 
           if(fabsf(zoom_x - sample->box[0]) <= hx)
             opposite_x = sample->box[2];
@@ -3499,10 +3498,6 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
           {
             sample->point[0] = opposite_x;
             sample->point[1] = opposite_y;
-            if(opposite_y == sample->box[3])
-              cursor = opposite_x == sample->box[2] ? GDK_TOP_LEFT_CORNER: GDK_TOP_RIGHT_CORNER;
-            else
-              cursor = opposite_x == sample->box[2] ? GDK_BOTTOM_LEFT_CORNER : GDK_BOTTOM_RIGHT_CORNER;
           }
           else
           {
@@ -3511,7 +3506,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
             sample->box[2] = fminf(1.0, zoom_x + delta_x);
             sample->box[3] = fminf(1.0, zoom_y + delta_y);
           }
-          dt_control_change_cursor(cursor);
+          dt_control_change_cursor(GDK_FLEUR);
         }
         else if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
         {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -878,12 +878,8 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
   }
 
   // disable color picker when changing image
-  if(dev->gui_module)
-  {
-    dev->gui_module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-  }
-  darktable.lib->proxy.colorpicker.primary_sample->size = DT_LIB_COLORPICKER_SIZE_NONE;
-  darktable.lib->proxy.colorpicker.picker_proxy = NULL;
+  if(darktable.lib->proxy.colorpicker.picker_proxy)
+    dt_iop_color_picker_reset(darktable.lib->proxy.colorpicker.picker_proxy->module, FALSE);
 
   // update aspect ratio
   if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
@@ -3093,8 +3089,8 @@ void enter(dt_view_t *self)
 void leave(dt_view_t *self)
 {
   dt_iop_color_picker_cleanup();
-  darktable.lib->proxy.colorpicker.primary_sample->size = DT_LIB_COLORPICKER_SIZE_NONE;
-  darktable.lib->proxy.colorpicker.picker_proxy = NULL;
+  if(darktable.lib->proxy.colorpicker.picker_proxy)
+    dt_iop_color_picker_reset(darktable.lib->proxy.colorpicker.picker_proxy->module, FALSE);
 
   _unregister_modules_drag_n_drop(self);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -397,8 +397,7 @@ static void _darkroom_pickers_draw(dt_view_t *self, cairo_t *cri,
 
     // draw the actual color sampled
     // FIXME: if an area sample is selected, when selected should fill it with colorpicker color?
-    // FIXME: don't draw central swatch if waiting on preview pipe to run with a sample?
-    if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
+    if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
     {
       if(sample == selected_sample)
         cairo_arc(cri, sample->point[0] * wd, sample->point[1] * ht, half_px * 2., 0., 2. * M_PI);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -397,6 +397,7 @@ static void _darkroom_pickers_draw(dt_view_t *self, cairo_t *cri,
 
     // draw the actual color sampled
     // FIXME: if an area sample is selected, when selected should fill it with colorpicker color?
+    // FIXME: don't draw central swatch if waiting on preview pipe to run with a sample?
     if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
     {
       if(sample == selected_sample)
@@ -747,6 +748,7 @@ void expose(
                                  || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
   // draw colorpicker for in focus module or execute module callback hook
+  // FIXME: draw picker in gui_post_expose() hook in libs/colorpicker.c -- catch would be that live samples would appear over guides, softproof/gamut text overlay would be hidden by picker
   if(dt_iop_color_picker_is_visible(dev))
   {
     GSList samples = { .data = darktable.lib->proxy.colorpicker.primary_sample, .next = NULL };

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3478,6 +3478,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
           gboolean on_corner_prev_box = TRUE;
           // initialized to calm gcc-11
           float opposite_x = 0.f, opposite_y = 0.f;
+          dt_cursor_t cursor = GDK_FLEUR;
 
           if(fabsf(zoom_x - sample->box[0]) <= hx)
             opposite_x = sample->box[2];
@@ -3497,6 +3498,10 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
           {
             sample->point[0] = opposite_x;
             sample->point[1] = opposite_y;
+            if(opposite_y == sample->box[3])
+              cursor = opposite_x == sample->box[2] ? GDK_TOP_LEFT_CORNER: GDK_TOP_RIGHT_CORNER;
+            else
+              cursor = opposite_x == sample->box[2] ? GDK_BOTTOM_LEFT_CORNER : GDK_BOTTOM_RIGHT_CORNER;
           }
           else
           {
@@ -3505,7 +3510,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
             sample->box[2] = fminf(1.0, zoom_x + delta_x);
             sample->box[3] = fminf(1.0, zoom_y + delta_y);
           }
-          dt_control_change_cursor(GDK_CROSSHAIR);
+          dt_control_change_cursor(cursor);
         }
         else if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
         {
@@ -3513,6 +3518,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
             dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
           else
             dt_dev_invalidate_from_gui(darktable.develop);
+          //dt_control_change_cursor(GDK_TARGET);
         }
       }
       dt_control_queue_redraw_center();

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -406,7 +406,7 @@ static void _darkroom_pickers_draw(dt_view_t *self, cairo_t *cri,
       else
         cairo_arc(cri, sample->point[0] * wd, sample->point[1] * ht, half_px, 0., 2. * M_PI);
 
-      set_color(cri, sample->rgb_display);
+      set_color(cri, sample->swatch);
       cairo_fill(cri);
     }
   }
@@ -3465,6 +3465,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
         const float delta_x = 0.01f;
         const float delta_y = delta_x * (float)dev->pipe->processed_width / (float)dev->pipe->processed_height;
 
+        // FIXME: here and in mouse move use to dt_lib_colorpicker_set_{box_area,point} interface? -- would require a different hack for figuring out base of the drag -- but if so have that routine figure out if can just pull the new sample from preview buffer and or need to update from iop with picker or just dt_dev_invalidate_from_gui()
         // hack: for box pickers, these represent the "base" point being dragged
         sample->point[0] = zoom_x;
         sample->point[1] = zoom_y;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3331,7 +3331,6 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
         // slight optimization: at higher zoom levels in particular,
         // no need to update unless are sampling a different preview
         // pipe pixel
-        // FIXME: get rid of this code when 400% zoom rendering is fixed for hidpi
         // FIXME: this makes less sense for an iop which may transform coordinates
         const float wd = (float)dev->preview_pipe->backbuf_width;
         const float ht = (float)dev->preview_pipe->backbuf_height;
@@ -3341,11 +3340,10 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
         const int cur_x = sample->point[0] * wd, cur_y = sample->point[1] * ht;
         if(prior_x != cur_x || prior_y != cur_y)
         {
-          // FIXME: this is a common enough idiom that it could be a function in proxy?
           if(darktable.lib->proxy.colorpicker.picker_proxy->module)
             dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
           else
-            // FIXME: if the primary picker has moved and the preview pixelpipe is valid, we don't have to rerun pixelpipe (even if cached), we could just calculate new picker results somewhere, e.g. in the proxy -- same goes for when user clicks on a new sample point, essentially could call _iop_record_point_area() and if it is
+            // NOTE: it could be possible to pull the new sample from output_backbuf, but then it would be 8-bit rather than float
             dt_dev_invalidate_from_gui(darktable.develop);
         }
       }


### PR DESCRIPTION
These are some improvements/fixes to the color picker code, meant as a follow-up to #9835.

User-visible changes:

- When create a new point primary colorpicker, its center swatch could display black until it is moved or an iop is changed. The center swatch will now update once the preview pipe is completed.
- When dragging a point picker, the cursor would flicker. This was because the code was trying to hide the cursor so that the the mouse would appear to be dragging the point picker as a "cursor". There's a bug somewhere which breaks this which I haven't yet found. As a compromise, the cursor stays on all the time now. The cursor for dragging a corner of the box picker is now a "fleur" cursor (four directional arrows). The cursor for dragging the point picker remains the left arrow cursor.
- When switching between images or from/to darkroom view, the color picker would turn off, but the eyedropper widget would still be drawn as active. Now the eyedropper is drawn as inactive in this case.

Internal fixes:

- Store picker results as an array of results by statistic type (mean/min/max). This folds together some quite-similar variables (e.g. `picked_color_rgb_{mean,min,max}`) and turns a bunch of switch statements by statistic into one line array lookups.
- Don't raise a `DT_SIGNAL_CONTROL_PICKERDATA_READY` when the primary picker is changed. It's enough to catch `DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED`.
- Eliminate `DT_LIB_COLORPICKER_SIZE_NONE` as a picker state. Now pickers can either be point or box. An inactive picker is signified by `darktable.lib->proxy.colorpicker.picker_proxy` being NULL.
- A separate path for primary and live sample picking depending on whether a box or a point sample, to make for minimal operations for point sample (as in this case mean/min/max are the same value).
- Some other misc. minor fixups/tidying.