### PR TITLE
utility: fix for librsvg 2.52

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -911,10 +911,18 @@ RsvgDimensionData dt_get_svg_dimension(RsvgHandle *svg)
     }
     else
     {
+#define VIEWPORT_SIZE 32767 //use maximum cairo surface size to have enough precision when size is converted to int
+      const RsvgRectangle viewport = {
+        .x = 0,
+        .y = 0,
+        .width = VIEWPORT_SIZE,
+        .height = VIEWPORT_SIZE,
+      };
+#undef VIEWPORT_SIZE
       RsvgRectangle rectangle;
-      rsvg_handle_get_geometry_for_element(svg, NULL, NULL, &rectangle, NULL);
-      dimension.width = lround(rectangle.width + rectangle.x);
-      dimension.height = lround(rectangle.height + rectangle.y);
+      rsvg_handle_get_geometry_for_layer(svg, NULL, &viewport, NULL, &rectangle, NULL);
+      dimension.width = lround(rectangle.width);
+      dimension.height = lround(rectangle.height);
     }
   #else
     rsvg_handle_get_dimensions(svg, &dimension);


### PR DESCRIPTION
dimensions weren't computed correctly when there was no intrinsic size:
1). offset shouldn't be added to size
2). returned value could have been small (<1) which rounds to zero

Fixes #10685