### PR TITLE
modulegroups: module search should include user-defined name

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -907,6 +907,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
                                  != NULL) ||
                                  (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_aliases(module->op), -1), -1,
                                                g_utf8_casefold(text_entered, -1))
+                                 != NULL) ||
+                                 (g_strstr_len(g_utf8_casefold(module->multi_name, -1), -1,
+                                               g_utf8_casefold(text_entered, -1))
                                  != NULL);
 
 


### PR DESCRIPTION
Resolves #8583.