### PR TITLE
lua preferences: do not add enum default value as additional item

### DIFF
--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -636,6 +636,8 @@ static int register_pref_sub(lua_State *L)
 
       int value = 0;
       built_elt->type_data.enum_data.default_value = strdup(luaL_checkstring(L, cur_param));
+      cur_param++;
+      
       while(!lua_isnoneornil(L, cur_param))
       {
         luaA_enum_value_type(L, enum_type, &value, luaL_checkstring(L, cur_param));


### PR DESCRIPTION
While trying to add a lua script preference setting of type "enum" (combobox) I noticed that the default value is set as an additional selection value. 
According to the preferenceExamples.lua script, the values should include the default value:
```
dt.preferences.register("preferenceExamples",        -- script: This is a string used to avoid name collision in preferences (i.e namespace). Set it to something unique, usually the name of the script handling the preference.
                        "preferenceExamplesEnum",  -- name
                        "enum",                       -- type
                        "Example Enum",              -- label
                        "Example Enum Tooltip",      -- tooltip
                        "Enum 1",                     -- default
                        "Enum 1", "Enum 2")           -- values
```
("Enum 1" is in the values and additionally as default value).
Doing so, the default value will be in the preferences drop down selection twice.

As it seems that no script (except the examples) from the distro currently uses the enum, I guess it's ok to change the behavior so that the default value is stored but not added to the list for the combobox.

The alternative is to omit the default value in the values enumeration. But than it will be impossible to have a "ordered" list where the default is not the first item.

As I do not have an overview of the entire impact of this small change, please check twice before merging. Thank you!
