### PR TITLE
Fix memleak while reading fractions for resourcelevel

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -404,7 +404,7 @@ void check_resourcelevel(const char *key, int *fractions, const int level)
   }
   else
   {
-    gchar *in = dt_conf_get_string(key);
+    const gchar *in = dt_conf_get_string_const(key);
     sscanf(in, "%i %i %i %i", &fractions[g], &fractions[g+1], &fractions[g+2], &fractions[g+3]);
   }
 }


### PR DESCRIPTION
reading in a conf key for interpretation should either use `dt_conf_get_string_const(key)` or free the sting later. 