### PR TITLE
midi keys mapped to module header reflect status

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3227,7 +3227,11 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
     g_free(text);
   }
 
-  return 0;
+  return element == DT_ACTION_ELEMENT_FOCUS ? darktable.develop->gui_module == module
+       : element == DT_ACTION_ELEMENT_ENABLE ? module->off &&
+                                               gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(module->off))
+       : element == DT_ACTION_ELEMENT_SHOW ? module->expanded
+       : 0;
 }
 
 const gchar *dt_action_effect_instance[]

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3410,12 +3410,17 @@ gboolean dt_shortcut_key_active(dt_input_device_t id, guint key)
   {
     dt_shortcut_t *s = g_sequence_get(existing);
 
-    if(s && s->action && s->action->type >= DT_ACTION_TYPE_WIDGET)
+    if(s && s->action)
     {
       const dt_action_def_t *definition = _action_find_definition(s->action);
       if(definition && definition->process)
       {
-        float value = definition->process(s->action->target, s->element, s->effect, NAN);
+        gpointer action_target = s->action->type == DT_ACTION_TYPE_IOP
+                               ? dt_iop_get_module_preferred_instance((dt_iop_module_so_t *)s->action)
+                               : s->action->type == DT_ACTION_TYPE_LIB
+                               ? s->action
+                               : s->action->target;
+        float value = definition->process(action_target, s->element, s->effect, NAN);
         return fmodf(value, 1) <= DT_VALUE_PATTERN_ACTIVE || fmodf(value, 2) > .5;
       }
     }

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -926,12 +926,12 @@ static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *accele
       dt_lib_gui_set_expanded(module, !dtgtk_expander_get_expanded(DTGTK_EXPANDER(module->expander)));
     else
       dt_lib_gui_set_expanded(module, TRUE);
-    }
-    else
-    {
-      /* else just toggle */
-      dt_lib_gui_set_expanded(module, !dtgtk_expander_get_expanded(DTGTK_EXPANDER(module->expander)));
-    }
+  }
+  else
+  {
+    /* else just toggle */
+    dt_lib_gui_set_expanded(module, !dtgtk_expander_get_expanded(DTGTK_EXPANDER(module->expander)));
+  }
   return TRUE;
 }
 
@@ -1255,7 +1255,7 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
     }
   }
 
-  return 0;
+  return element == DT_ACTION_ELEMENT_SHOW && dtgtk_expander_get_expanded(DTGTK_EXPANDER(module->expander));
 }
 
 static const dt_action_element_def_t _action_elements[]


### PR DESCRIPTION
If a midi button with a light is mapped to a module header button that enables, expands or focusses the module, then its light will reflect the current status. So it will light up if the module is in enabled, expanded or focused state.

I was reminded this needed to be implemented by #10475.