### PR TITLE
rework the whole collect-filter-sort UI

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -401,6 +401,27 @@
     <shortdescription>nb of use for the rule property</shortdescription>
     <longdescription>nb of use for the rule property</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/expand_0</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>visibility of the treeview</shortdescription>
+    <longdescription>visibility of the treeview for this rule</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/expand_1</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>visibility of the treeview</shortdescription>
+    <longdescription>visibility of the treeview for this rule</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/expand_17</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>visibility of the treeview</shortdescription>
+    <longdescription>visibility of the treeview for this rule</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" capability="opencl">
     <name>opencl</name>
     <type>bool</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -353,55 +353,6 @@
     <longdescription>tags case sensitivity. without the Sqlite ICU extension, insensivity works only for the 26 latin letters</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>plugins/lighttable/collect/most_used_nb</name>
-    <type>int</type>
-    <default>6</default>
-    <shortdescription>number of rules to show in the most used part of the menu.</shortdescription>
-    <longdescription>number of rules to show in the most used part of the menu.</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/collect/nb_use_1</name>
-    <type>int</type>
-    <default>6</default>
-    <shortdescription>nb of use for the rule property</shortdescription>
-    <longdescription>nb of use for the rule property</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/collect/nb_use_3</name>
-    <type>int</type>
-    <default>2</default>
-    <shortdescription>nb of use for the rule property</shortdescription>
-    <longdescription>nb of use for the rule property</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/collect/nb_use_12</name>
-    <type>int</type>
-    <default>1</default>
-    <shortdescription>nb of use for the rule property</shortdescription>
-    <longdescription>nb of use for the rule property</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/collect/nb_use_17</name>
-    <type>int</type>
-    <default>5</default>
-    <shortdescription>nb of use for the rule property</shortdescription>
-    <longdescription>nb of use for the rule property</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/collect/nb_use_18</name>
-    <type>int</type>
-    <default>3</default>
-    <shortdescription>nb of use for the rule property</shortdescription>
-    <longdescription>nb of use for the rule property</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/collect/nb_use_31</name>
-    <type>int</type>
-    <default>4</default>
-    <shortdescription>nb of use for the rule property</shortdescription>
-    <longdescription>nb of use for the rule property</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>plugins/lighttable/collect/expand_0</name>
     <type>bool</type>
     <default>true</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -352,6 +352,55 @@
     <shortdescription>tags case sensitivity</shortdescription>
     <longdescription>tags case sensitivity. without the Sqlite ICU extension, insensivity works only for the 26 latin letters</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/most_used_nb</name>
+    <type>int</type>
+    <default>6</default>
+    <shortdescription>number of rules to show in the most used part of the menu.</shortdescription>
+    <longdescription>number of rules to show in the most used part of the menu.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/nb_use_1</name>
+    <type>int</type>
+    <default>6</default>
+    <shortdescription>nb of use for the rule property</shortdescription>
+    <longdescription>nb of use for the rule property</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/nb_use_3</name>
+    <type>int</type>
+    <default>2</default>
+    <shortdescription>nb of use for the rule property</shortdescription>
+    <longdescription>nb of use for the rule property</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/nb_use_12</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>nb of use for the rule property</shortdescription>
+    <longdescription>nb of use for the rule property</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/nb_use_17</name>
+    <type>int</type>
+    <default>5</default>
+    <shortdescription>nb of use for the rule property</shortdescription>
+    <longdescription>nb of use for the rule property</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/nb_use_18</name>
+    <type>int</type>
+    <default>3</default>
+    <shortdescription>nb of use for the rule property</shortdescription>
+    <longdescription>nb of use for the rule property</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/collect/nb_use_31</name>
+    <type>int</type>
+    <default>4</default>
+    <shortdescription>nb of use for the rule property</shortdescription>
+    <longdescription>nb of use for the rule property</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" capability="opencl">
     <name>opencl</name>
     <type>bool</type>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1537,13 +1537,27 @@ filechooser row:hover,
   --------------------*/
 #collect-rule-widget
 {
-  background-color: @button_bg;
-  margin: 0.3em 0;
+  background-color: @button_border;
+  margin: 0.3em 0 0.5em 0;
   padding: 0 0.2em;
 }
