### PR TITLE
Add text & color label filters

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -726,6 +726,11 @@ l
   background-color: @field_active_bg;
 }
 
+#colors-filter-box
+{
+  font-size: 0.7em;
+}
+
 /*-------------------
   - Scope/Histogram -
   -------------------*/

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -396,6 +396,11 @@ spinbutton>button
   margin: 0.14em 0.07em;
 }
 
+.dt_opacity_06
+{
+  opacity: 0.6;
+}
+
 /*------------------------
   - Main header settings -
   ------------------------*/

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -401,6 +401,11 @@ spinbutton>button
   opacity: 0.6;
 }
 
+.dt_button_background
+{
+  background-color: @button_bg;
+}
+
 /*------------------------
   - Main header settings -
   ------------------------*/

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -721,6 +721,11 @@ l
   padding-top: 0.28em;
 }
 
+#filter-box entry
+{
+  background-color: @field_active_bg;
+}
+
 /*-------------------
   - Scope/Histogram -
   -------------------*/

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -346,9 +346,7 @@ checkbutton check:checked
 
 /* Button to open/close the dropdown section, especially header ones */
 #control-button,
-#control-button:checked,
-#filter-button,
-#filter-button:checked
+#control-button:checked
 {
   background-color: transparent;
   margin-left: 0.14em;
@@ -396,14 +394,26 @@ spinbutton>button
   margin: 0.14em 0.07em;
 }
 
-.dt_opacity_06
+.quick_filter_box
 {
-  opacity: 0.6;
+  background-color: @border_color;
+  padding: 0.01em;
 }
 
-.dt_button_background
+.dt_dimmed
 {
-  background-color: @button_bg;
+  opacity: 0.5;
+}
+
+.dt_font_resize_07
+{
+  font-size: 0.7em;
+}
+
+.dt_transparent_background,
+.dt_transparent_background:checked
+{
+  background-color: transparent;
 }
 
 /*------------------------
@@ -442,9 +452,7 @@ spinbutton>button
 #header-toolbar #dt-toggle-button,
 #header-toolbar #dt-button,
 #footer-toolbar #dt-toggle-button,
-#footer-toolbar #dt-button,
-#filter-button,
-#filter-button:checked
+#footer-toolbar #dt-button
 {
   padding: 0.07em;
   min-height: 2.4em; /* align toolbox button height on comboboxe's one */
@@ -724,21 +732,6 @@ l
 .search image.left
 {
   padding: 0 0.35em 0 0.21em;
-}
-
-#filter-box
-{
-  padding-top: 0.28em;
-}
-
-#filter-box entry
-{
-  background-color: @field_active_bg;
-}
-
-#colors-filter-box
-{
-  font-size: 0.7em;
 }
 
 /*-------------------
@@ -1889,7 +1882,6 @@ menuitem:hover > *:not(check),
 combobox window *:hover,
 radiobutton:hover label,
 #control-button:hover,
-#filter-button:hover,
 #history-button:hover,
 #history-button-enabled:hover,
 #history-button-always-enabled:hover,
@@ -1921,7 +1913,6 @@ menuitem:hover cellview,
 menuitem:hover > *,
 notebook tab:hover label,
 #control-button:hover,
-#filter-button:hover,
 #history-button:hover *,
 #history-button-enabled:hover *,
 #history-button-always-enabled:hover *,

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -595,6 +595,7 @@ char *dt_collection_get_text_filter(const dt_collection_t *collection)
 void dt_collection_set_text_filter(const dt_collection_t *collection, char *text_filter)
 {
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
+  g_free(params->text_filter);
   params->text_filter = text_filter;
 }
 

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -262,12 +262,14 @@ int dt_collection_update(const dt_collection_t *collection)
     {
       wq = dt_util_dstrcat(wq, " %s id IN (SELECT id FROM main.meta_data WHERE id=mi.id AND value LIKE '%s'"
                                           " UNION SELECT imgid AS id FROM main.tagged_images AS ti, data.tags AS t"
-                                          "   WHERE imgid=mi.id AND t.id=ti.tagid AND t.name LIKE '%s'"
+                                          "   WHERE imgid=mi.id AND t.id=ti.tagid AND"
+                                          "         (t.name LIKE '%s' OR t.synonyms LIKE '%s')"
                                           " UNION SELECT id FROM main.images"
                                           "   WHERE id=mi.id AND filename LIKE '%s'"
                                           " UNION SELECT i.id FROM main.images AS i, main.film_rolls AS fr"
                                           "   WHERE i.id=mi.id AND fr.id=i.film_id AND fr.folder LIKE '%s')",
                            and_operator(&and_term), collection->params.text_filter,
+                                                    collection->params.text_filter,
                                                     collection->params.text_filter,
                                                     collection->params.text_filter,
                                                     collection->params.text_filter);

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -148,6 +148,9 @@ typedef struct dt_collection_params_t
   /** flags for which filters to use, see COLLECTION_FILTER_x defines... */
   uint32_t filter_flags;
 
