### PR TITLE
return focus to main window after using zoom slider

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -365,6 +365,7 @@ static void _lib_lighttable_zoom_slider_changed(GtkRange *range, gpointer user_d
   gtk_entry_set_text(GTK_ENTRY(d->zoom_entry), i_as_str);
   _set_zoom(self, i);
   d->current_zoom = i;
+  gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
   g_free(i_as_str);
 }
 


### PR DESCRIPTION
When changing the zoom slider with the mouse and then pressing the arrow keys to continue navigating through the images, I continue to manipulate the zoom slider.

That is because after moving the zoom slider, focus is not reset to the main screen (compare this to `_lib_lighttable_zoom_entry_changed` which does reset the focus)