### PR TITLE
Improve monochrome images workflow

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -220,7 +220,7 @@ static void _pop_undo_execute(const int32_t imgid, const gboolean before, const 
 
 gboolean dt_image_is_matrix_correction_supported(const dt_image_t *img)
 {
-  return ((img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW )) && !dt_image_is_monochrome(img)) ? TRUE : FALSE;
+  return ((img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW )) && !(img->flags & DT_IMAGE_MONOCHROME)) ? TRUE : FALSE;
 }
 
 gboolean dt_image_is_rawprepare_supported(const dt_image_t *img)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -158,9 +158,9 @@ int dt_image_is_raw(const dt_image_t *img)
   return (img->flags & DT_IMAGE_RAW);
 }
 
-int dt_image_is_monochrome(const dt_image_t *img)
+gboolean dt_image_is_monochrome(const dt_image_t *img)
 {
-  return (img->flags & DT_IMAGE_MONOCHROME);
+  return (img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) ? TRUE : FALSE;
 }
 
 static void _image_set_monochrome_flag(const int32_t imgid, gboolean monochrome, gboolean undo_on)
@@ -218,14 +218,14 @@ static void _pop_undo_execute(const int32_t imgid, const gboolean before, const 
   _image_set_monochrome_flag(imgid, after, FALSE);
 }
 
-int dt_image_is_matrix_correction_supported(const dt_image_t *img)
+gboolean dt_image_is_matrix_correction_supported(const dt_image_t *img)
 {
-  return ((img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW )) && !(img->flags & DT_IMAGE_MONOCHROME) );
+  return ((img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW )) && !dt_image_is_monochrome(img)) ? TRUE : FALSE;
 }
 
-int dt_image_is_rawprepare_supported(const dt_image_t *img)
+gboolean dt_image_is_rawprepare_supported(const dt_image_t *img)
 {
-  return (img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW));
+  return (img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW)) ? TRUE : FALSE;
 }
 
 gboolean dt_image_use_monochrome_workflow(const dt_image_t *img)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -278,11 +278,11 @@ int dt_image_is_hdr(const dt_image_t *img);
 /** set the monochrome flags if monochrome is TRUE and clear it otherwise */
 void dt_image_set_monochrome_flag(const int32_t imgid, gboolean monochrome);
 /** returns non-zero if this image was taken using a monochrome camera */
-int dt_image_is_monochrome(const dt_image_t *img);
+gboolean dt_image_is_monochrome(const dt_image_t *img);
 /** returns non-zero if the image supports a color correction matrix */
-int dt_image_is_matrix_correction_supported(const dt_image_t *img);
+gboolean dt_image_is_matrix_correction_supported(const dt_image_t *img);
 /** returns non-zero if the image supports the rawprepare module */
-int dt_image_is_rawprepare_supported(const dt_image_t *img);
+gboolean dt_image_is_rawprepare_supported(const dt_image_t *img);
 /** returns the bitmask containing info about monochrome images */
 int dt_image_monochrome_flags(const dt_image_t *img);
 /** returns true if the image has been tested to be monochrome and the image wants monochrome workflow */

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1365,11 +1365,8 @@ void reload_defaults(dt_iop_module_t *module)
 {
   dt_image_t *img = &module->dev->image_storage;
   // can't be switched on for non-raw or x-trans images:
-  if(dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) &&
-     !(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)))
-    module->hide_enable_button = 0;
-  else
-    module->hide_enable_button = 1;
+  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !(dt_image_is_monochrome(img)));
+  module->hide_enable_button = !active;
 }
 
 /** commit is the synch point between core and gui, so it copies params to pipe data. */
@@ -1380,8 +1377,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   dt_iop_cacorrect_data_t *d = (dt_iop_cacorrect_data_t *) piece->data;
 
   dt_image_t *img = &pipe->image;
-  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) &&
-     !(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)));
+  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !(dt_image_is_monochrome(img)));
 
   if(!active) piece->enabled = 0;
 
@@ -1407,8 +1403,8 @@ void gui_update(dt_iop_module_t *self)
 
   dt_image_t *img = &self->dev->image_storage;
 
-  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) &&
-     !(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)));
+  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !(dt_image_is_monochrome(img)));
+  self->hide_enable_button = !active;
 
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), active ? "raw" : "non_raw");
 
@@ -1427,8 +1423,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   dt_image_t *img = &self->dev->image_storage;
 
