### PR TITLE
real page-up and page-down for culling

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -23,6 +23,7 @@
 #include "control/control.h"
 #include "gui/gtk.h"
 #include "views/view.h"
+#include "dtgtk/thumbtable.h"
 
 #define FULL_PREVIEW_IN_MEMORY_LIMIT 9
 #define ZOOM_MAX 100000.0f
@@ -1637,18 +1638,22 @@ gboolean dt_culling_key_move(dt_culling_t *table, dt_culling_move_t move)
   switch(move)
   {
     case DT_CULLING_MOVE_LEFT:
-    case DT_CULLING_MOVE_UP:
       val = -1;
       break;
-    case DT_CULLING_MOVE_RIGHT:
-    case DT_CULLING_MOVE_DOWN:
-      val = 1;
-      break;
-    case DT_CULLING_MOVE_PAGEUP:
+    case DT_CULLING_MOVE_UP:
       val = -1 * table->thumbs_count;
       break;
+    case DT_CULLING_MOVE_RIGHT:
+      val = 1;
+      break;
+    case DT_CULLING_MOVE_DOWN:
+      val = 1 * table->thumbs_count;
+      break;
+    case DT_CULLING_MOVE_PAGEUP:
+      val = -1 * dt_ui_thumbtable(darktable.gui->ui)->rows;
+      break;
     case DT_CULLING_MOVE_PAGEDOWN:
-      val = table->thumbs_count;
+      val = 1 * dt_ui_thumbtable(darktable.gui->ui)->rows;
       break;
     case DT_CULLING_MOVE_START:
       val = -1 * INT_MAX;


### PR DESCRIPTION
Currently, the page up / page down buttons in culling modes move the view forward by the number of active images. If this number is small (one or two) it is almost identical to navigating with the arrow keys and it takes very long to scroll through a bigger collection. Since there is no scroll bar, the page keys are the fastest option to advance.

I mapped the existing page-up page-down functionality to the up/down arrow keys and made the page up / page down buttons advance the view by the number of thumbnails displayed in the filmstrip at a time. This is a better representation of what a "page" is.