### PR TITLE
only send updates to active midi devices

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2731,6 +2731,8 @@ gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboo
 
 static gboolean _shortcut_match(dt_shortcut_t *f, gchar **fb_log)
 {
+  if(!darktable.view_manager->current_view) return FALSE;
+
   f->views = darktable.view_manager->current_view->view(darktable.view_manager->current_view);
   gpointer v = GINT_TO_POINTER(f->views);
 


### PR DESCRIPTION
fixes #10786

Checks (without crashing) if there is an active view when requesting updates to send to midi devices. So if sdl2 yields to the gtk idle loop during initialisation and if midi is already waiting with its first timed update, this will be handled more gracefully.

fixes #10785 

This second part is completely untested since I don't have access to midi or gamepad devices atm.

Previously, for each opened midi device all 128 possible knobs and keylights were updated a few times a second, because there is no reliable way (apart from a database or manual configuration, which haven't been implemented while waiting on demand and a sufficient sampling of device specs) to determine how many there are. Now, we wait for a knob to be turned or key to be pressed and only henceforth assume it should receive updates (and all lower numbered ones as well).

Using this approach, when switching between a view that does have keys mapped and one where they are not mapped, all lights will be switched off. The alternative approach, to only send updates to keys that have mappings, would leave on ghost lights. Also, more time would be spent searching for non-existent mappings.