### PR TITLE
export: add option to set file modification time to match datetime from exif

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -752,7 +752,7 @@ int main(int argc, char *arg[])
     metadata.flags = dt_lib_export_metadata_default_flags();
     metadata.list = NULL;
     if(storage->store(storage, sdata, id, format, fdata, num, total, high_quality, upscale, export_masks,
-                      icc_type, icc_filename, icc_intent, &metadata) != 0)
+                      icc_type, icc_filename, icc_intent, &metadata, FALSE) != 0)
       res = 1;
   }
 

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -110,6 +110,7 @@ dt_colorspaces_color_profile_type_t dt_exif_get_color_space(const uint8_t *data,
 
 /** look for datetime_taken in data. used for gphoto downloads */
 gboolean dt_exif_get_datetime_taken(const uint8_t *data, size_t size, time_t *datetime_taken);
+gboolean dt_exif_get_datetime_taken_from_exifblob(const uint8_t *exifblob, size_t size, time_t *datetime_taken);
 
 #ifdef __cplusplus
 }

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -76,7 +76,8 @@ int dt_imageio_export(const int32_t imgid, const char *filename, struct dt_image
                       const gboolean upscale, const gboolean copy_metadata, const gboolean export_masks,
                       dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                       dt_iop_color_intent_t icc_intent, dt_imageio_module_storage_t *storage,
-                      dt_imageio_module_data_t *storage_params, int num, int total, dt_export_metadata_t *metadata);
+                      dt_imageio_module_data_t *storage_params, int num, int total, dt_export_metadata_t *metadata,
+                      gboolean restore_datetime);
 
 int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  struct dt_imageio_module_format_t *format,
@@ -86,7 +87,8 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  const gboolean export_masks, dt_colorspaces_color_profile_type_t icc_type,
                                  const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
                                  dt_imageio_module_storage_t *storage, dt_imageio_module_data_t *storage_params,
-                                 int num, int total, dt_export_metadata_t *metadata);
+                                 int num, int total, dt_export_metadata_t *metadata,
+                                 gboolean restore_datetime);
 
 size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
                             dt_image_orientation_t orientation);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1276,7 +1276,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
     // no upscaling and signal we want thumbnail export
     res = dt_imageio_export_with_flags(imgid, "unused", &format, (dt_imageio_module_data_t *)&dat, TRUE, FALSE, FALSE,
                                        FALSE, TRUE, NULL, FALSE, FALSE, DT_COLORSPACE_NONE, NULL, DT_INTENT_LAST, NULL,
-                                       NULL, 1, 1, NULL);
+                                       NULL, 1, 1, NULL, FALSE);
     if(!res)
     {
       dt_print(DT_DEBUG_CACHE, "[mipmap_cache] generate mip %d for image %d from scratch\n", size, imgid);

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -45,7 +45,8 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
                        gboolean high_quality, gboolean upscale, gboolean export_masks,
                        char *style, gboolean style_append,
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-                       dt_iop_color_intent_t icc_intent, const gchar *metadata_export);
+                       dt_iop_color_intent_t icc_intent, const gchar *metadata_export,
+		       gboolean restore_datetime);
 void dt_control_merge_hdr();
 void dt_control_import(GList *imgs, const time_t datetime_override, const gboolean inplace);
 void dt_control_seed_denoise();

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -224,7 +224,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
           const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
           dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-          dt_export_metadata_t *metadata)
+          dt_export_metadata_t *metadata, gboolean restore_datetime)
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)sdata;
 
@@ -326,7 +326,7 @@ try_again:
 
   /* export image to file */
   if(dt_imageio_export(imgid, filename, format, fdata, high_quality, upscale, TRUE, export_masks, icc_type,
-                       icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_filename, icc_intent, self, sdata, num, total, metadata, restore_datetime) != 0)
   {
     fprintf(stderr, "[imageio_storage_disk] could not export to file: `%s'!\n", filename);
     dt_control_log(_("could not export to file `%s'!"), filename);

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -100,7 +100,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
           const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
           dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-          dt_export_metadata_t *metadata)
+          dt_export_metadata_t *metadata, gboolean restore_datetime)
 {
   dt_imageio_email_t *d = (dt_imageio_email_t *)sdata;
 
@@ -131,7 +131,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   attachment->file = g_build_filename(tmpdir, dirname, (char *)NULL);
 
   if(dt_imageio_export(imgid, attachment->file, format, fdata, high_quality, upscale, TRUE, export_masks, icc_type,
-                       icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_filename, icc_intent, self, sdata, num, total, metadata, restore_datetime) != 0)
   {
     fprintf(stderr, "[imageio_storage_email] could not export to file: `%s'!\n", attachment->file);
     dt_control_log(_("could not export to file `%s'!"), attachment->file);

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -214,7 +214,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
           const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
           dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-          dt_export_metadata_t *metadata)
+          dt_export_metadata_t *metadata, gboolean restore_datetime)
 {
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)sdata;
 
