### PR TITLE
[WIP] Segmentation based highlights recovery for bayer sensors

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -42,13 +42,6 @@
 DT_MODULE_INTROSPECTION(2, dt_iop_highlights_params_t)
 
 /* defines for the highlights recovery section */
-#define HLBORDER 8
-#define HLEPSILON 1e-5
-
-static size_t plane_size(size_t width, size_t height)
-{
-  return (size_t) dt_round_size((width + 4) * (height + 4), 16);
-}
 
 typedef enum dt_iop_highlights_mode_t
 {
@@ -1081,8 +1074,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->combine, _("combine close segments")); 
 }
 
-#undef HLBORDER
-#undef HLEPSILON
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -98,7 +98,7 @@ typedef struct dt_iop_highlights_params_t
 {
   dt_iop_highlights_mode_t mode;         // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
   float allclipped;                      // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights synthesis"
-  float reconstructing;                  // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.2 $DESCRIPTION: "reconstruct color"
+  float reconstructing;                  // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.4 $DESCRIPTION: "reconstruct color"
   float combine;                         // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
   float clip;                            // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
   dt_iop_highlights_maskmode_t maskmode; // $DEFAULT: DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES $DESCRIPTION: "debugging helpers"
@@ -184,7 +184,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     memcpy(n, o, sizeof *o);
     n->maskmode = DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES;
     n->allclipped = 0.0f;
-    n->reconstructing = 0.2f;
+    n->reconstructing = 0.4f;
     n->floatoption = 0.0f;
     n->option = DT_IO_HIGHLIGHTSMASK_OPTION_0;
     n->plane = DT_IO_PLANE_RED;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -54,13 +54,13 @@ typedef enum dt_iop_highlights_mode_t
 typedef struct dt_iop_highlights_params_t
 {
   dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
-  float reconstructing;          // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "cast balance"
-  float combine;                 // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
-  float threshold;
-  float clip;                    // $MIN: 0.0 $MAX: 2.0  $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
-  float feathering_details;      // $MIN: 2.0 $MAX: 8.0 $DEFAULT: 6.0 $DESCRIPTION: "details feathering"
-  float feathering_colors;       // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "colors feathering"
-  float noise_level;             // $MIN: 0. $MAX: 1.0 $DEFAULT: 0.05 $DESCRIPTION: "noise level"
+  float blendL;            // unused $DEFAULT: 1.0
+  float blendC;            // unused $DEFAULT: 0.0
+  float blendh;            // unused $DEFAULT: 0.0
+  float clip;              // $MIN: 0.0 $MAX: 2.0  $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
+  float reconstructing;    // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "cast balance"
+  float combine;           // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
+  float synthesis;
 } dt_iop_highlights_params_t;
 
 typedef struct dt_iop_highlights_gui_data_t
@@ -127,13 +127,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   {
     dt_iop_highlights_params_v2_t *o = (dt_iop_highlights_params_v2_t *)old_params;
     dt_iop_highlights_params_v3_t *n = (dt_iop_highlights_params_v3_t *)new_params;
-    n->clip = o->clip;
-    n->threshold = 0.0f;
+    memcpy(n, o, sizeof *o);
     n->reconstructing = 0.4f;
     n->combine = 2.0f;
-    n->feathering_details = 6.0f;
-    n->feathering_colors = 0.0f;
-    n->noise_level = 0.05f;
+    n->synthesis = 0.0f;
     return 0;  
   }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -25,7 +25,6 @@
 #include "bauhaus/bauhaus.h"
 #include "common/opencl.h"
 #include "common/imagebuf.h"
-#include "common/box_filters.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -40,19 +39,16 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
-DT_MODULE_INTROSPECTION(3, dt_iop_highlights_params_t)
+DT_MODULE_INTROSPECTION(2, dt_iop_highlights_params_t)
 
 /* defines for the highlights recovery section */
-#define HLDEVELOP 0
 #define HLBORDER 8
 #define HLEPSILON 1e-5
-#define HLMINSYNTHESIS 0
 
 static size_t plane_size(size_t width, size_t height)
 {
   return (size_t) dt_round_size((width + 4) * (height + 4), 16);
 }
-
 
 typedef enum dt_iop_highlights_mode_t
 {
@@ -62,49 +58,13 @@ typedef enum dt_iop_highlights_mode_t
   DT_IOP_HIGHLIGHTS_RECOVERY = 3, // $DESCRIPTION: "highlights recovery"
 } dt_iop_highlights_mode_t;
 
-typedef enum dt_iop_highlights_maskmode_t
-{
-  DT_IO_HIGHLIGHTSMASK_RECONSTR_NO = 0,    // $DESCRIPTION: "none"
-  DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES = 1, // $DESCRIPTION: "clipped planes"
-  DT_IO_HIGHLIGHTSMASK_MINIMUM_PLANE = 2,  // $DESCRIPTION: "colorize minimum"
-  DT_IO_HIGHLIGHTSMASK_SEGMENTS = 3,       // $DESCRIPTION: "segments"
-  DT_IO_HIGHLIGHTSMASK_SEGMENTWEIGHT = 4,  // $DESCRIPTION: "segment weight"
-  DT_IO_HIGHLIGHTSMASK_CANDIDATE = 5,      // $DESCRIPTION: "candidate"
-  DT_IO_HIGHLIGHTSMASK_CANDIDATE_LOC = 6,  // $DESCRIPTION: "candidate location"
-  DT_IO_HIGHLIGHTSMASK_PLANE = 7,          // $DESCRIPTION: "input plane"
-  DT_IO_HIGHLIGHTSMASK_PLANELATE = 8,      // $DESCRIPTION: "plane"
-  DT_IO_HIGHLIGHTSMASK_PLANEABOVE = 9,     // $DESCRIPTION: "plane over clip"
-  DT_IO_HIGHLIGHTSMASK_PLANEWEIGHT = 10,   // $DESCRIPTION: "plane weight"
-  DT_IO_HIGHLIGHTSMASK_MINIMUMPLANE = 11,  // $DESCRIPTION: "minimum plane"
-} dt_iop_highlights_maskmode_t;
-
-typedef enum dt_iop_highlights_option_t
-{
-  DT_IO_HIGHLIGHTSMASK_OPTION_0 = 0,  // $DESCRIPTION: "null"
-  DT_IO_HIGHLIGHTSMASK_OPTION_1 = 1,  // $DESCRIPTION: "one"
-  DT_IO_HIGHLIGHTSMASK_OPTION_2 = 2,  // $DESCRIPTION: "two"
-  DT_IO_HIGHLIGHTSMASK_OPTION_3 = 3,  // $DESCRIPTION: "three"
-} dt_iop_highlights_option_t;
-
-typedef enum dt_iop_highlights_plane_t
-{
-  DT_IO_PLANE_RED = 0,          // $DESCRIPTION: "red"
-  DT_IO_PLANE_GREEN1 = 1,       // $DESCRIPTION: "green1"
-  DT_IO_PLANE_GREEN2 = 2,       // $DESCRIPTION: "green2"
-  DT_IO_PLANE_BLUE = 3,         // $DESCRIPTION: "blue"
-} dt_iop_highlights_plane_t;
-
 typedef struct dt_iop_highlights_params_t
 {
-  dt_iop_highlights_mode_t mode;         // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
-  float allclipped;                      // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights synthesis"
-  float reconstructing;                  // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.4 $DESCRIPTION: "reconstruct color"
-  float combine;                         // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
-  float clip;                            // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
-  dt_iop_highlights_maskmode_t maskmode; // $DEFAULT: DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES $DESCRIPTION: "debugging helpers"
-  dt_iop_highlights_plane_t plane;       // $DEFAULT: DT_IO_PLANE_RED $DESCRIPTION: "plane"
-  float floatoption;                     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "float option"
-  dt_iop_highlights_option_t option;     // $DEFAULT: DT_IO_HIGHLIGHTSMASK_OPTION_0 $DESCRIPTION: "doption"
+  dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
+  float reconstructing;          // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "effect strength"
+  float combine;                 // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
+  float reserved3;
+  float clip; // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
 } dt_iop_highlights_params_t;
 
 typedef struct dt_iop_highlights_gui_data_t
@@ -113,15 +73,8 @@ typedef struct dt_iop_highlights_gui_data_t
   GtkWidget *mode_bayer;
   GtkWidget *mode_xtrans;
   GtkWidget *nonraw;
-  GtkWidget *allclipped;
   GtkWidget *reconstructing;
   GtkWidget *combine;
-  GtkWidget *maskmode;
-  GtkWidget *wdebug;
-  GtkWidget *plane;
-  GtkWidget *option;
-  GtkWidget *floatoption;
-  gint debug;
 } dt_iop_highlights_gui_data_t;
 
 typedef dt_iop_highlights_params_t dt_iop_highlights_data_t;
@@ -182,12 +135,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     dt_iop_highlights_params_v2_t *o = (dt_iop_highlights_params_v2_t *)old_params;
     dt_iop_highlights_params_v3_t *n = (dt_iop_highlights_params_v3_t *)new_params;
     memcpy(n, o, sizeof *o);
-    n->maskmode = DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES;
-    n->allclipped = 0.0f;
+    n->reserved3 = 0.0f;
     n->reconstructing = 0.4f;
-    n->floatoption = 0.0f;
-    n->option = DT_IO_HIGHLIGHTSMASK_OPTION_0;
-    n->plane = DT_IO_PLANE_RED;
     n->combine = 2.0f;
     return 0;  
   }
@@ -983,20 +932,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       break;
 
     case DT_IOP_HIGHLIGHTS_RECOVERY:
-      {
-        gboolean debug = FALSE;
-        if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL)
-        {
-          dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-          debug = g->debug;
-          const gboolean nomask = (data->maskmode == DT_IO_HIGHLIGHTSMASK_RECONSTR_NO) ||
-                                  (data->maskmode == DT_IO_HIGHLIGHTSMASK_MINIMUM_PLANE) ||
-                                  (data->maskmode == DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES);
-          if(!nomask && debug)
-            piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
-        }
-        process_recovery(piece, ivoid, ovoid, roi_in, roi_out, filters, data, debug);
-      }
+      process_recovery(piece, ivoid, ovoid, roi_in, roi_out, filters, data);
       break;
 
     default:
@@ -1069,49 +1005,25 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-static int _inplanemode(dt_iop_highlights_params_t *p)
-{
-  const gboolean planemode = (p->maskmode == DT_IO_HIGHLIGHTSMASK_SEGMENTS) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_SEGMENTWEIGHT) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_CANDIDATE) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_CANDIDATE_LOC) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_PLANE) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_PLANELATE) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_PLANEWEIGHT) ||
-                             (p->maskmode == DT_IO_HIGHLIGHTSMASK_PLANEABOVE);
-  return planemode;
-}
-
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean bayer =     (self->dev->image_storage.buf_dsc.filters != 9u);
   const gboolean israw =     (self->dev->image_storage.buf_dsc.filters != 0);
