### PR TITLE
po/copy part wb

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1244,6 +1244,18 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
   return result;
 }
 
+gboolean dt_history_check_module_exists_list(GList *hist, const char *operation, gboolean enabled)
+{
+  for(GList *h = hist; h; h = g_list_next(h))
+  {
+    const dt_history_item_t *item = (dt_history_item_t *)(h->data);
+
+    if(!g_strcmp0(item->op, operation) && (item->enabled || !enabled))
+      return TRUE;
+  }
+  return FALSE;
+}
+
 GList *dt_history_duplicate(GList *hist)
 {
   GList *result = NULL;

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -581,11 +581,12 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
 
 gboolean dt_history_module_skip_copy(const char*op, const int flags, gboolean dev_has_cc)
 {
-  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
-  // In scene-referred mode we still want to copy the temperature module which is
+  const gboolean is_modern_chroma =
+    dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
+  // In modern chromatic-adaptation mode we still want to copy the temperature module which is
   // needed for the color-calibration module.
   return (flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN))
-    && !(is_scene_referred && dev_has_cc && g_strcmp0(op, "temperature") == 0);
+    && !(is_modern_chroma && dev_has_cc && g_strcmp0(op, "temperature") == 0);
 }
 
 static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const int32_t dest_imgid, GList *ops, const gboolean copy_full)

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -542,7 +542,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
          && !(mod_src->default_enabled && mod_src->enabled
               && !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size) // it's not a enabled by default module with unmodified settings
               && !dt_iop_is_hidden(mod_src))
-         && (copy_full || !dt_history_module_skip_copy(mod_src->flags()))
+         && (copy_full || !dt_history_module_skip_copy(mod_src->op, mod_src->flags()))
         )
       {
         mod_list = g_list_prepend(mod_list, mod_src);
@@ -576,6 +576,15 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   g_list_free(modules_used);
 
   return 0;
+}
+
+gboolean dt_history_module_skip_copy(const char*op, const int flags)
+{
+  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
+  // In scene-referred mode we still want to copy the temperature module which is
+  // needed for the color-calibration module.
+  return (flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN))
+    && !(is_scene_referred && g_strcmp0(op, "temperature") == 0);
 }
 
 static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const int32_t dest_imgid, GList *ops, const gboolean copy_full)
@@ -618,7 +627,7 @@ static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const
       {
         dt_iop_module_so_t *module = (dt_iop_module_so_t *)modules->data;
 
-        if(dt_history_module_skip_copy(module->flags()))
+        if(dt_history_module_skip_copy(module->op, module->flags()))
         {
           if(skip_modules)
             skip_modules = dt_util_dstrcat(skip_modules, ",");

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1228,16 +1228,20 @@ int dt_history_compress_on_list(const GList *imgs)
   return uncompressed;
 }
 
-gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
+gboolean dt_history_check_module_exists(int32_t imgid, const char *operation, gboolean enabled)
 {
   gboolean result = FALSE;
   sqlite3_stmt *stmt;
 
   DT_DEBUG_SQLITE3_PREPARE_V2(
     dt_database_get(darktable.db),
-    "SELECT imgid FROM main.history WHERE imgid= ?1 AND operation = ?2", -1, &stmt, NULL);
+    "SELECT imgid"
+    " FROM main.history"
+    " WHERE imgid= ?1 AND operation = ?2 AND enabled in (1, ?3)",
+    -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, operation, -1, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, enabled);
   if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
   sqlite3_finalize(stmt);
 

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -79,10 +79,7 @@ gboolean dt_history_copy_parts(int imgid);
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo);
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo);
 
-static inline gboolean dt_history_module_skip_copy(const int flags)
-{
-  return flags & (IOP_FLAGS_DEPRECATED | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_HIDDEN);
-}
+gboolean dt_history_module_skip_copy(const char*op, const int flags);
 
 /** load a dt file and applies to selected images */
 int dt_history_load_and_apply_on_list(gchar *filename, const GList *list);

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -122,7 +122,7 @@ char *dt_history_get_items_as_string(int32_t imgid);
 char *dt_history_item_as_string(const char *name, gboolean enabled);
 
 /* check if a module exists in the history of corresponding image */