-#collect-rule-widget #section_label
+#collect-treeview
 {
-  border: none;
+  margin-bottom: 0.2em;
+}
+#collect-property,
+#collect-property *
+{
+  background-color: @button_border;
+  padding: 0;
+  color: @button_checked_fg;
+  font-family: sans-serif;
+  font-weight: 500;
+}
+#collect-property:hover,
+#collect-property:hover *
+{
+  background-color: @button_hover_bg;
 }
 #collect-operator arrow
 {
@@ -1558,10 +1572,27 @@ filechooser row:hover,
   background-image: none;
   background-color: transparent;
 }
+#collect-rule-special *
+{
+  background-color: @button_bg;
+}
+#collect-rule-special
+{
+  margin-left: 0.5em;
+}
+#collect-rating box
+{
+  background-color: transparent;
+}
 #collect-expand-line *
 {
   margin: 0;
   padding: 0;
+  font-size: 0.6em;
+}
+#collect-spacer-widget
+{
+  margin-top: 1em;
 }
 
 /*--------------------------------

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1535,12 +1535,12 @@ filechooser row:hover,
 /*--------------------
   - collect module -
   --------------------*/
-  #collect-rule-widget
-  {
-    background-color: @button_bg;
-    margin: 0.2em 0;
-    padding: 0 0.2em;
-  }
+#collect-rule-widget
+{
+  background-color: @button_bg;
+  margin: 0.3em 0;
+  padding: 0 0.2em;
+}
 #collect-rule-widget #section_label
 {
   border: none;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1535,11 +1535,16 @@ filechooser row:hover,
 /*--------------------
   - collect module -
   --------------------*/
-#collect-rule-widget
+#collect-rule-widget,
+#collect-sort-widget
 {
   background-color: @button_border;
   margin: 0.3em 0 0.5em 0;
   padding: 0 0.2em;
+}
+#collect-sort-widget
+{
+  margin: 0.2em 0;
 }
 #collect-treeview
 {
@@ -1572,12 +1577,14 @@ filechooser row:hover,
   background-image: none;
   background-color: transparent;
 }
+#collect-rule-special,
 #collect-rule-special *
 {
   background-color: @button_bg;
 }
 #collect-rule-special
 {
+  padding: 0.1em;
   margin-left: 0.5em;
 }
 #collect-rating box
@@ -1590,9 +1597,21 @@ filechooser row:hover,
   padding: 0;
   font-size: 0.6em;
 }
