### PR TITLE
Color calibration : enable color matching between pictures

### DIFF
--- a/src/develop/openmp_maths.h
+++ b/src/develop/openmp_maths.h
@@ -142,12 +142,3 @@ static inline float clamp_simd(const float x)
 {
   return fminf(fmaxf(x, 0.0f), 1.0f);
 }
-
-
-#ifdef _OPENMP
-#pragma omp declare simd
-#endif
-static inline float sqf(const float x)
-{
-  return x * x;
-}

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4347,9 +4347,10 @@ void gui_init(struct dt_iop_module_t *self)
   g->collapsible_spot = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->spot_mode, self, NULL, N_("spot mode"),
-                                _("correction automatically adjust the illuminant\n"
+                                _("\"correction\" automatically adjust the illuminant\n"
                                   "such that the input color is mapped to the target.\n"
-                                  "measure simply shows how an input color is mapped by the CAT."),
+                                  "\"measure\" simply shows how an input color is mapped by the CAT\n"
+                                  "and can be used to sample a target."),
                                 0, NULL, self,
                                 N_("correction"),
                                 N_("measure"));

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4295,8 +4295,38 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), FALSE, FALSE, 0);
 
+  g->illuminant = dt_bauhaus_combobox_from_params(self, N_("illuminant"));
+
+  g->illum_fluo = dt_bauhaus_combobox_from_params(self, "illum_fluo");
+
+  g->illum_led = dt_bauhaus_combobox_from_params(self, "illum_led");
+
+  g->temperature = dt_bauhaus_slider_from_params(self, N_("temperature"));
+  dt_bauhaus_slider_set_soft_range(g->temperature, 3000., 7000.);
+  dt_bauhaus_slider_set_step(g->temperature, 50.);
+  dt_bauhaus_slider_set_digits(g->temperature, 0);
+  dt_bauhaus_slider_set_format(g->temperature, "%.0f K");
+
+  g->illum_x = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 360., 0.5, 0, 1, 0);
+  dt_bauhaus_widget_set_label(g->illum_x, NULL, _("hue"));
+  dt_bauhaus_slider_set_format(g->illum_x, "%.1f °");
+  g_signal_connect(G_OBJECT(g->illum_x), "value-changed", G_CALLBACK(illum_xy_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_x), FALSE, FALSE, 0);
+
+  g->illum_y = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
+  dt_bauhaus_widget_set_label(g->illum_y, NULL, _("chroma"));
+  dt_bauhaus_slider_set_format(g->illum_y, "%.1f %%");
+  dt_bauhaus_slider_set_hard_max(g->illum_y, 300.f);
+  g_signal_connect(G_OBJECT(g->illum_y), "value-changed", G_CALLBACK(illum_xy_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_y), FALSE, FALSE, 0);
+
+  g->gamut = dt_bauhaus_slider_from_params(self, "gamut");
+  dt_bauhaus_slider_set_hard_max(g->gamut, 12.f);
+
+  g->clip = dt_bauhaus_toggle_from_params(self, "clip");
+
   g->spot_settings = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->spot_settings, NULL, N_("spot color mapping settings"));
+  dt_bauhaus_widget_set_label(g->spot_settings, NULL, N_("spot color mapping"));
   dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->spot_settings, TRUE);
   gtk_widget_set_tooltip_text(g->spot_settings, _("use a color checker target to autoset CAT and channels"));
@@ -4381,36 +4411,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(hhbox), FALSE, FALSE, 0);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->collapsible_spot), FALSE, FALSE, 0);
-
-  g->illuminant = dt_bauhaus_combobox_from_params(self, N_("illuminant"));
-
-  g->illum_fluo = dt_bauhaus_combobox_from_params(self, "illum_fluo");
-
-  g->illum_led = dt_bauhaus_combobox_from_params(self, "illum_led");
-
-  g->temperature = dt_bauhaus_slider_from_params(self, N_("temperature"));
-  dt_bauhaus_slider_set_soft_range(g->temperature, 3000., 7000.);
-  dt_bauhaus_slider_set_step(g->temperature, 50.);
-  dt_bauhaus_slider_set_digits(g->temperature, 0);
-  dt_bauhaus_slider_set_format(g->temperature, "%.0f K");
-
-  g->illum_x = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 360., 0.5, 0, 1, 0);
-  dt_bauhaus_widget_set_label(g->illum_x, NULL, _("hue"));
-  dt_bauhaus_slider_set_format(g->illum_x, "%.1f °");
-  g_signal_connect(G_OBJECT(g->illum_x), "value-changed", G_CALLBACK(illum_xy_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_x), FALSE, FALSE, 0);
-
-  g->illum_y = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
-  dt_bauhaus_widget_set_label(g->illum_y, NULL, _("chroma"));
-  dt_bauhaus_slider_set_format(g->illum_y, "%.1f %%");
-  dt_bauhaus_slider_set_hard_max(g->illum_y, 300.f);
-  g_signal_connect(G_OBJECT(g->illum_y), "value-changed", G_CALLBACK(illum_xy_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_y), FALSE, FALSE, 0);
-
-  g->gamut = dt_bauhaus_slider_from_params(self, "gamut");
-  dt_bauhaus_slider_set_hard_max(g->gamut, 12.f);
-
-  g->clip = dt_bauhaus_toggle_from_params(self, "clip");
 
   GtkWidget *first, *second, *third;
 #define NOTEBOOK_PAGE(var, short, label, tooltip, section, swap)              \

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -68,7 +68,6 @@ DT_MODULE_INTROSPECTION(3, dt_iop_channelmixer_rgb_params_t)
 
 
 #define CHANNEL_SIZE 4
-#define NORM_MIN 1e-6f
 #define INVERSE_SQRT_3 0.5773502691896258f
 
 typedef enum dt_iop_channelmixer_rgb_version_t
