### PR TITLE
add act_on debug switch to show the ids of the images to act on list

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -126,7 +126,7 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch,imageio,input,\n");
   printf("      ioporder,lighttable,lua,masks,memory,nan,opencl,params,perf,demosaic\n");
-  printf("      pwstorage,print,signal,sql,undo}\n");
+  printf("      pwstorage,print,signal,sql,undo,act_on}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
 #ifdef DT_HAVE_SIGNAL_TRACE
@@ -612,6 +612,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_PARAMS; // iop module params checks on console
         else if(!strcmp(argv[k + 1], "demosaic"))
           darktable.unmuted |= DT_DEBUG_DEMOSAIC;
+        else if(!strcmp(argv[k + 1], "act_on"))
+          darktable.unmuted |= DT_DEBUG_ACT_ON;
         else
           return usage(argv[0]);
         k++;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -268,6 +268,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
   DT_DEBUG_TILING         = 1 << 23,
+  DT_DEBUG_ACT_ON         = 1 << 24
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -830,6 +830,15 @@ const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gbo
   darktable.view_manager->act_on.inside_table = dt_ui_thumbtable(darktable.gui->ui)->mouse_inside;
   darktable.view_manager->act_on.ok = TRUE;
 
+  if((darktable.unmuted & DT_DEBUG_ACT_ON) == DT_DEBUG_ACT_ON)
+  {
+    gchar *tx = dt_util_dstrcat(NULL, "[images to act on] images list : ");
+    for(GList *ll = darktable.view_manager->act_on.images; ll; ll = g_list_next(ll))
+      tx = dt_util_dstrcat(tx, "%d ", GPOINTER_TO_INT(ll->data));
+    dt_print(DT_DEBUG_ACT_ON, "%s\n", tx);
+    g_free(tx);
+  }
+
   return darktable.view_manager->act_on.images;
 }
 
@@ -975,6 +984,9 @@ int dt_view_get_image_to_act_on()
       if(stmt) sqlite3_finalize(stmt);
     }
   }
+
+  if((darktable.unmuted & DT_DEBUG_ACT_ON) == DT_DEBUG_ACT_ON)
+    dt_print(DT_DEBUG_ACT_ON, "[images to act on] single image : %d\n", ret);
 
   return ret;
 }


### PR DESCRIPTION
as requested by @aurelienpierre to try to find the cause of an intermittent issue, this add a debug switch -d act_on in order to show on console the ids of the images to act on.
Note that it doesn't show the list in 2 cases : 
1. if we reuse the previous list (nothing as changed)
2. if some code get the list directly by using the query, but anyway, in this case, chance are that the query will be tweaked / changed for special purpose, and so the list has not really the same meaning.