### PR TITLE
po/collapsible section full gui rework, code sharing

### DIFF
--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -40,6 +40,7 @@
 @define-color plugin_bg_color @grey_50;
 @define-color plugin_fg_color @fg_color;
 @define-color plugin_label_color @grey_80;
+@define-color collapsible_bg_color shade(@plugin_fg_color, 0.6);
 
 /* Modules controls (sliders and comboboxes) */
 @define-color bauhaus_bg @bg_color;

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -40,7 +40,7 @@
 @define-color plugin_bg_color @grey_50;
 @define-color plugin_fg_color @fg_color;
 @define-color plugin_label_color @grey_80;
-@define-color collapsible_bg_color shade(@plugin_fg_color, 0.6);
+@define-color collapsible_bg_color shade(@plugin_fg_color, 0.55);
 
 /* Modules controls (sliders and comboboxes) */
 @define-color bauhaus_bg @bg_color;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2722,17 +2722,19 @@ Details :
   margin: 0 0.4em;
 }
 
-
-#collapsible *,
+#collapsible .box *,
 #iop-plugin-ui #collapsible #bauhaus-slider
 {
-    background-color: shade(@plugin_bg_color, 0.85);
-    color: shade(@plugin_fg_color, 1.3);
+    background-color: shade(@plugin_bg_color, 0.90);
+    color: shade(@plugin_fg_color, 1.2);
 }
 #collapsible
 {
-    background-color: shade(@plugin_bg_color, 0.85);
-    color: shade(@plugin_fg_color, 1.3);
+    background-color: shade(@plugin_bg_color, 0.90);
+    color: shade(@plugin_fg_color, 1.2);
     padding: 0px 2px 2px 10px;
     margin: 0 0 5px;
+    border-style: solid;
+    border-color: shade(@plugin_fg_color, 0.8);
+    border-width: 0 0 0 1px;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2721,3 +2721,18 @@ Details :
 {
   margin: 0 0.4em;
 }
+
+
+#collapsible *,
+#iop-plugin-ui #collapsible #bauhaus-slider
+{
+    background-color: shade(@plugin_bg_color, 0.85);
+    color: shade(@plugin_fg_color, 1.3);
+}
+#collapsible
+{
+    background-color: shade(@plugin_bg_color, 0.85);
+    color: shade(@plugin_fg_color, 1.3);
+    padding: 0px 2px 2px 10px;
+    margin: 0 0 5px;
+}

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2722,19 +2722,24 @@ Details :
   margin: 0 0.4em;
 }
 
-#collapsible .box *,
-#iop-plugin-ui #collapsible #bauhaus-slider
+/* Collapsible sections on lib & iop modules */
+
+#collapse-block,
+#collapsible #bauhaus-slider
 {
-    background-color: shade(@plugin_bg_color, 0.90);
-    color: shade(@plugin_fg_color, 1.2);
+ background-color: shade(@plugin_fg_color, 0.5);
 }
-#collapsible
+
+#collapsible,
+#collapse-block #section_label
 {
-    background-color: shade(@plugin_bg_color, 0.90);
-    color: shade(@plugin_fg_color, 1.2);
-    padding: 0px 2px 2px 10px;
-    margin: 0 0 5px;
-    border-style: solid;
-    border-color: shade(@plugin_fg_color, 0.8);
-    border-width: 0 0 0 1px;
+  padding: 0px 2px 2px 10px;
+  margin: 0;
+  border: none;
+  background-color: shade(@plugin_fg_color, 0.5);
+}
+
+#collapse-block .section-expander
+{
+  margin: 0.1em;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -86,6 +86,7 @@
 @define-color plugin_fg_color @fg_color;
 @define-color section_label shade(@plugin_fg_color, 0.95);
 @define-color plugin_label_color @grey_60;
+@define-color collapsible_bg_color shade(@plugin_fg_color, 0.5);
 
 /* Modules controls (sliders and comboboxes) */
 @define-color bauhaus_bg @bg_color;
@@ -2727,7 +2728,13 @@ Details :
 #collapse-block,
 #collapsible #bauhaus-slider
 {
- background-color: shade(@plugin_fg_color, 0.5);
+  background-color: @collapsible_bg_color;
+}
+
+/* for the import parameters to be more aligned with the imports buttons */
+#lib-plugin-ui #collapse-block
+{
+  margin: 1px;
 }
 
 #collapsible,
@@ -2736,7 +2743,7 @@ Details :
   padding: 0px 2px 2px 10px;
   margin: 0;
   border: none;
-  background-color: shade(@plugin_fg_color, 0.5);
+  background-color: @collapsible_bg_color;
 }
 
 #collapse-block .section-expander

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -69,11 +69,11 @@
 
 /* General */
 @define-color selected_bg_color @grey_35; /* legacy stuff */
