### PR TITLE
#10654 - import: Fixed crash when importing images with copy to path …

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -341,6 +341,7 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
   if(self->current_path && strcmp(self->current_path, new_path) == 0)
   {
     g_free(new_path);
+    new_path = NULL;
     if(currentok) return self->current_path;
   }
 

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -308,7 +308,15 @@ gboolean dt_util_test_writable_dir(const char *path)
   if(path == NULL) return FALSE;
 #ifdef _WIN32
   struct _stati64 stats;
-  if(_stati64(path, &stats)) return FALSE;
+
+  wchar_t *wpath = g_utf8_to_utf16(path, -1, NULL, NULL, NULL);
+  const int result = _wstati64(wpath, &stats);
+  g_free(wpath);
+
+  if(result)
+  { // error while testing path:
+    return FALSE;
+  }
 #else
   struct stat stats;
   if(stat(path, &stats)) return FALSE;


### PR DESCRIPTION
…containing Umlauts on Windows
Fix for #10654 
A small fix to prevent dt from crashing on Win when importing images into a folder containing Umlauts.
1. by using the wide char function to stat the directory and 
2. by nulling the new_path pointer after the free in case dt_util_test_writable_dir should return false for some other reasons to avoid the double free.