### PR TITLE
make metadata and tagging consistent (all selected)

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -561,7 +561,7 @@ gboolean dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE, FALSE));
+    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(!group_on, TRUE, FALSE));
   else
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -126,7 +126,7 @@ static void _update(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE, FALSE);
 
   // first we want to make sure the list of images to act on has changed
   // this is not the case if mouse hover change but still stay in selection for ex.
@@ -162,7 +162,7 @@ static void _update(dt_lib_module_t *self)
 
   // using dt_metadata_get() is not possible here. we want to do all this in a single pass, everything else
   // takes ages.
-  gchar *images = dt_view_get_images_to_act_on_query(TRUE);
+  gchar *images = dt_view_get_images_to_act_on_query(FALSE);
   imgs_count = g_list_length((GList *)imgs);
 
   if(images)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -152,7 +152,7 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
   dt_lib_cancel_postponed_update(self);
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
-  const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
+  const GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE, FALSE);
   const gboolean has_act_on = imgs != NULL;
 
   const gint dict_tags_sel_cnt =
@@ -983,7 +983,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
       }
       g_strfreev(tokens);
       GList *tags_r = dt_tag_get_tags(-1, TRUE);
-      const GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
+      const GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE, FALSE);
       dt_tag_set_tags(tags, imgs, TRUE, TRUE, TRUE);
       gboolean change = FALSE;
       for(GList *tag = tags; tag; tag = g_list_next(tag))
@@ -3203,7 +3203,7 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
 
   if(d->last_tag)
   {
-    const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE, FALSE);
+    const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE, FALSE);
     const gboolean res = dt_tag_attach_string_list(d->last_tag, imgs, TRUE);
     if(res) dt_image_synch_xmps(imgs);
     _init_treeview(self, 0);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1361,8 +1361,8 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
       _dbscan(p, img_count, epsilon, min_images);
       dt_show_times(&start, "[map] dbscan calculation");
 
-      // set the groups
-      const GList *sel_imgs = dt_view_get_images_to_act_on(TRUE, FALSE, FALSE);
+      // set the clusters
+      const GList *sel_imgs = dt_view_get_images_to_act_on(FALSE, FALSE, FALSE);
       int group = -1;
       for(i = 0; i< img_count; i++)
       {


### PR DESCRIPTION
following discussion on #10032

When a metadata action applies on all selected images, include those which are not visible (grouped and collapsed).

Notes:
- this may not exhaustive because sometimes a specific list of images is provided by the calling function. In that case this change has no effect.
- actions on file (delete, ... ) are applied on all images including not not visible
- actions of development are applied only on visible images.

A critical review is welcome.

