### PR TITLE
collect : fix folder expand

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -861,7 +861,8 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
     gtk_tree_view_expand_to_path(d->view, path);
     expanded = TRUE;
   }
-  else if(g_str_has_prefix(haystack, needle))
+  else if((dr->typing || _combo_get_active_collection(dr->combo) != DT_COLLECTION_PROP_FOLDERS)
+          && g_str_has_prefix(haystack, needle))
   {
     gtk_tree_view_expand_to_path(d->view, path);
     expanded = TRUE;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -826,6 +826,7 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   }
   else if(_combo_get_active_collection(dr->combo) == DT_COLLECTION_PROP_FOLDERS)
   {
+    if(g_str_has_suffix(needle, "*")) needle[strlen(needle) - 1] = '\0';
     if(g_str_has_suffix(needle, "/")) needle[strlen(needle) - 1] = '\0';
     if(g_str_has_suffix(haystack, "/")) haystack[strlen(haystack) - 1] = '\0';
   }


### PR DESCRIPTION
this fix #10446 
when we reconstruct the folder view and the collection include subfolders ('*' at the end of the text) we fail to re-expand and re-select the right entry in the treeview.

I have done 2 commits : 
1. fix for the folder expansion : quite safe and straightforward
2. fix for the folder selection : a little bit tricky as this can have more drawbacks (when typing, etc...) but in my tests all is ok