### PR TITLE
watermark: use a file chooser

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2953,6 +2953,13 @@
     <shortdescription>3D lut root folder</shortdescription>
     <longdescription>this folder (and sub-folders) contains Lut files used by lut3d modules. (need a restart).</longdescription>
   </dtconfig>
+  <dtconfig prefs="processing" section="general" restart="true">
+    <name>plugins/darkroom/watermark/custom_folder</name>
+    <type>dir</type>
+    <default>(None)</default>
+    <shortdescription>watermarks custom folder</shortdescription>
+    <longdescription>this folder (and sub-folders) contains SVG and PNG files used by watermark modules. (need a restart).</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="general">
     <name>plugins/darkroom/workflow</name>
     <type>


### PR DESCRIPTION
With DT recent improvements when coming to color grading (RYB vectorscope, samples, etc.) the watermark module is finding more use as palette overlay tool, rather than a simple "do once and forget" watermark tool.
Therefore the ability to only use predefined folders is becoming a limitation. We would like to use custom folders and a regular filechooser to select the SVG/PNG file. That would also benefit of the nice preview functionality of the (native) file chooser, depending on the OS:

![immagine](https://user-images.githubusercontent.com/43290988/133000728-efc6568b-e29e-41d8-a636-5b19e6b50962.png)

This PR introduces the capability to define custom folders and use a file chooser in watermark.
Fixes #9955 

It works on the model of the lut3D module, by defining a base folder in prefs

![immagine](https://user-images.githubusercontent.com/43290988/133000884-3590e570-133c-40a5-8a7b-8df82fd4ec6f.png)

and then we can choose files from that folder and its subfolders.
Initially, when the base folder is not defined (or after being reset to default), the modules behaves exactly like the current one:

![immagine](https://user-images.githubusercontent.com/43290988/133000983-35a24fa4-9ea8-46a4-995d-936bbaf9ddcb.png)

so if anyone is not interested in this functionality, nothing will change and the combobox will continue to be populated from the default user config folder / data folder.

Upon configuring the custom folder in prefs, the gui will change:
![immagine](https://user-images.githubusercontent.com/43290988/133000955-3eaa651d-10e9-4661-9cbb-ccc0fd6e71ac.png)

and the file chooser is activated. The selected file will be used as watermark and its folder will replace the user config folder for listing files in the combobox, while the data folder will remain active, so the default watermark files shipped with DT will still be there.