### PR TITLE
some bauhaus widget restructuring

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1072,6 +1072,7 @@ static void dt_bauhaus_combobox_destroy(dt_bauhaus_widget_t *widget, gpointer us
   d->entries = NULL;
   d->num_labels = 0;
   d->active = -1;
+  if(d->text) free(d->text);
 }
 
 GtkWidget *dt_bauhaus_combobox_new(dt_iop_module_t *self)
@@ -1114,7 +1115,7 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
   d->entries_ellipsis = PANGO_ELLIPSIZE_END;
   d->mute_scrolling = FALSE;
   d->populate = NULL;
-  memset(d->text, 0, sizeof(d->text));
+  d->text = NULL;
 
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_PRESS_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(w), TRUE);
@@ -1197,6 +1198,8 @@ void dt_bauhaus_combobox_set_editable(GtkWidget *widget, int editable)
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   d->editable = editable ? 1 : 0;
+  if(d->editable && !d->text)
+    d->text = calloc(1, DT_BAUHAUS_COMBO_MAX_TEXT);
 }
 
 int dt_bauhaus_combobox_get_editable(GtkWidget *widget)
@@ -1324,7 +1327,7 @@ void dt_bauhaus_combobox_set_text(GtkWidget *widget, const char *text)
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   if(!d->editable) return;
-  g_strlcpy(d->text, text, sizeof(d->text));
+  g_strlcpy(d->text, text, DT_BAUHAUS_COMBO_MAX_TEXT);
 }
 
 static void _bauhaus_combobox_set(GtkWidget *widget, const int pos, const gboolean mute)
@@ -1697,8 +1700,8 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
       else if(d->editable)
       {
         // otherwise, if combobox is editable, assume it is a custom input
-        memset(d->text, 0, sizeof(d->text));
-        g_strlcpy(d->text, darktable.bauhaus->keys, sizeof(d->text));
+        memset(d->text, 0, DT_BAUHAUS_COMBO_MAX_TEXT);
+        g_strlcpy(d->text, darktable.bauhaus->keys, DT_BAUHAUS_COMBO_MAX_TEXT);
         // select custom entry
         dt_bauhaus_combobox_set(widget, -1);
       }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -986,6 +986,11 @@ static void dt_bauhaus_slider_destroy(dt_bauhaus_widget_t *widget, gpointer user
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   if(d->timeout_handle) g_source_remove(d->timeout_handle);
   d->timeout_handle = 0;
+  if(d->grad_col)
+  {
+    free(d->grad_col);
+    free(d->grad_pos);
+  }
 }
 
 GtkWidget *dt_bauhaus_slider_new(dt_iop_module_t *self)
@@ -1032,6 +1037,8 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
   d->offset = 0.0f;
 
   d->grad_cnt = 0;
+  d->grad_col = NULL;
+  d->grad_pos = NULL;
 
   d->fill_feedback = feedback;
 
@@ -1403,6 +1410,12 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+
+  if(!d->grad_col)
+  {
+    d->grad_col = malloc(DT_BAUHAUS_SLIDER_MAX_STOPS * sizeof(*d->grad_col));
+    d->grad_pos = malloc(DT_BAUHAUS_SLIDER_MAX_STOPS * sizeof(*d->grad_pos));
+  }
   // need to replace stop?
   for(int k = 0; k < d->grad_cnt; k++)
   {

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -720,7 +720,6 @@ static void dt_bauhaus_widget_init(dt_bauhaus_widget_t *w, dt_iop_module_t *self
   w->quad_paint = 0;
   w->quad_paint_data = NULL;
   w->quad_toggle = 0;
-  w->combo_populate = NULL;
 
   switch(w->type)
   {
@@ -1107,6 +1106,7 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
   d->text_align = DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT;
   d->entries_ellipsis = PANGO_ELLIPSIZE_END;
   d->mute_scrolling = FALSE;
+  d->populate = NULL;
   memset(d->text, 0, sizeof(d->text));
 
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_PRESS_MASK);
@@ -1126,8 +1126,8 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
 void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidget *w, struct dt_iop_module_t **module))
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
-  if(w->type != DT_BAUHAUS_COMBOBOX) return;
-  w->combo_populate = fct;
+  if(w->type == DT_BAUHAUS_COMBOBOX)
+    w->data.combobox.populate = fct;
 }
 
 void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const char **texts)
@@ -2163,10 +2163,10 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
     {
       // we launch the dynamic populate fct if any
       dt_iop_module_t *module = (dt_iop_module_t *)(w->module);
-      if(w->combo_populate) w->combo_populate(GTK_WIDGET(w), &module);
+      const dt_bauhaus_combobox_data_t *d = &w->data.combobox;
+      if(d->populate) d->populate(GTK_WIDGET(w), &module);
       // comboboxes change immediately
       darktable.bauhaus->change_active = 1;
-      const dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       if(!d->num_labels) return;
       tmp.height = darktable.bauhaus->line_height * d->num_labels + 5 * darktable.bauhaus->widget_space;
       tmp.width *= d->scale;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -118,6 +118,7 @@ typedef struct dt_bauhaus_combobox_data_t
   PangoEllipsizeMode entries_ellipsis;
   GList *entries;
   gboolean mute_scrolling;   // if set, prevents to issue "data-changed"
+  void (*populate)(GtkWidget *w, struct dt_iop_module_t **module); // function to populate the combo list on the fly
 } dt_bauhaus_combobox_data_t;
 
 typedef union dt_bauhaus_data_t
@@ -159,9 +160,6 @@ typedef struct dt_bauhaus_widget_t
   int quad_toggle;
   // if a section label
   gboolean is_section;
-
-  // function to populate the combo list on the fly
-  void (*combo_populate)(GtkWidget *w, struct dt_iop_module_t **module);
 
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -74,9 +74,9 @@ typedef struct dt_bauhaus_slider_data_t
   float scale; // step width for loupe mode
   int digits;  // how many decimals to round to
 
-  float grad_col[DT_BAUHAUS_SLIDER_MAX_STOPS][3]; // colors for gradient slider
-  int grad_cnt;                                   // how many stops
-  float grad_pos[DT_BAUHAUS_SLIDER_MAX_STOPS];    // and position of these.
+  float (*grad_col)[3]; // colors for gradient slider
+  int grad_cnt;         // how many stops
+  float *grad_pos;      // and position of these.
 
   int fill_feedback; // fill the slider with brighter part up to the handle?
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -47,6 +47,7 @@ extern GType DT_BAUHAUS_WIDGET_TYPE;
 #define DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MAX 500
 #define DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MIN 25
 #define DT_BAUHAUS_SLIDER_MAX_STOPS 20
+#define DT_BAUHAUS_COMBO_MAX_TEXT 180
 
 typedef enum dt_bauhaus_type_t
 {
@@ -114,7 +115,7 @@ typedef struct dt_bauhaus_combobox_data_t
   int editable;         // 1 if arbitrary text may be typed
   int scale;            // scale of the combo popup from combo widget
   dt_bauhaus_combobox_alignment_t text_align; // if selected text in combo should be aligned to the left/right
-  char text[180];       // roughly as much as a slider
+  char *text;           // to hold arbitrary text if editable
   PangoEllipsizeMode entries_ellipsis;
   GList *entries;
   gboolean mute_scrolling;   // if set, prevents to issue "data-changed"


### PR DESCRIPTION
The combobox member function to automatically populate the dropdown was shared with sliders.  Clarifies data model and saves a theoretical amount of memory for each slider.