### PR TITLE
import: use transaction

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1490,6 +1490,7 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
     g_free(extra_file);
   }
 
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
   //insert a v0 record (which may be updated later if no v0 xmp exists)
   DT_DEBUG_SQLITE3_PREPARE_V2
     (dt_database_get(darktable.db),
@@ -1647,6 +1648,8 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   //synch database entries to xmp
   if(xmp_mode == DT_WRITE_XMP_ALWAYS)
     dt_image_synch_all_xmp(normalized_filename);
+
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 
   g_free(imgfname);
   g_free(basename);


### PR DESCRIPTION
Currently, importing does at least 11 SQL queries per image in various functions (insert in `images`, update image group id, update exif, insert in `tagged_images`). Wrapping the whole import in a transaction gives about 5-7% speedup (tested on i7-8550U with NVME; Linux), and also guarantees consistency: or everything is inserted and updated, or nothing.