### PR TITLE
Fix inability to run benchmark in locales with decimal comma

### DIFF
--- a/src/tests/benchmark/darktable-bench
+++ b/src/tests/benchmark/darktable-bench
@@ -228,7 +228,7 @@ def extract_seconds(line):
       line = line[:pos]
    else:
       return 0.0
-   return float(line.strip())
+   return float(line.strip().replace(',','.'))
    
 def run_benchmark(program,image,xmp,args):
    confdir=args.tempdir


### PR DESCRIPTION
When running in a locale with a decimal comma, darktable-bench will refuse to work with diagnostics:

`ValueError: could not convert string to float`

The fix is trivial, we just need to make sure that the commas are replaced by points before feeding the string to the float function.
