### PR TITLE
Switch CI to Ninja, fetch tag for nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ on:
 jobs:
 
   Linux-minimal:
-    name: Linux-minimal.${{ matrix.os.code }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}
+    name: Linux-minimal.${{ matrix.os.code }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     runs-on: ${{ matrix.os.label }}
     strategy:
       fail-fast: true
@@ -59,15 +59,20 @@ jobs:
           #- build
           - nofeatures
           - nofeatures_nosse
+        generator:
+          #- Unix Makefiles
+          - Ninja
         include:
           - os: { label: ubuntu-18.04, code: bionic }
             btype: RelWithDebInfo
             compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
             target: nofeatures
+            generator: Ninja
           - os: { label: ubuntu-18.04, code: bionic }
             btype: RelWithDebInfo
             compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
             target: nofeatures_nosse
+            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
@@ -75,8 +80,7 @@ jobs:
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
-      #GENERATOR: Ninja
-      GENERATOR: Unix Makefiles
+      GENERATOR: ${{ matrix.generator }}
       TARGET: ${{ matrix.target }}
       DARKTABLE_CLI: ${{ github.workspace }}/install/bin/darktable-cli
     steps:
@@ -164,7 +168,7 @@ jobs:
                  --conf plugins/lighttable/export/iccintent=0
 
   Linux:
-    name: Linux.${{ matrix.os.code }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}
+    name: Linux.${{ matrix.os.code }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     needs: Linux-minimal
     runs-on: ${{ matrix.os.label }}
     strategy:
@@ -189,40 +193,51 @@ jobs:
           - build
           - nofeatures
           - nofeatures_nosse
+        generator:
+          #- Unix Makefiles
+          - Ninja
         include:
           - os: { label: ubuntu-18.04, code: bionic }
             btype: RelWithDebInfo
             compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
             target: build
+            generator: Ninja
           - os: { label: ubuntu-18.04, code: bionic }
             btype: Release
             compiler: { compiler: GNU7,   CC: gcc-7,    CXX: g++-7,      packages: gcc-7 g++-7 }
             target: build
+            generator: Ninja
           - os: { label: ubuntu-latest, code: latest }
             btype: Debug
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
             target: skiptest
+            generator: Ninja
           - os: { label: ubuntu-latest, code: latest }
             btype: Debug
             compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
             target: skiptest
+            generator: Ninja
         exclude:
           - os: { label: ubuntu-20.04, code: focal }
             btype: RelWithDebInfo
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
             target: nofeatures
+            generator: Ninja
           - os: { label: ubuntu-20.04, code: focal }
             btype: RelWithDebInfo
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
             target: nofeatures_nosse
+            generator: Ninja
           - os: { label: ubuntu-20.04, code: focal }
             btype: RelWithDebInfo
             compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
             target: nofeatures
+            generator: Ninja
           - os: { label: ubuntu-20.04, code: focal }
             btype: RelWithDebInfo
             compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
             target: nofeatures_nosse
+            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
@@ -230,8 +245,7 @@ jobs:
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
-      #GENERATOR: Ninja # for some reason ninja started acting weird and generating files which called `ar` with linker flags instead of ar flags.
-      GENERATOR: Unix Makefiles
+      GENERATOR: ${{ matrix.generator }}
       TARGET: ${{ matrix.target }}
       DARKTABLE_CLI: ${{ github.workspace }}/install/bin/darktable-cli
     steps:
@@ -340,6 +354,9 @@ jobs:
         target:
           - skiptest
           - nofeatures
+        generator:
+          #- MSYS Makefiles
+          - Ninja
         include:
           # Uncomment if PR needs to generate windows package for testing.
           #- btype: Release
@@ -349,10 +366,7 @@ jobs:
           - btype: Debug
             compiler: { compiler: GNU,  CC: gcc,   CXX: g++ }
             target: skiptest
-            generator: MSYS Makefiles
-        generator:
-          - MSYS Makefiles
-          #- Ninja # do enable if confirmed that ninja is innocent in libxcf case
+            generator: Ninja
     defaults:
       run:
         shell: msys2 {0}
@@ -374,6 +388,7 @@ jobs:
           install: >-
             base-devel
             git
+            intltool
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-cmocka
@@ -416,6 +431,10 @@ jobs:
         with:
           submodules: true
           path: src
+      - name: Update lensfun data
+        if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
+        run: |
+          lensfun-update-data
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}"
@@ -441,7 +460,6 @@ jobs:
       - name: Package
         if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
         run: |
-          lensfun-update-data
           cd "${BUILD_DIR}"
           cmake --build "${BUILD_DIR}" --target package
       - name: Package upload
@@ -453,7 +471,7 @@ jobs:
           retention-days: 1
 
   macOS:
-    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}
+    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}.${{ matrix.generator }}
     needs: Linux-minimal
     runs-on: ${{ matrix.build.os }}
     strategy:
@@ -470,12 +488,15 @@ jobs:
         target:
           - skiptest
           - nofeatures
+        generator:
+          #- Unix Makefiles
+          - Ninja
         exclude:
           - build: { os: macos-10.15, xcode: 11.7 }
             compiler: { compiler: XCode,   CC: cc, CXX: c++ }
             btype: RelWithDebInfo
             target: skiptest
-
+            generator: Ninja
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
       CC: ${{ matrix.compiler.CC }}
@@ -488,8 +509,7 @@ jobs:
       INSTALL_PREFIX: ${{ github.workspace }}/install
       CMAKE_PREFIX_PATH: /usr/local/opt/libsoup@2:/usr/local/opt/icu4c
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
-      #GENERATOR: Ninja
-      GENERATOR: Unix Makefiles
+      GENERATOR: ${{ matrix.generator }}
       TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,6 @@ jobs:
           #- MSYS Makefiles
           - Ninja
         include:
-          # Uncomment if PR needs to generate windows package for testing.
           #- btype: Release
           #  compiler: { compiler: LLVM,  CC: clang,   CXX: clang++ }
           #  eco: -DBINARY_PACKAGE_BUILD=ON
@@ -431,10 +430,6 @@ jobs:
         with:
           submodules: true
           path: src
-      - name: Update lensfun data
-        if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
-        run: |
-          lensfun-update-data
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}"
@@ -457,18 +452,6 @@ jobs:
                  --conf worker_threads=4 -t 4 \
                  --conf plugins/lighttable/export/force_lcms2=FALSE \
                  --conf plugins/lighttable/export/iccintent=0
-      - name: Package
-        if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
-        run: |
-          cd "${BUILD_DIR}"
-          cmake --build "${BUILD_DIR}" --target package
-      - name: Package upload
-        if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
-        uses: 'actions/upload-artifact@v2'
-        with:
-          name: Win64.${{ matrix.compiler.compiler }}.${{ matrix.btype}}.${{ github.sha }}
-          path: ${{ env.BUILD_DIR }}/darktable-*.exe
-          retention-days: 1
 
   macOS:
     name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}.${{ matrix.generator }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
       INSTALL_PREFIX: ${{ github.workspace }}/install
       ECO: ${{ matrix.eco }}
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
-      GENERATOR: 'MSYS Makefiles'
+      GENERATOR: Ninja
       TARGET: ${{ matrix.target }}
     steps:
       - uses: msys2/setup-msys2@v2
@@ -38,6 +38,7 @@ jobs:
           install: >-
             base-devel
             git
+            intltool
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-ninja
@@ -77,8 +78,13 @@ jobs:
           update: true
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
           path: src
+      - name: Update lensfun data
+        if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
+        run: |
+          lensfun-update-data
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}"
@@ -100,7 +106,6 @@ jobs:
       - name: Package
         if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
         run: |
-          lensfun-update-data
           cd "${BUILD_DIR}"
           cmake --build "${BUILD_DIR}" --target package
       - name: Package upload

--- a/packaging/windows/BUILD.md
+++ b/packaging/windows/BUILD.md
@@ -1,60 +1,71 @@
-To build darktable for Windows operating system you have two basic option:
-A) Native compile using MSYS
+To build darktable for the Windows operating system you have two basic options:
+
+A) Native compile using MSYS2
+
 B) Cross compile on Linux
 
 ## A) Native compile using MSYS2:
-How to make a darktable windows installer (64 bit only):
+How to make a darktable Windows installer (x64 only):
 