@@ -500,36 +499,6 @@ static int get_white_balance_coeff(struct dt_iop_module_t *self, dt_aligned_pixe
   }
 
   return 0;
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd aligned(vector:16)
-#endif
-static inline float euclidean_norm(const dt_aligned_pixel_t vector)
-{
-  return fmaxf(sqrtf(sqf(vector[0]) + sqf(vector[1]) + sqf(vector[2])), NORM_MIN);
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd aligned(vector:16)
-#endif
-static inline void downscale_vector(dt_aligned_pixel_t vector, const float scaling)
-{
-  // check zero or NaN
-  const int valid = (scaling > NORM_MIN) && !isnan(scaling);
-  for(size_t c = 0; c < 3; c++) vector[c] = (valid) ? vector[c] / (scaling + NORM_MIN) : vector[c] / NORM_MIN;
-}
-
-
-#ifdef _OPENMP
-#pragma omp declare simd aligned(vector:16)
-#endif
-static inline void upscale_vector(dt_aligned_pixel_t vector, const float scaling)
-{
-  const int valid = (scaling > NORM_MIN) && !isnan(scaling);
-  for(size_t c = 0; c < 3; c++) vector[c] = (valid) ? vector[c] * (scaling + NORM_MIN) : vector[c] * NORM_MIN;
 }
 
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3816,6 +3816,21 @@ static void spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *s
 {
   if(darktable.gui->reset) return;
 
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+
+  dt_aligned_pixel_t Lch_target = { 0.f };
+
+  dt_iop_gui_enter_critical_section(self);
+  Lch_target[0] = dt_bauhaus_slider_get(g->lightness_spot);
+  Lch_target[1] = dt_bauhaus_slider_get(g->chroma_spot);
+  Lch_target[2] = dt_bauhaus_slider_get(g->hue_spot) / 360.f;
+  dt_iop_gui_leave_critical_section(self);
+
+  // Save the color on change
+  dt_conf_set_float("darkroom/modules/channelmixerrgb/lightness", Lch_target[0]);
+  dt_conf_set_float("darkroom/modules/channelmixerrgb/chroma", Lch_target[1]);
+  dt_conf_set_float("darkroom/modules/channelmixerrgb/hue", Lch_target[2] * 360.f);
+
   ++darktable.gui->reset;
   paint_hue(self);
   --darktable.gui->reset;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4113,8 +4113,8 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     {
       // Repack the MIX matrix to 3×3 to support the pseudoinverse function
       // I'm just too lazy to rewrite the pseudo-inverse for 3×4 padded input
-      float MIX_3x3[3][3];
-      pack_3xSSE_to_3x3(MIX, &MIX_3x3[0][0]);
+      float MIX_3x3[9];
+      pack_3xSSE_to_3x3(MIX, MIX_3x3);
 
       /* DEBUG
       fprintf(stdout, "Repacked channel mixer matrix :\n");
@@ -4124,12 +4124,12 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
       */
 
       // Invert the matrix
-      float MIX_INV_3x3[3][3];
-      matrice_pseudoinverse(MIX_3x3, MIX_INV_3x3, 3);
+      float MIX_INV_3x3[9];
+      matrice_pseudoinverse((float (*)[3])MIX_3x3, (float (*)[3])MIX_INV_3x3, 3);
 
       // Transpose and repack the inverse to SSE matrix because the inversion transposes too
       dt_colormatrix_t MIX_INV;
-      transpose_3x3_to_3xSSE(&MIX_INV_3x3[0][0], MIX_INV);
+      transpose_3x3_to_3xSSE(MIX_INV_3x3, MIX_INV);
 
       /* DEBUG
       fprintf(stdout, "Repacked inverted channel mixer matrix :\n");

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3827,19 +3827,24 @@ static void spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *s
   Lch_target[0] = dt_bauhaus_slider_get(g->lightness_spot);
   Lch_target[1] = dt_bauhaus_slider_get(g->chroma_spot);
   Lch_target[2] = dt_bauhaus_slider_get(g->hue_spot) / 360.f;
+  const gboolean use_mixing = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->use_mixing));
   dt_iop_gui_leave_critical_section(self);
 
   // Save the color on change
   dt_conf_set_float("darkroom/modules/channelmixerrgb/lightness", Lch_target[0]);
   dt_conf_set_float("darkroom/modules/channelmixerrgb/chroma", Lch_target[1]);
   dt_conf_set_float("darkroom/modules/channelmixerrgb/hue", Lch_target[2] * 360.f);
+  dt_conf_set_bool("darkroom/modules/channelmixerrgb/use_mixing", use_mixing);
 
   ++darktable.gui->reset;
   paint_hue(self);
   --darktable.gui->reset;
 
-  // Re-run auto illuminant if color picker is active
-  _auto_set_illuminant(self, darktable.develop->pipe);
+  // Re-run auto illuminant if color picker is active and mode is correct
+  const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
+  if(mode == DT_SPOT_MODE_CORRECT)
+    _auto_set_illuminant(self, darktable.develop->pipe);
+  // else : just record new values and do nothing
 }
 
 
@@ -4308,13 +4313,14 @@ void gui_init(struct dt_iop_module_t *self)
                                 N_("correction"),
                                 N_("measure"));
   gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(g->spot_mode), TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->spot_mode), "value-changed", G_CALLBACK(spot_settings_changed_callback), self);
 
   g->use_mixing = gtk_check_button_new_with_label(_("take channel mixing into account"));
   gtk_widget_set_tooltip_text(g->use_mixing,
                               _("compute the target by taking the channel mixing into account.\n"
                                 "if disabled, only the CAT is considered."));
   gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(g->use_mixing), TRUE, TRUE, 0);
-
+  g_signal_connect(G_OBJECT(g->use_mixing), "toggled", G_CALLBACK(spot_settings_changed_callback), self);
 
   GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width));
   GtkWidget *vvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -173,6 +173,7 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   GtkWidget *collapsible_spot, *hue_spot, *chroma_spot, *lightness_spot;
   GtkWidget *origin_spot, *target_spot;
   GtkWidget *Lch_origin, *Lch_target;
+  GtkWidget *use_mixing;
   dt_aligned_pixel_t spot_RGB;
 
 } dt_iop_channelmixer_rgb_gui_data_t;
@@ -3624,6 +3625,11 @@ void gui_update(struct dt_iop_module_t *self)
   // get the saved params
   dt_iop_gui_enter_critical_section(self);
 
+  gboolean use_mixing = TRUE;
+  if(dt_conf_key_exists("darkroom/modules/channelmixerrgb/use_mixing"))
+    use_mixing = dt_conf_get_bool("darkroom/modules/channelmixerrgb/use_mixing");
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->use_mixing), use_mixing);
+
   float lightness = 50.f;
   if(dt_conf_key_exists("darkroom/modules/channelmixerrgb/lightness"))
     lightness = dt_conf_get_float("darkroom/modules/channelmixerrgb/lightness");
@@ -3979,6 +3985,26 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   --darktable.gui->reset;
 
   const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
+  const gboolean use_mixing = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->use_mixing));
+
+  // build the channel mixing matrix - keep in synch with commit_params()
+  dt_colormatrix_t MIX = { { 0.f } };
+
+  float norm_R = 1.0f;
+  if(p->normalize_R) norm_R = p->red[0] + p->red[1] + p->red[2];
+
+  float norm_G = 1.0f;
+  if(p->normalize_G) norm_G = p->green[0] + p->green[1] + p->green[2];
+
+  float norm_B = 1.0f;
+  if(p->normalize_B) norm_B = p->blue[0] + p->blue[1] + p->blue[2];
+
+  for(int i = 0; i < 3; i++)
+  {
+    MIX[0][i] = p->red[i] / norm_R;
+    MIX[1][i] = p->green[i] / norm_G;
+    MIX[2][i] = p->blue[i] / norm_B;
+  }
 
   if(mode == DT_SPOT_MODE_MEASURE)
   {
@@ -4015,6 +4041,16 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     dt_aligned_pixel_t XYZ_output = { 0.f };
     chroma_adapt_pixel(XYZ, XYZ_output, LMS_illuminant, adaptation, pp);
 
+    // Optionaly, apply the channel mixing
+    if(use_mixing)
+    {
+      dt_aligned_pixel_t LMS_output = { 0.f };
+      convert_any_XYZ_to_LMS(XYZ_output, LMS_output, adaptation);
+      dt_aligned_pixel_t temp = { 0.f };
+      dot_product(LMS_output, MIX, temp);
+      convert_any_LMS_to_XYZ(temp, XYZ_output, adaptation);
+    }
+
     // Convert to Lab and Lch for GUI feedback
     dt_aligned_pixel_t Lab_output = { 0.f };
     dt_aligned_pixel_t Lch_output = { 0.f };
@@ -4032,6 +4068,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     dt_conf_set_float("darkroom/modules/channelmixerrgb/lightness", Lch_output[0]);
     dt_conf_set_float("darkroom/modules/channelmixerrgb/chroma", Lch_output[1]);
     dt_conf_set_float("darkroom/modules/channelmixerrgb/hue", Lch_output[2] * 360.f);
+    dt_conf_set_bool("darkroom/modules/channelmixerrgb/use_mixing", use_mixing);
   }
   else if(mode == DT_SPOT_MODE_CORRECT)
   {
@@ -4052,6 +4089,57 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     const float Y_target = XYZ_target[1];
     for(int c = 0; c < 3; c++) XYZ_target[c] /= Y_target;
     convert_any_XYZ_to_LMS(XYZ_target, LMS_target, p->adaptation);
+
+    // optionaly, apply the inverse mixing on the target
+    if(use_mixing)
+    {
+      // Repack the MIX matrix to 3×3 to support the pseudoinverse function
+      // I'm just too lazy to rewrite the pseudo-inverse for 3×4 padded input
+      float MIX_3x3[3][3];
+      pack_3xSSE_to_3x3(MIX, &MIX_3x3[0][0]);
+
+      /* DEBUG
+      fprintf(stdout, "Repacked channel mixer matrix :\n");
+      fprintf(stdout, "%f \t%f \t%f\n", MIX_3x3[0][0], MIX_3x3[0][1], MIX_3x3[0][2]);
+      fprintf(stdout, "%f \t%f \t%f\n", MIX_3x3[1][0], MIX_3x3[1][1], MIX_3x3[1][2]);
+      fprintf(stdout, "%f \t%f \t%f\n", MIX_3x3[2][0], MIX_3x3[2][1], MIX_3x3[2][2]);
+      */
+
+      // Invert the matrix
+      float MIX_INV_3x3[3][3];
+      matrice_pseudoinverse(MIX_3x3, MIX_INV_3x3, 3);
+
+      // Transpose and repack the inverse to SSE matrix because the inversion transposes too
+      dt_colormatrix_t MIX_INV;
+      transpose_3x3_to_3xSSE(&MIX_INV_3x3[0][0], MIX_INV);
+
+      /* DEBUG
+      fprintf(stdout, "Repacked inverted channel mixer matrix :\n");
+      fprintf(stdout, "%f \t%f \t%f\n", MIX_INV[0][0], MIX_INV[0][1], MIX_INV[0][2]);
+      fprintf(stdout, "%f \t%f \t%f\n", MIX_INV[1][0], MIX_INV[1][1], MIX_INV[1][2]);
+      fprintf(stdout, "%f \t%f \t%f\n", MIX_INV[2][0], MIX_INV[2][1], MIX_INV[2][2]);
+      */
+
+      // Undo the channel mixing on the reference color
+      // So we get the expected target color after the CAT
+      dt_aligned_pixel_t temp;
+      dot_product(LMS_target, MIX_INV, temp);
+
+      //fprintf(stdout, "LMS before channel mixer inversion : \t%f \t%f \t%f\n", LMS_target[0], LMS_target[1], LMS_target[2]);
+      //fprintf(stdout, "LMS after channel mixer inversion : \t%f \t%f \t%f\n", temp[0], temp[1], temp[2]);
+
+      // convert back to XYZ to normalize luminance again
+      // in case the matrix is not normalized
+      convert_any_LMS_to_XYZ(temp, XYZ_target, p->adaptation);
+      const float Y_mix = XYZ_target[1];
+      for(int c = 0; c < 3; c++) XYZ_target[c] /= Y_mix;
+      convert_any_XYZ_to_LMS(XYZ_target, LMS_target, p->adaptation);
+
+      //fprintf(stdout, "LMS target after everything : %f \t%f \t%f\n", LMS_target[0], LMS_target[1], LMS_target[2]);
+
+      // So now we got the target color after CAT and before mixing
+      // in LMS space
+    }
 
     // Get the input color in LMS space
     dt_aligned_pixel_t LMS = { 0.f };
@@ -4195,6 +4283,13 @@ void gui_init(struct dt_iop_module_t *self)
                                 N_("correction"),
                                 N_("measure"));
   gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(g->spot_mode), TRUE, TRUE, 0);
