### PR TITLE
print: setup of paper/medium on printer change

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -710,72 +710,31 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   dt_conf_set_string("plugins/print/print/printer", printer_name);
 
-  const char *default_paper = dt_conf_get_string_const("plugins/print/print/paper");
-
-  // next add corresponding papers
-
-  // first clear current list
-
+  // add papers for the given printer
   dt_bauhaus_combobox_clear(ps->papers);
-
-  // then add papers for the given printer
-
   if(ps->paper_list) g_list_free_full(ps->paper_list, free);
-
   ps->paper_list = dt_get_papers (&ps->prt.printer);
-  int np = 0;
-  gboolean ispaperset = FALSE;
-
   for(const GList *papers = ps->paper_list; papers; papers = g_list_next (papers))
   {
     const dt_paper_info_t *p = (dt_paper_info_t *)papers->data;
     dt_bauhaus_combobox_add(ps->papers, p->common_name);
-
-    if(ispaperset == FALSE && (!g_strcmp0(default_paper, p->common_name) || default_paper[0] == '\0'))
-    {
-      dt_bauhaus_combobox_set(ps->papers, np);
-      ispaperset = TRUE;
-    }
-
-    np++;
   }
+  const char *default_paper = dt_conf_get_string_const("plugins/print/print/paper");
+  if(!dt_bauhaus_combobox_set_from_text(ps->papers, default_paper))
+    dt_bauhaus_combobox_set(ps->papers, 0);
 
-  //  paper not found in this printer
-  if(!ispaperset) dt_bauhaus_combobox_set(ps->papers, 0);
-
-  // next add corresponding supported media
-
-  const char *default_medium = dt_conf_get_string_const("plugins/print/print/medium");
-
-  // first clear current list
-
+  // add corresponding supported media
   dt_bauhaus_combobox_clear(ps->media);
-
-  // then add papers for the given printer
-
   if(ps->media_list) g_list_free_full(ps->media_list, free);
-
-  ps->media_list = dt_get_media_type (&ps->prt.printer);
-  gboolean ismediaset = FALSE;
-
-  np = 0;
-
+  ps->media_list = dt_get_media_type(&ps->prt.printer);
   for(const GList *media = ps->media_list; media; media = g_list_next (media))
   {
     const dt_medium_info_t *m = (dt_medium_info_t *)media->data;
     dt_bauhaus_combobox_add(ps->media, m->common_name);
-
-    if(ismediaset == FALSE && (!g_strcmp0(default_medium, m->common_name) || default_medium[0] == '\0'))
-    {
-      dt_bauhaus_combobox_set(ps->media, np);
-      ismediaset = TRUE;
-    }
-
-    np++;
   }
-
-  //  media not found in this printer
-  if(!ismediaset) dt_bauhaus_combobox_set(ps->media, 0);
+  const char *default_medium = dt_conf_get_string_const("plugins/print/print/medium");
+  if(!dt_bauhaus_combobox_set_from_text(ps->media, default_medium))
+    dt_bauhaus_combobox_set(ps->media, 0);
 
   dt_view_print_settings(darktable.view_manager, &ps->prt, &ps->imgs);
 }

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -743,11 +743,6 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
   //  paper not found in this printer
   if(!ispaperset) dt_bauhaus_combobox_set(ps->papers, 0);
 
-  const dt_paper_info_t *paper = dt_get_paper(ps->paper_list, default_paper);
-
-  if(paper)
-    memcpy(&ps->prt.paper, paper, sizeof(dt_paper_info_t));
-
   // next add corresponding supported media
 
   const char *default_medium = dt_conf_get_string_const("plugins/print/print/medium");
@@ -781,11 +776,6 @@ static void _set_printer(const dt_lib_module_t *self, const char *printer_name)
 
   //  media not found in this printer
   if(!ismediaset) dt_bauhaus_combobox_set(ps->media, 0);
-
-  const dt_medium_info_t *medium = dt_get_medium(ps->media_list, default_medium);
-
-  if(medium)
-    memcpy(&ps->prt.medium, medium, sizeof(dt_medium_info_t));
 
   dt_view_print_settings(darktable.view_manager, &ps->prt, &ps->imgs);
 }


### PR DESCRIPTION
This simplifies code and may well fix #10781 (I can no longer reproduce it with this PR).

Changes:
1. As setting the combobox for paper/media already does appropriate internal setup via callbacks, don't duplicate this code in printer setup.
2. As the paper/media conf string value returned by `dt_conf_get_string_const()` is trashed once it is set in the combobox change callbacks, the code removed in 1) at the least does nothing useful, and at worst may have produced bad memory access.
3. Take advantage of bauhaus to set the paper/media from conf strings, simplifying combobox setup code.