-#collect-spacer-widget
+#collect-spacer
 {
   margin-top: 1em;
+}
+#collect-spacer2
+{
+  margin-top: 2em;
+}
+#collect-actions-widget :nth-child(2)
+{
+  margin-right: 0.6em;
+}
+#collect-actions-widget :nth-child(3)
+{
+  margin-left: 0.6em;
 }
 
 /*--------------------------------

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1526,9 +1526,42 @@ filechooser row:hover,
 
 #basics-box-labels #basics-header-box:first-child,
 #basics-box-labels #section_label,
+#basics-header-box #section_label,
 #basics-link
 {
   border: none;
+}
+
+/*--------------------
+  - collect module -
+  --------------------*/
+  #collect-rule-widget
+  {
+    background-color: @button_bg;
+    margin: 0.2em 0;
+    padding: 0 0.2em;
+  }
+#collect-rule-widget #section_label
+{
+  border: none;
+}
+#collect-operator arrow
+{
+  -gtk-icon-source: none;
+}
+#collect-operator
+{
+  background-image: none;
+}
+#collect-operator button
+{
+  background-image: none;
+  background-color: transparent;
+}
+#collect-expand-line *
+{
+  margin: 0;
+  padding: 0;
 }
 
 /*--------------------------------

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1910,7 +1910,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
             }
           }
         }
-        else if(operator && number1)
+        else if(operator&& g_strcmp0(operator, "=") && number1)
         {
           if(g_strcmp0(operator, "<=") == 0 || g_strcmp0(operator, "<") == 0)
           { // all below rating + rejected

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -676,6 +676,68 @@ gboolean dt_collection_get_sort_descending(const dt_collection_t *collection)
   return collection->params.descending;
 }
 
+const char *dt_collection_comparator_name(dt_collection_rating_comperator_t comp)
+{
+  switch(comp)
+  {
+    case DT_COLLECTION_RATING_COMP_LT:
+      return "<";
+    case DT_COLLECTION_RATING_COMP_LEQ:
+      return "<=";
+    case DT_COLLECTION_RATING_COMP_EQ:
+      return "=";
+    case DT_COLLECTION_RATING_COMP_GEQ:
+      return ">=";
+    case DT_COLLECTION_RATING_COMP_GT:
+      return ">";
+    case DT_COLLECTION_RATING_COMP_NE:
+      return "!=";
+    default:
+      return "";
+  }
+};
+
+const char *dt_collection_sort_name(dt_collection_sort_t sort)
+{
+  switch(sort)
+  {
+    case DT_COLLECTION_SORT_FILENAME:
+      return _("filename");
+    case DT_COLLECTION_SORT_DATETIME:
+      return _("capture time");
+    case DT_COLLECTION_SORT_IMPORT_TIMESTAMP:
+      return _("import time");
+    case DT_COLLECTION_SORT_CHANGE_TIMESTAMP:
+      return _("last modification time");
+    case DT_COLLECTION_SORT_EXPORT_TIMESTAMP:
+      return _("last export time");
+    case DT_COLLECTION_SORT_PRINT_TIMESTAMP:
+      return _("last print time");
+    case DT_COLLECTION_SORT_RATING:
+      return _("rating");
+    case DT_COLLECTION_SORT_ID:
+      return _("id");
+    case DT_COLLECTION_SORT_COLOR:
+      return _("color label");
+    case DT_COLLECTION_SORT_GROUP:
+      return _("group");
+    case DT_COLLECTION_SORT_PATH:
+      return _("full path");
+    case DT_COLLECTION_SORT_CUSTOM_ORDER:
+      return _("custom sort");
+    case DT_COLLECTION_SORT_TITLE:
+      return _("title");
+    case DT_COLLECTION_SORT_DESCRIPTION:
+      return _("description");
+    case DT_COLLECTION_SORT_ASPECT_RATIO:
+      return _("aspect ratio");
+    case DT_COLLECTION_SORT_SHUFFLE:
+      return _("shuffle");
+    default:
+      return "";
+  }
+};
+
 const char *dt_collection_name(dt_collection_properties_t prop)
 {
   char *col_name = NULL;

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -175,6 +175,10 @@ typedef struct dt_collection_t
 
 /* returns the name for the given collection property */
 const char *dt_collection_name(dt_collection_properties_t prop);
+/* returns the name for the given collection comparator property */
+const char *dt_collection_comparator_name(dt_collection_rating_comperator_t comp);
+/* returns the name for the given collection sort property */
+const char *dt_collection_sort_name(dt_collection_sort_t sort);
 
 /** instantiates a collection context, if clone equals NULL default query is constructed. */
 const dt_collection_t *dt_collection_new(const dt_collection_t *clone);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3235,6 +3235,7 @@ static gboolean _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_pr
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(rule->w_operator), _("or"));
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(rule->w_operator), _("and not"));
     gtk_widget_set_name(rule->w_operator, "collect-operator");
+    gtk_widget_set_tooltip_text(rule->w_operator, _("define how this rule should interact with the previous one"));
     gtk_box_pack_start(GTK_BOX(hbox), rule->w_operator, FALSE, FALSE, 0);
     g_signal_connect(G_OBJECT(rule->w_operator), "changed", G_CALLBACK(_event_rule_changed), rule);
   }
@@ -3248,6 +3249,7 @@ static gboolean _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_pr
     GtkWidget *eb = gtk_event_box_new();
     rule->w_prop = gtk_label_new(dt_collection_name(prop));
     gtk_widget_set_name(rule->w_prop, "section_label");
+    gtk_widget_set_tooltip_text(rule->w_prop, _("rule property"));
     gtk_container_add(GTK_CONTAINER(eb), rule->w_prop);
     g_object_set_data(G_OBJECT(eb), "rule", rule);
     g_signal_connect(G_OBJECT(eb), "button-press-event", G_CALLBACK(_event_rule_change_popup), self);
@@ -3274,6 +3276,7 @@ static gboolean _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_pr
     // remove button
     rule->w_close = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
     gtk_widget_set_name(GTK_WIDGET(rule->w_close), "basics-link");
+    gtk_widget_set_tooltip_text(rule->w_close, _("remove this collect rule"));
     g_signal_connect(G_OBJECT(rule->w_close), "button-press-event", G_CALLBACK(_event_rule_close), rule);
     gtk_widget_set_halign(rule->w_close, GTK_ALIGN_END);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlay), rule->w_close);
