### PR TITLE
Fix monochrome lens correction

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -1017,7 +1017,7 @@ clip_rotate_lanczos3(read_only image2d_t in, write_only image2d_t out, const int
 kernel void
 lens_distort_bilinear (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                const int iwidth, const int iheight, const int roi_in_x, const int roi_in_y, global float *pi,
-               const int do_nan_checks)
+               const int do_nan_checks, const int monochrome)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -1070,6 +1070,7 @@ lens_distort_bilinear (read_only image2d_t in, write_only image2d_t out, const i
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
 
+  if(monochrome) pixel.x = pixel.z = pixel.y;
   write_imagef (out, (int2)(x, y), pixel);
 }
 
@@ -1077,7 +1078,7 @@ lens_distort_bilinear (read_only image2d_t in, write_only image2d_t out, const i
 kernel void
 lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                       const int iwidth, const int iheight, const int roi_in_x, const int roi_in_y, global float *pi,
-                      const int do_nan_checks)
+                      const int do_nan_checks, const int monochrome)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -1206,6 +1207,7 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
   pixel.z = sum/weight;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  if(monochrome) pixel.x = pixel.z = pixel.y;
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -1215,7 +1217,7 @@ lens_distort_bicubic (read_only image2d_t in, write_only image2d_t out, const in
 kernel void
 lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                       const int iwidth, const int iheight, const int roi_in_x, const int roi_in_y, global float *pi,
-                      const int do_nan_checks)
+                      const int do_nan_checks, const int monochrome)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -1344,6 +1346,7 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
   pixel.z = sum/weight;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  if(monochrome) pixel.x = pixel.z = pixel.y;
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -1353,7 +1356,7 @@ lens_distort_lanczos2 (read_only image2d_t in, write_only image2d_t out, const i
 kernel void
 lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
                       const int iwidth, const int iheight, const int roi_in_x, const int roi_in_y, global float *pi,
-                      const int do_nan_checks)
+                      const int do_nan_checks, const int monochrome)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -1481,6 +1484,7 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
   pixel.z = sum/weight;
 
   pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  if(monochrome) pixel.x = pixel.z = pixel.y;
 
   write_imagef (out, (int2)(x, y), pixel);
 }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1,6 +1,6 @@
 ﻿/*
     This file is part of darktable,
-    Copyright (C) 2019-2021 darktable developers.
+    Copyright (C) 2019-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -371,6 +371,17 @@ static inline gboolean monochrome_img(const dt_image_t *img)
 {
   return (dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) ? TRUE : FALSE;
 }
+
+/* Why do we care about being a monochrome image or not?
+ The lensfun library does not have an algorithm for distortion or tca correction specialized for monochrome images,
+   the builtin correction works with subtle differences for the color channels leading to some colorizing of the images.
+ How is this fixed here:
+   Monochrome images (from pure monochrome cameras or cameras with the color filter removed from the sensor) have
+   all three rgb colors set to the same value by the demosaicer. 
+   Looking through lensfun code & docs the ApplySubpixelGeometryDistortion algorithm makes assumptions from given
+   coeffs how far data are displaced for the different wavelengths of light.
+   As green / Y channel is the most centric i took that as the canonical value instead of taking the mean.
+*/
 
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -367,6 +367,11 @@ static lfModifier * get_modifier(int *mods_done, int w, int h, const dt_iop_lens
   return mod;
 }
 
+static inline gboolean monochrome_img(const dt_image_t *img)
+{
+  return (dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) ? TRUE : FALSE;
+}
+
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -385,12 +390,15 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     return;
   }
 
+  const gboolean raw_monochrome = monochrome_img(&self->dev->image_storage);
+  const int used_lf_mask = (raw_monochrome) ? LF_MODIFY_ALL & ~LF_MODIFY_TCA : LF_MODIFY_ALL;
+
   const float orig_w = roi_in->scale * piece->buf_in.width, orig_h = roi_in->scale * piece->buf_in.height;
 
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
 
   int modflags;
-  const lfModifier *modifier = get_modifier(&modflags, orig_w, orig_h, d, LF_MODIFY_ALL, FALSE);
+  const lfModifier *modifier = get_modifier(&modflags, orig_w, orig_h, d, used_lf_mask, FALSE);
 
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
 
