### PR TITLE
po/db transactions - better (& global) outermost transactions support

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2380,7 +2380,7 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
     dt_collection_shift_image_positions(selected_images_length, target_image_pos, tagid);
 
     sqlite3_stmt *stmt = NULL;
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+    dt_database_start_transaction(darktable.db);
 
     // move images to their intended positions
     int64_t new_image_pos = target_image_pos;
@@ -2411,7 +2411,7 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
       new_image_pos++;
     }
     sqlite3_finalize(stmt);
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
   }
   else
   {
@@ -2438,7 +2438,7 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
     sqlite3_finalize(stmt);
     sqlite3_stmt *update_stmt = NULL;
 
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+    dt_database_start_transaction(darktable.db);
 
     // move images to last position in custom image order table
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -2467,7 +2467,7 @@ void dt_collection_move_before(const int32_t image_id, GList * selected_images)
     }
 
     sqlite3_finalize(update_stmt);
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
   }
 }
 

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -4400,6 +4400,14 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename)
 }
 
 // nested transactions support
+// NOTE: the nested support is actually not activated. This current implementation
+//       is just a refactoring of the previous code using:
+//       - dt_database_start_transaction()
+//       - dt_database_release_transaction()
+//       - dt_database_rollback_transaction()
+//
+//       With this refactoring we can count and check for nested transaction and unmatched
+//       transaction routines.
 
 void dt_database_start_transaction(const struct dt_database_t *db)
 {
@@ -4408,7 +4416,7 @@ void dt_database_start_transaction(const struct dt_database_t *db)
   // if top level a simple unamed transaction is used BEGIN / COMMIT / ROLLBACK
   // otherwise we use a savepoint (named transaction).
 
-  if(trxid == 0)
+  if(trxid == 0 || TRUE)
   {
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(db), "BEGIN IMMEDIATE TRANSACTION", NULL, NULL, NULL);
   }
@@ -4432,7 +4440,7 @@ void dt_database_release_transaction(const struct dt_database_t *db)
   if(trxid <= 0)
     fprintf(stderr, "[dt_database_start_transaction] COMMIT outside a transaction\n");
 
-  if(trxid == 1)
+  if(trxid == 1 || TRUE)
   {
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(db), "COMMIT TRANSACTION", NULL, NULL, NULL);
   }
@@ -4453,7 +4461,7 @@ void dt_database_rollback_transaction(const struct dt_database_t *db)
   if(trxid <= 0)
     fprintf(stderr, "[dt_database_start_transaction] ROLLBACK outside a transaction\n");
 
-  if(trxid == 1)
+  if(trxid == 1 || TRUE)
   {
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(db), "ROLLBACK TRANSACTION", NULL, NULL, NULL);
   }

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -4410,7 +4410,7 @@ void dt_database_start_transaction(const struct dt_database_t *db)
 
   if(trxid == 0)
   {
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+    DT_DEBUG_SQLITE3_EXEC(dt_database_get(db), "BEGIN IMMEDIATE TRANSACTION", NULL, NULL, NULL);
   }
 #ifdef USE_NESTED_TRANSACTIONS
   else

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -50,6 +50,13 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db);
 /** get possibly the freshest snapshot to restore */
 gchar *dt_database_get_most_recent_snap(const char* db_filename);
 
+
+// nested transactions support
+
+void dt_database_start_transaction(const struct dt_database_t *db);
+void dt_database_release_transaction(const struct dt_database_t *db);
+void dt_database_rollback_transaction(const struct dt_database_t *db);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -976,7 +976,7 @@ void dt_history_compress_on_image(const int32_t imgid)
   const char *op_mask_manager = "mask_manager";
   gboolean manager_position = FALSE;
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   // We must know for sure whether there is a mask manager at slot 0 in history
   // because only if this is **not** true history nums and history_end must be increased
@@ -1070,7 +1070,7 @@ void dt_history_compress_on_image(const int32_t imgid)
   dt_unlock_image(imgid);
   dt_history_hash_write_from_history(imgid, DT_HISTORY_HASH_CURRENT);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 }
