### PR TITLE
DNG GainMap support

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -72,7 +72,8 @@ rawprepare_1f_gainmap(read_only image2d_t in, write_only image2d_t out,
   const int id = BL(ry+cy+y, rx+cx+x);
   float pixel_scaled = (pixel - sub[id]) / div[id];
 
-  const float2 map_pt = ((float2)(x, y) * im_to_rel - map_origin) * rel_to_map;
+  // Add 0.5 to compensate for CLK_FILTER_LINEAR subtracting 0.5 from the specified coordinates
+  const float2 map_pt = ((float2)(rx+cx+x,ry+cy+y) * im_to_rel - map_origin) * rel_to_map + (float2)(0.5, 0.5);
   switch(id)
   {
     case 0:
@@ -133,7 +134,8 @@ rawprepare_1f_unnormalized_gainmap(read_only image2d_t in, write_only image2d_t 
   const int id = BL(ry+cy+y, rx+cx+x);
   float pixel_scaled = (pixel - sub[id]) / div[id];
 
-  const float2 map_pt = ((float2)(x, y) * im_to_rel - map_origin) * rel_to_map;
+  // Add 0.5 to compensate for CLK_FILTER_LINEAR subtracting 0.5 from the specified coordinates
+  const float2 map_pt = ((float2)(rx+cx+x,ry+cy+y) * im_to_rel - map_origin) * rel_to_map + (float2)(0.5, 0.5);
   switch(id)
   {
     case 0:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ FILE(GLOB SOURCE_FILES
   "common/iop_group.c"
   "common/iop_order.c"
   "common/iop_profile.c"
+  "common/dng_opcode.c"
   "control/conf.c"
   "control/control.c"
   "control/crawler.c"

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -26,36 +26,33 @@
 
 static double get_double(uint8_t *ptr)
 {
-  double v;
-  ((uint8_t *)&v)[0] = ptr[7];
-  ((uint8_t *)&v)[1] = ptr[6];
-  ((uint8_t *)&v)[2] = ptr[5];
-  ((uint8_t *)&v)[3] = ptr[4];
-  ((uint8_t *)&v)[4] = ptr[3];
-  ((uint8_t *)&v)[5] = ptr[2];
-  ((uint8_t *)&v)[6] = ptr[1];
-  ((uint8_t *)&v)[7] = ptr[0];
-  return v;
+  guint64 in;
+  union {
+    guint64 out;
+    double v;
+  } u;
+  memcpy(&in, ptr, sizeof(in));
+  u.out = GUINT64_FROM_BE(in);
+  return u.v;
 }
 
 static float get_float(uint8_t *ptr)
 {
-  float v;
-  ((uint8_t *)&v)[0] = ptr[3];
-  ((uint8_t *)&v)[1] = ptr[2];
-  ((uint8_t *)&v)[2] = ptr[1];
-  ((uint8_t *)&v)[3] = ptr[0];
-  return v;
+  guint32 in;
+  union {
+    guint32 out;
+    float v;
+  } u;
+  memcpy(&in, ptr, sizeof(in));
+  u.out = GUINT32_FROM_BE(in);
+  return u.v;
 }
 
 static uint32_t get_long(uint8_t *ptr)
 {
-  uint32_t v;
-  ((uint8_t *)&v)[0] = ptr[3];
-  ((uint8_t *)&v)[1] = ptr[2];
-  ((uint8_t *)&v)[2] = ptr[1];
-  ((uint8_t *)&v)[3] = ptr[0];
-  return v;
+  uint32_t in;
+  memcpy(&in, ptr, sizeof(in));
+  return GUINT32_FROM_BE(in);
 }
 
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
@@ -99,7 +96,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
       gm->map_planes = get_long(&param[72]);
       for(int i = 0; i < gain_count; i++)
         gm->map_gain[i] = get_float(&param[76 + 4*i]);
-      
+
       img->dng_gain_maps = g_list_append(img->dng_gain_maps, gm);
     }
     else

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -62,6 +62,7 @@ static uint32_t get_long(uint8_t *ptr)
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
 {
   g_list_free_full(img->dng_gain_maps, g_free);
+  img->dng_gain_maps = NULL;
 
   uint32_t count = get_long(&buf[0]);
   uint32_t offset = 4;

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -17,11 +17,10 @@
 */
 
 #include <glib.h>
-#include <stdint.h>
 #include <stdio.h>
 
+#include "debug.h"
 #include "dng_opcode.h"
-#include "image.h"
 
 #define OPCODE_ID_GAINMAP (9)
 
@@ -75,7 +74,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
 
     if(offset + 16 + param_size > buf_size)
     {
-      fprintf(stderr, "[dng_opcode] Invalid opcode size in OpcodeList2\n");
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] Invalid opcode size in OpcodeList2\n");
       return;
     }
 
@@ -105,7 +104,7 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
     }
     else
     {
-      fprintf(stderr, "[dng_opcode] OpcodeList2 has unsupported %s opcode %d\n",
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList2 has unsupported %s opcode %d\n",
         flags & 1 ? "optional" : "mandatory", opcode_id);
     }
 

--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -1,0 +1,114 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2011-2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <glib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "dng_opcode.h"
+#include "image.h"
+
+#define OPCODE_ID_GAINMAP (9)
+
+static double get_double(uint8_t *ptr)
+{
+  double v;
+  ((uint8_t *)&v)[0] = ptr[7];
+  ((uint8_t *)&v)[1] = ptr[6];
+  ((uint8_t *)&v)[2] = ptr[5];
+  ((uint8_t *)&v)[3] = ptr[4];
+  ((uint8_t *)&v)[4] = ptr[3];
+  ((uint8_t *)&v)[5] = ptr[2];
+  ((uint8_t *)&v)[6] = ptr[1];
+  ((uint8_t *)&v)[7] = ptr[0];
+  return v;
+}
+
+static float get_float(uint8_t *ptr)
+{
+  float v;
+  ((uint8_t *)&v)[0] = ptr[3];
+  ((uint8_t *)&v)[1] = ptr[2];
+  ((uint8_t *)&v)[2] = ptr[1];
+  ((uint8_t *)&v)[3] = ptr[0];
+  return v;
+}
+
+static uint32_t get_long(uint8_t *ptr)
+{
+  uint32_t v;
+  ((uint8_t *)&v)[0] = ptr[3];
+  ((uint8_t *)&v)[1] = ptr[2];
+  ((uint8_t *)&v)[2] = ptr[1];
+  ((uint8_t *)&v)[3] = ptr[0];
+  return v;
+}
+
+void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
+{
+  g_list_free_full(img->dng_gain_maps, g_free);
+
+  uint32_t count = get_long(&buf[0]);
+  uint32_t offset = 4;
+  while(count > 0)
+  {
+    uint32_t opcode_id = get_long(&buf[offset]);
+    uint32_t flags = get_long(&buf[offset + 8]);
+    uint32_t param_size = get_long(&buf[offset + 12]);
+    uint8_t *param = &buf[offset + 16];
+
+    if(offset + 16 + param_size > buf_size)
+    {
+      fprintf(stderr, "[dng_opcode] Invalid opcode size in OpcodeList2\n");
+      return;
+    }
+
+    if(opcode_id == OPCODE_ID_GAINMAP)
+    {
+      uint32_t gain_count = (param_size - 76) / 4;
+      dt_dng_gain_map_t *gm = g_malloc(sizeof(dt_dng_gain_map_t) + gain_count * sizeof(float));
+      gm->top = get_long(&param[0]);
+      gm->left = get_long(&param[4]);
+      gm->bottom = get_long(&param[8]);
+      gm->right = get_long(&param[12]);
+      gm->plane = get_long(&param[16]);
+      gm->planes = get_long(&param[20]);
+      gm->row_pitch = get_long(&param[24]);
+      gm->col_pitch = get_long(&param[28]);
+      gm->map_points_v = get_long(&param[32]);
+      gm->map_points_h = get_long(&param[36]);
+      gm->map_spacing_v = get_double(&param[40]);
+      gm->map_spacing_h = get_double(&param[48]);
+      gm->map_origin_v = get_double(&param[56]);
+      gm->map_origin_h = get_double(&param[64]);
+      gm->map_planes = get_long(&param[72]);
+      for(int i = 0; i < gain_count; i++)
+        gm->map_gain[i] = get_float(&param[76 + 4*i]);
+      
+      img->dng_gain_maps = g_list_append(img->dng_gain_maps, gm);
+    }
+    else
+    {
+      fprintf(stderr, "[dng_opcode] OpcodeList2 has unsupported %s opcode %d\n",
+        flags & 1 ? "optional" : "mandatory", opcode_id);
+    }
+
+    offset += 16 + param_size;
+    count--;
+  }
+}

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -1,0 +1,45 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2011-2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <glib.h>
+#include <stdint.h>
+#include "image.h"
+
+typedef struct dt_dng_gain_map_t
+{
+  uint32_t top;
+  uint32_t left;
+  uint32_t bottom;
+  uint32_t right;
+  uint32_t plane;
+  uint32_t planes;
+  uint32_t row_pitch;
+  uint32_t col_pitch;
+  uint32_t map_points_v;
+  uint32_t map_points_h;
+  double map_spacing_v;
+  double map_spacing_h;
+  double map_origin_v;
+  double map_origin_h;
+  uint32_t map_planes;
+  float map_gain[];
+} dt_dng_gain_map_t;
+
+void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t size, dt_image_t *img);

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <glib.h>
 #include <stdint.h>
 #include "image.h"
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -726,6 +726,10 @@ static gboolean dt_check_dng_opcodes(Exiv2::ExifData &exifData, dt_image_t *img)
     g_free(data);
     has_opcodes = TRUE;
   }
+  else
+  {
+    dt_vprint(DT_DEBUG_IMAGEIO, "DNG OpcodeList2 tag not found\n");
+  }
   return has_opcodes;
 }
 