-  const gboolean debug =     g->debug;
 
   dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
-  const gboolean planemode = _inplanemode(p);
   const gboolean recover =   bayer && (p->mode == DT_IOP_HIGHLIGHTS_RECOVERY);
 
   if(israw)
   {
     gtk_widget_set_visible(g->mode_bayer, bayer);
-    gtk_widget_set_visible(g->allclipped, recover && HLMINSYNTHESIS);
-    gtk_widget_set_visible(g->wdebug, recover);
     gtk_widget_set_visible(g->combine, recover);
     gtk_widget_set_visible(g->reconstructing, recover);
-    gtk_widget_set_visible(g->maskmode, recover && debug);
-    gtk_widget_set_visible(g->option, recover && debug && HLDEVELOP);
-    gtk_widget_set_visible(g->floatoption, recover && debug && HLDEVELOP);
-    gtk_widget_set_visible(g->plane, recover && debug && planemode);
     gtk_widget_set_visible(g->mode_xtrans, !bayer);
     gtk_widget_set_visible(g->nonraw, FALSE); 
     if(bayer)
     {
       dt_bauhaus_combobox_set_from_value(g->mode_bayer, p->mode);  
-      dt_bauhaus_combobox_set_from_value(g->maskmode, p->maskmode);
-      dt_bauhaus_combobox_set_from_value(g->option, p->option);
-      dt_bauhaus_combobox_set_from_value(g->plane, p->plane);
     }
     else
       dt_bauhaus_combobox_set_from_value(g->mode_xtrans, p->mode);  
@@ -1120,28 +1032,17 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   {
     gtk_widget_set_visible(g->mode_bayer, FALSE);
     gtk_widget_set_visible(g->mode_xtrans, FALSE);
-    gtk_widget_set_visible(g->allclipped, FALSE);
     gtk_widget_set_visible(g->reconstructing, FALSE);
-    gtk_widget_set_visible(g->maskmode, FALSE);
-    gtk_widget_set_visible(g->option, FALSE);
-    gtk_widget_set_visible(g->floatoption, FALSE);
-    gtk_widget_set_visible(g->plane, FALSE);
-    gtk_widget_set_visible(g->wdebug, FALSE);
     gtk_widget_set_visible(g->nonraw, TRUE);
     dt_bauhaus_combobox_set_from_value(g->nonraw, p->mode);  
   }
   dt_bauhaus_slider_set(g->clip, p->clip);
   dt_bauhaus_slider_set(g->reconstructing, p->reconstructing);
-  dt_bauhaus_slider_set(g->allclipped, p->allclipped);
   dt_bauhaus_slider_set(g->combine, p->combine);
 }
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  g->debug = FALSE;
-  dt_bauhaus_widget_set_quad_active(g->wdebug, g->debug);
-  dt_bauhaus_widget_set_quad_toggle(g->wdebug, g->debug);
   gui_changed(self, NULL, NULL);
 }
 
@@ -1151,50 +1052,9 @@ void reload_defaults(dt_iop_module_t *module)
   module->default_enabled = dt_image_is_rawprepare_supported(&(module->dev->image_storage));
 }
 
-static void debug_callback(GtkWidget *togglebutton, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_request_focus(self);
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  g->debug = !(g->debug);
-  dt_bauhaus_widget_set_quad_active(g->wdebug, g->debug);
-
-  gtk_widget_set_visible(g->maskmode, g->debug);
-  gtk_widget_set_visible(g->option, g->debug && HLDEVELOP);
-  gtk_widget_set_visible(g->floatoption, g->debug && HLDEVELOP);
-
-  dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
-  const gboolean planemode = _inplanemode(p);
-
-  gtk_widget_set_visible(g->plane, g->debug && planemode);
-  dt_dev_reprocess_center(self->dev);
-}
-
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  if(!in)
-  {
-    const gboolean was_debug = g->debug;
-    g->debug = FALSE;
-    dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->wdebug), FALSE);
-    gtk_widget_set_visible(g->maskmode, g->debug);
-    gtk_widget_set_visible(g->option, g->debug && HLDEVELOP);
-    gtk_widget_set_visible(g->floatoption, g->debug && HLDEVELOP);
-    dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
-    const gboolean planemode = _inplanemode(p);
-
-    gtk_widget_set_visible(g->plane, g->debug && planemode);
-    if(was_debug) dt_dev_reprocess_center(self->dev);
-  }
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_highlights_gui_data_t *g = IOP_GUI_ALLOC(highlights);
-  g->debug = FALSE;
   g->nonraw = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->nonraw, _("highlight reconstruction method"));
   for(int i=0;i<3;i++) dt_bauhaus_combobox_remove_at(g->nonraw, 1);
@@ -1211,11 +1071,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->clip, _("manually adjust the clipping threshold against magenta highlights."
                                          " Necessary for images with incorrect white point settings."));
 
-  g->allclipped = dt_bauhaus_slider_from_params(self, "allclipped");
-  gtk_widget_set_tooltip_text(g->allclipped, _("amount of highlights synthesis if all color planes are clipped")); 
-  dt_bauhaus_slider_set_factor(g->allclipped, 100.0f);
-  dt_bauhaus_slider_set_format(g->allclipped, "%.0f%%");
-
   g->reconstructing = dt_bauhaus_slider_from_params(self, "reconstructing");
   gtk_widget_set_tooltip_text(g->reconstructing, _("reduces an existing color cast in regions where color planes are clipped")); 
   dt_bauhaus_slider_set_factor(g->reconstructing, 100.0f);
@@ -1224,32 +1079,10 @@ void gui_init(struct dt_iop_module_t *self)
   g->combine = dt_bauhaus_slider_from_params(self, "combine");
   dt_bauhaus_slider_set_digits(g->combine, 0);
   gtk_widget_set_tooltip_text(g->combine, _("combine close segments")); 
-
-  g->wdebug = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->wdebug, NULL, N_("debugging aids"));
-  dt_bauhaus_widget_set_quad_paint(g->wdebug, dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->wdebug, TRUE);
-  g_signal_connect(G_OBJECT(g->wdebug), "quad-pressed", G_CALLBACK(debug_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->wdebug, FALSE, FALSE, 0);
-
-  g->maskmode = dt_bauhaus_combobox_from_params(self, "maskmode");
-  gtk_widget_set_tooltip_text(g->maskmode, _("show some of the internal algorithm masks")); 
-
-  g->plane = dt_bauhaus_combobox_from_params(self, "plane");
-  gtk_widget_set_tooltip_text(g->plane, _("select plane")); 
-
-  g->option = dt_bauhaus_combobox_from_params(self, "option");
-  gtk_widget_set_tooltip_text(g->option, _("developer option, usage changes")); 
-
-  g->floatoption = dt_bauhaus_slider_from_params(self, "floatoption");
-  gtk_widget_set_tooltip_text(g->floatoption, _("developer float option, usage changes")); 
-  dt_bauhaus_slider_set_digits(g->floatoption, 3);
 }
 
 #undef HLBORDER
-#undef HLDEVELOP
 #undef HLEPSILON
-#undef HLMINSYNTHESIS
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -54,10 +54,10 @@ typedef enum dt_iop_highlights_mode_t
 typedef struct dt_iop_highlights_params_t
 {
   dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
-  float reconstructing;          // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "effect strength"
+  float reconstructing;          // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "cast balance"
   float combine;                 // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
-  float reserved_recovery;
-  float clip;                    // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
+  float threshold;
+  float clip;                    // $MIN: 0.0 $MAX: 2.0  $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
   float feathering_details;      // $MIN: 2.0 $MAX: 8.0 $DEFAULT: 6.0 $DESCRIPTION: "details feathering"
   float feathering_colors;       // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "colors feathering"
   float noise_level;             // $MIN: 0. $MAX: 1.0 $DEFAULT: 0.05 $DESCRIPTION: "noise level"
@@ -66,11 +66,8 @@ typedef struct dt_iop_highlights_params_t
 typedef struct dt_iop_highlights_gui_data_t
 {
   GtkWidget *clip;
-  GtkWidget *mode_bayer;
-  GtkWidget *mode_xtrans;
-  GtkWidget *nonraw;
-  GtkWidget *reconstructing;
-  GtkWidget *combine;
+  GtkWidget *mode_bayer, *mode_xtrans, *nonraw;
+  GtkWidget *reconstructing, *combine;
 } dt_iop_highlights_gui_data_t;
 
 typedef dt_iop_highlights_params_t dt_iop_highlights_data_t;
@@ -120,9 +117,9 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   typedef struct dt_iop_highlights_params_v2_t
   {
     dt_iop_highlights_mode_t mode;
-    float reserved1;
-    float reserved2;
-    float reserved3;
+    float blendL; // unused $DEFAULT: 1.0
+    float blendC; // unused $DEFAULT: 0.0
+    float blendh; // unused $DEFAULT: 0.0    float reserved1;
     float clip;
   } dt_iop_highlights_params_v2_t;
 
@@ -130,8 +127,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   {
     dt_iop_highlights_params_v2_t *o = (dt_iop_highlights_params_v2_t *)old_params;
     dt_iop_highlights_params_v3_t *n = (dt_iop_highlights_params_v3_t *)new_params;
-    memcpy(n, o, sizeof *o);
-    n->reserved_recovery = 0.0f;
+    n->clip = o->clip;
+    n->threshold = 0.0f;
     n->reconstructing = 0.4f;
     n->combine = 2.0f;
     n->feathering_details = 6.0f;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -39,7 +39,7 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
-DT_MODULE_INTROSPECTION(2, dt_iop_highlights_params_t)
+DT_MODULE_INTROSPECTION(3, dt_iop_highlights_params_t)
 
 /* defines for the highlights recovery section */
 
@@ -56,8 +56,11 @@ typedef struct dt_iop_highlights_params_t
   dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
   float reconstructing;          // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "effect strength"
   float combine;                 // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
-  float reserved3;
-  float clip; // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
+  float reserved_recovery;
+  float clip;                    // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
+  float feathering_details;      // $MIN: 2.0 $MAX: 8.0 $DEFAULT: 6.0 $DESCRIPTION: "details feathering"
+  float feathering_colors;       // $MIN: -2.0 $MAX: 2.0 $DEFAULT: 0.0 $DESCRIPTION: "colors feathering"
+  float noise_level;             // $MIN: 0. $MAX: 1.0 $DEFAULT: 0.05 $DESCRIPTION: "noise level"
 } dt_iop_highlights_params_t;
 
 typedef struct dt_iop_highlights_gui_data_t
@@ -128,9 +131,12 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     dt_iop_highlights_params_v2_t *o = (dt_iop_highlights_params_v2_t *)old_params;
     dt_iop_highlights_params_v3_t *n = (dt_iop_highlights_params_v3_t *)new_params;
     memcpy(n, o, sizeof *o);
-    n->reserved3 = 0.0f;
+    n->reserved_recovery = 0.0f;
     n->reconstructing = 0.4f;
     n->combine = 2.0f;
+    n->feathering_details = 6.0f;
+    n->feathering_colors = 0.0f;
+    n->noise_level = 0.05f;
     return 0;  
   }
 

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -367,8 +367,14 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   }
 
   for(int p = 0; p < 4; p++)
