### PR TITLE
show all modules in history in modulegroup active group

### DIFF
--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1150,7 +1150,7 @@ static gboolean _lib_history_button_clicked_callback(GtkWidget *widget, GdkEvent
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return FALSE;
 
   // ctrl-click just show the corresponding module in modulegroups
-  if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
+  if(dt_modifier_is(e->state, GDK_SHIFT_MASK))
   {
     const int num = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "history-number"));
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)g_list_nth_data(darktable.develop->history, num - 1);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -72,7 +72,7 @@ typedef struct dt_lib_history_t
 /* compress history stack */
 static void _lib_history_compress_clicked_callback(GtkButton *widget, gpointer user_data);
 static gboolean _lib_history_compress_pressed_callback(GtkWidget *widget, GdkEventButton *e, gpointer user_data);
-static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer user_data);
+static gboolean _lib_history_button_clicked_callback(GtkWidget *widget, GdkEventButton *e, gpointer user_data);
 static void _lib_history_create_style_button_clicked_callback(GtkWidget *widget, gpointer user_data);
 /* signal callback for history change */
 static void _lib_history_will_change_callback(gpointer instance, GList *history, int history_end,
@@ -238,7 +238,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   if(selected) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
 
   /* set callback when clicked */
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_history_button_clicked_callback), self);
+  g_signal_connect(G_OBJECT(widget), "button-press-event", G_CALLBACK(_lib_history_button_clicked_callback), self);
 
   /* associate the history number */
   g_object_set_data(G_OBJECT(widget), "history-number", GINT_TO_POINTER(num + 1));
@@ -1143,11 +1143,24 @@ static gboolean _lib_history_compress_pressed_callback(GtkWidget *widget, GdkEve
   return TRUE;
 }
 
-static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer user_data)
+static gboolean _lib_history_button_clicked_callback(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
 {
   static int reset = 0;
-  if(reset) return;
-  if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return;
+  if(reset) return FALSE;
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return FALSE;
+
+  // ctrl-click just show the corresponding module in modulegroups
+  if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
+  {
+    const int num = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "history-number"));
+    dt_dev_history_item_t *hist = (dt_dev_history_item_t *)g_list_nth_data(darktable.develop->history, num - 1);
+    if(hist)
+    {
+      dt_dev_modulegroups_switch(darktable.develop, hist->module);
+      dt_iop_gui_set_expanded(hist->module, TRUE, TRUE);
+    }
+    return TRUE;
+  }
 
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_history_t *d = (dt_lib_history_t *)self->data;
@@ -1164,7 +1177,7 @@ static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer use
   g_list_free(children);
 
   reset = 0;
-  if(darktable.gui->reset) return;
+  if(darktable.gui->reset) return FALSE;
 
   dt_dev_undo_start_record(darktable.develop);
 
@@ -1179,6 +1192,7 @@ static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer use
 
   dt_iop_connect_accels_all();
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
+  return FALSE;
 }
 
 static void _lib_history_create_style_button_clicked_callback(GtkWidget *widget, gpointer user_data)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -122,9 +122,11 @@ typedef struct dt_lib_modulegroups_t
 
   GList *groups;
   gboolean show_search;
+  gboolean full_active;
 
   GList *edit_groups;
   gboolean edit_show_search;
+  gboolean edit_full_active;
   gchar *edit_preset;
   gboolean edit_ro;
   gboolean edit_basics_show;
@@ -135,7 +137,7 @@ typedef struct dt_lib_modulegroups_t
   gboolean editor_reset;
   GtkWidget *presets_combo, *presets_btn_remove, *presets_btn_dup, *presets_btn_rename, *presets_btn_new;
   GtkWidget *preset_groups_box, *preset_btn_add_group, *preset_read_only_label, *preset_reset_btn;
-  GtkWidget *edit_search_cb;
+  GtkWidget *edit_search_cb, *edit_full_active_cb;
   GtkWidget *basics_chkbox, *edit_basics_groupbox, *edit_basics_box;
   GtkWidget *edit_autoapply_chkbox, *edit_autoapply_btn;
 
