### PR TITLE
Improve up/down french translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: darktable 3.6\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-11-06 08:49+0100\n"
-"PO-Revision-Date: 2021-11-06 08:51+0100\n"
+"PO-Revision-Date: 2021-11-07 13:24+0100\n"
 "Last-Translator: Pascal Obry <pascal@obry.net>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -8351,11 +8351,11 @@ msgstr "modifier"
 
 #: ../src/gui/accelerators.c:104 ../src/gui/accelerators.c:534
 msgid "up"
-msgstr "haut"
+msgstr "monter"
 
 #: ../src/gui/accelerators.c:105 ../src/gui/accelerators.c:534
 msgid "down"
-msgstr "bas"
+msgstr "descendre"
 
 #: ../src/gui/accelerators.c:109
 msgid "set"


### PR DESCRIPTION
@TurboGit: after seeing issue #10349, I see that in french translation, we have twice "haut" et "bas" to translate "up/down" and "top/bottom" in effects dropdown menu. I so think it's better to translate "up/down" by "monter/descendre" here.