### PR TITLE
Fix blurring 9x9 kernel and introduce a weighed mask blur

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -726,31 +726,8 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
   }  
 
   {
-    // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
-    float kernel[9][9];
-    const float temp = -8.0f; // -2.0f * 2.0f * 2.0f; for a sigma of 2
-    float sum = 0.0f;
-    for(int i = -4; i <= 4; i++)
-    {
-      for(int j = -4; j <= 4; j++)
-      {
-        kernel[i + 4][j + 4] = expf( ((i*i) + (j*j)) / temp);
-        sum += kernel[i + 4][j + 4];
-      }
-    }
-    for(int i = 0; i < 9; i++)
-    {
-#if defined(__GNUC__)
-  #pragma GCC ivdep
-#endif
-      for(int j = 0; j < 9; j++)
-        kernel[i][j] /= sum;
-    }
-
-    float blurmat[13] = { kernel[4][4], kernel[3][4], kernel[3][3],               // 00: c00 c10 c11
-                          kernel[2][4], kernel[2][3], kernel[2][2],               // 03: c20 c21 c22
-                          kernel[1][4], kernel[1][3], kernel[1][2], kernel[1][1], // 06: c30 c31 c32 c33
-                          kernel[0][4], kernel[0][3], kernel[0][2]};              // 10: c40 c41 c42
+    float blurmat[13];
+    dt_masks_blur_9x9_coeff(blurmat, 2.0f);
     cl_mem dev_blurmat = NULL;
     dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
     if(dev_blurmat != NULL)
@@ -771,7 +748,6 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, struct dt_
       dt_opencl_release_mem_object(dev_blurmat);
       goto error;
     }
-
   }
 
   {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -437,6 +437,8 @@ void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *con
                                   const int height, const dt_aligned_pixel_t wb);
 void dt_masks_calc_detail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
 
+void dt_masks_blur_approx_weighed(float *const src, float *const out, float *const weight, const int width, const int height);
+
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);
 

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -439,6 +439,10 @@ void dt_masks_calc_detail_mask(float *const src, float *const out, float *const 
 
 void dt_masks_blur_approx_weighed(float *const src, float *const out, float *const weight, const int width, const int height);
 
+/** the output data are blurred-val * gain and are clipped to be within 0 to clip
+    The returned int might be used to expand the border as this depends on sigma */
+int dt_masks_blur_fast(float *const src, float *const out, const int width, const int height, const float sigma, const float gain, const float clip);
+
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);
 

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -429,8 +429,9 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          const float initial_ypos, const float xpos, const float ypos, float *px,
                                          float *py, const int adding);
 
-/** luminance mask support */
+/** detail mask support */
 void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
+void dt_masks_blur_9x9_coeff(float *coeffs, const float sigma);
 void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
 void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *const tmp, const int width,
                                   const int height, const dt_aligned_pixel_t wb);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -430,7 +430,7 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          float *py, const int adding);
 
 /** detail mask support */
