### PR TITLE
darkroom : avoid errors if image is not supported

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -647,6 +647,7 @@ void expose(
       {
         dev->image_invalid_cnt = 0;
         dt_view_manager_switch(darktable.view_manager, "lighttable");
+        return;
       }
     }
     else


### PR DESCRIPTION
as said in #10258 dt shouldn't throw errors if the image is not supported.
I'm not exactly sure this fix the mentioned crash (I can't reproduce) but at least here it fix some gtk errors/warnings