@@ -411,7 +419,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(padded_bufsize, ch, ch_width, d, interpolation, ivoid, mask_display, ovoid, roi_in, roi_out)	\
       dt_omp_sharedconst(buf)						\
-      shared(modifier)							\
+      shared(modifier, raw_monochrome)  \
       schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
@@ -437,6 +445,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
             out[c] = dt_interpolation_compute_sample(interpolation, inptr, pi0, pi1, roi_in->width,
                                                      roi_in->height, ch, ch_width);
           }
+
+          if(raw_monochrome) out[0] = out[2] = out[1];
 
           if(mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
           {
@@ -516,7 +526,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(padded_buf2size, ch, ch_width, d, interpolation, mask_display, ovoid, roi_in, roi_out) \
       dt_omp_sharedconst(buf2)						\
-      shared(buf, modifier)						\
+      shared(buf, modifier, raw_monochrome)	\
       schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
@@ -542,7 +552,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
             out[c] = dt_interpolation_compute_sample(interpolation, bufptr, pi0, pi1, roi_in->width,
                                                      roi_in->height, ch, ch_width);
           }
-
+          if(raw_monochrome) out[0] = out[2] = out[1];
           if(mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
           {
             if(d->do_nan_checks && (!isfinite(buf2ptr[2]) || !isfinite(buf2ptr[3])))
@@ -585,6 +595,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_lensfun_data_t *d = (dt_iop_lensfun_data_t *)piece->data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+
+  const gboolean raw_monochrome = monochrome_img(&self->dev->image_storage);
+  const int used_lf_mask = (raw_monochrome) ? LF_MODIFY_ALL & ~LF_MODIFY_TCA : LF_MODIFY_ALL;
 
   cl_mem dev_tmpbuf = NULL;
   cl_mem dev_tmp = NULL;
@@ -656,7 +669,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(dev_tmpbuf == NULL) goto error;
 
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
-  modifier = get_modifier(&modflags, orig_w, orig_h, d, LF_MODIFY_ALL, FALSE);
+  modifier = get_modifier(&modflags, orig_w, orig_h, d, used_lf_mask, FALSE);
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
 
   if(d->inverse)
@@ -667,7 +680,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(tmpbufwidth, roi_out) \
-      shared(tmpbuf, d, modifier) \
+      shared(tmpbuf, d, modifier, raw_monochrome) \
       schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
@@ -691,6 +704,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       dt_opencl_set_kernel_arg(devid, ldkernel, 7, sizeof(int), (void *)&roi_in_y);
       dt_opencl_set_kernel_arg(devid, ldkernel, 8, sizeof(cl_mem), (void *)&dev_tmpbuf);
       dt_opencl_set_kernel_arg(devid, ldkernel, 9, sizeof(int), (void *)&(d->do_nan_checks));
+      dt_opencl_set_kernel_arg(devid, ldkernel, 10, sizeof(int), (void *)&(raw_monochrome));
       err = dt_opencl_enqueue_kernel_2d(devid, ldkernel, osizes);
       if(err != CL_SUCCESS) goto error;
     }
@@ -784,7 +798,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(tmpbufwidth, roi_out) \
-      shared(tmpbuf, d, modifier) \
+      shared(tmpbuf, d, modifier, raw_monochrome) \
       schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
@@ -808,6 +822,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       dt_opencl_set_kernel_arg(devid, ldkernel, 7, sizeof(int), (void *)&roi_in_y);
       dt_opencl_set_kernel_arg(devid, ldkernel, 8, sizeof(cl_mem), (void *)&dev_tmpbuf);
       dt_opencl_set_kernel_arg(devid, ldkernel, 9, sizeof(int), (void *)&(d->do_nan_checks));
+      dt_opencl_set_kernel_arg(devid, ldkernel, 10, sizeof(int), (void *)&(raw_monochrome));
       err = dt_opencl_enqueue_kernel_2d(devid, ldkernel, osizes);
       if(err != CL_SUCCESS) goto error;
     }
@@ -862,7 +877,10 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   const float orig_w = piece->buf_in.width, orig_h = piece->buf_in.height;
   int modflags;
 
-  const lfModifier *modifier = get_modifier(&modflags, orig_w, orig_h, d, LF_MODIFY_ALL, TRUE);
+  const gboolean raw_monochrome = monochrome_img(&self->dev->image_storage);
+  const int used_lf_mask = (raw_monochrome) ? LF_MODIFY_ALL & ~LF_MODIFY_TCA : LF_MODIFY_ALL;
+
+  const lfModifier *modifier = get_modifier(&modflags, orig_w, orig_h, d, used_lf_mask, TRUE);
   if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
   {
 
@@ -891,9 +909,12 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
 
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f) return 0;
 
+  const gboolean raw_monochrome = monochrome_img(&self->dev->image_storage);
+  const int used_lf_mask = (raw_monochrome) ? LF_MODIFY_ALL & ~LF_MODIFY_TCA : LF_MODIFY_ALL;
+
   const float orig_w = piece->buf_in.width, orig_h = piece->buf_in.height;
   int modflags;
-  const lfModifier *modifier = get_modifier(&modflags, orig_w, orig_h, d, LF_MODIFY_ALL, FALSE);
+  const lfModifier *modifier = get_modifier(&modflags, orig_w, orig_h, d, used_lf_mask, FALSE);
 
   if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
   {
@@ -1113,7 +1134,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
   const lfCamera *camera = NULL;
   const lfCamera **cam = NULL;
-
+  const gboolean raw_monochrome = monochrome_img(&self->dev->image_storage);
   if(d->lens)
   {
     delete d->lens;
@@ -1175,6 +1196,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   lf_free(cam);
   d->modify_flags = p->modify_flags;
+  if(raw_monochrome) d->modify_flags &= ~LF_MODIFY_TCA;
   d->inverse = p->inverse;
   d->scale = p->scale;
   d->focal = p->focal;
@@ -1305,7 +1327,8 @@ void reload_defaults(dt_iop_module_t *module)
   d->distance = img->exif_focus_distance == 0.0f ? 1000.0f : img->exif_focus_distance;
   d->target_geom = LF_RECTILINEAR;
 
-  if(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) d->modify_flags &= ~LF_MODIFY_TCA;
+  if(monochrome_img(img))
+    d->modify_flags &= ~LF_MODIFY_TCA;
 
   // init crop from db:
   char model[100]; // truncate often complex descriptions.
@@ -2091,13 +2114,14 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
-
+  const gboolean raw_monochrome = monochrome_img(&self->dev->image_storage);
+  gtk_widget_set_visible(g->tca_override, !raw_monochrome);
   // update gui to show/hide tca sliders if tca_override was changed
   if(!w || w == g->tca_override)
   {
     // show tca sliders only iff tca_overwrite is set
-    gtk_widget_set_visible(g->tca_r, p->tca_override);
-    gtk_widget_set_visible(g->tca_b, p->tca_override);
+    gtk_widget_set_visible(g->tca_r, p->tca_override && !raw_monochrome);
+    gtk_widget_set_visible(g->tca_b, p->tca_override && !raw_monochrome);
   }
 
   if(w)


### PR DESCRIPTION
The lensfun library does not have an algorithm for distortion or tca correction specialized for monochrome images.

The builtin correction works with subtle differences for the color channels leading to some colorizing of the images here that can be seen both in the histogram and in the main darkroom window.

This pr makes sure the images are tested for being either a monochrome (like those from Leica) or
from a camera with a removed color filter. If so the output for all color channels is taken from
the green channel.

The relevance of this fix is of course not very strong as most people are using color sensors but for the happy Q2M owners this is a significant difference.

@TurboGit there is more monochrome handling stuff in my pipeline for 4.0 but i guess this might be a fix and not a feature :-) 

This is from current master
![Bildschirmfoto von 2022-02-04 05-49-56](https://user-images.githubusercontent.com/50982232/152474167-92e4ed0d-7627-46be-8836-ab8f5c4e1bae.png)

This is with the pr applied
![Bildschirmfoto von 2022-02-04 05-52-57](https://user-images.githubusercontent.com/50982232/152474222-0d0c49bc-05d0-48bd-af7b-cd113cceecc0.png)