+
+  g->use_mixing = gtk_check_button_new_with_label(_("take channel mixing into account"));
+  gtk_widget_set_tooltip_text(g->use_mixing,
+                              _("compute the target by taking the channel mixing into account.\n"
+                                "if disabled, only the CAT is considered."));
+  gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(g->use_mixing), TRUE, TRUE, 0);
+
 
   GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width));
   GtkWidget *vvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2697,13 +2697,16 @@ static void set_spot_callback(GtkWidget *togglebutton, dt_iop_module_t *self)
 
   // stupid toggle on/off
   dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
-  const gboolean state = gtk_widget_get_visible(g->collapsible_spot);
-  gtk_widget_set_visible(g->collapsible_spot, !state);
+  const gboolean state = !gtk_widget_get_visible(g->collapsible_spot);
+  gtk_widget_set_visible(g->collapsible_spot, state);
 
-  if(!state)
+  if(state)
     dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_DOWN, NULL);
   else
     dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+
+  // Remember the state
+  dt_conf_set_bool("darkroom/modules/channelmixerrgb/expand_picker_mapping", state);
 }
 
 static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
@@ -3648,9 +3651,17 @@ void gui_update(struct dt_iop_module_t *self)
     chroma = dt_conf_get_float("darkroom/modules/channelmixerrgb/chroma");
   dt_bauhaus_slider_set(g->chroma_spot, chroma);
 
