### PR TITLE
guides: refactor overlay color settings and add contrast

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1909,6 +1909,12 @@
     <shortdescription>expand the module when it is activated, and collapse it when disabled</shortdescription>
     <longdescription>this option allows to expand or collapse automatically the module when it is enabled or disabled.</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>darkroom/ui/overlay_contrast</name>
+    <type>float</type>
+    <default>0.5</default>
+    <shortdescription>contrast to use in darkroom overlays</shortdescription>
+  </dtconfig>
   <dtconfig prefs="lighttable" section="general">
     <name>lighttable/ui/scroll_to_module</name>
     <type>bool</type>

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2404,7 +2404,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
           cairo_set_line_width(cr, 5.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 3.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, 0.4, 0.8);
+        dt_draw_set_color_overlay(cr, FALSE, 0.9);
         cairo_stroke_preserve(cr);
         if(gui->group_selected == index && gui->seg_selected == seg2)
           cairo_set_line_width(cr, 5.0 / zoom_scale);
@@ -2413,7 +2413,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
           cairo_set_line_width(cr, 2.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 1.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, 0.8, 0.8);
+        dt_draw_set_color_overlay(cr, TRUE, 0.8);
         cairo_stroke(cr);
         // and we update the segment number
         seg = (seg + 1) % nb;
@@ -2437,7 +2437,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       {
         anchor_size = 5.0f / zoom_scale;
       }
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
+      dt_draw_set_color_overlay(cr, TRUE, 0.8);
       cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5),
                       gpt->points[k * 6 + 3] - (anchor_size * 0.5), anchor_size, anchor_size);
       cairo_fill_preserve(cr);
@@ -2449,7 +2449,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
+      dt_draw_set_color_overlay(cr, FALSE, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -2471,21 +2471,21 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
     cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke_preserve(cr);
     cairo_set_line_width(cr, 0.75 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
 
     if((gui->group_selected == index) && (k == gui->feather_dragging || k == gui->feather_selected))
       cairo_arc(cr, ffx, ffy, 3.0f / zoom_scale, 0, 2.0 * M_PI);
     else
       cairo_arc(cr, ffx, ffy, 1.5f / zoom_scale, 0, 2.0 * M_PI);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_fill_preserve(cr);
 
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke(cr);
   }
 
@@ -2503,14 +2503,14 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_set_dash(cr, dashed, len, 0);
     cairo_stroke_preserve(cr);
     if(gui->border_selected)
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
 
@@ -2554,13 +2554,13 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
 
     // we draw the source
@@ -2569,7 +2569,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     for(int i = nb * 3; i < gpt->source_count; i++) cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
     cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
@@ -2578,7 +2578,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -567,7 +567,7 @@ static void _circle_draw_lines(gboolean borders, gboolean source, cairo_t *cr, d
     else
       cairo_set_line_width(cr, 3.0 / zoom_scale);
   }
-  dt_draw_set_color_overlay(cr, 0.3, 0.8);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
   cairo_move_to(cr, points[2], points[3]);
   for(int i = 2; i < points_count; i++)
@@ -591,7 +591,7 @@ static void _circle_draw_lines(gboolean borders, gboolean source, cairo_t *cr, d
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
   }
-  dt_draw_set_color_overlay(cr, 0.8, 0.8);
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_stroke(cr);
 }
 
