### PR TITLE
Add a search box in presets perferences and shortcuts fixes

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1300,6 +1300,7 @@ dialog scrollbar
   margin-right: 0.35em;
 }
 
+#preset_controls entry,
 #shortcut_controls entry
 {
   min-width: 15em;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1486,7 +1486,10 @@ static gboolean _action_view_click(GtkWidget *widget, GdkEventButton *event, gpo
         gtk_tree_view_collapse_row(view, path);
       }
       else
+      {
         gtk_tree_selection_select_path(selection, path);
+        gtk_tree_view_set_cursor(view, path, NULL, FALSE);
+      }
 
       gtk_widget_grab_focus(widget);
     }
@@ -1502,6 +1505,7 @@ static gboolean _action_view_map(GtkTreeView *view, GdkEvent *event, gpointer fo
   GtkTreePath *path = gtk_tree_model_get_path(gtk_tree_view_get_model(view), found_iter);
   gtk_tree_view_expand_to_path(view, path);
   gtk_tree_view_scroll_to_cell(view, path, NULL, TRUE, 0.5, 0);
+  gtk_tree_view_set_cursor(view, path, NULL, FALSE);
   gtk_tree_path_free(path);
 
   gtk_tree_selection_select_iter(gtk_tree_view_get_selection(view), found_iter);
@@ -1940,6 +1944,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   GtkWidget *search_shortcuts = gtk_search_entry_new();
   gtk_entry_set_placeholder_text(GTK_ENTRY(search_shortcuts), _("search shortcuts list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_shortcuts), _("incrementally search the list of shortcuts\npress up or down keys to cycle through matches"));
+  g_signal_connect(G_OBJECT(search_shortcuts), "activate", G_CALLBACK(dt_gui_search_stop), shortcuts_view);
   g_signal_connect(G_OBJECT(search_shortcuts), "stop-search", G_CALLBACK(dt_gui_search_stop), shortcuts_view);
   gtk_tree_view_set_search_entry(shortcuts_view, GTK_ENTRY(search_shortcuts));
 
@@ -2030,6 +2035,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   GtkWidget *search_actions = gtk_search_entry_new();
   gtk_entry_set_placeholder_text(GTK_ENTRY(search_actions), _("search actions list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_actions), _("incrementally search the list of actions\npress up or down keys to cycle through matches"));
+  g_signal_connect(G_OBJECT(search_actions), "activate", G_CALLBACK(dt_gui_search_stop), actions_view);
   g_signal_connect(G_OBJECT(search_actions), "stop-search", G_CALLBACK(dt_gui_search_stop), actions_view);
   gtk_tree_view_set_search_entry(actions_view, GTK_ENTRY(search_actions));
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2076,6 +2076,10 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
                           send_iter, (GClosureNotify)g_free, G_CONNECT_AFTER);
   }
 
+  GtkTreePath *path = gtk_tree_path_new_first();
+  gtk_tree_view_set_cursor(shortcuts_view, path, NULL, FALSE);
+  gtk_tree_path_free(path);
+
   const int split_position = dt_conf_get_int("shortcuts/window_split");
   if(split_position) gtk_paned_set_position(GTK_PANED(container), split_position);
   g_signal_connect(G_OBJECT(shortcuts_view), "size-allocate", G_CALLBACK(_resize_shortcuts_view), container);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1994,7 +1994,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_widget_set_size_request(scroll, -1, 100);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   gtk_container_add(GTK_CONTAINER(scroll), GTK_WIDGET(shortcuts_view));
-  gtk_paned_pack1(GTK_PANED(container), scroll, TRUE, FALSE);
+  gtk_paned_pack2(GTK_PANED(container), scroll, TRUE, FALSE);
 
   // Creating the action selection treeview
   g_set_weak_pointer(&actions_store, gtk_tree_store_new(1, G_TYPE_POINTER)); // static
@@ -2059,7 +2059,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_widget_set_size_request(scroll, -1, 100);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   gtk_container_add(GTK_CONTAINER(scroll), GTK_WIDGET(actions_view));
-  gtk_paned_pack2(GTK_PANED(container), scroll, TRUE, FALSE);
+  gtk_paned_pack1(GTK_PANED(container), scroll, TRUE, FALSE);
 
   if(found_iter.user_data)
   {
@@ -2076,8 +2076,8 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
 
   GtkWidget *button_bar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0), *button = NULL;
   gtk_widget_set_name(button_bar, "shortcut_controls");
-  gtk_box_pack_start(GTK_BOX(button_bar), search_shortcuts, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(button_bar), search_actions, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(button_bar), search_shortcuts, FALSE, FALSE, 0);
 
   button = gtk_button_new_with_label(_("restore..."));
   gtk_widget_set_tooltip_text(button, "restore default shortcuts or previous state");

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3279,8 +3279,17 @@ gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEnt
 
 void dt_gui_search_stop(GtkSearchEntry *entry, GtkWidget *widget)
 {
-  gtk_entry_set_text(GTK_ENTRY(entry), "");
   gtk_widget_grab_focus(widget);
+
+  gtk_entry_set_text(GTK_ENTRY(entry), "");
+
+  if(GTK_IS_TREE_VIEW(widget))
+  {
+    GtkTreePath *path = NULL;
+    gtk_tree_view_get_cursor(GTK_TREE_VIEW(widget), &path, NULL);
+    gtk_tree_selection_select_path(gtk_tree_view_get_selection(GTK_TREE_VIEW(widget)), path);
+    gtk_tree_path_free(path);
+  }
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3266,6 +3266,23 @@ void dt_gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float
   cairo_fill(cr);
 }
 
+gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEntry *entry)
+{
+  if(gtk_search_entry_handle_event(entry, (GdkEvent *)event))
+  {
+    gtk_entry_grab_focus_without_selecting(GTK_ENTRY(entry));
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+void dt_gui_search_stop(GtkSearchEntry *entry, GtkWidget *widget)
+{
+  gtk_entry_set_text(GTK_ENTRY(entry), "");
+  gtk_widget_grab_focus(widget);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -437,7 +437,14 @@ void dt_gui_container_remove_children(GtkContainer *container);
 void dt_gui_container_destroy_children(GtkContainer *container);
 
 void dt_gui_menu_popup(GtkMenu *menu, GtkWidget *button, GdkGravity widget_anchor, GdkGravity menu_anchor);
+
 void dt_gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float x, float y);
+
+// event handler for "key-press-event" of GtkTreeView to decide if focus switches to GtkSearchEntry
+gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEntry *entry);
+
+// event handler for "stop-search" of GtkSearchEntry
+void dt_gui_search_stop(GtkSearchEntry *entry, GtkWidget *widget);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -47,24 +47,14 @@ typedef struct dt_gui_themetweak_widgets_t
   GtkWidget *apply_toggle, *save_button, *css_text_view;
 } dt_gui_themetweak_widgets_t;
 
-// FIXME: this is copypasta from gui/presets.c. better put these somewhere so that all places can access the
-// same data.
-static const int dt_gui_presets_exposure_value_cnt = 24;
-static const float dt_gui_presets_exposure_value[]
-    = { 0.,       1. / 8000, 1. / 4000, 1. / 2000, 1. / 1000, 1. / 1000, 1. / 500, 1. / 250,
-        1. / 125, 1. / 60,   1. / 30,   1. / 15,   1. / 15,   1. / 8,    1. / 4,   1. / 2,
-        1,        2,         4,         8,         15,        30,        60,       FLT_MAX };
-static const char *dt_gui_presets_exposure_value_str[]
-    = { "0",     "1/8000", "1/4000", "1/2000", "1/1000", "1/1000", "1/500", "1/250",
-        "1/125", "1/60",   "1/30",   "1/15",   "1/15",   "1/8",    "1/4",   "1/2",
-        "1\"",   "2\"",    "4\"",    "8\"",    "15\"",   "30\"",   "60\"",  "+" };
-static const int dt_gui_presets_aperture_value_cnt = 19;
-static const float dt_gui_presets_aperture_value[]
-    = { 0,    0.5,  0.7,  1.0,  1.4,  2.0,  2.8,  4.0,   5.6,    8.0,
-        11.0, 16.0, 22.0, 32.0, 45.0, 64.0, 90.0, 128.0, FLT_MAX };
-static const char *dt_gui_presets_aperture_value_str[]
-    = { "f/0",  "f/0.5", "f/0.7", "f/1.0", "f/1.4", "f/2",  "f/2.8", "f/4",   "f/5.6", "f/8",
-        "f/11", "f/16",  "f/22",  "f/32",  "f/45",  "f/64", "f/90",  "f/128", "f/+" };
+// link to values in gui/presets.c
+// move to presets.h if needed elsewhere
+extern const int dt_gui_presets_exposure_value_cnt;
+extern const float dt_gui_presets_exposure_value[];
+extern const char *dt_gui_presets_exposure_value_str[];
+extern const int dt_gui_presets_aperture_value_cnt;
+extern const float dt_gui_presets_aperture_value[];
+extern const char *dt_gui_presets_aperture_value_str[];
 
 // Values for the accelerators/presets treeview
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -734,11 +734,51 @@ static void tree_insert_presets(GtkTreeStore *tree_model)
   cairo_surface_destroy(check_cst);
 }
 
+static gboolean _search_func(GtkTreeModel *model, gint column, const gchar *key, GtkTreeIter *iter, gpointer search_data)
+{
+  gchar *key_case = g_utf8_casefold(key, -1), *label = NULL;
+
+  gtk_tree_model_get(model, iter, P_NAME_COLUMN, &label, -1);
+  gchar *name_case = g_utf8_casefold(label, -1);
+  g_free(label);
+  gtk_tree_model_get(model, iter, P_MODULE_COLUMN, &label, -1);
+  gchar *module_case = g_utf8_casefold(label, -1);
+  g_free(label);
+
+  const gboolean different = !((name_case && strstr(name_case, key_case))
+                               || (module_case && strstr(module_case, key_case)));
+
+  g_free(name_case);
+  g_free(module_case);
+  g_free(key_case);
+
+  if(!different)
+  {
+    GtkTreePath *path = gtk_tree_model_get_path(model, iter);
+    gtk_tree_view_expand_to_path(GTK_TREE_VIEW(search_data), path);
+    gtk_tree_path_free(path);
+
+    return FALSE;
+  }
+
+  GtkTreeIter child;
+  if(gtk_tree_model_iter_children(model, &child, iter))
+  {
+    do
+    {
+      _search_func(model, column, key, &child, search_data);
+    }
+    while(gtk_tree_model_iter_next(model, &child));
+  }
+
+  return TRUE;
+}
+
 static void init_tab_presets(GtkWidget *stack)
 {
   GtkWidget *container = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
-  GtkWidget *tree = gtk_tree_view_new();
+  GtkTreeView *tree = GTK_TREE_VIEW(gtk_tree_view_new());
   GtkTreeStore *model = gtk_tree_store_new(
       P_N_COLUMNS, G_TYPE_INT /*rowid*/, G_TYPE_STRING /*operation*/, G_TYPE_STRING /*module*/,
       GDK_TYPE_PIXBUF /*editable*/, G_TYPE_STRING /*name*/, G_TYPE_STRING /*model*/, G_TYPE_STRING /*maker*/,
@@ -759,48 +799,48 @@ static void init_tab_presets(GtkWidget *stack)
   // Setting up the cell renderers
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("module"), renderer, "text", P_MODULE_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_pixbuf_new();
   column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf", P_EDITABLE_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("name"), renderer, "text", P_NAME_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("model"), renderer, "text", P_MODEL_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("maker"), renderer, "text", P_MAKER_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("lens"), renderer, "text", P_LENS_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("ISO"), renderer, "text", P_ISO_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("exposure"), renderer, "text", P_EXPOSURE_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("aperture"), renderer, "text", P_APERTURE_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("focal length"), renderer, "text",
                                                     P_FOCAL_LENGTH_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   renderer = gtk_cell_renderer_pixbuf_new();
   column = gtk_tree_view_column_new_with_attributes(_("auto"), renderer, "pixbuf", P_AUTOAPPLY_COLUMN, NULL);
-  gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_append_column(tree, column);
 
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   gtk_box_pack_start(GTK_BOX(container), scroll, TRUE, TRUE, 0);
@@ -809,12 +849,20 @@ static void init_tab_presets(GtkWidget *stack)
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(hbox, "preset_controls");
 
+  GtkWidget *search_presets = gtk_search_entry_new();
+  gtk_box_pack_start(GTK_BOX(hbox), search_presets, FALSE, TRUE, 0);
+  gtk_entry_set_placeholder_text(GTK_ENTRY(search_presets), _("search presets list"));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(search_presets), _("incrementally search the list of presets\npress up or down keys to cycle through matches"));
+  g_signal_connect(G_OBJECT(search_presets), "stop-search", G_CALLBACK(dt_gui_search_stop), tree);
+  g_signal_connect(G_OBJECT(tree), "key-press-event", G_CALLBACK(dt_gui_search_start), search_presets);
+  gtk_tree_view_set_search_entry(tree, GTK_ENTRY(search_presets));
+
   GtkWidget *button = gtk_button_new_with_label(C_("preferences", "import..."));
-  gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, TRUE, 0);
+  gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(import_preset), (gpointer)model);
 
   button = gtk_button_new_with_label(C_("preferences", "export..."));
