### PR TITLE
Proposal: Introduce "preference->processingl->darktable resources" instead of several tuning options

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -190,13 +190,6 @@
     <shortdescription>darktable resources</shortdescription>
     <longdescription>defines how much darktable may take from your system resources. Can be changed at runtime. unrestricted will take almost all and might lead to swapping.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing" section="cpugpu" restart="true">
-    <name>cache_memory</name>
-    <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
-    <default>(1024 * 1024 * 512)</default>
-    <shortdescription>memory in MB to use for thumbnail cache</shortdescription>
-    <longdescription>this controls how much memory is going to be used for thumbnails and other buffers (needs a restart).</longdescription>
-  </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>cache_disk_backend</name>
     <type>bool</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -178,17 +178,18 @@
     <name>resourcelevel</name>
     <type>
       <enum>
-        <option>minimum</option>
+        <option>default</option>
+        <option>mini (debug)</option>
+        <option>reference (debug)</option>
         <option>small</option>
         <option>medium</option>
-        <option>default</option>
         <option>large</option>
         <option>unrestricted</option>
       </enum>
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources. Can be changed at runtime. unrestricted will take almost all and might lead to swapping.</longdescription>
+    <longdescription>defines how much darktable may take from your system resources. can be changed at runtime\n   mini: 0.5 GB free ram and 0.25GB free video ram.\n   reference: 8GB free ram and 2GB free video ram\n   unrestricted: will take almost all and might lead to swapping.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>cache_disk_backend</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -193,6 +193,13 @@
     <longdescription>defines how much darktable may take from your system resources. can be changed at runtime\n   mini: 0.5 GB free ram and 0.25GB free video ram.\n   reference: 8GB free ram and 2GB free video ram\n   unrestricted: will take almost all and might lead to swapping.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
+    <name>ui/performance</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>prefer performance over quality</shortdescription>
+    <longdescription>if switched on, thumbnails and previews are rendered at lower quality but 4 times faster</longdescription>
+  </dtconfig>
+  <dtconfig prefs="processing" section="cpugpu">
     <name>cache_disk_backend</name>
     <type>bool</type>
     <default>true</default>
@@ -3130,12 +3137,6 @@
     <default>-1.0</default>
     <shortdescription>overwrite the screen's dpi setting</shortdescription>
     <longdescription>if this value is &gt; 0.0 then it is used as the screen's dpi setting which is used to scale the gui</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>ui/performance</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>performance mode for thumbs and previews</shortdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/preview/max_in_memory_images</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -174,23 +174,22 @@
     <default>true</default>
     <shortdescription>do not show april 1st game</shortdescription>
   </dtconfig>
-<!-- be sure to keep the code in sync when changing this enum, see common/darktable.c -->
+<!-- be sure to keep the code in sync when changing this enum, see common/darktable.c void dt_get_sysresource_level() -->
   <dtconfig prefs="processing" section="cpugpu">
     <name>resourcelevel</name>
     <type>
       <enum>
-        <option>default</option>
-        <option>mini (debug)</option>
-        <option>reference (debug)</option>
         <option>small</option>
-        <option>medium</option>
+        <option>default</option>
         <option>large</option>
         <option>unrestricted</option>
+        <option>mini (debug)</option>
+        <option>reference (debug)</option>
       </enum>
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources. can be changed at runtime\n   mini: 0.5 GB free ram and 0.25GB free video ram.\n   reference: 8GB free ram and 2GB free video ram\n   unrestricted: will take almost all and might lead to swapping.</longdescription>
+    <longdescription>defines how much darktable may take from your system resources. lower the setting if you are using applications taking large parts of your systems memory or opencl/gl applications like games or hugin. increase if you are a mainly using darktable on your machine.\n - default - takes ~50% of your systems resources and gives darktable enough to be still performant.\n\nthere are some special modes\n\n - mini - dt takes 0.5 GB ram and 0.25GB video ram\n - reference: - dt takes 8GB ram and 2GB video ram\n - unrestricted - dt will take almost all of your systems resources and might lead to swapping and unexpected performance drops. use with caution!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -174,6 +174,22 @@
     <default>true</default>
     <shortdescription>do not show april 1st game</shortdescription>
   </dtconfig>
+  <dtconfig prefs="processing" section="cpugpu">
+    <name>resourcelevel</name>
+    <type>
+      <enum>
+        <option>minimum</option>
+        <option>small</option>
+        <option>medium</option>
+        <option>default</option>
+        <option>large</option>
+        <option>unrestricted</option>
+      </enum>
+    </type>
+    <default>default</default>
+    <shortdescription>darktable resources</shortdescription>
+    <longdescription>defines how much darktable may take from your system resources. Can be changed at runtime. unrestricted will take almost all and might lead to swapping.</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" restart="true">
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
@@ -201,27 +217,6 @@
     <default>true</default>
     <shortdescription>color manage cached thumbnails</shortdescription>
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="processing" section="cpugpu">
-    <name>host_memory_limit</name>
-    <type>int</type>
-    <default>1500</default>
-    <shortdescription>host memory limit (in MB) for tiling</shortdescription>
-    <longdescription>this variable controls the maximum amount of memory (in MB) a module may use during image processing. lower values will force memory hungry modules to process image with increasing number of tiles. setting this to 0 will omit any limit. values below 500 will be treated as 500.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="processing" section="cpugpu">
-    <name>singlebuffer_limit</name>
-    <type min="2" max="128">int</type>
-    <default>16</default>
-    <shortdescription>minimum amount of memory (in MB) for a single buffer in tiling</shortdescription>
-    <longdescription>minimum amount of memory (in MB) that tiling should take for a single image buffer.</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>opencl_memory_headroom</name>
-    <type>int</type>
-    <default>400</default>
-    <shortdescription>amount of OpenCL memory (in MB) which we assume as being reserved for the driver</shortdescription>
-    <longdescription>this amount of memory (in MB) will be subtracted from total GPU memory in order to calculate the available OpenCL memory. too low values will lead to out-of-memory situations in OpenCL processing. too high values will lead to unnecessary tiling (needs a restart).</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_avoid_atomics</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -174,6 +174,7 @@
     <default>true</default>
     <shortdescription>do not show april 1st game</shortdescription>
   </dtconfig>
