### PR TITLE
Fix variable expansion for import path in Windows

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -114,17 +114,9 @@ static gchar *_import_session_path_pattern()
 #ifdef WIN32
   gchar *s1 = dt_str_replace(base, "/", "\\\\");
   gchar *s2 = dt_str_replace(sub, "/", "\\\\");
-  gchar *s1d = g_ascii_strdown(s1, -1);
-  if(s1d && (strlen(s1d) > 1))
-  {
-    const char first = g_ascii_toupper(s1d[0]);
-    if(first >= 'A' && first <= 'Z' && s1d[1] == ':') // path format is <drive letter>:\path\to\file
-      s1d[0] = first;                                 // drive letter in uppercase looks nicer
-  }
-  res = g_build_path("\\\\", s1d, s2, (char *)NULL);
+  res = g_build_path("\\\\", s1, s2, (char *)NULL);
   g_free(s1);
   g_free(s2);
-  g_free(s1d);
 #else
   res = g_build_path(G_DIR_SEPARATOR_S, base, sub, (char *)NULL);
 #endif
@@ -328,8 +320,23 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
     return NULL;
   }
 
-  char *new_path = dt_variables_expand(self->vp, pattern, FALSE);
+
+#ifdef WIN32
+  gchar *s1 = dt_variables_expand(self->vp, pattern, FALSE);
+  gchar *new_path = g_ascii_strdown(s1, -1);
+  if(new_path && (strlen(new_path) > 1))
+  {
+    const char first = g_ascii_toupper(new_path[0]);
+    if(first >= 'A' && first <= 'Z' && new_path[1] == ':') // path format is <drive letter>:\path\to\file
+      new_path[0] = first;                                 // drive letter in uppercase looks nicer
+  g_free(s1);
+  }
+#else 
+  gchar *new_path = dt_variables_expand(self->vp, pattern, FALSE);
+#endif
+
   g_free(pattern);
+
 
   /* did the session path change ? */
   if(self->current_path && strcmp(self->current_path, new_path) == 0)


### PR DESCRIPTION
This PR fixes #10731, which is an unwanted side effect of #10246.
In fact, import paths in Windows need to be standardized when coming to upper/lower case, to avoid that DT interpretes the same folder in file system as different film rolls.
For example `C:\Photos`, `c:\photos`, `C:\photos` are the same thing in Windows, and the corresponding film roll must be the same.
In #10246 the normalization is implemented by putting the path in lowercase, except for the drive letter in uppercase.
However it is done before variable expansion, whith the result to lowercase the variable names too and then the expansion doesn't work correctly, as reportes in the linked issue.
The PR moves the normalization after variable expansion.
