### PR TITLE
Split culling mode in restricted and unrestricted (selection)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1373,6 +1373,20 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/culling_num_images_previous</name>
+    <type>int</type>
+    <default>2</default>
+    <shortdescription>number of images to display in culling when deactivating max_zoom_btn</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/max_zoom_btn</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>max zoom button position</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/culling_zoom_mode</name>
     <type>int</type>
     <default>0</default>

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2265,16 +2265,7 @@ void dt_collection_hint_message(const dt_collection_t *collection)
   const int c = dt_collection_get_count_no_group(collection);
   const int cs = dt_collection_get_selected_count(collection);
 
-  // no selection
-  if(cs == 0)
-  {
-    if(c == 1)
-      message = g_strdup_printf(_("%d image in current collection"), c);
-    else
-      message = g_strdup_printf(_("%d images in current collection"), c);
-  }
-  // exactly 1 image selected
-  else if(cs == 1)
+  if(cs == 1)
   {
     /* determine offset of the single selected image */
     GList *selected_imgids = dt_collection_get_selected(collection, 1);
@@ -2287,15 +2278,14 @@ void dt_collection_hint_message(const dt_collection_t *collection)
       selected++;
     }
     g_list_free(selected_imgids);
-    message = g_strdup_printf(_("selected %d image of %d (#%d) in current collection"), cs, c, selected);
+    message = g_strdup_printf(_("%d image of %d (#%d) in current collection is selected"), cs, c, selected);
   }
-  // more images selected
   else
   {
     message = g_strdup_printf(
       ngettext(
-        "selected %d image of %d in current collection",
-        "selected %d images of %d in current collection",
+        "%d image of %d in current collection is selected",
+        "%d images of %d in current collection are selected",
         cs),
       cs, c);
   }

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2265,7 +2265,16 @@ void dt_collection_hint_message(const dt_collection_t *collection)
   const int c = dt_collection_get_count_no_group(collection);
   const int cs = dt_collection_get_selected_count(collection);
 
-  if(cs == 1)
+  // no selection
+  if(cs == 0)
+  {
+    if(c == 1)
+      message = g_strdup_printf(_("%d image in current collection"), c);
+    else
+      message = g_strdup_printf(_("%d images in current collection"), c);
+  }
+  // exactly 1 image selected
+  else if(cs == 1)
   {
     /* determine offset of the single selected image */
     GList *selected_imgids = dt_collection_get_selected(collection, 1);
@@ -2278,14 +2287,15 @@ void dt_collection_hint_message(const dt_collection_t *collection)
       selected++;
     }
     g_list_free(selected_imgids);
-    message = g_strdup_printf(_("%d image of %d (#%d) in current collection is selected"), cs, c, selected);
+    message = g_strdup_printf(_("selected %d image of %d (#%d) in current collection"), cs, c, selected);
   }
+  // more images selected
   else
   {
     message = g_strdup_printf(
       ngettext(
-        "%d image of %d in current collection is selected",
-        "%d images of %d in current collection are selected",
+        "selected %d image of %d in current collection",
+        "selected %d images of %d in current collection",
         cs),
       cs, c);
   }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -3066,6 +3066,23 @@ void dtgtk_cairo_paint_lt_mode_fullpreview(cairo_t *cr, gint x, gint y, gint w, 
   FINISH
 }
 
+void dtgtk_cairo_paint_lt_btn_maxzoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  cairo_set_font_size (cr, DT_PIXEL_APPLY_DPI(0.4f));
+  cairo_text_extents_t te;
+  cairo_text_extents(cr, "dyn", &te);
+
+  PREAMBLE(1.4, 0, 0)
+
+  cairo_rectangle(cr, 0.05, 0.22, 0.95, 0.56);
+  cairo_stroke(cr);
+
+  cairo_move_to (cr, 0.09, 0.6);
+  cairo_show_text (cr, "dyn");
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -319,6 +319,10 @@ void dtgtk_cairo_paint_lt_mode_culling_dynamic(cairo_t *cr, gint x, gint y, gint
 /** Lighttable: Full Preview */
 void dtgtk_cairo_paint_lt_mode_fullpreview(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
+
+// Max zoom buttons
+void dtgtk_cairo_paint_lt_btn_maxzoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
 /** Paint a link icon for basic adjustments */
 void dtgtk_cairo_paint_link(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1412,7 +1412,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     g_signal_connect(G_OBJECT(thumb->w_altered), "leave-notify-event", G_CALLBACK(_event_btn_enter_leave), thumb);
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_altered);
 
-    // the group bouton
+    // the group button
     thumb->w_group = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_grouping, CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_name(thumb->w_group, "thumb_group");
     g_signal_connect(G_OBJECT(thumb->w_group), "button-release-event", G_CALLBACK(_event_grouping_release), thumb);


### PR DESCRIPTION
This PR contains some of the changes from #10728 which needed to be split because that PR was growing too big.

The changes in this PR are a prerequisit to everything in #10728 and #6025 because the new images_to_act_on algorithm prioritizes selected images over everything else and that would be a problem in culling because here a selection can act like a sub-collection (restricting movement). If we were to always act on all selected images, culling and culling dynamic would not work anymore. 

**This PR does not implement new layouts or removes old layouts. It is simply a reorganisation of the existing culling modes!**

Changes:
Darktable 3.8 behaves differently whether you enter culling and then select images or first select images and then enter culling. In the first case your movement is not restricted, in the second case it is restricted to the selection. So I made a split here into  modes **culling** `C` and **culling restricted** `X`. 

`C` is the old culling mode but you are always unrestricted, no matter in which order you entered the layout and selected images. 

`X` is also the old culling mode, but you are always restricted to a selection and therefore cannot enter this mode without selection. 

To avoid having now 3 culling modes, I merged the old culling dynamic with this restricted mode by adding a modifier button (`dyn`). Since navigation in culling dynamic is also limited to selection, the only difference between culling restricted and culling dynamic is the number of images displayed. The `dynamic` mode can still be reached via the old short-cut `Ctrl-X`.

(I am open to different names for the modes and a better button design for the `"dyn"` button. Will also rename variables in code accordingly.)

|Layout |Description  | Shortcut|
|--- | --- | ---|
|**culling**| same as old culling when entering without a selection. movement unrestricted even if a selection is present.|`C` (new)|
|**culling restricted** | same as old culling when entering with a selection. movement limited to selected images. shared zoom slider position with regular culling |`X` (same as before)|
|**culling dynamic mode**| same as old culling dynamic. can now be enabled by a small `dyn` modifier button that is only visible when in culling restricted layout. can also be reached directly via same shortcut as before. remembers its last position.|`Ctrl-X` (same as before)|

<p align="center">
<img src="https://user-images.githubusercontent.com/2805109/150838479-788fbc93-86a2-4b76-9ce3-460936ba228a.png" width="600" />
<p/>


### Known bugs that I was not able to fix (help required):
* for some reason when starting darktable the `dyn` button is always visible even though I hide it in all modes except culling restricted via code. I think something forces it to become visible again. Switching layout once after starting dt fixes this issue. I do not know what forces the button to be visible on startup
* the `dyn` button does not display the `Ctrl-X` key binding as the other buttons do...