### PR TITLE
Add a check for both "residential" and "residental" as alias 

### DIFF
--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -623,6 +623,8 @@ broken_bbox:
           place->type = LOCATION_TYPE_CITY;
         else if(strcmp(*avalue, "administrative") == 0)
           place->type = LOCATION_TYPE_ADMINISTRATIVE;
+        else if(strcmp(*avalue, "residental") == 0) // for backward compatibility
+          place->type = LOCATION_TYPE_RESIDENTIAL;
         else if(strcmp(*avalue, "residential") == 0)
           place->type = LOCATION_TYPE_RESIDENTIAL;
       }


### PR DESCRIPTION
Make sure that legacy alias (with typo)  is still supported

Follow-up to https://github.com/darktable-org/darktable/pull/11159#discussion_r809360886