### PR TITLE
Fix alignment issue with usage of DT_ALIGNED_ARRAY

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -748,7 +748,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
   dt_iop_order_iccprofile_info_t *profile_info = dt_ioppr_get_profile_info_from_list(dev, profile_type, profile_filename);
   if(profile_info == NULL)
   {
-    profile_info = malloc(sizeof(dt_iop_order_iccprofile_info_t));
+    profile_info = dt_alloc_align(64, sizeof(dt_iop_order_iccprofile_info_t));
     dt_ioppr_init_profile_info(profile_info, 0);
     const int err = dt_ioppr_generate_profile_info(profile_info, profile_type, profile_filename, intent);
     if(err == 0)
@@ -757,7 +757,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
     }
     else
     {
-      free(profile_info);
+      dt_free_align(profile_info);
       profile_info = NULL;
     }
   }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -178,7 +178,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
   while(dev->allprofile_info)
   {
     dt_ioppr_cleanup_profile_info((dt_iop_order_iccprofile_info_t *)dev->allprofile_info->data);
-    free(dev->allprofile_info->data);
+    dt_free_align(dev->allprofile_info->data);
     dev->allprofile_info = g_list_delete_link(dev->allprofile_info, dev->allprofile_info);
   }
   dt_pthread_mutex_destroy(&dev->history_mutex);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3314,13 +3314,13 @@ static void illum_xy_callback(GtkWidget *slider, gpointer user_data)
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = calloc(1, sizeof(dt_iop_channelmixer_rbg_data_t));
+  piece->data = dt_calloc_align(64, sizeof(dt_iop_channelmixer_rbg_data_t));
 }
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   self->dev->proxy.chroma_adaptation = NULL;
-  free(piece->data);
+  dt_free_align(piece->data);
   piece->data = NULL;
 }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2423,12 +2423,12 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = calloc(1, sizeof(dt_iop_filmicrgb_data_t));
+  piece->data = dt_calloc_align(64, sizeof(dt_iop_filmicrgb_data_t));
 }
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  free(piece->data);
+  dt_free_align(piece->data);
   piece->data = NULL;
 }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1859,7 +1859,7 @@ void view_leave(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)dt_alloc_align(64, sizeof(dt_lib_histogram_t));
+  dt_lib_histogram_t *d = (dt_lib_histogram_t *)dt_calloc_align(64, sizeof(dt_lib_histogram_t));
   self->data = (void *)d;
 
   dt_pthread_mutex_init(&d->lock, NULL);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1859,7 +1859,7 @@ void view_leave(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)g_malloc0(sizeof(dt_lib_histogram_t));
+  dt_lib_histogram_t *d = (dt_lib_histogram_t *)dt_alloc_align(64, sizeof(dt_lib_histogram_t));
   self->data = (void *)d;
 
   dt_pthread_mutex_init(&d->lock, NULL);
@@ -2113,7 +2113,7 @@ void gui_cleanup(dt_lib_module_t *self)
   dt_pthread_mutex_destroy(&d->lock);
   g_free(d->rgb2ryb_ypp);
   g_free(d->ryb2rgb_ypp);
-  g_free(self->data);
+  dt_free_align(self->data);
   self->data = NULL;
 }
 


### PR DESCRIPTION
Fixes the same root cause as #10202 in a few other places, same fix as #10211. I'm not currently able to reproduce any crash caused by this, but hopefully this will also fix #10100.

It is dangerous to apply the aligned attribute to a type that is used in various other structs, because it 'infects' those structs and any structs that contain them with the alignment requirement, which might not be obvious when using them. I did check every usage of DT_ALIGNED_ARRAY I could find, and this should cover all of them.