### PR TITLE
ashift: rename to rotate and perspective

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -117,12 +117,12 @@ DT_MODULE_INTROSPECTION(5, dt_iop_ashift_params_t)
 
 const char *name()
 {
-  return _("rotation and perspective");
+  return _("rotate and perspective");
 }
 
 const char *aliases()
 {
-  return _("rotate|keystone|distortion|crop|reframe");
+  return _("rotation|keystone|distortion|crop|reframe");
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -301,7 +301,7 @@ static inline void adjust_aabb(const float *p, float *aabb)
 
 const char *deprecated_msg()
 {
-  return _("this module is deprecated. please use the crop and/or rotation and perspective modules instead.");
+  return _("this module is deprecated. please use the crop and/or rotate and perspective modules instead.");
 }
 
 const char *name()


### PR DESCRIPTION
better fits with the naming conventions previously used in crop and rotate