### PR TITLE
Lua API additions to enable responsive cache

### DIFF
--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -271,13 +271,13 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(res == GTK_RESPONSE_YES)
   {
-#ifdef USE_LUA
-    _lua_signal_batch_history_change(imgs);
-#endif
     dt_history_delete_on_list(imgs, TRUE);
     GList *imgs_copy = g_list_copy((GList *)imgs);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                imgs_copy); // frees imgs_copy
+#ifdef USE_LUA
+    _lua_signal_batch_history_change(imgs);
+#endif
     dt_control_queue_redraw_center();
   }
 }
@@ -297,11 +297,11 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(dt_history_paste_on_list(imgs, TRUE))
   {
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                               g_list_copy((GList *)imgs));
 #ifdef USE_LUA
     _lua_signal_batch_history_change(imgs);
 #endif
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
-                               g_list_copy((GList *)imgs));
   }
 }
 
@@ -317,11 +317,11 @@ static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   GList* imgs_copy = g_list_copy((GList*)imgs);
   if(dt_history_paste_parts_on_list(imgs_copy, TRUE))
   {
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
+                               imgs_copy); // frees imgs_copy
 #ifdef USE_LUA
     _lua_signal_batch_history_change(imgs);
 #endif
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
-                               imgs_copy); // frees imgs_copy
   }
   else
   {

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -232,6 +232,16 @@ static void copy_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   }
 }
 
+#ifdef USE_LUA
+static void _lua_signal_batch_history_change()
+{
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "batch-history-change",
+      LUA_ASYNC_DONE);
+}
+#endif
+
 static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   gint res = GTK_RESPONSE_YES;
@@ -261,6 +271,9 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(res == GTK_RESPONSE_YES)
   {
+#ifdef USE_LUA
+    _lua_signal_batch_history_change(imgs);
+#endif
     dt_history_delete_on_list(imgs, TRUE);
     GList *imgs_copy = g_list_copy((GList *)imgs);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
@@ -284,6 +297,9 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(dt_history_paste_on_list(imgs, TRUE))
   {
+#ifdef USE_LUA
+    _lua_signal_batch_history_change(imgs);
+#endif
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                g_list_copy((GList *)imgs));
   }
@@ -301,6 +317,9 @@ static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   GList* imgs_copy = g_list_copy((GList*)imgs);
   if(dt_history_paste_parts_on_list(imgs_copy, TRUE))
   {
+#ifdef USE_LUA
+    _lua_signal_batch_history_change(imgs);
+#endif
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                imgs_copy); // frees imgs_copy
   }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -35,6 +35,9 @@
 #include <gtk/gtk.h>
 #include <stdlib.h>
 #include <libxml/parser.h>
+#ifdef USE_LUA
+#include "lua/call.h"
+#endif
 
 DT_MODULE(1)
 
@@ -226,7 +229,13 @@ static void _styles_row_activated_callback(GtkTreeView *view, GtkTreePath *path,
   if(name)
   {
     dt_styles_apply_to_list(name, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
-    g_free(name);
+ #ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "batch-style-applied",
+        LUA_ASYNC_DONE);
+#endif
+   g_free(name);
   }
 }
 
@@ -264,7 +273,17 @@ static void apply_clicked(GtkWidget *w, gpointer user_data)
 
   const GList *list = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
 
-  if(list) dt_multiple_styles_apply_to_list(style_names, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
+  if(list) 
+  {
+    dt_multiple_styles_apply_to_list(style_names, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "batch-style-applied",
+        LUA_ASYNC_DONE);
+#endif
+
+  }
 
   g_list_free_full(style_names, g_free);
 }

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -136,6 +136,14 @@ static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layo
   // we deal with fullpreview first.
   if(!d->fullpreview && layout == DT_LIGHTTABLE_LAYOUT_PREVIEW)
   {
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "lighttable-mode-changed",
+        LUA_ASYNC_TYPENAME, "dt_lighttable_layout_t", d->layout,
+        LUA_ASYNC_TYPENAME, "dt_lighttable_layout_t", layout,
+        LUA_ASYNC_DONE);
+#endif
     // special case for preview : we don't change previous values, just show full preview
     d->fullpreview = TRUE;
     _lib_lighttable_update_btn(self);
@@ -144,6 +152,14 @@ static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layo
   }
   else if(d->fullpreview && layout != DT_LIGHTTABLE_LAYOUT_PREVIEW)
   {
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "lighttable-mode-changed",
+        LUA_ASYNC_TYPENAME, "dt_lighttable_layout_t", DT_LIGHTTABLE_LAYOUT_PREVIEW,
+        LUA_ASYNC_TYPENAME, "dt_lighttable_layout_t", layout,
+        LUA_ASYNC_DONE);
+#endif
     d->fullpreview = FALSE;
     dt_view_lighttable_set_preview_state(darktable.view_manager, FALSE, FALSE);
     // and we continue to select the right layout...
