### PR TITLE
data/kernels: switch atomics to OpenCL 1.1+

### DIFF
--- a/data/kernels/bilateral.cl
+++ b/data/kernels/bilateral.cl
@@ -16,8 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
-
 #include "common.h"
 
 float4
@@ -64,10 +62,10 @@ atomic_add_f(
     // the following is equivalent to old_val.f = *val. however, as according to the opencl standard
     // we can not rely on global buffer val to be consistently cached (relaxed memory consistency) we 
     // access it via a slower but consistent atomic operation.
-    old_val.i = atom_add(ival, 0);
+    old_val.i = atomic_add(ival, 0);
     new_val.f = old_val.f + delta;
   }
-  while (atom_cmpxchg (ival, old_val.i, new_val.i) != old_val.i);
+  while (atomic_cmpxchg (ival, old_val.i, new_val.i) != old_val.i);
 #endif
 }
 

--- a/data/kernels/colorreconstruction.cl
+++ b/data/kernels/colorreconstruction.cl
@@ -17,8 +17,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
-
 #include "common.h"
 
 typedef enum dt_iop_colorreconstruct_precedence_t
@@ -83,10 +81,10 @@ atomic_add_f(
     // the following is equivalent to old_val.f = *val. however, as according to the opencl standard
     // we can not rely on global buffer val to be consistently cached (relaxed memory consistency) we 
     // access it via a slower but consistent atomic operation.
-    old_val.i = atom_add(ival, 0);
+    old_val.i = atomic_add(ival, 0);
     new_val.f = old_val.f + delta;
   }
-  while (atom_cmpxchg (ival, old_val.i, new_val.i) != old_val.i);
+  while (atomic_cmpxchg (ival, old_val.i, new_val.i) != old_val.i);
 #endif
 }
 


### PR DESCRIPTION
The cl_khr_global_int32_base_atomics extension became a core feature in
OpenCL 1.1, update the code accordingly.

https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics

It fixes build in Fedora Rawhide for aarch64 and ppc64le.