### PR TITLE
set notebook padding at label level not tab, fixing resizing error

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1088,15 +1088,11 @@ notebook tabs,
 }
 
 /* Set notebook tabs */
-notebook tab
+notebook tab label
 {
   border-bottom: 0.14em solid transparent;
   padding: 0.21em;
   font-weight: normal;
-}
-
-notebook tab label /* disabled tabs */
-{
   color: shade(@button_checked_fg, 0.75);
 }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2879,13 +2879,7 @@ static void _notebook_size_callback(GtkNotebook *notebook, GdkRectangle *allocat
   gtk_widget_get_allocation(sizes[0].data, &first);
   gtk_widget_get_allocation(sizes[n - 1].data, &last);
 
-  GtkBorder padding = { 3, 3, 3, 3 };
-/*gtk_style_context_get_padding(gtk_style_context_get_parent(gtk_widget_get_style_context(sizes[0].data)),
-                                gtk_widget_get_state_flags(sizes[0].data),
-                                &padding); // try to get tab (not label) padding*/
-
-  const gint total_space = last.x + last.width - first.x
-                           - (n - 1) * (padding.left + padding.right);
+  const gint total_space = last.x + last.width - first.x; // ignore tab padding; CSS sets padding for label
 
   if(total_space > 0)
   {


### PR DESCRIPTION
#6375 hardcoded the padding in notebook tabs because many attempts to find a way to pick up the actual padding set in css failed.

Then https://github.com/darktable-org/darktable/commit/697ce8790311c6659f5700c3813985ec28349e46 made padding dependent on font size, which, for large fonts or high resolution monitors, caused the resizing code to generate
`gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkNotebook
`

After a few more hours of trying to get the correct GtkStyleContext for the tab, I tried if setting the padding at the tab _label_ level made a significant difference visually. I didn't see any.

And now it is no longer necessary to adjust the allocatable width for the padding at all, since it now falls _within_ the tabs and is dealt with by ellipsizing.

@Nilvus your comments please. I haven't merged the two successive section of `notebook tab label` since the second has the comment "_disabled tabs_", although I don't understand why...