@@ -172,7 +188,16 @@ static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layo
     gtk_widget_set_sensitive(d->zoom, (d->layout != DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC && !d->fullpreview));
     gtk_range_set_value(GTK_RANGE(d->zoom), d->current_zoom);
 
-    dt_conf_set_int("plugins/lighttable/layout", layout);
+ #ifdef USE_LUA
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "lighttable-mode-changed",
+      LUA_ASYNC_TYPENAME, "dt_lighttable_layout_t", current_layout,
+      LUA_ASYNC_TYPENAME, "dt_lighttable_layout_t", layout,
+      LUA_ASYNC_DONE);
+#endif
+
+   dt_conf_set_int("plugins/lighttable/layout", layout);
     if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER || layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)
     {
       d->base_layout = layout;
@@ -657,6 +682,7 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_FILEMANAGER);
   luaA_enum_value(L, dt_lighttable_layout_t, DT_LIGHTTABLE_LAYOUT_CULLING);
   luaA_enum_value(L, dt_lighttable_layout_t, DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC);
+  luaA_enum_value(L, dt_lighttable_layout_t, DT_LIGHTTABLE_LAYOUT_PREVIEW);
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_LAST);
 }
 #endif

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -670,6 +670,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "batch-style-applied");
 
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "lighttable-mode-changed");
+ 
    return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -674,7 +674,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "lighttable-mode-changed");
- 
+  
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "image-history-changed");
    return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -659,6 +659,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L,"selection-changed");
+ 
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "batch-history-change");
   return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -664,7 +664,13 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "batch-history-change");
-  return 0;
+
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "batch-style-applied");
+
+   return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -949,6 +949,13 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
     if((xmp_mode == DT_WRITE_XMP_ALWAYS) || ((xmp_mode == DT_WRITE_XMP_LAZY) && !fresh))
       dt_image_synch_xmp(dev->image_storage.id);
     dt_history_hash_set_mipmap(dev->image_storage.id);
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "image-history-changed",
+        LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(dev->image_storage.id),
+        LUA_ASYNC_DONE);
+#endif
   }
 
   // cleanup visible masks
@@ -3159,6 +3166,13 @@ void leave(dt_view_t *self)
     if((xmp_mode == DT_WRITE_XMP_ALWAYS) || ((xmp_mode == DT_WRITE_XMP_LAZY) && !fresh))
       dt_image_synch_xmp(dev->image_storage.id);
     dt_history_hash_set_mipmap(dev->image_storage.id);
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "image-history-changed",
+        LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(dev->image_storage.id),
+        LUA_ASYNC_DONE);
+#endif
   }
 
   // clear gui.


### PR DESCRIPTION
Add events to the Lua API so that lighttable layout mode changes and image history changes can be detected and used to trigger image cache refreshes.

Attached is the responsive_cache.lua script if you want to play with it.  It's still a work in progress but it works.

## To use it
- Add the script 
- start darktable and start the script
- go to settings and lua options and change the setting to suit you.  The only setting that has to be set is the screen width so that the script knows what size thumbnails and full size preview images to generate.  
- start darktable and import a filmroll

## What it does
- on import the script generates the thumbnail cache for the imported images and then the full size preview cache.  If you normally to straight to culling with full size preview, then check the _generate_culling_cache_first_, otherwise it gets generated second
- if you need additional sizes generated, then you can add a comma separated list of sizes in the settings and they will also be generated after the thumbnails and culling caches.  My laptop screen is 1980 pixels wide, which is size 4 full size preview images and my big screen is 2560 pixels wide which is size 5 full size preview.  So I specify 4,5 in the extra sizes so that whenever I import with one screen size, the other gets generated too.
- If you apply a style in lighttable, then the thumbnail cache will be updated.  If the _always generate full size previews_ box is checked they will be updated too.
- If you make a history change in lighttable, then the thumbnail cache will be updated.  If the _always generate full size previews_ box is checked they will be updated too.
- If you are culling in full size preview mode and you've checked the _generate full resolution cache during full size preview_ box then when you change images in culling mode the full resolution image for the next image will be generated and cached.  It takes a second or so on my machine. I added a screen message that simply says ready when the next image full resolution image is cached.  If you go quick, then the events will cascade and the system will keep chugging away generating full resolution caches but darktable will become less responsive.  I don't tend to look at the full resolution images so I leave this option off.  If I need to see the full resolution image, I'm prepared to wait the second or two that it needs to generate.  I cull pretty quickly, so I'd rather have a responsiveness.
- In darkroom mode when the image changes, if the history stack is changed the thumbnail cache is updated.  This way when you edit a string of images in darkroom mode and then return to the lighttable you don't have to wait for the thumbnails to all regenerate.

If you run darktable with the -d lua flag, the script will tell you what it's doing, in the console, and give you timing information.

[responsive_cache.zip](https://github.com/darktable-org/darktable/files/7140429/responsive_cache.zip)


