### PR TITLE
tagging:  attempt to improve the suggestion mode

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -4,7 +4,7 @@
 	prefs (import|lighttable|darkroom|otherviews|processing|security|cpugpu|storage|misc) #IMPLIED
         section
         (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp|accel|general|modules|thumbs) #IMPLIED
-        dialog (collect|recentcollect|import) #IMPLIED
+        dialog (collect|recentcollect|import|tagging) #IMPLIED
         ui (yes|no) #IMPLIED
         restart (true|false) #IMPLIED
         capability CDATA #IMPLIED

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1740,14 +1740,21 @@
     <type min="0" max="100">int</type>
     <default>50</default>
     <shortdescription>suggested tags level of confidence</shortdescription>
-    <longdescription>level of confidence to include the tag in suggestions list, 0: all associations are listed, 100: only 100% matching associations are listed</longdescription>
+    <longdescription>level of confidence to include the tag in the suggestions list, 0: all associated tags, 99: 99% matching associated tags, 100: no matching tag to show only recent tags (faster)</longdescription>
   </dtconfig>
   <dtconfig dialog="tagging">
-    <name>plugins/lighttable/tagging/recent_tags</name>
+    <name>plugins/lighttable/tagging/nb_recent_tags</name>
     <type min="0" max="1000">int</type>
     <default>20</default>
     <shortdescription>number of recently attached tags</shortdescription>
-    <longdescription>number of recently attached tags which are included in suggestions list</longdescription>
+    <longdescription>number of recently attached tags which are included in the suggestions list</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tagging/recent_tags</name>
+    <type>string</type>
+    <default/>
+    <shortdescription/>
+    <longdescription/>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/creator_text_height</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1744,10 +1744,10 @@
   </dtconfig>
   <dtconfig dialog="tagging">
     <name>plugins/lighttable/tagging/nb_recent_tags</name>
-    <type min="0" max="1000">int</type>
+    <type min="-1" max="1000">int</type>
     <default>20</default>
     <shortdescription>number of recently attached tags</shortdescription>