@@ -837,13 +837,13 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
         cairo_set_line_width(cr, 2.5 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
+      dt_draw_set_color_overlay(cr, FALSE, 0.8);
       cairo_stroke_preserve(cr);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
         cairo_set_line_width(cr, 1.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 0.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
+      dt_draw_set_color_overlay(cr, TRUE, 0.8);
       cairo_stroke(cr);
     }
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -212,7 +212,7 @@ static void _ellipse_draw_shape(cairo_t *cr, double *dashed, const int selected,
     cairo_set_line_width(cr, 5.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 3.0 / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 0.8);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
   _ellipse_point_transform(xref, yref, points[10], points[11], sinr, cosr, &x, &y);
   cairo_move_to(cr, x, y);
@@ -228,7 +228,7 @@ static void _ellipse_draw_shape(cairo_t *cr, double *dashed, const int selected,
     cairo_set_line_width(cr, 2.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.8, 0.8);
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_stroke(cr);
 }
 
@@ -250,7 +250,7 @@ static void _ellipse_draw_border(cairo_t *cr, double *dashed, const float len, c
     cairo_set_line_width(cr, 2.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 0.8);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
   _ellipse_point_transform(xref, yref, border[10], border[11], sinr, cosr, &x, &y);
   cairo_move_to(cr, x, y);
@@ -267,7 +267,7 @@ static void _ellipse_draw_border(cairo_t *cr, double *dashed, const float len, c
     cairo_set_line_width(cr, 2.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.8, 0.8);
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_set_dash(cr, dashed, len, 4);
   cairo_stroke(cr);
 }
@@ -1474,7 +1474,7 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
     for(int i = 1; i < 5; i++)
     {
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
+      dt_draw_set_color_overlay(cr, TRUE, 0.8);
 
       if(i == gui->point_dragging || i == gui->point_selected)
         anchor_size = 7.0f / zoom_scale;
@@ -1490,7 +1490,7 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
+      dt_draw_set_color_overlay(cr, FALSE, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -1592,13 +1592,13 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
         cairo_set_line_width(cr, 2.5 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
+      dt_draw_set_color_overlay(cr, FALSE, 0.8);
       cairo_stroke_preserve(cr);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
         cairo_set_line_width(cr, 1.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 0.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
+      dt_draw_set_color_overlay(cr, TRUE, 0.8);
       cairo_stroke(cr);
     }
 
@@ -1608,7 +1608,7 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     _ellipse_point_transform(xrefs, yrefs, gpt->source[10], gpt->source[11], sinr, cosr, &x, &y);
     cairo_move_to(cr, x, y);
     for(int i = 6; i < gpt->source_count; i++)
@@ -1623,7 +1623,7 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -844,7 +844,7 @@ static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, 
       else
         cairo_set_line_width(cr, 3.0 / zoom_scale);
     }
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
     cairo_move_to(cr, x, y);
 
@@ -860,7 +860,7 @@ static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, 
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
   }
 }
@@ -881,7 +881,7 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
   {
     cairo_set_dash(cr, dashed, 0, 0);
     const float anchor_size = (selected) ? 7.0f / zoom_scale : 5.0f / zoom_scale;
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_rectangle(cr, anchor_x - (anchor_size * 0.5), anchor_y - (anchor_size * 0.5), anchor_size, anchor_size);
     cairo_fill_preserve(cr);
 
@@ -889,7 +889,7 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke(cr);
   }
 
@@ -901,16 +901,16 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
     // from start to end
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_move_to(cr, pivot_start_x, pivot_start_y);
     cairo_line_to(cr, pivot_end_x, pivot_end_y);
     cairo_stroke(cr);
 
     // start side of the gradient
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
     cairo_fill_preserve(cr);
     cairo_stroke(cr);
@@ -918,7 +918,7 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
     // end side of the gradient
     cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
     cairo_fill_preserve(cr);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke(cr);
 
     // draw arrow on the end of the gradient to clearly display the direction
@@ -936,7 +936,7 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
     const float arrow_y1 = pivot_end_y + (arrow_length * sinf(angle + arrow_angle));
     const float arrow_y2 = pivot_end_y + (arrow_length * sinf(angle - arrow_angle));
 
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_move_to(cr, pivot_end_x, pivot_end_y);
     cairo_line_to(cr, arrow_x1, arrow_y1);
     cairo_line_to(cr, arrow_x2, arrow_y2);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2008,14 +2008,14 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
           cairo_set_line_width(cr, 5.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 3.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, 0.3, 0.8);
+        dt_draw_set_color_overlay(cr, FALSE, 0.8);
         cairo_stroke_preserve(cr);
         if((gui->group_selected == index)
            && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2))
           cairo_set_line_width(cr, 2.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 1.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, 0.8, 0.8);
+        dt_draw_set_color_overlay(cr, TRUE, 0.8);
         cairo_stroke(cr);
         // and we update the segment number
         seg = (seg + 1) % nb;
@@ -2039,7 +2039,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       {
         anchor_size = 5.0f / zoom_scale;
       }
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
+      dt_draw_set_color_overlay(cr, TRUE, 0.8);
       cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5),
                       gpt->points[k * 6 + 3] - (anchor_size * 0.5), anchor_size, anchor_size);
       cairo_fill_preserve(cr);