+  gboolean show_collapsible = FALSE;
+  if(dt_conf_key_exists("darkroom/modules/channelmixerrgb/expand_picker_mapping"))
+    show_collapsible = dt_conf_get_bool("darkroom/modules/channelmixerrgb/expand_picker_mapping");
+  gtk_widget_set_visible(g->collapsible_spot, show_collapsible);
+
   dt_iop_gui_leave_critical_section(self);
 
-  gtk_widget_hide(g->collapsible_spot);
+  if(show_collapsible)
+    dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_DOWN, NULL);
+  else
+    dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
 
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
   dt_bauhaus_combobox_set(g->illum_fluo, p->illum_fluo);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -117,6 +117,13 @@ typedef enum dt_solving_strategy_t
 } dt_solving_strategy_t;
 
 
+typedef enum dt_spot_mode_t
+{
+  DT_SPOT_MODE_CORRECT = 0,
+  DT_SPOT_MODE_MEASURE = 1,
+  DT_SPOT_MODE_LAST
+} dt_spot_mode_t;
+
 typedef struct dt_iop_channelmixer_rgb_gui_data_t
 {
   GtkNotebook *notebook;
@@ -161,6 +168,13 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   float *delta_E_in;
 
   gchar *delta_E_label_text;
+
+  GtkWidget *spot_settings, *spot_mode;
+  GtkWidget *collapsible_spot, *hue_spot, *chroma_spot, *lightness_spot;
+  GtkWidget *origin_spot, *target_spot;
+  GtkWidget *Lch_origin, *Lch_target;
+  dt_aligned_pixel_t spot_RGB;
+
 } dt_iop_channelmixer_rgb_gui_data_t;
 
 typedef struct dt_iop_channelmixer_rbg_data_t
@@ -2671,6 +2685,23 @@ static void commit_profile_callback(GtkWidget *widget, GdkEventButton *event, gp
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
+static void set_spot_callback(GtkWidget *togglebutton, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_request_focus(self);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+
+  // stupid toggle on/off
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  const gboolean state = gtk_widget_get_visible(g->collapsible_spot);
+  gtk_widget_set_visible(g->collapsible_spot, !state);
+
+  if(!state)
+    dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_DOWN, NULL);
+  else
+    dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+}
+
 static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -3022,6 +3053,80 @@ static void update_xy_color(dt_iop_module_t *self)
   gtk_widget_queue_draw(g->illum_y);
 }
 