+<!-- be sure to keep the code in sync when changing this enum, see common/darktable.c -->
   <dtconfig prefs="processing" section="cpugpu">
     <name>resourcelevel</name>
     <type>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1616,54 +1616,24 @@ void dt_configure_performance()
 
   fprintf(stderr, "[defaults] found a %zu-bit system with %zu kb ram and %zu cores (%d atom based)\n",
           bits, mem, threads, atom_cores);
-  if(mem >= (16lu << 20) && threads > 4)
+  if(mem >= (4lu << 20) && threads >= 2)
   {
-    // CONFIG 0: at least 16GB RAM, and more than 6 CPU threads
-    // But respect if user has set higher values manually earlier
-    fprintf(stderr, "[defaults] setting very high quality defaults\n");
-    // if machine has at least 16GB RAM, use all of the total memory size leaving 4GB "breathing room"
-    dt_conf_set_int("host_memory_limit", MAX((mem - (4lu << 20)) >> 11, dt_conf_get_int("host_memory_limit")));
-    dt_conf_set_int("singlebuffer_limit", MAX(128, dt_conf_get_int("singlebuffer_limit")));
-    if(demosaic_quality == NULL || strlen(demosaic_quality) == 0
-       || !strcmp(demosaic_quality, "always bilinear (fast)"))
-      dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
-    dt_conf_set_bool("ui/performance", FALSE);
-  }
-  else if(mem >= (8lu << 20) && threads >= 4)
-  {
-    // CONFIG 1: at least 8GB RAM, and at least 4 CPU threads
-    // But respect if user has set higher values manually earlier
-    fprintf(stderr, "[defaults] setting high quality defaults\n");
-
-    // if machine has at least 8GB RAM, use half of the total memory size
-    dt_conf_set_int("host_memory_limit", MAX(mem >> 11, dt_conf_get_int("host_memory_limit")));
-    dt_conf_set_int("singlebuffer_limit", MAX(32, dt_conf_get_int("singlebuffer_limit")));
-    if(demosaic_quality == NULL || strlen(demosaic_quality) == 0
-       || !strcmp(demosaic_quality, "always bilinear (fast)"))
-      dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
-    dt_conf_set_bool("ui/performance", FALSE);
-  }
-  else if(mem >= (4lu << 20) && threads >= 2)
-  {
-    // CONFIG 2: at least 4GB RAM, and at least 2 CPU threads
+    // suggested minimum: at least 4GB RAM, and at least 2 CPU threads
     fprintf(stderr, "[defaults] setting standard defaults\n");
-
-    dt_conf_set_int("host_memory_limit", MAX(1500, dt_conf_get_int("host_memory_limit")));
-    dt_conf_set_int("singlebuffer_limit", MAX(16, dt_conf_get_int("singlebuffer_limit")));
     if(demosaic_quality == NULL || strlen(demosaic_quality) == 0
        || !strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
     dt_conf_set_bool("ui/performance", FALSE);
+    dt_conf_set_int("resourcelevel", DT_RESOURCE_LEVEL_MINIMUM);
   }
   else
   {
-    // CONFIG 3: for small and slow systems
+    // for small and slow systems
     // use very low/conservative settings
     fprintf(stderr, "[defaults] setting very conservative defaults\n");
-    dt_conf_set_int("host_memory_limit", 500);
-    dt_conf_set_int("singlebuffer_limit", 16);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "always bilinear (fast)");
     dt_conf_set_bool("ui/performance", TRUE);
+    dt_conf_set_int("resourcelevel", DT_RESOURCE_LEVEL_DEFAULT);
   }
 
   g_free(demosaic_quality);
@@ -1681,6 +1651,7 @@ void dt_configure_performance()
   // set cache_memory to half of freediskspace - 4gb (eg 1gb cache_mem in case of 6gb free space)
   if(freecache > (6lu << 20))
     dt_conf_set_int64("cache_memory", (freecache - (4lu << 20))/2);
+
 
   // enable cache_disk_backend_full when user has over 8gb free diskspace
   dt_conf_set_bool("cache_disk_backend_full", freecache > (8lu << 20));

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1197,7 +1197,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   // initialize resources stuff here
   if(!dt_conf_key_exists("resourcelevel"))
-    dt_conf_set_int("resourcelevel", 3);
+    dt_conf_set_int("resourcelevel", DT_RESOURCE_LEVEL_DEFAULT);
 
   darktable.dtresources.total_memory = _get_total_memory();
 
@@ -1307,6 +1307,10 @@ void dt_cleanup()
     free(darktable.imageio);
     free(darktable.gui);
   }
+
+  if(dt_conf_get_int("resourcelevel") == DT_RESOURCE_LEVEL_TESTING)
+    dt_conf_set_int("resourcelevel", DT_RESOURCE_LEVEL_DEFAULT);
+
   dt_image_cache_cleanup(darktable.image_cache);
   free(darktable.image_cache);
   dt_mipmap_cache_cleanup(darktable.mipmap_cache);
