### PR TITLE
colorbalancergb: don't soft-clip the sat fallback value

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -948,8 +948,8 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
   // Gamut mapping
   const float out_max_sat_h = lookup_gamut(gamut_lut, h);
   // if JC[0] == 0.f, the saturation / luminance ratio is infinite - assign the largest practical value we have
-  float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : out_max_sat_h;
-  sat = soft_clip(sat, 0.8f * out_max_sat_h, out_max_sat_h);
+  const float sat = (JC[0] > 0.f) ? soft_clip(JC[1] / JC[0], 0.8f * out_max_sat_h, out_max_sat_h)
+                                  : out_max_sat_h;
   const float max_C_at_sat = JC[0] * sat;
   // if sat == 0.f, the chroma is zero - assign the original luminance because there's no need to gamut map
   const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : JC[0];

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -672,8 +672,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // Gamut mapping
     const float out_max_sat_h = lookup_gamut(gamut_LUT, h);
     // if JC[0] == 0.f, the saturation / luminance ratio is infinite - assign the largest practical value we have
-    float sat = (JC[0] > 0.f) ? JC[1] / JC[0] : out_max_sat_h;
-    sat = soft_clip(sat, 0.8f * out_max_sat_h, out_max_sat_h);
+    const float sat = (JC[0] > 0.f) ? soft_clip(JC[1] / JC[0], 0.8f * out_max_sat_h, out_max_sat_h)
+                                    : out_max_sat_h;
     const float max_C_at_sat = JC[0] * sat;
     // if sat == 0.f, the chroma is zero - assign the original luminance because there's no need to gamut map
     const float max_J_at_sat = (sat > 0.f) ? JC[1] / sat : JC[0];


### PR DESCRIPTION
Fix for https://github.com/darktable-org/darktable/pull/10417 - apply the fallback `sat` value without `soft_clip()`, as the soft clipping function would actually reduce the value. Soft-clipping with infinity as a parameter would actually return `out_max_sat_h`, so this is the correct choice. Sorry for the hassle!