### PR TITLE
Use dt_apply_transposed_color_matrix() instead of dot_product() everywhere

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -855,8 +855,7 @@ static inline void dt_XYZ_D50_2_XYZ_D65(const dt_aligned_pixel_t XYZ_D50, dt_ali
       {  0.0631636f,  0.0210077f,  1.3299098f, 0.0f },
   };
 
-  for_each_channel(x)
-    XYZ_D65[x] = M_transposed[0][x] * XYZ_D50[0] + M_transposed[1][x] * XYZ_D50[1] + M_transposed[2][x] * XYZ_D50[2];
+  dt_apply_transposed_color_matrix(XYZ_D50, M_transposed, XYZ_D65);
 }
 
 #ifdef _OPENMP
@@ -878,8 +877,7 @@ static inline void dt_XYZ_D65_2_XYZ_D50(const dt_aligned_pixel_t XYZ_D65, dt_ali
       { -0.0501270f, -0.0170491f,  0.7521316f, 0.0f },
   };
 
-  for_each_channel(x)
-    XYZ_D50[x] = M_transposed[0][x] * XYZ_D65[0] + M_transposed[1][x] * XYZ_D65[1] + M_transposed[2][x] * XYZ_D65[2];
+  dt_apply_transposed_color_matrix(XYZ_D65, M_transposed, XYZ_D50);
 }
 
 
@@ -1034,15 +1032,15 @@ static inline void dt_JzAzBz_2_XYZ(const dt_aligned_pixel_t JzAzBz, dt_aligned_p
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-static const dt_colormatrix_t XYZ_D65_to_LMS_2006_D65
-    = { { 0.257085f, 0.859943f, -0.031061f, 0.f },
-        { -0.394427f, 1.175800f, 0.106423f, 0.f },
-        { 0.064856f, -0.076250f, 0.559067f, 0.f } };
+static const dt_colormatrix_t XYZ_D65_to_LMS_2006_D65_transposed
+    = { {  0.257085f, -0.394427f,  0.064856f, 0.f },
+        {  0.859943f,  1.175800f, -0.076250f, 0.f },
+        { -0.031061f,  0.106423f,  0.559067f, 0.f } };
 
-static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65
-    = { { 1.80794659f, -1.29971660f, 0.34785879f, 0.f },
-        { 0.61783960f, 0.39595453f, -0.04104687f, 0.f },
-        { -0.12546960f, 0.20478038f, 1.74274183f, 0.f } };
+static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65_transposed
+    = { {  1.80794659f,  0.61783960f, -0.12546960f, 0.f },
+        { -1.29971660f,  0.39595453f,  0.20478038f, 0.f },
+        {  0.34785879f, -0.04104687f,  1.74274183f, 0.f } };
 
 
 #ifdef _OPENMP
@@ -1050,7 +1048,7 @@ static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65
 #endif
 static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
-  dot_product(XYZ, XYZ_D65_to_LMS_2006_D65, LMS);
+  dt_apply_transposed_color_matrix(XYZ, XYZ_D65_to_LMS_2006_D65_transposed, LMS);
 }
 
 #ifdef _OPENMP
@@ -1058,7 +1056,7 @@ static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t L
 #endif
 static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
