### PR TITLE
Pass is_scaling to dt_imageio_export_with_flags.

### DIFF
--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -81,7 +81,7 @@ int dt_imageio_export(const int32_t imgid, const char *filename, struct dt_image
 int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  struct dt_imageio_module_format_t *format,
                                  struct dt_imageio_module_data_t *format_params, const gboolean ignore_exif,
-                                 const gboolean display_byteorder, const gboolean high_quality, const gboolean upscale,
+                                 const gboolean display_byteorder, const gboolean high_quality, const gboolean upscale, gboolean is_scaling,
                                  const gboolean thumbnail_export, const char *filter, const gboolean copy_metadata,
                                  const gboolean export_masks, dt_colorspaces_color_profile_type_t icc_type,
                                  const gchar *icc_filename, dt_iop_color_intent_t icc_intent,

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1275,7 +1275,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
     // export with flags: ignore exif (don't load from disk), don't swap byte order, don't do hq processing,
     // no upscaling and signal we want thumbnail export
     res = dt_imageio_export_with_flags(imgid, "unused", &format, (dt_imageio_module_data_t *)&dat, TRUE, FALSE, FALSE,
-                                       FALSE, TRUE, NULL, FALSE, FALSE, DT_COLORSPACE_NONE, NULL, DT_INTENT_LAST, NULL,
+                                       FALSE, FALSE, TRUE, NULL, FALSE, FALSE, DT_COLORSPACE_NONE, NULL, DT_INTENT_LAST, NULL,
                                        NULL, 1, 1, NULL);
     if(!res)
     {

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -490,7 +490,10 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
 
     const uint32_t imgid = GPOINTER_TO_INT(t->data);
 
-    dt_imageio_export_with_flags(imgid, "unused", &buf, (dt_imageio_module_data_t *)&dat, TRUE, FALSE, FALSE, TRUE,
+    const gboolean is_scaling =
+      dt_conf_is_equal("plugins/lighttable/export/resizing", "scaling");
+
+    dt_imageio_export_with_flags(imgid, "unused", &buf, (dt_imageio_module_data_t *)&dat, TRUE, FALSE, FALSE, TRUE, is_scaling,
                                  FALSE, "pre:rawprepare", FALSE, FALSE, DT_COLORSPACE_NONE, NULL, DT_INTENT_LAST, NULL,
                                  NULL, num, total, NULL);
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -304,10 +304,11 @@ static int _export_image(dt_job_t *job, dt_image_box *img)
   const gboolean high_quality = TRUE;
   const gboolean upscale = TRUE;
   const gboolean export_masks = FALSE;
+  const gboolean is_scaling = FALSE;
 
   dt_imageio_export_with_flags
     (img->imgid, "unused", &buf, (dt_imageio_module_data_t *)&dat, TRUE, FALSE,
-     high_quality, upscale, FALSE, NULL, FALSE, export_masks, params->buf_icc_type,
+     high_quality, upscale, is_scaling, FALSE, NULL, FALSE, export_masks, params->buf_icc_type,
      params->buf_icc_profile, params->buf_icc_intent,  NULL, NULL, 1, 1, NULL);
 
   img->exp_width = dat.head.width;

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -213,7 +213,7 @@ static int process_image(dt_slideshow_t *d, dt_slideshow_slot_t slot)
   {
     // the flags are: ignore exif, display byteorder, high quality, upscale, thumbnail
     dt_imageio_export_with_flags(id, "unused", &buf, (dt_imageio_module_data_t *)&dat, TRUE, TRUE,
-                                 high_quality, TRUE, FALSE, NULL, FALSE, FALSE, DT_COLORSPACE_DISPLAY,
+                                 high_quality, TRUE, FALSE, FALSE, NULL, FALSE, FALSE, DT_COLORSPACE_DISPLAY,
                                  NULL, DT_INTENT_LAST, NULL, NULL, 1, 1, NULL);
 
     // lock to copy back into the slot the rendered buffer, not that this is done only if

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -396,7 +396,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
     // darkroom view
     // FIXME: instead export image in work profile, then pass that to histogram process as well as converting to display profile for output, eliminating dt_view_image_get_surface() above
     if(!dt_imageio_export_with_flags(lib->image_id, "unused", &format, (dt_imageio_module_data_t *)&dat, TRUE,
-                                     FALSE, FALSE, FALSE, FALSE, NULL, FALSE, FALSE, histogram_type, histogram_filename,
+                                     FALSE, FALSE, FALSE, FALSE, FALSE, NULL, FALSE, FALSE, histogram_type, histogram_filename,
                                      DT_INTENT_PERCEPTUAL, NULL, NULL, 1, 1, NULL))
     {
       const dt_iop_order_iccprofile_info_t *const histogram_profile =


### PR DESCRIPTION
We want to disable the scaling mode when exporting with exact size like
in the print settings lib.

Fixes #10724.