### PR TITLE
UI improvements: new icons and more

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2471,17 +2471,26 @@ Details :
 
 /* Set red reject icon when visible */
 .dt_overlays_hover #thumb_main:hover #thumb_reject:active,
+.dt_overlays_hover #thumb_main:hover #thumb_reject:hover,
 .dt_overlays_hover_extended #thumb_main:hover #thumb_reject:active,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_reject:hover,
 .dt_overlays_always #thumb_reject:active,
 .dt_overlays_always #thumb_main:hover #thumb_reject:active,
 .dt_overlays_always #thumb_main:selected #thumb_reject:active,
+.dt_overlays_always #thumb_reject:hover,
+.dt_overlays_always #thumb_main:hover #thumb_reject:hover,
 .dt_overlays_always_extended #thumb_reject:active,
 .dt_overlays_always_extended #thumb_main:hover #thumb_reject:active,
 .dt_overlays_always_extended #thumb_main:selected #thumb_reject:active,
+.dt_overlays_always_extended #thumb_reject:hover,
+.dt_overlays_always_extended #thumb_main:hover #thumb_reject:hover,
 .dt_overlays_mixed #thumb_reject:active,
 .dt_overlays_mixed #thumb_main:hover #thumb_reject:active,
 .dt_overlays_mixed #thumb_main:selected #thumb_reject:active,
-.dt_overlays_hover_block #thumb_image:hover #thumb_reject:active
+.dt_overlays_mixed #thumb_reject:hover,
+.dt_overlays_mixed #thumb_main:hover #thumb_reject:hover,
+.dt_overlays_hover_block #thumb_main:hover #thumb_reject:active,
+.dt_overlays_hover_block #thumb_main:hover #thumb_reject:hover
 {
   color: red;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -494,7 +494,7 @@ spinbutton>button
 #iop-plugin-ui-main,
 #lib-plugin-ui-main
 {
-  padding: 0.42em 0.84em;
+  padding: 0.35em 0.7em;
 }
 
 /* Frame around blending boxes */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2298,7 +2298,8 @@ Details :
 }
 
 /* Set border color around thumbnails */
