### PR TITLE
[opencl] increase default mandatory lock timeout, log lock timeout

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -254,9 +254,9 @@
   <dtconfig>
     <name>opencl_mandatory_timeout</name>
     <type min="0">int</type>
-    <default>200</default>
+    <default>400</default>
     <shortdescription>timeout period for locking mandatory opencl device</shortdescription>
-    <longdescription>time period (in units of 5ms) after which we give up try-locking an opencl device for mandatory use. defaults to 200.</longdescription>
+    <longdescription>time period (in units of 5ms) after which we give up try-locking an opencl device for mandatory use. defaults to 400 (2 seconds).</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_use_pinned_memory</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -253,7 +253,7 @@
   </dtconfig>
   <dtconfig>
     <name>opencl_mandatory_timeout</name>
-    <type min="0">int</type>
+    <type min="100">int</type>
     <default>400</default>
     <shortdescription>timeout period for locking mandatory opencl device</shortdescription>
     <longdescription>time period (in units of 5ms) after which we give up try-locking an opencl device for mandatory use. defaults to 400 (2 seconds).</longdescription>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1458,6 +1458,7 @@ int dt_opencl_lock_device(const int pipetype)
 
       dt_iop_nap(usec);
     }
+    dt_print(DT_DEBUG_OPENCL, "[opencl_lock_device] reached opencl_mandatory_timeout trying to lock mandatory device, fallback to CPU");
   }
   else
   {


### PR DESCRIPTION
`opencl_mandatory_timeout` can be reached when using mandatory
device config and very heavy module like `diffuse or sharpen`

to somewhat workaround the problem 2 things are done:

* increase default timeout to 2 sec (instead of 1)
* log when reaching timeout to help debug issues and allow users to manually increase the limit

fixes #10828