### PR TITLE
Expose resources levels in darktablerc and bugfix

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1102,7 +1102,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   check_resourcelevel("resource_unrestricted", fractions, 4);
 
   darktable.dtresources.fractions = fractions;
-  darktable.dtresources.total_memory = _get_total_memory();
+  darktable.dtresources.total_memory = _get_total_memory() * 1024lu;
   dt_get_sysresource_level();
   darktable.dtresources.mipmap_memory = _get_mipmap_size();
   // initialize collection query


### PR DESCRIPTION
As discussed the resourcelevel fractions should be exposed in darktablerc so the user can finetune for own system.

As @elstoc pointed out, the given values are too far on the conservative side compared with old behaviour where users expected darktable at best performance. These sets should still be safe (as commented and discussed in the before pr #11167) but more performant.

As @kofa73 hinted i missed calculating "real bytes" for total memory. 