### PR TITLE
magic wand icon for TE

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2697,6 +2697,57 @@ void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, 
   FINISH
 }
 
+void _compass_star(cairo_t *cr, double cx, double cy, double size)
+{
+  const double a = size / 2.0;
+  const double b = size / 10.0;
+
+  cairo_move_to(cr, cx, cy - a);
+  cairo_line_to(cr, cx + b, cy - b);
+  cairo_line_to(cr, cx + a, cy);
+  cairo_line_to(cr, cx + b, cy + b);
+  cairo_line_to(cr, cx, cy + a);
+  cairo_line_to(cr, cx - b, cy + b);
+  cairo_line_to(cr, cx - a, cy);
+  cairo_line_to(cr, cx - b, cy - b);
+  cairo_close_path(cr);
+  cairo_fill(cr);
+}
+
+void dtgtk_cairo_paint_compass_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0 , 0)
+
+  _compass_star(cr, .5, .5, 1.);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_wand(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // the wand
+  cairo_move_to(cr, 1., .85);
+  cairo_line_to(cr, .85, 1.);
+  cairo_line_to(cr, .2, .35);
+  cairo_line_to(cr, .35, .2);
+  cairo_close_path(cr);
+  //cairo_stroke_preserve(cr);
+  cairo_fill_preserve(cr);
+  cairo_line_to(cr, .15, 0);
+  cairo_line_to(cr, 0, .15);
+  cairo_line_to(cr, .2, .35);
+  cairo_stroke(cr);
+
+  // the magic
+  _compass_star(cr, .5, .1, .25);
+  _compass_star(cr, .2, .65, .4);
+  _compass_star(cr, .75, .25, .5);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_lt_mode_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1.4, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -291,6 +291,10 @@ void dtgtk_cairo_paint_cut_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 void dtgtk_cairo_paint_display_wavelet_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a auto level icon for retouch */
 void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a generic four-pointed compass star */
+void dtgtk_cairo_paint_compass_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a magic wand for tone equalizer */
+void dtgtk_cairo_paint_wand(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 // Lighttable modes
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3264,8 +3264,8 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->exposure_boost, "%+.2f EV");
   gtk_widget_set_tooltip_text(g->exposure_boost, _("use this to slide the mask average exposure along channels\n"
                                                    "for a better control of the exposure correction with the available nodes.\n"
-                                                   "the button will auto-adjust the average exposure"));
-  dt_bauhaus_widget_set_quad_paint(g->exposure_boost, dtgtk_cairo_paint_auto_levels, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+                                                   "the magic wand will auto-adjust the average exposure"));
+  dt_bauhaus_widget_set_quad_paint(g->exposure_boost, dtgtk_cairo_paint_wand, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->exposure_boost, FALSE);
   g_signal_connect(G_OBJECT(g->exposure_boost), "quad-pressed", G_CALLBACK(auto_adjust_exposure_boost), self);
 
@@ -3276,8 +3276,8 @@ void gui_init(struct dt_iop_module_t *self)
                                                    "and dilate the mask contrast around -4EV\n"
                                                    "this allows to spread the exposure histogram over more channels\n"
                                                    "for a better control of the exposure correction.\n"
-                                                   "the button will auto-adjust the contrast"));
-  dt_bauhaus_widget_set_quad_paint(g->contrast_boost, dtgtk_cairo_paint_auto_levels, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+                                                   "the magic wand will auto-adjust the contrast"));
+  dt_bauhaus_widget_set_quad_paint(g->contrast_boost, dtgtk_cairo_paint_wand, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->contrast_boost, FALSE);
   g_signal_connect(G_OBJECT(g->contrast_boost), "quad-pressed", G_CALLBACK(auto_adjust_contrast_boost), self);
 


### PR DESCRIPTION
This PR includes a new "magic wand" cairo icon for Tone Equalizer.
 
![image](https://user-images.githubusercontent.com/43290988/134666430-35722608-d324-4b25-9702-3a9f9b959b20.png)

As a bonus, since I needed it, there is also a new generic four pointed "compass star" icon, for future use.

fixes #10063