### PR TITLE
ashift : various small fix

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3138,6 +3138,13 @@
     <longdescription>this is just for remembering whether to show values or not</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/ashift/autocrop_value</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>auto-crop mode</shortdescription>
+    <longdescription>0=off ; 1= largest area ; 2= original image</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/colorzones/bg_sat_factor</name>
     <type min="0.1" max="1.0">float</type>
     <default>0.5</default>

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5007,7 +5007,9 @@ static int _event_fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event,
       g->jobparams = g->lastfit = fitaxis;
     }
 
+    swap_shadow_crop_box(p, g);                             // temporarily update real crop box
     dt_dev_add_history_item(darktable.develop, self, TRUE); //also calls dt_control_queue_redraw_center
+    swap_shadow_crop_box(p, g);
     return TRUE;
   }
   return FALSE;
@@ -5058,7 +5060,9 @@ static int _event_fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event,
       g->jobparams = g->lastfit = fitaxis;
     }
 
+    swap_shadow_crop_box(p, g);                             // temporarily update real crop box
     dt_dev_add_history_item(darktable.develop, self, TRUE); //also calls dt_control_queue_redraw_center
+    swap_shadow_crop_box(p, g);
     return TRUE;
   }
   return FALSE;
@@ -5111,7 +5115,9 @@ static int _event_fit_both_button_clicked(GtkWidget *widget, GdkEventButton *eve
       g->jobparams = g->lastfit = fitaxis;
     }
 
+    swap_shadow_crop_box(p, g);                             // temporarily update real crop box
     dt_dev_add_history_item(darktable.develop, self, TRUE); //also calls dt_control_queue_redraw_center
+    swap_shadow_crop_box(p, g);
     return TRUE;
   }
   return FALSE;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -340,7 +340,7 @@ typedef struct dt_iop_ashift_params_t
   float orthocorr;   // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "lens dependence"
   float aspect;      // $MIN: 0.5 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "aspect adjust"
   dt_iop_ashift_mode_t mode;     // $DEFAULT: ASHIFT_MODE_GENERIC $DESCRIPTION: "lens model"
-  dt_iop_ashift_crop_t cropmode; // $DEFAULT: ASHIFT_CROP_OFF $DESCRIPTION: "automatic cropping"
+  dt_iop_ashift_crop_t cropmode; // $DEFAULT: ASHIFT_CROP_LARGEST $DESCRIPTION: "automatic cropping"
   float cl;          // $DEFAULT: 0.0
   float cr;          // $DEFAULT: 1.0
   float ct;          // $DEFAULT: 0.0
@@ -4957,6 +4957,7 @@ static void cropmode_callback(GtkWidget *widget, gpointer user_data)
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
 
+  dt_conf_set_int("plugins/darkroom/ashift/autocrop_value", dt_bauhaus_combobox_get(g->cropmode));
   swap_shadow_crop_box(p,g);	//temporarily update real crop box
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   swap_shadow_crop_box(p,g);
@@ -5338,6 +5339,8 @@ void reload_defaults(dt_iop_module_t *module)
   // init defaults:
   ((dt_iop_ashift_params_t *)module->default_params)->f_length = f_length;
   ((dt_iop_ashift_params_t *)module->default_params)->crop_factor = crop_factor;
+  ((dt_iop_ashift_params_t *)module->default_params)->cropmode
+      = dt_conf_get_int("plugins/darkroom/ashift/autocrop_value");
 
   // reset gui elements
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;


### PR DESCRIPTION
this fix #10102, this fix #10103, this fix #10104

@TurboGit : sorry for this messy PR : that's just to avoid too many rebasing...
This contain : 
1. fix direct click on structure buttons when module is disabled
2. ensure auto-crop area is saved after auto-fit
3. default auto-crop parameter to "largest area" to mimic c&r and save last choice for next use.

Note that with point 1, I've done a little cleaning and removed an unused parameter. This mean that the parameter structure has changed.
Considering the very short delay between the ashift rework merge and this PR, I've thought it was not worth the pain to update param version. So early tester may see a "version mismatch" message...
@TurboGit : if it's not ok for you, I can also update module version... just ask :)