### PR TITLE
no -p option in code: remove it from the comment

### DIFF
--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 #
-# Usage: extract_wb_from_images [-p]
-#        -p  do the purge, otherwise only display unused tags
+# Usage: extract_wb_from_images
 #
 
 commandline="$0 $*"


### PR DESCRIPTION
The comments in tools/extract_wb_from_images mention a -p option ("do the purge, otherwise only display unused tags"), which isn't implemented. The comment most likely is a copy and paste mistake.