### PR TITLE
Add white and black overlays colors on guides

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -60,7 +60,9 @@ typedef enum dt_dev_overlay_colors_t
   DT_DEV_OVERLAY_GREEN = 2,
   DT_DEV_OVERLAY_YELLOW = 3,
   DT_DEV_OVERLAY_CYAN = 4,
-  DT_DEV_OVERLAY_MAGENTA = 5
+  DT_DEV_OVERLAY_MAGENTA = 5,
+  DT_DEV_OVERLAY_WHITE = 6,
+  DT_DEV_OVERLAY_BLACK = 7
 } dt_dev_overlay_colors_t;
 
 typedef enum dt_dev_rawoverexposed_mode_t {

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -76,7 +76,14 @@ static inline void dt_draw_set_color_overlay(cairo_t *cr, double amt, double alp
   {
     cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 1.0 * amt, alpha);
   }
-
+  else if(overlay_color == DT_DEV_OVERLAY_WHITE)
+  {
+    cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, alpha);
+  }
+  else if(overlay_color == DT_DEV_OVERLAY_BLACK)
+  {
+    cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, alpha);
+  }
 }
 
 /** draws a rating star

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -702,7 +702,9 @@ GtkWidget *dt_guides_popover(dt_view_t *self, GtkWidget *button)
                                N_("green"),
                                N_("yellow"),
                                N_("cyan"),
-                               N_("magenta"));
+                               N_("magenta"),
+                               N_("white"),
+                               N_("black"));
   gtk_box_pack_start(GTK_BOX(vbox), darktable.view_manager->guides_colors, TRUE, TRUE, 0);
 
   gtk_container_add(GTK_CONTAINER(pop), vbox);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2024,7 +2024,7 @@ static gboolean _overlay_cycle_callback(GtkAccelGroup *accel_group, GObject *acc
                                              GdkModifierType modifier, gpointer data)
 {
   const int currentval = dt_conf_get_int("darkroom/ui/overlay_color");
-  const int nextval = (currentval + 1) % 5; // colors can go from 0 to 5
+  const int nextval = (currentval + 1) % 7; // colors can go from 0 to 7
   dt_conf_set_int("darkroom/ui/overlay_color", nextval);
   dt_control_queue_redraw_center();
   return TRUE;


### PR DESCRIPTION
This simply add quite standard white and black color on overlays guides. And of course, I hope I do all that good. It's working anyway on my side.

I was also just wondering if we keep the order as it is or if a better order could be more logical (or we don't care!). I had add those after actual ones just to be sure to not break existing choices of actual users.