### PR TITLE
Better rejected thumb css

### DIFF
--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -150,12 +150,3 @@
 {
   background-image: linear-gradient(rgba(246, 246, 246, 0.4) 0%, rgba(246, 246, 246, 0.2) 5%, rgba(226, 226, 226, 0) 100%);
 }
-
-/* Make inactive stars more discrete when not hovered */
-.dt_overlays_always #thumb_star,
-.dt_overlays_always_extended #thumb_star,
-.dt_overlays_mixed #thumb_star,
-.dt_overlays_hover_block #thumb_star
-{
-  color: shade(@thumbnail_font_color, 1.5);
-}

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2526,38 +2526,26 @@ Details :
   color: rgba(0,0,0,0.35); /* only the transparency is used to fade the image drawing */
 }
 
+.dt_thumbnail_rating_6#thumb_main:hover #thumb_image
+{
+  color: rgba(0,0,0,1); /* only the transparency is used to fade the image drawing */
+}
+
 .dt_thumbnail_rating_6 #thumb_back
 {
-  background-color: shade(@thumbnail_bg_color,0.9); /* also fade the thumb background */
+  background-color: shade(@thumbnail_bg_color,0.85); /* also fade the thumb background */
 }
 
 .dt_overlays_hover .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
-.dt_overlays_hover_extended .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
-.dt_overlays_hover_extended .dt_thumbnail_rating_6#thumb_main:hover #thumb_bottom_label,
 .dt_overlays_always .dt_thumbnail_rating_6 #thumb_ext,
 .dt_overlays_always .dt_thumbnail_rating_6 #thumb_altered,
-.dt_overlays_always .dt_thumbnail_rating_6#thumb_main:hover #thumb_ext,
-.dt_overlays_always .dt_thumbnail_rating_6#thumb_main:hover #thumb_altered,
-.dt_overlays_always .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
 .dt_overlays_always_extended .dt_thumbnail_rating_6 #thumb_ext,
 .dt_overlays_always_extended .dt_thumbnail_rating_6 #thumb_altered,
 .dt_overlays_always_extended .dt_thumbnail_rating_6 #thumb_bottom_label,
-.dt_overlays_always_extended .dt_thumbnail_rating_6#thumb_main:hover #thumb_ext,
-.dt_overlays_always_extended .dt_thumbnail_rating_6#thumb_main:hover #thumb_altered,
-.dt_overlays_always_extended .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
-.dt_overlays_always_extended .dt_thumbnail_rating_6#thumb_main:hover #thumb_bottom_label,
 .dt_overlays_mixed .dt_thumbnail_rating_6 #thumb_ext,
-.dt_overlays_mixed .dt_thumbnail_rating_6 #thumb_altered,
-.dt_overlays_mixed .dt_thumbnail_rating_6#thumb_main:hover #thumb_ext,
-.dt_overlays_mixed .dt_thumbnail_rating_6#thumb_main:hover #thumb_altered,
-.dt_overlays_mixed .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
-.dt_overlays_mixed .dt_thumbnail_rating_6#thumb_main:hover #thumb_bottom_label,
-.dt_overlays_hover_block .dt_thumbnail_rating_6#thumb_main:hover #thumb_ext,
-.dt_overlays_hover_block .dt_thumbnail_rating_6#thumb_main:hover #thumb_altered,
-.dt_overlays_hover_block .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
-.dt_overlays_hover_block .dt_thumbnail_rating_6#thumb_main:hover #thumb_bottom_label
+.dt_overlays_mixed .dt_thumbnail_rating_6 #thumb_altered
 {
-  color: rgba(0,0,0,0.25); /* only the transparency is used to fade the image drawing */
+  color: rgba(0,0,0,0.15); /* only the transparency is used to fade the image drawing */
 }
 
 /* Set local copy mark */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2528,12 +2528,13 @@ Details :
 
 .dt_thumbnail_rating_6#thumb_main:hover #thumb_image
 {
-  color: rgba(0,0,0,1); /* only the transparency is used to fade the image drawing */
+  color: rgba(0,0,0,1); /* take back image to normal state by removing transparency when hovering the image */
 }
 
 .dt_thumbnail_rating_6 #thumb_back
 {
-  background-color: shade(@thumbnail_bg_color,0.85); /* also fade the thumb background */
+  background-color: shade(@thumbnail_bg_color,0.75); /* also fade the thumb background */
+  border: 1px solid shade(@lighttable_bg_color, 0.75); /* this is needed to have appropriate border colors and avoid visible differences in border regardless of not rejected images */
 }
 
 .dt_overlays_always .dt_thumbnail_rating_6 #thumb_ext,
@@ -2544,7 +2545,7 @@ Details :
 .dt_overlays_mixed .dt_thumbnail_rating_6 #thumb_ext,
 .dt_overlays_mixed .dt_thumbnail_rating_6 #thumb_altered
 {
-  color: rgba(0,0,0,0.15); /* only the transparency is used to fade the image drawing */
+  color: rgba(0,0,0,0.15); /* add some transparency to infos items in thumbnail */
 }
 
 .dt_thumbnail_rating_6 #thumb_star

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2536,7 +2536,6 @@ Details :
   background-color: shade(@thumbnail_bg_color,0.85); /* also fade the thumb background */
 }
 
-.dt_overlays_hover .dt_thumbnail_rating_6#thumb_main:hover .dt_thumb_btn,
 .dt_overlays_always .dt_thumbnail_rating_6 #thumb_ext,
 .dt_overlays_always .dt_thumbnail_rating_6 #thumb_altered,
 .dt_overlays_always_extended .dt_thumbnail_rating_6 #thumb_ext,
@@ -2546,6 +2545,11 @@ Details :
 .dt_overlays_mixed .dt_thumbnail_rating_6 #thumb_altered
 {
   color: rgba(0,0,0,0.15); /* only the transparency is used to fade the image drawing */
+}
+
+.dt_thumbnail_rating_6 #thumb_star
+{
+  color: transparent; /* needed to hide completely stars in rejected images as they are not needed, except in hover mode if we want to un-reject images */
 }
 
 /* Set local copy mark */


### PR DESCRIPTION
A feedback from @aurelienpierre agreed on the fact that background around image should be darker for rejected images, as @TurboGit wanted. Maybe I was wrong, so I post something that should be a better compromise. Would be good to have some feedback from different people on this PR.

As @aurelienpierre also says, we need to thought of the fact that we can cancel a rejected image because we change our mind. To do that, it's good to be able to see image normally. That's why I remove hover effect and so allow to display image normally, only when hovering the image.

@AlicVB: your feedback is wanted too as you started the work on this.

I let this as a WIP to wait for more feedback.