### PR TITLE
avif: add XMP metadata

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -159,7 +159,7 @@ void init(dt_imageio_module_format_t *self)
             enum avif_color_mode_e);
   luaA_enum_value(darktable.lua_state.state,
                   enum avif_color_mode_e,
-                  AVIF_COLOR_MODE_GRAYSCALE);
+                  AVIF_COLOR_MODE_RGB);
   luaA_enum_value(darktable.lua_state.state,
                   enum avif_color_mode_e,
                   AVIF_COLOR_MODE_GRAYSCALE);

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -453,8 +453,16 @@ int write_image(struct dt_imageio_module_data_t *data,
 
   avifImageRGBToYUV(image, &rgb);
 
+  if(exif && exif_len > 0)
+    avifImageSetMetadataExif(image, exif, exif_len);
 
-  avifImageSetMetadataExif(image, exif, exif_len);
+  /* Workaround until exiv2 implements AVIF write support */
+  char *xmp_string = dt_exif_xmp_read_string(imgid);
+  if(xmp_string && (size_t xmp_len = strlen(xmp_string)) > 0)
+  {
+    avifImageSetMetadataXMP(image, xmp_string, xmp_len + 1);
+    g_free(xmp_string);
+  }
 
   encoder = avifEncoderCreate();
   if(encoder == NULL)
@@ -688,11 +696,6 @@ const char *extension(dt_imageio_module_data_t *data)
 const char *name()
 {
   return _("AVIF (8/10/12-bit)");
-}
-
-int flags(struct dt_imageio_module_data_t *data)
-{
-  return FORMAT_FLAGS_SUPPORT_XMP;
 }
 
 static void bit_depth_changed(GtkWidget *widget, gpointer user_data)

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -456,7 +456,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   if(exif && exif_len > 0)
     avifImageSetMetadataExif(image, exif, exif_len);
 
-  /* Workaround until exiv2 implements AVIF write support */
+  /* TODO: workaround; remove when exiv2 implements AVIF write support and update flags() */
   char *xmp_string = dt_exif_xmp_read_string(imgid);
   if(xmp_string && (size_t xmp_len = strlen(xmp_string)) > 0)
   {
@@ -696,6 +696,18 @@ const char *extension(dt_imageio_module_data_t *data)
 const char *name()
 {
   return _("AVIF (8/10/12-bit)");
+}
+
+int flags(struct dt_imageio_module_data_t *data)
+{
+  /*
+   * As of exiv2 0.27.5 there is no write support for the AVIF format, so
+   * we do not return the XMP supported flag currently.
+   * Once exiv2 write support is there, the flag can be returned, and the
+   * direct XMP embedding workaround using avifImageSetMetadataXMP() above
+   * can be removed.
+   */
+  return 0; /* FORMAT_FLAGS_SUPPORT_XMP; */
 }
 
 static void bit_depth_changed(GtkWidget *widget, gpointer user_data)


### PR DESCRIPTION
Fixes #8480

Adds XMP metadata the same way it is currently done for OpenEXR export.