### PR TITLE
fallback from midi knob press to knob turn for reset

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1736,7 +1736,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
       cairo_translate(cr, INNER_PADDING, 0);
 
-      dt_bauhaus_draw_baseline(w, cr, width);
+      dt_bauhaus_draw_baseline(w, cr, wd);
 
       cairo_save(cr);
       cairo_set_line_width(cr, 0.5);
@@ -1770,7 +1770,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_restore(cr);
 
       // draw indicator
-      dt_bauhaus_draw_indicator(w, d->oldpos + mouse_off, cr, width, *fg_color, *bg_color);
+      dt_bauhaus_draw_indicator(w, d->oldpos + mouse_off, cr, wd, *fg_color, *bg_color);
 
       // draw numerical value:
       cairo_save(cr);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1802,7 +1802,6 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       const int hovered = (darktable.bauhaus->mouse_y - darktable.bauhaus->widget_space) / darktable.bauhaus->line_height;
       gchar *keys = g_utf8_casefold(darktable.bauhaus->keys, -1);
       const PangoEllipsizeMode ellipsis = d->entries_ellipsis;
-      wd *= d->scale;
       ht = darktable.bauhaus->line_height;
 
       for(GList *it = d->entries; it; it = g_list_next(it))

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -406,13 +406,8 @@ dt_input_device_t dt_register_input_driver(dt_lib_module_t *module, const dt_inp
 {
   dt_input_device_t id = 10;
 
-  GSList *driver = darktable.control->input_drivers;
-  while(driver)
-  {
-    if(((dt_input_driver_definition_t *)driver->data)->module == module) return id;
-    driver = driver->next;
-    id += 10;
-  }
+  for(GSList *d = darktable.control->input_drivers; d; d = d->next, id += 10)
+    if(((dt_input_driver_definition_t *)d->data)->module == module) return id;
 
   dt_input_driver_definition_t *new_driver = calloc(1, sizeof(dt_input_driver_definition_t));
   *new_driver = *callbacks;
@@ -445,32 +440,30 @@ static gchar *_shortcut_key_move_name(dt_input_device_t id, guint key_or_move, g
   else
   {
     GSList *driver = darktable.control->input_drivers;
-    while(driver)
-    {
-      if((id -= 10) < 10)
-      {
-        dt_input_driver_definition_t *callbacks = driver->data;
-        gchar *without_device
-          = mods == DT_MOVE_NAME
-          ? callbacks->move_to_string(key_or_move, display)
-          : callbacks->key_to_string(key_or_move, display);
-
-        if(display && id == 0)
-          post_name = without_device;
-        else
-        {
-          char id_str[2] = "\0\0";
-          if(id) id_str[0] = '0' + id;
-
-          name = g_strdup_printf("%s%s:%s", display ? "" : callbacks->name, id_str, without_device);
-          g_free(without_device);
-        }
-        break;
-      }
+    while(driver && (id -= 10) > 10)
       driver = driver->next;
-    }
 
-    if(!driver) name = g_strdup(_("Unknown driver"));
+    if(!driver)
+      name = g_strdup(_("Unknown driver"));
+    else
+    {
+      dt_input_driver_definition_t *callbacks = driver->data;
+      gchar *without_device
+        = mods == DT_MOVE_NAME
+        ? callbacks->move_to_string(key_or_move, display)
+        : callbacks->key_to_string(key_or_move, display);
+
+      if(display && id == 0)
+        post_name = without_device;
+      else
+      {
+        char id_str[2] = "\0\0";
+        if(id) id_str[0] = '0' + id;
+
+        name = g_strdup_printf("%s%s:%s", display ? "" : callbacks->name, id_str, without_device);
+        g_free(without_device);
+      }
+    }
   }
   if(mods != DT_MOVE_NAME)
   {
@@ -2533,7 +2526,44 @@ static gboolean _shortcut_match(dt_shortcut_t *f)
   gboolean matched = FALSE;
 
   if(!_shortcut_closest_match(&existing, f, &matched, NULL))
-    return FALSE;
+  {
+    // see if there is a fallback from midi knob press to knob turn
+    if(!f->key_device || f->move_device || f->move)
+      return FALSE;
+
+    dt_input_device_t id = f->key_device;
+    GSList *driver = darktable.control->input_drivers;
+    while(driver && (id -= 10) > 10)
+      driver = driver->next;
+
+    if(!driver)
+      return FALSE;
+    else
+    {
+      dt_input_driver_definition_t *callbacks = driver->data;
+
+      if(callbacks->key_to_move &&
+         callbacks->key_to_move(callbacks->module, f->key_device, f->key, &f->move))
+      {
+        f->move_device = f->key_device;
+        f->key_device = 0;
+        f->key = 0;
+
+        existing = g_sequence_search(darktable.control->shortcuts, f, shortcut_compare_func, v);
+        if(!_shortcut_closest_match(&existing, f, &matched, NULL) && !f->action)
+          return FALSE;
+        else
+        {
+          const dt_action_def_t *def = _action_find_definition(f->action);
+
+          if(def && def->elements
+             && (def->elements[f->element].effects == dt_action_effect_value
+                 || def->elements[f->element].effects == dt_action_effect_selection))
+            f->effect = DT_ACTION_EFFECT_RESET;
+        }
+      }
+    }
+  }
 
   if(!matched && f->action)
   {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -444,7 +444,7 @@ static gchar *_shortcut_key_move_name(dt_input_device_t id, guint key_or_move, g
       driver = driver->next;
 
     if(!driver)
-      name = g_strdup(_("Unknown driver"));
+      name = g_strdup(_("unknown driver"));
     else
     {
       dt_input_driver_definition_t *callbacks = driver->data;

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -48,6 +48,8 @@ void dt_action_rename(dt_action_t *action, const gchar *new_name);
 
 typedef uint8_t dt_input_device_t;
 
+// FIXME this could eventually be refactored into dt_input_module_t
+// with its own _api.h and loader
 typedef struct dt_input_driver_definition_t
 {
   gchar *name;
@@ -55,6 +57,7 @@ typedef struct dt_input_driver_definition_t
   gboolean (*string_to_key)(const gchar *string, guint *key);
   gchar *(*move_to_string)(const guint move, const gboolean display);
   gboolean (*string_to_move)(const gchar *string, guint *move);
+  gboolean (*key_to_move)(dt_lib_module_t *self, const dt_input_device_t id, const guint key, guint *move);
   dt_lib_module_t *module;
 } dt_input_driver_definition_t;
 


### PR DESCRIPTION
Implements the default behaviour for Loupedeck and others where pressing a rotor down resets it to default position. Only turning the rotor needs to be mapped to a slider; the rotor _press_ can be assigned to something else, but if it has not been mapped to anything explicitly, it will fall back to resetting the same slider (or combo) that _turning_ the rotor is assigned to.

Midi devices where the note and cc do not have the same number will need an explicit override. Currently this is only implemented for x-touch mini and Loupedeck doesn't need it; other devices might not work correctly.

Also fixes #9944