-* Install MSYS2 (instructions and prerequisites can be found on official website: https://msys2.github.io/).
+* Install MSYS2 (instructions and prerequisites can be found on the official website: https://www.msys2.org)
 
-* Update the base MSYS2 system until no further updates are available using: `$ pacman -Syu`
+* Start the MSYS terminal and update the base system until no further updates are available by repeating:
+    ```bash
+    $ pacman -Syu
+    ```
 
-* From MSYS2 terminal, install x64 developer tools and x86_64 toolchain and git from the MSYS2 prompt:
+* From the MSYS terminal, install x64 developer tools, x86_64 toolchain and git:
+    ```bash
+    $ pacman -S --needed base-devel intltool git
+    $ pacman -S --needed mingw-w64-x86_64-{toolchain,cmake,ninja,nsis}
     ```
-    $ pacman -S base-devel
-    $ pacman -S mingw-w64-x86_64-{toolchain,cmake,nsis}
-    $ pacman -S git
-    ```
-* Install required libraries and dependencies:
-    ```
-    $ pacman -S mingw-w64-x86_64-{exiv2,lcms2,lensfun,dbus-glib,openexr,sqlite3,libxslt,libsoup,libavif,libheif,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,drmingw,gettext,python3,iso-codes,python3-jsonschema,python3-setuptools}
+
+* Install required libraries and dependencies for darktable:
+    ```bash
+    $ pacman -S --needed mingw-w64-x86_64-{exiv2,lcms2,lensfun,dbus-glib,openexr,sqlite3,libxslt,libsoup,libavif,libheif,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,drmingw,gettext,python3,iso-codes,python3-jsonschema,python3-setuptools}
     ```
 
 * Install optional libraries and dependencies:
+
+    for cLUT
+    ```bash
+    $ pacman -S --needed mingw-w64-x86_64-gmic
     ```
-    $ pacman -S mingw-w64-x86_64-gmic
-    ```
-    for NG Input with midi or gamepad devices
-    ```
-    $ pacman -S mingw-w64-x86_64-portmidi mingw-w64-x86_64-SDL2
+    for NG input with midi or gamepad devices
+    ```bash
+    $ pacman -S --needed mingw-w64-x86_64-{portmidi,SDL2}
     ```
 
-* Optional: Install libraries required for [testing](../../src/tests/unittests/README.md)
-    ```
-    $ pacman -S mingw-w64-x86_64-cmocka
+* Install optional libraries required for [testing](../../src/tests/unittests/README.md):
+    ```bash
+    $ pacman -S --needed mingw-w64-x86_64-cmocka
     ```
 
-* For gphoto2:
-    * You need to restart the MINGW64 or MSYS terminal to have CAMLIBS and IOLIBS environment variables properly set for LIBGPHOTO are available.
-    * make sure they aren't pointing into your normal windows installation in case you already have darktable installed. You can check them with:
-        ```
+* Switch to the MINGW64 terminal and update your lensfun database:
+    ```bash
+    $ lensfun-update-data
+    ```
+
+* For libgphoto2 tethering:
+    * You might need to restart the MINGW64 terminal to have CAMLIBS and IOLIBS environment variables properly set.
+    Make sure they aren't pointing into your normal Windows installation in case you already have darktable installed.
+    You can check them with:
+        ```bash
         $ echo $CAMLIBS
         $ echo $IOLIBS
         ```
-    * If you have to set them manually you can do so by setting the variables in your .bash_profile. Example:
+    * If you have to set them manually you can do so by setting the variables in your `~/.bash_profile`. Example:
         ```bash
-        export CAMLIBS="/mingw64/lib/libgphoto2/2.5.23/"
+        export CAMLIBS="/mingw64/lib/libgphoto2/2.5.27/"
         export IOLIBS="/mingw64/lib/libgphoto2_port/0.12.0/"
         ```
 
-* From MINGW64 terminal, update your lensfun database:
-    `lensfun-update-data`
+    Also use this program to install the USB driver on Windows for your camera:
+    https://zadig.akeo.ie
 
-    Also use this program to install USB driver on Windows for your camera:
-    http://zadig.akeo.ie/
-    When you run it, replace current Windows camera driver with WinUSB driver
+    When you run it, it will replace the current Windows camera driver with the WinUSB driver.
 
-* Modify your bash_profile file in your HOME directory and add the    following lines:
+* Modify the `.bash_profile` file in your `$HOME` directory and add the following lines:
     ```bash
     # Added as per http://wiki.gimp.org/wiki/Hacking:Building/Windows
     export PREFIX="/mingw64"
@@ -62,16 +73,19 @@ How to make a darktable windows installer (64 bit only):
     export PATH="$PREFIX/bin:$PATH"
     ```
 
-* By default cmake will only use one core during the build process.  To speed things up you might wish to add a line like:
+* By default CMake will only use one core during the build process. To speed things up you might wish to add a line like:
     ```bash
-   	export CMAKE_BUILD_PARALLEL_LEVEL="6"
+    export CMAKE_BUILD_PARALLEL_LEVEL="6"
     ```
-   to your .bash_profile file. This would use 6 cores.
+    to your `~/.bash_profile` file. This would use 6 cores.
 
-* Execute the following command to actviate profile changes `$ . .bash_profile`
-
-* From MINGW64 terminal, clone darktable git repository (in this example into ~/darktable):
+* Execute the following command to actviate profile changes:
+    ```bash
+    $ . .bash_profile
     ```
+
+* From the MINGW64 terminal, clone the darktable git repository (in this example into `~/darktable`):
+    ```bash
     $ cd ~
     $ git clone git://github.com/darktable-org/darktable.git
     $ cd darktable
@@ -80,37 +94,47 @@ How to make a darktable windows installer (64 bit only):
     ```
 
 * Finally build and install darktable:
-    ```
+    ```bash
     $ mkdir build
     $ cd build
-    $ cmake -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/darktable ../.
+    $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/darktable ../.
     $ cmake --build .
-    $ cmake --build . --target install
+    $ cmake --install .
     ```
     After this darktable will be installed in `/opt/darktable `directory and can be started by typing `/opt/darktable/bin/darktable.exe` in MSYS2 MINGW64 terminal.
 
     *NOTE: If you are using the Lua scripts, build the installer and install darktable.
-    The Lua scripts check the operating system and see windows and expect a windows shell when executing system commands.
+    The Lua scripts check the operating system and see Windows and expect a Windows shell when executing system commands.
     Running darktable from the MSYS2 MINGW64 terminal gives a bash shell and therefore the commands will not work.*
 
-* For building the installer image, which will  create darktable-<VERSION>.exe installer in current build directory, use: `$ cmake --build . --target package`
+* For building the installer image, which will create darktable-<VERSION>.exe installer in the current build directory, use:
+    ```bash
+    $ cmake --build . --target package
+    ```
 
     *NOTE: The package created will be optimized for the machine on which it has been built, but it could not run on other PCs with different hardware or different Windows version. If you want to create a "generic" package, change the first cmake command line as follows:*
+    ```bash
+    $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/darktable -DBINARY_PACKAGE_BUILD=ON ../.
     ```
-    $ cmake -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/darktable -DBINARY_PACKAGE_BUILD=ON ../.
-    ```
-It is now possible to build darktable on Windows using Ninja rather than Make.  This offers advantages of reduced build times for incremental builds (builds on Windows are significantly slower than with linux based systems).  To use Ninja you need to install it from an MSYS terminal with:
 
-`$ pacman -S mingw-w64-x86_64-ninja`
+While Ninja offers advantages of reduced build times for incremental builds (builds on Windows are significantly slower than with linux based systems), you can also fall back to more traditional Makefiles should the need arise. You'll need to install Autotools from an MSYS terminal with:
 
-Be careful as there is also a version of Ninja for MSYS and this will not work here.  Now return to a MINGW64 terminal and use this sequence
+```bash
+$ pacman -S --needed mingw-w64-x86_64-autotools
 ```
+
+Now return to the MINGW64 terminal and use this sequence instead:
+
+```bash
 $ mkdir build
 $ cd build
-$ cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/darktable ../.
+$ cmake -G 'MSYS Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/darktable ../.
 $ cmake --build .
 ```
-If you are in a hurry you can now run darktable by executing the darktable.exe found in the build/bin folder, install in /opt/darktable as described earlier, or create an install image.  If you like experimenting you could also install clang and use that instead of gcc/g++ as the toolchain.
+
+If you are in a hurry you can now run darktable by executing the `darktable.exe` found in the `build/bin` folder, install in `/opt/darktable` as described earlier, or create an install image.
+
+If you like experimenting you could also install clang and use that instead of gcc/g++ as the toolchain.
 
 
 ## B) Cross compile on Linux


### PR DESCRIPTION
Re https://github.com/darktable-org/darktable/issues/9745

Ninja builds have been working on my local machine for quite some time now (since 3.5), maybe I just skipped the problematic CMake version...