-@define-color border_color @grey_10; /* border, when used */
-@define-color bg_color @grey_15; /* general background */
-@define-color fg_color @grey_70; /* general text */
-@define-color base_color @fg_color; /* legacy stuff */
-@define-color text_color @grey_05; /* same */
+@define-color border_color @grey_10;      /* border, when used */
+@define-color bg_color @grey_15;          /* general background */
+@define-color fg_color @grey_70;          /* general text */
+@define-color base_color @fg_color;       /* legacy stuff */
+@define-color text_color @grey_05;        /* same */
 @define-color disabled_fg_color @grey_40; /* disabled controls */
 
 /* Scroll bars (sliders) */
@@ -2725,28 +2725,36 @@ Details :
 
 /* Collapsible sections on lib & iop modules */
 
-#collapse-block,
-#collapsible #bauhaus-slider
+#collapse-block
 {
-  background-color: @collapsible_bg_color;
-}
-
-/* for the import parameters to be more aligned with the imports buttons */
-#lib-plugin-ui #collapse-block
-{
-  margin: 1px;
+  border: 0.1em solid shade(@collapsible_bg_color, 0.9);
 }
 
 #collapsible,
 #collapse-block #section_label
 {
-  padding: 0px 2px 2px 10px;
+  padding: 0 0.14em 0.14em 0.7em;
   margin: 0;
   border: none;
+}
+
+#collapsible,
+#collapsible #bauhaus-slider
+{
+  border-top: 0.035em solid  shade(@section_label, 0.7);
   background-color: @collapsible_bg_color;
 }
 
+/* for the import parameters to be more aligned with the imports buttons */
+
+#lib-plugin-ui #collapse-block
+{
+  margin: 0.42em 0.07em;
+}
+
+#collapse-block #section_label,
 #collapse-block .section-expander
 {
   margin: 0.1em;
+  background-color: shade(@collapsible_bg_color, 0.95);
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3360,6 +3360,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   cs->expander = dtgtk_expander_new(destdisp_head, GTK_WIDGET(cs->container));
   gtk_box_pack_end(cs->parent, cs->expander, FALSE, FALSE, 0);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), expanded);
+  gtk_widget_set_name(cs->expander, "collapse-block");
 
   g_signal_connect(G_OBJECT(cs->toggle), "toggled",
                    G_CALLBACK(_coeffs_button_changed),  (gpointer)cs);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3324,6 +3324,12 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs)
     gtk_widget_hide(GTK_WIDGET(cs->container));
 }
 
+void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs)
+{
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), FALSE);
+  gtk_widget_hide(GTK_WIDGET(cs->container));
+}
+
 void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
                                     const char *confname, const char *label, GtkBox *parent)
 {

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -462,6 +462,9 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
 // routine to be called from gui_update
 void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 
+// routine to hide the collapsible section
+void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -142,6 +142,15 @@ typedef struct dt_gui_gtk_t
 
   dt_pthread_mutex_t mutex;
 } dt_gui_gtk_t;
+
+typedef struct _gui_collapsible_section_t
+{
+  GtkBox *parent;       // the parent widget
+  gchar *confname;      // configuration name for the toggle status
+  GtkWidget *toggle;    // toggle button
+  GtkWidget *expander;  // the expanded
+  GtkBox *container;    // the container for all widgets into the section
+} dt_gui_collapsible_section_t;
 
 static inline cairo_surface_t *dt_cairo_image_surface_create(cairo_format_t format, int width, int height) {
   cairo_surface_t *cst = cairo_image_surface_create(format, width * darktable.gui->ppd, height * darktable.gui->ppd);
@@ -445,6 +454,13 @@ gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEnt
 
 // event handler for "stop-search" of GtkSearchEntry
 void dt_gui_search_stop(GtkSearchEntry *entry, GtkWidget *widget);
+
+// create a collapsible section, insert in parent, return the container
+void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
+                                    const char *confname, const char *label,
+                                    GtkBox *parent);
+// routine to be called from gui_update
+void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -429,10 +429,6 @@ typedef struct dt_iop_ashift_gui_data_t
   GtkWidget *structure_auto;
   GtkWidget *structure_quad;
   GtkWidget *structure_lines;
