### PR TITLE
Import datetime detection for copy & import and from camera 

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -833,6 +833,13 @@
     <longdescription>only select images that have not already been imported</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
+    <name>ui_last/import_select_recognized_new</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>select only pictures recognized as new</shortdescription>
+    <longdescription>only select images that are not recognized as already imported.\nas based on filename and timestamp matching, the recognition can fail in certain circumstances</longdescription>
+  </dtconfig>
+  <dtconfig ui="yes">
     <name>ui_last/import_ignore_jpegs</name>
     <type>bool</type>
     <default>false</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -833,13 +833,6 @@
     <longdescription>only select images that have not already been imported</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
-    <name>ui_last/import_select_recognized_new</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription>select only pictures recognized as new</shortdescription>
-    <longdescription>only select images that are not recognized as already imported.\nas based on filename and timestamp matching, the recognition can fail in certain circumstances</longdescription>
-  </dtconfig>
-  <dtconfig ui="yes">
     <name>ui_last/import_ignore_jpegs</name>
     <type>bool</type>
     <default>false</default>

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1184,6 +1184,8 @@ void dt_camctl_select_camera(const dt_camctl_t *c, const dt_camera_t *cam)
 time_t dt_camctl_get_image_file_timestamp(const dt_camctl_t *c, const char *path, const char *filename)
 {
   time_t timestamp = 0;
+  if(!path || !filename)
+    return 0;
   // Lets check the type of file...
   CameraFileInfo cfi;
   if(!(gp_camera_file_get_info(c->active_camera->gpcam, path, filename, &cfi, c->gpcontext) == GP_OK))

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -210,7 +210,8 @@ typedef struct dt_camctl_listener_t
                                         void *data);
 
   /** Invoked when a image is downloaded while in tethered mode or by import */
-  void (*image_downloaded)(const dt_camera_t *camera, const char *filename, void *data);
+  void (*image_downloaded)(const dt_camera_t *camera, const char *in_path, const char *in_filename,
+                           const char *filename, void *data);
 
   /** Invoked when a image is found on storage.. such as from dt_camctl_get_previews(), if 0 is returned the
    * recurse is stopped.. */
@@ -273,6 +274,9 @@ int dt_camctl_can_enter_tether_mode(const dt_camctl_t *c, const dt_camera_t *cam
 void dt_camctl_tether_mode(const dt_camctl_t *c, const dt_camera_t *cam, gboolean enable);
 /** Imports the images in list from specified camera */
 void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *images);
+/** return the timestamp for file from camera CAUTION camera mutex already own*/
+time_t dt_camctl_get_image_file_timestamp(const dt_camctl_t *c, const char *in_path,
+                                          const char *in_filename);
 /** return the list of images from camera */
 GList *dt_camctl_get_images_list(const dt_camctl_t *c, dt_camera_t *cam);
 /** return the thumbnail of a camera image */

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -49,9 +49,21 @@ static const struct
   {"Xmp.dc.description", N_("description"), DT_METADATA_TYPE_USER, 1},
   {"Xmp.dc.rights", N_("rights"), DT_METADATA_TYPE_USER, 4},
   {"Xmp.acdsee.notes", N_("notes"), DT_METADATA_TYPE_USER, 5},
-  {"Xmp.darktable.version_name", N_("version name"), DT_METADATA_TYPE_OPTIONAL, 6}
+  {"Xmp.darktable.version_name", N_("version name"), DT_METADATA_TYPE_OPTIONAL, 6},
+  {"Xmp.darktable.image_id", N_("image id"), DT_METADATA_TYPE_INTERNAL, 7}
   // clang-format on
 };
+
+unsigned int dt_metadata_get_nb_user_metadata()
+{
+  unsigned int nb = 0;
+  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+  {
+    if(dt_metadata_def[i].type != DT_METADATA_TYPE_INTERNAL)
+      nb++;
+  }
+  return nb;
+}
 
 const char *dt_metadata_get_name_by_display_order(const uint32_t order)
 {

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -757,6 +757,24 @@ void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboo
   }
 }
 
+gboolean dt_metadata_already_imported(const char *filename, const char *datetime)
+{
+  if(!filename || !datetime)
+    return FALSE;
+  char *id = g_strconcat(filename, "-", datetime, NULL);
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT COUNT(*) FROM main.meta_data WHERE value=?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, id, -1, SQLITE_TRANSIENT);
+  gboolean res = FALSE;
+  if(sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_int(stmt, 0) != 0)
+    res = TRUE;
+  sqlite3_finalize(stmt);
+  g_free(id);
+  return res;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -775,6 +775,13 @@ gboolean dt_metadata_already_imported(const char *filename, const char *datetime
   return res;
 }
 
