### PR TITLE
colorspaces: refactor AVIF color profile detection

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1989,6 +1989,218 @@ gboolean dt_colorspaces_is_profile_equal(const char *fullname, const char *filen
     : !strcmp(_colorspaces_get_base_name(fullname), _colorspaces_get_base_name(filename));
 }
 
+dt_colorspaces_color_profile_type_t dt_colorspaces_cicp_to_type(const dt_colorspaces_cicp_t *cicp, const char *filename)
+{
+  switch(cicp->color_primaries)
+  {
+    /* Give up immediately if unspecified */
+    case DT_CICP_COLOR_PRIMARIES_UNSPECIFIED:
+      if(cicp->transfer_characteristics == DT_CICP_TRANSFER_CHARACTERISTICS_UNSPECIFIED
+         && cicp->matrix_coefficients == DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED)
+        return DT_COLORSPACE_NONE;
+      break; /* unspecified */
+
+    /* REC709 */
+    case DT_CICP_COLOR_PRIMARIES_REC709:
+
+      switch(cicp->transfer_characteristics)
+      {
+        /* SRGB */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_SRGB:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_SYCC:
+            case DT_CICP_MATRIX_COEFFICIENTS_REC601: /* support equivalents just in case of mistagging */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709: /* support incorrectly tagged legacy AVIFs exported before dt 3.8 */
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL: /* support incorrectly tagged files */
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_SRGB;
+            default:
+              break;
+          }
+
+          break; /* SRGB */
+
+        /* REC709 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_REC709:
+        case DT_CICP_TRANSFER_CHARACTERISTICS_REC601:      /* support equivalents just in case of mistagging */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_REC2020_10B: /* support equivalents just in case of mistagging */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_REC2020_12B: /* support equivalents just in case of mistagging */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_GAMMA22: /* support incorrectly tagged legacy AVIFs exported before dt 3.6 (gamma 2.2) */
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709:
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_REC709;
+            default:
+              break;
+          }
+
+          break; /* REC709 */
+
+        /* LINEAR REC709 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_LINEAR:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709:
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_LIN_REC709;
+            default:
+              break;
+          }
+
+          break; /* LINEAR REC709 */
+
+        default:
+          break;
+      }
+
+      break; /* REC709 */
+
+    /* REC2020 */
+    case DT_CICP_COLOR_PRIMARIES_REC2020:
+
+      switch(cicp->transfer_characteristics)
+      {
+        /* LINEAR REC2020 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_LINEAR:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC2020_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_LIN_REC2020;
+            default:
+              break;
+          }
+
+          break; /* LINEAR REC2020 */
+
+        /* PQ REC2020 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_PQ:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC2020_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_PQ_REC2020;
+            default:
+              break;
+          }
+
+          break; /* PQ REC2020 */
+
+        /* HLG REC2020 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_HLG:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC2020_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_HLG_REC2020;
+            default:
+              break;
+          }
+
+          break; /* HLG REC2020 */
+
+        default:
+          break;
+      }
+
+      break; /* REC2020 */
+
+    /* P3 */
+    case DT_CICP_COLOR_PRIMARIES_P3:
+
+      switch(cicp->transfer_characteristics)
+      {
+        /* PQ P3 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_PQ:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_PQ_P3;
+            default:
+              break;
+          }
+
+          break; /* PQ P3 */
+
+        /* HLG P3 */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_HLG:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_HLG_P3;
+            default:
+              break;
+          }
+
+          break; /* HLG P3 */
+
+        default:
+          break;
+      }
+
+      break; /* P3 */
+
+    /* XYZ */
+    case DT_CICP_COLOR_PRIMARIES_XYZ:
+
+      switch(cicp->transfer_characteristics)
+      {
+        /* LINEAR XYZ */
+        case DT_CICP_TRANSFER_CHARACTERISTICS_LINEAR:
+
+          switch(cicp->matrix_coefficients)
+          {
+            case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY:
+            case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
+              return DT_COLORSPACE_XYZ;
+            default:
+              break;
+          }
+
+          break; /* LINEAR XYZ */
+
+        default:
+          break;
+      }
+
+      break; /* XYZ */
+
+    default:
+      break;
+  }
+
+  if(filename != NULL)
+    dt_print(DT_DEBUG_IMAGEIO, "[colorin] unsupported CICP color profile for `%s': %d/%d/%d\n", filename,
+             cicp->color_primaries, cicp->transfer_characteristics, cicp->matrix_coefficients);
+
+  return DT_COLORSPACE_NONE;
+}
+
 static const dt_colorspaces_color_profile_t *_get_profile(dt_colorspaces_t *self,
                                                           dt_colorspaces_color_profile_type_t type,
                                                           const char *filename,

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -104,6 +104,43 @@ typedef enum dt_colorspaces_profile_direction_t
                              | DT_PROFILE_DIRECTION_DISPLAY2
 } dt_colorspaces_profile_direction_t;
 
