### PR TITLE
use proxy function to obtain wb coefficients

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -112,7 +112,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dev->proxy.exposure.module = NULL;
   dev->proxy.chroma_adaptation = NULL;
   dev->proxy.wb_is_D65 = TRUE; // don't display error messages until we know for sure it's FALSE
-  dev->proxy.wb_coeffs[0] = 0.f;
+  dev->proxy.temperature.module = NULL;
 
   dev->rawoverexposed.enabled = FALSE;
   dev->rawoverexposed.mode = dt_conf_get_int("darkroom/ui/rawoverexposed/mode");
@@ -141,7 +141,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
   dt_pthread_mutex_destroy(&dev->preview_pipe_mutex);
   dt_pthread_mutex_destroy(&dev->preview2_pipe_mutex);
   dev->proxy.chroma_adaptation = NULL;
-  dev->proxy.wb_coeffs[0] = 0.f;
+  dev->proxy.temperature.module = NULL;
   if(dev->pipe)
   {
     dt_dev_pixelpipe_cleanup(dev->pipe);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -144,6 +144,12 @@ typedef struct dt_dev_proxy_exposure_t
   float (*get_black)(struct dt_iop_module_t *exp);
 } dt_dev_proxy_exposure_t;
 
+typedef struct dt_dev_proxy_temperature_t
+{
+  struct dt_iop_module_t *module;
+  void (*get_wb_coeffs)(struct dt_iop_module_t *temp, dt_aligned_pixel_t wb_coeffs);
+} dt_dev_proxy_temperature_t;
+
 struct dt_dev_pixelpipe_t;
 typedef struct dt_develop_t
 {
@@ -227,6 +233,9 @@ typedef struct dt_develop_t
     // each element is dt_dev_proxy_exposure_t
     dt_dev_proxy_exposure_t exposure;
 
+    //proxy to access white balance coeffs
+    dt_dev_proxy_temperature_t temperature;
+
     // modulegroups plugin hooks
     struct
     {
@@ -279,7 +288,6 @@ typedef struct dt_develop_t
 
     // is the WB module using D65 illuminant and not doing full chromatic adaptation ?
     gboolean wb_is_D65;
-    dt_aligned_pixel_t wb_coeffs;
 
   } proxy;
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -494,9 +494,15 @@ static int get_white_balance_coeff(struct dt_iop_module_t *self, dt_aligned_pixe
 
   // Second, if the temperature module is not using these, for example because they are wrong
   // and user made a correct preset, find the WB adaptation ratio
-  if(self->dev->proxy.wb_coeffs[0] != 0.f)
+  
+  dt_dev_proxy_temperature_t *instance = &self->dev->proxy.temperature;
+
+  if(instance && instance->module && instance->get_wb_coeffs)
   {
-    for(size_t k = 0; k < 4; k++) custom_wb[k] = bwb[k] / self->dev->proxy.wb_coeffs[k];
+    dt_aligned_pixel_t wb_coeffs;
+    instance->get_wb_coeffs(instance->module, wb_coeffs);
+
+    for(size_t k = 0; k < 4; k++) custom_wb[k] = bwb[k] / wb_coeffs[k];
   }
 
   return 0;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -464,6 +464,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const dt_iop_temperature_data_t *const d = (dt_iop_temperature_data_t *)piece->data;
 
+  commit_params(self, self->params, NULL, piece);
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
   const float *const d_coeffs = d->coeffs;
@@ -578,6 +579,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 {
   const uint32_t filters = piece->pipe->dsc.filters;
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
+  commit_params(self, self->params, NULL, piece);
   if(filters)
   { // xtrans float mosaiced or bayer float mosaiced
     // plain C version is same speed for Bayer and actually a bit faster for Xtrans, so use it instead
@@ -629,6 +631,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
   dt_iop_temperature_global_data_t *gd = (dt_iop_temperature_global_data_t *)self->global_data;
 
+  commit_params(self, self->params, NULL, piece);
   const int devid = piece->pipe->devid;
   const uint32_t filters = piece->pipe->dsc.filters;
   cl_mem dev_coeffs = NULL;
@@ -694,6 +697,23 @@ error:
 }
 #endif
 
+static void dt_iop_temperature_get_wb_coeffs(struct dt_iop_module_t *self, dt_aligned_pixel_t wb_coeffs)
+{
+  dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
+
+  for(size_t k = 0; k < 4; k++) wb_coeffs[k] = 1.f;
+
+  if(self->hide_enable_button) return;
+
+  if(p)
+  {
+    wb_coeffs[0] = p->red;
+    wb_coeffs[1] = p->green;
+    wb_coeffs[2] = p->blue;
+    wb_coeffs[3] = p->g2;
+  }
+}
+
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
@@ -725,10 +745,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     self->dev->proxy.wb_is_D65 = is_D65;
   }
 
-  for(int k = 0; k < 4; k++)
-  {
-    self->dev->proxy.wb_coeffs[k] = d->coeffs[k];
-  }
+  //set up proxy to retrieve wb coeffs
+  dt_dev_proxy_temperature_t *temp = &self->dev->proxy.temperature;
+  temp->module = self;
+  temp->get_wb_coeffs = dt_iop_temperature_get_wb_coeffs;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -738,6 +758,7 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  self->dev->proxy.temperature.module = NULL;
   free(piece->data);
   piece->data = NULL;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -850,7 +850,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const int32_t imgid)
   // FIXME: synch with dev_init() and dev_cleanup() instead of redoing it
   dev->proxy.chroma_adaptation = NULL;
   dev->proxy.wb_is_D65 = TRUE;
-  dev->proxy.wb_coeffs[0] = 0.f;
+  dev->proxy.temperature.module = NULL;
 
 #ifdef USE_LUA
 


### PR DESCRIPTION
instead of storing the wb coeffs, access them directly from the white balance module.

Resolves #10482.