### PR TITLE
pixelpipe: tidy control flow and cache/scope/picker interaction

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2012,30 +2012,20 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
 post_process_collect_info:
 
-    if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
-    // Pick RGB/Lab for the primary colorpicker and live samples
-    if(dev->gui_attached && pipe == dev->preview_pipe
-       && (strcmp(module->op, "gamma") == 0) // only gamma provides meaningful RGB data
-       && input)
-    {
-      if(darktable.lib->proxy.colorpicker.picker_proxy || darktable.lib->proxy.colorpicker.live_samples)
-        _pixelpipe_pick_samples(dev, module, (const float *const )input, &roi_in);
-    }
-
-    // 4) final histogram:
+    // 4) colorpicker and final histogram:
     if(dt_atomic_get_int(&pipe->shutdown))
     {
       return 1;
     }
     if(dev->gui_attached && !dev->gui_leaving
        && pipe == dev->preview_pipe
-       && (strcmp(module->op, "gamma") == 0)
-       // input is NULL if using cached output, shouldn't happen for gamma
-       && input)
+       && (strcmp(module->op, "gamma") == 0) // only gamma provides meaningful RGB data
+       && input) // input is NULL if using cached output, shouldn't happen for gamma
     {
+      // Pick RGB/Lab for the primary colorpicker and live samples
+      if(darktable.lib->proxy.colorpicker.picker_proxy || darktable.lib->proxy.colorpicker.live_samples)
+        _pixelpipe_pick_samples(dev, module, (const float *const )input, &roi_in);
+
       // FIXME: read this from dt_ioppr_get_pipe_output_profile_info()?
       const dt_iop_order_iccprofile_info_t *const display_profile
         = dt_ioppr_add_profile_info_to_list(dev, darktable.color_profiles->display_type,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1934,18 +1934,15 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     // the user is likely to change that one soon, so keep it in cache.
     dt_dev_pixelpipe_cache_reweight(&(pipe->cache), input);
   }
+
+  // warn on NaN or infinity
 #ifndef _DEBUG
-  if(darktable.unmuted & DT_DEBUG_NAN)
+  if((darktable.unmuted & DT_DEBUG_NAN) && strcmp(module->op, "gamma") != 0)
 #endif
   {
     if(dt_atomic_get_int(&pipe->shutdown))
     {
       return 1;
-    }
-
-    if(strcmp(module->op, "gamma") == 0)
-    {
-      goto post_process_collect_info;
     }
 
 #ifdef HAVE_OPENCL
@@ -2017,8 +2014,6 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       g_free(module_label);
     }
   }
-
-post_process_collect_info:
 
   // 4) colorpicker and scopes:
   if(dt_atomic_get_int(&pipe->shutdown))

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2022,8 +2022,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   }
   if(dev->gui_attached && !dev->gui_leaving
      && pipe == dev->preview_pipe
-     && (strcmp(module->op, "gamma") == 0) // only gamma provides meaningful RGB data
-     && input) // input is NULL if using cached output, shouldn't happen for gamma
+     && (strcmp(module->op, "gamma") == 0)) // only gamma provides meaningful RGB data
   {
     // Pick RGB/Lab for the primary colorpicker and live samples
     if(darktable.lib->proxy.colorpicker.picker_proxy || darktable.lib->proxy.colorpicker.live_samples)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1135,7 +1135,6 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   if(pipe == dev->preview2_pipe && dev->preview2_loading) return 1;
   if(dev->gui_leaving) return 1;
 
-
   // 3) input -> output
   if(!modules)
   {
@@ -1194,101 +1193,93 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     }
 
     dt_show_times_f(&start, "[dev_pixelpipe]", "initing base buffer [%s]", _pipe_type_to_str(pipe->type));
+
+    if(dt_atomic_get_int(&pipe->shutdown))
+      return 1;
+
+    return 0;
   }
-  else
+
+  // 3b) recurse and obtain output array in &input
+
+  // get region of interest which is needed in input
+  if(dt_atomic_get_int(&pipe->shutdown))
   {
-    // 3b) recurse and obtain output array in &input
+    return 1;
+  }
+  module->modify_roi_in(module, piece, roi_out, &roi_in);
 
-    // get region of interest which is needed in input
-    if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
-    module->modify_roi_in(module, piece, roi_out, &roi_in);
+  // recurse to get actual data of input buffer
 
-    // recurse to get actual data of input buffer
+  dt_iop_buffer_dsc_t _input_format = { 0 };
+  dt_iop_buffer_dsc_t *input_format = &_input_format;
 
-    dt_iop_buffer_dsc_t _input_format = { 0 };
-    dt_iop_buffer_dsc_t *input_format = &_input_format;
+  piece = (dt_dev_pixelpipe_iop_t *)pieces->data;
 
-    piece = (dt_dev_pixelpipe_iop_t *)pieces->data;
+  piece->processed_roi_in = roi_in;
+  piece->processed_roi_out = *roi_out;
 
-    piece->processed_roi_in = roi_in;
-    piece->processed_roi_out = *roi_out;
+  if(dt_dev_pixelpipe_process_rec(pipe, dev, &input, &cl_mem_input, &input_format, &roi_in,
+                                  g_list_previous(modules), g_list_previous(pieces), pos - 1))
+    return 1;
 
-    if(dt_dev_pixelpipe_process_rec(pipe, dev, &input, &cl_mem_input, &input_format, &roi_in,
-                                    g_list_previous(modules), g_list_previous(pieces), pos - 1))
-      return 1;
+  const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
 
-    const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
+  piece->dsc_out = piece->dsc_in = *input_format;
 
-    piece->dsc_out = piece->dsc_in = *input_format;
+  module->output_format(module, pipe, piece, &piece->dsc_out);
 
-    module->output_format(module, pipe, piece, &piece->dsc_out);
+  **out_format = pipe->dsc = piece->dsc_out;
 
-    **out_format = pipe->dsc = piece->dsc_out;
+  const size_t out_bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
 
-    const size_t out_bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
+  // reserve new cache line: output
+  if(dt_atomic_get_int(&pipe->shutdown))
+  {
+    return 1;
+  }
 