+void dt_metadata_unix_time_to_text(char *exif, const size_t exif_len, const time_t *unix)
+{
+  struct tm tt;
+  (void)localtime_r(unix, &tt);
+  strftime(exif, exif_len, "%Y:%m:%d %H:%M:%S", &tt);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -33,6 +33,7 @@ typedef enum dt_metadata_t
   DT_METADATA_XMP_DC_RIGHTS,
   DT_METADATA_XMP_ACDSEE_NOTES,
   DT_METADATA_XMP_VERSION_NAME,
+  DT_METADATA_XMP_IMAGE_ID,
   DT_METADATA_NUMBER
 }
 dt_metadata_t;
@@ -60,6 +61,9 @@ typedef enum dt_metadata_flag_t
   DT_METADATA_FLAG_IMPORTED = 1 << 2    // metadata value changed
 }
 dt_metadata_flag_t;
+
+/** return the number of user metadata (!= DT_METADATA_TYPE_INTERNAL) */
+unsigned int dt_metadata_get_nb_user_metadata();
 
 /** return the metadata key by display order */
 const char *dt_metadata_get_name_by_display_order(const uint32_t order);

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -127,6 +127,9 @@ void dt_metadata_clear(const GList *imgs, const gboolean undo_on); // libs/metad
 /** check if the "Xmp.darktable.image_id" already exists */
 gboolean dt_metadata_already_imported(const char *filename, const char *datetime);
 
+/** temporary routine waiting for common datetime.c */
+void dt_metadata_unix_time_to_text(char *exif, const size_t exif_len, const time_t *unix);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -124,6 +124,9 @@ GList *dt_metadata_get_list_id(int id); // libs/image.c
 /** Remove metadata from specific images, or all selected for id == -1. */
 void dt_metadata_clear(const GList *imgs, const gboolean undo_on); // libs/metadata.c
 
+/** check if the "Xmp.darktable.image_id" already exists */
+gboolean dt_metadata_already_imported(const char *filename, const char *datetime);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -220,11 +220,25 @@ dt_job_t *dt_camera_capture_job_create(const char *jobcode, uint32_t delay, uint
 }
 
 /** Listener interface for import job */
-void _camera_import_image_downloaded(const dt_camera_t *camera, const char *filename, void *data)
+void _camera_import_image_downloaded(const dt_camera_t *camera, const char *in_path,
+                                     const char *in_filename, const char *filename, void *data)
 {
   // Import downloaded image to import filmroll
   dt_camera_import_t *t = (dt_camera_import_t *)data;
   const int32_t imgid = dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE, TRUE);
+
+  const time_t timestamp = dt_camctl_get_image_file_timestamp(darktable.camctl, in_path, in_filename);
+  if(timestamp && imgid >= 0)
+  {
+    GDateTime *dt_datetime = g_date_time_new_from_unix_local(timestamp);
+    gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+    gchar *id = g_strconcat(in_filename, "-", dt_txt, NULL);
+    dt_metadata_set(imgid, "Xmp.darktable.image_id", id, FALSE);
+    g_free(dt_txt);
+    g_free(id);
+    g_date_time_unref(dt_datetime);
+  }
+
   dt_control_queue_redraw_center();
   gchar *basename = g_path_get_basename(filename);
   const int num_images = g_list_length(t->images);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -227,16 +227,15 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *in_p
   dt_camera_import_t *t = (dt_camera_import_t *)data;
   const int32_t imgid = dt_image_import(dt_import_session_film_id(t->shared.session), filename, FALSE, TRUE);
 
