### PR TITLE
Rework tagging

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2756,7 +2756,7 @@ static gboolean _on_dict_treeview_key_press( GtkWidget *widget, GdkEventKey even
     case GDK_KEY_Return:
     case GDK_KEY_KP_Enter:
       _attach_selected_tag( dt_lib_module, d );
-      if( ! event.state & GDK_SHIFT_MASK ) 
+      if( ! ( event.state & GDK_SHIFT_MASK ) )
       {
         gtk_tree_selection_unselect_all( gtk_tree_view_get_selection( d->dictionary_view ) );
         gtk_entry_set_text( d->entry, "" );


### PR DESCRIPTION
Hi to everyone,

I tried to improve the keyboard handling in the tagging module a bit. It's not completed by now but I'd like have your feedback if I'm on the right way or better stop continuing...

Maybe merging to master is not so good at this point, but I don't have an other target branch... Therefore it's a draft PR.

My ideas about the workflow:

- When finished: Hitting Ctrl-T opens the tagging side panel and sets the focus to the entry field (not implemented yet because this should only be done when the panel is available and I don't now yet how to open it ....). Currently you have to click the entry field like before.
- start typing a tag name, the dictionary tree or list (mode doesn't matter) will be filtered according to the entry
- with arrow down you can switch the focus to the dictionary and select the tag
- hitting enter/return there will attach the tag and jump back to the entry field which is cleared and ready for the next tag
- hitting shift-enter in the dictionary will add the tag but leave the focus in the dictionary to select another tag
- hitting escape in the dictionary will set the focus back to the entry field without attaching the tag.
- from the tag entry, the arrow up moves the focus to the list of attached tags
- here you can hit delete key to detach the selected (currently also the internal ones..., todo is in the comments)
- hitting escape in the attached list moves the focus back to the entry field
- when detatching the last tag from the list of attached ones the focus is also set back to the entry field.

What also needs to be done: Disable the built-in search in the tree view.

With this modifications I can really add a lot of tags to the images quite quick.

Please let me know what you think about this and if it makes sense to continue the work.