-    // reserve new cache line: output
-    if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
-
-    gboolean important = FALSE;
-    if((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
-      important = (strcmp(module->op, "colorout") == 0);
-    else
-      important = (strcmp(module->op, "gamma") == 0);
-    if(important)
-      (void)dt_dev_pixelpipe_cache_get_important(&(pipe->cache), basichash, hash, bufsize, output, out_format);
-    else
-      (void)dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format);
+  gboolean important = FALSE;
+  if((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
+    important = (strcmp(module->op, "colorout") == 0);
+  else
+    important = (strcmp(module->op, "gamma") == 0);
+  if(important)
+    (void)dt_dev_pixelpipe_cache_get_important(&(pipe->cache), basichash, hash, bufsize, output, out_format);
+  else
+    (void)dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format);
 
 // if(module) printf("reserving new buf in cache for module %s %s: %ld buf %p\n", module->op, pipe ==
 // dev->preview_pipe ? "[preview]" : "", hash, *output);
 
-    if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
+  if(dt_atomic_get_int(&pipe->shutdown))
+  {
+    return 1;
+  }
 
-    dt_times_t start;
-    dt_get_times(&start);
+  dt_times_t start;
+  dt_get_times(&start);
 
-    dt_pixelpipe_flow_t pixelpipe_flow = (PIXELPIPE_FLOW_NONE | PIXELPIPE_FLOW_HISTOGRAM_NONE);
+  dt_pixelpipe_flow_t pixelpipe_flow = (PIXELPIPE_FLOW_NONE | PIXELPIPE_FLOW_HISTOGRAM_NONE);
 
-    // special case: user requests to see channel data in the parametric mask of a module, or the blending
-    // mask. In that case we skip all modules manipulating pixel content and only process image distorting
-    // modules. Finally "gamma" is responsible for displaying channel/mask data accordingly.
-    if(strcmp(module->op, "gamma") != 0
-       && (pipe->mask_display & (DT_DEV_PIXELPIPE_DISPLAY_ANY | DT_DEV_PIXELPIPE_DISPLAY_MASK))
-       && !(module->operation_tags() & IOP_TAG_DISTORT)
-       && (in_bpp == out_bpp) && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
-    {
-      // since we're not actually running the module, the output format is the same as the input format
-      **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
+  // special case: user requests to see channel data in the parametric mask of a module, or the blending
+  // mask. In that case we skip all modules manipulating pixel content and only process image distorting
+  // modules. Finally "gamma" is responsible for displaying channel/mask data accordingly.
+  if(strcmp(module->op, "gamma") != 0
+     && (pipe->mask_display & (DT_DEV_PIXELPIPE_DISPLAY_ANY | DT_DEV_PIXELPIPE_DISPLAY_MASK))
+     && !(module->operation_tags() & IOP_TAG_DISTORT)
+     && (in_bpp == out_bpp) && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
+  {
+    // since we're not actually running the module, the output format is the same as the input format
+    **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
 
 #ifdef HAVE_OPENCL
-      if(dt_opencl_is_inited() && pipe->opencl_enabled && pipe->devid >= 0 && (cl_mem_input != NULL))
-      {
-        *cl_mem_output = cl_mem_input;
-      }
-      else
-      {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-        dt_omp_firstprivate(in_bpp, out_bpp) \
-        shared(roi_out, roi_in, output, input) \
-        schedule(static)
-#endif
-        for(int j = 0; j < roi_out->height; j++)
-            memcpy(((char *)*output) + (size_t)out_bpp * j * roi_out->width,
-                   ((char *)input) + (size_t)in_bpp * j * roi_in.width,
-                   (size_t)in_bpp * roi_in.width);
-      }
-#else // don't HAVE_OPENCL
+    if(dt_opencl_is_inited() && pipe->opencl_enabled && pipe->devid >= 0 && (cl_mem_input != NULL))
+    {
+      *cl_mem_output = cl_mem_input;
+    }
+    else
+    {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
       dt_omp_firstprivate(in_bpp, out_bpp) \
@@ -1296,422 +1287,136 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       schedule(static)
 #endif
       for(int j = 0; j < roi_out->height; j++)
-            memcpy(((char *)*output) + (size_t)out_bpp * j * roi_out->width,
-                   ((char *)input) + (size_t)in_bpp * j * roi_in.width,
-                   (size_t)in_bpp * roi_in.width);
+          memcpy(((char *)*output) + (size_t)out_bpp * j * roi_out->width,
+                 ((char *)input) + (size_t)in_bpp * j * roi_in.width,
+                 (size_t)in_bpp * roi_in.width);
+    }
+#else // don't HAVE_OPENCL
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+    dt_omp_firstprivate(in_bpp, out_bpp) \
+    shared(roi_out, roi_in, output, input) \
+    schedule(static)
+#endif
+    for(int j = 0; j < roi_out->height; j++)
+          memcpy(((char *)*output) + (size_t)out_bpp * j * roi_out->width,
+                 ((char *)input) + (size_t)in_bpp * j * roi_in.width,
+                 (size_t)in_bpp * roi_in.width);
 #endif
 
-      return 0;
-    }
+    return 0;
+  }
 
 
-    /* get tiling requirement of module */
-    dt_develop_tiling_t tiling = { 0 };
-    tiling.factor_cl = tiling.maxbuf_cl = -1;	// set sentinel value to detect whether callback set sizes
-    module->tiling_callback(module, piece, &roi_in, roi_out, &tiling);
-    if (tiling.factor_cl < 0) tiling.factor_cl = tiling.factor; // default to CPU size if callback didn't set GPU
-    if (tiling.maxbuf_cl < 0) tiling.maxbuf_cl = tiling.maxbuf;
+  /* get tiling requirement of module */
+  dt_develop_tiling_t tiling = { 0 };
+  tiling.factor_cl = tiling.maxbuf_cl = -1;	// set sentinel value to detect whether callback set sizes
+  module->tiling_callback(module, piece, &roi_in, roi_out, &tiling);
+  if (tiling.factor_cl < 0) tiling.factor_cl = tiling.factor; // default to CPU size if callback didn't set GPU
+  if (tiling.maxbuf_cl < 0) tiling.maxbuf_cl = tiling.maxbuf;
 
-    /* does this module involve blending? */
-    if(piece->blendop_data && ((dt_develop_blend_params_t *)piece->blendop_data)->mask_mode != DEVELOP_MASK_DISABLED)
-    {
-      /* get specific memory requirement for blending */
-      dt_develop_tiling_t tiling_blendop = { 0 };
-      tiling_callback_blendop(module, piece, &roi_in, roi_out, &tiling_blendop);
+  /* does this module involve blending? */
+  if(piece->blendop_data && ((dt_develop_blend_params_t *)piece->blendop_data)->mask_mode != DEVELOP_MASK_DISABLED)
+  {
+    /* get specific memory requirement for blending */
+    dt_develop_tiling_t tiling_blendop = { 0 };
+    tiling_callback_blendop(module, piece, &roi_in, roi_out, &tiling_blendop);
 
-      /* aggregate in structure tiling */
-      tiling.factor = fmax(tiling.factor, tiling_blendop.factor);
-      tiling.factor_cl = fmax(tiling.factor_cl, tiling_blendop.factor);
-      tiling.maxbuf = fmax(tiling.maxbuf, tiling_blendop.maxbuf);
-      tiling.maxbuf_cl = fmax(tiling.maxbuf_cl, tiling_blendop.maxbuf);
-      tiling.overhead = fmax(tiling.overhead, tiling_blendop.overhead);
-    }
+    /* aggregate in structure tiling */
+    tiling.factor = fmax(tiling.factor, tiling_blendop.factor);
+    tiling.factor_cl = fmax(tiling.factor_cl, tiling_blendop.factor);
+    tiling.maxbuf = fmax(tiling.maxbuf, tiling_blendop.maxbuf);
+    tiling.maxbuf_cl = fmax(tiling.maxbuf_cl, tiling_blendop.maxbuf);
+    tiling.overhead = fmax(tiling.overhead, tiling_blendop.overhead);
+  }
 
-    /* remark: we do not do tiling for blendop step, neither in opencl nor on cpu. if overall tiling
-       requirements (maximum of module and blendop) require tiling for opencl path, then following blend
-       step is anyhow done on cpu. we assume that blending itself will never require tiling in cpu path,
-       because memory requirements will still be low enough. */
+  /* remark: we do not do tiling for blendop step, neither in opencl nor on cpu. if overall tiling
+     requirements (maximum of module and blendop) require tiling for opencl path, then following blend
+     step is anyhow done on cpu. we assume that blending itself will never require tiling in cpu path,
+     because memory requirements will still be low enough. */
 
-    assert(tiling.factor > 0.0f);
-    assert(tiling.factor_cl > 0.0f);
+  assert(tiling.factor > 0.0f);
+  assert(tiling.factor_cl > 0.0f);
 
-    if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
+  if(dt_atomic_get_int(&pipe->shutdown))
+  {
+    return 1;
+  }
 
 #ifdef HAVE_OPENCL
 
-    // Fetch RGB working profile
-    // if input is RAW, we can't color convert because RAW is not in a color space
-    // so we send NULL to by-pass
-    const dt_iop_order_iccprofile_info_t *const work_profile
-        = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
+  // Fetch RGB working profile
+  // if input is RAW, we can't color convert because RAW is not in a color space
+  // so we send NULL to by-pass
+  const dt_iop_order_iccprofile_info_t *const work_profile
+      = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
 
-    /* do we have opencl at all? did user tell us to use it? did we get a resource? */
-    if(dt_opencl_is_inited() && pipe->opencl_enabled && pipe->devid >= 0)
+  /* do we have opencl at all? did user tell us to use it? did we get a resource? */
+  if(dt_opencl_is_inited() && pipe->opencl_enabled && pipe->devid >= 0)
+  {
+    int success_opencl = TRUE;
+    dt_iop_colorspace_type_t input_cst_cl = input_format->cst;
+
+    /* if input is on gpu memory only, remember this fact to later take appropriate action */
+    int valid_input_on_gpu_only = (cl_mem_input != NULL);
+
+    /* pre-check if there is enough space on device for non-tiled processing */
+    const gboolean fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
+                                                                MAX(roi_in.height, roi_out->height), MAX(in_bpp, bpp),
+                                                                tiling.factor_cl, tiling.overhead);
+
+    /* general remark: in case of opencl errors within modules or out-of-memory on GPU, we transparently
+       fall back to the respective cpu module and continue in pixelpipe. If we encounter errors we set
+       pipe->opencl_error=1, return this function with value 1, and leave appropriate action to the calling
+       function, which normally would restart pixelpipe without opencl.
+       Late errors are sometimes detected when trying to get back data from device into host memory and
+       are treated in the same manner. */
+
+    /* try to enter opencl path after checking some module specific pre-requisites */
+    if(module->process_cl && piece->process_cl_ready
+       && !(((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW
+             || (pipe->type & DT_DEV_PIXELPIPE_PREVIEW2) == DT_DEV_PIXELPIPE_PREVIEW2)
+            && (module->flags() & IOP_FLAGS_PREVIEW_NON_OPENCL))
+       && (fits_on_device || piece->process_tiling_ready))
     {
-      int success_opencl = TRUE;
-      dt_iop_colorspace_type_t input_cst_cl = input_format->cst;
 
-      /* if input is on gpu memory only, remember this fact to later take appropriate action */
-      int valid_input_on_gpu_only = (cl_mem_input != NULL);
+      // fprintf(stderr, "[opencl_pixelpipe 0] factor %f, overhead %d, width %d, height %d, bpp %d\n",
+      // (double)tiling.factor, tiling.overhead, roi_in.width, roi_in.height, bpp);
 
-      /* pre-check if there is enough space on device for non-tiled processing */
-      const gboolean fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
-                                                             MAX(roi_in.height, roi_out->height), MAX(in_bpp, bpp),
-                                                             tiling.factor_cl, tiling.overhead);
+      // fprintf(stderr, "[opencl_pixelpipe 1] for module `%s', have bufs %p and %p \n", module->op,
+      // cl_mem_input, *cl_mem_output);
+      // fprintf(stderr, "[opencl_pixelpipe 1] module '%s'\n", module->op);
 
-      /* general remark: in case of opencl errors within modules or out-of-memory on GPU, we transparently
-         fall back to the respective cpu module and continue in pixelpipe. If we encounter errors we set
-         pipe->opencl_error=1, return this function with value 1, and leave appropriate action to the calling
-         function, which normally would restart pixelpipe without opencl.
-         Late errors are sometimes detected when trying to get back data from device into host memory and
-         are treated in the same manner. */
-
-      /* try to enter opencl path after checking some module specific pre-requisites */
-      if(module->process_cl && piece->process_cl_ready
-         && !(((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW
-               || (pipe->type & DT_DEV_PIXELPIPE_PREVIEW2) == DT_DEV_PIXELPIPE_PREVIEW2)
-              && (module->flags() & IOP_FLAGS_PREVIEW_NON_OPENCL))
-         && (fits_on_device || piece->process_tiling_ready))
+      if(fits_on_device)
       {
+        /* image is small enough -> try to directly process entire image with opencl */
 
-        // fprintf(stderr, "[opencl_pixelpipe 0] factor %f, overhead %d, width %d, height %d, bpp %d\n",
-        // (double)tiling.factor, tiling.overhead, roi_in.width, roi_in.height, bpp);
+        // fprintf(stderr, "[opencl_pixelpipe 2] module '%s' running directly with process_cl\n",
+        // module->op);
 
-        // fprintf(stderr, "[opencl_pixelpipe 1] for module `%s', have bufs %p and %p \n", module->op,
-        // cl_mem_input, *cl_mem_output);
-        // fprintf(stderr, "[opencl_pixelpipe 1] module '%s'\n", module->op);
-
-        if(fits_on_device)
+        /* input is not on gpu memory -> copy it there */
+        if(cl_mem_input == NULL)
         {
-          /* image is small enough -> try to directly process entire image with opencl */
-
-          // fprintf(stderr, "[opencl_pixelpipe 2] module '%s' running directly with process_cl\n",
-          // module->op);
-
-          /* input is not on gpu memory -> copy it there */
+          cl_mem_input = dt_opencl_alloc_device(pipe->devid, roi_in.width, roi_in.height, in_bpp);
           if(cl_mem_input == NULL)
           {
-            cl_mem_input = dt_opencl_alloc_device(pipe->devid, roi_in.width, roi_in.height, in_bpp);
-            if(cl_mem_input == NULL)
-            {
-              dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe] couldn't generate input buffer for module %s\n",
-                       module->op);
-              success_opencl = FALSE;
-            }
-
-            if(success_opencl)
-            {
-              cl_int err = dt_opencl_write_host_to_device(pipe->devid, input, cl_mem_input,
-                                                                       roi_in.width, roi_in.height, in_bpp);
-              if(err != CL_SUCCESS)
-              {
-                dt_print(DT_DEBUG_OPENCL,
-                         "[opencl_pixelpipe] couldn't copy image to opencl device for module %s\n",
-                         module->op);
-                success_opencl = FALSE;
-              }
-            }
+            dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe] couldn't generate input buffer for module %s\n",
+                     module->op);
+            success_opencl = FALSE;
           }
 
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            dt_opencl_release_mem_object(cl_mem_input);
-            return 1;
-          }
-
-          /* try to allocate GPU memory for output */
           if(success_opencl)
           {
-            *cl_mem_output = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
-            if(*cl_mem_output == NULL)
-            {
-              dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe] couldn't allocate output buffer for module %s\n",
-                       module->op);
-              success_opencl = FALSE;
-            }
-          }
-
-          // fprintf(stderr, "[opencl_pixelpipe 2] for module `%s', have bufs %p and %p \n", module->op,
-          // cl_mem_input, *cl_mem_output);
-
-          // indirectly give gpu some air to breathe (and to do display related stuff)
-          dt_iop_nap(darktable.opencl->micro_nap);
-
-          // transform to input colorspace
-          if(success_opencl)
-          {
-            success_opencl = dt_ioppr_transform_image_colorspace_cl(
-                module, piece->pipe->devid, cl_mem_input, cl_mem_input, roi_in.width, roi_in.height, input_cst_cl,
-                module->input_colorspace(module, pipe, piece), &input_cst_cl,
-                work_profile);
-          }
-
-          // histogram collection for module
-          if(success_opencl && (dev->gui_attached || !(piece->request_histogram & DT_REQUEST_ONLY_IN_GUI))
-             && (piece->request_histogram & DT_REQUEST_ON))
-          {
-            // we abuse the empty output buffer on host for intermediate storage of data in
-            // histogram_collect_cl()
-            size_t outbufsize = bpp * roi_out->width * roi_out->height;
-
-            histogram_collect_cl(pipe->devid, piece, cl_mem_input, &roi_in, &(piece->histogram),
-                                 piece->histogram_max, *output, outbufsize);
-            pixelpipe_flow |= (PIXELPIPE_FLOW_HISTOGRAM_ON_GPU);
-            pixelpipe_flow &= ~(PIXELPIPE_FLOW_HISTOGRAM_NONE | PIXELPIPE_FLOW_HISTOGRAM_ON_CPU);
-
-            if(piece->histogram && (module->request_histogram & DT_REQUEST_ON)
-               && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
-            {
-              const size_t buf_size = sizeof(uint32_t) * 4 * piece->histogram_stats.bins_count;
-              module->histogram = realloc(module->histogram, buf_size);
-              memcpy(module->histogram, piece->histogram, buf_size);
-              module->histogram_stats = piece->histogram_stats;
-              memcpy(module->histogram_max, piece->histogram_max, sizeof(piece->histogram_max));
-
-              if(module->widget) dt_control_queue_redraw_widget(module->widget);
-            }
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          /* now call process_cl of module; module should emit meaningful messages in case of error */
-          if(success_opencl)
-          {
-            success_opencl
-                = module->process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
-            pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU);
-            pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
-
-            // and save the output colorspace
-            pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            dt_opencl_release_mem_object(cl_mem_input);
-            return 1;
-          }
-
-          // Lab color picking for module
-          if(success_opencl && _request_color_pick(pipe, dev, module))
-          {
-            // ensure that we are using the right color space
-            dt_iop_colorspace_type_t picker_cst = _transform_for_picker(module, pipe->dsc.cst);
-            success_opencl = dt_ioppr_transform_image_colorspace_cl(
-                module, piece->pipe->devid, cl_mem_input, cl_mem_input, roi_in.width, roi_in.height,
-                input_cst_cl, picker_cst, &input_cst_cl, work_profile);
-            success_opencl &= dt_ioppr_transform_image_colorspace_cl(
-                module, piece->pipe->devid, *cl_mem_output, *cl_mem_output, roi_out->width, roi_out->height,
-                pipe->dsc.cst, picker_cst, &pipe->dsc.cst, work_profile);
-
-            // we abuse the empty output buffer on host for intermediate storage of data in
-            // pixelpipe_picker_cl()
-            const size_t outbufsize = bpp * roi_out->width * roi_out->height;
-
-            pixelpipe_picker_cl(pipe->devid, module, piece, &piece->dsc_in, cl_mem_input, &roi_in,
-                                module->picked_color, module->picked_color_min, module->picked_color_max,
-                                *output, outbufsize, input_cst_cl, PIXELPIPE_PICKER_INPUT);
-            pixelpipe_picker_cl(pipe->devid, module, piece, &pipe->dsc, (*cl_mem_output), roi_out,
-                                module->picked_output_color, module->picked_output_color_min,
-                                module->picked_output_color_max, *output, outbufsize, pipe->dsc.cst,
-                                PIXELPIPE_PICKER_OUTPUT);
-
-            DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          // blend needs input/output images with default colorspace
-          if(success_opencl && _transform_for_blend(module, piece))
-          {
-            dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
-            success_opencl = dt_ioppr_transform_image_colorspace_cl(
-                module, piece->pipe->devid, cl_mem_input, cl_mem_input, roi_in.width, roi_in.height,
-                input_cst_cl, blend_cst, &input_cst_cl, work_profile);
-            success_opencl &= dt_ioppr_transform_image_colorspace_cl(
-                module, piece->pipe->devid, *cl_mem_output, *cl_mem_output, roi_out->width, roi_out->height,
-                pipe->dsc.cst, blend_cst, &pipe->dsc.cst, work_profile);
-          }
-
-          /* process blending */
-          if(success_opencl)
-          {
-            success_opencl
-                = dt_develop_blend_process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
-            pixelpipe_flow |= (PIXELPIPE_FLOW_BLENDED_ON_GPU);
-            pixelpipe_flow &= ~(PIXELPIPE_FLOW_BLENDED_ON_CPU);
-          }
-
-          /* synchronization point for opencl pipe */
-          if(success_opencl && (!darktable.opencl->async_pixelpipe
-                                || (pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT))
-            success_opencl = dt_opencl_finish(pipe->devid);
-
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            dt_opencl_release_mem_object(cl_mem_input);
-            return 1;
-          }
-        }
-        else if(piece->process_tiling_ready)
-        {
-          /* image is too big for direct opencl processing -> try to process image via tiling */
-
-          // fprintf(stderr, "[opencl_pixelpipe 3] module '%s' tiling with process_tiling_cl\n", module->op);
-
-          /* we might need to copy back valid image from device to host */
-          if(cl_mem_input != NULL)
-          {
-            cl_int err;
-
-            /* copy back to CPU buffer, then clean unneeded buffer */
-            err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
-                                                in_bpp);
+            cl_int err = dt_opencl_write_host_to_device(pipe->devid, input, cl_mem_input,
+                                                                     roi_in.width, roi_in.height, in_bpp);
             if(err != CL_SUCCESS)
             {
-              /* late opencl error */
-              dt_print(
-                  DT_DEBUG_OPENCL,
-                  "[opencl_pixelpipe (a)] late opencl error detected while copying back to cpu buffer: %d\n",
-                  err);
-              dt_opencl_release_mem_object(cl_mem_input);
-              pipe->opencl_error = 1;
-              return 1;
+              dt_print(DT_DEBUG_OPENCL,
+                       "[opencl_pixelpipe] couldn't copy image to opencl device for module %s\n",
+                       module->op);
+              success_opencl = FALSE;
             }
-            else
-              input_format->cst = input_cst_cl;
-            dt_opencl_release_mem_object(cl_mem_input);
-            cl_mem_input = NULL;
-            valid_input_on_gpu_only = FALSE;
           }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          // indirectly give gpu some air to breathe (and to do display related stuff)
-          dt_iop_nap(darktable.opencl->micro_nap);
-
-          // transform to module input colorspace
-          if(success_opencl)
-          {
-            dt_ioppr_transform_image_colorspace(module, input, input, roi_in.width, roi_in.height,
-                                                input_format->cst, module->input_colorspace(module, pipe, piece),
-                                                &input_format->cst, work_profile);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          // histogram collection for module
-          if (success_opencl)
-          {
-            collect_histogram_on_CPU(pipe, dev, input, &roi_in, module, piece, &pixelpipe_flow);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          /* now call process_tiling_cl of module; module should emit meaningful messages in case of error */
-          if(success_opencl)
-          {
-            success_opencl
-                = module->process_tiling_cl(module, piece, input, *output, &roi_in, roi_out, in_bpp);
-            pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
-            pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_CPU);
-
-            // and save the output colorspace
-            pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          // Lab color picking for module
-          if(success_opencl && _request_color_pick(pipe, dev, module))
-          {
-            // ensure that we are using the right color space
-            dt_iop_colorspace_type_t picker_cst = _transform_for_picker(module, pipe->dsc.cst);
-            // FIXME: don't need to transform entire image colorspace when just picking a point
-            dt_ioppr_transform_image_colorspace(module, input, input, roi_in.width, roi_in.height,
-                                                input_format->cst, picker_cst, &input_format->cst,
-                                                work_profile);
-            dt_ioppr_transform_image_colorspace(module, *output, *output, roi_out->width, roi_out->height,
-                                                pipe->dsc.cst, picker_cst, &pipe->dsc.cst,
-                                                work_profile);
-
-            pixelpipe_picker(module, piece, &piece->dsc_in, (float *)input, &roi_in, module->picked_color,
-                             module->picked_color_min, module->picked_color_max, input_format->cst,
-                             PIXELPIPE_PICKER_INPUT);
-            pixelpipe_picker(module, piece, &pipe->dsc, (float *)(*output), roi_out, module->picked_output_color,
-                             module->picked_output_color_min, module->picked_output_color_max,
-                             pipe->dsc.cst, PIXELPIPE_PICKER_OUTPUT);
-
-            DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          // blend needs input/output images with default colorspace
-          if(success_opencl && _transform_for_blend(module, piece))
-          {
-            dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
-            dt_ioppr_transform_image_colorspace(module, input, input, roi_in.width, roi_in.height,
-                                                input_format->cst, blend_cst, &input_format->cst,
-                                                work_profile);
-            dt_ioppr_transform_image_colorspace(module, *output, *output, roi_out->width, roi_out->height,
-                                                pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
-                                                work_profile);
-          }
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-
-          /* do process blending on cpu (this is anyhow fast enough) */
-          if(success_opencl)
-          {
-            dt_develop_blend_process(module, piece, input, *output, &roi_in, roi_out);
-            pixelpipe_flow |= (PIXELPIPE_FLOW_BLENDED_ON_CPU);
-            pixelpipe_flow &= ~(PIXELPIPE_FLOW_BLENDED_ON_GPU);
-          }
-
-          /* synchronization point for opencl pipe */
-          if(success_opencl && (!darktable.opencl->async_pixelpipe
-                                || (pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT))
-            success_opencl = dt_opencl_finish(pipe->devid);
-
-          if(dt_atomic_get_int(&pipe->shutdown))
-          {
-            return 1;
-          }
-        }
-        else
-        {
-          /* image is too big for direct opencl and tiling is not allowed -> no opencl processing for this
-           * module */
-          success_opencl = FALSE;
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
@@ -1720,112 +1425,285 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           return 1;
         }
 
-        // if (rand() % 20 == 0) success_opencl = FALSE; // Test code: simulate spurious failures
-
-        /* finally check, if we were successful */
+        /* try to allocate GPU memory for output */
         if(success_opencl)
         {
-          /* Nice, everything went fine */
-
-          /* this is reasonable on slow GPUs only, where it's more expensive to reprocess the whole pixelpipe
-             than
-             regularly copying device buffers back to host. This would slow down fast GPUs considerably.
-             But it is worth copying data back from the GPU which is the input to the currently focused iop,
-             as that is the iop which is most likely to change next.
-          */
-          if((darktable.opencl->sync_cache == OPENCL_SYNC_TRUE) ||
-             ((darktable.opencl->sync_cache == OPENCL_SYNC_ACTIVE_MODULE) && (module == darktable.develop->gui_module)))
+          *cl_mem_output = dt_opencl_alloc_device(pipe->devid, roi_out->width, roi_out->height, bpp);
+          if(*cl_mem_output == NULL)
           {
-            /* write back input into cache for faster re-usal (not for export or thumbnails) */
-            if(cl_mem_input != NULL
-               && (pipe->type & DT_DEV_PIXELPIPE_EXPORT) != DT_DEV_PIXELPIPE_EXPORT
-               && (pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL) != DT_DEV_PIXELPIPE_THUMBNAIL)
-            {
-              cl_int err;
-
-              /* copy input to host memory, so we can find it in cache */
-              err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width,
-                                                  roi_in.height, in_bpp);
-              if(err != CL_SUCCESS)
-              {
-                /* late opencl error, not likely to happen here */
-                dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe (e)] late opencl error detected while copying "
-                                          "back to cpu buffer: %d\n",
-                         err);
-                /* that's all we do here, we later make sure to invalidate cache line */
-              }
-              else
-              {
-                /* success: cache line is valid now, so we will not need to invalidate it later */
-                valid_input_on_gpu_only = FALSE;
-
-                input_format->cst = input_cst_cl;
-                // TODO: check if we need to wait for finished opencl pipe before we release cl_mem_input
-                // dt_dev_finish(pipe->devid);
-              }
-            }
-
-            if(dt_atomic_get_int(&pipe->shutdown))
-            {
-              dt_opencl_release_mem_object(cl_mem_input);
-              return 1;
-            }
+            dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe] couldn't allocate output buffer for module %s\n",
+                     module->op);
+            success_opencl = FALSE;
           }
+        }
 
