### PR TITLE
Fix memory alignment issue in tone equalizer

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -347,6 +347,12 @@ void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 int dt_worker_threads();
 void *dt_alloc_align(size_t alignment, size_t size);
+static inline void* dt_calloc_align(size_t alignment, size_t size)
+{
+  void *buf = dt_alloc_align(alignment, size);
+  if(buf) memset(buf, 0, size);
+  return buf;
+}
 static inline float *dt_alloc_align_float(size_t pixels)
 {
   return (float*)__builtin_assume_aligned(dt_alloc_align(64, pixels * sizeof(float)), 64);

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -25,7 +25,9 @@
 #define DT_RESTRICT restrict
 #endif
 
-/* Helper to force heap vectors to be aligned on 64 bits blocks to enable AVX2 */
+// Helper to force heap vectors to be aligned on 64 byte blocks to enable AVX2
+// If this is applied to a struct member and the struct is allocated on the heap, then it must be allocated
+// on a 64 byte boundary to avoid crashes or undefined behavior because of unaligned memory access.
 #define DT_ALIGNED_ARRAY __attribute__((aligned(64)))
 #define DT_ALIGNED_PIXEL __attribute__((aligned(16)))
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -482,7 +482,8 @@ char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
 
 static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
 {
-  module->gui_data = (dt_iop_gui_data_t*)calloc(1, size);
+  // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct
+  module->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(64, size);
   dt_pthread_mutex_init(&module->gui_lock,NULL);
   return module->gui_data;
 }
@@ -490,7 +491,7 @@ static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t 
   (dt_iop_##module##_gui_data_t *)_iop_gui_alloc(self,sizeof(dt_iop_##module##_gui_data_t))
 
 #define IOP_GUI_FREE \
-  dt_pthread_mutex_destroy(&self->gui_lock);if(self->gui_data){free(self->gui_data);} self->gui_data = NULL
+  dt_pthread_mutex_destroy(&self->gui_lock);if(self->gui_data){dt_free_align(self->gui_data);} self->gui_data = NULL
 
 /* return a warning message, prefixed by the special character ⚠ */
 char *dt_iop_warning_message(const char *message);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -211,7 +211,7 @@ typedef struct dt_iop_toneequalizer_global_data_t
 
 typedef struct dt_iop_toneequalizer_gui_data_t
 {
-  // Mem arrays 64-bits aligned - contiguous memory
+  // Mem arrays 64-bytes aligned - contiguous memory
   float factors[PIXEL_CHAN] DT_ALIGNED_ARRAY;
   float gui_lut[UI_SAMPLES] DT_ALIGNED_ARRAY; // LUT for the UI graph
   float interpolation_matrix[CHANNELS * PIXEL_CHAN] DT_ALIGNED_ARRAY;
@@ -1597,13 +1597,13 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = calloc(1, sizeof(dt_iop_toneequalizer_data_t));
+  piece->data = dt_calloc_align(64, sizeof(dt_iop_toneequalizer_data_t));
 }
 
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  free(piece->data);
+  dt_free_align(piece->data);
   piece->data = NULL;
 }
 


### PR DESCRIPTION
Fixes #10202.

The problem was that the DT_ALIGNED_ARRAY attribute applied to members of dt_iop_toneequalizer_gui_data_t was telling the compiler that those members would be aligned to a 64 byte boundary, but gui_data was being allocated on the heap with only 16 byte alignment. The compiler vectorized the assignment to temp_user_params at toneequal.c:2081 using an AVX2 instruction that required 32 byte alignment, and when gui_data was not on a 32 byte boundary the segfault occurred.

I'm not sure if this is the best solution to the problem or if the same issue exists somewhere else - a quick check of usages of DT_ALIGNED_ARRAY didn't show any other cases where it was applied to a struct member that would be similarly affected, but I might have missed something.