### PR TITLE
Improve crawler

### DIFF
--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -410,9 +410,14 @@ void dt_control_crawler_show_image_list(GList *images)
                                                     DT_CONTROL_CRAWLER_COL_SELECTED, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
 
-  column = gtk_tree_view_column_new_with_attributes(_("path"), gtk_cell_renderer_text_new(), "text",
+  GtkCellRenderer *renderer_text = gtk_cell_renderer_text_new();
+  column = gtk_tree_view_column_new_with_attributes(_("path"), renderer_text, "text",
                                                     DT_CONTROL_CRAWLER_COL_IMAGE_PATH, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+  gtk_tree_view_column_set_expand(column, TRUE);
+  gtk_tree_view_column_set_resizable(column, TRUE);
+  gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(200));
+  g_object_set(renderer_text, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, NULL);
 
   column = gtk_tree_view_column_new_with_attributes(_("xmp timestamp"), gtk_cell_renderer_text_new(), "text",
                                                     DT_CONTROL_CRAWLER_COL_TS_XMP, NULL);


### PR DESCRIPTION
Fix the easy stuff from #10164.

![Screenshot_20211008_200956](https://user-images.githubusercontent.com/2779157/136616870-16a88739-e2a3-4662-86b2-3374a4f18cbd.png)

1. Remove the toggle button logic that used part of default Gtk `TreeView` selection methods and part of custom stuff,
2. Use only Gtk `TreeView` methods, which easily enable:
    1. Range selection through `Shift+Click`,
    2. Grouped selection through `Ctrl+Click`,
    3. Select all through `Ctrl+A`,
3. Rename the older buttons with more explicite names (reload and overwrite were not clear enough):
    1. Keep the xmp edit,
    2. Keep the database edit,
4. Add 2 options:
    1. Keep the oldest edit (regardless of its origin),
    2. Keep the newest edit (regardless of its origin),
5. Make the "select all" toggle button a standard button, add it "select none" and "invert selection",
6. Add new columns:
    1. "newest", to quickly show which of xmp or database is the most recent (avoids the pain of comparing timestamps in your head for very large image sets),
    2. "time difference", to quickly show how much newer the newest edit is.
7. Code refactoring.