### PR TITLE
Fix various demosaicer issues with amd drivers

### DIFF
--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -75,6 +75,6 @@ clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in, __write_
     color += yfilter*xfilter*(float4)(px, px, px, 0.0f);
     weight += yfilter*xfilter;
   }
-  color = weight > 0.0f ? color/weight : (float4)0.0f;
+  color = (weight > 0.0f) ? color/weight : (float4)0.0f;
   write_imagef (out, (int2)(x, y), color);
 }

--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -34,7 +34,7 @@ passthrough_monochrome (__read_only image2d_t in, __write_only image2d_t out, co
 
   color.xyz = pc.x;
 
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 
 /**

--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -515,7 +515,7 @@ clip_and_zoom_demosaic_half_size(__read_only image2d_t in, __write_only image2d_
     color += yfilter*xfilter*(float4)(p1, (p2+p3)*0.5f, p4, 0.0f);
     weight += yfilter*xfilter;
   }
-  color = weight > 0.0f ? color/weight : (float4)0.0f;
+  color = (weight > 0.0f) ? color/weight : (float4)0.0f;
   write_imagef (out, (int2)(x, y), color);
 }
 

--- a/data/kernels/demosaic_ppg.cl
+++ b/data/kernels/demosaic_ppg.cl
@@ -107,7 +107,7 @@ green_equilibration_lavg(read_only image2d_t in, write_only image2d_t out, const
     }
   }
 
-  write_imagef (out, (int2)(x, y), o);
+  write_imagef (out, (int2)(x, y), fmax(o, 0.0f));
 }
 
 
@@ -210,7 +210,7 @@ green_equilibration_favg_apply(read_only image2d_t in, write_only image2d_t out,
 
   pixel *= (isgreen1 ? gr_ratio : 1.0f);
 
-  write_imagef (out, (int2)(x, y), pixel);
+  write_imagef (out, (int2)(x, y), fmax(pixel, 0.0f));
 }
 
 #define SWAP(a, b)                \
@@ -294,7 +294,7 @@ pre_median(read_only image2d_t in, write_only image2d_t out, const int width, co
 
   float color = (c & 1) ? (cnt == 1 ? med[4] - 64.0f : med[(cnt - 1) / 2]) : buffer[0];
 
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 #undef SWAP
 
@@ -418,7 +418,7 @@ color_smoothing(read_only image2d_t in, write_only image2d_t out, const int widt
 
   o.z = fmax(s4 + o.y, 0.0f);
 
-  write_imagef(out, (int2) (x, y), o);
+  write_imagef(out, (int2) (x, y), fmax(o, 0.0f));
 }
 #undef cas
 
@@ -450,7 +450,7 @@ clip_and_zoom(read_only image2d_t in, write_only image2d_t out, const int width,
     color += px;
   }
   color /= (float4)((2*samples+1)*(2*samples+1));
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 
 
@@ -621,7 +621,7 @@ ppg_demosaic_green (read_only image2d_t in, write_only image2d_t out, const int 
       color.y = fmax(fmin(guessx*0.25f, M), m);
     }
   }
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 
 
@@ -679,7 +679,7 @@ ppg_demosaic_redblue (read_only image2d_t in, write_only image2d_t out, const in
   float4 color = buffer[0];
   if(x == 0 || y == 0 || x == (width-1) || y == (height-1))
   {
-    write_imagef (out, (int2)(x, y), color);  
+    write_imagef (out, (int2)(x, y), fmax(color, 0.0f));  
     return;
   }
 
@@ -730,7 +730,7 @@ ppg_demosaic_redblue (read_only image2d_t in, write_only image2d_t out, const in
       else color.x = (guess1 + guess2)*0.25f;
     }
   }
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 
 /**
@@ -774,5 +774,5 @@ border_interpolate(read_only image2d_t in, write_only image2d_t out, const int w
   else if(f == 2) o.z = i;
   else            o.y = i;
 
-  write_imagef (out, (int2)(x, y), o);
+  write_imagef (out, (int2)(x, y), fmax(o, 0.0f));
 }

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -56,7 +56,7 @@ __kernel void rcd_write_output (__write_only image2d_t out, global float *rgb0, 
   if(!(col >= border && col < w - border && row >= border && row < height - border)) return;
   const int idx = mad24(row, w, col);
 
-  write_imagef(out, (int2)(col, row), (float4)(scale * rgb0[idx], scale * rgb1[idx], scale * rgb2[idx], 0.0f));
+  write_imagef(out, (int2)(col, row), (float4)(fmax(scale * rgb0[idx], 0.0f), fmax(scale * rgb1[idx], 0.0f), fmax(scale * rgb2[idx], 0.0f), 0.0f));
 }
 
 // Step 1.1: Calculate a squared vertical and horizontal high pass filter on color differences
@@ -392,7 +392,7 @@ __kernel void write_blended_dual(__read_only image2d_t high, __read_only image2d
     const float4 blender = mask[idx];
     data = mix(low_val, high_val, blender);
   }
-  write_imagef(out, (int2)(col, row), data);
+  write_imagef(out, (int2)(col, row), fmax(data, 0.0f));
 }
 
 __kernel void fastblur_mask_9x9(global float *src, global float *out, const int w, const int height, global const float *kern)
@@ -524,7 +524,7 @@ kernel void rcd_border_green(read_only image2d_t in, write_only image2d_t out, c
       color.y = fmax(fmin(guessx*0.25f, M), m);
     }
   }
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 kernel void rcd_border_redblue(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                       const unsigned int filters, local float4 *buffer, const int border)
@@ -625,6 +625,6 @@ kernel void rcd_border_redblue(read_only image2d_t in, write_only image2d_t out,
       }
     }
   }
-  write_imagef (out, (int2)(x, y), color);
+  write_imagef (out, (int2)(x, y), fmax(color, 0.0f));
 }
 

--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -65,9 +65,9 @@ vng_border_interpolate(read_only image2d_t in, write_only image2d_t out, const i
   for(int c = 0; c < colors; c++)
   {
     if(c != f && count[c] != 0)
-      o[c] = sum[c] / count[c];
+      o[c] = fmax(sum[c] / count[c], 0.0f);
     else
-      o[c] = i;
+      o[c] = fmax(i, 0.0f);
   }
 
   write_imagef (out, (int2)(x, y), (float4)(o[0], o[1], o[2], o[3]));

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3444,10 +3444,10 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       dt_opencl_local_buffer_t locopt
         = (dt_opencl_local_buffer_t){ .xoffset = 2*3, .xfactor = 1, .yoffset = 2*3, .yfactor = 1,
                                       .cellsize = sizeof(float) * 1, .overhead = 0,
-                                      .sizex = 1 << 8, .sizey = 1 << 8 };
+                                      .sizex = 64, .sizey = 64 };
 
       if(!dt_opencl_local_buffer_opt(devid, gd->kernel_rcd_border_green, &locopt)) goto error;
-      const int myborder = 9;
+      const int myborder = 32;
       size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
       size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
       dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_border_green, 0, sizeof(cl_mem), &dev_in);
@@ -3465,10 +3465,10 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       dt_opencl_local_buffer_t locopt
         = (dt_opencl_local_buffer_t){ .xoffset = 2*1, .xfactor = 1, .yoffset = 2*1, .yfactor = 1,
                                       .cellsize = 4 * sizeof(float), .overhead = 0,
-                                      .sizex = 1 << 8, .sizey = 1 << 8 };
+                                      .sizex = 64, .sizey = 64 };
 
       if(!dt_opencl_local_buffer_opt(devid, gd->kernel_rcd_border_redblue, &locopt)) goto error;
-      const int myborder = 6;
+      const int myborder = 16;
       size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
       size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
       dt_opencl_set_kernel_arg(devid, gd->kernel_rcd_border_redblue, 0, sizeof(cl_mem), &dev_tmp);


### PR DESCRIPTION
As reported by @piratenpanda in #10778 
- crashes in modules later in the pipeline or
- visible artefacts in darkroom

seemed to be related to NaNs fired up the pipeline. We investigated this further and suspected driver issues but could isolate the underlying problem. Especially the border handling algorithms for ppg and rcd seemed to be a problem (i took the border code for rcd from old ppg code). As we know from other issues ( #9235 ) amd drivers are more picky about this.

I checked places where writing output was not absolutely safe to have fully correct data and ensured writing at least 0 instead of NaN via `fmax(0.0f, val)`

likely
Fixes  #10778
Fixes #10082 