### PR TITLE
Draft: Fix memory tuning oversights

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -167,7 +167,7 @@ static int usage(const char *argv0)
 }
 
 gboolean dt_is_dev_version()
-{
+
   // a dev version as an odd number after the first dot
   char *p = (char *)darktable_package_string;
   while(*p && (*p != '.')) p++;
@@ -1597,7 +1597,7 @@ void dt_configure_performance()
     // But respect if user has set higher values manually earlier
     fprintf(stderr, "[defaults] setting very high quality defaults\n");
     // if machine has at least 16GB RAM, use all of the total memory size leaving 4GB "breathing room"
-    dt_conf_set_int("host_memory_limit", MAX((mem - (4lu << 20)) >> 11, dt_conf_get_int("host_memory_limit")));
+    dt_conf_set_int("host_memory_limit", MAX((mem - (4lu << 20)) >> 10, dt_conf_get_int("host_memory_limit")));
     dt_conf_set_int("singlebuffer_limit", MAX(128, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL || strlen(demosaic_quality) == 0
        || !strcmp(demosaic_quality, "always bilinear (fast)"))


### PR DESCRIPTION
darktable performance tuning currently has the following problems:
- When calculating `host_memory_limit`, in the >= 16 GB case, 4 GB is subtracted from available memory, and then the result is halved (shifted right by 11 instead of 10, where `>> 10` would perform the kB -> MB conversion). I think the halving is done by accident, due to a copy-paste error from the 8 GB case.
- When calculating `cache_memory`, a similar calculation is done, involving the *free disk space*, not taking *available RAM* into account. For example, with 100 GB free disk space, `cache_memory` will be set to 48 GB, which is obviously wrong (think of what a single, multi-terabyte partition would result in).

Suggestions:
- Set `host_memory limit` to (free memory - 4 or 6 GB);
- Limit `cache_memory` to 10%(?) of available.

Alternatively, remove the settings from the config file altogether, and calculate them dynamically, based on available memory when darktable is started.

Fixes #11100, #11139.