### PR TITLE
avif: fix matrix coefficients used on sRGB export

### DIFF
--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -248,7 +248,9 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       case AVIF_TRANSFER_CHARACTERISTICS_SRGB:
 
         switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_BT709:
+        case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
+        case AVIF_MATRIX_COEFFICIENTS_BT470BG: /* BT601 coeffs */ 
+        case AVIF_MATRIX_COEFFICIENTS_BT709: /* support incorrectly tagged legacy files */
         case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_SRGB;
           break;

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -294,7 +294,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       case DT_COLORSPACE_SRGB:
           image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
           image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
-          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT470BG;
           break;
       case DT_COLORSPACE_REC709:
           image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;


### PR DESCRIPTION
See https://www.itu.int/rec/T-REC-H.273-202107-I/en - value of 5 is the only valid option if doing the conversion from R'G'B' in the sRGB->sYCC case (or identity, i.e. 0 if not).

[sYCC conversion](https://www.color.org/sYCC.pdf) is basically identical to the [JPEG YCbCr conversion](https://en.wikipedia.org/wiki/YCbCr#JPEG_conversion) using the legacy Rec 601 coeffs.
