### PR TITLE
refactor(darktable.c): no longer prefer XWayland over Wayland

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -895,12 +895,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // we need this REALLY early so that error messages can be shown, however after gtk_disable_setlocale
   if(init_gui)
   {
-#ifdef GDK_WINDOWING_WAYLAND
-    // There are currently bad interactions with Wayland (drop-downs
-    // are very narrow, scroll events lost). Until this is fixed, give
-    // priority to the XWayland backend for Wayland users.
-    gdk_set_allowed_backends("x11,*");
-#endif
     gtk_init(&argc, &argv);
 
     darktable.themes = NULL;


### PR DESCRIPTION
In #1453 / d9cbadc6bdcc55e998eaded4c19716bfe046b0ae we began forcing
XWayland to be picked over native Wayland by GTK, since at the time we
suffered from odd interactions with native Wayland.

Almost 6 years have passed since then and, as testing shows, most (if
not all) of the issues that motivated that change are now gone, so this
commit removes the explicit preference of XWayland.
