### PR TITLE
Add screenshot on Github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 darktable is an open source photography workflow application and non-destructive raw developer - a virtual lighttable and darkroom for photographers. It manages your digital negatives in a database, lets you view them through a zoomable lighttable and enables you to develop raw images, enhance them and export them to local or remote storage.
 
+![screenshot_lighttable](https://user-images.githubusercontent.com/45535283/148689197-e53dd75f-32f1-4297-9a0f-a9547fd4e7c7.jpg)
+
 darktable is **not** a free Adobe® Lightroom® replacement.
 
 [https://www.darktable.org/](https://www.darktable.org/ "darktable homepage")


### PR DESCRIPTION
Just add a screenshot to make people go to GIthub page see what darktable look like

It's not the last possible screenshot (only import module had changed) but it's same as darktable.org home page. I'm not sure it's really necessary to update it but if wanted, just ask and will do that (and so propose also in website).

Fix #10684. After some testings, adding more screenshot would just overload README and it's not its purpose.