### PR TITLE
portable _get_total_memory for linux

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1538,7 +1538,16 @@ static inline size_t _get_total_memory()
   size_t mem = 0;
   char *line = NULL;
   size_t len = 0;
-  if(getline(&line, &len, f) != -1) mem = atol(line + 10);
+  int first = 1, found = 0;
+  // return "MemTotal" or the value from the first line
+  while(!found && getline(&line, &len, f) != -1)
+  {
+    char *colon = strchr(line, ':');
+    if(!colon) continue;
+    found = !strncmp(line, "MemTotal:", 9);
+    if(found || first) mem = atol(colon + 1);
+    first = 0;
+  }
   fclose(f);
   if(len > 0) free(line);
   return mem;


### PR DESCRIPTION
The old code assumes that "MemTotal:" appears on the first line, which is not true for all architectures (for example Elbrus 2000, where the first line begins with "MemFullSize:"). As a fallback, the value from the first line is returned if "MemTotal" isn't found. 