### PR TITLE
css: fix font-family in default darktable.css to avoid pango critical messages

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -183,7 +183,6 @@
   background-image: none;
   color: @fg_color;
   font-size: 1em;
-  font-family: sans-serif;
   font-weight: normal;
   box-shadow:none;
   outline-style:none;
@@ -193,6 +192,16 @@
   padding: 0;
   min-width: 0;
   min-height: 0;
+}
+
+*
+{
+  font-family: "Roboto Medium", "Roboto",
+               "Segoe UI Semibold", "Segoe UI",
+               "SF Pro Display Medium", "SF Pro Display",
+               "Ubuntu Medium", "Ubuntu",
+               "Cantarell",
+                sans-serif;
 }
 
 /* Be sure now than all others UI widgets doesn't inherit font size already set and have no background color on start */
@@ -275,7 +284,6 @@ button,
   background-color: @button_bg;
   color: @button_fg;
   font-weight: normal;
-  font-family: sans-serif;
 }
 
 button:disabled,
@@ -321,7 +329,6 @@ textview
   background-color: @field_bg;
   border: 0.035em solid @border_color;
   margin: 0.14em 0;
-  font-family: sans;
 }
 
 entry selection
@@ -644,7 +651,6 @@ l
   color: @plugin_label_color;
   padding: 0 0.14em 0.14em 0.45em;
   font-weight: normal;
-  font-family: sans-serif;
   font-size: 1.1em;
 }
 
@@ -659,7 +665,6 @@ l
 {
   padding: 0;
   color: @section_label;
-  font-family: sans-serif;
   font-weight: 500;
 }
 
@@ -1027,7 +1032,6 @@ notebook tabs,
 #guides-line
 {
   color: @button_fg;
-  font-family: sans-serif;
 }
 
 #modules-tabs,


### PR DESCRIPTION
These changes in the darktable.css avoid the pango_font_describe and pango_font_description_get_variant assertions as discussed in issue https://github.com/darktable-org/darktable/issues/10882.

Additionally - at least on Win 10 - the font seems to be a good readable but yet elegant option.
Tested only on Win10 so far, so please be careful on other platforms as the darktable.css is included in other themes as well.
Maybe someone can test this on Linux/MacOS before merging.

Without the fix dt looks like this with the darktable.css theme (and prints pango critical on the console):
![grafik](https://user-images.githubusercontent.com/96134139/151035380-3652612c-801b-42e7-a191-b4be2706f24d.png)


After the fix, dt looks like this
![grafik](https://user-images.githubusercontent.com/96134139/151035251-bdb80c10-b41e-43f2-b20a-42333f2cd72d.png)
(which I think is pretty nice). 
