### PR TITLE
more native filechooser dialogs

### DIFF
--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -277,7 +277,7 @@ int dt_presets_import_from_file(const char *preset_path)
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 24, def);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 25, format);
 
-  result = (sqlite3_step(stmt) == SQLITE_OK);
+  result = (sqlite3_step(stmt) == SQLITE_DONE);
 
   sqlite3_finalize(stmt);
 

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -137,9 +137,19 @@ void dt_conf_set_folder_from_file_chooser(const char *name, GtkFileChooser *choo
 {
 
 #ifdef WIN32
-  // Windows native file chooser does not need to save current folder
-  // moreover gtk_file_chooser_get_current_folder() does not work for Windows
-  if(GTK_IS_FILE_CHOOSER_NATIVE(chooser)) return;
+  // for Windows native file chooser, gtk_file_chooser_get_current_folder()
+  // does not work, so we workaround
+  if(GTK_IS_FILE_CHOOSER_NATIVE(chooser))
+  {
+    gchar *pathname = gtk_file_chooser_get_filename(chooser);
+    if(pathname)
+    {
+      gchar *folder = g_path_get_dirname(pathname);
+      if(dt_conf_set_if_not_overridden(name, folder)) g_free(folder);
+      g_free(pathname);
+    }
+    return;
+  }
 #endif
 
   gchar *folder = gtk_file_chooser_get_current_folder(chooser);
@@ -319,12 +329,6 @@ const char *dt_conf_get_string_const(const char *name)
 
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *chooser)
 {
-
-#ifdef WIN32
-  // Windows native file chooser does not need to be manually set to current folder
-  if(GTK_IS_FILE_CHOOSER_NATIVE(chooser)) return TRUE;
-#endif
-
   const gchar *folder = dt_conf_get_string_const(name);
   if (folder)
   {

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1677,7 +1677,8 @@ void dt_control_move_images()
   }
 
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
-        _("open folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
+        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, 
+        _("_select as destination"), _("_cancel"));
 
   dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", GTK_FILE_CHOOSER(filechooser));
   if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
@@ -1738,7 +1739,8 @@ void dt_control_copy_images()
   }
 
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
-        _("open folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
+        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, 
+        _("_select as destination"), _("_cancel"));
 
   dt_conf_get_folder_to_file_chooser("ui_last/copymove_path", GTK_FILE_CHOOSER(filechooser));
   if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1823,7 +1823,6 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(chooser), FALSE);
 
   dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
-  //gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc"); is it accepted in Linux?
   if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1730,17 +1730,14 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
 
   if(resp != GTK_RESPONSE_OK) return;
 
-  GtkWidget *chooser = gtk_file_chooser_dialog_new(_("select file to export"), win, GTK_FILE_CHOOSER_ACTION_SAVE,
-                                                   _("_cancel"), GTK_RESPONSE_REJECT,
-                                                   _("_export"), GTK_RESPONSE_ACCEPT,
-                                                  NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(chooser);
-#endif
+  GtkFileChooserNative *chooser = gtk_file_chooser_native_new(
+        _("select file to export"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SAVE,
+        _("_export"), _("_cancel"));
+
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
   dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(chooser));
   gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc");
-  if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
 
@@ -1748,7 +1745,7 @@ static void _export_clicked(GtkButton *button, gpointer user_data)
     g_free(filename);
     dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(chooser));
   }
-  gtk_widget_destroy(chooser);
+  g_object_unref(chooser);
 }
 
 static void _import_id_changed(GtkComboBox *widget, gpointer user_data)
@@ -1820,16 +1817,14 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
 
   if(resp != GTK_RESPONSE_OK) return;
 
