### PR TITLE
Remove message if key press absorbed by entry widget

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3390,11 +3390,6 @@ void dt_shortcut_key_release(dt_input_device_t id, guint time, guint key)
       }
     }
   }
-  else
-  {
-    if(key != GDK_KEY_Left && key != GDK_KEY_Right && key != GDK_KEY_Up && key != GDK_KEY_Down)
-      fprintf(stderr, "[dt_shortcut_key_release] released key wasn't stored\n");
-  }
 }
 
 gboolean dt_shortcut_key_active(dt_input_device_t id, guint key)


### PR DESCRIPTION
The message `[dt_shortcut_key_release] released key wasn't stored\n` was useful as a diagnostic during development, but it gets shown every time a key is released while typing in an Entry or TextView widget.

This should be very low/no risk so would still be useful to include in the release in order to not confuse new users of input NG.