### PR TITLE
clicking on slider "header" focuses or pops up

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2818,7 +2818,7 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  if(d->is_dragging || event->x <= allocation.width - darktable.bauhaus->quad_width)
+  if(d->is_dragging || (event->x <= allocation.width - darktable.bauhaus->quad_width && event->y > get_line_height()))
   {
     // remember mouse position for motion effects in draw
     if(event->state & GDK_BUTTON1_MASK && event->type != GDK_2BUTTON_PRESS)

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2777,9 +2777,17 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
         dt_bauhaus_slider_data_t *d = &w->data.slider;
         d->is_dragging = 1;
       }
-      else if(event->x > allocation.width / 2)
+      else
       {
-        dt_bauhaus_show_popup(w);
+        int value_width;
+        char *text = dt_bauhaus_slider_get_text(GTK_WIDGET(w));
+        PangoLayout *layout = gtk_widget_create_pango_layout(widget, text);
+        pango_layout_get_size(layout, &value_width, NULL);
+        g_object_unref(layout);
+        g_free(text);
+
+        if(event->x > allocation.width - value_width/PANGO_SCALE - darktable.bauhaus->quad_width - INNER_PADDING)
+          dt_bauhaus_show_popup(w);
       }
     }
     return TRUE;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1694,6 +1694,8 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
     }
     case DT_BAUHAUS_SLIDER:
     {
+      if(darktable.bauhaus->end_mouse_y < get_line_height()) break;
+
       dt_bauhaus_slider_data_t *d = &w->data.slider;
       const float mouse_off = get_slider_line_offset(
           d->oldpos, d->scale, darktable.bauhaus->end_mouse_x / width,
@@ -2767,11 +2769,18 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
     }
     else
     {
-      const float l = 0.0f;
-      const float r = slider_right_pos((float)allocation.width);
-      dt_bauhaus_slider_set_normalized(w, (event->x / allocation.width - l) / (r - l));
-      dt_bauhaus_slider_data_t *d = &w->data.slider;
-      d->is_dragging = 1;
+      if(event->y > get_line_height())
+      {
+        const float l = 0.0f;
+        const float r = slider_right_pos((float)allocation.width);
+        dt_bauhaus_slider_set_normalized(w, (event->x / allocation.width - l) / (r - l));
+        dt_bauhaus_slider_data_t *d = &w->data.slider;
+        d->is_dragging = 1;
+      }
+      else if(event->x > allocation.width / 2)
+      {
+        dt_bauhaus_show_popup(w);
+      }
     }
     return TRUE;
   }


### PR DESCRIPTION
partially fixes #10478

Clicking on the text line of a bauhaus slider does not move the slider anymore, but instead only grabs focus (if  clicked on the left side) or pops up the editor (if clicked on the right side). Ideally, we'd test if the value text is being clicked on (as suggested in #10478) but that would mean redoing the whole cairo context setup just to figure out the length of the text). Splitting the header in left/right works equally well for me.

Styling the focused widget differently needs some careful fixes and probably some CSS. The are 9 calls to `gtk_widget_set_state_flags` some of which indiscriminately set it back to `GTK_STATE_FLAG_NORMAL` independent of focused state. Accepting a value in the popup _does_ result in the label+value being drawn in bold.