-gboolean dt_history_check_module_exists(int32_t imgid, const char *operation);
+gboolean dt_history_check_module_exists(int32_t imgid, const char *operation, gboolean enabled);
 
 /* check if a module exists in the history of corresponding image */
 gboolean dt_history_check_module_exists_list(GList *hist, const char *operation, gboolean enabled);

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -124,6 +124,9 @@ char *dt_history_item_as_string(const char *name, gboolean enabled);
 /* check if a module exists in the history of corresponding image */
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation);
 
+/* check if a module exists in the history of corresponding image */
+gboolean dt_history_check_module_exists_list(GList *hist, const char *operation, gboolean enabled);
+
 /** calculate history hash and save it to database*/
 void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_hash_t type);
 

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -79,7 +79,11 @@ gboolean dt_history_copy_parts(int imgid);
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo);
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo);
 
-gboolean dt_history_module_skip_copy(const char*op, const int flags);
+/** returns wether a module is to be skip from copy by default.
+    op         : operation to check
+    flags      : module flags
+    dev_has_cc : TRUE is the current image's history has Color Calibration **/
+gboolean dt_history_module_skip_copy(const char*op, const int flags, gboolean dev_has_cc);
 
 /** load a dt file and applies to selected images */
 int dt_history_load_and_apply_on_list(gchar *filename, const GList *list);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1425,7 +1425,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
         if(module->default_enabled
            && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK)
-           && !dt_history_check_module_exists(imgid, module->op))
+           && !dt_history_check_module_exists(imgid, module->op, FALSE))
         {
           fprintf(stderr,
                   "[_dev_auto_apply_presets] missing mandatory module %s for image %d\n",
@@ -1483,7 +1483,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
       if(((auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0)
           || (auto_apply_sharpen && strcmp(module->op, "sharpen") == 0)
           || (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
-         && !dt_history_check_module_exists(imgid, module->op)
+         && !dt_history_check_module_exists(imgid, module->op, FALSE)
          && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
       {
         _dev_insert_module(dev, module, imgid);
@@ -1620,7 +1620,7 @@ static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
-    if(!dt_history_check_module_exists(imgid, module->op)
+    if(!dt_history_check_module_exists(imgid, module->op, FALSE)
        && module->default_enabled
        && module->hide_enable_button
        && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
@@ -1633,7 +1633,7 @@ static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
-    if(!dt_history_check_module_exists(imgid, module->op)
+    if(!dt_history_check_module_exists(imgid, module->op, FALSE)
        && module->default_enabled
        && !module->hide_enable_button
        && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -260,7 +260,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
 
       if(!(flags & IOP_FLAGS_HIDDEN))
       {
-        const gboolean is_safe = !dt_history_module_skip_copy(flags);
+        const gboolean is_safe = !dt_history_module_skip_copy(item->op, flags);
 
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
         gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -249,6 +249,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
 
   /* fill list with history items */
   GList *items = dt_history_get_items(imgid, FALSE);
+  const gboolean has_cc = dt_history_check_module_exists_list(items, "channelmixerrgb", TRUE);
   if(items)
   {
     GtkTreeIter iter;
@@ -260,7 +261,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, int imgid, gboolean iscopy
 
       if(!(flags & IOP_FLAGS_HIDDEN))
       {
-        const gboolean is_safe = !dt_history_module_skip_copy(item->op, flags);
+        const gboolean is_safe = !dt_history_module_skip_copy(item->op, flags, has_cc);
 
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
         gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,


### PR DESCRIPTION
As reported by Aurélien, when in scene-referred mode it is not OK to skip the temperature in copy all as this module is working
together with the Color Calibration one.

So we copy temperature (or select it by default in the copy-parts dialog):
- if temperature is active
- and if color calibration if found in history
- and if in scene-referred mode

This makes the copy actually safer.