+  /** text filter */
+  char *text_filter;
+
   /** current film id */
   uint32_t film_id;
 
@@ -208,6 +211,11 @@ void dt_collection_set_filter_flags(const dt_collection_t *collection, uint32_t 
 uint32_t dt_collection_get_query_flags(const dt_collection_t *collection);
 /** set filter flags for collection */
 void dt_collection_set_query_flags(const dt_collection_t *collection, uint32_t flags);
+
+/** get text filter for collection */
+char *dt_collection_get_text_filter(const dt_collection_t *collection);
+/** set text filter for collection */
+void dt_collection_set_text_filter(const dt_collection_t *collection, char *text_filter);
 
 /** set the film_id of collection */
 void dt_collection_set_film_id(const dt_collection_t *collection, const int32_t film_id);

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -151,6 +151,9 @@ typedef struct dt_collection_params_t
   /** text filter */
   char *text_filter;
 
+  /** colors filter */
+  int colors_filter;
+
   /** current film id */
   uint32_t film_id;
 
@@ -216,6 +219,11 @@ void dt_collection_set_query_flags(const dt_collection_t *collection, uint32_t f
 char *dt_collection_get_text_filter(const dt_collection_t *collection);
 /** set text filter for collection */
 void dt_collection_set_text_filter(const dt_collection_t *collection, char *text_filter);
+
+/** get colors filter for collection */
+int dt_collection_get_colors_filter(const dt_collection_t *collection);
+/** set colors filter for collection */
+void dt_collection_set_colors_filter(const dt_collection_t *collection, int colors_filter);
 
 /** set the film_id of collection */
 void dt_collection_set_film_id(const dt_collection_t *collection, const int32_t film_id);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -209,7 +209,7 @@ void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   cairo_move_to(cr, 0.1, 0.95);
   cairo_line_to(cr, 0.2, 0.80);
   cairo_stroke(cr);
-  
+
   if(flags & CPF_DIRECTION_UP)
   {
     cairo_move_to(cr, 0.35, 0.05);
@@ -1543,7 +1543,7 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   #define CPF_USER_DATA_INCLUDE CPF_USER_DATA
   #define CPF_USER_DATA_EXCLUDE CPF_USER_DATA << 1
-  PREAMBLE(1, 0, 0)
+  PREAMBLE(1, 0, 0, 0)
 
   const double r = 0.4;
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1539,6 +1539,56 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   FINISH
 }
 
+void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  #define CPF_USER_DATA_INCLUDE CPF_USER_DATA
+  #define CPF_USER_DATA_EXCLUDE CPF_USER_DATA << 1
+  PREAMBLE(1, 0, 0)
+
+  const double r = 0.4;
+
+  const float alpha = flags & CPF_PRELIGHT ? 1.0 : 0.6;
+  const dt_colorlabels_enum color = (flags & 7);
+  const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
+
+  if(color < DT_COLORLABELS_LAST)
+  {
+    cairo_set_source_rgba(cr, colorlabels[color].red, colorlabels[color].green, colorlabels[color].blue, alpha);
+  }
+  else
+  {
+    cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, alpha);
+  }
+
+  if(flags & CPF_USER_DATA_INCLUDE)
+  {
+    cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
+    cairo_set_line_width(cr, .2);
+    cairo_stroke(cr);
+  }
+  else if(flags & CPF_USER_DATA_EXCLUDE)
+  {
+    /* fill base color */
+    cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
+    cairo_fill(cr);
+    cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.6);
+    cairo_set_line_width(cr, .2);
+    cairo_move_to(cr, 0.1, 0.1);
+    cairo_line_to(cr, 0.9, 0.9);
+    cairo_move_to(cr, 0.9, 0.1);
+    cairo_line_to(cr, 0.1, 0.9);
+    cairo_stroke(cr);
+  }
+  else
+  {
+    /* fill base color */
+    cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
+    cairo_fill(cr);
+  }
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(0.9, 1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -117,6 +117,8 @@ void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 void dtgtk_cairo_paint_aspectflip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a color label icon */
 void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a color label icon for selection */
+void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint the local copy symbol */
 void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint the reject icon on thumbs */

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -22,6 +22,7 @@
 #include "control/control.h"
 #include "develop/develop.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "dtgtk/button.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
@@ -386,18 +387,18 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), color_box, FALSE, FALSE, 4);
 
   // filter text
