### PR TITLE
add a memory leak basic detection

### DIFF
--- a/tools/memory_leaks.py
+++ b/tools/memory_leaks.py
@@ -22,7 +22,7 @@ import os
 import re
 directory = "../src/iop/"
 
-alloc_regex = r"([a-zA-Z0-9_-]+) = (dt_|c|m|dt_opencl_)alloc.*\(.+\)"
+alloc_regex = r"([a-zA-Z0-9_\-\>\.]+) = (dt_|c|m|dt_opencl_)alloc.*\(.+\)"
 
 for file in sorted(os.listdir(directory)):
   if file.endswith(".c") or file.endswith(".h"):

--- a/tools/memory_leaks.py
+++ b/tools/memory_leaks.py
@@ -33,7 +33,7 @@ def find_call_and_line(elem, file, directory):
   for line in f:
     line_number += 1
     if elem in line:
-      print("\t\t", elem, "found at line", line_number)
+      print("\t\t line", line_number, ":", elem.strip())
 
   f.close()
 
@@ -69,7 +69,7 @@ for file in sorted(os.listdir(directory)):
         variable_free_regex  = ".*release_mem_object.*\(%s\)" % variable_name
         buffer_type = "OpenCL"
       else:
-        variable_free_regex  = ".*free.*\(%s\)" % variable_name
+        variable_free_regex  = " \S*free.*\(%s\)" % variable_name
         buffer_type = "C"
       matches3 = re.findall(variable_free_regex, content, re.MULTILINE)
       frees = len(matches3)
@@ -80,12 +80,18 @@ for file in sorted(os.listdir(directory)):
         print("\tERROR: %s buffer `%s` is allocated %i time(s) but never freed" % (buffer_type, variable_name, allocs))
         for elem in matches2:
           find_call_and_line(elem, file, directory)
+        for elem in matches3:
+          find_call_and_line(elem, file, directory)
+
         faulty_allocs += 1
 
       elif(frees < allocs and frees > 0):
         print("\tWARNING: %s buffer `%s` is allocated %i time(s) but freed %i time(s)" % (buffer_type, variable_name, allocs, frees))
         for elem in matches2:
           find_call_and_line(elem, file, directory)
+        for elem in matches3:
+          find_call_and_line(elem, file, directory)
+
         suspicious_allocs += 1
 
       else:

--- a/tools/memory_leaks.py
+++ b/tools/memory_leaks.py
@@ -34,6 +34,7 @@ for file in sorted(os.listdir(directory)):
 
     safe_allocs = 0
     faulty_allocs = 0
+    suspicious_allocs = 0
 
     print("%s" % file)
 
@@ -60,18 +61,27 @@ for file in sorted(os.listdir(directory)):
       frees = len(matches3)
 
       # Note that for OpenCL, we may have more than one free for each alloc because of the error go-to
-      if(frees < allocs):
-        print("\t%s buffer `%s` is allocated %i time(s) but freed %i time(s)" % (buffer_type, variable_name, allocs, frees))
+      if(frees < allocs and frees == 0):
+        print("\tERROR: %s buffer `%s` is allocated %i time(s) but never freed" % (buffer_type, variable_name, allocs))
         for elem in matches2:
           print("\t\t", elem)
         faulty_allocs += 1
+
+      elif(frees < allocs and frees > 0):
+        print("\tWARNING: %s buffer `%s` is allocated %i time(s) but freed %i time(s)" % (buffer_type, variable_name, allocs, frees))
+        for elem in matches2:
+          print("\t\t", elem)
+        suspicious_allocs += 1
+
       else:
         safe_allocs += 1
 
     msg_type = "INFO"
-    if(faulty_allocs > 0):
+    if(suspicious_allocs > 0):
       msg_type = "WARNING"
+    if(faulty_allocs > 0):
+      msg_type = "ERROR"
 
-    print("\t%s: %i safe alloc(s) detected over %i\n" % (msg_type, safe_allocs, safe_allocs + faulty_allocs))
+    print("\t%s: %i safe alloc(s) detected over %i\n" % (msg_type, safe_allocs, safe_allocs + faulty_allocs + suspicious_allocs))
 
     f.close()

--- a/tools/memory_leaks.py
+++ b/tools/memory_leaks.py
@@ -22,7 +22,7 @@ import os
 import re
 directory = "../src/iop/"
 
