### PR TITLE
avoid gtk_button_set_label clearing ellipsize

### DIFF
--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -291,7 +291,7 @@ static void _image_preference_changed(gpointer instance, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t*)user_data;
   dt_lib_image_t *d = (dt_lib_image_t *)self->data;
-  gtk_button_set_label(GTK_BUTTON(d->delete_button), _image_get_delete_button_label());
+  gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->delete_button))), _image_get_delete_button_label());
   gtk_widget_set_tooltip_text(d->delete_button, _image_get_delete_button_tooltip());
 }
 

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -253,11 +253,11 @@ static void _display_buttons(dt_lib_module_t *self)
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->view));
   if(gtk_tree_selection_get_selected(selection, &model, &iter))
   {
-    gtk_button_set_label(GTK_BUTTON(d->new_button), _("new sub-location"));
+    gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->new_button))), _("new sub-location"));
   }
   else
   {
-    gtk_button_set_label(GTK_BUTTON(d->new_button), _("new location"));
+    gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->new_button))), _("new location"));
   }
 }
 
@@ -998,6 +998,7 @@ void gui_init(dt_lib_module_t *self)
 
   dt_conf_set_bool("plugins/map/showalllocations", FALSE);
   d->show_all_button = gtk_check_button_new_with_label(_("show all"));
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->show_all_button))), PANGO_ELLIPSIZE_END);
   gtk_widget_set_tooltip_text(d->show_all_button,
                               _("show all locations which are on the visible map"));
   gtk_box_pack_end(hbox, d->show_all_button, FALSE, FALSE, 8);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3908,9 +3908,8 @@ static void _manage_show_window(dt_lib_module_t *self)
 
   // reset button
   hb2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  d->preset_reset_btn = gtk_button_new();
+  d->preset_reset_btn = gtk_button_new_with_label(_("reset"));
   gtk_widget_set_name(d->preset_reset_btn, "modulegroups-reset");
-  gtk_button_set_label(GTK_BUTTON(d->preset_reset_btn), _("reset"));
   g_signal_connect(G_OBJECT(d->preset_reset_btn), "button-press-event", G_CALLBACK(_manage_editor_reset), self);
   gtk_box_pack_end(GTK_BOX(hb2), d->preset_reset_btn, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(vb_main), hb2, FALSE, TRUE, 0);


### PR DESCRIPTION
gtk_button_set_label destroys the existing label and creates a new one from scratch, losing all custom set properties in the process. This is especially annoying in the case of the "delete (trash)" label, which gets recreated every time the settings dialog is closed, and then causes a narrow side panel to scroll. Because it is in an equal-sized grid, the effect doubles :-)