### PR TITLE
Update lensfun 0.3.95 function calls

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -343,20 +343,20 @@ static lfModifier * get_modifier(int *mods_done, int w, int h, const dt_iop_lens
   int mods_done_tmp = 0;
 
 #ifdef LF_0395
-  mod = new lfModifier(d->crop, w, h, LF_PF_F32, (force_inverse) ? !d->inverse : d->inverse);
+  mod = new lfModifier(d->lens, d->focal, d->crop, w, h, LF_PF_F32, d->inverse);
   if(mods_todo & LF_MODIFY_DISTORTION)
-    mods_done_tmp |= mod->EnableDistortionCorrection(d->lens, d->focal);
+    mods_done_tmp |= mod->EnableDistortionCorrection();
   if((mods_todo & LF_MODIFY_GEOMETRY) && (d->lens->Type != d->target_geom))
-    mods_done_tmp |= mod->EnableProjectionTransform(d->lens, d->focal, d->target_geom);
+    mods_done_tmp |= mods_done_tmp |= mod->EnableProjectionTransform(d->lens->Type);
   if((mods_todo & LF_MODIFY_SCALE) && (d->scale != 1.0))
     mods_done_tmp |= mod->EnableScaling(d->scale);
   if(mods_todo & LF_MODIFY_TCA)
   {
     if(d->tca_override) mods_done_tmp |= mod->EnableTCACorrection(d->custom_tca);
-    else mods_done_tmp |= mod->EnableTCACorrection(d->lens, d->focal);
+    else mods_done_tmp |= mod->EnableTCACorrection();
   }
   if(mods_todo & LF_MODIFY_VIGNETTING)
-    mods_done_tmp |= mod->EnableVignettingCorrection(d->lens, d->focal, d->aperture, d->distance);
+    mods_done_tmp |= mod->EnableVignettingCorrection(d->aperture, d->distance);
 #else
   mod = new lfModifier(d->lens, d->crop, w, h);
   mods_done_tmp = mod->Initialize(d->lens, LF_PF_F32, d->focal, d->aperture, d->distance, d->scale, d->target_geom, mods_todo,
@@ -1146,18 +1146,14 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 #ifdef LF_0395
         const dt_image_t *img = &(self->dev->image_storage);
 
-        d->custom_tca =
-          {
-           .Model     = LF_TCA_MODEL_LINEAR,
-           .Focal     = p->focal,
-           .Terms     = { p->tca_r, p->tca_b },
-           .CalibAttr = {
-                         .CenterX = 0.0f,
-                         .CenterY = 0.0f,
-                         .CropFactor = d->crop,
-                         .AspectRatio = (float)img->width / (float)img->height
-                         }
-          };
+        d->custom_tca.Model = LF_TCA_MODEL_LINEAR;
+        d->custom_tca.Focal = p->focal;
+        d->custom_tca.Terms[0] = p->tca_r;
+        d->custom_tca.Terms[1] = p->tca_b;
+
+        d->custom_tca.CalibAttr.CropFactor = d->crop;
+        d->custom_tca.CalibAttr.AspectRatio = (float)img->width / (float)img->height;
+
 #else
         // add manual d->lens stuff:
         lfLensCalibTCA tca = { LF_TCA_MODEL_NONE };


### PR DESCRIPTION
Fixing errors like:
src/darktable/src/iop/lens.cc:346:92: error:
no matching function for call to
‘lfModifier::lfModifier(const float&, int&, int&, lfPixelFormat, int)’
346 |   mod = new lfModifier(d->crop, w, h, LF_PF_F32,
                             (force_inverse) ? !d->inverse : d->inverse);