### PR TITLE
in collections combo swap entries/sections alignment to avoid jump

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2026,7 +2026,7 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
                           available_width * (1.0f - ratio),
                           TRUE, FALSE, combo_ellipsis, FALSE, FALSE);
         else
-          show_pango_text(w, context, cr, text, INNER_PADDING, darktable.bauhaus->widget_space,
+          show_pango_text(w, context, cr, text, 0, darktable.bauhaus->widget_space,
                           available_width * (1.0f - ratio),
                           FALSE, FALSE, combo_ellipsis, FALSE, FALSE);
       }
@@ -2038,7 +2038,7 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
           show_pango_text(w, context, cr, text, width - darktable.bauhaus->quad_width - INNER_PADDING, darktable.bauhaus->widget_space, 0,
                           TRUE, FALSE, combo_ellipsis, FALSE, FALSE);
         else
-          show_pango_text(w, context, cr, text, INNER_PADDING, darktable.bauhaus->widget_space, 0,
+          show_pango_text(w, context, cr, text, 0, darktable.bauhaus->widget_space, 0,
                           FALSE, FALSE, combo_ellipsis, FALSE, FALSE);
       }
       g_free(label_text);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2837,16 +2837,18 @@ static void view_set_click(gpointer instance, gpointer user_data)
 
 static void _populate_collect_combo(GtkWidget *w)
 {
-#define ADD_COLLECT_ENTRY(value)                                                              \
-  dt_bauhaus_combobox_add_full(w, dt_collection_name(value), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, \
+#define ADD_COLLECT_ENTRY(value)                                                             \
+  dt_bauhaus_combobox_add_full(w, dt_collection_name(value), DT_BAUHAUS_COMBOBOX_ALIGN_LEFT, \
                                GUINT_TO_POINTER(value + 1), NULL, TRUE)
+#define ADD_COLLECT_SECTION(label)                                                           \
+  dt_bauhaus_combobox_add_full(w, label, DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, 0, NULL, FALSE)
 
-    dt_bauhaus_combobox_add_section(w, _("files"));
+    ADD_COLLECT_SECTION(_("files"));
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FILMROLL);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FOLDERS);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FILENAME);
 
-    dt_bauhaus_combobox_add_section(w, _("metadata"));
+    ADD_COLLECT_SECTION(_("metadata"));
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TAG);
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
     {
@@ -2865,7 +2867,7 @@ static void _populate_collect_combo(GtkWidget *w)
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_COLORLABEL);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GEOTAGGING);
 
-    dt_bauhaus_combobox_add_section(w, _("times"));
+    ADD_COLLECT_SECTION(_("times"));
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DAY);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TIME);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_IMPORT_TIMESTAMP);
@@ -2873,7 +2875,7 @@ static void _populate_collect_combo(GtkWidget *w)
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPORT_TIMESTAMP);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_PRINT_TIMESTAMP);
 
-    dt_bauhaus_combobox_add_section(w, _("capture details"));
+    ADD_COLLECT_SECTION(_("capture details"));
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_CAMERA);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LENS);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_APERTURE);
@@ -2882,7 +2884,7 @@ static void _populate_collect_combo(GtkWidget *w)
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ISO);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ASPECT_RATIO);
 
-    dt_bauhaus_combobox_add_section(w, _("darktable"));
+    ADD_COLLECT_SECTION(_("darktable"));
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUPING);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LOCAL_COPY);
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_HISTORY);
@@ -2890,6 +2892,7 @@ static void _populate_collect_combo(GtkWidget *w)
     ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ORDER);
 
 #undef ADD_COLLECT_ENTRY
+#undef ADD_COLLECT_SECTION
 }
 
 void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)


### PR DESCRIPTION
@TurboGit this was originally your work, so I'll leave it up to you if you think this PR is an _improvement_ or not.

Because the comboboxes in the collections module are left aligned whereas the list of options in the popup is right-aligned (with left-aligned section headers) when you click on the combo, the selected item jumps to the right. And when you then close the popup (by selecting an item) it jumps to the left again.

This PR swaps the alignment of the section headers to be right aligned and the entries to be left aligned and removes some padding for the "normal" (i.e. non-popup) display of the selected item so that when it is clicked it appears in the exact same location in the popup.

To me, the dynamic behavior is more pleasant like this, but the static look of the popup is non-standard (and arguably less pretty). So it is a matter of taste and I'm completely OK with you rejecting this PR if you don't like it. It was a very minor nit-pick for me, so I'm not interested in a lot of discussion and back-and-forth about it.

![image](https://user-images.githubusercontent.com/1549490/141647243-89749906-e299-4d7e-9240-b57287de24d4.png)
