### PR TITLE
Only list the main license in the project license

### DIFF
--- a/data/darktable.appdata.xml.in
+++ b/data/darktable.appdata.xml.in
@@ -7,7 +7,7 @@
   <id>darktable.desktop</id>
   <name>darktable</name>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+ AND GPL-2.0+ AND LGPL-2.0+ AND BSD-3-Clause AND MIT AND CC-BY-SA-1.0 AND CC-BY-2.5 AND CC-BY-SA-3.0</project_license>
+  <project_license>GPL-3.0+</project_license>
   <_summary>Organize and develop images from digital cameras</_summary>
   <translation type="gettext">darktable</translation>
   <description>


### PR DESCRIPTION
During the first round of fixes I missed the part that the license
field should only list the main license of the software.

See the discussion in https://github.com/darktable-org/darktable/issues/9674

Hopefully the final fix for #9674