### PR TITLE
Metadata: fixes segfault when leaving dt with a metadata field in focus

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -795,6 +795,7 @@ void gui_cleanup(dt_lib_module_t *self)
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    g_signal_handlers_block_by_func(d->textview[i], _lost_focus, self);
     g_free(d->setting_name[i]);
   }
   free(self->data);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -759,10 +759,6 @@ void gui_init(dt_lib_module_t *self)
     d->textview[i] = GTK_TEXT_VIEW(textview);
     gtk_widget_set_hexpand(textview, TRUE);
     gtk_widget_set_vexpand(textview, TRUE);
-
-    // doesn't work. Workaround => gui_post_expose
-    // gtk_widget_set_no_show_all(GTK_WIDGET(label), TRUE);
-    // gtk_widget_set_no_show_all(GTK_WIDGET(textview), TRUE);
   }
 
   d->init_layout = FALSE;


### PR DESCRIPTION
bug seen debugging #10582