### PR TITLE
fix stuck grabs in mapping mode

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3494,6 +3494,9 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
     {
       if(_sc.action)
       {
+        // we may interrupt a delayed release, so do the ungrab here if needed
+        if(!_pressed_keys) _ungrab_grab_widget();
+
         _sc.mods = _key_modifiers_clean(event->key.state);
         dt_shortcut_move(DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE, 0, DT_SHORTCUT_MOVE_NONE, 1);
       }


### PR DESCRIPTION
fixes #10461

This issue was caused by shortcuts with modifier keys where the key and the modifier are released simultaneously; in that case, the key/mouse grab would not be released. Hopefully this fixes the problem.

@elstoc please test. Ideally not just in mapping mode, but in the settings/shortcuts dialogs as well and with shortcuts with and without modifiers...