-  GtkWidget *chooser = gtk_file_chooser_dialog_new(_("select file to import"), win, GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                   _("_cancel"), GTK_RESPONSE_REJECT,
-                                                   _("_import"), GTK_RESPONSE_ACCEPT,
-                                                  NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(chooser);
-#endif
+  GtkFileChooserNative *chooser = gtk_file_chooser_native_new(
+        _("select file to import"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN,
+        _("_import"), _("_cancel"));
+  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(chooser), FALSE);
+
   dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
-  gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc");
-  if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
+  //gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "shortcutsrc"); is it accepted in Linux?
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
 
@@ -1866,7 +1861,7 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
     g_free(filename);
     dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   }
-  gtk_widget_destroy(chooser);
+  g_object_unref(chooser);
 
   dt_shortcuts_save(NULL, FALSE);
 }

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -968,17 +968,12 @@ static void _import_preset_from_file(const gchar* filename)
 static void import_preset(GtkButton *button, gpointer data)
 {
   GtkTreeModel *model = (GtkTreeModel *)data;
-  GtkWidget *chooser;
   GtkWindow *win = GTK_WINDOW(gtk_widget_get_toplevel(GTK_WIDGET(button)));
 
   // Zero value indicates import
-  chooser = gtk_file_chooser_dialog_new(_("select preset to import"), win, GTK_FILE_CHOOSER_ACTION_OPEN,
-                                        _("_cancel"), GTK_RESPONSE_CANCEL,
-                                        _("_open"), GTK_RESPONSE_ACCEPT,
-                                        NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(chooser);
-#endif
+  GtkFileChooserNative *chooser = gtk_file_chooser_native_new(
+        _("select preset(s) to import"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN,
+        _("_open"), _("_cancel"));
 
   dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(chooser), TRUE);
@@ -996,7 +991,7 @@ static void import_preset(GtkButton *button, gpointer data)
 
   gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(chooser), filter);
 
-  if(gtk_dialog_run(GTK_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
   {
     GSList *filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(chooser));
     g_slist_foreach(filenames, (GFunc)_import_preset_from_file, NULL);
@@ -1008,24 +1003,20 @@ static void import_preset(GtkButton *button, gpointer data)
 
     dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(chooser));
   }
-  gtk_widget_destroy(chooser);
+  g_object_unref(chooser);
 }
 
 static void export_preset(GtkButton *button, gpointer data)
 {
   GtkWindow *win = GTK_WINDOW(gtk_widget_get_toplevel(GTK_WIDGET(button)));
 
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(_("select directory"), win, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-                                                       _("_cancel"), GTK_RESPONSE_CANCEL,
-                                                       _("_save"), GTK_RESPONSE_ACCEPT,
-                                                       NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
-  dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+        _("_save"), _("_cancel"));
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
+
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filedir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     sqlite3_stmt *stmt;
@@ -1057,7 +1048,7 @@ static void export_preset(GtkButton *button, gpointer data)
 
     g_free(filedir);
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 }
 
 // Custom sort function for TreeModel entries for presets list

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -361,16 +361,13 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
     const gchar *name = gtk_entry_get_text(g->name);
 
     // ask for destination directory
-    GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-        _("select directory"), GTK_WINDOW(dialog), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-        GTK_RESPONSE_CANCEL, _("_select as output destination"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(filechooser);
-#endif
+    GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+          _("select directory"), GTK_WINDOW(dialog), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+          _("_select as output destination"), _("_cancel"));
     dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
 
     // save if accepted
-    if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+    if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
     {
       char *filedir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
       dt_presets_save_to_file(g->old_id, name, filedir);
@@ -379,7 +376,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
       dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
     }
 
-    gtk_widget_destroy(GTK_WIDGET(filechooser));
+    g_object_unref(GTK_WIDGET(filechooser));
     return; // we don't close the window so other actions can be performed if needed
   }
   else if(response_id == GTK_RESPONSE_REJECT && g->old_id)

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -118,7 +118,8 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
   disk_t *d = (disk_t *)self->gui_data;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