-.dt_group_left #thumb_back
+.dt_group_left #thumb_back,
+#thumb_main.dt_group_left:selected #thumb_back
 {
   border-left: 0.07em solid rgb(255, 187, 0);
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2021 Nicolas Auffray.
+    copyright (c) 2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -345,7 +345,9 @@ checkbutton check:checked
 
 /* Button to open/close the dropdown section, especially header ones */
 #control-button,
-#control-button:checked
+#control-button:checked,
+#filter-button,
+#filter-button:checked
 {
   background-color: transparent;
   margin-left: 0.14em;
@@ -429,12 +431,14 @@ spinbutton>button
 #header-toolbar #dt-toggle-button,
 #header-toolbar #dt-button,
 #footer-toolbar #dt-toggle-button,
-#footer-toolbar #dt-button
+#footer-toolbar #dt-button,
+#filter-button,
+#filter-button:checked
 {
   padding: 0.07em;
-  min-height: 2.56em; /* align toolbox button height on comboboxe's one */
-  min-width: 2.56em;
-  font-size: .7em;
+  min-height: 2.4em; /* align toolbox button height on comboboxe's one */
+  min-width: 2.4em;
+  font-size: .75em;
   border: 0;
 }
 
@@ -714,7 +718,7 @@ l
 #filter-box
 {
   min-width: 40em;
-  padding-top: 0.14em;
+  padding-top: 0.28em;
 }
 
 /*-------------------
@@ -1865,6 +1869,7 @@ menuitem:hover > *:not(check),
 combobox window *:hover,
 radiobutton:hover label,
 #control-button:hover,
+#filter-button:hover,
 #history-button:hover,
 #history-button-enabled:hover,
 #history-button-always-enabled:hover,
@@ -1896,6 +1901,7 @@ menuitem:hover cellview,
 menuitem:hover > *,
 notebook tab:hover label,
 #control-button:hover,
+#filter-button:hover,
 #history-button:hover *,
 #history-button-enabled:hover *,
 #history-button-always-enabled:hover *,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1887,6 +1887,7 @@ button:hover,
 button:hover cellview,
 button:hover image,
 button:hover label,
+#blending-box button:hover, /* needed for hover effect for some blending mask box buttons */
 button:checked cellview,
 button:checked image,
 button:checked label,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2271,12 +2271,12 @@ Details :
 
 #thumb_image
 {
-  margin: 25px; /* not real pixels. This is used as a per thousand of the thumb size and couldn't be scalable */
+  margin: 1.8em 1.2em; /* not real pixels. This is used as a per thousand of the thumb size and couldn't be scalable */
 }
 
 .dt_thumbnails_2 #thumb_image /* update consistently margins if big thumbnails (less images per row) are shown */
 {
-  margin: 1.4em;
+  margin: 1em 0.75em;
 }
 
 /* Set top margin on active image in filmstrip */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2297,25 +2297,27 @@ Details :
 }
 
 /* Set border color around thumbnails */
-.dt_group_left #thumb_back,
-#thumb_main.dt_group_left:selected #thumb_back
+.dt_group_left #thumb_back
 {
-  border-left: 2px solid rgb(255, 187, 0);
+  border-left: 0.07em solid rgb(255, 187, 0);
 }
+
 .dt_group_top #thumb_back,
 #thumb_main.dt_group_top:selected #thumb_back
 {
-  border-top: 2px solid rgb(255, 187, 0);
+  border-top: 0.07em solid rgb(255, 187, 0);
 }
+
 .dt_group_right #thumb_back,
 #thumb_main.dt_group_right:selected #thumb_back
 {
-  border-right: 2px solid rgb(255, 187, 0);
+  border-right: 0.07em solid rgb(255, 187, 0);
 }
+
 .dt_group_bottom #thumb_back,
 #thumb_main.dt_group_bottom:selected #thumb_back
 {
-  border-bottom: 2px solid rgb(255, 187, 0);
+  border-bottom: 0.07em solid rgb(255, 187, 0);
 }
 
 .dt_thumbtable_reorder #thumb_main:hover #thumb_back

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: darktable 3.6\n"
+"Project-Id-Version: darktable 3.9\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-07 08:06+0100\n"
-"PO-Revision-Date: 2022-02-07 08:08+0100\n"
-"Last-Translator: Pascal Obry <pascal@obry.net>\n"
+"POT-Creation-Date: 2022-02-10 22:14+0100\n"
+"PO-Revision-Date: 2022-02-10 22:21+0100\n"
+"Last-Translator: Nicolas Auffray <nicolas.auffray@zaclys.net>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
 #: ../build/bin/preferences_gen.h:81 ../build/bin/preferences_gen.h:3744
@@ -5371,12 +5371,12 @@ msgstr "darktable - maintenance"
 msgid "later"
 msgstr "plus tard"
 
-#: ../src/common/exif.cc:4226
+#: ../src/common/exif.cc:4226 ../src/common/exif.cc:4228
 #, c-format
 msgid "cannot read xmp file '%s': '%s'"
 msgstr "impossible de lire le fichier xmp « %s » : « %s »"
 
-#: ../src/common/exif.cc:4278
+#: ../src/common/exif.cc:4278 ../src/common/exif.cc:4280
 #, c-format
 msgid "cannot write xmp file '%s': '%s'"
 msgstr "impossible d'écrire le fichier xmp « %s » : « %s »"
@@ -7978,6 +7978,14 @@ msgstr "actuelle"
 msgid "leader"
 msgstr "tête de groupe"
 
+#: ../src/dtgtk/thumbnail.c:98
+msgid ""
+"\n"
+"click here to set this image as group leader\n"
+msgstr ""
+"\n"
+"cliquer ici pour définir cette image comme tête de groupe\n"
+
 #. and the number of grouped images
 #: ../src/dtgtk/thumbnail.c:129
 msgid "grouped images"
@@ -8766,7 +8774,8 @@ msgstr ""
 #: ../src/gui/accelerators.c:1826 ../src/gui/accelerators.c:1905
 #: ../src/gui/gtk.c:3009 ../src/imageio/format/pdf.c:662
 #: ../src/iop/denoiseprofile.c:3597 ../src/iop/lens.cc:2282
-#: ../src/iop/rawdenoise.c:907 ../src/libs/tools/filter.c:186
+#: ../src/iop/lens.cc:2245 ../src/iop/rawdenoise.c:907
+#: ../src/libs/tools/filter.c:186
 msgid "all"
 msgstr "tout"
 
@@ -22178,11 +22187,11 @@ msgstr "rejetées"
 msgid "all except rejected"
 msgstr "tout sauf rejetées"
 
-#: ../src/libs/tools/filter.c:201
+#: ../src/libs/tools/filter.c:202
 msgid "sort by"
 msgstr "trier par"
 
-#: ../src/libs/tools/filter.c:202
+#: ../src/libs/tools/filter.c:203
 msgid "determine the sort order of shown images"
 msgstr "spécifie l'ordre de tri des images affichées"
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1515,7 +1515,7 @@ static void dt_bauhaus_draw_quad(dt_bauhaus_widget_t *w, cairo_t *cr)
     switch(w->type)
     {
       case DT_BAUHAUS_COMBOBOX:
-        cairo_translate(cr, width - darktable.bauhaus->quad_width * .5f, height * .33f);
+        cairo_translate(cr, width - darktable.bauhaus->quad_width * .5f, height * .4f);
         draw_equilateral_triangle(cr, darktable.bauhaus->quad_width * .3f);
         cairo_fill_preserve(cr);
         cairo_set_line_width(cr, 0.5);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2021 darktable developers.
+    Copyright (C) 2012-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1516,7 +1516,7 @@ static void dt_bauhaus_draw_quad(dt_bauhaus_widget_t *w, cairo_t *cr)
     {
       case DT_BAUHAUS_COMBOBOX:
         cairo_translate(cr, width - darktable.bauhaus->quad_width * .5f, height * .33f);
-        draw_equilateral_triangle(cr, darktable.bauhaus->quad_width * .25f);
+        draw_equilateral_triangle(cr, darktable.bauhaus->quad_width * .3f);
         cairo_fill_preserve(cr);
         cairo_set_line_width(cr, 0.5);
         set_color(cr, darktable.bauhaus->color_border);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1483,17 +1483,20 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   }
   else
   {
-    cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, alpha);
+    cairo_set_line_width(cr, 0.12);
+    cairo_set_source_rgba(cr, 0.9, 0.9, 0.9, alpha);
+    cairo_move_to(cr, 0.9, 0.1);
+    cairo_line_to(cr, 0.1, 0.9);
+    cairo_stroke(cr);
     def = TRUE;
   }
   cairo_fill(cr);
 
-  /* draw cross overlay if highlighted */
+  /* draw slash overlay on delete label icon */  
   if(def == TRUE && (flags & CPF_PRELIGHT))
   {
-    cairo_set_source_rgba(cr, 0.5, 0.0, 0.0, 0.8);
-    cairo_move_to(cr, 0.0, 0.0);
-    cairo_line_to(cr, 1.0, 1.0);
+    cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
+    cairo_set_source_rgba(cr, 0.6, 0.6, 0.6, 0.6);
     cairo_move_to(cr, 0.9, 0.1);
     cairo_line_to(cr, 0.1, 0.9);
     cairo_stroke(cr);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -212,24 +212,24 @@ void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   
   if(flags & CPF_DIRECTION_UP)
   {
-    cairo_move_to(cr, 0.40, 0.05);
+    cairo_move_to(cr, 0.35, 0.05);
     cairo_line_to(cr, 0.45, 0.05);
-    cairo_move_to(cr, 0.40, 0.35);
+    cairo_move_to(cr, 0.35, 0.35);
     cairo_line_to(cr, 0.65, 0.35);
-    cairo_move_to(cr, 0.40, 0.65);
+    cairo_move_to(cr, 0.35, 0.65);
     cairo_line_to(cr, 0.85, 0.65);
-    cairo_move_to(cr, 0.40, 0.95);
+    cairo_move_to(cr, 0.35, 0.95);
     cairo_line_to(cr, 1.00, 0.95);
   }
   else
   {
-    cairo_move_to(cr, 0.40, 0.05);
+    cairo_move_to(cr, 0.35, 0.05);
     cairo_line_to(cr, 1.00, 0.05);
-    cairo_move_to(cr, 0.40, 0.35);
+    cairo_move_to(cr, 0.35, 0.35);
     cairo_line_to(cr, 0.85, 0.35);
-    cairo_move_to(cr, 0.40, 0.65);
+    cairo_move_to(cr, 0.35, 0.65);
     cairo_line_to(cr, 0.65, 0.65);
-    cairo_move_to(cr, 0.40, 0.95);
+    cairo_move_to(cr, 0.35, 0.95);
     cairo_line_to(cr, 0.45, 0.95);
   }
   cairo_stroke(cr);
@@ -1498,14 +1498,10 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 {
   PREAMBLE(1, 1, 0, 0)
 
-  gboolean def = FALSE;
   double r = 0.4;
 
   /* fill base color */
   cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
-  float alpha = 1.0;
-
-  if((flags & 8) && !(flags & CPF_PRELIGHT)) alpha = 0.6;
 
   const dt_colorlabels_enum color = (flags & 7);
 
@@ -1517,24 +1513,13 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   }
   else
   {
-    cairo_set_line_width(cr, 0.12);
-    cairo_set_source_rgba(cr, 0.9, 0.9, 0.9, alpha);
-    cairo_move_to(cr, 0.9, 0.1);
-    cairo_line_to(cr, 0.1, 0.9);
+    cairo_set_line_width(cr, 0.1);
+    cairo_set_source_rgb(cr, 0.9, 0.9, 0.9);
+    cairo_move_to(cr, 0.15, 0.85);
+    cairo_line_to(cr, 0.85, 0.15);
     cairo_stroke(cr);
-    def = TRUE;
   }
   cairo_fill(cr);
-
-  /* draw slash overlay on delete label icon */  
-  if(def == TRUE && (flags & CPF_PRELIGHT))
-  {
-    cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
-    cairo_set_source_rgba(cr, 0.6, 0.6, 0.6, 0.6);
-    cairo_move_to(cr, 0.9, 0.1);
-    cairo_line_to(cr, 0.1, 0.9);
-    cairo_stroke(cr);
-  }
 
   FINISH
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1570,6 +1570,36 @@ void dtgtk_cairo_paint_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   FINISH
 }
 
+void dtgtk_cairo_paint_unratestar(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  cairo_push_group(cr);
+
+  // we create the path
+  dt_draw_star(cr, 1 / 2., 1. / 2., 1. / 2., 1. / 5.);
+
+  // we create the cross line
+  cairo_move_to(cr, 0.05, 0.95);
+  cairo_line_to(cr, 0.85, 0.0);
+  cairo_stroke(cr);
+
+  // then erase some parts around cross line
+  cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+  cairo_set_line_width(cr, 0.05);
+  cairo_move_to(cr, 0.0, 0.88);
+  cairo_line_to(cr, 0.78, 0.0);
+  cairo_move_to(cr, 0.10, 1.0);
+  cairo_line_to(cr, 0.92, 0.0);
+  cairo_set_source_rgba(cr, 0, 1.0, 0, 1.0);
+  cairo_stroke(cr);
+
+  cairo_pop_group_to_source(cr);
+  cairo_paint(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1546,26 +1546,21 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 1, 0, 0)
+  PREAMBLE(0.9, 1, 0, 0)
 
-  // circle around (mouse over effect)
-  if(flags & CPF_PRELIGHT)
-  {
-    cairo_arc(cr, 0.5, 0.5, 0.5, 0.0, 2.0 * M_PI);
-  }
+  // the reject icon
+  cairo_arc(cr, 0.5, 0.5, 0.5, 0.0, 2.0 * M_PI);
+  cairo_move_to(cr, 0.7, 0.3);
+  cairo_line_to(cr, 0.3, 0.7);
+  cairo_move_to(cr, 0.3, 0.3);
+  cairo_line_to(cr, 0.7, 0.7);
+  cairo_stroke(cr);
 
   if(flags & CPF_DIRECTION_RIGHT)
   {
     // that means the image is rejected, so we draw the cross in red bold
     cairo_set_source_rgb(cr, 1.0, 0, 0);
   }
-
-  // the cross
-  cairo_move_to(cr, 0.2, 0.2);
-  cairo_line_to(cr, 0.8, 0.8);
-  cairo_move_to(cr, 0.8, 0.2);
-  cairo_line_to(cr, 0.2, 0.8);
-  cairo_stroke(cr);
 
   FINISH
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1823,22 +1823,27 @@ void dtgtk_cairo_paint_help(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 
 void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.5 * 0.95, 1, 0.5, 0.5)
+  PREAMBLE(1, 1, 0, 0)
 
-  cairo_arc(cr, 0.0, 0.0, 1., 0., 2.0f * M_PI);
+  cairo_move_to(cr, 0.30, 0.15);
+  cairo_line_to(cr, 0.95, 0.15);
+  cairo_move_to(cr, 0.95, 0.15);
+  cairo_line_to(cr, 0.95, 0.65);
+  cairo_move_to(cr, 0.20, 0.25);
+  cairo_line_to(cr, 0.85, 0.25);
+  cairo_move_to(cr, 0.85, 0.25);
+  cairo_line_to(cr, 0.85, 0.75);
   cairo_stroke(cr);
-  cairo_arc(cr, -0.35, -0.33, 0.25, 0., 2.0f * M_PI);
-  cairo_fill(cr);
-  cairo_stroke(cr);
-  cairo_arc(cr, -0.35, 0.35, 0.25, 0., 2.0f * M_PI);
-  cairo_fill(cr);
-  cairo_stroke(cr);
-  cairo_arc(cr, 0.35, -0.35, 0.25, 0., 2.0f * M_PI);
-  cairo_fill(cr);
-  cairo_stroke(cr);
-  cairo_arc(cr, 0.35, 0.35, 0.25, 0., 2.0f * M_PI);
-  cairo_fill(cr);
-  cairo_stroke(cr);
+  if(flags & CPF_ACTIVE)
+  {
+    cairo_rectangle(cr, 0.05, 0.35, 0.7, 0.5);
+    cairo_fill(cr);
+  }
+  else
+  {
+    cairo_rectangle(cr, 0.05, 0.35, 0.7, 0.5);
+    cairo_stroke(cr);
+  }
 
   FINISH
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -198,6 +198,56 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   FINISH
 }
 
+void dtgtk_cairo_paint_sortby_alt(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1.15, 1, 0, 0)
+
+  cairo_move_to(cr, 0.1, 0.05);
+  cairo_line_to(cr, 0.1, 0.95);
+  cairo_move_to(cr, 0.0, 0.80);
+  cairo_line_to(cr, 0.1, 0.95);
+  cairo_move_to(cr, 0.1, 0.95);
+  cairo_line_to(cr, 0.2, 0.80);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.40, 0.05);
+  cairo_line_to(cr, 0.45, 0.05);
+  cairo_move_to(cr, 0.40, 0.35);
+  cairo_line_to(cr, 0.65, 0.35);
+  cairo_move_to(cr, 0.40, 0.65);
+  cairo_line_to(cr, 0.85, 0.65);
+  cairo_move_to(cr, 0.40, 0.95);
+  cairo_line_to(cr, 1.00, 0.95);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1.15, 1, 0, 0)
+
+  cairo_move_to(cr, 0.1, 0.05);
+  cairo_line_to(cr, 0.1, 0.95);
+  cairo_move_to(cr, 0.0, 0.80);
+  cairo_line_to(cr, 0.1, 0.95);
+  cairo_move_to(cr, 0.1, 0.95);
+  cairo_line_to(cr, 0.2, 0.80);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.40, 0.05);
+  cairo_line_to(cr, 1.00, 0.05);
+  cairo_move_to(cr, 0.40, 0.35);
+  cairo_line_to(cr, 0.85, 0.35);
+  cairo_move_to(cr, 0.40, 0.65);
+  cairo_line_to(cr, 0.65, 0.65);
+  cairo_move_to(cr, 0.40, 0.95);
+  cairo_line_to(cr, 0.45, 0.95);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -198,31 +198,6 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   FINISH
 }
 
