### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ However, this JPEG thumbnail is processed by the firmware of the camera, with pr
 and colors, sharpness and contrast that might not look the same as
 darktable processing (which is what you see when opening the image in the darkroom view).
 Camera manufacturers don't publish details of the pixel processing they perform in their firmware
-so their look is not exactly or easily reproducable by other software.
+so their look is not exactly or easily reproducible by other software.
 
 However, once RAW images have been edited in darktable,
 the lighttable thumbnail should exactly match the darkroom preview, as they are processed in the same way.

--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -350,7 +350,7 @@ static inline float4 chroma_adapt_RGB(const float4 RGB,
 * while keeping the same overall code structure for maintenance.
 *
 * The reference C version in src/iop/channelmixerrgb.c does it differently
-* since C has an explicite -funswitchloop option, but OpenCL doesn't and
+* since C has an explicit -funswitchloop option, but OpenCL doesn't and
 * we have to do it manually using macros and duplicating kernels.
 */
 

--- a/packaging/macosx/gtk-mac-bundler-0.7.4.patch
+++ b/packaging/macosx/gtk-mac-bundler-0.7.4.patch
@@ -21,7 +21,7 @@ diff -uNr gtk-mac-bundler-0.7.4-orig/bundler/bundler.py gtk-mac-bundler-0.7.4/bu
          def name_filter(filename):
 @@ -585,14 +587,21 @@
              if program.name == "" or program.name == None:
-                 raise "No program name to tranlate!"
+                 raise "No program name to translate!"
  
 +            p = re.compile("^\${prefix(:.*?)?}/")
 +            m = p.match(program.source)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1651,7 +1651,7 @@ static void _fill_mask(const size_t numpoints, float *const bufptr, const float 
   const float sin_alpha = sinf(alpha);
 
   // Determine the strength of the mask for each of the distorted points.  If inside the border of the ellipse,
-  // the strength is always 1.0; if outside the fallow region, it is 0.0, and in between it falls off quadratically.
+  // the strength is always 1.0; if outside the falloff region, it is 0.0, and in between it falls off quadratically.
   // To compute this, we need to do the equivalent of projecting the vector from the center of the ellipse to the
   // given point until it intersect the ellipse and the outer edge of the falloff, respectively.  The ellipse can
   // be rotated, but we can compensate for that by applying a rotation matrix for the same rotation in the opposite

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -79,7 +79,7 @@ typedef struct dt_culling_t
 dt_culling_t *dt_culling_new(dt_culling_mode_t mode);
 // reload all thumbs from scratch.
 void dt_culling_full_redraw(dt_culling_t *table, gboolean force);
-// initialise culling offset/naviagtion mode, etc before entering.
+// initialise culling offset/navigation mode, etc before entering.
 // if offset is > 0 it'll be used as offset, otherwise offset will be determined by other means
 void dt_culling_init(dt_culling_t *table, int offset);
 // move by key actions.

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -318,7 +318,7 @@ void dt_ui_restore_panels(struct dt_ui_t *ui);
 void dt_ui_update_scrollbars(struct dt_ui_t *ui);
 /** show or hide scrollbars */
 void dt_ui_scrollbars_show(struct dt_ui_t *ui, gboolean show);
-/** \brief toggle view of panels eg. collaps/expands to previous view state */
+/** \brief toggle view of panels eg. collapse/expands to previous view state */
 void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
 /** \brief draw user's attention */
 void dt_ui_notify_user();

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -40,7 +40,7 @@ typedef enum _style_items_columns_t
 
 static gboolean _gui_hist_is_copy_module_order_set(dt_history_copy_item_t *d)
 {
-  /* iterate trough TreeModel to find if module order was copied (num=-1 and active)  */
+  /* iterate through TreeModel to find if module order was copied (num=-1 and active)  */
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->items));
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3092,7 +3092,7 @@ static void _do_get_structure_lines(dt_iop_module_t *self)
 
   do_clean_structure(self, p, TRUE);
 
-  // if the button is unselcted, we don't go further
+  // if the button is unselected, we don't go further
   if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->structure_lines)))
   {
     dt_control_queue_redraw_center();
@@ -4683,7 +4683,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     g->lastx = x;
     g->lasty = y;
 
-    // we instanciate a new line with both extrema at the current position
+    // we instantiate a new line with both extrema at the current position
     // and enable the "move point" mode with the second extrema
     const float pr_d = self->dev->preview_downsampling;
     float pts[2] = { pzx * wd, pzy * ht };
@@ -5207,7 +5207,7 @@ static int _event_structure_auto_clicked(GtkWidget *widget, GdkEventButton *even
     else
       enhance = ASHIFT_ENHANCE_NONE;
 
-    // if the button is unselcted, we don't go further
+    // if the button is unselected, we don't go further
     if(enhance == ASHIFT_ENHANCE_NONE && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
     {
       _gui_update_structure_states(self, widget);
@@ -5716,7 +5716,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed", G_CALLBACK(cropmode_callback), self);
 
-  // we put the detailled values under an expander
+  // we put the detailed values under an expander
   g->values_expanded = dt_conf_get_bool("plugins/darkroom/ashift/expand_values");
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
   GtkWidget *header_evb = gtk_event_box_new();

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1327,7 +1327,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // we show a error on stderr if we have clamped something
     if(d->cx != p->cx || d->cy != p->cy || d->cw != fabsf(p->cw) || d->ch != fabsf(p->ch))
     {
-      fprintf(stderr, "[crop&rotate] invalid crop datas for %d : x=%0.04f y=%0.04f w=%0.04f h=%0.04f\n",
+      fprintf(stderr, "[crop&rotate] invalid crop data for %d : x=%0.04f y=%0.04f w=%0.04f h=%0.04f\n",
               pipe->image.id, p->cx, p->cy, p->cw, p->ch);
     }
   }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1335,7 +1335,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
                              { 0.0f, 0.0f, 0.0f } };
   set_up_conversion_matrices(toY0U0V0, toRGB, wb);
 
-  // more stength in Y0U0V0 in order to get a similar smoothing as in other modes
+  // more strength in Y0U0V0 in order to get a similar smoothing as in other modes
   // otherwise, result was much less denoised in Y0U0V0 mode.
   const float compensate_strength = (d->wavelet_color_mode == MODE_RGB) ? 1.0f : 2.5f;
   // update the coeffs with strength and scale
@@ -2247,7 +2247,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
                                  { 0.0f, 0.0f, 0.0f } };
   set_up_conversion_matrices(toY0U0V0_tmp, toRGB_tmp, wb);
 
-  // more stength in Y0U0V0 in order to get a similar smoothing as in other modes
+  // more strength in Y0U0V0 in order to get a similar smoothing as in other modes
   // otherwise, result was much less denoised in Y0U0V0 mode.
   const float compensate_strength = (d->wavelet_color_mode == MODE_RGB) ? 1.0f : 2.5f;
 

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -108,7 +108,7 @@ void dt_lib_cleanup(dt_lib_t *lib);
 
 /** creates a label widget for the expander, with callback to enable/disable this module. */
 GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module);
-/** set a expand/collaps plugin expander */
+/** set an expand/collapse plugin expander */
 void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded);
 /** get the expanded state of a plugin */
 gboolean dt_lib_gui_get_expanded(dt_lib_module_t *module);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -182,7 +182,7 @@ static float _mm_to_hscreen(dt_lib_print_settings_t *ps, const float value, cons
     + (ps->imgs.screen.page.width * value / width);
 }
 
-// vertial mm to pixels
+// vertical mm to pixels
 static float _mm_to_vscreen(dt_lib_print_settings_t *ps, const float value, const gboolean offset)
 {
   float width, height;
@@ -1836,7 +1836,7 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
       const dt_image_box *box = &ps->imgs.box[ps->selected];
 
       // we could use a simpler solution but we want to use the same formulae used
-      // to fill the editable box values to avoid discrepencies between values due
+      // to fill the editable box values to avoid discrepancies between values due
       // to rounding errors.
 
       float pwidth, pheight;


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,./src/external,./src/common,./data/pswp -L ba,bloc,dinamic,hist,ist,inout,uint,ue,webp
`