+/* CICP color primaries (Recommendation ITU-T H.273) */
+typedef enum dt_colorspaces_cicp_color_primaries_t
+{
+    DT_CICP_COLOR_PRIMARIES_REC709 = 1,
+    DT_CICP_COLOR_PRIMARIES_UNSPECIFIED = 2,
+    DT_CICP_COLOR_PRIMARIES_REC2020 = 9,
+    DT_CICP_COLOR_PRIMARIES_XYZ = 10,
+    DT_CICP_COLOR_PRIMARIES_P3 = 12 // D65
+} dt_colorspaces_cicp_color_primaries_t;
+
+/* CICP transfer characteristics (Recommendation ITU-T H.273) */
+typedef enum dt_colorspaces_cicp_transfer_characteristics_t
+{
+    DT_CICP_TRANSFER_CHARACTERISTICS_REC709 = 1,
+    DT_CICP_TRANSFER_CHARACTERISTICS_UNSPECIFIED = 2,
+    DT_CICP_TRANSFER_CHARACTERISTICS_GAMMA22 = 4,
+    DT_CICP_TRANSFER_CHARACTERISTICS_REC601 = 6,
+    DT_CICP_TRANSFER_CHARACTERISTICS_LINEAR = 8,
+    DT_CICP_TRANSFER_CHARACTERISTICS_SRGB = 13,
+    DT_CICP_TRANSFER_CHARACTERISTICS_REC2020_10B = 14,
+    DT_CICP_TRANSFER_CHARACTERISTICS_REC2020_12B = 15,
+    DT_CICP_TRANSFER_CHARACTERISTICS_PQ = 16,
+    DT_CICP_TRANSFER_CHARACTERISTICS_HLG = 18
+} dt_colorspaces_cicp_transfer_characteristics_t;
+
+/* CICP matrix coefficients (Recommendation ITU-T H.273) */
+typedef enum dt_colorspaces_cicp_matrix_coefficients_t
+{
+    DT_CICP_MATRIX_COEFFICIENTS_IDENTITY = 0,
+    DT_CICP_MATRIX_COEFFICIENTS_REC709 = 1,
+    DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED = 2,
+    DT_CICP_MATRIX_COEFFICIENTS_SYCC = 5,
+    DT_CICP_MATRIX_COEFFICIENTS_REC601 = 6,
+    DT_CICP_MATRIX_COEFFICIENTS_REC2020_NCL = 9,
+    DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL = 12
+} dt_colorspaces_cicp_matrix_coefficients_t;
+
 typedef struct dt_colorspaces_t
 {
   GList *profiles;
@@ -152,12 +189,20 @@ typedef struct dt_colorspaces_color_profile_t
   int work_pos;                             // position in working combo box, -1 if not applicable
 } dt_colorspaces_color_profile_t;
 
