### PR TITLE
 fallback disabling and logging, shortcut description improvements and mapping mode button fix 

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -47,6 +47,13 @@
     <shortdescription>keyboard shortcut slider precision</shortdescription>
   </dtconfig>
   <dtconfig>
+    <name>accel/enable_fallbacks</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>enable shortcut fallbacks</shortdescription>
+    <longdescription>enables default meanings for additional buttons, modifiers or moves when used in combination with a base shortcut</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>bauhaus/scale</name>
     <type>float</type>
     <default>1.4</default>

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -120,6 +120,7 @@ void dt_control_init(dt_control_t *s)
   s->combo_introspection = g_hash_table_new(NULL, NULL);
   s->combo_list = g_hash_table_new(NULL, NULL);
   s->shortcuts = g_sequence_new(g_free);
+  s->enable_fallbacks = dt_conf_get_bool("accel/enable_fallbacks");
   s->mapping_widget = NULL;
   s->widget_definitions = g_ptr_array_new ();
   s->input_drivers = NULL;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -121,7 +121,7 @@ void dt_control_key_accelerators_off(struct dt_control_t *s);
 int dt_control_is_key_accelerators_on(struct dt_control_t *s);
 
 #define DT_CTL_LOG_SIZE 10
-#define DT_CTL_LOG_MSG_SIZE 200
+#define DT_CTL_LOG_MSG_SIZE 1000
 #define DT_CTL_LOG_TIMEOUT 5000
 #define DT_CTL_TOAST_SIZE 10
 #define DT_CTL_TOAST_MSG_SIZE 300

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -139,6 +139,7 @@ typedef struct dt_control_t
 
   GHashTable *widgets, *combo_introspection, *combo_list;
   GSequence *shortcuts;
+  gboolean enable_fallbacks;
   GtkWidget *mapping_widget;
   dt_action_element_t element;
   GPtrArray *widget_definitions;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2420,6 +2420,9 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(lab, description);
     g_free(description);
   }
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_LABEL]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
+                   GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
+
   /* add multi instances menu button */
   hw[IOP_MODULE_INSTANCE] = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT, NULL);
   module->multimenu_button = GTK_WIDGET(hw[IOP_MODULE_INSTANCE]);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3508,7 +3508,7 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
       _ungrab_at_focus_loss();
     return FALSE;
   case GDK_WINDOW_STATE:
-    if(event->window_state.changed_mask == GDK_WINDOW_STATE_FOCUSED)
+    if(!(event->window_state.new_window_state & GDK_WINDOW_STATE_FOCUSED))
       _ungrab_at_focus_loss();
     return FALSE;
   case GDK_FOCUS_CHANGE: // dialog boxes and switch to other app release grab

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2928,8 +2928,7 @@ static float _process_shortcut(float move_size)
 
     if(++consecutive_unmatched >= 3)
     {
-      _ungrab_grab_widget();
-      _sc = (dt_shortcut_t) { 0 };
+      _ungrab_at_focus_loss();
       consecutive_unmatched = 0;
     }
   }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -500,7 +500,7 @@ static gboolean _shortcut_is_move(dt_shortcut_t *s)
           s->move != DT_SHORTCUT_MOVE_NONE) && !s->direction;
 }
 