-          /* we can now release cl_mem_input */
+        // fprintf(stderr, "[opencl_pixelpipe 2] for module `%s', have bufs %p and %p \n", module->op,
+        // cl_mem_input, *cl_mem_output);
+
+        // indirectly give gpu some air to breathe (and to do display related stuff)
+        dt_iop_nap(darktable.opencl->micro_nap);
+
+        // transform to input colorspace
+        if(success_opencl)
+        {
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(
+              module, piece->pipe->devid, cl_mem_input, cl_mem_input, roi_in.width, roi_in.height, input_cst_cl,
+              module->input_colorspace(module, pipe, piece), &input_cst_cl,
+              work_profile);
+        }
+
+        // histogram collection for module
+        if(success_opencl && (dev->gui_attached || !(piece->request_histogram & DT_REQUEST_ONLY_IN_GUI))
+           && (piece->request_histogram & DT_REQUEST_ON))
+        {
+          // we abuse the empty output buffer on host for intermediate storage of data in
+          // histogram_collect_cl()
+          size_t outbufsize = bpp * roi_out->width * roi_out->height;
+
+          histogram_collect_cl(pipe->devid, piece, cl_mem_input, &roi_in, &(piece->histogram),
+                               piece->histogram_max, *output, outbufsize);
+          pixelpipe_flow |= (PIXELPIPE_FLOW_HISTOGRAM_ON_GPU);
+          pixelpipe_flow &= ~(PIXELPIPE_FLOW_HISTOGRAM_NONE | PIXELPIPE_FLOW_HISTOGRAM_ON_CPU);
+
+          if(piece->histogram && (module->request_histogram & DT_REQUEST_ON)
+             && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
+          {
+            const size_t buf_size = sizeof(uint32_t) * 4 * piece->histogram_stats.bins_count;
+            module->histogram = realloc(module->histogram, buf_size);
+            memcpy(module->histogram, piece->histogram, buf_size);
+            module->histogram_stats = piece->histogram_stats;
+            memcpy(module->histogram_max, piece->histogram_max, sizeof(piece->histogram_max));
+
+            if(module->widget) dt_control_queue_redraw_widget(module->widget);
+          }
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        /* now call process_cl of module; module should emit meaningful messages in case of error */
+        if(success_opencl)
+        {
+          success_opencl
+              = module->process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
+          pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU);
+          pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
+
+          // and save the output colorspace
+          pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          dt_opencl_release_mem_object(cl_mem_input);
+          return 1;
+        }
+
+        // Lab color picking for module
+        if(success_opencl && _request_color_pick(pipe, dev, module))
+        {
+          // ensure that we are using the right color space
+          dt_iop_colorspace_type_t picker_cst = _transform_for_picker(module, pipe->dsc.cst);
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(
+              module, piece->pipe->devid, cl_mem_input, cl_mem_input, roi_in.width, roi_in.height,
+              input_cst_cl, picker_cst, &input_cst_cl, work_profile);
+          success_opencl &= dt_ioppr_transform_image_colorspace_cl(
+              module, piece->pipe->devid, *cl_mem_output, *cl_mem_output, roi_out->width, roi_out->height,
+              pipe->dsc.cst, picker_cst, &pipe->dsc.cst, work_profile);
+
+          // we abuse the empty output buffer on host for intermediate storage of data in
+          // pixelpipe_picker_cl()
+          const size_t outbufsize = bpp * roi_out->width * roi_out->height;
+
+          pixelpipe_picker_cl(pipe->devid, module, piece, &piece->dsc_in, cl_mem_input, &roi_in,
+                              module->picked_color, module->picked_color_min, module->picked_color_max,
+                              *output, outbufsize, input_cst_cl, PIXELPIPE_PICKER_INPUT);
+          pixelpipe_picker_cl(pipe->devid, module, piece, &pipe->dsc, (*cl_mem_output), roi_out,
+                              module->picked_output_color, module->picked_output_color_min,
+                              module->picked_output_color_max, *output, outbufsize, pipe->dsc.cst,
+                              PIXELPIPE_PICKER_OUTPUT);
+
+          DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        // blend needs input/output images with default colorspace
+        if(success_opencl && _transform_for_blend(module, piece))
+        {
+          dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
+          success_opencl = dt_ioppr_transform_image_colorspace_cl(
+              module, piece->pipe->devid, cl_mem_input, cl_mem_input, roi_in.width, roi_in.height,
+              input_cst_cl, blend_cst, &input_cst_cl, work_profile);
+          success_opencl &= dt_ioppr_transform_image_colorspace_cl(
+              module, piece->pipe->devid, *cl_mem_output, *cl_mem_output, roi_out->width, roi_out->height,
+              pipe->dsc.cst, blend_cst, &pipe->dsc.cst, work_profile);
+        }
+
+        /* process blending */
+        if(success_opencl)
+        {
+          success_opencl
+              = dt_develop_blend_process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
+          pixelpipe_flow |= (PIXELPIPE_FLOW_BLENDED_ON_GPU);
+          pixelpipe_flow &= ~(PIXELPIPE_FLOW_BLENDED_ON_CPU);
+        }
+
+        /* synchronization point for opencl pipe */
+        if(success_opencl && (!darktable.opencl->async_pixelpipe
+                              || (pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT))
+          success_opencl = dt_opencl_finish(pipe->devid);
+
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          dt_opencl_release_mem_object(cl_mem_input);
+          return 1;
+        }
+      }
+      else if(piece->process_tiling_ready)
+      {
+        /* image is too big for direct opencl processing -> try to process image via tiling */
+
+        // fprintf(stderr, "[opencl_pixelpipe 3] module '%s' tiling with process_tiling_cl\n", module->op);
+
+        /* we might need to copy back valid image from device to host */
+        if(cl_mem_input != NULL)
+        {
+          cl_int err;
+
+          /* copy back to CPU buffer, then clean unneeded buffer */
+          err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
+                                              in_bpp);
+          if(err != CL_SUCCESS)
+          {
+            /* late opencl error */
+            dt_print(
+                DT_DEBUG_OPENCL,
+                "[opencl_pixelpipe (a)] late opencl error detected while copying back to cpu buffer: %d\n",
+                err);
+            dt_opencl_release_mem_object(cl_mem_input);
+            pipe->opencl_error = 1;
+            return 1;
+          }
+          else
+            input_format->cst = input_cst_cl;
           dt_opencl_release_mem_object(cl_mem_input);
           cl_mem_input = NULL;
-          // we speculate on the next plug-in to possibly copy back cl_mem_output to output,
-          // so we're not just yet invalidating the (empty) output cache line.
+          valid_input_on_gpu_only = FALSE;
         }
-        else
+
+        if(dt_atomic_get_int(&pipe->shutdown))
         {
-          /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
-          dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe] could not run module '%s' on gpu. falling back to cpu path\n",
-                   module->op);
-
-          // fprintf(stderr, "[opencl_pixelpipe 4] module '%s' running on cpu\n", module->op);
-
-          /* we might need to free unused output buffer */
-          if(*cl_mem_output != NULL)
-          {
-            dt_opencl_release_mem_object(*cl_mem_output);
-            *cl_mem_output = NULL;
-          }
-
-          /* check where our input buffer is located */
-          if(cl_mem_input != NULL)
-          {
-            cl_int err;
-
-            /* copy back to host memory, then clean no longer needed opencl buffer.
-               important info: in order to make this possible, opencl modules must
-               not spoil their input buffer, even in case of errors. */
-            err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
-                                                in_bpp);
-            if(err != CL_SUCCESS)
-            {
-              /* late opencl error */
-              dt_print(
-                  DT_DEBUG_OPENCL,
-                  "[opencl_pixelpipe (b)] late opencl error detected while copying back to cpu buffer: %d\n",
-                  err);
-              dt_opencl_release_mem_object(cl_mem_input);
-              pipe->opencl_error = 1;
-              return 1;
-            }
-            else
-              input_format->cst = input_cst_cl;
-
-            /* this is a good place to release event handles as we anyhow need to move from gpu to cpu here */
-            (void)dt_opencl_finish(pipe->devid);
-            dt_opencl_release_mem_object(cl_mem_input);
-            valid_input_on_gpu_only = FALSE;
-          }
-          if (pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
-                                       module, piece, &tiling, &pixelpipe_flow))
-            return 1;
+          return 1;
         }
