### PR TITLE
improve consistency for mouse action mods in H screen

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2223,7 +2223,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
         gtk_overlay_add_overlay(GTK_OVERLAY(overlay), GTK_WIDGET(sl->label[k]));
       }
 
-      gtk_widget_set_tooltip_text(GTK_WIDGET(sl->slider), _("double click to reset. press 'a' to toggle available slider modes.\npress 'c' to toggle view of channel data. press 'm' to toggle mask view."));
+      gtk_widget_set_tooltip_text(GTK_WIDGET(sl->slider), _("double-click to reset. press 'a' to toggle available slider modes.\npress 'c' to toggle view of channel data. press 'm' to toggle mask view."));
       gtk_widget_set_tooltip_text(GTK_WIDGET(sl->head), _(slider_tooltip[in_out]));
 
       g_signal_connect(G_OBJECT(sl->slider), "value-changed", G_CALLBACK(_blendop_blendif_sliders_callback), bd);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -638,7 +638,7 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
     if(!gtk_widget_is_sensitive(widget)) return FALSE;
     if(user_data) // shortcuts treeview
     {
-      gtk_tooltip_set_text(tooltip, _("press Del to delete selected shortcut\ndouble click to add new shortcut\nstart typing for incremental search"));
+      gtk_tooltip_set_text(tooltip, _("press Del to delete selected shortcut\ndouble-click to add new shortcut\nstart typing for incremental search"));
       return TRUE;
     }
 
@@ -652,7 +652,7 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
     gtk_tree_view_set_tooltip_row(GTK_TREE_VIEW(widget), tooltip, path);
     gtk_tree_path_free(path);
 
-    markup_text = g_markup_escape_text(_("click to filter shortcut list\ndouble click to define new shortcut\nstart typing for incremental search"), -1);
+    markup_text = g_markup_escape_text(_("click to filter shortcut list\ndouble-click to define new shortcut\nstart typing for incremental search"), -1);
   }
   else
   {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -513,9 +513,9 @@ static gchar *_shortcut_description(dt_shortcut_t *s)
 
   add_hint("%s%s", key_name, s->key_device || s->key ? "" : move_name);
 
-  if(s->press & DT_SHORTCUT_DOUBLE) add_hint(" %s", _("double"));
-  if(s->press & DT_SHORTCUT_TRIPLE) add_hint(" %s", _("triple"));
   if(s->press & DT_SHORTCUT_LONG  ) add_hint(" %s", _("long"));
+  if(s->press & DT_SHORTCUT_DOUBLE) add_hint(" %s", _("double-press")); else
+  if(s->press & DT_SHORTCUT_TRIPLE) add_hint(" %s", _("triple-press")); else
   if(s->press) add_hint(" %s", _("press"));
   if(s->button)
   {
@@ -523,10 +523,10 @@ static gchar *_shortcut_description(dt_shortcut_t *s)
     if(s->button & DT_SHORTCUT_LEFT  ) add_hint(" %s", C_("accel", "left"));
     if(s->button & DT_SHORTCUT_RIGHT ) add_hint(" %s", C_("accel", "right"));
     if(s->button & DT_SHORTCUT_MIDDLE) add_hint(" %s", C_("accel", "middle"));
-    if(s->click  & DT_SHORTCUT_DOUBLE) add_hint(" %s", C_("accel", "double"));
-    if(s->click  & DT_SHORTCUT_TRIPLE) add_hint(" %s", C_("accel", "triple"));
     if(s->click  & DT_SHORTCUT_LONG  ) add_hint(" %s", C_("accel", "long"));
-    add_hint(" %s", _("click"));
+    if(s->click  & DT_SHORTCUT_DOUBLE) add_hint(" %s", C_("accel", "double-click")); else
+    if(s->click  & DT_SHORTCUT_TRIPLE) add_hint(" %s", C_("accel", "triple-click")); else
+      add_hint(" %s", _("click"));
   }
 
   if(*move_name && (s->key_device || s->key))

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -293,7 +293,7 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
 
   gtk_combo_box_set_active(GTK_COMBO_BOX(widget), darktable.l10n->selected);
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(language_callback), 0);
-  gtk_widget_set_tooltip_text(labelev,  _("double click to reset to the system language"));
+  gtk_widget_set_tooltip_text(labelev,  _("double_click to reset to the system language"));
   gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);
   gtk_widget_set_tooltip_text(widget, _("set the language of the user interface. the system default is marked with an * (needs a restart)"));
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3055,7 +3055,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       dt_control_change_cursor(GDK_BOTTOM_LEFT_CORNER);
     else if(grab == GRAB_NONE)
     {
-      dt_control_hinter_message(darktable.control, _("<b>commit</b>: double click, <b>straighten</b>: right-drag"));
+      dt_control_hinter_message(darktable.control, _("<b>commit</b>: double-click, <b>straighten</b>: right-drag"));
       dt_control_change_cursor(GDK_LEFT_PTR);
     }
     if(grab != GRAB_NONE)
