### PR TITLE
add possibility to bypass pragma quick_check on launch

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -127,6 +127,13 @@
     <shortdescription>how many snapshots to keep</shortdescription>
     <longdescription>after successfully creating snapshot, how many older snapshots to keep (excluding mandatory version update ones). enter -1 to keep all snapshots\nkeep in mind that snapshots do take some space and you only need the most recent one for successful restore</longdescription>
   </dtconfig>
+  <dtconfig prefs="storage" section="database">
+    <name>database/quick_check</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>perform quick_check pragma on launch</shortdescription>
+    <longdescription>in some cases the launch of darktable can take up to 1 min. This happens only after a system boot and only if you have imported a large number of pictures (>= 40k ~ 60k).\nNot doing this systematic check at startup can significantly reduce this time, but does not allow to identify any inconsistency in the DB at startup.\nNevertheless, to get back to normal launch times, you should also uncheck \"look for updated xmp files on startup\"</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>min_panel_width</name>
     <type>int</type>
@@ -318,6 +325,13 @@
     <default>only large entries</default>
     <shortdescription>store xmp tags in compressed format</shortdescription>
     <longdescription>entries in xmp tags can get rather large and may exceed the available space to store the history stack in output files. this option allows xmp tags to be compressed and save space.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="storage" section="xmp">
+    <name>run_crawler_on_start</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>look for updated xmp files on startup</shortdescription>
+    <longdescription>check file modification times of all xmp files on startup to check if any got updated in the meantime.\nIn some cases the launch of darktable can take up to 1 min. This happens only after a system boot and only if you have imported a large number of pictures (>= 40k ~ 60k).\nNot doing this systematic ckeck of xmp files at startup can significantly reduce this time, but does not allow to identify any inconsistency between xmp files and DB content.\nNevertheless, to get back to normal launch times, you should also uncheck \"perform quick_check pragma on launch\"</longdescription>
   </dtconfig>
   <dtconfig prefs="misc" section="tags">
     <name>omit_tag_hierarchy</name>
@@ -2973,13 +2987,6 @@
     <default>300</default>
     <shortdescription>DPI value for exported files</shortdescription>
     <longdescription/>
-  </dtconfig>
-  <dtconfig prefs="storage" section="xmp">
-    <name>run_crawler_on_start</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>look for updated xmp files on startup</shortdescription>
-    <longdescription>check file modification times of all xmp files on startup to check if any got updated in the meantime</longdescription>
   </dtconfig>
   <dtconfig prefs="security" section="other">
     <name>plugins/lighttable/audio_player</name>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2982,7 +2982,18 @@ start:
   }
   else
   {
-    gchar* data_status = _get_pragma_string_val(db->handle, "data.quick_check");
+    gchar* data_status;
+    if (dt_conf_get_bool("database/quick_check"))
+    {
+      data_status = _get_pragma_string_val(db->handle, "data.quick_check");
+      dt_print(DT_DEBUG_SQL, "[init sql] with data pragma.quick_check\n");
+    }
+    else
+    {
+      data_status = g_strdup("ok");
+      dt_print(DT_DEBUG_SQL, "[init sql] without data pragma.quick_check\n");
+    }
+
     rc = sqlite3_prepare_v2(db->handle, "select value from data.db_info where key = 'version'", -1, &stmt, NULL);
     if(!g_strcmp0(data_status, "ok") && rc == SQLITE_OK && sqlite3_step(stmt) == SQLITE_ROW)
     {
@@ -3159,7 +3170,18 @@ start:
     }
   }
 
-  gchar* libdb_status = _get_pragma_string_val(db->handle, "main.quick_check");
+  gchar* libdb_status;
+  if (dt_conf_get_bool("database/quick_check"))
+    {
+    libdb_status = _get_pragma_string_val(db->handle, "main.quick_check");
+    dt_print(DT_DEBUG_SQL, "[init sql] with library pragma.quick_check\n");
+    }
+    else
+    {
+    libdb_status = g_strdup("ok");
+    dt_print(DT_DEBUG_SQL, "[init sql] without library pragma.quick_check\n");
+    }
+
   // next we are looking at the library database
   // does the db contain the new 'db_info' table?
   rc = sqlite3_prepare_v2(db->handle, "select value from main.db_info where key = 'version'", -1, &stmt, NULL);


### PR DESCRIPTION
In some cases the launch of darktable can take up to 1 min. This happens only after a system boot and only if you have imported many pictures (>= 40k ~ 60k).
Not doing this systematic check at startup can significantly reduce this time, but does not allow identifying any inconsistency in the DB at startup.
Nevertheless, to get back to normal launch times, you should also uncheck "look for updated xmp files on startup"