### PR TITLE
Replace deprecated functions to compile with librsvg 2.52

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -417,9 +417,18 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
   char *dtlogo = g_build_filename(datadir, "pixmaps", logo, NULL);
   RsvgHandle *svg = rsvg_handle_new_from_file(dtlogo, &error);
   if(svg)
-  {
+  {  
     RsvgDimensionData dimension;
-    rsvg_handle_get_dimensions(svg, &dimension);
+    // rsvg_handle_get_dimensions has been deprecated in librsvg 2.52
+    #if LIBRSVG_CHECK_VERSION (2, 52, 0)
+      double width;
+      double height;
+      rsvg_handle_get_intrinsic_size_in_pixels(svg, &width, &height);
+      dimension.width = width;
+      dimension.height = height;
+    #else      
+      rsvg_handle_get_dimensions(svg, &dimension);
+    #endif 
 
     const float ppd = darktable.gui ? darktable.gui->ppd : 1.0;
 
@@ -448,7 +457,19 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
     {
       cairo_t *cr = cairo_create(surface);
       cairo_scale(cr, factor, factor);
-      rsvg_handle_render_cairo(svg, cr);
+      
+      // rsvg_handle_render_cairo has been deprecated in librsvg 2.52
+      #if LIBRSVG_CHECK_VERSION (2, 52, 0)
+        RsvgRectangle viewport;
+	      viewport.x = 0;
+	      viewport.y = 0;
+	      viewport.width = final_width;
+	      viewport.height = final_height;
+        rsvg_handle_render_document(svg, cr, &viewport, &error);
+      #else
+        rsvg_handle_render_cairo(svg, cr);
+      #endif  
+
       cairo_destroy(cr);
       cairo_surface_flush(surface);
     }

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -726,8 +726,19 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   switch(type)
   {
     case DT_WTM_SVG:
-      rsvg_handle_get_dimensions(svg, &dimension);
+      
+      // rsvg_handle_get_dimensions has been deprecated in librsvg 2.52
+      #if LIBRSVG_CHECK_VERSION (2, 52, 0)
+        double width;
+        double height;
+        rsvg_handle_get_intrinsic_size_in_pixels(svg, &width, &height);
+        dimension.width = width;
+        dimension.height = height;
+      #else
+        rsvg_handle_get_dimensions(svg, &dimension);
+      #endif 
       break;
+      
     case DT_WTM_PNG:
       // load png into surface 2
       surface_two = cairo_image_surface_create_from_png(filename);
@@ -912,7 +923,19 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case DT_WTM_SVG:
       cairo_scale(cr_two, scale, scale);
       /* render svg into surface*/
-      rsvg_handle_render_cairo(svg, cr_two);
+      
+      // rsvg_handle_render_cairo has been deprecated in librsvg 2.52
+      #if LIBRSVG_CHECK_VERSION (2, 52, 0)
+        GError *error = NULL;
+        RsvgRectangle viewport;
+	      viewport.x = 0;
+	      viewport.y = 0;
+	      viewport.width = dimension.width;
+	      viewport.height = dimension.height;
+        rsvg_handle_render_document(svg, cr_two, &viewport, &error);
+      #else
+        rsvg_handle_render_cairo(svg, cr_two);
+      #endif  
       break;
     case DT_WTM_PNG:
       cairo_scale(cr, scale, scale);


### PR DESCRIPTION
fixes #10013

I needed to make the following changes to compile dt again with the latest librsvg in Arch. I am not sure how to proceed further.  I think proper checks for newer versions of librsvg need to be implemented to only change the functions for librsvg versions which deprecate those functions and still be compatible with older versions. If someone could point me to the proper place in the cmake scripts that would be helpful. I felt kinda lost when looking how to do this. 