### PR TITLE
tone equalizer: fix pickers behaviour

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1731,16 +1731,6 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 
   if(darktable.gui->reset) return;
 
-  if(!g->luminance_valid || self->dev->pipe->processing || !g->histogram_valid)
-  {
-    ++darktable.gui->reset;
-    gboolean active = dt_bauhaus_widget_get_quad_active(quad);
-    dt_bauhaus_widget_set_quad_active(quad, !active);
-    --darktable.gui->reset;
-    dt_control_log(_("wait for the preview to finish recomputing"));
-    return;
-  }
-
   dt_iop_request_focus(self);
 
   if(p->exposure_boost != 0.0f || !self->enabled)
@@ -1754,6 +1744,16 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
+    return;
+  }
+
+  if(!g->luminance_valid || self->dev->pipe->processing || !g->histogram_valid)
+  {
+    ++darktable.gui->reset;
+    gboolean active = dt_bauhaus_widget_get_quad_active(quad);
+    dt_bauhaus_widget_set_quad_active(quad, !active);
+    --darktable.gui->reset;
+    dt_control_log(_("wait for the preview to finish recomputing"));
     return;
   }
 
@@ -1790,16 +1790,6 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
 
   if(darktable.gui->reset) return;
 
-  if(!g->luminance_valid || self->dev->pipe->processing || !g->histogram_valid)
-  {
-    ++darktable.gui->reset;
-    gboolean active = dt_bauhaus_widget_get_quad_active(quad);
-    dt_bauhaus_widget_set_quad_active(quad, !active);
-    --darktable.gui->reset;
-    dt_control_log(_("wait for the preview to finish recomputing"));
-    return;
-  }
-
   dt_iop_request_focus(self);
 
   if(p->contrast_boost != 0.0f || !self->enabled)
@@ -1813,6 +1803,16 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
+    return;
+  }
+
+  if(!g->luminance_valid || self->dev->pipe->processing || !g->histogram_valid)
+  {
+    ++darktable.gui->reset;
+    gboolean active = dt_bauhaus_widget_get_quad_active(quad);
+    dt_bauhaus_widget_set_quad_active(quad, !active);
+    --darktable.gui->reset;
+    dt_control_log(_("wait for the preview to finish recomputing"));
     return;
   }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1678,12 +1678,24 @@ void gui_update(struct dt_iop_module_t *self)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
-  if (w == g->details)
+  if(w == g->method     ||
+     w == g->blending   ||
+     w == g->feathering ||
+     w == g->iterations ||
+     w == g->quantization)
+  {
+    invalidate_luminance_cache(self);
+  }
+  else if (w == g->details)
+  {
+    invalidate_luminance_cache(self);
     show_guiding_controls(self);
+  }
   else if (w == g->contrast_boost || w == g->exposure_boost)
+  {
+    invalidate_luminance_cache(self);
     dt_bauhaus_widget_set_quad_active(w, FALSE);
-
-  invalidate_luminance_cache(self);
+  }
 }
 
 static void smoothing_callback(GtkWidget *slider, gpointer user_data)

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1726,12 +1726,22 @@ static void smoothing_callback(GtkWidget *slider, gpointer user_data)
 static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_request_focus(self);
-
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+
+  if(darktable.gui->reset) return;
+
+  if(!g->luminance_valid || self->dev->pipe->processing || !g->histogram_valid)
+  {
+    ++darktable.gui->reset;
+    gboolean active = dt_bauhaus_widget_get_quad_active(quad);
+    dt_bauhaus_widget_set_quad_active(quad, !active);
+    --darktable.gui->reset;
+    dt_control_log(_("wait for the preview to finish recomputing"));
+    return;
+  }
+
+  dt_iop_request_focus(self);
 
   if(p->exposure_boost != 0.0f || !self->enabled)
   {
@@ -1739,17 +1749,11 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
     p->exposure_boost = 0.0f;
     ++darktable.gui->reset;
     dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
+    dt_bauhaus_widget_set_quad_active(quad, FALSE);
     --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
-    dt_bauhaus_widget_set_quad_active(quad, FALSE);
-    return;
-  }
-
-  if(!g->luminance_valid || self->dev->pipe->processing)
-  {
-    dt_control_log(_("wait for the preview to finish recomputing"));
     return;
   }
 
@@ -1764,7 +1768,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
   dt_iop_gui_leave_critical_section(self);
 
   update_histogram(self);
-  p->exposure_boost += target - g->histogram_average;
+  p->exposure_boost = target - g->histogram_average;
 
   // Update the GUI stuff
   ++darktable.gui->reset;
@@ -1781,12 +1785,22 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_request_focus(self);
-
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+
+  if(darktable.gui->reset) return;
+
+  if(!g->luminance_valid || self->dev->pipe->processing || !g->histogram_valid)
+  {
+    ++darktable.gui->reset;
+    gboolean active = dt_bauhaus_widget_get_quad_active(quad);
+    dt_bauhaus_widget_set_quad_active(quad, !active);
+    --darktable.gui->reset;
+    dt_control_log(_("wait for the preview to finish recomputing"));
+    return;
+  }
+
+  dt_iop_request_focus(self);
 
   if(p->contrast_boost != 0.0f || !self->enabled)
   {
@@ -1794,17 +1808,11 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
     p->contrast_boost = 0.0f;
     ++darktable.gui->reset;
     dt_bauhaus_slider_set_soft(g->contrast_boost, p->contrast_boost);
+    dt_bauhaus_widget_set_quad_active(quad, FALSE);
     --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
-    dt_bauhaus_widget_set_quad_active(quad, FALSE);
-    return;
-  }
-
-  if(!g->luminance_valid || self->dev->pipe->processing)
-  {
-    dt_control_log(_("wait for the preview to finish recomputing"));
     return;
   }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -573,6 +573,7 @@ static void invalidate_luminance_cache(dt_iop_module_t *const self)
   g->thumb_preview_hash = 0;
   g->ui_preview_hash = 0;
   dt_iop_gui_leave_critical_section(self);
+  dt_iop_refresh_preview(self);
 }
 
 
@@ -1670,7 +1671,6 @@ void gui_update(struct dt_iop_module_t *self)
 
   show_guiding_controls(self);
   invalidate_luminance_cache(self);
-  dt_iop_refresh_preview(self);
 
   dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
 }
@@ -1684,7 +1684,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     dt_bauhaus_widget_set_quad_active(w, FALSE);
 
   invalidate_luminance_cache(self);
-  dt_iop_refresh_preview(self);
 }
 
 static void smoothing_callback(GtkWidget *slider, gpointer user_data)
@@ -1731,7 +1730,6 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
     --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
-    dt_iop_refresh_preview(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     dt_bauhaus_widget_set_quad_active(quad, FALSE);
     return;
@@ -1787,7 +1785,6 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
     --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
-    dt_iop_refresh_preview(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     dt_bauhaus_widget_set_quad_active(quad, FALSE);
     return;


### PR DESCRIPTION
This fixes #9995 and fixes #9997 by refreshing the preview image whenever the luminance cache is invalidated, in order to recalculate luminance mask bar and histogram, so to update correctly the gui, plus setting the correct baseline for the next auto-correction and avoid the current erratic behaviour.
Also the behaviour of the picker buttons is fixed, so they can be active if and only if the mask exposure compensation and mask contrast compensation sliders respectively are set on the auto-correction values.
Any change in those values, by moving the sliders or resetting the module will also turn off the pickers.