-void dtgtk_cairo_paint_sortby_alt(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
-{
-  PREAMBLE(1.15, 1, 0, 0)
-
-  cairo_move_to(cr, 0.1, 0.05);
-  cairo_line_to(cr, 0.1, 0.95);
-  cairo_move_to(cr, 0.0, 0.80);
-  cairo_line_to(cr, 0.1, 0.95);
-  cairo_move_to(cr, 0.1, 0.95);
-  cairo_line_to(cr, 0.2, 0.80);
-  cairo_stroke(cr);
-
-  cairo_move_to(cr, 0.40, 0.05);
-  cairo_line_to(cr, 0.45, 0.05);
-  cairo_move_to(cr, 0.40, 0.35);
-  cairo_line_to(cr, 0.65, 0.35);
-  cairo_move_to(cr, 0.40, 0.65);
-  cairo_line_to(cr, 0.85, 0.65);
-  cairo_move_to(cr, 0.40, 0.95);
-  cairo_line_to(cr, 1.00, 0.95);
-  cairo_stroke(cr);
-
-  FINISH
-}
-
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1.15, 1, 0, 0)
@@ -234,15 +209,29 @@ void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   cairo_move_to(cr, 0.1, 0.95);
   cairo_line_to(cr, 0.2, 0.80);
   cairo_stroke(cr);