-  const time_t timestamp = dt_camctl_get_image_file_timestamp(darktable.camctl, in_path, in_filename);
+  const time_t timestamp = (!in_path || !in_filename) ? 0 :
+               dt_camctl_get_image_file_timestamp(darktable.camctl, in_path, in_filename);
   if(timestamp && imgid >= 0)
   {
-    GDateTime *dt_datetime = g_date_time_new_from_unix_local(timestamp);
-    gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+    char dt_txt[DT_DATETIME_LENGTH];
+    dt_metadata_unix_time_to_text(dt_txt, sizeof(dt_txt), &timestamp);
     gchar *id = g_strconcat(in_filename, "-", dt_txt, NULL);
     dt_metadata_set(imgid, "Xmp.darktable.image_id", id, FALSE);
-    g_free(dt_txt);
     g_free(id);
-    g_date_time_unref(dt_datetime);
   }
 
   dt_control_queue_redraw_center();

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2083,6 +2083,24 @@ static int _control_import_image_copy(const char *filename,
     if(!imgid) dt_control_log(_("error loading file `%s'"), output);
     else
     {
+      GError *error = NULL;
+      GFile *gfile = g_file_new_for_path(filename);
+      GFileInfo *info = g_file_query_info(gfile,
+                                G_FILE_ATTRIBUTE_STANDARD_NAME ","
+                                G_FILE_ATTRIBUTE_TIME_MODIFIED,
+                                G_FILE_QUERY_INFO_NONE, NULL, &error);
+      const char *fn = g_file_info_get_name(info);
+      // FIXME set a routine common with import.c
+      const guint64 datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+      GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
+      gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+      char *id = g_strconcat(fn, "-", dt_txt, NULL);
+      dt_metadata_set(imgid, "Xmp.darktable.image_id", id, FALSE);
+      g_free(id);
+      g_free(dt_txt);
+      g_date_time_unref(dt_datetime);
+      g_object_unref(info);
+      g_object_unref(gfile);
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(imgid));
       if((imgid & 3) == 3)
       {

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2091,14 +2091,12 @@ static int _control_import_image_copy(const char *filename,
                                 G_FILE_QUERY_INFO_NONE, NULL, &error);
       const char *fn = g_file_info_get_name(info);
       // FIXME set a routine common with import.c
-      const guint64 datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
-      GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
-      gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+      const time_t datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+      char dt_txt[DT_DATETIME_LENGTH];
+      dt_metadata_unix_time_to_text(dt_txt, sizeof(dt_txt), &datetime);
       char *id = g_strconcat(fn, "-", dt_txt, NULL);
       dt_metadata_set(imgid, "Xmp.darktable.image_id", id, FALSE);
       g_free(id);
-      g_free(dt_txt);
-      g_date_time_unref(dt_datetime);
       g_object_unref(info);
       g_object_unref(gfile);
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(imgid));

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -245,6 +245,8 @@ static void _import_metadata_presets_update(dt_import_metadata_t *metadata)
     uint32_t total_len = 0;
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
     {
+      if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+        continue;
       metadata_param[i] = buf;
       metadata_len[i] = strlen(metadata_param[i]) + 1;
       buf += metadata_len[i];
@@ -258,6 +260,8 @@ static void _import_metadata_presets_update(dt_import_metadata_t *metadata)
       gtk_list_store_set(metadata->m_model, &iter, 0, (char *)sqlite3_column_text(stmt, 0), -1);
       for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
       {
+        if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+          continue;
         gtk_list_store_set(metadata->m_model, &iter, i+1, metadata_param[i], -1);
       }
     }

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -825,7 +825,8 @@ static gboolean _update_files_list(gpointer user_data)
   gtk_tree_view_set_model(d->from.treeview, model);
   g_object_unref(model);
 
-  if(dt_conf_get_bool("ui_last/import_select_new"))
+  if((d->import_case == DT_IMPORT_INPLACE && dt_conf_get_bool("ui_last/import_select_new")) ||
+     (d->import_case != DT_IMPORT_INPLACE && dt_conf_get_bool("ui_last/import_select_recognized_new")))
     _do_select_new(self);
   else
     _do_select_all(self);
@@ -1765,7 +1766,9 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
 
-  d->import_new = dt_gui_preferences_bool(grid, "ui_last/import_select_new", col++, line, TRUE);
+  d->import_new = dt_gui_preferences_bool(grid,
+            d->import_case == DT_IMPORT_INPLACE ? "ui_last/import_select_new" : "ui_last/import_select_recognized_new",
+            col++, line, TRUE);
   gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
   g_signal_connect(G_OBJECT(d->import_new), "toggled", G_CALLBACK(_import_new_toggled), self);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -825,8 +825,7 @@ static gboolean _update_files_list(gpointer user_data)
   gtk_tree_view_set_model(d->from.treeview, model);
   g_object_unref(model);
 
-  if((d->import_case == DT_IMPORT_INPLACE && dt_conf_get_bool("ui_last/import_select_new")) ||
-     (d->import_case != DT_IMPORT_INPLACE && dt_conf_get_bool("ui_last/import_select_recognized_new")))
+  if(dt_conf_get_bool("ui_last/import_select_new"))
     _do_select_new(self);
   else
     _do_select_all(self);
@@ -1766,9 +1765,7 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
 
-  d->import_new = dt_gui_preferences_bool(grid,
-            d->import_case == DT_IMPORT_INPLACE ? "ui_last/import_select_new" : "ui_last/import_select_recognized_new",
-            col++, line, TRUE);
+  d->import_new = dt_gui_preferences_bool(grid, "ui_last/import_select_new", col++, line, TRUE);
   gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
   g_signal_connect(G_OBJECT(d->import_new), "toggled", G_CALLBACK(_import_new_toggled), self);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -687,6 +687,58 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
 
   const gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
   const gboolean include_jpegs = !dt_conf_get_bool("ui_last/import_ignore_jpegs");
+  while((info = g_file_enumerator_next_file(dir_files, NULL, &error)))
+  {
+    const char *uifilename = g_file_info_get_display_name(info);
+    const char *filename = g_file_info_get_name(info);
+    if(!filename)
+      continue;
+    const guint64 datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+    GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
+    gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+    const GFileType filetype = g_file_info_get_file_type(info);
+    gchar *uifullname = g_build_filename(folder, uifilename, NULL);
+    gchar *fullname = g_build_filename(folder, filename, NULL);
+
+    if(recursive && filetype == G_FILE_TYPE_DIRECTORY)
+    {
+      nb = _import_set_file_list(fullname, folder_lgth, nb, self);
+    }
+    // supported image format to import
+    else if(filetype != G_FILE_TYPE_DIRECTORY && dt_supported_image(filename))
+    {
+      const char *ext = g_strrstr(filename, ".");
+      if(include_jpegs || (ext && g_ascii_strncasecmp(ext, ".jpg", sizeof(".jpg"))
+                               && g_ascii_strncasecmp(ext, ".jpeg", sizeof(".jpeg"))))
+      {
+        gboolean already_imported = FALSE;
+        if(d->import_case == DT_IMPORT_INPLACE)
+        {
+          /* check if image is already imported, using previously fetched filroll id */
+          if(filmroll_id != -1)
+            already_imported = dt_image_get_id(filmroll_id, filename) != -1 ? TRUE : FALSE;
+        }
+        else already_imported = dt_metadata_already_imported(&fullname[offset], dt_txt);
+
+        GtkTreeIter iter;
+        gtk_list_store_append(d->from.store, &iter);
+        gtk_list_store_set(d->from.store, &iter,
+                           DT_IMPORT_UI_EXISTS, already_imported ? "✔" : " ",
+                           DT_IMPORT_UI_FILENAME, &uifullname[offset],
+                           DT_IMPORT_FILENAME, &fullname[offset],
+                           DT_IMPORT_UI_DATETIME, dt_txt,
+                           DT_IMPORT_DATETIME, datetime,
+                           DT_IMPORT_THUMB, d->from.eye, -1);
+        nb++;
+      }
+    }
+
+    g_free(dt_txt);
+    g_free(fullname);
+    g_free(uifullname);
+    g_date_time_unref(dt_datetime);
+    g_object_unref(info);
+  }
   if(dir_files)
   {
     while((info = g_file_enumerator_next_file(dir_files, NULL, &error)))
@@ -1541,21 +1593,18 @@ static void _set_files_list(GtkWidget *rbox, dt_lib_module_t* self)
   d->from.treeview = GTK_TREE_VIEW(gtk_tree_view_new());
   gtk_container_add(GTK_CONTAINER(d->from.w), GTK_WIDGET(d->from.treeview));
 
-  if(d->import_case == DT_IMPORT_INPLACE)
-  {
-    GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
-    GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("✔", renderer, "text",
-                                                      DT_IMPORT_UI_EXISTS, NULL);
-    g_object_set (renderer, "xalign", 0.5, NULL);
-    gtk_tree_view_append_column(d->from.treeview, column);
-    gtk_tree_view_column_set_alignment(column, 0.5);
-    gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(10));
-    GtkWidget *header = gtk_tree_view_column_get_button(column);
-    gtk_widget_set_tooltip_text(header, _("mark already imported pictures"));
-  }
-
   GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
-  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("name"), renderer, "text",
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("✔", renderer, "text",
+                                                    DT_IMPORT_UI_EXISTS, NULL);
+  g_object_set(renderer, "xalign", 0.5, NULL);
+  gtk_tree_view_append_column(d->from.treeview, column);
+  gtk_tree_view_column_set_alignment(column, 0.5);
+  gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(25));
+  GtkWidget *header = gtk_tree_view_column_get_button(column);
+  gtk_widget_set_tooltip_text(header, _("mark already imported pictures"));
+
+  renderer = gtk_cell_renderer_text_new();
+  column = gtk_tree_view_column_new_with_attributes(_("name"), renderer, "text",
                                                     DT_IMPORT_UI_FILENAME, NULL);
   gtk_tree_view_append_column(d->from.treeview, column);
 