+static void paint_hue(dt_iop_module_t *self)
+{
+  // update the fill background color of LCh sliders
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+
+  const float hue = dt_bauhaus_slider_get(g->hue_spot);
+
+  const float hue_min = DT_BAUHAUS_WIDGET(g->hue_spot)->data.slider.min;
+  const float hue_max = DT_BAUHAUS_WIDGET(g->hue_spot)->data.slider.max;
+
+  const float lightness_min = DT_BAUHAUS_WIDGET(g->lightness_spot)->data.slider.min;
+  const float lightness_max = DT_BAUHAUS_WIDGET(g->lightness_spot)->data.slider.max;
+
+  const float chroma_min = DT_BAUHAUS_WIDGET(g->chroma_spot)->data.slider.min;
+  const float chroma_max = DT_BAUHAUS_WIDGET(g->chroma_spot)->data.slider.max;
+
+  const float hue_range = hue_max - hue_min;
+  const float lightness_range = lightness_max - lightness_min;
+  const float chroma_range = chroma_max - chroma_min;
+
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
+    const float x = hue_min + stop * hue_range;
+    dt_aligned_pixel_t RGB = { 0 };
+    const dt_aligned_pixel_t Lch = { 67.f, 96.f, x / 360.f};
+    dt_aligned_pixel_t Lab = { 0 };
+    dt_aligned_pixel_t XYZ = { 0 };
+
+    dt_LCH_2_Lab(Lch, Lab);
+    dt_Lab_to_XYZ(Lab, XYZ);
+    dt_XYZ_to_sRGB(XYZ, RGB);
+
+    dt_bauhaus_slider_set_stop(g->hue_spot, stop, RGB[0], RGB[1], RGB[2]);
+  }
+
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
+    const float x = lightness_min + stop * lightness_range;
+    dt_aligned_pixel_t RGB = { 0 };
+    const dt_aligned_pixel_t Lch = { x, 0.f, 0. };
+    dt_aligned_pixel_t Lab = { 0 };
+    dt_aligned_pixel_t XYZ = { 0 };
+
+    dt_LCH_2_Lab(Lch, Lab);
+    dt_Lab_to_XYZ(Lab, XYZ);
+    dt_XYZ_to_sRGB(XYZ, RGB);
+
+    dt_bauhaus_slider_set_stop(g->lightness_spot, stop, RGB[0], RGB[1], RGB[2]);
+  }
+
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = ((float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1));
+    const float x = chroma_min + stop * chroma_range;
+    dt_aligned_pixel_t RGB = { 0 };
+    const dt_aligned_pixel_t Lch = { 50., x, hue / 360.f };
+    dt_aligned_pixel_t Lab = { 0 };
+    dt_aligned_pixel_t XYZ = { 0 };
+
+    dt_LCH_2_Lab(Lch, Lab);
+    dt_Lab_to_XYZ(Lab, XYZ);
+    dt_XYZ_to_sRGB(XYZ, RGB);
+
+    dt_bauhaus_slider_set_stop(g->chroma_spot, stop, RGB[0], RGB[1], RGB[2]);
+  }
+
+  gtk_widget_queue_draw(g->hue_spot);
+  gtk_widget_queue_draw(g->lightness_spot);
+  gtk_widget_queue_draw(g->chroma_spot);
+  gtk_widget_queue_draw(g->target_spot);
+}
+
 static void _convert_GUI_colors(dt_iop_channelmixer_rgb_params_t *p,
                                 const struct dt_iop_order_iccprofile_info_t *const work_profile,
                                 const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB)
@@ -3324,6 +3429,80 @@ static gboolean illuminant_color_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   return TRUE;
 }
 
+static gboolean target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+
+  // Init
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
+  cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+  cairo_t *cr = cairo_create(cst);
+
+  // Margins
+  const double INNER_PADDING = 4.0;
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  width -= 2* INNER_PADDING;
+  height -= 2 * margin;
+
+  // Paint target color
+  dt_aligned_pixel_t RGB = { 0 };
+  dt_aligned_pixel_t Lch = { 0 };
+  dt_aligned_pixel_t Lab = { 0 };
+  dt_aligned_pixel_t XYZ = { 0 };
+  Lch[0] = dt_bauhaus_slider_get(g->lightness_spot);
+  Lch[1] = dt_bauhaus_slider_get(g->chroma_spot);
+  Lch[2] = dt_bauhaus_slider_get(g->hue_spot) / 360.f;
+  dt_LCH_2_Lab(Lch, Lab);
+  dt_Lab_to_XYZ(Lab, XYZ);
+  dt_XYZ_to_sRGB(XYZ, RGB);
+
+  cairo_set_source_rgb(cr, RGB[0], RGB[1], RGB[2]);
+  cairo_rectangle(cr, INNER_PADDING, margin, width, height);
+  cairo_fill(cr);
+
+  // Clean
+  cairo_stroke(cr);
+  cairo_destroy(cr);
+  cairo_set_source_surface(crf, cst, 0, 0);
+  cairo_paint(crf);
+  cairo_surface_destroy(cst);
+  return TRUE;
+}
+
+static gboolean origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+
+  // Init
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
+  cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+  cairo_t *cr = cairo_create(cst);
+
+  // Margins
+  const double INNER_PADDING = 4.0;
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  width -= 2* INNER_PADDING;
+  height -= 2 * margin;
+
+  cairo_set_source_rgb(cr, g->spot_RGB[0], g->spot_RGB[1], g->spot_RGB[2]);
+  cairo_rectangle(cr, INNER_PADDING, margin, width, height);
+  cairo_fill(cr);
+
+  // Clean
+  cairo_stroke(cr);
+  cairo_destroy(cr);
+  cairo_set_source_surface(crf, cst, 0, 0);
+  cairo_paint(crf);
+  cairo_surface_destroy(cst);
+  return TRUE;
+}
+
 static void update_approx_cct(dt_iop_module_t *self)
 {
   dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
@@ -3439,6 +3618,12 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
+  dt_bauhaus_combobox_set(g->spot_mode, DT_SPOT_MODE_CORRECT);
+  dt_bauhaus_slider_set(g->lightness_spot, 50.f);
+  dt_bauhaus_slider_set(g->chroma_spot, 0.f);
+  dt_bauhaus_slider_set(g->hue_spot, 0.f);
+  gtk_widget_hide(g->collapsible_spot);
+
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
   dt_bauhaus_combobox_set(g->illum_fluo, p->illum_fluo);
   dt_bauhaus_combobox_set(g->illum_led, p->illum_led);
@@ -3509,6 +3694,12 @@ void gui_update(struct dt_iop_module_t *self)
   g->is_profiling_started = FALSE;
   gtk_widget_hide(g->collapsible);
   dt_bauhaus_widget_set_quad_paint(g->start_profiling, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+
+  g->spot_RGB[0] = 0.f;
+  g->spot_RGB[1] = 0.f;
+  g->spot_RGB[2] = 0.f;
+  g->spot_RGB[3] = 0.f;
+
   gui_changed(self, NULL, NULL);
 }
 
@@ -3595,6 +3786,17 @@ void reload_defaults(dt_iop_module_t *module)
   }
 }
 
