### PR TITLE
Initialize the max iso input field with a reasonable value

### DIFF
--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -667,7 +667,7 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
     gtk_entry_set_text(GTK_ENTRY(g->maker), "%");
     gtk_entry_set_text(GTK_ENTRY(g->lens), "%");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->iso_min), 0);
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->iso_max), FLT_MAX);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->iso_max), 3276800);
 
     float val = 0;
     int k = 0;


### PR DESCRIPTION
Although the range of values for the max ISO extends up to FLT_MAX, we are not required to set the maximum value as the initial field value. Instead, it would be logical to choose an initial value that is the maximum ISO among the existing cameras available to users (currently it is 3 276 800, the extended ISO value of Nikon D5/D6). Thus, we will initially have the full range of values possible in practice, without specifying absurdly large value in the interface.
