### PR TITLE
Only toggle colorlabel if all images have the label

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -137,9 +137,9 @@ static void _colorlabels_execute(const GList *imgs, const int labels, GList **un
   if(action == DT_CA_TOGGLE)
   {
     // if we are supposed to toggle color labels, first check if all images have that label
-    for(const GList *images = imgs; images; images = g_list_next((GList *)images))
+    for(const GList *image = imgs; image; image = g_list_next((GList *)image))
     {
-      const int image_id = GPOINTER_TO_INT(images->data);
+      const int image_id = GPOINTER_TO_INT(image->data);
       const uint8_t before = dt_colorlabels_get_labels(image_id);
 
       // as long as a single image does not have the label we do not toggle the label for all images
@@ -155,9 +155,9 @@ static void _colorlabels_execute(const GList *imgs, const int labels, GList **un
 
 
 
-  for(const GList *images = imgs; images; images = g_list_next((GList *)images))
+  for(const GList *image = imgs; image; image = g_list_next((GList *)image))
   {
-    const int image_id = GPOINTER_TO_INT(images->data);
+    const int image_id = GPOINTER_TO_INT(image->data);
     const uint8_t before = dt_colorlabels_get_labels(image_id);
     uint8_t after = 0;
     switch(action)

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -132,8 +132,29 @@ typedef enum dt_colorlabels_actions_t
 
 
 
-static void _colorlabels_execute(const GList *imgs, const int labels, GList **undo, const gboolean undo_on, const int action)
+static void _colorlabels_execute(const GList *imgs, const int labels, GList **undo, const gboolean undo_on, int action)
 {
+  if(action == DT_CA_TOGGLE)
+  {
+    // if we are supposed to toggle color labels, first check if all images have that label
+    for(const GList *images = imgs; images; images = g_list_next((GList *)images))
+    {
+      const int image_id = GPOINTER_TO_INT(images->data);
+      const uint8_t before = dt_colorlabels_get_labels(image_id);
+
+      // as long as a single image does not have the label we do not toggle the label for all images
+      // but add the label to all unlabeled images first
+      if(!(before & labels))
+      {
+        action = DT_CA_ADD;
+        break;
+      }
+    }
+  }
+
+
+
+
   for(const GList *images = imgs; images; images = g_list_next((GList *)images))
   {
     const int image_id = GPOINTER_TO_INT(images->data);


### PR DESCRIPTION
This addresses #10734
Currently setting a colorlabel via F1 inverts the red colorlabel on all images in the selection. 

This can remove the label from images by accident if the user does not realize that he had applied that label before to some of the images.

The code change checks all images for the existence of the label and changes the action from TOGGLE to ADD if at least one image does not have the color label. Therefore color labels will only be removed if all images have the color label.