### PR TITLE
print correct message when applying style using double click

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -634,8 +634,14 @@ void dt_styles_apply_to_list(const char *name, const GList *list, gboolean dupli
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
-  if(!selected) dt_control_log(_("no image selected!"));
-  dt_control_log(_("style %s successfully applied!"), name);
+  if(!selected)
+  {
+    dt_control_log(_("no image selected!"));
+  }
+  else
+  {
+    dt_control_log(_("style %s successfully applied!"), name);
+  }
 }
 
 void dt_multiple_styles_apply_to_list(GList *styles, const GList *list, gboolean duplicate)


### PR DESCRIPTION
Noticed that when applying a style using the double click method, it would print a success message, when no image was selected.