### PR TITLE
make perspective helpers shortcuttable actions

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -581,7 +581,11 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
     const int newimgid = dt_image_duplicate(imgid);
     if(newimgid != -1)
     {
-      dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL, TRUE, TRUE);
+      if(GPOINTER_TO_INT(params->data))
+        dt_history_delete_on_image(newimgid);
+      else
+        dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL, TRUE, TRUE);
+
       // a duplicate should keep the change time stamp of the original
       dt_image_cache_set_change_timestamp_from_image(darktable.image_cache, newimgid, imgid);
 
@@ -1518,11 +1522,11 @@ void dt_control_gpx_apply(const gchar *filename, int32_t filmid, const gchar *tz
                      _control_gpx_apply_job_create(filename, filmid, tz, imgs));
 }
 
-void dt_control_duplicate_images()
+void dt_control_duplicate_images(gboolean virgin)
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
                      dt_control_generic_images_job_create(&dt_control_duplicate_images_job_run,
-                                                          N_("duplicate images"), 0, NULL, PROGRESS_SIMPLE, TRUE));
+                                                          N_("duplicate images"), 0, GINT_TO_POINTER(virgin), PROGRESS_SIMPLE, TRUE));
 }
 
 void dt_control_flip_images(const int32_t cw)

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -33,7 +33,7 @@ void dt_control_datetime(const long int offset, const char *datetime, GList *img
 void dt_control_write_sidecar_files();
 void dt_control_delete_images();
 void dt_control_delete_image(int imgid);
-void dt_control_duplicate_images();
+void dt_control_duplicate_images(gboolean virgin);
 void dt_control_flip_images(const int32_t cw);
 void dt_control_monochrome_images(const int32_t mode);
 gboolean dt_control_remove_images();

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -207,7 +207,9 @@ static float _action_process_button(gpointer target, dt_action_element_t element
 
   if(!isnan(move_size) && gtk_widget_is_sensitive(target))
   {
-    if(effect != DT_ACTION_EFFECT_ACTIVATE || !gtk_widget_activate(GTK_WIDGET(target)))
+    if(effect != DT_ACTION_EFFECT_ACTIVATE
+      || !g_signal_handler_find(target, G_SIGNAL_MATCH_ID, g_signal_lookup("clicked", gtk_button_get_type()), 0, NULL, NULL, NULL)
+      || !gtk_widget_activate(GTK_WIDGET(target)))
     {
       GdkEvent *event = gdk_event_new(GDK_BUTTON_PRESS);
       event->button.state = effect == DT_ACTION_EFFECT_ACTIVATE_CTRL

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5803,15 +5803,15 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_grid_attach(auto_grid, dt_ui_label_new(_("fit")), 0, 1, 1, 1);
 
-  g->fit_v = dtgtk_togglebutton_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
+  g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_v), TRUE);
   gtk_grid_attach(auto_grid, g->fit_v, 1, 1, 1, 1);
 
-  g->fit_h = dtgtk_togglebutton_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
+  g->fit_h = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_h), TRUE);
   gtk_grid_attach(auto_grid, g->fit_h, 2, 1, 1, 1);
 
-  g->fit_both = dtgtk_togglebutton_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
+  g->fit_both = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_both), TRUE);
   gtk_grid_attach(auto_grid, g->fit_both, 3, 1, 1, 1);
 
@@ -5868,9 +5868,9 @@ void gui_init(struct dt_iop_module_t *self)
                    (gpointer)self);
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
 
-  dt_action_define_iop(self, N_("fit"), N_("vertical"), g->fit_v, &dt_action_def_toggle);
-  dt_action_define_iop(self, N_("fit"), N_("horizontal"), g->fit_h, &dt_action_def_toggle);
-  dt_action_define_iop(self, N_("fit"), N_("both"), g->fit_both, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("fit"), N_("vertical"), g->fit_v, &dt_action_def_button);
+  dt_action_define_iop(self, N_("fit"), N_("horizontal"), g->fit_h, &dt_action_def_button);
+  dt_action_define_iop(self, N_("fit"), N_("both"), g->fit_both, &dt_action_def_button);
   dt_action_define_iop(self, N_("structure"), N_("rectangle"), g->structure_quad, &dt_action_def_toggle);
   dt_action_define_iop(self, N_("structure"), N_("lines"), g->structure_lines, &dt_action_def_toggle);
   dt_action_define_iop(self, N_("structure"), N_("auto"), g->structure_auto, &dt_action_def_toggle);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5803,15 +5803,15 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_grid_attach(auto_grid, dt_ui_label_new(_("fit")), 0, 1, 1, 1);
 