@@ -3312,6 +3315,7 @@ static gboolean _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_pr
     // the button to switch from raw to specific widgets (only shown if there's some)
     rule->w_raw_switch = dtgtk_button_new(dtgtk_cairo_paint_sorting, CPF_STYLE_FLAT, NULL);
     gtk_widget_set_name(GTK_WIDGET(rule->w_raw_switch), "control-button");
+    gtk_widget_set_tooltip_text(rule->w_raw_switch, _("switch from raw UI to more friendly widgets"));
     g_signal_connect(G_OBJECT(rule->w_raw_switch), "button-press-event", G_CALLBACK(_event_rule_raw_switch), rule);
     gtk_box_pack_end(GTK_BOX(rule->w_widget_box), rule->w_raw_switch, FALSE, TRUE, 0);
     gtk_widget_set_no_show_all(rule->w_raw_switch, TRUE);
@@ -3326,6 +3330,7 @@ static gboolean _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_pr
     gtk_widget_set_name(hbox, "collect-expand-line");
     rule->w_expand = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_STYLE_FLAT | CPF_DIRECTION_UP, NULL);
     gtk_widget_set_name(GTK_WIDGET(rule->w_expand), "control-button");
+    gtk_widget_set_tooltip_text(rule->w_expand, _("show/hide the list of proposals"));
     gtk_box_pack_start(GTK_BOX(hbox), rule->w_expand, TRUE, TRUE, 0);
     g_signal_connect(G_OBJECT(rule->w_expand), "button-press-event", G_CALLBACK(_event_rule_expand), rule);
   }
@@ -4266,14 +4271,15 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
   GtkWidget *bhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_end(GTK_BOX(self->widget), bhbox, TRUE, TRUE, 0);
-  GtkWidget *btn = dt_ui_button_new(_("add rule..."), _("add new rule to collect images"), NULL);
+  GtkWidget *btn = dt_ui_button_new(_("add rule..."), _("append new rule to collect images"), NULL);
   g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_event_add_rule), self);
   gtk_box_pack_start(GTK_BOX(bhbox), btn, TRUE, TRUE, 0);
-  btn = dt_ui_button_new(_("add sort..."), _("add new sorting"), NULL);
+  btn = dt_ui_button_new(_("add sort..."), _("append new sorting"), NULL);
   // g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_event_add_rule), self);
   gtk_box_pack_start(GTK_BOX(bhbox), btn, FALSE, TRUE, 0);
   btn = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_STYLE_FLAT, NULL);
   g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_event_history_show), self);
+  gtk_widget_set_tooltip_text(btn, _("revert to a previous set of rules"));
   gtk_box_pack_start(GTK_BOX(bhbox), btn, FALSE, TRUE, 0);
   gtk_widget_show_all(bhbox);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3132,7 +3132,15 @@ static gboolean _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_pr
     g_signal_connect(G_OBJECT(rule->w_close), "button-press-event", G_CALLBACK(_event_rule_close), rule);
     gtk_widget_set_halign(rule->w_close, GTK_ALIGN_END);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlay), rule->w_close);
+    gtk_widget_set_no_show_all(rule->w_close, TRUE);
+  }
 