@@ -3120,7 +3120,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     else
     {
       dt_control_hinter_message(darktable.control, _("<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</b>: ctrl+drag\n"
-                                                     "<b>straighten</b>: right-drag, <b>commit</b>: double click"));
+                                                     "<b>straighten</b>: right-drag, <b>commit</b>: double-click"));
     }
     dt_control_queue_redraw_center();
   }

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1208,7 +1208,7 @@ static gboolean checker_motion_notify(GtkWidget *widget, GdkEventMotion *event,
       _("(%2.2f %2.2f %2.2f)\n"
         "altered patches are marked with an outline\n"
         "click to select\n"
-        "double click to reset\n"
+        "double-click to reset\n"
         "right click to delete patch\n"
         "shift+click while color picking to replace patch"),
       p->source_L[patch], p->source_a[patch], p->source_b[patch]);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1580,7 +1580,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       dt_control_change_cursor(GDK_BOTTOM_LEFT_CORNER);
     else if(grab == GRAB_NONE)
     {
-      dt_control_hinter_message(darktable.control, _("<b>commit</b>: double click"));
+      dt_control_hinter_message(darktable.control, _("<b>commit</b>: double-click"));
       dt_control_change_cursor(GDK_LEFT_PTR);
     }
     if(grab != GRAB_NONE)
@@ -1592,7 +1592,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     dt_control_change_cursor(GDK_FLEUR);
     g->cropping = 0;
     dt_control_hinter_message(darktable.control, _("<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</b>: ctrl+drag\n"
-                                                   "<b>commit</b>: double click"));
+                                                   "<b>commit</b>: double-click"));
     dt_control_queue_redraw_center();
   }
   return 0;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -383,7 +383,7 @@ static inline void convert_to_spline_v3(dt_iop_filmicrgb_params_t* n)
 
   dt_iop_filmic_rgb_spline_t spline;
   dt_iop_filmic_rgb_compute_spline(n, &spline);
-  
+
   // from the spline, compute new values for contrast, balance, and latitude to update spline_version to v3
   float grey_log = spline.x[2];
   float toe_log = fminf(spline.x[1], grey_log);
@@ -677,7 +677,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       gboolean compensate_icc_black; // $DEFAULT: FALSE $DESCRIPTION: "compensate output ICC profile black point"
       gint internal_version; // $DEFAULT: 2020 $DESCRIPTION: "version of the spline generator"
     } dt_iop_filmicrgb_params_v4_t;
-    
+
     dt_iop_filmicrgb_params_v4_t *o = (dt_iop_filmicrgb_params_v4_t *)old_params;
     dt_iop_filmicrgb_params_t *n = (dt_iop_filmicrgb_params_t *)new_params;
     *n = *(dt_iop_filmicrgb_params_t*)o; // structure didn't change except the enum instead of gint for internal_version
@@ -3151,7 +3151,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
         const float ymax = g->spline.y[4];
         // we multiply SAFETY_MARGIN by 1.1f to avoid possible false negatives due to float errors
         const float y_margin = SAFETY_MARGIN * 1.1f * (ymax - ymin);
-        gboolean red = (((k == 1) && (y - ymin <= y_margin)) 
+        gboolean red = (((k == 1) && (y - ymin <= y_margin))
                      || ((k == 3) && (ymax - y <= y_margin)));
         float start_angle = 0.0f;
         float end_angle = 2.f * M_PI;
@@ -3835,7 +3835,7 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
       gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("cycle through graph views.\n"
                                                          "left click: cycle forward.\n"
                                                          "right click: cycle backward.\n"
-                                                         "double click: reset to look view."));
+                                                         "double-click: reset to look view."));
     }
     else
     {

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -140,7 +140,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->compress_button = dt_ui_button_new(_("compress history stack"),
                                         _("create a minimal history stack which produces the same image\n"
-                                          "ctrl-click to truncate history to the selected item"), NULL);
+                                          "ctrl+click to truncate history to the selected item"), NULL);
   g_signal_connect(G_OBJECT(d->compress_button), "clicked", G_CALLBACK(_lib_history_compress_clicked_callback), self);
   g_signal_connect(G_OBJECT(d->compress_button), "button-press-event", G_CALLBACK(_lib_history_compress_pressed_callback), self);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -661,7 +661,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       {
         char tooltip_filmroll[300] = {0};
         dt_image_film_roll(img, text, sizeof(text));
-        snprintf(tooltip_filmroll, sizeof(tooltip_filmroll), _("double click to jump to film roll\n%s"), text);
+        snprintf(tooltip_filmroll, sizeof(tooltip_filmroll), _("double-click to jump to film roll\n%s"), text);
         _metadata_update_tooltip(md_internal_filmroll, tooltip_filmroll, self);
         _metadata_update_value(md_internal_filmroll, text, self);
       }

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -167,7 +167,7 @@ static int get_keys(lua_State *L)
   g_list_free(keys);
   return 1;
 }
