### PR TITLE
actions don't check visibility of missing widgets

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2904,7 +2904,7 @@ static float _process_action(dt_action_t *action, int instance,
 
     if(definition && definition->process
         && (action->type < DT_ACTION_TYPE_WIDGET
-            || definition->no_widget
+            || !action_target
             || !_widget_invisible(action_target)))
       return_value = definition->process(action_target, element, effect, move_size);
     else if(!isnan(move_size))


### PR DESCRIPTION
fixes #10181 

The rating actions are linked to the row of stars in the bottom bar in the lighttable, but as well to the stars in the thumbnail overlays, so you can see (or assign) thumbnails via both routes. The last widget that was created gets assigned to the action. However we don't need to know the widget to perform the action, so don't check its visibility, because it may just have been deleted when the thumbnail was hidden.