-static gchar *_shortcut_description(dt_shortcut_t *s, gboolean full)
+static gchar *_shortcut_description(dt_shortcut_t *s)
 {
   static gchar hint[1024];
   int length = 0;
@@ -536,45 +536,60 @@ static gchar *_shortcut_description(dt_shortcut_t *s, gboolean full)
   g_free(key_name);
   g_free(move_name);
 
-  if(full)
+  return hint + (hint[0] == ' ' ? 1 : 0);
+}
+
+static gchar *_action_description(dt_shortcut_t *s, int components)
+{
+  static gchar hint[1024];
+  int length = 0;
+  hint[0] = 0;
+
+  if(components == 2)
   {
-    if(s->instance == 1)
-      add_hint(", %s", _("first instance"));
-    else if(s->instance == -1)
-      add_hint(", %s", _("last instance"));
-    else if(s->instance != 0)
-      add_hint(", %s %+d", _("relative instance"), s->instance);
-
-    if(s->speed != 1.0)
-      add_hint(", %s *%g", _("speed"), s->speed);
-
-    const dt_action_def_t *def = _action_find_definition(s->action);
-
-    if(def && def->elements)
-    {
-      // if(s->element || !def->fallbacks ) add_hint(", %s", def->elements[s->element].name);  // "+fallback"
-      if(def->elements[s->element].effects == dt_action_effect_selection
-          && s->effect > DT_ACTION_EFFECT_COMBO_SEPARATOR)
-      {
-        dt_introspection_type_enum_tuple_t *values
-          = g_hash_table_lookup(darktable.control->combo_introspection, s->action);
-        if(values)
-          add_hint(", %s", _(values[s->effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1].description));
-        else
-        {
-          gchar **strings
-            = g_hash_table_lookup(darktable.control->combo_list, s->action);
-          if(strings)
-            add_hint(", %s", _(strings[s->effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1]));
-        }
-      }
-      else if(s->effect > 0) add_hint(", %s", _(def->elements[s->element].effects[s->effect]));
-    }
+    gchar *action_label = _action_full_label(s->action);
+    add_hint("%s", action_label);
+    g_free(action_label);
   }
+
+  if(s->instance == 1)
+    add_hint(", %s", _("first instance"));
+  else if(s->instance == -1)
+    add_hint(", %s", _("last instance"));
+  else if(s->instance != 0)
+    add_hint(", %s %+d", _("relative instance"), s->instance);
+
+  const dt_action_def_t *def = _action_find_definition(s->action);
+
+  if(def && def->elements)
+  {
+    if(components && (s->element || (!def->fallbacks && def->elements->name)))
+      add_hint(", %s", def->elements[s->element].name);
+
+    if(def->elements[s->element].effects == dt_action_effect_selection
+        && s->effect > DT_ACTION_EFFECT_COMBO_SEPARATOR)
+    {
+      dt_introspection_type_enum_tuple_t *values
+        = g_hash_table_lookup(darktable.control->combo_introspection, s->action);
+      if(values)
+        add_hint(", %s", _(values[s->effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1].description));
+      else
+      {
+        gchar **strings
+          = g_hash_table_lookup(darktable.control->combo_list, s->action);
+        if(strings)
+          add_hint(", %s", _(strings[s->effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1]));
+      }
+    }
+    else if(s->effect > 0) add_hint(", %s", _(def->elements[s->element].effects[s->effect]));
+  }
+
+  if(s->speed != 1.0)
+    add_hint(", %s *%g", _("speed"), s->speed);
 
 #undef add_hint
 
-  return hint + (hint[0] == ' ' ? 1 : 0);
+  return hint;
 }
 
 static void _insert_shortcut_in_list(GHashTable *ht, char *shortcut, dt_action_t *ac, char *label)
@@ -605,7 +620,7 @@ GHashTable *dt_shortcut_category_lists(dt_view_type_flags_t v)
   {
     dt_shortcut_t *s = g_sequence_get(iter);
     if(s && s->views & v)
-      _insert_shortcut_in_list(ht, _shortcut_description(s, TRUE), s->action, g_strdup(s->action->label));
+      _insert_shortcut_in_list(ht, _shortcut_description(s), s->action, g_strdup_printf("%s%s", s->action->label, _action_description(s, 1)));
   }
 
   return ht;
@@ -679,10 +694,13 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
         s->element == darktable.control->element ||
         (s->element == DT_ACTION_ELEMENT_DEFAULT && has_fallbacks)))
     {
-      gchar *desc_escaped = g_markup_escape_text(_shortcut_description(s, TRUE), -1);
-      description = dt_util_dstrcat(description, "%s<b><big>%s</big></b>",
-                                                 description ? "\n" : "", desc_escaped);
-      g_free(desc_escaped);
+      gchar *sc_escaped = g_markup_escape_text(_shortcut_description(s), -1);
+      gchar *ac_escaped = g_markup_escape_text(_action_description(s, 0), -1);
+      description = dt_util_dstrcat(description, "%s<b><big>%s</big></b><i>%s</i>",
+                                                 description ? "\n" : "",
+                                                 sc_escaped, ac_escaped);
+      g_free(sc_escaped);
+      g_free(ac_escaped);
     }
   }
 