-  
+
 static void get_pref_name(char *tgt, size_t size, const char *script, const char *name)
 {
   snprintf(tgt, size, "lua/%s/%s", script, name);
@@ -184,7 +184,7 @@ static int read_pref(lua_State *L)
   char pref_name[1024];
   if(strcmp(script, "darktable") != 0)
     get_pref_name(pref_name, sizeof(pref_name), script, name);
-  else 
+  else
     snprintf(pref_name, sizeof(pref_name), "%s", name);
   switch(i)
   {
@@ -650,7 +650,7 @@ static int register_pref_sub(lua_State *L)
 
 
       g_object_ref_sink(G_OBJECT(built_elt->widget));
-      built_elt->tooltip_reset = g_strdup_printf(  _("double click to reset to `%s'"),
+      built_elt->tooltip_reset = g_strdup_printf(  _("double-click to reset to `%s'"),
           built_elt->type_data.enum_data.default_value);
       built_elt->update_widget = update_widget_enum;
       break;
@@ -665,7 +665,7 @@ static int register_pref_sub(lua_State *L)
       built_elt->widget = gtk_file_chooser_button_new(_("select directory"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
       gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(built_elt->widget), 20);
       g_object_ref_sink(G_OBJECT(built_elt->widget));
-      built_elt->tooltip_reset = g_strdup_printf( _("double click to reset to `%s'"), built_elt->type_data.dir_data.default_value);
+      built_elt->tooltip_reset = g_strdup_printf( _("double-click to reset to `%s'"), built_elt->type_data.dir_data.default_value);
       built_elt->update_widget = update_widget_dir;
       break;
     case pref_file:
@@ -689,7 +689,7 @@ static int register_pref_sub(lua_State *L)
         dt_conf_set_string(pref_name, built_elt->type_data.string_data.default_value);
 
       built_elt->widget = gtk_entry_new();
-      built_elt->tooltip_reset= g_strdup_printf( _("double click to reset to `%s'"),
+      built_elt->tooltip_reset= g_strdup_printf( _("double-click to reset to `%s'"),
           built_elt->type_data.string_data.default_value);
       g_object_ref_sink(G_OBJECT(built_elt->widget));
       built_elt->update_widget = update_widget_string;
@@ -728,7 +728,7 @@ static int register_pref_sub(lua_State *L)
         built_elt->widget = gtk_spin_button_new_with_range(min, max, 1);
         gtk_spin_button_set_digits(GTK_SPIN_BUTTON(built_elt->widget), 0);
         g_object_ref_sink(G_OBJECT(built_elt->widget));
-        built_elt->tooltip_reset = g_strdup_printf( _("double click to reset to `%d'"),
+        built_elt->tooltip_reset = g_strdup_printf( _("double-click to reset to `%d'"),
             built_elt->type_data.int_data.default_value);
         built_elt->update_widget = update_widget_int;
         break;
@@ -769,7 +769,7 @@ static int register_pref_sub(lua_State *L)
         if(!dt_conf_key_exists(pref_name))
           dt_conf_set_string(pref_name, built_elt->type_data.lua_data.default_value);
 
-        built_elt->tooltip_reset= g_strdup_printf( _("double click to reset to `%s'"),
+        built_elt->tooltip_reset= g_strdup_printf( _("double-click to reset to `%s'"),
             built_elt->type_data.lua_data.default_value);
 
         lua_widget widget;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1493,7 +1493,7 @@ GSList *dt_mouse_action_create_simple(GSList *actions, dt_mouse_action_type_t ty
 {
   dt_mouse_action_t *a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = type;
-  a->key.accel_mods = accel;
+  a->mods = accel;
   g_strlcpy(a->name, description, sizeof(a->name));
   return g_slist_append(actions, a);
 }
@@ -1503,16 +1503,17 @@ GSList *dt_mouse_action_create_format(GSList *actions, dt_mouse_action_type_t ty
 {
   dt_mouse_action_t *a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = type;
-  a->key.accel_mods = accel;
+  a->mods = accel;
   g_snprintf(a->name, sizeof(a->name), format_string, replacement);
   return g_slist_append(actions, a);
 }
 
 static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
 {
-  gchar *atxt = gtk_accelerator_get_label(ma->key.accel_key, ma->key.accel_mods);
-  if(strcmp(atxt, ""))
-    atxt = dt_util_dstrcat(atxt, "+");
+  gchar *atxt = NULL;
+  if(ma->mods & GDK_SHIFT_MASK  ) atxt = dt_util_dstrcat(atxt, "%s+", _("shift"));
+  if(ma->mods & GDK_CONTROL_MASK) atxt = dt_util_dstrcat(atxt, "%s+", _("ctrl"));
+  if(ma->mods & GDK_MOD1_MASK   ) atxt = dt_util_dstrcat(atxt, "%s+", _("alt"));
 
   switch(ma->action)
   {

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -109,7 +109,7 @@ typedef enum dt_view_surface_value_t
 
 typedef struct dt_mouse_action_t
 {
-  GtkAccelKey key;
+  GdkModifierType mods;
   dt_mouse_action_type_t action;
   gchar name[256];
 } dt_mouse_action_t;


### PR DESCRIPTION
The help screen (H) shows mouse actions (non-input NG ones) that have modifier keys using a standard gtk function which uses capitals for Shift/Ctrl/Alt. Everywhere else (also for input NG shortcuts in the same screen) those are shown lower case. This PR restores consistency.