-  gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, TRUE, 0);
+  gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(export_preset), (gpointer)model);
 
   gtk_box_pack_start(GTK_BOX(container), hbox, FALSE, FALSE, 0);
@@ -828,14 +876,13 @@ static void init_tab_presets(GtkWidget *stack)
   g_signal_connect(G_OBJECT(tree), "key-press-event", G_CALLBACK(tree_key_press_presets), (gpointer)model);
 
   // Setting up the search functionality
-  gtk_tree_view_set_search_column(GTK_TREE_VIEW(tree), P_NAME_COLUMN);
-  gtk_tree_view_set_enable_search(GTK_TREE_VIEW(tree), TRUE);
+  gtk_tree_view_set_search_equal_func(tree, _search_func, tree, NULL);
 
   // Attaching the model to the treeview
-  gtk_tree_view_set_model(GTK_TREE_VIEW(tree), GTK_TREE_MODEL(model));
+  gtk_tree_view_set_model(tree, GTK_TREE_MODEL(model));
 
   // Adding the treeview to its containers
-  gtk_container_add(GTK_CONTAINER(scroll), tree);
+  gtk_container_add(GTK_CONTAINER(scroll), GTK_WIDGET(tree));
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
   g_object_unref(G_OBJECT(model));

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -853,6 +853,7 @@ static void init_tab_presets(GtkWidget *stack)
   gtk_box_pack_start(GTK_BOX(hbox), search_presets, FALSE, TRUE, 0);
   gtk_entry_set_placeholder_text(GTK_ENTRY(search_presets), _("search presets list"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(search_presets), _("incrementally search the list of presets\npress up or down keys to cycle through matches"));
+  g_signal_connect(G_OBJECT(search_presets), "activate", G_CALLBACK(dt_gui_search_stop), tree);
   g_signal_connect(G_OBJECT(search_presets), "stop-search", G_CALLBACK(dt_gui_search_stop), tree);
   g_signal_connect(G_OBJECT(tree), "key-press-event", G_CALLBACK(dt_gui_search_start), search_presets);
   gtk_tree_view_set_search_entry(tree, GTK_ENTRY(search_presets));

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -38,26 +38,26 @@
 #include <stdlib.h>
 
 
-static const int _dt_gui_presets_exposure_value_cnt = 24;
-static const float _dt_gui_presets_exposure_value[]
+const int dt_gui_presets_exposure_value_cnt = 24;
+const float dt_gui_presets_exposure_value[]
     = { 0.,       1. / 8000, 1. / 4000, 1. / 2000, 1. / 1000, 1. / 1000, 1. / 500, 1. / 250,
         1. / 125, 1. / 60,   1. / 30,   1. / 15,   1. / 15,   1. / 8,    1. / 4,   1. / 2,
         1,        2,         4,         8,         15,        30,        60,       FLT_MAX };
-static const char *_dt_gui_presets_exposure_value_str[]
+const char *dt_gui_presets_exposure_value_str[]
     = { "0",     "1/8000", "1/4000", "1/2000", "1/1000", "1/1000", "1/500", "1/250",
         "1/125", "1/60",   "1/30",   "1/15",   "1/15",   "1/8",    "1/4",   "1/2",
         "1\"",   "2\"",    "4\"",    "8\"",    "15\"",   "30\"",   "60\"",  "+" };
-static const int _dt_gui_presets_aperture_value_cnt = 19;
-static const float _dt_gui_presets_aperture_value[]
+const int dt_gui_presets_aperture_value_cnt = 19;
+const float dt_gui_presets_aperture_value[]
     = { 0, 0.5, 0.7, 1.0, 1.4, 2.0, 2.8, 4.0, 5.6, 8.0, 11.0, 16.0, 22.0, 32.0, 45.0, 64.0, 90.0, 128.0, FLT_MAX };
-static const char *_dt_gui_presets_aperture_value_str[]
+const char *dt_gui_presets_aperture_value_str[]
     = { "f/0",  "f/0.5", "f/0.7", "f/1.0", "f/1.4", "f/2",  "f/2.8", "f/4",   "f/5.6", "f/8",
         "f/11", "f/16",  "f/22",  "f/32",  "f/45",  "f/64", "f/90",  "f/128", "f/+" };
 
 // format string and corresponding flag stored into the database
-static const char *_dt_gui_presets_format_value_str[5]
+static const char *_gui_presets_format_value_str[5]
     = { N_("non-raw"), N_("raw"), N_("HDR"), N_("monochrome"), N_("color") };
-static const int _dt_gui_presets_format_flag[5] = { FOR_LDR, FOR_RAW, FOR_HDR, FOR_NOT_MONO, FOR_NOT_COLOR };
+static const int _gui_presets_format_flag[5] = { FOR_LDR, FOR_RAW, FOR_HDR, FOR_NOT_MONO, FOR_NOT_COLOR };
 
 // this is also called for non-gui applications linking to libdarktable!
 // so beware, don't use any darktable.gui stuff here .. (or change this behaviour in darktable.c)
@@ -309,19 +309,19 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, gtk_entry_get_text(GTK_ENTRY(g->lens)), -1, SQLITE_TRANSIENT);
     DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 6, gtk_spin_button_get_value(GTK_SPIN_BUTTON(g->iso_min)));
     DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, gtk_spin_button_get_value(GTK_SPIN_BUTTON(g->iso_max)));
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, _dt_gui_presets_exposure_value[dt_bauhaus_combobox_get(g->exposure_min)]);
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, _dt_gui_presets_exposure_value[dt_bauhaus_combobox_get(g->exposure_max)]);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, dt_gui_presets_exposure_value[dt_bauhaus_combobox_get(g->exposure_min)]);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, dt_gui_presets_exposure_value[dt_bauhaus_combobox_get(g->exposure_max)]);
     DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10,
