### PR TITLE
Improve shortcuts view showing default elements/effects

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1089,8 +1089,7 @@ static void _fill_shortcut_fields(GtkTreeViewColumn *column, GtkCellRenderer *ce
               field_text = g_strdup(_(strings[s->effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1]));
           }
         }
-        else if((s->effect == 0 && s->action->type == DT_ACTION_TYPE_FALLBACK)
-                || (s->effect > 0 ))
+        else if(s->effect > 0 || s->action->type != DT_ACTION_TYPE_FALLBACK)
           field_text = g_strdup(_(elements[s->element].effects[s->effect]));
         if(s->effect == 0) weight = PANGO_WEIGHT_LIGHT;
         editable = TRUE;
@@ -1170,7 +1169,9 @@ static void _element_editing_started(GtkCellRenderer *renderer, GtkCellEditable 
 
   int show_all = s->action->type != DT_ACTION_TYPE_FALLBACK;
   for(const dt_action_element_def_t *element = _action_find_elements(s->action); element && element->name ; element++)
-    gtk_list_store_insert_with_values(store, NULL, -1, 0, show_all++ ? _(element->name) : "", -1);
+    gtk_list_store_insert_with_values(store, NULL, -1, 0, show_all++ ? _(element->name) : _("(unchanged)"), -1);
+
+  gtk_combo_box_set_active(combo_box, s->element);
 }
 
 static void _element_changed(GtkCellRendererCombo *combo, char *path_string, GtkTreeIter *new_iter, gpointer data)
@@ -1193,10 +1194,17 @@ static void _element_changed(GtkCellRendererCombo *combo, char *path_string, Gtk
   dt_shortcuts_save(NULL, FALSE);
 }
 
+enum
+{
+  DT_ACTION_EFFECT_COLUMN_NAME,
+  DT_ACTION_EFFECT_COLUMN_SEPARATOR,
+  DT_ACTION_EFFECT_COLUMN_WEIGHT,
+};
+
 static gboolean _effects_separator_func(GtkTreeModel *model, GtkTreeIter *iter, gpointer data)
 {
   gboolean is_separator;
-  gtk_tree_model_get(model, iter, 1, &is_separator, -1);
+  gtk_tree_model_get(model, iter, DT_ACTION_EFFECT_COLUMN_SEPARATOR, &is_separator, -1);
   return is_separator;
 }
 
@@ -1210,9 +1218,19 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
 
   const dt_action_element_def_t *elements = _action_find_elements(s->action);
   int show_all = s->action->type != DT_ACTION_TYPE_FALLBACK;
+  int bold_move = _shortcut_is_move(s) ? DT_ACTION_EFFECT_DEFAULT_KEY : DT_ACTION_EFFECT_DEFAULT_DOWN + 1;
   if(elements)
-    for(const gchar **effect = elements[s->element].effects; *effect ; effect++)
-      gtk_list_store_insert_with_values(store, NULL, -1, 0, show_all++ ? _(*effect) : "", -1);
+    for(const gchar **effect = elements[s->element].effects; *effect ; effect++, bold_move++)
+      gtk_list_store_insert_with_values(store, NULL, -1,
+                                        DT_ACTION_EFFECT_COLUMN_NAME, show_all++ ? _(*effect) : _("(unchanged)"),
+                                        DT_ACTION_EFFECT_COLUMN_WEIGHT, bold_move >  DT_ACTION_EFFECT_DEFAULT_KEY
+                                                                     && bold_move <= DT_ACTION_EFFECT_DEFAULT_DOWN
+                                                                      ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL,
+                                        -1);
+
+  GList *cell = gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(combo_box));
+  gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(combo_box), cell->data, "weight", DT_ACTION_EFFECT_COLUMN_WEIGHT);
+  g_list_free(cell);
 
   if(elements[s->element].effects == dt_action_effect_selection)
   {
@@ -1223,10 +1241,13 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
     if(values)
     {
       // insert empty/separator row
-      gtk_list_store_insert_with_values(store, NULL, -1, 1, TRUE, -1);
+      gtk_list_store_insert_with_values(store, NULL, -1, DT_ACTION_EFFECT_COLUMN_SEPARATOR, TRUE, -1);
 
       while(values->name)
-        gtk_list_store_insert_with_values(store, NULL, -1, 0, _((values++)->description), -1);
+        gtk_list_store_insert_with_values(store, NULL, -1,
+                                          DT_ACTION_EFFECT_COLUMN_NAME, _((values++)->description),
+                                          DT_ACTION_EFFECT_COLUMN_WEIGHT, PANGO_WEIGHT_NORMAL,
+                                          -1);
     }
     else
     {
@@ -1235,13 +1256,18 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
       if(strings)
       {
         // insert empty/separator row
-        gtk_list_store_insert_with_values(store, NULL, -1, 1, TRUE, -1);
+        gtk_list_store_insert_with_values(store, NULL, -1, DT_ACTION_EFFECT_COLUMN_SEPARATOR, TRUE, -1);
 
         while(*strings)
-          gtk_list_store_insert_with_values(store, NULL, -1, 0, _(*(strings++)), -1);
+          gtk_list_store_insert_with_values(store, NULL, -1,
+                                            DT_ACTION_EFFECT_COLUMN_NAME, _(*(strings++)),
+                                            DT_ACTION_EFFECT_COLUMN_WEIGHT, PANGO_WEIGHT_NORMAL,
+                                            -1);
       }
     }
   }
