### PR TITLE
move focus widget before deleting multi-instance

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -504,6 +504,7 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
                           module->expander, -1);
 
     dt_iop_gui_cleanup_module(module);
+    gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
     gtk_widget_destroy(module->widget);
   }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -495,17 +495,9 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   // we remove the plugin effectively
   if(!dt_iop_is_hidden(module))
   {
-    // we just hide the module to avoid lots of gtk critical warnings
-    gtk_widget_hide(module->expander);
-
-    // we move the module far away, to avoid problems when reordering instance after that
-    // FIXME: ?????
-    gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER),
-                          module->expander, -1);
-
     dt_iop_gui_cleanup_module(module);
     gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
-    gtk_widget_destroy(module->widget);
+    gtk_widget_destroy(module->expander);
   }
 
   // we remove all references in the history stack and dev->iop

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -395,12 +395,8 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
       // we remove the plugin effectively
       if(!dt_iop_is_hidden(mod))
       {
-        // we just hide the module to avoid lots of gtk critical warnings
-        gtk_widget_hide(mod->expander);
-
-        // this is copied from dt_iop_gui_delete_callback(), not sure why the above sentence...
-        gtk_widget_destroy(mod->widget);
         dt_iop_gui_cleanup_module(mod);
+        gtk_widget_destroy(mod->expander);
       }
 
       iop_list = g_list_remove_link(iop_list, modules);


### PR DESCRIPTION
This partially fixes one of the bugs that came up in #10384 (https://github.com/darktable-org/darktable/issues/10384#issuecomment-981770474)

Aparently there has been a long standing issue (concluding from the years old comment) that destroying the module header gui still leaves the focused widget focused. When the focus is then later on moved to something else, gtk wants to clean up the previously focussed one and crashes.

This fix forces the focus to the center widget whenever a multi-instance is deleted. I don't like doing this (because focus should stay where it is assigned and not move around on its own) but I haven't found a reliable way to determine if the module-to-be-deleted contained the focused widget or not; the obvious ways to do so failed. Which may also be why gtk itself doesn't take care of this correctly. The real underlying cause still escapes me, but I think this "workaround" is better than the previous one (which did not remove the module header at all!).