-  GtkWidget *values_expander;
-  GtkWidget *values_box;
-  GtkWidget *values_toggle;
-  gboolean values_expanded;
   gboolean straightening;
   float straighten_x;
   float straighten_y;
@@ -491,6 +487,7 @@ typedef struct dt_iop_ashift_gui_data_t
   float draw_pointmove_x;
   float draw_pointmove_y;
   float *draw_points;
+  dt_gui_collapsible_section_t cs;
 } dt_iop_ashift_gui_data_t;
 
 typedef struct dt_iop_ashift_data_t
@@ -5421,11 +5418,7 @@ void gui_update(struct dt_iop_module_t *self)
   // copy crop box into shadow variables
   _shadow_crop_box(p,g);
 
-  // update values expander
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->values_toggle));
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->values_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->values_expander), active);
+  dt_gui_update_collapsible_section(&g->cs);
 }
 
 void reload_defaults(dt_iop_module_t *module)
@@ -5639,29 +5632,6 @@ static float log2_curve(GtkWidget *self, float inval, dt_bauhaus_curve_t dir)
   return outval;
 }
 
-static void _event_values_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->values_toggle));
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->values_expander), active);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->values_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
-  g->values_expanded = active;
-  dt_conf_set_bool("plugins/darkroom/ashift/expand_values", active);
-}
-
-static void _event_values_expander_click(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
-{
-  if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return;
-
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->values_toggle),
-                               !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->values_toggle)));
-}
-
 static int _event_structure_quad_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -5767,33 +5737,15 @@ void gui_init(struct dt_iop_module_t *self)
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
   g_signal_connect(G_OBJECT(g->cropmode), "value-changed", G_CALLBACK(cropmode_callback), self);
 
-  // we put the detailed values under an expander
-  g->values_expanded = dt_conf_get_bool("plugins/darkroom/ashift/expand_values");
-  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  GtkWidget *header_evb = gtk_event_box_new();
-  GtkWidget *destdisp = dt_ui_section_label_new(_("perspective"));
-  GtkStyleContext *context = gtk_widget_get_style_context(destdisp_head);
-  gtk_style_context_add_class(context, "section-expander");
-  gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
-
-  g->values_toggle
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->values_toggle), g->values_expanded);
-  gtk_widget_set_name(GTK_WIDGET(g->values_toggle), "control-button");
-
   GtkWidget *main_box = self->widget;
-  g->values_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), header_evb, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), g->values_toggle, FALSE, FALSE, 0);
 
-  g->values_expander = dtgtk_expander_new(destdisp_head, g->values_box);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->values_expander), TRUE);
-  gtk_box_pack_end(GTK_BOX(main_box), g->values_expander, FALSE, FALSE, 0);
+  dt_gui_new_collapsible_section
+    (&g->cs,
+     "plugins/darkroom/ashift/expand_values",
+     _("manual perspective"),
+     GTK_BOX(main_box));
 
-  g_signal_connect(G_OBJECT(g->values_toggle), "toggled", G_CALLBACK(_event_values_button_changed), (gpointer)self);
-
-  g_signal_connect(G_OBJECT(header_evb), "button-release-event", G_CALLBACK(_event_values_expander_click),
-                   (gpointer)self);
+  self->widget = GTK_WIDGET(g->cs.container);
 
   g->lensshift_v = dt_bauhaus_slider_from_params(self, "lensshift_v");
   dt_bauhaus_slider_set_soft_range(g->lensshift_v, -LENSSHIFT_RANGE, LENSSHIFT_RANGE);
@@ -5829,10 +5781,12 @@ void gui_init(struct dt_iop_module_t *self)
   g->aspect = dt_bauhaus_slider_from_params(self, "aspect");
   dt_bauhaus_slider_set_curve(g->aspect, log2_curve);
 
-  gtk_box_pack_start(GTK_BOX(g->values_box), g->specifics, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->cs.container), g->specifics, TRUE, TRUE, 0);
 
