### PR TITLE
correctly display change indicator when resetting some prefs

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2970,7 +2970,7 @@
   <dtconfig prefs="processing" section="general" restart="true">
     <name>plugins/darkroom/lut3d/def_path</name>
     <type>dir</type>
-    <default></default>
+    <default>$(home)</default>
     <shortdescription>3D lut root folder</shortdescription>
     <longdescription>this folder (and sub-folders) contains Lut files used by lut3d modules. (need a restart).</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -171,7 +171,7 @@
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
     <default>(1024 * 1024 * 512)</default>
-    <shortdescription>memory in megabytes to use for thumbnail cache</shortdescription>
+    <shortdescription>memory in MB to use for thumbnail cache</shortdescription>
     <longdescription>this controls how much memory is going to be used for thumbnails and other buffers (needs a restart).</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -794,6 +794,7 @@ gboolean dt_conf_is_default(const char *name)
   case DT_BOOL:
     return dt_conf_get_bool(name) == dt_confgen_get_bool(name, DT_DEFAULT);
     break;
+  case DT_PATH:
   case DT_STRING:
   case DT_ENUM:
   default:
@@ -805,6 +806,34 @@ gboolean dt_conf_is_default(const char *name)
     }
   }
 }
+
+gchar* dt_conf_expand_default_dir(const char *dir)
+{
+  // expand special dirs
+#define CONFIG_DIR "$(config)"
+#define HOME_DIR   "$(home)"
+
+  gchar *path = NULL;
+  if(g_str_has_prefix(dir, CONFIG_DIR))
+  {
+    gchar configdir[PATH_MAX] = { 0 };
+    dt_loc_get_user_config_dir(configdir, sizeof(configdir));
+    path = g_strdup_printf("%s%s", configdir, dir + strlen(CONFIG_DIR));
+  }
+  else if(g_str_has_prefix(dir, HOME_DIR))
+  {
+    gchar *homedir = dt_loc_get_home_dir(NULL);
+    path = g_strdup_printf("%s%s", homedir, dir + strlen(HOME_DIR));
+    g_free(homedir);
+  }
+  else path = g_strdup(dir);
+
+  gchar *normalized_path = dt_util_normalize_path(path);
+  g_free(path);
+
+  return normalized_path;
+}
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -34,6 +34,7 @@ typedef enum dt_confgen_type_t
   DT_INT64,
   DT_FLOAT,
   DT_BOOL,
+  DT_PATH,
   DT_STRING,
   DT_ENUM
 } dt_confgen_type_t;
@@ -122,6 +123,7 @@ const char *dt_confgen_get_label(const char *name);
 const char *dt_confgen_get_tooltip(const char *name);
 
 gboolean dt_conf_is_default(const char *name);
+gchar* dt_conf_expand_default_dir(const char *dir);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/tools/generate_darktablerc_conf.xsl
+++ b/tools/generate_darktablerc_conf.xsl
@@ -97,6 +97,7 @@ static void _insert_type(const char *name, const char *value)
   else if (!strcmp(value, "bool"))  item->type = DT_BOOL;
   else if (!strcmp(value, "float")) item->type = DT_FLOAT;
   else if (!strcmp(value, "enum"))  item->type = DT_ENUM;
+  else if (!strcmp(value, "dir"))   item->type = DT_PATH;
   else                              item->type = DT_STRING;
 }
 
@@ -146,10 +147,6 @@ void dt_confgen_init()
 
     <xsl:text>   // </xsl:text><xsl:value-of select="$name" />
     <xsl:text>&#xA;</xsl:text>
