### PR TITLE
Add new lua event - darkroom-image-history-changed

### DIFF
--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -659,6 +659,12 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L,"selection-changed");
+
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "darkroom-image-history-changed");
+
   return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -958,6 +958,13 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
     if((xmp_mode == DT_WRITE_XMP_ALWAYS) || ((xmp_mode == DT_WRITE_XMP_LAZY) && !fresh))
       dt_image_synch_xmp(dev->image_storage.id);
     dt_history_hash_set_mipmap(dev->image_storage.id);
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "darkroom-image-history-changed",
+        LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(dev->image_storage.id),
+        LUA_ASYNC_DONE);
+#endif
   }
 
   // cleanup visible masks
@@ -3160,6 +3167,13 @@ void leave(dt_view_t *self)
     if((xmp_mode == DT_WRITE_XMP_ALWAYS) || ((xmp_mode == DT_WRITE_XMP_LAZY) && !fresh))
       dt_image_synch_xmp(dev->image_storage.id);
     dt_history_hash_set_mipmap(dev->image_storage.id);
+#ifdef USE_LUA
+    dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+        0, NULL, NULL,
+        LUA_ASYNC_TYPENAME, "const char*", "darkroom-image-history-changed",
+        LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(dev->image_storage.id),
+        LUA_ASYNC_DONE);
+#endif
   }
 
   // clear gui.


### PR DESCRIPTION
Add a new lua event, darkroom-image-history-changed, that is triggered when changing images or leaving darkroom view if the image has been modified.