### PR TITLE
fixes cmake warning: implicitly converting 'BOOLEAN' to 'STRING' type.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1042,7 +1042,7 @@ set(CPACK_COMPONENTS_ALL DTApplication DTDebugSymbols DTDocuments)
 
 if (USE_LIBRAW)
   set(LIBRAW_PATH "${CMAKE_CURRENT_SOURCE_DIR}/external/LibRaw" CACHE STRING "Relative path to libraw directory (default=CMAKE_CURRENT_SOURCE_DIR)")
-   set(ENABLE_EXAMPLES OFF CACHE BOOL "")
+  set(ENABLE_EXAMPLES OFF CACHE BOOL "")
   set(DT_SUPPORTED_EXTENSIONS ${DT_SUPPORTED_EXTENSIONS} libraw CACHE INTERNAL "")
 
   # LibRaw sub-module

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1042,7 +1042,7 @@ set(CPACK_COMPONENTS_ALL DTApplication DTDebugSymbols DTDocuments)
 
 if (USE_LIBRAW)
   set(LIBRAW_PATH "${CMAKE_CURRENT_SOURCE_DIR}/external/LibRaw" CACHE STRING "Relative path to libraw directory (default=CMAKE_CURRENT_SOURCE_DIR)")
-  set(ENABLE_EXAMPLES OFF CACHE BOOL "")
+   set(ENABLE_EXAMPLES OFF CACHE BOOL "")
   set(DT_SUPPORTED_EXTENSIONS ${DT_SUPPORTED_EXTENSIONS} libraw CACHE INTERNAL "")
 
   # LibRaw sub-module

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1042,7 +1042,7 @@ set(CPACK_COMPONENTS_ALL DTApplication DTDebugSymbols DTDocuments)
 
 if (USE_LIBRAW)
   set(LIBRAW_PATH "${CMAKE_CURRENT_SOURCE_DIR}/external/LibRaw" CACHE STRING "Relative path to libraw directory (default=CMAKE_CURRENT_SOURCE_DIR)")
-  set(ENABLE_EXAMPLES OFF CACHE BOOLEAN "")
+  set(ENABLE_EXAMPLES OFF CACHE BOOL "")
   set(DT_SUPPORTED_EXTENSIONS ${DT_SUPPORTED_EXTENSIONS} libraw CACHE INTERNAL "")
 
   # LibRaw sub-module


### PR DESCRIPTION
This PR fixes the following CMake warning on manjaro using cmake version 3.21.3.

Make Warning (dev) at src/CMakeLists.txt:1045 (set):
  implicitly converting 'BOOLEAN' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.