+  // we only show the close button if there's more than 1 rule
+  dt_lib_collect_t *d = get_collect(rule);
+  gtk_widget_set_visible(rule->w_close, (d->nb_rules > 1));
+
+  if(newmain)
+  {
     // the second line
     rule->w_widget_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_box_pack_start(GTK_BOX(rule->w_main), rule->w_widget_box, TRUE, TRUE, 0);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2585,20 +2585,32 @@ static void _widget_init(dt_lib_collect_rule_t *rule, const dt_collection_proper
   _widget_raw_set_tooltip(rule);
   g_signal_connect(G_OBJECT(rule->w_raw_text), "activate", G_CALLBACK(_event_rule_changed), rule);
   g_signal_connect(G_OBJECT(rule->w_raw_text), "changed", G_CALLBACK(_event_entry_changed), rule);
+  gtk_widget_set_no_show_all(rule->w_raw_text, TRUE);
   gtk_box_pack_start(GTK_BOX(rule->w_widget_box), rule->w_raw_text, TRUE, TRUE, 0);
 
   // initialize the specific entries if any
+  gboolean widgets_ok = FALSE;
   switch(prop)
   {
     case DT_COLLECTION_PROP_RATING:
       _rating_widget_init(rule, prop, text, self);
+      widgets_ok = _widget_update(rule);
       break;
     default:
       // nothing to do
       break;
   }
 
-  gtk_widget_set_no_show_all(rule->w_raw_text, (rule->w_specific != NULL));
+  // set the visibility for the eventual special widgets
+  if(rule->w_special_box)
+  {
+    gtk_widget_show_all(rule->w_special_box); // we ensure all the childs widgets are shown by default
+    gtk_widget_set_no_show_all(rule->w_special_box, TRUE);
+    gtk_widget_set_visible(rule->w_special_box, widgets_ok);
+    gtk_widget_set_visible(rule->w_raw_text, !widgets_ok);
+  }
+  else
+    gtk_widget_set_visible(rule->w_raw_text, TRUE);
 
   // the button to switch from raw to specific widgets (only shown if there's some)
   rule->w_raw_switch = dtgtk_button_new(dtgtk_cairo_paint_sorting, CPF_STYLE_FLAT, NULL);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2404,19 +2404,19 @@ static void _rating_decode(const gchar *txt, int *comp, int *mode)
     return;
   }
   // unstarred only
-  if(!strcmp(txt, "=0"))
+  if(!strcmp(txt, "0") || !strcmp(txt, "=0"))
   {
     *mode = DT_COLLECTION_FILTER_STAR_NO;
     return;
   }
   // rejected only
-  if(!strcmp(txt, "X"))
+  if(!strcmp(txt, "-1") || !strcmp(txt, "=-1"))
   {
     *mode = DT_COLLECTION_FILTER_REJECT;
     return;
   }
   // all except rejected
-  if(!strcmp(txt, "!X"))
+  if(!strcmp(txt, "<>-1"))
   {
     *mode = DT_COLLECTION_FILTER_NOT_REJECT;
     return;
@@ -2468,11 +2468,11 @@ static void _rating_changed(GtkWidget *widget, gpointer user_data)
   {
     // direct content
     if(mode == DT_COLLECTION_FILTER_STAR_NO)
-      txt = dt_util_dstrcat(txt, "=0");
+      txt = dt_util_dstrcat(txt, "0");
     else if(mode == DT_COLLECTION_FILTER_REJECT)
-      txt = dt_util_dstrcat(txt, "X");
+      txt = dt_util_dstrcat(txt, "-1");
     else if(mode == DT_COLLECTION_FILTER_NOT_REJECT)
-      txt = dt_util_dstrcat(txt, "!X");
+      txt = dt_util_dstrcat(txt, "<>-1");
   }
 
   gtk_entry_set_text(GTK_ENTRY(rule->w_raw_text), txt);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -34,6 +34,8 @@ typedef struct dt_lib_tool_filter_t
   GtkWidget *comparator;
   GtkWidget *sort;
   GtkWidget *reverse;
+
+  gboolean manual_update;
 } dt_lib_tool_filter_t;
 
 #ifdef USE_LUA
@@ -46,21 +48,21 @@ typedef enum dt_collection_sort_order_t
 
 /* proxy function to intelligently reset filter */
 static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter);
+/* proxy function to update the sort widgets without throwing events */
+static void _lib_filter_update_sort(dt_lib_module_t *self, dt_collection_sort_t sort, gboolean asc);
 
 /* callback for filter combobox change */
 static void _lib_filter_combobox_changed(GtkWidget *widget, gpointer user_data);
 /* callback for sort combobox change */
 static void _lib_filter_sort_combobox_changed(GtkWidget *widget, gpointer user_data);
 /* callback for reverse sort check button change */
-static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget, gpointer user_data);
+static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget, dt_lib_module_t *self);
 /* callback for rating comparator combobox change */
 static void _lib_filter_comparator_changed(GtkWidget *widget, gpointer user_data);
 /* updates the query and redraws the view */
 static void _lib_filter_update_query(dt_lib_module_t *self, dt_collection_properties_t changed_property);
 /* make sure that the comparator button matches what is shown in the filter dropdown */
 static gboolean _lib_filter_sync_combobox_and_comparator(dt_lib_module_t *self);
-/* save the images order if the first collect filter is on tag*/
-static void _lib_filter_set_tag_order(dt_lib_module_t *self);
 /* images order change from outside */
 static void _lib_filter_images_order_change(gpointer instance, int order, dt_lib_module_t *self);
 