@@ -1589,9 +1593,10 @@ int dt_worker_threads()
 
 size_t dt_get_available_mem()
 {
-  const size_t total_mem = darktable.dtresources.total_memory;
   const int level = darktable.dtresources.level;  
-
+  const size_t total_mem = darktable.dtresources.total_memory;
+  if(level == DT_RESOURCE_LEVEL_UNRESTRICTED) return total_mem;
+  if(level == DT_RESOURCE_LEVEL_TESTING)      return 8192lu * 1024lu * 1024lu;
   const size_t available = total_mem / 6 * level;
   return MAX(512lu * 1024lu * 1024lu, available);
 }

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1072,11 +1072,10 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   //  1 cpu singlebuffer
   //  2 mipmap size
   //  3 opencl available
-  static int fractions[24] = {
-      512,   28, 128, 600,  // default
+  static int fractions[20] = {
+      512,   32, 128, 600,  // default
         0,    0,  16,   0,  // mini
       128,   16,  64, 256,  // small
-      400,   32, 128, 512,  // medium
       700,   64, 128, 750,  // large
     16384, 1024, 128, 900   // unrestricted
   };
@@ -1280,17 +1279,19 @@ void dt_get_sysresource_level()
   const char *config = dt_conf_get_string_const("resourcelevel");
   /** These levels must correspond with preferences in xml.in **and** fractions
       Please note: absolute values for "reference (debug)"
+      If we want a new setting here, we must
+        - add a string->level conversion here
+        - add a line of fraction in int fractions[] above
+        - add a line in 
   */
   if(config)
   {
          if(!strcmp(config, "default"))           darktable.dtresources.level = 0; 
     else if(!strcmp(config, "mini (debug)"))      darktable.dtresources.level = 1;
     else if(!strcmp(config, "small"))             darktable.dtresources.level = 2;
-    else if(!strcmp(config, "medium"))            darktable.dtresources.level = 3;
-    else if(!strcmp(config, "large"))             darktable.dtresources.level = 4;
-    else if(!strcmp(config, "unrestricted"))      darktable.dtresources.level = 5;
+    else if(!strcmp(config, "large"))             darktable.dtresources.level = 3;
+    else if(!strcmp(config, "unrestricted"))      darktable.dtresources.level = 4;
     else if(!strcmp(config, "reference (debug)")) darktable.dtresources.level = -1;
-
     dt_print(DT_DEBUG_MEMORY, "[dt_get_sysresource_level] switched to %i as `%s'\n", darktable.dtresources.level, config);
   }
   else

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1587,6 +1587,20 @@ int dt_worker_threads()
   return 1;
 }
 
+size_t dt_get_available_mem()
+{
+  const size_t total_mem = darktable.dtresources.total_memory;
+  const int level = darktable.dtresources.level;  
+
+  const size_t available = total_mem / 6 * level;
+  return MAX(512lu * 1024lu * 1024lu, available);
+}
+
+size_t dt_get_singlebuffer_mem()
+{
+  return MAX(2lu * 1024lu * 1024lu, dt_get_available_mem() / 16);
+}
+
 void dt_configure_performance()
 {
   const int atom_cores = _get_num_atom_cores();

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -134,7 +134,6 @@ static int usage(const char *argv0)
 #endif
   printf(">\n");
   printf("  --datadir <data directory>\n");
-  printf("  --enforce-tiling\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
@@ -621,7 +620,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
         if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted = 0xffffffff & ~DT_DEBUG_TILING; // enable all debug information except the enforce-tiling flag
+          darktable.unmuted = 0xffffffff; // enable all debug information
         else if(!strcmp(argv[k + 1], "cache"))
           darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
         else if(!strcmp(argv[k + 1], "control"))
@@ -803,11 +802,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifdef HAVE_OPENCL
         exclude_opencl = TRUE;
 #endif
-        argv[k] = NULL;
-      }
-      else if(!strcmp(argv[k], "--enforce-tiling"))
-      {
-        darktable.unmuted |= DT_DEBUG_TILING;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--"))

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1197,10 +1197,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   // initialize resources stuff here
   if(!dt_conf_key_exists("resourcelevel"))
-    dt_conf_set_int("resourcelevel", 2);
+    dt_conf_set_int("resourcelevel", 3);
 
   darktable.dtresources.total_memory = _get_total_memory();
-  darktable.dtresources.level = dt_conf_get_int("resourcelevel");
 
 /* init lua last, since it's user made stuff it must be in the real environment */
 #ifdef USE_LUA

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -386,6 +386,11 @@ static inline size_t _get_total_memory()
 #endif
 }
 
+static size_t _get_mipmap_size()
+{
+  return darktable.dtresources.total_memory / 8;
+}
+
 int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load_data, lua_State *L)
 {
   double start_wtime = dt_get_wtime();
@@ -1200,7 +1205,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_conf_set_int("resourcelevel", DT_RESOURCE_LEVEL_DEFAULT);
 
   darktable.dtresources.total_memory = _get_total_memory();
-
+  darktable.dtresources.mipmap_memory = _get_mipmap_size();
 /* init lua last, since it's user made stuff it must be in the real environment */
 #ifdef USE_LUA
   dt_lua_init(darktable.lua_state.state, lua_command);
@@ -1647,11 +1652,6 @@ void dt_configure_performance()
     freecache = g_file_info_get_attribute_uint64(gfileinfo, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
   g_object_unref(gfile);
   g_object_unref(gfileinfo);
-
-  // set cache_memory to half of freediskspace - 4gb (eg 1gb cache_mem in case of 6gb free space)
-  if(freecache > (6lu << 20))
-    dt_conf_set_int64("cache_memory", (freecache - (4lu << 20))/2);
-
 
   // enable cache_disk_backend_full when user has over 8gb free diskspace
   dt_conf_set_bool("cache_disk_backend_full", freecache > (8lu << 20));

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1071,6 +1071,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_film_set_folder_status();
   }
 
+  // this is where the sync is to be done if the enum for pref resourcelevel in darktableconfig.xml.in is changed 
   // setup resource fractions now                           def  min small  med large  unrestricted
   const int default_available[DT_RESOURCE_LEVELS_NUM]    = { 512,  0,  128, 400,  700, 10000 };
   const int default_singlebuf[DT_RESOURCE_LEVELS_NUM]    = { 128,  0,   16,  32,   64,  1024 };

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -354,6 +354,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 int dt_worker_threads();
+size_t dt_get_available_mem();
+size_t dt_get_singlebuffer_mem();
+
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)
 {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -279,10 +279,21 @@ typedef struct dt_codepath_t
   unsigned int OPENMP_SIMD : 1; // always stays the last one
 } dt_codepath_t;
 
