### PR TITLE
calculate dropdown natural width for filter and popovers

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -718,7 +718,6 @@ l
 
 #filter-box
 {
-  min-width: 40em;
   padding-top: 0.28em;
 }
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2099,24 +2099,23 @@ static void dt_bauhaus_get_preferred_width(GtkWidget *widget, gint *minimum_size
   {
     dt_bauhaus_combobox_data_t *d = &w->data.combobox;
 
-    int label_width, entry_width, pango_height;
-
-    PangoLayout *layout = gtk_widget_create_pango_layout(widget, w->label);
+    PangoLayout *layout = gtk_widget_create_pango_layout(widget, NULL);
     pango_layout_set_font_description(layout, darktable.bauhaus->pango_font_desc);
-    pango_layout_get_size(layout, &label_width, &pango_height);
+    int pango_width;
 
     for(GList *i = d->entries; i; i = i->next)
     {
       const dt_bauhaus_combobox_entry_t *entry = i->data;
       pango_layout_set_text(layout, entry->label, -1);
-      pango_layout_get_size(layout, &entry_width, &pango_height);
-      const gint text_width = entry_width/PANGO_SCALE;
+      pango_layout_get_size(layout, &pango_width, NULL);
 
-      if(text_width > *natural_size)
-        *natural_size = text_width;
+      if(pango_width / PANGO_SCALE > *natural_size)
+        *natural_size = pango_width / PANGO_SCALE;
     }
 
-    *natural_size += label_width/PANGO_SCALE + darktable.bauhaus->quad_width + 3 * INNER_PADDING;
+    pango_layout_set_text(layout, w->label, -1);
+    pango_layout_get_size(layout, &pango_width, NULL);
+    *natural_size += pango_width / PANGO_SCALE + darktable.bauhaus->quad_width + 3 * INNER_PADDING;
 
     g_object_unref(layout);
   }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -512,6 +512,9 @@ static void dt_bh_init(DtBauhausWidget *class)
   // TODO: the common code from bauhaus_widget_init() could go here.
 }
 
+static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf);
+static void dt_bauhaus_get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size);
+
 static void dt_bh_class_init(DtBauhausWidgetClass *class)
 {
   darktable.bauhaus->signals[DT_BAUHAUS_VALUE_CHANGED_SIGNAL]
@@ -521,10 +524,9 @@ static void dt_bh_class_init(DtBauhausWidgetClass *class)
       = g_signal_new("quad-pressed", G_TYPE_FROM_CLASS(class), G_SIGNAL_RUN_LAST, 0, NULL, NULL,
                      g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
 
-  // TODO: could init callbacks once per class for more efficiency:
-  // GtkWidgetClass *widget_class;
-  // widget_class = GTK_WIDGET_CLASS (class);
-  // widget_class->draw = dt_bauhaus_draw;
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (class);
+  widget_class->draw = dt_bauhaus_draw;
+  widget_class->get_preferred_width = dt_bauhaus_get_preferred_width;
 }
 
 void dt_bauhaus_load_theme()
@@ -701,8 +703,6 @@ static gboolean dt_bauhaus_combobox_motion_notify(GtkWidget *widget, GdkEventMot
 
 // static gboolean
 // dt_bauhaus_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
-static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data);
-
 
 // end static init/cleanup
 // =================================================
@@ -743,8 +743,6 @@ static void dt_bauhaus_widget_init(dt_bauhaus_widget_t *w, dt_iop_module_t *self
                                        | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
                                        | GDK_FOCUS_CHANGE_MASK
                                        | darktable.gui->scroll_mask);
-
-  g_signal_connect(G_OBJECT(w), "draw", G_CALLBACK(dt_bauhaus_draw), NULL);
 
   // for combobox, where mouse-release triggers a selection, we need to catch this
   // event where the mouse-press occurred, which will be this widget. we just pass
@@ -1959,7 +1957,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   return TRUE;
 }
 
-static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
+static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf)
 {
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -2092,6 +2090,36 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   gdk_rgba_free(bg_color);
 
   return TRUE;
+}
+
+static void dt_bauhaus_get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size)
+{
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type == DT_BAUHAUS_COMBOBOX)
+  {
+    dt_bauhaus_combobox_data_t *d = &w->data.combobox;
+
+    int label_width, entry_width, pango_height;
+
+    PangoLayout *layout = gtk_widget_create_pango_layout(widget, w->label);
+    pango_layout_set_font_description(layout, darktable.bauhaus->pango_font_desc);
+    pango_layout_get_size(layout, &label_width, &pango_height);
+
+    for(GList *i = d->entries; i; i = i->next)
+    {
+      const dt_bauhaus_combobox_entry_t *entry = i->data;
+      pango_layout_set_text(layout, entry->label, -1);
+      pango_layout_get_size(layout, &entry_width, &pango_height);
+      const gint text_width = entry_width/PANGO_SCALE;
+
+      if(text_width > *natural_size)
+        *natural_size = text_width;
+    }
+
+    *natural_size += label_width/PANGO_SCALE + darktable.bauhaus->quad_width + 3 * INNER_PADDING;
+
+    g_object_unref(layout);
+  }
 }
 
 void dt_bauhaus_hide_popup()

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -691,7 +691,6 @@ static void _settings_contrast_changed(GtkWidget *slider, _guides_settings_t *gw
 GtkWidget *dt_guides_popover(dt_view_t *self, GtkWidget *button)
 {
   GtkWidget *pop = gtk_popover_new(button);
-  gtk_widget_set_size_request(GTK_WIDGET(pop), 350, -1);
 
   // create a new struct for all the widgets
   _guides_settings_t *gw = (_guides_settings_t *)g_malloc0(sizeof(_guides_settings_t));

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -153,9 +153,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *dropdowns = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_name(dropdowns, "filter-box");
-  gtk_box_set_homogeneous(GTK_BOX(dropdowns), TRUE);
+  gtk_widget_set_name(self->widget, "filter-box");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
 
   GtkWidget *overlay = gtk_overlay_new();
@@ -194,7 +192,7 @@ void gui_init(dt_lib_module_t *self)
                                N_("all except rejected"));
   gtk_container_add(GTK_CONTAINER(overlay), d->filter);
 
-  gtk_box_pack_start(GTK_BOX(dropdowns), overlay, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), overlay, TRUE, TRUE, 0);
   gtk_widget_set_margin_end (overlay, 20);
 
   /* sort combobox */
