### PR TITLE
macOS packaging: add ports to support midi devices for NG Input

### DIFF
--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -42,7 +42,7 @@ How to make disk image with darktable application bundle (64 bit Intel only):
      $ portindex ~/ports
     Add "file:///Users/<username>/ports" (change <username> to your actual login) to /opt/local/etc/macports/sources.conf before [default] line.
     Install required dependencies:
-     $ sudo port install git exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg libsoup openexr json-glib flickcurl GraphicsMagick openjpeg webp libsecret pugixml osm-gps-map adwaita-icon-theme tango-icon-theme intltool iso-codes libomp gmic libheif
+     $ sudo port install git exiv2 libgphoto2 gtk-osx-application-gtk3 lensfun librsvg libsoup openexr json-glib flickcurl GraphicsMagick openjpeg webp libsecret pugixml osm-gps-map adwaita-icon-theme tango-icon-theme intltool iso-codes libomp gmic libheif portmidi libsdl2
      $ sudo port select --set python2 python27
     Clone darktable git repository (in this example into ~/src):
      $ mkdir ~/src


### PR DESCRIPTION
to enable NG Input with midi devices portmidi and libsdl2 are required