+typedef enum dt_sys_resources_levels_t
+{
+  DT_RESOURCE_LEVEL_MINIMUM = 0,
+  DT_RESOURCE_LEVEL_SMALL = 1,
+  DT_RESOURCE_LEVEL_MEDIUM = 2,
+  DT_RESOURCE_LEVEL_DEFAULT = 3,
+  DT_RESOURCE_LEVEL_MAXIMUM = 4,
+  DT_RESOURCE_LEVEL_UNRESTRICTED = 5,
+  DT_RESOURCE_LEVEL_TESTING = 6,
+} dt_sys_resources_levels_t;
+
 typedef struct dt_sys_resources_t
 {
   size_t total_memory;
-  int level;
+  dt_sys_resources_levels_t level;
 } dt_sys_resources_t;
 
 typedef struct darktable_t

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -279,6 +279,12 @@ typedef struct dt_codepath_t
   unsigned int OPENMP_SIMD : 1; // always stays the last one
 } dt_codepath_t;
 
+typedef struct dt_sys_resources_t
+{
+  size_t total_memory;
+  int level;
+} dt_sys_resources_t;
+
 typedef struct darktable_t
 {
   dt_codepath_t codepath;
@@ -333,6 +339,7 @@ typedef struct darktable_t
   int32_t unmuted_signal_dbg_acts;
   gboolean unmuted_signal_dbg[DT_SIGNAL_COUNT];
   GTimeZone *utc_tz;
+  struct dt_sys_resources_t dtresources;
 } darktable_t;
 
 typedef struct

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -279,22 +279,18 @@ typedef struct dt_codepath_t
   unsigned int OPENMP_SIMD : 1; // always stays the last one
 } dt_codepath_t;
 
-typedef enum dt_sys_resources_levels_t
-{
-  DT_RESOURCE_LEVEL_MINIMUM = 0,
-  DT_RESOURCE_LEVEL_SMALL = 1,
-  DT_RESOURCE_LEVEL_MEDIUM = 2,
-  DT_RESOURCE_LEVEL_DEFAULT = 3,
-  DT_RESOURCE_LEVEL_MAXIMUM = 4,
-  DT_RESOURCE_LEVEL_UNRESTRICTED = 5,
-  DT_RESOURCE_LEVEL_TESTING = 6,
-} dt_sys_resources_levels_t;
-
+/* These are hard-wired and must correspond with darktableconfig.xml.in */ 
+#define DT_RESOURCE_LEVELS_NUM 6
 typedef struct dt_sys_resources_t
 {
   size_t total_memory;
   size_t mipmap_memory;
-  dt_sys_resources_levels_t level;
+  int level;
+  /* fractions are calculated as res=input / 1024  * fraction */
+  int fract_available[DT_RESOURCE_LEVELS_NUM];
+  int fract_singlebuf[DT_RESOURCE_LEVELS_NUM];
+  int fract_mipmap[DT_RESOURCE_LEVELS_NUM];
+  int fract_cl_available[DT_RESOURCE_LEVELS_NUM];
 } dt_sys_resources_t;
 
 typedef struct darktable_t

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -293,6 +293,7 @@ typedef enum dt_sys_resources_levels_t
 typedef struct dt_sys_resources_t
 {
   size_t total_memory;
+  size_t mipmap_memory;
   dt_sys_resources_levels_t level;
 } dt_sys_resources_t;
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -268,8 +268,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_SIGNAL         = 1 << 20,
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
-  DT_DEBUG_TILING         = 1 << 23,
-  DT_DEBUG_ACT_ON         = 1 << 24
+  DT_DEBUG_ACT_ON         = 1 << 23
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -156,7 +156,7 @@ typedef unsigned int u_int;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 3
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 4
 
 // every module has to define this:
 #ifdef _DEBUG

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -279,18 +279,13 @@ typedef struct dt_codepath_t
   unsigned int OPENMP_SIMD : 1; // always stays the last one
 } dt_codepath_t;
 
-/* These are hard-wired and must correspond with darktableconfig.xml.in */ 
-#define DT_RESOURCE_LEVELS_NUM 6
 typedef struct dt_sys_resources_t
 {
   size_t total_memory;
   size_t mipmap_memory;
+  int *fractions; // fractions are calculated as res=input / 1024  * fraction
+  int group;
   int level;
-  /* fractions are calculated as res=input / 1024  * fraction */
-  int fract_available[DT_RESOURCE_LEVELS_NUM];
-  int fract_singlebuf[DT_RESOURCE_LEVELS_NUM];
-  int fract_mipmap[DT_RESOURCE_LEVELS_NUM];
-  int fract_cl_available[DT_RESOURCE_LEVELS_NUM];
 } dt_sys_resources_t;
 
 typedef struct darktable_t
@@ -359,6 +354,7 @@ typedef struct
 extern darktable_t darktable;
 
 int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load_data, lua_State *L);
+void dt_get_sysresource_level();
 void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 int dt_worker_threads();

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -535,8 +535,7 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
 
   // adjust numbers to be large enough to hold what mem limit suggests.
   // we want at least 100MB, and consider 8G just still reasonable.
