### PR TITLE
make CL headroom management as per-device [edited]

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -204,7 +204,7 @@
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>singlebuffer_limit</name>
-    <type min="2" max="128">int</type>
+    <type min="8" max="128">int</type>
     <default>16</default>
     <shortdescription>minimum amount of memory (in MB) for a single buffer in tiling</shortdescription>
     <longdescription>minimum amount of memory (in MB) that tiling should take for a single image buffer.</longdescription>
@@ -212,7 +212,7 @@
   <dtconfig>
     <name>opencl_memory_headroom</name>
     <type>int</type>
-    <default>400</default>
+    <default>800</default>
     <shortdescription>amount of OpenCL memory (in MB) which we assume as being reserved for the driver</shortdescription>
     <longdescription>this amount of memory (in MB) will be subtracted from total GPU memory in order to calculate the available OpenCL memory. too low values will lead to out-of-memory situations in OpenCL processing. too high values will lead to unnecessary tiling (needs a restart).</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -212,7 +212,7 @@
   <dtconfig>
     <name>opencl_memory_headroom</name>
     <type>int</type>
-    <default>800</default>
+    <default>600</default>
     <shortdescription>amount of OpenCL memory (in MB) which we assume as being reserved for the driver</shortdescription>
     <longdescription>this amount of memory (in MB) will be subtracted from total GPU memory in order to calculate the available OpenCL memory. too low values will lead to out-of-memory situations in OpenCL processing. too high values will lead to unnecessary tiling (needs a restart).</longdescription>
   </dtconfig>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1581,12 +1581,6 @@ int dt_worker_threads()
   return 1;
 }
 