@@ -225,6 +227,7 @@ void gui_init(dt_lib_module_t *self)
   /* initialize proxy */
   darktable.view_manager->proxy.filter.module = self;
   darktable.view_manager->proxy.filter.reset_filter = _lib_filter_reset;
+  darktable.view_manager->proxy.filter.update_sort = _lib_filter_update_sort;
 
   g_signal_connect_swapped(G_OBJECT(d->comparator), "map",
                            G_CALLBACK(_lib_filter_sync_combobox_and_comparator), self);
@@ -299,18 +302,6 @@ static void _lib_filter_combobox_changed(GtkWidget *widget, gpointer user_data)
   _lib_filter_update_query(user_data, DT_COLLECTION_PROP_RATING);
 }
 
-/* save the images order if the first collect filter is on tag*/
-static void _lib_filter_set_tag_order(dt_lib_module_t *self)
-{
-  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
-  if(darktable.collection->tagid)
-  {
-    const uint32_t sort = items[dt_bauhaus_combobox_get(d->sort)];
-    const gboolean descending = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->reverse));
-    dt_tag_set_tag_order_by_id(darktable.collection->tagid, sort, descending);
-  }
-}
-
 static void _lib_filter_images_order_change(gpointer instance, const int order, dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
@@ -318,8 +309,9 @@ static void _lib_filter_images_order_change(gpointer instance, const int order, 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse), order & DT_COLLECTION_ORDER_FLAG);
 }
 
-static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
+static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget, dt_lib_module_t *self)
 {
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
   const gboolean reverse = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
   if(reverse)
@@ -328,14 +320,9 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
     dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_UP, NULL);
   gtk_widget_queue_draw(GTK_WIDGET(widget));
 
-  /* update last settings */
-  dt_collection_set_sort(darktable.collection, DT_COLLECTION_SORT_NONE, reverse);
+  if(d->manual_update) return;
 
-  /* save the images order */
-  _lib_filter_set_tag_order(user_data);
-
-  /* update query and view */
-  _lib_filter_update_query(user_data, DT_COLLECTION_PROP_SORT);
+  dt_view_collect_set_sort(darktable.view_manager, items[dt_bauhaus_combobox_get(d->sort)], reverse);
 }
 
 static void _lib_filter_comparator_changed(GtkWidget *widget, gpointer user_data)
@@ -347,14 +334,11 @@ static void _lib_filter_comparator_changed(GtkWidget *widget, gpointer user_data
 
 static void _lib_filter_sort_combobox_changed(GtkWidget *widget, gpointer user_data)
 {
-  /* update the ui last settings */
-  dt_collection_set_sort(darktable.collection, items[dt_bauhaus_combobox_get(widget)], -1);
-
-  /* save the images order */
-  _lib_filter_set_tag_order(user_data);
-
-  /* update the query and view */
-  _lib_filter_update_query(user_data, DT_COLLECTION_PROP_SORT);
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  if(d->manual_update) return;
+  const gboolean reverse = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->reverse));
+  dt_view_collect_set_sort(darktable.view_manager, items[dt_bauhaus_combobox_get(d->sort)], reverse);
 }
 
 static void _lib_filter_update_query(dt_lib_module_t *self, dt_collection_properties_t changed_property)
@@ -396,6 +380,15 @@ static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter)
     /* Reset to topmost item, 'all' */
     dt_bauhaus_combobox_set(dropdowns->filter, 0);
   }
+}
+
+static void _lib_filter_update_sort(dt_lib_module_t *self, dt_collection_sort_t sort, gboolean asc)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  d->manual_update = TRUE;
+  dt_bauhaus_combobox_set(d->sort, sort);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse), asc);
+  d->manual_update = FALSE;
 }
 
 #ifdef USE_LUA

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -947,6 +947,12 @@ void dt_view_filter_reset(const dt_view_manager_t *vm, gboolean smart_filter)
     vm->proxy.filter.reset_filter(vm->proxy.filter.module, smart_filter);
 }
 
+void dt_view_filter_update_sort(const dt_view_manager_t *vm, int sort, gboolean asc)
+{
+  if(vm->proxy.filter.module && vm->proxy.filter.update_sort)
+    vm->proxy.filter.update_sort(vm->proxy.filter.module, sort, asc);
+}
+
 void dt_view_active_images_reset(gboolean raise)
 {
   if(!darktable.view_manager->active_images) return;
@@ -1052,6 +1058,11 @@ void dt_view_collection_update(const dt_view_manager_t *vm)
     vm->proxy.module_collect.update(vm->proxy.module_collect.module);
 }
 