-    if(combining) dt_image_transform_closing(isegments[p].data, pwidth, pheight, combining, HLBORDER);
-
+  {
+    if(combining)
+    {
+      dt_image_transform_erode(isegments[p].data, pwidth, pheight, 0, HLBORDER);
+      dt_image_transform_dilate(isegments[p].data, pwidth, pheight, 1, HLBORDER);
+      dt_image_transform_closing(isegments[p].data, pwidth, pheight, combining, HLBORDER);
+    }
+  }
   if(dt_get_num_threads() >= HLSEGPLANES)
   {
 #ifdef _OPENMP
@@ -423,6 +429,14 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
             candidates[pp]    = isegments[pp].refcol[pid];   
             const size_t loc  = isegments[pp].ref[pid];
             if(loc) cand_minimum[pp] = pminimum[loc];
+          }
+          else if(pid == 0)
+          {
+            segid[pp] = 1;          
+            float sum = 0.0f;
+            for(int y = -2; y < 3; y++)
+              for(int x = -2; x < 3; x++) sum += pminimum[i + y*pwidth +x];
+            candidates[pp]    = 1.0f - (0.04f * sum);   
           }
         }     
 

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -222,7 +222,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
 
-  const float clip = data->clip;
+  const float clip = fminf(1.0f, 0.97f * data->clip);
   const float reconstruct = data->reconstructing;
   const int combining = (int) data->combine;
   const dt_iop_highlights_maskmode_t maskmode = data->maskmode;

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -447,7 +447,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
 
         if(restore)
         {
-          const float correction = corr_coeff[p] * (1.0 + 0.5f * reconstruct);
+          const float correction = corr_coeff[p] * (0.7 + 1.5f * reconstruct);
           float val = candidate + pminimum[i] - candidates_minimum;
           val = 1.0f + (val - 1.0f) * correction;
           val = clip * fmaxf(1.0f, val);

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -94,7 +94,7 @@ typedef enum dt_iop_highlights_plane_t
 #include "iop/highlights_algos/segmentation.h"
 
 #define SQR(x) ((x) * (x))
-static float calc_weight(float *p, const int w)
+static float calc_weight(const float *p, const int w)
 {
   if(p[0] >= 1.0f) return HLEPSILON;
   const int w2 = 2*w;
@@ -127,13 +127,13 @@ static float calc_weight(float *p, const int w)
 }
 #undef SQR
 
-static void calc_plane_candidates(float *s, float *pmin, dt_iop_segmentation_t *seg, const int width, const int height, const float maxval)
+static void calc_plane_candidates(const float *s, const float *pmin, dt_iop_segmentation_t *seg, const int width, const int height, const float maxval)
 {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(s, pmin, seg) \
   dt_omp_sharedconst(width, height) \
-  schedule(dynamic)
+  schedule(dynamic) aligned(s, pmin : 64)
 #endif
   for(int id = 2; id < seg->nr + 2; id++)
   {

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -70,11 +70,18 @@ both have problems with identifying the clipped segments in a plane. I ended up 
 #define HLSEGPLANES 4
 #define HLMAXSEGMENTS 0x4000
 #define HLBADWEIGHT 0.3f
+#define HLBORDER 8
+#define HLEPSILON 1e-5
 
 #ifdef __GNUC__
   #pragma GCC push_options
   #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno", "ivopts")
 #endif
+
+static size_t plane_size(size_t width, size_t height)
+{
+  return (size_t) dt_round_size((width + 4) * (height + 4), 16);
+}
 
 typedef enum dt_iop_highlights_plane_t
 {
@@ -258,7 +265,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
     icoeffs[2] = 1.5f;
   }
   const float coeffs[4] = { icoeffs[0], icoeffs[1], icoeffs[1], icoeffs[2]};
-  float corr_coeff[4]   = { icoeffs[1] + icoeffs[2], icoeffs[0] + icoeffs[2], icoeffs[0] + icoeffs[2], icoeffs[0] + icoeffs[1]};
+  float corr_coeff[4]   = { fmaxf(icoeffs[1], icoeffs[2]), fmaxf(icoeffs[0], icoeffs[2]), fmaxf(icoeffs[0], icoeffs[2]), fmaxf(icoeffs[0], icoeffs[1])};
   const float mincoeff  = fminf(corr_coeff[0], fminf(corr_coeff[1], corr_coeff[3]));
   for(int c = 0; c < 4; c++) corr_coeff[c] /= mincoeff;
 
@@ -485,4 +492,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
 #undef HLMAXSEGMENTS
 #undef HLBADWEIGHT
 #undef HLSEGPLANES
+#undef HLBORDER
+#undef HLEPSILON
+
 

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -1,0 +1,570 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+Highlights restoration II
+
+** Overview **
+
+The new highlight restoration II algorithm only works for standard bayer sensors.
+It has been developed in collaboration by Iain from the gmic team and Hanno Schwalm from dt.
+
+The original idea was presented by Iain in pixls.us in: https://discuss.pixls.us/t/highlight-recovery-teaser/17670
+
+and has been extensively discussed over the last months.
+Prototyping and testing ideas has been done by Iain using gmic, Hanno did the implementation and integration into dt’s
+codebase. No other external modules (like gmic …) are used, the current code has been tuned for performance using omp,
+no OpenCL codepath yet.
+
+** Main ideas **
+
+The algorithm follows these basic ideas:
+1. We understand the bayer data as superpixels, each having one red, one blue and two green photosites
+2. We analyse all data (without wb correction applied) on the channels independently so resulting in 4 color-planes
+3. We want to keep details as much as possible; we assume that details are best represented in the color channel having
+   the minimum value. So beside the 4 color planes we also have a plane holding the minimum values (pminimum)
+4. In all 4 color planes we look for isolated areas being clipped (segments).
+   Inside these segments including borders around we look for a candidate to represent the value we take for restoration.
+   Choosing the candidate is done at all non-clipped locations of a segment, the best candidate is selected via a weighing
+   function - the weight is derived from
+   - the local standard deviation in a 5x5 area and
+   - the median value of unclipped positions also in a 5x5 area.
+   The best candidate points to the location in the color plane holding the reference value.
+   If there is no good candidate we use an approximation.
+5. We evaluated several ways to further reduce the pre-existing color cast, atm we calc linearly while using a correction
+   coeff for every plane.
+   We also tried using some gamma correction which helped in some cases but was unstable in others.
+6. The restored value at position 'i' is basically calculated as
+     val = candidate + pminimum[i] - pminimum[candidate_location;
+7. For locations with all planes clipped we might do a synthesis in pminimum, the value for every position is derived
+   from the local gradient at the border and basically the distance.
+   This code part has been surprisingly difficult to implement (avoiding ridges, good transition, … ),
+   the existing code is working ok (with some minor issues) but is rather slow and not perfect.
+   It has not been included in the first pr and will be re-evaluated.
+
+For segmentation i implemented and tested several approaches including Felszenzwalb and a watershed algo,
+both have problems with identifying the clipped segments in a plane. I ended up with this:
+
+1. Doing the segmentation in every color plane.
+2. The segmentation algorithm uses a modified floodfill, it also takes care of the surrounding rectangle of every segment
+   and marks the segment borders.
+3. After segmentation we check every segment for
+   - the segment's best candidate via the weighing function
+   - the candidates location
+4. To combine small segments for a shared candidate we use a morphological closing operation, the radius of that op
+   can be chosen interactively between 0 and 10.
+
+Hanno & Ian 2021/12
+
+Issues not solved yet:
+1. possibly combine segments over larger distances, but how can we define a rule for that?
+2. for segments with all color channels clipped the colors might be bad.
+   Some preps to check for inter-channel work has been done already ... 
+*/
+
+#define HLFPLANES 5
+#define HLSEGPLANES 4
+#define HLMAXSEGMENTS 0x4000
+#define HLBADWEIGHT 0.3f
+
+#ifdef __GNUC__
+  #pragma GCC push_options
+  #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno", "ivopts")
+#endif
+
+#include "iop/highlights_algos/segmentation.h"
+#include "common/distance_transform.h"
+
+#if HLMINSYNTHESIS
+ #include "iop/highlights_algos/min_synthesis.c"
+#endif
+
+#define SQR(x) ((x) * (x))
+static float calc_weight(float *p, const int w)
+{
+  if(p[0] >= 1.0f) return HLEPSILON;
+  const int w2 = 2*w;
+  const float av = 0.04f *
+      (p[-w2-2] + p[-w2-1] + p[-w2] + p[-w2+1] + p[-w2+2] +
+       p[-w-2]  + p[-w-1]  + p[-w]  + p[-w+1]  + p[-w+2] +
+       p[-2]    + p[-1]    + p[0]   + p[1]     + p[2] +
+       p[w-2]   + p[w-1]   + p[w]   + p[w+1]   + p[w+2] +
+       p[w2-2]  + p[w2-1]  + p[w2]  + p[w2+1]  + p[w2+2]);
+  const float sd = sqrtf(0.04f *
+      (SQR(p[-w2-2]-av) + SQR(p[-w2-1]-av) + SQR(p[-w2]-av) + SQR(p[-w2+1]-av) + SQR(p[-w2+2]-av) +
+       SQR(p[-w-2]-av)  + SQR(p[-w-1]-av)  + SQR(p[-w]-av)  + SQR(p[-w+1]-av)  + SQR(p[-w+2]-av) +
+       SQR(p[-2]-av)    + SQR(p[-1]-av)    + SQR(p[0]-av)   + SQR(p[1]-av)     + SQR(p[2]-av) +
+       SQR(p[w-2]-av)   + SQR(p[w-1]-av)   + SQR(p[w]-av)   + SQR(p[w+1]-av)   + SQR(p[w+2]-av) +
+       SQR(p[w2-2]-av)  + SQR(p[w2-1]-av)  + SQR(p[w2]-av)  + SQR(p[w2+1]-av)  + SQR(p[w2+2]-av)));
+  const float smoothness = (fmaxf(HLEPSILON, 1.0f - 4.0f * sd));
+
+  float val = 0.0f;
+  float cnt = 0.0f;
+  for(int y = -2; y < 3; y++)
+  {
+    for(int x = -2; x < 3; x++)
+    {
+      const float t = p[y*w + x];
+      val += (t < 1.0f) ? t    : 0.0f;
+      cnt += (t < 1.0f) ? 1.0f : 0.0f;
+    }
+  }
+  return fmaxf(HLEPSILON, smoothness * (val / fmaxf(1.0f, cnt)));
+}
+#undef SQR
+
+static void calc_plane_candidates(float *s, float *pmin, dt_iop_segmentation_t *seg, const int width, const int height, const float maxval)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(s, pmin, seg) \
+  dt_omp_sharedconst(width, height) \
+  schedule(dynamic)
+#endif
+  for(int id = 2; id < seg->nr + 2; id++)
+  {
+    int *segmap    = seg->data;
+    size_t testref = 0;
+    float testweight = 0.0f;
+    for(int row = seg->ymin[id] -1 ; row < seg->ymax[id] + 2; row++)
+    {
+      for(int col = seg->xmin[id] -1; col < seg->xmax[id] + 2; col++)
+      {
+        const size_t pos = row * width + col;
+        const int sid = segmap[pos] & (HLMAXSEGMENTS-1);
+        if((sid == id) && (s[pos] < 1.0f)) // we test for a) being in segment and b) unclipped
+        {
+          const float wht = calc_weight(&s[pos], width);
+          if(wht > testweight)
+          {
+            testweight = wht;
+            testref = pos;
+          }        
+        }
+      }
+    }
+
+    if(testref)
+    {
+      float sum  = 0.0f;
+      float pix = 0.0f;
+      float candidate = 0.0f;
+      if(testweight > HLBADWEIGHT)
+      {
+        seg->ref[id] = testref;
+        segmap[testref] = 2*HLMAXSEGMENTS + id;
+        for(int y = -2; y < 3; y++)
+        {
+          for(int x = -2; x < 3; x++)
+          {
+            const float rr = s[testref + y*width + x];
+            sum += (rr < 1.0f) ? rr   : 0.0f;
+            pix += (rr < 1.0f) ? 1.0f : 0.0f;
+          }
+        }
+        candidate = sum / fmaxf(1.0f, pix);
+      }
+      else
+      {
+        for(int row = seg->ymin[id]; row < seg->ymax[id] + 1; row++)
+        {
+          for(int col = seg->xmin[id]; col < seg->xmax[id] + 1; col++)
+          {
+            const size_t pos = row * width + col;
+            const int sid = segmap[pos];
+            if(segmap[pos] == sid)
+            {
+              sum += pmin[pos];
+              pix += 1.0f;
+            }
+          }
+        }
+        candidate = 1.0f - sum / fmaxf(1.0f, pix);
+      }
+      seg->refcol[id] = fminf(1.0f - HLEPSILON, candidate);
+    }  
+  }
+}
+
+static inline int pos2plane(const int row, const int col, const uint32_t filters)
+{
+  const int c = FC(row, col, filters);
+  if(c == 0)      return 0;
+  else if(c == 2) return 3;
+  else return 1 + (row&1);
+}
+
+static inline int plane2bitmask(const int p)
+{
+  const int masks[4] = { 0x01, 0x06, 0x06, 0x08 };
+  return masks[p&3];
+}
+
+static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         const uint32_t filters, dt_iop_highlights_data_t *data, const gboolean debug)
+{
+  const float *const in = (const float *const)ivoid;
+  float *const out = (float *const)ovoid;
+
+  const float clip = data->clip;
+  const float reconstruct = data->reconstructing;
+  const int combining = (int) data->combine;
+  const dt_iop_highlights_maskmode_t maskmode = data->maskmode;
+  const dt_iop_highlights_plane_t selplane = MAX( 0, MIN(HLSEGPLANES -1, data->plane));
+
+  const int doption = data->option;
+  const float foption = data->floatoption;
+
+  const int width = roi_out->width;
+  const int height = roi_out->height;
+
+  const int pwidth  = ((width + 1 ) / 2) + (2 * HLBORDER);
+  const int pheight = ((height + 1) / 2) + (2 * HLBORDER);
+
+  const size_t p_size = plane_size(pwidth, pheight);
+  const int p_off  = (HLBORDER * pwidth) + HLBORDER;
+
+  dt_iop_image_copy(out, in, width * height);
+
+  const gboolean run_fast = (piece->pipe->type & DT_DEV_PIXELPIPE_FAST) == DT_DEV_PIXELPIPE_FAST;
+
+  if((filters == 0) || (filters == 9u) || run_fast) return;
+
+  float *fbuffer = dt_alloc_align_float(HLFPLANES * p_size);
+  uint8_t *locmask  = dt_alloc_align(16, p_size * sizeof(uint8_t));
+
+  if(!fbuffer || !locmask)
+  {
+    fprintf(stderr, "[highlights reconstruction in recovery mode] internal buffer allocation problem\n");
+    dt_free_align(fbuffer);
+    dt_free_align(locmask);
+    return;
+  }
+
+  dt_times_t time0 = { 0 }, time1 = { 0 }, time2 = { 0 }, time3 = { 0 }, time4 = { 0 };
+  const gboolean info = (((darktable.unmuted & DT_DEBUG_PERF) || HLDEVELOP) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
+  if(info) dt_get_times(&time0);
+
+  float icoeffs[4] = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};  
+  // make sure we have so wb coeffs
+  if((icoeffs[0] < 0.1f) || (icoeffs[0] < 0.1f) || (icoeffs[0] < 0.1f))
+  {
+    fprintf(stderr, "[highlights reconstruction in recovery mode] no white balance coeffs found, choosing stupid defaults\n");
+    icoeffs[0] = 2.0f;
+    icoeffs[1] = 1.0f;
+    icoeffs[2] = 1.5f;
+  }
+  const float coeffs[4] = { icoeffs[0], icoeffs[1], icoeffs[1], icoeffs[2]};
+  float corr_coeff[4]   = { icoeffs[1] + icoeffs[2], icoeffs[0] + icoeffs[2], icoeffs[0] + icoeffs[2], icoeffs[0] + icoeffs[1]};
+  const float mincoeff  = fminf(corr_coeff[0], fminf(corr_coeff[1], corr_coeff[3]));
+  for(int c = 0; c < 4; c++) corr_coeff[c] /= mincoeff;
+
+  float *plane[HLFPLANES];
+  for(int i = 0; i < HLFPLANES; i++)
+    plane[i] = fbuffer + i * p_size;
+
+  float *const pminimum  = plane[4];
+
+/* 
+  We fill the planes [0-3] by the data from the photosites.
+  These will be modified by the reconstruction algorithm and will at last be written to out.
+  As we have temperature corrected values as input we revert the temperature coeffs here.
+  The size of input rectangle can be odd meaning the planes might be not exactly of equal size
+  so we possibly fill latest row/col by previous.
+*/
+  float maxval = 0.0f;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  reduction(max : maxval) \
+  dt_omp_firstprivate(in, plane, coeffs) \
+  dt_omp_sharedconst(width, p_off, height, pwidth, filters, clip) \
+  schedule(simd:static) aligned(in : 64)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, i = row*width; col < width; col++, i++)
+    {
+      const int p = pos2plane(row, col, filters);
+      const size_t o = (row/2)*pwidth + (col/2) + p_off;
+      const float val = fminf(1.0f, (in[i] / coeffs[p]) / clip);
+      plane[p][o] = val;
+      maxval = fmaxf(maxval, val);          
+      if(col >= width-2)      plane[p][o+1] = val;
+      if(row >= height-2)     plane[p][o+pwidth] = val;
+    }
+  }
+  if((maxval < 1.0f) && !debug)
+  {
+    if(info) fprintf(stderr, "[highlights reconstruction recovery mode] early exit because of no clipped data\n");
+    dt_free_align(fbuffer);
+    dt_free_align(locmask);
+    return;
+  }
+
+  dt_iop_segmentation_t isegments[HLSEGPLANES];
+  for(int i = 0; i < HLSEGPLANES; i++)
+    dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HLMAXSEGMENTS);
+
+  for(int i = 0; i < 4; i++)
+    dt_masks_extend_border(plane[i], pwidth, pheight, HLBORDER);
+
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(plane, pminimum, locmask) \
+  dt_omp_sharedconst(p_size) \
+  schedule(simd:static) aligned(pminimum, plane, : 64)
+#endif
+  for(int i = 0; i < p_size; i++)
+  {
+    const float minval = fminf(plane[0][i], fminf(plane[1][i], fminf(plane[2][i], plane[3][i])));
+    pminimum[i] = minval;
+    uint8_t mask = 0;
+    for(int p = 0; p < 4; p++)
+    {
+      if(plane[p][i] >= 1.0f)   mask |= (0x01 << p); // mark as clipped
+      if(plane[p][i] == minval) mask |= (0x10 << p); // mark as minimum defined by this plane
+    }
+    locmask[i] = mask;   
+  }
+
+  if(info) dt_get_times(&time1);
+#if HLMINSYNTHESIS
+  if((data->allclipped > 0.0f) && (maxval >= 1.0f))
+    maxval = reconstruct_minimum_plane(pminimum, pwidth, pheight, data->allclipped);
+#endif
+  if(info) dt_get_times(&time2);
+
+  // prepare the segmentation process by writing the int mask; 1 for condition on, otherwise 0
+  for(int p = 0; p < 4; p++)
+  {
+    dt_iop_segmentation_t *seg = &isegments[p];
+    float *src = plane[p];
+    int *map  = seg->data; 
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(src, map) \
+  dt_omp_sharedconst(pwidth, pheight) \
+  schedule(static)
+#endif
+    for(size_t i = 0; i < pwidth * pheight; i++)
+      map[i]  = (src[i] >= 1.0f) ? 1 : 0;
+  }
+
+  for(int p = 0; p < 4; p++)
+    if(combining) dt_image_transform_closing(isegments[p].data, pwidth, pheight, combining, HLBORDER);
+
+  if(dt_get_num_threads() >= HLSEGPLANES)
+  {
+#ifdef _OPENMP
+  #pragma omp parallel num_threads(HLSEGPLANES)
+#endif
+    {
+      segmentize_plane(&isegments[dt_get_thread_num()], pwidth, pheight);
+    }
+  }
+  else
+  {
+    for(int p = 0; p < HLSEGPLANES; p++)
+      segmentize_plane(&isegments[p], pwidth, pheight);
+  }
+
+  for(int p = 0; p < HLSEGPLANES; p++)
+    calc_plane_candidates(plane[p], pminimum, &isegments[p], pwidth, pheight, maxval);
+
+  if(info) dt_get_times(&time3);
+
+  float max_correction = 1.0f;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  reduction(max : max_correction) \
+  dt_omp_firstprivate(out, plane, pminimum, isegments, coeffs, corr_coeff, locmask) \
+  dt_omp_sharedconst(width, height, pheight, pwidth, p_size, clip, reconstruct, p_off, filters, debug, maskmode, doption, foption) \
+  schedule(simd:static) aligned(out, plane, pminimum : 64)
+#endif
+  for(int row = 0; row < height; row++)
+  {
+    for(int col = 0, o = row * width; col < width; col++, o++)
+    {
+      const int i = (row/2)*pwidth + (col/2) + p_off;
+      const int p = pos2plane(row, col, filters);
+      if(locmask[i] & (0x01 << p))
+      {
+        float candidates_minimum = 0.0f;
+        float candidate = 0.0f;
+        gboolean restore = FALSE;
+
+        int segid[4]          = { 0, 0, 0, 0 };
+        float candidates[4]   = { 0.0f, 0.0f, 0.0f, 0.0f };
+        float cand_minimum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+        // Prepare data for interchannel corrections, so far only used by greens mixing
+        for(int pp = 0; pp < 4; pp++)
+        {
+          const int pid = isegments[pp].data[i] & (HLMAXSEGMENTS-1);
+          if((pid > 1) && (pid < isegments[pp].nr+2))
+          {
+            segid[pp]         = pid;          
+            candidates[pp]    = isegments[pp].refcol[pid];   
+            const size_t loc  = isegments[pp].ref[pid];
+            if(loc) cand_minimum[pp] = pminimum[loc];
+          }
+        }     
+
+        if((p == DT_IO_PLANE_GREEN1 || p == DT_IO_PLANE_GREEN2) && segid[DT_IO_PLANE_GREEN1] && segid[DT_IO_PLANE_GREEN2])
+        {
+          // we take the median of greens candidates.          
+          if((candidates[DT_IO_PLANE_GREEN1] >= 0.0f) && (cand_minimum[DT_IO_PLANE_GREEN1] >= 0.0f) &&
+             (candidates[DT_IO_PLANE_GREEN2] >= 0.0f) && (cand_minimum[DT_IO_PLANE_GREEN2] >= 0.0f))                  
+          {
+            candidate = 0.5f * (candidates[DT_IO_PLANE_GREEN1] + candidates[DT_IO_PLANE_GREEN2]);
+            candidates_minimum = 0.5f * (cand_minimum[DT_IO_PLANE_GREEN1] + cand_minimum[DT_IO_PLANE_GREEN2]);
+            restore = TRUE;
+          }
+        }
+
+        if(segid[p] && !restore)
+        {
+          candidate = candidates[p];
+          candidates_minimum = cand_minimum[p];
+          restore = TRUE;
+        }
+
+        if(restore)
+        {
+          const float correction = corr_coeff[p] * (1.0 + 0.5f * reconstruct);
+          float val = candidate + pminimum[i] - candidates_minimum;
+          val = 1.0f + (val - 1.0f) * correction;
+          val = clip * fmaxf(1.0f, val);
+          out[o] = val * coeffs[p];
+          max_correction = fmaxf(max_correction, val);
+          if(debug && ((maskmode == DT_IO_HIGHLIGHTSMASK_PLANELATE) || (maskmode == DT_IO_HIGHLIGHTSMASK_PLANEABOVE))) plane[p][i] = val;
+        }
+      }
+    }
+  }
+
+  for(int k = 0; k < 4; k++)
+    piece->pipe->dsc.processed_maximum[k] *= max_correction;
+
+  if(info) 
+  {
+    dt_get_times(&time4);
+    fprintf(stderr, "Highlight recovery: %4.1fMpix, maxval=%.2f, maxcorr=%.2f, option=%i, foption=%.3f", (float) (width * height) / 1.0e6f, maxval, max_correction, doption, foption);
+    fprintf(stderr, "\n Segments(combine %i): ", combining);
+    for(int i=0; i<HLSEGPLANES; i++)  { fprintf(stderr, " %6i", isegments[i].nr); }
+    fprintf(stderr, "\n Performance (all)   %.3f",   time4.clock - time0.clock);
+    fprintf(stderr, "\n    initialize       %.3f",   time1.clock - time0.clock);
+    fprintf(stderr, "\n    synth minimum    %.3f",   time2.clock - time1.clock);
+    fprintf(stderr, "\n    segmentation     %.3f",   time3.clock - time2.clock);
+    fprintf(stderr, "\n    output           %.3f\n", time4.clock - time3.clock);
+  }
+
+  if(debug && maskmode)
+  {
+    dt_iop_image_fill(out, 0.0f, width, height, 1);
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(out, plane, pminimum, isegments, locmask, coeffs) \
+  dt_omp_sharedconst(maskmode, width, height, pwidth, p_off, selplane, filters, p_size) \
+  schedule(static) aligned(out, plane, pminimum : 64)
+#endif
+    for(size_t row = 0; row < height; row++)
+    {
+      for(size_t col = 0, o = row*width; col < width; col++, o++)
+      {
+        const size_t i = (row/2)*pwidth + (col/2) + p_off;
+        const int p = pos2plane(row, col, filters);
+        dt_iop_segmentation_t *seg = &isegments[selplane];            
+        const int c = seg->data[i];
+        const int cc = c & (HLMAXSEGMENTS - 1);
+        float val = 0.0f;
+        switch(maskmode)
+        {
+          case DT_IO_HIGHLIGHTSMASK_RECONSTR_NO:
+            break;
+          case DT_IO_HIGHLIGHTSMASK_CLIPPED_PLANES:
+            if(locmask[i] & (1 << p)) val = 1.0f;
+            break;
+          case DT_IO_HIGHLIGHTSMASK_MINIMUM_PLANE:
+            if(((locmask[i] >> 4) & plane2bitmask(p)) != 0) val = 1.0f;
+            break;
+          case DT_IO_HIGHLIGHTSMASK_SEGMENTS:
+            if((c>1) && (c < HLMAXSEGMENTS)) val = 0.1f + (0.1f * (float) (c & 7));
+            break;
+          case DT_IO_HIGHLIGHTSMASK_SEGMENTWEIGHT:
+            if((c>1) && (c < HLMAXSEGMENTS))
+            {
+             const size_t cref = seg->ref[cc];
+             const float wht = (cref) ? calc_weight(&plane[selplane][cref], pwidth) : 0.0f;            
+             val = (wht < HLBADWEIGHT) ? 0.1f : 0.4f + 0.6f * wht;
+            }
+            break;
+          case DT_IO_HIGHLIGHTSMASK_CANDIDATE:
+            if((c>1) && (c < HLMAXSEGMENTS)) val = seg->refcol[cc];
+            break;
+          case DT_IO_HIGHLIGHTSMASK_CANDIDATE_LOC:
+            if((c > 1) && (c < HLMAXSEGMENTS))  val = 0.1f;
+            else if(c > 2*HLMAXSEGMENTS+1)              // mark the reference point
+            {
+              val = 1.0f;
+              if((row > 0) && (row < height-1) && (col > 0) && (col < width-1))
+                out[o-1] = out[o+1] = out[o-width] = out[o+width] = 1.0f; 
+            }
+            break;
+          case DT_IO_HIGHLIGHTSMASK_PLANE:
+            val = 0.5f * plane[selplane][i];
+            break;
+          case DT_IO_HIGHLIGHTSMASK_PLANELATE:
+            val = 0.5f * plane[selplane][i];
+            break;
+          case DT_IO_HIGHLIGHTSMASK_PLANEABOVE:
+            val = 0.5f * (plane[selplane][i] - 1.0f);
+            break;
+          case DT_IO_HIGHLIGHTSMASK_PLANEWEIGHT:
+            val = calc_weight(&plane[selplane][i], pwidth);
+            break;
+          case DT_IO_HIGHLIGHTSMASK_MINIMUMPLANE:
+            val = 0.5f * pminimum[i];
+            break;
+        }
+        if(maskmode == DT_IO_HIGHLIGHTSMASK_CANDIDATE_LOC)
+          out[o] = fmaxf(out[o], fminf(1.0f, fmaxf(0.0f, val)));
+        else
+          out[o] = fminf(1.0f, fmaxf(0.0f, val));
+      }
+    }
+  }
+
+  for(int i = 0; i < HLSEGPLANES; i++)
+    dt_segmentation_free_struct(&isegments[i]);
+
+  dt_free_align(fbuffer);
+  dt_free_align(locmask);
+}
+
+// revert specific aggressive optimizing
+#ifdef __GNUC__
+  #pragma GCC pop_options
+#endif
+
+#undef HLFPLANES
+#undef HLMAXSEGMENTS
+#undef HLBADWEIGHT
+#undef HLSEGPLANES
+

