### PR TITLE
exif: remove ICC and few more tags

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1674,7 +1674,13 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
         "Exif.Image.StripOffsets",
         "Exif.Image.RowsPerStrip",
         "Exif.Image.StripByteCounts",
+        "Exif.Image.TileWidth",
+        "Exif.Image.TileLength",
+        "Exif.Image.TileOffsets",
+        "Exif.Image.TileByteCounts",
         "Exif.Image.PlanarConfiguration",
+        "Exif.Image.InterColorProfile",
+        "Exif.Image.TIFFEPStandardID",
         "Exif.Image.DNGVersion",
         "Exif.Image.DNGBackwardVersion"
       };


### PR DESCRIPTION
Fixes #10985

In the TIFF export case, the newly requested ICC profile is currently written back to the same tag explicitly by the `tiff.c` writer anyway.