+void dt_view_collect_set_sort(const dt_view_manager_t *vm, int sort, gboolean asc)
+{
+  if(vm->proxy.module_collect.module)
+    vm->proxy.module_collect.set_sort(vm->proxy.module_collect.module, sort, asc);
+}
 
 int32_t dt_view_tethering_get_selected_imgid(const dt_view_manager_t *vm)
 {

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -256,6 +256,7 @@ typedef struct dt_view_manager_t
     {
       struct dt_lib_module_t *module;
       void (*reset_filter)(struct dt_lib_module_t *, gboolean smart_filter);
+      void (*update_sort)(struct dt_lib_module_t *, int sort, gboolean asc);
     } filter;
 
     /* module collection proxy object */
@@ -263,6 +264,7 @@ typedef struct dt_view_manager_t
     {
       struct dt_lib_module_t *module;
       void (*update)(struct dt_lib_module_t *);
+      void (*set_sort)(struct dt_lib_module_t *, int sort, gboolean asc);
     } module_collect;
 
     /* filmstrip proxy object */
@@ -398,11 +400,13 @@ const char *dt_view_tethering_get_job_code(const dt_view_manager_t *vm);
 
 /** update the collection module */
 void dt_view_collection_update(const dt_view_manager_t *vm);
+void dt_view_collect_set_sort(const dt_view_manager_t *vm, int sort, gboolean asc);
 
 /*
  * Filter dropdown proxy
  */
 void dt_view_filter_reset(const dt_view_manager_t *vm, gboolean smart_filter);
+void dt_view_filter_update_sort(const dt_view_manager_t *vm, int sort, gboolean asc);
 
 // active images functions
 void dt_view_active_images_reset(gboolean raise);


### PR DESCRIPTION
### Why ?
lot of issues / feature requests have been raised to point inconsistencies, issues, difficulty to use this key part of dt.
Even for experienced users, use of collect module is complex for lot of daily actions and tend to use the "quick & dirty" filter bar for that, which in turn tend to become more and more complex and big (see #6675 #10694)

this is also related to #10718 #10643 ...
### Idea
my idea here is to try to do the following :
First : no regression in actual features. Actual collect module is really powerful, and we have to keep that !
for the "easy to use" part :
- as few clicks as possible for usual features
- self-explanatory UI (as much as possible)
- avoid redundancy
for the "design" part :
- avoid cluttered UI
- let as much space as possible (in modules panels and in central view)

### basic idea
The main idea is to re-centralize everything in the collect module :
- the "collect" part
- the "recent collection" module
- the filtering bar
- the sort bar

Once done, we may also want to move the top bar icons (prefs, shortcuts, ...) to somewhere else (bottom bar ?) and gain 1 line for the images which would be really great imho !
Of course the main problem here is how to design the "new" collect module to avoid cluttering and make it easier to use...

### draft proposal
![collect2](https://user-images.githubusercontent.com/1818223/147661387-b89fc1eb-76a6-4d76-9c28-590f3dd2ecc1.png)
- each rule can be shown in 2 way : the "raw" entry which is the same as the current one *or* by default, more friendly widgets (in the example screenshot, I've reused the filter rating part...) One can switch between the 2 with the icon on the right
- current "tree/list" part can be shown for each rule with the expand button *and* using the completion popup of the "raw" entry
- in the "add rule" popup, the first lines allow to *append* presets to the existing rules
- the right icon of the last line show the list of the recently used collection (and replace the module)
- one can add several sort order if needed
- rule and sort blocks can be reordered by mouse if needed
- several fix / enhancement need to be done to the actual filters (rating and rejected, relative date-time, etc...)
- on preset saving, ask the user which rule/sort he want to save. So one can save "basic presets" or "filtering presets"
- for default rules, I would propose to have "folder -all- + rating -all-" so that would improve discoverability and we are 1:1 to the actual situation, with the "filter bar" content inside the collect module with as few clicks needed to change them

###  Question :
the main one : Do we need this ? (I'm convinced we do, but I'm not alone here !)

### about this PR
Be careful : the PR content is far from finish, only the basics is functional (but buggy)... No need to point bugs or whatever at the moment ! (there would be too many)
This is a huge task. Once we agree (or not) with the main things, I will accept gracefully if some of you want to help me, esp. for the "friendly widgets" part !