### PR TITLE
fix notebook tooltips

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -626,17 +626,22 @@ GHashTable *dt_shortcut_category_lists(dt_view_type_flags_t v)
   return ht;
 }
 
-static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
-                                           GtkTooltip *tooltip, gpointer user_data)
+gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
+                                      GtkTooltip *tooltip, gpointer user_data)
 {
   gchar *markup_text = NULL;
   gchar *description = NULL;
   dt_action_t *action = NULL;
+  int show_element = 0;
 
-  if(GTK_IS_TREE_VIEW(widget))
+  gchar *original_markup = gtk_widget_get_tooltip_markup(widget);
+
+  const gchar *widget_name = gtk_widget_get_name(widget);
+  if(!strcmp(widget_name, "actions_view") || !strcmp(widget_name, "shortcuts_view"))
   {
     if(!gtk_widget_is_sensitive(widget)) return FALSE;
-    if(user_data) // shortcuts treeview
+
+    if(!strcmp(widget_name, "shortcuts_view"))
     {
       gtk_tooltip_set_text(tooltip, _("press Del to delete selected shortcut\ndouble click to add new shortcut\nstart typing for incremental search"));
       return TRUE;
@@ -648,6 +653,7 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
     if(!gtk_tree_view_get_tooltip_context(GTK_TREE_VIEW(widget), &x, &y, keyboard_mode, &model, &path, &iter))
       return FALSE;
 
+    show_element = 1;
     gtk_tree_model_get(model, &iter, 0, &action, -1);
     gtk_tree_view_set_tooltip_row(GTK_TREE_VIEW(widget), tooltip, path);
     gtk_tree_path_free(path);
@@ -657,6 +663,12 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
   else
   {
     action = g_hash_table_lookup(darktable.control->widgets, widget);
+    if(!action)
+    {
+      widget = gtk_widget_get_parent(widget);
+      action = g_hash_table_lookup(darktable.control->widgets, widget);
+      show_element = -1;
+    }
 
     if(darktable.control->mapping_widget == widget)
     {
@@ -676,7 +688,7 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
   const dt_action_def_t *def = _action_find_definition(action);
   const gboolean has_fallbacks = def && def->fallbacks;
 
-  if(def && (darktable.control->element || !has_fallbacks))
+  if(def && (darktable.control->element || !has_fallbacks) && show_element == 0)
   {
     const gchar *element_name = NULL;
     for(int i = 0; i <= darktable.control->element; i++)
@@ -698,7 +710,7 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
         (s->element == DT_ACTION_ELEMENT_DEFAULT && has_fallbacks)))
     {
       gchar *sc_escaped = g_markup_escape_text(_shortcut_description(s), -1);
-      gchar *ac_escaped = g_markup_escape_text(_action_description(s, 0), -1);
+      gchar *ac_escaped = g_markup_escape_text(_action_description(s, show_element > 0 ? 1 : 0), -1);
       description = dt_util_dstrcat(description, "%s<b><big>%s</big></b><i>%s</i>",
                                                  description ? "\n" : "",
                                                  sc_escaped, ac_escaped);
@@ -707,21 +719,16 @@ static gboolean _shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gb
     }
   }
 
-  gchar *original_markup = gtk_widget_get_tooltip_markup(widget);
-  if(description || (original_markup && markup_text))
+  if(description || original_markup || markup_text)
   {
     markup_text = dt_util_dstrcat(markup_text, "%s%s%s%s",
-                                  markup_text? "\n\n" : "",
+                                  markup_text && (original_markup || description) ? "\n\n" : "",
                                   original_markup ? original_markup : "",
                                   original_markup && description ? "\n" : "",
                                   description ? description : "");
-    g_free(description);
-  }
-  g_free(original_markup);
-
-  if(markup_text)
-  {
     gtk_tooltip_set_markup(tooltip, markup_text);
+    g_free(description);
+    g_free(original_markup);
     g_free(markup_text);
 
     return TRUE;
@@ -2030,7 +2037,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_tree_selection_set_select_function(gtk_tree_view_get_selection(shortcuts_view),
                                          _shortcut_selection_function, NULL, NULL);
   g_object_set(shortcuts_view, "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(shortcuts_view), "query-tooltip", G_CALLBACK(_shortcut_tooltip_callback), GINT_TO_POINTER(TRUE));
+  gtk_widget_set_name(GTK_WIDGET(shortcuts_view), "shortcuts_view");
   g_signal_connect(G_OBJECT(shortcuts_view), "row-activated", G_CALLBACK(_shortcut_row_activated), filtered_shortcuts);
   g_signal_connect(G_OBJECT(shortcuts_view), "key-press-event", G_CALLBACK(_shortcut_key_pressed), NULL);
   g_signal_connect(G_OBJECT(shortcuts_view), "key-press-event", G_CALLBACK(dt_gui_search_start), search_shortcuts);
@@ -2119,7 +2126,7 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_tree_view_set_search_entry(actions_view, GTK_ENTRY(search_actions));
 
   g_object_set(actions_view, "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(actions_view), "query-tooltip", G_CALLBACK(_shortcut_tooltip_callback), NULL);
+  gtk_widget_set_name(GTK_WIDGET(actions_view), "actions_view");
   g_signal_connect(G_OBJECT(actions_view), "row-activated", G_CALLBACK(_action_row_activated), _actions_store);
   g_signal_connect(G_OBJECT(actions_view), "button-press-event", G_CALLBACK(_action_view_click), _actions_store);
   g_signal_connect(G_OBJECT(actions_view), "key-press-event", G_CALLBACK(dt_gui_search_start), search_actions);
@@ -3770,7 +3777,6 @@ dt_action_t *dt_action_define(dt_action_t *owner, const gchar *section, const gc
       g_hash_table_insert(darktable.control->widgets, widget, ac);
 
       gtk_widget_set_has_tooltip(widget, TRUE);
-      g_signal_connect(G_OBJECT(widget), "query-tooltip", G_CALLBACK(_shortcut_tooltip_callback), NULL);
       g_signal_connect(G_OBJECT(widget), "destroy", G_CALLBACK(_remove_widget_from_hashtable), NULL);
     }
   }

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -36,6 +36,8 @@ void dt_shortcuts_reinitialise();
 void dt_shortcuts_select_view(dt_view_type_flags_t view);
 
 gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_data);
+gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
+                                      GtkTooltip *tooltip, gpointer user_data);
 
 float dt_action_process(const gchar *action, int instance, const gchar *element, const gchar *effect, float size);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1202,6 +1202,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   widget = dt_ui_main_window(darktable.gui->ui);
   g_signal_connect(G_OBJECT(widget), "configure-event", G_CALLBACK(_window_configure), NULL);
   g_signal_connect(G_OBJECT(widget), "event", G_CALLBACK(dt_shortcut_dispatcher), NULL);
+  g_signal_override_class_handler("query-tooltip", gtk_widget_get_type(), G_CALLBACK(dt_shortcut_tooltip_callback));
 
   // register keys for view switching
   dt_accel_register_global(NC_("accel", "switch views/tethering"), GDK_KEY_t, 0);
@@ -2989,7 +2990,9 @@ GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const ch
   GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   if(strlen(text) > 2)
     gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  if(tooltip) gtk_widget_set_tooltip_text(label, tooltip);
+  gtk_widget_set_tooltip_text(label, tooltip ? tooltip : text);
+  gtk_widget_set_has_tooltip(GTK_WIDGET(notebook), FALSE);
+
   gint page_num = gtk_notebook_append_page(notebook, page, label);
   gtk_container_child_set(GTK_CONTAINER(notebook), page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
   if(page_num == 1 &&


### PR DESCRIPTION
fixes #10606

Show the shortcut tooltips for tab labels rather than the notebook itself. This fixes the issue that an empty area of a notebook page would show a tooltip as well. It also makes displaying of shortcuts for individual tabs when the tab has a tooltip (different from its name) more reliable.

This is achieved by overriding the "query-tooltip" default handler for _all_ widgets, rather than setting one up for each action (or tab) individually. This could potentially impact/break _all_ tooltips, so this is definitely not 3.8 material.

Separately, adds the element to the list of shortcuts shown in the tooltip for an action in the shortcuts dialog.
 
![image](https://user-images.githubusercontent.com/1549490/145895922-eabe6acb-23d1-4414-829b-9034d82a6f8c.png)