-  GtkWidget *text_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  d->text = gtk_entry_new();
-  gtk_entry_set_width_chars(GTK_ENTRY(d->text), 10);
-  gtk_box_pack_start(GTK_BOX(text_box), d->text, FALSE, FALSE, 0);
-  gtk_widget_set_tooltip_text(d->text, _("filter the text across metadata, tags and complete filename"
-                                         "\nuse `%' as wildcard"));
+  d->text = gtk_search_entry_new();
+  GtkStyleContext *context = gtk_widget_get_style_context(d->text);
+  gtk_style_context_add_class(context, "dt_button_background");
+  gtk_entry_set_placeholder_text(GTK_ENTRY(d->text), _("search text"));
+  g_signal_connect(G_OBJECT(d->text), "search-changed", G_CALLBACK(_text_entry_changed), self);
   g_signal_connect(G_OBJECT(d->text), "activate", G_CALLBACK(_text_entry_activated), self);
-  g_signal_connect(G_OBJECT(d->text), "changed", G_CALLBACK(_text_entry_changed), self);
-  GtkWidget *reset_button = dtgtk_button_new(dtgtk_cairo_paint_multiply_small, CPF_STYLE_FLAT, NULL);
-  gtk_box_pack_start(GTK_BOX(text_box), reset_button, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(reset_button), "clicked", G_CALLBACK(_reset_text_entry), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), text_box, FALSE, FALSE, 4);
+  g_signal_connect(G_OBJECT(d->text), "stop-search", G_CALLBACK(_reset_text_entry), self);
+  gtk_entry_set_width_chars(GTK_ENTRY(d->text), 14);
+  gtk_widget_set_tooltip_text(d->text, _("filter the text accross metadata, tags and complete filename"
+                                         "\nhit Home then Enter to serach without default start and end wildcards"
+                                         "\nuse `%' as wildcard"));
+  gtk_box_pack_start(GTK_BOX(self->widget), d->text, FALSE, FALSE, 4);
 
   /* sort combobox */
   const dt_collection_sort_t sort = dt_collection_get_sort_field(darktable.collection);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -155,8 +155,11 @@ int position()
 
 static void _text_entry_activated(GtkEntry *entry, dt_lib_module_t *self)
 {
+  const int pos = gtk_editable_get_position(GTK_EDITABLE(entry));
+  char *text = pos ? g_strconcat("%", gtk_entry_get_text(entry), "%", NULL)
+                   : g_strdup(gtk_entry_get_text(entry));
   g_free(dt_collection_get_text_filter(darktable.collection));
-  dt_collection_set_text_filter(darktable.collection, g_strdup(gtk_entry_get_text(entry)));
+  dt_collection_set_text_filter(darktable.collection, text);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_SORT, NULL);
 }
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -351,7 +351,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
   gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
 
-  GtkWidget *label = gtk_label_new(_("filter"));
+  GtkWidget *label = gtk_label_new(C_("quickfilter", "filter"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);


### PR DESCRIPTION
Enhancement:
Adds a text filter which acts on all image text data: metadata, tags, filename and path.

Bug fix:
On every click / selection, the full collection query was executed two or three times. Now it reuses the memory.collected_images table instead.

Notes
I've found some difficulty in setting up an acceptable layout. Some strange behaviors I haven't explained:
- in darktable.c `min-width` looks like a minimum width but acts as a constant width.
- between the filter area and the 5 main buttons on the right, there is a not compressible zone, which could be used in case of small screen width.

Beside this, the usage of gtk_box_set_homogeneous() is not very convenient for fields of different width EDIT I've removed it but I'm not sure that's right.