-  GtkWidget *helpers = dt_ui_section_label_new(_("perspective helpers"));
-  gtk_box_pack_start(GTK_BOX(g->values_box), helpers, TRUE, TRUE, 0);
+  self->widget = main_box;
+
+  GtkWidget *helpers = dt_ui_section_label_new(_("perspective"));
+  gtk_box_pack_start(GTK_BOX(self->widget), helpers, TRUE, TRUE, 0);
 
   GtkGrid *auto_grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(auto_grid, 2 * DT_BAUHAUS_SPACE);
@@ -5867,7 +5821,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach(auto_grid, g->fit_both, 3, 1, 1, 1);
 
   gtk_widget_show_all(GTK_WIDGET(auto_grid));
-  gtk_box_pack_start(GTK_BOX(g->values_box), GTK_WIDGET(auto_grid), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(auto_grid), TRUE, TRUE, 0);
 
   self->widget = main_box;
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -154,14 +154,13 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   gboolean checker_ready;       // notify that a checker bounding box is ready to be used
   dt_colormatrix_t mix;
 
-  GtkWidget *start_profiling;
   gboolean is_profiling_started;
-  GtkWidget *collapsible;
   GtkWidget *checkers_list, *optimize, *safety, *label_delta_E, *button_profile, *button_validate, *button_commit;
 
   float *delta_E_in;
 
   gchar *delta_E_label_text;
+  dt_gui_collapsible_section_t cs;
 } dt_iop_channelmixer_rgb_gui_data_t;
 
 typedef struct dt_iop_channelmixer_rbg_data_t
@@ -2601,13 +2600,7 @@ static void start_profiling_callback(GtkWidget *togglebutton, dt_iop_module_t *s
   if(wd == 0.f || ht == 0.f) return;
 
   dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
-  g->is_profiling_started = !g->is_profiling_started;
-  gtk_widget_set_visible(g->collapsible, g->is_profiling_started);
-
-  if(g->is_profiling_started)
-    dt_bauhaus_widget_set_quad_paint(g->start_profiling, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_DOWN, NULL);
-  else
-    dt_bauhaus_widget_set_quad_paint(g->start_profiling, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+  g->is_profiling_started = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->cs.toggle));
 
   // init bounding box
   dt_iop_gui_enter_critical_section(self);
@@ -3537,9 +3530,11 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_gui_leave_critical_section(self);
 
+  // always disable profiling mode by default
   g->is_profiling_started = FALSE;
-  gtk_widget_hide(g->collapsible);
-  dt_bauhaus_widget_set_quad_paint(g->start_profiling, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+
+  dt_gui_hide_collapsible_section(&g->cs);
+
   gui_changed(self, NULL, NULL);
 }
 
@@ -3947,15 +3942,18 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_notebook_set_current_page(g->notebook, active_page);
 
   // Add the color checker collapsible panel
-  g->start_profiling = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->start_profiling, NULL, N_("calibrate with a color checker"));
-  dt_bauhaus_widget_set_quad_paint(g->start_profiling, dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->start_profiling, TRUE);
-  gtk_widget_set_tooltip_text(g->start_profiling, _("use a color checker target to autoset CAT and channels"));
-  g_signal_connect(G_OBJECT(g->start_profiling), "quad-pressed", G_CALLBACK(start_profiling_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->start_profiling), TRUE, TRUE, 0);
 
-  g->collapsible = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_new_collapsible_section
+    (&g->cs,
+     "plugins/darkroom/ashift/expand_values",
+     N_("calibrate with a color checker"),
+     GTK_BOX(self->widget));
+
+  gtk_widget_set_tooltip_text(g->cs.toggle,
+                              _("use a color checker target to autoset CAT and channels"));
+  g_signal_connect(G_OBJECT(g->cs.toggle), "toggled", G_CALLBACK(start_profiling_callback), self);
+
+  GtkWidget *collapsible = GTK_WIDGET(g->cs.container);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->checkers_list, self, NULL, N_("chart"),
                                 _("choose the vendor and the type of your chart"),
@@ -3966,7 +3964,7 @@ void gui_init(struct dt_iop_module_t *self)
                                 N_("Datacolor SpyderCheckr 24 post-2018"),
                                 N_("Datacolor SpyderCheckr 48 pre-2018"),
                                 N_("Datacolor SpyderCheckr 48 post-2018"));