@@ -1091,7 +1091,7 @@ void dt_history_truncate_on_image(const int32_t imgid, const int32_t history_end
     return;
   }
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   // delete end of history
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -1125,7 +1125,7 @@ void dt_history_truncate_on_image(const int32_t imgid, const int32_t history_end
   dt_unlock_image(imgid);
   dt_history_hash_write_from_history(imgid, DT_HISTORY_HASH_CURRENT);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 }

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -56,7 +56,7 @@ void dt_history_snapshot_undo_create(const int32_t imgid, int *snap_id, int *his
     *snap_id = sqlite3_column_int(stmt, 0) + 1;
   sqlite3_finalize(stmt);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   if(*history_end == 0)
   {
@@ -114,10 +114,10 @@ void dt_history_snapshot_undo_create(const int32_t imgid, int *snap_id, int *his
   sqlite3_finalize(stmt);
 
   if(all_ok)
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
   else
   {
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "ROLLBACK_TRANSACTION", NULL, NULL, NULL);
+    dt_database_rollback_transaction(darktable.db);
     fprintf(stderr, "[dt_history_snapshot_undo_create] fails to create a snapshot for %d\n", imgid);
   }
 
@@ -132,7 +132,7 @@ static void _history_snapshot_undo_restore(const int32_t imgid, const int snap_i
 
   dt_lock_image(imgid);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_history_delete_on_image_ext(imgid, FALSE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
@@ -194,10 +194,10 @@ static void _history_snapshot_undo_restore(const int32_t imgid, const int snap_i
   sqlite3_finalize(stmt);
 
   if(all_ok)
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
   else
   {
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "ROLLBACK_TRANSACTION", NULL, NULL, NULL);
+    dt_database_rollback_transaction(darktable.db);
     fprintf(stderr, "[_history_snapshot_undo_restore] fails to restore a snapshot for %d\n", imgid);
   }
   dt_unlock_image(imgid);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1490,7 +1490,7 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
     g_free(extra_file);
   }
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "SAVEPOINT impimg", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   //insert a v0 record (which may be updated later if no v0 xmp exists)
   DT_DEBUG_SQLITE3_PREPARE_V2
@@ -1650,7 +1650,7 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   if(xmp_mode == DT_WRITE_XMP_ALWAYS)
     dt_image_synch_all_xmp(normalized_filename);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "RELEASE SAVEPOINT impimg", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 
   g_free(imgfname);
   g_free(basename);

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -73,7 +73,7 @@ GList *dt_control_crawler_run()
                      &inner_stmt, NULL);
 
   // let's wrap this into a transaction, it might make it a little faster.
-  sqlite3_exec(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -202,7 +202,7 @@ GList *dt_control_crawler_run()
     free(extra_path);
   }
 
-  sqlite3_exec(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 
   sqlite3_finalize(stmt);
   sqlite3_finalize(inner_stmt);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1685,7 +1685,8 @@ static void _dev_merge_history(dt_develop_t *dev, const int imgid)
                                   -1, &stmt, NULL);
 
       // let's wrap this into a transaction, it might make it a little faster.
-      sqlite3_exec(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+      dt_database_start_transaction(darktable.db);
+
       for(GList *r = rowids; r; r = g_list_next(r))
       {
         DT_DEBUG_SQLITE3_CLEAR_BINDINGS(stmt);
@@ -1698,7 +1699,7 @@ static void _dev_merge_history(dt_develop_t *dev, const int imgid)
         v++;
       }
 
-      sqlite3_exec(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+      dt_database_release_transaction(darktable.db);
 
       g_list_free(rowids);
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1060,7 +1060,7 @@ static void export_preset(GtkButton *button, gpointer data)
     sqlite3_stmt *stmt;
 
     // we have n+1 selects for saving presets, using single transaction for whole process saves us microlocks
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+    dt_database_start_transaction(darktable.db);
 
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                 "SELECT rowid, name, operation FROM data.presets WHERE writeprotect = 0",
@@ -1080,7 +1080,7 @@ static void export_preset(GtkButton *button, gpointer data)
 
     sqlite3_finalize(stmt);
 
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "END TRANSACTION", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
 
     dt_conf_set_folder_from_file_chooser("ui_last/export_path", GTK_FILE_CHOOSER(filechooser));
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -757,7 +757,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
   dt_iop_atrous_params_t p;
   p.octaves = 7;
   p.mix = 1.0f;
@@ -1024,7 +1024,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: fine blur, strength 1"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 static void reset_mix(dt_iop_module_t *self)

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -396,13 +396,13 @@ static void set_presets(dt_iop_module_so_t *self, const basecurve_preset_t *pres
 void init_presets(dt_iop_module_so_t *self)
 {
   // sql begin
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   set_presets(self, basecurve_presets, basecurve_presets_cnt, FALSE);
   set_presets(self, basecurve_camera_presets, basecurve_camera_presets_cnt, TRUE);
 
   // sql commit
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 static float exposure_increment(float stops, int e, float fusion, float bias)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -657,7 +657,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_gui_presets_add_generic(_("swap R and B"), self->op, self->version(),
                              &(dt_iop_channelmixer_params_t){ { 0, 0, 0, 0, 0, 1, 0 },
@@ -771,7 +771,7 @@ void init_presets(dt_iop_module_so_t *self)
                              sizeof(dt_iop_channelmixer_params_t), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -587,7 +587,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.mode = DT_IOP_COLORZONES_MODE_SMOOTH;
   p.splines_version = DT_IOP_COLORZONES_SPLINES_V2;
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   // red black white
   p.channel = DT_IOP_COLORZONES_h;
@@ -731,7 +731,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("HSL base setting"), self->op,
                              version, &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 static void _reset_display_selection(dt_iop_module_t *self)

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -123,7 +123,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_iop_dither_params_t tmp
       = (dt_iop_dither_params_t){ DITHER_FSAUTO, 0, { 0.0f, { 0.0f, 0.0f, 1.0f, 1.0f }, -200.0f } };
@@ -134,7 +134,7 @@ void init_presets(dt_iop_module_so_t *self)
   // make it auto-apply for all images:
   // dt_gui_presets_update_autoapply(_("dither"), self->op, self->version(), 1);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 #ifdef _OPENMP

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -415,7 +415,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_flip_params_t p = (dt_iop_flip_params_t){ ORIENTATION_NONE };
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   p.orientation = ORIENTATION_NULL;
   dt_gui_presets_add_generic(_("autodetect"), self->op,
@@ -446,7 +446,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("rotate by 180 degrees"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_NONE);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 void reload_defaults(dt_iop_module_t *self)

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -66,7 +66,7 @@ typedef struct dt_iop_graduatednd_global_data_t
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_gui_presets_add_generic(_("neutral gray ND2 (soft)"), self->op, self->version(),
                              &(dt_iop_graduatednd_params_t){ 1, 0, 0, 50, 0, 0 },
@@ -114,7 +114,7 @@ void init_presets(dt_iop_module_so_t *self)
                              &(dt_iop_graduatednd_params_t){ 2, 0, 0, 50, 0.082927, 0.25 },
                              sizeof(dt_iop_graduatednd_params_t), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 typedef struct dt_iop_graduatednd_gui_data_t

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -304,7 +304,7 @@ void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_lowlight_params_t p;
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   p.transition_x[0] = 0.000000;
   p.transition_x[1] = 0.200000;
@@ -469,7 +469,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("night"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 // fills in new parameters based on mouse position (in 0,1)

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -563,13 +563,13 @@ void init_global(dt_iop_module_so_t *module)
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_gui_presets_add_generic(_("local contrast mask"), self->op, self->version(),
                              &(dt_iop_lowpass_params_t){ 0, 50.0f, -1.0f, 0.0f, 0.0f, LOWPASS_ALGO_GAUSSIAN, 1 },
                              sizeof(dt_iop_lowpass_params_t), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 void cleanup_global(dt_iop_module_so_t *module)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -115,7 +115,7 @@ const char *description(struct dt_iop_module_t *self)
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_gui_presets_add_generic(_("passthrough"), self->op, self->version(),
                              &(dt_iop_rawprepare_params_t){.x = 0,
@@ -129,7 +129,7 @@ void init_presets(dt_iop_module_so_t *self)
                                                            .raw_white_point = UINT16_MAX },
                              sizeof(dt_iop_rawprepare_params_t), 1, DEVELOP_BLEND_CS_NONE);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 static int compute_proper_crop(dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_in, int value)

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -49,7 +49,7 @@ typedef struct dt_iop_relight_params_t
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   dt_gui_presets_add_generic(_("fill-light 0.25EV with 4 zones"), self->op, self->version(),
                              &(dt_iop_relight_params_t){ 0.25, 0.25, 4.0 }, sizeof(dt_iop_relight_params_t),
@@ -59,7 +59,7 @@ void init_presets(dt_iop_module_so_t *self)
                              &(dt_iop_relight_params_t){ -0.25, 0.25, 4.0 }, sizeof(dt_iop_relight_params_t),
                              1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 typedef struct dt_iop_relight_gui_data_t

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -108,7 +108,7 @@ const char *description(struct dt_iop_module_t *self)
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
 
   // shadows: #ED7212
   // highlights: #ECA413
@@ -146,7 +146,7 @@ void init_presets(dt_iop_module_so_t *self)
       &(dt_iop_splittoning_params_t){ 28.0 / 360.0, 39.0 / 100.0, 28.0 / 360.0, 8.0 / 100.0, 0.60, 0.0 },
       sizeof(dt_iop_splittoning_params_t), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -935,7 +935,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
   dt_iop_vignette_params_t p;
   p.scale = 40.0f;
   p.falloff_scale = 100.0f;
@@ -950,7 +950,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.unbound = TRUE;
   dt_gui_presets_add_generic(_("lomo"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -357,7 +357,8 @@ static void delete_clicked(GtkWidget *w, gpointer user_data)
 
   if(can_delete)
   {
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+    dt_database_start_transaction(darktable.db);
+
     for (const GList *style = style_names; style; style = g_list_next(style))
     {
       dt_styles_delete_by_name_adv((char*)style->data, single_raise);
@@ -368,7 +369,7 @@ static void delete_clicked(GtkWidget *w, gpointer user_data)
       // this also calls _gui_styles_update_view
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
     }
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT TRANSACTION", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
   }
   g_list_free_full(style_names, g_free);
 }
@@ -928,12 +929,13 @@ void gui_cleanup(dt_lib_module_t *self)
 
 void gui_reset(dt_lib_module_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
+  dt_database_start_transaction(darktable.db);
+
   GList *all_styles = dt_styles_get_list("");
 
   if(all_styles == NULL)
   {
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "END TRANSACTION", NULL, NULL, NULL);
+    dt_database_release_transaction(darktable.db);
     return;
   }
 
@@ -950,7 +952,7 @@ void gui_reset(dt_lib_module_t *self)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
   }
   g_list_free_full(all_styles, dt_style_free);
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT TRANSACTION", NULL, NULL, NULL);
+  dt_database_release_transaction(darktable.db);
   _update(self);
 }
 


### PR DESCRIPTION
Add new transaction API to support nested transaction using savepoints transparently and only when needed.