-    <xsl:text>   _insert_default("</xsl:text><xsl:value-of select="$name" />
-    <xsl:text>", "</xsl:text><xsl:apply-templates select="default"/>
-    <xsl:text>");</xsl:text>
-    <xsl:text>&#xA;</xsl:text>
 
     <xsl:apply-templates select="type"/>
 
@@ -185,6 +182,24 @@ void dt_confgen_init()
       <xsl:text>", "</xsl:text><xsl:value-of select="."/>
       <xsl:text>");</xsl:text>
       <xsl:text>&#xA;</xsl:text>
+    </xsl:otherwise>
+  </xsl:choose>
+
+  <xsl:choose>
+    <xsl:when test="../type = 'dir'">
+      <xsl:text>   gchar *default_path = dt_conf_expand_default_dir("</xsl:text><xsl:apply-templates select="../default"/>
+	  <xsl:text>");</xsl:text>
+	  <xsl:text>&#xA;</xsl:text>
+      <xsl:text>   _insert_default("</xsl:text><xsl:value-of select="../name" />
+	  <xsl:text>", default_path);</xsl:text>
+	  <xsl:text>&#xA;</xsl:text>
+	  <xsl:text>   g_free(default_path);&#xA;</xsl:text>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:text>   _insert_default("</xsl:text><xsl:value-of select="../name" />
+	  <xsl:text>", "</xsl:text><xsl:apply-templates select="../default"/>
+	  <xsl:text>");</xsl:text>
+	  <xsl:text>&#xA;</xsl:text>
     </xsl:otherwise>
   </xsl:choose>
 

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -594,12 +594,12 @@ gboolean restart_required = FALSE;
   </xsl:template>
 
   <xsl:template match="dtconfig[type='dir']" mode="reset">
-    <xsl:text>
-      dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", "</xsl:text><xsl:value-of select="default"/><xsl:text>");
-      gchar *folder = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
-      gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(widget), folder);
-      g_free(folder);
-    </xsl:text>
+    <xsl:text>    gchar *path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
+    dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", path);
+    g_free(path);
+    path = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
+    gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(widget), path);
+    g_free(path);</xsl:text>
   </xsl:template>
 
 <!-- CALLBACK -->
@@ -644,16 +644,13 @@ gboolean restart_required = FALSE;
     gtk_tree_model_get(gtk_combo_box_get_model(GTK_COMBO_BOX(widget)), &amp;iter, 0, &amp;s, -1);
     dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", s);
     g_free(s);
-  }
-</xsl:text>
+  }</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='dir']" mode="change">
-    <xsl:text>
-    gchar *folder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
-    dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", folder);
-    g_free(folder);
-    </xsl:text>
+    <xsl:text>  gchar *folder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
+  dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", folder);
+  g_free(folder);</xsl:text>
   </xsl:template>
 
 <!-- TAB -->
@@ -707,7 +704,9 @@ gboolean restart_required = FALSE;
     <xsl:text>g_signal_connect(G_OBJECT(widget), "selection-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
     <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
-    snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
+    gchar *default_path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
+    snprintf(tooltip, 1024, _("double click to reset to `%s'"), default_path);
+    g_free(default_path);
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
     </xsl:text>
   </xsl:template>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -94,7 +94,7 @@ static void set_widget_label_default(GtkWidget *widget, const char *confstr, Gtk
     gchar *c_state = NULL;
     gtk_tree_model_iter_nth_child(model, &iter, NULL, active);
     gtk_tree_model_get(model, &iter, 0, &c_state, -1);
-    is_default = (strcmp(c_state, c_default) == 0);
+    is_default = (g_strcmp0(c_state, c_default) == 0);
   }
   else if(GTK_IS_SPIN_BUTTON(widget))
   {
@@ -107,13 +107,13 @@ static void set_widget_label_default(GtkWidget *widget, const char *confstr, Gtk
   {
     const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
     const gchar *c_state = gtk_entry_get_text(GTK_ENTRY(widget));
-    is_default = (strcmp(c_state, c_default) == 0);
+    is_default = (g_strcmp0(c_state, c_default) == 0);
   }
   else if(GTK_IS_FILE_CHOOSER(widget))
   {
     const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
     const gchar *c_state = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
-    is_default = (strcmp(c_state, c_default) == 0);
+    is_default = (g_strcmp0(c_state, c_default) == 0);
   }
   else
   {


### PR DESCRIPTION
This PR will fix #10141 ~~(partially)~~, by securing that the "preference changed" circle indicator is correctly updated upon reset.

1.  Memory in MB to use for thumbnail cache
Here the "factor" logic was implemented not 100% correctly, basically the reset didn't work whenever  `factor != 1.0` (only one case so far)

2.  3D lut root folder
The signal handling was incorrect for file chooser buttons, plus code to update the indicator was missing. Now it works if a meaningful default path is set in `darktableconfig.xml.in`.
~~However: the default path ATM can only be a static string representing an absolute path and that can't never work for all OSs.
The solution could be perhaps to implement variables, but I don't believe it is worth the effort for only one case~~