-void dt_masks_extend_border(float *mask, const int width, const int height, const int border);
+void dt_masks_extend_border(float *const mask, const int width, const int height, const int border);
 void dt_masks_blur_9x9_coeff(float *coeffs, const float sigma);
 void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
 void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *const tmp, const int width,

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -90,9 +90,18 @@ static inline float sqrf(float a)
   return a * a;
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(mask : 64)
+#endif
 void dt_masks_extend_border(float *mask, const int width, const int height, const int border)
 {
   if(border <= 0) return;
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(mask) \
+  dt_omp_sharedconst(width, height, border) \
+  schedule(simd:static)
+ #endif
   for(int row = border; row < height - border; row++)
   {
     const int idx = row * width;
@@ -102,6 +111,12 @@ void dt_masks_extend_border(float *mask, const int width, const int height, cons
       mask[idx + width - i - 1] = mask[idx + width - border -1];
     }
   }
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(mask) \
+  dt_omp_sharedconst(width, height, border) \
+  schedule(simd:static)
+ #endif
   for(int col = 0; col < width; col++)
   {
     const float top = mask[border * width + MIN(width - border - 1, MAX(col, border))];
@@ -114,41 +129,111 @@ void dt_masks_extend_border(float *mask, const int width, const int height, cons
   }
 }
 
+void _masks_blur_5x5_coeff(float *c, const float sigma)
+{
+  float kernel[5][5];
+  const float temp = -2.0f * sqrf(sigma);
+  const float range = sqrf(3.0f * 0.84f);
+  float sum = 0.0f;
+  for(int k = -2; k <= 2; k++)
+  {
+    for(int j = -2; j <= 2; j++)
+    {
+      if((sqrf(k) + sqrf(j)) <= range)
+      {
+        kernel[k + 2][j + 2] = expf((sqrf(k) + sqrf(j)) / temp);
+        sum += kernel[k + 2][j + 2];
+      }
+      else
+        kernel[k + 2][j + 2] = 0.0f;
+    }
+  }
+  for(int i = 0; i < 5; i++)
+  {
+#if defined(__GNUC__)
+  #pragma GCC ivdep
+#endif
+    for(int j = 0; j < 5; j++)
+      kernel[i][j] /= sum;
+  }
+  /* c21 */ c[0]  = kernel[0][1];
+  /* c20 */ c[1]  = kernel[0][2];
+  /* c11 */ c[2]  = kernel[1][1];
+  /* c10 */ c[3]  = kernel[1][2];
+  /* c00 */ c[4]  = kernel[2][2];
+}
+#define FAST_BLUR_5 ( \
+  blurmat[0] * ((src[i - w2 - 1] + src[i - w2 + 1]) + (src[i - w1 - 2] + src[i - w1 + 2]) + (src[i + w1 - 2] + src[i + w1 + 2]) + (src[i + w2 - 1] + src[i + w2 + 1])) + \
+  blurmat[1] * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) + \
+  blurmat[2] * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) + \
+  blurmat[3] * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) + \
+  blurmat[4] * src[i] )
+
+void dt_masks_blur_9x9_coeff(float *c, const float sigma)
+{
+  float kernel[9][9];
+  const float temp = -2.0f * sqrf(sigma);
+  const float range = sqrf(3.0f * 1.5f);
+  float sum = 0.0f;
+  for(int k = -4; k <= 4; k++)
+  {
+    for(int j = -4; j <= 4; j++)
+    {
+      if((sqrf(k) + sqrf(j)) <= range)
+      {
+        kernel[k + 4][j + 4] = expf((sqrf(k) + sqrf(j)) / temp);
+        sum += kernel[k + 4][j + 4];
+      }
+      else
+        kernel[k + 4][j + 4] = 0.0f;
+    }
+  }
+  for(int i = 0; i < 9; i++)
+  {
+#if defined(__GNUC__)
+  #pragma GCC ivdep
+#endif
+    for(int j = 0; j < 9; j++)
+      kernel[i][j] /= sum;
+  }
+  /* c00 */ c[0]  = kernel[4][4];
+  /* c10 */ c[1]  = kernel[3][4];
+  /* c11 */ c[2]  = kernel[3][3];
+  /* c20 */ c[3]  = kernel[2][4];
+  /* c21 */ c[4]  = kernel[2][3];
+  /* c22 */ c[5]  = kernel[2][2];
+  /* c30 */ c[6]  = kernel[1][4];
+  /* c31 */ c[7]  = kernel[1][3];
+  /* c32 */ c[8]  = kernel[1][2];
+  /* c33 */ c[9]  = kernel[1][1];
+  /* c40 */ c[10] = kernel[0][4];
+  /* c41 */ c[11] = kernel[0][3];
+  /* c42 */ c[12] = kernel[0][2];
+}
+
+#define FAST_BLUR_9 ( \
+  blurmat[12] * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) + \
+  blurmat[11] * (src[i - w4 - 1] + src[i - w4 + 1] + src[i - w1 - 4] + src[i - w1 + 4] + src[i + w1 - 4] + src[i + w1 + 4] + src[i + w4 - 1] + src[i + w4 + 1]) + \
+  blurmat[10] * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) + \
+  blurmat[9]  * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) + \
+  blurmat[8]  * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) + \
+  blurmat[7]  * (src[i - w3 - 1] + src[i - w3 + 1] + src[i - w1 - 3] + src[i - w1 + 3] + src[i + w1 - 3] + src[i + w1 + 3] + src[i + w3 - 1] + src[i + w3 + 1]) + \
+  blurmat[6]  * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) + \
+  blurmat[5]  * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) + \
+  blurmat[4]  * (src[i - w2 - 1] + src[i - w2 + 1] + src[i - w1 - 2] + src[i - w1 + 2] + src[i + w1 - 2] + src[i + w1 + 2] + src[i + w2 - 1] + src[i + w2 + 1]) + \
+  blurmat[3]  * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) + \
+  blurmat[2]  * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) + \
+  blurmat[1]  * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) + \
+  blurmat[0]  * src[i] )
+
 #ifdef _OPENMP
 #pragma omp declare simd aligned(src, out : 64)
 #endif
 void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, const int width, const int height, const float sigma)
 {
-  // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here
-  float kernel[9][9];
-  const float temp = 2.0f * sqrf(sigma);
-  float sum = 0.0f;
-  for(int i = -4; i <= 4; i++)
-  {
-    for(int j = -4; j <= 4; j++)
-    {
-      kernel[i + 4][j + 4] = expf( -(sqrf(i) + sqrf(j)) / temp);
-      sum += kernel[i + 4][j + 4];
-    }
-  }
-  for(int i = 0; i < 9; i++)
-  {
-    for(int j = 0; j < 9; j++)
-      kernel[i][j] /= sum;
-  }
-  const float c42 = kernel[0][2];
-  const float c41 = kernel[0][3];
-  const float c40 = kernel[0][4];
-  const float c33 = kernel[1][1];
-  const float c32 = kernel[1][2];
-  const float c31 = kernel[1][3];
-  const float c30 = kernel[1][4];
-  const float c22 = kernel[2][2];
-  const float c21 = kernel[2][3];
-  const float c20 = kernel[2][4];
-  const float c11 = kernel[3][3];
-  const float c10 = kernel[3][4];
-  const float c00 = kernel[4][4];
+  float blurmat[13];
+  dt_masks_blur_9x9_coeff(blurmat, sigma);
+
   const int w1 = width;
   const int w2 = 2*width;
   const int w3 = 3*width;
@@ -156,7 +241,7 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
   dt_omp_firstprivate(src, out) \
-  dt_omp_sharedconst(c42, c41, c40, c33, c32, c31, c30, c22, c21, c20, c11, c10, c00, w1, w2, w3, w4, width, height) \
+  dt_omp_sharedconst(blurmat, width, height, w1, w2, w3, w4) \
   schedule(simd:static)
  #endif
   for(int row = 4; row < height - 4; row++)
@@ -169,24 +254,80 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
     for(int col = 4; col < width - 4; col++)
     {
       const int i = row * width + col;
-      const float val = c42 * (src[i - w4 - 2] + src[i - w4 + 2] + src[i - w2 - 4] + src[i - w2 + 4] + src[i + w2 - 4] + src[i + w2 + 4] + src[i + w4 - 2] + src[i + w4 + 2]) +
-                        c41 * (src[i - w4 - 1] + src[i - w4 + 1] + src[i - w1 - 4] + src[i - w1 + 4] + src[i + w1 - 4] + src[i + w1 + 4] + src[i + w4 - 1] + src[i + w4 + 1]) +
-                        c40 * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) +
-                        c33 * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) +
-                        c32 * (src[i - w3 - 2] + src[i - w3 + 2] + src[i - w2 - 3] + src[i - w2 + 3] + src[i + w2 - 3] + src[i + w2 + 3] + src[i + w3 - 2] + src[i + w3 + 2]) +
-                        c31 * (src[i - w3 - 1] + src[i - w3 + 1] + src[i - w1 - 3] + src[i - w1 + 3] + src[i + w1 - 3] + src[i + w1 + 3] + src[i + w3 - 1] + src[i + w3 + 1]) +
-                        c30 * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) +
-                        c22 * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) +
-                        c21 * (src[i - w2 - 1] + src[i - w2 + 1] + src[i - w1 - 2] + src[i - w1 + 2] + src[i + w1 - 2] + src[i + w1 + 2] + src[i + w2 - 1] + src[i + w2 + 1]) +
-                        c20 * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) +
-                        c11 * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) +
-                        c10 * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) +
-                        c00 * src[i];
-      out[i] = fminf(1.0f, fmaxf(0.0f, val));
+      out[i] = fminf(1.0f, fmaxf(0.0f, FAST_BLUR_9));
     }
   }
   dt_masks_extend_border(out, width, height, 4);
 }