-  const int64_t cache_memory = dt_conf_get_int64("cache_memory");
-  const size_t max_mem = CLAMPS(cache_memory, 100u << 20, ((size_t)8) << 30);
+  const size_t max_mem = CLAMPS(darktable.dtresources.mipmap_memory, 100u << 20, ((size_t)8) << 30);
   // Fixed sizes for the thumbnail mip levels, selected for coverage of most screen sizes
   int32_t mipsizes[DT_MIPMAP_F][2] = {
     { 180, 110 },             // mip0 - ~1/2 size previous one

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2445,8 +2445,12 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
 cl_ulong dt_opencl_get_device_available(const int devid)
 {
   if(!darktable.opencl->inited || devid < 0) return 0;
+  const size_t maxmem = darktable.opencl->dev[devid].max_global_mem;
+  const int level = darktable.dtresources.level;
+  if(level == DT_RESOURCE_LEVEL_UNRESTRICTED) return maxmem - 200ul * 1024ul * 1024ul;
+  if(level == DT_RESOURCE_LEVEL_TESTING)      return 1024lu  * 1024ul * 1024ul;
   const size_t disposable = (size_t)darktable.opencl->dev[devid].max_global_mem - 400ul * 1024ul * 1024ul;
-  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 4ul * (size_t)darktable.dtresources.level); 
+  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 4ul * (size_t)level); 
   return available;
 }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2437,20 +2437,18 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
                                       (float)darktable.opencl->dev[devid].memory_in_use/(1024*1024));
 }
 
-/* amount of graphics memory declared as available depend on max_global_mem and resourcelevel.
-   - we garantee a headroom of 400MB in all cases
-   - the returned available is the level/4 fraction
-   - we garantee a minimum of 256MB to simulate a minimum system
+/* amount of graphics memory declared as available depends on max_global_mem and "resourcelevel". We garantee
+   - a headroom of 400MB in all cases
+   - 256MB to simulate a minimum system
+   - 2GB to simalate a reference system 
 */
 cl_ulong dt_opencl_get_device_available(const int devid)
 {
   if(!darktable.opencl->inited || devid < 0) return 0;
-  const size_t maxmem = darktable.opencl->dev[devid].max_global_mem;
   const int level = darktable.dtresources.level;
-  if(level == DT_RESOURCE_LEVEL_UNRESTRICTED) return maxmem - 200ul * 1024ul * 1024ul;
-  if(level == DT_RESOURCE_LEVEL_TESTING)      return 1024lu  * 1024ul * 1024ul;
+  if(level < 0) return 2048lu  * 1024ul * 1024ul;
   const size_t disposable = (size_t)darktable.opencl->dev[devid].max_global_mem - 400ul * 1024ul * 1024ul;
-  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 4ul * (size_t)level); 
+  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 1024ul * darktable.dtresources.fract_cl_available[level]); 
   return available;
 }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2437,38 +2437,92 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
                                       (float)darktable.opencl->dev[devid].memory_in_use/(1024*1024));
 }
 
-/** check if image size fit into limits given by OpenCL runtime */
-int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
-                                const float factor, const size_t overhead)
+/* amount of graphics memory declared as available depend on max_global_mem and resourcelevel.
+   - we garantee a headroom of 400MB in all cases
+   - the returned available is the level/4 fraction
+   - we garantee a minimum of 256MB to simulate a minimum system
+*/
+cl_ulong dt_opencl_get_device_available(const int devid)
 {
-  static float headroom = -1.0f;
-
-  if(!darktable.opencl->inited || devid < 0) return FALSE;
-
-  /* first time run */
-  if(headroom < 0.0f)
-  {
-    headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-
-    /* don't let the user play games with us */
-    headroom = fmin((float)darktable.opencl->dev[devid].max_global_mem, fmax(headroom, 0.0f));
-    dt_conf_set_int("opencl_memory_headroom", headroom / 1024 / 1024);
-  }
-
-  float singlebuffer = (float)width * height * bpp;
-  float total = factor * singlebuffer + overhead;
-
-  if(darktable.opencl->dev[devid].max_image_width < width
-     || darktable.opencl->dev[devid].max_image_height < height)
-    return FALSE;
-
-  if(darktable.opencl->dev[devid].max_mem_alloc < singlebuffer) return FALSE;
-
-  if(darktable.opencl->dev[devid].max_global_mem < total + headroom) return FALSE;
-
-  return TRUE;
+  if(!darktable.opencl->inited || devid < 0) return 0;
+  const size_t disposable = (size_t)darktable.opencl->dev[devid].max_global_mem - 400ul * 1024ul * 1024ul;
+  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 4ul * (size_t)darktable.dtresources.level); 
+  return available;
 }
 