@@ -913,7 +917,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
     if (dt_check_usercrop(exifData, img))
       {
-        img->flags |= DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS;
+        img->flags |= DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS;
         guint tagid = 0;
         char tagname[64];
         snprintf(tagname, sizeof(tagname), "darktable|mode|exif-crop");
@@ -923,7 +927,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
     if(dt_check_dng_opcodes(exifData, img))
     {
-      img->flags |= DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS;
+      img->flags |= DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS;
     }
 
     /*

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -715,6 +715,9 @@ static gboolean dt_check_dng_opcodes(Exiv2::ExifData &exifData, dt_image_t *img)
 {
   gboolean has_opcodes = FALSE;
   Exiv2::ExifData::const_iterator pos = exifData.findKey(Exiv2::ExifKey("Exif.SubImage1.OpcodeList2"));
+  // DNGs without an embedded preview have the opcodes under Exif.Image instead of Exif.SubImage1
+  if(pos == exifData.end())
+    pos = exifData.findKey(Exiv2::ExifKey("Exif.Image.OpcodeList2"));
   if(pos != exifData.end())
   {
     uint8_t *data = (uint8_t *)g_malloc(pos->size());

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -72,8 +72,8 @@ int dt_exif_read_from_blob(dt_image_t *img, uint8_t *blob, const int size);
 int dt_exif_read_blob(uint8_t **blob, const char *path, const int imgid, const int sRGB, const int out_width,
                       const int out_height, const int dng_mode);
 
-/** Reads exif DefaultUserCrop */
-void dt_exif_img_check_usercrop(dt_image_t *img, const char *filename);
+/** Reads exif tags that are not cached in the database */
+void dt_exif_img_check_additional_tags(dt_image_t *img, const char *filename);
 
 /** write blob to file exif. merges with existing exif information.*/
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1828,8 +1828,7 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[3] = NAN;
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
-  img->dng_opcode_list_2 = NULL;
-  img->dng_opcode_list_2_size = 0;
+  img->dng_gain_maps = NULL;
   img->cache_entry = 0;
 
   for(int k=0; k<4; k++)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1828,6 +1828,8 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[3] = NAN;
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
+  img->dng_opcode_list_2 = NULL;
+  img->dng_opcode_list_2_size = 0;
   img->cache_entry = 0;
 
   for(int k=0; k<4; k++)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -84,9 +84,9 @@ typedef enum
   DT_IMAGE_4BAYER = 16384,
   // image was detected as monochrome
   DT_IMAGE_MONOCHROME = 32768,
-  // image has exif tags which are not cached in the database but must be read and stored in dt_image_t when
-  // the image is loaded.
-  DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS = 65536,
+  // DNG image has exif tags which are not cached in the database but must be read and stored in dt_image_t
+  // when the image is loaded.
+  DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS = 65536,
   // image is an sraw
   DT_IMAGE_S_RAW = 1 << 17,
   // image has a monochrome preview tested

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -84,8 +84,9 @@ typedef enum
   DT_IMAGE_4BAYER = 16384,
   // image was detected as monochrome
   DT_IMAGE_MONOCHROME = 32768,
-  // image has usercrop information
-  DT_IMAGE_HAS_USERCROP = 65536,
+  // image has exif tags which are not cached in the database but must be read and stored in dt_image_t when
+  // the image is loaded.
+  DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS = 65536,
   // image is an sraw
   DT_IMAGE_S_RAW = 1 << 17,
   // image has a monochrome preview tested
@@ -261,6 +262,11 @@ typedef struct dt_image_t
 
   /* DefaultUserCrop */
   dt_boundingbox_t usercrop;
+
+  /* DNG opcodes from exif tag to be applied prior to demosaic */
+  uint8_t *dng_opcode_list_2;
+  uint32_t dng_opcode_list_2_size;
+
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -263,9 +263,8 @@ typedef struct dt_image_t
   /* DefaultUserCrop */
   dt_boundingbox_t usercrop;
 
-  /* DNG opcodes from exif tag to be applied prior to demosaic */
-  uint8_t *dng_opcode_list_2;
-  uint32_t dng_opcode_list_2_size;
+  /* GainMaps from DNG OpcodeList2 exif tag */
+  GList *dng_gain_maps;
 
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -168,6 +168,7 @@ void dt_image_cache_deallocate(void *data, dt_cache_entry_t *entry)
 {
   dt_image_t *img = (dt_image_t *)entry->data;
   g_free(img->profile);
+  g_free(img->dng_opcode_list_2);
   g_free(img);
 }
 

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -168,7 +168,7 @@ void dt_image_cache_deallocate(void *data, dt_cache_entry_t *entry)
 {
   dt_image_t *img = (dt_image_t *)entry->data;
   g_free(img->profile);
-  g_free(img->dng_opcode_list_2);
+  g_list_free_full(img->dng_gain_maps, g_free);
   g_free(img);
 }
 

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -272,9 +272,9 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     // FIXME: grab r->metadata.colorMatrix.
 
-    // Get DefaultUserCrop
-    if (img->flags & DT_IMAGE_HAS_USERCROP)
-      dt_exif_img_check_usercrop(img, filename);
+    // Get additional exif tags that are not cached in the database
+    if (img->flags & DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS)
+      dt_exif_img_check_additional_tags(img, filename);
 
     if(r->getDataType() == TYPE_FLOAT32)
     {

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -273,7 +273,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     // FIXME: grab r->metadata.colorMatrix.
 
     // Get additional exif tags that are not cached in the database
-    if (img->flags & DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS)
+    if (img->flags & DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS)
       dt_exif_img_check_additional_tags(img, filename);
 
     if(r->getDataType() == TYPE_FLOAT32)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -798,6 +798,7 @@ void gui_update(dt_iop_module_t *self)
   for(int i = 1; i < 4; i++)
     gtk_widget_set_visible(g->black_level_separate[i], !is_monochrome);
 
+  gtk_widget_set_visible(g->flat_field, check_gain_maps(self, NULL));
   dt_bauhaus_combobox_set(g->flat_field, p->flat_field);
 }
 


### PR DESCRIPTION
Implements #8728. Danger - this changes the parameters of the rawprepare module and will break your edits! This seems to work but definitely needs careful review from someone who knows more than I do about the internals of darktable.

The GainMap is documented in the Opcode List Processing section of the [Adobe DNG Spec](https://wwwimages.adobe.com/content/dam/Adobe/en/products/photoshop/pdfs/dng_spec_1.5.0.0.pdf). This feature is to support DNGs that are produced as the native raw format of devices like smartphones and GoPros, not for DNGs produced by Adobe DNG Converter.

**Usage**
Since the GainMaps are applied to the entire image after black point subtraction but before demosaicing, the raw black / white point (rawprepare) module is the appropriate place to apply the GainMap. A new option "flat field correction" has been added to rawprepare, which is only visible for images which contain a GainMap which is of a form that we can apply. The option is enabled by default for supported images, since it is mandatory to apply and the colors can be completely wrong near the edges of the image if it is needed but not applied.

For any images containing a GainMap that were already in the library before upgrading to a version with this feature, the flat field correction option will not appear. To fix this, use the refresh exif button in selected images - metadata in the lighttable. The reason is that the image in the database would not have the flag set that indicates the image contains additional exif tags.

**Implementation**
CPU and OpenCL are both supported. I don't know much about openmp / vectorization / etc, but the CPU version seems fast enough. The loop that applies the GainMap takes about 3x longer than the loop that does the black point subtraction and scaling, which is only 30 or 40ms on my system.

The definition of the GainMap in the DNG spec is very open ended - I did not try to support every possible valid GainMap, just the typical ones from phones etc: four GainMaps, one for each RGGB Bayer filter, of the same size, which cover the entire image. If the GainMap is valid but unsupported the option does not appear in rawprepare.

There was an existing feature to support the DefaultUserCrop exif tag, which sets a flag in the sql database indicating that the image has something in the exif tags which isn't itself stored in the database, but needs to be loaded from the image file into dt_image_t. I just extended this to also handle the OpcodeList2 exif tag at the same time. In the future this could also support getting the OpcodeList3 tag containing the WarpRectilinear opcode, for lens distortion correction.

For putting dynamically allocated memory inside dt_image_t, I followed the example of the profile field which is set by the colorin module and freed from dt_image_cache_deallocate.

**Validation**
I got a few samples to test from [this thread](https://discuss.pixls.us/t/looking-for-samples-smartphone-dngs-with-embedded-gainmap/27296). A couple, like the Samsungs, contained no-op gain maps (size 1x1) which are ignored.

To validate that the GainMaps were being applied correctly I used the Adobe DNG SDK implementation as a reference.
I had been using the [dngpreprocess](https://github.com/paolodepetrillo/raw2dng/tree/dngpreprocess) script to make phone photos usable in darktable prior to this feature. It takes the original dng and uses the Adobe DNG SDK to perform black point subtraction, rescale white point to 1.0, apply the GainMaps, and writes out a floating point DNG for further processing.
For test images I compared three cases exported from darktable with default settings: the preprocessed dng, the original dng with flat field correction on and OpenCL off, and with OpenCL on. All three implementations produce almost the same results, although not exactly down to the last bit.

The only other open source raw developer which currently supports the GainMap is [ART](https://bitbucket.org/agriggio/art/wiki/Home) - see [gainmap.cc](https://bitbucket.org/agriggio/art/src/master/rtengine/gainmap.cc).