### PR TITLE
CI: make macOS build find libsoup, icu and osmgpsmap dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,7 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
+      CMAKE_PREFIX_PATH: /usr/local/opt/libsoup@2:/usr/local/opt/icu4c
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
       #GENERATOR: Ninja
       GENERATOR: Unix Makefiles


### PR DESCRIPTION
This brings CI build closer to full-featured compilation.
Still missing:

- exiv2 with ISOBMFF support
- correct lensfun version (homebrew has broken alpha release 0.3.95 instead of latest stable 0.3.2)