### PR TITLE
import: don't expect that filename comes from g_file_get_parse_name()

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -302,7 +302,6 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
 static const char *_import_session_path(struct dt_import_session_t *self, gboolean current)
 {
   const gboolean currentok = dt_util_test_writable_dir(self->current_path);
-  fprintf(stderr, " _import_session_path testing `%s' %i", self->current_path, currentok);
 
   if(current && self->current_path != NULL)
   {
@@ -331,7 +330,7 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
       new_path[0] = first;                                 // drive letter in uppercase looks nicer
   g_free(s1);
   }
-#else 
+#else
   gchar *new_path = dt_variables_expand(self->vp, pattern, FALSE);
 #endif
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -666,7 +666,7 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   GError *error = NULL;
-  GFile *gfolder = g_file_parse_name(folder);
+  GFile *gfolder = g_file_new_for_path(folder);
 
   // if folder is root, consider one folder separator less
   int offset = (g_path_skip_root(folder)[0] ? folder_lgth + 1 : folder_lgth);
@@ -955,7 +955,7 @@ static void _get_folders_list(GtkTreeStore *store, GtkTreeIter *parent,
   // each time a new folder is added, it is set as not expanded and assigned a fake child
   // when expanded, the children are added and the fake child is reused
   GError *error = NULL;
-  GFile *gfolder = g_file_parse_name(folder);
+  GFile *gfolder = g_file_new_for_path(folder);
   GFileEnumerator *dir_files = g_file_enumerate_children(gfolder,
                                   G_FILE_ATTRIBUTE_STANDARD_NAME ","
                                   G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME ","


### PR DESCRIPTION
attempt to fix #9740

That's still work on my debian sid without gnome (mount).
It would be great if someone could test this on a gnome (samba or not) mount. TIA.