@@ -1570,7 +1619,7 @@ static void _set_files_list(GtkWidget *rbox, dt_lib_module_t* self)
                                                     DT_IMPORT_UI_DATETIME, NULL);
   gtk_tree_view_append_column(d->from.treeview, column);
   gtk_tree_view_column_set_sort_column_id(column, DT_IMPORT_DATETIME);
-  GtkWidget *header = gtk_tree_view_column_get_button(column);
+  header = gtk_tree_view_column_get_button(column);
   gtk_widget_set_tooltip_text(header, _("file 'modified date/time', may be different from 'Exif date/time'"));
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(d->from.store),
                                        DT_IMPORT_DATETIME, GTK_SORT_ASCENDING);
@@ -1732,12 +1781,9 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   gtk_box_pack_start(GTK_BOX(box), select_none, FALSE, FALSE, 2);
   g_signal_connect(select_none, "clicked", G_CALLBACK(_do_select_none_clicked), self);
 
-  if(d->import_case == DT_IMPORT_INPLACE)
-  {
-    GtkWidget *select_new = gtk_button_new_with_label(_("select new"));
-    gtk_box_pack_start(GTK_BOX(box), select_new, FALSE, FALSE, 2);
-    g_signal_connect(select_new, "clicked", G_CALLBACK(_do_select_new_clicked), self);
-  }
+  GtkWidget *select_new = gtk_button_new_with_label(_("select new"));
+  gtk_box_pack_start(GTK_BOX(box), select_new, FALSE, FALSE, 2);
+  g_signal_connect(select_new, "clicked", G_CALLBACK(_do_select_new_clicked), self);
 
   d->from.img_nb = gtk_label_new("");
   gtk_widget_set_halign(d->from.img_nb, GTK_ALIGN_END);
