### PR TITLE
Windows translation bundling alternative

### DIFF
--- a/packaging/macosx/darktable.bundle
+++ b/packaging/macosx/darktable.bundle
@@ -27,7 +27,7 @@
   <translations name="libgphoto2-6">${prefix}/share/locale</translations>
   <translations name="gtk30">${prefix}/share/locale</translations>
   <translations name="gtk-mac-integration">${prefix}/share/locale</translations>
-  <translations name="iso_639">${prefix}/share/locale</translations>
+  <translations name="iso_639-2">${prefix}/share/locale</translations>
   <translations name="darktable">${prefix:dt}/share/locale</translations>
   <data>${prefix:dt}/share/darktable</data>
   <data>${prefix}/share/glib-2.0/schemas/org.gtk.Settings.*.gschema.xml</data>

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -145,21 +145,21 @@ static void get_language_names(GList *languages)
   // on windows we are shipping the translations of iso-codes along ours
   char localedir[PATH_MAX] = { 0 };
   dt_loc_get_localedir(localedir, sizeof(localedir));
-  bindtextdomain("iso_639", localedir);
+  bindtextdomain("iso_639-2", localedir);
 #else
 #ifdef __APPLE__
   if(res_path)
   {
     char localedir[PATH_MAX] = { 0 };
     dt_loc_get_localedir(localedir, sizeof(localedir));
-    bindtextdomain("iso_639", localedir);
+    bindtextdomain("iso_639-2", localedir);
   }
   else
 #endif
-  bindtextdomain("iso_639", ISO_CODES_LOCALEDIR);
+  bindtextdomain("iso_639-2", ISO_CODES_LOCALEDIR);
 #endif
 
-  bind_textdomain_codeset("iso_639", "UTF-8");
+  bind_textdomain_codeset("iso_639-2", "UTF-8");
 
   parser = json_parser_new();
   if(!json_parser_load_from_file(parser, filename, &error))
@@ -229,7 +229,7 @@ static void get_language_names(GList *languages)
           g_setenv("LANGUAGE", language->code, TRUE);
           setlocale (LC_ALL, language->code);
 
-          char *localized_name = g_strdup(dgettext("iso_639", name));
+          char *localized_name = g_strdup(dgettext("iso_639-2", name));
 
           /* If original and localized names are the same for other than English,
            * maybe localization failed. Try now in the main dialect. */
@@ -241,7 +241,7 @@ static void get_language_names(GList *languages)
             g_setenv("LANGUAGE", language->base_code, TRUE);
             setlocale (LC_ALL, language->base_code);
 
-            localized_name = g_strdup(dgettext("iso_639", name));
+            localized_name = g_strdup(dgettext("iso_639-2", name));
           }
 
           /*  there might be several language names; use the first one  */


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/9433 in a somewhat different way: bundles only the explicitly required translation catalogs for any locale available, thus reducing the installer size (this is the case already for macOS).

Also switch to canonical "iso_639-2" for all installers.