-
-  cairo_move_to(cr, 0.40, 0.05);
-  cairo_line_to(cr, 1.00, 0.05);
-  cairo_move_to(cr, 0.40, 0.35);
-  cairo_line_to(cr, 0.85, 0.35);
-  cairo_move_to(cr, 0.40, 0.65);
-  cairo_line_to(cr, 0.65, 0.65);
-  cairo_move_to(cr, 0.40, 0.95);
-  cairo_line_to(cr, 0.45, 0.95);
+  
+  if(flags & CPF_DIRECTION_UP)
+  {
+    cairo_move_to(cr, 0.40, 0.05);
+    cairo_line_to(cr, 0.45, 0.05);
+    cairo_move_to(cr, 0.40, 0.35);
+    cairo_line_to(cr, 0.65, 0.35);
+    cairo_move_to(cr, 0.40, 0.65);
+    cairo_line_to(cr, 0.85, 0.65);
+    cairo_move_to(cr, 0.40, 0.95);
+    cairo_line_to(cr, 1.00, 0.95);
+  }
+  else
+  {
+    cairo_move_to(cr, 0.40, 0.05);
+    cairo_line_to(cr, 1.00, 0.05);
+    cairo_move_to(cr, 0.40, 0.35);
+    cairo_line_to(cr, 0.85, 0.35);
+    cairo_move_to(cr, 0.40, 0.65);
+    cairo_line_to(cr, 0.65, 0.65);
+    cairo_move_to(cr, 0.40, 0.95);
+    cairo_line_to(cr, 0.45, 0.95);
+  }
   cairo_stroke(cr);
 
   FINISH

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -200,7 +200,7 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
 
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1.15, 1, 0, 0)
+  PREAMBLE(0.8, 0.8, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.05);
   cairo_line_to(cr, 0.1, 0.95);
