### PR TITLE
Add a "tune OpenCLperformance" button

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -182,7 +182,6 @@
         <option>small</option>
         <option>default</option>
         <option>large</option>
-        <option>tuned cl</option>
         <option>unrestricted</option>
         <option>mini (debug)</option>
         <option>reference (debug)</option>
@@ -190,7 +189,7 @@
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources. lower the setting if you are using simultaneously applications taking large parts of your systems memory or opencl/gl applications like games or hugin. increase if you are using darktable alone on your machine.\n - default: takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - tuned cl: tunes your graphics card for best performance\n\nthere are some special modes:\n\n - mini: darktable takes 0.5 GB ram and 0.25GB video ram\n - reference: - darktable takes 8GB ram and 2GB video ram\n - unrestricted: darktable will take almost all of your systems resources and might lead to swapping and unexpected performance drops. use with caution!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - Use `small` if you are simultaneously using applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - Use `large` if you want darktable to take most of your systems resources for performance. Probably best option while exporting images.\n\nspecial modes used for tests and debugging:\n\n - mini: darktable takes 0.5 GB ram and 0.25GB video ram\n - reference: - darktable takes 8GB ram and 2GB video ram\n - unrestricted: darktable will take almost all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>
@@ -368,6 +367,13 @@
     <default>default</default>
     <shortdescription>OpenCL scheduling profile</shortdescription>
     <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems. default - GPU processes full and CPU processes preview pipe (adaptable by config parameters); multiple GPUs - process both pixelpipes in parallel on two different GPUs; very fast GPU - process both pixelpipes sequentially on the GPU.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="processing" section="cpugpu" capability="opencl">
+    <name>tuneopencl</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>tune OpenCL performance</shortdescription>
+    <longdescription>if switched on, darktable tunes OpenCL for best performance, overrides static settings in resourcelevel</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_synch_cache</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -182,6 +182,7 @@
         <option>small</option>
         <option>default</option>
         <option>large</option>
+        <option>tuned cl</option>
         <option>unrestricted</option>
         <option>mini (debug)</option>
         <option>reference (debug)</option>
@@ -189,7 +190,7 @@
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources. lower the setting if you are using simultaneously applications taking large parts of your systems memory or opencl/gl applications like games or hugin. increase if you are using darktable alone on your machine.\n - default: takes ~50%% of your systems resources and gives darktable enough to be still performant.\n\nthere are some special modes:\n\n - mini: darktable takes 0.5 GB ram and 0.25GB video ram\n - reference: - darktable takes 8GB ram and 2GB video ram\n - unrestricted: darktable will take almost all of your systems resources and might lead to swapping and unexpected performance drops. use with caution!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources. lower the setting if you are using simultaneously applications taking large parts of your systems memory or opencl/gl applications like games or hugin. increase if you are using darktable alone on your machine.\n - default: takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - tuned cl: tunes your graphics card for best performance\n\nthere are some special modes:\n\n - mini: darktable takes 0.5 GB ram and 0.25GB video ram\n - reference: - darktable takes 8GB ram and 2GB video ram\n - unrestricted: darktable will take almost all of your systems resources and might lead to swapping and unexpected performance drops. use with caution!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1088,18 +1088,20 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   //  1 cpu singlebuffer
   //  2 mipmap size
   //  3 opencl available
