### PR TITLE
ignore brew lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ compile_commands.json
 .settings/
 diff*png
 output*png
+Brewfile.lock.json


### PR DESCRIPTION
when installing packages on MacOs via brew:
cd .ci
brew bundle install

the mentioned generated lockfile is to be ignored