### PR TITLE
colorbalancergb: fix black pixels in gamut mapping

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -947,10 +947,12 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
 
   // Gamut mapping
   const float out_max_sat_h = lookup_gamut(gamut_lut, h);
-  float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : 0.f;
+  // if JC[0] == 0.f, the saturation / luminance ratio is infinite - assign the largest practical value we have
+  float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : out_max_sat_h;
   sat = soft_clip(sat, 0.8f * out_max_sat_h, out_max_sat_h);
   const float max_C_at_sat = JC[0] * sat;
-  const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : 0.f;
+  // if sat == 0.f, the chroma is zero - assign the original luminance because there's no need to gamut map
+  const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : JC[0];
   JC[0] = (JC[0] + max_J_at_sat) / 2.f;
   JC[1] = (JC[1] + max_C_at_sat) / 2.f;
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -671,10 +671,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     // Gamut mapping
     const float out_max_sat_h = lookup_gamut(gamut_LUT, h);
-    float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : 0.f;
+    // if JC[0] == 0.f, the saturation / luminance ratio is infinite - assign the largest practical value we have
+    float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : out_max_sat_h;
     sat = soft_clip(sat, 0.8f * out_max_sat_h, out_max_sat_h);
     const float max_C_at_sat = JC[0] * sat;
-    const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : 0.f;
+    // if sat == 0.f, the chroma is zero - assign the original luminance because there's no need to gamut map
+    const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : JC[0];
     JC[0] = (JC[0] + max_J_at_sat) / 2.f;
     JC[1] = (JC[1] + max_C_at_sat) / 2.f;
 


### PR DESCRIPTION
Fix https://github.com/darktable-org/darktable/issues/10416 - as simple as possible fix. The special handling of zero in denominator incorrectly pushed both J and C to zero in some cases.

@aurelienpierre: I have some further improvement ideas for the brilliance / saturation algorithm and probably also gamut mapping, aiming to more gracefully handle this kind of boundary situations. However they would break existing edits somewhat and therefore require more handling. However this one shouldn't break any edits in a meaningful way, so it's probably best to target this to 3.8 release and the further improvements for later releases.