### PR TITLE
po/help-l10n

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2293,14 +2293,7 @@
   <dtconfig>
     <name>context_help/url</name>
     <type>string</type>
-    <default>https://darktable.org/usermanual/</default>
-    <shortdescription/>
-    <longdescription/>
-  </dtconfig>
-  <dtconfig>
-    <name>context_help/dev_url</name>
-    <type>string</type>
-    <default>https://darktable-org.github.io/dtdocs/</default>
+    <default>https://docs.darktable.org/usermanual/</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>


### PR DESCRIPTION
Brings support for new documentation URL scheme for the online help.

See https://github.com/darktable-org/dtdocs/issues/76 