### PR TITLE
tone equalizer: better mask autotune (for testing)

### DIFF
--- a/src/common/luminance_mask.h
+++ b/src/common/luminance_mask.h
@@ -78,7 +78,6 @@ typedef enum dt_iop_luminance_mask_method_t
  * backfire in the exposure computations.
  **/
 
-/*
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
@@ -88,17 +87,7 @@ static float linear_contrast(const float pixel, const float fulcrum, const float
   // Increase the slope of the value around a fulcrum value
   return fmaxf((pixel - fulcrum) * contrast + fulcrum, MIN_FLOAT);
 }
-*/
 
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-__DT_CLONE_TARGETS__
-static float log_contrast(const float pixel, const float fulcrum, const float contrast)
-{
-  // Increase the slope of the value around a fulcrum value
-  return fmaxf(pixel * powf(pixel / fulcrum, contrast), MIN_FLOAT);
-}
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(image, luminance:64) uniform(image, luminance)
@@ -120,7 +109,7 @@ static void pixel_rgb_mean(const float *const restrict image,
   for(int c = 0; c < 3; ++c)
     lum += image[k + c];
 
-  luminance[k / ch] = log_contrast(exposure_boost * lum / 3.0f, fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(exposure_boost * lum / 3.0f, fulcrum, contrast_boost);
 }
 
 
@@ -137,7 +126,7 @@ static void pixel_rgb_value(const float *const restrict image,
   // max(RGB) is equivalent to HSV value
 
   const float lum = exposure_boost * fmaxf(fmaxf(image[k], image[k + 1]), image[k + 2]);
-  luminance[k / ch] = log_contrast(lum, fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(lum, fulcrum, contrast_boost);
 }
 
 
@@ -155,7 +144,7 @@ static void pixel_rgb_lightness(const float *const restrict image,
 
   const float max_rgb = fmaxf(fmaxf(image[k], image[k + 1]), image[k + 2]);
   const float min_rgb = fminf(fminf(image[k], image[k + 1]), image[k + 2]);
-  luminance[k / ch] = log_contrast(exposure_boost * (max_rgb + min_rgb) / 2.0f, fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(exposure_boost * (max_rgb + min_rgb) / 2.0f, fulcrum, contrast_boost);
 }
 
 #ifdef _OPENMP
@@ -178,7 +167,7 @@ static void pixel_rgb_norm_1(const float *const restrict image,
     for(int c = 0; c < 3; ++c)
       lum += fabsf(image[k + c]);
 
-  luminance[k / ch] = log_contrast(exposure_boost * lum, fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(exposure_boost * lum, fulcrum, contrast_boost);
 }
 
 
@@ -201,7 +190,7 @@ static void pixel_rgb_norm_2(const float *const restrict image,
 #endif
   for(int c = 0; c < 3; ++c) result += image[k + c] * image[k + c];
 
-  luminance[k / ch] = log_contrast(exposure_boost * sqrtf(result), fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(exposure_boost * sqrtf(result), fulcrum, contrast_boost);
 }
 
 
@@ -232,7 +221,7 @@ static void pixel_rgb_norm_power(const float *const restrict image,
     denominator += RGB_square;
   }
 
-  luminance[k / ch] = log_contrast(exposure_boost * numerator / denominator, fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(exposure_boost * numerator / denominator, fulcrum, contrast_boost);
 }
 
 #ifdef _OPENMP
@@ -257,7 +246,7 @@ static void pixel_rgb_geomean(const float *const restrict image,
     lum *= fabsf(image[k + c]);
   }
 
-  luminance[k / ch] = log_contrast(exposure_boost * powf(lum, 1.0f / 3.0f), fulcrum, contrast_boost);
+  luminance[k / ch] = linear_contrast(exposure_boost * powf(lum, 1.0f / 3.0f), fulcrum, contrast_boost);
 }
 
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1370,8 +1370,8 @@ static inline void compute_log_histogram_and_stats(const float *const restrict l
 #endif
   for(size_t k = 0; k < num_elem; k++)
   {
-    // extended histogram bins between [-8; +8] EV remapped between [0 ; 2 * UI_SAMPLES]
-    const int index = CLAMP((int)(((log2f(luminance[k]) + 8.0f) / 16.0f) * (float)TEMP_SAMPLES), 0, TEMP_SAMPLES - 1);
+    // extended histogram bins between [-10; +6] EV remapped between [0 ; 2 * UI_SAMPLES]
+    const int index = CLAMP((int)(((log2f(luminance[k]) + 10.0f) / 16.0f) * (float)TEMP_SAMPLES), 0, TEMP_SAMPLES - 1);
     temp_hist[index] += 1;
   }
 
@@ -1392,15 +1392,15 @@ static inline void compute_log_histogram_and_stats(const float *const restrict l
   }
 
   // Convert decile positions to exposures
-  *first_decile = 16.0 * (float)first_pos / (float)(TEMP_SAMPLES - 1) - 8.0;
-  *last_decile = 16.0 * (float)last_pos / (float)(TEMP_SAMPLES - 1) - 8.0;
+  *first_decile = 16.0 * (float)first_pos / (float)(TEMP_SAMPLES - 1) - 10.0;
+  *last_decile = 16.0 * (float)last_pos / (float)(TEMP_SAMPLES - 1) - 10.0;
 
   *max_histogram = 0;
   // remap the extended histogram into the normal one
   // bins between [-8; 0] EV remapped between [0 ; UI_SAMPLES]
   for(size_t k = 0; k < TEMP_SAMPLES; ++k)
   {
-    float EV = 16.0 * (float)k / (float)(TEMP_SAMPLES - 1) - 8.0;
+    float EV = 16.0 * (float)k / (float)(TEMP_SAMPLES - 1) - 10.0;
     int i = CLAMP((int)(((EV + 8.0f) / 8.0f) * (float)UI_SAMPLES), 0, UI_SAMPLES - 1);
     histogram[i] += temp_hist[k];
 


### PR DESCRIPTION
_This PR is not ready for merging as it will break old edits and presets._

It is meant to test and discuss improved algorithm for mask auto-tune pickers in tone equalizer.
If those changer are accepted, I will transform it in a real PR.

Today one issue in tone equalizer is the effectiveness of the pickers for auto exposure and contrast correction, also reflected in discussions in DT forums. Moreover, there is cross-talk between the two sliders, as exposure correction changes contrast and vice-versa.
Here, we introduce two changes:

**1) auto-exposure correction**
This is the easiest, as it will not break edits.
The auto-exposure correction is based on mask histogram deciles. However, those are calculated on an histogram restricted in the [-8, 0] EV range. Luminance values outside that range are capped and counted in the first or last bin of the histogram.
This is especially an issue for the highlights part, as TE comes in the unbound part of the pipeline and after exposure correction most of the times the luminance exceeds 0 EV. This can lead to an inaccurate estimation of `g->histogram_last_decile` and underestimating the amount of exposure correction.
The solution implemented here is to calculate first an extended histogram in the [-8, +8] EV range (with double number of bins), use that for deciles estimation and then remap the extended histogram in the normal one.
It is not computationally expensive, just another small array of integers.
I couldn't find a method to avoid the two steps with temp extended histogram and calculate the deciles directly in the OpenMP parallel loop. Maybe someone more expert than me can find a better implementation.
Also I changed deciles in "ventiles" as with deciles we get potentially 20% of pixels out of reach of the TE correction and this is way too much, as most often than not the whole purpose TE is used is to fix those extreme values.
Overall the new auto correction works really well and in most cases is the only adjustment needed for the mask.

**2) contrast correction and auto-contrast**
this is trickier, as it will break old edits and it requires to step up TE  version.
the issue here is the use of a linear contrast function

```
static float linear_contrast(const float pixel, const float fulcrum, const float contrast)
{
  // Increase the slope of the value around a fulcrum value
  return fmaxf((pixel - fulcrum) * contrast + fulcrum, MIN_FLOAT);
}
```
the use of subtraction with non log encoded data quickly drives to negative numbers as contrast correction increases, which then are capped to `MIN_FLOAT`. The result is the histogram change in asymmetrical way, the shadows part extend much more and  the luminance mask goes black for the shadows.
I replaced that function with a log contrast like others used in DT (for example in color balance rbg)

```
static float log_contrast(const float pixel, const float fulcrum, const float contrast)
{
  // Increase the slope of the value around a fulcrum value
  return fmaxf(pixel * powf(pixel / fulcrum, contrast), MIN_FLOAT);
}
```
The auto correction math is updated as a consequence.
I am aware of the problems with non-linear correction and color, but here it is just a monochromatic mask and nothing bad seems to happen.
Overall the contrast slider and the auto picker behave really well IMO, it is super easy to nail a mask that covers all correction nodes and TE becomes a joy to use.

@aurelienpierre please test the PR if you like and give me feedback.
