### PR TITLE
Consistent uppercase enum naming in imageop.h and color_conversion.h

### DIFF
--- a/data/kernels/color_conversion.h
+++ b/data/kernels/color_conversion.h
@@ -22,13 +22,13 @@
 // must be in synch with dt_iop_colorspace_type_t in imageop.h
 typedef enum dt_iop_colorspace_type_t
 {
-  iop_cs_NONE = -1,
-  iop_cs_RAW = 0,
-  iop_cs_Lab = 1,
-  iop_cs_rgb = 2,
-  iop_cs_LCh = 3,
-  iop_cs_HSL = 4,
-  iop_cs_JzCzhz = 5,
+  IOP_CS_NONE = -1,
+  IOP_CS_RAW = 0,
+  IOP_CS_LAB = 1,
+  IOP_CS_RGB = 2,
+  IOP_CS_LCH = 3,
+  IOP_CS_HSL = 4,
+  IOP_CS_JZCZHZ = 5,
 } dt_iop_colorspace_type_t;
 
 // must be in synch with dt_colorspaces_iccprofile_info_cl_t

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -150,7 +150,7 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *const dsc, co
   const float w = 1.0f / (float)size;
 
   // code path for small region, especially for color picker point mode
-  if(cst_to == iop_cs_LCh)
+  if(cst_to == IOP_CS_LCH)
   {
     for(size_t j = box[1]; j < box[3]; j++)
     {
@@ -158,7 +158,7 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *const dsc, co
       _color_picker_lch(picked_color, picked_color_min, picked_color_max, pixel + offset, w, stride);
     }
   }
-  else if(cst_to == iop_cs_HSL)
+  else if(cst_to == IOP_CS_HSL)
   {
     for(size_t j = box[1]; j < box[3]; j++)
     {
@@ -166,7 +166,7 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *const dsc, co
       _color_picker_hsl(picked_color, picked_color_min, picked_color_max, pixel + offset, w, stride);
     }
   }
-  else if(cst_to == iop_cs_JzCzhz)
+  else if(cst_to == IOP_CS_JZCZHZ)
   {
     for(size_t j = box[1]; j < box[3]; j++)
     {
@@ -213,7 +213,7 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const ds
     mmax[n] = -INFINITY;
   }
 
-  if(cst_to == iop_cs_LCh)
+  if(cst_to == IOP_CS_LCH)
   {
 #ifdef _OPENMP
 #pragma omp parallel default(none) \
@@ -234,7 +234,7 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const ds
       }
     }
   }
-  else if(cst_to == iop_cs_HSL)
+  else if(cst_to == IOP_CS_HSL)
   {
 #ifdef _OPENMP
 #pragma omp parallel default(none) \
@@ -255,7 +255,7 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *const ds
       }
     }
   }
