### PR TITLE
Bugfix: RCD OpenCL tiling

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5351,7 +5351,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     tiling->xalign = 2;
     tiling->yalign = 2;
     tiling->overlap = 10;
-  }
+    tiling->factor_cl = tiling->factor + 3.0f;
+   }
   else if(demosaicing_method == DT_IOP_DEMOSAIC_LMMSE)
   {
     tiling->factor = 1.0f + ioratio;


### PR DESCRIPTION
The tiling factor for OpenCl had been not implemented as required leading to untiled
execution on small graphics cards likely failing and thus falling back to cpu code.