-  g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
+  g->fit_v = dtgtk_togglebutton_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_v), TRUE);
   gtk_grid_attach(auto_grid, g->fit_v, 1, 1, 1, 1);
 
-  g->fit_h = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
+  g->fit_h = dtgtk_togglebutton_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_h), TRUE);
   gtk_grid_attach(auto_grid, g->fit_h, 2, 1, 1, 1);
 
-  g->fit_both = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
+  g->fit_both = dtgtk_togglebutton_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_both), TRUE);
   gtk_grid_attach(auto_grid, g->fit_both, 3, 1, 1, 1);
 
@@ -5867,6 +5867,13 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->structure_auto), "button-press-event", G_CALLBACK(_event_structure_auto_clicked),
                    (gpointer)self);
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
+
+  dt_action_define_iop(self, N_("fit"), N_("vertical"), g->fit_v, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("fit"), N_("horizontal"), g->fit_h, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("fit"), N_("both"), g->fit_both, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("structure"), N_("rectangle"), g->structure_quad, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("structure"), N_("lines"), g->structure_lines, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("structure"), N_("auto"), g->structure_auto, &dt_action_def_toggle);
 
   /* add signal handler for preview pipe finish to redraw the overlay */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -458,7 +458,10 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_image_t *d = (dt_lib_image_t *)malloc(sizeof(dt_lib_image_t));
   self->data = (void *)d;
   self->timeout_handle = 0;
-  self->widget = gtk_notebook_new();
+
+  static struct dt_action_def_t notebook_def = { };
+  self->widget = GTK_WIDGET(dt_ui_notebook_new(&notebook_def));
+  dt_action_define(DT_ACTION(self), NULL, N_("page"), GTK_WIDGET(self->widget), &notebook_def);
   dt_gui_add_help_link(self->widget, dt_get_help_url("image"));
 
   GtkWidget *page1 = dt_ui_notebook_page(GTK_NOTEBOOK(self->widget), N_("images"), NULL);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -136,6 +136,13 @@ static void _ungroup_helper_function(void)
   }
 }
 
+static gboolean _duplicate_virgin(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval, GdkModifierType modifier, gpointer data)
+{
+  dt_control_duplicate_images(TRUE);
+
+  return TRUE;
+}
+
 static void button_clicked(GtkWidget *widget, gpointer user_data)
 {
   const int i = GPOINTER_TO_INT(user_data);
@@ -145,7 +152,7 @@ static void button_clicked(GtkWidget *widget, gpointer user_data)
     dt_control_delete_images();
   // else if(i == 2) dt_control_write_sidecar_files();
   else if(i == 3)
-    dt_control_duplicate_images();
+    dt_control_duplicate_images(FALSE);
   else if(i == 4)
     dt_control_flip_images(1);
   else if(i == 5)
@@ -659,6 +666,7 @@ void init_key_accels(dt_lib_module_t *self)
   dt_accel_register_lib(self, NC_("accel", "rotate selected images 90 degrees CCW"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "create HDR"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "duplicate"), GDK_KEY_d, GDK_CONTROL_MASK);
+  dt_accel_register_lib(self, NC_("accel", "duplicate virgin"), GDK_KEY_d, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
   dt_accel_register_lib(self, NC_("accel", "reset rotation"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "copy the image locally"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "resync the local copy"), 0, 0);
@@ -685,6 +693,7 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_button_lib(self, "rotate selected images 90 degrees CCW", d->rotate_ccw_button);
   dt_accel_connect_button_lib(self, "create HDR", d->create_hdr_button);
   dt_accel_connect_button_lib(self, "duplicate", d->duplicate_button);
+  dt_accel_connect_lib(self, "duplicate virgin", g_cclosure_new(G_CALLBACK(_duplicate_virgin), self, NULL));
   dt_accel_connect_button_lib(self, "reset rotation", d->reset_button);
   dt_accel_connect_button_lib(self, "copy the image locally", d->cache_button);
   dt_accel_connect_button_lib(self, "resync the local copy", d->uncache_button);


### PR DESCRIPTION
Fix dt_action_def_button so that it detects if the button listens to the "clicked" event and if not, always sends a button-press-event.

Add a shortcut for the selected image[s] tab.

Fixes #10732 Add a shortcut in the selected image[s] module to duplicate virgin images. This used to be handled by the thumbtable module (pre-3.8). This new implementation differs in that it acts on _all_ selected images in the lighttable (like all the other features of the module do) rather than just the image under the cursor.
I had intended to implement this as a ctrl+click feature of the duplicate button, but that requires listening to the button-press-event, rather than clicked, and that doesn't work in gtk when the button is hidden. As a consequence this feature is _only_ available in lighttable via a shortcut (as before) and the shortcut is not shown when hovering over the duplicate button (only in the shortcuts dialog).