### PR TITLE
Relicense promo svg

### DIFF
--- a/data/darktable.appdata.xml.in
+++ b/data/darktable.appdata.xml.in
@@ -7,7 +7,7 @@
   <id>darktable.desktop</id>
   <name>darktable</name>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+ AND GPL-2.0+ AND LGPL-2.0+ AND BSD-3-Clause AND MIT AND CC-BY-SA-1.0 AND CC-BY-2.5 AND CC-BY-NC-3.0</project_license>
+  <project_license>GPL-3.0+ AND GPL-2.0+ AND LGPL-2.0+ AND BSD-3-Clause AND MIT AND CC-BY-SA-1.0 AND CC-BY-2.5 AND CC-BY-SA-3.0</project_license>
   <_summary>Organize and develop images from digital cameras</_summary>
   <translation type="gettext">darktable</translation>
   <description>

--- a/data/watermarks/promo.svg
+++ b/data/watermarks/promo.svg
@@ -289,7 +289,7 @@
         </dc:creator>
         <dc:language>english</dc:language>
         <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-nc/3.0/" />
+           rdf:resource="http://creativecommons.org/licenses/by-sa/3.0/" />
         <dc:date>2010</dc:date>
         <dc:contributor>
           <cc:Agent>
@@ -298,7 +298,7 @@
         </dc:contributor>
       </cc:Work>
       <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-nc/3.0/">
+         rdf:about="http://creativecommons.org/licenses/by-sa/3.0/">
         <cc:permits
            rdf:resource="http://creativecommons.org/ns#Reproduction" />
         <cc:permits


### PR DESCRIPTION
Change the license of promo.svg to CC-BY-SA-3.0

In [#10002][0] the author and creator (@MRIG) offered to drop the file or
relicense the file if necessary. As [parafin][1] pointed out, dropping
the file might break edits. So apply the 2nd option.

Fixes #10002

Update the appdata file with the new license combination

With the change in b5f4026cd we have no more files in CC-BY-NC-3.0.

This should fix #9674.

[0]: https://github.com/darktable-org/darktable/issues/10002#issuecomment-919335546
[1]: https://github.com/darktable-org/darktable/issues/9674#issuecomment-993679181