+
+static void spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+
+  ++darktable.gui->reset;
+  paint_hue(self);
+  --darktable.gui->reset;
+}
+
+
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
@@ -3655,6 +3857,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   }
 
   ++darktable.gui->reset;
+
+  if(!w || w == g->hue_spot || w == g->chroma_spot || w == g->lightness_spot || w == g->spot_settings)
+  {
+    paint_hue(self);
+  }
 
   if(!w || w == g->illuminant || w == g->illum_fluo || w == g->illum_led || w == g->temperature)
   {
@@ -3737,38 +3944,143 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   // Convert to XYZ
   dt_aligned_pixel_t XYZ;
   dot_product(RGB, work_profile->matrix_in, XYZ);
+  dt_XYZ_to_sRGB(XYZ, g->spot_RGB);
 
-  // Convert to xyY
-  const float sum = fmaxf(XYZ[0] + XYZ[1] + XYZ[2], NORM_MIN);
-  XYZ[0] /= sum;   // x
-  XYZ[2] = XYZ[1]; // Y
-  XYZ[1] /= sum;   // y
+  // Convert to Lch for GUI feedback (input)
+  dt_aligned_pixel_t Lab;
+  dt_aligned_pixel_t Lch;
+  dt_XYZ_to_Lab(XYZ, Lab);
+  dt_Lab_2_LCH(Lab, Lch);
 
-  p->x = XYZ[0];
-  p->y = XYZ[1];
-
+  // Write report in GUI
   ++darktable.gui->reset;
-
-  check_if_close_to_daylight(p->x, p->y, &p->temperature, &p->illuminant, NULL);
-
-  dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
-  dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
-  dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
-
-  const dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
-  dt_aligned_pixel_t Lch = { 0 };
-  dt_xyY_to_Lch(xyY, Lch);
-  dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
-  dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);
-
-  update_illuminants(self);
-  update_approx_cct(self);
-  update_illuminant_color(self);
-  paint_temperature_background(self);
-
+  gtk_label_set_text(GTK_LABEL(g->Lch_origin),
+                     g_strdup_printf(_("L : \t%.1f %%\nh : \t%.1f °\nc : \t%.1f"),
+                                     Lch[0], Lch[2] * 360.f, Lch[1] ));
   --darktable.gui->reset;
 
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
+
+  if(mode == DT_SPOT_MODE_MEASURE)
+  {
+    // Keep the following in sync with commit_params()
+
+    // find x y coordinates of illuminant for CIE 1931 2° observer
+    float x = p->x;
+    float y = p->y;
+    dt_adaptation_t adaptation = p->adaptation;
+    dt_aligned_pixel_t custom_wb;
+    get_white_balance_coeff(self, custom_wb);
+    illuminant_to_xy(p->illuminant, &(self->dev->image_storage), custom_wb, &x, &y, p->temperature, p->illum_fluo, p->illum_led);
+
+    // if illuminant is set as camera, x and y are set on-the-fly at commit time, so we need to set adaptation too
+    if(p->illuminant == DT_ILLUMINANT_CAMERA) check_if_close_to_daylight(x, y, NULL, NULL, &adaptation);
+
+    // Convert illuminant from xyY to XYZ
+    dt_aligned_pixel_t XYZ_illuminant = { 0.f };
+    illuminant_xy_to_XYZ(x, y, XYZ_illuminant);
+
+    // Convert illuminant from XYZ to Bradford modified LMS
+    dt_aligned_pixel_t LMS_illuminant = { 0.f };
+    convert_any_XYZ_to_LMS(XYZ_illuminant, LMS_illuminant, adaptation);
+
+    // For the non-linear Bradford
+    const float pp = powf(0.818155f / LMS_illuminant[2], 0.0834f);
+
+    //fprintf(stdout, "illuminant: %i\n", p->illuminant);
+    //fprintf(stdout, "x: %f, y: %f\n", x, y);
+    //fprintf(stdout, "X: %f - Y: %f - Z: %f\n", XYZ_illuminant[0], XYZ_illuminant[1], XYZ_illuminant[2]);
+    //fprintf(stdout, "L: %f - M: %f - S: %f\n", LMS_illuminant[0], LMS_illuminant[1], LMS_illuminant[2]);
+
+    // Finally, chroma-adapt the pixel
+    dt_aligned_pixel_t XYZ_output = { 0.f };
+    chroma_adapt_pixel(XYZ, XYZ_output, LMS_illuminant, adaptation, pp);
+
+    // Convert to Lab and Lch for GUI feedback
+    dt_aligned_pixel_t Lab_output = { 0.f };
+    dt_aligned_pixel_t Lch_output = { 0.f };
+    dt_XYZ_to_Lab(XYZ_output, Lab_output);
+    dt_Lab_2_LCH(Lab_output, Lch_output);
+
+    // Return the values in sliders
+    ++darktable.gui->reset;
+    dt_bauhaus_slider_set_soft(g->lightness_spot, Lch_output[0]);
+    dt_bauhaus_slider_set_soft(g->chroma_spot, Lch_output[1]);
+    dt_bauhaus_slider_set_soft(g->hue_spot, Lch_output[2] * 360.f);
+    paint_hue(self);
+    --darktable.gui->reset;
+  }
+  else if(mode == DT_SPOT_MODE_CORRECT)
+  {
+    // Get the target color in LMS space
+    dt_aligned_pixel_t Lch_target = { 0.f };
+    dt_aligned_pixel_t Lab_target = { 0.f };
+    dt_aligned_pixel_t XYZ_target = { 0.f };
+    dt_aligned_pixel_t LMS_target = { 0.f };
+    Lch_target[0] = dt_bauhaus_slider_get(g->lightness_spot);
+    Lch_target[1] = dt_bauhaus_slider_get(g->chroma_spot);
+    Lch_target[2] = dt_bauhaus_slider_get(g->hue_spot) / 360.f;
+    dt_LCH_2_Lab(Lch_target, Lab_target);
+    dt_Lab_to_XYZ(Lab_target, XYZ_target);
+    const float Y_target = XYZ_target[1];
+    for(int c = 0; c < 3; c++) XYZ_target[c] /= Y_target;
+    convert_any_XYZ_to_LMS(XYZ_target, LMS_target, p->adaptation);
+
+    // Get the input color in LMS space
+    dt_aligned_pixel_t LMS = { 0.f };
+    const float Y = XYZ[1];
+    for(int c = 0; c < 3; c++) XYZ[c] /= Y;
+    convert_any_XYZ_to_LMS(XYZ, LMS, p->adaptation);
+
+    // Find the illuminant
+    dt_aligned_pixel_t D50;
+    convert_D50_to_LMS(p->adaptation, D50);
+
+    dt_aligned_pixel_t illuminant_LMS = { 0.f };
+    dt_aligned_pixel_t illuminant_XYZ = { 0.f };
+
+    // We solve the equation : target color / input color = D50 / illuminant, for illuminant
+    for(int c = 0; c < 3; c++) illuminant_LMS[c] = D50[c] * LMS[c] / LMS_target[c];
+    convert_any_LMS_to_XYZ(illuminant_LMS, illuminant_XYZ, p->adaptation);
+
+    // Convert to xyY
+    const float sum = fmaxf(illuminant_XYZ[0] + illuminant_XYZ[1] + illuminant_XYZ[2], NORM_MIN);
+    illuminant_XYZ[0] /= sum;              // x
+    illuminant_XYZ[2] = illuminant_XYZ[1]; // Y
+    illuminant_XYZ[1] /= sum;              // y
+
+    p->x = illuminant_XYZ[0];
+    p->y = illuminant_XYZ[1];
+
+    // Force illuminant to custom, the daylight/black body approximations are
+    // not accurate enough for color matching
+    p->illuminant = DT_ILLUMINANT_CUSTOM;
+
+    ++darktable.gui->reset;
+
+    check_if_close_to_daylight(p->x, p->y, &p->temperature, NULL, NULL);
+
+    dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
+    dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
+    dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
+
+    const dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
+    dt_aligned_pixel_t Lch_illuminant = { 0 };
+    dt_xyY_to_Lch(xyY, Lch_illuminant);
+    dt_bauhaus_slider_set(g->illum_x, Lch_illuminant[2] / M_PI * 180.f);
+    dt_bauhaus_slider_set_soft(g->illum_y, Lch_illuminant[1]);
+
+    update_illuminants(self);
+    update_approx_cct(self);
+    update_illuminant_color(self);
+    paint_hue(self);
+    paint_temperature_background(self);
+    gtk_widget_queue_draw(g->origin_spot);
+
+    --darktable.gui->reset;
+
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+  }
 }
 
 
