### PR TITLE
__DT_CLONE_TARGETS__ was undefined on aarch64

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -133,6 +133,8 @@ typedef unsigned int u_int;
 # elif defined(__PPC64__)
 /* __PPC64__ is the only macro tested for in is_supported_platform.h, other macros would fail there anyway. */
 #define __DT_CLONE_TARGETS__ __attribute__((target_clones("default","cpu=power9")))
+# else
+#define __DT_CLONE_TARGETS__
 # endif
 #else
 #define __DT_CLONE_TARGETS__


### PR DESCRIPTION
- it's probably broken on armv7 too and other non intel arch

I haven't tested the build yet.

See https://github.com/flathub/org.darktable.Darktable/pull/81
(flathub build)

**NOTE** I couldn't figure out what a proper value would be. neon is always on on aarch64