+
+  gtk_combo_box_set_active(combo_box, s->effect == -1 ? 1 : s->effect);
 }
 
 static void _effect_changed(GtkCellRendererCombo *combo, char *path_string, GtkTreeIter *new_iter, gpointer data)
@@ -1972,7 +1998,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   _add_prefs_column(shortcuts_view, renderer, _("element"), SHORTCUT_VIEW_ELEMENT);
 
   renderer = gtk_cell_renderer_combo_new();
-  GtkListStore *effects = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_BOOLEAN);
+  GtkListStore *effects = gtk_list_store_new(3, G_TYPE_STRING, G_TYPE_BOOLEAN, G_TYPE_INT);
   g_object_set(renderer, "model", effects, "text-column", 0, "has-entry", FALSE, NULL);
   g_signal_connect(renderer, "editing-started" , G_CALLBACK(_effect_editing_started), filtered_shortcuts);
   g_signal_connect(renderer, "changed", G_CALLBACK(_effect_changed), filtered_shortcuts);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1221,12 +1221,14 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
   int bold_move = _shortcut_is_move(s) ? DT_ACTION_EFFECT_DEFAULT_KEY : DT_ACTION_EFFECT_DEFAULT_DOWN + 1;
   if(elements)
     for(const gchar **effect = elements[s->element].effects; *effect ; effect++, bold_move++)
+    {
       gtk_list_store_insert_with_values(store, NULL, -1,
                                         DT_ACTION_EFFECT_COLUMN_NAME, show_all++ ? _(*effect) : _("(unchanged)"),
                                         DT_ACTION_EFFECT_COLUMN_WEIGHT, bold_move >  DT_ACTION_EFFECT_DEFAULT_KEY
                                                                      && bold_move <= DT_ACTION_EFFECT_DEFAULT_DOWN
                                                                       ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL,
                                         -1);
+    }
 
   GList *cell = gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(combo_box));
   gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(combo_box), cell->data, "weight", DT_ACTION_EFFECT_COLUMN_WEIGHT);
@@ -1244,10 +1246,12 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
       gtk_list_store_insert_with_values(store, NULL, -1, DT_ACTION_EFFECT_COLUMN_SEPARATOR, TRUE, -1);
 
       while(values->name)
+      {
         gtk_list_store_insert_with_values(store, NULL, -1,
                                           DT_ACTION_EFFECT_COLUMN_NAME, _((values++)->description),
                                           DT_ACTION_EFFECT_COLUMN_WEIGHT, PANGO_WEIGHT_NORMAL,
                                           -1);
+      }
     }
     else
     {
@@ -1259,10 +1263,12 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
         gtk_list_store_insert_with_values(store, NULL, -1, DT_ACTION_EFFECT_COLUMN_SEPARATOR, TRUE, -1);
 
         while(*strings)
+        {
           gtk_list_store_insert_with_values(store, NULL, -1,
                                             DT_ACTION_EFFECT_COLUMN_NAME, _(*(strings++)),
                                             DT_ACTION_EFFECT_COLUMN_WEIGHT, PANGO_WEIGHT_NORMAL,
                                             -1);
+        }
       }
     }
   }


### PR DESCRIPTION
fixes #10046

For all shortcuts, the selected element and effect is shown even if it is the default (but lighter in that case). _Except_ for **Move** shortcuts (f.e. midi knob or mouse wheel) because in that case the 2nd and 3rd effects are the defaults for up and down. In that case, when you open the effects dropdown the up and down options are marked bold.

For _fallbacks_, the element and effect are not shown if they don't change the setting in the base shortcut. In the dropdown this is now listed as "(unchanged)" rather than empty.

The dropdowns for element and effect are now also correctly initialised to the current setting when you open them, so you can immediately click to close without actually changing the value.

![image](https://user-images.githubusercontent.com/1549490/134382603-c818518f-dc41-4584-b653-e0958e2470b7.png)
