### PR TITLE
Make sure to check out all git tags before creating version strings

### DIFF
--- a/packaging/Solaris_11/build_ips
+++ b/packaging/Solaris_11/build_ips
@@ -23,6 +23,10 @@ AWK=/usr/bin/nawk
 GIT=/usr/bin/git
 
 REPODIR=/tmp/darktable.repo.$$
+
+# make sure we have the latest tags also in our local repo clone
+git fetch --tags 2>&1 > /dev/null
+
 # change MYPUBLISHER if you want
 MYPUBLISHER=
 CSET=`git rev-parse --short=15 --verify HEAD`

--- a/packaging/macosx/make-app-bundle
+++ b/packaging/macosx/make-app-bundle
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e -o pipefail
 trap 'echo "${BASH_SOURCE[0]}{${FUNCNAME[0]}}:${LINENO}: Error: command \`${BASH_COMMAND}\` failed with exit code $?"' ERR
+
+# make sure we have the latest tags also in our local repo clone
+git fetch --tags 2>&1 > /dev/null
+
 cd "$(dirname "$0")"/
 
 lensfun-update-data || true

--- a/tools/check_camera_support
+++ b/tools/check_camera_support
@@ -228,7 +228,7 @@ class CameraSupportState
   end
 
   def matrix_listing
-    puts "<!-- valid as of #{Time.now.strftime("%Y/%m/%d")}, #{IO.popen("git describe").readlines[0]} -->"
+    puts "<!-- valid as of #{Time.now.strftime("%Y/%m/%d")}, #{IO.popen("git fetch --all --tags 2>&1 > /dev/null && git describe").readlines[0]} -->"
     puts "<table class=\"smalltext altrows u-full-width\">"
 
     counts = [0, 0, 0, 0]

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -5,6 +5,9 @@ DT_SRC_DIR=$(cd "$DT_SRC_DIR/../" && pwd -P)
 
 cd "$DT_SRC_DIR" || exit
 
+# make sure we have the latest tags also in our local repo clone
+git fetch --tags 2>&1 > /dev/null
+
 git shortlog -sne release-3.1.0..HEAD
 
 echo "are you sure these guys received proper credit in the about dialog?"

--- a/tools/get_git_version_string.sh
+++ b/tools/get_git_version_string.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# make sure we have the latest tags also in our local repo clone
+git fetch --tags 2>&1 > /dev/null
+
 VERSION="$(git describe --tags --dirty)"
 
 if [ $? -eq 0 ] ;


### PR DESCRIPTION
In https://github.com/darktable-org/darktable/issues/10446#issuecomment-974872530 I came across the problem that all dt scripts creating a version string (using `git describe`) are relying on the fact that the git tags are in sync with the repo and do not make sure that all remote tags are present locally.
In my case this lead to the problem that my version string was always prefixed with `3.5.0` although I checked out master, I only did not make sure that all remote tags were present in my repo checkout, a simple `git fetch --tags` did the trick and gave me the correct `3.7.0` version prefix.