### PR TITLE
Check if we're importing actual darktable preset

### DIFF
--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -201,6 +201,13 @@ int dt_presets_import_from_file(const char *preset_path)
   if(!doc)
     return FALSE;
 
+  xmlNodePtr root = xmlDocGetRootElement(doc);
+  if(!root || xmlStrcmp(root->name, BAD_CAST "darktable_preset") != 0)
+  {
+    xmlFreeDoc(doc);
+    return FALSE;
+  }
+
   gchar *name = get_preset_element(doc, "name");
   gchar *description = get_preset_element(doc, "description");
   gchar *operation = get_preset_element(doc, "operation");

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -112,7 +112,9 @@ static int32_t dt_styles_get_id_by_name(const char *name);
 
 gboolean dt_styles_exists(const char *name)
 {
-  return (dt_styles_get_id_by_name(name)) != 0 ? TRUE : FALSE;
+  if(name)
+    return (dt_styles_get_id_by_name(name)) != 0 ? TRUE : FALSE;
+  return FALSE;
 }
 
 static void _dt_style_cleanup_multi_instance(int id)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -558,10 +558,12 @@ static void import_clicked(GtkWidget *w, gpointer user_data)
       if(document != NULL)
         root = xmlDocGetRootElement(document);
 
-      if(document == NULL || root == NULL)
+      if(document == NULL || root == NULL || xmlStrcmp(root->name, BAD_CAST "darktable_style"))
       {
         dt_print(DT_DEBUG_CONTROL,
                  "[styles] file %s is not a style file\n", (char*)filename->data);
+        if(document)
+          xmlFreeDoc(document);
         continue;
       }
 


### PR DESCRIPTION
fixes #10009 

The file chooser selectors are correct so no problem there. So just to be sure - test if file being imported is actual preset.

//EDIT:

Additionally hardens style import and makes sure style import doesn't leak memory (or at least fixed mem leaks I've spotted)