@@ -985,11 +1003,9 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
             else
             {
               gchar *old_labels = existing_labels;
-              gchar *new_label = _action_full_label(e->action);
               existing_labels = g_strdup_printf("%s\n%s",
                                                 existing_labels ? existing_labels : "",
-                                                new_label);
-              g_free(new_label);
+                                                _action_description(e, 2));
               g_free(old_labels);
             }
           }
@@ -1071,7 +1087,7 @@ static void _fill_shortcut_fields(GtkTreeViewColumn *column, GtkCellRenderer *ce
     switch(field)
     {
     case SHORTCUT_VIEW_DESCRIPTION:
-      field_text = g_strdup(_shortcut_description(s, FALSE));
+      field_text = g_strdup(_shortcut_description(s));
       break;
     case SHORTCUT_VIEW_ACTION:
       if(s->action)
@@ -2565,7 +2581,10 @@ static guint _focus_loss_press = 0;
 
 static void _lookup_mapping_widget()
 {
+  if(_sc.action) return;
   _sc.action = g_hash_table_lookup(darktable.control->widgets, darktable.control->mapping_widget);
+  if(!_sc.action) return;
+
   _sc.instance = 0;
   if(_sc.action->target != darktable.control->mapping_widget)
   {
@@ -2617,11 +2636,11 @@ static gboolean _widget_invisible(GtkWidget *w)
           (g_strcmp0(gtk_widget_get_name(p), "lib-plugin-ui-main") && !gtk_widget_get_visible(p)));
 }
 
-gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboolean *fully_matched, const dt_action_def_t *def)
+gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboolean *fully_matched, const dt_action_def_t *def, char **fb_log)
 {
   *current = g_sequence_iter_prev(*current);
   dt_shortcut_t *c = g_sequence_get(*current);
-//dt_print(DT_DEBUG_INPUT, "  [_shortcut_closest_match] shortcut considered: %s\n", _shortcut_description(c, TRUE));
+//dt_print(DT_DEBUG_INPUT, "  [_shortcut_closest_match] shortcut considered: %s\n", _shortcut_description(c));
 
   gboolean applicable;
   while((applicable =
@@ -2642,7 +2661,7 @@ gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboo
   {
     *current = g_sequence_iter_prev(*current);
     c = g_sequence_get(*current);
-//dt_print(DT_DEBUG_INPUT, "  [_shortcut_closest_match] shortcut considered: %s\n", _shortcut_description(c, TRUE));
+//dt_print(DT_DEBUG_INPUT, "  [_shortcut_closest_match] shortcut considered: %s\n", _shortcut_description(c));
   }
 
   if(applicable)
@@ -2665,6 +2684,10 @@ gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboo
     s->action = c->action;
 
     *fully_matched = !(s->mods || s->press || s->button || s->click || s->move_device || s->move);
+
+    if(*fb_log)
+      *fb_log = dt_util_dstrcat(*fb_log, "\n%s \u2192 %s", _shortcut_description(c), _action_description(c, 2));
+
     return TRUE;
   }
   else
@@ -2674,7 +2697,7 @@ gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboo
   }
 }
 
