### PR TITLE
improve dialog options of deletion error and bug fix

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -838,8 +838,8 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
       GTK_MESSAGE_QUESTION,
       GTK_BUTTONS_NONE,
       modal_dialog->send_to_trash
-        ? _("could not send %s to trash%s\n%s\n\n do you want to try to remove the file from disk without using trash?")
-        : _("could not remove from disk %s%s\n%s"),
+        ? _("could not send %s to trash%s\n%s\n\n do you want to physically delete the file from disk without using trash?")
+        : _("could not physically delete from disk %s%s\n%s"),
       modal_dialog->filename,
       modal_dialog->error_message != NULL ? ": " : "",
       modal_dialog->error_message != NULL ? modal_dialog->error_message : "");
@@ -849,15 +849,15 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
 
   if (modal_dialog->send_to_trash)
   {
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("yes, delete this image"), _DT_DELETE_DIALOG_CHOICE_DELETE);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("yes, delete this and subsequent images"), _DT_DELETE_DIALOG_CHOICE_DELETE_ALL);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("no, remove this image from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("yes, physically delete"), _DT_DELETE_DIALOG_CHOICE_DELETE);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("yes, physically delete this and subsequent files"), _DT_DELETE_DIALOG_CHOICE_DELETE_ALL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("no, only remove this image from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
   }
   else
   {
     gtk_dialog_add_button(GTK_DIALOG(dialog), _("remove this image from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
   }
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("skip image"), _DT_DELETE_DIALOG_CHOICE_CONTINUE);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("skip file"), _DT_DELETE_DIALOG_CHOICE_CONTINUE);
   gtk_dialog_add_button(GTK_DIALOG(dialog), _("abort process"), _DT_DELETE_DIALOG_CHOICE_STOP);
 
   gtk_window_set_title(
@@ -1625,8 +1625,8 @@ void dt_control_delete_images()
 
     dialog = gtk_message_dialog_new(
         GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        send_to_trash ? ngettext("do you really want to physically delete %d image\n(using trash if possible)?",
-                                 "do you really want to physically delete %d images\n(using trash if possible)?", number)
+        send_to_trash ? ngettext("do you really want to physically delete %d image?\n(using trash if possible)",
+                                 "do you really want to physically delete %d images?\n(using trash if possible)", number)
                       : ngettext("do you really want to physically delete %d image from disk?",
                                  "do you really want to physically delete %d images from disk?", number),
         number);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -812,9 +812,10 @@ typedef struct _dt_delete_modal_dialog_t
 enum _dt_delete_status
 {
   _DT_DELETE_STATUS_UNKNOWN = 0,
-  _DT_DELETE_STATUS_OK_TO_REMOVE = 1,
-  _DT_DELETE_STATUS_SKIP_FILE = 2,
-  _DT_DELETE_STATUS_STOP_PROCESSING = 3
+  _DT_DELETE_STATUS_DELETED = 1,
+  _DT_DELETE_STATUS_REMOVE = 2,
+  _DT_DELETE_STATUS_SKIP_FILE = 3,
+  _DT_DELETE_STATUS_STOP_PROCESSING = 4
 };
 
 enum _dt_delete_dialog_choice
@@ -837,8 +838,8 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
       GTK_MESSAGE_QUESTION,
       GTK_BUTTONS_NONE,
       modal_dialog->send_to_trash
-        ? _("could not send %s to trash%s%s")
-        : _("could not physically delete %s%s%s"),
+        ? _("could not send %s to trash%s\n%s\n\n do you want to try to remove the file from disk without using trash?")
+        : _("could not remove from disk %s%s\n%s"),
       modal_dialog->filename,
       modal_dialog->error_message != NULL ? ": " : "",
       modal_dialog->error_message != NULL ? modal_dialog->error_message : "");
