### PR TITLE
Add CR3 cameras to Release Notes now they are supported

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -268,12 +268,35 @@ You are strongly advised to take a backup first.
 
 ### Base Support
 
+- Canon EOS R
+- Canon EOS RP
+- Canon EOS R5
+- Canon EOS R6
+- Canon EOS 6D Mark II
+- Canon EOS 250D
+- Canon EOS 850D
+- Canon EOS 90D
+- Canon EOS 1D X Mark III
+- Canon EOS M50
+- Canon EOS M50 Mark II
+- Canon EOS M200
+- Canon PowerShot G5 X Mark II
+- Canon PowerShot G7 X Mark III
 
 ### White Balance Presets
 
+- Canon EOS R (with finetuning)
+- Canon EOS RP (with finetuning)
+- Canon EOS R5 (with finetuning)
+- Canon EOS R6
+- Canon EOS M50 (with finetuning)
 
 ### Noise Profiles
 
+- Canon EOS R
+- Canon EOS RP
+- Canon EOS R5
+- Canon EOS R6
 
 ### Custom Color matrices
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -285,11 +285,11 @@ You are strongly advised to take a backup first.
 
 ### White Balance Presets
 
-- Canon EOS R (with finetuning)
-- Canon EOS RP (with finetuning)
-- Canon EOS R5 (with finetuning)
+- Canon EOS R (with fine-tuning)
+- Canon EOS RP (with fine-tuning)
+- Canon EOS R5 (with fine-tuning)
 - Canon EOS R6
-- Canon EOS M50 (with finetuning)
+- Canon EOS M50 (with fine-tuning)
 
 ### Noise Profiles
 


### PR DESCRIPTION
I tried to add all supported cr3 cameras to the Release Notes and the respective white balance presets and noise profiles. I am not sure if we want the "with fine-tuning" but I wanted to discern the missing fine-tuning for the R6. Also not sure about the order of the cameras. 