+cl_ulong dt_opencl_get_device_memalloc(const int devid)
+{
+  if(!darktable.opencl->inited || devid < 0) return 0;
+  return darktable.opencl->dev[devid].max_mem_alloc;
+}
+
+/* As there is no portable way to get the unused memory of a cl device we check for required
+   memory by testing.
+   clCreateBuffer does not tell an error condition if there is no memory available (this
+   is according to standard), to make sure the buffer is really allocated in graphics mem we
+   force a small memory access.
+*/
+static gboolean _cl_test_available(const int devid, const size_t required)
+{
+  #define DT_TEST_AVAILABLE_BUFS 8
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+  cl_mem sbuf = (darktable.opencl->dlocl->symbols->dt_clCreateBuffer)(darktable.opencl->dev[devid].context,
+                 CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS, 16, NULL, &err);
+  if(!sbuf) return FALSE;
+
+  int checked = 0;
+  cl_mem tbuf[DT_TEST_AVAILABLE_BUFS];
+  size_t remaining = required;
+  while((remaining > 0) && (checked < DT_TEST_AVAILABLE_BUFS) && (err == CL_SUCCESS))
+  {
+    size_t now = MIN(darktable.opencl->dev[devid].max_mem_alloc, remaining);
+    remaining = remaining - now;  
+    tbuf[checked] = (darktable.opencl->dlocl->symbols->dt_clCreateBuffer)(darktable.opencl->dev[devid].context,
+                     CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS, now, NULL, &err);
+    if(err == CL_SUCCESS)
+    {
+      err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)(darktable.opencl->dev[devid].cmd_queue,
+                                                                   sbuf, tbuf[checked], 0, 0, 16, 0, NULL, NULL);
+      checked++;
+    }
+  }
+  const gboolean success = (err == CL_SUCCESS);
+
+  (darktable.opencl->dlocl->symbols->dt_clReleaseMemObject)(sbuf);
+  for(int i = 0; i < checked; i++)
+    if(tbuf[i]) (darktable.opencl->dlocl->symbols->dt_clReleaseMemObject)(tbuf[i]);
+
+  if(!success)
+    dt_print(DT_DEBUG_OPENCL, "[_buffer_fits_device] had no success for %luMB on device %i\n",
+      required / 1024lu / 1024lu, devid); 
+ 
+  return success;
+}
+
+
+gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
+                                const float factor, const size_t overhead)
+{
+  if(!darktable.opencl->inited || devid < 0) return FALSE;
+
+  const size_t required  = width * height * bpp;
+  const size_t total = factor * required + overhead;
+
+  if((dt_opencl_get_device_memalloc(devid) < required) || (dt_opencl_get_device_available(devid) < total))
+    return FALSE;  
+  if(darktable.opencl->dev[devid].max_image_width < width || darktable.opencl->dev[devid].max_image_height < height)
+    return FALSE;
+  return _cl_test_available(devid, total);
+}
+
+/** check if buffer fits into limits given by OpenCL runtime */
+gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
+{
+  if(!darktable.opencl->inited || devid < 0) return FALSE;
+
+  if((dt_opencl_get_device_memalloc(devid) < required) || (dt_opencl_get_device_available(devid) < required)) return FALSE; 
+  return _cl_test_available(devid, required);
+}
 
 /** round size to a multiple of the value given in config parameter opencl_size_roundup */
 int dt_opencl_roundup(int size)
@@ -2614,13 +2668,6 @@ static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t pr
       break;
   }
   dt_pthread_mutex_unlock(&darktable.opencl->lock);
-}
-
-/** get global memory of device */
-cl_ulong dt_opencl_get_max_global_mem(const int devid)
-{
-  if(!darktable.opencl->inited || devid < 0) return 0;
-  return darktable.opencl->dev[devid].max_global_mem;
 }
 
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2448,7 +2448,8 @@ cl_ulong dt_opencl_get_device_available(const int devid)
   const int level = darktable.dtresources.level;
   if(level < 0) return 2048lu  * 1024ul * 1024ul;
   const size_t disposable = (size_t)darktable.opencl->dev[devid].max_global_mem - 400ul * 1024ul * 1024ul;
-  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 1024ul * darktable.dtresources.fract_cl_available[level]); 
+  const int fraction = darktable.dtresources.fractions[darktable.dtresources.group + 3];
+  const size_t available = MAX(256ul * 1024ul * 1024ul, disposable / 1024ul * fraction); 
   return available;
 }
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -368,14 +368,19 @@ int dt_opencl_get_mem_context_id(cl_mem mem);
 void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t action);
 
 /** check if image size fit into limits given by OpenCL runtime */
-int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
+gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
+/** check if buffer fits into limits given by OpenCL runtime */
+gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required);
+
+/** get available memory for the device */
+cl_ulong dt_opencl_get_device_available(const int devid);
+
+/** get size of allocatable single buffer */
+cl_ulong dt_opencl_get_device_memalloc(const int devid);
 
 /** round size to a multiple of the value given in config parameter opencl_size_roundup */
 int dt_opencl_roundup(int size);
-
-/** get global memory of device */
-cl_ulong dt_opencl_get_max_global_mem(const int devid);
 
 /** get next free slot in eventlist and manage size of eventlist */
 cl_event *dt_opencl_events_get_slot(const int devid, const char *tag);
@@ -491,12 +496,20 @@ static inline int dt_opencl_update_settings(void)
 {
   return 0;
 }
-static inline int dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
+static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)
+{
+  return FALSE;
+}
+static inline gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
+{
+  return FALSE;
+}
+static inline size_t dt_opencl_get_device_available(const int devid)
 {
   return 0;
 }
-static inline int dt_opencl_get_max_global_mem(const int devid)
+static inline size_t dt_opencl_get_device_memalloc(const int devid)
 {
   return 0;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -982,7 +982,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
                                           tiling->factor, tiling->overhead));
 
   /* process module on cpu. use tiling if needed and possible. */
