### PR TITLE
Fix tiling

### DIFF
--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -176,7 +176,7 @@ const char *description(struct dt_iop_module_t *self)
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
 }
 
 int default_group()

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -34,6 +34,7 @@
 #include "develop/imageop_math.h"
 #include "develop/noise_generator.h"
 #include "develop/openmp_maths.h"
+#include "develop/tiling.h"
 #include "dtgtk/button.h"
 #include "dtgtk/drawingarea.h"
 #include "dtgtk/expander.h"
@@ -48,7 +49,7 @@
 
 DT_MODULE_INTROSPECTION(2, dt_iop_diffuse_params_t)
 
-#define MAX_NUM_SCALES 12
+#define MAX_NUM_SCALES 10
 typedef struct dt_iop_diffuse_params_t
 {
   // global parameters
@@ -149,7 +150,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -467,6 +468,31 @@ static inline unsigned int num_steps_to_reach_equivalent_sigma(const float sigma
     radius = sqrtf(sqf(radius) + sqf((float)(1 << s) * sigma_filter));
   }
   return s + 1;
+}
+
+void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
+                     struct dt_develop_tiling_t *tiling)
+{
+  dt_iop_diffuse_data_t *data = (dt_iop_diffuse_data_t *)piece->data;
+
+  const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
+  const float final_radius = (data->radius + data->radius_center) * 2.f / scale;
+  const int diffusion_scales = num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
+  const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
+  const int max_filter_radius = (1 << scales);
+
+  // in + out + 2 * tmp + 2 * LF + s details + grey mask
+  tiling->factor = 6.25f + scales;
+  tiling->factor_cl = 6.25f + scales;
+
+  tiling->maxbuf = 1.0f;
+  tiling->maxbuf_cl = 1.0f;
+  tiling->overhead = 0;
+  tiling->overlap = max_filter_radius;
+  tiling->xalign = 1;
+  tiling->yalign = 1;
+  return;
 }
 
 static inline void init_reconstruct(float *const restrict reconstructed, const size_t width, const size_t height)


### PR DESCRIPTION
Fix #10017 by enabling tiling and setting tiles padding when relevant.

We also downsize the max wavelets scales in both filmic reconstruction and diffuse to 10, that is a diameter of 1024 × 2 + 1 px (`radius = 1 << 10`), which needs a padding size of 1024 px. Previously, we allowed 12 scales, which needs a padding size of `1 << 12 = 4096 px` and there is no way this will fit in GPU vRAM.