@@ -2051,7 +2051,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
+      dt_draw_set_color_overlay(cr, FALSE, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -2073,21 +2073,21 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
     cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke_preserve(cr);
     cairo_set_line_width(cr, 0.75 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
 
     if((gui->group_selected == index) && (k == gui->feather_dragging || k == gui->feather_selected))
       cairo_arc(cr, ffx, ffy, 3.0f / zoom_scale, 0, 2.0 * M_PI);
     else
       cairo_arc(cr, ffx, ffy, 1.5f / zoom_scale, 0, 2.0 * M_PI);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_fill_preserve(cr);
 
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke(cr);
   }
 
@@ -2116,14 +2116,14 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_set_dash(cr, dashed, len, 0);
     cairo_stroke_preserve(cr);
     if(gui->border_selected)
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
 
@@ -2139,7 +2139,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       {
         anchor_size = 5.0f / zoom_scale;
       }
-      dt_draw_set_color_overlay(cr, 0.8, 0.8);
+      dt_draw_set_color_overlay(cr, TRUE, 0.8);
       cairo_rectangle(cr, gpt->border[k * 6] - (anchor_size * 0.5), gpt->border[k * 6 + 1] - (anchor_size * 0.5),
                       anchor_size, anchor_size);
       cairo_fill_preserve(cr);
@@ -2148,7 +2148,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.3, 0.8);
+      dt_draw_set_color_overlay(cr, FALSE, 0.8);
       cairo_set_dash(cr, dashed, 0, 0);
       cairo_stroke(cr);
     }
@@ -2198,13 +2198,13 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
 
     // we draw the source
@@ -2213,7 +2213,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 0.8);
+    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     for(int i = nb * 3; i < gpt->source_count; i++) cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
     cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
@@ -2222,7 +2222,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.8, 0.8);
+    dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -50,33 +50,7 @@ typedef struct dt_draw_curve_t
 /** set color based on gui overlay preference */
 static inline void dt_draw_set_color_overlay(cairo_t *cr, double amt, double alpha)
 {
-  const int overlay_color = dt_conf_get_int("darkroom/ui/overlay_color");
-
-  if(overlay_color == DT_DEV_OVERLAY_GRAY)
-  {
-    cairo_set_source_rgba(cr, 1.0 * amt, 1.0 * amt, 1.0 * amt, alpha);
-  }
-  else if(overlay_color == DT_DEV_OVERLAY_RED)
-  {
-    cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 0.0, alpha);
-  }
-  else if(overlay_color == DT_DEV_OVERLAY_GREEN)
-  {
-    cairo_set_source_rgba(cr, 0.0, 1.0 * amt, 0.0, alpha);
-  }
-  else if(overlay_color == DT_DEV_OVERLAY_YELLOW)
-  {
-    cairo_set_source_rgba(cr, 1.0 * amt, 1.0 * amt, 0.0, alpha);
-  }
-  else if(overlay_color == DT_DEV_OVERLAY_CYAN)
-  {
-    cairo_set_source_rgba(cr, 0.0, 1.0 * amt, 1.0 * amt, alpha);
-  }
-  else if(overlay_color == DT_DEV_OVERLAY_MAGENTA)
-  {
-    cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 1.0 * amt, alpha);
-  }
-
+  cairo_set_source_rgba(cr, darktable.gui->overlay_red * amt, darktable.gui->overlay_green * amt, darktable.gui->overlay_blue * amt, alpha);
 }
 
 /** draws a rating star

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -48,12 +48,15 @@ typedef struct dt_draw_curve_t
 } dt_draw_curve_t;
 
 /** set color based on gui overlay preference */
-static inline void dt_draw_set_color_overlay(cairo_t *cr, double amt, double alpha)
+static inline void dt_draw_set_color_overlay(cairo_t *cr, gboolean bright, double alpha)
 {
-  if(amt > 0.5)
+  double amt;
+
+  if(bright)
     amt = 0.5 + darktable.gui->overlay_contrast * 0.5;
   else
     amt = (1.0 - darktable.gui->overlay_contrast) * 0.5;
+
   cairo_set_source_rgba(cr, darktable.gui->overlay_red * amt, darktable.gui->overlay_green * amt, darktable.gui->overlay_blue * amt, alpha);
 }
 

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -50,6 +50,10 @@ typedef struct dt_draw_curve_t
 /** set color based on gui overlay preference */
 static inline void dt_draw_set_color_overlay(cairo_t *cr, double amt, double alpha)
 {
+  if(amt > 0.5)
+    amt = 0.5 + darktable.gui->overlay_contrast * 0.5;
+  else
+    amt = (1.0 - darktable.gui->overlay_contrast) * 0.5;
   cairo_set_source_rgba(cr, darktable.gui->overlay_red * amt, darktable.gui->overlay_green * amt, darktable.gui->overlay_blue * amt, alpha);
 }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -25,6 +25,7 @@
 #include "common/file_location.h"
 #include "common/image.h"
 #include "common/image_cache.h"
