### PR TITLE
Updated RELEASE_NOTES and set lua API version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -260,6 +260,25 @@ You are strongly advised to take a backup first.
 - Fix a rare but possible wrong White Balance just after importing a
   picture or while resetting the development history.
 
+## Lua
+
+- Moved from Lua 5.3 to Lua 5.4
+
+- Lua API is now 8.0.0
+
+- added darktable.print_toast() and darktable.print_hinter() functions to print toast and hinter messages respectively
+
+- added is_altered() field to dt_lua_image data type to determine if and image has been altered since being imported
+
+- added generate_cache() function to the dt_lua_image data type so that a mipmap cache image can be generated without
+  having to run darktable-generate-cache
+
+- added function darktable.gui.libs.snapshots.clear_snapshots() to delete any snapshots.
+
+- added event darkroom-image-loaded that is triggered when an image is loaded into darkroom view.  The image is returned.
+
+- added event darkroom-image-history-changed that is triggered when an the image history is changed in darkroom view.  The image is returned.
+
 ## Notes
 
 - The 3.8.x series of darktable releases will be the last which supports macOS 10.7 and building with Xcode 11.

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -35,6 +35,7 @@
 // 2.4.0 was 5.0.0 (going to lua 5.3 is a major API bump)
 // 3.2.0 was 6.0.0 (removed facebook, flickr, and picasa from types.dt_imageio_storage_module_t)
 // 3.6.0 was 7.0.0 (added naming to events, selections, and actions)
+// 3.8.0 was 8.0.0 (moved to lua 5.4 and added some events)
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 8
 /* backward compatible API change */
@@ -42,7 +43,7 @@
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */
-#define LUA_API_VERSION_SUFFIX "dev"
+#define LUA_API_VERSION_SUFFIX ""
 
 /** initialize lua stuff at DT start time */
 int dt_lua_init_configuration(lua_State *L);


### PR DESCRIPTION
Added the Lua section to the release notes.  Removed dev from the API version number.

Sorry it's so late.  Too much real life.