-  gtk_box_pack_start(GTK_BOX(g->collapsible), GTK_WIDGET(g->checkers_list), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->checkers_list), TRUE, TRUE, 0);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->optimize, self, NULL, N_("optimize for"),
                                 _("choose the colors that will be optimized with higher priority.\n"
@@ -3983,7 +3981,7 @@ void gui_init(struct dt_iop_module_t *self)
                                 N_("sky and water colors"),
                                 N_("average delta E"),
                                 N_("maximum delta E"));
-  gtk_box_pack_start(GTK_BOX(g->collapsible), GTK_WIDGET(g->optimize), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->optimize), TRUE, TRUE, 0);
 
   g->safety = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 1., 0.1, 0.5, 3, TRUE);
   dt_bauhaus_widget_set_label(g->safety, NULL, _("patch scale"));
@@ -3991,10 +3989,10 @@ void gui_init(struct dt_iop_module_t *self)
                                            "useful when the perspective correction is sloppy or\n"
                                            "the patches frame cast a shadows on the edges of the patch." ));
   g_signal_connect(G_OBJECT(g->safety), "value-changed", G_CALLBACK(safety_changed_callback), self);
-  gtk_box_pack_start(GTK_BOX(g->collapsible), GTK_WIDGET(g->safety), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->safety), TRUE, TRUE, 0);
 
   g->label_delta_E = dt_ui_label_new("");
-  gtk_box_pack_start(GTK_BOX(g->collapsible), GTK_WIDGET(g->label_delta_E), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->label_delta_E), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->label_delta_E, _("the delta E is using the CIE 2000 formula."));
 
   GtkWidget *toolbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
@@ -4014,9 +4012,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->button_validate, _("check the output delta E"));
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_validate), FALSE, FALSE, 0);
 
-  gtk_box_pack_start(GTK_BOX(g->collapsible), GTK_WIDGET(toolbar), FALSE, FALSE, 0);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->collapsible), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(toolbar), FALSE, FALSE, 0);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -78,7 +78,7 @@ typedef struct dt_iop_temperature_params_t
 
 typedef struct dt_iop_temperature_gui_data_t
 {
-  GtkWidget *scale_k, *scale_tint, *coeff_widgets, *scale_r, *scale_g, *scale_b, *scale_g2;
+  GtkWidget *scale_k, *scale_tint, *scale_r, *scale_g, *scale_b, *scale_g2;
   GtkWidget *presets;
   GtkWidget *finetune;
   GtkWidget *buttonbar;
@@ -86,8 +86,6 @@ typedef struct dt_iop_temperature_gui_data_t
   GtkWidget *btn_asshot; //As Shot
   GtkWidget *btn_user;
   GtkWidget *btn_d65;
-  GtkWidget *coeffs_expander;
-  GtkWidget *coeffs_toggle;
   GtkWidget *temp_label;
   GtkWidget *balance_label;
   int preset_cnt;
@@ -99,8 +97,8 @@ typedef struct dt_iop_temperature_gui_data_t
   double XYZ_to_CAM[4][3], CAM_to_XYZ[3][4];
   int colored_sliders;
   int blackbody_is_confusing;
-  int expand_coeffs;
   gboolean button_bar_visible;
+  dt_gui_collapsible_section_t cs;
 } dt_iop_temperature_gui_data_t;
 
 typedef struct dt_iop_temperature_data_t
@@ -1285,12 +1283,8 @@ void gui_update(struct dt_iop_module_t *self)
     _temp_array_from_params(g->mod_coeff, p);
   }
 
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle));
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
   gtk_widget_set_visible(GTK_WIDGET(g->finetune), show_finetune);
   gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), active);
 
   const int preset = dt_bauhaus_combobox_get(g->presets);
 
@@ -1303,6 +1297,8 @@ void gui_update(struct dt_iop_module_t *self)
   color_finetuning_slider(self);
 
   _display_wb_error(self);
+
+  dt_gui_update_collapsible_section(&g->cs);
 
   gtk_widget_queue_draw(self->widget);
 }
@@ -1786,27 +1782,6 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_SPOT);
 }
 