-  if(needs_tiling || (darktable.unmuted & DT_DEBUG_TILING))
+  if(needs_tiling)
   {
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2134,23 +2134,8 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
                                                      int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
-  darktable.dtresources.level = 0;
-  const char *config = dt_conf_get_string_const("resourcelevel");
-  /** These levels must correspond with preferences in xml.in **and** fractions
-      Please note: As there are absolute values for "reference (debug)"
-  */
-  if(config)
-  {
-         if(!strcmp(config, "default"))           darktable.dtresources.level = 0; 
-    else if(!strcmp(config, "mini (debug)"))      darktable.dtresources.level = 1;
-    else if(!strcmp(config, "small"))             darktable.dtresources.level = 2;
-    else if(!strcmp(config, "medium"))            darktable.dtresources.level = 3;
-    else if(!strcmp(config, "large"))             darktable.dtresources.level = 4;
-    else if(!strcmp(config, "unrestricted"))      darktable.dtresources.level = 5;
-    else if(!strcmp(config, "reference (debug)")) darktable.dtresources.level = -1;
-  }
-  dt_print(DT_DEBUG_MEMORY, "[dt_dev_pixelpipe_process_rec_and_backcopy] level `%s' as %i\n", config, darktable.dtresources.level);
-
+  darktable.dtresources.group = 4 * darktable.dtresources.level; 
+  
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1358,7 +1358,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       int valid_input_on_gpu_only = (cl_mem_input != NULL);
 
       /* pre-check if there is enough space on device for non-tiled processing */
-      const int fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
+      const gboolean fits_on_device = dt_opencl_image_fits_device(pipe->devid, MAX(roi_in.width, roi_out->width),
                                                              MAX(roi_in.height, roi_out->height), MAX(in_bpp, bpp),
                                                              tiling.factor_cl, tiling.overhead);
 
@@ -2134,6 +2134,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
                                                      int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
+  darktable.dtresources.level = dt_conf_get_int("resourcelevel");
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2134,7 +2134,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
                                                      int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
-  darktable.dtresources.level = dt_conf_get_int("resourcelevel");
+  darktable.dtresources.level = MIN(DT_RESOURCE_LEVEL_TESTING, MAX(0, dt_conf_get_int("resourcelevel")));
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2134,7 +2134,23 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
                                                      int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
-  darktable.dtresources.level = MIN(DT_RESOURCE_LEVEL_TESTING, MAX(0, dt_conf_get_int("resourcelevel")));
+  darktable.dtresources.level = 0;
+  const char *config = dt_conf_get_string_const("resourcelevel");
+  /** These levels must correspond with preferences in xml.in **and** fractions
+      Please note: As there are absolute values for "reference (debug)"
+  */
+  if(config)
+  {
+         if(!strcmp(config, "default"))           darktable.dtresources.level = 0; 
+    else if(!strcmp(config, "mini (debug)"))      darktable.dtresources.level = 1;
+    else if(!strcmp(config, "small"))             darktable.dtresources.level = 2;
+    else if(!strcmp(config, "medium"))            darktable.dtresources.level = 3;
+    else if(!strcmp(config, "large"))             darktable.dtresources.level = 4;
+    else if(!strcmp(config, "unrestricted"))      darktable.dtresources.level = 5;
+    else if(!strcmp(config, "reference (debug)")) darktable.dtresources.level = -1;
+  }
+  dt_print(DT_DEBUG_MEMORY, "[dt_dev_pixelpipe_process_rec_and_backcopy] level `%s' as %i\n", config, darktable.dtresources.level);
+
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1235,16 +1235,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
   int width = _min(roi_in->width, darktable.opencl->dev[devid].max_image_width);
   int height = _min(roi_in->height, darktable.opencl->dev[devid].max_image_height);
@@ -1605,16 +1599,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
             ? 0.85f
             : 1.0f; // avoid problems when pinned buffer size gets too close to max_mem_alloc size
 
-  /* shall we enforce tiling */
-  const gboolean force_tile = (darktable.unmuted & DT_DEBUG_TILING);
-  /* calculate optimal size of tiles */
-  float headroom = dt_conf_get_float("opencl_memory_headroom") * 1024.0f * 1024.0f;
-  headroom = fmin(fmax(headroom, 0.0f), (float)darktable.opencl->dev[devid].max_global_mem);
-  float available = darktable.opencl->dev[devid].max_global_mem - headroom;
-  if(force_tile) available = fmin(available, 500.0f * 1024.0f * 1024.0f);
+  const float available = (float)dt_opencl_get_device_available(devid);
   const float factor = fmax(tiling.factor_cl + pinned_buffer_overhead, 1.0f);
   const float singlebuffer = fmin(fmax((available - tiling.overhead) / factor, 0.0f),
-                                  pinned_buffer_slack * darktable.opencl->dev[devid].max_mem_alloc);
+                                  pinned_buffer_slack * (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmax(tiling.maxbuf_cl, 1.0f);
 
   int width = _min(_max(roi_in->width, roi_out->width), darktable.opencl->dev[devid].max_image_width);

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -2053,7 +2053,6 @@ int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, co
 {
   const size_t available = dt_get_available_mem();
   const size_t total = factor * width * height * bpp + overhead;
-  // do we want unrestricted memory as for host_memory_limit == 0 ?
 
   if(total <= available)
     return TRUE;

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -712,6 +712,7 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
     const float zoom_ratio = th->zoom_100 > 1 ? th->zoom / th->zoom_100 : table->zoom_ratio;
     dt_thumbnail_resize(th, th->width, th->height, TRUE, zoom_ratio);
   }
+  dt_get_sysresource_level();
 }
 
 static void _dt_selection_changed_callback(gpointer instance, gpointer user_data)

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -713,6 +713,7 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
     dt_thumbnail_resize(th, th->width, th->height, TRUE, zoom_ratio);
   }
   dt_get_sysresource_level();