-  dot_product(LMS, LMS_2006_D65_to_XYZ_D65, XYZ);
+  dt_apply_transposed_color_matrix(LMS, LMS_2006_D65_to_XYZ_D65_transposed, XYZ);
 }
 
 /*
@@ -1068,22 +1066,22 @@ static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t X
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-static const dt_colormatrix_t filmlightRGB_D65_to_LMS_D65
-    = { { 0.95f, 0.38f, 0.00f, 0.f },
-        { 0.05f, 0.62f, 0.03f, 0.f },
-        { 0.00f, 0.00f, 0.97f, 0.f } };
+static const dt_colormatrix_t filmlightRGB_D65_to_LMS_D65_transposed
+    = { { 0.95f, 0.05f, 0.00f, 0.f },
+        { 0.38f, 0.62f, 0.00f, 0.f },
+        { 0.00f, 0.03f, 0.97f, 0.f } };
 
-static const dt_colormatrix_t LMS_D65_to_filmlightRGB_D65
-    = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
-        { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
-        {         0.f,          0.f,  1.03092784f, 0.f } };
+static const dt_colormatrix_t LMS_D65_to_filmlightRGB_D65_transposed
+    = { {  1.0877193f,  -0.0877193f,  0.f,         0.f },
+        { -0.66666667f,  1.66666667f, 0.f,         0.f },
+        {  0.02061856f, -0.05154639f, 1.03092784f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
 static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t LMS)
 {
-  dot_product(RGB, filmlightRGB_D65_to_LMS_D65, LMS);
+  dt_apply_transposed_color_matrix(RGB, filmlightRGB_D65_to_LMS_D65_transposed, LMS);
 }
 
 #ifdef _OPENMP
@@ -1091,7 +1089,7 @@ static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pi
 #endif
 static inline void LMS_to_gradingRGB(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB)
 {
-  dot_product(LMS, LMS_D65_to_filmlightRGB_D65, RGB);
+  dt_apply_transposed_color_matrix(LMS, LMS_D65_to_filmlightRGB_D65_transposed, RGB);
 }
 
 

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -172,6 +172,10 @@ static inline void dt_apply_transposed_color_matrix(const dt_aligned_pixel_t in,
 {
   // using dt_aligned_pixel_t instead of float* for the function parameters gives GCC enough info to vectorize
   // and eliminate intermediate memory writes without going through major contortions
+  //
+  // N.B. there used to be a function called dot_product() which multiplied the input vector by the
+  // untransposed color matrix. However the transposed version is faster (better SIMD code) so
+  // this shall be used instead in all occasions.
   for_each_channel(r)
     out[r] = matrix[0][r] * in[0] + matrix[1][r] * in[1] + matrix[2][r] * in[2];
 }

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -207,20 +207,6 @@ static inline float scalar_product(const dt_aligned_pixel_t v_1, const dt_aligne
   return acc;
 }
 
-
-#ifdef _OPENMP
-#pragma omp declare simd uniform(M) aligned(M:64) aligned(v_in, v_out:16)
-#endif
-static inline void dot_product(const dt_aligned_pixel_t v_in, const dt_colormatrix_t M, dt_aligned_pixel_t v_out)
-{
-  // specialized 3×4 dot products of 4×1 RGB-alpha pixels
-  #ifdef _OPENMP
-  #pragma omp simd aligned(M:64) aligned(v_in, v_out:16)
-  #endif
-  for(size_t i = 0; i < 3; ++i) v_out[i] = scalar_product(v_in, M[i]);
-}
-
-
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -687,7 +687,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       case DT_ADAPTATION_FULL_BRADFORD:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_XYZ, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ, temp_one);
         const float Y = temp_one[1];
 
         // Convert to LMS
@@ -699,7 +699,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
           upscale_vector(temp_one, Y);
 
           // Compute the 3D mix - this is a rotation + homothety of the vector base
-          dot_product(temp_one, MIX, temp_two);
+          dt_apply_transposed_color_matrix(temp_one, MIX, temp_two);
         }
         convert_bradford_LMS_to_XYZ(temp_two, temp_one);
 
@@ -708,7 +708,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       case DT_ADAPTATION_LINEAR_BRADFORD:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_XYZ, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ, temp_one);
         const float Y = temp_one[1];
 
         // Convert to LMS
@@ -720,7 +720,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
           upscale_vector(temp_one, Y);
 
           // Compute the 3D mix - this is a rotation + homothety of the vector base
-          dot_product(temp_one, MIX, temp_two);
+          dt_apply_transposed_color_matrix(temp_one, MIX, temp_two);
         }
         convert_bradford_LMS_to_XYZ(temp_two, temp_one);
 
@@ -729,7 +729,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       case DT_ADAPTATION_CAT16:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_XYZ, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ, temp_one);
         const float Y = temp_one[1];
 
         // Convert to LMS
@@ -741,7 +741,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
           upscale_vector(temp_one, Y);
 
           // Compute the 3D mix - this is a rotation + homothety of the vector base
-          dot_product(temp_one, MIX, temp_two);
+          dt_apply_transposed_color_matrix(temp_one, MIX, temp_two);
         }
         convert_CAT16_LMS_to_XYZ(temp_two, temp_one);
 
@@ -750,7 +750,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       case DT_ADAPTATION_XYZ:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_XYZ, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ, temp_one);
         const float Y = temp_one[1];
 
         // Do white balance in XYZ
@@ -759,7 +759,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
         upscale_vector(temp_two, Y);
 
         // Compute the 3D mix in XYZ - this is a rotation + homothety of the vector base
-        dot_product(temp_two, MIX, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, MIX, temp_one);
 
         break;
       }
@@ -769,10 +769,10 @@ static inline void loop_switch(const float *const restrict in, float *const rest
         // No white balance.
 
         // Compute the 3D mix in RGB - this is a rotation + homothety of the vector base
-        dot_product(temp_two, MIX, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, MIX, temp_one);
 
         // Convert from RGB to XYZ
-        dot_product(temp_one, RGB_to_XYZ, temp_two);
+        dt_apply_transposed_color_matrix(temp_one, RGB_to_XYZ, temp_two);
 
         for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) temp_one[c] = temp_two[c];
         break;
@@ -804,7 +804,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       case DT_ADAPTATION_LAST:
       {
         // Convert from XYZ to RGB
-        dot_product(temp_two, XYZ_to_RGB, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, XYZ_to_RGB, temp_one);
         break;
       }
     }
@@ -846,7 +846,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
         case DT_ADAPTATION_LAST:
         {
           // Convert from RBG to XYZ
-          dot_product(temp_two, RGB_to_XYZ, temp_one);
+          dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ, temp_one);
           break;
         }
       }
@@ -857,7 +857,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       if(clip) for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; c++) temp_one[c] = fmaxf(temp_one[c], 0.0f);
 
       // Convert back to RGB
-      dot_product(temp_one, XYZ_to_RGB, temp_two);
+      dt_apply_transposed_color_matrix(temp_one, XYZ_to_RGB, temp_two);
 
       if(clip)
         for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; c++) out[k + c] = fmaxf(temp_two[c], 0.0f);
@@ -910,7 +910,7 @@ static inline void auto_detect_WB(const float *const restrict in, dt_illuminant_
         RGB[c] = fmaxf(in[index + c], 0.0f);
 
       // Convert to XYZ
-      dot_product(RGB, RGB_to_XYZ, XYZ);
+      dt_apply_transposed_color_matrix(RGB, RGB_to_XYZ, XYZ);
 
       // Convert to xyY
       const float sum = fmaxf(XYZ[0] + XYZ[1] + XYZ[2], NORM_MIN);
@@ -1372,7 +1372,7 @@ static const extraction_result_t _extract_patches(const float *const restrict in
 
     // Convert to XYZ
     dt_aligned_pixel_t XYZ = { 0 };
-    dot_product(patches + k * 4, RGB_to_XYZ, XYZ);
+    dt_apply_transposed_color_matrix(patches + k * 4, RGB_to_XYZ, XYZ);
     for(size_t c = 0; c < 3; c++) patches[k * 4 + c] = XYZ[c];
   }
 
@@ -1436,8 +1436,8 @@ static const extraction_result_t _extract_patches(const float *const restrict in
       for(size_t c = 0; c < 3; c++) XYZ_test[c] = patches[k * 4 + c];
       dt_Lab_to_XYZ(g->checker->values[k].Lab, XYZ_ref);
 
-      dot_product(XYZ_test, XYZ_to_CAM, RGB_test);
-      dot_product(XYZ_ref, XYZ_to_CAM, RGB_ref);
+      dt_apply_transposed_color_matrix(XYZ_test, XYZ_to_CAM, RGB_test);
+      dt_apply_transposed_color_matrix(XYZ_ref, XYZ_to_CAM, RGB_ref);
 
       // Undo exposure module settings
       for(int c = 0; c < 3; c++)
@@ -1468,8 +1468,8 @@ static const extraction_result_t _extract_patches(const float *const restrict in
       for(size_t c = 0; c < 3; c++) XYZ_test[c] = patches[k * 4 + c];
       dt_Lab_to_XYZ(g->checker->values[k].Lab, XYZ_ref);
 
-      dot_product(XYZ_test, XYZ_to_CAM, RGB_test);
-      dot_product(XYZ_ref, XYZ_to_CAM, RGB_ref);
+      dt_apply_transposed_color_matrix(XYZ_test, XYZ_to_CAM, RGB_test);
+      dt_apply_transposed_color_matrix(XYZ_ref, XYZ_to_CAM, RGB_ref);
 
       // Undo exposure module settings
       for(int c = 0; c < 3; c++)
@@ -1714,6 +1714,9 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   dt_free_align(Y);
   dt_free_align(A);
 
+  dt_colormatrix_t mix_transposed;
+  transpose_3xSSE(g->mix, mix_transposed);
+
   // apply the matrix mix
   for(size_t k = 0; k < g->checker->patches; k++)
   {
@@ -1725,7 +1728,7 @@ void extract_color_checker(const float *const restrict in, float *const restrict
     for(size_t c = 0; c < 3; c++) temp[c] = sample[c];
 
     convert_any_XYZ_to_LMS(temp, LMS_test, kind);
-      dot_product(LMS_test, g->mix, temp);
+      dt_apply_transposed_color_matrix(LMS_test, mix_transposed, temp);
     convert_any_LMS_to_XYZ(temp, sample, kind);
   }
 
@@ -1882,9 +1885,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   if(work_profile)
   {
     // work profile can't be fetched in commit_params since it is not yet initialised
-    memcpy(RGB_to_XYZ, work_profile->matrix_in, sizeof(RGB_to_XYZ));
-    memcpy(XYZ_to_RGB, work_profile->matrix_out, sizeof(XYZ_to_RGB));
-    memcpy(XYZ_to_CAM, input_profile->matrix_out, sizeof(XYZ_to_CAM));
+    memcpy(RGB_to_XYZ, work_profile->matrix_in_transposed, sizeof(RGB_to_XYZ));
+    memcpy(XYZ_to_RGB, work_profile->matrix_out_transposed, sizeof(XYZ_to_RGB));
+    memcpy(XYZ_to_CAM, input_profile->matrix_out_transposed, sizeof(XYZ_to_CAM));
   }
 
   assert(piece->colors == 4);
@@ -1927,6 +1930,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     if(exit) return;
   }
 
+  dt_colormatrix_t MIX_transposed;
+  transpose_3xSSE(data->MIX, MIX_transposed);
+
   if(data->illuminant_type == DT_ILLUMINANT_CAMERA)
   {
     // The camera illuminant is a behaviour rather than a preset of values:
@@ -1961,7 +1967,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     case DT_ADAPTATION_FULL_BRADFORD:
     {
       loop_switch(in, out, roi_out->width, roi_out->height, ch,
-                  XYZ_to_RGB, RGB_to_XYZ, data->MIX,
+                  XYZ_to_RGB, RGB_to_XYZ, MIX_transposed,
                   data->illuminant, data->saturation, data->lightness, data->grey,
                   data->p, data->gamut, data->clip, data->apply_grey, DT_ADAPTATION_FULL_BRADFORD, data->version);
       break;
@@ -1969,7 +1975,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     case DT_ADAPTATION_LINEAR_BRADFORD:
     {
       loop_switch(in, out, roi_out->width, roi_out->height, ch,
-                  XYZ_to_RGB, RGB_to_XYZ, data->MIX,
+                  XYZ_to_RGB, RGB_to_XYZ, MIX_transposed,
                   data->illuminant, data->saturation, data->lightness, data->grey,
                   data->p, data->gamut, data->clip, data->apply_grey, DT_ADAPTATION_LINEAR_BRADFORD, data->version);
       break;
@@ -1977,7 +1983,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     case DT_ADAPTATION_CAT16:
     {
       loop_switch(in, out, roi_out->width, roi_out->height, ch,
-                  XYZ_to_RGB, RGB_to_XYZ, data->MIX,
+                  XYZ_to_RGB, RGB_to_XYZ, MIX_transposed,
                   data->illuminant, data->saturation, data->lightness, data->grey,
                   data->p, data->gamut, data->clip, data->apply_grey, DT_ADAPTATION_CAT16, data->version);
       break;
@@ -1985,7 +1991,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     case DT_ADAPTATION_XYZ:
     {
       loop_switch(in, out, roi_out->width, roi_out->height, ch,
-                  XYZ_to_RGB, RGB_to_XYZ, data->MIX,
+                  XYZ_to_RGB, RGB_to_XYZ, MIX_transposed,
                   data->illuminant, data->saturation, data->lightness, data->grey,
                   data->p, data->gamut, data->clip, data->apply_grey, DT_ADAPTATION_XYZ, data->version);
       break;
@@ -1993,7 +1999,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     case DT_ADAPTATION_RGB:
     {
       loop_switch(in, out, roi_out->width, roi_out->height, ch,
-                  XYZ_to_RGB, RGB_to_XYZ, data->MIX,
+                  XYZ_to_RGB, RGB_to_XYZ, MIX_transposed,
                   data->illuminant, data->saturation, data->lightness, data->grey,
                   data->p, data->gamut, data->clip, data->apply_grey, DT_ADAPTATION_RGB, data->version);
       break;
@@ -3767,7 +3773,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
   // Convert to XYZ
   dt_aligned_pixel_t XYZ;
-  dot_product(RGB, work_profile->matrix_in, XYZ);
+  dt_apply_transposed_color_matrix(RGB, work_profile->matrix_in_transposed, XYZ);
 
   // Convert to xyY
   const float sum = fmaxf(XYZ[0] + XYZ[1] + XYZ[2], NORM_MIN);


### PR DESCRIPTION
Use `dt_apply_transposed_color_matrix()` instead of `dot_product()` everywhere.

Two reasons:

1. the code (at least SIMD) code for `dt_apply_transposed_color_matrix()` is better than that for `dot_product()`. This should result in performance gains in IOPs that heavily use color matrices, especially Color calibration.
2. There's no reason to have two ways of doing essentially the same thing.

In `colorbalancergb.c`, the order of multiplication of color matrices is reversed because transposition of a matrix product reverses the multiplication order: `(ABC)^T = C^T B^T A^T`.