+
+        // indirectly give gpu some air to breathe (and to do display related stuff)
+        dt_iop_nap(darktable.opencl->micro_nap);
+
+        // transform to module input colorspace
+        if(success_opencl)
+        {
+          dt_ioppr_transform_image_colorspace(module, input, input, roi_in.width, roi_in.height,
+                                              input_format->cst, module->input_colorspace(module, pipe, piece),
+                                              &input_format->cst, work_profile);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        // histogram collection for module
+        if (success_opencl)
+        {
+          collect_histogram_on_CPU(pipe, dev, input, &roi_in, module, piece, &pixelpipe_flow);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        /* now call process_tiling_cl of module; module should emit meaningful messages in case of error */
+        if(success_opencl)
+        {
+          success_opencl
+              = module->process_tiling_cl(module, piece, input, *output, &roi_in, roi_out, in_bpp);
+          pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
+          pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_CPU);
+
+          // and save the output colorspace
+          pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        // Lab color picking for module
+        if(success_opencl && _request_color_pick(pipe, dev, module))
+        {
+          // ensure that we are using the right color space
+          dt_iop_colorspace_type_t picker_cst = _transform_for_picker(module, pipe->dsc.cst);
+          // FIXME: don't need to transform entire image colorspace when just picking a point
+          dt_ioppr_transform_image_colorspace(module, input, input, roi_in.width, roi_in.height,
+                                              input_format->cst, picker_cst, &input_format->cst,
+                                              work_profile);
+          dt_ioppr_transform_image_colorspace(module, *output, *output, roi_out->width, roi_out->height,
+                                              pipe->dsc.cst, picker_cst, &pipe->dsc.cst,
+                                              work_profile);
+
+          pixelpipe_picker(module, piece, &piece->dsc_in, (float *)input, &roi_in, module->picked_color,
+                           module->picked_color_min, module->picked_color_max, input_format->cst,
+                           PIXELPIPE_PICKER_INPUT);
+          pixelpipe_picker(module, piece, &pipe->dsc, (float *)(*output), roi_out, module->picked_output_color,
+                           module->picked_output_color_min, module->picked_output_color_max,
+                           pipe->dsc.cst, PIXELPIPE_PICKER_OUTPUT);
+
+          DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        // blend needs input/output images with default colorspace
+        if(success_opencl && _transform_for_blend(module, piece))
+        {
+          dt_iop_colorspace_type_t blend_cst = dt_develop_blend_colorspace(piece, pipe->dsc.cst);
+          dt_ioppr_transform_image_colorspace(module, input, input, roi_in.width, roi_in.height,
+                                              input_format->cst, blend_cst, &input_format->cst,
+                                              work_profile);
+          dt_ioppr_transform_image_colorspace(module, *output, *output, roi_out->width, roi_out->height,
+                                              pipe->dsc.cst, blend_cst, &pipe->dsc.cst,
+                                              work_profile);
+        }
+
+        if(dt_atomic_get_int(&pipe->shutdown))
+        {
+          return 1;
+        }
+
+        /* do process blending on cpu (this is anyhow fast enough) */
+        if(success_opencl)
+        {
+          dt_develop_blend_process(module, piece, input, *output, &roi_in, roi_out);
+          pixelpipe_flow |= (PIXELPIPE_FLOW_BLENDED_ON_CPU);
+          pixelpipe_flow &= ~(PIXELPIPE_FLOW_BLENDED_ON_GPU);
+        }
+
+        /* synchronization point for opencl pipe */
+        if(success_opencl && (!darktable.opencl->async_pixelpipe
+                              || (pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT))
+          success_opencl = dt_opencl_finish(pipe->devid);
 
         if(dt_atomic_get_int(&pipe->shutdown))
         {
@@ -1834,27 +1712,106 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       }
       else
       {
-        /* we are not allowed to use opencl for this module */
+        /* image is too big for direct opencl and tiling is not allowed -> no opencl processing for this
+         * module */
+        success_opencl = FALSE;
+      }
 
-        // fprintf(stderr, "[opencl_pixelpipe 3] for module `%s', have bufs %p and %p \n", module->op,
-        // cl_mem_input, *cl_mem_output);
+      if(dt_atomic_get_int(&pipe->shutdown))
+      {
+        dt_opencl_release_mem_object(cl_mem_input);
+        return 1;
+      }
 
-        *cl_mem_output = NULL;
+      // if (rand() % 20 == 0) success_opencl = FALSE; // Test code: simulate spurious failures
 
-        /* cleanup unneeded opencl buffer, and copy back to CPU buffer */
+      /* finally check, if we were successful */
+      if(success_opencl)
+      {
+        /* Nice, everything went fine */
+
+        /* this is reasonable on slow GPUs only, where it's more expensive to reprocess the whole pixelpipe
+           than
+           regularly copying device buffers back to host. This would slow down fast GPUs considerably.
+           But it is worth copying data back from the GPU which is the input to the currently focused iop,
+           as that is the iop which is most likely to change next.
+        */
+        if((darktable.opencl->sync_cache == OPENCL_SYNC_TRUE) ||
+           ((darktable.opencl->sync_cache == OPENCL_SYNC_ACTIVE_MODULE) && (module == darktable.develop->gui_module)))
+        {
+          /* write back input into cache for faster re-usal (not for export or thumbnails) */
+          if(cl_mem_input != NULL
+             && (pipe->type & DT_DEV_PIXELPIPE_EXPORT) != DT_DEV_PIXELPIPE_EXPORT
+             && (pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL) != DT_DEV_PIXELPIPE_THUMBNAIL)
+          {
+            cl_int err;
+
+            /* copy input to host memory, so we can find it in cache */
+            err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width,
+                                                roi_in.height, in_bpp);
+            if(err != CL_SUCCESS)
+            {
+              /* late opencl error, not likely to happen here */
+              dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe (e)] late opencl error detected while copying "
+                                        "back to cpu buffer: %d\n",
+                       err);
+              /* that's all we do here, we later make sure to invalidate cache line */
+            }
+            else
+            {
+              /* success: cache line is valid now, so we will not need to invalidate it later */
+              valid_input_on_gpu_only = FALSE;
+
+              input_format->cst = input_cst_cl;
+              // TODO: check if we need to wait for finished opencl pipe before we release cl_mem_input
+              // dt_dev_finish(pipe->devid);
+            }
+          }
+
+          if(dt_atomic_get_int(&pipe->shutdown))
+          {
+            dt_opencl_release_mem_object(cl_mem_input);
+            return 1;
+          }
+        }
+
+        /* we can now release cl_mem_input */
+        dt_opencl_release_mem_object(cl_mem_input);
+        cl_mem_input = NULL;
+        // we speculate on the next plug-in to possibly copy back cl_mem_output to output,
+        // so we're not just yet invalidating the (empty) output cache line.
+      }
+      else
+      {
+        /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
+        dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe] could not run module '%s' on gpu. falling back to cpu path\n",
+                 module->op);
+
+        // fprintf(stderr, "[opencl_pixelpipe 4] module '%s' running on cpu\n", module->op);
+
+        /* we might need to free unused output buffer */
+        if(*cl_mem_output != NULL)
+        {
+          dt_opencl_release_mem_object(*cl_mem_output);
+          *cl_mem_output = NULL;
+        }
+
+        /* check where our input buffer is located */
         if(cl_mem_input != NULL)
         {
           cl_int err;
 
+          /* copy back to host memory, then clean no longer needed opencl buffer.
+             important info: in order to make this possible, opencl modules must
+             not spoil their input buffer, even in case of errors. */
           err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
                                               in_bpp);