@@ -1755,12 +1801,11 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   guint col = 0;
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
-  if(d->import_case == DT_IMPORT_INPLACE)
-  {
-    d->import_new = dt_gui_preferences_bool(grid, "ui_last/import_select_new", col++, line, TRUE);
-    gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
-    g_signal_connect(G_OBJECT(d->import_new), "toggled", G_CALLBACK(_import_new_toggled), self);
-  }
+
+  d->import_new = dt_gui_preferences_bool(grid, "ui_last/import_select_new", col++, line, TRUE);
+  gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
+  g_signal_connect(G_OBJECT(d->import_new), "toggled", G_CALLBACK(_import_new_toggled), self);
+
   if(d->import_case != DT_IMPORT_CAMERA)
   {
     d->recursive = dt_gui_preferences_bool(grid, "ui_last/import_recursive", col++, line, TRUE);
@@ -1861,7 +1906,7 @@ static void _do_select_new(dt_lib_module_t* self)
     {
       gchar *sel = NULL;
       gtk_tree_model_get(model, &iter, DT_IMPORT_UI_EXISTS, &sel, -1);
-      if((d->import_case != DT_IMPORT_INPLACE) || (sel && !strcmp(sel, " ")))
+      if(sel && !strcmp(sel, " "))
         gtk_tree_selection_select_iter(selection, &iter);
     }
     while(gtk_tree_model_iter_next(model, &iter));

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -384,11 +384,13 @@ static guint _import_from_camera_set_file_list(dt_lib_module_t *self)
     if(include_jpegs || (ext && g_ascii_strncasecmp(ext, ".jpg", sizeof(".jpg"))
                              && g_ascii_strncasecmp(ext, ".jpeg", sizeof(".jpeg"))))
     {
-      const guint64 datetime = file->timestamp;
+      const time_t datetime = file->timestamp;
       GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
       gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
       gchar *basename = g_path_get_basename(file->filename);
-      const gboolean already_imported = dt_metadata_already_imported(basename, dt_txt);
+      char dtid[DT_DATETIME_LENGTH];
+      dt_metadata_unix_time_to_text(dtid, sizeof(dtid), &datetime);
+      const gboolean already_imported = dt_metadata_already_imported(basename, dtid);
       g_free(basename);
       GtkTreeIter iter;
       gtk_list_store_append(d->from.store, &iter);
@@ -688,61 +690,9 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
   /* get filmroll id for current directory. if not present, checking the db whether
     the image has already been imported can be skipped */
   int32_t filmroll_id = dt_film_get_id(folder);
-
   const gboolean recursive = dt_conf_get_bool("ui_last/import_recursive");
   const gboolean include_jpegs = !dt_conf_get_bool("ui_last/import_ignore_jpegs");
-  while((info = g_file_enumerator_next_file(dir_files, NULL, &error)))
-  {
-    const char *uifilename = g_file_info_get_display_name(info);
-    const char *filename = g_file_info_get_name(info);
-    if(!filename)
-      continue;
-    const guint64 datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
-    GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
-    gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
-    const GFileType filetype = g_file_info_get_file_type(info);
-    gchar *uifullname = g_build_filename(folder, uifilename, NULL);
-    gchar *fullname = g_build_filename(folder, filename, NULL);
 
-    if(recursive && filetype == G_FILE_TYPE_DIRECTORY)
-    {
-      nb = _import_set_file_list(fullname, folder_lgth, nb, self);
-    }
-    // supported image format to import
-    else if(filetype != G_FILE_TYPE_DIRECTORY && dt_supported_image(filename))
-    {
-      const char *ext = g_strrstr(filename, ".");
-      if(include_jpegs || (ext && g_ascii_strncasecmp(ext, ".jpg", sizeof(".jpg"))
-                               && g_ascii_strncasecmp(ext, ".jpeg", sizeof(".jpeg"))))
-      {
-        gboolean already_imported = FALSE;
-        if(d->import_case == DT_IMPORT_INPLACE)
-        {
-          /* check if image is already imported, using previously fetched filroll id */
-          if(filmroll_id != -1)
-            already_imported = dt_image_get_id(filmroll_id, filename) != -1 ? TRUE : FALSE;
-        }
-        else already_imported = dt_metadata_already_imported(&fullname[offset], dt_txt);
-
-        GtkTreeIter iter;
-        gtk_list_store_append(d->from.store, &iter);
-        gtk_list_store_set(d->from.store, &iter,
-                           DT_IMPORT_UI_EXISTS, already_imported ? "✔" : " ",
-                           DT_IMPORT_UI_FILENAME, &uifullname[offset],
-                           DT_IMPORT_FILENAME, &fullname[offset],
-                           DT_IMPORT_UI_DATETIME, dt_txt,
-                           DT_IMPORT_DATETIME, datetime,
-                           DT_IMPORT_THUMB, d->from.eye, -1);
-        nb++;
-      }
-    }
-
-    g_free(dt_txt);
-    g_free(fullname);
-    g_free(uifullname);
-    g_date_time_unref(dt_datetime);
-    g_object_unref(info);
-  }
   if(dir_files)
   {
     while((info = g_file_enumerator_next_file(dir_files, NULL, &error)))
@@ -751,7 +701,7 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
       const char *filename = g_file_info_get_name(info);
       if(!filename)
         continue;
-      const guint64 datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+      const time_t datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
       GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
       gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
       const GFileType filetype = g_file_info_get_file_type(info);
@@ -769,11 +719,20 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
         if(include_jpegs || (ext && g_ascii_strncasecmp(ext, ".jpg", sizeof(".jpg"))
                                  && g_ascii_strncasecmp(ext, ".jpeg", sizeof(".jpeg"))))
         {
-          /* check if image is already imported, using previously fetched filroll id */
           gboolean already_imported = FALSE;
-          if(filmroll_id != -1)
+          if(d->import_case == DT_IMPORT_INPLACE)
           {
-            already_imported = dt_image_get_id(filmroll_id, filename) != -1 ? TRUE : FALSE;
+            /* check if image is already imported, using previously fetched filroll id */
+            if(filmroll_id != -1)
+              already_imported = dt_image_get_id(filmroll_id, filename) != -1 ? TRUE : FALSE;
+          }
+          else
+          {
+            gchar *basename = g_path_get_basename(filename);
+            char dtid[DT_DATETIME_LENGTH];
+            dt_metadata_unix_time_to_text(dtid, sizeof(dtid), &datetime);
+            already_imported = dt_metadata_already_imported(basename, dtid);
+            g_free(basename);
           }
 
           GtkTreeIter iter;

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -387,9 +387,13 @@ static guint _import_from_camera_set_file_list(dt_lib_module_t *self)
       const guint64 datetime = file->timestamp;
       GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
       gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+      gchar *basename = g_path_get_basename(file->filename);
+      const gboolean already_imported = dt_metadata_already_imported(basename, dt_txt);
+      g_free(basename);
       GtkTreeIter iter;
       gtk_list_store_append(d->from.store, &iter);
       gtk_list_store_set(d->from.store, &iter,
+                         DT_IMPORT_UI_EXISTS, already_imported ? "✔" : " ",
                          DT_IMPORT_UI_FILENAME, file->filename,
                          DT_IMPORT_FILENAME, file->filename,
                          DT_IMPORT_UI_DATETIME, dt_txt,

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -201,6 +201,8 @@ static void _update(dt_lib_module_t *self)
       if(sqlite3_column_bytes(stmt, 1))
       {
         const uint32_t key = (uint32_t)sqlite3_column_int(stmt, 0);
+        if(key >= DT_METADATA_NUMBER)
+          continue;
         char *value = g_strdup((char *)sqlite3_column_text(stmt, 1));
         const uint32_t count = (uint32_t)sqlite3_column_int(stmt, 2);
         metadata_count[key] = (count == imgs_count) ? 2 : 1;  // if = all images have the same metadata

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -214,6 +214,8 @@ static void _update(dt_lib_module_t *self)
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
     const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
+    if(dt_metadata_get_type(keyid) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     g_list_free_full(d->metadata_list[i], g_free);
     d->metadata_list[i] = metadata[keyid];
     _fill_text_view(i, metadata_count[keyid], self);
@@ -243,6 +245,8 @@ static void _append_kv(GList **l, const gchar *key, const gchar *value)
 static void _metadata_set_list(const int i, GList **key_value, dt_lib_metadata_t *d)
 {
   const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
+  if(dt_metadata_get_type(i) == DT_METADATA_TYPE_INTERNAL)
+    return;
   gchar *metadata = _get_buffer_text(GTK_TEXT_VIEW(d->textview[i]));
   if(metadata && !_is_leave_unchanged(GTK_TEXT_VIEW(d->textview[i])))
     _append_kv(key_value, dt_metadata_get_key(keyid), metadata);
@@ -399,6 +403,8 @@ static void _update_layout(dt_lib_module_t *self)
   GtkWidget *first = NULL, *previous = NULL;
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     const gchar *name = dt_metadata_get_name_by_display_order(i);
     const int type = dt_metadata_get_type_by_display_order(i);
     gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
@@ -638,7 +644,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
                          DT_METADATA_PREF_COL_VISIBLE, &new_visible,
                          DT_METADATA_PREF_COL_PRIVATE, &new_private,
                          -1);
-      if(i < DT_METADATA_NUMBER)
+      if(i < DT_METADATA_NUMBER && dt_metadata_get_type(i) != DT_METADATA_TYPE_INTERNAL)
       {
         gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name[i]);
         uint32_t flag = dt_conf_get_int(setting);
@@ -800,6 +806,8 @@ void gui_init(dt_lib_module_t *self)
 
   for(int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     GtkWidget *label = dt_ui_label_new(_(dt_metadata_get_name_by_display_order(i)));
     GtkWidget *labelev = gtk_event_box_new();
     gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
@@ -884,6 +892,8 @@ void gui_cleanup(dt_lib_module_t *self)
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     g_signal_handlers_block_by_func(d->textview[i], _lost_focus, self);
     g_free(d->setting_name[i]);
   }
@@ -894,7 +904,7 @@ void gui_cleanup(dt_lib_module_t *self)
 static void add_rights_preset(dt_lib_module_t *self, char *name, char *string)
 {
   // to be adjusted the nb of metadata items changes
-  const unsigned int metadata_nb = DT_METADATA_NUMBER;
+  const unsigned int metadata_nb = dt_metadata_get_nb_user_metadata();
   const unsigned int params_size = strlen(string) + metadata_nb;
 
   char *params = calloc(sizeof(char), params_size);
@@ -983,6 +993,8 @@ void *get_params(dt_lib_module_t *self, int *size)
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
     GtkTextBuffer *buffer = gtk_text_view_get_buffer((GtkTextView *)d->textview[i]);
     GtkTextIter start, end;
@@ -999,6 +1011,8 @@ void *get_params(dt_lib_module_t *self, int *size)
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     memcpy(params + pos, metadata[i], metadata_len[i]);
     pos += metadata_len[i];
     g_free(metadata[i]);
@@ -1021,6 +1035,8 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   uint32_t total_len = 0;
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     metadata[i] = buf;
     if(!metadata[i]) return 1;
     metadata_len[i] = strlen(metadata[i]) + 1;
@@ -1035,6 +1051,8 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
+    if(dt_metadata_get_type_by_display_order(i) == DT_METADATA_TYPE_INTERNAL)
+      continue;
     if(metadata[i][0] != '\0') _append_kv(&key_value, dt_metadata_get_key(i), metadata[i]);
   }
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -151,7 +151,7 @@ static const char *_labels[] = {
 
   /* xmp */
   //FIXME: reserve DT_METADATA_NUMBER places
-  "","","","","","","",
+  "","","","","","","","",
 
   /* geotagging */
   N_("latitude"),
@@ -188,10 +188,10 @@ int position()
 
 static gboolean _is_metadata_ui(const int i)
 {
-  // internal metadata ar not to be shown on the ui
+  // internal metadata are not to be shown on the ui
   if(i >= md_xmp_metadata && i < md_xmp_metadata + DT_METADATA_NUMBER)
   {
-    const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
+    const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i - md_xmp_metadata);
     return !(dt_metadata_get_type(keyid) == DT_METADATA_TYPE_INTERNAL);
   }
   else return TRUE;
@@ -951,10 +951,10 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       g_strlcpy(text, NODATA_STRING, sizeof(text));
 
       const uint32_t keyid = dt_metadata_get_keyid_by_display_order((uint32_t)(md - md_xmp_metadata));
-      const gchar *const key = dt_metadata_get_key(keyid);
       const gboolean hidden = dt_metadata_get_type(keyid) == DT_METADATA_TYPE_INTERNAL;
       if(! hidden)
       {
+        const gchar *const key = dt_metadata_get_key(keyid);
         GList *res = dt_metadata_get(img->id, key, NULL);
         if(res)
         {
@@ -962,8 +962,8 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
           _filter_non_printable(text, sizeof(text));
           g_list_free_full(res, &g_free);
         }
+        _metadata_update_value(md, text, self);
       }
-      _metadata_update_value(md, text, self);
     }
   }
   dt_image_cache_read_release(darktable.image_cache, img);
@@ -1218,7 +1218,7 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 
   GtkTreeIter iter;
   d->metadata = g_list_sort(d->metadata, _lib_metadata_sort_order);
-  for(GList *meta = d->metadata; meta; meta= g_list_next(meta))
+  for(GList *meta = d->metadata; meta; meta = g_list_next(meta))
   {
     dt_lib_metadata_info_t *m = (dt_lib_metadata_info_t *)meta->data;
     if(!_is_metadata_ui(m->index))

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -485,7 +485,8 @@ static const char *_camera_request_image_path(const dt_camera_t *camera, char *e
   return dt_import_session_path(lib->session, FALSE);
 }
 
-static void _camera_capture_image_downloaded(const dt_camera_t *camera, const char *filename, void *data)
+static void _camera_capture_image_downloaded(const dt_camera_t *camera, const char *in_folder,
+                                             const char *in_filename, const char *filename, void *data)
 {
   dt_capture_t *lib = (dt_capture_t *)data;
 


### PR DESCRIPTION
Solves a pixls.us [request](https://discuss.pixls.us/t/potential-improvements-to-import-and-copy-in-darktable/29074).

If merged before #10844 this function will have to be aligned afterwards.

Principle: Save in an internal (not visible from the user) metadata ("Xmp.darktable.image_id") the orignal filename + timestamp.
At import time looks if the corresponding metadata value already exists or not.

The first commit fixes several bugs related to internal metadata which has not be used so far.

![image](https://user-images.githubusercontent.com/23012047/151604632-4b26c945-6833-4ede-8a6a-0dedfd1d8ddf.png)

Limitation: the detection doesn't happen for images imported before this PR ...
 
