### PR TITLE
dt_datetime_exif_to_numbers: add NULL check

### DIFF
--- a/src/common/datetime.c
+++ b/src/common/datetime.c
@@ -61,9 +61,12 @@ gboolean dt_datetime_exif_to_numbers(dt_datetime_t *dt, const char *exif)
     g_strlcpy(sdt, exif, sizeof(sdt));
     sdt[4] = sdt[7] = '-';
     GDateTime *gdt = g_date_time_new_from_iso8601(sdt, darktable.utc_tz);
-    const gboolean res = _datetime_gdatetime_to_numbers(dt, gdt);
-    g_date_time_unref(gdt);
-    return res;
+    if(gdt)
+    {
+      const gboolean res = _datetime_gdatetime_to_numbers(dt, gdt);
+      g_date_time_unref(gdt);
+      return res;
+    }
   }
   return FALSE;
 }


### PR DESCRIPTION
Importing a large directory of (mostly older and non-raw) images, I encountered several `GLib-CRITICAL **: 10:14:55.654: g_date_time_unref: assertion 'datetime != NULL' failed` in the terminal. With this check, the message disappears. Pinging @phweyland as the datetime expert.