@@ -391,7 +391,7 @@ void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   PREAMBLE(1, 1, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.45, 0, 2 * M_PI);
-  cairo_stroke(cr);
+  cairo_fill(cr);
 
   if((flags & CPF_ACTIVE))
   {

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1498,6 +1498,8 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 {
   PREAMBLE(1, 1, 0, 0)
 
+  cairo_push_group(cr);
+
   double r = 0.4;
 
   /* fill base color */
@@ -1518,8 +1520,21 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
     cairo_move_to(cr, 0.15, 0.85);
     cairo_line_to(cr, 0.85, 0.15);
     cairo_stroke(cr);
+
+    // then erase some parts around cross line
+    cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+    cairo_set_line_width(cr, 0.05);
+    cairo_move_to(cr, 0.1, 0.78);
+    cairo_line_to(cr, 0.78, 0.15);
+    cairo_move_to(cr, 0.20, 0.9);
+    cairo_line_to(cr, 0.92, 0.15);
+    cairo_set_source_rgba(cr, 0, 1.0, 0, 1.0);
+    cairo_stroke(cr);
   }
   cairo_fill(cr);
+
+  cairo_pop_group_to_source(cr);
+  cairo_paint(cr);
 
   FINISH
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1515,11 +1515,6 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
     set_color(cr, colorlabels[color]);
   }
