### PR TITLE
metadata: fix auto-resizing of textview widgets

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -748,7 +748,14 @@ void gui_init(dt_lib_module_t *self)
     d->swindow[i] = swindow;
     gtk_widget_set_size_request(d->swindow[i], -1, DT_PIXEL_APPLY_DPI(30));
 
-    gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview), GTK_WRAP_WORD);
+    //workaround for a Gtk issue where the textview does not wrap correctly
+    //while resizing the panel or typing into the widget
+    //reported upstream to https://gitlab.gnome.org/GNOME/gtk/-/issues/4042
+    //see also discussions on https://github.com/darktable-org/darktable/pull/10584
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swindow), GTK_POLICY_NEVER, GTK_POLICY_ALWAYS);
+
+
+    gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview), GTK_WRAP_WORD_CHAR);
     gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(textview), FALSE);
     gtk_widget_add_events(textview, GDK_FOCUS_CHANGE_MASK);
     g_signal_connect(textview, "key-press-event", G_CALLBACK(_key_pressed), self);


### PR DESCRIPTION
Resolves #10582.