### PR TITLE
cmake: Make sure libraw is a static library

### DIFF
--- a/src/external/LibRaw-cmake/CMakeLists.txt
+++ b/src/external/LibRaw-cmake/CMakeLists.txt
@@ -465,7 +465,7 @@ if(RAWSPEED_SUPPORT_CAN_BE_COMPILED)
 endif()
 
 
-add_library(raw ${libraw_LIB_SRCS})
+add_library(raw STATIC ${libraw_LIB_SRCS})
 add_library(libraw::libraw ALIAS raw)
 target_compile_definitions(raw PRIVATE LIBRAW_NOTHREADS)
 
@@ -523,7 +523,7 @@ set_target_properties(raw PROPERTIES COMPILE_PDB_NAME "raw")
 
 set(libraw_r_LIB_SRCS ${libraw_LIB_SRCS})
 
-add_library(raw_r ${libraw_r_LIB_SRCS})
+add_library(raw_r STATIC ${libraw_r_LIB_SRCS})
 add_library(libraw::libraw_r ALIAS raw_r)
 
 # Flag to export library symbols


### PR DESCRIPTION
Without this we build a shared library by default:

```
[  340s] [ 33%] Linking CXX shared library libraw.so
```

https://build.opensuse.org/build/graphics:darktable:master/openSUSE_Tumbleweed/x86_64/darktable/_log