### PR TITLE
imageio: refactor some ICC profile reading

### DIFF
--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -216,19 +216,12 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
   if (avif->icc.size > 0) {
     avifRWData icc = avif->icc;
 
-    if (icc.data == NULL || icc.size == 0) {
+    if (icc.data == NULL) {
       ret = DT_IMAGEIO_FILE_CORRUPTED;
       goto out;
     }
 
-    uint8_t *data = (uint8_t *)g_malloc0(sizeof(uint8_t) * icc.size);
-    if (data == NULL) {
-      dt_print(DT_DEBUG_IMAGEIO,
-               "Failed to allocate ICC buffer for AVIF image [%s]\n",
-               filename);
-      ret = DT_IMAGEIO_FILE_CORRUPTED;
-      goto out;
-    }
+    uint8_t *data = (uint8_t *)g_malloc(icc.size);
     memcpy(data, icc.data, icc.size);
 
     cp->icc_profile_size = icc.size;

--- a/src/common/imageio_j2k.c
+++ b/src/common/imageio_j2k.c
@@ -327,7 +327,6 @@ int dt_imageio_j2k_read_profile(const char *filename, uint8_t **out)
   opj_codec_t *d_codec = NULL;
   OPJ_CODEC_FORMAT codec;
   opj_stream_t *d_stream = NULL; /* Stream */
-  gboolean res = FALSE;
   unsigned int length = 0;
   *out = NULL;
 
@@ -429,14 +428,11 @@ int dt_imageio_j2k_read_profile(const char *filename, uint8_t **out)
     goto another_end_of_the_world;
   }
 
-  if(image->icc_profile_buf)
+  if(image->icc_profile_len > 0 && image->icc_profile_buf)
   {
-    res = TRUE;
     length = image->icc_profile_len;
-    *out = image->icc_profile_buf;
-
-    image->icc_profile_buf = NULL;
-    image->icc_profile_len = 0;
+    *out = (uint8_t *)g_malloc(image->icc_profile_len);
+    memcpy(*out, image->icc_profile_buf, image->icc_profile_len);
   }
 
 another_end_of_the_world:
@@ -446,7 +442,7 @@ another_end_of_the_world:
   /* free image data structure */
   opj_image_destroy(image);
 
-  return res ? length : 0;
+  return length;
 }
 
 

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -457,8 +457,7 @@ static boolean read_icc_profile(j_decompress_ptr dinfo, JOCTET **icc_data_ptr, u
   if(total_length == 0) return FALSE; /* found only empty markers? */
 
   /* Allocate space for assembled data */
-  icc_data = (JOCTET *)calloc(total_length, sizeof(JOCTET));
-  if(icc_data == NULL) return FALSE; /* oops, out of memory */
+  icc_data = (JOCTET *)g_malloc(total_length * sizeof(JOCTET));
 
   /* and fill it in */
   for(marker = dinfo->marker_list; marker != NULL; marker = marker->next)

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -232,7 +232,7 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out)
   if(png_get_valid(image.png_ptr, image.info_ptr, PNG_INFO_iCCP) != 0
      && png_get_iCCP(image.png_ptr, image.info_ptr, &name, &compression_type, &profile, &proflen) != 0)
   {
-    *out = (uint8_t *)malloc(proflen);
+    *out = (uint8_t *)g_malloc(proflen);
     memcpy(*out, profile, proflen);
   }
   else

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -503,14 +503,17 @@ int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)
     cmsSaveProfileToMem(profile, 0, &profile_len);
     if(profile_len > 0)
     {
-      *out = (uint8_t *)malloc(profile_len);
+      *out = (uint8_t *)g_malloc(profile_len);
       cmsSaveProfileToMem(profile, *out, &profile_len);
     }
   }
   else if(TIFFGetField(tiff, TIFFTAG_ICCPROFILE, &profile_len, &profile))
   {
-    *out = (uint8_t *)malloc(profile_len);
-    memcpy(*out, profile, profile_len);
+    if(profile_len > 0)
+    {
+      *out = (uint8_t *)g_malloc(profile_len);
+      memcpy(*out, profile, profile_len);
+    }
   }
   else
     profile_len = 0;


### PR DESCRIPTION
"Fixes" memory allocation `g_malloc()` is now used everywhere since `g_free()` is used to release the profile data.

Fixed a bug where J2K profile reader wasn't allocating and copying the actual profile.

Removed checks for NULL pointer (not needed w/ `g_malloc()`), but improved some other checks.

Also abstracted an AVIF structure so it can be reused for HEIF in the future as well.