### PR TITLE
Update README - Clang 13.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Building
 ### Dependencies
 
 Compatible compilers:
-* Clang: 8, 9, 10
+* Clang: 8, 9, 10, 13
 * GCC: 8, 9, 10
 * Mingw64: 6, 7
 


### PR DESCRIPTION
I successfully compiled darktable for tigerlake CPU without issue on my Arch Linux with Clang 13.0.1-1, darktable works without any issues.

Operating System: Arch Linux
KDE Plasma Version: 5.23.5
KDE Frameworks Version: 5.90.0
Qt Version: 5.15.2
Kernel Version: 5.16.8-1-cachyos-bore-lto (64-bit)
Graphics Platform: Wayland
Processors: 8 × 11th Gen Intel® Core™ i5-1135G7 @ 2.40GHz
Memory: 7.5 GiB of RAM
Graphics Processor: Mesa Intel® Xe Graphics