### PR TITLE
fix module headers help links

### DIFF
--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -78,7 +78,7 @@ dt_help_url urls_db[] =
   {"lighttable_filemanager",     "lighttable/lighttable-modes/filemanager/"},
   {"lighttable_zoomable",        "lighttable/lighttable-modes/zoomable-lighttable/"},
   {"darkroom_bottom_panel",      "darkroom/darkroom-view-layout/#bottom-panel"},
-  {"module_interacting",         "darkroom/interacting-with-modules/"},
+  {"module_header",              "darkroom/processing-modules/module-header/"},
   {"tethering_session",          "module-reference/utility-modules/tethering/session/"},
   {"tethering_live_view",        "module-reference/utility-modules/tethering/live-view/"},
   {"module_toolbox",             NULL},

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2485,7 +2485,9 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   for(int i = 0; i < IOP_MODULE_LAST; i++)
     if(hw[i]) dt_action_define(&module->so->actions, NULL, NULL, hw[i], NULL);
 
-  dt_gui_add_help_link(header, dt_get_help_url("module_interacting"));
+  dt_gui_add_help_link(header, dt_get_help_url("module_header"));
+  // for the module label, point to module specific help page
+  dt_gui_add_help_link(hw[IOP_MODULE_LABEL], dt_get_help_url(module->op));
 
   gtk_widget_set_halign(hw[IOP_MODULE_LABEL], GTK_ALIGN_START);
   gtk_widget_set_halign(hw[IOP_MODULE_INSTANCE], GTK_ALIGN_END);


### PR DESCRIPTION
this fix #10256 

- for the header label : point to the module specific help page
- for the header icons, fix the link (thanks @elstoc )