+typedef struct dt_colorspaces_cicp_t
+{
+    dt_colorspaces_cicp_color_primaries_t color_primaries;
+    dt_colorspaces_cicp_transfer_characteristics_t transfer_characteristics;
+    dt_colorspaces_cicp_matrix_coefficients_t matrix_coefficients;
+} dt_colorspaces_cicp_t;
+
 int mat3inv_float(float *const dst, const float *const src);
 int mat3inv_double(double *const dst, const double *const src);
 int mat3inv(float *const dst, const float *const src);
 
 /** populate the global color profile lists */
 dt_colorspaces_t *dt_colorspaces_init();
+
 /** cleanup on shutdown */
 void dt_colorspaces_cleanup(dt_colorspaces_t *self);
 
@@ -213,6 +258,7 @@ void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l);
 
 /** trigger updating the display profile from the system settings (x atom, colord, ...) */
 void dt_colorspaces_set_display_profile(const dt_colorspaces_color_profile_type_t profile_type);
+
 /** get the profile described by type & filename.
  *  this doesn't support image specifics like embedded profiles or camera matrices */
 const dt_colorspaces_color_profile_t *
@@ -223,6 +269,9 @@ dt_colorspaces_get_profile(dt_colorspaces_color_profile_type_t type, const char 
  *  fullname is always the fullpathname to the profile and filename may be a full pathname
  *  or just a base name */
 gboolean  dt_colorspaces_is_profile_equal(const char *fullname, const char *filename);
+
+/** try to infer profile type from CICP */
+dt_colorspaces_color_profile_type_t dt_colorspaces_cicp_to_type(const dt_colorspaces_cicp_t *cicp, const char *filename);
 
 /** update the display transforms of srgb and adobergb to the display profile.
  * make sure that darktable.color_profiles->xprofile_lock is held when calling this! */

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -22,7 +22,7 @@
 #include "config.h"
 #endif
 
-#include "common/darktable.h"
+#include "common/colorspaces.h"
 #include "common/dtpthread.h"
 #include "develop/format.h"
 #include <glib.h>

--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -30,15 +30,11 @@
 #include <strings.h>
 
 #include "control/control.h"
-#include "common/colorspaces.h"
-#include "common/darktable.h"
 #include "common/exif.h"
 #include "control/conf.h"
 #include "develop/develop.h"
 #include "imageio.h"
 #include "imageio_avif.h"
-
-#include <avif/avif.h>
 
 dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
                                          const char *filename,
@@ -190,12 +186,17 @@ out:
   return ret;
 }
 
-dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, struct avif_color_profile *cp)
+int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorspaces_cicp_t *cicp)
 {
-  dt_imageio_retval_t ret;
+  /* set default return values */
+  int size = 0;
+  *out = NULL;
+  cicp->color_primaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+  cicp->transfer_characteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+  cicp->matrix_coefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+
   avifDecoder *decoder = NULL;
   avifImage avif_image = {0};
-  avifImage *avif = NULL;
   avifResult result;
 
   decoder = avifDecoderCreate();
@@ -204,7 +205,6 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to create AVIF decoder for image [%s]\n",
              filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
 
@@ -214,204 +214,28 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to parse AVIF image [%s]: %s\n",
              filename, avifResultToString(result));
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
-  avif = &avif_image;
 