-static void _coeffs_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle));
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), active);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
-  g->expand_coeffs = active;
-  dt_conf_set_bool("plugins/darkroom/temperature/expand_coefficients", active);
-}
-
-static void _coeffs_expander_click(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
-{
-  if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return;
-
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle)));
-}
 
 static void gui_sliders_update(struct dt_iop_module_t *self)
 {
@@ -1824,10 +1799,10 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
     dt_bauhaus_widget_set_label(g->scale_g2, NULL, N_("yellow"));
     gtk_widget_set_tooltip_text(g->scale_g2, _("yellow channel coefficient"));
 
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_b, 0);
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_g2, 1);
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_g, 2);
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_r, 3);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_b, 0);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g2, 1);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g, 2);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_r, 3);
   }
   else
   {
@@ -1840,10 +1815,10 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
     dt_bauhaus_widget_set_label(g->scale_g2, NULL, N_("emerald"));
     gtk_widget_set_tooltip_text(g->scale_g2, _("emerald channel coefficient"));
 
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_r, 0);
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_g, 1);
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_b, 2);
-    gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_g2, 3);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_r, 0);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g, 1);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_b, 2);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g2, 3);
   }
 
   gtk_widget_set_visible(GTK_WIDGET(g->scale_g2), (img->flags & DT_IMAGE_4BAYER));
@@ -1905,7 +1880,6 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
   _display_wb_error(self);
 }
 
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_temperature_gui_data_t *g = IOP_GUI_ALLOC(temperature);
@@ -1916,7 +1890,6 @@ void gui_init(struct dt_iop_module_t *self)
   const char *config = dt_conf_get_string_const("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
-  g->expand_coeffs = dt_conf_get_bool("plugins/darkroom/temperature/expand_coefficients");
 
   const int feedback = g->colored_sliders ? 0 : 1;
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
@@ -1955,30 +1928,13 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->scale_tint, _("color tint of the image, from magenta (value < 1) to green (value > 1)"));
   gtk_box_pack_start(box_enabled, g->scale_tint, TRUE, TRUE, 0);
 
-  // collapsible section for coeffs that are generally not to be used
-  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  GtkWidget *header_evb = gtk_event_box_new();
-  GtkWidget *destdisp = dt_ui_section_label_new(_("channel coefficients"));
-  context = gtk_widget_get_style_context(destdisp_head);
-  gtk_style_context_add_class(context, "section-expander");
-  gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
+  dt_gui_new_collapsible_section
+    (&g->cs,
+     "plugins/darkroom/temperature/expand_coefficients",
+     _("channel coefficients"),
+     GTK_BOX(box_enabled));
 
-  g->coeffs_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle), g->expand_coeffs);
-  gtk_widget_set_name(GTK_WIDGET(g->coeffs_toggle), "control-button");
-
-  g->coeff_widgets = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), header_evb, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), g->coeffs_toggle, FALSE, FALSE, 0);
-
-  g->coeffs_expander = dtgtk_expander_new(destdisp_head, g->coeff_widgets);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), TRUE);
-  gtk_box_pack_end(box_enabled, g->coeffs_expander, FALSE, FALSE, 0);
-
-  g_signal_connect(G_OBJECT(g->coeffs_toggle), "toggled", G_CALLBACK(_coeffs_button_changed),  (gpointer)self);
-
-  g_signal_connect(G_OBJECT(header_evb), "button-release-event", G_CALLBACK(_coeffs_expander_click),
-                   (gpointer)self);
+  self->widget = GTK_WIDGET(g->cs.container);
 
   g->scale_r = dt_bauhaus_slider_from_params(self, N_("red"));
   g->scale_g = dt_bauhaus_slider_from_params(self, N_("green"));
@@ -2083,11 +2039,6 @@ void gui_reset(struct dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), preset == DT_IOP_TEMP_AS_SHOT);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), preset == DT_IOP_TEMP_USER);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), preset == DT_IOP_TEMP_D65);
-
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), g->expand_coeffs);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (g->expand_coeffs?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle), g->expand_coeffs);
 
   color_finetuning_slider(self);
   color_rgb_sliders(self);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -117,13 +117,6 @@ typedef enum dt_import_case_t
   DT_IMPORT_TETHER
 } dt_import_case_t;
 