+#include "gui/guides.h"
 #include "bauhaus/bauhaus.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -1135,6 +1136,9 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   // Initializing widgets
   _init_widgets(gui);
+
+  //init overlay colors
+  dt_guides_set_overlay_colors(dt_conf_get_int("darkroom/ui/overlay_color"));
 
   /* Have the delete event (window close) end the program */
   snprintf(path, sizeof(path), "%s/icons", datadir);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1138,7 +1138,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   _init_widgets(gui);
 
   //init overlay colors
-  dt_guides_set_overlay_colors(dt_conf_get_int("darkroom/ui/overlay_color"));
+  dt_guides_set_overlay_colors();
 
   /* Have the delete event (window close) end the program */
   snprintf(path, sizeof(path), "%s/icons", datadir);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -123,7 +123,7 @@ typedef struct dt_gui_gtk_t
 
   gboolean show_overlays;
   gboolean show_focus_peaking;
-  double overlay_red, overlay_blue, overlay_green;
+  double overlay_red, overlay_blue, overlay_green, overlay_contrast;
   GtkWidget *focus_peaking_button;
 
   double dpi, dpi_factor, ppd, ppd_thb;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -123,6 +123,7 @@ typedef struct dt_gui_gtk_t
 
   gboolean show_overlays;
   gboolean show_focus_peaking;
+  double overlay_red, overlay_blue, overlay_green;
   GtkWidget *focus_peaking_button;
 
   double dpi, dpi_factor, ppd, ppd_thb;

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -651,9 +651,29 @@ static void _settings_flip_changed(GtkWidget *w, _guides_settings_t *gw)
   dt_control_queue_redraw_center();
 }
 
+void dt_guides_set_overlay_colors(int overlay_color)
+{
+  darktable.gui->overlay_red = darktable.gui->overlay_green = darktable.gui->overlay_blue = 0.0f;
+
+  if(overlay_color == DT_DEV_OVERLAY_GRAY)
+    darktable.gui->overlay_red = darktable.gui->overlay_green = darktable.gui->overlay_blue = 1.0f;
+  else if(overlay_color == DT_DEV_OVERLAY_RED)
+    darktable.gui->overlay_red = 1.0f;
+  else if(overlay_color == DT_DEV_OVERLAY_GREEN)
+    darktable.gui->overlay_green = 1.0f;
+  else if(overlay_color == DT_DEV_OVERLAY_YELLOW)
+    darktable.gui->overlay_red = darktable.gui->overlay_green = 1.0f;
+  else if(overlay_color == DT_DEV_OVERLAY_CYAN)
+    darktable.gui->overlay_green = darktable.gui->overlay_blue = 1.0f;
+  else if(overlay_color == DT_DEV_OVERLAY_MAGENTA)
+    darktable.gui->overlay_red = darktable.gui->overlay_blue = 1.0f;
+}
+
 static void _settings_colors_changed(GtkWidget *combo, _guides_settings_t *gw)
 {
-  dt_conf_set_int("darkroom/ui/overlay_color", dt_bauhaus_combobox_get(combo));
+  const int overlay_color = dt_bauhaus_combobox_get(combo);
+  dt_conf_set_int("darkroom/ui/overlay_color", overlay_color);
+  dt_guides_set_overlay_colors(overlay_color);
   dt_control_queue_redraw_center();
 }
 

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -163,21 +163,21 @@ static void dt_guides_draw_grid(cairo_t *cr, const float x, const float y, const
   cairo_set_line_width(cr, 1.0 / zoom_scale);
 
   cairo_set_dash(cr, &dashes, 1, 0);
-  dt_draw_set_color_overlay(cr, 0.2, 0.3);
+  dt_draw_set_color_overlay(cr, FALSE, 0.3);
   dt_draw_horizontal_lines(cr, (1 + nbh) * (1 + subdiv), x, y, right, bottom);
   dt_draw_vertical_lines(cr, (1 + nbv) * (1 + subdiv), x, y, right, bottom);
   cairo_set_dash(cr, &dashes, 1, dashes);
-  dt_draw_set_color_overlay(cr, 0.8, 0.3);
+  dt_draw_set_color_overlay(cr, TRUE, 0.3);
   dt_draw_horizontal_lines(cr, (1 + nbh) * (1 + subdiv), x, y, right, bottom);
   dt_draw_vertical_lines(cr, (1 + nbv) * (1 + subdiv), x, y, right, bottom);
 
   cairo_set_dash(cr, &dashes, 1, 0);
-  dt_draw_set_color_overlay(cr, 0.2, 0.5);
+  dt_draw_set_color_overlay(cr, FALSE, 0.5);
   dt_draw_horizontal_lines(cr, 1 + nbh, x, y, right, bottom);
   dt_draw_vertical_lines(cr, 1 + nbv, x, y, right, bottom);
 
   cairo_set_dash(cr, &dashes, 1, dashes);
-  dt_draw_set_color_overlay(cr, 0.8, 0.5);
+  dt_draw_set_color_overlay(cr, TRUE, 0.5);
   dt_draw_horizontal_lines(cr, 1 + nbh, x, y, right, bottom);
   dt_draw_vertical_lines(cr, 1 + nbv, x, y, right, bottom);
 }