-  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) &&
-     !(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)));
+  const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !(dt_image_is_monochrome(img)));
 
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), active ? "raw" : "non_raw");
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3563,19 +3563,21 @@ void reload_defaults(dt_iop_module_t *module)
   // adaptation set we default to RGB (none) in this instance.
   // try to register the CAT here
   declare_cat_on_pipe(module, is_modern);
+  const dt_image_t *img = &module->dev->image_storage;
+
   // check if we could register
   gboolean CAT_already_applied =
     (module->dev->proxy.chroma_adaptation != NULL)       // CAT exists
-    && (module->dev->proxy.chroma_adaptation != module); // and it is not us
+    && (module->dev->proxy.chroma_adaptation != module)
+    && (!dt_image_is_monochrome(img)); // and it is not us
 
   module->default_enabled = FALSE;
-
-  const dt_image_t *img = &module->dev->image_storage;
 
   dt_aligned_pixel_t custom_wb;
   if(!CAT_already_applied
      && is_modern
-     && !get_white_balance_coeff(module, custom_wb))
+     && !get_white_balance_coeff(module, custom_wb)
+     && !dt_image_is_monochrome(img))
   {
     // if workflow = modern and we find WB coeffs, take care of white balance here
     if(find_temperature_from_raw_coeffs(img, custom_wb, &(d->x), &(d->y)))
@@ -3608,7 +3610,7 @@ void reload_defaults(dt_iop_module_t *module)
       g->delta_E_label_text = NULL;
     }
 
-    if(dt_image_is_matrix_correction_supported(img))
+    if(dt_image_is_matrix_correction_supported(img) && !dt_image_is_monochrome(img))
     {
       if(dt_bauhaus_combobox_length(g->illuminant) < DT_ILLUMINANT_CAMERA + 1)
         dt_bauhaus_combobox_add_full(g->illuminant, _("as shot in camera"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3567,9 +3567,9 @@ void reload_defaults(dt_iop_module_t *module)
 
   // check if we could register
   gboolean CAT_already_applied =
-    (module->dev->proxy.chroma_adaptation != NULL)       // CAT exists
-    && (module->dev->proxy.chroma_adaptation != module)
-    && (!dt_image_is_monochrome(img)); // and it is not us
+    (module->dev->proxy.chroma_adaptation != NULL)      // CAT exists
+    && (module->dev->proxy.chroma_adaptation != module) // and it is not us
+    && (!dt_image_is_monochrome(img));
 
   module->default_enabled = FALSE;
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1900,7 +1900,7 @@ void reload_defaults(dt_iop_module_t *module)
     d->type = color_profile;
   else if(img->flags & DT_IMAGE_4BAYER) // 4Bayer images have been pre-converted to rec2020
     d->type = DT_COLORSPACE_LIN_REC2020;
-  else if (img->flags & DT_IMAGE_MONOCHROME)
+  else if(dt_image_is_monochrome(img))
     d->type = DT_COLORSPACE_LIN_REC709;
   else if(img->colorspace == DT_IMAGE_COLORSPACE_SRGB)
     d->type = DT_COLORSPACE_SRGB;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1232,8 +1232,12 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
+  const gboolean monochrome = dt_image_is_monochrome(&self->dev->image_storage);
   dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
   dt_iop_colorreconstruct_params_t *p = (dt_iop_colorreconstruct_params_t *)self->params;
+
+  self->hide_enable_button = monochrome;
+  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), !monochrome ? "default" : "monochrome");
 
   dt_bauhaus_slider_set(g->threshold, p->threshold);
   dt_bauhaus_slider_set(g->spatial, p->spatial);
@@ -1281,6 +1285,8 @@ void gui_init(struct dt_iop_module_t *self)
   g->can = NULL;
   g->hash = 0;
 
+  GtkWidget *box_enabled = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
   dt_bauhaus_slider_set_step(g->threshold, 0.1f);
   g->spatial = dt_bauhaus_slider_from_params(self, N_("spatial"));
@@ -1307,6 +1313,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->range, _("how far to look for replacement colors in the luminance dimension"));
   gtk_widget_set_tooltip_text(g->precedence, _("if and how to give precedence to specific replacement colors"));
   gtk_widget_set_tooltip_text(g->hue, _("the hue tone which should be given precedence over other hue tones"));
+
+  GtkWidget *monochromes = dt_ui_label_new(_("not applicable"));
+  gtk_widget_set_tooltip_text(monochromes, _("no highlights reconstruction for monochrome images"));
+
+  self->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  gtk_stack_add_named(GTK_STACK(self->widget), monochromes, "monochrome");
+  gtk_stack_add_named(GTK_STACK(self->widget), box_enabled, "default");
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5710,7 +5710,12 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   changed ^= img->flags & DT_IMAGE_MONOCHROME_BAYER;
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
   if(changed)