-                                 _dt_gui_presets_aperture_value[dt_bauhaus_combobox_get(g->aperture_min)]);
+                                 dt_gui_presets_aperture_value[dt_bauhaus_combobox_get(g->aperture_min)]);
     DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 11,
-                                 _dt_gui_presets_aperture_value[dt_bauhaus_combobox_get(g->aperture_max)]);
+                                 dt_gui_presets_aperture_value[dt_bauhaus_combobox_get(g->aperture_max)]);
     DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 12, gtk_spin_button_get_value(GTK_SPIN_BUTTON(g->focal_length_min)));
     DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 13, gtk_spin_button_get_value(GTK_SPIN_BUTTON(g->focal_length_max)));
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 14, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->autoapply)));
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 15, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->filter)));
     int format = 0;
     for(int k = 0; k < 5; k++)
-      format += gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->format_btn[k])) * _dt_gui_presets_format_flag[k];
+      format += gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->format_btn[k])) * _gui_presets_format_flag[k];
     format ^= DT_PRESETS_FOR_NOT;
 
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 16, format);
@@ -563,10 +563,10 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
   g->exposure_max = dt_bauhaus_combobox_new(NULL);
   gtk_widget_set_tooltip_text(g->exposure_min, _("minimum exposure time"));
   gtk_widget_set_tooltip_text(g->exposure_max, _("maximum exposure time"));