-  else if(color == 7)
-  {
-    // don't fill
-    cairo_set_source_rgba(cr, 0, 0, 0, 0);
-  }
   else
   {
     cairo_set_line_width(cr, 0.12);

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -55,8 +55,6 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
 void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a solid arrow left/right/up/down */
 void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
-/** Paint a sort by alt icon */
-void dtgtk_cairo_paint_sortby_alt(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
 /** Paint a sort by icon */
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
 /** Paint a store icon */

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -55,6 +55,10 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
 void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a solid arrow left/right/up/down */
 void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
+/** Paint a sort by alt icon */
+void dtgtk_cairo_paint_sortby_alt(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
+/** Paint a sort by icon */
+void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
 /** Paint a store icon */
 void dtgtk_cairo_paint_store(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a reset icon */

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -123,6 +123,8 @@ void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, g
 void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a rating icon on thumbs */
 void dtgtk_cairo_paint_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint an icon for unrating star on thumbs */
+void dtgtk_cairo_paint_unratestar(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an altered icon on thumbs */
 void dtgtk_cairo_paint_altered(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an audio icon on thumbs */

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -89,13 +89,13 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
 
   // the group leader
   if(thumb->imgid == thumb->groupid)
-    tt = g_strdup_printf("\n<b>%s (%s)</b>", _("current"), _("leader"));
+    tt = g_strdup_printf("\n\u2022 <b>%s (%s)</b>", _("current"), _("leader"));
   else
   {
     const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->groupid, 'r');
     if(img)
     {
-      tt = g_strdup_printf("\n<b>%s (%s)</b>", img->filename, _("leader"));
+      tt = g_strdup_printf("%s\n\u2022 <b>%s (%s)</b>", _("\nclick here to set this image as group leader\n"), img->filename, _("leader"));
       dt_image_cache_read_release(darktable.image_cache, img);
     }
   }
@@ -115,10 +115,10 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
     if(id != thumb->groupid)
     {
       if(id == thumb->imgid)
-        tt = dt_util_dstrcat(tt, "\n%s", _("current"));
+        tt = dt_util_dstrcat(tt, "\n\u2022 %s", _("current"));
       else
       {
-        tt = dt_util_dstrcat(tt, "\n%s", sqlite3_column_text(stmt, 2));
+        tt = dt_util_dstrcat(tt, "\n\u2022 %s", sqlite3_column_text(stmt, 2));
         if(v > 0) tt = dt_util_dstrcat(tt, " v%d", v);
       }
     }

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -195,6 +195,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_container_add(GTK_CONTAINER(overlay), d->filter);
 
   gtk_box_pack_start(GTK_BOX(dropdowns), overlay, TRUE, TRUE, 0);
+  gtk_widget_set_margin_end (overlay, 20);
 
   /* sort combobox */
   const dt_collection_sort_t sort = dt_collection_get_sort_field(darktable.collection);
@@ -202,11 +203,11 @@ void gui_init(dt_lib_module_t *self)
                                          _("determine the sort order of shown images"),
                                          _filter_get_items(sort), _lib_filter_sort_combobox_changed, self,
                                          _sort_names);
-  gtk_box_pack_start(GTK_BOX(dropdowns), d->sort, TRUE, TRUE, 4);
+  gtk_box_pack_start(GTK_BOX(dropdowns), d->sort, TRUE, TRUE, 2);
 
   /* reverse order checkbutton */
   d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
-  gtk_widget_set_name(GTK_WIDGET(d->reverse), "control-button");
+  gtk_widget_set_name(GTK_WIDGET(d->reverse), "filter-button");
   if(darktable.collection->params.descending)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
                                  CPF_DIRECTION_DOWN, NULL);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -205,10 +205,10 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(dropdowns), d->sort, TRUE, TRUE, 4);
 
   /* reverse order checkbutton */
-  d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_UP, NULL);
+  d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby_alt, CPF_DIRECTION_UP, NULL);
   gtk_widget_set_name(GTK_WIDGET(d->reverse), "control-button");
   if(darktable.collection->params.descending)