-          // if (rand() % 5 == 0) err = !CL_SUCCESS; // Test code: simulate spurious failures
           if(err != CL_SUCCESS)
           {
             /* late opencl error */
             dt_print(
                 DT_DEBUG_OPENCL,
-                "[opencl_pixelpipe (c)] late opencl error detected while copying back to cpu buffer: %d\n",
+                "[opencl_pixelpipe (b)] late opencl error detected while copying back to cpu buffer: %d\n",
                 err);
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = 1;
@@ -1868,123 +1825,138 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           dt_opencl_release_mem_object(cl_mem_input);
           valid_input_on_gpu_only = FALSE;
         }
-
         if (pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
                                      module, piece, &tiling, &pixelpipe_flow))
           return 1;
       }
 
-      /* input is still only on GPU? Let's invalidate CPU input buffer then */
-      if(valid_input_on_gpu_only) dt_dev_pixelpipe_cache_invalidate(&(pipe->cache), input);
+      if(dt_atomic_get_int(&pipe->shutdown))
+      {
+        return 1;
+      }
     }
     else
     {
-      /* opencl is not inited or not enabled or we got no resource/device -> everything runs on cpu */
+      /* we are not allowed to use opencl for this module */
+
+      // fprintf(stderr, "[opencl_pixelpipe 3] for module `%s', have bufs %p and %p \n", module->op,
+      // cl_mem_input, *cl_mem_output);
+
+      *cl_mem_output = NULL;
+
+      /* cleanup unneeded opencl buffer, and copy back to CPU buffer */
+      if(cl_mem_input != NULL)
+      {
+        cl_int err;
+
+        err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
+                                            in_bpp);
+        // if (rand() % 5 == 0) err = !CL_SUCCESS; // Test code: simulate spurious failures
+        if(err != CL_SUCCESS)
+        {
+          /* late opencl error */
+          dt_print(
+              DT_DEBUG_OPENCL,
+              "[opencl_pixelpipe (c)] late opencl error detected while copying back to cpu buffer: %d\n",
+              err);
+          dt_opencl_release_mem_object(cl_mem_input);
+          pipe->opencl_error = 1;
+          return 1;
+        }
+        else
+          input_format->cst = input_cst_cl;
+
+        /* this is a good place to release event handles as we anyhow need to move from gpu to cpu here */
+        (void)dt_opencl_finish(pipe->devid);
+        dt_opencl_release_mem_object(cl_mem_input);
+        valid_input_on_gpu_only = FALSE;
+      }
 
       if (pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
                                    module, piece, &tiling, &pixelpipe_flow))
         return 1;
     }