-  for(int k = 0; k < _dt_gui_presets_exposure_value_cnt; k++)
-    dt_bauhaus_combobox_add(g->exposure_min, _dt_gui_presets_exposure_value_str[k]);
-  for(int k = 0; k < _dt_gui_presets_exposure_value_cnt; k++)
-    dt_bauhaus_combobox_add(g->exposure_max, _dt_gui_presets_exposure_value_str[k]);
+  for(int k = 0; k < dt_gui_presets_exposure_value_cnt; k++)
+    dt_bauhaus_combobox_add(g->exposure_min, dt_gui_presets_exposure_value_str[k]);
+  for(int k = 0; k < dt_gui_presets_exposure_value_cnt; k++)
+    dt_bauhaus_combobox_add(g->exposure_max, dt_gui_presets_exposure_value_str[k]);
   gtk_grid_attach(GTK_GRID(g->details), label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(g->details), g->exposure_min, label, GTK_POS_RIGHT, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(g->details), g->exposure_max, g->exposure_min, GTK_POS_RIGHT, 1, 1);
@@ -578,10 +578,10 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
   g->aperture_max = dt_bauhaus_combobox_new(NULL);
   gtk_widget_set_tooltip_text(g->aperture_min, _("minimum aperture value"));
   gtk_widget_set_tooltip_text(g->aperture_max, _("maximum aperture value"));