@@ -3824,7 +4136,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), g->approx_cct, FALSE, FALSE, 0);
 
   g->illum_color = GTK_WIDGET(gtk_drawing_area_new());
-  gtk_widget_set_size_request(g->illum_color, 2 * DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width), -1);
+  gtk_widget_set_size_request(g->illum_color, 2 * DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width),
+                                              DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->illum_color),
                               _("this is the color of the scene illuminant before chromatic adaptation\n"
                                 "this color will be turned into pure white by the adaptation."));
@@ -3836,6 +4149,85 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->color_picker, _("set white balance to detected from area"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), FALSE, FALSE, 0);
+
+  g->spot_settings = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->spot_settings, NULL, N_("spot color mapping settings"));
+  dt_bauhaus_widget_set_quad_paint(g->spot_settings, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->spot_settings, TRUE);
+  gtk_widget_set_tooltip_text(g->spot_settings, _("use a color checker target to autoset CAT and channels"));
+  g_signal_connect(G_OBJECT(g->spot_settings), "quad-pressed", G_CALLBACK(set_spot_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->spot_settings), TRUE, TRUE, 0);
+
+  g->collapsible_spot = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->spot_mode, self, NULL, N_("spot mode"),
+                                _("correction automatically adjust the illuminant\n"
+                                  "such that the input color is mapped to the target.\n"
+                                  "measure simply shows how an input color is mapped by the CAT."),
+                                0, NULL, self,
+                                N_("correction"),
+                                N_("measure"));
+  gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(g->spot_mode), TRUE, TRUE, 0);
+
+  GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width));
+  GtkWidget *vvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  gtk_box_pack_start(GTK_BOX(vvbox), dt_ui_section_label_new(_("input")), FALSE, FALSE, 0);
+
+  g->origin_spot = GTK_WIDGET(gtk_drawing_area_new());
+  gtk_widget_set_size_request(g->origin_spot, 2 * DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width),
+                                              DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->origin_spot),
+                              _("this is the input color that should be mapped to the target."));
+
+  g_signal_connect(G_OBJECT(g->origin_spot), "draw", G_CALLBACK(origin_color_draw), self);
+  gtk_box_pack_start(GTK_BOX(vvbox), g->origin_spot, TRUE, TRUE, 0);
+
+  g->Lch_origin = gtk_label_new(_("L : \tN/A \nh : \tN/A\nc : \tN/A"));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->Lch_origin),
+                              _("these Lch coordinates are computed from CIE Lab 1976 coordinates."));
+  gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->Lch_origin), FALSE, FALSE, 0);
+
+  gtk_box_pack_start(GTK_BOX(hhbox), GTK_WIDGET(vvbox), FALSE, FALSE, DT_BAUHAUS_SPACE);
+
+  vvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  gtk_box_pack_start(GTK_BOX(vvbox), dt_ui_section_label_new(_("target")), TRUE, TRUE, 0);
+
+  g->target_spot = GTK_WIDGET(gtk_drawing_area_new());
+  gtk_widget_set_size_request(g->target_spot, 2 * DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width),
+                                              DT_PIXEL_APPLY_DPI(darktable.bauhaus->quad_width));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->target_spot),
+                              _("this is the desired target color after mapping."));
+
+  g_signal_connect(G_OBJECT(g->target_spot), "draw", G_CALLBACK(target_color_draw), self);
+  gtk_box_pack_start(GTK_BOX(vvbox), g->target_spot, TRUE, TRUE, 0);
+
+  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
+  dt_bauhaus_widget_set_label(g->lightness_spot, NULL, _("lightness"));
+  dt_bauhaus_slider_set_format(g->lightness_spot, "%.1f %%");
+  dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);
+  gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->lightness_spot), TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed", G_CALLBACK(spot_settings_changed_callback), self);
+
+  g->hue_spot = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 360., 0.5, 0, 1, 0);
+  dt_bauhaus_widget_set_label(g->hue_spot, NULL, _("hue"));
+  dt_bauhaus_slider_set_format(g->hue_spot, "%.1f °");
+  dt_bauhaus_slider_set_default(g->hue_spot, 0.f);
+  gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->hue_spot), TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->hue_spot), "value-changed", G_CALLBACK(spot_settings_changed_callback), self);
+
+  g->chroma_spot = dt_bauhaus_slider_new_with_range(self, 0., 128., 0.5, 0, 1);
+  dt_bauhaus_widget_set_label(g->chroma_spot, NULL, _("chroma"));
+  dt_bauhaus_slider_set_default(g->chroma_spot, 0.f);
+  gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->chroma_spot), TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->chroma_spot), "value-changed", G_CALLBACK(spot_settings_changed_callback), self);
+
+  gtk_box_pack_start(GTK_BOX(hhbox), GTK_WIDGET(vvbox), TRUE, TRUE, DT_BAUHAUS_SPACE);
+
+  gtk_box_pack_start(GTK_BOX(g->collapsible_spot), GTK_WIDGET(hhbox), FALSE, FALSE, 0);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->collapsible_spot), FALSE, FALSE, 0);
 
   g->illuminant = dt_bauhaus_combobox_from_params(self, N_("illuminant"));
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -54,8 +54,6 @@
 #include <string.h>
 #include <time.h>
 