-#else // HAVE_OPENCL
+
+    /* input is still only on GPU? Let's invalidate CPU input buffer then */
+    if(valid_input_on_gpu_only) dt_dev_pixelpipe_cache_invalidate(&(pipe->cache), input);
+  }
+  else
+  {
+    /* opencl is not inited or not enabled or we got no resource/device -> everything runs on cpu */
+
     if (pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
                                  module, piece, &tiling, &pixelpipe_flow))
       return 1;
+  }
+#else // HAVE_OPENCL
+  if (pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
+                               module, piece, &tiling, &pixelpipe_flow))
+    return 1;
 #endif // HAVE_OPENCL
 
-    char histogram_log[32] = "";
-    if(!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE))
-    {
-      snprintf(histogram_log, sizeof(histogram_log), ", collected histogram on %s",
-               (pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_ON_GPU
-                    ? "GPU"
-                    : pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_ON_CPU ? "CPU" : ""));
-    }
+  char histogram_log[32] = "";
+  if(!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE))
+  {
+    snprintf(histogram_log, sizeof(histogram_log), ", collected histogram on %s",
+             (pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_ON_GPU
+                  ? "GPU"
+                  : pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_ON_CPU ? "CPU" : ""));
+  }
 
-    gchar *module_label = dt_history_item_get_name(module);
-    dt_show_times_f(
-        &start, "[dev_pixelpipe]", "processed `%s' on %s%s%s, blended on %s [%s]", module_label,
-        pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_GPU
-            ? "GPU"
-            : pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_CPU ? "CPU" : "",
-        pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_WITH_TILING ? " with tiling" : "",
-        (!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE) && (piece->request_histogram & DT_REQUEST_ON))
-            ? histogram_log
-            : "",
-        pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_GPU
-            ? "GPU"
-            : pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_CPU ? "CPU" : "",
-        _pipe_type_to_str(pipe->type));
-    g_free(module_label);
-    module_label = NULL;
+  gchar *module_label = dt_history_item_get_name(module);
+  dt_show_times_f(
+      &start, "[dev_pixelpipe]", "processed `%s' on %s%s%s, blended on %s [%s]", module_label,
+      pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_GPU
+          ? "GPU"
+          : pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_CPU ? "CPU" : "",
+      pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_WITH_TILING ? " with tiling" : "",
+      (!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE) && (piece->request_histogram & DT_REQUEST_ON))
+          ? histogram_log
+          : "",
+      pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_GPU
+          ? "GPU"
+          : pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_CPU ? "CPU" : "",
+      _pipe_type_to_str(pipe->type));
+  g_free(module_label);
+  module_label = NULL;
 