--- a/src/iop/highlights_algos/hlrecovery.c
+++ b/src/iop/highlights_algos/hlrecovery.c
@@ -281,7 +281,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   reduction(max : maxval) \
   dt_omp_firstprivate(in, plane, coeffs) \
   dt_omp_sharedconst(width, p_off, height, pwidth, filters, clip) \
-  schedule(simd:static) aligned(in : 64)
+  schedule(simd:static) aligned(in, plane : 64)
 #endif
   for(size_t row = 0; row < height; row++)
   {
@@ -315,7 +315,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(plane, pminimum, locmask, isegments) \
   dt_omp_sharedconst(pwidth, pheight) \
-  schedule(simd:static) aligned(pminimum, plane, : 64)
+  schedule(simd:static) aligned(pminimum, plane : 64)
 #endif
   for(size_t i = 0; i < pwidth * pheight; i++)
   {

--- a/src/iop/highlights_algos/segmentation.h
+++ b/src/iop/highlights_algos/segmentation.h
@@ -36,7 +36,8 @@ typedef struct dt_iop_segmentation_t
   int *ymin;
   int *ymax;
   size_t *ref;    // possibly a reference point for location
-  float *refcol;  // holds averaged reference color or 0  
+  float *val1;
+  float *val2;  
   int nr;         // number of found segments
 } dt_iop_segmentation_t;
 
@@ -70,14 +71,8 @@ void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, co
   seg->ymin =   dt_alloc_align(64, segments * sizeof(int));
   seg->ymax =   dt_alloc_align(64, segments * sizeof(int));
   seg->ref =    dt_alloc_align(64, segments * sizeof(size_t));
-  seg->refcol = dt_alloc_align_float(segments);
-  // make sure for the first 2 segments
-  for(int i = 0; i < 2; i++)
-  {
-    seg->size[i] = 0;
-    seg->ref[i] = 0;
-    seg->refcol[i] = 0.0f;
-  }
+  seg->val1 =   dt_alloc_align_float(segments);
+  seg->val2 =   dt_alloc_align_float(segments);
 }
 
 void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
