### PR TITLE
fix copy&import path in Windows

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -114,7 +114,11 @@ static gchar *_import_session_path_pattern()
   }
 
 #ifdef WIN32
-  res = g_build_path("\\\\", base, sub, (char *)NULL);
+  gchar *s1 = dt_str_replace(base, "/", "\\\\");
+  gchar *s2 = dt_str_replace(sub, "/", "\\\\");
+  res = g_build_path("\\\\", s1, s2, (char *)NULL);
+  g_free(s1);
+  g_free(s2);
 #else
   res = g_build_path(G_DIR_SEPARATOR_S, base, sub, (char *)NULL);
 #endif

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -960,6 +960,15 @@ char *dt_copy_filename_extension(const char *filename1, const char *filename2)
   return output;
 }
 
+// replaces all occurences of a substring in a string
+gchar *dt_str_replace(const char *string, const char *search, const char *replace)
+{
+  gchar **split = g_strsplit(string, search, -1);
+  gchar *res = g_strjoinv(replace, split);
+  g_strfreev(split);
+  return res;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -110,6 +110,9 @@ gboolean dt_has_same_path_basename(const char *filename1, const char *filename2)
 // set the filename2 extension to filename1 - return NULL if fails - result should be freed
 char *dt_copy_filename_extension(const char *filename1, const char *filename2);
 
+// replaces all occurences of a substring in a string
+gchar *dt_str_replace(const char *string, const char *search, const char *replace);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
This fixes #10232, a corner case for Copy & Import in Windows.
C&I works well when using the file chooser to select the base directory or when user manually inputs the path using `\\` as separator, but it has an issue when user manually uses `/`
Import works as Windows supports both separators, however the folders are not displayed correctly in the collection.
Instead of patching every time the way those path are manipulated, I prefer to solve the issue by replacing all `/` with `\\` at import.
I had to define a utility function for this, can be handy for other cases.

