### PR TITLE
Fix for - Drag and drop into lighttable fails if it's empty #8914 - feedback needed

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1696,7 +1696,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
   }
 }
 
-static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint x, gint y,
+void dt_thumbtable_event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint x, gint y,
                                 GtkSelectionData *selection_data, guint target_type, guint time,
                                 gpointer user_data)
 {
@@ -1801,7 +1801,7 @@ dt_thumbtable_t *dt_thumbtable_new()
   g_signal_connect_after(table->widget, "drag-begin", G_CALLBACK(_event_dnd_begin), table);
   g_signal_connect_after(table->widget, "drag-end", G_CALLBACK(_event_dnd_end), table);
   g_signal_connect(table->widget, "drag-data-get", G_CALLBACK(_event_dnd_get), table);
-  g_signal_connect(table->widget, "drag-data-received", G_CALLBACK(_event_dnd_received), table);
+  g_signal_connect(table->widget, "drag-data-received", G_CALLBACK(dt_thumbtable_event_dnd_received), table);
 
   g_signal_connect(G_OBJECT(table->widget), "scroll-event", G_CALLBACK(_event_scroll), table);
   g_signal_connect(G_OBJECT(table->widget), "draw", G_CALLBACK(_event_draw), table);

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -124,6 +124,9 @@ gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, int imgid
 // check if the mentioned image is visible
 gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, int imgid);
 
+// drag & drop receive function - handles dropping of files in the center view (files are added to the library)
+void dt_thumbtable_event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint x, gint y, GtkSelectionData *selection_data, guint target_type, guint time, gpointer user_data);
+
 // move by key actions.
 // this key accels are not managed here but inside view
 gboolean dt_thumbtable_key_move(dt_thumbtable_t *table, dt_thumbtable_move_t move, gboolean select);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -382,52 +382,7 @@ static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint
                                 GtkSelectionData *selection_data, guint target_type, guint time,
                                 gpointer user_data)
 {
-  gboolean success = FALSE;
-
-  if((target_type == DND_TARGET_URI) && (selection_data != NULL)
-     && (gtk_selection_data_get_length(selection_data) >= 0))
-  {
-    gchar **uri_list = g_strsplit_set((gchar *)gtk_selection_data_get_data(selection_data), "\r\n", 0);
-    if(uri_list)
-    {
-      gchar **image_to_load = uri_list;
-      while(*image_to_load)
-      {
-        if(**image_to_load)
-        {
-          dt_load_from_string(*image_to_load, FALSE, NULL); // TODO: do we want to open the image in darkroom mode?
-                                                            // If yes -> set to TRUE.
-        }
-        image_to_load++;
-      }
-    }
-    g_strfreev(uri_list);
-    success = TRUE;
-  }
-  else if((target_type == DND_TARGET_IMGID) && (selection_data != NULL)
-          && (gtk_selection_data_get_length(selection_data) >= 0))
-  {
-    dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
-    if(table->drag_list)
-    {
-      if(darktable.collection->params.sort == DT_COLLECTION_SORT_CUSTOM_ORDER
-         && table->mode != DT_THUMBTABLE_MODE_ZOOM)
-      {
-        // source = dest = thumbtable => we are reordering
-        // set order to "user defined" (this shouldn't trigger anything)
-        const int32_t mouse_over_id = dt_control_get_mouse_over_id();
-        dt_collection_move_before(mouse_over_id, table->drag_list);
-        dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
-                                   g_list_copy(table->drag_list));
-        success = TRUE;
-      }
-    }
-    else
-    {
-      // we don't catch anything here at the moment
-    }
-  }
-  gtk_drag_finish(context, success, FALSE, time);
+	dt_thumbtable_event_dnd_received(widget, context, x, y, selection_data, target_type, time, user_data);
 }
 
 // display help text in the center view if there's no image to show

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -378,13 +378,6 @@ void cleanup(dt_view_t *self)
   free(self->data);
 }
 
-static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint x, gint y,
-                                GtkSelectionData *selection_data, guint target_type, guint time,
-                                gpointer user_data)
-{
-	dt_thumbtable_event_dnd_received(widget, context, x, y, selection_data, target_type, time, user_data);
-}
-
 // display help text in the center view if there's no image to show
 static int _lighttable_expose_empty(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
                                     int32_t pointery)
@@ -1293,7 +1286,7 @@ void gui_init(dt_view_t *self)
 
   // enable drag & drop
   gtk_drag_dest_set(dt_ui_center_base(darktable.gui->ui), GTK_DEST_DEFAULT_ALL, target_list_all, n_targets_all, GDK_ACTION_MOVE);
-  g_signal_connect(G_OBJECT(dt_ui_center_base(darktable.gui->ui)), "drag-data-received", G_CALLBACK(_event_dnd_received), NULL);
+  g_signal_connect(G_OBJECT(dt_ui_center_base(darktable.gui->ui)), "drag-data-received", G_CALLBACK(dt_thumbtable_event_dnd_received), NULL);
 
   /* add the global focus peaking button in toolbox */
   dt_view_manager_module_toolbox_add(darktable.view_manager, darktable.gui->focus_peaking_button,


### PR DESCRIPTION
Fixes #8914

This should fix the problem mentioned in the title.

But I need some feedback about the implementation: I copied the complete function static void _event_dnd_received(...) from thumbtable.c to lighttable.c. So same function in 2 files. I think that is not a good solution because redundancy of code should nomally be avoided. So, where is the right place to put this function or is it ok to have it 2 times?