### PR TITLE
Fix default blend colorspace for contrast equalizer module and dummy IOP

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -154,7 +154,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return iop_cs_rgb;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -125,7 +125,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return iop_cs_rgb;
 }
 
 // Whenever new fields are added to (or removed from) dt_iop_..._params_t or when their meaning


### PR DESCRIPTION
Fix Issue #10080:
- Set default blend mode colorspace to scene referred.
- Adjust default correspondingly in boilerplate file 'useless.c' in case future modules will be based on it