@@ -807,7 +807,7 @@ void dt_guides_draw(cairo_t *cr, const float left, const float top, const float 
   cairo_rectangle(cr, left, top, width, height);
   cairo_clip(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 1.0);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_set_dash(cr, &dashes, 0, 0);
 
   // Move coordinates to local center selection.
@@ -823,7 +823,7 @@ void dt_guides_draw(cairo_t *cr, const float left, const float top, const float 
 
   cairo_stroke_preserve(cr);
   cairo_set_dash(cr, &dashes, 1, 0);
-  dt_draw_set_color_overlay(cr, 0.8, 1.0);
+  dt_draw_set_color_overlay(cr, TRUE, 1.0);
   cairo_stroke(cr);
 
   cairo_restore(cr);

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -61,6 +61,8 @@ void dt_guides_add_module_menuitem(void *menu, struct dt_iop_module_t *module);
 void dt_guides_init_module_widget(GtkWidget *box, struct dt_iop_module_t *module);
 void dt_guides_update_module_widget(struct dt_iop_module_t *module);
 
+void dt_guides_set_overlay_colors(int overlay_color);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -61,7 +61,7 @@ void dt_guides_add_module_menuitem(void *menu, struct dt_iop_module_t *module);
 void dt_guides_init_module_widget(GtkWidget *box, struct dt_iop_module_t *module);
 void dt_guides_update_module_widget(struct dt_iop_module_t *module);
 
-void dt_guides_set_overlay_colors(int overlay_color);
+void dt_guides_set_overlay_colors();
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3947,7 +3947,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_fill(cr);
 
     // draw white outline around clipping area
-    dt_draw_set_color_overlay(cr, 0.7, 1.0);
+    dt_draw_set_color_overlay(cr, TRUE, 1.0);
     cairo_set_line_width(cr, 2.0 / zoom_scale);
     cairo_move_to(cr, C[0][0], C[0][1]);
     cairo_line_to(cr, C[1][0], C[1][1]);
@@ -3980,13 +3980,13 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
       const double size_arrow = base_size / 25.0f;
 
       cairo_set_line_width(cr, 2.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.7, 1.0);
+      dt_draw_set_color_overlay(cr, TRUE, 1.0);
       cairo_arc (cr, xpos, ypos, size_circle, 0, 2.0 * M_PI);
       cairo_stroke(cr);
       cairo_fill(cr);
 
       cairo_set_line_width(cr, 2.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, 0.7, 1.0);
+      dt_draw_set_color_overlay(cr, TRUE, 1.0);
 
       // horizontal line
       cairo_move_to(cr, xpos - size_line, ypos);
@@ -4030,7 +4030,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_scale(cr, zoom_scale, zoom_scale);
     cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
-    dt_draw_set_color_overlay(cr, 0.3, 1.0);
+    dt_draw_set_color_overlay(cr, FALSE, 1.0);
 
     float pzx, pzy;
     dt_dev_get_pointer_zoom_pos(dev, pointerx, pointery, &pzx, &pzy);
@@ -4193,7 +4193,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   if((g->current_structure_method == ASHIFT_METHOD_QUAD || g->current_structure_method == ASHIFT_METHOD_LINES)
      && g->draw_points)
   {
-    dt_draw_set_color_overlay(cr, 0.3, 1.0);
+    dt_draw_set_color_overlay(cr, FALSE, 1.0);
     const int nb = (g->current_structure_method == ASHIFT_METHOD_LINES) ? g->lines_count * 2 : 4;
     for(int i = 0; i < nb; i++)
     {

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2348,7 +2348,7 @@ static void gui_draw_sym(cairo_t *cr, float x, float y, float scale, gboolean ac
   pango_layout_set_font_description(layout, desc);
   pango_layout_set_text(layout, "ꝏ", -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
-  dt_draw_set_color_overlay(cr, 0.5, 0.7);
+  dt_draw_set_color_overlay(cr, TRUE, 0.5);
   dt_gui_draw_rounded_rectangle(
       cr, ink.width + DT_PIXEL_APPLY_DPI(4) * scale, ink.height + DT_PIXEL_APPLY_DPI(8) * scale,
       x - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(2) * scale, y - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(4) * scale);
@@ -2409,7 +2409,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   {
     cairo_set_line_width(cr, dashes / 2.0);
     cairo_rectangle(cr, g->clip_x * wd, g->clip_y * ht, g->clip_w * wd, g->clip_h * ht);
-    dt_draw_set_color_overlay(cr, 0.7, 1.0);
+    dt_draw_set_color_overlay(cr, TRUE, 1.0);
     cairo_stroke(cr);
   }
 
@@ -2458,7 +2458,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_guides_draw(cr, g->clip_x * wd, g->clip_y * ht, g->clip_w * wd, g->clip_h * ht, zoom_scale);
 
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 1.0);
+  dt_draw_set_color_overlay(cr, FALSE, 1.0);
   const int border = DT_PIXEL_APPLY_DPI(30.0) / zoom_scale;
   if(g->straightening)
   {
@@ -2722,7 +2722,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                                     c[0] - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(4) * pr_d,
                                     c[1] - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(6) * pr_d);
       cairo_move_to(cr, c[0] - ink.width / 2.0, c[1] - 3.0 * ink.height / 4.0);
-      dt_draw_set_color_overlay(cr, 0.2, 0.9);
+      dt_draw_set_color_overlay(cr, FALSE, 0.9);
       pango_cairo_show_layout(cr, layout);
       pango_font_description_free(desc);
       g_object_unref(layout);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1348,7 +1348,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   {
     cairo_set_line_width(cr, dashes / 2.0);
     cairo_rectangle(cr, g->clip_x * wd, g->clip_y * ht, g->clip_w * wd, g->clip_h * ht);
-    dt_draw_set_color_overlay(cr, 0.7, 1.0);
+    dt_draw_set_color_overlay(cr, TRUE, 1.0);
     cairo_stroke(cr);
   }
 
@@ -1397,7 +1397,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_guides_draw(cr, g->clip_x * wd, g->clip_y * ht, g->clip_w * wd, g->clip_h * ht, zoom_scale);
 
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 1.0);
+  dt_draw_set_color_overlay(cr, FALSE, 1.0);
   const int border = DT_PIXEL_APPLY_DPI(30.0) / zoom_scale;
 
   const _grab_region_t grab = g->cropping ? g->cropping : _gui_get_grab(pzx, pzy, g, border, wd, ht);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -499,7 +499,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(5.0) / zoom_scale);
   else
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 0.8);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
   cairo_move_to(cr, xa, ya);
   cairo_line_to(cr, xb, yb);
@@ -509,7 +509,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
   else
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.8, 0.8);
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_move_to(cr, xa, ya);
   cairo_line_to(cr, xb, yb);
   cairo_stroke(cr);
@@ -531,14 +531,14 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_close_path(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
   if(g->selected == 1 || g->dragging == 1)
-    dt_draw_set_color_overlay(cr, 0.8, 1.0);
+    dt_draw_set_color_overlay(cr, TRUE, 1.0);
   else
-    dt_draw_set_color_overlay(cr, 0.8, 0.5);
+    dt_draw_set_color_overlay(cr, TRUE, 0.5);
   cairo_fill_preserve(cr);
   if(g->selected == 1 || g->dragging == 1)
-    dt_draw_set_color_overlay(cr, 0.3, 1.0);
+    dt_draw_set_color_overlay(cr, FALSE, 1.0);
   else
-    dt_draw_set_color_overlay(cr, 0.3, 0.5);
+    dt_draw_set_color_overlay(cr, FALSE, 0.5);
   cairo_stroke(cr);
 
   x1 = xb - (xb - xa) * ext / l;
@@ -553,14 +553,14 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_close_path(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
   if(g->selected == 2 || g->dragging == 2)
-    dt_draw_set_color_overlay(cr, 0.8, 1.0);
+    dt_draw_set_color_overlay(cr, TRUE, 1.0);
   else
-    dt_draw_set_color_overlay(cr, 0.8, 0.5);
+    dt_draw_set_color_overlay(cr, TRUE, 0.5);
   cairo_fill_preserve(cr);
   if(g->selected == 2 || g->dragging == 2)
-    dt_draw_set_color_overlay(cr, 0.3, 1.0);
+    dt_draw_set_color_overlay(cr, FALSE, 1.0);
   else
-    dt_draw_set_color_overlay(cr, 0.3, 0.5);
+    dt_draw_set_color_overlay(cr, FALSE, 0.5);
   cairo_stroke(cr);
 }
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -413,10 +413,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                       -vignette_fy, zoom_scale);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.3, 0.8);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
-  dt_draw_set_color_overlay(cr, 0.8, 0.8);
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);
 }
 

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -136,7 +136,7 @@ static void _draw_sym(cairo_t *cr, float x, float y, gboolean vertical, gboolean
   else
     cairo_move_to(cr, x - (ink.width / 2.0), y + (-inv * (ink.height * 1.2f) - DT_PIXEL_APPLY_DPI(2)));
 
-  dt_draw_set_color_overlay(cr, 0.3, 0.9);
+  dt_draw_set_color_overlay(cr, FALSE, 0.9);
   pango_cairo_show_layout(cr, layout);
   pango_font_description_free(desc);
   g_object_unref(layout);
@@ -183,7 +183,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     cairo_fill(cri);
 
     // draw the split line using the selected overlay color
-    dt_draw_set_color_overlay(cri, 0.8, 0.7);
+    dt_draw_set_color_overlay(cri, TRUE, 0.7);
 
     cairo_set_line_width(cri, 1.);
 
@@ -247,7 +247,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
       const gint ry = (d->vertical ? height * 0.5 : height * d->vp_ypointer) - (s * 0.5);
 
       const gboolean display_rotation = (abs(pointerx - rx) < 40) && (abs(pointery - ry) < 40);
-      dt_draw_set_color_overlay(cri, 0.8, display_rotation ? 1.0 : 0.3);
+      dt_draw_set_color_overlay(cri, TRUE, display_rotation ? 1.0 : 0.3);
 
       cairo_set_line_width(cri, 0.5);
       dtgtk_cairo_paint_refresh(cri, rx, ry, s, s, 0, NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2026,6 +2026,7 @@ static gboolean _overlay_cycle_callback(GtkAccelGroup *accel_group, GObject *acc
   const int currentval = dt_conf_get_int("darkroom/ui/overlay_color");
   const int nextval = (currentval + 1) % 5; // colors can go from 0 to 5
   dt_conf_set_int("darkroom/ui/overlay_color", nextval);
+  dt_guides_set_overlay_colors(nextval);
   dt_control_queue_redraw_center();
   return TRUE;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2026,7 +2026,7 @@ static gboolean _overlay_cycle_callback(GtkAccelGroup *accel_group, GObject *acc
   const int currentval = dt_conf_get_int("darkroom/ui/overlay_color");
   const int nextval = (currentval + 1) % 5; // colors can go from 0 to 5
   dt_conf_set_int("darkroom/ui/overlay_color", nextval);
-  dt_guides_set_overlay_colors(nextval);
+  dt_guides_set_overlay_colors();
   dt_control_queue_redraw_center();
   return TRUE;
 }

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -229,7 +229,7 @@ typedef struct dt_view_manager_t
   } audio;
 
   // toggle button for guides (in the module toolbox)
-  GtkWidget *guides_toggle, *guides, *guides_colors, *guides_popover;
+  GtkWidget *guides_toggle, *guides, *guides_colors, *guides_contrast, *guides_popover;
 
   /*
    * Proxy


### PR DESCRIPTION
Set the r,g,b colors for darkroom overlays once and store to darktable.gui for use in drawing code. This avoids constant retrieval of configuration value on draw

Also adds a new "contrast" slider, to increase the contrast between light and dark parts of dashed lines in overlays.

This probably now supersedes #11058.