### PR TITLE
colorzones: fix creating curve based on area picker

### DIFF
--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2456,7 +2456,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_POINT_AREA, hbox, iop_cs_LCh);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click or right-click to select an area"));
   gtk_widget_set_name(c->colorpicker, "keep-active");
-  c->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
+  c->colorpicker_set_values = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, hbox, iop_cs_LCh);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
                                dtgtk_cairo_paint_colorpicker_set_values,
                                CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);


### PR DESCRIPTION
This picker's colorspace wasn't specified, so it defaulted to the module's default colorspace (`iop_cs_Lab`). The picker should return data in Lch.

This drew nonsensical curves when selecting by saturation or hue. In particular, for hue selection (the default), `h` is `[0,2*M_PI]`, hence using `b` resulted in both inaccurate and out of bounds data.

This bug was caused by c25920869a551d794447b345cf17ef849d9a9308 which properly retained the "pick from GUI" picker to LCh but lost the LCh setting for the "create curve" picker.

Note that the bisect in the bug report blames 45484aba426178034e1ceec5ff324707d2524565, but I think the problem commit is as above.

Fixes #10109.