-  for(int k = 0; k < _dt_gui_presets_aperture_value_cnt; k++)
-    dt_bauhaus_combobox_add(g->aperture_min, _dt_gui_presets_aperture_value_str[k]);
-  for(int k = 0; k < _dt_gui_presets_aperture_value_cnt; k++)
-    dt_bauhaus_combobox_add(g->aperture_max, _dt_gui_presets_aperture_value_str[k]);
+  for(int k = 0; k < dt_gui_presets_aperture_value_cnt; k++)
+    dt_bauhaus_combobox_add(g->aperture_min, dt_gui_presets_aperture_value_str[k]);
+  for(int k = 0; k < dt_gui_presets_aperture_value_cnt; k++)
+    dt_bauhaus_combobox_add(g->aperture_max, dt_gui_presets_aperture_value_str[k]);
   gtk_grid_attach(GTK_GRID(g->details), label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(g->details), g->aperture_min, label, GTK_POS_RIGHT, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(g->details), g->aperture_max, g->aperture_min, GTK_POS_RIGHT, 1, 1);
@@ -607,7 +607,7 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
 
   for(int i = 0; i < 5; i++)
   {
-    g->format_btn[i] = gtk_check_button_new_with_label(_(_dt_gui_presets_format_value_str[i]));
+    g->format_btn[i] = gtk_check_button_new_with_label(_(_gui_presets_format_value_str[i]));
     gtk_grid_attach(GTK_GRID(g->details), g->format_btn[i], 1, line + i, 2, 1);
   }
 
