### PR TITLE
filmicrgb: make slope at gray point only depend on contrast

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -198,6 +198,9 @@ You are strongly advised to take a backup first.
 
 - Add a search box in preset preferences and shortcuts.
 
+- Improved curve handling in filmic. Curve should be easier to control, as
+  some side-effects of some parameters on others have been eliminated.
+
 ## Bug Fixes
 
 - Multiple memory leaks have been fixed.

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -425,6 +425,14 @@ static inline void convert_to_spline_v3(dt_iop_filmicrgb_params_t* n)
   else
     balance = -0.5f * (1.0f - fmaxf(grey_display - toe_display, 0.0f) / fmaxf(grey_display - toe_display_ref, 1E-5f));
 
+  if(n->spline_version == DT_FILMIC_SPLINE_VERSION_V1)
+  {
+    // black and white point need to be updated as well,
+    // as code path for v3 will raise them to power 1.0f / hardness,
+    // while code path for v1 did not.
+    n->black_point_target = powf(black_display, hardness) * 100.0f;
+    n->white_point_target = powf(white_display, hardness) * 100.0f;
+  }
   n->latitude = latitude * 100.0f;
   n->contrast = contrast;
   n->balance = balance * 100.0f;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -186,8 +186,8 @@ typedef struct dt_iop_filmicrgb_params_t
   float black_point_target; // $MIN: 0.000 $MAX: 20.000 $DEFAULT: 0.01517634 $DESCRIPTION: "target black luminance"
   float white_point_target; // $MIN: 0 $MAX: 1600 $DEFAULT: 100 $DESCRIPTION: "target white luminance"
   float output_power;       // $MIN: 1 $MAX: 10 $DEFAULT: 4.0 $DESCRIPTION: "hardness"
-  float latitude;           // $MIN: 0.01 $MAX: 99 $DEFAULT: 25.0
-  float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.35
+  float latitude;           // $MIN: 0.01 $MAX: 99 $DEFAULT: 50.0
+  float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.1
   float saturation;         // $MIN: -50 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "extreme luminance saturation"
   float balance;            // $MIN: -50 $MAX: 50 $DEFAULT: 0.0 $DESCRIPTION: "shadows ↔ highlights balance"
   float noise_level;        // $MIN: 0.0 $MAX: 6.0 $DEFAULT: 0.2f $DESCRIPTION: "add noise in highlights"
@@ -3866,7 +3866,7 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("look"), NULL);
 
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
-  dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
+  dt_bauhaus_slider_set_soft_range(g->contrast, 0.5, 3.0);
   dt_bauhaus_slider_set_digits(g->contrast, 3);
   dt_bauhaus_slider_set_step(g->contrast, .01);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
@@ -3879,7 +3879,7 @@ void gui_init(dt_iop_module_t *self)
                                                  "decrease to mute highlights."));
 
   g->latitude = dt_bauhaus_slider_from_params(self, N_("latitude"));
-  dt_bauhaus_slider_set_soft_range(g->latitude, 0.1, 50.0);
+  dt_bauhaus_slider_set_soft_range(g->latitude, 0.1, 90.0);
   dt_bauhaus_slider_set_format(g->latitude, "%.2f %%");
   gtk_widget_set_tooltip_text(g->latitude,
                               _("width of the linear domain in the middle of the curve,\n"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2215,10 +2215,12 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
 
     // Apply the highlights/shadows balance as a shift along the contrast slope
     // negative values drag to the left and compress the shadows, on the UI negative is the inverse
-    float balance_correction = (balance > 0.0f) ? 2.0f * balance * fminf(toe_log - xmin, shoulder_log - grey_log)
-                                                : 2.0f * balance * fminf(grey_log - toe_log, xmax - shoulder_log);
+    float balance_correction = (balance > 0.0f) ? 2.0f * balance * (shoulder_log - grey_log)
+                                                : 2.0f * balance * (grey_log - toe_log);
     toe_log -= balance_correction;
     shoulder_log -= balance_correction;
+    toe_log = fmaxf(toe_log, xmin);
+    shoulder_log = fminf(shoulder_log, xmax);
 
     // y coordinates
     toe_display = (toe_log * contrast + linear_intercept);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3000,12 +3000,19 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       float y = filmic_spline(value, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4, g->spline.M5,
                               g->spline.latitude_min, g->spline.latitude_max, g->spline.type);
 
-      if(y > g->spline.y[4] + 1E-5)
+      // curve is drawn in orange when above maximum
+      // or below minimum.
+      // we use a small margin in the comparison
+      // to avoid drawing curve in orange when it
+      // is right above or right below the limit
+      // due to floating point errors
+      const float margin = 1E-5;
+      if(y > g->spline.y[4] + margin)
       {
         y = fminf(y, 1.0f);
         cairo_set_source_rgb(cr, 0.75, .5, 0.);
       }
-      else if(y < g->spline.y[0] - 1E-5)
+      else if(y < g->spline.y[0] - margin)
       {
         y = fmaxf(y, 0.f);
         cairo_set_source_rgb(cr, 0.75, .5, 0.);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -378,6 +378,9 @@ inline static gboolean dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_p
 // convert parameters from spline v1 or v2 to spline v3
 static inline void convert_to_spline_v3(dt_iop_filmicrgb_params_t* n)
 {
+  if(n->spline_version == DT_FILMIC_SPLINE_VERSION_V3)
+    return;
+
   dt_iop_filmic_rgb_spline_t spline;
   dt_iop_filmic_rgb_compute_spline(n, &spline);
   


### PR DESCRIPTION
Fixes #9979 
The PR is work in progress, as **it does not handle backward compatibility yet nor opencl.**

I noticed that slope of central part of filmic actually depends on a lot of parameters, while I thought it was meant to be controled by contrast only.
It depends both on white and black relative exposure, and on hardness (even when hidden), and on contrast of course.

This leads to misleading behavior, like the fact that increasing white relative exposure helps to recover the shadows.

Dependency on white and black relative exposure was due to the fact that we divide the input by dynamic range before applying the curve. This is easy to correct, by multiplying contrast by dynamic range: `x*c = (x/DR) * (c*DR)`

Dependency on hardness is a bit more complicated to correct, but not really hard either, we just have to compensate for the derivative of the power function at gray point.

Examples:
Before (notice the huge change of slope, while contrast value was not changed at all):

![Capture d’écran du 2021-10-15 21-46-04](https://user-images.githubusercontent.com/34063828/137548374-c5e82a58-5bac-41ad-92fa-c0b8c727574f.png)
![Capture d’écran du 2021-10-15 21-46-10](https://user-images.githubusercontent.com/34063828/137548379-12f00e26-479d-426e-b22c-225ae79789b8.png)

After (slope at gray point remains the same, result depends less on the values of white and black exposure, and depends mostly on contrast actually):
![Capture d’écran du 2021-10-15 21-47-05](https://user-images.githubusercontent.com/34063828/137548437-630993b3-133d-4592-bcbe-18bb9f1974b1.png)
![Capture d’écran du 2021-10-15 21-47-12](https://user-images.githubusercontent.com/34063828/137548438-d0b5d40f-25bd-492b-a945-8f25fc13f972.png)

(of course, these edits were just for demonstration purpose, but sorry anyway for your eyes ;-) )