-alloc_regex = r"([a-zA-Z0-9_\-\>\.]+) = (dt_|c|m|dt_opencl_)alloc.*\(.+\)"
+alloc_regex = r"([a-zAq'-Z0-9_\-\>\.\[\]]+) = (dt_|c|m|dt_opencl_)alloc.*\(.+\)"
 
 for file in sorted(os.listdir(directory)):
   if file.endswith(".c") or file.endswith(".h"):

--- a/tools/memory_leaks.py
+++ b/tools/memory_leaks.py
@@ -44,7 +44,7 @@ for file in sorted(os.listdir(directory)):
       alloc_type = match.group(2)
 
       # Look how many times the variable is allocated
-      variable_alloc_regex = "%s = %salloc.*\(.+\)" % (variable_name, alloc_type)
+      variable_alloc_regex = " %s = %salloc.*\(.+\)" % (variable_name, alloc_type)
       matches2 = re.findall(variable_alloc_regex, content, re.MULTILINE)
       allocs = len(matches2)
 

--- a/tools/memory_leaks.py
+++ b/tools/memory_leaks.py
@@ -1,0 +1,77 @@
+#
+#   This file is part of darktable,
+#   Copyright (C) 2022 darktable developers.
+#
+#   darktable is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   darktable is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Read each IOP file, parse it for buffer allocs, and check if we have a corresponding free
+
+import os
+import re
+directory = "../src/iop/"
+
+alloc_regex = r"([a-zA-Z0-9_-]+) = (dt_|c|m|dt_opencl_)alloc.*\(.+\)"
+
+for file in sorted(os.listdir(directory)):
+  if file.endswith(".c") or file.endswith(".h"):
+    f = open(os.path.join(directory, file), "r")
+    content = f.read()
+
+    # Find all allocs and extract the name of the pointer to the allocation
+    matches = re.finditer(alloc_regex, content, re.MULTILINE)
+
+    safe_allocs = 0
+    faulty_allocs = 0
+
+    print("%s" % file)
+
+    for matchNum, match in enumerate(matches):
+      # Get the name of the pointer to the allocation
+      variable_name = match.group(1)
+      alloc_type = match.group(2)
+
+      # Look how many times the variable is allocated
+      variable_alloc_regex = "%s = %salloc.*\(.+\)" % (variable_name, alloc_type)
+      matches2 = re.findall(variable_alloc_regex, content, re.MULTILINE)
+      allocs = len(matches2)
+
+      # Look how many times the variable is freed
+      variable_free_regex = r""
+      buffer_type = ""
+      if(alloc_type == "dt_opencl_"):
+        variable_free_regex  = ".*release_mem_object.*\(%s\)" % variable_name
+        buffer_type = "OpenCL"
+      else:
+        variable_free_regex  = ".*free.*\(%s\)" % variable_name
+        buffer_type = "C"
+      matches3 = re.findall(variable_free_regex, content, re.MULTILINE)
+      frees = len(matches3)
+
+      # Note that for OpenCL, we may have more than one free for each alloc because of the error go-to
+      if(frees < allocs):
+        print("\t%s buffer `%s` is allocated %i time(s) but freed %i time(s)" % (buffer_type, variable_name, allocs, frees))
+        for elem in matches2:
+          print("\t\t", elem)
+        faulty_allocs += 1
+      else:
+        safe_allocs += 1
+
+    msg_type = "INFO"
+    if(faulty_allocs > 0):
+      msg_type = "WARNING"
+
+    print("\t%s: %i safe alloc(s) detected over %i\n" % (msg_type, safe_allocs, safe_allocs + faulty_allocs))
+
+    f.close()


### PR DESCRIPTION
Small Python script checking in IOP that C and OpenCL buffers are freed as many times as they are allocated. This is a basic memory leak detection, of course it yields some false positive and does not track aliases.

Output against current master:

```
$ python memory_leaks.py 
Permutohedral.h
        INFO: 0 safe alloc(s) detected over 0

ashift.c
        INFO: 12 safe alloc(s) detected over 12

ashift_lsd.c
        INFO: 1 safe alloc(s) detected over 1

ashift_nmsimplex.c
        INFO: 0 safe alloc(s) detected over 0

atrous.c
        INFO: 5 safe alloc(s) detected over 5

basecurve.c
        INFO: 9 safe alloc(s) detected over 9

basicadj.c
        INFO: 3 safe alloc(s) detected over 3

bilat.c
        INFO: 1 safe alloc(s) detected over 1

bloom.c
        INFO: 1 safe alloc(s) detected over 1

blurs.c
        INFO: 10 safe alloc(s) detected over 10

borders.c
        INFO: 1 safe alloc(s) detected over 1

cacorrect.c
        INFO: 6 safe alloc(s) detected over 6

cacorrectrgb.c
        WARNING: C buffer `manifold_higher` is allocated 2 time(s) but freed 1 time(s)
                 manifold_higher = dt_alloc_align_float(width * height * 4)
                 manifold_higher = dt_alloc_align_float(width * height * 4)
        WARNING: C buffer `manifold_lower` is allocated 2 time(s) but freed 1 time(s)
                 manifold_lower = dt_alloc_align_float(width * height * 4)
                 manifold_lower = dt_alloc_align_float(width * height * 4)
        WARNING: C buffer `in_out` is allocated 2 time(s) but freed 1 time(s)
                 in_out = dt_alloc_align_float(width * height * 4)
                 in_out = dt_alloc_align_float(width * height * 4)
        WARNING: C buffer `manifolds` is allocated 2 time(s) but freed 1 time(s)
                 manifolds = dt_alloc_align_float(ds_width * ds_height * 6)
                 manifolds = dt_alloc_align_float(width * height * 6)
        WARNING: 6 safe alloc(s) detected over 10

censorize.c
        INFO: 2 safe alloc(s) detected over 2

channelmixer.c
        INFO: 1 safe alloc(s) detected over 1

channelmixerrgb.c
        INFO: 6 safe alloc(s) detected over 6

choleski.h
        INFO: 4 safe alloc(s) detected over 4

clahe.c
        INFO: 4 safe alloc(s) detected over 4

clipping.c
        INFO: 1 safe alloc(s) detected over 1

colisa.c
        INFO: 0 safe alloc(s) detected over 0

colorbalance.c
        INFO: 2 safe alloc(s) detected over 2

colorbalancergb.c
        WARNING: C buffer `LUT` is allocated 2 time(s) but freed 1 time(s)
                 LUT = dt_alloc_align_float(LUT_ELEM)
                 LUT = dt_alloc_sse_ps(LUT_ELEM)
        WARNING: 3 safe alloc(s) detected over 4

colorchecker.c
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_colorchecker_params_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t))
        ERROR: 5 safe alloc(s) detected over 7

colorcontrast.c
        INFO: 1 safe alloc(s) detected over 1

colorcorrection.c
        INFO: 1 safe alloc(s) detected over 1

colorin.c
        INFO: 1 safe alloc(s) detected over 1

colorize.c
        INFO: 1 safe alloc(s) detected over 1

colormapping.c
        INFO: 8 safe alloc(s) detected over 8

colorout.c
        INFO: 2 safe alloc(s) detected over 2

colorreconstruction.c
        WARNING: C buffer `b->buf` is allocated 2 time(s) but freed 1 time(s)
                 b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
                 b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
        WARNING: C buffer `bf->buf` is allocated 2 time(s) but freed 1 time(s)
                 bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
                 bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
        WARNING: C buffer `b->buf` is allocated 2 time(s) but freed 1 time(s)
                 b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
                 b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
        WARNING: C buffer `bf->buf` is allocated 2 time(s) but freed 1 time(s)
                 bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
                 bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z)
        WARNING: 0 safe alloc(s) detected over 4

colortransfer.c
        INFO: 7 safe alloc(s) detected over 7

colorzones.c
        ERROR: C buffer `gd` is allocated 1 time(s) but never freed
                 gd = malloc(sizeof(dt_iop_colorzones_global_data_t))
        ERROR: C buffer `d` is allocated 2 time(s) but never freed
                 d = malloc(sizeof(dt_iop_colorzones_global_data_t))
                 d = malloc(sizeof(dt_iop_colorzones_data_t))
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_colorzones_params_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t))
        ERROR: 0 safe alloc(s) detected over 4

crop.c
        INFO: 1 safe alloc(s) detected over 1

defringe.c
        INFO: 2 safe alloc(s) detected over 2

demosaic.c
        WARNING: OpenCL buffer `high_image` is allocated 2 time(s) but freed 1 time(s)
                 high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4)
                 high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4)
        WARNING: OpenCL buffer `high_image` is allocated 2 time(s) but freed 1 time(s)
                 high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4)
                 high_image = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float) * 4)
        WARNING: 39 safe alloc(s) detected over 41

denoiseprofile.c
        INFO: 9 safe alloc(s) detected over 9

diffuse.c
        INFO: 11 safe alloc(s) detected over 11

dither.c
        INFO: 1 safe alloc(s) detected over 1

dual_demosaic.c
        INFO: 3 safe alloc(s) detected over 3

equalizer.c
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_equalizer_params_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_equalizer_params_t))
        ERROR: 0 safe alloc(s) detected over 2

equalizer_eaw.h
        INFO: 4 safe alloc(s) detected over 4

exposure.c
        INFO: 1 safe alloc(s) detected over 1

filmic.c
        INFO: 3 safe alloc(s) detected over 3

filmicrgb.c
        INFO: 20 safe alloc(s) detected over 20

finalscale.c
        INFO: 3 safe alloc(s) detected over 3

flip.c
        INFO: 1 safe alloc(s) detected over 1

gamma.c
        ERROR: C buffer `module->data` is allocated 1 time(s) but never freed
                 module->data = malloc(sizeof(dt_iop_gamma_data_t))
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_gamma_params_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_gamma_params_t))
        ERROR: 0 safe alloc(s) detected over 3

gaussian_elimination.h
        INFO: 3 safe alloc(s) detected over 3

globaltonemap.c
        INFO: 4 safe alloc(s) detected over 4

graduatednd.c
        INFO: 1 safe alloc(s) detected over 1

grain.c
        INFO: 1 safe alloc(s) detected over 1

hazeremoval.c
        ERROR: C buffer `gd` is allocated 1 time(s) but never freed
                 gd = malloc(sizeof(*gd))
        ERROR: 6 safe alloc(s) detected over 7

highlights.c
        INFO: 1 safe alloc(s) detected over 1

highpass.c
        INFO: 3 safe alloc(s) detected over 3

hotpixels.c
        INFO: 1 safe alloc(s) detected over 1

invert.c
        INFO: 1 safe alloc(s) detected over 1

iop_api.h
        INFO: 0 safe alloc(s) detected over 0

levels.c
        INFO: 1 safe alloc(s) detected over 1

liquify.c
        WARNING: C buffer `buffer` is allocated 2 time(s) but freed 1 time(s)
                 buffer = malloc(sizeof(float) * 2 * len)
                 buffer = malloc(sizeof(float complex) * INTERPOLATION_POINTS)
        ERROR: C buffer `lookup` is allocated 2 time(s) but never freed
                 lookup = dt_alloc_align(64, sizeof(float complex) * (distance + 2))
                 lookup = dt_alloc_align_float((size_t)(distance + 2))
        ERROR: C buffer `map` is allocated 2 time(s) but never freed
                 map = dt_alloc_align(64, sizeof(float complex) * mapsize)
                 map = dt_alloc_align(64, sizeof(float complex) * mapsize)
        ERROR: C buffer `imap` is allocated 1 time(s) but never freed
                 imap = dt_alloc_align(64, sizeof(float complex) * mapsize)
        WARNING: C buffer `k` is allocated 4 time(s) but freed 1 time(s)
                 k = malloc(sizeof(float) * 2)
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
        WARNING: C buffer `k` is allocated 4 time(s) but freed 1 time(s)
                 k = malloc(sizeof(float) * 2)
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
        WARNING: C buffer `k` is allocated 4 time(s) but freed 1 time(s)
                 k = malloc(sizeof(float) * 2)
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
        WARNING: C buffer `k` is allocated 4 time(s) but freed 1 time(s)
                 k = malloc(sizeof(float) * 2)
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
                 k = malloc(sizeof(float) * ((size_t)kdesc.size * kdesc.resolution + 1))
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, module->params_size)
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, module->params_size)
        ERROR: C buffer `w` is allocated 3 time(s) but never freed
                 w = malloc(sizeof(dt_liquify_warp_t))
                 w = malloc(sizeof(dt_liquify_warp_t))
                 w = malloc(sizeof(dt_liquify_warp_t))
        ERROR: C buffer `w` is allocated 3 time(s) but never freed
                 w = malloc(sizeof(dt_liquify_warp_t))
                 w = malloc(sizeof(dt_liquify_warp_t))
                 w = malloc(sizeof(dt_liquify_warp_t))
        WARNING: C buffer `buffer` is allocated 2 time(s) but freed 1 time(s)
                 buffer = malloc(sizeof(float) * 2 * len)
                 buffer = malloc(sizeof(float complex) * INTERPOLATION_POINTS)
        ERROR: C buffer `w` is allocated 3 time(s) but never freed
                 w = malloc(sizeof(dt_liquify_warp_t))
                 w = malloc(sizeof(dt_liquify_warp_t))
                 w = malloc(sizeof(dt_liquify_warp_t))
        WARNING: C buffer `a` is allocated 2 time(s) but freed 1 time(s)
                 a = malloc(module->params_size)
                 a = malloc(sizeof(float) * n)
        ERROR: 5 safe alloc(s) detected over 20

lmmse_demosaic.c
        INFO: 1 safe alloc(s) detected over 1

lowlight.c
        INFO: 0 safe alloc(s) detected over 0

lowpass.c
        INFO: 1 safe alloc(s) detected over 1

lut3d.c
        INFO: 6 safe alloc(s) detected over 6

mask_manager.c
        INFO: 1 safe alloc(s) detected over 1

monochrome.c
        INFO: 2 safe alloc(s) detected over 2

negadoctor.c
        INFO: 0 safe alloc(s) detected over 0

nlmeans.c
        INFO: 3 safe alloc(s) detected over 3

overexposed.c
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_overexposed_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_overexposed_t))
        ERROR: 1 safe alloc(s) detected over 3

profile_gamma.c
        INFO: 1 safe alloc(s) detected over 1

rawdenoise.c
        WARNING: C buffer `img` is allocated 2 time(s) but freed 1 time(s)
                 img = dt_alloc_align_float(size)
                 img = dt_alloc_align_float((size_t)width * (height+2))
        WARNING: 1 safe alloc(s) detected over 2

rawoverexposed.c
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_rawoverexposed_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_rawoverexposed_t))
        ERROR: 6 safe alloc(s) detected over 8

rawprepare.c
        INFO: 2 safe alloc(s) detected over 2

rcd_demosaic.c
        INFO: 4 safe alloc(s) detected over 4

relight.c
        INFO: 1 safe alloc(s) detected over 1

retouch.c
        ERROR: C buffer `mask_tmp` is allocated 1 time(s) but never freed
                 mask_tmp = dt_alloc_align_float((size_t)roi_mask_scaled->width * roi_mask_scaled->height)
        ERROR: 8 safe alloc(s) detected over 9

rgbcurve.c
        INFO: 0 safe alloc(s) detected over 0

rgblevels.c
        INFO: 2 safe alloc(s) detected over 2

rotatepixels.c
        INFO: 1 safe alloc(s) detected over 1

scalepixels.c
        INFO: 1 safe alloc(s) detected over 1

shadhi.c
        INFO: 2 safe alloc(s) detected over 2

sharpen.c
        INFO: 3 safe alloc(s) detected over 3

soften.c
        INFO: 3 safe alloc(s) detected over 3

splittoning.c
        INFO: 1 safe alloc(s) detected over 1

spots.c
        ERROR: C buffer `module->params` is allocated 1 time(s) but never freed
                 module->params = calloc(1, sizeof(dt_iop_spots_params_t))
        ERROR: C buffer `module->default_params` is allocated 1 time(s) but never freed
                 module->default_params = calloc(1, sizeof(dt_iop_spots_params_t))
        ERROR: 2 safe alloc(s) detected over 4

svd.h
        INFO: 1 safe alloc(s) detected over 1

temperature.c
        ERROR: C buffer `preset` is allocated 1 time(s) but never freed
                 preset = malloc(sizeof(dt_iop_temperature_preset_data_t))
        ERROR: 1 safe alloc(s) detected over 2

tonecurve.c
        INFO: 0 safe alloc(s) detected over 0

toneequal.c
        WARNING: C buffer `luminance` is allocated 2 time(s) but freed 1 time(s)
                 luminance = dt_alloc_sse_ps(num_elem)
                 luminance = dt_alloc_sse_ps(num_elem)
        WARNING: C buffer `luminance` is allocated 2 time(s) but freed 1 time(s)
                 luminance = dt_alloc_sse_ps(num_elem)
                 luminance = dt_alloc_sse_ps(num_elem)
        WARNING: 2 safe alloc(s) detected over 4

useless.c
        INFO: 1 safe alloc(s) detected over 1

velvia.c
        INFO: 1 safe alloc(s) detected over 1

vibrance.c
        INFO: 1 safe alloc(s) detected over 1

vignette.c
        INFO: 1 safe alloc(s) detected over 1

watermark.c
        INFO: 1 safe alloc(s) detected over 1

zonesystem.c
        INFO: 1 safe alloc(s) detected over 1

```

Note: the `data` allocs detected as false-positive are redundant and useless, since this buffer is already allocated by the IOP management lib.