### PR TITLE
Add support for IPAPGothic font (Update darktable-elegant-darker.css)

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -74,9 +74,9 @@ box *
     font-family: "Roboto Light", "Roboto",                  /* best case scenario */
                  "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
                  "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
-                 "Ubuntu Light", "Ubuntu",                  /* Ubuntu default */
+                 "Ubuntu Light", "Ubuntu", "IPAPGothic",    /* Ubuntu default */
                  "Cantarell",                               /* Gnome default */
-                 sans-serif;                                /* default default */
+                  sans-serif;                                /* default default */
 }
 
 button,
@@ -86,7 +86,7 @@ button,
     font-family: "Roboto Medium", "Roboto",
                  "Segoe UI Semibold", "Segoe UI",
                  "SF Pro Display Medium", "SF Pro Display",
-                 "Ubuntu Medium", "Ubuntu",
+                 "Ubuntu Medium", "Ubuntu", "IPAPGothic",
                  "Cantarell",
                   sans-serif;
 }
@@ -97,9 +97,9 @@ button,
     font-family: "Roboto Condensed", "Roboto",
                  "Segoe UI Condensed", "Segoe UI",
                  "SF Pro Display", "SF Pro Display",
-                 "Ubuntu Condensed", "Ubuntu",
+                 "Ubuntu Condensed", "Ubuntu", "IPAPGothic",
                  "Cantarell",
-                 sans-serif;
+                  sans-serif;
 }
 
 notebook tabs,
@@ -111,7 +111,7 @@ tooltip label,
     font-family: "Roboto",
                  "Segoe UI",
                  "SF Pro Text",
-                 "Ubuntu",
+                 "Ubuntu", "IPAPGothic",
                  "Cantarell",
                   sans-serif;
 }

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -295,7 +295,7 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(language_callback), 0);
   gtk_widget_set_tooltip_text(labelev,  _("double click to reset to the system language"));
   gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);
-  gtk_widget_set_tooltip_text(widget, _("set the language of the user interface. the system default is marked with an *. User of the Japanese interface on Linux is adviced to install IPAPGothic font (needs a restart)"));
+  gtk_widget_set_tooltip_text(widget, _("set the language of the user interface. the system default is marked with an * (needs a restart)"));
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_language_widget), (gpointer)widget);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -295,7 +295,7 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(language_callback), 0);
   gtk_widget_set_tooltip_text(labelev,  _("double click to reset to the system language"));
   gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);
-  gtk_widget_set_tooltip_text(widget, _("set the language of the user interface. the system default is marked with an * (needs a restart)"));
+  gtk_widget_set_tooltip_text(widget, _("set the language of the user interface. the system default is marked with an *. User of the Japanese interface on Linux is adviced to install IPAPGothic font (needs a restart)"));
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_language_widget), (gpointer)widget);


### PR DESCRIPTION
This PR is intended to offer a solution for some practical problems caused by the Japanese font which darktable is currently using on Linux.

**What are the problems?**

(Following problems occur only on Linux systems.)

1. In the Japanese interface, some lines (e.g. module names, descriptions) are not fully displayed when the font size is set to a reasonable value, that is, not too small and Japapese letters and Latin letters are somewhat balanced. When the font size is set for Japanese letters and every item is fully displayed, Latin letters are so small that they are illegible and some sliders overlap their description.

2.  When a message in two lines is displayed in the top panel, for example when the mouse cursor is on a mask, the top panel expands and the panels below, among which is the central image view, shrink or, in the other word, move. It makes some opearations such as refinement of a drawn mask difficult and frustrating.

These problems have been reported with screenshots on pixls.us. See https://discuss.pixls.us/t/feature-request-for-changing-fonts/28549 (post #3 and #10) for details.

**Why do the problems occur?**

Short answer: because the Japanese font which darktable is currently using on Linux is a non-proportional font and is bigger than that of Western characters.

Long answer: the file “darktable-elegant-darker.css” defines which fonts darktable utilizes. According to it, darktable currently prefers to use Roboto fonts, Ubuntu fonts, or Cantarell font on Linux. But they do not cover non Western characters. Therefore darktable adopts a system sans-serif font for Japanese letters while one of the three fonts mentioned above for Western characters.
On some Linux systems, the default system sans-serif font, for example Noto sasns CJK font on Ubuntu, is a non-proportional font and is significantly bigger than the fonts which darktable is using for Western characters for which the interface of darktable is optimized. It causes the problems reported above.

**How can the problems be solved?**

By modifying the file “darktable-elegant-darker.css” to enable IPAPGothic font to be utilized in darktable on Linux systems. 
The IPA font is a propotional font and covers both Japanese letters and Western characters.  The font, which is produced by the Japanese government, is sellected because it is widely used, free to use, and easily available on Linux systems.


**Notes**

To utilize IPAPGothic font, the user needs to...

1. install IPAPGothic font himself on most Linux systems, because the font is, just like any other proportional fonts, not pre-installed.

2. use a interface theme other than “darktable” or the “darktable-icons”, because the font is not applied with them.

When the user does not install IPAPGothic font, darktable uses Roboto fonts, Ubuntu fonts, or Cantarell font for what they cover and a system sans-serif font for Japanese letters on Linux, which means that the new feature has no effect.