### PR TITLE
shortcuts: add global/no-op action

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -848,6 +848,12 @@ void dt_gui_store_last_preset(const char *name)
   darktable.gui->last_preset = g_strdup(name);
 }
 
+static gboolean _gui_noop_action_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
+                                                    guint keyval, GdkModifierType modifier, gpointer p)
+{
+  return TRUE;
+}
+
 static gboolean _gui_switch_view_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
                                                     guint keyval, GdkModifierType modifier, gpointer p)
 {
@@ -1204,6 +1210,13 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_accel_register_global(NC_("accel", "switch views/map"), GDK_KEY_m, 0);
   dt_accel_register_global(NC_("accel", "switch views/slideshow"), GDK_KEY_s, 0);
   dt_accel_register_global(NC_("accel", "switch views/print"), GDK_KEY_p, 0);
+
+  //an action that does nothing - used for overriding/removing default shortcuts
+  dt_accel_register_global(NC_("accel", "no-op"), 0, 0);
+
+  dt_accel_connect_global("no-op",
+                          g_cclosure_new(G_CALLBACK(_gui_noop_action_callback),
+                                         NULL, NULL));
 
   dt_accel_connect_global("switch views/tethering",
                           g_cclosure_new(G_CALLBACK(_gui_switch_view_key_accel_callback),


### PR DESCRIPTION
Provides a "no-op" bucket for shortcuts that don't do anything.

Adding shortcuts to this action allows darktable default shortcuts to be permanently removed (overridden) globally by either allocating a matching shortcut in the shortcut maintenance window or manually editing shortcutsrc.

This essentially provides a workaround to #10452 pending a more considered solution, which may also make use of the global/no-op action.