### PR TITLE
tags presets: append preset's tags instead of replacing.

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -981,23 +981,14 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
         entry++;
       }
       g_strfreev(tokens);
-      GList *tags_r = dt_tag_get_tags(-1, TRUE);
       GList *imgs = dt_act_on_get_images(FALSE, FALSE, FALSE);
-      dt_tag_set_tags(tags, imgs, TRUE, TRUE, TRUE);
+      dt_tag_set_tags(tags, imgs, TRUE, FALSE, TRUE);
       g_list_free(imgs);
       gboolean change = FALSE;
       for(GList *tag = tags; tag; tag = g_list_next(tag))
       {
         _update_attached_count(GPOINTER_TO_INT(tag->data), d->dictionary_view, d->tree_flag);
         change = TRUE;
-      }
-      for(GList *tag = tags_r; tag; tag = g_list_next(tag))
-      {
-        if(!g_list_find(tags, tag->data))
-        {
-          _update_attached_count(GPOINTER_TO_INT(tag->data), d->dictionary_view, d->tree_flag);
-          change = TRUE;
-        }
       }
 
       if(change)
@@ -1007,7 +998,6 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
         dt_image_synch_xmp(-1);
       }
       g_list_free(tags);
-      g_list_free(tags_r);
     }
   }
   return 0;


### PR DESCRIPTION
fixes #10741

reverts a change made in #7993. 
I agree that the behavior requested in #10741 is more useful.
Should not impact first import as there there is no previous tag. 
The only consequence is for re-import with the intention to restart on tags presets state. But is that a meaningful use case ?

