### PR TITLE
Improved handling of opencl buffers

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -219,7 +219,7 @@
   <dtconfig>
     <name>opencl_memory_headroom</name>
     <type>int</type>
-    <default>400</default>
+    <default>600</default>
     <shortdescription>amount of OpenCL memory (in MB) which we assume as being reserved for the driver</shortdescription>
     <longdescription>this amount of memory (in MB) will be subtracted from total GPU memory in order to calculate the available OpenCL memory. too low values will lead to out-of-memory situations in OpenCL processing. too high values will lead to unnecessary tiling (needs a restart).</longdescription>
   </dtconfig>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -135,6 +135,7 @@ static int usage(const char *argv0)
   printf(">\n");
   printf("  --datadir <data directory>\n");
   printf("  --enforce-tiling\n");
+  printf("  --enforce-lowmem\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
@@ -567,7 +568,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
         if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted = 0xffffffff & ~DT_DEBUG_TILING; // enable all debug information except the enforce-tiling flag
+          darktable.unmuted = 0xffffffff & ~(DT_DEBUG_TILING | DT_DEBUG_LOWMEM); // enable all debug information except the enforce-tiling and enforce-lowmem flags
         else if(!strcmp(argv[k + 1], "cache"))
           darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
         else if(!strcmp(argv[k + 1], "control"))
@@ -754,6 +755,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(!strcmp(argv[k], "--enforce-tiling"))
       {
         darktable.unmuted |= DT_DEBUG_TILING;
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--enforce-lowmem"))
+      {
+        darktable.unmuted |= DT_DEBUG_LOWMEM;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--"))
@@ -1046,6 +1052,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
 #ifdef HAVE_OPENCL
   dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+  dt_opencl_preallocate_lowmem();
 #endif
 
   darktable.points = (dt_points_t *)calloc(1, sizeof(dt_points_t));

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -157,12 +157,9 @@ typedef unsigned int u_int;
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
 #define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
-<<<<<<< HEAD
-=======
 
 // A good suggestion but maybe on the lower side as we can increase automatically
 #define DT_CL_SAFEHEADROOM 600
->>>>>>> 589d9bb98 (Improved handling of opencl buffers)
 
 // every module has to define this:
 #ifdef _DEBUG

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -157,6 +157,12 @@ typedef unsigned int u_int;
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
 #define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
+<<<<<<< HEAD
+=======
+
+// A good suggestion but maybe on the lower side as we can increase automatically
+#define DT_CL_SAFEHEADROOM 600
+>>>>>>> 589d9bb98 (Improved handling of opencl buffers)
 
 // every module has to define this:
 #ifdef _DEBUG
@@ -269,7 +275,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
   DT_DEBUG_TILING         = 1 << 23,
-  DT_DEBUG_ACT_ON         = 1 << 24
+  DT_DEBUG_ACT_ON         = 1 << 24,
+  DT_DEBUG_LOWMEM         = 1 << 25
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -693,13 +693,12 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(ch >= 3);
   assert(w >= 1);
 
-  const cl_ulong max_global_mem = dt_opencl_get_max_global_mem(devid);
-  const size_t reserved_memory = (size_t)(dt_conf_get_float("opencl_memory_headroom") * 1024 * 1024);
+  const cl_ulong available_memory = dt_opencl_get_device_available(devid);
   // estimate required memory for OpenCL code path with a safety factor of 5/4
   const size_t required_memory
       = darktable.opencl->dev[devid].memory_in_use + (size_t)width * height * sizeof(float) * 18 * 5 / 4;
   int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  if(max_global_mem - reserved_memory > required_memory)
+  if(available_memory > required_memory)
     err = guided_filter_cl_impl(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
   if(err != CL_SUCCESS)
   {

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -693,12 +693,14 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(ch >= 3);
   assert(w >= 1);
 
-  const cl_ulong available_memory = dt_opencl_get_device_available(devid);
   // estimate required memory for OpenCL code path with a safety factor of 5/4
-  const size_t required_memory
-      = darktable.opencl->dev[devid].memory_in_use + (size_t)width * height * sizeof(float) * 18 * 5 / 4;
+  // avoid checking for available memory by headroom and used memory as unsafe.
+  // instead use safer version
+  const size_t required = (size_t)width * height * sizeof(float) * 18 * 5 / 4;
+  const gboolean fits = dt_opencl_buffer_fits_device(devid, required);
+
   int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  if(available_memory > required_memory)
+  if(fits)
     err = guided_filter_cl_impl(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
   if(err != CL_SUCCESS)
   {

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2500,7 +2500,8 @@ static inline cl_ulong _opencl_get_device_headroom(const int devid)
 cl_ulong dt_opencl_get_device_available(const int devid)
 {
   if(!darktable.opencl->inited || devid < 0) return 0;
-  return MAX(0, _opencl_get_max_global_mem(devid) - _opencl_get_device_headroom(devid));
+  const gboolean lowmem = (darktable.unmuted & DT_DEBUG_LOWMEM);
+  return MAX(0, (lowmem) ? 512lu * 1024lu * 1024lu : _opencl_get_max_global_mem(devid) - _opencl_get_device_headroom(devid));
 }
 
 cl_ulong dt_opencl_get_device_memalloc(const int devid)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -380,6 +380,8 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
 /** check if image size fit into limits given by OpenCL runtime */
 gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
+/** check if buffer fits into limits given by OpenCL runtime */
+gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required);
 
 /** tune headroom according to recorded cl allocation errors */
 void dt_opencl_device_tune_headroom(const int devid);
@@ -512,6 +514,10 @@ static inline int dt_opencl_update_settings(void)
 }
 static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)
+{
+  return FALSE;
+}
+gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
 {
   return FALSE;
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -517,7 +517,7 @@ static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t
 {
   return FALSE;
 }
-gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
+static inline gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
 {
   return FALSE;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1358,7 +1358,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       int valid_input_on_gpu_only = (cl_mem_input != NULL);
 
       /* pre-check if there is enough space on device for non-tiled processing */
-      const int fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
+      const gboolean fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
                                                              MAX(roi_in.height, roi_out->height), MAX(in_bpp, bpp),
                                                              tiling.factor_cl, tiling.overhead);
 
@@ -2164,6 +2164,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
       }
     }
   }
+  dt_opencl_device_tune_headroom(pipe->devid);  
 #endif
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
   return ret;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1235,16 +1235,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
   int width = _min(roi_in->width, darktable.opencl->dev[devid].max_image_width);
   int height = _min(roi_in->height, darktable.opencl->dev[devid].max_image_height);
@@ -1605,16 +1599,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
 
   int width = _min(_max(roi_in->width, roi_out->width), darktable.opencl->dev[devid].max_image_width);


### PR DESCRIPTION
As the opencl memory requirements lately got significantly larger it became obvious we have to
improve headroom management.

1. The global headroom setting (default was 0.4GB) might be a bit too far on the low side
   for current systems.
2. As we might have several CL devices available we don't want a global headroom but
   as "per device".
3. If we detect a CL buffer allocation problem this gets reminded in a device flag, at the end
   of pipeline processing code the flag is checked and the headroom is possibly increased by a large
   step or decreased by a small step. So overall, the headroom for a device gets dynamically tuned
   depending on resources.
4. Allocating a CL buffer might not return an error condition even if there is not enough memory
   available on the device.
   This behaviour is CL conform (implementation depending) but leads to detection of too-low CL memory
   **not** while allocating but much later in the pipeline while processing cl kernels.
   DT handles that by falling back to CPU code but
5. a wrongful assumption of available memory leading to cpu-fallback instead of tiled CL code is
   bad as tiled CL path is very likely still faster than cpu.
   The culprit is `dt_opencl_image_fits_device()` not fully & safe testing.
   The new implementation does a safe test by allocating a buffer of requested size, does an access to
   it, frees the buffer and only reports a fit if that was successfull.

Frequently we have issues reported on systems with relatively small graphics memory.
These are sometimes pretty difficult to reproduce/analyse on systems with lot of cl memory
so a new debugging option `--enfor-lowmem` has been introduced.
This allocates buffers (and ensures they are accessed) leaving cl memory at ~1GB only at runtime.

Partly initially done in #11065 