### PR TITLE
check if imported: simple yes/no test does not need to fetch entire row

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1700,7 +1700,7 @@ gboolean dt_images_already_imported(const gchar *filename)
   gchar *file = g_path_get_basename(filename);
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT *"
+                              "SELECT images.id"
                               " FROM main.images, main.film_rolls"
                               " WHERE film_rolls.folder = ?1"
                               "       AND images.film_id = film_rolls.id"


### PR DESCRIPTION
Shaves off about 1 msec on my i7-8550U with NVME, and marginally less memory is used. Since this function is called recursively in import, huge directory listings will benefit more. Wondering if the function should not be refactored to accept two parameters, i.e. dir and filename, instead of the entire path which we have to split up again in its components.