### PR TITLE
diffuse: fix diffusion directionality control

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -114,7 +114,7 @@ inline void rotation_matrix_isophote(const float4 c2,
   // c dampens the gradient direction
   a[0][0] = cos_theta2 + c2 * sin_theta2;
   a[1][1] = c2 * cos_theta2 + sin_theta2;
-  a[0][1] = a[1][0] = (c2 - 1.0f) * cos_theta_sin_theta;
+  a[0][1] = a[1][0] = (1.0f - c2) * cos_theta_sin_theta;
 }
 
 inline void rotation_matrix_gradient(const float4 c2,
@@ -129,7 +129,7 @@ inline void rotation_matrix_gradient(const float4 c2,
   // c dampens the isophote direction
   a[0][0] = c2 * cos_theta2 + sin_theta2;
   a[1][1] = cos_theta2 + c2 * sin_theta2;
-  a[0][1] = a[1][0] = (1.0f - c2) * cos_theta_sin_theta;
+  a[0][1] = a[1][0] = (c2 - 1.0f) * cos_theta_sin_theta;
 }
 
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -603,7 +603,7 @@ static inline void rotation_matrix_isophote(const dt_aligned_pixel_t c2, const d
   {
     a[0][0][c] = cos_theta2[c] + c2[c] * sin_theta2[c];
     a[1][1][c] = c2[c] * cos_theta2[c] + sin_theta2[c];
-    a[0][1][c] = a[1][0][c] = (c2[c] - 1.0f) * cos_theta_sin_theta[c];
+    a[0][1][c] = a[1][0][c] = (1.0f - c2[c]) * cos_theta_sin_theta[c];
   }
 }
 
@@ -623,7 +623,7 @@ static inline void rotation_matrix_gradient(const dt_aligned_pixel_t c2, const d
   {
     a[0][0][c] = c2[c] * cos_theta2[c] + sin_theta2[c];
     a[1][1][c] = cos_theta2[c] + c2[c] * sin_theta2[c];
-    a[0][1][c] = a[1][0][c] = (1.0f - c2[c]) * cos_theta_sin_theta[c];
+    a[0][1][c] = a[1][0][c] = (c2[c] - 1.f) * cos_theta_sin_theta[c];
   }
 }
 


### PR DESCRIPTION
Watching @s7habo's latest [video](https://youtu.be/pAbyORw0mng?t=545) about the _diffuse or sharpen_ module, the way the anisotropy direction sliders acted on a synthetic image felt way off. Specifically, why increasing the value to favour diffusion in the isophote direction makes the diffusion leak from diagonal directions to the circle while it is stopped in the horizontal and vertical directions? The intuitive result here should have been stopping the diffusion altogether at the edge of the circle, regardless of the direction.

I could reproduce the issue myself and went looking for a bug in the code. Reading the paper, I couldn't find any fault. However I thought there still could be a discrepancy with the rotation matrices. Specifically, what if the angle of the gradient is meant to be negated? It didn't seem to be the case based on the paper, but I tried that and it actually fixed the issue.

Test with a circle image. Positive value in 1st order speed, varying the 1st degree diffusion directionality.

| directionality | master | with fix |
| --- | --- | --- |
| +400 | ![circle](https://user-images.githubusercontent.com/5001906/155211584-c0668564-9aad-4838-a0c1-24c6e087f21c.jpg) | ![circle_02](https://user-images.githubusercontent.com/5001906/155211609-7227283b-bcc9-425b-b009-ba75c23b655c.jpg) |
| -400 | ![circle_01](https://user-images.githubusercontent.com/5001906/155211651-a142c2f4-4275-43ac-8a17-3b676e92e55f.jpg) | ![circle_03](https://user-images.githubusercontent.com/5001906/155211678-796bb533-d229-4b8d-8176-7c58d5d562d0.jpg) |

With the fix, the diffusion is uniformly reduced around the circle's perimeter independent of the direction, as was expected. Notice that with current master build, turning directionality all the way up to positive doesn't prevent diffusion from crossing edges but makes it leak in funny directions.

Here's the test image and XMP:
<img src="https://user-images.githubusercontent.com/5001906/155211903-2af84f03-8827-43e5-a238-cb07dbaa6f2e.png" width="100" height="100" />
[circle.png.xmp.txt](https://github.com/darktable-org/darktable/files/8119909/circle.png.xmp.txt)

Here's another one with a real-world image instead.

| directionality | master | with fix |
| --- | --- | --- |
| +400 | ![P7230233_07](https://user-images.githubusercontent.com/5001906/155210719-fd6ef955-c6ac-420e-9d41-b31c6b88e1a2.jpg) | ![P7230233_04](https://user-images.githubusercontent.com/5001906/155210828-0e5039ee-37be-48ba-b837-0a022c644550.jpg) |
| -400 | ![P7230233_08](https://user-images.githubusercontent.com/5001906/155210942-cbdef9de-2cc2-420d-866a-2ff05ee4bbaf.jpg) | ![P7230233_05](https://user-images.githubusercontent.com/5001906/155211011-38100836-0107-44c2-851a-460b656946a3.jpg) |
 
Here you can see the effect of the negative value more clearly than with the synthetic image. With the fix, the clouds leak into the bridge straight across the surface.

I also went through the built-in presets to look for any ill effects with the new code but didn't find any.

Based on these tests I'm fairly convinced this is a correct fix for an actual bug in the module. What's left to do:

* review / comments from @aurelienpierre 
* explain / prove why this change is correct
* figure out how to preserve old edits while keeping code clean enough

For the proof part, my best guess at the moment is an error in the diffusion matrix established in [this paper](https://www.cs.cmu.edu/~jkh/462_s07/reaction_diffusion.pdf) which is in turn cited by [the paper](https://www.researchgate.net/publication/220663968) that the module is based on. I did a few calculations and found something that could be a mistake in the aforementioned paper. Or then the error could be interpreting the rotation angle wrongly, i.e. it should be negated. Both the potential mistake in paper and the negation of the angle have the same effect in the final maths.