-
-#define NORM_MIN 1.52587890625e-05f // norm can't be < to 2^(-16)
 #define INVERSE_SQRT_3 0.5773502691896258f
 #define SAFETY_MARGIN 0.01f
 
@@ -383,7 +381,7 @@ static inline void convert_to_spline_v3(dt_iop_filmicrgb_params_t* n)
 
   dt_iop_filmic_rgb_spline_t spline;
   dt_iop_filmic_rgb_compute_spline(n, &spline);
-  
+
   // from the spline, compute new values for contrast, balance, and latitude to update spline_version to v3
   float grey_log = spline.x[2];
   float toe_log = fminf(spline.x[1], grey_log);
@@ -677,7 +675,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       gboolean compensate_icc_black; // $DEFAULT: FALSE $DESCRIPTION: "compensate output ICC profile black point"
       gint internal_version; // $DEFAULT: 2020 $DESCRIPTION: "version of the spline generator"
     } dt_iop_filmicrgb_params_v4_t;
-    
+
     dt_iop_filmicrgb_params_v4_t *o = (dt_iop_filmicrgb_params_v4_t *)old_params;
     dt_iop_filmicrgb_params_t *n = (dt_iop_filmicrgb_params_t *)new_params;
     *n = *(dt_iop_filmicrgb_params_t*)o; // structure didn't change except the enum instead of gint for internal_version
@@ -3151,7 +3149,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
         const float ymax = g->spline.y[4];
         // we multiply SAFETY_MARGIN by 1.1f to avoid possible false negatives due to float errors
         const float y_margin = SAFETY_MARGIN * 1.1f * (ymax - ymin);
-        gboolean red = (((k == 1) && (y - ymin <= y_margin)) 
+        gboolean red = (((k == 1) && (y - ymin <= y_margin))
                      || ((k == 3) && (ymax - y <= y_margin)));
         float start_angle = 0.0f;
         float end_angle = 2.f * M_PI;


### PR DESCRIPTION
When shooting the same subject over some period of time, it happens that the lighting conditions may slightly change, and so will the colors. So far, the only way to compensate for that is by using a grey card and doing a spot WB on it. Unfortunately, we can't reshoot a greey card every time a cloud passes by the sun. So this usually ends in never-ending fine-tuning

This feature allows to compute the white balance on any arbitrary color known a priori, not just grey. It may be used in 2 different cases:

1. you know beforehand the expected color coordinates (in Lch space) of some surface,
2. you have done one reference edit and can sample one reference color in it to propagate the look on the rest of the series.

In case 1, directly input the Lch coordinates of your surface and use the color picker as usual on the corresponding color ("spot mode" set to "correct"). 

In case 2, first you need to sample a reference object in the reference with the color-picker ("spot mode" set to "measure"), then go to the rest of the series and resample the same object (but this time, "spot mode" on "correct"). In case you have done a secondary color-grading, it will ensure the same normalization to all pictures and so the same effect of the following grading.

![Screenshot_20211207_150411](https://user-images.githubusercontent.com/2779157/145043385-3d95e6b0-f259-4a9c-85ab-8680dc2adfcc.png)

## Limitations

This only works at the CAT (white-balancing) level and only affects the illuminant settings. ~~If you have some channel mixing after, it will not be taken into account, which is not a problem if you process pictures in batch (with similar profiling). However, if you expect some arbitrary color coordinates **after** the whole calibration (including some profiling saved as channel mixer) or if you had to use different profiles, you may color-match in a following instance where no mixing is done (that gives you one profiling + base WB instance, and one color-matching instance).~~ **EDIT** : You can now optionally set the target color taking into account the channel mixing/profile, so you only need one instance.

This will always force a custom illuminant because the daylight and black body approximation don't allow a good-enough color matching.

Notice that to get exact color matching, brightness/luminance/exposure also needs to be taken into account, which will be dealt with in another PR. This only deals with chromaticity.