@@ -637,19 +637,19 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
 
     float val = sqlite3_column_double(stmt, 7);
     int k = 0;
-    for(; k < _dt_gui_presets_exposure_value_cnt && val > _dt_gui_presets_exposure_value[k]; k++)
+    for(; k < dt_gui_presets_exposure_value_cnt && val > dt_gui_presets_exposure_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->exposure_min, k);
     val = sqlite3_column_double(stmt, 8);
-    for(k = 0; k < _dt_gui_presets_exposure_value_cnt && val > _dt_gui_presets_exposure_value[k]; k++)
+    for(k = 0; k < dt_gui_presets_exposure_value_cnt && val > dt_gui_presets_exposure_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->exposure_max, k);
     val = sqlite3_column_double(stmt, 9);
-    for(k = 0; k < _dt_gui_presets_aperture_value_cnt && val > _dt_gui_presets_aperture_value[k]; k++)
+    for(k = 0; k < dt_gui_presets_aperture_value_cnt && val > dt_gui_presets_aperture_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->aperture_min, k);
     val = sqlite3_column_double(stmt, 10);
-    for(k = 0; k < _dt_gui_presets_aperture_value_cnt && val > _dt_gui_presets_aperture_value[k]; k++)
+    for(k = 0; k < dt_gui_presets_aperture_value_cnt && val > dt_gui_presets_aperture_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->aperture_max, k);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->focal_length_min), sqlite3_column_double(stmt, 11));
@@ -658,7 +658,7 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->filter), sqlite3_column_int(stmt, 14));
     const int format = (sqlite3_column_int(stmt, 15)) ^ DT_PRESETS_FOR_NOT;
     for(k = 0; k < 5; k++)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->format_btn[k]), format & (_dt_gui_presets_format_flag[k]));
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->format_btn[k]), format & (_gui_presets_format_flag[k]));
   }
   else
   {
@@ -671,19 +671,19 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
 
     float val = 0;
     int k = 0;
-    for(; k < _dt_gui_presets_exposure_value_cnt && val > _dt_gui_presets_exposure_value[k]; k++)
+    for(; k < dt_gui_presets_exposure_value_cnt && val > dt_gui_presets_exposure_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->exposure_min, k);
     val = 100000000;
-    for(k = 0; k < _dt_gui_presets_exposure_value_cnt && val > _dt_gui_presets_exposure_value[k]; k++)
+    for(k = 0; k < dt_gui_presets_exposure_value_cnt && val > dt_gui_presets_exposure_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->exposure_max, k);
     val = 0;
-    for(k = 0; k < _dt_gui_presets_aperture_value_cnt && val > _dt_gui_presets_aperture_value[k]; k++)
+    for(k = 0; k < dt_gui_presets_aperture_value_cnt && val > dt_gui_presets_aperture_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->aperture_min, k);
     val = 100000000;
-    for(k = 0; k < _dt_gui_presets_aperture_value_cnt && val > _dt_gui_presets_aperture_value[k]; k++)
+    for(k = 0; k < dt_gui_presets_aperture_value_cnt && val > dt_gui_presets_aperture_value[k]; k++)
       ;
     dt_bauhaus_combobox_set(g->aperture_max, k);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->focal_length_min), 0);
