### PR TITLE
denoiseprofile: fix partially black thumbnails in lighttable

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1024,6 +1024,7 @@ static inline void precondition_Y0U0V0(const float *const in, float *const buf, 
       }
       buf[j+c] = sum;
     }
+    buf[j+3] = 0;
   }
 }
 


### PR DESCRIPTION
I sometimes (depending on previous actions) get partially black thumbnails in lighttable when using profiled denoise in Y0U0V0 wavelets mode (auto or not), see example screenshot (OpenCL disabled):
![Screenshot 2021-10-17 at 17 13 52](https://user-images.githubusercontent.com/2099800/137633534-c6bddda0-e809-4567-972c-89a6d02c69ab.png)

I tracked it down to uninitialized 4th channel of precond buffer, zeroing it out fixes the issue for me, hence this PR. No idea about the maths, obviously somewhere later in the algorithm this 4th channel is used and correct result is only produced when it's zero. So maybe the real bug is that this "unused" channel is accessed at all, though I suspect it's done for faster computations and doing full write over the allocated buffer seems right in any case. Pinging @ralfbrown and @rawfiner to review.