### PR TITLE
Fix print when the page & image box are remove and added.

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -472,13 +472,20 @@ static int _print_job_run(dt_job_t *job)
 {
   dt_lib_print_job_t *params = dt_control_job_get_params(job);
 
+  // get first image on a box, needed as print leader
+
+  int imgid = -1;
+
   // compute the needed size for picture for the given printer resolution
 
   for(int k=0; k<params->imgs.count; k++)
   {
     if(params->imgs.box[k].imgid > -1)
+    {
+      if(imgid == -1) imgid = params->imgs.box[k].imgid;
       if(_export_and_setup_pos(job, &params->imgs.box[k], k))
         return 1;
+    }
   }
 
   if(dt_control_job_get_state(job) == DT_JOB_STATE_CANCELLED) return 0;
@@ -506,7 +513,7 @@ static int _print_job_run(dt_job_t *job)
 
   // send to CUPS
 
-  dt_print_file (params->imgs.box[0].imgid, params->pdf_filename, params->job_title, &params->prt);
+  dt_print_file (imgid, params->pdf_filename, params->job_title, &params->prt);
   dt_control_job_set_progress(job, 1.0);
 
   // add tag for this image
@@ -601,7 +608,18 @@ static void _print_button_clicked(GtkWidget *widget, gpointer user_data)
   const dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_print_settings_t *ps = (dt_lib_print_settings_t *)self->data;
 
-  const int imgid = ps->imgs.box[0].imgid;
+  int imgid = -1;
+
+  // at least one image on a box
+
+  for(int k=0; k<ps->imgs.count; k++)
+  {
+    if(ps->imgs.box[k].imgid > -1)
+    {
+      imgid = ps->imgs.box[k].imgid;
+      break;
+    }
+  }
 
   if(imgid == -1)
   {
@@ -630,7 +648,7 @@ static void _print_button_clicked(GtkWidget *widget, gpointer user_data)
 
   // what to call the image?
   GList *res;
-  if((res = dt_metadata_get(params->imgs.box[0].imgid, "Xmp.dc.title", NULL)) != NULL)
+  if((res = dt_metadata_get(imgid, "Xmp.dc.title", NULL)) != NULL)
   {
     // FIXME: in metadata_view.c, non-printables are filtered, should we do this here?
     params->job_title = g_strdup((gchar *)res->data);
@@ -638,7 +656,7 @@ static void _print_button_clicked(GtkWidget *widget, gpointer user_data)
   }
   else
   {
-    const dt_image_t *img = dt_image_cache_get(darktable.image_cache, params->imgs.box[0].imgid, 'r');
+    const dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
     if(!img)
     {
       // in this case no need to release from cache what we couldn't get


### PR DESCRIPTION
When a preset is used and box are remove and/or added it may be
impossible to print and getting the message:

   cannot print until a picture is selected

This is because the code was expecting the first image to be
on box[0] which is not always the case.