-  else if(cst_to == iop_cs_JzCzhz)
+  else if(cst_to == IOP_CS_JZCZHZ)
   {
 #ifdef _OPENMP
 #pragma omp parallel default(none) \
@@ -594,11 +594,11 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const p
                             const dt_iop_colorspace_type_t picker_cst,
                             const dt_iop_order_iccprofile_info_t *const profile)
 {
-  if((dsc->channels == 4u) && ((image_cst == picker_cst) || (picker_cst == iop_cs_NONE)))
+  if((dsc->channels == 4u) && ((image_cst == picker_cst) || (picker_cst == IOP_CS_NONE)))
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);
-  else if(dsc->channels == 4u && image_cst == iop_cs_Lab && picker_cst == iop_cs_LCh)
+  else if(dsc->channels == 4u && image_cst == IOP_CS_LAB && picker_cst == IOP_CS_LCH)
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);
-  else if(dsc->channels == 4u && image_cst == iop_cs_rgb && (picker_cst == iop_cs_HSL || picker_cst == iop_cs_JzCzhz))
+  else if(dsc->channels == 4u && image_cst == IOP_CS_RGB && (picker_cst == IOP_CS_HSL || picker_cst == IOP_CS_JZCZHZ))
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);
   else if(dsc->channels == 4u) // This is a fallback, better than crashing as happens with monochromes
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst, profile);

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -369,12 +369,12 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
 {
   switch(cst)
   {
-    case iop_cs_RAW:
+    case IOP_CS_RAW:
       dt_histogram_worker(histogram_params, histogram_stats, pixel, histogram, histogram_helper_cs_RAW, profile_info);
       histogram_stats->ch = 1u;
       break;
 
-    case iop_cs_rgb:
+    case IOP_CS_RGB:
       if(compensate_middle_grey && profile_info)
         dt_histogram_worker(histogram_params, histogram_stats, pixel, histogram, histogram_helper_cs_rgb_compensated, profile_info);
       else
@@ -382,9 +382,9 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
       histogram_stats->ch = 3u;
       break;
 
-    case iop_cs_Lab:
+    case IOP_CS_LAB:
     default:
-      if(cst_to != iop_cs_LCh)
+      if(cst_to != IOP_CS_LCH)
         dt_histogram_worker(histogram_params, histogram_stats, pixel, histogram, histogram_helper_cs_Lab, profile_info);
       else
         dt_histogram_worker(histogram_params, histogram_stats, pixel, histogram, histogram_helper_cs_Lab_LCh, profile_info);
@@ -402,12 +402,12 @@ void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_sta
   uint32_t *hist = *histogram;
   switch(cst)
   {
-    case iop_cs_RAW:
+    case IOP_CS_RAW:
       for(int k = 0; k < 4 * histogram_stats->bins_count; k += 4)
         histogram_max[0] = histogram_max[0] > hist[k] ? histogram_max[0] : hist[k];
       break;
 
-    case iop_cs_rgb:
+    case IOP_CS_RGB:
       // don't count <= 0 pixels
       for(int k = 4; k < 4 * histogram_stats->bins_count; k += 4)
         histogram_max[0] = histogram_max[0] > hist[k] ? histogram_max[0] : hist[k];
@@ -419,9 +419,9 @@ void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_sta
         histogram_max[3] = histogram_max[3] > hist[k] ? histogram_max[3] : hist[k];
       break;
 
-    case iop_cs_Lab:
+    case IOP_CS_LAB:
     default:
-      if(cst_to == iop_cs_LCh)
+      if(cst_to == IOP_CS_LCH)
       {
         // don't count <= 0 pixels
         for(int k = 4; k < 4 * histogram_stats->bins_count; k += 4)

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -125,7 +125,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
     {
       img->buf_dsc.channels = 4;
       img->buf_dsc.datatype = TYPE_FLOAT;
-      img->buf_dsc.cst = iop_cs_rgb;
+      img->buf_dsc.cst = IOP_CS_RGB;
     }
     else if(img->flags & DT_IMAGE_HDR)
     {
@@ -133,13 +133,13 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
       {
         img->buf_dsc.channels = 1;
         img->buf_dsc.datatype = TYPE_FLOAT;
-        img->buf_dsc.cst = iop_cs_RAW;
+        img->buf_dsc.cst = IOP_CS_RAW;
       }
       else
       {
         img->buf_dsc.channels = 4;
         img->buf_dsc.datatype = TYPE_FLOAT;
-        img->buf_dsc.cst = iop_cs_rgb;
+        img->buf_dsc.cst = IOP_CS_RGB;
       }
     }
     else
@@ -147,7 +147,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
       // raw
       img->buf_dsc.channels = 1;
       img->buf_dsc.datatype = TYPE_UINT16;
-      img->buf_dsc.cst = iop_cs_RAW;
+      img->buf_dsc.cst = IOP_CS_RAW;
     }
   }
   else

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -393,7 +393,7 @@ dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, d
   // needed to alloc correct buffer size:
   img->buf_dsc.channels = 4;
   img->buf_dsc.datatype = TYPE_FLOAT;
-  img->buf_dsc.cst = iop_cs_rgb;
+  img->buf_dsc.cst = IOP_CS_RGB;
   dt_imageio_retval_t ret;
   dt_image_loader_t loader;
 #ifdef HAVE_OPENEXR
@@ -567,7 +567,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_jpeg(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->buf_dsc.cst = iop_cs_rgb; // jpeg is always RGB
+    img->buf_dsc.cst = IOP_CS_RGB; // jpeg is always RGB
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_S_RAW;
@@ -592,7 +592,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_png(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->buf_dsc.cst = iop_cs_rgb; // png is always RGB
+    img->buf_dsc.cst = IOP_CS_RGB; // png is always RGB
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_S_RAW;
@@ -606,7 +606,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_j2k(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->buf_dsc.cst = iop_cs_rgb; // j2k is always RGB
+    img->buf_dsc.cst = IOP_CS_RGB; // j2k is always RGB
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
@@ -620,7 +620,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_pnm(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->buf_dsc.cst = iop_cs_rgb; // pnm is always RGB
+    img->buf_dsc.cst = IOP_CS_RGB; // pnm is always RGB
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_S_RAW;
@@ -1146,7 +1146,7 @@ dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename
   dt_imageio_retval_t ret = dt_imageio_open_gm(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->buf_dsc.cst = iop_cs_rgb;
+    img->buf_dsc.cst = IOP_CS_RGB;
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_S_RAW;

--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -91,7 +91,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
 
   img->buf_dsc.channels = 4;
   img->buf_dsc.datatype = TYPE_FLOAT;
-  img->buf_dsc.cst = iop_cs_rgb;
+  img->buf_dsc.cst = IOP_CS_RGB;
 
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(mipbuf == NULL)

--- a/src/common/imageio_heif.c
+++ b/src/common/imageio_heif.c
@@ -118,7 +118,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
 
   img->buf_dsc.channels = 4;
   img->buf_dsc.datatype = TYPE_FLOAT;
-  img->buf_dsc.cst = iop_cs_rgb;
+  img->buf_dsc.cst = IOP_CS_RGB;
 
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(mipbuf == NULL)

--- a/src/common/imageio_libraw.c
+++ b/src/common/imageio_libraw.c
@@ -291,7 +291,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename
   img->buf_dsc.channels = 1;
 
   img->buf_dsc.datatype = TYPE_UINT16;
-  img->buf_dsc.cst = iop_cs_RAW;
+  img->buf_dsc.cst = IOP_CS_RAW;
 
   // Allocate and copy image from libraw buffer to dt
   void *buf = dt_mipmap_cache_alloc(mbuf, img);

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -359,7 +359,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     // if buf is NULL, we quit the fct here
     if(!mbuf)
     {
-      img->buf_dsc.cst = iop_cs_RAW;
+      img->buf_dsc.cst = IOP_CS_RAW;
       img->loader = LOADER_RAWSPEED;
       return DT_IMAGEIO_OK;
     }
@@ -409,7 +409,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
-  img->buf_dsc.cst = iop_cs_RAW;
+  img->buf_dsc.cst = IOP_CS_RAW;
   img->loader = LOADER_RAWSPEED;
 
   return DT_IMAGEIO_OK;
@@ -437,7 +437,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
   // if buf is NULL, we quit the fct here
   if(!mbuf)
   {
-    img->buf_dsc.cst = iop_cs_RAW;
+    img->buf_dsc.cst = IOP_CS_RAW;
     img->loader = LOADER_RAWSPEED;
     return DT_IMAGEIO_OK;
   }
@@ -540,7 +540,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
     }
   }
 
-  img->buf_dsc.cst = iop_cs_RAW;
+  img->buf_dsc.cst = IOP_CS_RAW;
   img->loader = LOADER_RAWSPEED;
 
   //  Check if the camera is missing samples

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -413,7 +413,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
 
   t.image->buf_dsc.channels = 4;
   t.image->buf_dsc.datatype = TYPE_FLOAT;
-  t.image->buf_dsc.cst = iop_cs_rgb;
+  t.image->buf_dsc.cst = IOP_CS_RGB;
 
   t.mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, t.image);
   if(!t.mipbuf)
@@ -448,12 +448,12 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   if((photometric == PHOTOMETRIC_CIELAB || photometric == PHOTOMETRIC_ICCLAB) && t.bpp == 8 && t.sampleformat == SAMPLEFORMAT_UINT)
   {
     ok = _read_chunky_8_Lab(&t, photometric);
-    t.image->buf_dsc.cst = iop_cs_Lab;
+    t.image->buf_dsc.cst = IOP_CS_LAB;
   }
   else if((photometric == PHOTOMETRIC_CIELAB || photometric == PHOTOMETRIC_ICCLAB) && t.bpp == 16 && t.sampleformat == SAMPLEFORMAT_UINT)
   {
     ok = _read_chunky_16_Lab(&t, photometric);
-    t.image->buf_dsc.cst = iop_cs_Lab;
+    t.image->buf_dsc.cst = IOP_CS_LAB;
   }
   else if(t.bpp == 8 && t.sampleformat == SAMPLEFORMAT_UINT)
     ok = _read_chunky_8(&t);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -265,14 +265,14 @@ static void _transform_lcms2(struct dt_iop_module_t *self, const float *const im
 
   *converted_cst = cst_to;
 
-  if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
+  if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_LAB)
   {
     dt_print(DT_DEBUG_DEV,
              "[_transform_lcms2] transfoming from RGB to Lab (%s %s)\n", self->op, self->multi_name);
     _transform_from_to_rgb_lab_lcms2(image_in, image_out, width, height, profile_info->type,
                                      profile_info->filename, profile_info->intent, 1);
   }
-  else if(cst_from == iop_cs_Lab && cst_to == iop_cs_rgb)
+  else if(cst_from == IOP_CS_LAB && cst_to == IOP_CS_RGB)
   {
     dt_print(DT_DEBUG_DEV,
              "[_transform_lcms2] transfoming from Lab to RGB (%s %s)\n", self->op, self->multi_name);
@@ -580,11 +580,11 @@ static inline void _transform_matrix(struct dt_iop_module_t *self,
 
   *converted_cst = cst_to;
 
-  if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
+  if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_LAB)
   {
     _transform_rgb_to_lab_matrix(image_in, image_out, width, height, profile_info);
   }
-  else if(cst_from == iop_cs_Lab && cst_to == iop_cs_rgb)
+  else if(cst_from == IOP_CS_LAB && cst_to == IOP_CS_RGB)
   {
     _transform_lab_to_rgb_matrix(image_in, image_out, width, height, profile_info);
   }
@@ -1085,7 +1085,7 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
     {
       dt_get_times(&end_time);
       fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n",
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
+          (cst_from == IOP_CS_RGB) ? "RGB": "Lab", (cst_to == IOP_CS_RGB) ? "RGB": "Lab",
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -1097,7 +1097,7 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
     {
       dt_get_times(&end_time);
       fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n",
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
+          (cst_from == IOP_CS_RGB) ? "RGB": "Lab", (cst_to == IOP_CS_RGB) ? "RGB": "Lab",
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -1336,11 +1336,11 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
 
-    if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
+    if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_LAB)
     {
       kernel_transform = darktable.opencl->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_lab;
     }
-    else if(cst_from == iop_cs_Lab && cst_to == iop_cs_rgb)
+    else if(cst_from == IOP_CS_LAB && cst_to == IOP_CS_RGB)
     {
       kernel_transform = darktable.opencl->colorspaces->kernel_colorspaces_transform_lab_to_rgb_matrix;
     }
@@ -1414,7 +1414,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     {
       dt_get_times(&end_time);
       fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n",
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
+          (cst_from == IOP_CS_RGB) ? "RGB": "Lab", (cst_to == IOP_CS_RGB) ? "RGB": "Lab",
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -67,16 +67,16 @@ static inline dt_develop_blend_colorspace_t _blend_default_module_blend_colorspa
   {
     switch(module->blend_colorspace(module, NULL, NULL))
     {
-      case iop_cs_RAW:
+      case IOP_CS_RAW:
         return DEVELOP_BLEND_CS_RAW;
-      case iop_cs_Lab:
-      case iop_cs_LCh:
+      case IOP_CS_LAB:
+      case IOP_CS_LCH:
         return DEVELOP_BLEND_CS_LAB;
-      case iop_cs_rgb:
+      case IOP_CS_RGB:
         return is_scene_referred ? DEVELOP_BLEND_CS_RGB_SCENE : DEVELOP_BLEND_CS_RGB_DISPLAY;
-      case iop_cs_HSL:
+      case IOP_CS_HSL:
         return DEVELOP_BLEND_CS_RGB_DISPLAY;
-      case iop_cs_JzCzhz:
+      case IOP_CS_JZCZHZ:
         return DEVELOP_BLEND_CS_RGB_SCENE;
       default:
         return DEVELOP_BLEND_CS_NONE;
@@ -139,12 +139,12 @@ dt_iop_colorspace_type_t dt_develop_blend_colorspace(const dt_dev_pixelpipe_iop_
   switch(bp->blend_cst)
   {
     case DEVELOP_BLEND_CS_RAW:
-      return iop_cs_RAW;
+      return IOP_CS_RAW;
     case DEVELOP_BLEND_CS_LAB:
-      return iop_cs_Lab;
+      return IOP_CS_LAB;
     case DEVELOP_BLEND_CS_RGB_DISPLAY:
     case DEVELOP_BLEND_CS_RGB_SCENE:
-      return iop_cs_rgb;
+      return IOP_CS_RGB;
     default:
       return cst;
   }
@@ -471,7 +471,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 
   // get channel max values depending on colorspace
   const dt_develop_blend_colorspace_t blend_csp = d->blend_cst;
-  const dt_iop_colorspace_type_t cst = dt_develop_blend_colorspace(piece, iop_cs_NONE);
+  const dt_iop_colorspace_type_t cst = dt_develop_blend_colorspace(piece, IOP_CS_NONE);
 
   // check if mask should be suppressed temporarily (i.e. just set to global opacity value)
   const gboolean suppress_mask = self->suppress_mask && self->dev->gui_attached && (self == self->dev->gui_module)
@@ -590,7 +590,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
       _develop_mask_post_processing operation = post_operations[index];
       if(operation == DEVELOP_MASK_POST_FEATHER_IN)
       {
-        const float guide_weight = cst == iop_cs_rgb ? 100.0f : 1.0f;
+        const float guide_weight = cst == IOP_CS_RGB ? 100.0f : 1.0f;
         float *restrict guide = (float *restrict)ivoid;
         if(!rois_equal)
           guide = _develop_blend_process_copy_region(guide, ch * iwidth, ch * xoffs, ch * yoffs,
@@ -603,7 +603,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
       }
       else if(operation == DEVELOP_MASK_POST_FEATHER_OUT)
       {
-        const float guide_weight = cst == iop_cs_rgb ? 100.0f : 1.0f;
+        const float guide_weight = cst == IOP_CS_RGB ? 100.0f : 1.0f;
         _develop_blend_process_feather((const float *const restrict)ovoid, mask, owidth, oheight, ch,
                                        guide_weight, d->feathering_radius, roi_out->scale / piece->iscale);
       }
@@ -862,7 +862,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
 
   // get channel max values depending on colorspace
   const dt_develop_blend_colorspace_t blend_csp = d->blend_cst;
-  const dt_iop_colorspace_type_t cst = dt_develop_blend_colorspace(piece, iop_cs_NONE);
+  const dt_iop_colorspace_type_t cst = dt_develop_blend_colorspace(piece, IOP_CS_NONE);
 
   // check if mask should be suppressed temporarily (i.e. just set to global
   // opacity value)
@@ -1087,7 +1087,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
         int w = (int)(2 * d->feathering_radius * roi_out->scale / piece->iscale + 0.5f);
         if (w < 1) w = 1;
         const float sqrt_eps = 1.0f;
-        const float guide_weight = cst == iop_cs_rgb ? 100.0f : 1.0f;
+        const float guide_weight = cst == IOP_CS_RGB ? 100.0f : 1.0f;
 
         cl_mem guide = dev_in;
         if(!rois_equal)
@@ -1114,7 +1114,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
         int w = (int)(2 * d->feathering_radius * roi_out->scale / piece->iscale + 0.5f);
         if (w < 1) w = 1;
         const float sqrt_eps = 1.0f;
-        const float guide_weight = cst == iop_cs_rgb ? 100.0f : 1.0f;
+        const float guide_weight = cst == IOP_CS_RGB ? 100.0f : 1.0f;
 
         guided_filter_cl(devid, dev_out, dev_mask_1, dev_mask_2, owidth, oheight, ch, w, sqrt_eps, guide_weight,
                          0.0f, 1.0f);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -265,20 +265,20 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab);
 static inline dt_iop_colorspace_type_t _blendif_colorpicker_cst(dt_iop_gui_blend_data_t *data)
 {
   dt_iop_colorspace_type_t cst = dt_iop_color_picker_get_active_cst(data->module);
-  if(cst == iop_cs_NONE)
+  if(cst == IOP_CS_NONE)
   {
     switch(data->channel_tabs_csp)
     {
       case DEVELOP_BLEND_CS_LAB:
-        cst = iop_cs_Lab;
+        cst = IOP_CS_LAB;
         break;
       case DEVELOP_BLEND_CS_RGB_DISPLAY:
       case DEVELOP_BLEND_CS_RGB_SCENE:
-        cst = iop_cs_rgb;
+        cst = IOP_CS_RGB;
         break;
       case DEVELOP_BLEND_CS_RAW:
       case DEVELOP_BLEND_CS_NONE:
-        cst = iop_cs_NONE;
+        cst = IOP_CS_NONE;
         break;
     }
   }
@@ -320,12 +320,12 @@ static void _blendif_scale(dt_iop_gui_blend_data_t *data, dt_iop_colorspace_type
 
   switch(cst)
   {
-    case iop_cs_Lab:
+    case IOP_CS_LAB:
       out[CHANNEL_INDEX_L] = (in[0] / _get_boost_factor(data, 0, in_out)) / 100.0f;
       out[CHANNEL_INDEX_a] = ((in[1] / _get_boost_factor(data, 1, in_out)) + 128.0f) / 256.0f;
       out[CHANNEL_INDEX_b] = ((in[2] / _get_boost_factor(data, 2, in_out)) + 128.0f) / 256.0f;
       break;
-    case iop_cs_rgb:
+    case IOP_CS_RGB:
       if(work_profile == NULL)
         out[CHANNEL_INDEX_g] = 0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2];
       else
@@ -339,16 +339,16 @@ static void _blendif_scale(dt_iop_gui_blend_data_t *data, dt_iop_colorspace_type
       out[CHANNEL_INDEX_G] = in[1] / _get_boost_factor(data, 2, in_out);
       out[CHANNEL_INDEX_B] = in[2] / _get_boost_factor(data, 3, in_out);
       break;
-    case iop_cs_LCh:
+    case IOP_CS_LCH:
       out[CHANNEL_INDEX_C] = (in[1] / _get_boost_factor(data, 3, in_out)) / (128.0f * sqrtf(2.0f));
       out[CHANNEL_INDEX_h] = in[2] / _get_boost_factor(data, 4, in_out);
       break;
-    case iop_cs_HSL:
+    case IOP_CS_HSL:
       out[CHANNEL_INDEX_H] = in[0] / _get_boost_factor(data, 4, in_out);
       out[CHANNEL_INDEX_S] = in[1] / _get_boost_factor(data, 5, in_out);
       out[CHANNEL_INDEX_l] = in[2] / _get_boost_factor(data, 6, in_out);
       break;
-    case iop_cs_JzCzhz:
+    case IOP_CS_JZCZHZ:
       out[CHANNEL_INDEX_Jz] = in[0] / _get_boost_factor(data, 4, in_out);
       out[CHANNEL_INDEX_Cz] = in[1] / _get_boost_factor(data, 5, in_out);
       out[CHANNEL_INDEX_hz] = in[2] / _get_boost_factor(data, 6, in_out);
@@ -365,12 +365,12 @@ static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *
 
   switch(cst)
   {
-    case iop_cs_Lab:
+    case IOP_CS_LAB:
       out[CHANNEL_INDEX_L] = in[0];
       out[CHANNEL_INDEX_a] = in[1];
       out[CHANNEL_INDEX_b] = in[2];
       break;
-    case iop_cs_rgb:
+    case IOP_CS_RGB:
       if(work_profile == NULL)
         out[CHANNEL_INDEX_g] = (0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2]) * 100.0f;
       else
@@ -383,16 +383,16 @@ static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *
       out[CHANNEL_INDEX_G] = in[1] * 100.0f;
       out[CHANNEL_INDEX_B] = in[2] * 100.0f;
       break;
-    case iop_cs_LCh:
+    case IOP_CS_LCH:
       out[CHANNEL_INDEX_C] = in[1] / (128.0f * sqrtf(2.0f)) * 100.0f;
       out[CHANNEL_INDEX_h] = in[2] * 360.0f;
       break;
-    case iop_cs_HSL:
+    case IOP_CS_HSL:
       out[CHANNEL_INDEX_H] = in[0] * 360.0f;
       out[CHANNEL_INDEX_S] = in[1] * 100.0f;
       out[CHANNEL_INDEX_l] = in[2] * 100.0f;
       break;
-    case iop_cs_JzCzhz:
+    case IOP_CS_JZCZHZ:
       out[CHANNEL_INDEX_Jz] = in[0] * 100.0f;
       out[CHANNEL_INDEX_Cz] = in[1] * 100.0f;
       out[CHANNEL_INDEX_hz] = in[2] * 360.0f;
@@ -534,7 +534,7 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
      *
      * TODO: revisit if/once there semi-raw iops (e.g temperature) with blending
      */
-    if(data->module->blend_colorspace(data->module, NULL, NULL) == iop_cs_RAW)
+    if(data->module->blend_colorspace(data->module, NULL, NULL) == IOP_CS_RAW)
     {
       data->module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->showmask), FALSE);
@@ -878,28 +878,28 @@ static void _blendop_blendif_disp_alternative_reset(GtkWidget *widget, dt_iop_mo
 
 static dt_iop_colorspace_type_t _blendop_blendif_get_picker_colorspace(dt_iop_gui_blend_data_t *bd)
 {
-  dt_iop_colorspace_type_t picker_cst = iop_cs_NONE;
+  dt_iop_colorspace_type_t picker_cst = IOP_CS_NONE;
 
   if(bd->channel_tabs_csp == DEVELOP_BLEND_CS_RGB_DISPLAY)
   {
     if(bd->tab < 4)
-      picker_cst = iop_cs_rgb;
+      picker_cst = IOP_CS_RGB;
     else
-      picker_cst = iop_cs_HSL;
+      picker_cst = IOP_CS_HSL;
   }
   else if(bd->channel_tabs_csp == DEVELOP_BLEND_CS_RGB_SCENE)
   {
     if(bd->tab < 4)
-      picker_cst = iop_cs_rgb;
+      picker_cst = IOP_CS_RGB;
     else
-      picker_cst = iop_cs_JzCzhz;
+      picker_cst = IOP_CS_JZCZHZ;
   }
   else if(bd->channel_tabs_csp == DEVELOP_BLEND_CS_LAB)
   {
     if(bd->tab < 3)
-      picker_cst = iop_cs_Lab;
+      picker_cst = IOP_CS_LAB;
     else
-      picker_cst = iop_cs_LCh;
+      picker_cst = IOP_CS_LCH;
   }
 
   return picker_cst;
@@ -1510,7 +1510,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
         : dt_ioppr_get_iop_work_profile_info(module, module->dev->iop);
 
     gboolean reverse_hues = FALSE;
-    if(cst == iop_cs_HSL && tab == CHANNEL_INDEX_H)
+    if(cst == IOP_CS_HSL && tab == CHANNEL_INDEX_H)
     {
       if((raw_max[3] - raw_min[3]) < (raw_max[0] - raw_min[0]) && raw_min[3] < 0.5f && raw_max[3] > 0.5f)
       {
@@ -1519,7 +1519,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
         reverse_hues = TRUE;
       }
     }
-    else if((cst == iop_cs_LCh && tab == CHANNEL_INDEX_h) || (cst == iop_cs_JzCzhz && tab == CHANNEL_INDEX_hz))
+    else if((cst == IOP_CS_LCH && tab == CHANNEL_INDEX_h) || (cst == IOP_CS_JZCZHZ && tab == CHANNEL_INDEX_hz))
     {
       if((raw_max[3] - raw_min[3]) < (raw_max[2] - raw_min[2]) && raw_min[3] < 0.5f && raw_max[3] > 0.5f)
       {
@@ -2813,7 +2813,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
      *
      * TODO: revisit if/once there semi-raw iops (e.g temperature) with blending
      */
-    if(module->blend_colorspace(module, NULL, NULL) == iop_cs_RAW)
+    if(module->blend_colorspace(module, NULL, NULL) == IOP_CS_RAW)
     {
       module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), FALSE);
@@ -2969,7 +2969,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->channel_tabs_csp = DEVELOP_BLEND_CS_NONE;
     bd->output_channels_shown = FALSE;
     dt_iop_colorspace_type_t cst = module->blend_colorspace(module, NULL, NULL);
-    bd->blendif_support = (cst == iop_cs_Lab || cst == iop_cs_rgb);
+    bd->blendif_support = (cst == IOP_CS_LAB || cst == IOP_CS_RGB);
     bd->masks_support = !(module->flags() & IOP_FLAGS_NO_MASKS);
 
     bd->masks_modes = NULL;

--- a/src/develop/format.c
+++ b/src/develop/format.c
@@ -46,7 +46,7 @@ void default_input_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_de
   dsc->datatype = TYPE_FLOAT;
   dsc->cst = self->input_colorspace(self, pipe, piece);
 
-  if(dsc->cst != iop_cs_RAW) return;
+  if(dsc->cst != IOP_CS_RAW) return;
 
   if(dt_image_is_raw(&pipe->image)) dsc->channels = 1;
 
@@ -64,7 +64,7 @@ void default_output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_d
   dsc->datatype = TYPE_FLOAT;
   dsc->cst = self->output_colorspace(self, pipe, piece);
 
-  if(dsc->cst != iop_cs_RAW) return;
+  if(dsc->cst != IOP_CS_RAW) return;
 
   if(dt_image_is_raw(&pipe->image)) dsc->channels = 1;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -392,12 +392,12 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
     /* set button state */
     char option[1024];
     snprintf(option, sizeof(option), "plugins/darkroom/%s/visible", module->op);
-    dt_iop_module_state_t state = DT_IOP_STATE_HIDDEN;
+    dt_iop_module_state_t state = IOP_STATE_HIDDEN;
     if(dt_conf_get_bool(option))
     {
-      state = DT_IOP_STATE_ACTIVE;
+      state = IOP_STATE_ACTIVE;
       snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
-      if(dt_conf_get_bool(option)) state = DT_IOP_STATE_FAVORITE;
+      if(dt_conf_get_bool(option)) state = IOP_STATE_FAVORITE;
     }
     dt_iop_gui_set_state(module, state);
   }
@@ -2607,9 +2607,9 @@ static gboolean _show_module_callback(GtkAccelGroup *accel_group, GObject *accel
   dt_iop_module_t *module = (dt_iop_module_t *)data;
 
   // Showing the module, if it isn't already visible
-  if(module->so->state == DT_IOP_STATE_HIDDEN)
+  if(module->so->state == IOP_STATE_HIDDEN)
   {
-    dt_iop_gui_set_state(module, DT_IOP_STATE_ACTIVE);
+    dt_iop_gui_set_state(module, IOP_STATE_ACTIVE);
   }
 
   const uint32_t current_group = dt_dev_modulegroups_get(module->dev);
@@ -2742,7 +2742,7 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
 
   char option[1024];
   GList *mods = NULL;
-  if(state == DT_IOP_STATE_HIDDEN)
+  if(state == IOP_STATE_HIDDEN)
   {
     for(mods = darktable.develop->iop; mods; mods = g_list_next(mods))
     {
@@ -2755,7 +2755,7 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
     snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
     dt_conf_set_bool(option, FALSE);
   }
-  else if(state == DT_IOP_STATE_ACTIVE)
+  else if(state == IOP_STATE_ACTIVE)
   {
     if(!darktable.gui->reset)
     {
@@ -2782,7 +2782,7 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
     snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
     dt_conf_set_bool(option, FALSE);
   }
-  else if(state == DT_IOP_STATE_FAVORITE)
+  else if(state == IOP_STATE_FAVORITE)
   {
     for(mods = darktable.develop->iop; mods; mods = g_list_next(mods))
     {

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -358,7 +358,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
     module->picked_color_min[k] = module->picked_output_color_min[k] = 666.0f;
     module->picked_color_max[k] = module->picked_output_color_max[k] = -666.0f;
   }
-  module->histogram_cst = iop_cs_NONE;
+  module->histogram_cst = IOP_CS_NONE;
   module->histogram = NULL;
   module->histogram_max[0] = module->histogram_max[1] = module->histogram_max[2] = module->histogram_max[3]
       = 0;
@@ -392,12 +392,12 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
     /* set button state */
     char option[1024];
     snprintf(option, sizeof(option), "plugins/darkroom/%s/visible", module->op);
-    dt_iop_module_state_t state = dt_iop_state_HIDDEN;
+    dt_iop_module_state_t state = DT_IOP_STATE_HIDDEN;
     if(dt_conf_get_bool(option))
     {
-      state = dt_iop_state_ACTIVE;
+      state = DT_IOP_STATE_ACTIVE;
       snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
-      if(dt_conf_get_bool(option)) state = dt_iop_state_FAVORITE;
+      if(dt_conf_get_bool(option)) state = DT_IOP_STATE_FAVORITE;
     }
     dt_iop_gui_set_state(module, state);
   }
@@ -1445,7 +1445,7 @@ static void _init_module_so(void *m)
 
         if((module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) &&
            !(module->flags() & IOP_FLAGS_NO_MASKS) &&
-           (cst == iop_cs_Lab || cst == iop_cs_rgb))
+           (cst == IOP_CS_LAB || cst == IOP_CS_RGB))
         {
           GtkWidget *iopw = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
           dt_iop_gui_init_blending(iopw, module_instance);
@@ -2607,9 +2607,9 @@ static gboolean _show_module_callback(GtkAccelGroup *accel_group, GObject *accel
   dt_iop_module_t *module = (dt_iop_module_t *)data;
 
   // Showing the module, if it isn't already visible
-  if(module->so->state == dt_iop_state_HIDDEN)
+  if(module->so->state == DT_IOP_STATE_HIDDEN)
   {
-    dt_iop_gui_set_state(module, dt_iop_state_ACTIVE);
+    dt_iop_gui_set_state(module, DT_IOP_STATE_ACTIVE);
   }
 
   const uint32_t current_group = dt_dev_modulegroups_get(module->dev);
@@ -2742,7 +2742,7 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
 
   char option[1024];
   GList *mods = NULL;
-  if(state == dt_iop_state_HIDDEN)
+  if(state == DT_IOP_STATE_HIDDEN)
   {
     for(mods = darktable.develop->iop; mods; mods = g_list_next(mods))
     {
@@ -2755,7 +2755,7 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
     snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
     dt_conf_set_bool(option, FALSE);
   }
-  else if(state == dt_iop_state_ACTIVE)
+  else if(state == DT_IOP_STATE_ACTIVE)
   {
     if(!darktable.gui->reset)
     {
@@ -2782,7 +2782,7 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
     snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
     dt_conf_set_bool(option, FALSE);
   }
-  else if(state == dt_iop_state_FAVORITE)
+  else if(state == DT_IOP_STATE_FAVORITE)
   {
     for(mods = darktable.develop->iop; mods; mods = g_list_next(mods))
     {

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -114,11 +114,10 @@ typedef enum dt_iop_flags_t
 /** status of a module*/
 typedef enum dt_iop_module_state_t
 {
-  DT_IOP_STATE_HIDDEN = 0, // keep first
-  DT_IOP_STATE_ACTIVE,
-  DT_IOP_STATE_FAVORITE,
-  DT_IOP_STATE_LAST
-
+  IOP_STATE_HIDDEN = 0, // keep first
+  IOP_STATE_ACTIVE,
+  IOP_STATE_FAVORITE,
+  IOP_STATE_LAST
 } dt_iop_module_state_t;
 
 typedef struct dt_iop_gui_data_t

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -114,10 +114,10 @@ typedef enum dt_iop_flags_t
 /** status of a module*/
 typedef enum dt_iop_module_state_t
 {
-  dt_iop_state_HIDDEN = 0, // keep first
-  dt_iop_state_ACTIVE,
-  dt_iop_state_FAVORITE,
-  dt_iop_state_LAST
+  DT_IOP_STATE_HIDDEN = 0, // keep first
+  DT_IOP_STATE_ACTIVE,
+  DT_IOP_STATE_FAVORITE,
+  DT_IOP_STATE_LAST
 
 } dt_iop_module_state_t;
 
@@ -141,13 +141,13 @@ typedef enum dt_dev_request_colorpick_flags_t
 /** colorspace enums, must be in synch with dt_iop_colorspace_type_t in color_conversion.cl */
 typedef enum dt_iop_colorspace_type_t
 {
-  iop_cs_NONE = -1,
-  iop_cs_RAW = 0,
-  iop_cs_Lab = 1,
-  iop_cs_rgb = 2,
-  iop_cs_LCh = 3,
-  iop_cs_HSL = 4,
-  iop_cs_JzCzhz = 5,
+  IOP_CS_NONE = -1,
+  IOP_CS_RAW = 0,
+  IOP_CS_LAB = 1,
+  IOP_CS_RGB = 2,
+  IOP_CS_LCH = 3,
+  IOP_CS_HSL = 4,
+  IOP_CS_JZCZHZ = 5,
 } dt_iop_colorspace_type_t;
 
 /** part of the module which only contains the cached dlopen stuff. */
@@ -217,8 +217,8 @@ typedef struct dt_iop_module_t
   /** maximum levels in histogram, one per channel */
   uint32_t histogram_max[4];
   /** requested colorspace for the histogram, valid options are:
-   * iop_cs_NONE: module colorspace
-   * iop_cs_LCh: for Lab modules
+   * IOP_CS_NONE: module colorspace
+   * IOP_CS_LCH: for Lab modules
    */
   dt_iop_colorspace_type_t histogram_cst;
   /** scale the histogram so the middle grey is at .5 */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -326,7 +326,7 @@ void dt_dev_pixelpipe_create_nodes(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
     piece->histogram_stats.bins_count = 0;
     piece->histogram_stats.pixels = 0;
     piece->colors
-        = ((module->default_colorspace(module, pipe, NULL) == iop_cs_RAW) && (dt_image_is_raw(&pipe->image)))
+        = ((module->default_colorspace(module, pipe, NULL) == IOP_CS_RAW) && (dt_image_is_raw(&pipe->image)))
               ? 1
               : 4;
     piece->iscale = pipe->iscale;
@@ -812,7 +812,7 @@ static void _pixelpipe_pick_from_image(dt_iop_module_t *module,
     // padding, e.g. is equivalent to float[x*4], and that on failure
     // it's OK not to touch output
     int converted_cst;
-    dt_ioppr_transform_image_colorspace(module, picked_rgb[0], sample->lab[0], 3, 1, iop_cs_rgb, iop_cs_Lab,
+    dt_ioppr_transform_image_colorspace(module, picked_rgb[0], sample->lab[0], 3, 1, IOP_CS_RGB, IOP_CS_LAB,
                                         &converted_cst, display_profile);
     if(display_profile && histogram_profile)
       dt_ioppr_transform_image_colorspace_rgb(picked_rgb[0], sample->scope[0], 3, 1,
@@ -825,7 +825,7 @@ static void _pixelpipe_pick_from_image(dt_iop_module_t *module,
     int converted_cst;
     // mean = min = max == pixel sample, so only need to do colorspace work on a single point
     memcpy(sample->display[0], pixel + 4 * (roi_in->width * y + x), sizeof(dt_aligned_pixel_t));
-    dt_ioppr_transform_image_colorspace(module, sample->display[0], sample->lab[0], 1, 1, iop_cs_rgb, iop_cs_Lab,
+    dt_ioppr_transform_image_colorspace(module, sample->display[0], sample->lab[0], 1, 1, IOP_CS_RGB, IOP_CS_LAB,
                                         &converted_cst, display_profile);
     if(display_profile && histogram_profile)
       dt_ioppr_transform_image_colorspace_rgb(sample->display[0], sample->scope[0], 1, 1,
@@ -883,17 +883,17 @@ static dt_iop_colorspace_type_t _transform_for_picker(dt_iop_module_t *self, con
 
   switch(picker_cst)
   {
-    case iop_cs_RAW:
-      return iop_cs_RAW;
-    case iop_cs_Lab:
-    case iop_cs_LCh:
-      return iop_cs_Lab;
-    case iop_cs_rgb:
-    case iop_cs_HSL:
-    case iop_cs_JzCzhz:
-      return iop_cs_rgb;
-    case iop_cs_NONE:
-      // iop_cs_NONE is used by temperature.c as it may work in RAW or RGB
+    case IOP_CS_RAW:
+      return IOP_CS_RAW;
+    case IOP_CS_LAB:
+    case IOP_CS_LCH:
+      return IOP_CS_LAB;
+    case IOP_CS_RGB:
+    case IOP_CS_HSL:
+    case IOP_CS_JZCZHZ:
+      return IOP_CS_RGB;
+    case IOP_CS_NONE:
+      // IOP_CS_NONE is used by temperature.c as it may work in RAW or RGB
       // return the pipe color space to avoid any additional conversions
       return cst;
     default:
@@ -958,7 +958,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
   // if input is RAW, we can't color convert because RAW is not in a color space
   // so we send NULL to by-pass
   const dt_iop_order_iccprofile_info_t *const work_profile
-      = (input_format->cst != iop_cs_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
+      = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
 
   // transform to module input colorspace
   dt_ioppr_transform_image_colorspace(module, input, input, roi_in->width, roi_in->height, input_format->cst,
@@ -1348,7 +1348,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     // if input is RAW, we can't color convert because RAW is not in a color space
     // so we send NULL to by-pass
     const dt_iop_order_iccprofile_info_t *const work_profile
-        = (input_format->cst != iop_cs_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
+        = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
 
     /* do we have opencl at all? did user tell us to use it? did we get a resource? */
     if(dt_opencl_is_inited() && pipe->opencl_enabled && pipe->devid >= 0)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -138,7 +138,7 @@ static void _init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
   // module is NULL if primary colorpicker
   picker->module     = module;
   picker->kind       = kind;
-  picker->picker_cst = module ? module->default_colorspace(module, NULL, NULL) : iop_cs_NONE;
+  picker->picker_cst = module ? module->default_colorspace(module, NULL, NULL) : IOP_CS_NONE;
   picker->colorpick  = button;
   picker->changed    = FALSE;
 
@@ -259,7 +259,7 @@ dt_iop_colorspace_type_t dt_iop_color_picker_get_active_cst(dt_iop_module_t *mod
   if(picker && picker->module == module)
     return picker->picker_cst;
   else
-    return iop_cs_NONE;
+    return IOP_CS_NONE;
 }
 
 static void _iop_color_picker_pickerdata_ready_callback(gpointer instance, dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
@@ -362,7 +362,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
 
 GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w)
 {
-  return _color_picker_new(module, kind, w, FALSE, iop_cs_NONE);
+  return _color_picker_new(module, kind, w, FALSE, IOP_CS_NONE);
 }
 
 GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -44,9 +44,9 @@ typedef struct dt_iop_color_picker_t
   dt_iop_module_t *module;
   dt_iop_color_picker_kind_t kind;
   /** requested colorspace for the color picker, valid options are:
-   * iop_cs_NONE: module colorspace
-   * iop_cs_LCh: for Lab modules
-   * iop_cs_HSL: for RGB modules
+   * IOP_CS_NONE: module colorspace
+   * IOP_CS_LCH: for Lab modules
+   * IOP_CS_HSL: for RGB modules
    */
   dt_iop_colorspace_type_t picker_cst;
   /** used to avoid recursion when a parameter is modified in the apply() */

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -158,7 +158,7 @@ int operation_tags_filter()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 typedef enum dt_iop_ashift_method_t

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -154,7 +154,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -354,7 +354,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static void set_presets(dt_iop_module_so_t *self, const basecurve_preset_t *presets, int count, gboolean camera)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -161,7 +161,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static void _turn_select_region_off(struct dt_iop_module_t *self)

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -117,7 +117,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -90,7 +90,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -97,7 +97,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -108,7 +108,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -208,7 +208,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -104,7 +104,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -182,7 +182,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -98,7 +98,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static inline void make_noise(float *const output, const float noise, const size_t width, const size_t height)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -155,7 +155,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -223,7 +223,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -81,7 +81,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -347,7 +347,7 @@ int operation_tags_filter()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static int gui_has_focus(struct dt_iop_module_t *self)

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -100,7 +100,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -174,7 +174,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -186,7 +186,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -142,7 +142,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -116,7 +116,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -92,7 +92,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -152,7 +152,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int input_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
@@ -162,15 +162,15 @@ int input_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
   {
     const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
     if(d->type == DT_COLORSPACE_LAB)
-      return iop_cs_Lab;
+      return IOP_CS_LAB;
   }
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                       dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 static void _resolve_work_profile(dt_colorspaces_color_profile_type_t *work_type, char *work_filename)

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -96,7 +96,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -168,7 +168,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 static void capture_histogram(const float *col, const int width, const int height, int *hist)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -108,28 +108,28 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int input_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                      dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                       dt_dev_pixelpipe_iop_t *piece)
 {
-  int cst = iop_cs_rgb;
+  int cst = IOP_CS_RGB;
   if(piece)
   {
     const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
-    if(d->type == DT_COLORSPACE_LAB) cst = iop_cs_Lab;
+    if(d->type == DT_COLORSPACE_LAB) cst = IOP_CS_LAB;
   }
   else
   {
     dt_iop_colorout_params_t *p = (dt_iop_colorout_params_t *)self->params;
-    if(p->type == DT_COLORSPACE_LAB) cst = iop_cs_Lab;
+    if(p->type == DT_COLORSPACE_LAB) cst = IOP_CS_LAB;
   }
   return cst;
 }

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -152,7 +152,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -120,7 +120,7 @@ const char *deprecated_msg()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 #if 0

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -160,7 +160,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
@@ -856,11 +856,11 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           dt_ioppr_transform_image_colorspace_rgb(pick_max, pick_max, 1, 1, histogram_profile, work_profile,
                                                   "color zones");
 
-          dt_ioppr_transform_image_colorspace(self, pick_mean, pick_mean, 1, 1, iop_cs_rgb, iop_cs_Lab,
+          dt_ioppr_transform_image_colorspace(self, pick_mean, pick_mean, 1, 1, IOP_CS_RGB, IOP_CS_LAB,
                                               &converted_cst, work_profile);
-          dt_ioppr_transform_image_colorspace(self, pick_min, pick_min, 1, 1, iop_cs_rgb, iop_cs_Lab,
+          dt_ioppr_transform_image_colorspace(self, pick_min, pick_min, 1, 1, IOP_CS_RGB, IOP_CS_LAB,
                                               &converted_cst, work_profile);
-          dt_ioppr_transform_image_colorspace(self, pick_max, pick_max, 1, 1, iop_cs_rgb, iop_cs_Lab,
+          dt_ioppr_transform_image_colorspace(self, pick_max, pick_max, 1, 1, IOP_CS_RGB, IOP_CS_LAB,
                                               &converted_cst, work_profile);
 
           dt_Lab_2_LCH(pick_mean, pick_mean);
@@ -2407,7 +2407,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colorzones_gui_data_t *c = IOP_GUI_ALLOC(colorzones);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->default_params;
 
-  self->histogram_cst = iop_cs_LCh;
+  self->histogram_cst = IOP_CS_LCH;
 
   c->channel = dt_conf_get_int("plugins/darkroom/colorzones/gui_channel");
   for(int ch = 0; ch < DT_IOP_COLORZONES_MAX_CHANNELS; ch++)
@@ -2453,10 +2453,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new("   "), FALSE, FALSE, 0);
 
   // color pickers
-  c->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_POINT_AREA, hbox, iop_cs_LCh);
+  c->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_POINT_AREA, hbox, IOP_CS_LCH);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click or right-click to select an area"));
   gtk_widget_set_name(c->colorpicker, "keep-active");
-  c->colorpicker_set_values = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, hbox, iop_cs_LCh);
+  c->colorpicker_set_values = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, hbox, IOP_CS_LCH);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
                                dtgtk_cairo_paint_colorpicker_set_values,
                                CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -166,7 +166,7 @@ int operation_tags_filter()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static int _gui_has_focus(struct dt_iop_module_t *self)

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -102,7 +102,7 @@ const char *deprecated_msg()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 // Verify before actually using this

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -239,7 +239,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
@@ -281,13 +281,13 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 int input_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                      dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                       dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static const char* method2string(dt_iop_demosaic_method_t method)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -735,7 +735,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 typedef union floatint_t

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -155,7 +155,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -118,7 +118,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -102,7 +102,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *deprecated_msg()

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -129,7 +129,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static void dt_iop_exposure_set_exposure(struct dt_iop_module_t *self, const float exposure);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -181,7 +181,7 @@ const char *deprecated_msg()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -369,7 +369,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 inline static gboolean dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_params_t *const p,

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -51,7 +51,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -97,7 +97,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -55,7 +55,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -117,7 +117,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -166,7 +166,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static inline float f(const float t, const float c, const float x)

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -440,7 +440,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 // see: http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -128,7 +128,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -99,7 +99,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -96,7 +96,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -89,7 +89,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 /* Detect hot sensor pixels based on the 4 surrounding sites. Pixels

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -137,7 +137,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 void init_key_accels(dt_iop_module_so_t *self)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -180,7 +180,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -122,7 +122,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -317,7 +317,7 @@ int operation_tags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 /******************************************************************************/

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -107,7 +107,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 static float lookup(const float *lut, const float i)

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -148,7 +148,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -154,7 +154,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -58,7 +58,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -89,7 +89,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -173,7 +173,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -104,7 +104,7 @@ const char *description(struct dt_iop_module_t *self)
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -84,7 +84,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -117,7 +117,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -145,7 +145,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 #define BIT16 65536.0

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -81,7 +81,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 static void process_common_setup(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -101,7 +101,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_RAW;
+  return IOP_CS_RAW;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -104,7 +104,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 #define GAUSS(a, b, c, x) (a * powf(2.718281828f, (-powf((x - b), 2) / (powf(c, 2)))))

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -222,7 +222,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
@@ -3180,7 +3180,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
 
       if(work_profile)
         dt_ioppr_transform_image_colorspace(self, img_dest, img_dest, roi_mask_scaled->width,
-                                            roi_mask_scaled->height, iop_cs_rgb, iop_cs_Lab, &converted_cst,
+                                            roi_mask_scaled->height, IOP_CS_RGB, IOP_CS_LAB, &converted_cst,
                                             work_profile);
       else
         image_rgb2lab(img_dest, roi_mask_scaled->width, roi_mask_scaled->height, 4, use_sse);
@@ -3192,7 +3192,7 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
 
       if(work_profile)
         dt_ioppr_transform_image_colorspace(self, img_dest, img_dest, roi_mask_scaled->width,
-                                            roi_mask_scaled->height, iop_cs_Lab, iop_cs_rgb, &converted_cst,
+                                            roi_mask_scaled->height, IOP_CS_LAB, IOP_CS_RGB, &converted_cst,
                                             work_profile);
       else
         image_lab2rgb(img_dest, roi_mask_scaled->width, roi_mask_scaled->height, 4, use_sse);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -133,7 +133,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -113,7 +113,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -88,7 +88,7 @@ int operation_tags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -72,7 +72,7 @@ int operation_tags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -187,7 +187,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -85,7 +85,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -96,7 +96,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -93,7 +93,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -82,7 +82,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -218,9 +218,9 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 {
   // This module may work in RAW or RGB (e.g. for TIFF files) depending on the input
   // The module does not change the color space between the input and output, therefore implement it here
-  if(piece && piece->dsc_in.cst != iop_cs_RAW)
-    return iop_cs_rgb;
-  return iop_cs_RAW;
+  if(piece && piece->dsc_in.cst != IOP_CS_RAW)
+    return IOP_CS_RGB;
+  return IOP_CS_RAW;
 }
 
 /*
@@ -2004,10 +2004,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance to as shot"));
 
   // create color picker to be able to send its signal when spot selected,
-  // this module may expect data in RAW or RGB, setting the color picker CST to iop_cs_NONE will make the color
+  // this module may expect data in RAW or RGB, setting the color picker CST to IOP_CS_NONE will make the color
   // picker to depend on the number of color channels of the pixels. It is done like this as we may not know the
   // actual kind of data we are using in the GUI (it is part of the pipeline).
-  g->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, NULL, iop_cs_NONE);
+  g->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, NULL, IOP_CS_NONE);
   dt_action_define_iop(self, N_("settings"), N_("from image area"), g->colorpicker, &dt_action_def_toggle);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -204,7 +204,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -336,7 +336,7 @@ int flags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -92,7 +92,7 @@ const char *deprecated_msg()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -125,7 +125,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 // Whenever new fields are added to (or removed from) dt_iop_..._params_t or when their meaning

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -96,7 +96,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -85,7 +85,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 const char *description(struct dt_iop_module_t *self)

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -174,7 +174,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -316,7 +316,7 @@ int operation_tags()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 // sets text / color / font widgets sensitive based on watermark file type

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -129,7 +129,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_Lab;
+  return IOP_CS_LAB;
 }
 
 /* get the zone index of pixel lightness from zonemap */

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -177,7 +177,7 @@ static void _lib_histogram_process_histogram(dt_lib_histogram_t *const d, const 
                                              const dt_histogram_roi_t *const roi)
 {
   dt_dev_histogram_collection_params_t histogram_params = { 0 };
-  const dt_iop_colorspace_type_t cst = iop_cs_rgb;
+  const dt_iop_colorspace_type_t cst = IOP_CS_RGB;
   dt_dev_histogram_stats_t histogram_stats = { .bins_count = HISTOGRAM_BINS, .ch = 4, .pixels = 0 };
   uint32_t histogram_max[4] = { 0 };
 
@@ -190,8 +190,8 @@ static void _lib_histogram_process_histogram(dt_lib_histogram_t *const d, const 
 
   // FIXME: for point sample, calculate whole graph and the point sample values, draw these on top of the graph
   // FIXME: set up "custom" histogram worker which can do colorspace conversion on fly -- in cases that we need to do that -- may need to add from colorspace to dt_dev_histogram_collection_params_t
-  dt_histogram_helper(&histogram_params, &histogram_stats, cst, iop_cs_NONE, input, &d->histogram, FALSE, NULL);
-  dt_histogram_max_helper(&histogram_stats, cst, iop_cs_NONE, &d->histogram, histogram_max);
+  dt_histogram_helper(&histogram_params, &histogram_stats, cst, IOP_CS_NONE, input, &d->histogram, FALSE, NULL);
+  dt_histogram_max_helper(&histogram_stats, cst, IOP_CS_NONE, &d->histogram, histogram_max);
   d->histogram_max = MAX(MAX(histogram_max[0], histogram_max[1]), histogram_max[2]);
 }
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1347,9 +1347,9 @@ static void _preset_retrieve_old_presets(dt_lib_module_t *self)
       const int op_len = strlen(op);
       dt_iop_module_state_t state = p[pos + op_len + 1];
 
-      if(state == dt_iop_state_ACTIVE)
+      if(state == DT_IOP_STATE_ACTIVE)
         list = dt_util_dstrcat(list, "|%s", op);
-      else if(state == dt_iop_state_FAVORITE)
+      else if(state == DT_IOP_STATE_FAVORITE)
       {
         fav = dt_util_dstrcat(fav, "|%s", op);
         list = dt_util_dstrcat(list, "|%s", op);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1347,9 +1347,9 @@ static void _preset_retrieve_old_presets(dt_lib_module_t *self)
       const int op_len = strlen(op);
       dt_iop_module_state_t state = p[pos + op_len + 1];
 
-      if(state == DT_IOP_STATE_ACTIVE)
+      if(state == IOP_STATE_ACTIVE)
         list = dt_util_dstrcat(list, "|%s", op);
-      else if(state == DT_IOP_STATE_FAVORITE)
+      else if(state == IOP_STATE_FAVORITE)
       {
         fav = dt_util_dstrcat(fav, "|%s", op);
         list = dt_util_dstrcat(list, "|%s", op);


### PR DESCRIPTION
This PR takes care that consistent upper-case style enum names are used in  `imageop.h` and `color_conversion.h`.