### PR TITLE
Filmic v6

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -714,3 +714,34 @@ static inline void XYZ_adapt_D50(float4 *lms_in,
   const float4 D50 = { 0.9642119944211994f, 1.0f, 0.8251882845188288f, 0.f };
   *lms_in *= D50 / origin_illuminant;
 }
+
+static inline float4 gamut_check_Yrg(float4 Ych)
+{
+  // Do a test conversion to Yrg
+  float4 Yrg = Ych_to_Yrg(Ych);
+
+  // Gamut-clip in Yrg at constant hue and luminance
+  // e.g. find the max chroma value that fits in gamut at the current hue
+  const float D65[4] = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
+  float max_c = Ych.y;
+  const float cos_h = native_cos(Ych.z);
+  const float sin_h = native_sin(Ych.z);
+
+  if(Yrg.y < 0.f)
+  {
+    max_c = fmin(-D65[0] / cos_h, max_c);
+  }
+  if(Yrg.z < 0.f)
+  {
+    max_c = fmin(-D65[1] / sin_h, max_c);
+  }
+  if(Yrg.y + Yrg.z > 1.f)
+  {
+    max_c = fmin((1.f - D65[0] - D65[1]) / (cos_h + sin_h), max_c);
+  }
+
+  // Overwrite chroma with the sanitized value and
+  Ych.y = max_c;
+
+  return Ych;
+}

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -427,7 +427,7 @@ static inline float4 gamut_check_RGB(constant const float *const matrix_in, cons
   // would need to be mixed in to bring the pixel back in gamut.
   float4 RGB_brightened = Ych_to_pipe_RGB(Ych_in, matrix_out);
   const float min_pix = fmin(fmin(RGB_brightened.x, RGB_brightened.y), RGB_brightened.z);
-  const float black_offset = fmax(display_black - min_pix, 0.f);
+  const float black_offset = fmax(-min_pix, 0.f);
   RGB_brightened += black_offset;
   const float4 Ych_brightened = pipe_RGB_to_Ych(RGB_brightened, matrix_in);
 
@@ -435,7 +435,7 @@ static inline float4 gamut_check_RGB(constant const float *const matrix_in, cons
   // Note, however, that this doesn't actually desaturate the color like mixing
   // white would do. We will next find the chroma change needed to bring the pixel
   // into gamut.
-  const float Y = fmin((Ych_in.x + Ych_brightened.x) / 2.f, CIE_Y_1931_to_CIE_Y_2006(display_white));
+  const float Y = clamp((Ych_in.x + Ych_brightened.x) / 2.f, CIE_Y_1931_to_CIE_Y_2006(display_black), CIE_Y_1931_to_CIE_Y_2006(display_white));
 
   // Precompute sin and cos of hue for reuse
   const float cos_h = native_cos(Ych_in.z);

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -427,7 +427,7 @@ static inline float4 gamut_check_RGB(float4 RGB_in, float4 Ych_in,
     // Perform a black offset to fit back in gamut
     // This gives us a whitest version of the current color.
     // It's not saturation-invariant.
-    float4 RGB_brightened = RGB_in - min_pix;
+    float4 RGB_brightened = RGB_in + fabs(min_pix);
     float4 Ych_brightened = pipe_RGB_to_Ych(RGB_brightened, matrix_in);
 
     // Get the locus of the clamped pixel.

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -374,8 +374,11 @@ static inline float4 filmic_desaturate_v4(const float4 Ych_original, float4 Ych_
 
 // Pipeline and ICC luminance is CIE Y 1931
 // Kirk Ych/Yrg uses CIE Y 2006
-// 1 CIE Y 1931 = 0.945302269001 CIE Y 2006, so we need to adjust that
-#define CIE_Y_1931_to_CIE_Y_2006(x) 0.945302269001f * x
+// 1 CIE Y 1931 = 1.0578615402627207 CIE Y 2006, so we need to adjust that
+// Warning: only applies to achromatic XYZ i.e. those aligned with
+// D50 white point. CAT16 chromatic adaptation from D50 to D65 white point
+// has been taken in account in the calculation.
+#define CIE_Y_1931_to_CIE_Y_2006(x) 1.0578615402627207f * x
 
 
 static inline float clip_chroma_one_channel(constant const float *const coeffs, const float target_rgb,

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -556,11 +556,11 @@ static inline float4 filmic_split_v4(const float4 i,
   for(int c = 0; c < 3; c++)
   {
     // Log tonemapping
-    o[c] = log_tonemapping_v2(i[c], grey_value, black_exposure, dynamic_range);
+    output[c] = log_tonemapping_v2(input[c], grey_value, black_exposure, dynamic_range);
 
     // Filmic S curve on the max RGB
     // Apply the transfer function of the display
-    o[c] = native_powr(clamp(filmic_spline(o[c], M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
+    output[c] = native_powr(clamp(filmic_spline(output[c], M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
                        display_black,
                        display_white), output_power);
   }

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -351,7 +351,7 @@ static inline float4 filmic_desaturate_v4(const float4 Ych_original, float4 Ych_
   // where `(yc - y1)` is user-defined as `saturation * (y2 - y1)`
   // so `chroma = c1 + saturation * (c2 - c1)`
   // when saturation = 0, we stay at the saturation-invariant final chroma
-  // when saturation > 1, we go back towards the initial chroma before tone-mapping
+  // when saturation > 0, we go back towards the initial chroma before tone-mapping
   // when saturation < 0, we amplify the initial -> final chroma change
   const float delta_chroma = saturation * (chroma_original - chroma_final);
 
@@ -444,7 +444,7 @@ static inline float4 gamut_check_RGB(constant const float *const matrix_in, cons
   // First calculate the maximum chroma where RGB components still stay below white point
   const float chroma_clipped_to_white = clip_chroma(matrix_out, display_white, Y, cos_h, sin_h);
   // Calculate the maximum chroma where RGB components still stay above black point
-  const float chroma_clipped_to_black = clip_chroma(matrix_out, display_black, Y, cos_h, sin_h);
+  const float chroma_clipped_to_black = clip_chroma(matrix_out, 0.f, Y, cos_h, sin_h);
   // Take the smallest of current chroma, white limit chroma and black limit chroma.
   const float new_chroma = fmin(fmin(Ych_in.y, chroma_clipped_to_white), chroma_clipped_to_black);
 
@@ -453,7 +453,7 @@ static inline float4 gamut_check_RGB(constant const float *const matrix_in, cons
   const float4 RGB_out = Ych_to_pipe_RGB(Ych, matrix_out);
 
   // Clamp in target RGB as a final catch-all
-  return clamp(RGB_out, display_black, display_white);
+  return clamp(RGB_out, 0.f, display_white);
 }
 
 static inline float4 gamut_mapping(float4 Ych_final, float4 Ych_original, float4 pix_out,

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -362,7 +362,7 @@ static inline float4 filmic_desaturate_v4(const float4 Ych_original, float4 Ych_
   const int user_desat = (saturation < 0.f);
 
   chroma_final = (filmic_brightens && filmic_resat)
-                      ? chroma_original // force original lower sat if brightening
+                      ? (chroma_original + chroma_final) / 2.f // force original lower sat if brightening
                   : ((user_resat && filmic_desat) || user_desat)
                       ? chroma_final + delta_chroma // allow resaturation only if filmic desaturated, allow desat anytime
                       : chroma_final;

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -576,31 +576,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const float chroma_factor = fmaxf(1.f + chroma_boost + vibrance, 0.f);
     Ych[1] *= chroma_factor;
 
-    // Do a test conversion to Yrg
-    Ych_to_Yrg(Ych, Yrg);
+    // clip chroma at constant hue and Y if needed
+    gamut_check_Yrg(Ych);
 
-    // Gamut-clip in Yrg at constant hue and luminance
-    // e.g. find the max chroma value that fits in gamut at the current hue
-    const dt_aligned_pixel_t D65 = { 0.21962576f, 0.54487092f, 0.23550333f, 0.f };
-    float max_c = Ych[1];
-    const float cos_h = cosf(Ych[2]);
-    const float sin_h = sinf(Ych[2]);
-
-    if(Yrg[1] < 0.f)
-    {
-      max_c = fminf(-D65[0] / cos_h, max_c);
-    }
-    if(Yrg[2] < 0.f)
-    {
-      max_c = fminf(-D65[1] / sin_h, max_c);
-    }
-    if(Yrg[1] + Yrg[2] > 1.f)
-    {
-      max_c = fminf((1.f - D65[0] - D65[1]) / (cos_h + sin_h), max_c);
-    }
-
-    // Overwrite chroma with the sanitized value and go to Yrg for real
-    Ych[1] = max_c;
+    // go to Yrg for real
     Ych_to_Yrg(Ych, Yrg);
 
     // Go to LMS

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1639,7 +1639,7 @@ static inline void gamut_check_RGB(dt_aligned_pixel_t RGB_in, dt_aligned_pixel_t
     // This gives us a whitest version of the current color.
     // It's not saturation-invariant.
     dt_aligned_pixel_t RGB_brightened = { 0.f };
-    for_each_channel(c, aligned(RGB_brightened)) RGB_brightened[c] = RGB_in[c] - min_pix;
+    for_each_channel(c, aligned(RGB_brightened)) RGB_brightened[c] = RGB_in[c] + fabsf(min_pix);
 
     dt_aligned_pixel_t Ych_brightened = { 0.f };
     pipe_RGB_to_Ych(RGB_brightened, matrix_in, Ych_brightened);
@@ -1750,7 +1750,7 @@ static inline void filmic_chroma_v4(const float *const restrict in, float *const
 
     // Now, it is still possible that one channel > display white because of saturation.
     // We have already clipped Y, so we know that any problem now is caused by c
-    gamut_check_RGB(pix_out, Ych_final, input_matrix, input_matrix, display_black, display_white);
+    gamut_check_RGB(pix_out, Ych_final, input_matrix, output_matrix, display_black, display_white);
   }
 }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2241,14 +2241,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
   const dt_iop_order_iccprofile_info_t *const export_profile = dt_ioppr_get_pipe_output_profile_info(piece->pipe);
   const int use_work_profile = (work_profile == NULL) ? 0 : 1;
-  cl_mem dev_profile_info = NULL;
-  cl_mem dev_profile_lut = NULL;
-  dt_colorspaces_iccprofile_info_cl_t *profile_info_cl;
-  cl_float *profile_lut_cl = NULL;
-
-  err = dt_ioppr_build_iccprofile_params_cl(work_profile, devid, &profile_info_cl, &profile_lut_cl,
-                                            &dev_profile_info, &dev_profile_lut);
-  if(err != CL_SUCCESS) goto error;
 
   // See colorbalancergb.c for details
   dt_colormatrix_t input_matrix;         // pipeline RGB -> LMS 2006
@@ -2263,6 +2255,15 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   cl_mem output_matrix_cl = dt_opencl_copy_host_to_device_constant(devid, 12 * sizeof(float), output_matrix);
   cl_mem export_input_matrix_cl = NULL;
   cl_mem export_output_matrix_cl = NULL;
+
+  cl_mem dev_profile_info = NULL;
+  cl_mem dev_profile_lut = NULL;
+  dt_colorspaces_iccprofile_info_cl_t *profile_info_cl;
+  cl_float *profile_lut_cl = NULL;
+
+  err = dt_ioppr_build_iccprofile_params_cl(work_profile, devid, &profile_info_cl, &profile_lut_cl,
+                                            &dev_profile_info, &dev_profile_lut);
+  if(err != CL_SUCCESS) goto error;
 
   if(use_output_profile)
   {
@@ -3003,7 +3004,6 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   else
     d->saturation = (2.0f * p->saturation / 100.0f + 1.0f);
 
-  fprintf(stdout, "sat: %f\n", d->saturation);
   d->sigma_toe = powf(d->spline.latitude_min / 3.0f, 2.0f);
   d->sigma_shoulder = powf((1.0f - d->spline.latitude_max) / 3.0f, 2.0f);
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1568,7 +1568,7 @@ static inline void filmic_desaturate_v4(const dt_aligned_pixel_t Ych_original, d
   const int user_desat = (saturation < 0.f);
 
   chroma_final = (filmic_brightens && filmic_resat)
-                      ? chroma_original // force original lower sat if brightening
+                      ? (chroma_original + chroma_final) / 2.f // force original lower sat if brightening
                   : ((user_resat && filmic_desat) || user_desat)
                       ? chroma_final + delta_chroma // allow resaturation only if filmic desaturated, allow desat anytime
                       : chroma_final;
@@ -4448,7 +4448,7 @@ void gui_init(dt_iop_module_t *self)
                                             "at one extremity of the histogram."));
 
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
-  dt_bauhaus_slider_set_soft_max(g->saturation, 50.0);
+  dt_bauhaus_slider_set_soft_range(g->saturation, -50.0, 50.0);
   dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\n"
                                                "specifically at extreme luminances.\n"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1578,8 +1578,11 @@ static inline void filmic_desaturate_v4(const dt_aligned_pixel_t Ych_original, d
 
 // Pipeline and ICC luminance is CIE Y 1931
 // Kirk Ych/Yrg uses CIE Y 2006
-// 1 CIE Y 1931 = 0.945302269001 CIE Y 2006, so we need to adjust that
-#define CIE_Y_1931_to_CIE_Y_2006(x) 0.945302269001f * x
+// 1 CIE Y 1931 = 1.0578615402627207 CIE Y 2006, so we need to adjust that
+// Warning: only applies to achromatic XYZ i.e. those aligned with
+// D50 white point. CAT16 chromatic adaptation from D50 to D65 white point
+// has been taken in account in the calculation.
+#define CIE_Y_1931_to_CIE_Y_2006(x) 1.0578615402627207f * x
 
 
 static inline float clip_chroma_one_channel(const float coeffs[3], const float target_rgb, const float Y,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1557,7 +1557,7 @@ static inline void filmic_desaturate_v4(const dt_aligned_pixel_t Ych_original, d
   // where `(yc - y1)` is user-defined as `saturation * (y2 - y1)`
   // so `chroma = c1 + saturation * (c2 - c1)`
   // when saturation = 0, we stay at the saturation-invariant final chroma
-  // when saturation > 1, we go back towards the initial chroma before tone-mapping
+  // when saturation > 0, we go back towards the initial chroma before tone-mapping
   // when saturation < 0, we amplify the initial -> final chroma change
   const float delta_chroma = saturation * (chroma_original - chroma_final);
 
@@ -1648,7 +1648,7 @@ static inline void gamut_check_RGB(const dt_colormatrix_t matrix_in, const dt_co
   // First calculate the maximum chroma where RGB components still stay below white point
   const float chroma_clipped_to_white = clip_chroma(matrix_out, display_white, Y, cos_h, sin_h);
   // Calculate the maximum chroma where RGB components still stay above black point
-  const float chroma_clipped_to_black = clip_chroma(matrix_out, display_black, Y, cos_h, sin_h);
+  const float chroma_clipped_to_black = clip_chroma(matrix_out, 0.f, Y, cos_h, sin_h);
   // Take the smallest of current chroma, white limit chroma and black limit chroma.
   const float new_chroma = MIN(MIN(Ych_in[1], chroma_clipped_to_white), chroma_clipped_to_black);
 
@@ -1657,7 +1657,7 @@ static inline void gamut_check_RGB(const dt_colormatrix_t matrix_in, const dt_co
   Ych_to_pipe_RGB(Ych, matrix_out, RGB_out);
 
   // Clamp in target RGB as a final catch-all
-  for_each_channel(c, aligned(RGB_out)) RGB_out[c] = CLAMP(RGB_out[c], display_black, display_white);
+  for_each_channel(c, aligned(RGB_out)) RGB_out[c] = CLAMP(RGB_out[c], 0.f, display_white);
 }
 
 
@@ -3712,7 +3712,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_move_to(cr, -2. * g->inset - g->zero_width - g->ink.x,
                     -g->line_height - g->inset - 0.5 * g->ink.height - g->ink.y);
       pango_cairo_show_layout(cr, layout);
-      cairo_stroke(cr);  dt_bauhaus_slider_set_soft_max(g->saturation, 50.0);
+      cairo_stroke(cr);
 
 
       // mark the x axis legend

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1631,7 +1631,7 @@ static inline void gamut_check_RGB(const dt_colormatrix_t matrix_in, const dt_co
   dt_aligned_pixel_t RGB_brightened = { 0.f };
   Ych_to_pipe_RGB(Ych_in, matrix_out, RGB_brightened);
   const float min_pix = MIN(MIN(RGB_brightened[0], RGB_brightened[1]), RGB_brightened[2]);
-  const float black_offset = MAX(display_black - min_pix, 0.f);
+  const float black_offset = MAX(-min_pix, 0.f);
   for_each_channel(c) RGB_brightened[c] += black_offset;
   dt_aligned_pixel_t Ych_brightened = { 0.f };
   pipe_RGB_to_Ych(RGB_brightened, matrix_in, Ych_brightened);
@@ -1640,7 +1640,7 @@ static inline void gamut_check_RGB(const dt_colormatrix_t matrix_in, const dt_co
   // Note, however, that this doesn't actually desaturate the color like mixing
   // white would do. We will next find the chroma change needed to bring the pixel
   // into gamut.
-  const float Y = MIN((Ych_in[0] + Ych_brightened[0]) / 2.f, CIE_Y_1931_to_CIE_Y_2006(display_white));
+  const float Y = CLAMP((Ych_in[0] + Ych_brightened[0]) / 2.f, CIE_Y_1931_to_CIE_Y_2006(display_black), CIE_Y_1931_to_CIE_Y_2006(display_white));
   // Precompute sin and cos of hue for reuse
   const float cos_h = cosf(Ych_in[2]);
   const float sin_h = sinf(Ych_in[2]);

--- a/tools/derive_filmic_v6_gamut_mapping.py
+++ b/tools/derive_filmic_v6_gamut_mapping.py
@@ -1,0 +1,48 @@
+# Derive equation for gamut mapping in Yrg in Filmic v6
+# Based on equations of Yrg -> LMS conversion in
+# src/common/colorspaces_inline_conversions.h
+
+from sympy import *
+from sympy.solvers.solveset import solveset_real
+
+init_printing(use_unicode=True)
+
+# ch = cos(hue), sh = sin(hue)
+Y, c, ch, sh = symbols('Y c ch sh')
+
+# Go from polar coordinates to Yrg
+Yrg = Matrix([[Y, c * ch + 0.21962576, c * sh + 0.54487092]]).transpose()
+
+# Form normalized rgb
+r = Yrg[1, 0]
+g = Yrg[2, 0]
+rgb = Matrix([[r, g, 1 - r - g]]).transpose()
+
+# Transform to normalized lms space
+rgb_to_lms = Matrix([
+    [0.95, 0.38, 0.00],
+    [0.05, 0.62, 0.03],
+    [0.00, 0.00, 0.97]
+])
+lms = rgb_to_lms * rgb
+
+# Apply normalization based on luminance
+coeff = Y / (0.68990272 * lms[0, 0] + 0.34832189 * lms[1, 0])
+LMS = coeff * lms
+
+# LMS is converted to target RGB.
+# Here, A is a single row of the LMS -> RGB conversion matrix.
+# Thus this corresponds to calculating one component of
+# target RGB. Each component is calculated the same way, coefficients
+# are just different.
+a1, a2, a3 = symbols("a1 a2 a3")
+A = Matrix([[a1, a2, a3]])
+component = (A * LMS)[0, 0]
+
+# k is the target RGB component value (black or white luminance in gamut mapping)
+k = symbols('k')
+
+# Solve for chroma that gives the desired extreme value k for one components.
+# The chroma will be calculated for each component separately, and the smallest
+# value will be chosen to stay in gamut.
+pprint(solveset_real(component - k, c))


### PR DESCRIPTION
That crossed #10975 by a thread.

What's new ?

1. we ditch the mandatory desaturation to white, since it was too harsh in many cases and we don't need it because…
2. introduce 2 steps of gamut mapping, one against LMS cone space, one against pipeline RGB, and I'm considering mapping to output RGB directly,
3. for the non-chrominance preserving method (independent RGB channels), we still enforce hue to be passed along from input to output. We still keep the desaturing behaviour in highlights but we set the original chroma in shadows to avoid resaturating. 
4. Bottom line is all methods now preserve hue. Chrominance-preserving norms preserve saturation as well.

OpenCL available, but there is a discrepancy between C and OpenCL that I need to find. Reference implementation is OpenCL. I publish now to show @flannelhead

The gamut-mapping is much simpler than in #10975 and done in Kirk Yrg space (linear). Hue is preserved at all cost, then we do a test projection in RGB. Out-of-gamut are spotted if any coordinate exceeds [0; 1]. In which case, we record the Ych value of:
1. the original color,
2. the clipped color (closest in-gamut color, but at a different hue), 
3. the darkened color (closest color at same saturation).
From the clipped color, we update the Y value (usually a bit brighter, which is desirable to retain luminance consistency of colored lights), and from the darkened color, we update the chroma estimation (chroma at same saturation and lower luminance is actually lower than original). So we march like this toward the boundary of the gamut, and iterate up to 8 times until we find it.