### PR TITLE
remove realpath call in relative file name code path of dt_util_normalize_path()

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -671,16 +671,8 @@ gchar *dt_util_normalize_path(const gchar *_input)
     char *current_dir = g_get_current_dir();
     char *tmp_filename = g_build_filename(current_dir, filename, NULL);
     g_free(filename);
-    filename = g_realpath(tmp_filename);
-    if(filename == NULL)
-    {
-      g_free(current_dir);
-      g_free(tmp_filename);
-      g_free(filename);
-      return NULL;
-    }
+    filename = tmp_filename;
     g_free(current_dir);
-    g_free(tmp_filename);
   }
 
 #ifdef _WIN32

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 #
-# Usage: extract_wb_from_images [-p]
-#        -p  do the purge, otherwise only display unused tags
+# Usage: extract_wb_from_images
 #
 
 commandline="$0 $*"


### PR DESCRIPTION
This is for #9734, and removes an inconsistency between the handling of absolute and relative file name arguments.

See https://github.com/darktable-org/darktable/issues/9734#issuecomment-1046087732 for the reasoning.