+
+void _masks_blur_13x13_coeff(float *c, const float sigma)
+{
+  float kernel[13][13];
+  const float temp = -2.0f * sqrf(sigma);
+  const float range = sqrf(3.0f * 2.0f);
+  float sum = 0.0f;
+  for(int k = -6; k <= 6; k++)
+  {
+    for(int j = -6; j <= 6; j++)
+    {
+      if((sqrf(k) + sqrf(j)) <= range)
+      {
+        kernel[k + 6][j + 6] = expf((sqrf(k) + sqrf(j)) / temp);
+        sum += kernel[k + 6][j + 6];
+      }
+      else
+        kernel[k + 6][j + 6] = 0.0f;
+    }
+  }
+  for(int i = 0; i < 13; i++)
+  {
+#if defined(__GNUC__)
+  #pragma GCC ivdep
+#endif
+    for(int j = 0; j < 13; j++)
+      kernel[i][j] /= sum;
+  }
+  /* c60 */ c[0]  = kernel[0][6];
+  /* c53 */ c[1]  = kernel[1][3];
+  /* c52 */ c[2]  = kernel[1][4];
+  /* c51 */ c[3]  = kernel[1][5];
+  /* c50 */ c[4]  = kernel[1][6];
+  /* c44 */ c[5]  = kernel[2][2];
+  /* c42 */ c[6]  = kernel[2][4];
+  /* c41 */ c[7]  = kernel[2][5];
+  /* c40 */ c[8]  = kernel[2][6];
+  /* c33 */ c[9]  = kernel[3][3];
+  /* c32 */ c[10] = kernel[3][4];
+  /* c31 */ c[11] = kernel[3][5];
+  /* c30 */ c[12] = kernel[3][6];
+  /* c22 */ c[13] = kernel[4][4];
+  /* c21 */ c[14] = kernel[4][5];
+  /* c20 */ c[15] = kernel[4][6];
+  /* c11 */ c[16] = kernel[5][5];
+  /* c10 */ c[17] = kernel[5][6];
+  /* c00 */ c[18] = kernel[6][6];
+}
+
+#define FAST_BLUR_13 ( \
+  blurmat[0] * (src[i - w6] + src[i - 6] + src[i + 6] + src[i + w6]) + \
+  blurmat[1] * ((src[i - w5 - 3] + src[i - w5 + 3]) + (src[i - w3 - 5] + src[i - w3 + 5]) + (src[i + w3 - 5] + src[i + w3 + 5]) + (src[i + w5 - 3] + src[i + w5 + 3])) + \
+  blurmat[2] * ((src[i - w5 - 2] + src[i - w5 + 2]) + (src[i - w2 - 5] + src[i - w2 + 5]) + (src[i + w2 - 5] + src[i + w2 + 5]) + (src[i + w5 - 2] + src[i + w5 + 2])) + \
+  blurmat[3] * ((src[i - w5 - 1] + src[i - w5 + 1]) + (src[i - w1 - 5] + src[i - w1 + 5]) + (src[i + w1 - 5] + src[i + w1 + 5]) + (src[i + w5 - 1] + src[i + w5 + 1])) + \
+  blurmat[4] * ((src[i - w5] + src[i - 5] + src[i + 5] + src[i + w5]) + ((src[i - w4 - 3] + src[i - w4 + 3]) + (src[i - w3 - 4] + src[i - w3 + 4]) + (src[i + w3 - 4] + src[i + w3 + 4]) + (src[i + w4 - 3] + src[i + w4 + 3]))) + \
+  blurmat[5] * (src[i - w4 - 4] + src[i - w4 + 4] + src[i + w4 - 4] + src[i + w4 + 4]) + \
+  blurmat[6] * ((src[i - w4 - 2] + src[i - w4 + 2]) + (src[i - w2 - 4] + src[i - w2 + 4]) + (src[i + w2 - 4] + src[i + w2 + 4]) + (src[i + w4 - 2] + src[i + w4 + 2])) + \
+  blurmat[7] * ((src[i - w4 - 1] + src[i - w4 + 1]) + (src[i - w1 - 4] + src[i - w1 + 4]) + (src[i + w1 - 4] + src[i + w1 + 4]) + (src[i + w4 - 1] + src[i + w4 + 1])) + \
+  blurmat[8] * (src[i - w4] + src[i - 4] + src[i + 4] + src[i + w4]) + \
+  blurmat[9] * (src[i - w3 - 3] + src[i - w3 + 3] + src[i + w3 - 3] + src[i + w3 + 3]) + \
+  blurmat[10] * ((src[i - w3 - 2] + src[i - w3 + 2]) + (src[i - w2 - 3] + src[i - w2 + 3]) + (src[i + w2 - 3] + src[i + w2 + 3]) + (src[i + w3 - 2] + src[i + w3 + 2])) + \
+  blurmat[11] * ((src[i - w3 - 1] + src[i - w3 + 1]) + (src[i - w1 - 3] + src[i - w1 + 3]) + (src[i + w1 - 3] + src[i + w1 + 3]) + (src[i + w3 - 1] + src[i + w3 + 1])) + \
+  blurmat[12] * (src[i - w3] + src[i - 3] + src[i + 3] + src[i + w3]) + \
+  blurmat[13] * (src[i - w2 - 2] + src[i - w2 + 2] + src[i + w2 - 2] + src[i + w2 + 2]) + \
+  blurmat[14] * ((src[i - w2 - 1] + src[i - w2 + 1]) + (src[i - w1 - 2] + src[i - w1 + 2]) + (src[i + w1 - 2] + src[i + w1 + 2]) + (src[i + w2 - 1] + src[i + w2 + 1])) + \
+  blurmat[15] * (src[i - w2] + src[i - 2] + src[i + 2] + src[i + w2]) + \
+  blurmat[16] * (src[i - w1 - 1] + src[i - w1 + 1] + src[i + w1 - 1] + src[i + w1 + 1]) + \
+  blurmat[17] * (src[i - w1] + src[i - 1] + src[i + 1] + src[i + w1]) + \
+  blurmat[18] * src[i] )
 
 void dt_masks_calc_rawdetail_mask(float *const restrict src, float *const restrict mask, float *const restrict tmp,
                                   const int width, const int height, const dt_aligned_pixel_t wb)
