### PR TITLE
Respect high_quality setting while exporting (bugfix 11068)

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -812,10 +812,12 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     sRGB = 0;
   }
 
+  // if is_scaling is used don't override high_quality
   // get only once at the beginning, in case the user changes it on the way:
   const gboolean high_quality_processing
       = ((format_params->max_width == 0 || format_params->max_width >= pipe.processed_width)
-         && (format_params->max_height == 0 || format_params->max_height >= pipe.processed_height))
+         && (format_params->max_height == 0 || format_params->max_height >= pipe.processed_height)
+         && !is_scaling)
             ? FALSE
             : high_quality;
 
@@ -920,16 +922,16 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
       }
     }
 
-    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] imgid %d, pipe %ix%i, range %ix%i --> exact %i, upscale %i, corrected %i, scale %.7f, corr %.6f, size %ix%i\n",
+    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] imgid %d, pipe %ix%i, range %ix%i --> exact %i, upscale %i, hq %i, corrected %i, scale %.7f, corr %.6f, size %ix%i\n",
              imgid, pipe.processed_width, pipe.processed_height, format_params->max_width, format_params->max_height,
-             exact_size, upscale, corrected, scale, corrscale, processed_width, processed_height);
+             exact_size, upscale, high_quality_processing, corrected, scale, corrscale, processed_width, processed_height);
   }
   else
   {
     processed_width = floor(scale * pipe.processed_width);
     processed_height = floor(scale * pipe.processed_height);
-    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] (direct) imgid %d, pipe %ix%i, range %ix%i --> size %ix%i / %ix%i\n",
-             imgid, pipe.processed_width, pipe.processed_height, format_params->max_width, format_params->max_height,
+    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] (direct) imgid %d, hq %i, pipe %ix%i, range %ix%i --> size %ix%i / %ix%i\n",
+             imgid, high_quality_processing, pipe.processed_width, pipe.processed_height, format_params->max_width, format_params->max_height,
              processed_width, processed_height, width, height);
   }
 


### PR DESCRIPTION
As reported by @kofa73 in #11068 we might export files via low-quality processing if we set the size
using  "by scale".

In addition to the report - to reproduce - the issue was evident only if there was no data in
the "by size" fields so it got unnoticed.

Fixes #11068

@TurboGit a bugfix still for 3.8.1 ?