+  {
     dt_imageio_update_monochrome_workflow_tag(self->dev->image_storage.id, mask_bw);
+    // only done if one of the passthrough monochrome demosaicers has changed
+    // we reload the image so all modules respect this setting
+    dt_dev_reload_image(self->dev, self->dev->image_storage.id);
+  }
 }
 void gui_update(struct dt_iop_module_t *self)
 {

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -301,8 +301,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 void reload_defaults(dt_iop_module_t *module)
 {
+  const dt_image_t *img = &module->dev->image_storage;
+  const gboolean enabled = dt_image_is_raw(img) && !dt_image_is_monochrome(img);
   // can't be switched on for non-raw images:
-  module->hide_enable_button = !dt_image_is_raw(&module->dev->image_storage);
+  module->hide_enable_button = !enabled;
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
@@ -316,7 +318,11 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   d->permissive = p->permissive;
   d->markfixed = p->markfixed && ((pipe->type & DT_DEV_PIXELPIPE_EXPORT) != DT_DEV_PIXELPIPE_EXPORT)
     && ((pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL) != DT_DEV_PIXELPIPE_THUMBNAIL);
-  if(!(dt_image_is_raw(&pipe->image)) || p->strength == 0.0) piece->enabled = 0;
+
+  const dt_image_t *img = &pipe->image;
+  const gboolean enabled = dt_image_is_raw(img) && !dt_image_is_monochrome(img);
+
+  if(!enabled || p->strength == 0.0) piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -341,6 +347,11 @@ void gui_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(g->permissive, p->permissive);
   g->pixels_fixed = -1;
   gtk_label_set_text(g->message, "");
+
+  const dt_image_t *img = &self->dev->image_storage;
+  const gboolean enabled = dt_image_is_raw(img) && !dt_image_is_monochrome(img);
+  // can't be switched on for non-raw images:
+  self->hide_enable_button = !enabled;
 
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
 }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1138,7 +1138,13 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
-  if(self->hide_enable_button) return;
+  const gboolean monochrome = dt_image_is_monochrome(&self->dev->image_storage);
+  const gboolean is_raw = dt_image_is_matrix_correction_supported(&self->dev->image_storage);
+  self->hide_enable_button = monochrome;  
+  self->default_enabled = is_raw;
+  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "disabled" : "enabled");
+
+//  if(self->hide_enable_button) return;
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -1429,6 +1435,7 @@ void reload_defaults(dt_iop_module_t *module)
   if(!module->dev || module->dev->image_storage.id == -1) return;
 
   const gboolean is_raw = dt_image_is_matrix_correction_supported(&module->dev->image_storage);
+  const gboolean monochrome = dt_image_is_monochrome(&module->dev->image_storage);
   const gboolean is_modern =
     dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
 
@@ -1438,7 +1445,7 @@ void reload_defaults(dt_iop_module_t *module)
   // White balance module doesn't need to be enabled for monochrome raws (like
   // for leica monochrom cameras). prepare_matrices is a noop as well, as there
   // isn't a color matrix, so we can skip that as well.
-  if(dt_image_is_monochrome(&(module->dev->image_storage)))
+  if(monochrome)
   {
     module->hide_enable_button = 1;
   }


### PR DESCRIPTION
True monochrome images like those from Leica and images from cameras that have the color
matrix filter in front of the sensor removed should be treated the same in the user interface
as much as possible.

1. The testing function dt_image_is_monochrome() tests for both types of sensors now.
   Also this function - plus a few others - are defined to return a gboolean now instead of int.

2. In colorin.c make sure we use DT_COLORSPACE_LIN_REC709 for both types of monochromes

3. The raw chromatic aberration module should be switched off for monochromes

4. Changing the demosaicer to one of the monochrome passthrough modes works flawlessly.
   But - a number of modules rely on a proper setting of being a monochrome image and the gui widgets need to be updated at runtime.
   To get this working `dt_dev_reload_image()` is executed if the `DT_IMAGE_MONOCHROME_BAYER`
   had changed leading to a complete new setup of all modules.

5. highlights reconstruction does not make sens for raw-monochromes at all, the module gets deactivated and can not be switched on.

6. temperature gets disabled for all monochromes

7. In channelmixerrgb we check for monochromes and set mode to pass in defaults.

8. No hotpixels for monchromes

