### PR TITLE
Selecting a range with Shift-Mouseclick requires a starting point

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -279,6 +279,9 @@ void dt_selection_select_range(dt_selection_t *selection, uint32_t imgid)
 {
   if(!selection->collection) return;
 
+  // selecting a range requires at least one image to be selected already
+  if(!dt_collection_get_selected_count(darktable.collection)) return;
+
   /* get start and end rows for range selection */
   sqlite3_stmt *stmt;
   int rc = 0;


### PR DESCRIPTION
A user is expected to select one picture and then to shift-click another one to select all images in between. 
If the user removes his selection via Ctrl-Shift-A and then does a shift-click - there is no starting point for the range and the call should fail.

The old behavior of DT was to use the last selected picture (which is no longer selected) as starting point. This commit fixes this behavior.