@@ -203,7 +201,7 @@ void gui_init(dt_lib_module_t *self)
                                          _("determine the sort order of shown images"),
                                          _filter_get_items(sort), _lib_filter_sort_combobox_changed, self,
                                          _sort_names);
-  gtk_box_pack_start(GTK_BOX(dropdowns), d->sort, TRUE, TRUE, 2);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->sort, TRUE, TRUE, 2);
 
   /* reverse order checkbutton */
   d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
@@ -211,9 +209,7 @@ void gui_init(dt_lib_module_t *self)
   if(darktable.collection->params.descending)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
                                  CPF_DIRECTION_DOWN, NULL);
-  gtk_widget_set_halign(d->reverse, GTK_ALIGN_START);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dropdowns, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), d->reverse, FALSE, FALSE, 0);
 
   /* select the last value and connect callback */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2275,9 +2275,6 @@ void gui_init(dt_view_t *self)
   gtk_widget_set_tooltip_text(dev->second_window.button, _("display a second darkroom image window"));
   dt_view_manager_view_toolbox_add(darktable.view_manager, dev->second_window.button, DT_VIEW_DARKROOM);
 
-  const int dialog_width       = 350;
-  const int large_dialog_width = 550; // for dialog with profile names
-
   /* Enable ISO 12646-compliant colour assessment conditions */
   dev->iso_12646.button
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT, NULL);
@@ -2305,7 +2302,6 @@ void gui_init(dt_view_t *self)
     // and the popup window
     dev->rawoverexposed.floating_window = gtk_popover_new(dev->rawoverexposed.button);
     connect_button_press_release(dev->rawoverexposed.button, dev->rawoverexposed.floating_window);
-    gtk_widget_set_size_request(GTK_WIDGET(dev->rawoverexposed.floating_window), dialog_width, -1);
 
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_add(GTK_CONTAINER(dev->rawoverexposed.floating_window), vbox);
@@ -2363,7 +2359,6 @@ void gui_init(dt_view_t *self)
     // and the popup window
     dev->overexposed.floating_window = gtk_popover_new(dev->overexposed.button);
     connect_button_press_release(dev->overexposed.button, dev->overexposed.floating_window);
-    gtk_widget_set_size_request(GTK_WIDGET(dev->overexposed.floating_window), dialog_width, -1);
 
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_add(GTK_CONTAINER(dev->overexposed.floating_window), vbox);
@@ -2445,7 +2440,6 @@ void gui_init(dt_view_t *self)
     connect_button_press_release(dev->second_window.button, dev->profile.floating_window);
     connect_button_press_release(dev->profile.softproof_button, dev->profile.floating_window);
     connect_button_press_release(dev->profile.gamut_button, dev->profile.floating_window);
-    gtk_widget_set_size_request(GTK_WIDGET(dev->profile.floating_window), large_dialog_width, -1);
 
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_add(GTK_CONTAINER(dev->profile.floating_window), vbox);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1235,7 +1235,6 @@ void gui_init(dt_view_t *self)
   // and the popup window
   lib->profile_floating_window = gtk_popover_new(profile_button);
 
-  gtk_widget_set_size_request(GTK_WIDGET(lib->profile_floating_window), 550, -1);
   g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
   g_signal_connect_swapped(G_OBJECT(profile_button), "button-press-event", G_CALLBACK(gtk_widget_show_all), lib->profile_floating_window);
 


### PR DESCRIPTION
Reverts #10768 and should provide a better solution for language independently sufficiently wide combos (that don't force a minimum window size because they ellipsize if not enough space).

@phweyland I'm sorry, this will cause you another rebase I'm afraid, but hopefully a simpler one (since the extra layer of nested boxes is no longer needed and you don't need to specify a hard minimum size in CSS). Let me know if this is causing issues for you and need help/review. I'm afraid I haven't got round to looking at #10694 yet.

This PR helps with any use of bauhaus dropdowns outside of the side panels, for example in the popovers for overexposed etc buttons; hardcoded minimum popover sizes are no longer necessary and the space used changes depending on language and font size.

I've also connected the default "draw" callback for bauhaus directly to the type rather than via signals individually connected for each widget. Not sure why this wasn't done before (the correct code was commented out) so maybe I'm overlooking a problem, but it seems to work fine for me.  