-  static int fractions[20] = {
+  static int fractions[24] = {
       512,   32, 128, 700,  // default
         0,    0,  16,   0,  // mini
       128,   16,  64, 400,  // small
       700,   64, 128, 900,  // large
-    16384, 1024, 128, 1024  // unrestricted
+    16384, 1024, 128, 1024, // unrestricted
+      700,   64, 128,   0,  // tunedcl
   };
   // Allow the settings for each performance level to be changed via darktablerc
   check_resourcelevel("resource_default", fractions, 0);
   check_resourcelevel("resource_small", fractions, 2);
   check_resourcelevel("resource_large", fractions, 3);
   check_resourcelevel("resource_unrestricted", fractions, 4);
+  check_resourcelevel("resource_tuned", fractions, 5);
 
   darktable.dtresources.fractions = fractions;
   darktable.dtresources.total_memory = _get_total_memory() * 1024lu;
@@ -1303,7 +1305,7 @@ void dt_get_sysresource_level()
       If we want a new setting here, we must
         - add a string->level conversion here
         - add a line of fraction in int fractions[] above
-        - add a line in
+        - add a line in darktableconfig.xml.in
   */
   if(config)
   {
@@ -1312,6 +1314,7 @@ void dt_get_sysresource_level()
     else if(!strcmp(config, "small"))             darktable.dtresources.level = 2;
     else if(!strcmp(config, "large"))             darktable.dtresources.level = 3;
     else if(!strcmp(config, "unrestricted"))      darktable.dtresources.level = 4;
+    else if(!strcmp(config, "tuned cl"))          darktable.dtresources.level = 5;
     else if(!strcmp(config, "reference (debug)")) darktable.dtresources.level = -1;
     else if(!strcmp(config, "reference"))         darktable.dtresources.level = -1;
     dt_print(DT_DEBUG_MEMORY, "[dt_get_sysresource_level] switched to %i as `%s'\n", darktable.dtresources.level, config);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1088,20 +1088,18 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   //  1 cpu singlebuffer
   //  2 mipmap size
   //  3 opencl available
-  static int fractions[24] = {
-      512,   32, 128, 700,  // default
-        0,    0,  16,   0,  // mini
-      128,   16,  64, 400,  // small
-      700,   64, 128, 900,  // large
+  static int fractions[20] = {
+        0,    0,  16,    0, // mini
+      128,   16,  64,  400, // small
+      512,   32, 128,  700, // default
+      700,   64, 128,  900, // large
     16384, 1024, 128, 1024, // unrestricted
-      700,   64, 128,   0,  // tunedcl
   };
   // Allow the settings for each performance level to be changed via darktablerc
-  check_resourcelevel("resource_default", fractions, 0);
-  check_resourcelevel("resource_small", fractions, 2);
+  check_resourcelevel("resource_default", fractions, 2);
+  check_resourcelevel("resource_small", fractions, 1);
   check_resourcelevel("resource_large", fractions, 3);
   check_resourcelevel("resource_unrestricted", fractions, 4);
-  check_resourcelevel("resource_tuned", fractions, 5);
 
   darktable.dtresources.fractions = fractions;
   darktable.dtresources.total_memory = _get_total_memory() * 1024lu;
@@ -1298,7 +1296,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
 void dt_get_sysresource_level()
 {
-  darktable.dtresources.level = 0;
+  darktable.dtresources.tunecl = dt_conf_get_bool("tuneopencl");
+  darktable.dtresources.level = 2;
   const char *config = dt_conf_get_string_const("resourcelevel");
   /** These levels must correspond with preferences in xml.in **and** fractions
       Please note: absolute values for "reference (debug)"
@@ -1309,18 +1308,18 @@ void dt_get_sysresource_level()
   */
   if(config)
   {
-         if(!strcmp(config, "default"))           darktable.dtresources.level = 0;
-    else if(!strcmp(config, "mini (debug)"))      darktable.dtresources.level = 1;
-    else if(!strcmp(config, "small"))             darktable.dtresources.level = 2;
+         if(!strcmp(config, "default"))           darktable.dtresources.level = 2;
+    else if(!strcmp(config, "small"))             darktable.dtresources.level = 1;
     else if(!strcmp(config, "large"))             darktable.dtresources.level = 3;
+    else if(!strcmp(config, "mini (debug)"))      darktable.dtresources.level = 0;
     else if(!strcmp(config, "unrestricted"))      darktable.dtresources.level = 4;
-    else if(!strcmp(config, "tuned cl"))          darktable.dtresources.level = 5;
     else if(!strcmp(config, "reference (debug)")) darktable.dtresources.level = -1;
     else if(!strcmp(config, "reference"))         darktable.dtresources.level = -1;
-    dt_print(DT_DEBUG_MEMORY, "[dt_get_sysresource_level] switched to %i as `%s'\n", darktable.dtresources.level, config);
+    dt_print(DT_DEBUG_MEMORY, "[dt_get_sysresource_level] switched to %i as `%s', OpenCL tuning=%s\n", darktable.dtresources.level, config, (darktable.dtresources.tunecl) ? "ON" : "OFF");
   }
   else
     dt_print(DT_DEBUG_MEMORY, "[dt_get_sysresource_level] switched to default as missing `resorcelevel' conf\n");
+
 }
 
 void dt_cleanup()

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -285,6 +285,7 @@ typedef struct dt_sys_resources_t
   int *fractions; // fractions are calculated as res=input / 1024  * fraction
   int group;
   int level;
+  int tunecl;
 } dt_sys_resources_t;
 
 typedef struct darktable_t

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -120,6 +120,7 @@ typedef struct dt_opencl_device_t
   float benchmark;
   size_t memory_in_use;
   size_t peak_memory;
+  size_t tuned_available;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;


### PR DESCRIPTION
Some users might fear worse performance with the new "darktable resources" runtime
checks (or have experienced so after the first merged pr's) and wanted ways to tune
the system as they did with "cl headroom".

a small reminder
 - headroom was global and didn't work good with several devices
 - you might be running other opencl apps when starting dt so the static headroom
   was too small and you ended up with cl errors and fallback to cpu code.

The "tuned cl" mode is preset to the same values for cpu related stuff.

For OpenCL is does a test for available graphics memory for every device **once** when
starting darltable and returns the found free memory from now on whenever we want to know
via `dt_opencl_get_device_available(const int devid)`
(It keeps a safety headroom margin of 128MB)

Found free memory and old-style headroom are reported via -d opencl if you are curious.