### PR TITLE
performance: speed up heal tool's adaptation code

### DIFF
--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -200,11 +200,11 @@ static float dt_heal_laplace_iteration(float *const restrict active_pixels,
         float aa = a;
         dt_aligned_pixel_t left = { 0.0f };
         dt_aligned_pixel_t right = { 0.0f };
-        if (col >= lroffset/4) // first pixel in original stamp?
+        if (col > 0 || lroffset) // first pixel in original stamp?
           for_each_channel(c) left[c] = neighbor_pixels[index - 4 + lroffset + c];
         else
           aa -= 1.0f;
-        if (col <= 1 && col + lroffset/4 < width) // last pixel in original stamp?
+        if (col + 1 < width || lroffset == 0) // last pixel in original stamp?
           for_each_channel(c) right[c] = neighbor_pixels[index + lroffset + c];
         else
           aa -= 1.0f;
@@ -258,7 +258,8 @@ static size_t collect_color_runs(const float *const restrict mask, const size_t 
   }
   gboolean in_run = FALSE;
   unsigned run_start = 0;
-  for(size_t col = start; col < width; col += 2)
+  size_t col;
+  for(col = start; col < width; col += 2)
   {
     if(mask[col])
     {
@@ -280,9 +281,9 @@ static size_t collect_color_runs(const float *const restrict mask, const size_t 
   if(in_run)  // finish off a run that doesn't have a zero pixel to its right
   {
     runs[2*count] = start_index + run_start / 2;
-    const unsigned runlen = (width - run_start) / 2;
+    const unsigned runlen = (col - run_start) / 2;
     runs[2*count + 1] = runlen;
-    if (runlen > 1 && run_start + 2*runlen == width)
+    if (runlen > 1 && col > width)
     {
       // split off the final pixel into its own run
       runs[2*count + 1]--;


### PR DESCRIPTION
The adaptation loop in retouch's heal tool is memory-bound.  This PR rearranges things so that memory traffic is substantially reduced.  Passes integration test 0075.
```
Thr	Master	PR	(%ch)
  1	11.7486	7.6876	-34.6%
  2	5.5646	4.2658	-23.3%
  4	2.3430	2.3002	-1.8%
  8	1.1740	1.2662	7.9%
 12	0.9226	0.9658	4.7%
 16	0.8374	0.7926	-5.3%
 24	0.7342	0.6496	-11.5%
 32	0.7378	0.5738	-22.2%
```
I haven't figured out yet why the code is slower at medium thread counts....  The timings are for the entire retouch module with multiple shapes (which are applied sequentially), so more than just the adaptation loop contributes to the times.