@@ -244,7 +385,7 @@ void dt_masks_calc_detail_mask(float *const restrict src, float *const restrict 
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(src, tmp, msize, threshold, detail) \
-  schedule(simd:static) aligned(src, tmp : 64)
+  schedule(simd:static) aligned(src, tmp, out : 64)
 #endif
   for(int idx = 0; idx < msize; idx++)
   {
@@ -253,3 +394,7 @@ void dt_masks_calc_detail_mask(float *const restrict src, float *const restrict 
   }
   dt_masks_blur_9x9(tmp, out, width, height, 2.0f);
 }
+#undef FAST_BLUR_5
+#undef FAST_BLUR_9
+#undef FAST_BLUR_13
+

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -341,7 +341,8 @@ void dt_masks_blur_approx_weighed(float *const restrict src, float *const restri
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(src, out, weight) \
-  dt_omp_sharedconst(coeffs, width, height, w1, w2, w3, w4, w5, w6) \
+  dt_omp_sharedconst(width, height, w1, w2, w3, w4, w5, w6) \
+  shared(coeffs) \
   schedule(simd:static) aligned(src, out, weight : 64)
  #endif
   for(int row = 6; row < height - 6; row++)

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -154,31 +154,8 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   }
 
   {
-    // For a blurring sigma of 2.0f a 13x13 kernel would be optimally required but the 9x9 is by far good enough here 
-    float kernel[9][9];
-    const float temp = -2.0f * (2.0f * 2.0f);
-    float sum = 0.0f;
-    for(int i = -4; i <= 4; i++)
-    {
-      for(int j = -4; j <= 4; j++)
-      {
-        kernel[i + 4][j + 4] = expf(((i*i) + (j*j)) / temp);
-        sum += kernel[i + 4][j + 4];
-      }
-    }
-    for(int i = 0; i < 9; i++)
-    {
-#if defined(__GNUC__)
-  #pragma GCC ivdep
-#endif
-      for(int j = 0; j < 9; j++)
-        kernel[i][j] /= sum;
-    }
-
-    float blurmat[13] = { kernel[4][4], kernel[3][4], kernel[3][3],               // 00: c00 c10 c11
-                          kernel[2][4], kernel[2][3], kernel[2][2],               // 03: c20 c21 c22
-                          kernel[1][4], kernel[1][3], kernel[1][2], kernel[1][1], // 06: c30 c31 c32 c33
-                          kernel[0][4], kernel[0][3], kernel[0][2]};              // 10: c40 c41 c42
+    float blurmat[13];
+    dt_masks_blur_9x9_coeff(blurmat, 2.0f);
     cl_mem dev_blurmat = NULL;
     dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
     if(dev_blurmat != NULL)


### PR DESCRIPTION
As reported in #10001 there was a bug for calculating the calculation of the 9x9 gaussian kernel leading to an error of ~2%.
This error did not lead to visual artefacts (and thus does not require new module versions for details mask and dual demosaicing) but should be corrected. As required this code holds a refactured function to calculate it.

Also - there is a new function here:
`void dt_masks_blur_approx_weighed(float *const src, float *const out, float *const weight, const int width, const int height);`

blurring the mask found in `scr` writing it to `out`. The sigma of the blurring is not constant but for every location it is taken from `weight` on a per-pixel base. Internally it uses 5x5, 9x9 and 13x13 fast kernels, sigmas are supported in the range 0.1 - 5.0 in 0.1 steps. (code is used in new highlights reconstruction method ...)

I checked the performance of the kernel macros vs inline functions, the macro version is definitely faster as the code vectorizes better.