-    <longdescription>number of recently attached tags which are included in the suggestions list</longdescription>
+    <longdescription>number of recently attached tags which are included in the suggestions list. The value `-1' clears the memory</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/tagging/recent_tags</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1735,6 +1735,20 @@
     <shortdescription>height of the tagging dictionary view</shortdescription>
     <longdescription>maximum height the tagging dictionary view will grow to before scrolling</longdescription>
   </dtconfig>
+  <dtconfig dialog="tagging">
+    <name>plugins/lighttable/tagging/confidence</name>
+    <type min="0" max="100">int</type>
+    <default>50</default>
+    <shortdescription>suggested tags level of confidence</shortdescription>
+    <longdescription>level of confidence to include the tag in suggestions list, 0: all associations are listed, 100: only 100% matching associations are listed</longdescription>
+  </dtconfig>
+  <dtconfig dialog="tagging">
+    <name>plugins/lighttable/tagging/recent_tags</name>
+    <type min="0" max="1000">int</type>
+    <default>20</default>
+    <shortdescription>number of recently attached tags</shortdescription>
+    <longdescription>number of recently attached tags which are included in suggestions list</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/creator_text_height</name>
     <type>int</type>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2381,7 +2381,8 @@ static void _create_memory_schema(dt_database_t *db)
       NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.tmp_selection (imgid INTEGER PRIMARY KEY)", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.taglist "
-                           "(tmpid INTEGER PRIMARY KEY, id INTEGER UNIQUE ON CONFLICT IGNORE, count INTEGER)",
+                           "(tmpid INTEGER PRIMARY KEY, id INTEGER UNIQUE ON CONFLICT IGNORE, "
+                           "count INTEGER DEFAULT 0, count2 INTEGER DEFAULT 0)",
                NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.similar_tags (tagid INTEGER PRIMARY KEY)", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.darktable_tags (tagid INTEGER PRIMARY KEY)", NULL, NULL, NULL);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1038,45 +1038,42 @@ uint32_t dt_tag_get_suggestions(GList **result)
 {
   sqlite3_stmt *stmt;
 
+  const uint32_t nb_selected = dt_selected_images_count();
+  const int nb_recent = dt_conf_get_int("plugins/lighttable/tagging/nb_recent_tags");
   const uint32_t confidence = dt_conf_get_int("plugins/lighttable/tagging/confidence");
-  // image count per tag
-  if(confidence != 100)
-  {
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "INSERT INTO memory.taglist (id, count)"
-                                " SELECT S.tagid, COUNT(*)"
-                                "  FROM main.tagged_images AS S"
-                                "  WHERE S.tagid NOT IN memory.darktable_tags"
-                                "  GROUP BY S.tagid",
-                                -1, &stmt, NULL);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
+  const char *slist = dt_conf_get_string_const("plugins/lighttable/tagging/recent_tags");
 
-  // already attached tags
+  // get attached tags with how many times they are attached in db and on selected images
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "INSERT INTO memory.similar_tags (tagid)"
-                              " SELECT DISTINCT tagid FROM main.tagged_images"
-                              " WHERE imgid IN main.selected_images"
-                              " AND tagid NOT IN memory.darktable_tags",
+                              "INSERT INTO memory.taglist (id, count, count2)"
+                              "  SELECT S.tagid, COUNT(imgid) AS count,"
+                              "    CASE WHEN count2 IS NULL THEN 0 ELSE count2 END AS count2"
+                              "  FROM main.tagged_images AS S"
+                              "  LEFT JOIN ("
+                              "    SELECT tagid, COUNT(imgid) AS count2"
+                              "    FROM main.tagged_images"
+                              "    WHERE imgid IN main.selected_images"
+                              "    GROUP BY tagid) AS at"
+                              "  ON at.tagid = S.tagid"
+                              "  WHERE S.tagid NOT IN memory.darktable_tags"
+                              "  GROUP BY S.tagid",
                               -1, &stmt, NULL);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  const uint32_t nb_selected = dt_selected_images_count();
-  const char *slist = dt_conf_get_string_const("plugins/lighttable/tagging/recent_tags");
   char *query = NULL;
   if(confidence != 100)
-    query = g_strdup_printf("SELECT td.name, tagid2,"
-                            " CASE WHEN t21.count IS NULL THEN 0 ELSE t21.count END AS fc,"
-                            " CASE WHEN c22 IS NULL THEN 0 ELSE c22 END AS sc,"
+    query = g_strdup_printf("SELECT td.name, tagid2, t21.count, t21.count2,"
                             " td.flags, td.synonyms FROM ("
+                            // get tags with required confidence
                             "  SELECT DISTINCT tagid2 FROM ("
                             "    SELECT tagid2 FROM ("
+                            // get how many times (tag1, tag2) are attached together (c12)
                             "      SELECT tagid1, tagid2, count(*) AS c12"
                             "      FROM ("
                             "        SELECT DISTINCT tagid AS tagid1, imgid FROM main.tagged_images"
-                            "        WHERE tagid IN memory.similar_tags) AS t1"
+                            "        JOIN memory.taglist AS t00"
+                            "        ON t00.id = tagid1 AND t00.count2 > 0) AS t1"
                             "      JOIN ("
                             "        SELECT DISTINCT tagid AS tagid2, imgid FROM main.tagged_images"
                             "        WHERE tagid NOT IN memory.darktable_tags) AS t2"
@@ -1084,42 +1081,36 @@ uint32_t dt_tag_get_suggestions(GList **result)
                             "      GROUP BY tagid1, tagid2)"
                             "    JOIN memory.taglist AS t01"
                             "    ON t01.id = tagid1"
-                            "    JOIN ("
-                            "      SELECT tagid, COUNT(DISTINCT imgid) AS c02 FROM main.tagged_images"
-                            "      WHERE imgid IN main.selected_images"
-                            "      GROUP BY tagid) AS t02"
-                            "    ON t02.tagid = tagid1"
-                            "    WHERE (t01.count-c02) != 0 AND (100 * c12 / (t01.count-c02) >= %d)) "
+                            "    JOIN memory.taglist AS t02"
+                            "    ON t02.id = tagid2"
+                            // filter by confidence and reject tags attached on all selected images
+                            "    WHERE (t01.count-t01.count2) != 0"
+                            "      AND (100 * c12 / (t01.count-t01.count2) >= %d)"
+                            "      AND t02.count2 != %d) "
                             "  UNION"
-                            "  SELECT id AS tagid2 FROM data.tags AS tn"
-                            "  WHERE tn.name IN (\'%s\')) "
+                            // get recent list tags
+                            "  SELECT * FROM ("
+                            "    SELECT tn.id AS tagid2 FROM data.tags AS tn"
+                            "    JOIN memory.taglist AS t02"
+                            "    ON t02.id = tn.id"
+                            "    WHERE tn.name IN (\'%s\')"
+                            // reject tags attached on all selected images and keep the required number
+                            "      AND t02.count2 != %d LIMIT %d)) "
                             "LEFT JOIN memory.taglist AS t21 "
                             "ON t21.id = tagid2 "
-                            "LEFT JOIN ("
-                            "  SELECT tagid, COUNT(DISTINCT imgid) AS c22 FROM main.tagged_images"
-                            "  WHERE imgid IN main.selected_images"
-                            "  GROUP BY tagid) AS t22 "
-                            "ON t22.tagid = tagid2 "
-                            "LEFT JOIN data.tags as td ON td.id = tagid2 "
-                            "WHERE sc != %d",
-                            confidence, slist, nb_selected);
+                            "LEFT JOIN data.tags as td ON td.id = tagid2 ",
+                            confidence, nb_selected, slist, nb_selected, nb_recent);
   else
-    query = g_strdup_printf("SELECT td.name, tagid2,"
-                            " CASE WHEN t21.count IS NULL THEN 0 ELSE t21.count END AS fc,"
-                            " CASE WHEN c22 IS NULL THEN 0 ELSE c22 END AS sc,"
-                            " td.flags, td.synonyms FROM ("
-                            "  SELECT id AS tagid2 FROM data.tags AS tn"
-                            "  WHERE tn.name IN (\'%s\')) "
-                            "LEFT JOIN memory.taglist AS t21 "
-                            "ON t21.id = tagid2 "
-                            "LEFT JOIN ("
-                            "  SELECT tagid, COUNT(DISTINCT imgid) AS c22 FROM main.tagged_images"
-                            "  WHERE imgid IN main.selected_images"
-                            "  GROUP BY tagid) AS t22 "
-                            "ON t22.tagid = tagid2 "
-                            "LEFT JOIN data.tags as td ON td.id = tagid2 "
-                            "WHERE sc != %d",
-                            slist, nb_selected);
+    query = g_strdup_printf("SELECT tn.name, tn.id, count, count2,"
+                            "  tn.flags, tn.synonyms "
+                            // get recent list tags
+                            "FROM data.tags AS tn "
+                            "JOIN memory.taglist AS t02 "
+                            "ON t02.id = tn.id "
+                            "WHERE tn.name IN (\'%s\')"
+                            // reject tags attached on all selected images and keep the required number
+                            "  AND t02.count2 != %d LIMIT %d",
+                            slist, nb_selected, nb_recent);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query,
                               -1, &stmt, NULL);
 
@@ -1144,7 +1135,6 @@ uint32_t dt_tag_get_suggestions(GList **result)
 
   sqlite3_finalize(stmt);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.similar_tags", NULL, NULL, NULL);
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.taglist", NULL, NULL, NULL);
   g_free(query);
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1060,6 +1060,7 @@ uint32_t dt_tag_get_suggestions(GList **result)
   sqlite3_finalize(stmt);
 
   const uint32_t nb_selected = dt_selected_images_count();
+  const uint32_t confidence = dt_conf_get_int("plugins/lighttable/tagging/confidence");
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "SELECT td.name, tagid2,"
                               " CASE WHEN t21.count IS NULL THEN 0 ELSE t21.count END AS fc,"
@@ -1082,7 +1083,7 @@ uint32_t dt_tag_get_suggestions(GList **result)
                               "    WHERE imgid IN main.selected_images"
                               "    GROUP BY tagid) AS t02"
                               "  ON t02.tagid = tagid1"
-                              "  WHERE (t01.count-c02) != 0 AND 100 * c12 / (t01.count-c02) >= 50) "
+                              "  WHERE (t01.count-c02) != 0 AND (100 * c12 / (t01.count-c02) >= ?2)) "
                               "LEFT JOIN memory.taglist AS t21 "
                               "ON t21.id = tagid2 "
                               "LEFT JOIN ("
@@ -1094,6 +1095,7 @@ uint32_t dt_tag_get_suggestions(GList **result)
                               "WHERE sc != ?1",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, nb_selected);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, confidence);
 
   /* ... and create the result list to send upwards */
   uint32_t count = 0;

--- a/src/gui/preferences_dialogs.h
+++ b/src/gui/preferences_dialogs.h
@@ -21,6 +21,7 @@
 GtkWidget *dt_prefs_init_dialog_collect(GtkWidget *dialog);
 GtkWidget *dt_prefs_init_dialog_recentcollect(GtkWidget *dialog);
 GtkWidget *dt_prefs_init_dialog_import(GtkWidget *dialog);
+GtkWidget *dt_prefs_init_dialog_tagging(GtkWidget *dialog);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3545,7 +3545,8 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("tagging settings"), GTK_WINDOW(win),
                                                   GTK_DIALOG_DESTROY_WITH_PARENT,
                                                  _("cancel"), GTK_RESPONSE_NONE,
-                                                 _("save"), GTK_RESPONSE_YES, NULL);
+                                                 _("save"), GTK_RESPONSE_ACCEPT, NULL);
+  g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
   dt_prefs_init_dialog_tagging(dialog);
 
 #ifdef GDK_WINDOWING_QUARTZ

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2569,8 +2569,7 @@ static void _update_layout(dt_lib_module_t *self)
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->dictionary_view));
 
   const gboolean active_s = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->toggle_suggestion_button));
-  d->suggestion_flag = (dt_conf_key_exists("plugins/lighttable/tagging/nosuggestion")
-                        && !dt_conf_get_bool("plugins/lighttable/tagging/nosuggestion"));
+  d->suggestion_flag = dt_conf_get_bool("plugins/lighttable/tagging/nosuggestion");
   if(active_s != d->suggestion_flag)
   {
     g_signal_handler_block (d->toggle_suggestion_button, d->suggestion_button_handler);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3506,13 +3506,21 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
   return TRUE;
 }
 
+static int _get_recent_tags_list_length()
+{
+  const int length = dt_conf_get_int("plugins/lighttable/tagging/nb_recent_tags");
+  if(length == -1) return length;
+  else if(length >= 10/2) return length * 2;
+  else return 10;
+}
+
 static void _size_recent_tags_list()
 {
   const char *list = dt_conf_get_string_const("plugins/lighttable/tagging/recent_tags");
   if(!list[0])
     return;
-  const int length = dt_conf_get_int("plugins/lighttable/tagging/nb_recent_tags");
-  if(!length)
+  const int length = _get_recent_tags_list_length();
+  if(length == -1)
   {
     dt_conf_set_string("plugins/lighttable/tagging/recent_tags", "");
     return;
@@ -3577,9 +3585,9 @@ static void _save_last_tag_used(const char *tagnames, dt_lib_tagging_t *d)
   g_free(d->last_tag);
   d->last_tag = g_strdup(tagnames);
 
-  const int nb_recent = dt_conf_get_int("plugins/lighttable/tagging/nb_recent_tags");
+  const int nb_recent = _get_recent_tags_list_length();
 
-  if(nb_recent)
+  if(nb_recent != -1)
   {
     GList *ntags = dt_util_str_to_glist(",", tagnames);
     if(ntags)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -22,6 +22,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "dtgtk/button.h"
+#include "gui/preferences_dialogs.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/drag_and_drop.h"
@@ -3506,6 +3507,36 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
   gtk_window_present(GTK_WINDOW(d->floating_tag_window));
 
   return TRUE;
+}
+
+void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
+{
+  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("tagging settings"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                 _("cancel"), GTK_RESPONSE_NONE,
+                                                 _("save"), GTK_RESPONSE_YES, NULL);
+  dt_prefs_init_dialog_tagging(dialog);
+
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(dialog);
+#endif
+  gtk_widget_show_all(dialog);
+  gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+  if(!d->tree_flag && d->suggestion_flag)
+  {
+    _init_treeview(self, 1);
+    _update_atdetach_buttons(self);
+  }
+}
+
+void set_preferences(void *menu, dt_lib_module_t *self)
+{
+  GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
+  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -488,6 +488,14 @@ gboolean restart_required = FALSE;
   </xsl:for-each>
   <xsl:value-of select="$dialog_end" />
 
+  <!-- dialog: tagging -->
+
+  <xsl:text>&#xA;GtkWidget *dt_prefs_init_dialog_tagging</xsl:text><xsl:value-of select="$dialog_start"/>
+  <xsl:for-each select="./dtconfiglist/dtconfig[@dialog='tagging']">
+      <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+  <xsl:value-of select="$dialog_end" />
+
   <!-- closing credits -->
   <xsl:text>&#xA;#endif&#xA;</xsl:text>
 


### PR DESCRIPTION
Set normal dictionary list as default mode.

The suggestions mode still exits because that was the original tags behavior but it is more source of trouble than useful.
I would like to remove this mode. Would everyone agree ?

EDIT: please find the updated description [here](https://github.com/darktable-org/darktable/pull/11030#issuecomment-1028429468).