### PR TITLE
imageio_libraw: Windows unicode support redux

### DIFF
--- a/src/common/imageio_libraw.c
+++ b/src/common/imageio_libraw.c
@@ -221,7 +221,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename
   libraw_data_t *raw = libraw_init(0);
   if(!raw) return DT_IMAGEIO_FILE_CORRUPTED;
 
-#ifdef LIBRAW_WIN32_UNICODEPATHS
+#if defined(_WIN32) && (defined(UNICODE) || defined(_UNICODE))
   wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
   libraw_err = libraw_open_wfile(raw, wfilename);
   g_free(wfilename);


### PR DESCRIPTION
Improves on https://github.com/darktable-org/darktable/pull/10525