### PR TITLE
Fix dt_interpolation_resample if out == NULL

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -978,6 +978,11 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                          : "[dev_process_export] pixel pipeline processing");
 
   uint8_t *outbuf = pipe.backbuf;
+  if(outbuf == NULL)
+  {
+    dt_print(DT_DEBUG_IMAGEIO, "[dt_imageio_export_with_flags] no valid output buffer\n");
+    goto error;
+  }
 
   // downconversion to low-precision formats:
   if(bpp == 8)

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1715,6 +1715,12 @@ void dt_interpolation_resample(const struct dt_interpolation *itor, float *out,
                                const float *const in, const dt_iop_roi_t *const roi_in,
                                const int32_t in_stride)
 {
+  if(out == NULL)
+  {
+    dt_print(DT_DEBUG_MEMORY, "[dt_interpolation_resample] no valid output buffer\n");
+    return;
+  }
+
   if(darktable.codepath.OPENMP_SIMD)
     return dt_interpolation_resample_plain(itor, out, roi_out, out_stride, in, roi_in, in_stride);
 #if defined(__SSE2__)


### PR DESCRIPTION
Very strong upscaling in export can lead to a NULL pointer as output in finalsize.

Can be triggered by writing a file in export and "set set by scale" to a very large value like 1000 and allow upscaling = true.

The resampling code will have no valid output buffer, also export with flags.

I concider this to be a safe bugfix so for 3.8.1