### PR TITLE
Getting rid of opencl headroom

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -135,6 +135,7 @@ static int usage(const char *argv0)
   printf(">\n");
   printf("  --datadir <data directory>\n");
   printf("  --enforce-tiling\n");
+  printf("  --enforce-lowmem\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
@@ -567,7 +568,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
         if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted = 0xffffffff & ~DT_DEBUG_TILING; // enable all debug information except the enforce-tiling flag
+          darktable.unmuted = 0xffffffff & ~(DT_DEBUG_TILING | DT_DEBUG_LOWMEM); // enable all debug information except the enforce-tiling and enforce-lowmem flags
         else if(!strcmp(argv[k + 1], "cache"))
           darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
         else if(!strcmp(argv[k + 1], "control"))
@@ -754,6 +755,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(!strcmp(argv[k], "--enforce-tiling"))
       {
         darktable.unmuted |= DT_DEBUG_TILING;
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--enforce-lowmem"))
+      {
+        darktable.unmuted |= DT_DEBUG_LOWMEM;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--"))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -158,6 +158,9 @@ typedef unsigned int u_int;
 // bump this number and make sure you have an updated logic in dt_configure_performance()
 #define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
 
+// A good suggestion but maybe on the lower side as we can increase automatically
+#define DT_CL_SAFEHEADROOM 600
+
 // every module has to define this:
 #ifdef _DEBUG
 #define DT_MODULE(MODVER)                                                                                    \
@@ -269,7 +272,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
   DT_DEBUG_TILING         = 1 << 23,
-  DT_DEBUG_ACT_ON         = 1 << 24
+  DT_DEBUG_ACT_ON         = 1 << 24,
+  DT_DEBUG_LOWMEM         = 1 << 25
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -33,6 +33,7 @@
 #define DT_OPENCL_VENDOR_AMD 4098
 #define DT_OPENCL_VENDOR_NVIDIA 4318
 #define DT_OPENCL_VENDOR_INTEL 0x8086u
+#define DT_OPENCL_AVAILABLE_INTERVAL 10.0
 
 #include "common/darktable.h"
 
@@ -120,6 +121,8 @@ typedef struct dt_opencl_device_t
   float benchmark;
   size_t memory_in_use;
   size_t peak_memory;
+  size_t available_mem;
+  double available_timer;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;
@@ -214,6 +217,9 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
 
 /** cleans up the opencl subsystem. */
 void dt_opencl_cleanup(dt_opencl_t *cl);
+
+/** recalculate available memory for device */
+void dt_opencl_recalculate_available_mem(const int devid);
 
 /** cleans up command queue. */
 int dt_opencl_finish(const int devid);
@@ -368,14 +374,19 @@ int dt_opencl_get_mem_context_id(cl_mem mem);
 void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t action);
 
 /** check if image size fit into limits given by OpenCL runtime */
-int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
+gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
+/** check if buffer fits into limits given by OpenCL runtime */
+gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required);
+
+/** get available memory for the device */
+cl_ulong dt_opencl_get_device_available(const int devid);
+
+/** get size of allocatable single buffer */
+cl_ulong dt_opencl_get_device_memalloc(const int devid);
 
 /** round size to a multiple of the value given in config parameter opencl_size_roundup */
 int dt_opencl_roundup(int size);
-
-/** get global memory of device */
-cl_ulong dt_opencl_get_max_global_mem(const int devid);
 
 /** get next free slot in eventlist and manage size of eventlist */
 cl_event *dt_opencl_events_get_slot(const int devid, const char *tag);
@@ -419,6 +430,9 @@ static inline void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl
 static inline void dt_opencl_cleanup(dt_opencl_t *cl)
 {
 }
+static inline void dt_opencl_recalculate_available_mem(const int devid)
+{
+} 
 static inline int dt_opencl_finish(const int devid)
 {
   return -1;
@@ -491,12 +505,20 @@ static inline int dt_opencl_update_settings(void)
 {
   return 0;
 }
-static inline int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
+static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)
+{
+  return FALSE;
+}
+static inline gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
+{
+  return FALSE;
+}
+static inline size_t dt_opencl_get_device_available(const int devid)
 {
   return 0;
 }
-static inline int dt_opencl_get_max_global_mem(const int devid)
+static inline size_t dt_opencl_get_device_memalloc(const int devid)
 {
   return 0;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1358,7 +1358,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       int valid_input_on_gpu_only = (cl_mem_input != NULL);
 
       /* pre-check if there is enough space on device for non-tiled processing */
-      const int fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
+      const gboolean fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
                                                              MAX(roi_in.height, roi_out->height), MAX(in_bpp, bpp),
                                                              tiling.factor_cl, tiling.overhead);
 
@@ -2134,6 +2134,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
                                                      int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
+  dt_opencl_recalculate_available_mem(pipe->devid);
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1235,16 +1235,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
   int width = _min(roi_in->width, darktable.opencl->dev[devid].max_image_width);
   int height = _min(roi_in->height, darktable.opencl->dev[devid].max_image_height);
@@ -1605,16 +1599,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
 
   int width = _min(_max(roi_in->width, roi_out->width), darktable.opencl->dev[devid].max_image_width);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5351,6 +5351,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     tiling->xalign = 2;
     tiling->yalign = 2;
     tiling->overlap = 10;
+    tiling->factor_cl = tiling->factor + 3.0f;
   }
   else if(demosaicing_method == DT_IOP_DEMOSAIC_LMMSE)
   {


### PR DESCRIPTION
As the opencl memory requirements lately got significantly larger it became obvious we have to
improve headroom management.

What is currently wrong with headroom at all?

As a short overview about how the pixelpipe works if opencl is enabled:
For every module to be processed we check if all cl memory requirements fit into the graphics card memory via `dt_opencl_image_fits_device()`. It takes `total-memory-on-card - headroom` as available for granted and if it fits, it processes the whole stuff as is, otherwise it starts tiling using opencl.
If there is an error it falls back to cpu code.

This is leading to fallbacks because of two reasons.
1. It might very well be, there are currently other applications requiring cl memory, dt won't know about
   this and detects an allocation error late while processing the pipeline and has to start again via
   cpu fallback. (it doesn't know it should better try with tiling)
2. Allocating a CL buffer might not return an error condition even if there is not enough memory available on the device.
   This behaviour is CL conform (implementation depending) but leads to detection of too-low CL memory
   **not** while allocating but much later in the pipeline while processing cl kernels.

Until now we had to avoid cpu-fallback by increasing headroom. This
1. might not be sufficient as other apps take memory
2. might be much too high (user increased headroom to take care of situations as in 1)
3. doesn't take account for the situation with several cl devices available.

After this pr we won't use headroom any more. Instead - we calculate the device's available memory by `dt_opencl_recalculate_available_mem(const int devid)` at regular intervals before processing the pipeline and use that result in `dt_opencl_image_fits_device()`.
As there is no public cl function telling used / available memory this is done by brute force testing.
That takes some time (~60msec) but a) it's done not often and b) the performance penalty is outweighed by the avoid-fallback advantage.    

Frequently we have issues reported on systems with relatively small graphics memory.
These are sometimes pretty difficult to reproduce/analyse on systems with lots of cl memory so a new debugging option
`--enforce-lowmem` has been introduced, at runtime it restricts the reported available memory as on a 1GB card.

Replaces #11115 