@@ -89,7 +84,8 @@ void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
   dt_free_align(seg->xmax);
   dt_free_align(seg->ymax);
   dt_free_align(seg->ref);
-  dt_free_align(seg->refcol);
+  dt_free_align(seg->val1);
+  dt_free_align(seg->val2);
 }
 
 static inline void _dilate_0(int *img, int *o, const int w1, const int height, const int border)
@@ -473,7 +469,8 @@ static int floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, in
 
   seg->size[id] = 0;
   seg->ref[id] = 0;
-  seg->refcol[id] = 0.0f;
+  seg->val1[id] = 0.0f;
+  seg->val2[id] = 0.0f;
   seg->xmin[id] = min_x;
   seg->xmax[id] = max_x;
   seg->ymin[id] = min_y;

--- a/src/iop/highlights_algos/segmentation.h
+++ b/src/iop/highlights_algos/segmentation.h
@@ -88,7 +88,7 @@ void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
   dt_free_align(seg->val2);
 }
 
-static inline void _dilate_0(int *img, int *o, const int w1, const int height, const int border)
+static inline void _dilate_0(const int *img, int *o, const int w1, const int height, const int border)
 {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
@@ -105,7 +105,7 @@ static inline void _dilate_0(int *img, int *o, const int w1, const int height, c
   }
 }
 
