### PR TITLE
Fix/7402 import css broken on windows

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2680,7 +2680,6 @@ void dt_gui_load_theme(const char *theme)
 {
   char theme_css[PATH_MAX] = { 0 };
   g_snprintf(theme_css, sizeof(theme_css), "%s.css", theme);
-  fprintf(stderr, "%s: trying to load theme %s\n", G_STRFUNC, theme_css);
 
   if(!dt_conf_key_exists("use_system_font"))
     dt_conf_set_bool("use_system_font", TRUE);
@@ -2710,30 +2709,19 @@ void dt_gui_load_theme(const char *theme)
   path = g_build_filename(configdir, "themes", theme_css, NULL);
   if(!g_file_test(path, G_FILE_TEST_EXISTS))
   {
-    fprintf(stderr, "%s: path %s does not exist\n", G_STRFUNC, path);
-
     // dt dir theme
     path = g_build_filename(datadir, "themes", theme_css, NULL);
     if(!g_file_test(path, G_FILE_TEST_EXISTS))
     {
-      fprintf(stderr, "%s: path %s does not exist\n", G_STRFUNC, path);
-
       // fallback to default theme
       path = g_build_filename(datadir, "themes/darktable.css", NULL);
       dt_conf_set_string("ui_last/theme", "darktable");
-      fprintf(stderr, "%s: setting theme to the safe default: %s\n", G_STRFUNC, theme);
     }
     else
-    {
       dt_conf_set_string("ui_last/theme", theme);
-      fprintf(stderr, "%s: setting ui to %s\n", G_STRFUNC, theme);
-    }
   }
   else
-  {
     dt_conf_set_string("ui_last/theme", theme);
-    fprintf(stderr, "%s: setting ui to %s\n", G_STRFUNC, theme);
-  }
 
   GError *error = NULL;
 
@@ -2752,7 +2740,7 @@ void dt_gui_load_theme(const char *theme)
   gchar *usercsspath_uri = g_filename_to_uri(usercsspath, NULL, &error);
   if(usercsspath_uri == NULL)
     fprintf(stderr, "%s: could not convert path %s to URI. Error: %s\n", G_STRFUNC, usercsspath, error->message);
-else
+  else
     fprintf(stderr, "%s: usercsspath_uri: %s\n", G_STRFUNC, usercsspath_uri);
 
   gchar *themecss = NULL;
@@ -2760,12 +2748,10 @@ else
   {
     themecss = g_strjoin(NULL, "@import url('", path_uri,
                                            "'); @import url('", usercsspath_uri, "');", NULL);
-    fprintf(stderr, "%s: importing %s and %s to %s\n", G_STRFUNC, path_uri, usercsspath_uri, themecss);
   }
   else
   {
     themecss = g_strjoin(NULL, "@import url('", path_uri, "');", NULL);
-    fprintf(stderr, "%s: import alone: %s to: %s\n", G_STRFUNC, path_uri, themecss);
   }
 
   g_free(path_uri);
@@ -2775,7 +2761,6 @@ else
 
   if(dt_conf_get_bool("ui/hide_tooltips"))
   {
-    fprintf(stderr, "%s: tooltips \n", G_STRFUNC);
     gchar *newcss = g_strjoin(NULL, themecss, " tooltip {opacity: 0; background: transparent;}", NULL);
     g_free(themecss);
     themecss = newcss;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2678,6 +2678,10 @@ void dt_gui_add_help_link(GtkWidget *widget, const char *link)
 // load a CSS theme
 void dt_gui_load_theme(const char *theme)
 {
+  char theme_css[PATH_MAX] = { 0 };
+  g_snprintf(theme_css, sizeof(theme_css), "%s.css", theme);
+  fprintf(stderr, "%s: trying to load theme %s\n", G_STRFUNC, theme_css);
+
   if(!dt_conf_key_exists("use_system_font"))
     dt_conf_set_bool("use_system_font", TRUE);
 
@@ -2697,63 +2701,81 @@ void dt_gui_load_theme(const char *theme)
     g_free(font_name);
   }
 
-  char path[PATH_MAX] = { 0 }, datadir[PATH_MAX] = { 0 }, configdir[PATH_MAX] = { 0 }, usercsspath[PATH_MAX] = { 0 };
+  gchar *path, *usercsspath;
+  char datadir[PATH_MAX] = { 0 }, configdir[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  // user dir them
-  g_snprintf(path, sizeof(path), "%s/themes/%s.css", configdir, theme);
+  // user dir theme
+  path = g_build_filename(configdir, "themes", theme_css, NULL);
   if(!g_file_test(path, G_FILE_TEST_EXISTS))
   {
+    fprintf(stderr, "%s: path %s does not exist\n", G_STRFUNC, path);
+
     // dt dir theme
-    g_snprintf(path, sizeof(path), "%s/themes/%s.css", datadir, theme);
+    path = g_build_filename(datadir, "themes", theme_css, NULL);
     if(!g_file_test(path, G_FILE_TEST_EXISTS))
     {
+      fprintf(stderr, "%s: path %s does not exist\n", G_STRFUNC, path);
+
       // fallback to default theme
-      g_snprintf(path, sizeof(path), "%s/themes/darktable.css", datadir);
+      path = g_build_filename(datadir, "themes/darktable.css", NULL);
       dt_conf_set_string("ui_last/theme", "darktable");
+      fprintf(stderr, "%s: setting theme to the safe default: %s\n", G_STRFUNC, theme);
     }
     else
+    {
       dt_conf_set_string("ui_last/theme", theme);
+      fprintf(stderr, "%s: setting ui to %s\n", G_STRFUNC, theme);
+    }
   }
   else
+  {
     dt_conf_set_string("ui_last/theme", theme);
+    fprintf(stderr, "%s: setting ui to %s\n", G_STRFUNC, theme);
+  }
 
   GError *error = NULL;
+
   GtkStyleProvider *themes_style_provider = GTK_STYLE_PROVIDER(gtk_css_provider_new());
   gtk_style_context_add_provider_for_screen
     (gdk_screen_get_default(), themes_style_provider, GTK_STYLE_PROVIDER_PRIORITY_USER + 1);
 
-  g_snprintf(usercsspath, sizeof(usercsspath), "%s/user.css", configdir);
+  usercsspath = g_build_filename(configdir, "/user.css", NULL);
 
-  char *c1 = path;
-  char *c2 = usercsspath;
+  gchar *path_uri = g_filename_to_uri(path, NULL, &error);
+  if(path_uri == NULL)
+    fprintf(stderr, "%s: could not convert path %s to URI. Error: %s\n", G_STRFUNC, path, error->message);
+  else
+    fprintf(stderr, "%s: path_uri: %s\n", G_STRFUNC, path_uri);
 
-#ifdef _WIN32
-  // for Windows, we need to remove the drive letter and the colon, if present, and replace '\' with '/'
-  c1 = strchr(path, ':');
-  c1 = (c1 == NULL ? path : c1 + 1);
-  c2 = strchr(usercsspath, ':');
-  c2 = (c2 == NULL ? usercsspath : c2 + 1);
-
-  c1 = g_strdelimit(c1, "\\", '/');
-  c2 = g_strdelimit(c2, "\\", '/');
-#endif
+  gchar *usercsspath_uri = g_filename_to_uri(usercsspath, NULL, &error);
+  if(usercsspath_uri == NULL)
+    fprintf(stderr, "%s: could not convert path %s to URI. Error: %s\n", G_STRFUNC, usercsspath, error->message);
+else
+    fprintf(stderr, "%s: usercsspath_uri: %s\n", G_STRFUNC, usercsspath_uri);
 
   gchar *themecss = NULL;
-
-  if(dt_conf_get_bool("themes/usercss") && g_file_test(c2, G_FILE_TEST_EXISTS))
+  if(dt_conf_get_bool("themes/usercss") && g_file_test(usercsspath, G_FILE_TEST_EXISTS))
   {
-    themecss = g_strjoin(NULL, "@import url('", c1,
-                                           "'); @import url('", c2, "');", NULL);
+    themecss = g_strjoin(NULL, "@import url('", path_uri,
+                                           "'); @import url('", usercsspath_uri, "');", NULL);
+    fprintf(stderr, "%s: importing %s and %s to %s\n", G_STRFUNC, path_uri, usercsspath_uri, themecss);
   }
   else
   {
-    themecss = g_strjoin(NULL, "@import url('", c1, "');", NULL);
+    themecss = g_strjoin(NULL, "@import url('", path_uri, "');", NULL);
+    fprintf(stderr, "%s: import alone: %s to: %s\n", G_STRFUNC, path_uri, themecss);
   }
+
+  g_free(path_uri);
+  g_free(usercsspath_uri);
+  g_free(path);
+  g_free(usercsspath);
 
   if(dt_conf_get_bool("ui/hide_tooltips"))
   {
+    fprintf(stderr, "%s: tooltips \n", G_STRFUNC);
     gchar *newcss = g_strjoin(NULL, themecss, " tooltip {opacity: 0; background: transparent;}", NULL);
     g_free(themecss);
     themecss = newcss;
@@ -2761,10 +2783,9 @@ void dt_gui_load_theme(const char *theme)
 
   if(!gtk_css_provider_load_from_data(GTK_CSS_PROVIDER(themes_style_provider), themecss, -1, &error))
   {
-    fprintf(stderr, "%s: error parsing combined CSS: %s\n", G_STRFUNC, error->message);
+    fprintf(stderr, "%s: error parsing combined CSS %s: %s\n", G_STRFUNC, themecss, error->message);
     g_clear_error(&error);
   }
-
 
   g_free(themecss);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2714,7 +2714,7 @@ void dt_gui_load_theme(const char *theme)
     if(!g_file_test(path, G_FILE_TEST_EXISTS))
     {
       // fallback to default theme
-      path = g_build_filename(datadir, "themes/darktable.css", NULL);
+      path = g_build_filename(datadir, "themes", "darktable.css", NULL);
       dt_conf_set_string("ui_last/theme", "darktable");
     }
     else
@@ -2729,7 +2729,7 @@ void dt_gui_load_theme(const char *theme)
   gtk_style_context_add_provider_for_screen
     (gdk_screen_get_default(), themes_style_provider, GTK_STYLE_PROVIDER_PRIORITY_USER + 1);
 
-  usercsspath = g_build_filename(configdir, "/user.css", NULL);
+  usercsspath = g_build_filename(configdir, "user.css", NULL);
 
   gchar *path_uri = g_filename_to_uri(path, NULL, &error);
   if(path_uri == NULL)


### PR DESCRIPTION
Fixes #7402 

This PR fixes a windows only issue that happened due to manual hacky assembly of filepathes only having one OS in mind.

#5440 tried to fix opening css files on windows by removing drive letters making it relative pathes on windows (relative to the drive of the cwd). Thats why #7402 fails only on windows when the startup path is on a different drive than the dt installation.

#5440 incorrectly states 

> css @import() statement doesn't like backslashes or drive letters.

Instead css @import() statements work fine with uris. 