@@ -1260,12 +1260,12 @@ void dt_gui_favorite_presets_menu_show()
 }
 
 
-static void _dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32_t version,
-                                                     dt_iop_params_t *params, int32_t params_size,
-                                                     dt_develop_blend_params_t *bl_params, dt_iop_module_t *module,
-                                                     const dt_image_t *image,
-                                                     void (*pick_callback)(GtkMenuItem *, void *),
-                                                     void *callback_data)
+static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32_t version,
+                                                  dt_iop_params_t *params, int32_t params_size,
+                                                  dt_develop_blend_params_t *bl_params, dt_iop_module_t *module,
+                                                  const dt_image_t *image,
+                                                  void (*pick_callback)(GtkMenuItem *, void *),
+                                                  void *callback_data)
 {
   GtkMenu *menu = darktable.gui->presets_popup_menu;
   if(menu) gtk_widget_destroy(GTK_WIDGET(menu));
@@ -1478,14 +1478,14 @@ void dt_gui_presets_popup_menu_show_for_params(dt_dev_operation_t op, int32_t ve
                                                void (*pick_callback)(GtkMenuItem *, void *),
                                                void *callback_data)
 {
-  _dt_gui_presets_popup_menu_show_internal(op, version, params, params_size, blendop_params, NULL, image,
-                                           pick_callback, callback_data);
+  _gui_presets_popup_menu_show_internal(op, version, params, params_size, blendop_params, NULL, image,
+                                        pick_callback, callback_data);
 }
 
 void dt_gui_presets_popup_menu_show_for_module(dt_iop_module_t *module)
 {
-  _dt_gui_presets_popup_menu_show_internal(module->op, module->version(), module->params, module->params_size,
-                                           module->blend_params, module, &module->dev->image_storage, NULL, NULL);
+  _gui_presets_popup_menu_show_internal(module->op, module->version(), module->params, module->params_size,
+                                        module->blend_params, module, &module->dev->image_storage, NULL, NULL);
 }
 
 void dt_gui_presets_update_mml(const char *name, dt_dev_operation_t op, const int32_t version,

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -235,12 +235,6 @@ static void _text_entry_changed_callback(GtkEntry *entry, dt_lib_module_t *self)
   _lib_modulegroups_update_iop_visibility(self);
 }
 
-static void _stop_search(GtkSearchEntry *entry, gpointer user_data)
-{
-  gtk_entry_set_text(GTK_ENTRY(entry), "");
-  gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
-}
-
 static DTGTKCairoPaintIconFunc _buttons_get_icon_fct(const gchar *icon)
 {
   if(g_strcmp0(icon, "active") == 0)
@@ -2744,7 +2738,7 @@ void gui_init(dt_lib_module_t *self)
   dt_action_define(&darktable.view_manager->proxy.darkroom.view->actions, NULL, "search modules", d->text_entry, NULL);
   gtk_entry_set_placeholder_text(GTK_ENTRY(d->text_entry), _("search modules by name or tag"));
   g_signal_connect(G_OBJECT(d->text_entry), "search-changed", G_CALLBACK(_text_entry_changed_callback), self);
-  g_signal_connect(G_OBJECT(d->text_entry), "stop-search", G_CALLBACK(_stop_search), NULL);
+  g_signal_connect(G_OBJECT(d->text_entry), "stop-search", G_CALLBACK(dt_gui_search_stop), dt_ui_center(darktable.gui->ui));
   gtk_box_pack_start(GTK_BOX(d->hbox_search_box), d->text_entry, TRUE, TRUE, 0);
   gtk_entry_set_width_chars(GTK_ENTRY(d->text_entry), 0);
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(d->text_entry), GTK_ENTRY_ICON_SECONDARY, _("clear text"));


### PR DESCRIPTION
This adds a permanent search box in the presets tab of preferences and moves the export/import buttons to the right, so the look is consistent with the shortcuts tab. The search function itself is also improved so that it does case insensitive search into the modules (it expands them when needed).

The search boxes in both tabs are improved so that pressing Enter takes you to the tree view with the found entry selected (and another Enter opens the edit box or starts defining a shortcut).

The shortcut list for the active view is now expanded when the preferences dialog was just openen. Also fixes #10039.

In the shortcuts dialog (or tab in preferences) the shortcuts and actions lists (and their corresponding search boxes) have been swapped; fixes #10040.

Edit: #10046 needs more thought (and a separate PR). Removed commit from this PR.