@@ -821,17 +823,17 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
   for(const GList *modules = darktable.develop->iop; modules; modules = g_list_next(modules))
   {
     /*
-     * iterate over ip modules and do various test to
+     * iterate over iop modules and do various test to
      * detect if the modules should be shown or not.
      */
-      dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-      GtkWidget *w = module->expander;
+    dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
+    GtkWidget *w = module->expander;
 
-      if ((DT_IOP_ORDER_INFO) && (module->enabled))
-      {
-        fprintf(stderr,"\n%20s %d",module->op, module->iop_order);
-        if(dt_iop_is_hidden(module)) fprintf(stderr,", hidden");
-      }
+    if((DT_IOP_ORDER_INFO) && (module->enabled))
+    {
+      fprintf(stderr, "\n%20s %d", module->op, module->iop_order);
+      if(dt_iop_is_hidden(module)) fprintf(stderr, ", hidden");
+    }
 
       /* skip modules without an gui */
       if(dt_iop_is_hidden(module)) continue;
@@ -897,7 +899,10 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
 
         case DT_MODULEGROUP_ACTIVE_PIPE:
         {
-          show_module = module->enabled;
+          if(d->full_active)
+            show_module = dt_history_check_module_exists(darktable.develop->image_storage.id, module->op);
+          else
+            show_module = module->enabled;
         }
         break;
 
@@ -1126,7 +1131,7 @@ static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref
 /* presets syntax :
   Layout presets are saved as string consisting of blocs separated by ꬹ
   OPTIONSꬹBLOC_0ꬹBLOC_1ꬹBLOC_2....
-  OPTION : just show_search(0-1)
+  OPTION : show_search(0-1) | active == history (0-1)
   BLOC_0 : reserved for future use. Always 1
   BLOC_1.... : blocs describing each group, contains :
     name|icon_name||iop_name_0|iop_name_1....
@@ -1145,10 +1150,11 @@ static gchar *_preset_retrieve_old_layout_updated()
     // group name and icon
     if(i == 0)
     {
-      ret = dt_util_dstrcat(ret, "1ꬹ1|||%s",
-                            "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
-                            "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
-                            "|ashift/rotation|denoiseprofile|lens|bilat");
+      ret = dt_util_dstrcat(
+          ret, "1|0ꬹ1|||%s",
+          "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
+          "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
+          "|ashift/rotation|denoiseprofile|lens|bilat");
       ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
     }
     else if(i == 1)
@@ -1199,10 +1205,11 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
     if(i == 0)
     {
       // we don't have to care about "modern" workflow for temperature as it's more recent than this layout
-      ret = dt_util_dstrcat(ret, "1ꬹ1|||%s",
-                            "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
-                            "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
-                            "|ashift/rotation|denoiseprofile|lens|bilat");
+      ret = dt_util_dstrcat(
+          ret, "1|0ꬹ1|||%s",
+          "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
+          "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
+          "|ashift/rotation|denoiseprofile|lens|bilat");
       ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
     }
     else if(i == 1)
@@ -1339,7 +1346,8 @@ static gchar *_preset_to_string(dt_lib_module_t *self, gboolean edition)
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
   gchar *res = NULL;
   const gboolean show_search = edition ? d->edit_show_search : d->show_search;
-  res = dt_util_dstrcat(res, "%d", show_search ? 1 : 0);
+  const gboolean full_active = edition ? d->edit_full_active : d->full_active;
+  res = dt_util_dstrcat(res, "%d|%d", show_search ? 1 : 0, full_active ? 1 : 0);
 
   const gboolean basics_show = edition ? d->edit_basics_show : d->basics_show;
   GList *basics = edition ? d->edit_basics : d->basics;
@@ -1373,14 +1381,20 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
 
   gboolean show_search = TRUE;
+  gboolean full_active = FALSE;
 
   gchar **gr = g_strsplit(txt, "ꬹ", -1);
 
   // read the general options
   if(g_strv_length(gr) > 0)
   {
-    // we just have show_search for instance
-    if(!g_strcmp0(gr[0], "0")) show_search = FALSE;
+    gchar **gr2 = g_strsplit(gr[0], "|", -1);
+    // do we show the search bar
+    if(!g_strcmp0(gr2[0], "0")) show_search = FALSE;
+    // do we show all history module in active group
+    if(g_strv_length(gr2) > 1 && (g_strcmp0(gr2[1], "1") == 0)) full_active = TRUE;
+
+    g_strfreev(gr2);
   }
 
   // read the basics widgets
@@ -1444,11 +1458,13 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   if(edition)
   {
     d->edit_show_search = show_search;
+    d->edit_full_active = full_active;
     d->edit_groups = res;
   }
   else
   {
     d->show_search = show_search;
+    d->full_active = full_active;
     d->groups = res;
   }
 }
@@ -1457,14 +1473,14 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
 #define SNQA()                                                                                                    \
   {                                                                                                               \
     g_free(tx);                                                                                                   \
-    tx = g_strdup("1ꬹ0||");                                                                                       \
+    tx = g_strdup("1|0ꬹ0||");                                                                                   \
   }
 
 // start quick access
 #define SQA(is_modern, is_scene_referred)                                                                         \
   {                                                                                                               \
     g_free(tx);                                                                                                   \
-    tx = g_strdup_printf("1ꬹ1||");                                                                                 \
+    tx = g_strdup_printf("1|0ꬹ1||");                                                                            \
     if(is_scene_referred)                                                                                         \
     {                                                                                                             \
       AM("filmicrgb/white relative exposure");                                                                    \
@@ -2077,6 +2093,7 @@ static void _manage_editor_save(dt_lib_module_t *self)
 
   // get all the values
   d->edit_show_search = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->edit_search_cb));
+  d->edit_full_active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->edit_full_active_cb));
   gchar *params = _preset_to_string(self, TRUE);
 
   // update the preset in the database
@@ -2628,6 +2645,36 @@ static gboolean _manage_direct_basic_popup(GtkWidget *widget, GdkEventButton *ev
   return FALSE;
 }
 
+static void _manage_direct_full_active_toggled(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
+  d->full_active = gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget));
+  const int cur = d->current;
+  _manage_direct_save(self);
+  d->current = cur;
+  _lib_modulegroups_update_iop_visibility(self);
+}
+
+static gboolean _manage_direct_active_popup(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)
+{
+  if(event->type == GDK_BUTTON_PRESS && event->button == 3)
+  {
+    dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
+    GtkWidget *pop = gtk_menu_new();
+    gtk_widget_set_name(pop, "modulegroups-popup");
+
+    GtkWidget *smt = gtk_check_menu_item_new_with_label(_("show all module in history"));
+    gtk_widget_set_name(smt, "modulegroups-popup-item");
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(smt), d->full_active);
+    g_signal_connect(G_OBJECT(smt), "toggled", G_CALLBACK(_manage_direct_full_active_toggled), self);
+    gtk_menu_shell_append(GTK_MENU_SHELL(pop), smt);
+
+    dt_gui_menu_popup(GTK_MENU(pop), widget, GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH);
+    return TRUE;
+  }
+  return FALSE;
+}
+
 static void _dt_dev_image_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
   dt_develop_t *dev = darktable.develop;
@@ -2722,6 +2769,7 @@ void gui_init(dt_lib_module_t *self)
 
   // active group button
   d->active_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_active, pf, NULL);
+  g_signal_connect(d->active_btn, "button-press-event", G_CALLBACK(_manage_direct_active_popup), self);
   g_signal_connect(d->active_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->active_btn, _("show only active modules"));
   gtk_box_pack_start(GTK_BOX(d->hbox_groups), d->active_btn, TRUE, TRUE, 0);
@@ -3294,6 +3342,14 @@ static void _manage_editor_search_toggle(GtkWidget *button, dt_lib_module_t *sel
   d->edit_show_search = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
 }
 
+static void _manage_editor_full_active_toggle(GtkWidget *button, dt_lib_module_t *self)
+{
+  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
+  if(d->editor_reset) return;
+
+  d->edit_full_active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+}
+
 static void _preset_autoapply_changed(dt_gui_presets_edit_dialog_t *g)
 {
   dt_lib_module_t *self = g->data;
@@ -3565,6 +3621,10 @@ static void _manage_editor_load(const char *preset, dt_lib_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->edit_search_cb), d->edit_show_search);
   gtk_widget_set_sensitive(d->edit_search_cb, !d->edit_ro);
 
+  // full_active checkbox
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->edit_full_active_cb), d->edit_full_active);
+  gtk_widget_set_sensitive(d->edit_full_active_cb, !d->edit_ro);
+
   // basics checkbox
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->basics_chkbox), d->edit_basics_show);
   gtk_widget_set_sensitive(d->basics_chkbox, !d->edit_ro);
@@ -3753,7 +3813,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(vb), hb2, FALSE, TRUE, 2);
   gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, TRUE, 2);
 
-  // presets settings (search + quick access)
+  // presets settings (search + quick access + full active)
   vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   d->edit_search_cb = gtk_check_button_new_with_label(_("show search line"));
   gtk_widget_set_name(d->edit_search_cb, "modulegroups_editor_setting");
@@ -3763,6 +3823,11 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_widget_set_name(d->basics_chkbox, "modulegroups_editor_setting");
   g_signal_connect(G_OBJECT(d->basics_chkbox), "toggled", G_CALLBACK(_manage_editor_basics_toggle), self);
   gtk_box_pack_start(GTK_BOX(vb), d->basics_chkbox, FALSE, TRUE, 0);
+  d->edit_full_active_cb = gtk_check_button_new_with_label(_("show all history in active group"));
+  gtk_widget_set_name(d->edit_full_active_cb, "modulegroups_editor_setting");
+  g_signal_connect(G_OBJECT(d->edit_full_active_cb), "toggled", G_CALLBACK(_manage_editor_full_active_toggle),
+                   self);
+  gtk_box_pack_start(GTK_BOX(vb), d->edit_full_active_cb, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, TRUE, 0);
 
   // presets settings (autoapply)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3842,7 +3842,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   gtk_widget_set_name(d->edit_full_active_cb, "modulegroups_editor_setting");
   gtk_widget_set_tooltip_text(
       d->edit_full_active_cb,
-      _("show modules in the history regardless of whether or not they are currently enabled"))
+      _("show modules that are present in the history stack, regardless of whether or not they are currently enabled"))
       g_signal_connect(G_OBJECT(d->edit_full_active_cb), "toggled", G_CALLBACK(_manage_editor_full_active_toggle),
                        self);
   gtk_box_pack_start(GTK_BOX(vb), d->edit_full_active_cb, FALSE, TRUE, 0);


### PR DESCRIPTION
this fix #10343 

- this add an option to modulegroups to show all modules present in history inside modulegroup active tab. the option can be activated in the preset manager or directly by right-clicking on the active icon
- this add ctrl-click to an entry of the history lib to show the corresponding module.

Please test. I hope that I don't break anything, esp. with the last commit which touch a sensible area...