### PR TITLE
Factorize the on/off history item representation.

### DIFF
--- a/src/common/history.h
+++ b/src/common/history.h
@@ -120,6 +120,9 @@ GList *dt_history_get_items(int32_t imgid, gboolean enabled);
 /** get list of history items for image as a nice string */
 char *dt_history_get_items_as_string(int32_t imgid);
 
+/** get a single history item as string with enabled status */
+char *dt_history_item_as_string(const char *name, gboolean enabled);
+
 /* check if a module exists in the history of corresponding image */
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation);
 

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1111,14 +1111,16 @@ GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)
 
         if(multi_name && *multi_name && strcmp(multi_name, "0") != 0) has_multi_name = TRUE;
 
+        char *itname = dt_history_item_as_string
+          (dt_iop_get_localized_name((char *)sqlite3_column_text(stmt, 3)),
+           sqlite3_column_int(stmt, 4));
+
         if(has_multi_name)
-          g_snprintf(iname, sizeof(iname), "%s %s (%s)",
-                     dt_iop_get_localized_name((gchar *)sqlite3_column_text(stmt, 3)), multi_name,
-                     (sqlite3_column_int(stmt, 4) != 0) ? _("on") : _("off"));
+          g_snprintf(iname, sizeof(iname), "%s %s", itname, multi_name);
         else
-          g_snprintf(iname, sizeof(iname), "%s (%s)",
-                     dt_iop_get_localized_name((gchar *)sqlite3_column_text(stmt, 3)),
-                     (sqlite3_column_int(stmt, 4) != 0) ? _("on") : _("off"));
+          g_snprintf(iname, sizeof(iname), "%s", itname);
+
+        g_free(itname);
 
         item->params = NULL;
         item->blendop_params = NULL;


### PR DESCRIPTION
The on/off strings are replaced by standard symbol characters
for better readability.

We have only two places where the on/off status for an history item was still using strings. And it was not really easy/nice to read.

Before (English):

![Capture d’écran de 2021-12-28 10-24-57](https://user-images.githubusercontent.com/467069/147551433-d889ce9d-1f52-47d2-b3e0-8fa6fc266124.png)
![Capture d’écran de 2021-12-28 10-25-01](https://user-images.githubusercontent.com/467069/147551441-613aa4ff-04b2-452a-a1b8-e3eb79fae77d.png)

Before (French, even worst as the gender is present):

![Capture d’écran de 2021-12-28 10-24-09](https://user-images.githubusercontent.com/467069/147551520-737ba186-de01-4a43-af11-64c246133979.png)
![Capture d’écran de 2021-12-28 10-24-33](https://user-images.githubusercontent.com/467069/147551536-c82ad153-c38a-4a8c-b9e2-33e3342dda23.png)

After, just a simple icon:

![Capture d’écran de 2021-12-28 10-26-16](https://user-images.githubusercontent.com/467069/147551572-0c8f839f-d747-45a3-8409-c57f858b1573.png)
![Capture d’écran de 2021-12-28 10-26-22](https://user-images.githubusercontent.com/467069/147551576-815263b5-4601-4dd1-a7af-c34e4eca0c05.png)