-  if(avif->icc.size > 0)
+  if(avif_image.icc.size > 0)
   {
-    avifRWData icc = avif->icc;
+    avifRWData *icc = &avif_image.icc;
 
-    if(icc.data == NULL)
-    {
-      ret = DT_IMAGEIO_FILE_CORRUPTED;
-      goto out;
-    }
+    if(icc->data == NULL) goto out;
 
-    uint8_t *data = (uint8_t *)g_malloc(icc.size);
-    memcpy(data, icc.data, icc.size);
-
-    cp->icc_profile_size = icc.size;
-    cp->icc_profile = data;
-  } else {
-    switch(avif->colorPrimaries) {
-    /*
-     * BT709
-     */
-    case AVIF_COLOR_PRIMARIES_BT709:
-
-      switch (avif->transferCharacteristics) {
-      /*
-       * SRGB
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_SRGB:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
-        case AVIF_MATRIX_COEFFICIENTS_BT470BG: /* BT601 coeffs */ 
-        case AVIF_MATRIX_COEFFICIENTS_BT709: /* support incorrectly tagged legacy files */
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_SRGB;
-          break;
-        default:
-          break;
-        }
-
-        break; /* SRGB */
-
-      /*
-       * BT709
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_BT709:
-      case AVIF_TRANSFER_CHARACTERISTICS_BT470M: /* support incorrectly tagged legacy files */
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_BT709:
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_REC709;
-          break;
-        default:
-          break;
-        }
-
-        break; /* GAMMA22 BT709 */
-
-      /*
-       * LINEAR BT709
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_BT709:
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_LIN_REC709;
-          break;
-        default:
-          break;
-        }
-
-        break; /* LINEAR BT709 */
-
-      default:
-        break;
-      }
-
-      break; /* BT709 */
-
-    /*
-     * BT2020
-     */
-    case AVIF_COLOR_PRIMARIES_BT2020:
-
-      switch (avif->transferCharacteristics) {
-      /*
-       * LINEAR BT2020
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_LIN_REC2020;
-          break;
-        default:
-          break;
-        }
-
-        break; /* LINEAR BT2020 */
-
-      /*
-       * PQ BT2020
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_PQ_REC2020;
-          break;
-        default:
-          break;
-        }
-
-        break; /* PQ BT2020 */
-
-      /*
-       * HLG BT2020
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_HLG:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_HLG_REC2020;
-          break;
-        default:
-          break;
-        }
-
-        break; /* HLG BT2020 */
-
-      default:
-        break;
-      }
-
-      break; /* BT2020 */
-
-    /*
-     * P3
-     */
-    case AVIF_COLOR_PRIMARIES_SMPTE432:
-
-      switch (avif->transferCharacteristics) {
-      /*
-       * PQ P3
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_PQ_P3;
-          break;
-        default:
-          break;
-        }
-
-        break; /* PQ P3 */
-
-      /*
-       * HLG P3
-       */
-      case AVIF_TRANSFER_CHARACTERISTICS_HLG:
-
-        switch (avif->matrixCoefficients) {
-        case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-          cp->type = DT_COLORSPACE_HLG_P3;
-          break;
-        default:
-          break;
-        }
-
-        break; /* HLG P3 */
-
-      default:
-        break;
-      }
-
-      break; /* P3 */
-
-    default:
-      dt_print(DT_DEBUG_IMAGEIO,
-               "Unsupported color profile for %s\n",
-               filename);
-      break;
-    }
+    *out = (uint8_t *)g_malloc0(icc->size);
+    memcpy(*out, icc->data, icc->size);
+    size = icc->size;
+  }
+  else
+  {
+    cicp->color_primaries = avif_image.colorPrimaries;
+    cicp->transfer_characteristics = avif_image.transferCharacteristics;
+    cicp->matrix_coefficients = avif_image.matrixCoefficients;
   }
 
-  ret = DT_IMAGEIO_OK;
 out:
   avifDecoderDestroy(decoder);
 
-  return ret;
+  return size;
 }

--- a/src/common/imageio_avif.h
+++ b/src/common/imageio_avif.h
@@ -20,18 +20,11 @@
 
 #pragma once
 
-#include "common/colorspaces.h"
 #include "common/image.h"
 #include "common/mipmap_cache.h"
-
-struct avif_color_profile {
-    dt_colorspaces_color_profile_type_t type;
-    size_t icc_profile_size;
-    uint8_t *icc_profile;
-};
 
 dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
                                          const char *filename,
                                          dt_mipmap_buffer_t *buf);
-dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename,
-                                                       struct avif_color_profile *cp);
+
+int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorspaces_cicp_t *cicp);


### PR DESCRIPTION
Factors out the color profile detection and parsing from the AVIF reader into the general colorspace methods.

This will simplify [the pending addition of HEIF reader](https://github.com/darktable-org/darktable/pull/8800) and future readers like [JXL](https://github.com/libjxl/libjxl/blob/main/lib/include/jxl/color_encoding.h) which can also use CICP codes alongside ICC profiles.