@@ -343,7 +343,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   // export image to file. need this to be able to access meaningful
   // fdata->width and height below.
   if(dt_imageio_export(imgid, filename, format, fdata, high_quality, upscale, TRUE, export_masks, icc_type,
-                       icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_filename, icc_intent, self, sdata, num, total, metadata, restore_datetime) != 0)
   {
     fprintf(stderr, "[imageio_storage_gallery] could not export to file: `%s'!\n", filename);
     dt_control_log(_("could not export to file `%s'!"), filename);
@@ -382,7 +382,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   ext = format->extension(fdata);
   sprintf(c, "-thumb.%s", ext);
   if(dt_imageio_export(imgid, filename, format, fdata, FALSE, TRUE, FALSE, export_masks, icc_type, icc_filename,
-                       icc_intent, self, sdata, num, total, NULL) != 0)
+                       icc_intent, self, sdata, num, total, NULL, FALSE) != 0)
   {
     fprintf(stderr, "[imageio_storage_gallery] could not export to file: `%s'!\n", filename);
     dt_control_log(_("could not export to file `%s'!"), filename);

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -70,7 +70,7 @@ REQUIRED(int, store, struct dt_imageio_module_storage_t *self, struct dt_imageio
                      struct dt_imageio_module_format_t *format, struct dt_imageio_module_data_t *fdata, const int num,
                      const int total, const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
                      const enum dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-                     enum dt_iop_color_intent_t icc_intent, struct dt_export_metadata_t *metadata);
+                     enum dt_iop_color_intent_t icc_intent, struct dt_export_metadata_t *metadata, gboolean restore_datetime);
 /* called once at the end (after exporting all images), if implemented. */
 OPTIONAL(void, finalize_store, struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data);
 

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -216,7 +216,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
           const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
           dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-          dt_export_metadata_t *metadata)
+          dt_export_metadata_t *metadata, gboolean restore_datetime)
 {
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)sdata;
 
@@ -351,7 +351,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 
   /* export image to file */
   dt_imageio_export(imgid, filename, format, fdata, high_quality, upscale, TRUE, export_masks, icc_type, icc_filename,
-                    icc_intent, self, sdata, num, total, metadata);
+                    icc_intent, self, sdata, num, total, metadata, restore_datetime);
 
   printf("[export_job] exported to `%s'\n", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -908,7 +908,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
           const gboolean high_quality, const gboolean upscale, const gboolean export_masks,
           dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-          dt_export_metadata_t *metadata)
+          dt_export_metadata_t *metadata, gboolean restore_datetime)
 {
   dt_storage_piwigo_gui_data_t *ui = self->gui_data;
 
@@ -970,7 +970,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     }
   }
   if(dt_imageio_export(imgid, fname, format, fdata, high_quality, upscale, TRUE, export_masks, icc_type, icc_filename,
-                       icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_intent, self, sdata, num, total, metadata, restore_datetime) != 0)
   {
     fprintf(stderr, "[imageio_storage_piwigo] could not export to file: `%s'!\n", fname);
     dt_control_log(_("could not export to file `%s'!"), fname);

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -214,7 +214,7 @@ static int process_image(dt_slideshow_t *d, dt_slideshow_slot_t slot)
     // the flags are: ignore exif, display byteorder, high quality, upscale, thumbnail
     dt_imageio_export_with_flags(id, "unused", &buf, (dt_imageio_module_data_t *)&dat, TRUE, TRUE,
                                  high_quality, TRUE, FALSE, NULL, FALSE, FALSE, DT_COLORSPACE_DISPLAY,
-                                 NULL, DT_INTENT_LAST, NULL, NULL, 1, 1, NULL);
+                                 NULL, DT_INTENT_LAST, NULL, NULL, 1, 1, NULL, FALSE);
 
     // lock to copy back into the slot the rendered buffer, not that this is done only if
     // the slot rank is still the same as the local buffer rank. This can be false if the


### PR DESCRIPTION
Hi!

One feature I miss from darktable is the ability to automatically set the modification time of the exported images to match the date and time of the photo based on exif data. Basically an "exiv2 -T rename *.jpg" on Linux. I couldn't find anything related in darktable, but I might be wrong. So I created this proof of concept pull request. I know this is nowhere near production ready, but I wanted to get feedback early.

Is there any similar existing feature in darktable that I missed?
Is this feature even welcomed by the community?

If so, is this the right approach? I basically added a boolean option to the export module, passed along the value to the exporting functions and implemented it in dt_imageio_export_with_flags().

There are some TODOs and debug printf statements in the patch, it might even have whitespace issues, it probably doesn't work on Windows... as I said it is nowhere near production ready, but I'd really like to get some feedback on the general direction.

Thanks!