### PR TITLE
Remove modules deprecated in 3.4 from deprecated module group.

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1866,18 +1866,10 @@ void init_presets(dt_lib_module_t *self)
   // this modules are deprecated in 3.4 and should be removed from this group in 3.8 (1 year later)
   SNQA();
   SMG(C_("modulegroup", "deprecated"), "basic");
-  AM("zonesystem");
-  AM("invert");
-  AM("channelmixer");
-  AM("globaltonemap");
-  AM("relight");
-  AM("tonemap");
-  AM("vibrance");
-  AM("basicadj");
-  // these modules are deprecated in 3.6 and should be removed 1 year later
+  // these modules are deprecated in 3.6 and should be removed in 4.0 (1 year later)
   AM("spots");
   AM("defringe");
-  // these modules are deprecated in 3.8 and should be removed 1 year later
+  // these modules are deprecated in 3.8 and should be removed in 4.1 (1 year later)
   AM("clipping");
 
   dt_lib_presets_add(_(DEPRECATED_PRESET_NAME), self->plugin_name, self->version(), tx, strlen(tx), TRUE);


### PR DESCRIPTION
One year after they are definitly removed from there.

Part of #8265.