-size_t dt_opencl_memory_headroom()
-{
-  const size_t safe_headroom = MAX(DT_CL_SAFEHEADROOM, dt_conf_get_int("opencl_memory_headroom"));
-  return safe_headroom * 1024 * 1024;
-}
-
 void dt_configure_performance()
 {
   const int atom_cores = _get_num_atom_cores();

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1049,6 +1049,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
 #ifdef HAVE_OPENCL
   dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+  dt_opencl_preallocate_lowmem();
 #endif
 
   darktable.points = (dt_points_t *)calloc(1, sizeof(dt_points_t));

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -135,6 +135,7 @@ static int usage(const char *argv0)
   printf(">\n");
   printf("  --datadir <data directory>\n");
   printf("  --enforce-tiling\n");
+  printf("  --enforce-lowmem\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
@@ -567,7 +568,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
         if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted = 0xffffffff & ~DT_DEBUG_TILING; // enable all debug information except the enforce-tiling flag
+          darktable.unmuted = 0xffffffff & ~(DT_DEBUG_TILING | DT_DEBUG_LOWMEM); // enable all debug information except the enforce-tiling and enforce-lowmem flags
         else if(!strcmp(argv[k + 1], "cache"))
           darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
         else if(!strcmp(argv[k + 1], "control"))
@@ -754,6 +755,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(!strcmp(argv[k], "--enforce-tiling"))
       {
         darktable.unmuted |= DT_DEBUG_TILING;
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--enforce-lowmem"))
+      {
+        darktable.unmuted |= DT_DEBUG_LOWMEM;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--"))

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1581,10 +1581,10 @@ int dt_worker_threads()
   return 1;
 }
 
-float dt_opencl_memory_headroom()
+size_t dt_opencl_memory_headroom()
 {
-  const float safe_headroom = fmaxf(DT_CL_SAFEHEADROOM, dt_conf_get_float("opencl_memory_headroom"));
-  return safe_headroom * 1024.0f * 1024.0f;
+  const size_t safe_headroom = MAX(DT_CL_SAFEHEADROOM, dt_conf_get_int("opencl_memory_headroom"));
+  return safe_headroom * 1024 * 1024;
 }
 
 void dt_configure_performance()

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1581,6 +1581,12 @@ int dt_worker_threads()
   return 1;
 }
 
+float dt_opencl_memory_headroom()
+{
+  const float safe_headroom = fmaxf(DT_CL_SAFEHEADROOM, dt_conf_get_float("opencl_memory_headroom"));
+  return safe_headroom * 1024.0f * 1024.0f;
+}
+
 void dt_configure_performance()
 {
   const int atom_cores = _get_num_atom_cores();
@@ -1591,24 +1597,24 @@ void dt_configure_performance()
 
   fprintf(stderr, "[defaults] found a %zu-bit system with %zu kb ram and %zu cores (%d atom based)\n",
           bits, mem, threads, atom_cores);
-  if(mem >= (16lu << 20) && threads > 6 && atom_cores == 0)
+  if(mem >= (16lu << 20) && threads > 4)
   {
-    // CONFIG 0: at least 16GB RAM, and more than 6 CPU cores, no atom
+    // CONFIG 0: at least 16GB RAM, and more than 6 CPU threads
     // But respect if user has set higher values manually earlier
-    fprintf(stderr, "[defaults] setting ultra high quality defaults\n");
+    fprintf(stderr, "[defaults] setting very high quality defaults\n");
     // if machine has at least 16GB RAM, use all of the total memory size leaving 4GB "breathing room"
     dt_conf_set_int("host_memory_limit", MAX((mem - (4lu << 20)) >> 11, dt_conf_get_int("host_memory_limit")));
-    dt_conf_set_int("singlebuffer_limit", MAX(64, dt_conf_get_int("singlebuffer_limit")));
+    dt_conf_set_int("singlebuffer_limit", MAX(128, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL || strlen(demosaic_quality) == 0
        || !strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
     dt_conf_set_bool("ui/performance", FALSE);
   }
-  else if(mem >= (8lu << 20) && threads > 4 && atom_cores == 0)
+  else if(mem >= (8lu << 20) && threads >= 4)
   {
-    // CONFIG 1: at least 8GB RAM, and more than 4 CPU cores, no atom
+    // CONFIG 1: at least 8GB RAM, and at least 4 CPU threads
     // But respect if user has set higher values manually earlier
-    fprintf(stderr, "[defaults] setting very high quality defaults\n");
+    fprintf(stderr, "[defaults] setting high quality defaults\n");
 
     // if machine has at least 8GB RAM, use half of the total memory size
     dt_conf_set_int("host_memory_limit", MAX(mem >> 11, dt_conf_get_int("host_memory_limit")));
@@ -1618,11 +1624,10 @@ void dt_configure_performance()
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
     dt_conf_set_bool("ui/performance", FALSE);
   }
-  else if(mem > (2lu << 20) && threads >= 4 && atom_cores == 0)
+  else if(mem >= (4lu << 20) && threads >= 2)
   {
-    // CONFIG 2: at least 2GB RAM, and at least 4 CPU cores, no atom
-    // But respect if user has set higher values manually earlier
-    fprintf(stderr, "[defaults] setting high quality defaults\n");
+    // CONFIG 2: at least 4GB RAM, and at least 2 CPU threads
+    fprintf(stderr, "[defaults] setting standard defaults\n");
 
     dt_conf_set_int("host_memory_limit", MAX(1500, dt_conf_get_int("host_memory_limit")));
     dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
@@ -1631,25 +1636,15 @@ void dt_configure_performance()
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
     dt_conf_set_bool("ui/performance", FALSE);
   }
-  else if(mem < (1lu << 20) || threads <= 2 || atom_cores > 0)
+  else
   {
-    // CONFIG 3: For less than 1GB RAM or 2 or less cores, or for atom processors
+    // CONFIG 3: for small and slow systems
     // use very low/conservative settings
     fprintf(stderr, "[defaults] setting very conservative defaults\n");
     dt_conf_set_int("host_memory_limit", 500);
-    dt_conf_set_int("singlebuffer_limit", 8);
+    dt_conf_set_int("singlebuffer_limit", 16);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "always bilinear (fast)");
     dt_conf_set_bool("ui/performance", TRUE);
-  }
-  else
-  {
-    // CONFIG 4: for everything else use explicit defaults
-    fprintf(stderr, "[defaults] setting normal defaults\n");
-
-    dt_conf_set_int("host_memory_limit", 1500);
-    dt_conf_set_int("singlebuffer_limit", 16);
-    dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
-    dt_conf_set_bool("ui/performance", FALSE);
   }
 
   g_free(demosaic_quality);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -159,7 +159,7 @@ typedef unsigned int u_int;
 // bump this number and make sure you have an updated logic in dt_configure_performance()
 #define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
 
-#define DT_CL_SAFEHEADROOM 800.0f
+#define DT_CL_SAFEHEADROOM 800
 
 // every module has to define this:
 #ifdef _DEBUG
@@ -351,7 +351,7 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((for
 void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 int dt_worker_threads();
-float dt_opencl_memory_headroom();
+size_t dt_opencl_memory_headroom();
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)
 {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -273,7 +273,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
   DT_DEBUG_TILING         = 1 << 23,
-  DT_DEBUG_ACT_ON         = 1 << 24
+  DT_DEBUG_ACT_ON         = 1 << 24,
+  DT_DEBUG_LOWMEM         = 1 << 25
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -157,7 +157,9 @@ typedef unsigned int u_int;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 2
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
+
+#define DT_CL_SAFEHEADROOM 800.0f
 
 // every module has to define this:
 #ifdef _DEBUG
@@ -349,6 +351,7 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((for
 void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 int dt_worker_threads();
+float dt_opencl_memory_headroom();
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)
 {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -159,7 +159,8 @@ typedef unsigned int u_int;
 // bump this number and make sure you have an updated logic in dt_configure_performance()
 #define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
 
-#define DT_CL_SAFEHEADROOM 800
+// A good suggestion but maybe on the lower side as we can increase automatically
+#define DT_CL_SAFEHEADROOM 600
 
 // every module has to define this:
 #ifdef _DEBUG
@@ -351,7 +352,6 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((for
 void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 int dt_worker_threads();
-size_t dt_opencl_memory_headroom();
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)
 {

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -694,7 +694,7 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(w >= 1);
 
   const cl_ulong max_global_mem = dt_opencl_get_max_global_mem(devid);
-  const size_t reserved_memory = dt_opencl_memory_headroom();
+  const cl_ulong reserved_memory = dt_opencl_get_device_headroom(devid);
   // estimate required memory for OpenCL code path with a safety factor of 5/4
   const size_t required_memory
       = darktable.opencl->dev[devid].memory_in_use + (size_t)width * height * sizeof(float) * 18 * 5 / 4;

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -694,7 +694,7 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(w >= 1);
 
   const cl_ulong max_global_mem = dt_opencl_get_max_global_mem(devid);
-  const size_t reserved_memory = (size_t)(dt_conf_get_float("opencl_memory_headroom") * 1024 * 1024);
+  const size_t reserved_memory = (size_t)(dt_opencl_memory_headroom());
   // estimate required memory for OpenCL code path with a safety factor of 5/4
   const size_t required_memory
       = darktable.opencl->dev[devid].memory_in_use + (size_t)width * height * sizeof(float) * 18 * 5 / 4;

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -694,7 +694,7 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(w >= 1);
 
   const cl_ulong max_global_mem = dt_opencl_get_max_global_mem(devid);
-  const size_t reserved_memory = (size_t)(dt_opencl_memory_headroom());
+  const size_t reserved_memory = dt_opencl_memory_headroom();
   // estimate required memory for OpenCL code path with a safety factor of 5/4
   const size_t required_memory
       = darktable.opencl->dev[devid].memory_in_use + (size_t)width * height * sizeof(float) * 18 * 5 / 4;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2449,7 +2449,7 @@ int dt_opencl_image_fits_device(const int devid, const size_t width, const size_
   /* first time run */
   if(headroom < 0.0f)
   {
-    headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
+    headroom = dt_opencl_memory_headroom();
 
     /* don't let the user play games with us */
     headroom = fmin((float)darktable.opencl->dev[devid].max_global_mem, fmax(headroom, 0.0f));

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -888,6 +888,8 @@ finally:
 
 void dt_opencl_preallocate_lowmem()
 {
+  if(!dt_opencl_is_enabled() || ((darktable.unmuted & DT_DEBUG_LOWMEM) == 0))
+    return;
   dt_opencl_t *cl = darktable.opencl;
   for(int devid = 0; cl->dev && devid < cl->num_devs; devid++)
   {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -33,6 +33,7 @@
 #define DT_OPENCL_VENDOR_AMD 4098
 #define DT_OPENCL_VENDOR_NVIDIA 4318
 #define DT_OPENCL_VENDOR_INTEL 0x8086u
+#define DT_OPENCL_LOWMEM_BUF 32
 
 #include "common/darktable.h"
 
@@ -122,6 +123,7 @@ typedef struct dt_opencl_device_t
   size_t memory_in_use;
   size_t peak_memory;
   gboolean mem_error;
+  cl_mem lowmem_buff[DT_OPENCL_LOWMEM_BUF];  
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;
@@ -213,6 +215,9 @@ int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_in
 
 /** inits the opencl subsystem. */
 void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics);
+
+/** preallocate buffers for --enforce-lowmem */
+void dt_opencl_preallocate_lowmem();
 
 /** cleans up the opencl subsystem. */
 void dt_opencl_cleanup(dt_opencl_t *cl);
@@ -429,6 +434,9 @@ static inline void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl
   cl->error_count = 0;
   dt_conf_set_bool("opencl", FALSE);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] this version of darktable was built without opencl support\n");
+}
+static inline void dt_opencl_preallocate_lowmem()
+{
 }
 static inline void dt_opencl_cleanup(dt_opencl_t *cl)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -121,6 +121,7 @@ typedef struct dt_opencl_device_t
   float benchmark;
   size_t memory_in_use;
   size_t peak_memory;
+  gboolean mem_error;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;
@@ -372,6 +373,9 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
 gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
 
+/** tune headroom according to recorded cl allocation errors */
+void dt_opencl_device_tune_headroom(const int devid);
+
 /** get headroom for the device */
 cl_ulong dt_opencl_get_device_headroom(const int devid);
 
@@ -505,6 +509,9 @@ static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t
                                               const unsigned bpp, const float factor, const size_t overhead)
 {
   return FALSE;
+}
+static inline void dt_opencl_device_tune_headroom(const int devid)
+{
 }
 static inline size_t dt_opencl_get_device_headroom(const int devid)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -368,7 +368,7 @@ int dt_opencl_get_mem_context_id(cl_mem mem);
 void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t action);
 
 /** check if image size fit into limits given by OpenCL runtime */
-int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
+gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
 
 /** round size to a multiple of the value given in config parameter opencl_size_roundup */
@@ -491,10 +491,10 @@ static inline int dt_opencl_update_settings(void)
 {
   return 0;
 }
-static inline int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
+static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)
 {
-  return 0;
+  return FALSE;
 }
 static inline int dt_opencl_get_max_global_mem(const int devid)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -506,15 +506,15 @@ static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t
 {
   return FALSE;
 }
-static inline cl_ulong dt_opencl_get_device_headroom(const int devid)
+static inline size_t dt_opencl_get_device_headroom(const int devid)
 {
   return 0;
 }
-static inline cl_ulong dt_opencl_get_device_available(const int devid)
+static inline size_t dt_opencl_get_device_available(const int devid)
 {
   return 0;
 }
-static inline cl_ulong dt_opencl_get_device_memalloc(const int devid)
+static inline size_t dt_opencl_get_device_memalloc(const int devid)
 {
   return 0;
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -272,6 +272,9 @@ int dt_opencl_enqueue_kernel_2d(const int dev, const int kernel, const size_t *s
 int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const int kernel, const size_t *sizes,
                                            const size_t *local);
 
+/** check an allocation problem in err and report to the flags in cl device struct */
+void dt_opencl_keep_memerror(const int devid, const int cl_errorcode);
+
 /** check if opencl is inited */
 int dt_opencl_is_inited(void);
 
@@ -556,6 +559,9 @@ static inline int dt_opencl_events_flush(const int devid, const int reset)
   return 0;
 }
 static inline void dt_opencl_events_profiling(const int devid, const int aggregated)
+{
+}
+void inline void dt_opencl_keep_memerror(const int devid, const int cl_errorcode)
 {
 }
 #endif

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -561,7 +561,7 @@ static inline int dt_opencl_events_flush(const int devid, const int reset)
 static inline void dt_opencl_events_profiling(const int devid, const int aggregated)
 {
 }
-void inline void dt_opencl_keep_memerror(const int devid, const int cl_errorcode)
+static inline void dt_opencl_keep_memerror(const int devid, const int cl_errorcode)
 {
 }
 #endif

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -95,6 +95,7 @@ typedef struct dt_opencl_device_t
   cl_command_queue cmd_queue;
   size_t max_image_width;
   size_t max_image_height;
+  size_t headroom;
   cl_ulong max_mem_alloc;
   cl_ulong max_global_mem;
   cl_ulong used_global_mem;
@@ -371,6 +372,15 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
 gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
 
+/** get headroom for the device */
+cl_ulong dt_opencl_get_device_headroom(const int devid);
+
+/** get available memory for the device */
+cl_ulong dt_opencl_get_device_available(const int devid);
+
+/** get size of allocatable single buffer */
+cl_ulong dt_opencl_get_device_memalloc(const int devid);
+
 /** round size to a multiple of the value given in config parameter opencl_size_roundup */
 int dt_opencl_roundup(int size);
 
@@ -496,6 +506,19 @@ static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t
 {
   return FALSE;
 }
+static inline cl_ulong dt_opencl_get_device_headroom(const int devid)
+{
+  return 0;
+}
+static inline cl_ulong dt_opencl_get_device_available(const int devid)
+{
+  return 0;
+}
+static inline cl_ulong dt_opencl_get_device_memalloc(const int devid)
+{
+  return 0;
+}
+
 static inline int dt_opencl_get_max_global_mem(const int devid)
 {
   return 0;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1358,7 +1358,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       int valid_input_on_gpu_only = (cl_mem_input != NULL);
 
       /* pre-check if there is enough space on device for non-tiled processing */
-      const int fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
+      const gboolean fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
                                                              MAX(roi_in.height, roi_out->height), MAX(in_bpp, bpp),
                                                              tiling.factor_cl, tiling.overhead);
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2164,6 +2164,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
       }
     }
   }
+  dt_opencl_device_tune_headroom(pipe->devid);  
 #endif
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
   return ret;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1238,10 +1238,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   /* shall we enforce tiling */
   const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
   /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
+  float headroom = dt_opencl_memory_headroom();
   headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
   float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  if(force_tile) available = fmin(available, DT_CL_SAFEHEADROOM * 1024.0f * 1024.0f);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
                                   pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
@@ -1608,10 +1608,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   /* shall we enforce tiling */
   const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
   /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
+  float headroom = dt_opencl_memory_headroom();
   headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
   float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  if(force_tile) available = fmin(available, DT_CL_SAFEHEADROOM * 1024.0f * 1024.0f);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
                                   pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1238,7 +1238,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   /* shall we enforce tiling */
   const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
   /* calculate optimal size of tiles */
-  float headroom = dt_opencl_memory_headroom();
+  float headroom = (float)dt_opencl_memory_headroom();
   headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
   float available = darktable.opencl->dev[devid].max_global_mem - headroom;
   if(force_tile) available = fmin(available, DT_CL_SAFEHEADROOM * 1024.0f * 1024.0f);
@@ -1608,7 +1608,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   /* shall we enforce tiling */
   const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
   /* calculate optimal size of tiles */
-  float headroom = dt_opencl_memory_headroom();
+  float headroom = (float)dt_opencl_memory_headroom();
   headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
   float available = darktable.opencl->dev[devid].max_global_mem - headroom;
   if(force_tile) available = fmin(available, DT_CL_SAFEHEADROOM * 1024.0f * 1024.0f);

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1235,16 +1235,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = (float)dt_opencl_memory_headroom();
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, DT_CL_SAFEHEADROOM * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
   int width = _min(roi_in->width, darktable.opencl->dev[devid].max_image_width);
   int height = _min(roi_in->height, darktable.opencl->dev[devid].max_image_height);
@@ -1605,16 +1599,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = (float)dt_opencl_memory_headroom();
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, DT_CL_SAFEHEADROOM * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
 
   int width = _min(_max(roi_in->width, roi_out->width), darktable.opencl->dev[devid].max_image_width);


### PR DESCRIPTION
I guess there might be discussions here but i thought again about proper performance settings
while running dt_configure_performance().

The settings seemed to be good but were to much leaning on cpu cores for mem-hungry modules
like the recent diffuse-or-sharpen leading to frustrating performance for some users.
So - a new suggestion for that.

Also - the default opencl headroom seems to be a bit small for current systems.
I think, it might be better to go for a pretty safe setting initially, users knowing their
system can better decide how to tune.

EDITED:
***
latest commits implement headroom management as per device and allows simulation a very small graphics cards via the debugging option`--enforce-tiling` for better performance testing and debugging of opencl code.

Not yet increasing headroom if opencl modules returned an error because of missed allocations. 
***
Some related discussions on pixels.us threads or in issues #11052 #10922

@ralfbrown i saw your "automatic check" comment, i am not sure if that is a really good idea, i remember running hugin in the background - but didn't think about that - and was surprised dt was so slow :-) An automatic correction would have left me with an unobserved slowed-down dt afterwards. 0.8GB are pretty safe for all systems and the 0.8-0.4 loss won't hurt on common 4GB cards imho.  