-static gboolean _shortcut_match(dt_shortcut_t *f)
+static gboolean _shortcut_match(dt_shortcut_t *f, gchar **fb_log)
 {
   f->views = darktable.view_manager->current_view->view(darktable.view_manager->current_view);
   gpointer v = GINT_TO_POINTER(f->views);
@@ -2683,7 +2706,7 @@ static gboolean _shortcut_match(dt_shortcut_t *f)
 
   gboolean matched = FALSE;
 
-  if(!_shortcut_closest_match(&existing, f, &matched, NULL))
+  if(!_shortcut_closest_match(&existing, f, &matched, NULL, fb_log))
   {
     // see if there is a fallback from midi knob press to knob turn
     if(!f->key_device || f->move_device || f->move)
@@ -2708,7 +2731,7 @@ static gboolean _shortcut_match(dt_shortcut_t *f)
         f->key = 0;
 
         existing = g_sequence_search(darktable.control->shortcuts, f, _shortcut_compare_func, v);
-        if(!_shortcut_closest_match(&existing, f, &matched, NULL) && !f->action)
+        if(!_shortcut_closest_match(&existing, f, &matched, NULL, fb_log) && !f->action)
           return FALSE;
         else
         {
@@ -2736,7 +2759,7 @@ static gboolean _shortcut_match(dt_shortcut_t *f)
     const dt_action_def_t *def = _action_find_definition(matched_action);
 
     existing = g_sequence_search(darktable.control->shortcuts, f, _shortcut_compare_func, v);
-    while(_shortcut_closest_match(&existing, f, &matched, def) && !matched) {};
+    while(_shortcut_closest_match(&existing, f, &matched, def, fb_log) && !matched) {};
 
     if(!matched && def && def->elements[f->element].effects == dt_action_effect_value)
     {
@@ -2744,11 +2767,14 @@ static gboolean _shortcut_match(dt_shortcut_t *f)
                                           .target = GINT_TO_POINTER(DT_ACTION_TYPE_VALUE_FALLBACK) };
       f->action = &value_action;
       existing = g_sequence_search(darktable.control->shortcuts, f, _shortcut_compare_func, v);
-      while(_shortcut_closest_match(&existing, f, &matched, def) && !matched) {};
+      while(_shortcut_closest_match(&existing, f, &matched, def, fb_log) && !matched) {};
     }
 
     if(f->move && !f->move_device && !(f->mods || f->press || f->button || f->click))
     {
+      if(*fb_log)
+        *fb_log = dt_util_dstrcat(*fb_log, "\n%s \u2192 %s", _shortcut_description(f), _("fallback to move"));
+
       f->effect = DT_ACTION_EFFECT_DEFAULT_MOVE;
       matched = TRUE;
     }
@@ -2889,13 +2915,19 @@ static void _ungrab_at_focus_loss()
 
 static float _process_shortcut(float move_size)
 {
+  float return_value = NAN;
+
   dt_shortcut_t fsc = _sc;
   fsc.action = NULL;
   fsc.element  = 0;
 
   static int consecutive_unmatched = 0;
 
-  if(_shortcut_match(&fsc))
+  gchar *fb_log = darktable.control->mapping_widget && !isnan(move_size)
+                ? g_strdup_printf("[ %s ]", _shortcut_description(&fsc))
+                : NULL;
+
+  if(_shortcut_match(&fsc, &fb_log))
   {
     consecutive_unmatched = 0;
 
@@ -2912,7 +2944,7 @@ static float _process_shortcut(float move_size)
         fsc.effect = DT_ACTION_EFFECT_DEFAULT_UP;
     }
 
-    return _process_action(fsc.action, fsc.instance, fsc.element, fsc.effect, move_size);
+    return_value =  _process_action(fsc.action, fsc.instance, fsc.element, fsc.effect, move_size);
   }
   else if(!isnan(move_size))
   {
@@ -2920,11 +2952,11 @@ static float _process_shortcut(float move_size)
     {
       gchar *base_label = NULL;
       _action_distinct_label(&base_label, fsc.action, "");
-      dt_toast_log(_("no fallback for %s (%s)"), _shortcut_description(&fsc, TRUE), base_label);
+      dt_toast_log(_("no fallback for %s (%s)"), _shortcut_description(&fsc), base_label);
       g_free(base_label);
     }
     else
-      dt_toast_log(_("%s not assigned"), _shortcut_description(&_sc, TRUE));
+      dt_toast_log(_("%s not assigned"), _shortcut_description(&_sc));
 
     if(++consecutive_unmatched >= 3)
     {
@@ -2933,7 +2965,13 @@ static float _process_shortcut(float move_size)
     }
   }
 
-  return NAN;
+  if(fb_log)
+  {
+    dt_control_log("%s", fb_log);
+    g_free(fb_log);
+  }
+
+  return return_value;
 }
 
 float dt_action_process(const gchar *action, int instance, const gchar *element, const gchar *effect, float move_size)
@@ -3049,10 +3087,9 @@ float dt_shortcut_move(dt_input_device_t id, guint time, guint move, double size
 
     dt_print(DT_DEBUG_INPUT,
              "  [dt_shortcut_move] shortcut received: %s\n",
-             _shortcut_description(&_sc, TRUE));
+             _shortcut_description(&_sc));
 
-    if(darktable.control->mapping_widget
-       && !_sc.action) _lookup_mapping_widget();
+    _lookup_mapping_widget();
 
     if(_sc.action)
     {
@@ -3065,9 +3102,8 @@ float dt_shortcut_move(dt_input_device_t id, guint time, guint move, double size
         dt_shortcut_t s = _sc;
         if(_insert_shortcut(&s, TRUE))
         {
-          gchar *label = _action_full_label(s.action);
-          dt_control_log(_("%s assigned to %s"), _shortcut_description(&s, TRUE), label);
-          g_free(label);
+          dt_control_log(_("%s assigned to %s"),
+                         _shortcut_description(&s), _action_description(&s, 2));
 
           if(darktable.control->mapping_widget)
             gtk_widget_trigger_tooltip_query(darktable.control->mapping_widget);
@@ -3173,15 +3209,21 @@ void dt_shortcut_key_press(dt_input_device_t id, guint time, guint key)
     }
     if(s
        && !_sc.action
-       && !darktable.control->mapping_widget
        && s->effect == DT_ACTION_EFFECT_HOLD
        && s->action
-       && s->action->type >= DT_ACTION_TYPE_WIDGET)
+       && s->action->type >= DT_ACTION_TYPE_WIDGET
+       && !g_hash_table_lookup(darktable.control->widgets, darktable.control->mapping_widget))
     {
       const dt_action_def_t *definition = _action_find_definition(s->action);
       if(definition && definition->process
          && definition->elements[s->element].effects == dt_action_effect_hold)
       {
+        if(darktable.control->mapping_widget)
+        {
+          dt_control_log("[ %s ]\n%s \u2192 %s", _shortcut_description(&_sc),
+                         _shortcut_description(s), _action_description(s, 2));
+        }
+
         definition->process(NULL, s->element, DT_ACTION_EFFECT_ON, 1);
 
         this_key.hold_def = definition;
@@ -3214,7 +3256,7 @@ void dt_shortcut_key_press(dt_input_device_t id, guint time, guint key)
       {
         _sc.press = 0;
 
-        if(darktable.control->mapping_widget && !_sc.action) _lookup_mapping_widget();
+        _lookup_mapping_widget();
       }
 
       GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "all-scroll");

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1355,7 +1355,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   // toggle focus peaking everywhere
   dt_accel_register_global(NC_("accel", "toggle focus peaking"), GDK_KEY_f, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
-  dt_accel_connect_button_lib_as_global(NULL, "toggle focus peaking", darktable.gui->focus_peaking_button);
+  dt_action_define(&darktable.control->actions_global, NULL, "toggle focus peaking", darktable.gui->focus_peaking_button, &dt_action_def_toggle);
 
   return 0;
 }

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -789,7 +789,8 @@ static void _set_mapping_mode_cursor(GtkWidget *widget)
 
   if(widget && !strcmp(gtk_widget_get_name(widget), "module-header"))
     cursor = GDK_BASED_ARROW_DOWN;
-  else if(darktable.control->mapping_widget && darktable.develop)
+  else if(g_hash_table_lookup(darktable.control->widgets, darktable.control->mapping_widget)
+          && darktable.develop)
   {
     switch(dt_dev_modulegroups_basics_module_toggle(darktable.develop, widget, FALSE))
     {
@@ -814,8 +815,7 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
     if(event->crossing.mode == GDK_CROSSING_UNGRAB) break;
   case GDK_GRAB_BROKEN:
   case GDK_FOCUS_CHANGE:
-    darktable.control->mapping_widget = g_hash_table_lookup(darktable.control->widgets, event_widget)
-                                      ? event_widget : NULL;
+    darktable.control->mapping_widget = event_widget;
     _set_mapping_mode_cursor(event_widget);
     break;
   case GDK_BUTTON_PRESS:

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -52,8 +52,9 @@ static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user
 static void _lib_preferences_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for help button */
 static void _lib_help_button_clicked(GtkWidget *widget, gpointer user_data);
-/* callback for key mapping button */
+/* callbacks for key mapping button */
 static void _lib_keymap_button_clicked(GtkWidget *widget, gpointer user_data);
+static gboolean _lib_keymap_button_press_release(GtkWidget *button, GdkEventButton *event, gpointer user_data);
 
 const char *name(dt_lib_module_t *self)
 {
@@ -399,6 +400,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the grouping button */
   d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.control->actions_global, NULL, "grouping", d->grouping_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->grouping_button, FALSE, FALSE, 0);
   if(darktable.gui->grouping)
     gtk_widget_set_tooltip_text(d->grouping_button, _("expand grouped images"));
@@ -510,12 +512,15 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the shortcuts button */
   d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, CPF_STYLE_FLAT, NULL);
+  dt_action_define(&darktable.control->actions_global, NULL, "shortcuts", d->keymap_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->keymap_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->keymap_button, _("define shortcuts\n"
                                                   "hover over a widget and press keys with mouse click and scroll or move combinations\n"
                                                   "repeat same combination again to delete mapping\n"
                                                   "click on a widget, module or screen area to open the dialog for further configuration"));
   g_signal_connect(G_OBJECT(d->keymap_button), "clicked", G_CALLBACK(_lib_keymap_button_clicked), d);
+  g_signal_connect(G_OBJECT(d->keymap_button), "button-press-event", G_CALLBACK(_lib_keymap_button_press_release), d);
+  g_signal_connect(G_OBJECT(d->keymap_button), "button-release-event", G_CALLBACK(_lib_keymap_button_press_release), d);
   dt_gui_add_help_link(d->keymap_button, dt_get_help_url("global_toolbox_keymap"));
 
   // the rest of these is added in reverse order as they are always put at the end of the container.
@@ -805,14 +810,41 @@ static void _set_mapping_mode_cursor(GtkWidget *widget)
   dt_control_forbid_change_cursor();
 }
 
+static void _show_shortcuts_prefs(GtkWidget *w)
+{
+  GtkWidget *shortcuts_dialog = gtk_dialog_new_with_buttons(_("shortcuts"), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)),
+                                                            GTK_DIALOG_DESTROY_WITH_PARENT, NULL, NULL);
+  if(!_shortcuts_dialog_posize.w)
+    gtk_window_set_default_size(GTK_WINDOW(shortcuts_dialog),
+                                DT_PIXEL_APPLY_DPI(dt_conf_get_int("ui_last/shortcuts_dialog_width")),
+                                DT_PIXEL_APPLY_DPI(dt_conf_get_int("ui_last/shortcuts_dialog_height")));
+  else
+  {
+    gtk_window_move(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.x, _shortcuts_dialog_posize.y);
+    gtk_window_resize(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.w, _shortcuts_dialog_posize.h);
+  }
+  g_signal_connect(G_OBJECT(shortcuts_dialog), "configure-event", G_CALLBACK(_resize_shortcuts_dialog), NULL);
+
+  //grab the content area of the dialog
+  GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(shortcuts_dialog));
+  gtk_box_pack_start(GTK_BOX(content), dt_shortcuts_prefs(w), TRUE, TRUE, 0);
+
+  gtk_widget_show_all(shortcuts_dialog);
+  gtk_dialog_run(GTK_DIALOG(shortcuts_dialog));
+  gtk_widget_destroy(shortcuts_dialog);
+}
+
 static void _main_do_event_keymap(GdkEvent *event, gpointer data)
 {
   GtkWidget *event_widget = gtk_get_event_widget(event);
 
   switch(event->type)
   {
+  case GDK_LEAVE_NOTIFY:
   case GDK_ENTER_NOTIFY:
-    if(event->crossing.mode == GDK_CROSSING_UNGRAB) break;
+    if(darktable.control->mapping_widget
+       && event->crossing.mode == GDK_CROSSING_UNGRAB)
+      break;
   case GDK_GRAB_BROKEN:
   case GDK_FOCUS_CHANGE:
     darktable.control->mapping_widget = event_widget;
@@ -854,26 +886,7 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
         break;
 
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
-      GtkWidget *shortcuts_dialog = gtk_dialog_new_with_buttons(_("shortcuts"), GTK_WINDOW(main_window),
-                                                                GTK_DIALOG_DESTROY_WITH_PARENT, NULL, NULL);
-      if(!_shortcuts_dialog_posize.w)
-        gtk_window_set_default_size(GTK_WINDOW(shortcuts_dialog),
-                                    DT_PIXEL_APPLY_DPI(dt_conf_get_int("ui_last/shortcuts_dialog_width")),
-                                    DT_PIXEL_APPLY_DPI(dt_conf_get_int("ui_last/shortcuts_dialog_height")));
-      else
-      {
-        gtk_window_move(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.x, _shortcuts_dialog_posize.y);
-        gtk_window_resize(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.w, _shortcuts_dialog_posize.h);
-      }
-      g_signal_connect(G_OBJECT(shortcuts_dialog), "configure-event", G_CALLBACK(_resize_shortcuts_dialog), NULL);
-
-      //grab the content area of the dialog
-      GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(shortcuts_dialog));
-      gtk_box_pack_start(GTK_BOX(content), dt_shortcuts_prefs(event_widget), TRUE, TRUE, 0);
-
-      gtk_widget_show_all(shortcuts_dialog);
-      gtk_dialog_run(GTK_DIALOG(shortcuts_dialog));
-      gtk_widget_destroy(shortcuts_dialog);
+      _show_shortcuts_prefs(event_widget);
     }
 
     return;
