### PR TITLE
Add IMAGE.EXIF as variable.

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -370,6 +370,15 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup(params->data->exif_lens);
   else if(_has_prefix(variable, "ID") || _has_prefix(variable, "IMAGE.ID"))
     result = g_strdup_printf("%d", params->imgid);
+  else if(_has_prefix(variable, "IMAGE.EXIF"))
+  {
+    gchar buffer[1024];
+    const dt_image_t *img = params->img ? (dt_image_t *)params->img
+                                        : dt_image_cache_get(darktable.image_cache, params->imgid, 'r');
+    dt_image_print_exif(img, buffer, sizeof(buffer));
+    if(params->img == NULL) dt_image_cache_read_release(darktable.image_cache, img);
+    result = g_strdup(buffer);
+  }
   else if(_has_prefix(variable, "VERSION.NAME") || _has_prefix(variable, "VERSION_NAME"))
   {
     GList *res = dt_metadata_get(params->imgid, "Xmp.darktable.version_name", NULL);

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -227,6 +227,7 @@ const dt_gtkentry_completion_spec *dt_gtkentry_get_default_path_compl_list()
           { "LABELS", N_("$(LABELS) - color labels as text") },
           { "LABELS.ICONS", N_("$(LABELS.ICONS) - color labels as icons") },
           { "ID", N_("$(ID) - image ID") },
+          { "IMAGE.EXIF", N_("$(IMAGE.EXIF) - common image's EXIF") },
           { "TITLE", N_("$(TITLE) - title from metadata") },
           { "DESCRIPTION", N_("$(DESCRIPTION) - description from metadata") },
           { "CREATOR", N_("$(CREATOR) - creator from metadata") },


### PR DESCRIPTION
This was removed in previous refactoring of variables support.

Fixes integration test 0032-watermark.