-static inline void _erode_0(int *img, int *o, const int w1, const int height, const int border)
+static inline void _erode_0(const int *img, int *o, const int w1, const int height, const int border)
 {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
@@ -123,7 +123,7 @@ static inline void _erode_0(int *img, int *o, const int w1, const int height, co
   }
 }
 
-static inline void _dilate_1(int *img, int *o, const int w1, const int height, const int border)
+static inline void _dilate_1(const int *img, int *o, const int w1, const int height, const int border)
 {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
@@ -140,7 +140,7 @@ static inline void _dilate_1(int *img, int *o, const int w1, const int height, c
   }
 }
 
-static inline void _erode_1(int *img, int *o, const int w1, const int height, const int border)
+static inline void _erode_1(const int *img, int *o, const int w1, const int height, const int border)
 {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
@@ -158,7 +158,7 @@ static inline void _erode_1(int *img, int *o, const int w1, const int height, co
   }
 }
 
-static inline void _dilate_2(int *img, int *o, const int w1, const int height, const int border)
+static inline void _dilate_2(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
 #ifdef _OPENMP
@@ -178,7 +178,7 @@ static inline void _dilate_2(int *img, int *o, const int w1, const int height, c
   }
 }
 
-static inline void _erode_2(int *img, int *o, const int w1, const int height, const int border)
+static inline void _erode_2(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
 #ifdef _OPENMP
@@ -198,7 +198,7 @@ static inline void _erode_2(int *img, int *o, const int w1, const int height, co
   }
 }
 
-static inline void _dilate_3(int *img, int *o, const int w1, const int height, const int border)
+static inline void _dilate_3(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
   const int w3 = 3*w1;
@@ -223,7 +223,7 @@ static inline void _dilate_3(int *img, int *o, const int w1, const int height, c
   }
 }
 
-static inline void _erode_3(int *img, int *o, const int w1, const int height, const int border)
+static inline void _erode_3(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
   const int w3 = 3*w1;
@@ -248,7 +248,7 @@ static inline void _erode_3(int *img, int *o, const int w1, const int height, co
   }
 }
 
-static inline void _dilate_4(int *img, int *o, const int w1, const int height, const int border)
+static inline void _dilate_4(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
   const int w3 = 3*w1;
@@ -276,7 +276,7 @@ static inline void _dilate_4(int *img, int *o, const int w1, const int height, c
   }
 }
 
-static inline void _erode_4(int *img, int *o, const int w1, const int height, const int border)
+static inline void _erode_4(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
   const int w3 = 3*w1;
@@ -305,7 +305,7 @@ static inline void _erode_4(int *img, int *o, const int w1, const int height, co
   }
 }
 
-static inline void _dilate_5(int *img, int *o, const int w1, const int height, const int border)
+static inline void _dilate_5(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
   const int w3 = 3*w1;
@@ -336,7 +336,7 @@ static inline void _dilate_5(int *img, int *o, const int w1, const int height, c
   }
 }
 