-        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_select as output destination"), _("_cancel"));
+        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+        _("_select as output destination"), _("_cancel"));
 
   gchar *old = g_strdup(gtk_entry_get_text(d->entry));
   char *c = g_strstr_len(old, -1, "$");

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -104,20 +104,16 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
 {
   gallery_t *d = (gallery_t *)self->gui_data;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_select as output destination"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+         _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, 
+         _("_select as output destination"), _("_cancel"));
 
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
   gchar *old = g_strdup(gtk_entry_get_text(d->entry));
   char *c = g_strstr_len(old, -1, "$");
   if(c) *c = '\0';
   gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), old);
   g_free(old);
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     char *composed = g_build_filename(dir, "$(FILE_NAME)", NULL);
@@ -132,7 +128,7 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
     g_free(composed);
     g_free(escaped);
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 }
 
 static void entry_changed_callback(GtkEntry *entry, gpointer user_data)

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -103,20 +103,16 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
 {
   latex_t *d = (latex_t *)self->gui_data;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_select as output destination"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, 
+        _("_select as output destination"), _("_cancel"));
 
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
   gchar *old = g_strdup(gtk_entry_get_text(d->entry));
   char *c = g_strstr_len(old, -1, "$");
   if(c) *c = '\0';
   gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), old);
   g_free(old);
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *dir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     char *composed = g_build_filename(dir, "$(FILE_NAME)", NULL);
@@ -131,7 +127,7 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
     g_free(composed);
     g_free(escaped);
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 }
 
 static void entry_changed_callback(GtkEntry *entry, gpointer user_data)

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1552,9 +1552,9 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
     return;
   }
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select lut file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN, _("_cancel"), GTK_RESPONSE_CANCEL,
-      _("_select"), GTK_RESPONSE_ACCEPT, (char *)NULL);
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select lut file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN,
+        _("_select"), _("_cancel"));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
   char *composed = g_build_filename(lutfolder, p->filepath, NULL);
@@ -1588,7 +1588,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
   gtk_file_filter_set_name(filter, _("all files"));
   gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filepath = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     if (strcmp(lutfolder, filepath) < 0)
@@ -1606,7 +1606,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
     gtk_widget_set_sensitive(g->filepath, p->filepath[0]);
   }
   g_free(lutfolder);
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 }
 
 static void _show_hide_colorspace(dt_iop_module_t *self)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -414,7 +414,6 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
 {
   GtkTreeView *treeview = GTK_TREE_VIEW(userdata);
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser;
 
   GtkTreeSelection *selection;
   GtkTreeIter iter, child;
@@ -432,21 +431,17 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
   gtk_tree_model_iter_parent(model, &iter, &child);
   gtk_tree_model_get(model, &child, DT_LIB_COLLECT_COL_PATH, &tree_path, -1);
 
-  filechooser = gtk_file_chooser_dialog_new(
-    _("search filmroll"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-    GTK_RESPONSE_CANCEL, _("_open"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+          _("search filmroll"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+          _("_open"), _("_cancel"));
 
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
   if(tree_path != NULL)
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), tree_path);
   else
     goto error;
 
   // run the dialog
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     gint id = -1;
     sqlite3_stmt *stmt;
@@ -511,12 +506,12 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
   }
   g_free(tree_path);
   g_free(new_path);
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
   return;
 
 error:
   /* Something wrong happened */
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
   dt_control_log(_("problem selecting new path for the filmroll in %s"), tree_path);
 
   g_free(tree_path);

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -104,12 +104,11 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
   const int act_on_any = imgs != NULL;  // list length > 0?
   const int act_on_one = g_list_is_singleton(imgs); // list length == 1?
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("open sidecar file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_open"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+          _("open sidecar file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN,
+          _("_open"), _("_cancel"));
+  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
+
   if(act_on_one)
   {
     //single image to load xmp to, assume we want to load from same dir
@@ -147,7 +146,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
   gtk_file_filter_set_name(filter, _("all files"));
   gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     gchar *dtfilename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     if(dt_history_load_and_apply_on_list(dtfilename, imgs) != 0)
@@ -176,7 +175,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     }
     g_free(dtfilename);
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
   gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
 }
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1541,7 +1541,7 @@ static void _lib_import_select_folder(GtkWidget *widget, dt_lib_module_t *self)
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
   GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
-      _("open folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
+      _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_open"), _("_cancel"));
 
   // run the native dialog
   dt_conf_get_folder_to_file_chooser("ui_last/import_last_place", GTK_FILE_CHOOSER(filechooser));

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -390,16 +390,14 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
   gint overwrite = 0;
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
-      GTK_RESPONSE_CANCEL, _("_save"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+        _("_save"), _("_cancel"));
+
   dt_conf_get_folder_to_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     char *filedir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
 
@@ -516,7 +514,7 @@ static void export_clicked(GtkWidget *w, gpointer user_data)
     dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
     g_free(filedir);
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
   g_list_free_full(style_names, g_free);
 }
 
@@ -527,12 +525,10 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
   gint overwrite = 0;
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select style"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN, _("_cancel"), GTK_RESPONSE_CANCEL,
-      _("_open"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select style"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN,
+        _("_open"), _("_cancel"));
+
   dt_conf_get_folder_to_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), TRUE);
 
