### PR TITLE
common:dwt: Add missing include for __DT_CLONE_TARGETS__

### DIFF
--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "common/darktable.h"
 #include "common/imagebuf.h"
 #include "control/control.h"
 #include "develop/imageop.h"


### PR DESCRIPTION
```
In file included from src/common/dwt.c:19:
src/common/imagebuf.h:59:21: error: expected ';' before 'static'
   59 | __DT_CLONE_TARGETS__
      |                     ^
      |                     ;
   60 | static inline void dt_simd_memcpy(const float *const __restrict__ in,
      | ~~~~~~
```