@@ -848,12 +849,16 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
 
   if (modal_dialog->send_to_trash)
   {
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("physically delete"), _DT_DELETE_DIALOG_CHOICE_DELETE);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("physically delete all files"), _DT_DELETE_DIALOG_CHOICE_DELETE_ALL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("yes, delete this image"), _DT_DELETE_DIALOG_CHOICE_DELETE);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("yes, delete this and subsequent images"), _DT_DELETE_DIALOG_CHOICE_DELETE_ALL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("no, remove this image from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
   }
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("only remove from the image library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("skip to next file"), _DT_DELETE_DIALOG_CHOICE_CONTINUE);
-  gtk_dialog_add_button(GTK_DIALOG(dialog), _("stop process"), _DT_DELETE_DIALOG_CHOICE_STOP);
+  else
+  {
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("remove this image from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
+  }
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("skip image"), _DT_DELETE_DIALOG_CHOICE_CONTINUE);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("abort process"), _DT_DELETE_DIALOG_CHOICE_STOP);
 
   gtk_window_set_title(
       GTK_WINDOW(dialog),
@@ -926,7 +931,7 @@ static enum _dt_delete_status delete_file_from_disk(const char *filename, gboole
     if (delete_success
         || g_error_matches(gerror, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
     {
-      delete_status = _DT_DELETE_STATUS_OK_TO_REMOVE;
+      delete_status = _DT_DELETE_STATUS_DELETED;
     }
     else if (send_to_trash && *delete_on_trash_error)
     {
@@ -968,7 +973,8 @@ static enum _dt_delete_status delete_file_from_disk(const char *filename, gboole
       }
       else if (res == _DT_DELETE_DIALOG_CHOICE_REMOVE)
       {
-        delete_status = _DT_DELETE_STATUS_OK_TO_REMOVE;
+        // only remove the file from the database
+        delete_status = _DT_DELETE_STATUS_REMOVE;
       }
       else if (res == _DT_DELETE_DIALOG_CHOICE_CONTINUE)
       {
@@ -1019,6 +1025,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
                               "SELECT COUNT(*) FROM main.images WHERE filename IN (SELECT filename FROM "
                               "main.images WHERE id = ?1) AND film_id IN (SELECT film_id FROM main.images WHERE "
                               "id = ?1)", -1, &stmt, NULL);
+  // loop through all images to delete
   while(t)
   {
     enum _dt_delete_status delete_status = _DT_DELETE_STATUS_UNKNOWN;
@@ -1044,31 +1051,40 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
       if (dt_image_local_copy_reset(imgid))
         goto delete_next_file;
 
-      snprintf(imgidstr, sizeof(imgidstr), "%d", imgid);
-      _set_remove_flag(imgidstr);
-      dt_image_remove(imgid);
-
       // there are no further duplicates so we can remove the source data file
       delete_status = delete_file_from_disk(filename, &delete_on_trash_error);
-      if (delete_status != _DT_DELETE_STATUS_OK_TO_REMOVE)
-        goto delete_next_file;
-
-      // all sidecar files - including left-overs - can be deleted;
-      // left-overs can result when previously duplicates have been REMOVED;
-      // no need to keep them as the source data file is gone.
-
-      GList *files = dt_image_find_duplicates(filename);
-
-      for(GList *file_iter = files; file_iter; file_iter = g_list_next(file_iter))
+      if(delete_status == _DT_DELETE_STATUS_REMOVE || delete_status == _DT_DELETE_STATUS_DELETED)
       {
-        delete_status = delete_file_from_disk(file_iter->data, &delete_on_trash_error);
-        if (delete_status != _DT_DELETE_STATUS_OK_TO_REMOVE)
-          break;
-      }
+        // if the file has been deleted or should only be removed -> remove image from collection
+        snprintf(imgidstr, sizeof(imgidstr), "%d", imgid);
+        _set_remove_flag(imgidstr);
+        dt_image_remove(imgid);
 
-      g_list_free_full(files, g_free);
+        if(delete_status == _DT_DELETE_STATUS_DELETED)
+        {
+          // if image has been deleted,
+          // all sidecar files - including left-overs - can be deleted;
+          // left-overs can result when previously duplicates have been REMOVED;
+          // no need to keep them as the source data file is gone.
+
+          GList *files = dt_image_find_duplicates(filename);
+
+          for(GList *file_iter = files; file_iter; file_iter = g_list_next(file_iter))
+          {
+            delete_status = delete_file_from_disk(file_iter->data, &delete_on_trash_error);
+            if (delete_status != _DT_DELETE_STATUS_DELETED)
+              break;
+          }
+          g_list_free_full(files, g_free);
+        }
+      }
+      else
+      {
+        // no deletion nor removal from library
+        goto delete_next_file;
+      }
     }
-    else
+    else // duplicates exist
     {
       // don't remove the actual source data if there are further duplicates using it;
       // just delete the xmp file of the duplicate selected.


### PR DESCRIPTION
This PR addresses #8862 which is about unclear instructions and accidental removal of an image from the image library in case the deletion of a file fails.
To reproduce, remove write access to some images:
```
# chown root:root *
# chmod 644 *
```
and try to send the some images to trash. The deletion will fail - if you chose to abort or skip, the first image of your selection will be removed from the collection!

Bugfix: I moved the lines of code that remove the image from the library a little bit further back so that it will only be done if the deletion was successful. It is now possible to abort the process and all images remain in the collection.

Dialog change:
I tried to be more explicit what options are available to the user. Before, it was unclear that DT tries to delete the image a second time (this time without using trash). I hope the other changes make the process more transparent.

**Bonus question:**
If the deletion of a file fails and the user choses the option "remove image from library", should DT try to remove the xmp files? Currently, it does exactly that but I think the xmp files should remain since the image file also remains on disk.