-typedef struct dt_expander_t
-{
-  GtkWidget *toggle;
-  GtkWidget *widgets;
-  GtkWidget *expander;
-} dt_expander_t;
-
 typedef struct dt_lib_import_t
 {
 #ifdef HAVE_GPHOTO2
@@ -140,7 +133,6 @@ typedef struct dt_lib_import_t
   GtkWidget *import_new;
   dt_import_metadata_t metadata;
   GtkBox *devices;
-  dt_expander_t exp;
   dt_import_case_t import_case;
   struct
   {
@@ -159,13 +151,15 @@ typedef struct dt_lib_import_t
     GtkWidget *img_nb;
     GtkGrid *patterns;
     GtkWidget *datetime;
-    dt_expander_t exp;
+    dt_gui_collapsible_section_t cs;
     guint fn_line;
     GtkWidget *info;
   } from;
   GtkListStore *placesModel;
   GtkWidget *placesView;
   GtkTreeSelection *placesSelection;
+
+  dt_gui_collapsible_section_t cs;
 
 #ifdef USE_LUA
   GtkWidget *extra_lua_widgets;
@@ -856,63 +850,19 @@ static void _do_select_new_clicked(GtkWidget *widget, dt_lib_module_t* self)
   _do_select_new(self);
 }
 
-static void _expander_update(GtkWidget *toggle, GtkWidget *expander)
+static void _expander_create(dt_gui_collapsible_section_t *cs,
+                             GtkBox *parent,
+                             const char *label,
+                             const char *pref_key)
 {
-  const char *key = gtk_widget_get_name(expander);
-  const gboolean active = dt_conf_get_bool(key);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle), active);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(expander), active);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
-}
+  dt_gui_new_collapsible_section
+    (cs,
+     pref_key,
+     label,
+     parent);
 
-static void _expander_button_changed(GtkWidget *toggle, GtkWidget *expander)
-{
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle));
-  const char *key = gtk_widget_get_name(expander);
-  dt_conf_set_bool(key, active);
-  _expander_update(GTK_WIDGET(toggle), expander);
-}
-
-static void _expander_click(GtkWidget *expander, GdkEventButton *e, GtkWidget *toggle)
-{
-  if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return;
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle), !active);
-}
-
-static void _expander_create(dt_expander_t *exp, const char *label,
-                             const char *pref_key, const char *css_key)
-{
-  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *header_evb = gtk_event_box_new();
-  GtkStyleContext *context = gtk_widget_get_style_context(destdisp_head);
-  gtk_style_context_add_class(context, "section-expander");
-  GtkWidget *destdisp = dt_ui_section_label_new(_(label));
-  gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
-
-  GtkWidget *toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle), TRUE);
-  gtk_widget_set_name(toggle, "control-button");
-
-  gtk_box_pack_start(GTK_BOX(destdisp_head), header_evb, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), toggle, FALSE, FALSE, 0);
-
-  GtkWidget *widgets = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  GtkWidget *expander = dtgtk_expander_new(destdisp_head, widgets);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(expander), TRUE);
-  GtkWidget *expander_frame = dtgtk_expander_get_frame(DTGTK_EXPANDER(expander));
-  if(css_key)
-    gtk_widget_set_name(expander_frame, css_key);
-
-  gtk_widget_set_name(expander, pref_key);
-  g_signal_connect(G_OBJECT(toggle), "toggled", G_CALLBACK(_expander_button_changed),  (gpointer)expander);
-  g_signal_connect(G_OBJECT(header_evb), "button-release-event", G_CALLBACK(_expander_click),
-                   (gpointer)toggle);
-
-  exp->toggle = toggle;
-  exp->widgets = widgets;
-  exp->expander = expander;
+  GtkWidget *expander_frame = dtgtk_expander_get_frame(DTGTK_EXPANDER(cs->expander));
+  gtk_widget_set_name(expander_frame, "import_metadata");
 }
 
 static void _resize_dialog(GtkWidget *widget, dt_lib_module_t* self)
@@ -1686,8 +1636,8 @@ static void _set_expander_content(GtkWidget *rbox, dt_lib_module_t* self)
   gtk_box_pack_start(GTK_BOX(import_patterns), GTK_WIDGET(grid), FALSE, FALSE, 0);
 
   // collapsible section