-    // in case we get this buffer from the cache in the future, cache some stuff:
-    **out_format = piece->dsc_out = pipe->dsc;
+  // in case we get this buffer from the cache in the future, cache some stuff:
+  **out_format = piece->dsc_out = pipe->dsc;
 
-    if(module == darktable.develop->gui_module)
-    {
-      // give the input buffer to the currently focused plugin more weight.
-      // the user is likely to change that one soon, so keep it in cache.
-      dt_dev_pixelpipe_cache_reweight(&(pipe->cache), input);
-    }
+  if(module == darktable.develop->gui_module)
+  {
+    // give the input buffer to the currently focused plugin more weight.
+    // the user is likely to change that one soon, so keep it in cache.
+    dt_dev_pixelpipe_cache_reweight(&(pipe->cache), input);
+  }
 #ifndef _DEBUG
-    if(darktable.unmuted & DT_DEBUG_NAN)
+  if(darktable.unmuted & DT_DEBUG_NAN)
 #endif
+  {
+    if(dt_atomic_get_int(&pipe->shutdown))
     {
-      if(dt_atomic_get_int(&pipe->shutdown))
-      {
-        return 1;
-      }
+      return 1;
+    }
 
-      if(strcmp(module->op, "gamma") == 0)
-      {
-        goto post_process_collect_info;
-      }
+    if(strcmp(module->op, "gamma") == 0)
+    {
+      goto post_process_collect_info;
+    }
 
 #ifdef HAVE_OPENCL
-      if(*cl_mem_output != NULL)
-        dt_opencl_copy_device_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp);
+    if(*cl_mem_output != NULL)
+      dt_opencl_copy_device_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height, bpp);
 #endif
 