-static inline void _erode_5(int *img, int *o, const int w1, const int height, const int border)
+static inline void _erode_5(const int *img, int *o, const int w1, const int height, const int border)
 {
   const int w2 = 2*w1;
   const int w3 = 3*w1;
@@ -408,12 +408,11 @@ static void _intimage_erode(int *src, int *out, const int width, const int heigh
 void dt_image_transform_dilate(int *img, const int width, const int height, const int radius, const int border)
 {
   if(radius < 0) return;
-  int *tmp = dt_alloc_align(16, width * height * sizeof(int));
+  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
   if(!tmp) return;
 
   const int rad = MIN(radius, 10);
   _intimage_dilate(img, tmp, width, height, MIN(5, rad), border);
-  const int rad2 = rad - 5;
 
   if(rad < 6)
   {
@@ -421,18 +420,17 @@ void dt_image_transform_dilate(int *img, const int width, const int height, cons
     dt_free_align(tmp);
     return;
   }
-  _intimage_dilate(tmp, img, width, height, MIN(5, rad2), border);
+  _intimage_dilate(tmp, img, width, height, MIN(5, rad - 5), border);
 }
   
 void dt_image_transform_erode(int *img, const int width, const int height, const int radius, const int border)
 {
   if(radius < 0) return;
-  int *tmp = dt_alloc_align(16, width * height * sizeof(int));
+  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
   if(!tmp) return;
 
   const int rad = MIN(radius, 10);
   _intimage_erode(img, tmp, width, height, MIN(5, rad), border);
-  const int rad2 = rad - 5;
 
   if(rad < 6)
   {
@@ -440,7 +438,7 @@ void dt_image_transform_erode(int *img, const int width, const int height, const
     dt_free_align(tmp);
     return;
   }
-  _intimage_erode(tmp, img, width, height, MIN(5, rad2), border);
+  _intimage_erode(tmp, img, width, height, MIN(5, rad - 5), border);
 }
   
 void dt_image_transform_closing(int *img, const int width, const int height, const int radius, const int border)
@@ -450,7 +448,7 @@ void dt_image_transform_closing(int *img, const int width, const int height, con
   dt_image_transform_erode(img, width, height, radius, border);
 }
 
-static int floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, int w, const int h, const int id, dt_ff_stack_t *stack)
+static int floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, const int w, const int h, const int id, dt_ff_stack_t *stack)
 {
   if((id < 2) || (id >= HLMAXSEGMENTS - 1)) return 0;
 

--- a/src/iop/highlights_algos/segmentation.h
+++ b/src/iop/highlights_algos/segmentation.h
@@ -1,0 +1,627 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2021 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* Internal segmentation algorithms
+   - morphological closing operation supporting radius up to 10, tuned for performance
+   Hanno Schwalm 2021/12
+*/
+
+typedef struct dt_pos_t
+{
+  int xpos;
+  int ypos;
+} dt_pos_t;
+
+typedef struct dt_iop_segmentation_t
+{
+  int *data;      // holding segment id's for every location
+  int *size;      // size of segment      
+  int *xmin;      // bounding rectangle for each segment
+  int *xmax;
+  int *ymin;
+  int *ymax;
+  size_t *ref;    // possibly a reference point for location
+  float *refcol;  // holds averaged reference color or 0  
+  int nr;         // number of found segments
+} dt_iop_segmentation_t;
+
+typedef struct dt_ff_stack_t
+{
+  int pos;
+  dt_pos_t *el;
+} dt_ff_stack_t;
+
+static inline void push_stack(int xpos, int ypos, dt_ff_stack_t *stack)
+{
+  const int i = stack->pos;
+  stack->el[i].xpos = xpos;
+  stack->el[i].ypos = ypos;
+  stack->pos++;
+}
+
+static inline dt_pos_t * pop_stack(dt_ff_stack_t *stack)
+{
+  if(stack->pos > 0) stack->pos--;  
+  return &stack->el[stack->pos];
+}
+
+void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, const int height, const int segments)
+{
+  seg->nr = 0;
+  seg->data =   dt_alloc_align(64, width * height * sizeof(int));
+  seg->size =   dt_alloc_align(64, segments * sizeof(int));
+  seg->xmin =   dt_alloc_align(64, segments * sizeof(int));
+  seg->xmax =   dt_alloc_align(64, segments * sizeof(int));
+  seg->ymin =   dt_alloc_align(64, segments * sizeof(int));
+  seg->ymax =   dt_alloc_align(64, segments * sizeof(int));
+  seg->ref =    dt_alloc_align(64, segments * sizeof(size_t));
+  seg->refcol = dt_alloc_align_float(segments);
+  // make sure for the first 2 segments
+  for(int i = 0; i < 2; i++)
+  {
+    seg->size[i] = 0;
+    seg->ref[i] = 0;
+    seg->refcol[i] = 0.0f;
+  }
+}
+
+void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
+{
+  dt_free_align(seg->data);
+  dt_free_align(seg->size);
+  dt_free_align(seg->xmin);
+  dt_free_align(seg->ymin);
+  dt_free_align(seg->xmax);
+  dt_free_align(seg->ymax);
+  dt_free_align(seg->ref);
+  dt_free_align(seg->refcol);
+}
+
+static inline void _dilate_1(int *img, int *o, const int w1, const int height, const int border)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+      o[i] =   img[i-w1-1] | img[i-w1] | img[i-w1+1] |
+               img[i-1]    | img[i]    | img[i+1] |
+               img[i+w1-1] | img[i+w1] | img[i+w1+1];
+  }
+}
+
+static inline void _erode_1(int *img, int *o, const int w1, const int height, const int border)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+      o[i] =   img[i-w1-1] & img[i-w1] & img[i-w1+1] &
+               img[i-1]    & img[i]    & img[i+1] &
+               img[i+w1-1] & img[i+w1] & img[i+w1+1];
+
+  }
+}
+
+static inline void _dilate_2(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+      o[i] =         img[i-w2-1] | img[i-w2] | img[i-w2+1] |
+       img[i-w1-2] | img[i-w1-1] | img[i-w1] | img[i-w1+1] | img[i-w1+2] | 
+       img[i-2] |    img[i-1]    |    img[i] | img[i+1]    | img[i+2] |
+       img[i+w1-2] | img[i+w1-1] | img[i+w1] | img[i+w1+1] | img[i+w1+2] |
+                     img[i+w2-1] | img[i+w2] | img[i+w2+1];
+  }
+}
+
+static inline void _erode_2(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+      o[i] =         img[i-w2-1] & img[i-w2] & img[i-w2+1] &
+       img[i-w1-2] & img[i-w1-1] & img[i-w1] & img[i-w1+1] & img[i-w1+2] & 
+       img[i-2] &    img[i-1]    &    img[i] & img[i+1]    & img[i+2] &
+       img[i+w1-2] & img[i+w1-1] & img[i+w1] & img[i+w1+1] & img[i+w1+2] &
+                     img[i+w2-1] & img[i+w2] & img[i+w2+1];
+  }
+}
+
+static inline void _dilate_3(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, w3, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    {
+        o[i] =                               img[i-w3-1] | img[i-w3] | img[i-w3+1] |
+                               img[i-w2-2] | img[i-w2-1] | img[i-w2] | img[i-w2+1] | img[i-w2+2] | 
+                 img[i-w1-3] | img[i-w1-2] | img[i-w1-1] | img[i-w1] | img[i-w1+1] | img[i-w1+2] | img[i-w1+3] | 
+                 img[i-3]    | img[i-2]    | img[i-1]    | img[i]    | img[i+1]    | img[i+2]    | img[i+3]    | 
+                 img[i+w1-3] | img[i+w1-2] | img[i+w1-1] | img[i+w1] | img[i+w1+1] | img[i+w1+2] | img[i+w1+3] | 
+                               img[i+w2-2] | img[i+w2-1] | img[i+w2] | img[i+w2+1] | img[i+w2+2] |
+                                             img[i+w3-1] | img[i+w3] | img[i+w3+1]; 
+    }
+  }
+}
+
+static inline void _erode_3(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, w3, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    {
+        o[i] =                               img[i-w3-1] & img[i-w3] & img[i-w3+1] &
+                               img[i-w2-2] & img[i-w2-1] & img[i-w2] & img[i-w2+1] & img[i-w2+2] & 
+                 img[i-w1-3] & img[i-w1-2] & img[i-w1-1] & img[i-w1] & img[i-w1+1] & img[i-w1+2] & img[i-w1+3] & 
+                 img[i-3]    & img[i-2]    & img[i-1]    & img[i]    & img[i+1]    & img[i+2]    & img[i+3]    & 
+                 img[i+w1-3] & img[i+w1-2] & img[i+w1-1] & img[i+w1] & img[i+w1+1] & img[i+w1+2] & img[i+w1+3] & 
+                               img[i+w2-2] & img[i+w2-1] & img[i+w2] & img[i+w2+1] & img[i+w2+2] &
+                                             img[i+w3-1] & img[i+w3] & img[i+w3+1]; 
+    }
+  }
+}
+
+static inline void _dilate_4(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+  const int w4 = 4*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, w3, w4, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    {
+        o[i] =                     img[i-w4-2] | img[i-w4-1] | img[i-w4] | img[i-w4+1] | img[i-w4+2] |
+                     img[i-w3-3] | img[i-w3-2] | img[i-w3-1] | img[i-w3] | img[i-w3+1] | img[i-w3+2] | img[i-w3+3] |
+       img[i-w2-4] | img[i-w2-3] | img[i-w2-2] | img[i-w2-1] | img[i-w2] | img[i-w2+1] | img[i-w2+2] | img[i-w2+3] | img[i-w2+4] | 
+       img[i-w1-4] | img[i-w1-3] | img[i-w1-2] | img[i-w1-1] | img[i-w1] | img[i-w1+1] | img[i-w1+2] | img[i-w1+3] | img[i-w1+4] | 
+       img[i-4]    | img[i-3]    | img[i-2]    | img[i-1]    | img[i]    | img[i+1]    | img[i+2]    | img[i+3]    | img[i+4] | 
+       img[i+w1-4] | img[i+w1-3] | img[i+w1-2] | img[i+w1-1] | img[i+w1] | img[i+w1+1] | img[i+w1+2] | img[i+w1+3] | img[i+w1+4] | 
+       img[i+w2-4] | img[i+w2-3] | img[i+w2-2] | img[i+w2-1] | img[i+w2] | img[i+w2+1] | img[i+w2+2] | img[i+w2+3] | img[i+w2+4] | 
+                     img[i+w3-3] | img[i+w3-2] | img[i+w3-1] | img[i+w3] | img[i+w3+1] | img[i+w3+2] | img[i+w3+3] |
+                                   img[i+w4-2] | img[i+w4-1] | img[i+w4] | img[i+w4+1] | img[i+w4+2]; 
+    }
+  }
+}
+
+static inline void _erode_4(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+  const int w4 = 4*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, w3, w4, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    {
+        o[i] =                     img[i-w4-2] & img[i-w4-1] & img[i-w4] & img[i-w4+1] & img[i-w4+2] &
+                     img[i-w3-3] & img[i-w3-2] & img[i-w3-1] & img[i-w3] & img[i-w3+1] & img[i-w3+2] & img[i-w3+3] &
+       img[i-w2-4] & img[i-w2-3] & img[i-w2-2] & img[i-w2-1] & img[i-w2] & img[i-w2+1] & img[i-w2+2] & img[i-w2+3] & img[i-w2+4] & 
+       img[i-w1-4] & img[i-w1-3] & img[i-w1-2] & img[i-w1-1] & img[i-w1] & img[i-w1+1] & img[i-w1+2] & img[i-w1+3] & img[i-w1+4] & 
+       img[i-4]    & img[i-3]    & img[i-2]    & img[i-1]    & img[i]    & img[i+1]    & img[i+2]    & img[i+3]    & img[i+4] & 
+       img[i+w1-4] & img[i+w1-3] & img[i+w1-2] & img[i+w1-1] & img[i+w1] & img[i+w1+1] & img[i+w1+2] & img[i+w1+3] & img[i+w1+4] & 
+       img[i+w2-4] & img[i+w2-3] & img[i+w2-2] & img[i+w2-1] & img[i+w2] & img[i+w2+1] & img[i+w2+2] & img[i+w2+3] & img[i+w2+4] & 
+                     img[i+w3-3] & img[i+w3-2] & img[i+w3-1] & img[i+w3] & img[i+w3+1] & img[i+w3+2] & img[i+w3+3] &
+                                   img[i+w4-2] & img[i+w4-1] & img[i+w4] & img[i+w4+1] & img[i+w4+2]; 
+
+    }
+  }
+}
+
+static inline void _dilate_5(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+  const int w4 = 4*w1;
+  const int w5 = 5*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, w3, w4, w5, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    {
+      o[i] =                                     img[i-w5-2] | img[i-w5-1] | img[i-w5] | img[i-w5+1] | img[i-w5+2] |
+                                   img[i-w4-3] | img[i-w4-2] | img[i-w4-1] | img[i-w4] | img[i-w4+1] | img[i-w4+2] | img[i-w4+3] |
+                     img[i-w3-4] | img[i-w3-3] | img[i-w3-2] | img[i-w3-1] | img[i-w3] | img[i-w3+1] | img[i-w3+2] | img[i-w3+3] | img[i-w3+4] |
+       img[i-w2-5] | img[i-w2-4] | img[i-w2-3] | img[i-w2-2] | img[i-w2-1] | img[i-w2] | img[i-w2+1] | img[i-w2+2] | img[i-w2+3] | img[i-w2+4] | img[i-w2+5] | 
+       img[i-w1-5] | img[i-w1-4] | img[i-w1-3] | img[i-w1-2] | img[i-w1-1] | img[i-w1] | img[i-w1+1] | img[i-w1+2] | img[i-w1+3] | img[i-w1+4] | img[i-w1+5] | 
+       img[i-5]    | img[i-4]    | img[i-3]    | img[i-2]    | img[i-1]    | img[i]    | img[i+1]    | img[i+2]    | img[i+3]    | img[i+4]    | img[i+5] | 
+       img[i+w1-5] | img[i+w1-4] | img[i+w1-3] | img[i+w1-2] | img[i+w1-1] | img[i+w1] | img[i+w1+1] | img[i+w1+2] | img[i+w1+3] | img[i+w1+4] | img[i+w1+5] | 
+       img[i+w2-5] | img[i+w2-4] | img[i+w2-3] | img[i+w2-2] | img[i+w2-1] | img[i+w2] | img[i+w2+1] | img[i+w2+2] | img[i+w2+3] | img[i+w2+4] | img[i+w2+5] |  
+                     img[i+w3-4] | img[i+w3-3] | img[i+w3-2] | img[i+w3-1] | img[i+w3] | img[i+w3+1] | img[i+w3+2] | img[i+w3+3] | img[i+w3+4] | 
+                                   img[i+w4-3] | img[i+w4-2] | img[i+w4-1] | img[i+w4] | img[i+w4+1] | img[i+w4+2] | img[i+w4+3] |
+                                                 img[i+w5-2] | img[i+w5-1] | img[i+w5] | img[i+w5+1] | img[i+w5+2]; 
+    }
+  }
+}
+
+static inline void _erode_5(int *img, int *o, const int w1, const int height, const int border)
+{
+  const int w2 = 2*w1;
+  const int w3 = 3*w1;
+  const int w4 = 4*w1;
+  const int w5 = 5*w1;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, w2, w3, w4, w5, border) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    {
+      o[i] =                                     img[i-w5-2] & img[i-w5-1] & img[i-w5] & img[i-w5+1] & img[i-w5+2] &
+                                   img[i-w4-3] & img[i-w4-2] & img[i-w4-1] & img[i-w4] & img[i-w4+1] & img[i-w4+2] & img[i-w4+3] &
+                     img[i-w3-4] & img[i-w3-3] & img[i-w3-2] & img[i-w3-1] & img[i-w3] & img[i-w3+1] & img[i-w3+2] & img[i-w3+3] & img[i-w3+4] &
+       img[i-w2-5] & img[i-w2-4] & img[i-w2-3] & img[i-w2-2] & img[i-w2-1] & img[i-w2] & img[i-w2+1] & img[i-w2+2] & img[i-w2+3] & img[i-w2+4] & img[i-w2+5] & 
+       img[i-w1-5] & img[i-w1-4] & img[i-w1-3] & img[i-w1-2] & img[i-w1-1] & img[i-w1] & img[i-w1+1] & img[i-w1+2] & img[i-w1+3] & img[i-w1+4] & img[i-w1+5] & 
+       img[i-5]    & img[i-4]    & img[i-3]    & img[i-2]    & img[i-1]    & img[i]    & img[i+1]    & img[i+2]    & img[i+3]    & img[i+4]    & img[i+5] & 
+       img[i+w1-5] & img[i+w1-4] & img[i+w1-3] & img[i+w1-2] & img[i+w1-1] & img[i+w1] & img[i+w1+1] & img[i+w1+2] & img[i+w1+3] & img[i+w1+4] & img[i+w1+5] & 
+       img[i+w2-5] & img[i+w2-4] & img[i+w2-3] & img[i+w2-2] & img[i+w2-1] & img[i+w2] & img[i+w2+1] & img[i+w2+2] & img[i+w2+3] & img[i+w2+4] & img[i+w2+5] &  
+                     img[i+w3-4] & img[i+w3-3] & img[i+w3-2] & img[i+w3-1] & img[i+w3] & img[i+w3+1] & img[i+w3+2] & img[i+w3+3] & img[i+w3+4] & 
+                                   img[i+w4-3] & img[i+w4-2] & img[i+w4-1] & img[i+w4] & img[i+w4+1] & img[i+w4+2] & img[i+w4+3] &
+                                                 img[i+w5-2] & img[i+w5-1] & img[i+w5] & img[i+w5+1] & img[i+w5+2]; 
+    }
+  }
+}
+
+static inline void _intimage_borderfill(int *d, const int width, const int height, const int val, const int border)
+{
+  for(int i = 0; i < border * width; i++)                            
+    d[i] = val;
+  for(int i = (height - border - 1) * width; i < width*height; i++)
+    d[i] = val;
+  for(int row = border; row < height - border; row++)
+  {
+    int *p1 = d + row*width;
+    int *p2 = d + (row+1)*width - border;
+    for(int i = 0; i < border; i++)
+      p1[i] = p2[i] = val;
+  }
+}
+
+static void _intimage_dilate(int *src, int *out, const int width, const int height, const int rad, const int border)
+{
+  _intimage_borderfill(src, width, height, 0, border);
+  if(rad == 1)       _dilate_1(src, out, width, height, border);
+  else if(rad == 2)  _dilate_2(src, out, width, height, border);
+  else if(rad == 3)  _dilate_3(src, out, width, height, border);
+  else if(rad == 4)  _dilate_4(src, out, width, height, border);
+  else               _dilate_5(src, out, width, height, border);
+}
+
+static void _intimage_erode(int *src, int *out, const int width, const int height, const int rad, const int border)
+{
+  _intimage_borderfill(src, width, height, 1, border);
+  if(rad == 1)       _erode_1(src, out, width, height, border);
+  else if(rad == 2)  _erode_2(src, out, width, height, border);
+  else if(rad == 3)  _erode_3(src, out, width, height, border);
+  else if(rad == 4)  _erode_4(src, out, width, height, border);
+  else               _erode_5(src, out, width, height, border);
+}
+
+void dt_image_transform_closing(int *img, const int width, const int height, const int radius, const int border)
+{
+  if(radius < 1) return;
+  int *tmp = dt_alloc_align(16, width * height * sizeof(int));
+  if(!tmp) return;
+
+  const int rad = MIN(radius, 10);
+  _intimage_dilate(img, tmp, width, height, MIN(5, rad), border);
+  const int rad2 = rad - 5;
+
+  if(rad < 6)
+  {
+    _intimage_erode(tmp, img, width, height, MIN(5, rad), border);
+    dt_free_align(tmp);
+    return;
+  }
+  _intimage_dilate(tmp, img, width, height, rad2, border);
+  _intimage_erode(img, tmp, width, height, 5, border);
+  _intimage_erode(tmp, img, width, height, rad2, border);
+  dt_free_align(tmp);
+}
+
+static int floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, int w, const int h, const int id, dt_ff_stack_t *stack)
+{
+  if((id < 2) || (id >= HLMAXSEGMENTS - 1)) return 0;
+
+  int *d = seg->data;
+
+  int xp = 0;
+  int yp = 0;
+  size_t rp = 0;
+  int min_x = xin;
+  int max_x = xin;
+  int min_y = yin;
+  int max_y = yin;
+
+  int cnt = 0;
+  stack->pos = 0;
+
+  seg->size[id] = 0;
+  seg->ref[id] = 0;
+  seg->refcol[id] = 0.0f;
+  seg->xmin[id] = min_x;
+  seg->xmax[id] = max_x;
+  seg->ymin[id] = min_y;
+  seg->ymax[id] = max_y;
+
+  push_stack(xin, yin, stack);
+  while(stack->pos)
+  {
+    dt_pos_t *coord = pop_stack(stack);
+    const int x = coord->xpos;
+    const int y = coord->ypos;
+    if(d[y*w+x] == 1)
+    {
+      int yUp = y - 1, yDown = y + 1;
+      gboolean lastXUp = FALSE, lastXDown = FALSE, firstXUp = FALSE, firstXDown = FALSE;
+      d[y*w+x] = id;
+      cnt++;
+      if(yUp >= HLBORDER && d[yUp*w+x] == 1)
+      {
+        push_stack(x, yUp, stack); firstXUp = lastXUp = TRUE;
+      }
+      else
+      {
+        xp = x;
+        yp = yUp;
+        rp = yp*w + xp;
+        if(xp > HLBORDER+2 && d[rp] == 0)
+        {
+          min_x = MIN(min_x, xp);
+          max_x = MAX(max_x, xp);
+          min_y = MIN(min_y, yp);
+          max_y = MAX(max_y, yp);
+          d[rp] = HLMAXSEGMENTS+id;
+        }
+      }
+      
+      if(yDown < h-HLBORDER && d[yDown*w+x] == 1)
+      {
+        push_stack(x, yDown, stack); firstXDown = lastXDown = TRUE;
+      }
+      else
+      {
+        xp = x;
+        yp = yDown;
+        rp = yp*w + xp;
+        if(yp < h-HLBORDER-3 && d[rp] == 0)
+        {
+          min_x = MIN(min_x, xp);
+          max_x = MAX(max_x, xp);
+          min_y = MIN(min_y, yp);
+          max_y = MAX(max_y, yp);
+          d[rp] = HLMAXSEGMENTS+id;
+        }
+      }
+      
+      int xr = x + 1;
+      while(xr < w-HLBORDER && d[y*w+xr] == 1)
+      {
+        d[y*w+xr] = id;
+        cnt++;
+        if(yUp >= HLBORDER && d[yUp*w + xr] == 1)
+        {
+          if(!lastXUp) { push_stack(xr, yUp, stack); lastXUp = TRUE; }
+        }
+        else
+        {
+          xp = xr;
+          yp = yUp;
+          rp = yp*w + xp;
+          if(yp > HLBORDER+2 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXUp = FALSE;
+        }
+
+        if(yDown < h-HLBORDER && d[yDown*w+xr] == 1)
+        {
+          if(!lastXDown) { push_stack(xr, yDown, stack); lastXDown = TRUE; }
+        }
+        else
+        {
+          xp = xr;
+          yp = yDown;
+          rp = yp*w + xp;
+          if(yp < h-HLBORDER-3 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXDown = FALSE;
+        }
+        xr++;
+      }
+
+      xp = xr;
+      yp = y;
+      rp = yp*w + xp;
+      if(xp < w-HLBORDER-3 && d[rp] == 0) 
+      {
+        min_x = MIN(min_x, xp);
+        max_x = MAX(max_x, xp);
+        min_y = MIN(min_y, yp);
+        max_y = MAX(max_y, yp);
+        d[rp] = HLMAXSEGMENTS+id;
+      }
+
+      int xl = x - 1;
+      lastXUp = firstXUp;
+      lastXDown = firstXDown;
+      while(xl >= HLBORDER && d[y*w+xl] == 1)
+      {
+        d[y*w+xl] = id;
+        cnt++;
+        if(yUp >= HLBORDER && d[yUp*w+xl] == 1)
+        {
+          if(!lastXUp) { push_stack(xl, yUp, stack); lastXUp = TRUE; }
+        }
+        else
+        {
+          xp = xl;
+          yp = yUp;
+          rp = yp*w + xp;
+          if(yp > HLBORDER+2 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXUp = FALSE;
+        }
+
+        if(yDown < h-HLBORDER && d[yDown*w+xl] == 1)
+        {
+          if(!lastXDown) { push_stack(xl, yDown, stack); lastXDown = TRUE; }
+        }
+        else
+        {
+          xp = xl;
+          yp = yDown;
+          rp = yp*w + xp;
+          if(yp < h-HLBORDER-3 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXDown = FALSE;
+        }
+        xl--;
+      }
+
+      d[y*w+x] = id;
+
+      xp = xl;
+      yp = y;
+      rp = yp*w + xp;
+      if(xp > HLBORDER+2 && d[rp] == 0)
+      {
+        min_x = MIN(min_x, xp);
+        max_x = MAX(max_x, xp);
+        min_y = MIN(min_y, yp);
+        max_y = MAX(max_y, yp);
+        d[rp] = HLMAXSEGMENTS+id;
+      }
+      cnt++;
+    }
+  }
+
+  seg->size[id] = cnt;
+  seg->xmin[id] = min_x;
+  seg->xmax[id] = max_x;
+  seg->ymin[id] = min_y;
+  seg->ymax[id] = max_y;
+  if(cnt) seg->nr += 1;
+  return cnt;
+}
+
+static void segmentize_plane(dt_iop_segmentation_t *seg, const int width, const int height)
+{
+  dt_ff_stack_t stack;  
+  stack.el = dt_alloc_align(16, width * height * sizeof(int));
+  if(!stack.el) return;
+ 
+  int id = 2;
+  for(int row = HLBORDER; row < height - HLBORDER; row++)
+  {
+    for(int col = HLBORDER; col < width - HLBORDER; col++)
+    {
+      if(id >= HLMAXSEGMENTS-1) goto finish;
+      if(seg->data[width * row + col] == 1)
+      {
+        if(floodfill_segmentize(row, col, seg, width, height, id, &stack) > 0) id++;
+      }
+    }
+  }
+
+  finish:
+  dt_free_align(stack.el);
+}
+


### PR DESCRIPTION
EDIT: reflection current status

The new highlight recovery algorithm only works for standard bayer sensors.
It has been developed in collaboration by Iain from the gmic team and me.

The original idea was presented by Iain in pixls.us in: https://discuss.pixls.us/t/highlight-recovery-teaser/17670

and has been extensively discussed over the last months. No other external modules (like gmic …) are used. no OpenCL codepath yet.

I have been testing this on many images (all with very heavy clipping) and this algo does not fix all problems but for the vast majority of images is it far better than what we have atm. On 'normal' images - some parts are blown out because of wrong exposure like clouds, building surfaces, skin ... - this works just good imho.

@rawfiner - i promised to ping you.
@aurelienpierre - any comments?

The algorithm follows these basic ideas:
1. We understand the bayer data as superpixels, each having one red, one blue and two green photosites
2. We analyse all data (without wb correction applied) on the channels independently so resulting in 4 color-planes
3. We want to keep details as much as possible; we assume that details are best represented in the color channel having
   the minimum value. So beside the 4 color planes we also have a plane holding the minimum values (pminimum)
4. In all 4 color planes we look for isolated areas being clipped (segments).
   Inside these segments (including borders around) we look for a candidate to represent the value we take for restoration.
   Choosing the candidate is done at all non-clipped locations of a segment, the best candidate is selected via a weighing
   function - the weight is derived from
   - the local standard deviation in a 5x5 area and
   - the median value of unclipped positions also in a 5x5 area.
   The best candidate points to the location in the color plane holding the reference value.
   If there is no good candidate we use an averaging approximation over the whole sehment.
5. We evaluated several ways to further reduce the pre-existing color cast, atm we calc linearly while using a correction
   coeff for every plane.
   We also tried using some gamma correction which helped in some cases but was unstable in others.
6. The restored value at position 'i' is basically calculated as
     val = candidate + pminimum[i] - pminimum[candidate_location];

For the segmentation i implemented and tested several approaches including Felszenzwalb and a watershed algo,
both have problems with identifying the clipped segments in a plane. I ended up with this:

1. Doing the segmentation in every color plane.
2. The segmentation algorithm uses a modified floodfill, it also takes care of the surrounding rectangle of every segment
   and marks the segment borders.
3. After segmentation we check every segment for
   - the segment's best candidate via the weighing function
   - the candidates location
4. To combine small segments for a shared candidate we use a morphological closing operation, the radius of that op
   can be chosen interactively between 0 and 10.
5. To avoid single clipped photosites (often found at smooth transitions from not-clipped to clipped) we prepose
   a morphological opening with a very small radius before segmentation. 
