### PR TITLE
Do not overwrite link between action and widget if exists

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2907,7 +2907,6 @@ static float _process_action(dt_action_t *action, int instance,
     if(definition && definition->process
         && (action->type < DT_ACTION_TYPE_WIDGET
             || definition->no_widget
-            || !action_target
             || !_widget_invisible(action_target)))
       return_value = definition->process(action_target, element, effect, move_size);
     else if(!isnan(move_size))
@@ -3757,7 +3756,7 @@ dt_action_t *dt_action_define(dt_action_t *owner, const gchar *section, const gc
     }
     else if(!darktable.control->accel_initialising)
     {
-      if(label && action_def) ac->target = widget;
+      if(label && action_def && !ac->target) ac->target = widget;
       g_hash_table_insert(darktable.control->widgets, widget, ac);
 
       gtk_widget_set_has_tooltip(widget, TRUE);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1064,7 +1064,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
     {
       if(!dt_iop_is_hidden(module))
       {
-        module->gui_init(module);
+        dt_iop_gui_init(module);
 
         /* add module to right panel */
         dt_iop_gui_set_expander(module);


### PR DESCRIPTION
Revert the "fix" from #10181, which causes all kinds of problems, for example #10414, and implement a "better" one.

This is specifically meant to deal with the case of rating ("star") widgets, which get linked to the ratings action. New stars are created (and linked) for each thumbnail overlay, but when the most recently created thumbnail gets destroyed, the action is left without a widget to point to.

Update: now tested (by @MStraeten see below) so ready to merge...

Fixes #10414