-      if((*out_format)->datatype == TYPE_FLOAT && (*out_format)->channels == 4)
-      {
-        int hasinf = 0, hasnan = 0;
-        dt_aligned_pixel_t min = { FLT_MAX };
-        dt_aligned_pixel_t max = { FLT_MIN };
+    if((*out_format)->datatype == TYPE_FLOAT && (*out_format)->channels == 4)
+    {
+      int hasinf = 0, hasnan = 0;
+      dt_aligned_pixel_t min = { FLT_MAX };
+      dt_aligned_pixel_t max = { FLT_MIN };
 
-        for(int k = 0; k < 4 * roi_out->width * roi_out->height; k++)
-        {
-          if((k & 3) < 3)
-          {
-            float f = ((float *)(*output))[k];
-            if(isnan(f))
-              hasnan = 1;
-            else if(isinf(f))
-              hasinf = 1;
-            else
-            {
-              min[k & 3] = fmin(f, min[k & 3]);
-              max[k & 3] = fmax(f, max[k & 3]);
-            }
-          }
-        }
-        module_label = dt_history_item_get_name(module);
-        if(hasnan)
-          fprintf(stderr, "[dev_pixelpipe] module `%s' outputs NaNs! [%s]\n", module_label,
-                  _pipe_type_to_str(pipe->type));
-        if(hasinf)
-          fprintf(stderr, "[dev_pixelpipe] module `%s' outputs non-finite floats! [%s]\n", module_label,
-                  _pipe_type_to_str(pipe->type));
-        fprintf(stderr, "[dev_pixelpipe] module `%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]\n", module_label,
-                min[0], min[1], min[2], max[0], max[1], max[2], _pipe_type_to_str(pipe->type));
-        g_free(module_label);
-      }
-      else if((*out_format)->datatype == TYPE_FLOAT && (*out_format)->channels == 1)
+      for(int k = 0; k < 4 * roi_out->width * roi_out->height; k++)
       {
-        int hasinf = 0, hasnan = 0;
-        float min = FLT_MAX;
-        float max = FLT_MIN;
-
-        for(int k = 0; k < roi_out->width * roi_out->height; k++)
+        if((k & 3) < 3)
         {
           float f = ((float *)(*output))[k];
           if(isnan(f))
@@ -1993,52 +1965,82 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             hasinf = 1;
           else
           {
-            min = fmin(f, min);
-            max = fmax(f, max);
+            min[k & 3] = fmin(f, min[k & 3]);
+            max[k & 3] = fmax(f, max[k & 3]);
           }
         }
-        module_label = dt_history_item_get_name(module);
-        if(hasnan)
-          fprintf(stderr, "[dev_pixelpipe] module `%s' outputs NaNs! [%s]\n", module_label,
-                  _pipe_type_to_str(pipe->type));
-        if(hasinf)
-          fprintf(stderr, "[dev_pixelpipe] module `%s' outputs non-finite floats! [%s]\n", module_label,
-                  _pipe_type_to_str(pipe->type));
-        fprintf(stderr, "[dev_pixelpipe] module `%s' min: (%f) max: (%f) [%s]\n", module_label, min, max,
-                _pipe_type_to_str(pipe->type));
-        g_free(module_label);
       }
+      module_label = dt_history_item_get_name(module);
+      if(hasnan)
+        fprintf(stderr, "[dev_pixelpipe] module `%s' outputs NaNs! [%s]\n", module_label,
+                _pipe_type_to_str(pipe->type));
+      if(hasinf)
+        fprintf(stderr, "[dev_pixelpipe] module `%s' outputs non-finite floats! [%s]\n", module_label,
+                _pipe_type_to_str(pipe->type));
+      fprintf(stderr, "[dev_pixelpipe] module `%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]\n", module_label,
+              min[0], min[1], min[2], max[0], max[1], max[2], _pipe_type_to_str(pipe->type));
+      g_free(module_label);
     }
+    else if((*out_format)->datatype == TYPE_FLOAT && (*out_format)->channels == 1)
+    {
+      int hasinf = 0, hasnan = 0;
+      float min = FLT_MAX;
+      float max = FLT_MIN;
+
+      for(int k = 0; k < roi_out->width * roi_out->height; k++)
+      {
+        float f = ((float *)(*output))[k];
+        if(isnan(f))
+          hasnan = 1;
+        else if(isinf(f))
+          hasinf = 1;
+        else
+        {
+          min = fmin(f, min);
+          max = fmax(f, max);
+        }
+      }
+      module_label = dt_history_item_get_name(module);
+      if(hasnan)
+        fprintf(stderr, "[dev_pixelpipe] module `%s' outputs NaNs! [%s]\n", module_label,
+                _pipe_type_to_str(pipe->type));
+      if(hasinf)
+        fprintf(stderr, "[dev_pixelpipe] module `%s' outputs non-finite floats! [%s]\n", module_label,
+                _pipe_type_to_str(pipe->type));
+      fprintf(stderr, "[dev_pixelpipe] module `%s' min: (%f) max: (%f) [%s]\n", module_label, min, max,
+              _pipe_type_to_str(pipe->type));
+      g_free(module_label);
+    }
+  }
 
 post_process_collect_info:
 
-    // 4) colorpicker and final histogram:
-    if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
-    if(dev->gui_attached && !dev->gui_leaving
-       && pipe == dev->preview_pipe
-       && (strcmp(module->op, "gamma") == 0) // only gamma provides meaningful RGB data
-       && input) // input is NULL if using cached output, shouldn't happen for gamma
-    {
-      // Pick RGB/Lab for the primary colorpicker and live samples
-      if(darktable.lib->proxy.colorpicker.picker_proxy || darktable.lib->proxy.colorpicker.live_samples)
-        _pixelpipe_pick_samples(dev, module, (const float *const )input, &roi_in);
+  // 4) colorpicker and final histogram:
+  if(dt_atomic_get_int(&pipe->shutdown))
+  {
+    return 1;
+  }
+  if(dev->gui_attached && !dev->gui_leaving
+     && pipe == dev->preview_pipe
+     && (strcmp(module->op, "gamma") == 0) // only gamma provides meaningful RGB data
+     && input) // input is NULL if using cached output, shouldn't happen for gamma
+  {
+    // Pick RGB/Lab for the primary colorpicker and live samples
+    if(darktable.lib->proxy.colorpicker.picker_proxy || darktable.lib->proxy.colorpicker.live_samples)
+      _pixelpipe_pick_samples(dev, module, (const float *const )input, &roi_in);
 
-      // FIXME: read this from dt_ioppr_get_pipe_output_profile_info()?
-      const dt_iop_order_iccprofile_info_t *const display_profile
-        = dt_ioppr_add_profile_info_to_list(dev, darktable.color_profiles->display_type,
-                                            darktable.color_profiles->display_filename, INTENT_RELATIVE_COLORIMETRIC);
+    // FIXME: read this from dt_ioppr_get_pipe_output_profile_info()?
+    const dt_iop_order_iccprofile_info_t *const display_profile
+      = dt_ioppr_add_profile_info_to_list(dev, darktable.color_profiles->display_type,
+                                          darktable.color_profiles->display_filename, INTENT_RELATIVE_COLORIMETRIC);
 
-      // Since histogram is being treated as the second-to-last link
-      // in the pixelpipe and has a "process" call, why not treat it
-      // as an iop? Granted, other views such as tether may also
-      // benefit via a histogram.
-      darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, input,
-                                             roi_in.width, roi_in.height,
-                                             display_profile, dt_ioppr_get_histogram_profile_info(dev));
-    }
+    // Since histogram is being treated as the second-to-last link
+    // in the pixelpipe and has a "process" call, why not treat it
+    // as an iop? Granted, other views such as tether may also
+    // benefit via a histogram.
+    darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, input,
+                                           roi_in.width, roi_in.height,
+                                           display_profile, dt_ioppr_get_histogram_profile_info(dev));
   }
 
   if(dt_atomic_get_int(&pipe->shutdown))


### PR DESCRIPTION
This is a bit of tidying of the huge `dt_dev_pixelpipe_process_rec()` function.

- Eliminate goto's to `post_process_collect_info`, which resulted in confusing control flow. Do this by:
  - Not trying to run pickers/scope if pulling output from the cache, as when we do run these, we don't use the cache.
  - Using a conditional when testing for NaN/infinite pixels.
- If initing the base buffer, return immediately after that. This eliminates a huge else clause containing the predominant case (recursive callback of prior iop).
- The colorpicker and scope work were wrapped in quite similar conditionals. Combine these.
- Don't handle case of no input buffer when running scopes/colorpicker, as scopes/picker will only run if we've recursively populated the input buffer from a prior iop.

The end result should be almost no noticeable functional changes, but more legible control flow.

I'd recommend using github's "Hide whitespace" option or using git diff flag `--ignore-space-change` to reveal that this is actually a fairly succinct set of changes.