### PR TITLE
minor usability: change position of "module order" tickbox in selective copy-paste dialog to the end (fixes #9671)

### DIFF
--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -52,7 +52,7 @@ static gboolean _gui_hist_is_copy_module_order_set(dt_history_copy_item_t *d)
   do
   {
       gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &active, DT_HIST_ITEMS_COL_NUM, &num, -1);
-      if (active && (num == -1)) module_order_was_copied = TRUE;
+      if(active && (num == -1)) module_order_was_copied = TRUE;
   }
   while(gtk_tree_model_iter_next(model, &iter));
 

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -40,15 +40,23 @@ typedef enum _style_items_columns_t
 
 static gboolean _gui_hist_is_copy_module_order_set(dt_history_copy_item_t *d)
 {
-  /* first item is the copy-module */
+  /* iterate trough TreeModel to find if module order was copied (num=-1 and active)  */
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->items));
 
   gboolean active = FALSE;
+  gboolean module_order_was_copied = FALSE;
   gint num = 0;
-  if(gtk_tree_model_get_iter_first(model, &iter))
-    gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &active, DT_HIST_ITEMS_COL_NUM, &num, -1);
-  return active && (num == -1);
+
+  gtk_tree_model_get_iter_first(model, &iter);
+  do
+  {
+      gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &active, DT_HIST_ITEMS_COL_NUM, &num, -1);
+      if (active && (num == -1)) module_order_was_copied = TRUE;
+  }
+  while(gtk_tree_model_iter_next(model, &iter));
+
+  return module_order_was_copied;
 }
 
 static GList *_gui_hist_get_active_items(dt_history_copy_item_t *d)
@@ -231,20 +239,6 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
   {
     GtkTreeIter iter;
 
-    /* first item is for copying the module order, or if paste and was selected */
-    if(iscopy || d->copy_iop_order)
-    {
-      const dt_iop_order_t order = dt_ioppr_get_iop_order_version(imgid);
-      char *label = g_strdup_printf("%s (%s)", _("modules order"), dt_iop_order_string(order));
-      gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-      gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
-                         DT_HIST_ITEMS_COL_ENABLED, TRUE,
-                         DT_HIST_ITEMS_COL_NAME, label,
-                         DT_HIST_ITEMS_COL_NUM, -1,
-                         -1);
-      g_free(label);
-    }
-
     for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
     {
       const dt_history_item_t *item = (dt_history_item_t *)items_iter->data;
@@ -263,6 +257,20 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
       }
     }
     g_list_free_full(items, dt_history_item_free);
+
+    /* last item is for copying the module order, or if paste and was selected */
+	if(iscopy || d->copy_iop_order)
+	{
+	  const dt_iop_order_t order = dt_ioppr_get_iop_order_version(imgid);
+	  char *label = g_strdup_printf("%s (%s)", _("modules order"), dt_iop_order_string(order));
+	  gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
+	  gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
+						 DT_HIST_ITEMS_COL_ENABLED, TRUE,
+						 DT_HIST_ITEMS_COL_NAME, label,
+						 DT_HIST_ITEMS_COL_NUM, -1,
+						 -1);
+	  g_free(label);
+	}
   }
   else
   {


### PR DESCRIPTION
This fixes #9671. It was labeled with "good first contribution", so I though I try to fix it. Is it ok to make a pull request directly or should the issue first be assigned to the one who is working at the issue?

Can anyone take a look at my changes to see if it is ok.

Besides I have a question in relation to the selective copy-paste dialog. Is there a reason why the module order entry is not shown in the paste dialog when module order is not selected in the copy dialog?
All the other entries are also shown if they are not selected in the copy dialog and you have the possibility to activate modules for pasting which has not been selected in the copy dialog.