-    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_solid_arrow,
+    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
                                  CPF_DIRECTION_DOWN, NULL);
   gtk_widget_set_halign(d->reverse, GTK_ALIGN_START);
 
@@ -323,9 +323,9 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
   const gboolean reverse = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
   if(reverse)
-    dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
+    dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_sortby, CPF_DIRECTION_DOWN, NULL);
   else
-    dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_UP, NULL);
+    dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_sortby_alt, CPF_DIRECTION_UP, NULL);
   gtk_widget_queue_draw(GTK_WIDGET(widget));
 
   /* update last settings */

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -205,7 +205,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(dropdowns), d->sort, TRUE, TRUE, 4);
 
   /* reverse order checkbutton */
-  d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby_alt, CPF_DIRECTION_UP, NULL);
+  d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
   gtk_widget_set_name(GTK_WIDGET(d->reverse), "control-button");
   if(darktable.collection->params.descending)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
@@ -325,7 +325,7 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
   if(reverse)
     dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_sortby, CPF_DIRECTION_DOWN, NULL);
   else
-    dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_sortby_alt, CPF_DIRECTION_UP, NULL);
+    dtgtk_togglebutton_set_paint(widget, dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
   gtk_widget_queue_draw(GTK_WIDGET(widget));
 
   /* update last settings */


### PR DESCRIPTION
Hi there,

I spent some hours to start learning Cairo code (and so a little darktable related Gtk/C code too) to propose you some new UI improvements.

First, thanks to @difrkaguilar mockups (#8453), I made sort by icons to replace the arrow in filter toolbar.

Before
![image](https://user-images.githubusercontent.com/45535283/150686635-1edcffcd-1022-4169-a897-f97161ef0cc7.png)

After
![image](https://user-images.githubusercontent.com/45535283/150686773-e308d682-f5a6-4e61-8943-744427809376.png)

I also find that grey delete label color icon is too way similar to other label color and could be, at first, seen a 6th color label. Thus, red cross is quite awful in 2022. Thanks to @Zlitchufdux (#8497) mockup, I so propose a new icon:

Before
![image](https://user-images.githubusercontent.com/45535283/150686730-8120a614-16cd-4422-bb0d-9050eab49b30.png)

After
![delete-label-color-icon](https://user-images.githubusercontent.com/45535283/150686776-46c58dfb-a612-4da8-93ea-d64bf5da5f68.png)

This PR also adds some little CSS tweaks on thumbnails:
- a thinner yellow group border
- thanks to a work on thumbnails with @AlicVB for is #10959, I reduce a little margins to let more space to the images

I let this PR as a WIP for a few days for review and because I plan to update some other icons. If I can do that quickly, I will add them to that PR. If not, I will do another PR.

Reviews from people cited above are of course especially requested and all reviews are welcomed too of course.

And fix #10659