### PR TITLE
show current order in order lib module's header

### DIFF
--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -24,6 +24,7 @@
 #include "libs/lib.h"
 #include <gtk/gtk.h>
 #include <stdlib.h>
+#include <dtgtk/expander.h>
 
 DT_MODULE(1)
 
@@ -58,6 +59,19 @@ int position()
 void update(dt_lib_module_t *self)
 {
   dt_lib_ioporder_t *d = (dt_lib_ioporder_t *)self->data;
+
+  if(!d->widget)
+  {
+    if(!self->expander) return;
+
+    d->widget = gtk_label_new("");
+    g_signal_connect(G_OBJECT(d->widget), "destroy", G_CALLBACK(gtk_widget_destroyed), &d->widget);
+    gtk_widget_show(d->widget);
+    gtk_box_pack_start(GTK_BOX(dtgtk_expander_get_header(DTGTK_EXPANDER(self->expander))), d->widget, TRUE, TRUE, 0);
+
+    gtk_widget_destroy(self->arrow);
+    self->arrow = NULL;
+  }
 
   const dt_iop_order_t kind = dt_ioppr_get_iop_order_list_kind(darktable.develop->iop_order_list);
 
@@ -137,14 +151,9 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  GtkWidget *label = gtk_label_new(_("current order"));
-
-  d->widget = gtk_label_new("");
+  d->widget = NULL; // initialise in first update when header has been set up
   d->current_mode = -1;
   d->last_custom_iop_order = NULL;
-
-  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->widget, TRUE, TRUE, 0);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
                             G_CALLBACK(_image_loaded_callback), self);
@@ -177,7 +186,8 @@ void gui_reset (dt_lib_module_t *self)
     dt_dev_pixelpipe_rebuild(darktable.develop);
 
     d->current_mode = DT_IOP_ORDER_V30;
-    gtk_label_set_text(GTK_LABEL(d->widget), _("v3.0"));
+    if(d->widget)
+      gtk_label_set_text(GTK_LABEL(d->widget), _("v3.0"));
     g_list_free_full(iop_order_list, free);
   }
 }

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -779,7 +779,7 @@ static void presets_popup_callback(GtkButton *button, dt_lib_module_t *module)
 
 void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
 {
-  if(!module->expander) return;
+  if(!module->expander || !module->arrow) return;
 
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->expander), expanded);
 


### PR DESCRIPTION
The "module order" lib needs to be expanded to see the currenctly active order, meaning that two lines are taken up. This PR moves the label into the header.

before
![image](https://user-images.githubusercontent.com/1549490/134816543-1ed41fa1-aad6-402f-bfcb-d496b55d3553.png)

after
![image](https://user-images.githubusercontent.com/1549490/134816280-9cf1a18b-b5f1-4996-94cf-8cd59eb86105.png)

The expander triangle should be removed and clicking on the header should not expand the (empty) module. But maybe this should instead be a non-expanding module (setting expandable to false removes the header) containing just a single dropdown to change the order. Or maybe it should be part of the modulegroup module at the top.

Opinions/mock-ups welcome.