-  _expander_create(&d->from.exp, _("naming rules"), "ui_last/session_expander_import", "import_metadata");
-  gtk_box_pack_start(GTK_BOX(import_patterns), d->from.exp.expander, FALSE, FALSE, 0);
+  _expander_create(&d->from.cs, GTK_BOX(import_patterns),
+                   _("naming rules"), "ui_last/session_expander_import");
 
   // import patterns
   grid = GTK_GRID(gtk_grid_new());
@@ -1712,7 +1662,7 @@ static void _set_expander_content(GtkWidget *rbox, dt_lib_module_t* self)
   GtkWidget *usefn = dt_gui_preferences_bool(grid, "session/use_filename", 0, line++, FALSE);
   d->from.fn_line = line;
   dt_gui_preferences_string(grid, "session/filename_pattern", 0, line++);
-  gtk_box_pack_start(GTK_BOX(d->from.exp.widgets), GTK_WIDGET(grid), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(d->from.cs.container), GTK_WIDGET(grid), FALSE, FALSE, 0);
   d->from.patterns = grid;
   _update_layout(self);
   g_signal_connect(usefn, "toggled", G_CALLBACK(_usefn_toggled), self);
@@ -1844,7 +1794,7 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   {
     _set_expander_content(rbox, self);
     gtk_widget_show_all(d->from.dialog);
-    _expander_update(d->from.exp.toggle, d->from.exp.expander);
+    dt_gui_update_collapsible_section(&d->from.cs);
   }
   else
   {
@@ -2070,8 +2020,8 @@ void gui_init(dt_lib_module_t *self)
 #endif
 
   // collapsible section
-  _expander_create(&d->exp, _("parameters"), "ui_last/expander_import", "import_metadata");
-  gtk_box_pack_start(GTK_BOX(self->widget), d->exp.expander, FALSE, FALSE, 0);
+
+  _expander_create(&d->cs, GTK_BOX(self->widget), _("parameters"), "ui_last/expander_import");
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
@@ -2080,21 +2030,22 @@ void gui_init(dt_lib_module_t *self)
   d->rating = dt_gui_preferences_int(grid, "ui_last/import_initial_rating", 0, line++);
   d->apply_metadata = dt_gui_preferences_bool(grid, "ui_last/import_apply_metadata", 0, line++, FALSE);
   d->metadata.apply_metadata = d->apply_metadata;
-  gtk_box_pack_start(GTK_BOX(d->exp.widgets), GTK_WIDGET(grid), FALSE, FALSE, 0);
-  d->metadata.box = d->exp.widgets;
+  gtk_box_pack_start(GTK_BOX(d->cs.container), GTK_WIDGET(grid), FALSE, FALSE, 0);
+  d->metadata.box = GTK_WIDGET(d->cs.container);
   dt_import_metadata_init(&d->metadata);
 
 #ifdef USE_LUA
-  /* initialize the lua area  and make sure it survives its parent's destruction*/
+  /* initialize the lua area and make sure it survives its parent's destruction*/
   d->extra_lua_widgets = gtk_box_new(GTK_ORIENTATION_VERTICAL,5);
   g_object_ref_sink(d->extra_lua_widgets);
-  gtk_box_pack_start(GTK_BOX(d->exp.widgets), d->extra_lua_widgets, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(d->cs.container), d->extra_lua_widgets, FALSE, FALSE, 0);
   gtk_container_foreach(GTK_CONTAINER(d->extra_lua_widgets), reset_child, NULL);
 #endif
 
   gtk_widget_show_all(self->widget);
   gtk_widget_set_no_show_all(self->widget, TRUE);
-  _expander_update(d->exp.toggle, d->exp.expander);
+
+  dt_gui_update_collapsible_section(&d->cs);
 }
 
 void gui_cleanup(dt_lib_module_t *self)


### PR DESCRIPTION
Rework the collapsible sections. Share code in Gtk for the creation, the update and the style.

The new support has been used in temperature:

![image](https://user-images.githubusercontent.com/467069/151712084-cebd0550-6044-43fc-8900-a21cc0223c60.png)

And in crop:

![image](https://user-images.githubusercontent.com/467069/151712072-44f96017-a154-4e25-b740-d24b30deddda.png)

This idea is to use it consistently to have a common style for collapsible section. Also the section is made visible by using a slight change in the background.

This sections are also intended to be used in the two following PR: #10579 & #10581

It will be also used in new **rotate and perspective**.

The idea is also to use it in **color calibration** module which as a different collapsible UI.