+  dt_configure_ppd_dpi(darktable.gui);
 }
 
 static void _dt_selection_changed_callback(gpointer instance, gpointer user_data)

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1295,7 +1295,7 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
 {
   if(!user_data) return;
   dt_get_sysresource_level();
-
+  dt_configure_ppd_dpi(darktable.gui);
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   _thumbs_ask_for_discard(table);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1294,6 +1294,8 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
 {
   if(!user_data) return;
+  dt_get_sysresource_level();
+
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   _thumbs_ask_for_discard(table);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -341,6 +341,9 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
   // selecting darktables system resources
+  dt_sys_resources_levels_t oldlevel = dt_conf_get_int("resourcelevel");
+  if((oldlevel < DT_RESOURCE_LEVEL_MINIMUM) || (oldlevel > DT_RESOURCE_LEVEL_UNRESTRICTED))
+    oldlevel = DT_RESOURCE_LEVEL_DEFAULT;
   label = gtk_label_new(_("darktable resources"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);
   widget = gtk_combo_box_text_new();
@@ -349,12 +352,14 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("minimal"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("minimum"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("small"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("medium"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("default/large"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("maximum"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), dt_conf_get_int("resourcelevel"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("default"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("large"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("unrestricted"));
+  
+  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), oldlevel);
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(resources_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set darktable resource taking\nUse larger setting to gain some perormance, this might take away resources from other applications."));
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -148,7 +148,6 @@ static void resources_callback(GtkWidget *widget, gpointer user_data)
 {
   const int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
   dt_conf_set_int("resourcelevel", selected);
-  darktable.dtresources.level = selected;
 }
 
 static void usercss_callback(GtkWidget *widget, gpointer user_data)
@@ -352,12 +351,12 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("minimal"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("small"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("default"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("large"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("medium"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("default/large"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("maximum"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), darktable.dtresources.level);
+  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), dt_conf_get_int("resourcelevel"));
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(resources_callback), 0);
-  gtk_widget_set_tooltip_text(widget, _("set darktable resource taking"));
+  gtk_widget_set_tooltip_text(widget, _("set darktable resource taking\nUse larger setting to gain some perormance, this might take away resources from other applications."));
 
   GtkWidget *useperfmode = gtk_check_button_new();
   label = gtk_label_new(_("prefer performance over quality"));

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -144,6 +144,13 @@ static void theme_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
+static void resources_callback(GtkWidget *widget, gpointer user_data)
+{
+  const int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
+  dt_conf_set_int("resourcelevel", selected);
+  darktable.dtresources.level = selected;
+}
+
 static void usercss_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_conf_set_bool("themes/usercss", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
@@ -333,6 +340,24 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
 
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
+
+  // selecting darktables system resources
+  label = gtk_label_new(_("darktable resources"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  widget = gtk_combo_box_text_new();
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("minimal"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("small"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("default"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("large"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("maximum"));
+  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), darktable.dtresources.level);
+  g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(resources_callback), 0);
+  gtk_widget_set_tooltip_text(widget, _("set darktable resource taking"));
 
   GtkWidget *useperfmode = gtk_check_button_new();
   label = gtk_label_new(_("prefer performance over quality"));

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -156,12 +156,6 @@ static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
   reload_ui_last_theme();
 }
 
-static void use_performance_callback(GtkWidget *widget, gpointer user_data)
-{
-  dt_conf_set_bool("ui/performance", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-  dt_configure_ppd_dpi(darktable.gui);
-}
-
 static void dpi_scaling_changed_callback(GtkWidget *widget, gpointer user_data)
 {
   float dpi = gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget));
@@ -333,19 +327,6 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
 
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
-
-  GtkWidget *useperfmode = gtk_check_button_new();
-  label = gtk_label_new(_("prefer performance over quality"));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), useperfmode, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(useperfmode,
-                              _("if switched on, thumbnails and previews are rendered at lower quality but 4 times faster"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(useperfmode), dt_conf_get_bool("ui/performance"));
-  g_signal_connect(G_OBJECT(useperfmode), "toggled", G_CALLBACK(use_performance_callback), 0);
 
   //Font size check and spin buttons
   GtkWidget *usesysfont = gtk_check_button_new();

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -144,12 +144,6 @@ static void theme_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
-static void resources_callback(GtkWidget *widget, gpointer user_data)
-{
-  const int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-  dt_conf_set_int("resourcelevel", selected);
-}
-
 static void usercss_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_conf_set_bool("themes/usercss", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
@@ -339,29 +333,6 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
 
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
-
-  // selecting darktables system resources
-  dt_sys_resources_levels_t oldlevel = dt_conf_get_int("resourcelevel");
-  if((oldlevel < DT_RESOURCE_LEVEL_MINIMUM) || (oldlevel > DT_RESOURCE_LEVEL_UNRESTRICTED))
-    oldlevel = DT_RESOURCE_LEVEL_DEFAULT;
-  label = gtk_label_new(_("darktable resources"));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  widget = gtk_combo_box_text_new();
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("minimum"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("small"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("medium"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("default"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("large"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("unrestricted"));
-  
-  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), oldlevel);
-  g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(resources_callback), 0);
-  gtk_widget_set_tooltip_text(widget, _("set darktable resource taking\nUse larger setting to gain some perormance, this might take away resources from other applications."));
 
   GtkWidget *useperfmode = gtk_check_button_new();
   label = gtk_label_new(_("prefer performance over quality"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1888,6 +1888,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_no_show_all(display_intent, TRUE);
     gtk_widget_set_visible(display_intent, FALSE);
   }
+  dt_get_sysresource_level();
 }
 
 static void _preference_prev_downsample_change(gpointer instance, gpointer user_data)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1889,6 +1889,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_visible(display_intent, FALSE);
   }
   dt_get_sysresource_level();
+  dt_configure_ppd_dpi(darktable.gui);
 }
 
 static void _preference_prev_downsample_change(gpointer instance, gpointer user_data)


### PR DESCRIPTION
There are currently several config options (headroom, host memory limit, single buffer) that are not intuitive and require help for users and are related to system resources and dt performance.

Instead i propose a "general" setting in 5 steps that describes how much of your system's resources you are willing to give to darktable. 

In this pr the headroom managing has been implemented, you can change the setting on the fly.
- if you want to run a hugin session while running dt (just give more resources)
- an additional benefit, by setting to "minimal" the graphics card will have room as a small card leading to better ways debugging tiling.

If this proposal finds approval, i would implement removal of "host memory limit" and "single buffer" and possibly "thumbnail cache" too leading to less preferences.

Should replace #11135

Pinging @TurboGit , @parafin and @elstoc here as you commented on earlier proposals.