@@ -549,7 +545,7 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
 
   gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     GSList *filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(filechooser));
 
@@ -696,7 +692,7 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
     _gui_styles_update_view(d);
     dt_conf_set_folder_from_file_chooser("ui_last/import_path", GTK_FILE_CHOOSER(filechooser));
   }
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 }
 
 static gboolean entry_callback(GtkEntry *entry, gpointer user_data)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2295,17 +2295,14 @@ static void _import_button_clicked(GtkButton *button, dt_lib_module_t *self)
   }
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(_("Select a keyword file"), GTK_WINDOW(win),
-                                                       GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                       _("_cancel"), GTK_RESPONSE_CANCEL,
-                                                       _("_import"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select a keyword file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN,
+        _("_import"), _("_cancel"));
+
   gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), last_dirname);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     char *dirname = g_path_get_dirname(filename);
@@ -2319,7 +2316,7 @@ static void _import_button_clicked(GtkButton *button, dt_lib_module_t *self)
     g_free(dirname);
   }
 
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
   _init_treeview(self, 1);
 }
 
@@ -2334,18 +2331,15 @@ static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
   }
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(_("Select file to export to"), GTK_WINDOW(win),
-                                                       GTK_FILE_CHOOSER_ACTION_SAVE,
-                                                       _("_cancel"), GTK_RESPONSE_CANCEL,
-                                                       _("_export"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(filechooser);
-#endif
+  GtkFileChooserNative *filechooser = gtk_file_chooser_native_new(
+        _("select file to export to"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SAVE,
+        _("_export"), _("_cancel"));
+
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(filechooser), TRUE);
   gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), last_dirname);
   gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(filechooser), export_filename);
 
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
   {
     char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
     char *dirname = g_path_get_dirname(filename);
@@ -2361,7 +2355,7 @@ static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
 
   g_date_time_unref(now);
   g_free(export_filename);
-  gtk_widget_destroy(filechooser);
+  g_object_unref(filechooser);
 }
 
 static void _update_layout(dt_lib_module_t *self)


### PR DESCRIPTION
See posts below

---
This PR concludes the migration to Gtk native file choosers for image I/O operations.
Also I changed some strings to be more similar to the older dialogs

What is done now is:

- Import, Copy & Import
- Export to disk, latex, gallery
- Copy / Move
- Search Filmroll

so basically all what concerns images I/O is migrated. What is left on Gtk non native dialogs is I/O about:

- acceletarors
- presets
- styles
- preferences
- history
- tagging
- geotagging
- 3D luts

I am not sure the above is worth to migrate