### PR TITLE
diffuse: better fix for directionality control

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -114,7 +114,7 @@ inline void rotation_matrix_isophote(const float4 c2,
   // c dampens the gradient direction
   a[0][0] = cos_theta2 + c2 * sin_theta2;
   a[1][1] = c2 * cos_theta2 + sin_theta2;
-  a[0][1] = a[1][0] = (1.0f - c2) * cos_theta_sin_theta;
+  a[0][1] = a[1][0] = (c2 - 1.0f) * cos_theta_sin_theta;
 }
 
 inline void rotation_matrix_gradient(const float4 c2,
@@ -129,7 +129,7 @@ inline void rotation_matrix_gradient(const float4 c2,
   // c dampens the isophote direction
   a[0][0] = c2 * cos_theta2 + sin_theta2;
   a[1][1] = cos_theta2 + c2 * sin_theta2;
-  a[0][1] = a[1][0] = (c2 - 1.0f) * cos_theta_sin_theta;
+  a[0][1] = a[1][0] = (1.0f - c2) * cos_theta_sin_theta;
 }
 
 

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -135,15 +135,20 @@ inline void rotation_matrix_gradient(const float4 c2,
 
 inline void build_matrix(const float4 a[2][2], float4 kern[9])
 {
-  const float4 b13 = a[0][1] / 2.0f;
-  const float4 b11 = -b13;
+  const float4 b11 = a[0][1] / 2.0f;
+  const float4 b13 = -b11;
   const float4 b22 = -2.0f * (a[0][0] + a[1][1]);
 
   // build the kernel of rotated anisotropic laplacian
   // from https://www.researchgate.net/publication/220663968 :
-  // [ [ -a12 / 2,  a22,           a12 / 2  ],
+  // [ [ a12 / 2,  a22,            -a12 / 2 ],
   //   [ a11,      -2 (a11 + a22), a11      ],
-  //   [ a12 / 2,   a22,          -a12 / 2  ] ]
+  //   [ -a12 / 2,   a22,          a12 / 2  ] ]
+  // N.B. we have flipped the signs of the a12 terms
+  // compared to the paper. There's probably a mismatch
+  // of coordinate convention between the paper and the
+  // original derivation of this convolution mask
+  // (Witkin 1991, https://doi.org/10.1145/127719.122750).
   kern[0] = b11;
   kern[1] = a[1][1];
   kern[2] = b13;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -635,15 +635,20 @@ static inline void build_matrix(const dt_aligned_pixel_t a[2][2], dt_aligned_pix
 {
   for_each_channel(c)
   {
-    const float b13 = a[0][1][c] / 2.0f;
-    const float b11 = -b13;
+    const float b11 = a[0][1][c] / 2.0f;
+    const float b13 = -b11;
     const float b22 = -2.0f * (a[0][0][c] + a[1][1][c]);
 
     // build the kernel of rotated anisotropic laplacian
     // from https://www.researchgate.net/publication/220663968 :
-    // [ [ -a12 / 2,  a22,           a12 / 2  ],
+    // [ [ a12 / 2,  a22,            -a12 / 2 ],
     //   [ a11,      -2 (a11 + a22), a11      ],
-    //   [ a12 / 2,   a22,          -a12 / 2  ] ]
+    //   [ -a12 / 2,   a22,          a12 / 2  ] ]
+    // N.B. we have flipped the signs of the a12 terms
+    // compared to the paper. There's probably a mismatch
+    // of coordinate convention between the paper and the
+    // original derivation of this convolution mask
+    // (Witkin 1991, https://doi.org/10.1145/127719.122750).
     kernel[0][c] = b11;
     kernel[1][c] = a[1][1][c];
     kernel[2][c] = b13;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -603,7 +603,7 @@ static inline void rotation_matrix_isophote(const dt_aligned_pixel_t c2, const d
   {
     a[0][0][c] = cos_theta2[c] + c2[c] * sin_theta2[c];
     a[1][1][c] = c2[c] * cos_theta2[c] + sin_theta2[c];
-    a[0][1][c] = a[1][0][c] = (1.0f - c2[c]) * cos_theta_sin_theta[c];
+    a[0][1][c] = a[1][0][c] = (c2[c] - 1.0f) * cos_theta_sin_theta[c];
   }
 }
 
@@ -623,7 +623,7 @@ static inline void rotation_matrix_gradient(const dt_aligned_pixel_t c2, const d
   {
     a[0][0][c] = c2[c] * cos_theta2[c] + sin_theta2[c];
     a[1][1][c] = cos_theta2[c] + c2[c] * sin_theta2[c];
-    a[0][1][c] = a[1][0][c] = (c2[c] - 1.f) * cos_theta_sin_theta[c];
+    a[0][1][c] = a[1][0][c] = (1.0f - c2[c]) * cos_theta_sin_theta[c];
   }
 }
 


### PR DESCRIPTION
A second iteration of https://github.com/darktable-org/darktable/pull/11206, flipping the sign in the proper place (as far as I've now understood the matter correctly) and adding a comment about it.

Mathematically, the net result is exactly the same as before but the code reads out easier.