@@ -895,8 +908,6 @@ static void _lib_keymap_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
   {
-    dt_control_change_cursor(GDK_X_CURSOR);
-    dt_control_forbid_change_cursor();
     gdk_event_handler_set(_main_do_event_keymap, user_data, NULL);
   }
   else
@@ -905,6 +916,26 @@ static void _lib_keymap_button_clicked(GtkWidget *widget, gpointer user_data)
     dt_control_allow_change_cursor();
     dt_control_change_cursor(GDK_LEFT_PTR);
     gdk_event_handler_set((GdkEventFunc)gtk_main_do_event, NULL, NULL);
+  }
+}
+
+static gboolean _lib_keymap_button_press_release(GtkWidget *button, GdkEventButton *event, gpointer user_data)
+{
+  static guint start_time = 0;
+
+  int delay = 0;
+  g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);
+
+  if((event->type == GDK_BUTTON_PRESS && event->button == 3) ||
+     (event->type == GDK_BUTTON_RELEASE && event->time - start_time > delay))
+  {
+    _show_shortcuts_prefs(NULL);
+    return TRUE;
+  }
+  else
+  {
+    start_time = event->time;
+    return FALSE;
   }
 }
 
@@ -928,10 +959,8 @@ void connect_key_accels(dt_lib_module_t *self)
 {
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
 
-  dt_accel_connect_button_lib_as_global(self, "grouping", d->grouping_button);
   dt_accel_connect_button_lib_as_global(self, "thumbnail overlays options", d->overlays_button);
   dt_accel_connect_button_lib_as_global(self, "preferences", d->preferences_button);
-  dt_accel_connect_button_lib_as_global(self, "shortcuts", d->keymap_button);
 
   dt_accel_connect_lib_as_global( self, "thumbnail overlays/no overlays",
       g_cclosure_new(G_CALLBACK(_overlays_accels_callback), GINT_TO_POINTER(DT_THUMBNAIL_OVERLAYS_NONE), NULL));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2198,8 +2198,11 @@ static gboolean _quickbutton_press_release(GtkWidget *button, GdkEventButton *ev
 {
   static guint start_time = 0;
 
+  int delay = 0;
+  g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);
+
   if((event->type == GDK_BUTTON_PRESS && event->button == 3) ||
-     (event->type == GDK_BUTTON_RELEASE && event->time - start_time > 600))
+     (event->type == GDK_BUTTON_RELEASE && event->time - start_time > delay))
   {
     gtk_popover_set_relative_to(GTK_POPOVER(popover), button);
 


### PR DESCRIPTION
fixes #10054
This add a toggle in the shortcuts dialog to enable fallbacks. By default they are not enabled, to avoid confusion.

To help understand fallbacks, if a shortcut is executed while in mapping mode, a new toast appears. You need to _not_ be over a mappable widget to do this, otherwise a new shortcut will be created. The toast shows the different shortcuts and fallbacks that are used to interpret a command. It is shown in the center-screen toast so it doesn't get overwritten by the top-of-screen toast that shows to resulting change to sliders etc. when the action is executed.

![image](https://user-images.githubusercontent.com/1549490/135321720-97a40cad-82f7-4e39-957a-69b985d66c28.png)

This PR also cleans up the shortcut and associated actions descriptions.
- in the tooltips (now shows element/effect/speed/instance in _italic_ behind the shortcut combination)
- in the H window (shows speed etc in the action instead of shortcut column 
- In the control toast confirming a new mapping
- in the confirmation dialog to overwrite conflicting shortcuts

Additionally fixes #10105 
Changed shortcuts for shortcut mapping mode from "button" to "toggle". This also enables directly opening the shortcuts dialog by right-clicking (or long clicking) on the button. If  you assign a shortcut key to the button, you can also long press it to open the dialog (if you haven't disabled fallbacks).

