### PR TITLE
Standardise slider step size and make individually configurable

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -74,6 +74,13 @@
     <shortdescription>widget scale</shortdescription>
     <longdescription>scaling factor for bauhaus widgets, will affect font size</longdescription>
   </dtconfig>
+  <dtconfig prefs="misc" section="interface">
+    <name>bauhaus/zoom_step</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>scale slider step with min/max</shortdescription>
+    <longdescription>vary bauhaus slider step size with min/max range</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>database</name>
     <type>string</type>

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -26,7 +26,7 @@
 @define-color selected_bg_color @grey_55; /* legacy stuff */
 @define-color border_color @grey_40; /* border, when used */
 @define-color bg_color @grey_45; /* general background */
-@define-color fg_color @grey_95; /* general text */
+@define-color fg_color @grey_90; /* general text */
 @define-color base_color @fg_color; /* legacy stuff */
 @define-color text_color @grey_35; /* same */
 @define-color disabled_fg_color @grey_65; /* disabled controls */
@@ -49,7 +49,7 @@
 @define-color bauhaus_indicator_border @grey_50;
 @define-color bauhaus_fill @grey_70;
 @define-color bauhaus_bg_hover @grey_65;
-@define-color bauhaus_fg_hover @grey_95;
+@define-color bauhaus_fg_hover @grey_100;
 @define-color bauhaus_fg_selected @grey_85;
 @define-color bauhaus_fg_disabled alpha(@bauhaus_fg, 0.5);
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.5);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -879,14 +879,6 @@ float dt_bauhaus_slider_get_default(GtkWidget *widget)
   return d->defpos;
 }
 
-void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max)
-{
-  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
-  dt_bauhaus_slider_data_t *d = &w->data.slider;
-  d->hard_min = hard_min;
-  d->hard_max = hard_max;
-}
-
 extern const dt_action_def_t dt_action_def_slider;
 extern const dt_action_def_t dt_action_def_combo;
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2391,6 +2391,10 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
 
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
+  // handle speed adjustment in mapping mode in dispatcher
+  if(darktable.control->mapping_widget)
+    return dt_shortcut_dispatcher(widget, (GdkEvent*)event, user_data);
+
   gtk_widget_grab_focus(widget);
 
   int delta_y;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -720,7 +720,6 @@ static void dt_bauhaus_widget_init(dt_bauhaus_widget_t *w, dt_iop_module_t *self
   w->quad_paint = 0;
   w->quad_paint_data = NULL;
   w->quad_toggle = 0;
-  w->combo_populate = NULL;
 
   switch(w->type)
   {
@@ -1102,6 +1101,7 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
   d->text_align = DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT;
   d->entries_ellipsis = PANGO_ELLIPSIZE_END;
   d->mute_scrolling = FALSE;
+  d->populate = NULL;
   memset(d->text, 0, sizeof(d->text));
 
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_PRESS_MASK);
@@ -1121,8 +1121,8 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
 void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidget *w, struct dt_iop_module_t **module))
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
-  if(w->type != DT_BAUHAUS_COMBOBOX) return;
-  w->combo_populate = fct;
+  if(w->type == DT_BAUHAUS_COMBOBOX)
+    w->data.combobox.populate = fct;
 }
 
 void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const char **texts)
@@ -2189,10 +2189,10 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
     {
       // we launch the dynamic populate fct if any
       dt_iop_module_t *module = (dt_iop_module_t *)(w->module);
-      if(w->combo_populate) w->combo_populate(GTK_WIDGET(w), &module);
+      const dt_bauhaus_combobox_data_t *d = &w->data.combobox;
+      if(d->populate) d->populate(GTK_WIDGET(w), &module);
       // comboboxes change immediately
       darktable.bauhaus->change_active = 1;
-      const dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       if(!d->num_labels) return;
       tmp.height = darktable.bauhaus->line_height * d->num_labels + 5 * darktable.bauhaus->widget_space;
       tmp.width *= d->scale;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -981,6 +981,11 @@ static void dt_bauhaus_slider_destroy(dt_bauhaus_widget_t *widget, gpointer user
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   if(d->timeout_handle) g_source_remove(d->timeout_handle);
   d->timeout_handle = 0;
+  if(d->grad_col)
+  {
+    free(d->grad_col);
+    free(d->grad_pos);
+  }
 }
 
 GtkWidget *dt_bauhaus_slider_new(dt_iop_module_t *self)
@@ -1027,6 +1032,8 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
   d->offset = 0.0f;
 
   d->grad_cnt = 0;
+  d->grad_col = NULL;
+  d->grad_pos = NULL;
 
   d->fill_feedback = feedback;
 
@@ -1398,6 +1405,12 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+
+  if(!d->grad_col)
+  {
+    d->grad_col = malloc(DT_BAUHAUS_SLIDER_MAX_STOPS * sizeof(*d->grad_col));
+    d->grad_pos = malloc(DT_BAUHAUS_SLIDER_MAX_STOPS * sizeof(*d->grad_pos));
+  }
   // need to replace stop?
   for(int k = 0; k < d->grad_cnt; k++)
   {

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1067,6 +1067,7 @@ static void dt_bauhaus_combobox_destroy(dt_bauhaus_widget_t *widget, gpointer us
   d->entries = NULL;
   d->num_labels = 0;
   d->active = -1;
+  if(d->text) free(d->text);
 }
 
 GtkWidget *dt_bauhaus_combobox_new(dt_iop_module_t *self)
@@ -1109,7 +1110,7 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
   d->entries_ellipsis = PANGO_ELLIPSIZE_END;
   d->mute_scrolling = FALSE;
   d->populate = NULL;
-  memset(d->text, 0, sizeof(d->text));
+  d->text = NULL;
 
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_PRESS_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(w), TRUE);
@@ -1192,6 +1193,8 @@ void dt_bauhaus_combobox_set_editable(GtkWidget *widget, int editable)
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   d->editable = editable ? 1 : 0;
+  if(d->editable && !d->text)
+    d->text = calloc(1, DT_BAUHAUS_COMBO_MAX_TEXT);
 }
 
 int dt_bauhaus_combobox_get_editable(GtkWidget *widget)
@@ -1319,7 +1322,7 @@ void dt_bauhaus_combobox_set_text(GtkWidget *widget, const char *text)
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   if(!d->editable) return;
-  g_strlcpy(d->text, text, sizeof(d->text));
+  g_strlcpy(d->text, text, DT_BAUHAUS_COMBO_MAX_TEXT);
 }
 
 static void _bauhaus_combobox_set(GtkWidget *widget, const int pos, const gboolean mute)
@@ -1692,8 +1695,8 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
       else if(d->editable)
       {
         // otherwise, if combobox is editable, assume it is a custom input
-        memset(d->text, 0, sizeof(d->text));
-        g_strlcpy(d->text, darktable.bauhaus->keys, sizeof(d->text));
+        memset(d->text, 0, DT_BAUHAUS_COMBO_MAX_TEXT);
+        g_strlcpy(d->text, darktable.bauhaus->keys, DT_BAUHAUS_COMBO_MAX_TEXT);
         // select custom entry
         dt_bauhaus_combobox_set(widget, -1);
       }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2356,20 +2356,7 @@ static gboolean dt_bauhaus_slider_add_delta_internal(GtkWidget *widget, float de
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   const dt_bauhaus_slider_data_t *d = &w->data.slider;
 
-  float multiplier = 0.0f;
-
-  if(dt_modifier_is(state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
+  float multiplier = dt_accel_get_speed_multiplier(widget, state);
 
   const float min_visible = powf(10.0f, -d->digits) / (d->max - d->min);
   if(fabsf(delta*multiplier) < min_visible)
@@ -3152,7 +3139,9 @@ static float _action_process_slider(gpointer target, dt_action_element_t element
       case DT_ACTION_EFFECT_UP:
         d->is_dragging = 1;
         const float step = dt_bauhaus_slider_get_step(widget);
-        float multiplier = dt_accel_get_slider_scale_multiplier();
+
+        // get slider_precision
+        float multiplier = dt_accel_get_speed_multiplier(NULL, GDK_MODIFIER_MASK);
 
         if(move_size && fabsf(move_size * step * multiplier) < min_visible)
           multiplier = min_visible / fabsf(move_size * step);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1363,9 +1363,9 @@ const char *dt_bauhaus_combobox_get_text(GtkWidget *widget)
   const dt_bauhaus_combobox_data_t *d = _combobox_data(widget);
   if(!d) return NULL;
 
-  if(d->editable && d->active < 0)
+  if(d->active < 0)
   {
-    return d->text;
+    return d->editable ? d->text : NULL;
   }
   else
   {

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2913,7 +2913,7 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
     }
     else
     {
-      if(event->y > get_line_height())
+      if(event->y > darktable.bauhaus->line_height)
       {
         const float l = 0.0f;
         const float r = slider_right_pos((float)allocation.width);
@@ -2970,16 +2970,16 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  if(d->is_dragging || (event->x <= allocation.width - darktable.bauhaus->quad_width && event->y > get_line_height()))
-  {
-    // remember mouse position for motion effects in draw
-    if(event->state & GDK_BUTTON1_MASK && event->type != GDK_2BUTTON_PRESS)
+  if(d->is_dragging && event->state & GDK_BUTTON1_MASK)
     {
       bauhaus_request_focus(w);
       const float l = 0.0f;
       const float r = slider_right_pos((float)allocation.width);
       dt_bauhaus_slider_set_normalized(w, (event->x / allocation.width - l) / (r - l));
-    }
+  }
+
+  if(event->x <= allocation.width - darktable.bauhaus->quad_width)
+  {
     darktable.control->element = event->x > (0.1 * (allocation.width - darktable.bauhaus->quad_width)) &&
                                  event->x < (0.9 * (allocation.width - darktable.bauhaus->quad_width))
                                ? DT_ACTION_ELEMENT_VALUE

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -285,7 +285,6 @@ GtkWidget *dt_bauhaus_slider_new_action(dt_action_t *self, float min, float max,
 
 // outside doesn't see the real type, we cast it internally.
 void dt_bauhaus_slider_set(GtkWidget *w, float pos);
-void dt_bauhaus_slider_set_soft(GtkWidget *w, float pos);
 void dt_bauhaus_slider_set_val(GtkWidget *w, float val);
 float dt_bauhaus_slider_get(GtkWidget *w);
 float dt_bauhaus_slider_get_val(GtkWidget *w);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -118,6 +118,7 @@ typedef struct dt_bauhaus_combobox_data_t
   PangoEllipsizeMode entries_ellipsis;
   GList *entries;
   gboolean mute_scrolling;   // if set, prevents to issue "data-changed"
+  void (*populate)(GtkWidget *w, struct dt_iop_module_t **module); // function to populate the combo list on the fly
 } dt_bauhaus_combobox_data_t;
 
 typedef union dt_bauhaus_data_t
@@ -159,9 +160,6 @@ typedef struct dt_bauhaus_widget_t
   int quad_toggle;
   // if a section label
   gboolean is_section;
-
-  // function to populate the combo list on the fly
-  void (*combo_populate)(GtkWidget *w, struct dt_iop_module_t **module);
 
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -72,7 +72,6 @@ typedef struct dt_bauhaus_slider_data_t
   float min, max; // min and max range
   float soft_min, soft_max;
   float hard_min, hard_max;
-  float scale; // step width for loupe mode
   int digits;  // how many decimals to round to
 
   float (*grad_col)[3]; // colors for gradient slider

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -287,7 +287,7 @@ void dt_bauhaus_slider_set(GtkWidget *w, float pos);
 void dt_bauhaus_slider_set_val(GtkWidget *w, float val);
 float dt_bauhaus_slider_get(GtkWidget *w);
 float dt_bauhaus_slider_get_val(GtkWidget *w);
-char *dt_bauhaus_slider_get_text(GtkWidget *w);
+char *dt_bauhaus_slider_get_text(GtkWidget *w, float val);
 
 void dt_bauhaus_slider_set_soft_min(GtkWidget* w, float val);
 float dt_bauhaus_slider_get_soft_min(GtkWidget* w);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -80,9 +80,9 @@ typedef struct dt_bauhaus_slider_data_t
 
   int fill_feedback : 1; // fill the slider with brighter part up to the handle?
 
-  char format[24]; // numeric value is printed with this string
-  float factor;    // multiplication factor before printing
-  float offset;    // addition before printing
+  const char *format;   // numeric value is printed with this format
+  float factor;         // multiplication factor before printing
+  float offset;         // addition before printing
 
   int is_dragging : 1;  // indicates is mouse is dragging slider
   int is_changed : 1;   // indicates new data

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -74,9 +74,9 @@ typedef struct dt_bauhaus_slider_data_t
   float scale; // step width for loupe mode
   int digits;  // how many decimals to round to
 
-  float grad_col[DT_BAUHAUS_SLIDER_MAX_STOPS][3]; // colors for gradient slider
-  int grad_cnt;                                   // how many stops
-  float grad_pos[DT_BAUHAUS_SLIDER_MAX_STOPS];    // and position of these.
+  float (*grad_col)[3]; // colors for gradient slider
+  int grad_cnt;         // how many stops
+  float *grad_pos;      // and position of these.
 
   int fill_feedback; // fill the slider with brighter part up to the handle?
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -47,6 +47,7 @@ extern GType DT_BAUHAUS_WIDGET_TYPE;
 #define DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MAX 500
 #define DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MIN 25
 #define DT_BAUHAUS_SLIDER_MAX_STOPS 20
+#define DT_BAUHAUS_COMBO_MAX_TEXT 180
 
 typedef enum dt_bauhaus_type_t
 {
@@ -114,7 +115,7 @@ typedef struct dt_bauhaus_combobox_data_t
   int editable;         // 1 if arbitrary text may be typed
   int scale;            // scale of the combo popup from combo widget
   dt_bauhaus_combobox_alignment_t text_align; // if selected text in combo should be aligned to the left/right
-  char text[180];       // roughly as much as a slider
+  char *text;           // to hold arbitrary text if editable
   PangoEllipsizeMode entries_ellipsis;
   GList *entries;
   gboolean mute_scrolling;   // if set, prevents to issue "data-changed"

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -295,6 +295,7 @@ void dt_bauhaus_slider_set_soft_min(GtkWidget* w, float val);
 float dt_bauhaus_slider_get_soft_min(GtkWidget* w);
 void dt_bauhaus_slider_set_soft_max(GtkWidget* w, float val);
 float dt_bauhaus_slider_get_soft_max(GtkWidget* w);
+void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max);
 
 void dt_bauhaus_slider_set_hard_min(GtkWidget* w, float val);
 float dt_bauhaus_slider_get_hard_min(GtkWidget* w);
@@ -316,9 +317,7 @@ void dt_bauhaus_slider_set_offset(GtkWidget *w, float offset);
 void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g, float b);
 void dt_bauhaus_slider_clear_stops(GtkWidget *widget);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
-void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max);
 float dt_bauhaus_slider_get_default(GtkWidget *widget);
-void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max);
 void dt_bauhaus_slider_set_curve(GtkWidget *widget, float (*curve)(float value, dt_bauhaus_curve_t dir));
 
 // combobox:

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -141,7 +141,6 @@ void dt_control_init(dt_control_t *s)
   s->gui_thread = pthread_self();
 
   // s->last_expose_time = dt_get_wtime();
-  s->key_accelerators_on = 1;
   s->log_pos = s->log_ack = 0;
   s->log_busy = 0;
   s->log_message_timeout_id = 0;
@@ -171,22 +170,6 @@ void dt_control_init(dt_control_t *s)
   s->dev_zoom_y = 0;
   s->dev_zoom = DT_ZOOM_FIT;
   s->lock_cursor_shape = FALSE;
-}
-
-void dt_control_key_accelerators_on(struct dt_control_t *s)
-{
-  if(!s->key_accelerators_on) s->key_accelerators_on = 1;
-}
-
-void dt_control_key_accelerators_off(struct dt_control_t *s)
-{
-  s->key_accelerators_on = 0;
-}
-
-
-int dt_control_is_key_accelerators_on(struct dt_control_t *s)
-{
-  return s->key_accelerators_on;
 }
 
 void dt_control_forbid_change_cursor()
@@ -811,7 +794,7 @@ int dt_control_key_pressed_override(guint key, guint state)
     }
     return 1;
   }
-  else if(key == ':' && darktable.control->key_accelerators_on)
+  else if(key == ':')
   {
     darktable.control->vimkey[0] = ':';
     darktable.control->vimkey[1] = 0;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -50,8 +50,6 @@ void dt_control_button_released(double x, double y, int which, uint32_t state);
 void dt_control_mouse_moved(double x, double y, double pressure, int which);
 void dt_control_mouse_leave();
 void dt_control_mouse_enter();
-int dt_control_key_pressed(guint key, guint state);
-int dt_control_key_released(guint key, guint state);
 int dt_control_key_pressed_override(guint key, guint state);
 gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer user_data);
 void dt_control_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
@@ -112,13 +110,6 @@ struct dt_control_t;
 
 /** sets the hinter message */
 void dt_control_hinter_message(const struct dt_control_t *s, const char *message);
-
-/** turn the use of key accelerators on */
-void dt_control_key_accelerators_on(struct dt_control_t *s);
-/** turn the use of key accelerators on */
-void dt_control_key_accelerators_off(struct dt_control_t *s);
-
-int dt_control_is_key_accelerators_on(struct dt_control_t *s);
 
 #define DT_CTL_LOG_SIZE 10
 #define DT_CTL_LOG_MSG_SIZE 1000
@@ -181,7 +172,6 @@ typedef struct dt_control_t
   // gui settings
   dt_pthread_mutex_t global_mutex, image_mutex;
   double last_expose_time;
-  int key_accelerators_on;
 
   // job management
   int32_t running;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2239,10 +2239,10 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(sl->box), TRUE, FALSE, 0);
     }
 
-    bd->channel_boost_factor_slider = dt_bauhaus_slider_new_with_range(module, 0.0f, 3.0f, .02f, 0.0f, 3);
+    bd->channel_boost_factor_slider = dt_bauhaus_slider_new_with_range(module, 0.0f, 18.0f, .02f, 0.0f, 3);
     dt_bauhaus_slider_set_format(bd->channel_boost_factor_slider, _("%.2f EV"));
     dt_bauhaus_widget_set_label(bd->channel_boost_factor_slider, N_("blend"), N_("boost factor"));
-    dt_bauhaus_slider_enable_soft_boundaries(bd->channel_boost_factor_slider, 0.0, 18.0);
+    dt_bauhaus_slider_set_soft_range(bd->channel_boost_factor_slider, 0.0, 3.0);
     gtk_widget_set_tooltip_text(bd->channel_boost_factor_slider, _("adjust the boost factor of the channel mask"));
     gtk_widget_set_sensitive(bd->channel_boost_factor_slider, FALSE);
 
@@ -2957,6 +2957,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
   /* create and add blend mode if module supports it */
   if(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
   {
+    ++darktable.gui->reset;
     --darktable.bauhaus->skip_accel;
 
     module->blend_data = g_malloc0(sizeof(dt_iop_gui_blend_data_t));
@@ -3064,11 +3065,11 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                                "\nby default the output will be blended on top of the input,"
                                                                "\norder can be reversed by clicking on the icon (input on top of output)"));
 
-    bd->blend_mode_parameter_slider = dt_bauhaus_slider_new_with_range(module, -3.0f, 3.0f, .02f, 0.0f, 3);
+    bd->blend_mode_parameter_slider = dt_bauhaus_slider_new_with_range(module, -18.0f, 18.0f, .02f, 0.0f, 3);
     dt_bauhaus_widget_set_field(bd->blend_mode_parameter_slider, &module->blend_params->blend_parameter, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->blend_mode_parameter_slider, N_("blend"), N_("blend fulcrum"));
     dt_bauhaus_slider_set_format(bd->blend_mode_parameter_slider, _("%.2f EV"));
-    dt_bauhaus_slider_enable_soft_boundaries(bd->blend_mode_parameter_slider, -18.0, 18.0);
+    dt_bauhaus_slider_set_soft_range(bd->blend_mode_parameter_slider, -3.0, 3.0);
     gtk_widget_set_tooltip_text(bd->blend_mode_parameter_slider, _("adjust the fulcrum used by some blending"
                                                                    " operations"));
     gtk_widget_set_visible(bd->blend_mode_parameter_slider, FALSE);
@@ -3196,6 +3197,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->blend_inited = 1;
 
     ++darktable.bauhaus->skip_accel;
+    --darktable.gui->reset;
   }
 }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -637,7 +637,7 @@ static void _blendop_blend_mode_callback(GtkWidget *combo, dt_iop_gui_blend_data
     else
     {
       bp->blend_parameter = 0.0f;
-      dt_bauhaus_slider_set_soft(data->blend_mode_parameter_slider, bp->blend_parameter);
+      dt_bauhaus_slider_set(data->blend_mode_parameter_slider, bp->blend_parameter);
       gtk_widget_set_sensitive(data->blend_mode_parameter_slider, FALSE);
     }
     dt_dev_add_history_item(darktable.develop, data->module, TRUE);
@@ -1059,7 +1059,7 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
     boost_factor = bp->blendif_boost_factors[channel->param_channels[0]] - channel->boost_factor_offset;
   }
   gtk_widget_set_sensitive(GTK_WIDGET(data->channel_boost_factor_slider), boost_factor_enabled);
-  dt_bauhaus_slider_set_soft(GTK_WIDGET(data->channel_boost_factor_slider), boost_factor);
+  dt_bauhaus_slider_set(GTK_WIDGET(data->channel_boost_factor_slider), boost_factor);
 
   --darktable.gui->reset;
 }
@@ -2747,7 +2747,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   gboolean blend_mode_reversed = (module->blend_params->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->blend_modes_blend_order), blend_mode_reversed);
 
-  dt_bauhaus_slider_set_soft(bd->blend_mode_parameter_slider, module->blend_params->blend_parameter);
+  dt_bauhaus_slider_set(bd->blend_mode_parameter_slider, module->blend_params->blend_parameter);
   gtk_widget_set_sensitive(bd->blend_mode_parameter_slider,
                            _blendif_blend_parameter_enabled(bd->blend_modes_csp, module->blend_params->blend_mode));
   gtk_widget_set_visible(bd->blend_mode_parameter_slider, bd->blend_modes_csp == DEVELOP_BLEND_CS_RGB_SCENE);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1889,7 +1889,6 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget, GdkEventCrossing *even
   _blendop_blendif_channel_mask_view(widget, module, mode);
 
   gtk_widget_grab_focus(widget);
-  dt_control_key_accelerators_off(darktable.control);
   return FALSE;
 }
 
@@ -1931,7 +1930,6 @@ static gboolean _blendop_blendif_leave(GtkWidget *widget, GdkEventCrossing *even
       data->timeout_handle = g_timeout_add(1000, _blendop_blendif_leave_delayed, module);
   dt_pthread_mutex_unlock(&data->lock);
 
-  if(!darktable.control->key_accelerators_on) dt_control_key_accelerators_on(darktable.control);
   return FALSE;
 }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2238,7 +2238,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     }
 
     bd->channel_boost_factor_slider = dt_bauhaus_slider_new_with_range(module, 0.0f, 18.0f, .02f, 0.0f, 3);
-    dt_bauhaus_slider_set_format(bd->channel_boost_factor_slider, _("%.2f EV"));
+    dt_bauhaus_slider_set_format(bd->channel_boost_factor_slider, _(" EV"));
     dt_bauhaus_widget_set_label(bd->channel_boost_factor_slider, N_("blend"), N_("boost factor"));
     dt_bauhaus_slider_set_soft_range(bd->channel_boost_factor_slider, 0.0, 3.0);
     gtk_widget_set_tooltip_text(bd->channel_boost_factor_slider, _("adjust the boost factor of the channel mask"));
@@ -3066,7 +3066,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->blend_mode_parameter_slider = dt_bauhaus_slider_new_with_range(module, -18.0f, 18.0f, .02f, 0.0f, 3);
     dt_bauhaus_widget_set_field(bd->blend_mode_parameter_slider, &module->blend_params->blend_parameter, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->blend_mode_parameter_slider, N_("blend"), N_("blend fulcrum"));
-    dt_bauhaus_slider_set_format(bd->blend_mode_parameter_slider, _("%.2f EV"));
+    dt_bauhaus_slider_set_format(bd->blend_mode_parameter_slider, _(" EV"));
     dt_bauhaus_slider_set_soft_range(bd->blend_mode_parameter_slider, -3.0, 3.0);
     gtk_widget_set_tooltip_text(bd->blend_mode_parameter_slider, _("adjust the fulcrum used by some blending"
                                                                    " operations"));
@@ -3075,7 +3075,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 1, 100.0, 0);
     dt_bauhaus_widget_set_field(bd->opacity_slider, &module->blend_params->opacity, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->opacity_slider, N_("blend"), N_("opacity"));
-    dt_bauhaus_slider_set_format(bd->opacity_slider, "%.0f%%");
+    dt_bauhaus_slider_set_format(bd->opacity_slider, "%");
     module->fusion_slider = bd->opacity_slider;
     gtk_widget_set_tooltip_text(bd->opacity_slider, _("set the opacity of the blending"));
 
@@ -3091,8 +3091,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
     dt_bauhaus_widget_set_label(bd->details_slider, N_("blend"), N_("details threshold"));
-    dt_bauhaus_slider_set_factor(bd->details_slider, 100.0f);
-    dt_bauhaus_slider_set_format(bd->details_slider, "%.0f%%");
+    dt_bauhaus_slider_set_format(bd->details_slider, "%");
     gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask (using raw data), "
                                                       "\npositive values selects areas with strong details, "
                                                       "\nnegative values select flat areas"));
@@ -3106,20 +3105,19 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->feathering_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 250.0, 0.1, 0.0, 1);
     dt_bauhaus_widget_set_field(bd->feathering_radius_slider, &module->blend_params->feathering_radius, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->feathering_radius_slider, N_("blend"), N_("feathering radius"));
-    dt_bauhaus_slider_set_format(bd->feathering_radius_slider, "%.1f px");
+    dt_bauhaus_slider_set_format(bd->feathering_radius_slider, " px");
     gtk_widget_set_tooltip_text(bd->feathering_radius_slider, _("spatial radius of feathering"));
 
     bd->blur_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0.1, 0.0, 1);
     dt_bauhaus_widget_set_field(bd->blur_radius_slider, &module->blend_params->blur_radius, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->blur_radius_slider, N_("blend"), N_("blurring radius"));
-    dt_bauhaus_slider_set_format(bd->blur_radius_slider, "%.1f px");
+    dt_bauhaus_slider_set_format(bd->blur_radius_slider, " px");
     gtk_widget_set_tooltip_text(bd->blur_radius_slider, _("radius for gaussian blur of blend mask"));
 
     bd->brightness_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
     dt_bauhaus_widget_set_field(bd->brightness_slider, &module->blend_params->brightness, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->brightness_slider, N_("blend"), N_("mask opacity"));
-    dt_bauhaus_slider_set_factor(bd->brightness_slider, 100.0f);
-    dt_bauhaus_slider_set_format(bd->brightness_slider, "%+.0f%%");
+    dt_bauhaus_slider_set_format(bd->brightness_slider, "%");
     gtk_widget_set_tooltip_text(bd->brightness_slider, _("shifts and tilts the tone curve of the blend mask to adjust its "
                                                          "brightness without affecting fully transparent/fully opaque "
                                                          "regions"));
@@ -3127,8 +3125,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->contrast_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
     dt_bauhaus_widget_set_field(bd->contrast_slider, &module->blend_params->contrast, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->contrast_slider, N_("blend"), N_("mask contrast"));
-    dt_bauhaus_slider_set_factor(bd->contrast_slider, 100.0f);
-    dt_bauhaus_slider_set_format(bd->contrast_slider, "%+.0f%%");
+    dt_bauhaus_slider_set_format(bd->contrast_slider, "%");
     gtk_widget_set_tooltip_text(bd->contrast_slider, _("gives the tone curve of the blend mask an s-like shape to "
                                                        "adjust its contrast"));
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2237,7 +2237,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(sl->box), TRUE, FALSE, 0);
     }
 
-    bd->channel_boost_factor_slider = dt_bauhaus_slider_new_with_range(module, 0.0f, 18.0f, .02f, 0.0f, 3);
+    bd->channel_boost_factor_slider = dt_bauhaus_slider_new_with_range(module, 0.0f, 18.0f, 0, 0.0f, 3);
     dt_bauhaus_slider_set_format(bd->channel_boost_factor_slider, _(" EV"));
     dt_bauhaus_widget_set_label(bd->channel_boost_factor_slider, N_("blend"), N_("boost factor"));
     dt_bauhaus_slider_set_soft_range(bd->channel_boost_factor_slider, 0.0, 3.0);
@@ -3063,7 +3063,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                                "\nby default the output will be blended on top of the input,"
                                                                "\norder can be reversed by clicking on the icon (input on top of output)"));
 
-    bd->blend_mode_parameter_slider = dt_bauhaus_slider_new_with_range(module, -18.0f, 18.0f, .02f, 0.0f, 3);
+    bd->blend_mode_parameter_slider = dt_bauhaus_slider_new_with_range(module, -18.0f, 18.0f, 0, 0.0f, 3);
     dt_bauhaus_widget_set_field(bd->blend_mode_parameter_slider, &module->blend_params->blend_parameter, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->blend_mode_parameter_slider, N_("blend"), N_("blend fulcrum"));
     dt_bauhaus_slider_set_format(bd->blend_mode_parameter_slider, _(" EV"));
@@ -3072,7 +3072,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                                    " operations"));
     gtk_widget_set_visible(bd->blend_mode_parameter_slider, FALSE);
 
-    bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 1, 100.0, 0);
+    bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0, 100.0, 0);
     dt_bauhaus_widget_set_field(bd->opacity_slider, &module->blend_params->opacity, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->opacity_slider, N_("blend"), N_("opacity"));
     dt_bauhaus_slider_set_format(bd->opacity_slider, "%");
@@ -3089,7 +3089,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(bd->masks_invert_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_invert_callback), bd);
 
-    bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, .01f, 0.0f, 2);
+    bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, 0, 0.0f, 2);
     dt_bauhaus_widget_set_label(bd->details_slider, N_("blend"), N_("details threshold"));
     dt_bauhaus_slider_set_format(bd->details_slider, "%");
     gtk_widget_set_tooltip_text(bd->details_slider, _("adjust the threshold for the details mask (using raw data), "
@@ -3102,19 +3102,19 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                                _("choose to guide mask by input or output image and"
                                                                  "\nchoose to apply feathering before or after mask blur"));
 
-    bd->feathering_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 250.0, 0.1, 0.0, 1);
+    bd->feathering_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 250.0, 0, 0.0, 1);
     dt_bauhaus_widget_set_field(bd->feathering_radius_slider, &module->blend_params->feathering_radius, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->feathering_radius_slider, N_("blend"), N_("feathering radius"));
     dt_bauhaus_slider_set_format(bd->feathering_radius_slider, " px");
     gtk_widget_set_tooltip_text(bd->feathering_radius_slider, _("spatial radius of feathering"));
 
-    bd->blur_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0.1, 0.0, 1);
+    bd->blur_radius_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0, 0.0, 1);
     dt_bauhaus_widget_set_field(bd->blur_radius_slider, &module->blend_params->blur_radius, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->blur_radius_slider, N_("blend"), N_("blurring radius"));
     dt_bauhaus_slider_set_format(bd->blur_radius_slider, " px");
     gtk_widget_set_tooltip_text(bd->blur_radius_slider, _("radius for gaussian blur of blend mask"));
 
-    bd->brightness_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
+    bd->brightness_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0, 0.0, 2);
     dt_bauhaus_widget_set_field(bd->brightness_slider, &module->blend_params->brightness, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->brightness_slider, N_("blend"), N_("mask opacity"));
     dt_bauhaus_slider_set_format(bd->brightness_slider, "%");
@@ -3122,7 +3122,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                          "brightness without affecting fully transparent/fully opaque "
                                                          "regions"));
 
-    bd->contrast_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0.01, 0.0, 2);
+    bd->contrast_slider = dt_bauhaus_slider_new_with_range(module, -1.0, 1.0, 0, 0.0, 2);
     dt_bauhaus_widget_set_field(bd->contrast_slider, &module->blend_params->contrast, DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->contrast_slider, N_("blend"), N_("mask contrast"));
     dt_bauhaus_slider_set_format(bd->contrast_slider, "%");

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1782,6 +1782,8 @@ void dt_iop_gui_update(dt_iop_module_t *module)
   {
     if(module->gui_data)
     {
+      dt_bauhaus_update_module(module);
+
       if(module->params && module->gui_update)
       {
         if(module->widget && dt_conf_get_bool("plugins/darkroom/show_warnings"))
@@ -3150,6 +3152,18 @@ gboolean dt_iop_have_required_input_format(const int req_ch, struct dt_iop_modul
     }
     return FALSE;
   }
+}
+
+void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data)
+{
+  if(!action || action->type != DT_ACTION_TYPE_IOP_INSTANCE) return;
+  dt_iop_module_t *module = (dt_iop_module_t *)action;
+
+  if(module->gui_changed) module->gui_changed(module, widget, data);
+
+  dt_iop_color_picker_reset(module, TRUE);
+
+  dt_dev_add_history_item(darktable.develop, module, TRUE);
 }
 
 enum

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -78,8 +78,6 @@ typedef struct dt_iop_gui_simple_callback_t
   int index;
 } dt_iop_gui_simple_callback_t;
 
-static void _iop_panel_label(dt_iop_module_t *module);
-
 void dt_iop_load_default_params(dt_iop_module_t *module)
 {
   memcpy(module->params, module->default_params, module->params_size);
@@ -1084,7 +1082,7 @@ static void _iop_panel_label(dt_iop_module_t *module)
   g_object_set(G_OBJECT(lab), "xalign", 0.0, (gchar *)0);
 }
 
-static void _iop_gui_update_header(dt_iop_module_t *module)
+void dt_iop_gui_update_header(dt_iop_module_t *module)
 {
   if (!module->header)                  /* some modules such as overexposed don't actually have a header */
     return;
@@ -1131,11 +1129,6 @@ void dt_iop_gui_set_enable_button(dt_iop_module_t *module)
   }
 }
 
-void dt_iop_gui_update_header(dt_iop_module_t *module)
-{
-  _iop_gui_update_header(module);
-}
-
 void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
                                        const char* const trouble_msg,
                                        const char* const trouble_tooltip,
@@ -1151,12 +1144,6 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
   if(!dt_iop_is_hidden(module) && module->gui_data && dt_conf_get_bool("plugins/darkroom/show_warnings"))
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TROUBLE_MESSAGE,
                                   module, trouble_msg, trouble_tooltip);
-}
-
-static void _iop_gui_update_label(dt_iop_module_t *module)
-{
-  if(!module->header) return;
-  _iop_panel_label(module);
 }
 
 void dt_iop_gui_init(dt_iop_module_t *module)
@@ -1189,7 +1176,7 @@ void dt_iop_reload_defaults(dt_iop_module_t *module)
   dt_iop_load_default_params(module);
   if(darktable.gui) --darktable.gui->reset;
 
-  if(module->header) _iop_gui_update_header(module);
+  if(module->header) dt_iop_gui_update_header(module);
 }
 
 void dt_iop_cleanup_histogram(gpointer data, gpointer user_data)
@@ -1808,8 +1795,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
       dt_iop_gui_update_blending(module);
       dt_iop_gui_update_expanded(module);
     }
-    _iop_gui_update_label(module);
-    dt_iop_gui_set_enable_button(module);
+    dt_iop_gui_update_header(module);
     dt_iop_show_hide_header_buttons(module, NULL, FALSE, FALSE);
     dt_guides_update_module_widget(module);
   }
@@ -2518,7 +2504,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   module->expander = expander;
 
   /* update header */
-  _iop_gui_update_header(module);
+  dt_iop_gui_update_header(module);
 
   gtk_widget_set_hexpand(module->widget, FALSE);
   gtk_widget_set_vexpand(module->widget, FALSE);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -150,8 +150,6 @@ typedef enum dt_iop_colorspace_type_t
 } dt_iop_colorspace_type_t;
 
 /** part of the module which only contains the cached dlopen stuff. */
-struct dt_iop_module_so_t;
-struct dt_iop_module_t;
 typedef struct dt_iop_module_so_t
 {
   dt_action_t actions; // !!! NEEDS to be FIRST (to be able to cast convert)
@@ -272,7 +270,10 @@ typedef struct dt_iop_module_t
   /** fusion slider */
   GtkWidget *fusion_slider;
 
+  /* list of instance widgets and associated actions. Bauhaus with field pointer at end, starting from widget_list_bh */
   GSList *widget_list;
+  GSList *widget_list_bh;
+
   /** show/hide guide button and combobox */
   GtkWidget *guides_toggle;
   GtkWidget *guides_combo;
@@ -301,6 +302,12 @@ typedef struct dt_iop_module_t
   // introspection related data
   gboolean have_introspection;
 } dt_iop_module_t;
+
+typedef struct dt_action_target_t
+{
+  dt_action_t *action;
+  void *target;
+} dt_action_target_t;
 
 /** loads and inits the modules in the plugins/ directory. */
 void dt_iop_load_modules_so(void);
@@ -499,6 +506,8 @@ gboolean dt_iop_have_required_input_format(const int required_ch, struct dt_iop_
 
 /* bring up module rename dialog */
 void dt_iop_gui_rename_module(dt_iop_module_t *module);
+
+void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -276,10 +276,6 @@ typedef struct dt_iop_module_t
   /** show/hide guide button and combobox */
   GtkWidget *guides_toggle;
   GtkWidget *guides_combo;
-  /** list of closures: show, enable/disable */
-  GSList *accel_closures;
-  GSList *accel_closures_local;
-  gboolean local_closures_connected;
 
   /** flag in case the module has troubles (bad settings) - if TRUE, show a warning sign next to module label */
   gboolean has_trouble;
@@ -293,7 +289,6 @@ typedef struct dt_iop_module_t
   gboolean multi_show_up;
   gboolean multi_show_down;
   gboolean multi_show_new;
-  GtkWidget *duplicate_button;
   GtkWidget *multimenu_button;
 
   /** delayed-event handling */

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -95,33 +95,14 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
       const float max = f->Float.Max;
       offset = f->header.offset + param_index * sizeof(float);
       const float defval = *(float*)(d + offset);
-      int digits = 2;
-      float step = 0;
 
-      const float top = fminf(max-min, fmaxf(fabsf(min),fabsf(max)));
-      if (top>=100)
-      {
-        step = 1.f;
-      }
-      else
-      {
-        step = top / 100;
-        const float log10step = log10f(step);
-        const float fdigits = floorf(log10step+.1);
-        step = powf(10.f,fdigits);
-        if (log10step - fdigits > .5)
-          step *= 5;
-        if (fdigits < -2.f)
-          digits = -fdigits;
-      }
-
-      slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, step, defval, digits, 1);
+      slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 0, defval, 2, 1);
 
       const char *post = ""; // set " %%", " EV" etc
 
       if (min < 0 || (post && *post))
       {
-        str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), digits, post);
+        str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), 2, post);
 
         dt_bauhaus_slider_set_format(slider, str);
 

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -84,7 +84,6 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   const dt_introspection_field_t *f = self->so->get_f(param_name);
 
   GtkWidget *slider = NULL;
-  gchar *str = NULL;
   size_t offset = 0;
 
   if(f)
@@ -96,18 +95,10 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
       offset = f->header.offset + param_index * sizeof(float);
       const float defval = *(float*)(d + offset);
 
-      slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 0, defval, 2, 1);
+      const float top = fminf(max-min, fmaxf(fabsf(min), fabsf(max)));
+      const int digits = MAX(2, -floorf(log10f(top/100)+.1));
 
-      const char *post = ""; // set " %%", " EV" etc
-
-      if (min < 0 || (post && *post))
-      {
-        str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), 2, post);
-
-        dt_bauhaus_slider_set_format(slider, str);
-
-        g_free(str);
-      }
+      slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 0, defval, digits, 1);
     }
     else if(f->header.type == DT_INTROSPECTION_TYPE_INT)
     {
@@ -144,7 +135,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
       }
       else
       {
-        str = dt_util_str_replace(f->header.field_name, "_", " ");
+        gchar *str = dt_util_str_replace(f->header.field_name, "_", " ");
 
         dt_bauhaus_widget_set_label(slider,  NULL, str);
 
@@ -154,7 +145,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   }
   else
   {
-    str = g_strdup_printf("'%s' is not a float/int/unsigned short/slider parameter", param_name);
+    gchar *str = g_strdup_printf("'%s' is not a float/int/unsigned short/slider parameter", param_name);
 
     slider = dt_bauhaus_slider_new(self);
     dt_bauhaus_widget_set_label(slider, NULL, str);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -20,7 +20,6 @@
 #include "develop/imageop.h"
 #include "bauhaus/bauhaus.h"
 #include "dtgtk/button.h"
-#include "gui/color_picker_proxy.h"
 #include "gui/accelerators.h"
 
 #ifdef GDK_WINDOWING_QUARTZ
@@ -44,79 +43,6 @@ typedef struct dt_module_param_t
   void            *param;
 } dt_module_param_t;
 
-static inline void process_changed_value(dt_iop_module_t *self, GtkWidget *widget, void *data)
-{
-  if(!self) self = (dt_iop_module_t *)(DT_BAUHAUS_WIDGET(widget)->module);
-
-  if(self->gui_changed) self->gui_changed(self, widget, data);
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-void dt_iop_slider_float_callback(GtkWidget *slider, float *field)
-{
-  if(darktable.gui->reset) return;
-
-  float previous = *field;
-  *field = dt_bauhaus_slider_get(slider);
-
-  if (*field != previous) process_changed_value(NULL, slider, &previous);
-}
-
-void dt_iop_slider_int_callback(GtkWidget *slider, int *field)
-{
-  if(darktable.gui->reset) return;
-
-  int previous = *field;
-  *field = dt_bauhaus_slider_get(slider);
-
-  if(*field != previous) process_changed_value(NULL, slider, &previous);
-}
-
-void dt_iop_slider_ushort_callback(GtkWidget *slider, unsigned short *field)
-{
-  if(darktable.gui->reset) return;
-
-  unsigned short previous = *field;
-  *field = dt_bauhaus_slider_get(slider);
-
-  if(*field != previous) process_changed_value(NULL, slider, &previous);
-}
-
-void dt_iop_combobox_enum_callback(GtkWidget *combobox, int *field)
-{
-  if(darktable.gui->reset) return;
-
-  int previous = *field;
-
-  *field = GPOINTER_TO_INT(dt_bauhaus_combobox_get_data(combobox));
-
-  if(*field != previous) process_changed_value(NULL, combobox, &previous);
-}
-
-void dt_iop_combobox_int_callback(GtkWidget *combobox, int *field)
-{
-  if(darktable.gui->reset) return;
-
-  int previous = *field;
-
-  *field = dt_bauhaus_combobox_get(combobox);
-
-  if(*field != previous) process_changed_value(NULL, combobox, &previous);
-}
-
-void dt_iop_combobox_bool_callback(GtkWidget *combobox, gboolean *field)
-{
-  if(darktable.gui->reset) return;
-
-  gboolean previous = *field;
-  *field = dt_bauhaus_combobox_get(combobox);
-
-  if(*field != previous) process_changed_value(NULL, combobox, &previous);
-}
-
 static void _iop_toggle_callback(GtkWidget *togglebutton, dt_module_param_t *data)
 {
   if(darktable.gui->reset) return;
@@ -127,7 +53,10 @@ static void _iop_toggle_callback(GtkWidget *togglebutton, dt_module_param_t *dat
   gboolean previous = *field;
   *field = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(togglebutton));
 
-  if(*field != previous) process_changed_value(self, togglebutton, &previous);
+  if(*field != previous)
+  {
+    dt_iop_gui_changed(DT_ACTION(self), togglebutton, &previous);
+  }
 }
 
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param)
@@ -155,7 +84,8 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   const dt_introspection_field_t *f = self->so->get_f(param_name);
 
   GtkWidget *slider = NULL;
-  gchar *str;
+  gchar *str = NULL;
+  size_t offset = 0;
 
   if(f)
   {
@@ -163,7 +93,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
     {
       const float min = f->Float.Min;
       const float max = f->Float.Max;
-      const size_t offset = f->header.offset + param_index * sizeof(float);
+      offset = f->header.offset + param_index * sizeof(float);
       const float defval = *(float*)(d + offset);
       int digits = 2;
       float step = 0;
@@ -197,42 +127,32 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
 
         g_free(str);
       }
-
-      g_signal_connect(G_OBJECT(slider), "value-changed",
-                       G_CALLBACK(dt_iop_slider_float_callback),
-                       p + offset);
     }
     else if(f->header.type == DT_INTROSPECTION_TYPE_INT)
     {
       const int min = f->Int.Min;
       const int max = f->Int.Max;
-      const size_t offset = f->header.offset + param_index * sizeof(int);
+      offset = f->header.offset + param_index * sizeof(int);
       const int defval = *(int*)(d + offset);
 
       slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 1, defval, 0, 1);
-
-      g_signal_connect(G_OBJECT(slider), "value-changed",
-                       G_CALLBACK(dt_iop_slider_int_callback),
-                       p + offset);
     }
     else if(f->header.type == DT_INTROSPECTION_TYPE_USHORT)
     {
       const unsigned short min = f->UShort.Min;
       const unsigned short max = f->UShort.Max;
-      const size_t offset = f->header.offset + param_index * sizeof(unsigned short);
+      offset = f->header.offset + param_index * sizeof(unsigned short);
       const unsigned short defval = *(unsigned short*)(d + offset);
 
       slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 1, defval, 0, 1);
-
-      g_signal_connect(G_OBJECT(slider), "value-changed",
-                       G_CALLBACK(dt_iop_slider_ushort_callback),
-                       p + offset);
     }
     else f = NULL;
   }
 
   if(f)
   {
+    dt_bauhaus_widget_set_field(slider, p + offset, f->header.type);
+
     if(!skip_label)
     {
       if (*f->header.description)
@@ -282,6 +202,8 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
             f->header.type == DT_INTROSPECTION_TYPE_UINT ||
             f->header.type == DT_INTROSPECTION_TYPE_BOOL ))
   {
+    dt_bauhaus_widget_set_field(combobox, p + f->header.offset, f->header.type);
+
     if (*f->header.description)
     {
       // we do not want to support a context as it break all translations see #5498
@@ -301,31 +223,20 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
     {
       dt_bauhaus_combobox_add(combobox, _("no"));
       dt_bauhaus_combobox_add(combobox, _("yes"));
-
-      g_signal_connect(G_OBJECT(combobox), "value-changed", G_CALLBACK(dt_iop_combobox_bool_callback), p + f->header.offset);
     }
-    else
+    else if(f->header.type == DT_INTROSPECTION_TYPE_ENUM)
     {
-      if(f->header.type == DT_INTROSPECTION_TYPE_ENUM)
+      for(dt_introspection_type_enum_tuple_t *iter = f->Enum.values; iter && iter->name; iter++)
       {
-        for(dt_introspection_type_enum_tuple_t *iter = f->Enum.values; iter && iter->name; iter++)
-        {
-          // we do not want to support a context as it break all translations see #5498
-          // dt_bauhaus_combobox_add_full(combobox, g_dpgettext2(NULL, "introspection description", iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
-          if(*iter->description)
-            dt_bauhaus_combobox_add_full(combobox, gettext(iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
-        }
-
-        dt_action_t *action = dt_action_locate(&self->so->actions, (gchar **)(const gchar *[]){ *f->header.description ? f->header.description : f->header.field_name, NULL}, FALSE);
-        if(action && f->Enum.values)
-          g_hash_table_insert(darktable.control->combo_introspection, action, f->Enum.values);
-
-        g_signal_connect(G_OBJECT(combobox), "value-changed", G_CALLBACK(dt_iop_combobox_enum_callback), p + f->header.offset);
+        // we do not want to support a context as it break all translations see #5498
+        // dt_bauhaus_combobox_add_full(combobox, g_dpgettext2(NULL, "introspection description", iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
+        if(*iter->description)
+          dt_bauhaus_combobox_add_full(combobox, gettext(iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
       }
-      else
-      {
-        g_signal_connect(G_OBJECT(combobox), "value-changed", G_CALLBACK(dt_iop_combobox_int_callback), p + f->header.offset);
-      }
+
+      dt_action_t *action = dt_action_locate(&self->so->actions, (gchar **)(const gchar *[]){ *f->header.description ? f->header.description : f->header.field_name, NULL}, FALSE);
+      if(action && f->Enum.values)
+        g_hash_table_insert(darktable.control->combo_introspection, action, f->Enum.values);
     }
   }
   else

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -34,13 +34,6 @@ GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
                              GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
                              DTGTKCairoPaintIconFunc paint, gint paintflags, GtkWidget *box);
 
-void dt_iop_slider_float_callback(GtkWidget *slider, float *field);
-void dt_iop_slider_int_callback(GtkWidget *slider, int *field);
-void dt_iop_slider_ushort_callback(GtkWidget *slider, unsigned short *field);
-void dt_iop_combobox_enum_callback(GtkWidget *combobox, int *field);
-void dt_iop_combobox_int_callback(GtkWidget *combobox, int *field);
-void dt_iop_combobox_bool_callback(GtkWidget *combobox, gboolean *field);
-
 /* returns up or !up depending on the masks_updown preference */
 gboolean dt_mask_scroll_increases(int up);
 

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -25,6 +25,7 @@
 #include "develop/develop.h"
 #include "gradientslider.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 
 #define DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MAX 50
 #define DTGTK_GRADIENT_SLIDER_VALUE_CHANGED_DELAY_MIN 10
@@ -228,22 +229,7 @@ static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble d
 
   if(selected == -1) return TRUE;
 
-  float multiplier;
-
-  if(dt_modifier_is(state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
-
-  delta *= multiplier;
+  delta *= dt_accel_get_speed_multiplier(widget, state);
 
   gslider->position[selected] = gslider->position[selected] + delta;
   _clamp_marker(gslider, selected);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -38,15 +38,12 @@
 
 static void _thumb_resize_overlays(dt_thumbnail_t *thumb);
 
-static void _set_flag(GtkWidget *w, GtkStateFlags flag, gboolean over)
+static void _set_flag(GtkWidget *w, GtkStateFlags flag, gboolean activate)
 {
-  int flags = gtk_widget_get_state_flags(w);
-  if(over)
-    flags |= flag;
+  if(activate)
+    gtk_widget_set_state_flags(w, flag, FALSE);
   else
-    flags &= ~flag;
-
-  gtk_widget_set_state_flags(w, flags, TRUE);
+    gtk_widget_unset_state_flags(w, flag);
 }
 
 // create a new extended infos line from strach

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -22,16 +22,15 @@
 static void _thumbnail_btn_class_init(GtkDarktableThumbnailBtnClass *klass);
 static void _thumbnail_btn_init(GtkDarktableThumbnailBtn *button);
 static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr);
-static gboolean _thumbnail_btn_enter_notify_callback(GtkWidget *widget, GdkEventCrossing *event);
-static gboolean _thumbnail_btn_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event);
+static gboolean _thumbnail_btn_enter_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event);
 
 static void _thumbnail_btn_class_init(GtkDarktableThumbnailBtnClass *klass)
 {
   GtkWidgetClass *widget_class = (GtkWidgetClass *)klass;
 
   widget_class->draw = _thumbnail_btn_draw;
-  widget_class->enter_notify_event = _thumbnail_btn_enter_notify_callback;
-  widget_class->leave_notify_event = _thumbnail_btn_leave_notify_callback;
+  widget_class->enter_notify_event = _thumbnail_btn_enter_leave_notify_callback;
+  widget_class->leave_notify_event = _thumbnail_btn_enter_leave_notify_callback;
 }
 
 static void _thumbnail_btn_init(GtkDarktableThumbnailBtn *button)
@@ -101,25 +100,15 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
   return TRUE;
 }
 
-static gboolean _thumbnail_btn_enter_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
+static gboolean _thumbnail_btn_enter_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
 {
   g_return_val_if_fail(widget != NULL, FALSE);
 
-  int flags = gtk_widget_get_state_flags(widget);
-  flags |= GTK_STATE_FLAG_PRELIGHT;
+  if(event->type == GDK_ENTER_NOTIFY)
+    gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_PRELIGHT, FALSE);
+  else
+    gtk_widget_unset_state_flags(widget, GTK_STATE_FLAG_PRELIGHT);
 
-  gtk_widget_set_state_flags(widget, flags, TRUE);
-  gtk_widget_queue_draw(widget);
-  return FALSE;
-}
-static gboolean _thumbnail_btn_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event)
-{
-  g_return_val_if_fail(widget != NULL, FALSE);
-
-  int flags = gtk_widget_get_state_flags(widget);
-  flags &= ~GTK_STATE_FLAG_PRELIGHT;
-
-  gtk_widget_set_state_flags(widget, flags, TRUE);
   gtk_widget_queue_draw(widget);
   return FALSE;
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -64,12 +64,6 @@ typedef struct dt_device_key_t
   dt_action_element_t hold_element;
 } dt_device_key_t;
 
-typedef struct dt_action_target_t
-{
-  dt_action_t *action;
-  void *target;
-} dt_action_target_t;
-
 #define DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE 0
 
 const char *move_string[]

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -683,11 +683,12 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
         ? dt_dev_modulegroups_basics_module_toggle(darktable.develop, widget, FALSE)
         : 0;
 
-      markup_text = g_markup_printf_escaped("%s\n%s\n%s%s",
+      markup_text = g_markup_printf_escaped("%s\n%s\n%s%s\n%s",
                                             _("press keys with mouse click and scroll or move combinations to create a shortcut"),
                                             _("click to open shortcut configuration"),
                                             add_remove_qap > 0 ? _("ctrl+click to add to quick access panel\n") :
                                             add_remove_qap < 0 ? _("ctrl+click to remove from quick access panel\n")  : "",
+                                            _("scroll to change default speed"),
                                             _("right click to exit mapping mode"));
     }
   }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3447,8 +3447,6 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
 {
 //  dt_print(DT_DEBUG_INPUT, "  [shortcut_dispatcher] %d\n", event->type);
 
-  if(!darktable.control->key_accelerators_on) return FALSE; // FIXME should eventually no longer be needed
-
   if(_pressed_keys == NULL)
   {
     if(_grab_widget && event->type == GDK_BUTTON_PRESS)
@@ -3492,7 +3490,7 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
 
     _sc.mods = _key_modifiers_clean(event->key.state);
 
-    // FIXME: eventually clean up per-view and global key_pressed handlers
+    // FIXME: for vimkeys and game. Needs generalising for non-bauhaus/non-darkroom
     if(!_grab_widget && !darktable.control->mapping_widget &&
        dt_control_key_pressed_override(event->key.keyval, dt_gui_translated_key_state(&event->key))) return TRUE;
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -192,8 +192,8 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_path);
 // UX miscellaneous functions
 void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *text);
 
-// Get the scale multiplier for adjusting sliders with shortcuts
-float dt_accel_get_slider_scale_multiplier();
+// Get the speed multiplier for adjusting sliders and other widgets
+float dt_accel_get_speed_multiplier(GtkWidget *widget, guint state);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -494,9 +494,6 @@ gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event, int *delta_x
   // accumulates scrolling regardless of source or the widget being scrolled
   static gdouble acc_x = 0.0, acc_y = 0.0;
 
-  if(gdk_event_get_pointer_emulated((GdkEvent*)event))
-    return FALSE; // avoid double counting real and emulated events when receiving smooth scrolls
-
   gboolean handled = FALSE;
 
   switch(event->direction)

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -870,7 +870,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   0); /* digits */
   dt_bauhaus_widget_set_label(gui->quality,  NULL, N_("quality"));
   dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT));
-  dt_bauhaus_slider_set_format(gui->quality, "%.2f%%");
+  dt_bauhaus_slider_set_format(gui->quality, "%");
 
   gtk_widget_set_tooltip_text(gui->quality,
           _("the quality of an image, less quality means fewer details.\n"

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -450,17 +450,14 @@ static void _set_paper_size(dt_imageio_module_format_t *self, const char *text)
   g_signal_handlers_block_by_func(d->size, size_toggle_callback, self);
 
   int pos = 0;
-  const GList *entries;
-  for(entries = dt_bauhaus_combobox_get_entries(d->size); entries; entries = g_list_next(entries))
+  for(; pos < dt_bauhaus_combobox_length(d->size); pos++)
   {
-    const dt_bauhaus_combobox_entry_t *entry = (dt_bauhaus_combobox_entry_t *)entries->data;
     if((pos < dt_pdf_paper_sizes_n && !strcasecmp(text, dt_pdf_paper_sizes[pos].name))
-        || !strcasecmp(text, entry->label))
+        || !strcasecmp(text, dt_bauhaus_combobox_get_entry(d->size, pos)))
       break;
-    pos++;
   }
 
-  if(entries)
+  if(pos < dt_bauhaus_combobox_length(d->size))
   {
     // we jumped out of the loop -> found it
     dt_bauhaus_combobox_set(d->size, pos);

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -336,7 +336,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
   dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT));
-  dt_bauhaus_slider_set_format(gui->quality, "%.2f%%");
+  dt_bauhaus_slider_set_format(gui->quality, "%");
   gtk_widget_set_tooltip_text(gui->quality, _("applies only to lossy setting"));
   if(quality > 0 && quality <= 100) dt_bauhaus_slider_set(gui->quality, quality);
   gtk_box_pack_start(GTK_BOX(self->widget), gui->quality, TRUE, TRUE, 0);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5604,7 +5604,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   }
 }
 
-static float log10_curve(GtkWidget *self, float inval, dt_bauhaus_curve_t dir)
+static float log10_curve(float inval, dt_bauhaus_curve_t dir)
 {
   float outval;
   if(dir == DT_BAUHAUS_SET)
@@ -5618,7 +5618,7 @@ static float log10_curve(GtkWidget *self, float inval, dt_bauhaus_curve_t dir)
   return outval;
 }
 
-static float log2_curve(GtkWidget *self, float inval, dt_bauhaus_curve_t dir)
+static float log2_curve(float inval, dt_bauhaus_curve_t dir)
 {
   float outval;
   if(dir == DT_BAUHAUS_SET)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5688,7 +5688,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->rotation = dt_bauhaus_slider_from_params(self, N_("rotation"));
   dt_bauhaus_slider_set_step(g->rotation, 0.25);
-  dt_bauhaus_slider_set_format(g->rotation, "%.2f°");
+  dt_bauhaus_slider_set_format(g->rotation, "°");
   dt_bauhaus_slider_set_soft_range(g->rotation, -ROTATION_RANGE, ROTATION_RANGE);
 
   g->cropmode = dt_bauhaus_combobox_from_params(self, "cropmode");
@@ -5721,14 +5721,15 @@ void gui_init(struct dt_iop_module_t *self)
   g->f_length = dt_bauhaus_slider_from_params(self, "f_length");
   dt_bauhaus_slider_set_soft_range(g->f_length, 10.0f, 1000.0f);
   dt_bauhaus_slider_set_curve(g->f_length, log10_curve);
-  dt_bauhaus_slider_set_format(g->f_length, "%.0fmm");
+  dt_bauhaus_slider_set_digits(g->f_length, 0);
+  dt_bauhaus_slider_set_format(g->f_length, " mm");
   dt_bauhaus_slider_set_step(g->f_length, 1.0);
 
   g->crop_factor = dt_bauhaus_slider_from_params(self, "crop_factor");
   dt_bauhaus_slider_set_soft_range(g->crop_factor, 1.0f, 2.0f);
 
   g->orthocorr = dt_bauhaus_slider_from_params(self, "orthocorr");
-  dt_bauhaus_slider_set_format(g->orthocorr, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->orthocorr, "%");
   // this parameter could serve to finetune between generic model (0%) and specific model (100%).
   // however, users can more easily get the same effect with the aspect adjust parameter so we keep
   // this one hidden.

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3232,10 +3232,10 @@ static void do_fit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_as
   do_crop(module, p);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
-  dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
-  dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-  dt_bauhaus_slider_set_soft(g->shear, p->shear);
+  dt_bauhaus_slider_set(g->rotation, p->rotation);
+  dt_bauhaus_slider_set(g->lensshift_v, p->lensshift_v);
+  dt_bauhaus_slider_set(g->lensshift_h, p->lensshift_h);
+  dt_bauhaus_slider_set(g->shear, p->shear);
   --darktable.gui->reset;
 }
 
@@ -4831,7 +4831,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     if(a > 180.0) a -= 360.0;
 
     a -= dt_bauhaus_slider_get(g->rotation);
-    dt_bauhaus_slider_set_soft(g->rotation, -a);
+    dt_bauhaus_slider_set(g->rotation, -a);
     return TRUE;
   }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3196,19 +3196,21 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
 }
 
 // helper function to start parameter fit and report about errors
-static int do_fit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_ashift_fitaxis_t dir)
+static void do_fit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_ashift_fitaxis_t dir)
 {
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
 
-  if(g->fitting) return FALSE;
+  if(g->fitting) return;
 
   // if no structure available get it
   if(g->lines == NULL)
-    if(!_do_get_structure_auto(module, p, ASHIFT_ENHANCE_NONE)) goto error;
+    if(!_do_get_structure_auto(module, p, ASHIFT_ENHANCE_NONE)) return;
 
   g->fitting = 1;
 
   dt_iop_ashift_nmsresult_t res = nmsfit(module, p, dir);
+
+  g->fitting = 0;
 
   switch(res)
   {
@@ -3216,27 +3218,25 @@ static int do_fit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_ash
       dt_control_log(
           _("not enough structure for automatic correction\nminimum %d lines in each relevant direction"),
           MINIMUM_FITLINES);
-      goto error;
-      break;
+      return;
     case NMS_DID_NOT_CONVERGE:
     case NMS_INSANE:
       dt_control_log(_("automatic correction failed, please correct manually"));
-      goto error;
-      break;
+      return;
     case NMS_SUCCESS:
     default:
       break;
   }
 
-  g->fitting = 0;
-
   // finally apply cropping
   do_crop(module, p);
-  return TRUE;
 
-error:
-  g->fitting = 0;
-  return FALSE;
+  ++darktable.gui->reset;
+  dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
+  dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
+  dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
+  dt_bauhaus_slider_set_soft(g->shear, p->shear);
+  --darktable.gui->reset;
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
@@ -5095,15 +5095,7 @@ static int _event_fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event,
     if(self->enabled)
     {
       // module is enable -> we process directly
-      if(do_fit(self, p, fitaxis))
-      {
-        ++darktable.gui->reset;
-        dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
-        dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
-        dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-        dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        --darktable.gui->reset;
-      }
+      do_fit(self, p, fitaxis);
     }
     else
     {
@@ -5148,15 +5140,7 @@ static int _event_fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event,
     if(self->enabled)
     {
       // module is enable -> we process directly
-      if(do_fit(self, p, fitaxis))
-      {
-        ++darktable.gui->reset;
-        dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
-        dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
-        dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-        dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        --darktable.gui->reset;
-      }
+      do_fit(self, p, fitaxis);
     }
     else
     {
@@ -5203,15 +5187,7 @@ static int _event_fit_both_button_clicked(GtkWidget *widget, GdkEventButton *eve
     if(self->enabled)
     {
       // module is enable -> we process directly
-      if(do_fit(self, p, fitaxis))
-      {
-        ++darktable.gui->reset;
-        dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
-        dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
-        dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-        dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        --darktable.gui->reset;
-      }
+      do_fit(self, p, fitaxis);
     }
     else
     {
@@ -5334,15 +5310,7 @@ static void _event_process_after_preview_callback(gpointer instance, gpointer us
       break;
 
     case ASHIFT_JOBCODE_FIT:
-      if(do_fit(self, p, (dt_iop_ashift_fitaxis_t)jobparams))
-      {
-        ++darktable.gui->reset;
-        dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
-        dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
-        dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-        dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        --darktable.gui->reset;
-      }
+      do_fit(self, p, (dt_iop_ashift_fitaxis_t)jobparams);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       break;
 
@@ -5401,17 +5369,6 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
-
-  dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
-  dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
-  dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-  dt_bauhaus_slider_set_soft(g->shear, p->shear);
-  dt_bauhaus_slider_set_soft(g->f_length, p->f_length);
-  dt_bauhaus_slider_set_soft(g->crop_factor, p->crop_factor);
-  dt_bauhaus_slider_set(g->orthocorr, p->orthocorr);
-  dt_bauhaus_slider_set(g->aspect, p->aspect);
-  dt_bauhaus_combobox_set(g->mode, p->mode);
-  dt_bauhaus_combobox_set(g->cropmode, p->cropmode);
 
   gtk_widget_set_visible(g->specifics, p->mode == ASHIFT_MODE_SPECIFIC);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5687,7 +5687,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->draw_line_move = -1;
 
   g->rotation = dt_bauhaus_slider_from_params(self, N_("rotation"));
-  dt_bauhaus_slider_set_step(g->rotation, 0.25);
   dt_bauhaus_slider_set_format(g->rotation, "°");
   dt_bauhaus_slider_set_soft_range(g->rotation, -ROTATION_RANGE, ROTATION_RANGE);
 
@@ -5723,7 +5722,6 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_curve(g->f_length, log10_curve);
   dt_bauhaus_slider_set_digits(g->f_length, 0);
   dt_bauhaus_slider_set_format(g->f_length, " mm");
-  dt_bauhaus_slider_set_step(g->f_length, 1.0);
 
   g->crop_factor = dt_bauhaus_slider_from_params(self, "crop_factor");
   dt_bauhaus_slider_set_soft_range(g->crop_factor, 1.0f, 2.0f);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1033,7 +1033,7 @@ static void reset_mix(dt_iop_module_t *self)
   dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
   c->drag_params = *p;
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(c->mix, p->mix);
+  dt_bauhaus_slider_set(c->mix, p->mix);
   --darktable.gui->reset;
 }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1425,15 +1425,11 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
   dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)self->gui_data;
-  dt_bauhaus_combobox_set(g->cmb_preserve_colors, p->preserve_colors);
-  dt_bauhaus_combobox_set(g->fusion, p->exposure_fusion);
 
   gtk_widget_set_visible(g->exposure_step, p->exposure_fusion != 0);
   gtk_widget_set_visible(g->exposure_bias, p->exposure_fusion != 0);
 
   dt_iop_cancel_history_update(self);
-  dt_bauhaus_slider_set(g->exposure_step, p->exposure_stops);
-  dt_bauhaus_slider_set(g->exposure_bias, p->exposure_bias);
   // gui curve is read directly from params during expose event.
   gtk_widget_queue_draw(self->widget);
 }

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -2100,7 +2100,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                   "(-1: reduce highlight, +1: reduce shadows)"));
   gtk_widget_set_no_show_all(c->exposure_bias, TRUE);
   gtk_widget_set_visible(c->exposure_bias, p->exposure_fusion != 0 ? TRUE : FALSE);
-  c->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0.5f, 0.0f, 2);
+  c->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(c->logbase, NULL, N_("scale for graph"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);  g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1951,21 +1951,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
   int ch = 0;
   dt_iop_basecurve_node_t *basecurve = p->basecurve[ch];
 
-  float multiplier;
-
-  if(dt_modifier_is(state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
-
+  float multiplier = dt_accel_get_speed_multiplier(widget, state);
   dx *= multiplier;
   dy *= multiplier;
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -545,18 +545,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  dt_bauhaus_slider_set(g->sl_black_point, p->black_point);
-  dt_bauhaus_slider_set(g->sl_exposure, p->exposure);
-  dt_bauhaus_slider_set(g->sl_hlcompr, p->hlcompr);
-  dt_bauhaus_slider_set(g->sl_contrast, p->contrast);
-  dt_bauhaus_combobox_set(g->cmb_preserve_colors, p->preserve_colors);
-  dt_bauhaus_slider_set(g->sl_middle_grey, p->middle_grey);
-  dt_bauhaus_slider_set(g->sl_brightness, p->brightness);
-  dt_bauhaus_slider_set(g->sl_saturation, p->saturation);
-  dt_bauhaus_slider_set(g->sl_vibrance, p->vibrance);
-  dt_bauhaus_slider_set(g->sl_clip, p->clip);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_select_region), g->draw_selected_region);
 }

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -575,7 +575,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->sl_black_point = dt_bauhaus_slider_from_params(self, "black_point");
   dt_bauhaus_slider_set_soft_range(g->sl_black_point, -0.1, 0.1);
-  dt_bauhaus_slider_set_step(g->sl_black_point, .001);
   dt_bauhaus_slider_set_digits(g->sl_black_point, 4);
   gtk_widget_set_tooltip_text(g->sl_black_point, _("adjust the black level to unclip negative RGB values.\n"
                                                     "you should never use it to add more density in blacks!\n"
@@ -584,7 +583,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->sl_exposure = dt_bauhaus_slider_from_params(self, N_("exposure"));
   dt_bauhaus_slider_set_soft_range(g->sl_exposure, -4.0, 4.0);
-  dt_bauhaus_slider_set_step(g->sl_exposure, .02);
   dt_bauhaus_slider_set_format(g->sl_exposure, _(" EV"));
   gtk_widget_set_tooltip_text(g->sl_exposure, _("adjust the exposure correction"));
 
@@ -601,7 +599,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->sl_middle_grey = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                       dt_bauhaus_slider_from_params(self, "middle_grey"));
-  dt_bauhaus_slider_set_step(g->sl_middle_grey, .5);
   dt_bauhaus_slider_set_format(g->sl_middle_grey, "%");
   gtk_widget_set_tooltip_text(g->sl_middle_grey, _("middle gray adjustment"));
   g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback), self);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -585,7 +585,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->sl_exposure = dt_bauhaus_slider_from_params(self, N_("exposure"));
   dt_bauhaus_slider_set_soft_range(g->sl_exposure, -4.0, 4.0);
   dt_bauhaus_slider_set_step(g->sl_exposure, .02);
-  dt_bauhaus_slider_set_format(g->sl_exposure, _("%.2f EV"));
+  dt_bauhaus_slider_set_format(g->sl_exposure, _(" EV"));
   gtk_widget_set_tooltip_text(g->sl_exposure, _("adjust the exposure correction"));
 
   g->sl_hlcompr = dt_bauhaus_slider_from_params(self, "hlcompr");
@@ -602,7 +602,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->sl_middle_grey = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                       dt_bauhaus_slider_from_params(self, "middle_grey"));
   dt_bauhaus_slider_set_step(g->sl_middle_grey, .5);
-  dt_bauhaus_slider_set_format(g->sl_middle_grey, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->sl_middle_grey, "%");
   gtk_widget_set_tooltip_text(g->sl_middle_grey, _("middle gray adjustment"));
   g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback), self);
 

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -398,9 +398,8 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
   dt_iop_bilat_params_t *p = (dt_iop_bilat_params_t *)self->params;
-  dt_bauhaus_slider_set(g->detail, p->detail);
-  dt_bauhaus_combobox_set(g->mode, p->mode);
 
+// FIXME check by hand
   if(p->mode == s_mode_local_laplacian)
   {
     dt_bauhaus_slider_set(g->highlights, p->sigma_r);

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -428,7 +428,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->mode, _("the filter used for local contrast enhancement. bilateral is faster but can lead to artifacts around edges for extreme settings."));
 
   g->detail = dt_bauhaus_slider_from_params(self, N_("detail"));
-  dt_bauhaus_slider_set_step(g->detail, 0.01);
   dt_bauhaus_slider_set_offset(g->detail, 100);
   dt_bauhaus_slider_set_format(g->detail, "%");
   gtk_widget_set_tooltip_text(g->detail, _("changes the local contrast"));
@@ -452,13 +451,11 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->range, NULL, N_("contrast"));
   gtk_widget_set_tooltip_text(g->range, _("L difference to detect edges (range sigma of bilateral filter)"));
 
-  dt_bauhaus_slider_set_step(g->highlights, 0.01);
   dt_bauhaus_widget_set_label(g->highlights, NULL, N_("highlights"));
   dt_bauhaus_slider_set_hard_max(g->highlights, 2.0);
   dt_bauhaus_slider_set_format(g->highlights, "%");
   gtk_widget_set_tooltip_text(g->highlights, _("changes the local contrast of highlights"));
 
-  dt_bauhaus_slider_set_step(g->shadows, 0.01);
   dt_bauhaus_widget_set_label(g->shadows, NULL, N_("shadows"));
   dt_bauhaus_slider_set_hard_max(g->shadows, 2.0);
   dt_bauhaus_slider_set_format(g->shadows, "%");

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -399,7 +399,6 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
   dt_iop_bilat_params_t *p = (dt_iop_bilat_params_t *)self->params;
 
-// FIXME check by hand
   if(p->mode == s_mode_local_laplacian)
   {
     dt_bauhaus_slider_set(g->highlights, p->sigma_r);
@@ -430,9 +429,8 @@ void gui_init(dt_iop_module_t *self)
 
   g->detail = dt_bauhaus_slider_from_params(self, N_("detail"));
   dt_bauhaus_slider_set_step(g->detail, 0.01);
-  dt_bauhaus_slider_set_factor(g->detail, 100);
   dt_bauhaus_slider_set_offset(g->detail, 100);
-  dt_bauhaus_slider_set_format(g->detail, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->detail, "%");
   gtk_widget_set_tooltip_text(g->detail, _("changes the local contrast"));
 
   ++darktable.bauhaus->skip_accel;
@@ -442,11 +440,13 @@ void gui_init(dt_iop_module_t *self)
   g->shadows = dt_bauhaus_slider_from_params(self, "sigma_s");
   --darktable.bauhaus->skip_accel;
 
+  dt_bauhaus_slider_set_hard_min(g->spatial, 3.0);
   dt_bauhaus_slider_set_default(g->spatial, 50.0);
   dt_bauhaus_slider_set_digits(g->spatial, 0);
   dt_bauhaus_widget_set_label(g->spatial, NULL, N_("coarseness"));
   gtk_widget_set_tooltip_text(g->spatial, _("feature size of local details (spatial sigma of bilateral filter)"));
 
+  dt_bauhaus_slider_set_hard_min(g->range, 1.0);
   dt_bauhaus_slider_set_default(g->range, 20.0);
   dt_bauhaus_slider_set_digits(g->range, 0);
   dt_bauhaus_widget_set_label(g->range, NULL, N_("contrast"));
@@ -454,14 +454,14 @@ void gui_init(dt_iop_module_t *self)
 
   dt_bauhaus_slider_set_step(g->highlights, 0.01);
   dt_bauhaus_widget_set_label(g->highlights, NULL, N_("highlights"));
-  dt_bauhaus_slider_set_factor(g->highlights, 100);
-  dt_bauhaus_slider_set_format(g->highlights, "%.0f%%");
+  dt_bauhaus_slider_set_hard_max(g->highlights, 2.0);
+  dt_bauhaus_slider_set_format(g->highlights, "%");
   gtk_widget_set_tooltip_text(g->highlights, _("changes the local contrast of highlights"));
 
   dt_bauhaus_slider_set_step(g->shadows, 0.01);
   dt_bauhaus_widget_set_label(g->shadows, NULL, N_("shadows"));
-  dt_bauhaus_slider_set_factor(g->shadows, 100);
-  dt_bauhaus_slider_set_format(g->shadows, "%.0f%%");
+  dt_bauhaus_slider_set_hard_max(g->shadows, 2.0);
+  dt_bauhaus_slider_set_format(g->shadows, "%");
   gtk_widget_set_tooltip_text(g->shadows, _("changes the local contrast of shadows"));
 
   g->midtone = dt_bauhaus_slider_from_params(self, "midtone");
@@ -475,10 +475,6 @@ void gui_init(dt_iop_module_t *self)
   g_object_set(G_OBJECT(g->range), "no-show-all", TRUE, NULL);
   g_object_set(G_OBJECT(g->spatial), "no-show-all", TRUE, NULL);
 
-  dt_bauhaus_slider_set_hard_min(g->spatial, 3.0);
-  dt_bauhaus_slider_set_hard_min(g->range, 1.0);
-  dt_bauhaus_slider_set_hard_max(g->highlights, 2.0);
-  dt_bauhaus_slider_set_hard_max(g->shadows, 2.0);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -301,7 +301,6 @@ void gui_init(dt_iop_module_t *self)
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
   gtk_widget_set_tooltip_text(g->radius, _("spatial extent of the gaussian"));
   dt_bauhaus_slider_set_soft_range(g->radius, 1.0, 30.0);
-  dt_bauhaus_slider_set_step(g->radius, 1.0);
 
   g->red = dt_bauhaus_slider_from_params(self, N_("red"));
   gtk_widget_set_tooltip_text(g->red, _("how much to blur red"));

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -277,17 +277,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_bilateral_gui_data_t *g = (dt_iop_bilateral_gui_data_t *)self->gui_data;
-  dt_iop_bilateral_params_t *p = (dt_iop_bilateral_params_t *)self->params;
-  dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  // dt_bauhaus_slider_set(g->scale2, p->sigma[1]);
-  dt_bauhaus_slider_set_soft(g->red, p->red);
-  dt_bauhaus_slider_set_soft(g->green, p->green);
-  dt_bauhaus_slider_set_soft(g->blue, p->blue);
-}
-
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling)

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -383,15 +383,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  const dt_iop_bloom_params_t *p = (dt_iop_bloom_params_t *)self->params;
-  dt_iop_bloom_gui_data_t *g = (dt_iop_bloom_gui_data_t *)self->gui_data;
-  dt_bauhaus_slider_set(g->size, p->size);
-  dt_bauhaus_slider_set(g->threshold, p->threshold);
-  dt_bauhaus_slider_set(g->strength, p->strength);
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_bloom_gui_data_t *g = IOP_GUI_ALLOC(bloom);

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -388,15 +388,15 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_bloom_gui_data_t *g = IOP_GUI_ALLOC(bloom);
 
   g->size = dt_bauhaus_slider_from_params(self, N_("size"));
-  dt_bauhaus_slider_set_format(g->size, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->size, "%");
   gtk_widget_set_tooltip_text(g->size, _("the size of bloom"));
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
-  dt_bauhaus_slider_set_format(g->threshold, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->threshold, "%");
   gtk_widget_set_tooltip_text(g->threshold, _("the threshold of light"));
 
   g->strength = dt_bauhaus_slider_from_params(self, N_("strength"));
-  dt_bauhaus_slider_set_format(g->strength, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->strength, "%");
   gtk_widget_set_tooltip_text(g->strength, _("the strength of bloom"));
 }
 

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -784,21 +784,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)self->gui_data;
-  dt_iop_blurs_params_t *p = (dt_iop_blurs_params_t *)self->params;
-
-  dt_bauhaus_combobox_set_from_value(g->type, p->type);
-  dt_bauhaus_slider_set(g->radius, p->radius);
-
-  dt_bauhaus_slider_set(g->blades, p->blades);
-  dt_bauhaus_slider_set(g->concavity, p->concavity);
-  dt_bauhaus_slider_set(g->linearity, p->linearity);
-  dt_bauhaus_slider_set(g->rotation, p->rotation);
-
-  dt_bauhaus_slider_set(g->angle, p->angle);
-  dt_bauhaus_slider_set(g->curvature, p->curvature);
-  dt_bauhaus_slider_set(g->offset, p->offset);
-
+// FIXME check why needed
   gui_changed(self, NULL, NULL);
 }
 

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -808,7 +808,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
-  dt_bauhaus_slider_set_format(g->radius, "%.f px");
+  dt_bauhaus_slider_set_format(g->radius, " px");
 
   g->type = dt_bauhaus_combobox_from_params(self, "type");
 
@@ -817,11 +817,11 @@ void gui_init(dt_iop_module_t *self)
   g->linearity = dt_bauhaus_slider_from_params(self, "linearity");
   g->rotation = dt_bauhaus_slider_from_params(self, "rotation");
   dt_bauhaus_slider_set_factor(g->rotation, DEG_TO_RAD);
-  dt_bauhaus_slider_set_format(g->rotation, "%.f °");
+  dt_bauhaus_slider_set_format(g->rotation, "°");
 
   g->angle = dt_bauhaus_slider_from_params(self, "angle");
   dt_bauhaus_slider_set_factor(g->angle, DEG_TO_RAD);
-  dt_bauhaus_slider_set_format(g->angle, "%.f °");
+  dt_bauhaus_slider_set_format(g->angle, "°");
 
 
   g->curvature = dt_bauhaus_slider_from_params(self, "curvature");

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1023,9 +1023,8 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->default_params;
 
   g->size = dt_bauhaus_slider_from_params(self, "size");
-  dt_bauhaus_slider_set_factor(g->size, 100);
   dt_bauhaus_slider_set_digits(g->size, 4);
-  dt_bauhaus_slider_set_format(g->size, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->size, "%");
   gtk_widget_set_tooltip_text(g->size, _("size of the border in percent of the full image"));
 
   g->aspect = dt_bauhaus_combobox_new(self);
@@ -1069,17 +1068,15 @@ void gui_init(struct dt_iop_module_t *self)
   gui_init_positions(self);
 
   g->frame_size = dt_bauhaus_slider_from_params(self, "frame_size");
-  dt_bauhaus_slider_set_factor(g->frame_size, 100);
   dt_bauhaus_slider_set_step(g->frame_size, 0.005);
   dt_bauhaus_slider_set_digits(g->frame_size, 4);
-  dt_bauhaus_slider_set_format(g->frame_size, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->frame_size, "%");
   gtk_widget_set_tooltip_text(g->frame_size, _("size of the frame line in percent of min border width"));
 
   g->frame_offset = dt_bauhaus_slider_from_params(self, "frame_offset");
-  dt_bauhaus_slider_set_factor(g->frame_offset, 100);
   dt_bauhaus_slider_set_step(g->frame_size, 0.005);
   dt_bauhaus_slider_set_digits(g->frame_offset, 4);
-  dt_bauhaus_slider_set_format(g->frame_offset, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->frame_offset, "%");
   gtk_widget_set_tooltip_text(g->frame_offset, _("offset of the frame line beginning on picture side"));
 
   GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -897,8 +897,8 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
-  dt_bauhaus_slider_set(g->size, p->size);
 
+// FIXME by hand
   // ----- Aspect
   int k = 0;
   for(; k < DT_IOP_BORDERS_ASPECT_COUNT; k++)
@@ -913,9 +913,6 @@ void gui_update(struct dt_iop_module_t *self)
   {
       dt_bauhaus_combobox_set(g->aspect, k);
   }
-
-  // ----- aspect orientation
-  dt_bauhaus_combobox_set(g->aspect_orient, p->aspect_orient);
 
   // ----- Position H
   for(k = 0; k < DT_IOP_BORDERS_POSITION_H_COUNT; k++)
@@ -944,11 +941,6 @@ void gui_update(struct dt_iop_module_t *self)
   {
     dt_bauhaus_combobox_set(g->pos_v, k);
   }
-  dt_bauhaus_slider_set(g->aspect_slider, p->aspect);
-  dt_bauhaus_slider_set(g->pos_h_slider, p->pos_h);
-  dt_bauhaus_slider_set(g->pos_v_slider, p->pos_v);
-  dt_bauhaus_slider_set(g->frame_size, p->frame_size);
-  dt_bauhaus_slider_set(g->frame_offset, p->frame_offset);
 
   // ----- Border Color
   GdkRGBA c = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1051,7 +1051,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->pos_h, _("select the horizontal position ratio relative to top "
                                           "or right click and type your own (y:h)"));
   g->pos_h_slider = dt_bauhaus_slider_from_params(self, "pos_h");
-  dt_bauhaus_slider_set_step(g->pos_h_slider, 0.1);
   gtk_widget_set_tooltip_text(g->pos_h_slider, _("custom horizontal position"));
 
   g->pos_v = dt_bauhaus_combobox_new(self);
@@ -1062,19 +1061,16 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->pos_v, _("select the vertical position ratio relative to left "
                                           "or right click and type your own (x:w)"));
   g->pos_v_slider = dt_bauhaus_slider_from_params(self, "pos_v");
-  dt_bauhaus_slider_set_step(g->pos_v_slider, 0.1);
   gtk_widget_set_tooltip_text(g->pos_v_slider, _("custom vertical position"));
 
   gui_init_positions(self);
 
   g->frame_size = dt_bauhaus_slider_from_params(self, "frame_size");
-  dt_bauhaus_slider_set_step(g->frame_size, 0.005);
   dt_bauhaus_slider_set_digits(g->frame_size, 4);
   dt_bauhaus_slider_set_format(g->frame_size, "%");
   gtk_widget_set_tooltip_text(g->frame_size, _("size of the frame line in percent of min border width"));
 
   g->frame_offset = dt_bauhaus_slider_from_params(self, "frame_offset");
-  dt_bauhaus_slider_set_step(g->frame_size, 0.005);
   dt_bauhaus_slider_set_digits(g->frame_offset, 4);
   dt_bauhaus_slider_set_format(g->frame_offset, "%");
   gtk_widget_set_tooltip_text(g->frame_offset, _("offset of the frame line beginning on picture side"));

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -707,10 +707,6 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)self->gui_data;
   dt_iop_cacorrectrgb_params_t *p = (dt_iop_cacorrectrgb_params_t *)self->params;
 
-  dt_bauhaus_combobox_set_from_value(g->guide_channel, p->guide_channel);
-  dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  dt_bauhaus_slider_set_soft(g->strength, p->strength);
-  dt_bauhaus_combobox_set_from_value(g->mode, p->mode);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->refine_manifolds), p->refine_manifolds);
 }
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -407,13 +407,10 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_censorize_gui_data_t *g = IOP_GUI_ALLOC(censorize);
 
   g->radius_1 = dt_bauhaus_slider_from_params(self, N_("radius_1"));
-  dt_bauhaus_slider_set_step(g->radius_1, 0.1);
 
   g->pixelate = dt_bauhaus_slider_from_params(self, N_("pixelate"));
-  dt_bauhaus_slider_set_step(g->pixelate, 0.1);
 
   g->radius_2 = dt_bauhaus_slider_from_params(self, N_("radius_2"));
-  dt_bauhaus_slider_set_step(g->radius_2, 0.1);
 
   g->noise = dt_bauhaus_slider_from_params(self, N_("noise"));
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -402,16 +402,6 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 #endif
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_censorize_gui_data_t *g = (dt_iop_censorize_gui_data_t *)self->gui_data;
-  dt_iop_censorize_params_t *p = (dt_iop_censorize_params_t *)self->params;
-  dt_bauhaus_slider_set(g->radius_1, p->radius_1);
-  dt_bauhaus_slider_set(g->pixelate, p->pixelate);
-  dt_bauhaus_slider_set(g->radius_2, p->radius_2);
-  dt_bauhaus_slider_set(g->noise, p->noise);
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_censorize_gui_data_t *g = IOP_GUI_ALLOC(censorize);

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -630,19 +630,19 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->output_channel), "value-changed", G_CALLBACK(output_callback), self);
 
   /* red */
-  g->scale_red = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->red[CHANNEL_RED], 3);
+  g->scale_red = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0, p->red[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_red, _("amount of red channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_red, NULL, N_("red"));
   g_signal_connect(G_OBJECT(g->scale_red), "value-changed", G_CALLBACK(red_callback), self);
 
   /* green */
-  g->scale_green = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->green[CHANNEL_RED], 3);
+  g->scale_green = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0, p->green[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_green, _("amount of green channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_green, NULL, N_("green"));
   g_signal_connect(G_OBJECT(g->scale_green), "value-changed", G_CALLBACK(green_callback), self);
 
   /* blue */
-  g->scale_blue = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->blue[CHANNEL_RED], 3);
+  g->scale_blue = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0, p->blue[CHANNEL_RED], 3);
   gtk_widget_set_tooltip_text(g->scale_blue, _("amount of blue channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_blue, NULL, N_("blue"));
   g_signal_connect(G_OBJECT(g->scale_blue), "value-changed", G_CALLBACK(blue_callback), self);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3628,36 +3628,10 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_gui_leave_critical_section(self);
 
-  dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
-  dt_bauhaus_combobox_set(g->illum_fluo, p->illum_fluo);
-  dt_bauhaus_combobox_set(g->illum_led, p->illum_led);
-  dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
-  dt_bauhaus_slider_set_soft(g->gamut, p->gamut);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->clip), p->clip);
-
-  dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
-
-  dt_bauhaus_slider_set_soft(g->scale_red_R, p->red[0]);
-  dt_bauhaus_slider_set_soft(g->scale_red_G, p->red[1]);
-  dt_bauhaus_slider_set_soft(g->scale_red_B, p->red[2]);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_R), p->normalize_R);
-
-  dt_bauhaus_slider_set_soft(g->scale_green_R, p->green[0]);
-  dt_bauhaus_slider_set_soft(g->scale_green_G, p->green[1]);
-  dt_bauhaus_slider_set_soft(g->scale_green_B, p->green[2]);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_G), p->normalize_G);
-
-  dt_bauhaus_slider_set_soft(g->scale_blue_R, p->blue[0]);
-  dt_bauhaus_slider_set_soft(g->scale_blue_G, p->blue[1]);
-  dt_bauhaus_slider_set_soft(g->scale_blue_B, p->blue[2]);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_B), p->normalize_B);
-
-  dt_bauhaus_slider_set_soft(g->scale_saturation_R, p->saturation[0]);
-  dt_bauhaus_slider_set_soft(g->scale_saturation_G, p->saturation[1]);
-  dt_bauhaus_slider_set_soft(g->scale_saturation_B, p->saturation[2]);
 
   if(p->version != CHANNELMIXERRGB_V_3)
     dt_bauhaus_combobox_set(g->saturation_version, p->version);
@@ -3665,17 +3639,7 @@ void gui_update(struct dt_iop_module_t *self)
     gtk_widget_hide(GTK_WIDGET(g->saturation_version));
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_sat), p->normalize_sat);
-
-  dt_bauhaus_slider_set_soft(g->scale_lightness_R, p->lightness[0]);
-  dt_bauhaus_slider_set_soft(g->scale_lightness_G, p->lightness[1]);
-  dt_bauhaus_slider_set_soft(g->scale_lightness_B, p->lightness[2]);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_light), p->normalize_light);
-
-  dt_bauhaus_slider_set_soft(g->scale_grey_R, p->grey[0]);
-  dt_bauhaus_slider_set_soft(g->scale_grey_G, p->grey[1]);
-  dt_bauhaus_slider_set_soft(g->scale_grey_B, p->grey[2]);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_grey), p->normalize_grey);
 
   dt_iop_gui_enter_critical_section(self);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2657,25 +2657,25 @@ static void commit_profile_callback(GtkWidget *widget, GdkEventButton *event, gp
 
   ++darktable.gui->reset;
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
-  dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
+  dt_bauhaus_slider_set(g->temperature, p->temperature);
 
   dt_aligned_pixel_t xyY = { p->x, p->y, 1.f };
   dt_aligned_pixel_t Lch = { 0 };
   dt_xyY_to_Lch(xyY, Lch);
   dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
-  dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);
+  dt_bauhaus_slider_set(g->illum_y, Lch[1]);
 
-  dt_bauhaus_slider_set_soft(g->scale_red_R, p->red[0]);
-  dt_bauhaus_slider_set_soft(g->scale_red_G, p->red[1]);
-  dt_bauhaus_slider_set_soft(g->scale_red_B, p->red[2]);
+  dt_bauhaus_slider_set(g->scale_red_R, p->red[0]);
+  dt_bauhaus_slider_set(g->scale_red_G, p->red[1]);
+  dt_bauhaus_slider_set(g->scale_red_B, p->red[2]);
 
-  dt_bauhaus_slider_set_soft(g->scale_green_R, p->green[0]);
-  dt_bauhaus_slider_set_soft(g->scale_green_G, p->green[1]);
-  dt_bauhaus_slider_set_soft(g->scale_green_B, p->green[2]);
+  dt_bauhaus_slider_set(g->scale_green_R, p->green[0]);
+  dt_bauhaus_slider_set(g->scale_green_G, p->green[1]);
+  dt_bauhaus_slider_set(g->scale_green_B, p->green[2]);
 
-  dt_bauhaus_slider_set_soft(g->scale_blue_R, p->blue[0]);
-  dt_bauhaus_slider_set_soft(g->scale_blue_G, p->blue[1]);
-  dt_bauhaus_slider_set_soft(g->scale_blue_B, p->blue[2]);
+  dt_bauhaus_slider_set(g->scale_blue_R, p->blue[0]);
+  dt_bauhaus_slider_set(g->scale_blue_G, p->blue[1]);
+  dt_bauhaus_slider_set(g->scale_blue_B, p->blue[2]);
 
   --darktable.gui->reset;
 
@@ -2706,7 +2706,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 
   ++darktable.gui->reset;
 
-  dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
+  dt_bauhaus_slider_set(g->temperature, p->temperature);
   dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
   dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
 
@@ -2714,7 +2714,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
   dt_aligned_pixel_t Lch;
   dt_xyY_to_Lch(xyY, Lch);
   dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
-  dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);
+  dt_bauhaus_slider_set(g->illum_y, Lch[1]);
 
   update_illuminants(self);
   update_approx_cct(self);
@@ -3563,7 +3563,7 @@ static void illum_xy_callback(GtkWidget *slider, gpointer user_data)
   p->temperature = t;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
+  dt_bauhaus_slider_set(g->temperature, p->temperature);
   update_approx_cct(self);
   update_illuminant_color(self);
   paint_temperature_background(self);
@@ -3655,7 +3655,7 @@ void gui_update(struct dt_iop_module_t *self)
   g->safety_margin = 0.5f;
   if(dt_conf_key_exists("darkroom/modules/channelmixerrgb/safety"))
     g->safety_margin = dt_conf_get_float("darkroom/modules/channelmixerrgb/safety");
-  dt_bauhaus_slider_set_soft(g->safety, g->safety_margin);
+  dt_bauhaus_slider_set(g->safety, g->safety_margin);
 
   dt_iop_gui_leave_critical_section(self);
 
@@ -3875,10 +3875,10 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     // set to a nonzero value, the hue setting will remain unchanged.
     if(Lch[1] > 0)
       dt_bauhaus_slider_set(g->illum_x, Lch[2] / M_PI * 180.f);
-    dt_bauhaus_slider_set_soft(g->illum_y, Lch[1]);
+    dt_bauhaus_slider_set(g->illum_y, Lch[1]);
 
     // Redraw the temperature background color taking new soft bounds into account
-    dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
+    dt_bauhaus_slider_set(g->temperature, p->temperature);
     paint_temperature_background(self);
   }
 
@@ -4026,9 +4026,9 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 
     // Return the values in sliders
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(g->lightness_spot, Lch_output[0]);
-    dt_bauhaus_slider_set_soft(g->chroma_spot, Lch_output[1]);
-    dt_bauhaus_slider_set_soft(g->hue_spot, Lch_output[2] * 360.f);
+    dt_bauhaus_slider_set(g->lightness_spot, Lch_output[0]);
+    dt_bauhaus_slider_set(g->chroma_spot, Lch_output[1]);
+    dt_bauhaus_slider_set(g->hue_spot, Lch_output[2] * 360.f);
     paint_hue(self);
     --darktable.gui->reset;
 
@@ -4142,7 +4142,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 
     check_if_close_to_daylight(p->x, p->y, &p->temperature, NULL, NULL);
 
-    dt_bauhaus_slider_set_soft(g->temperature, p->temperature);
+    dt_bauhaus_slider_set(g->temperature, p->temperature);
     dt_bauhaus_combobox_set(g->illuminant, p->illuminant);
     dt_bauhaus_combobox_set(g->adaptation, p->adaptation);
 
@@ -4150,7 +4150,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     dt_aligned_pixel_t Lch_illuminant = { 0 };
     dt_xyY_to_Lch(xyY, Lch_illuminant);
     dt_bauhaus_slider_set(g->illum_x, Lch_illuminant[2] / M_PI * 180.f);
-    dt_bauhaus_slider_set_soft(g->illum_y, Lch_illuminant[1]);
+    dt_bauhaus_slider_set(g->illum_y, Lch_illuminant[1]);
 
     update_illuminants(self);
     update_approx_cct(self);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4088,7 +4088,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(g->csspot.container), GTK_WIDGET(g->spot_mode), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->spot_mode), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
 
-  g->use_mixing = gtk_check_button_new_with_label(_("take channel mixing into account"));
+  gchar *label = N_("take channel mixing into account");
+  g->use_mixing = gtk_check_button_new_with_label(_(label));
+  dt_action_define_iop(self, NULL, label, g->use_mixing, &dt_action_def_toggle);
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->use_mixing))), PANGO_ELLIPSIZE_END);
   gtk_widget_set_tooltip_text(g->use_mixing,
                               _("compute the target by taking the channel mixing into account.\n"
                                 "if disabled, only the CAT is considered."));

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4063,7 +4063,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_y), FALSE, FALSE, 0);
 
   g->gamut = dt_bauhaus_slider_from_params(self, "gamut");
-  dt_bauhaus_slider_set_hard_max(g->gamut, 4.f);
+  dt_bauhaus_slider_set_soft_max(g->gamut, 4.f);
 
   g->clip = dt_bauhaus_toggle_from_params(self, "clip");
 
@@ -4159,20 +4159,14 @@ void gui_init(struct dt_iop_module_t *self)
                                                                               \
   first = dt_bauhaus_slider_from_params(self, swap ? #var "[2]" : #var "[0]");\
   dt_bauhaus_slider_set_digits(first, 3);                                     \
-  dt_bauhaus_slider_set_hard_min(first, -2.f);                                \
-  dt_bauhaus_slider_set_hard_max(first, 2.f);                                 \
   dt_bauhaus_widget_set_label(first, section, N_("input R"));                 \
                                                                               \
   second = dt_bauhaus_slider_from_params(self, #var "[1]");                   \
   dt_bauhaus_slider_set_digits(second, 3);                                    \
-  dt_bauhaus_slider_set_hard_min(second, -2.f);                               \
-  dt_bauhaus_slider_set_hard_max(second, 2.f);                                \
   dt_bauhaus_widget_set_label(second, section, N_("input G"));                \
                                                                               \
   third = dt_bauhaus_slider_from_params(self, swap ? #var "[0]" : #var "[2]");\
   dt_bauhaus_slider_set_digits(third, 3);                                     \
-  dt_bauhaus_slider_set_hard_min(third, -2.f);                                \
-  dt_bauhaus_slider_set_hard_max(third, 2.f);                                 \
   dt_bauhaus_widget_set_label(third, section, N_("input B"));                 \
                                                                               \
   g->scale_##var##_R = swap ? third : first;                                  \

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4048,17 +4048,17 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->temperature, 3000., 7000.);
   dt_bauhaus_slider_set_step(g->temperature, 50.);
   dt_bauhaus_slider_set_digits(g->temperature, 0);
-  dt_bauhaus_slider_set_format(g->temperature, "%.0f K");
+  dt_bauhaus_slider_set_format(g->temperature, " K");
 
   g->illum_x = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., ILLUM_X_MAX, 0.5, 0, 1, 0);
   dt_bauhaus_widget_set_label(g->illum_x, NULL, _("hue"));
-  dt_bauhaus_slider_set_format(g->illum_x, "%.1f °");
+  dt_bauhaus_slider_set_format(g->illum_x, "°");
   g_signal_connect(G_OBJECT(g->illum_x), "value-changed", G_CALLBACK(illum_xy_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_x), FALSE, FALSE, 0);
 
   g->illum_y = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
   dt_bauhaus_widget_set_label(g->illum_y, NULL, _("chroma"));
-  dt_bauhaus_slider_set_format(g->illum_y, "%.1f %%");
+  dt_bauhaus_slider_set_format(g->illum_y, "%");
   dt_bauhaus_slider_set_hard_max(g->illum_y, ILLUM_Y_MAX);
   g_signal_connect(G_OBJECT(g->illum_y), "value-changed", G_CALLBACK(illum_xy_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_y), FALSE, FALSE, 0);
@@ -4132,14 +4132,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., LIGHTNESS_MAX, 0.5, 0, 1);
   dt_bauhaus_widget_set_label(g->lightness_spot, NULL, _("lightness"));
-  dt_bauhaus_slider_set_format(g->lightness_spot, "%.1f %%");
+  dt_bauhaus_slider_set_format(g->lightness_spot, "%");
   dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->lightness_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
 
   g->hue_spot = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., HUE_MAX, 0.5, 0, 1, 0);
   dt_bauhaus_widget_set_label(g->hue_spot, NULL, _("hue"));
-  dt_bauhaus_slider_set_format(g->hue_spot, "%.1f °");
+  dt_bauhaus_slider_set_format(g->hue_spot, "°");
   dt_bauhaus_slider_set_default(g->hue_spot, 0.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->hue_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->hue_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4046,7 +4046,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->temperature = dt_bauhaus_slider_from_params(self, N_("temperature"));
   dt_bauhaus_slider_set_soft_range(g->temperature, 3000., 7000.);
-  dt_bauhaus_slider_set_step(g->temperature, 50.);
   dt_bauhaus_slider_set_digits(g->temperature, 0);
   dt_bauhaus_slider_set_format(g->temperature, " K");
 
@@ -4159,21 +4158,18 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, label, _(tooltip));         \
                                                                               \
   first = dt_bauhaus_slider_from_params(self, swap ? #var "[2]" : #var "[0]");\
-  dt_bauhaus_slider_set_step(first, 0.005);                                   \
   dt_bauhaus_slider_set_digits(first, 3);                                     \
   dt_bauhaus_slider_set_hard_min(first, -2.f);                                \
   dt_bauhaus_slider_set_hard_max(first, 2.f);                                 \
   dt_bauhaus_widget_set_label(first, section, N_("input R"));                 \
                                                                               \
   second = dt_bauhaus_slider_from_params(self, #var "[1]");                   \
-  dt_bauhaus_slider_set_step(second, 0.005);                                  \
   dt_bauhaus_slider_set_digits(second, 3);                                    \
   dt_bauhaus_slider_set_hard_min(second, -2.f);                               \
   dt_bauhaus_slider_set_hard_max(second, 2.f);                                \
   dt_bauhaus_widget_set_label(second, section, N_("input G"));                \
                                                                               \
   third = dt_bauhaus_slider_from_params(self, swap ? #var "[0]" : #var "[2]");\
-  dt_bauhaus_slider_set_step(third, 0.005);                                   \
   dt_bauhaus_slider_set_digits(third, 3);                                     \
   dt_bauhaus_slider_set_hard_min(third, -2.f);                                \
   dt_bauhaus_slider_set_hard_max(third, 2.f);                                 \

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4049,13 +4049,13 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->temperature, 0);
   dt_bauhaus_slider_set_format(g->temperature, " K");
 
-  g->illum_x = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., ILLUM_X_MAX, 0.5, 0, 1, 0);
+  g->illum_x = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., ILLUM_X_MAX, 0, 0, 1, 0);
   dt_bauhaus_widget_set_label(g->illum_x, NULL, _("hue"));
   dt_bauhaus_slider_set_format(g->illum_x, "°");
   g_signal_connect(G_OBJECT(g->illum_x), "value-changed", G_CALLBACK(illum_xy_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_x), FALSE, FALSE, 0);
 
-  g->illum_y = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
+  g->illum_y = dt_bauhaus_slider_new_with_range(self, 0., 100., 0, 0, 1);
   dt_bauhaus_widget_set_label(g->illum_y, NULL, _("chroma"));
   dt_bauhaus_slider_set_format(g->illum_y, "%");
   dt_bauhaus_slider_set_hard_max(g->illum_y, ILLUM_Y_MAX);
@@ -4129,21 +4129,21 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->target_spot), "draw", G_CALLBACK(target_color_draw), self);
   gtk_box_pack_start(GTK_BOX(vvbox), g->target_spot, TRUE, TRUE, 0);
 
-  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., LIGHTNESS_MAX, 0.5, 0, 1);
+  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., LIGHTNESS_MAX, 0, 0, 1);
   dt_bauhaus_widget_set_label(g->lightness_spot, NULL, _("lightness"));
   dt_bauhaus_slider_set_format(g->lightness_spot, "%");
   dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->lightness_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
 
-  g->hue_spot = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., HUE_MAX, 0.5, 0, 1, 0);
+  g->hue_spot = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., HUE_MAX, 0, 0, 1, 0);
   dt_bauhaus_widget_set_label(g->hue_spot, NULL, _("hue"));
   dt_bauhaus_slider_set_format(g->hue_spot, "°");
   dt_bauhaus_slider_set_default(g->hue_spot, 0.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->hue_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->hue_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
 
-  g->chroma_spot = dt_bauhaus_slider_new_with_range(self, 0., CHROMA_MAX, 0.5, 0, 1);
+  g->chroma_spot = dt_bauhaus_slider_new_with_range(self, 0., CHROMA_MAX, 0, 0, 1);
   dt_bauhaus_widget_set_label(g->chroma_spot, NULL, _("chroma"));
   dt_bauhaus_slider_set_default(g->chroma_spot, 0.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->chroma_spot), TRUE, TRUE, 0);
@@ -4239,7 +4239,7 @@ void gui_init(struct dt_iop_module_t *self)
                                 N_("maximum delta E"));
   gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->optimize), TRUE, TRUE, 0);
 
-  g->safety = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 1., 0.1, 0.5, 3, TRUE);
+  g->safety = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 1., 0, 0.5, 3, TRUE);
   dt_bauhaus_widget_set_label(g->safety, NULL, _("patch scale"));
   gtk_widget_set_tooltip_text(g->safety, _("reduce the radius of the patches to select the more or less central part.\n"
                                            "useful when the perspective correction is sloppy or\n"

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -337,10 +337,8 @@ void gui_init(struct dt_iop_module_t *self)
   g->label2 = dtgtk_reset_label_new(_("amount"), self, &p->slope, sizeof(float));
   gtk_box_pack_start(GTK_BOX(g->vbox1), g->label2, TRUE, TRUE, 0);
 
-  g->scale1 = dt_bauhaus_slider_new_with_range(NULL, 0.0, 256.0, 1.0,
-                                               p->radius, 0);
-  g->scale2 = dt_bauhaus_slider_new_with_range(NULL, 1.0, 3.0, 0.05,
-                                               p->slope, 2);
+  g->scale1 = dt_bauhaus_slider_new_with_range(NULL, 0.0, 256.0, 0, p->radius, 0);
+  g->scale2 = dt_bauhaus_slider_new_with_range(NULL, 1.0, 3.0, 0, p->slope, 2);
   // dtgtk_slider_set_format_type(g->scale2,DARKTABLE_SLIDER_FORMAT_PERCENT);
 
   gtk_box_pack_start(GTK_BOX(g->vbox2), GTK_WIDGET(g->scale1), TRUE, TRUE, 0);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1941,12 +1941,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
-  /* update ui elements */
-  dt_bauhaus_slider_set(g->angle, p->angle);
-  dt_bauhaus_slider_set(g->cx, p->cx);
-  dt_bauhaus_slider_set(g->cy, p->cy);
-  dt_bauhaus_slider_set(g->cw, p->cw);
-  dt_bauhaus_slider_set(g->ch, p->ch);
   int hvflip = 0;
   if(p->cw < 0)
   {
@@ -2024,8 +2018,6 @@ void gui_update(struct dt_iop_module_t *self)
   g->clip_y = CLAMPF(p->cy, 0.0f, 0.9f);
   g->clip_w = CLAMPF(fabsf(p->cw) - p->cx, 0.1f, 1.0f - g->clip_x);
   g->clip_h = CLAMPF(fabsf(p->ch) - p->cy, 0.1f, 1.0f - g->clip_y);
-
-  dt_bauhaus_combobox_set(g->crop_auto, p->crop_auto);
 }
 
 static void hvflip_callback(GtkWidget *widget, dt_iop_module_t *self)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2129,7 +2129,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->angle = dt_bauhaus_slider_from_params(self, N_("angle"));
   dt_bauhaus_slider_set_step(g->angle, 0.25);
   dt_bauhaus_slider_set_factor(g->angle, -1.0);
-  dt_bauhaus_slider_set_format(g->angle, "%.02f°");
+  dt_bauhaus_slider_set_format(g->angle, "°");
   gtk_widget_set_tooltip_text(g->angle, _("right-click and drag a line on the image to drag a straight line"));
 
   g->keystone_type = dt_bauhaus_combobox_new(self);
@@ -2266,28 +2266,26 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->cx = dt_bauhaus_slider_from_params(self, "cx");
   dt_bauhaus_slider_set_digits(g->cx, 4);
-  dt_bauhaus_slider_set_factor(g->cx, 100.0);
-  dt_bauhaus_slider_set_format(g->cx, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->cx, "%");
   gtk_widget_set_tooltip_text(g->cx, _("the left margin cannot overlap with the right margin"));
 
   g->cw = dt_bauhaus_slider_from_params(self, "cw");
   dt_bauhaus_slider_set_digits(g->cw, 4);
   dt_bauhaus_slider_set_factor(g->cw, -100.0);
   dt_bauhaus_slider_set_offset(g->cw, 100.0);
-  dt_bauhaus_slider_set_format(g->cw, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->cw, "%");
   gtk_widget_set_tooltip_text(g->cw, _("the right margin cannot overlap with the left margin"));
 
   g->cy = dt_bauhaus_slider_from_params(self, "cy");
   dt_bauhaus_slider_set_digits(g->cy, 4);
-  dt_bauhaus_slider_set_factor(g->cy, 100.0);
-  dt_bauhaus_slider_set_format(g->cy, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->cy, "%");
   gtk_widget_set_tooltip_text(g->cy, _("the top margin cannot overlap with the bottom margin"));
 
   g->ch = dt_bauhaus_slider_from_params(self, "ch");
   dt_bauhaus_slider_set_digits(g->ch, 4);
   dt_bauhaus_slider_set_factor(g->ch, -100.0);
   dt_bauhaus_slider_set_offset(g->ch, 100.0);
-  dt_bauhaus_slider_set_format(g->ch, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->ch, "%");
   gtk_widget_set_tooltip_text(g->ch, _("the bottom margin cannot overlap with the top margin"));
 
   self->widget = GTK_WIDGET(g->notebook);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2127,7 +2127,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->hvflip, TRUE, TRUE, 0);
 
   g->angle = dt_bauhaus_slider_from_params(self, N_("angle"));
-  dt_bauhaus_slider_set_step(g->angle, 0.25);
   dt_bauhaus_slider_set_factor(g->angle, -1.0);
   dt_bauhaus_slider_set_format(g->angle, "°");
   gtk_widget_set_tooltip_text(g->angle, _("right-click and drag a line on the image to drag a straight line"));

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -279,16 +279,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_colisa_gui_data_t *g = (dt_iop_colisa_gui_data_t *)self->gui_data;
-  dt_iop_colisa_params_t *p = (dt_iop_colisa_params_t *)self->params;
-  dt_bauhaus_slider_set(g->contrast, p->contrast);
-  dt_bauhaus_slider_set(g->brightness, p->brightness);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-}
-
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 2; // basic.cl, from programs.conf

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1987,7 +1987,7 @@ void gui_init(dt_iop_module_t *self)
                                                                             \
   g->hue_##which = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,          \
                    dt_bauhaus_slider_new_with_range_and_feedback(self,      \
-                   0.0f, 360.0f, 1.0f, 0.0f, 2, 0));                        \
+                   0.0f, 360.0f, 0, 0.0f, 2, 0));                           \
   dt_bauhaus_widget_set_label(g->hue_##which, section, N_("hue"));          \
   dt_bauhaus_slider_set_format(g->hue_##which, "°");                        \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.0f,   1.0f, 0.0f, 0.0f);     \
@@ -2003,7 +2003,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->hue_##which, TRUE, TRUE, 0); \
                                                                             \
   g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(self,      \
-                   0.0f, 100.0f, 0.05f, 0.0f, 2, 0);                        \
+                   0.0f, 100.0f, 0, 0.0f, 2, 0);                            \
   dt_bauhaus_slider_set_soft_max(g->sat_##which, satspan);                  \
   dt_bauhaus_widget_set_label(g->sat_##which, section, N_("saturation"));   \
   dt_bauhaus_slider_set_format(g->sat_##which, "%");                        \

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1531,31 +1531,6 @@ void set_visible_widgets(dt_iop_colorbalance_gui_data_t *g)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-
-  dt_bauhaus_combobox_set(g->mode, p->mode);
-
-  dt_bauhaus_slider_set_soft(g->grey, p->grey);
-  dt_bauhaus_slider_set_soft(g->saturation, p->saturation);
-  dt_bauhaus_slider_set_soft(g->saturation_out, p->saturation_out);
-  dt_bauhaus_slider_set_soft(g->contrast, p->contrast);
-
-  dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR]));
-  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE]);
-
-  dt_bauhaus_slider_set_soft(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
-  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE]);
-
-  dt_bauhaus_slider_set_soft(g->gain_factor, p->gain[CHANNEL_FACTOR]);
-  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE]);
-
   dt_iop_color_picker_reset(self, TRUE);
   _check_tuner_picker_labels(self);
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1880,21 +1880,19 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.5f, 1.5f);
   dt_bauhaus_slider_set_digits(g->saturation, 4);
   dt_bauhaus_slider_set_step(g->saturation, .005);
-  dt_bauhaus_slider_set_factor(g->saturation, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_widget_set_tooltip_text(g->saturation, _("saturation correction before the color balance"));
 
   g->saturation_out = dt_bauhaus_slider_from_params(self, "saturation_out");
   dt_bauhaus_slider_set_soft_range(g->saturation_out, 0.5f, 1.5f);
   dt_bauhaus_slider_set_digits(g->saturation_out, 4);
   dt_bauhaus_slider_set_step(g->saturation_out, .005);
-  dt_bauhaus_slider_set_factor(g->saturation_out, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_out, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation_out, "%");
   gtk_widget_set_tooltip_text(g->saturation_out, _("saturation correction after the color balance"));
 
   g->grey = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
             dt_bauhaus_slider_from_params(self, "grey"));
-  dt_bauhaus_slider_set_format(g->grey, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->grey, "%");
   dt_bauhaus_slider_set_step(g->grey, .5);
   gtk_widget_set_tooltip_text(g->grey, _("adjust to match a neutral tone"));
 
@@ -1904,7 +1902,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->contrast, .005);
   dt_bauhaus_slider_set_factor(g->contrast, -100.0f);
   dt_bauhaus_slider_set_offset(g->contrast, 100.0f);
-  dt_bauhaus_slider_set_format(g->contrast, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("contrast"));
 
 #ifdef SHOW_COLOR_WHEELS
@@ -1986,7 +1984,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->which##_factor, 4);                       \
   dt_bauhaus_slider_set_factor(g->which##_factor, 100.0);                   \
   dt_bauhaus_slider_set_offset(g->which##_factor, - 100.0);                 \
-  dt_bauhaus_slider_set_format(g->which##_factor, "%.2f %%");               \
+  dt_bauhaus_slider_set_format(g->which##_factor,"%");                      \
   dt_bauhaus_slider_set_feedback(g->which##_factor, 0);                     \
   dt_bauhaus_slider_set_stop(g->which##_factor, 0.0, 0.0, 0.0, 0.0);        \
   dt_bauhaus_slider_set_stop(g->which##_factor, 1.0, 1.0, 1.0, 1.0);        \
@@ -1997,7 +1995,7 @@ void gui_init(dt_iop_module_t *self)
                    dt_bauhaus_slider_new_with_range_and_feedback(self,      \
                    0.0f, 360.0f, 1.0f, 0.0f, 2, 0));                        \
   dt_bauhaus_widget_set_label(g->hue_##which, section, N_("hue"));          \
-  dt_bauhaus_slider_set_format(g->hue_##which, "%.2f °");                   \
+  dt_bauhaus_slider_set_format(g->hue_##which, "°");                        \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.0f,   1.0f, 0.0f, 0.0f);     \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.166f, 1.0f, 1.0f, 0.0f);     \
   dt_bauhaus_slider_set_stop(g->hue_##which, 0.322f, 0.0f, 1.0f, 0.0f);     \
@@ -2014,7 +2012,7 @@ void gui_init(dt_iop_module_t *self)
                    0.0f, 100.0f, 0.05f, 0.0f, 2, 0);                        \
   dt_bauhaus_slider_set_soft_max(g->sat_##which, satspan);                  \
   dt_bauhaus_widget_set_label(g->sat_##which, section, N_("saturation"));   \
-  dt_bauhaus_slider_set_format(g->sat_##which, "%.2f %%");                  \
+  dt_bauhaus_slider_set_format(g->sat_##which, "%");                        \
   dt_bauhaus_slider_set_stop(g->sat_##which, 0.0f, 0.2f, 0.2f, 0.2f);       \
   dt_bauhaus_slider_set_stop(g->sat_##which, 1.0f, 1.0f, 1.0f, 1.0f);       \
   gtk_widget_set_tooltip_text(g->sat_##which, _("select the saturation"));  \

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1879,27 +1879,23 @@ void gui_init(dt_iop_module_t *self)
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.5f, 1.5f);
   dt_bauhaus_slider_set_digits(g->saturation, 4);
-  dt_bauhaus_slider_set_step(g->saturation, .005);
   dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_widget_set_tooltip_text(g->saturation, _("saturation correction before the color balance"));
 
   g->saturation_out = dt_bauhaus_slider_from_params(self, "saturation_out");
   dt_bauhaus_slider_set_soft_range(g->saturation_out, 0.5f, 1.5f);
   dt_bauhaus_slider_set_digits(g->saturation_out, 4);
-  dt_bauhaus_slider_set_step(g->saturation_out, .005);
   dt_bauhaus_slider_set_format(g->saturation_out, "%");
   gtk_widget_set_tooltip_text(g->saturation_out, _("saturation correction after the color balance"));
 
   g->grey = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
             dt_bauhaus_slider_from_params(self, "grey"));
   dt_bauhaus_slider_set_format(g->grey, "%");
-  dt_bauhaus_slider_set_step(g->grey, .5);
   gtk_widget_set_tooltip_text(g->grey, _("adjust to match a neutral tone"));
 
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
   dt_bauhaus_slider_set_soft_range(g->contrast, 0.5f, 1.5f);
   dt_bauhaus_slider_set_digits(g->contrast, 4);
-  dt_bauhaus_slider_set_step(g->contrast, .005);
   dt_bauhaus_slider_set_factor(g->contrast, -100.0f);
   dt_bauhaus_slider_set_offset(g->contrast, 100.0f);
   dt_bauhaus_slider_set_format(g->contrast, "%");
@@ -1966,7 +1962,6 @@ void gui_init(dt_iop_module_t *self)
   sprintf(field_name, "%s[%d]", #which, CHANNEL_##N);                       \
   g->which##_##c = dt_bauhaus_slider_from_params(self, field_name);         \
   dt_bauhaus_slider_set_soft_range(g->which##_##c, -span+1.0, span+1.0);    \
-  dt_bauhaus_slider_set_step(g->which##_##c, span / 100.0f);                \
   dt_bauhaus_slider_set_digits(g->which##_##c, 5);                          \
   dt_bauhaus_slider_set_offset(g->which##_##c, -1.0);                       \
   dt_bauhaus_slider_set_feedback(g->which##_##c, 0);                        \
@@ -1980,7 +1975,6 @@ void gui_init(dt_iop_module_t *self)
   g->which##_factor = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,       \
                       dt_bauhaus_slider_from_params(self, field_name));     \
   dt_bauhaus_slider_set_soft_range(g->which##_factor, -span+1.0, span+1.0); \
-  dt_bauhaus_slider_set_step(g->which##_factor, span / 100.0f);             \
   dt_bauhaus_slider_set_digits(g->which##_factor, 4);                       \
   dt_bauhaus_slider_set_factor(g->which##_factor, 100.0);                   \
   dt_bauhaus_slider_set_offset(g->which##_factor, - 100.0);                 \

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -901,9 +901,9 @@ static inline void set_RGB_sliders(GtkWidget *R, GtkWidget *G, GtkWidget *B, flo
     p[CHANNEL_BLUE] = rgb[2] * 2.0f;
 
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(R, p[CHANNEL_RED]);
-    dt_bauhaus_slider_set_soft(G, p[CHANNEL_GREEN]);
-    dt_bauhaus_slider_set_soft(B, p[CHANNEL_BLUE]);
+    dt_bauhaus_slider_set(R, p[CHANNEL_RED]);
+    dt_bauhaus_slider_set(G, p[CHANNEL_GREEN]);
+    dt_bauhaus_slider_set(B, p[CHANNEL_BLUE]);
     --darktable.gui->reset;
   }
 }
@@ -921,15 +921,15 @@ static inline void set_HSL_sliders(GtkWidget *hue, GtkWidget *sat, float RGB[4])
 
   if(h != -1.0f)
   {
-    dt_bauhaus_slider_set_soft(hue, h * 360.0f);
-    dt_bauhaus_slider_set_soft(sat, s * 100.0f);
+    dt_bauhaus_slider_set(hue, h * 360.0f);
+    dt_bauhaus_slider_set(sat, s * 100.0f);
     update_saturation_slider_color(GTK_WIDGET(sat), h);
     gtk_widget_queue_draw(GTK_WIDGET(sat));
   }
   else
   {
-    dt_bauhaus_slider_set_soft(hue, -1.0f);
-    dt_bauhaus_slider_set_soft(sat, 0.0f);
+    dt_bauhaus_slider_set(hue, -1.0f);
+    dt_bauhaus_slider_set(sat, 0.0f);
     gtk_widget_queue_draw(GTK_WIDGET(sat));
   }
 }
@@ -985,7 +985,7 @@ static void apply_autogrey(dt_iop_module_t *self)
   p->grey = XYZ[1] * 100.0f;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->grey, p->grey);
+  dt_bauhaus_slider_set(g->grey, p->grey);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1021,9 +1021,9 @@ static void apply_lift_neutralize(dt_iop_module_t *self)
   p->lift[CHANNEL_BLUE] = RGB[2] + 1.0f;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE]);
+  dt_bauhaus_slider_set(g->lift_r, p->lift[CHANNEL_RED]);
+  dt_bauhaus_slider_set(g->lift_g, p->lift[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set(g->lift_b, p->lift[CHANNEL_BLUE]);
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
   --darktable.gui->reset;
 
@@ -1060,9 +1060,9 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
   p->gamma[CHANNEL_BLUE] = CLAMP(2.0 - RGB[2], 0.0001f, 2.0f);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE]);
+  dt_bauhaus_slider_set(g->gamma_r, p->gamma[CHANNEL_RED]);
+  dt_bauhaus_slider_set(g->gamma_g, p->gamma[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set(g->gamma_b, p->gamma[CHANNEL_BLUE]);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
   --darktable.gui->reset;
 
@@ -1099,9 +1099,9 @@ static void apply_gain_neutralize(dt_iop_module_t *self)
   p->gain[CHANNEL_BLUE] = RGB[2];
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE]);
+  dt_bauhaus_slider_set(g->gain_r, p->gain[CHANNEL_RED]);
+  dt_bauhaus_slider_set(g->gain_g, p->gain[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set(g->gain_b, p->gain[CHANNEL_BLUE]);
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
   --darktable.gui->reset;
 
@@ -1126,7 +1126,7 @@ static void apply_lift_auto(dt_iop_module_t *self)
   p->lift[CHANNEL_FACTOR] = -p->gain[CHANNEL_FACTOR] * XYZ[1] + 1.0f;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_factor, p->lift[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set(g->lift_factor, p->lift[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1151,7 +1151,7 @@ static void apply_gamma_auto(dt_iop_module_t *self)
       = 2.0f - logf(0.1842f) / logf(MAX(p->gain[CHANNEL_FACTOR] * XYZ[1] + p->lift[CHANNEL_FACTOR] - 1.0f, 0.000001f));
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1175,7 +1175,7 @@ static void apply_gain_auto(dt_iop_module_t *self)
   p->gain[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR] / (XYZ[1]);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gain_factor, p->gain[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set(g->gain_factor, p->gain[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1279,17 +1279,17 @@ static void apply_autocolor(dt_iop_module_t *self)
   p->gain[CHANNEL_BLUE] = RGB_gain[2];
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE]);
+  dt_bauhaus_slider_set(g->lift_r, p->lift[CHANNEL_RED]);
+  dt_bauhaus_slider_set(g->lift_g, p->lift[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set(g->lift_b, p->lift[CHANNEL_BLUE]);
 
-  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE]);
+  dt_bauhaus_slider_set(g->gamma_r, p->gamma[CHANNEL_RED]);
+  dt_bauhaus_slider_set(g->gamma_g, p->gamma[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set(g->gamma_b, p->gamma[CHANNEL_BLUE]);
 
-  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED]);
-  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN]);
-  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE]);
+  dt_bauhaus_slider_set(g->gain_r, p->gain[CHANNEL_RED]);
+  dt_bauhaus_slider_set(g->gain_g, p->gain[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set(g->gain_b, p->gain[CHANNEL_BLUE]);
 
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
@@ -1343,9 +1343,9 @@ static void apply_autoluma(dt_iop_module_t *self)
   }
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_factor, p->lift[CHANNEL_FACTOR]);
-  dt_bauhaus_slider_set_soft(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
-  dt_bauhaus_slider_set_soft(g->gain_factor, p->gain[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set(g->lift_factor, p->lift[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set(g->gain_factor, p->gain[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1171,8 +1171,8 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 static void paint_chroma_slider(GtkWidget *w, const float hue)
 {
-  const float x_min = DT_BAUHAUS_WIDGET(w)->data.slider.soft_min;
-  const float x_max = DT_BAUHAUS_WIDGET(w)->data.slider.soft_max;
+  const float x_min = 0;
+  const float x_max = 1;
   const float x_range = x_max - x_min;
 
   // Varies x in range around current y param

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1126,39 +1126,39 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   {
     p->global_H = hue;
     p->global_C = Ych[1] * Ych[0];
-    dt_bauhaus_slider_set_soft(g->global_H, p->global_H);
-    dt_bauhaus_slider_set_soft(g->global_C, p->global_C);
+    dt_bauhaus_slider_set(g->global_H, p->global_H);
+    dt_bauhaus_slider_set(g->global_C, p->global_C);
   }
   else if(picker == g->shadows_H)
   {
     p->shadows_H = hue;
     p->shadows_C = Ych[1] * Ych[0];
-    dt_bauhaus_slider_set_soft(g->shadows_H, p->shadows_H);
-    dt_bauhaus_slider_set_soft(g->shadows_C, p->shadows_C);
+    dt_bauhaus_slider_set(g->shadows_H, p->shadows_H);
+    dt_bauhaus_slider_set(g->shadows_C, p->shadows_C);
   }
   else if(picker == g->midtones_H)
   {
     p->midtones_H = hue;
     p->midtones_C = Ych[1] * Ych[0];
-    dt_bauhaus_slider_set_soft(g->midtones_H, p->midtones_H);
-    dt_bauhaus_slider_set_soft(g->midtones_C, p->midtones_C);
+    dt_bauhaus_slider_set(g->midtones_H, p->midtones_H);
+    dt_bauhaus_slider_set(g->midtones_C, p->midtones_C);
   }
   else if(picker == g->highlights_H)
   {
     p->highlights_H = hue;
     p->highlights_C = Ych[1] * Ych[0];
-    dt_bauhaus_slider_set_soft(g->highlights_H, p->highlights_H);
-    dt_bauhaus_slider_set_soft(g->highlights_C, p->highlights_C);
+    dt_bauhaus_slider_set(g->highlights_H, p->highlights_H);
+    dt_bauhaus_slider_set(g->highlights_C, p->highlights_C);
   }
   else if(picker == g->white_fulcrum)
   {
     p->white_fulcrum = log2f(max_Ych[0]);
-    dt_bauhaus_slider_set_soft(g->white_fulcrum, p->white_fulcrum);
+    dt_bauhaus_slider_set(g->white_fulcrum, p->white_fulcrum);
   }
   else if(picker == g->grey_fulcrum)
   {
     p->grey_fulcrum = Ych[0];
-    dt_bauhaus_slider_set_soft(g->grey_fulcrum, p->grey_fulcrum);
+    dt_bauhaus_slider_set(g->grey_fulcrum, p->grey_fulcrum);
   }
   else
     fprintf(stderr, "[colorbalancergb] unknown color picker\n");
@@ -1486,7 +1486,7 @@ void gui_update(dt_iop_module_t *self)
 
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->checker_color_2_picker), &color);
 
-  dt_bauhaus_slider_set_soft(g->checker_size, dt_conf_get_int("plugins/darkroom/colorbalancergb/checker/size"));
+  dt_bauhaus_slider_set(g->checker_size, dt_conf_get_int("plugins/darkroom/colorbalancergb/checker/size"));
 }
 
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1461,48 +1461,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 void gui_update(dt_iop_module_t *self)
 {
   dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
-  dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
-
-  dt_bauhaus_slider_set_soft(g->hue_angle, p->hue_angle);
-  dt_bauhaus_slider_set_soft(g->vibrance, p->vibrance);
-  dt_bauhaus_slider_set_soft(g->contrast, p->contrast);
-
-  dt_bauhaus_slider_set_soft(g->chroma_global, p->chroma_global);
-  dt_bauhaus_slider_set_soft(g->chroma_highlights, p->chroma_highlights);
-  dt_bauhaus_slider_set_soft(g->chroma_midtones, p->chroma_midtones);
-  dt_bauhaus_slider_set_soft(g->chroma_shadows, p->chroma_shadows);
-
-  dt_bauhaus_slider_set_soft(g->saturation_global, p->saturation_global);
-  dt_bauhaus_slider_set_soft(g->saturation_highlights, p->saturation_highlights);
-  dt_bauhaus_slider_set_soft(g->saturation_midtones, p->saturation_midtones);
-  dt_bauhaus_slider_set_soft(g->saturation_shadows, p->saturation_shadows);
-
-  dt_bauhaus_slider_set_soft(g->brilliance_global, p->brilliance_global);
-  dt_bauhaus_slider_set_soft(g->brilliance_highlights, p->brilliance_highlights);
-  dt_bauhaus_slider_set_soft(g->brilliance_midtones, p->brilliance_midtones);
-  dt_bauhaus_slider_set_soft(g->brilliance_shadows, p->brilliance_shadows);
-
-  dt_bauhaus_slider_set_soft(g->global_C, p->global_C);
-  dt_bauhaus_slider_set_soft(g->global_H, p->global_H);
-  dt_bauhaus_slider_set_soft(g->global_Y, p->global_Y);
-
-  dt_bauhaus_slider_set_soft(g->shadows_C, p->shadows_C);
-  dt_bauhaus_slider_set_soft(g->shadows_H, p->shadows_H);
-  dt_bauhaus_slider_set_soft(g->shadows_Y, p->shadows_Y);
-  dt_bauhaus_slider_set_soft(g->shadows_weight, p->shadows_weight);
-
-  dt_bauhaus_slider_set_soft(g->midtones_C, p->midtones_C);
-  dt_bauhaus_slider_set_soft(g->midtones_H, p->midtones_H);
-  dt_bauhaus_slider_set_soft(g->midtones_Y, p->midtones_Y);
-  dt_bauhaus_slider_set_soft(g->white_fulcrum, p->white_fulcrum);
-
-  dt_bauhaus_slider_set_soft(g->highlights_C, p->highlights_C);
-  dt_bauhaus_slider_set_soft(g->highlights_H, p->highlights_H);
-  dt_bauhaus_slider_set_soft(g->highlights_Y, p->highlights_Y);
-  dt_bauhaus_slider_set_soft(g->highlights_weight, p->highlights_weight);
-
-  dt_bauhaus_slider_set_soft(g->mask_grey_fulcrum, p->mask_grey_fulcrum);
-  dt_bauhaus_slider_set_soft(g->grey_fulcrum, p->grey_fulcrum);
 
   gui_changed(self, NULL, NULL);
   dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1532,23 +1532,20 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("master"), _("global grading"));
 
   g->hue_angle = dt_bauhaus_slider_from_params(self, "hue_angle");
-  dt_bauhaus_slider_set_digits(g->hue_angle, 4);
   dt_bauhaus_slider_set_step(g->hue_angle, 1.);
-  dt_bauhaus_slider_set_format(g->hue_angle, "%.2f °");
+  dt_bauhaus_slider_set_format(g->hue_angle, "°");
   gtk_widget_set_tooltip_text(g->hue_angle, _("rotate all hues by an angle, at the same luminance"));
 
   g->vibrance = dt_bauhaus_slider_from_params(self, "vibrance");
   dt_bauhaus_slider_set_soft_range(g->vibrance, -0.5, 0.5);
   dt_bauhaus_slider_set_digits(g->vibrance, 4);
-  dt_bauhaus_slider_set_factor(g->vibrance, 100.0f);
-  dt_bauhaus_slider_set_format(g->vibrance, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->vibrance, "%");
   gtk_widget_set_tooltip_text(g->vibrance, _("increase colorfulness mostly on low-chroma colors"));
 
   g->contrast = dt_bauhaus_slider_from_params(self, "contrast");
   dt_bauhaus_slider_set_soft_range(g->contrast, -0.5, 0.5);
   dt_bauhaus_slider_set_digits(g->contrast, 4);
-  dt_bauhaus_slider_set_factor(g->contrast, 100.0f);
-  dt_bauhaus_slider_set_format(g->contrast, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("increase the contrast at constant chromaticity"));
 
   ++darktable.bauhaus->skip_accel;
@@ -1558,26 +1555,22 @@ void gui_init(dt_iop_module_t *self)
   g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
   dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
   dt_bauhaus_slider_set_digits(g->chroma_global, 4);
-  dt_bauhaus_slider_set_factor(g->chroma_global, 100.0f);
-  dt_bauhaus_slider_set_format(g->chroma_global, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->chroma_global, "%");
   gtk_widget_set_tooltip_text(g->chroma_global, _("increase colorfulness at same luminance globally"));
 
   g->chroma_shadows = dt_bauhaus_slider_from_params(self, "chroma_shadows");
   dt_bauhaus_slider_set_digits(g->chroma_shadows, 4);
-  dt_bauhaus_slider_set_factor(g->chroma_shadows, 100.0f);
-  dt_bauhaus_slider_set_format(g->chroma_shadows, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->chroma_shadows, "%");
   gtk_widget_set_tooltip_text(g->chroma_shadows, _("increase colorfulness at same luminance mostly in shadows"));
 
   g->chroma_midtones = dt_bauhaus_slider_from_params(self, "chroma_midtones");
   dt_bauhaus_slider_set_digits(g->chroma_midtones, 4);
-  dt_bauhaus_slider_set_factor(g->chroma_midtones, 100.0f);
-  dt_bauhaus_slider_set_format(g->chroma_midtones, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->chroma_midtones, "%");
   gtk_widget_set_tooltip_text(g->chroma_midtones, _("increase colorfulness at same luminance mostly in mid-tones"));
 
   g->chroma_highlights = dt_bauhaus_slider_from_params(self, "chroma_highlights");
   dt_bauhaus_slider_set_digits(g->chroma_highlights, 4);
-  dt_bauhaus_slider_set_factor(g->chroma_highlights, 100.0f);
-  dt_bauhaus_slider_set_format(g->chroma_highlights, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->chroma_highlights, "%");
   gtk_widget_set_tooltip_text(g->chroma_highlights, _("increase colorfulness at same luminance mostly in highlights"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual saturation grading")), FALSE, FALSE, 0);
@@ -1585,29 +1578,25 @@ void gui_init(dt_iop_module_t *self)
   g->saturation_global = dt_bauhaus_slider_from_params(self, "saturation_global");
   dt_bauhaus_slider_set_soft_range(g->saturation_global, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->saturation_global, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_global, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_global, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation_global, "%");
   gtk_widget_set_tooltip_text(g->saturation_global, _("add or remove saturation by an absolute amount"));
 
   g->saturation_shadows = dt_bauhaus_slider_from_params(self, "saturation_shadows");
   dt_bauhaus_slider_set_soft_range(g->saturation_shadows, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->saturation_shadows, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_shadows, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_shadows, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation_shadows, "%");
   gtk_widget_set_tooltip_text(g->saturation_shadows, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
   g->saturation_midtones= dt_bauhaus_slider_from_params(self, "saturation_midtones");
   dt_bauhaus_slider_set_soft_range(g->saturation_midtones, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->saturation_midtones, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_midtones, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_midtones, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation_midtones, "%");
   gtk_widget_set_tooltip_text(g->saturation_midtones, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
   g->saturation_highlights = dt_bauhaus_slider_from_params(self, "saturation_highlights");
   dt_bauhaus_slider_set_soft_range(g->saturation_highlights, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->saturation_highlights, 4);
-  dt_bauhaus_slider_set_factor(g->saturation_highlights, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation_highlights, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation_highlights, "%");
   gtk_widget_set_tooltip_text(g->saturation_highlights, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual brilliance grading")), FALSE, FALSE, 0);
@@ -1615,29 +1604,25 @@ void gui_init(dt_iop_module_t *self)
   g->brilliance_global = dt_bauhaus_slider_from_params(self, "brilliance_global");
   dt_bauhaus_slider_set_soft_range(g->brilliance_global, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->brilliance_global, 4);
-  dt_bauhaus_slider_set_factor(g->brilliance_global, 100.0f);
-  dt_bauhaus_slider_set_format(g->brilliance_global, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->brilliance_global, "%");
   gtk_widget_set_tooltip_text(g->brilliance_global, _("add or remove brilliance by an absolute amount"));
 
   g->brilliance_shadows = dt_bauhaus_slider_from_params(self, "brilliance_shadows");
   dt_bauhaus_slider_set_soft_range(g->brilliance_shadows, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->brilliance_shadows, 4);
-  dt_bauhaus_slider_set_factor(g->brilliance_shadows, 100.0f);
-  dt_bauhaus_slider_set_format(g->brilliance_shadows, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->brilliance_shadows, "%");
   gtk_widget_set_tooltip_text(g->brilliance_shadows, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
 
   g->brilliance_midtones= dt_bauhaus_slider_from_params(self, "brilliance_midtones");
   dt_bauhaus_slider_set_soft_range(g->brilliance_midtones, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->brilliance_midtones, 4);
-  dt_bauhaus_slider_set_factor(g->brilliance_midtones, 100.0f);
-  dt_bauhaus_slider_set_format(g->brilliance_midtones, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->brilliance_midtones, "%");
   gtk_widget_set_tooltip_text(g->brilliance_midtones, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
 
   g->brilliance_highlights = dt_bauhaus_slider_from_params(self, "brilliance_highlights");
   dt_bauhaus_slider_set_soft_range(g->brilliance_highlights, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->brilliance_highlights, 4);
-  dt_bauhaus_slider_set_factor(g->brilliance_highlights, 100.0f);
-  dt_bauhaus_slider_set_format(g->brilliance_highlights, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->brilliance_highlights, "%");
   gtk_widget_set_tooltip_text(g->brilliance_highlights, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
 
   // Page 4-ways
@@ -1647,95 +1632,83 @@ void gui_init(dt_iop_module_t *self)
 
   g->global_Y = dt_bauhaus_slider_from_params(self, "global_Y");
   dt_bauhaus_slider_set_soft_range(g->global_Y, -0.05, 0.05);
-  dt_bauhaus_slider_set_factor(g->global_Y, 100.0f);
   dt_bauhaus_slider_set_digits(g->global_Y, 4);
-  dt_bauhaus_slider_set_format(g->global_Y, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->global_Y, "%");
   gtk_widget_set_tooltip_text(g->global_Y, _("global luminance offset"));
 
   g->global_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "global_H"));
   dt_bauhaus_slider_set_feedback(g->global_H, 0);
   dt_bauhaus_slider_set_step(g->global_H, 10.);
-  dt_bauhaus_slider_set_digits(g->global_H, 4);
-  dt_bauhaus_slider_set_format(g->global_H, "%.2f °");
+  dt_bauhaus_slider_set_format(g->global_H, "°");
   gtk_widget_set_tooltip_text(g->global_H, _("hue of the global color offset"));
 
   g->global_C = dt_bauhaus_slider_from_params(self, "global_C");
   dt_bauhaus_slider_set_soft_range(g->global_C, 0., 0.01);
   dt_bauhaus_slider_set_digits(g->global_C, 4);
-  dt_bauhaus_slider_set_factor(g->global_C, 100.0f);
-  dt_bauhaus_slider_set_format(g->global_C, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->global_C, "%");
   gtk_widget_set_tooltip_text(g->global_C, _("chroma of the global color offset"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("shadows lift")), FALSE, FALSE, 0);
 
   g->shadows_Y = dt_bauhaus_slider_from_params(self, "shadows_Y");
   dt_bauhaus_slider_set_soft_range(g->shadows_Y, -1.0, 1.0);
-  dt_bauhaus_slider_set_factor(g->shadows_Y, 100.0f);
   dt_bauhaus_slider_set_digits(g->shadows_Y, 4);
-  dt_bauhaus_slider_set_format(g->shadows_Y, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->shadows_Y, "%");
   gtk_widget_set_tooltip_text(g->shadows_Y, _("luminance gain in shadows"));
 
   g->shadows_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "shadows_H"));
   dt_bauhaus_slider_set_feedback(g->shadows_H, 0);
   dt_bauhaus_slider_set_step(g->shadows_H, 10.);
-  dt_bauhaus_slider_set_digits(g->shadows_H, 4);
-  dt_bauhaus_slider_set_format(g->shadows_H, "%.2f °");
+  dt_bauhaus_slider_set_format(g->shadows_H, "°");
   gtk_widget_set_tooltip_text(g->shadows_H, _("hue of the color gain in shadows"));
 
   g->shadows_C = dt_bauhaus_slider_from_params(self, "shadows_C");
   dt_bauhaus_slider_set_soft_range(g->shadows_C, 0., 0.5);
   dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
   dt_bauhaus_slider_set_digits(g->shadows_C, 4);
-  dt_bauhaus_slider_set_factor(g->shadows_C, 100.0f);
-  dt_bauhaus_slider_set_format(g->shadows_C, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->shadows_C, "%");
   gtk_widget_set_tooltip_text(g->shadows_C, _("chroma of the color gain in shadows"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights gain")), FALSE, FALSE, 0);
 
   g->highlights_Y = dt_bauhaus_slider_from_params(self, "highlights_Y");
   dt_bauhaus_slider_set_soft_range(g->highlights_Y, -0.5, 0.5);
-  dt_bauhaus_slider_set_factor(g->highlights_Y, 100.0f);
   dt_bauhaus_slider_set_digits(g->highlights_Y, 4);
-  dt_bauhaus_slider_set_format(g->highlights_Y, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->highlights_Y, "%");
   gtk_widget_set_tooltip_text(g->highlights_Y, _("luminance gain in highlights"));
 
   g->highlights_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "highlights_H"));
   dt_bauhaus_slider_set_feedback(g->highlights_H, 0);
   dt_bauhaus_slider_set_step(g->highlights_H, 10.);
-  dt_bauhaus_slider_set_digits(g->highlights_H, 4);
-  dt_bauhaus_slider_set_format(g->highlights_H, "%.2f °");
+  dt_bauhaus_slider_set_format(g->highlights_H, "°");
   gtk_widget_set_tooltip_text(g->highlights_H, _("hue of the color gain in highlights"));
 
   g->highlights_C = dt_bauhaus_slider_from_params(self, "highlights_C");
   dt_bauhaus_slider_set_soft_range(g->highlights_C, 0., 0.2);
   dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
   dt_bauhaus_slider_set_digits(g->highlights_C, 4);
-  dt_bauhaus_slider_set_factor(g->highlights_C, 100.0f);
-  dt_bauhaus_slider_set_format(g->highlights_C, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->highlights_C, "%");
   gtk_widget_set_tooltip_text(g->highlights_C, _("chroma of the color gain in highlights"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("power")), FALSE, FALSE, 0);
 
   g->midtones_Y = dt_bauhaus_slider_from_params(self, "midtones_Y");
   dt_bauhaus_slider_set_soft_range(g->midtones_Y, -0.25, 0.25);
-  dt_bauhaus_slider_set_factor(g->midtones_Y, 100.0f);
   dt_bauhaus_slider_set_digits(g->midtones_Y, 4);
-  dt_bauhaus_slider_set_format(g->midtones_Y, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->midtones_Y, "%");
   gtk_widget_set_tooltip_text(g->midtones_Y, _("luminance exponent in mid-tones"));
 
   g->midtones_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "midtones_H"));
   dt_bauhaus_slider_set_feedback(g->midtones_H, 0);
   dt_bauhaus_slider_set_step(g->midtones_H, 10.);
-  dt_bauhaus_slider_set_digits(g->midtones_H, 4);
-  dt_bauhaus_slider_set_format(g->midtones_H, "%.2f °");
+  dt_bauhaus_slider_set_format(g->midtones_H, "°");
   gtk_widget_set_tooltip_text(g->midtones_H, _("hue of the color exponent in mid-tones"));
 
   g->midtones_C = dt_bauhaus_slider_from_params(self, "midtones_C");
   dt_bauhaus_slider_set_soft_range(g->midtones_C, 0., 0.1);
   dt_bauhaus_slider_set_step(g->midtones_C, 0.005);
   dt_bauhaus_slider_set_digits(g->midtones_C, 4);
-  dt_bauhaus_slider_set_factor(g->midtones_C, 100.0f);
-  dt_bauhaus_slider_set_format(g->midtones_C, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->midtones_C, "%");
   gtk_widget_set_tooltip_text(g->midtones_C, _("chroma of the color exponent in mid-tones"));
 
   --darktable.bauhaus->skip_accel;
@@ -1757,8 +1730,7 @@ void gui_init(dt_iop_module_t *self)
   g->shadows_weight = dt_bauhaus_slider_from_params(self, "shadows_weight");
   dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
   dt_bauhaus_slider_set_step(g->shadows_weight, 0.1);
-  dt_bauhaus_slider_set_format(g->shadows_weight, "%.2f %%");
-  dt_bauhaus_slider_set_factor(g->shadows_weight, 100.0f);
+  dt_bauhaus_slider_set_format(g->shadows_weight, "%");
   gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
   dt_bauhaus_widget_set_quad_paint(g->shadows_weight, dtgtk_cairo_paint_showmask,
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
@@ -1768,8 +1740,7 @@ void gui_init(dt_iop_module_t *self)
   g->mask_grey_fulcrum = dt_bauhaus_slider_from_params(self, "mask_grey_fulcrum");
   dt_bauhaus_slider_set_digits(g->mask_grey_fulcrum, 4);
   dt_bauhaus_slider_set_step(g->mask_grey_fulcrum, 0.01);
-  dt_bauhaus_slider_set_format(g->mask_grey_fulcrum, "%.2f %%");
-  dt_bauhaus_slider_set_factor(g->mask_grey_fulcrum, 100.0f);
+  dt_bauhaus_slider_set_format(g->mask_grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->mask_grey_fulcrum, _("position of the middle-gray reference for masking"));
   dt_bauhaus_widget_set_quad_paint(g->mask_grey_fulcrum, dtgtk_cairo_paint_showmask,
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
@@ -1779,8 +1750,7 @@ void gui_init(dt_iop_module_t *self)
   g->highlights_weight = dt_bauhaus_slider_from_params(self, "highlights_weight");
   dt_bauhaus_slider_set_step(g->highlights_weight, 0.1);
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
-  dt_bauhaus_slider_set_format(g->highlights_weight, "%.2f %%");
-  dt_bauhaus_slider_set_factor(g->highlights_weight, 100.0f);
+  dt_bauhaus_slider_set_format(g->highlights_weight, "%");
   gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
   dt_bauhaus_widget_set_quad_paint(g->highlights_weight, dtgtk_cairo_paint_showmask,
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
@@ -1792,16 +1762,14 @@ void gui_init(dt_iop_module_t *self)
   g->white_fulcrum = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_fulcrum"));
   dt_bauhaus_slider_set_soft_range(g->white_fulcrum, -2., +2.);
   dt_bauhaus_slider_set_step(g->white_fulcrum, 0.1);
-  dt_bauhaus_slider_set_digits(g->white_fulcrum, 4);
-  dt_bauhaus_slider_set_format(g->white_fulcrum, "%.2f EV");
+  dt_bauhaus_slider_set_format(g->white_fulcrum, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_fulcrum, _("peak white luminance value used to normalize the power function"));
 
   g->grey_fulcrum = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_fulcrum"));
   dt_bauhaus_slider_set_soft_range(g->grey_fulcrum, 0.1, 0.5);
-  dt_bauhaus_slider_set_factor(g->grey_fulcrum, 100.0f);
   dt_bauhaus_slider_set_step(g->grey_fulcrum, 0.01);
   dt_bauhaus_slider_set_digits(g->grey_fulcrum, 4);
-  dt_bauhaus_slider_set_format(g->grey_fulcrum, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->grey_fulcrum, _("peak gray luminance value used to normalize the power function"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("mask preview settings")), FALSE, FALSE, 0);
@@ -1825,7 +1793,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(row2), FALSE, FALSE, 0);
 
   g->checker_size = dt_bauhaus_slider_new_with_range(self, 2., 32., 1., 8., 0);
-  dt_bauhaus_slider_set_format(g->checker_size, "%.0f px");
+  dt_bauhaus_slider_set_format(g->checker_size, " px");
   dt_bauhaus_widget_set_label(g->checker_size,  NULL, _("checkerboard size"));
   g_signal_connect(G_OBJECT(g->checker_size), "value-changed", G_CALLBACK(checker_size_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->checker_size), FALSE, FALSE, 0);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1532,7 +1532,6 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("master"), _("global grading"));
 
   g->hue_angle = dt_bauhaus_slider_from_params(self, "hue_angle");
-  dt_bauhaus_slider_set_step(g->hue_angle, 1.);
   dt_bauhaus_slider_set_format(g->hue_angle, "°");
   gtk_widget_set_tooltip_text(g->hue_angle, _("rotate all hues by an angle, at the same luminance"));
 
@@ -1638,7 +1637,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->global_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "global_H"));
   dt_bauhaus_slider_set_feedback(g->global_H, 0);
-  dt_bauhaus_slider_set_step(g->global_H, 10.);
   dt_bauhaus_slider_set_format(g->global_H, "°");
   gtk_widget_set_tooltip_text(g->global_H, _("hue of the global color offset"));
 
@@ -1658,13 +1656,11 @@ void gui_init(dt_iop_module_t *self)
 
   g->shadows_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "shadows_H"));
   dt_bauhaus_slider_set_feedback(g->shadows_H, 0);
-  dt_bauhaus_slider_set_step(g->shadows_H, 10.);
   dt_bauhaus_slider_set_format(g->shadows_H, "°");
   gtk_widget_set_tooltip_text(g->shadows_H, _("hue of the color gain in shadows"));
 
   g->shadows_C = dt_bauhaus_slider_from_params(self, "shadows_C");
   dt_bauhaus_slider_set_soft_range(g->shadows_C, 0., 0.5);
-  dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
   dt_bauhaus_slider_set_digits(g->shadows_C, 4);
   dt_bauhaus_slider_set_format(g->shadows_C, "%");
   gtk_widget_set_tooltip_text(g->shadows_C, _("chroma of the color gain in shadows"));
@@ -1679,13 +1675,11 @@ void gui_init(dt_iop_module_t *self)
 
   g->highlights_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "highlights_H"));
   dt_bauhaus_slider_set_feedback(g->highlights_H, 0);
-  dt_bauhaus_slider_set_step(g->highlights_H, 10.);
   dt_bauhaus_slider_set_format(g->highlights_H, "°");
   gtk_widget_set_tooltip_text(g->highlights_H, _("hue of the color gain in highlights"));
 
   g->highlights_C = dt_bauhaus_slider_from_params(self, "highlights_C");
   dt_bauhaus_slider_set_soft_range(g->highlights_C, 0., 0.2);
-  dt_bauhaus_slider_set_step(g->shadows_C, 0.01);
   dt_bauhaus_slider_set_digits(g->highlights_C, 4);
   dt_bauhaus_slider_set_format(g->highlights_C, "%");
   gtk_widget_set_tooltip_text(g->highlights_C, _("chroma of the color gain in highlights"));
@@ -1700,13 +1694,11 @@ void gui_init(dt_iop_module_t *self)
 
   g->midtones_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "midtones_H"));
   dt_bauhaus_slider_set_feedback(g->midtones_H, 0);
-  dt_bauhaus_slider_set_step(g->midtones_H, 10.);
   dt_bauhaus_slider_set_format(g->midtones_H, "°");
   gtk_widget_set_tooltip_text(g->midtones_H, _("hue of the color exponent in mid-tones"));
 
   g->midtones_C = dt_bauhaus_slider_from_params(self, "midtones_C");
   dt_bauhaus_slider_set_soft_range(g->midtones_C, 0., 0.1);
-  dt_bauhaus_slider_set_step(g->midtones_C, 0.005);
   dt_bauhaus_slider_set_digits(g->midtones_C, 4);
   dt_bauhaus_slider_set_format(g->midtones_C, "%");
   gtk_widget_set_tooltip_text(g->midtones_C, _("chroma of the color exponent in mid-tones"));
@@ -1729,7 +1721,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->shadows_weight = dt_bauhaus_slider_from_params(self, "shadows_weight");
   dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
-  dt_bauhaus_slider_set_step(g->shadows_weight, 0.1);
   dt_bauhaus_slider_set_format(g->shadows_weight, "%");
   gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
   dt_bauhaus_widget_set_quad_paint(g->shadows_weight, dtgtk_cairo_paint_showmask,
@@ -1739,7 +1730,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->mask_grey_fulcrum = dt_bauhaus_slider_from_params(self, "mask_grey_fulcrum");
   dt_bauhaus_slider_set_digits(g->mask_grey_fulcrum, 4);
-  dt_bauhaus_slider_set_step(g->mask_grey_fulcrum, 0.01);
   dt_bauhaus_slider_set_format(g->mask_grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->mask_grey_fulcrum, _("position of the middle-gray reference for masking"));
   dt_bauhaus_widget_set_quad_paint(g->mask_grey_fulcrum, dtgtk_cairo_paint_showmask,
@@ -1748,7 +1738,6 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->mask_grey_fulcrum), "quad-pressed", G_CALLBACK(mask_callback), self);
 
   g->highlights_weight = dt_bauhaus_slider_from_params(self, "highlights_weight");
-  dt_bauhaus_slider_set_step(g->highlights_weight, 0.1);
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
   dt_bauhaus_slider_set_format(g->highlights_weight, "%");
   gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
@@ -1761,13 +1750,11 @@ void gui_init(dt_iop_module_t *self)
 
   g->white_fulcrum = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_fulcrum"));
   dt_bauhaus_slider_set_soft_range(g->white_fulcrum, -2., +2.);
-  dt_bauhaus_slider_set_step(g->white_fulcrum, 0.1);
   dt_bauhaus_slider_set_format(g->white_fulcrum, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_fulcrum, _("peak white luminance value used to normalize the power function"));
 
   g->grey_fulcrum = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_fulcrum"));
   dt_bauhaus_slider_set_soft_range(g->grey_fulcrum, 0.1, 0.5);
-  dt_bauhaus_slider_set_step(g->grey_fulcrum, 0.01);
   dt_bauhaus_slider_set_digits(g->grey_fulcrum, 4);
   dt_bauhaus_slider_set_format(g->grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->grey_fulcrum, _("peak gray luminance value used to normalize the power function"));

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1779,7 +1779,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->checker_color_2_picker), "color-set", G_CALLBACK(checker_2_picker_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(row2), FALSE, FALSE, 0);
 
-  g->checker_size = dt_bauhaus_slider_new_with_range(self, 2., 32., 1., 8., 0);
+  g->checker_size = dt_bauhaus_slider_new_with_range(self, 2., 32., 0, 8., 0);
   dt_bauhaus_slider_set_format(g->checker_size, " px");
   dt_bauhaus_widget_set_label(g->checker_size,  NULL, _("checkerboard size"));
   g_signal_connect(G_OBJECT(g->checker_size), "value-changed", G_CALLBACK(checker_size_callback), self);

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1353,25 +1353,25 @@ void gui_init(struct dt_iop_module_t *self)
 
   dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, g->combobox_patch);
 
-  g->scale_L = dt_bauhaus_slider_new_with_range(self, -100.0, 200.0, 1.0, 0.0f, 2);
+  g->scale_L = dt_bauhaus_slider_new_with_range(self, -100.0, 200.0, 0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_L, _("adjust target color Lab 'L' channel\nlower values darken target color while higher brighten it"));
   dt_bauhaus_widget_set_label(g->scale_L, NULL, N_("lightness"));
 
-  g->scale_a = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
+  g->scale_a = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_a, _("adjust target color Lab 'a' channel\nlower values shift target color towards greens while higher shift towards magentas"));
   dt_bauhaus_widget_set_label(g->scale_a, NULL, N_("green-magenta offset"));
   dt_bauhaus_slider_set_stop(g->scale_a, 0.0, 0.0, 1.0, 0.2);
   dt_bauhaus_slider_set_stop(g->scale_a, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_a, 1.0, 1.0, 0.0, 0.2);
 
-  g->scale_b = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 1.0, 0.0f, 2);
+  g->scale_b = dt_bauhaus_slider_new_with_range(self, -256.0, 256.0, 0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_b, _("adjust target color Lab 'b' channel\nlower values shift target color towards blues while higher shift towards yellows"));
   dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue-yellow offset"));
   dt_bauhaus_slider_set_stop(g->scale_b, 0.0, 0.0, 0.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 0.5, 1.0, 1.0, 1.0);
   dt_bauhaus_slider_set_stop(g->scale_b, 1.0, 1.0, 1.0, 0.0);
 
-  g->scale_C = dt_bauhaus_slider_new_with_range(self, -128.0, 128.0, 1.0f, 0.0f, 2);
+  g->scale_C = dt_bauhaus_slider_new_with_range(self, -128.0, 128.0, 0, 0.0f, 2);
   gtk_widget_set_tooltip_text(g->scale_C, _("adjust target color saturation\nadjusts 'a' and 'b' channels of target color in Lab space simultaneously\nlower values scale towards lower saturation while higher scale towards higher saturation"));
   dt_bauhaus_widget_set_label(g->scale_C, NULL, N_("saturation"));
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -509,21 +509,7 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
   if(!handled) return FALSE;
 
-  float multiplier;
-
-  if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
-
+  float multiplier = dt_accel_get_speed_multiplier(widget, event->state);
   dx *= multiplier;
   dy *= multiplier;
 

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -344,7 +344,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->hue = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, dt_bauhaus_slider_from_params(self, N_("hue")));
   dt_bauhaus_slider_set_feedback(g->hue, 0);
   dt_bauhaus_slider_set_factor(g->hue, 360.0f);
-  dt_bauhaus_slider_set_format(g->hue, "%.2f°");
+  dt_bauhaus_slider_set_format(g->hue, "°");
   dt_bauhaus_slider_set_stop(g->hue, 0.0f  , 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.322f, 0.0f, 1.0f, 0.0f);
@@ -355,19 +355,18 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue, _("select the hue tone"));
 
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
-  dt_bauhaus_slider_set_factor(g->saturation, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->saturation, "%");
   dt_bauhaus_slider_set_stop(g->saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(g->saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   gtk_widget_set_tooltip_text(g->saturation, _("select the saturation shadow tone"));
 
   g->lightness = dt_bauhaus_slider_from_params(self, N_("lightness"));
-  dt_bauhaus_slider_set_format(g->lightness, "%.2f%%");
+  dt_bauhaus_slider_set_format(g->lightness, "%");
   dt_bauhaus_slider_set_step(g->lightness, 0.1);
   gtk_widget_set_tooltip_text(g->lightness, _("lightness of color"));
 
   g->source_mix = dt_bauhaus_slider_from_params(self, "source_lightness_mix");
-  dt_bauhaus_slider_set_format(g->source_mix, "%.2f%%");
+  dt_bauhaus_slider_set_format(g->source_mix, "%");
   dt_bauhaus_slider_set_step(g->source_mix, 0.1);
   gtk_widget_set_tooltip_text(g->source_mix, _("mix value of source lightness"));
 }

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -327,11 +327,6 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
-  dt_bauhaus_slider_set(g->hue, p->hue);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-  dt_bauhaus_slider_set(g->lightness, p->lightness);
-  dt_bauhaus_slider_set(g->source_mix, p->source_lightness_mix);
-
   update_saturation_slider_end_color(g->saturation, p->hue);
 }
 

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -362,12 +362,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->lightness = dt_bauhaus_slider_from_params(self, N_("lightness"));
   dt_bauhaus_slider_set_format(g->lightness, "%");
-  dt_bauhaus_slider_set_step(g->lightness, 0.1);
   gtk_widget_set_tooltip_text(g->lightness, _("lightness of color"));
 
   g->source_mix = dt_bauhaus_slider_from_params(self, "source_lightness_mix");
   dt_bauhaus_slider_set_format(g->source_mix, "%");
-  dt_bauhaus_slider_set_step(g->source_mix, 0.1);
   gtk_widget_set_tooltip_text(g->source_mix, _("mix value of source lightness"));
 }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1071,11 +1071,11 @@ void gui_init(struct dt_iop_module_t *self)
   g->dominance = dt_bauhaus_slider_from_params(self, "dominance");
   gtk_widget_set_tooltip_text(g->dominance, _("how clusters are mapped. low values: based on color "
                                               "proximity, high values: based on color dominance"));
-  dt_bauhaus_slider_set_format(g->dominance, "%.02f%%");
+  dt_bauhaus_slider_set_format(g->dominance, "%");
 
   g->equalization = dt_bauhaus_slider_from_params(self, "equalization");
   gtk_widget_set_tooltip_text(g->equalization, _("level of histogram equalization"));
-  dt_bauhaus_slider_set_format(g->equalization, "%.02f%%");
+  dt_bauhaus_slider_set_format(g->equalization, "%");
 
   /* add signal handler for preview pipe finished: process clusters if requested */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -840,16 +840,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_colormapping_params_t *p = (dt_iop_colormapping_params_t *)self->params;
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
-  dt_bauhaus_slider_set(g->clusters, p->n);
-  dt_bauhaus_slider_set(g->dominance, p->dominance);
-  dt_bauhaus_slider_set(g->equalization, p->equalization);
-  dt_control_queue_redraw_widget(self->widget);
-}
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 8; // extended.cl, from programs.conf

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1289,7 +1289,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->precedence = dt_bauhaus_combobox_from_params(self, N_("precedence"));
   g->hue = dt_bauhaus_slider_from_params(self, N_("hue"));
   dt_bauhaus_slider_set_factor(g->hue, 360.0f);
-  dt_bauhaus_slider_set_format(g->hue, "%.2f°");
+  dt_bauhaus_slider_set_format(g->hue, "°");
   dt_bauhaus_slider_set_feedback(g->hue, 0);
   dt_bauhaus_slider_set_stop(g->hue, 0.0f,   1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1282,10 +1282,8 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *box_enabled = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
-  dt_bauhaus_slider_set_step(g->threshold, 0.1f);
   g->spatial = dt_bauhaus_slider_from_params(self, N_("spatial"));
   g->range = dt_bauhaus_slider_from_params(self, N_("range"));
-  dt_bauhaus_slider_set_step(g->range, 0.1f);
   g->precedence = dt_bauhaus_combobox_from_params(self, N_("precedence"));
   g->hue = dt_bauhaus_slider_from_params(self, N_("hue"));
   dt_bauhaus_slider_set_factor(g->hue, 360.0f);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1239,12 +1239,6 @@ void gui_update(struct dt_iop_module_t *self)
   self->hide_enable_button = monochrome;
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), !monochrome ? "default" : "monochrome");
 
-  dt_bauhaus_slider_set(g->threshold, p->threshold);
-  dt_bauhaus_slider_set(g->spatial, p->spatial);
-  dt_bauhaus_slider_set(g->range, p->range);
-  dt_bauhaus_combobox_set(g->precedence, p->precedence);
-  dt_bauhaus_slider_set(g->hue, p->hue);
-
   gtk_widget_set_visible(g->hue, p->precedence == COLORRECONSTRUCT_PRECEDENCE_HUE);
 
   dt_iop_gui_enter_critical_section(self);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2494,7 +2494,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(c->mode, _("choose between a smoother or stronger effect"));
 
   c->strength = dt_bauhaus_slider_from_params(self, "strength");
-  dt_bauhaus_slider_set_step(c->strength, 10.0f);
   dt_bauhaus_slider_set_format(c->strength, "%");
   gtk_widget_set_tooltip_text(c->strength, _("make effect stronger or weaker"));
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2495,7 +2495,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   c->strength = dt_bauhaus_slider_from_params(self, "strength");
   dt_bauhaus_slider_set_step(c->strength, 10.0f);
-  dt_bauhaus_slider_set_format(c->strength, "%.01f%%");
+  dt_bauhaus_slider_set_format(c->strength, "%");
   gtk_widget_set_tooltip_text(c->strength, _("make effect stronger or weaker"));
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2468,7 +2468,9 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *hbox_select_by = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   // edit by area
-  c->chk_edit_by_area = gtk_check_button_new_with_label(_("edit by area"));
+  gchar *label = N_("edit by area");
+  c->chk_edit_by_area = gtk_check_button_new_with_label(_(label));
+  dt_action_define_iop(self, NULL, label, c->chk_edit_by_area, &dt_action_def_toggle);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(c->chk_edit_by_area))), PANGO_ELLIPSIZE_START);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->chk_edit_by_area), c->edit_by_area);
   gtk_widget_set_tooltip_text(c->chk_edit_by_area, _("edit the curve nodes by area"));

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1563,21 +1563,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, i
   int ch = c->channel;
   dt_iop_colorzones_node_t *curve = p->curve[ch];
 
-  float multiplier;
-
-  if(dt_modifier_is(state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
-
+  float multiplier = dt_accel_get_speed_multiplier(widget, state);
   dx *= multiplier;
   dy *= multiplier;
   if(p->splines_version == DT_IOP_COLORZONES_SPLINES_V1)
@@ -2363,7 +2349,7 @@ static float _action_process_zones(gpointer target, dt_action_element_t element,
       if(!close_enough)
         node = _add_node(curve, &p->curve_num_nodes[ch], x, return_value);
 
-      _move_point_internal(self, target, node, 0.f, move_size / 100, 0);
+      _move_point_internal(self, target, node, 0.f, move_size / 100, GDK_MODIFIER_MASK);
       return_value = curve[node].y;
       break;
     default:

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2558,10 +2558,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
 
-  dt_bauhaus_combobox_set(g->select_by, p->channel);
-  dt_bauhaus_slider_set(g->strength, p->strength);
   dt_bauhaus_combobox_set(g->interpolator, p->curve_type[g->channel]);
-  dt_bauhaus_combobox_set(g->mode, p->mode);
 
   dt_iop_cancel_history_update(self);
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1184,28 +1184,26 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->cx = dt_bauhaus_slider_from_params(self, "cx");
   dt_bauhaus_slider_set_digits(g->cx, 4);
-  dt_bauhaus_slider_set_factor(g->cx, 100.0);
-  dt_bauhaus_slider_set_format(g->cx, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->cx, "%");
   gtk_widget_set_tooltip_text(g->cx, _("the left margin cannot overlap with the right margin"));
 
   g->cw = dt_bauhaus_slider_from_params(self, "cw");
   dt_bauhaus_slider_set_digits(g->cw, 4);
   dt_bauhaus_slider_set_factor(g->cw, -100.0);
   dt_bauhaus_slider_set_offset(g->cw, 100.0);
-  dt_bauhaus_slider_set_format(g->cw, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->cw, "%");
   gtk_widget_set_tooltip_text(g->cw, _("the right margin cannot overlap with the left margin"));
 
   g->cy = dt_bauhaus_slider_from_params(self, "cy");
   dt_bauhaus_slider_set_digits(g->cy, 4);
-  dt_bauhaus_slider_set_factor(g->cy, 100.0);
-  dt_bauhaus_slider_set_format(g->cy, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->cy, "%");
   gtk_widget_set_tooltip_text(g->cy, _("the top margin cannot overlap with the bottom margin"));
 
   g->ch = dt_bauhaus_slider_from_params(self, "ch");
   dt_bauhaus_slider_set_digits(g->ch, 4);
   dt_bauhaus_slider_set_factor(g->ch, -100.0);
   dt_bauhaus_slider_set_offset(g->ch, 100.0);
-  dt_bauhaus_slider_set_format(g->ch, "%0.2f %%");
+  dt_bauhaus_slider_set_format(g->ch, "%");
   gtk_widget_set_tooltip_text(g->ch, _("the bottom margin cannot overlap with the top margin"));
 
   self->widget = box_enabled;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -926,12 +926,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
-  /* update ui elements */
-  dt_bauhaus_slider_set(g->cx, p->cx);
-  dt_bauhaus_slider_set(g->cy, p->cy);
-  dt_bauhaus_slider_set(g->cw, p->cw);
-  dt_bauhaus_slider_set(g->ch, p->ch);
-
   //  set aspect ratio based on the current image, if not found let's default
   //  to free aspect.
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5725,15 +5725,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
-  dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)self->params;
 
   gui_changed(self, NULL, NULL);
-
-  dt_bauhaus_slider_set(g->median_thrs, p->median_thrs);
-  dt_bauhaus_combobox_set(g->color_smoothing, p->color_smoothing);
-  dt_bauhaus_combobox_set(g->greeneq, p->green_eq);
-  dt_bauhaus_combobox_set(g->lmmse_refine, p->lmmse_refine);
-  dt_bauhaus_slider_set(g->dual_thrs, p->dual_thrs);
 
   g->show_mask = FALSE;
   dt_bauhaus_widget_set_quad_active(g->dual_mask, g->show_mask);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5776,12 +5776,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->demosaic_method_xtrans, _("xtrans sensor demosaicing method, Markesteijn 3-pass and frequency domain chroma are slow.\ndual demosaicers double processing time."));
 
   g->median_thrs = dt_bauhaus_slider_from_params(self, "median_thrs");
-  dt_bauhaus_slider_set_step(g->median_thrs, 0.001);
   dt_bauhaus_slider_set_digits(g->median_thrs, 3);
   gtk_widget_set_tooltip_text(g->median_thrs, _("threshold for edge-aware median.\nset to 0.0 to switch off\n"
                                                 "set to 1.0 to ignore edges"));
   g->dual_thrs = dt_bauhaus_slider_from_params(self, "dual_thrs");
-  dt_bauhaus_slider_set_step(g->dual_thrs, 0.01);
   dt_bauhaus_slider_set_digits(g->dual_thrs, 2);
   gtk_widget_set_tooltip_text(g->dual_thrs, _("contrast threshold for dual demosaic.\nset to 0.0 for high frequency content\n"
                                                 "set to 1.0 for flat content"));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3054,14 +3054,6 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
 
-  dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  dt_bauhaus_slider_set_soft(g->nbhood, p->nbhood);
-  dt_bauhaus_slider_set_soft(g->strength, p->strength);
-  dt_bauhaus_slider_set_soft(g->overshooting, p->overshooting);
-  dt_bauhaus_slider_set_soft(g->shadows, p->shadows);
-  dt_bauhaus_slider_set_soft(g->bias, p->bias);
-  dt_bauhaus_slider_set_soft(g->scattering, p->scattering);
-  dt_bauhaus_slider_set_soft(g->central_pixel_weight, p->central_pixel_weight);
   dt_bauhaus_combobox_set(g->profile, -1);
   unsigned combobox_index = 0;
   switch (p->mode)
@@ -3119,7 +3111,6 @@ void gui_update(dt_iop_module_t *self)
     dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
   }
   dt_bauhaus_combobox_set(g->mode, combobox_index);
-  dt_bauhaus_combobox_set(g->wavelet_color_mode, p->wavelet_color_mode);
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3567,10 +3567,8 @@ void gui_init(dt_iop_module_t *self)
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_range(g->radius, 0.0, 8.0);
-  dt_bauhaus_slider_set_step(g->radius, 1.0);
   dt_bauhaus_slider_set_digits(g->radius, 0);
   g->nbhood = dt_bauhaus_slider_from_params(self, "nbhood");
-  dt_bauhaus_slider_set_step(g->nbhood, 1.0);
   dt_bauhaus_slider_set_digits(g->nbhood, 0);
   g->scattering = dt_bauhaus_slider_from_params(self, "scattering");
   dt_bauhaus_slider_set_soft_max(g->scattering, 1.0f);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3017,8 +3017,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     {
       gtk_widget_set_visible(g->radius, TRUE);
       gtk_widget_set_visible(g->scattering, TRUE);
-      dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
-      dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
       gtk_widget_set_visible(g->radius, FALSE);
       gtk_widget_set_visible(g->scattering, FALSE);
     }
@@ -3027,8 +3027,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
       // we are in wavelets mode.
       // we need to show the box_nlm, setting the sliders to visible is not enough
       gtk_widget_show_all(g->box_nlm);
-      dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
-      dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
       gtk_widget_hide(g->box_nlm);
     }
     gtk_widget_set_visible(g->shadows, TRUE);
@@ -3105,8 +3105,8 @@ void gui_update(dt_iop_module_t *self)
   if((p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO))
   {
     const float gain = p->overshooting;
-    dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
-    dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
+    dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
+    dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
     dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
     dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
   }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3572,10 +3572,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->nbhood, 0);
   g->scattering = dt_bauhaus_slider_from_params(self, "scattering");
   dt_bauhaus_slider_set_soft_max(g->scattering, 1.0f);
-  dt_bauhaus_slider_set_step(g->scattering, 0.01f);
   g->central_pixel_weight = dt_bauhaus_slider_from_params(self, "central_pixel_weight");
   dt_bauhaus_slider_set_soft_max(g->central_pixel_weight, 1.0f);
-  dt_bauhaus_slider_set_step(g->central_pixel_weight, 0.01f);
 
   g->box_wavelets = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
@@ -3682,13 +3680,10 @@ void gui_init(dt_iop_module_t *self)
 
   g->overshooting = dt_bauhaus_slider_from_params(self, "overshooting");
   dt_bauhaus_slider_set_soft_max(g->overshooting, 4.0f);
-  dt_bauhaus_slider_set_step(g->overshooting, 0.05f);
   g->strength = dt_bauhaus_slider_from_params(self, N_("strength"));
   dt_bauhaus_slider_set_soft_max(g->strength, 4.0f);
   dt_bauhaus_slider_set_digits(g->strength, 3);
-  dt_bauhaus_slider_set_step(g->strength, 0.05f);
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
-  dt_bauhaus_slider_set_step(g->shadows, 0.05f);
   g->bias = dt_bauhaus_slider_from_params(self, "bias");
   dt_bauhaus_slider_set_soft_range(g->bias, -10.0f, 10.0f);
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1490,7 +1490,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->radius_center = dt_bauhaus_slider_from_params(self, "radius_center");
   dt_bauhaus_slider_set_soft_range(g->radius_center, 0., 512.);
-  dt_bauhaus_slider_set_format(g->radius_center, "%.0f px");
+  dt_bauhaus_slider_set_format(g->radius_center, " px");
   gtk_widget_set_tooltip_text(
       g->radius_center, _("main scale of the diffusion.\n"
                           "zero makes diffusion act on the finest details more heavily.\n"
@@ -1500,7 +1500,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_range(g->radius, 1., 512.);
-  dt_bauhaus_slider_set_format(g->radius, "%.0f px");
+  dt_bauhaus_slider_set_format(g->radius, " px");
   gtk_widget_set_tooltip_text(
       g->radius, _("width of the diffusion around the center radius.\n"
                    "high values diffuse on a large band of radii.\n"
@@ -1510,9 +1510,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion speed")), FALSE, FALSE, 0);
 
   g->first = dt_bauhaus_slider_from_params(self, "first");
-  dt_bauhaus_slider_set_factor(g->first, 100.0f);
   dt_bauhaus_slider_set_digits(g->first, 4);
-  dt_bauhaus_slider_set_format(g->first, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->first, "%");
   gtk_widget_set_tooltip_text(g->first, _("smoothing or sharpening of smooth details (gradients).\n"
                                           "positive values diffuse and blur.\n"
                                           "negative values sharpen.\n"
@@ -1520,8 +1519,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->second = dt_bauhaus_slider_from_params(self, "second");
   dt_bauhaus_slider_set_digits(g->second, 4);
-  dt_bauhaus_slider_set_factor(g->second, 100.0f);
-  dt_bauhaus_slider_set_format(g->second, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->second, "%");
   gtk_widget_set_tooltip_text(g->second, _("smoothing or sharpening of sharp details.\n"
                                           "positive values diffuse and blur.\n"
                                           "negative values sharpen.\n"
@@ -1529,8 +1527,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->third = dt_bauhaus_slider_from_params(self, "third");
   dt_bauhaus_slider_set_digits(g->third, 4);
-  dt_bauhaus_slider_set_factor(g->third, 100.0f);
-  dt_bauhaus_slider_set_format(g->third, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->third, "%");
   gtk_widget_set_tooltip_text(g->third, _("smoothing or sharpening of sharp details.\n"
                                           "positive values diffuse and blur.\n"
                                           "negative values sharpen.\n"
@@ -1538,8 +1535,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->fourth = dt_bauhaus_slider_from_params(self, "fourth");
   dt_bauhaus_slider_set_digits(g->fourth, 4);
-  dt_bauhaus_slider_set_factor(g->fourth, 100.0f);
-  dt_bauhaus_slider_set_format(g->fourth, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->fourth, "%");
   gtk_widget_set_tooltip_text(g->fourth, _("smoothing or sharpening of sharp details (gradients).\n"
                                            "positive values diffuse and blur.\n"
                                            "negative values sharpen.\n"
@@ -1549,8 +1545,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->anisotropy_first = dt_bauhaus_slider_from_params(self, "anisotropy_first");
   dt_bauhaus_slider_set_digits(g->anisotropy_first, 4);
-  dt_bauhaus_slider_set_factor(g->anisotropy_first, 100.0f);
-  dt_bauhaus_slider_set_format(g->anisotropy_first, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->anisotropy_first, "%");
   gtk_widget_set_tooltip_text(g->anisotropy_first,
                               _("anisotropy of the diffusion.\n"
                                 "zero makes the diffusion isotrope (same in all directions)\n"
@@ -1559,8 +1554,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->anisotropy_second = dt_bauhaus_slider_from_params(self, "anisotropy_second");
   dt_bauhaus_slider_set_digits(g->anisotropy_second, 4);
-  dt_bauhaus_slider_set_factor(g->anisotropy_second, 100.0f);
-  dt_bauhaus_slider_set_format(g->anisotropy_second, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->anisotropy_second, "%");
   gtk_widget_set_tooltip_text(g->anisotropy_second,
                               _("anisotropy of the diffusion.\n"
                                 "zero makes the diffusion isotrope (same in all directions)\n"
@@ -1569,8 +1563,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->anisotropy_third = dt_bauhaus_slider_from_params(self, "anisotropy_third");
   dt_bauhaus_slider_set_digits(g->anisotropy_third, 4);
-  dt_bauhaus_slider_set_factor(g->anisotropy_third, 100.0f);
-  dt_bauhaus_slider_set_format(g->anisotropy_third, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->anisotropy_third, "%");
   gtk_widget_set_tooltip_text(g->anisotropy_third,
                               _("anisotropy of the diffusion.\n"
                                 "zero makes the diffusion isotrope (same in all directions)\n"
@@ -1579,8 +1572,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->anisotropy_fourth = dt_bauhaus_slider_from_params(self, "anisotropy_fourth");
   dt_bauhaus_slider_set_digits(g->anisotropy_fourth, 4);
-  dt_bauhaus_slider_set_factor(g->anisotropy_fourth, 100.0f);
-  dt_bauhaus_slider_set_format(g->anisotropy_fourth, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->anisotropy_fourth, "%");
   gtk_widget_set_tooltip_text(g->anisotropy_fourth,
                               _("anisotropy of the diffusion.\n"
                                 "zero makes the diffusion isotrope (same in all directions)\n"
@@ -1590,8 +1582,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("edges management")), FALSE, FALSE, 0);
 
   g->sharpness = dt_bauhaus_slider_from_params(self, "sharpness");
-  dt_bauhaus_slider_set_factor(g->sharpness, 100.0f);
-  dt_bauhaus_slider_set_format(g->sharpness, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->sharpness, "%");
   gtk_widget_set_tooltip_text(g->sharpness,
                               _("increase or decrease the sharpness of the highest frequencies"));
 
@@ -1612,8 +1603,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion spatiality")), FALSE, FALSE, 0);
 
   g->threshold = dt_bauhaus_slider_from_params(self, "threshold");
-  dt_bauhaus_slider_set_factor(g->threshold, 100.0f);
-  dt_bauhaus_slider_set_format(g->threshold, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->threshold, "%");
   gtk_widget_set_tooltip_text(g->threshold,
                               _("luminance threshold for the mask.\n"
                                 "0. disables the luminance masking and applies the module on the whole image.\n"

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -53,26 +53,26 @@ DT_MODULE_INTROSPECTION(2, dt_iop_diffuse_params_t)
 typedef struct dt_iop_diffuse_params_t
 {
   // global parameters
-  int iterations;           // $MIN: 1   $MAX: 128   $DEFAULT: 1  $DESCRIPTION: "iterations"
+  int iterations;           // $MIN: 0    $MAX: 500  $DEFAULT: 1  $DESCRIPTION: "iterations"
   float sharpness;          // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "sharpness"
-  int radius;               // $MIN: 1   $MAX: 512   $DEFAULT: 8  $DESCRIPTION: "radius span"
-  float regularization;     // $MIN: 0. $MAX: 4.   $DEFAULT: 0. $DESCRIPTION: "edge sensitivity"
-  float variance_threshold; // $MIN: -2. $MAX: 2.   $DEFAULT: 0. $DESCRIPTION: "edge threshold"
+  int radius;               // $MIN: 0    $MAX: 2048 $DEFAULT: 8  $DESCRIPTION: "radius span"
+  float regularization;     // $MIN: 0.   $MAX: 4.   $DEFAULT: 0. $DESCRIPTION: "edge sensitivity"
+  float variance_threshold; // $MIN: -2.  $MAX: 2.   $DEFAULT: 0. $DESCRIPTION: "edge threshold"
 
-  float anisotropy_first;         // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "1st order anisotropy"
-  float anisotropy_second;        // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "2nd order anisotropy"
-  float anisotropy_third;         // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "3rd order anisotropy"
-  float anisotropy_fourth;        // $MIN: -10. $MAX: 10.   $DEFAULT: 0. $DESCRIPTION: "4th order anisotropy"
+  float anisotropy_first;   // $MIN: -10. $MAX: 10.  $DEFAULT: 0. $DESCRIPTION: "1st order anisotropy"
+  float anisotropy_second;  // $MIN: -10. $MAX: 10.  $DEFAULT: 0. $DESCRIPTION: "2nd order anisotropy"
+  float anisotropy_third;   // $MIN: -10. $MAX: 10.  $DEFAULT: 0. $DESCRIPTION: "3rd order anisotropy"
+  float anisotropy_fourth;  // $MIN: -10. $MAX: 10.  $DEFAULT: 0. $DESCRIPTION: "4th order anisotropy"
 
-  float threshold; // $MIN: 0.  $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
+  float threshold;          // $MIN: 0.   $MAX: 8.   $DEFAULT: 0. $DESCRIPTION: "luminance masking threshold"
 
-  float first; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "1st order speed"
-  float second; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "2nd order speed"
-  float third; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "3rd order speed"
-  float fourth; // $MIN: -1. $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "4th order speed"
+  float first;              // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "1st order speed"
+  float second;             // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "2nd order speed"
+  float third;              // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "3rd order speed"
+  float fourth;             // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "4th order speed"
 
   // v2
-  int radius_center;      // $MIN: 0 $MAX: 512 $DEFAULT: 0 $DESCRIPTION: "central radius"
+  int radius_center;        // $MIN: 0    $MAX: 1024 $DEFAULT: 0  $DESCRIPTION: "central radius"
 
   // new versions add params mandatorily at the end, so we can memcpy old parameters at the beginning
 
@@ -1482,14 +1482,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion properties")), FALSE, FALSE, 0);
 
   g->iterations = dt_bauhaus_slider_from_params(self, "iterations");
-  dt_bauhaus_slider_enable_soft_boundaries(g->iterations, 0., 500);
+  dt_bauhaus_slider_set_soft_range(g->iterations, 1., 128);
   gtk_widget_set_tooltip_text(g->iterations,
                               _("more iterations make the effect stronger but the module slower.\n"
                                 "this is analogous to giving more time to the diffusion reaction.\n"
                                 "if you plan on sharpening or inpainting, more iterations help reconstruction."));
 
   g->radius_center = dt_bauhaus_slider_from_params(self, "radius_center");
-  dt_bauhaus_slider_enable_soft_boundaries(g->radius_center, 0., 1024.);
+  dt_bauhaus_slider_set_soft_range(g->radius_center, 0., 512.);
   dt_bauhaus_slider_set_format(g->radius_center, "%.0f px");
   gtk_widget_set_tooltip_text(
       g->radius_center, _("main scale of the diffusion.\n"
@@ -1499,7 +1499,7 @@ void gui_init(struct dt_iop_module_t *self)
                           "increase to act on local contrast instead."));
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
-  dt_bauhaus_slider_enable_soft_boundaries(g->radius, 0., 2048.);
+  dt_bauhaus_slider_set_soft_range(g->radius, 1., 512.);
   dt_bauhaus_slider_set_format(g->radius, "%.0f px");
   gtk_widget_set_tooltip_text(
       g->radius, _("width of the diffusion around the center radius.\n"

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1474,29 +1474,6 @@ void cleanup_global(dt_iop_module_so_t *module)
 #endif
 
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_diffuse_gui_data_t *g = (dt_iop_diffuse_gui_data_t *)self->gui_data;
-  dt_iop_diffuse_params_t *p = (dt_iop_diffuse_params_t *)self->params;
-  dt_bauhaus_slider_set_soft(g->iterations, p->iterations);
-  dt_bauhaus_slider_set_soft(g->fourth, p->fourth);
-  dt_bauhaus_slider_set_soft(g->third, p->third);
-  dt_bauhaus_slider_set_soft(g->second, p->second);
-  dt_bauhaus_slider_set_soft(g->first, p->first);
-
-  dt_bauhaus_slider_set_soft(g->variance_threshold, p->variance_threshold);
-  dt_bauhaus_slider_set_soft(g->regularization, p->regularization);
-  dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  dt_bauhaus_slider_set_soft(g->radius_center, p->radius_center);
-  dt_bauhaus_slider_set_soft(g->sharpness, p->sharpness);
-  dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
-
-  dt_bauhaus_slider_set_soft(g->anisotropy_first, p->anisotropy_first);
-  dt_bauhaus_slider_set_soft(g->anisotropy_second, p->anisotropy_second);
-  dt_bauhaus_slider_set_soft(g->anisotropy_third, p->anisotropy_third);
-  dt_bauhaus_slider_set_soft(g->anisotropy_fourth, p->anisotropy_fourth);
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_diffuse_gui_data_t *g = IOP_GUI_ALLOC(diffuse);

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -862,7 +862,6 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
   dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)self->params;
-  dt_bauhaus_combobox_set(g->dither_type, p->dither_type);
 #if 0
   dt_bauhaus_slider_set(g->radius, p->random.radius);
 
@@ -871,8 +870,6 @@ void gui_update(struct dt_iop_module_t *self)
   dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[2], 2);
   dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->range), p->random.range[3], 3);
 #endif
-
-  dt_bauhaus_slider_set(g->damping, p->random.damping);
 
   gtk_widget_set_visible(g->random, p->dither_type == DITHER_RANDOM);
 }

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -905,7 +905,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text(g->damping, _("damping level of random dither"));
   dt_bauhaus_slider_set_digits(g->damping, 3);
-  dt_bauhaus_slider_set_format(g->damping, "%.0fdB");
+  dt_bauhaus_slider_set_format(g->damping, " dB");
 
 #if 0
   gtk_box_pack_start(GTK_BOX(g->random), g->radius, TRUE, TRUE, 0);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1134,7 +1134,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->target_spot), "draw", G_CALLBACK(_target_color_draw), self);
   gtk_box_pack_start(GTK_BOX(vvbox), g->target_spot, TRUE, TRUE, 0);
 
-  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
+  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0, 0, 1);
   dt_bauhaus_widget_set_label(g->lightness_spot, NULL, _("lightness"));
   dt_bauhaus_slider_set_format(g->lightness_spot, "%");
   dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -569,17 +569,12 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
-  dt_bauhaus_combobox_set(g->mode, p->mode);
-
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias), p->compensate_exposure_bias);
   /* xgettext:no-c-format */
   gchar *label = g_strdup_printf(_("compensate camera exposure (%+.1f EV)"), _get_exposure_bias(self));
   gtk_button_set_label(GTK_BUTTON(g->compensate_exposure_bias), label);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->compensate_exposure_bias))), PANGO_ELLIPSIZE_MIDDLE);
   g_free(label);
-
-  dt_bauhaus_slider_set_soft(g->black, p->black);
-  dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
 
   g->spot_RGB[0] = 0.f;
   g->spot_RGB[1] = 0.f;
@@ -595,9 +590,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->lightness_spot, lightness);
 
   dt_iop_gui_leave_critical_section(self);
-
-  dt_bauhaus_slider_set(g->deflicker_percentile, p->deflicker_percentile);
-  dt_bauhaus_slider_set(g->deflicker_target_level, p->deflicker_target_level);
 
   free(g->deflicker_histogram);
   g->deflicker_histogram = NULL;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -645,7 +645,7 @@ static void _exposure_set_white(struct dt_iop_module_t *self, const float white)
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
+  dt_bauhaus_slider_set(g->exposure, p->exposure);
   --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -702,7 +702,7 @@ static void _exposure_set_black(struct dt_iop_module_t *self, const float black)
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->black, p->black);
+  dt_bauhaus_slider_set(g->black, p->black);
   --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -774,7 +774,7 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 
     // Return the values in sliders
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(g->lightness_spot, Lab_out[0]);
+    dt_bauhaus_slider_set(g->lightness_spot, Lab_out[0]);
     _paint_hue(self);
     --darktable.gui->reset;
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1038,7 +1038,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->exposure = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                                     dt_bauhaus_slider_from_params(self, N_("exposure")));
   gtk_widget_set_tooltip_text(g->exposure, _("adjust the exposure correction"));
-  dt_bauhaus_slider_set_step(g->exposure, 0.02);
   dt_bauhaus_slider_set_digits(g->exposure, 3);
   dt_bauhaus_slider_set_format(g->exposure, _(" EV"));
   dt_bauhaus_slider_set_soft_range(g->exposure, -3.0, 4.0);
@@ -1053,7 +1052,6 @@ void gui_init(struct dt_iop_module_t *self)
                               _("where in the histogram to meter for deflicking. E.g. 50% is median"));
 
   g->deflicker_target_level = dt_bauhaus_slider_from_params(self, "deflicker_target_level");
-  dt_bauhaus_slider_set_step(g->deflicker_target_level, 0.1);
   dt_bauhaus_slider_set_format(g->deflicker_target_level, _(" EV"));
   gtk_widget_set_tooltip_text(g->deflicker_target_level,
                               _("where to place the exposure level for processed pics, EV below overexposure."));
@@ -1082,7 +1080,6 @@ void gui_init(struct dt_iop_module_t *self)
                                           "you should never use it to add more density in blacks!\n"
                                           "if poorly set, it will clip near-black colors out of gamut\n"
                                           "by pushing RGB values into negatives."));
-  dt_bauhaus_slider_set_step(g->black, 0.001);
   dt_bauhaus_slider_set_digits(g->black, 4);
   dt_bauhaus_slider_set_soft_range(g->black, -0.1, 0.1);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1040,21 +1040,21 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->exposure, _("adjust the exposure correction"));
   dt_bauhaus_slider_set_step(g->exposure, 0.02);
   dt_bauhaus_slider_set_digits(g->exposure, 3);
-  dt_bauhaus_slider_set_format(g->exposure, _("%.2f EV"));
+  dt_bauhaus_slider_set_format(g->exposure, _(" EV"));
   dt_bauhaus_slider_set_soft_range(g->exposure, -3.0, 4.0);
 
   GtkWidget *vbox_deflicker = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_deflicker, "deflicker");
 
   g->deflicker_percentile = dt_bauhaus_slider_from_params(self, "deflicker_percentile");
-  dt_bauhaus_slider_set_format(g->deflicker_percentile, "%.2f%%");
+  dt_bauhaus_slider_set_format(g->deflicker_percentile, "%");
   gtk_widget_set_tooltip_text(g->deflicker_percentile,
                               // xgettext:no-c-format
                               _("where in the histogram to meter for deflicking. E.g. 50% is median"));
 
   g->deflicker_target_level = dt_bauhaus_slider_from_params(self, "deflicker_target_level");
   dt_bauhaus_slider_set_step(g->deflicker_target_level, 0.1);
-  dt_bauhaus_slider_set_format(g->deflicker_target_level, _("%.2f EV"));
+  dt_bauhaus_slider_set_format(g->deflicker_target_level, _(" EV"));
   gtk_widget_set_tooltip_text(g->deflicker_target_level,
                               _("where to place the exposure level for processed pics, EV below overexposure."));
 
@@ -1139,7 +1139,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0.5, 0, 1);
   dt_bauhaus_widget_set_label(g->lightness_spot, NULL, _("lightness"));
-  dt_bauhaus_slider_set_format(g->lightness_spot, "%.1f %%");
+  dt_bauhaus_slider_set_format(g->lightness_spot, "%");
   dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->lightness_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -962,8 +962,8 @@ static void _paint_hue(dt_iop_module_t *self)
   // update the fill background color of LCh sliders
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  const float lightness_min = DT_BAUHAUS_WIDGET(g->lightness_spot)->data.slider.min;
-  const float lightness_max = DT_BAUHAUS_WIDGET(g->lightness_spot)->data.slider.max;
+  const float lightness_min = dt_bauhaus_slider_get_hard_min(g->lightness_spot);
+  const float lightness_max = dt_bauhaus_slider_get_hard_max(g->lightness_spot);
 
   const float lightness_range = lightness_max - lightness_min;
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1593,7 +1593,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, 0.1, 36.0);
   dt_bauhaus_widget_set_label(g->grey_point_source, NULL, N_("middle gray luminance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->grey_point_source, "%");
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
                                                       "except in back-lighting situations, this should be around 18%."));
   g_signal_connect(G_OBJECT(g->grey_point_source), "value-changed", G_CALLBACK(grey_point_source_callback), self);
@@ -1604,7 +1604,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_widget_set_label(g->white_point_source, NULL, N_("white relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->white_point_source, "%.2f EV");
+  dt_bauhaus_slider_set_format(g->white_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between middle gray and pure white.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "adjust so highlights clipping is avoided"));
@@ -1616,7 +1616,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3.0);
   dt_bauhaus_widget_set_label(g->black_point_source, NULL, N_("black relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->black_point_source, "%.2f EV");
+  dt_bauhaus_slider_set_format(g->black_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle gray and pure black.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "increase to get more contrast.\ndecrease to recover more details in low-lights."));
@@ -1627,7 +1627,7 @@ void gui_init(dt_iop_module_t *self)
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->security_factor, 2);
   dt_bauhaus_widget_set_label(g->security_factor, NULL, N_("safety factor"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range.\n"
                                                     "useful in conjunction with \"auto tune levels\"."));
   g_signal_connect(G_OBJECT(g->security_factor), "value-changed", G_CALLBACK(security_threshold_callback), self);
@@ -1656,7 +1656,7 @@ void gui_init(dt_iop_module_t *self)
   g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 0.01, 16.0, 0.05, p->latitude_stops, 3);
   dt_bauhaus_slider_set_soft_range(g->latitude_stops, 2, 8.0);
   dt_bauhaus_widget_set_label(g->latitude_stops, NULL, N_("latitude"));
-  dt_bauhaus_slider_set_format(g->latitude_stops, "%.2f EV");
+  dt_bauhaus_slider_set_format(g->latitude_stops, _(" EV"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->latitude_stops, _("width of the linear domain in the middle of the curve.\n"
                                                    "increase to get more contrast at the extreme luminances.\n"
@@ -1667,7 +1667,7 @@ void gui_init(dt_iop_module_t *self)
   g->balance = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->balance, 2);
   dt_bauhaus_widget_set_label(g->balance, NULL, N_("shadows/highlights balance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->balance, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->balance, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->balance, "%");
   gtk_widget_set_tooltip_text(g->balance, _("slides the latitude along the slope\nto give more room to shadows or highlights.\n"
                                             "use it if you need to protect the details\nat one extremity of the histogram."));
   g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
@@ -1676,7 +1676,7 @@ void gui_init(dt_iop_module_t *self)
   g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0.5, p->global_saturation, 2);
   dt_bauhaus_widget_set_label(g->global_saturation, NULL, N_("global saturation"));
   dt_bauhaus_slider_set_soft_range(g->global_saturation, 0.0, 200.0);
-  dt_bauhaus_slider_set_format(g->global_saturation, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->global_saturation, "%");
   gtk_box_pack_start(GTK_BOX(self->widget), g->global_saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->global_saturation, _("desaturates the input of the module globally.\n"
                                                       "you need to set this value below 100%\nif the chrominance preservation is enabled."));
@@ -1686,7 +1686,7 @@ void gui_init(dt_iop_module_t *self)
   g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0.5, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
   dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.0, 200.0);
-  dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_box_pack_start(GTK_BOX(self->widget), g->saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\nspecifically at extreme luminances.\n"
                                                "decrease if shadows and/or highlights are over-saturated."));
@@ -1738,7 +1738,7 @@ void gui_init(dt_iop_module_t *self)
   g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->black_point_target, 2);
   dt_bauhaus_widget_set_label(g->black_point_target, NULL, N_("target black luminance"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->black_point_target, FALSE, FALSE, 0);
-  dt_bauhaus_slider_set_format(g->black_point_target, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->black_point_target, "%");
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
                                                         "this should be 0%\nexcept if you want a faded look"));
   g_signal_connect(G_OBJECT(g->black_point_target), "value-changed", G_CALLBACK(black_point_target_callback), self);
@@ -1747,7 +1747,7 @@ void gui_init(dt_iop_module_t *self)
   g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0.5, p->grey_point_target, 2);
   dt_bauhaus_widget_set_label(g->grey_point_target, NULL, N_("target middle gray"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->grey_point_target, FALSE, FALSE, 0);
-  dt_bauhaus_slider_set_format(g->grey_point_target, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->grey_point_target, "%");
   gtk_widget_set_tooltip_text(g->grey_point_target, _("middle gray value of the target display or color space.\n"
                                                       "you should never touch that unless you know what you are doing."));
   g_signal_connect(G_OBJECT(g->grey_point_target), "value-changed", G_CALLBACK(grey_point_target_callback), self);
@@ -1756,7 +1756,7 @@ void gui_init(dt_iop_module_t *self)
   g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1., p->white_point_target, 2);
   dt_bauhaus_widget_set_label(g->white_point_target, NULL, N_("target white luminance"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->white_point_target, FALSE, FALSE, 0);
-  dt_bauhaus_slider_set_format(g->white_point_target, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->white_point_target, "%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "
                                                         "this should be 100%\nexcept if you want a faded look"));
   g_signal_connect(G_OBJECT(g->white_point_target), "value-changed", G_CALLBACK(white_point_target_callback), self);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1589,8 +1589,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("logarithmic shaper")), FALSE, FALSE, 0);
 
   // grey_point_source slider
-  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.1, 36., 0.1, p->grey_point_source, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->grey_point_source, 0.0, 100.0);
+  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 100., 0.1, p->grey_point_source, 2);
+  dt_bauhaus_slider_set_soft_range(g->grey_point_source, 0.1, 36.0);
   dt_bauhaus_widget_set_label(g->grey_point_source, NULL, N_("middle gray luminance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
@@ -1600,8 +1600,8 @@ void gui_init(dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->grey_point_source);
 
   // White slider
-  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 2.0, 8.0, 0.1, p->white_point_source, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->white_point_source, 0.0, 16.0);
+  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 16.0, 0.1, p->white_point_source, 2);
+  dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_widget_set_label(g->white_point_source, NULL, N_("white relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->white_point_source, "%.2f EV");
@@ -1612,8 +1612,8 @@ void gui_init(dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->white_point_source);
 
   // Black slider
-  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -14.0, -3.0, 0.1, p->black_point_source, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->black_point_source, -16.0, -0.1);
+  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.1, 0.1, p->black_point_source, 2);
+  dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3.0);
   dt_bauhaus_widget_set_label(g->black_point_source, NULL, N_("black relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->black_point_source, "%.2f EV");
@@ -1644,8 +1644,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("filmic S curve")), FALSE, FALSE, 0);
 
   // contrast slider
-  g->contrast = dt_bauhaus_slider_new_with_range(self, 1., 2., 0.01, p->contrast, 3);
-  dt_bauhaus_slider_enable_soft_boundaries(g->contrast, 0.0, 5.0);
+  g->contrast = dt_bauhaus_slider_new_with_range(self, 0., 5., 0.01, p->contrast, 3);
+  dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
   dt_bauhaus_widget_set_label(g->contrast, NULL, N_("contrast"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
@@ -1653,8 +1653,8 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
 
   // latitude slider
-  g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 2., 8.0, 0.05, p->latitude_stops, 3);
-  dt_bauhaus_slider_enable_soft_boundaries(g->latitude_stops, 0.01, 16.0);
+  g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 0.01, 16.0, 0.05, p->latitude_stops, 3);
+  dt_bauhaus_slider_set_soft_range(g->latitude_stops, 2, 8.0);
   dt_bauhaus_widget_set_label(g->latitude_stops, NULL, N_("latitude"));
   dt_bauhaus_slider_set_format(g->latitude_stops, "%.2f EV");
   gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
@@ -1673,9 +1673,9 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
 
   // saturation slider
-  g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 200., 0.5, p->global_saturation, 2);
+  g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0.5, p->global_saturation, 2);
   dt_bauhaus_widget_set_label(g->global_saturation, NULL, N_("global saturation"));
-  dt_bauhaus_slider_enable_soft_boundaries(g->global_saturation, 0.0, 1000.0);
+  dt_bauhaus_slider_set_soft_range(g->global_saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->global_saturation, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(self->widget), g->global_saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->global_saturation, _("desaturates the input of the module globally.\n"
@@ -1683,9 +1683,9 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->global_saturation), "value-changed", G_CALLBACK(global_saturation_callback), self);
 
   // saturation slider
-  g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 200., 0.5, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
+  g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0.5, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
   dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
-  dt_bauhaus_slider_enable_soft_boundaries(g->saturation, 0.0, 1000.0);
+  dt_bauhaus_slider_set_soft_range(g->saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(self->widget), g->saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\nspecifically at extreme luminances.\n"

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1589,7 +1589,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("logarithmic shaper")), FALSE, FALSE, 0);
 
   // grey_point_source slider
-  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 100., 0.1, p->grey_point_source, 2);
+  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 100., 0, p->grey_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, 0.1, 36.0);
   dt_bauhaus_widget_set_label(g->grey_point_source, NULL, N_("middle gray luminance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
@@ -1600,7 +1600,7 @@ void gui_init(dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->grey_point_source);
 
   // White slider
-  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 16.0, 0.1, p->white_point_source, 2);
+  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 16.0, 0, p->white_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_widget_set_label(g->white_point_source, NULL, N_("white relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
@@ -1612,7 +1612,7 @@ void gui_init(dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->white_point_source);
 
   // Black slider
-  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.1, 0.1, p->black_point_source, 2);
+  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.1, 0, p->black_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3.0);
   dt_bauhaus_widget_set_label(g->black_point_source, NULL, N_("black relative exposure"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
@@ -1624,7 +1624,7 @@ void gui_init(dt_iop_module_t *self)
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->black_point_source);
 
   // Security factor
-  g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->security_factor, 2);
+  g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 0, p->security_factor, 2);
   dt_bauhaus_widget_set_label(g->security_factor, NULL, N_("safety factor"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%");
@@ -1644,7 +1644,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("filmic S curve")), FALSE, FALSE, 0);
 
   // contrast slider
-  g->contrast = dt_bauhaus_slider_new_with_range(self, 0., 5., 0.01, p->contrast, 3);
+  g->contrast = dt_bauhaus_slider_new_with_range(self, 0., 5., 0, p->contrast, 3);
   dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
   dt_bauhaus_widget_set_label(g->contrast, NULL, N_("contrast"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
@@ -1653,7 +1653,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
 
   // latitude slider
-  g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 0.01, 16.0, 0.05, p->latitude_stops, 3);
+  g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 0.01, 16.0, 0, p->latitude_stops, 3);
   dt_bauhaus_slider_set_soft_range(g->latitude_stops, 2, 8.0);
   dt_bauhaus_widget_set_label(g->latitude_stops, NULL, N_("latitude"));
   dt_bauhaus_slider_set_format(g->latitude_stops, _(" EV"));
@@ -1664,7 +1664,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->latitude_stops), "value-changed", G_CALLBACK(latitude_stops_callback), self);
 
   // balance slider
-  g->balance = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->balance, 2);
+  g->balance = dt_bauhaus_slider_new_with_range(self, -50., 50., 0, p->balance, 2);
   dt_bauhaus_widget_set_label(g->balance, NULL, N_("shadows/highlights balance"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->balance, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->balance, "%");
@@ -1673,7 +1673,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
 
   // saturation slider
-  g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0.5, p->global_saturation, 2);
+  g->global_saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0, p->global_saturation, 2);
   dt_bauhaus_widget_set_label(g->global_saturation, NULL, N_("global saturation"));
   dt_bauhaus_slider_set_soft_range(g->global_saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->global_saturation, "%");
@@ -1683,7 +1683,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->global_saturation), "value-changed", G_CALLBACK(global_saturation_callback), self);
 
   // saturation slider
-  g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0.5, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
+  g->saturation = dt_bauhaus_slider_new_with_range(self, 0., 1000., 0, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f *100.0f, 2);
   dt_bauhaus_widget_set_label(g->saturation, NULL, N_("extreme luminance saturation"));
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->saturation, "%");
@@ -1735,7 +1735,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
 
   // Black slider
-  g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->black_point_target, 2);
+  g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0, p->black_point_target, 2);
   dt_bauhaus_widget_set_label(g->black_point_target, NULL, N_("target black luminance"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->black_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->black_point_target, "%");
@@ -1744,7 +1744,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->black_point_target), "value-changed", G_CALLBACK(black_point_target_callback), self);
 
   // grey_point_source slider
-  g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0.5, p->grey_point_target, 2);
+  g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0, p->grey_point_target, 2);
   dt_bauhaus_widget_set_label(g->grey_point_target, NULL, N_("target middle gray"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->grey_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_target, "%");
@@ -1753,7 +1753,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->grey_point_target), "value-changed", G_CALLBACK(grey_point_target_callback), self);
 
   // White slider
-  g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1., p->white_point_target, 2);
+  g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0, p->white_point_target, 2);
   dt_bauhaus_widget_set_label(g->white_point_target, NULL, N_("target white luminance"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->white_point_target, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->white_point_target, "%");
@@ -1762,7 +1762,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->white_point_target), "value-changed", G_CALLBACK(white_point_target_callback), self);
 
   // power/gamma slider
-  g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 2.4, 0.1, p->output_power, 2);
+  g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 2.4, 0, p->output_power, 2);
   dt_bauhaus_widget_set_label(g->output_power, NULL, N_("target gamma"));
   gtk_box_pack_start(GTK_BOX(extra_options), g->output_power, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->output_power, _("power or gamma of the transfer function\nof the display or color space.\n"

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -689,7 +689,7 @@ static void sanitize_latitude(dt_iop_filmic_params_t *p, dt_iop_filmic_gui_data_
     // it can never be higher than the dynamic range
     p->latitude_stops =  (p->white_point_source - p->black_point_source) * 0.99f;
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(g->latitude_stops, p->latitude_stops);
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
     --darktable.gui->reset;
   }
 }
@@ -711,9 +711,9 @@ static void apply_auto_grey(dt_iop_module_t *self)
   p->white_point_source = p->white_point_source + grey_var;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -738,7 +738,7 @@ static void apply_auto_black(dt_iop_module_t *self)
   p->black_point_source = EVmin;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
   --darktable.gui->reset;
 
   sanitize_latitude(p, g);
@@ -766,7 +766,7 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
   p->white_point_source = EVmax;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
   --darktable.gui->reset;
 
   sanitize_latitude(p, g);
@@ -796,8 +796,8 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->black_point_source = EVmin;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
   --darktable.gui->reset;
 
   sanitize_latitude(p, g);
@@ -837,9 +837,9 @@ static void apply_autotune(dt_iop_module_t *self)
   p->white_point_source = EVmax;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
   --darktable.gui->reset;
 
   sanitize_latitude(p, g);
@@ -877,8 +877,8 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->white_point_source = p->white_point_source + grey_var;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
   --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -1373,15 +1373,15 @@ void gui_update(dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->security_factor, p->security_factor);
-  dt_bauhaus_slider_set_soft(g->white_point_target, p->white_point_target);
-  dt_bauhaus_slider_set_soft(g->grey_point_target, p->grey_point_target);
-  dt_bauhaus_slider_set_soft(g->black_point_target, p->black_point_target);
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  dt_bauhaus_slider_set_soft(g->latitude_stops, p->latitude_stops);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->security_factor, p->security_factor);
+  dt_bauhaus_slider_set(g->white_point_target, p->white_point_target);
+  dt_bauhaus_slider_set(g->grey_point_target, p->grey_point_target);
+  dt_bauhaus_slider_set(g->black_point_target, p->black_point_target);
+  dt_bauhaus_slider_set(g->output_power, p->output_power);
+  dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
   dt_bauhaus_slider_set(g->contrast, p->contrast);
   dt_bauhaus_slider_set(g->global_saturation, p->global_saturation);
   dt_bauhaus_slider_set(g->saturation, (powf(10.0f, p->saturation/100.0f) - 1.0f) / 9.0f * 100.0f);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3961,7 +3961,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_structure_vs_texture = dt_bauhaus_slider_from_params(self, "reconstruct_structure_vs_texture");
-  dt_bauhaus_slider_set_step(g->reconstruct_structure_vs_texture, 0.1);
   dt_bauhaus_slider_set_format(g->reconstruct_structure_vs_texture, "%");
   gtk_widget_set_tooltip_text(g->reconstruct_structure_vs_texture,
                               /* xgettext:no-c-format */
@@ -3973,7 +3972,6 @@ void gui_init(dt_iop_module_t *self)
                                 "decrease if all RGB channels are clipped over large areas."));
 
   g->reconstruct_bloom_vs_details = dt_bauhaus_slider_from_params(self, "reconstruct_bloom_vs_details");
-  dt_bauhaus_slider_set_step(g->reconstruct_bloom_vs_details, 0.1);
   dt_bauhaus_slider_set_format(g->reconstruct_bloom_vs_details, "%");
   gtk_widget_set_tooltip_text(g->reconstruct_bloom_vs_details,
                               /* xgettext:no-c-format */
@@ -3986,7 +3984,6 @@ void gui_init(dt_iop_module_t *self)
 
   // Bloom threshold
   g->reconstruct_grey_vs_color = dt_bauhaus_slider_from_params(self, "reconstruct_grey_vs_color");
-  dt_bauhaus_slider_set_step(g->reconstruct_grey_vs_color, 0.1);
   dt_bauhaus_slider_set_format(g->reconstruct_grey_vs_color, "%");
   gtk_widget_set_tooltip_text(g->reconstruct_grey_vs_color,
                               /* xgettext:no-c-format */
@@ -4003,7 +4000,6 @@ void gui_init(dt_iop_module_t *self)
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
   dt_bauhaus_slider_set_soft_range(g->contrast, 0.5, 3.0);
   dt_bauhaus_slider_set_digits(g->contrast, 3);
-  dt_bauhaus_slider_set_step(g->contrast, .01);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
                                              "affects mostly the mid-tones"));
 
@@ -4041,14 +4037,12 @@ void gui_init(dt_iop_module_t *self)
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_from_params(self, "black_point_target");
-  dt_bauhaus_slider_set_step(g->black_point_target, .001);
   dt_bauhaus_slider_set_digits(g->black_point_target, 4);
   dt_bauhaus_slider_set_format(g->black_point_target, "%");
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
                                                        "this should be 0%\nexcept if you want a faded look"));
 
   g->grey_point_target = dt_bauhaus_slider_from_params(self, "grey_point_target");
-  dt_bauhaus_slider_set_step(g->grey_point_target, .01);
   dt_bauhaus_slider_set_digits(g->grey_point_target, 4);
   dt_bauhaus_slider_set_format(g->grey_point_target, "%");
   gtk_widget_set_tooltip_text(g->grey_point_target,
@@ -4057,7 +4051,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->white_point_target = dt_bauhaus_slider_from_params(self, "white_point_target");
   dt_bauhaus_slider_set_soft_max(g->white_point_target, 100.0);
-  dt_bauhaus_slider_set_step(g->white_point_target, .01);
   dt_bauhaus_slider_set_digits(g->white_point_target, 4);
   dt_bauhaus_slider_set_format(g->white_point_target, "%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3879,7 +3879,7 @@ void gui_init(dt_iop_module_t *self)
   g->grey_point_source
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point_source"));
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, .1, 36.0);
-  dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->grey_point_source, "%");
   gtk_widget_set_tooltip_text(g->grey_point_source,
                               _("adjust to match the average luminance of the image's subject.\n"
                                 "the value entered here will then be remapped to 18.45%.\n"
@@ -3889,7 +3889,7 @@ void gui_init(dt_iop_module_t *self)
   g->white_point_source
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_point_source"));
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
-  dt_bauhaus_slider_set_format(g->white_point_source, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->white_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_point_source,
                               _("number of stops between middle gray and pure white.\n"
                                 "this is a reading a lightmeter would give you on the scene.\n"
@@ -3899,7 +3899,7 @@ void gui_init(dt_iop_module_t *self)
   g->black_point_source
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "black_point_source"));
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3);
-  dt_bauhaus_slider_set_format(g->black_point_source, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->black_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(
       g->black_point_source, _("number of stops between middle gray and pure black.\n"
                                "this is a reading a lightmeter would give you on the scene.\n"
@@ -3908,7 +3908,7 @@ void gui_init(dt_iop_module_t *self)
   // Dynamic range scaling
   g->security_factor = dt_bauhaus_slider_from_params(self, "security_factor");
   dt_bauhaus_slider_set_soft_max(g->security_factor, 50);
-  dt_bauhaus_slider_set_format(g->security_factor, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("symmetrically enlarge or shrink the computed dynamic range.\n"
                                                     "useful to give a safety margin to extreme luminances."));
 
@@ -3932,7 +3932,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_threshold = dt_bauhaus_slider_from_params(self, "reconstruct_threshold");
-  dt_bauhaus_slider_set_format(g->reconstruct_threshold, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->reconstruct_threshold, _(" EV"));
   gtk_widget_set_tooltip_text(g->reconstruct_threshold,
                               _("set the exposure threshold upon which\n"
                                 "clipped highlights get reconstructed.\n"
@@ -3942,7 +3942,7 @@ void gui_init(dt_iop_module_t *self)
                                 "increase to exclude more areas."));
 
   g->reconstruct_feather = dt_bauhaus_slider_from_params(self, "reconstruct_feather");
-  dt_bauhaus_slider_set_format(g->reconstruct_feather, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->reconstruct_feather, _(" EV"));
   gtk_widget_set_tooltip_text(g->reconstruct_feather,
                               _("soften the transition between clipped highlights and valid pixels.\n"
                                 "decrease to make the transition harder and sharper,\n"
@@ -3962,7 +3962,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->reconstruct_structure_vs_texture = dt_bauhaus_slider_from_params(self, "reconstruct_structure_vs_texture");
   dt_bauhaus_slider_set_step(g->reconstruct_structure_vs_texture, 0.1);
-  dt_bauhaus_slider_set_format(g->reconstruct_structure_vs_texture, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->reconstruct_structure_vs_texture, "%");
   gtk_widget_set_tooltip_text(g->reconstruct_structure_vs_texture,
                               /* xgettext:no-c-format */
                               _("decide which reconstruction strategy to favor,\n"
@@ -3974,7 +3974,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->reconstruct_bloom_vs_details = dt_bauhaus_slider_from_params(self, "reconstruct_bloom_vs_details");
   dt_bauhaus_slider_set_step(g->reconstruct_bloom_vs_details, 0.1);
-  dt_bauhaus_slider_set_format(g->reconstruct_bloom_vs_details, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->reconstruct_bloom_vs_details, "%");
   gtk_widget_set_tooltip_text(g->reconstruct_bloom_vs_details,
                               /* xgettext:no-c-format */
                               _("decide which reconstruction strategy to favor,\n"
@@ -3987,7 +3987,7 @@ void gui_init(dt_iop_module_t *self)
   // Bloom threshold
   g->reconstruct_grey_vs_color = dt_bauhaus_slider_from_params(self, "reconstruct_grey_vs_color");
   dt_bauhaus_slider_set_step(g->reconstruct_grey_vs_color, 0.1);
-  dt_bauhaus_slider_set_format(g->reconstruct_grey_vs_color, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->reconstruct_grey_vs_color, "%");
   gtk_widget_set_tooltip_text(g->reconstruct_grey_vs_color,
                               /* xgettext:no-c-format */
                               _("decide which reconstruction strategy to favor,\n"
@@ -4015,7 +4015,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->latitude = dt_bauhaus_slider_from_params(self, N_("latitude"));
   dt_bauhaus_slider_set_soft_range(g->latitude, 0.1, 90.0);
-  dt_bauhaus_slider_set_format(g->latitude, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->latitude, "%");
   gtk_widget_set_tooltip_text(g->latitude,
                               _("width of the linear domain in the middle of the curve,\n"
                                 "increase to get more contrast and less desaturation at extreme luminances,\n"
@@ -4023,7 +4023,7 @@ void gui_init(dt_iop_module_t *self)
                                 "this has no effect on mid-tones."));
 
   g->balance = dt_bauhaus_slider_from_params(self, "balance");
-  dt_bauhaus_slider_set_format(g->balance, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->balance, "%");
   gtk_widget_set_tooltip_text(g->balance, _("slides the latitude along the slope\n"
                                             "to give more room to shadows or highlights.\n"
                                             "use it if you need to protect the details\n"
@@ -4031,7 +4031,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
   dt_bauhaus_slider_set_soft_max(g->saturation, 50.0);
-  dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\n"
                                                "specifically at extreme luminances.\n"
                                                "increase if shadows and/or highlights are under-saturated."));
@@ -4043,14 +4043,14 @@ void gui_init(dt_iop_module_t *self)
   g->black_point_target = dt_bauhaus_slider_from_params(self, "black_point_target");
   dt_bauhaus_slider_set_step(g->black_point_target, .001);
   dt_bauhaus_slider_set_digits(g->black_point_target, 4);
-  dt_bauhaus_slider_set_format(g->black_point_target, "%.4f %%");
+  dt_bauhaus_slider_set_format(g->black_point_target, "%");
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
                                                        "this should be 0%\nexcept if you want a faded look"));
 
   g->grey_point_target = dt_bauhaus_slider_from_params(self, "grey_point_target");
   dt_bauhaus_slider_set_step(g->grey_point_target, .01);
   dt_bauhaus_slider_set_digits(g->grey_point_target, 4);
-  dt_bauhaus_slider_set_format(g->grey_point_target, "%.4f %%");
+  dt_bauhaus_slider_set_format(g->grey_point_target, "%");
   gtk_widget_set_tooltip_text(g->grey_point_target,
                               _("middle gray value of the target display or color space.\n"
                                 "you should never touch that unless you know what you are doing."));
@@ -4059,7 +4059,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_max(g->white_point_target, 100.0);
   dt_bauhaus_slider_set_step(g->white_point_target, .01);
   dt_bauhaus_slider_set_digits(g->white_point_target, 4);
-  dt_bauhaus_slider_set_format(g->white_point_target, "%.4f %%");
+  dt_bauhaus_slider_set_format(g->white_point_target, "%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "
                                                        "this should be 100%\nexcept if you want a faded look"));
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2093,10 +2093,10 @@ static void apply_auto_grey(dt_iop_module_t *self)
                     / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->output_power, p->output_power);
   --darktable.gui->reset;
 
   gtk_widget_queue_draw(self->widget);
@@ -2122,8 +2122,8 @@ static void apply_auto_black(dt_iop_module_t *self)
                     / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->output_power, p->output_power);
   --darktable.gui->reset;
 
   gtk_widget_queue_draw(self->widget);
@@ -2150,8 +2150,8 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
                     / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->output_power, p->output_power);
   --darktable.gui->reset;
 
   gtk_widget_queue_draw(self->widget);
@@ -2188,10 +2188,10 @@ static void apply_autotune(dt_iop_module_t *self)
                     / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->output_power, p->output_power);
   --darktable.gui->reset;
 
   gtk_widget_queue_draw(self->widget);
@@ -4159,8 +4159,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
         p->white_point_source = p->white_point_source + grey_var;
       }
 
-      dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-      dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
+      dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+      dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
     }
 
     if(p->auto_hardness)
@@ -4168,7 +4168,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
                         / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
     gtk_widget_set_visible(GTK_WIDGET(g->output_power), !p->auto_hardness);
-    dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+    dt_bauhaus_slider_set(g->output_power, p->output_power);
 
     --darktable.gui->reset;
   }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2638,34 +2638,8 @@ void gui_update(dt_iop_module_t *self)
 
   // fetch last view in dartablerc
 
-  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
-  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  dt_bauhaus_slider_set_soft(g->security_factor, p->security_factor);
-  dt_bauhaus_slider_set_soft(g->reconstruct_threshold, p->reconstruct_threshold);
-  dt_bauhaus_slider_set_soft(g->reconstruct_feather, p->reconstruct_feather);
-  dt_bauhaus_slider_set_soft(g->reconstruct_bloom_vs_details, p->reconstruct_bloom_vs_details);
-  dt_bauhaus_slider_set_soft(g->reconstruct_grey_vs_color, p->reconstruct_grey_vs_color);
-  dt_bauhaus_slider_set_soft(g->reconstruct_structure_vs_texture, p->reconstruct_structure_vs_texture);
-  dt_bauhaus_slider_set_soft(g->white_point_target, p->white_point_target);
-  dt_bauhaus_slider_set_soft(g->grey_point_target, p->grey_point_target);
-  dt_bauhaus_slider_set_soft(g->black_point_target, p->black_point_target);
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  dt_bauhaus_slider_set_soft(g->latitude, p->latitude);
-  dt_bauhaus_slider_set_soft(g->contrast, p->contrast);
-  dt_bauhaus_slider_set_soft(g->saturation, p->saturation);
-  dt_bauhaus_slider_set_soft(g->balance, p->balance);
-
-  dt_bauhaus_combobox_set_from_value(g->version, p->version);
-  dt_bauhaus_combobox_set_from_value(g->preserve_color, p->preserve_color);
-  dt_bauhaus_combobox_set_from_value(g->shadows, p->shadows);
-  dt_bauhaus_combobox_set_from_value(g->highlights, p->highlights);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->auto_hardness), p->auto_hardness);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->custom_grey), p->custom_grey);
-
-  dt_bauhaus_slider_set_soft(g->high_quality_reconstruction, p->high_quality_reconstruction);
-  dt_bauhaus_slider_set_soft(g->noise_level, p->noise_level);
-  dt_bauhaus_combobox_set(g->noise_distribution, p->noise_distribution);
 
   gui_changed(self, NULL, NULL);
 }

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -618,12 +618,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
-  dt_iop_global_tonemap_params_t *p = (dt_iop_global_tonemap_params_t *)self->params;
-
-  dt_bauhaus_combobox_set(g->operator, p->operator);
-  dt_bauhaus_slider_set(g->drago.bias, p->drago.bias);
-  dt_bauhaus_slider_set(g->drago.max_light, p->drago.max_light);
-  dt_bauhaus_slider_set(g->detail, p->detail);
 
   gui_changed(self, NULL, 0);
 
@@ -640,7 +634,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->lwmax = NAN;
   g->hash = 0;
 
-  g->operator= dt_bauhaus_combobox_from_params(self, N_("operator"));
+  g->operator = dt_bauhaus_combobox_from_params(self, N_("operator"));
   gtk_widget_set_tooltip_text(g->operator, _("the global tonemap operator"));
 
   g->drago.bias = dt_bauhaus_slider_from_params(self, "drago.bias");

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -642,7 +642,6 @@ void gui_init(struct dt_iop_module_t *self)
                                                "the higher the more details in blacks"));
 
   g->drago.max_light = dt_bauhaus_slider_from_params(self, "drago.max_light");
-  dt_bauhaus_slider_set_step(g->drago.max_light, 10);
   gtk_widget_set_tooltip_text(g->drago.max_light, _("the target light for tonemapper specified as cd/m2"));
 
   g->detail = dt_bauhaus_slider_from_params(self, N_("detail"));

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1095,22 +1095,22 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_graduatednd_gui_data_t *g = IOP_GUI_ALLOC(graduatednd);
 
   g->density = dt_bauhaus_slider_from_params(self, "density");
-  dt_bauhaus_slider_set_format(g->density, _("%.2f EV"));
+  dt_bauhaus_slider_set_format(g->density, _(" EV"));
   gtk_widget_set_tooltip_text(g->density, _("the density in EV for the filter"));
 
   g->hardness = dt_bauhaus_slider_from_params(self, "hardness");
-  dt_bauhaus_slider_set_format(g->hardness, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->hardness, "%");
   /* xgettext:no-c-format */
   gtk_widget_set_tooltip_text(g->hardness, _("hardness of graduation:\n0% = soft, 100% = hard"));
 
   g->rotation = dt_bauhaus_slider_from_params(self, "rotation");
-  dt_bauhaus_slider_set_format(g->rotation, "%.2f°");
+  dt_bauhaus_slider_set_format(g->rotation, "°");
   gtk_widget_set_tooltip_text(g->rotation, _("rotation of filter -180 to 180 degrees"));
 
   g->hue = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, dt_bauhaus_slider_from_params(self, "hue"));
   dt_bauhaus_slider_set_feedback(g->hue, 0);
   dt_bauhaus_slider_set_factor(g->hue, 360.0f);
-  dt_bauhaus_slider_set_format(g->hue, "%.2f°");
+  dt_bauhaus_slider_set_format(g->hue, "°");
   dt_bauhaus_slider_set_stop(g->hue, 0.0f, 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.322f, 0.0f, 1.0f, 0.0f);
@@ -1121,8 +1121,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue, _("select the hue tone of filter"));
 
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
-  dt_bauhaus_slider_set_factor(g->saturation, 100.0f);
-  dt_bauhaus_slider_set_format(g->saturation, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->saturation, "%");
   dt_bauhaus_slider_set_stop(g->saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(g->saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   gtk_widget_set_tooltip_text(g->saturation, _("select the saturation of filter"));

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1086,12 +1086,6 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
-  dt_bauhaus_slider_set(g->density, p->density);
-  dt_bauhaus_slider_set(g->hardness, p->hardness);
-  dt_bauhaus_slider_set(g->rotation, p->rotation);
-  dt_bauhaus_slider_set(g->hue, p->hue);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-
   g->define = 0;
   update_saturation_slider_end_color(g->saturation, p->hue);
 }

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -551,16 +551,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_grain_gui_data_t *g = (dt_iop_grain_gui_data_t *)self->gui_data;
-  dt_iop_grain_params_t *p = (dt_iop_grain_params_t *)self->params;
-
-  dt_bauhaus_slider_set(g->scale, p->scale);
-  dt_bauhaus_slider_set(g->strength, p->strength);
-  dt_bauhaus_slider_set(g->midtones_bias, p->midtones_bias);
-}
-
 void init_global(struct dt_iop_module_so_t *self)
 {
   _simplex_noise_init();

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -563,17 +563,16 @@ void gui_init(struct dt_iop_module_t *self)
   /* courseness */
   g->scale = dt_bauhaus_slider_from_params(self, "scale");
   dt_bauhaus_slider_set_factor(g->scale, GRAIN_SCALE_FACTOR);
-  dt_bauhaus_slider_set_step(g->scale, 20.0/GRAIN_SCALE_FACTOR);
-  dt_bauhaus_slider_set_digits(g->scale, 5);
-  dt_bauhaus_slider_set_format(g->scale, _("%.0f ISO"));
+  dt_bauhaus_slider_set_digits(g->scale, 0);
+  dt_bauhaus_slider_set_format(g->scale, " ISO");
   gtk_widget_set_tooltip_text(g->scale, _("the grain size (~ISO of the film)"));
 
   g->strength = dt_bauhaus_slider_from_params(self, N_("strength"));
-  dt_bauhaus_slider_set_format(g->strength, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->strength, "%");
   gtk_widget_set_tooltip_text(g->strength, _("the strength of applied grain"));
 
   g->midtones_bias = dt_bauhaus_slider_from_params(self, "midtones_bias");
-  dt_bauhaus_slider_set_format(g->midtones_bias, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->midtones_bias, "%");
   gtk_widget_set_tooltip_text(g->midtones_bias, _("amount of mid-tones bias from the photographic paper response modeling. the greater the bias, the more pronounced the fall off of the grain in shadows and highlights"));
 }
 

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -201,7 +201,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->strength, _("amount of haze reduction"));
 
   g->distance = dt_bauhaus_slider_from_params(self, N_("distance"));
-  dt_bauhaus_slider_set_step(g->distance, 0.005);
   dt_bauhaus_slider_set_digits(g->distance, 3);
   gtk_widget_set_tooltip_text(g->distance, _("limit haze removal up to a specific spatial depth"));
 }

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -176,9 +176,6 @@ void cleanup_global(dt_iop_module_so_t *self)
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
-  dt_iop_hazeremoval_params_t *p = (dt_iop_hazeremoval_params_t *)self->params;
-  dt_bauhaus_slider_set(g->strength, p->strength);
-  dt_bauhaus_slider_set(g->distance, p->distance);
 
   dt_iop_gui_enter_critical_section(self);
   g->distance_max = NAN;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -959,15 +959,6 @@ void gui_update(struct dt_iop_module_t *self)
   self->default_enabled = dt_image_is_rawprepare_supported(&self->dev->image_storage) && !monochrome;
   self->hide_enable_button = monochrome;
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "default" : "monochrome");
-
-  if(!monochrome)
-  {
-    dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-    dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
-
-    dt_bauhaus_slider_set(g->clip, p->clip);
-    dt_bauhaus_combobox_set(g->mode, p->mode);
-  }
 }
 
 void reload_defaults(dt_iop_module_t *module)

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -363,14 +363,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_highpass_gui_data_t *g = (dt_iop_highpass_gui_data_t *)self->gui_data;
-  dt_iop_highpass_params_t *p = (dt_iop_highpass_params_t *)self->params;
-  dt_bauhaus_slider_set(g->sharpness, p->sharpness);
-  dt_bauhaus_slider_set(g->contrast, p->contrast);
-}
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 4; // highpass.cl, from programs.conf

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -392,11 +392,11 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_highpass_gui_data_t *g = IOP_GUI_ALLOC(highpass);
 
   g->sharpness = dt_bauhaus_slider_from_params(self, N_("sharpness"));
-  dt_bauhaus_slider_set_format(g->sharpness, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->sharpness, "%");
   gtk_widget_set_tooltip_text(g->sharpness, _("the sharpness of highpass filter"));
 
   g->contrast = dt_bauhaus_slider_from_params(self, "contrast");
-  dt_bauhaus_slider_set_format(g->contrast, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("the contrast of highpass filter"));
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -383,7 +383,6 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(box_raw), "draw", G_CALLBACK(draw), self);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
-  dt_bauhaus_slider_set_step(g->threshold, 0.005);
   dt_bauhaus_slider_set_digits(g->threshold, 4);
   gtk_widget_set_tooltip_text(g->threshold, _("lower threshold for hot pixel"));
 

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -341,8 +341,6 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)self->gui_data;
   dt_iop_hotpixels_params_t *p = (dt_iop_hotpixels_params_t *)self->params;
-  dt_bauhaus_slider_set(g->strength, p->strength);
-  dt_bauhaus_slider_set(g->threshold, p->threshold);
   gtk_toggle_button_set_active(g->markfixed, p->markfixed);
   gtk_toggle_button_set_active(g->permissive, p->permissive);
   g->pixels_fixed = -1;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -372,7 +372,7 @@ static lfModifier * get_modifier(int *mods_done, int w, int h, const dt_iop_lens
    the builtin correction works with subtle differences for the color channels leading to some colorizing of the images.
  How is this fixed here:
    Monochrome images (from pure monochrome cameras or cameras with the color filter removed from the sensor) have
-   all three rgb colors set to the same value by the demosaicer. 
+   all three rgb colors set to the same value by the demosaicer.
    Looking through lensfun code & docs the ApplySubpixelGeometryDistortion algorithm makes assumptions from given
    coeffs how far data are displaced for the different wavelengths of light.
    As green / Y channel is the most centric i took that as the canonical value instead of taking the mean.
@@ -2392,7 +2392,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   // scale
   g->scale = dt_bauhaus_slider_from_params(self, N_("scale"));
-  dt_bauhaus_slider_set_step(g->scale, 0.005);
   dt_bauhaus_slider_set_digits(g->scale, 3);
   dt_bauhaus_widget_set_quad_paint(g->scale, dtgtk_cairo_paint_refresh, 0, NULL);
   g_signal_connect(G_OBJECT(g->scale), "quad-pressed", G_CALLBACK(autoscale_pressed), self);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2476,9 +2476,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->target_geom, p->target_geom - LF_UNKNOWN - 1);
   dt_bauhaus_combobox_set(g->reverse, p->inverse);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->tca_override), p->tca_override);
-  dt_bauhaus_slider_set(g->tca_r, p->tca_r);
-  dt_bauhaus_slider_set(g->tca_b, p->tca_b);
-  dt_bauhaus_slider_set(g->scale, p->scale);
   const lfCamera **cam = NULL;
   g->camera = NULL;
   if(p->camera[0])

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -663,17 +663,14 @@ void gui_init(dt_iop_module_t *self)
   c->percentile_black = dt_bauhaus_slider_from_params(self, N_("black"));
   gtk_widget_set_tooltip_text(c->percentile_black, _("black percentile"));
   dt_bauhaus_slider_set_format(c->percentile_black, "%");
-  dt_bauhaus_slider_set_step(c->percentile_black, 0.1);
 
   c->percentile_grey = dt_bauhaus_slider_from_params(self, N_("gray"));
   gtk_widget_set_tooltip_text(c->percentile_grey, _("gray percentile"));
   dt_bauhaus_slider_set_format(c->percentile_grey, "%");
-  dt_bauhaus_slider_set_step(c->percentile_grey, 0.1);
 
   c->percentile_white = dt_bauhaus_slider_from_params(self, N_("white"));
   gtk_widget_set_tooltip_text(c->percentile_white, _("white percentile"));
   dt_bauhaus_slider_set_format(c->percentile_white, "%");
-  dt_bauhaus_slider_set_step(c->percentile_white, 0.1);
 
   gtk_stack_add_named(GTK_STACK(c->mode_stack), vbox_automatic, "automatic");
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -550,9 +550,6 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->mode, p->mode);
-  dt_bauhaus_slider_set(g->percentile_black, p->black);
-  dt_bauhaus_slider_set(g->percentile_grey, p->gray);
-  dt_bauhaus_slider_set(g->percentile_white, p->white);
 
   gui_changed(self, g->mode, 0);
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -662,17 +662,17 @@ void gui_init(dt_iop_module_t *self)
 
   c->percentile_black = dt_bauhaus_slider_from_params(self, N_("black"));
   gtk_widget_set_tooltip_text(c->percentile_black, _("black percentile"));
-  dt_bauhaus_slider_set_format(c->percentile_black, "%.1f%%");
+  dt_bauhaus_slider_set_format(c->percentile_black, "%");
   dt_bauhaus_slider_set_step(c->percentile_black, 0.1);
 
   c->percentile_grey = dt_bauhaus_slider_from_params(self, N_("gray"));
   gtk_widget_set_tooltip_text(c->percentile_grey, _("gray percentile"));
-  dt_bauhaus_slider_set_format(c->percentile_grey, "%.1f%%");
+  dt_bauhaus_slider_set_format(c->percentile_grey, "%");
   dt_bauhaus_slider_set_step(c->percentile_grey, 0.1);
 
   c->percentile_white = dt_bauhaus_slider_from_params(self, N_("white"));
   gtk_widget_set_tooltip_text(c->percentile_white, _("white percentile"));
-  dt_bauhaus_slider_set_format(c->percentile_white, "%.1f%%");
+  dt_bauhaus_slider_set_format(c->percentile_white, "%");
   dt_bauhaus_slider_set_step(c->percentile_white, 0.1);
 
   gtk_stack_add_named(GTK_STACK(c->mode_stack), vbox_automatic, "automatic");

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -847,7 +847,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(lowlight_scrolled), self);
 
   c->scale_blueness = dt_bauhaus_slider_from_params(self, "blueness");
-  dt_bauhaus_slider_set_format(c->scale_blueness, "%0.2f%%");
+  dt_bauhaus_slider_set_format(c->scale_blueness, "%");
   gtk_widget_set_tooltip_text(c->scale_blueness, _("blueness in shadows"));
 }
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -573,7 +573,6 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_lowpass_gui_data_t *g = IOP_GUI_ALLOC(lowpass);
 
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
-  dt_bauhaus_slider_set_step(g->radius, 0.1);
   g->lowpass_algo = dt_bauhaus_combobox_from_params(self, "lowpass_algo");
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -540,18 +540,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_lowpass_gui_data_t *g = (dt_iop_lowpass_gui_data_t *)self->gui_data;
-  dt_iop_lowpass_params_t *p = (dt_iop_lowpass_params_t *)self->params;
-  dt_bauhaus_slider_set(g->radius, p->radius);
-  dt_bauhaus_combobox_set(g->lowpass_algo, p->lowpass_algo);
-  dt_bauhaus_slider_set(g->contrast, p->contrast);
-  dt_bauhaus_slider_set(g->brightness, p->brightness);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-  // gtk_combo_box_set_active(g->order, p->order);
-}
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 6; // gaussian.cl, from programs.conf

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1489,7 +1489,7 @@ gboolean check_extension(char *filename)
   return res;
 }
 
-static gint list_str_cmp(gconstpointer a, gconstpointer b)
+static gint array_str_cmp(gconstpointer a, gconstpointer b)
 {
   return g_strcmp0(((dt_bauhaus_combobox_entry_t *)a)->label, ((dt_bauhaus_combobox_entry_t *)b)->label);
 }
@@ -1524,7 +1524,7 @@ static void update_filepath_combobox(dt_iop_lut3d_gui_data_t *g, char *filepath,
       }
       dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(g->filepath);
       dt_bauhaus_combobox_data_t *combo_data = &w->data.combobox;
-      combo_data->entries = g_list_sort(combo_data->entries, list_str_cmp);
+      g_ptr_array_sort(combo_data->entries, array_str_cmp);
       closedir(d);
     }
     if (!dt_bauhaus_combobox_set_from_text(g->filepath, filepath))

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1644,8 +1644,6 @@ void gui_update(dt_iop_module_t *self)
     update_filepath_combobox(g, p->filepath, lutfolder);
   }
   g_free(lutfolder);
-  dt_bauhaus_combobox_set(g->colorspace, p->colorspace);
-  dt_bauhaus_combobox_set(g->interpolation, p->interpolation);
 
   _show_hide_colorspace(self);
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -349,10 +349,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
-  dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
-  dt_bauhaus_slider_set(g->highlights, p->highlights);
   g->dragging = FALSE;
-  gtk_widget_queue_draw(self->widget);
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -823,7 +823,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->Dmin_R = dt_bauhaus_slider_from_params(self, "Dmin[0]");
   dt_bauhaus_slider_set_digits(g->Dmin_R, 4);
-  dt_bauhaus_slider_set_step(g->Dmin_R, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_R, "%");
   dt_bauhaus_slider_set_factor(g->Dmin_R, 100);
   dt_bauhaus_widget_set_label(g->Dmin_R, NULL, N_("D min red component"));
@@ -834,7 +833,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->Dmin_G = dt_bauhaus_slider_from_params(self, "Dmin[1]");
   dt_bauhaus_slider_set_digits(g->Dmin_G, 4);
-  dt_bauhaus_slider_set_step(g->Dmin_G, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_G, "%");
   dt_bauhaus_slider_set_factor(g->Dmin_G, 100);
   dt_bauhaus_widget_set_label(g->Dmin_G, NULL, N_("D min green component"));
@@ -845,7 +843,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->Dmin_B = dt_bauhaus_slider_from_params(self, "Dmin[2]");
   dt_bauhaus_slider_set_digits(g->Dmin_B, 4);
-  dt_bauhaus_slider_set_step(g->Dmin_B, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_B, "%");
   dt_bauhaus_slider_set_factor(g->Dmin_B, 100);
   dt_bauhaus_widget_set_label(g->Dmin_B, NULL, N_("D min blue component"));
@@ -957,7 +954,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->black = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "black"));
   dt_bauhaus_slider_set_digits(g->black, 4);
-  dt_bauhaus_slider_set_step(g->black, 0.0005);
   dt_bauhaus_slider_set_factor(g->black, 100);
   dt_bauhaus_slider_set_format(g->black, "%");
   gtk_widget_set_tooltip_text(g->black, _("correct the density of black after the inversion,\n"

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -824,7 +824,7 @@ void gui_init(dt_iop_module_t *self)
   g->Dmin_R = dt_bauhaus_slider_from_params(self, "Dmin[0]");
   dt_bauhaus_slider_set_digits(g->Dmin_R, 4);
   dt_bauhaus_slider_set_step(g->Dmin_R, 0.0025);
-  dt_bauhaus_slider_set_format(g->Dmin_R, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->Dmin_R, "%");
   dt_bauhaus_slider_set_factor(g->Dmin_R, 100);
   dt_bauhaus_widget_set_label(g->Dmin_R, NULL, N_("D min red component"));
   gtk_widget_set_tooltip_text(g->Dmin_R, _("adjust the color and shade of the film transparent base.\n"
@@ -835,7 +835,7 @@ void gui_init(dt_iop_module_t *self)
   g->Dmin_G = dt_bauhaus_slider_from_params(self, "Dmin[1]");
   dt_bauhaus_slider_set_digits(g->Dmin_G, 4);
   dt_bauhaus_slider_set_step(g->Dmin_G, 0.0025);
-  dt_bauhaus_slider_set_format(g->Dmin_G, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->Dmin_G, "%");
   dt_bauhaus_slider_set_factor(g->Dmin_G, 100);
   dt_bauhaus_widget_set_label(g->Dmin_G, NULL, N_("D min green component"));
   gtk_widget_set_tooltip_text(g->Dmin_G, _("adjust the color and shade of the film transparent base.\n"
@@ -846,7 +846,7 @@ void gui_init(dt_iop_module_t *self)
   g->Dmin_B = dt_bauhaus_slider_from_params(self, "Dmin[2]");
   dt_bauhaus_slider_set_digits(g->Dmin_B, 4);
   dt_bauhaus_slider_set_step(g->Dmin_B, 0.0025);
-  dt_bauhaus_slider_set_format(g->Dmin_B, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->Dmin_B, "%");
   dt_bauhaus_slider_set_factor(g->Dmin_B, 100);
   dt_bauhaus_widget_set_label(g->Dmin_B, NULL, N_("D min blue component"));
   gtk_widget_set_tooltip_text(g->Dmin_B, _("adjust the color and shade of the film transparent base.\n"
@@ -859,7 +859,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(_("dynamic range of the film")), FALSE, FALSE, 0);
 
   g->D_max = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "D_max"));
-  dt_bauhaus_slider_set_format(g->D_max, "%.2f dB");
+  dt_bauhaus_slider_set_format(g->D_max, " dB");
   gtk_widget_set_tooltip_text(g->D_max, _("maximum density of the film, corresponding to white after inversion.\n"
                                           "this value depends on the film specifications, the developing process,\n"
                                           "the dynamic range of the scene and the scanner exposure settings."));
@@ -867,7 +867,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(_("scanner exposure settings")), FALSE, FALSE, 0);
 
   g->offset = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "offset"));
-  dt_bauhaus_slider_set_format(g->offset, "%+.2f dB");
+  dt_bauhaus_slider_set_format(g->offset, " dB");
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->offset);
   gtk_widget_set_tooltip_text(g->offset, _("correct the exposure of the scanner, for all RGB channels,\n"
                                            "before the inversion, so blacks are neither clipped or too pale."));
@@ -959,7 +959,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->black, 4);
   dt_bauhaus_slider_set_step(g->black, 0.0005);
   dt_bauhaus_slider_set_factor(g->black, 100);
-  dt_bauhaus_slider_set_format(g->black, "%+.2f %%");
+  dt_bauhaus_slider_set_format(g->black, "%");
   gtk_widget_set_tooltip_text(g->black, _("correct the density of black after the inversion,\n"
                                           "to adjust the global contrast while avoiding clipping shadows."));
 
@@ -972,7 +972,7 @@ void gui_init(dt_iop_module_t *self)
   g->soft_clip = dt_bauhaus_slider_from_params(self, "soft_clip");
   dt_bauhaus_slider_set_factor(g->soft_clip, 100);
   dt_bauhaus_slider_set_digits(g->soft_clip, 4);
-  dt_bauhaus_slider_set_format(g->soft_clip, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->soft_clip, "%");
   gtk_widget_set_tooltip_text(g->soft_clip, _("gradually compress specular highlights past this value\n"
                                               "to avoid clipping while pushing the exposure for mid-tones.\n"
                                               "this somewhat reproduces the behaviour of matte paper."));
@@ -984,7 +984,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_min(g->exposure, -1.0);
   dt_bauhaus_slider_set_hard_max(g->exposure, 1.0);
   dt_bauhaus_slider_set_default(g->exposure, 0.0);
-  dt_bauhaus_slider_set_format(g->exposure, "%+.2f EV");
+  dt_bauhaus_slider_set_format(g->exposure, _(" EV"));
   gtk_widget_set_tooltip_text(g->exposure, _("correct the printing exposure after inversion to adjust\n"
                                              "the global contrast and avoid clipping highlights."));
 

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -1042,34 +1042,8 @@ void gui_update(dt_iop_module_t *const self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
-  dt_bauhaus_combobox_set(g->film_stock, p->film_stock);
 
-  // Dmin
-  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0]);
-  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1]);
-  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2]);
-
-  // Dmax
-  dt_bauhaus_slider_set(g->D_max, p->D_max);
-
-  // Scanner exposure offset
-  dt_bauhaus_slider_set(g->offset, p->offset);
-
-  // WB_high
-  dt_bauhaus_slider_set(g->wb_high_R, p->wb_high[0]);
-  dt_bauhaus_slider_set(g->wb_high_G, p->wb_high[1]);
-  dt_bauhaus_slider_set(g->wb_high_B, p->wb_high[2]);
-
-  // WB_low
-  dt_bauhaus_slider_set(g->wb_low_R, p->wb_low[0]);
-  dt_bauhaus_slider_set(g->wb_low_G, p->wb_low[1]);
-  dt_bauhaus_slider_set(g->wb_low_B, p->wb_low[2]);
-
-  // Print
   dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));     // warning: GUI is in EV
-  dt_bauhaus_slider_set(g->black, p->black);
-  dt_bauhaus_slider_set(g->gamma, p->gamma);
-  dt_bauhaus_slider_set(g->soft_clip, p->soft_clip);
 
   // Update custom stuff
   gui_changed(self, NULL, NULL);

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -504,17 +504,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(dt_iop_module_t *self)
-{
-  // let gui slider match current parameters:
-  dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
-  dt_iop_nlmeans_params_t *p = (dt_iop_nlmeans_params_t *)self->params;
-  dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  dt_bauhaus_slider_set_soft(g->strength, p->strength);
-  dt_bauhaus_slider_set(g->luma, p->luma);
-  dt_bauhaus_slider_set(g->chroma, p->chroma);
-}
-
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_nlmeans_gui_data_t *g = IOP_GUI_ALLOC(nlmeans);

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -511,20 +511,17 @@ void gui_init(dt_iop_module_t *self)
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_max(g->radius, 4.0f);
   dt_bauhaus_slider_set_digits(g->radius, 0);
-  dt_bauhaus_slider_set_format(g->radius, "%.0f");
   gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match"));
   g->strength = dt_bauhaus_slider_from_params(self, N_("strength"));
   dt_bauhaus_slider_set_soft_max(g->strength, 100.0f);
   dt_bauhaus_slider_set_digits(g->strength, 0);
-  dt_bauhaus_slider_set_format(g->strength, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->strength, "%");
   gtk_widget_set_tooltip_text(g->strength, _("strength of the effect"));
   g->luma = dt_bauhaus_slider_from_params(self, N_("luma"));
-  dt_bauhaus_slider_set_factor(g->luma, 100.0f);
-  dt_bauhaus_slider_set_format(g->luma, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->luma, "%");
   gtk_widget_set_tooltip_text(g->luma, _("how much to smooth brightness"));
   g->chroma = dt_bauhaus_slider_from_params(self, N_("chroma"));
-  dt_bauhaus_slider_set_factor(g->chroma, 100.0f);
-  dt_bauhaus_slider_set_format(g->chroma, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->chroma, "%");
   gtk_widget_set_tooltip_text(g->chroma, _("how much to smooth colors"));
 }
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -642,7 +642,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->grey_point
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point"));
-  dt_bauhaus_slider_set_step(g->grey_point, 0.5);
   dt_bauhaus_slider_set_format(g->grey_point, "%");
   gtk_widget_set_tooltip_text(g->grey_point, _("adjust to match the average luma of the subject"));
 
@@ -661,7 +660,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(_("optimize automatically")), FALSE, FALSE, 0);
 
   g->security_factor = dt_bauhaus_slider_from_params(self, "security_factor");
-  dt_bauhaus_slider_set_step(g->security_factor, 0.1);
   dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is useful when noise perturbates the measurements"));
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -587,17 +587,8 @@ void gui_reset(dt_iop_module_t *self)
 void gui_update(dt_iop_module_t *self)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
-
-  dt_bauhaus_combobox_set(g->mode, p->mode);
-  dt_bauhaus_slider_set_soft(g->linear, p->linear);
-  dt_bauhaus_slider_set_soft(g->gamma, p->gamma);
-  dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
-  dt_bauhaus_slider_set_soft(g->grey_point, p->grey_point);
-  dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
-  dt_bauhaus_slider_set_soft(g->security_factor, p->security_factor);
 
   gui_changed(self, g->mode, 0);
 }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -643,26 +643,26 @@ void gui_init(dt_iop_module_t *self)
   g->grey_point
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point"));
   dt_bauhaus_slider_set_step(g->grey_point, 0.5);
-  dt_bauhaus_slider_set_format(g->grey_point, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->grey_point, "%");
   gtk_widget_set_tooltip_text(g->grey_point, _("adjust to match the average luma of the subject"));
 
   g->shadows_range
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "shadows_range"));
   dt_bauhaus_slider_set_soft_max(g->shadows_range, 0.0);
-  dt_bauhaus_slider_set_format(g->shadows_range, "%.2f EV");
+  dt_bauhaus_slider_set_format(g->shadows_range, _(" EV"));
   gtk_widget_set_tooltip_text(g->shadows_range, _("number of stops between middle gray and pure black\nthis is a reading a posemeter would give you on the scene"));
 
   g->dynamic_range
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "dynamic_range"));
   dt_bauhaus_slider_set_soft_range(g->dynamic_range, 0.5, 16.0);
-  dt_bauhaus_slider_set_format(g->dynamic_range, "%.2f EV");
+  dt_bauhaus_slider_set_format(g->dynamic_range, _(" EV"));
   gtk_widget_set_tooltip_text(g->dynamic_range, _("number of stops between pure black and pure white\nthis is a reading a posemeter would give you on the scene"));
 
   gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(_("optimize automatically")), FALSE, FALSE, 0);
 
   g->security_factor = dt_bauhaus_slider_from_params(self, "security_factor");
   dt_bauhaus_slider_set_step(g->security_factor, 0.1);
-  dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is useful when noise perturbates the measurements"));
 
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -462,8 +462,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     p->shadows_range = EVmin;
 
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
-    dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
+    dt_bauhaus_slider_set(g->dynamic_range, p->dynamic_range);
+    dt_bauhaus_slider_set(g->shadows_range, p->shadows_range);
     --darktable.gui->reset;
   }
 }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -568,10 +568,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_rawdenoise_gui_data_t *g = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
-  dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
   dt_iop_cancel_history_update(self);
-  dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
   gtk_widget_queue_draw(self->widget);
 }
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -599,7 +599,7 @@ void gui_update(dt_iop_module_t *self)
       av += p->raw_black_level_separate[i];
 
     for(int i = 0; i < 4; i++)
-      dt_bauhaus_slider_set_soft(g->black_level_separate[i], av / 4);
+      dt_bauhaus_slider_set(g->black_level_separate[i], av / 4);
   }
 
   // don't show upper three black levels for monochromes
@@ -619,7 +619,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     {
       const int val = p->raw_black_level_separate[0];
       for(int i = 1; i < 4; i++)
-        dt_bauhaus_slider_set_soft(g->black_level_separate[i], val);
+        dt_bauhaus_slider_set(g->black_level_separate[i], val);
     }
   }
 }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -601,25 +601,10 @@ void gui_update(dt_iop_module_t *self)
     for(int i = 0; i < 4; i++)
       dt_bauhaus_slider_set_soft(g->black_level_separate[i], av / 4);
   }
-  else
-  {
-    for(int i = 0; i < 4; i++)
-      dt_bauhaus_slider_set_soft(g->black_level_separate[i], p->raw_black_level_separate[i]);
-  }
 
   // don't show upper three black levels for monochromes
   for(int i = 1; i < 4; i++)
     gtk_widget_set_visible(g->black_level_separate[i], !is_monochrome);
-
-  dt_bauhaus_slider_set_soft(g->white_point, p->raw_white_point);
-
-  if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
-  {
-    dt_bauhaus_slider_set_soft(g->x, p->x);
-    dt_bauhaus_slider_set_soft(g->y, p->y);
-    dt_bauhaus_slider_set_soft(g->width, p->width);
-    dt_bauhaus_slider_set_soft(g->height, p->height);
-  }
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -282,7 +282,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sliderbox), TRUE, FALSE, 0);
 
   g->width = dt_bauhaus_slider_from_params(self, N_("width"));
-  dt_bauhaus_slider_set_step(g->width, 0.5);
   gtk_widget_set_tooltip_text(g->width, _("width of fill-light area defined in zones"));
 }
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -264,7 +264,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_relight_gui_data_t *g = IOP_GUI_ALLOC(relight);
 
   g->exposure = dt_bauhaus_slider_from_params(self, "ev");
-  dt_bauhaus_slider_set_format(g->exposure, _("%.2f EV"));
+  dt_bauhaus_slider_set_format(g->exposure, _(" EV"));
   gtk_widget_set_tooltip_text(g->exposure, _("the fill-light in EV"));
 
   /* lightnessslider */
@@ -282,7 +282,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sliderbox), TRUE, FALSE, 0);
 
   g->width = dt_bauhaus_slider_from_params(self, N_("width"));
-  dt_bauhaus_slider_set_format(g->width, "%.1f");
   dt_bauhaus_slider_set_step(g->width, 0.5);
   gtk_widget_set_tooltip_text(g->width, _("width of fill-light area defined in zones"));
 }

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -237,8 +237,6 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)self->params;
-  dt_bauhaus_slider_set(g->exposure, p->ev);
-  dt_bauhaus_slider_set(g->width, p->width);
   dtgtk_gradient_slider_set_value(g->center, p->center);
 }
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2347,7 +2347,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->cmb_blur_type, _("type for the blur algorithm"));
 
   g->sl_blur_radius = dt_bauhaus_slider_from_params(self, "blur_radius");
-  dt_bauhaus_slider_set_step(g->sl_blur_radius, 0.1);
   dt_bauhaus_slider_set_format(g->sl_blur_radius, " px");
   gtk_widget_set_tooltip_text(g->sl_blur_radius, _("radius of the selected blur type"));
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2336,8 +2336,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->sl_fill_brightness = dt_bauhaus_slider_from_params(self, "fill_brightness");
   dt_bauhaus_slider_set_digits(g->sl_fill_brightness, 4);
-  dt_bauhaus_slider_set_factor(g->sl_fill_brightness, 100.0f);
-  dt_bauhaus_slider_set_format(g->sl_fill_brightness, "%+.2f%%");
+  dt_bauhaus_slider_set_format(g->sl_fill_brightness, "%");
   gtk_widget_set_tooltip_text(g->sl_fill_brightness,
                               _("adjusts color brightness to fine-tune it. works with erase as well"));
 
@@ -2349,14 +2348,13 @@ void gui_init(dt_iop_module_t *self)
 
   g->sl_blur_radius = dt_bauhaus_slider_from_params(self, "blur_radius");
   dt_bauhaus_slider_set_step(g->sl_blur_radius, 0.1);
-  dt_bauhaus_slider_set_format(g->sl_blur_radius, "%.1f px");
+  dt_bauhaus_slider_set_format(g->sl_blur_radius, " px");
   gtk_widget_set_tooltip_text(g->sl_blur_radius, _("radius of the selected blur type"));
 
   // mask opacity
   g->sl_mask_opacity = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.05, 1., 3);
   dt_bauhaus_widget_set_label(g->sl_mask_opacity, NULL, N_("mask opacity"));
-  dt_bauhaus_slider_set_factor(g->sl_mask_opacity, 100.0f);
-  dt_bauhaus_slider_set_format(g->sl_mask_opacity, "%.2f%%");
+  dt_bauhaus_slider_set_format(g->sl_mask_opacity, "%");
   gtk_widget_set_tooltip_text(g->sl_mask_opacity, _("set the opacity on the selected shape"));
   g_signal_connect(G_OBJECT(g->sl_mask_opacity), "value-changed", G_CALLBACK(rt_mask_opacity_callback), self);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2351,7 +2351,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->sl_blur_radius, _("radius of the selected blur type"));
 
   // mask opacity
-  g->sl_mask_opacity = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.05, 1., 3);
+  g->sl_mask_opacity = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0, 1., 3);
   dt_bauhaus_widget_set_label(g->sl_mask_opacity, NULL, N_("mask opacity"));
   dt_bauhaus_slider_set_format(g->sl_mask_opacity, "%");
   gtk_widget_set_tooltip_text(g->sl_mask_opacity, _("set the opacity on the selected shape"));

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -569,21 +569,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
   const int ch = g->channel;
   dt_iop_rgbcurve_node_t *curve = p->curve_nodes[ch];
 
-  float multiplier;
-
-  if(dt_modifier_is(state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
-
+  float multiplier = dt_accel_get_speed_multiplier(widget, state);
   dx *= multiplier;
   dy *= multiplier;
 

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -683,11 +683,11 @@ void gui_init(struct dt_iop_module_t *self)
   g->shadhi_algo = dt_bauhaus_combobox_from_params(self, "shadhi_algo");
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
   g->compress = dt_bauhaus_slider_from_params(self, N_("compress"));
-  dt_bauhaus_slider_set_format(g->compress, "%.02f%%");
+  dt_bauhaus_slider_set_format(g->compress, "%");
   g->shadows_ccorrect = dt_bauhaus_slider_from_params(self, "shadows_ccorrect");
-  dt_bauhaus_slider_set_format(g->shadows_ccorrect, "%.02f%%");
+  dt_bauhaus_slider_set_format(g->shadows_ccorrect, "%");
   g->highlights_ccorrect = dt_bauhaus_slider_from_params(self, "highlights_ccorrect");
-  dt_bauhaus_slider_set_format(g->highlights_ccorrect, "%.02f%%");
+  dt_bauhaus_slider_set_format(g->highlights_ccorrect, "%");
 
   gtk_widget_set_tooltip_text(g->shadows, _("correct shadows"));
   gtk_widget_set_tooltip_text(g->highlights, _("correct highlights"));

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -656,20 +656,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_shadhi_gui_data_t *g = (dt_iop_shadhi_gui_data_t *)self->gui_data;
-  dt_iop_shadhi_params_t *p = (dt_iop_shadhi_params_t *)self->params;
-  dt_bauhaus_slider_set(g->shadows, p->shadows);
-  dt_bauhaus_slider_set(g->highlights, p->highlights);
-  dt_bauhaus_slider_set(g->whitepoint, p->whitepoint);
-  dt_bauhaus_slider_set(g->radius, p->radius);
-  dt_bauhaus_combobox_set(g->shadhi_algo, p->shadhi_algo);
-  dt_bauhaus_slider_set(g->compress, p->compress);
-  dt_bauhaus_slider_set(g->shadows_ccorrect, p->shadows_ccorrect);
-  dt_bauhaus_slider_set(g->highlights_ccorrect, p->highlights_ccorrect);
-}
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 6; // gaussian.cl, from programs.conf

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -447,17 +447,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
   dt_bauhaus_slider_set_soft_max(g->radius, 8.0);
-  dt_bauhaus_slider_set_step(g->radius, 0.1);
   dt_bauhaus_slider_set_digits(g->radius, 3);
   gtk_widget_set_tooltip_text(g->radius, _("spatial extent of the unblurring"));
 
   g->amount = dt_bauhaus_slider_from_params(self, N_("amount"));
-  dt_bauhaus_slider_set_step(g->amount, 0.01);
   dt_bauhaus_slider_set_digits(g->amount, 3);
   gtk_widget_set_tooltip_text(g->amount, _("strength of the sharpen"));
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
-  dt_bauhaus_slider_set_step(g->threshold, 0.1);
   dt_bauhaus_slider_set_digits(g->threshold, 3);
   gtk_widget_set_tooltip_text(g->threshold, _("threshold to activate sharpen"));
 }

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -420,15 +420,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_sharpen_gui_data_t *g = (dt_iop_sharpen_gui_data_t *)self->gui_data;
-  dt_iop_sharpen_params_t *p = (dt_iop_sharpen_params_t *)self->params;
-  dt_bauhaus_slider_set_soft(g->radius, p->radius);
-  dt_bauhaus_slider_set(g->amount, p->amount);
-  dt_bauhaus_slider_set(g->threshold, p->threshold);
-}
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 7; // sharpen.cl, from programs.conf

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -393,19 +393,19 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_soften_gui_data_t *g = IOP_GUI_ALLOC(soften);
 
   g->size = dt_bauhaus_slider_from_params(self, N_("size"));
-  dt_bauhaus_slider_set_format(g->size, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->size, "%");
   gtk_widget_set_tooltip_text(g->size, _("the size of blur"));
 
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
-  dt_bauhaus_slider_set_format(g->saturation, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->saturation, "%");
   gtk_widget_set_tooltip_text(g->saturation, _("the saturation of blur"));
 
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));
-  dt_bauhaus_slider_set_format(g->brightness, _("%.2f EV"));
+  dt_bauhaus_slider_set_format(g->brightness, _(" EV"));
   gtk_widget_set_tooltip_text(g->brightness, _("the brightness of blur"));
 
   g->amount = dt_bauhaus_slider_from_params(self, "amount");
-  dt_bauhaus_slider_set_format(g->amount, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->amount, "%");
   gtk_widget_set_tooltip_text(g->amount, _("the mix of effect"));
 }
 

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -388,17 +388,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_soften_gui_data_t *g = (dt_iop_soften_gui_data_t *)self->gui_data;
-  dt_iop_soften_params_t *p = (dt_iop_soften_params_t *)self->params;
-  dt_bauhaus_slider_set(g->size, p->size);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-  dt_bauhaus_slider_set(g->brightness, p->brightness);
-  dt_bauhaus_slider_set(g->amount, p->amount);
-}
-
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_soften_gui_data_t *g = IOP_GUI_ALLOC(soften);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -532,6 +532,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->balance_scale = dt_bauhaus_slider_from_params(self, N_("balance"));
   dt_bauhaus_slider_set_feedback(g->balance_scale, 0);
+  dt_bauhaus_slider_set_digits(g->balance_scale, 4);
   dt_bauhaus_slider_set_factor(g->balance_scale, -100.0);
   dt_bauhaus_slider_set_offset(g->balance_scale, +100.0);
   dt_bauhaus_slider_set_stop(g->balance_scale, 0.0f, 0.5f, 0.5f, 0.5f);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -510,13 +510,13 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->shadow_hue_gslider = dt_bauhaus_slider_from_params(self, "shadow_hue");
   dt_bauhaus_slider_set_factor(g->shadow_hue_gslider, 360.0f);
-  dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "%.2f°");
+  dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "°");
   g->shadow_sat_gslider = dt_bauhaus_slider_from_params(self, "shadow_saturation");
 
   GtkWidget *highlights_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->highlight_hue_gslider = dt_bauhaus_slider_from_params(self, "highlight_hue");
   dt_bauhaus_slider_set_factor(g->highlight_hue_gslider, 360.0f);
-  dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "%.2f°");
+  dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "°");
   g->highlight_sat_gslider = dt_bauhaus_slider_from_params(self, "highlight_saturation");
   --darktable.bauhaus->skip_accel;
 
@@ -532,17 +532,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->balance_scale = dt_bauhaus_slider_from_params(self, N_("balance"));
   dt_bauhaus_slider_set_feedback(g->balance_scale, 0);
-  dt_bauhaus_slider_set_step(g->balance_scale, 0.001);
-  dt_bauhaus_slider_set_digits(g->balance_scale, 4);
   dt_bauhaus_slider_set_factor(g->balance_scale, -100.0);
   dt_bauhaus_slider_set_offset(g->balance_scale, +100.0);
-  dt_bauhaus_slider_set_format(g->balance_scale, "%.2f");
   dt_bauhaus_slider_set_stop(g->balance_scale, 0.0f, 0.5f, 0.5f, 0.5f);
   dt_bauhaus_slider_set_stop(g->balance_scale, 1.0f, 0.5f, 0.5f, 0.5f);
   gtk_widget_set_tooltip_text(g->balance_scale, _("the balance of center of split-toning"));
 
   g->compress_scale = dt_bauhaus_slider_from_params(self, N_("compress"));
-  dt_bauhaus_slider_set_format(g->compress_scale, "%.2f%%");
+  dt_bauhaus_slider_set_format(g->compress_scale, "%");
   gtk_widget_set_tooltip_text(g->compress_scale, _("compress the effect on highlights/shadows and\npreserve mid-tones"));
 }
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1926,14 +1926,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   //Match UI order: temp first, then tint (like every other app ever)
   g->scale_k = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,
-                                                             10., 5000.0, 0, feedback);
+                                                             0, 5000.0, 0, feedback);
   dt_bauhaus_slider_set_format(g->scale_k, " K");
   dt_bauhaus_widget_set_label(g->scale_k, NULL, N_("temperature"));
   gtk_widget_set_tooltip_text(g->scale_k, _("color temperature (in Kelvin)"));
   gtk_box_pack_start(box_enabled, g->scale_k, TRUE, TRUE, 0);
 
   g->scale_tint = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TINT, DT_IOP_HIGHEST_TINT,
-                                                                .01, 1.0, 3, feedback);
+                                                                0, 1.0, 3, feedback);
   dt_bauhaus_widget_set_label(g->scale_tint, NULL, N_("tint"));
   gtk_widget_set_tooltip_text(g->scale_tint, _("color tint of the image, from magenta (value < 1) to green (value > 1)"));
   gtk_box_pack_start(box_enabled, g->scale_tint, TRUE, TRUE, 0);
@@ -1997,7 +1997,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->presets, _("choose white balance setting"));
   gtk_box_pack_start(box_enabled, g->presets, TRUE, TRUE, 0);
 
-  g->finetune = dt_bauhaus_slider_new_with_range_and_feedback(self, -9.0, 9.0, 1.0, 0.0, 0, feedback);
+  g->finetune = dt_bauhaus_slider_new_with_range_and_feedback(self, -9.0, 9.0, 0, 0.0, 0, feedback);
   dt_bauhaus_widget_set_label(g->finetune, NULL, N_("finetune"));
   dt_bauhaus_slider_set_format(g->finetune, " mired");
   gtk_widget_set_tooltip_text(g->finetune, _("fine tune camera's white balance setting"));

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1954,10 +1954,6 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->scale_g, 3);
   dt_bauhaus_slider_set_digits(g->scale_b, 3);
   dt_bauhaus_slider_set_digits(g->scale_g2, 3);
-  dt_bauhaus_slider_set_step(g->scale_r, 0.05);
-  dt_bauhaus_slider_set_step(g->scale_g, 0.05);
-  dt_bauhaus_slider_set_step(g->scale_b, 0.05);
-  dt_bauhaus_slider_set_step(g->scale_g2, 0.05);
 
   gtk_widget_set_no_show_all(g->scale_g2, TRUE);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1927,7 +1927,7 @@ void gui_init(struct dt_iop_module_t *self)
   //Match UI order: temp first, then tint (like every other app ever)
   g->scale_k = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,
                                                              10., 5000.0, 0, feedback);
-  dt_bauhaus_slider_set_format(g->scale_k, "%.0f K");
+  dt_bauhaus_slider_set_format(g->scale_k, " K");
   dt_bauhaus_widget_set_label(g->scale_k, NULL, N_("temperature"));
   gtk_widget_set_tooltip_text(g->scale_k, _("color temperature (in Kelvin)"));
   gtk_box_pack_start(box_enabled, g->scale_k, TRUE, TRUE, 0);
@@ -2003,7 +2003,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->finetune = dt_bauhaus_slider_new_with_range_and_feedback(self, -9.0, 9.0, 1.0, 0.0, 0, feedback);
   dt_bauhaus_widget_set_label(g->finetune, NULL, N_("finetune"));
-  dt_bauhaus_slider_set_format(g->finetune, _("%.0f mired"));
+  dt_bauhaus_slider_set_format(g->finetune, " mired");
   gtk_widget_set_tooltip_text(g->finetune, _("fine tune camera's white balance setting"));
   gtk_box_pack_start(box_enabled, g->finetune, TRUE, TRUE, 0);
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -823,12 +823,9 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
-  dt_bauhaus_combobox_set_from_value(g->autoscale_ab, p->tonecurve_autoscale_ab);
-
   gui_changed(self, g->autoscale_ab, 0);
 
   dt_bauhaus_combobox_set(g->interpolator, p->tonecurve_type[ch_L]);
-  dt_bauhaus_combobox_set(g->preserve_colors, p->preserve_colors);
   g->loglogscale = eval_grey(dt_bauhaus_slider_get(g->logbase));
   // that's all, gui curve is read directly from params during expose event.
   gtk_widget_queue_draw(self->widget);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1209,7 +1209,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->preserve_colors = dt_bauhaus_combobox_from_params(self, "preserve_colors");
   gtk_widget_set_tooltip_text(c->preserve_colors, _("method to preserve colors when applying contrast"));
 
-  c->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0.5f, 0.0f, 2);
+  c->logbase = dt_bauhaus_slider_new_with_range(self, 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(c->logbase, NULL, N_("scale for graph"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1038,21 +1038,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
   int ch = c->channel;
   dt_iop_tonecurve_node_t *tonecurve = p->tonecurve[ch];
 
-  float multiplier;
-
-  if(dt_modifier_is(state, GDK_SHIFT_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-  }
-  else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-  }
-  else
-  {
-    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-  }
-
+  float multiplier = dt_accel_get_speed_multiplier(widget, state);
   dx *= multiplier;
   dy *= multiplier;
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1652,15 +1652,15 @@ void show_guiding_controls(struct dt_iop_module_t *self)
 void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g, dt_iop_toneequalizer_params_t *p)
 {
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->noise, p->noise);
-  dt_bauhaus_slider_set_soft(g->ultra_deep_blacks, p->ultra_deep_blacks);
-  dt_bauhaus_slider_set_soft(g->deep_blacks, p->deep_blacks);
-  dt_bauhaus_slider_set_soft(g->blacks, p->blacks);
-  dt_bauhaus_slider_set_soft(g->shadows, p->shadows);
-  dt_bauhaus_slider_set_soft(g->midtones, p->midtones);
-  dt_bauhaus_slider_set_soft(g->highlights, p->highlights);
-  dt_bauhaus_slider_set_soft(g->whites, p->whites);
-  dt_bauhaus_slider_set_soft(g->speculars, p->speculars);
+  dt_bauhaus_slider_set(g->noise, p->noise);
+  dt_bauhaus_slider_set(g->ultra_deep_blacks, p->ultra_deep_blacks);
+  dt_bauhaus_slider_set(g->deep_blacks, p->deep_blacks);
+  dt_bauhaus_slider_set(g->blacks, p->blacks);
+  dt_bauhaus_slider_set(g->shadows, p->shadows);
+  dt_bauhaus_slider_set(g->midtones, p->midtones);
+  dt_bauhaus_slider_set(g->highlights, p->highlights);
+  dt_bauhaus_slider_set(g->whites, p->whites);
+  dt_bauhaus_slider_set(g->speculars, p->speculars);
   --darktable.gui->reset;
 }
 
@@ -1670,7 +1670,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
-  dt_bauhaus_slider_set_soft(g->smoothing, logf(p->smoothing) / logf(sqrtf(2.0f)) - 1.0f);
+  dt_bauhaus_slider_set(g->smoothing, logf(p->smoothing) / logf(sqrtf(2.0f)) - 1.0f);
 
   show_guiding_controls(self);
   invalidate_luminance_cache(self);
@@ -1740,7 +1740,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
   {
     // activate module and do nothing
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
+    dt_bauhaus_slider_set(g->exposure_boost, p->exposure_boost);
     --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
@@ -1783,7 +1783,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 
   // Update the GUI stuff
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
+  dt_bauhaus_slider_set(g->exposure_boost, p->exposure_boost);
   --darktable.gui->reset;
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1807,7 +1807,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
   {
     // activate module and do nothing
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(g->contrast_boost, p->contrast_boost);
+    dt_bauhaus_slider_set(g->contrast_boost, p->contrast_boost);
     --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
@@ -1861,7 +1861,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
 
   // Update the GUI stuff
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->contrast_boost, p->contrast_boost);
+  dt_bauhaus_slider_set(g->contrast_boost, p->contrast_boost);
   --darktable.gui->reset;
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3195,8 +3195,8 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(area_motion_notify), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double-click to reset the curve"));
 
-  g->smoothing = dt_bauhaus_slider_new_with_range(self, -1.0f, +1.0f, 0.1, 0.0f, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->smoothing, -2.33f, 1.67f);
+  g->smoothing = dt_bauhaus_slider_new_with_range(self, -2.33f, +1.67f, 0.1, 0.0f, 2);
+  dt_bauhaus_slider_set_soft_range(g->smoothing, -1.0f, 1.0f);
   dt_bauhaus_widget_set_label(g->smoothing, NULL, N_("curve smoothing"));
   gtk_widget_set_tooltip_text(g->smoothing, _("positive values will produce more progressive tone transitions\n"
                                               "but the curve might become oscillatory in some settings.\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3186,7 +3186,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(area_motion_notify), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double-click to reset the curve"));
 
-  g->smoothing = dt_bauhaus_slider_new_with_range(self, -2.33f, +1.67f, 0.1, 0.0f, 2);
+  g->smoothing = dt_bauhaus_slider_new_with_range(self, -2.33f, +1.67f, 0, 0.0f, 2);
   dt_bauhaus_slider_set_soft_range(g->smoothing, -1.0f, 1.0f);
   dt_bauhaus_widget_set_label(g->smoothing, NULL, N_("curve smoothing"));
   gtk_widget_set_tooltip_text(g->smoothing, _("positive values will produce more progressive tone transitions\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3128,39 +3128,39 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
   dt_bauhaus_slider_set_step(g->noise, .05);
-  dt_bauhaus_slider_set_format(g->noise, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->noise, _(" EV"));
 
   g->ultra_deep_blacks = dt_bauhaus_slider_from_params(self, "ultra_deep_blacks");
   dt_bauhaus_slider_set_step(g->ultra_deep_blacks, .05);
-  dt_bauhaus_slider_set_format(g->ultra_deep_blacks, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->ultra_deep_blacks, _(" EV"));
 
   g->deep_blacks = dt_bauhaus_slider_from_params(self, "deep_blacks");
   dt_bauhaus_slider_set_step(g->deep_blacks, .05);
-  dt_bauhaus_slider_set_format(g->deep_blacks, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->deep_blacks, _(" EV"));
 
   g->blacks = dt_bauhaus_slider_from_params(self, "blacks");
   dt_bauhaus_slider_set_step(g->blacks, .05);
-  dt_bauhaus_slider_set_format(g->blacks, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->blacks, _(" EV"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
   dt_bauhaus_slider_set_step(g->shadows, .05);
-  dt_bauhaus_slider_set_format(g->shadows, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->shadows, _(" EV"));
 
   g->midtones = dt_bauhaus_slider_from_params(self, "midtones");
   dt_bauhaus_slider_set_step(g->midtones, .05);
-  dt_bauhaus_slider_set_format(g->midtones, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->midtones, _(" EV"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "highlights");
   dt_bauhaus_slider_set_step(g->highlights, .05);
-  dt_bauhaus_slider_set_format(g->highlights, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->highlights, _(" EV"));
 
   g->whites = dt_bauhaus_slider_from_params(self, "whites");
   dt_bauhaus_slider_set_step(g->whites, .05);
-  dt_bauhaus_slider_set_format(g->whites, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->whites, _(" EV"));
 
   g->speculars = dt_bauhaus_slider_from_params(self, "speculars");
   dt_bauhaus_slider_set_step(g->speculars, .05);
-  dt_bauhaus_slider_set_format(g->speculars, _("%+.2f EV"));
+  dt_bauhaus_slider_set_format(g->speculars, _(" EV"));
 
   dt_bauhaus_widget_set_label(g->noise, N_("simple"), N_("-8 EV"));
   dt_bauhaus_widget_set_label(g->ultra_deep_blacks, N_("simple"), N_("-7 EV"));
@@ -3229,7 +3229,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->blending = dt_bauhaus_slider_from_params(self, "blending");
   dt_bauhaus_slider_set_soft_range(g->blending, 1.0, 45.0);
-  dt_bauhaus_slider_set_format(g->blending, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->blending, "%");
   gtk_widget_set_tooltip_text(g->blending, _("diameter of the blur in percent of the largest image size\n"
                                              "warning: big values of this parameter can make the darkroom\n"
                                              "preview much slower if denoise profiled is used."));
@@ -3256,14 +3256,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->quantization = dt_bauhaus_slider_from_params(self, "quantization");
   dt_bauhaus_slider_set_step(g->quantization, 0.25);
-  dt_bauhaus_slider_set_format(g->quantization, "%+.2f EV");
+  dt_bauhaus_slider_set_format(g->quantization, _(" EV"));
   gtk_widget_set_tooltip_text(g->quantization, _("0 disables the quantization.\n"
                                                  "higher values posterize the luminance mask to help the guiding\n"
                                                  "produce piece-wise smooth areas when using high feathering values"));
 
   g->exposure_boost = dt_bauhaus_slider_from_params(self, "exposure_boost");
   dt_bauhaus_slider_set_soft_range(g->exposure_boost, -4.0, 4.0);
-  dt_bauhaus_slider_set_format(g->exposure_boost, "%+.2f EV");
+  dt_bauhaus_slider_set_format(g->exposure_boost, _(" EV"));
   gtk_widget_set_tooltip_text(g->exposure_boost, _("use this to slide the mask average exposure along channels\n"
                                                    "for a better control of the exposure correction with the available nodes.\n"
                                                    "the magic wand will auto-adjust the average exposure"));
@@ -3273,7 +3273,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->contrast_boost = dt_bauhaus_slider_from_params(self, "contrast_boost");
   dt_bauhaus_slider_set_soft_range(g->contrast_boost, -2.0, 2.0);
-  dt_bauhaus_slider_set_format(g->contrast_boost, "%+.2f EV");
+  dt_bauhaus_slider_set_format(g->contrast_boost, _(" EV"));
   gtk_widget_set_tooltip_text(g->contrast_boost, _("use this to counter the averaging effect of the guided filter\n"
                                                    "and dilate the mask contrast around -4EV\n"
                                                    "this allows to spread the exposure histogram over more channels\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3127,39 +3127,30 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("simple"), NULL);
 
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
-  dt_bauhaus_slider_set_step(g->noise, .05);
   dt_bauhaus_slider_set_format(g->noise, _(" EV"));
 
   g->ultra_deep_blacks = dt_bauhaus_slider_from_params(self, "ultra_deep_blacks");
-  dt_bauhaus_slider_set_step(g->ultra_deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->ultra_deep_blacks, _(" EV"));
 
   g->deep_blacks = dt_bauhaus_slider_from_params(self, "deep_blacks");
-  dt_bauhaus_slider_set_step(g->deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->deep_blacks, _(" EV"));
 
   g->blacks = dt_bauhaus_slider_from_params(self, "blacks");
-  dt_bauhaus_slider_set_step(g->blacks, .05);
   dt_bauhaus_slider_set_format(g->blacks, _(" EV"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
-  dt_bauhaus_slider_set_step(g->shadows, .05);
   dt_bauhaus_slider_set_format(g->shadows, _(" EV"));
 
   g->midtones = dt_bauhaus_slider_from_params(self, "midtones");
-  dt_bauhaus_slider_set_step(g->midtones, .05);
   dt_bauhaus_slider_set_format(g->midtones, _(" EV"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "highlights");
-  dt_bauhaus_slider_set_step(g->highlights, .05);
   dt_bauhaus_slider_set_format(g->highlights, _(" EV"));
 
   g->whites = dt_bauhaus_slider_from_params(self, "whites");
-  dt_bauhaus_slider_set_step(g->whites, .05);
   dt_bauhaus_slider_set_format(g->whites, _(" EV"));
 
   g->speculars = dt_bauhaus_slider_from_params(self, "speculars");
-  dt_bauhaus_slider_set_step(g->speculars, .05);
   dt_bauhaus_slider_set_format(g->speculars, _(" EV"));
 
   dt_bauhaus_widget_set_label(g->noise, N_("simple"), N_("-8 EV"));
@@ -3236,7 +3227,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->feathering = dt_bauhaus_slider_from_params(self, "feathering");
   dt_bauhaus_slider_set_soft_range(g->feathering, 0.1, 50.0);
-  dt_bauhaus_slider_set_step(g->feathering, 0.2);
   gtk_widget_set_tooltip_text(g->feathering, _("precision of the feathering :\n"
                                                "higher values force the mask to follow edges more closely\n"
                                                "but may void the effect of the smoothing\n"
@@ -3255,7 +3245,6 @@ void gui_init(struct dt_iop_module_t *self)
 
 
   g->quantization = dt_bauhaus_slider_from_params(self, "quantization");
-  dt_bauhaus_slider_set_step(g->quantization, 0.25);
   dt_bauhaus_slider_set_format(g->quantization, _(" EV"));
   gtk_widget_set_tooltip_text(g->quantization, _("0 disables the quantization.\n"
                                                  "higher values posterize the luminance mask to help the guiding\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1651,6 +1651,7 @@ void show_guiding_controls(struct dt_iop_module_t *self)
 
 void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g, dt_iop_toneequalizer_params_t *p)
 {
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->noise, p->noise);
   dt_bauhaus_slider_set_soft(g->ultra_deep_blacks, p->ultra_deep_blacks);
   dt_bauhaus_slider_set_soft(g->deep_blacks, p->deep_blacks);
@@ -1660,6 +1661,7 @@ void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g, dt_iop_toneequa
   dt_bauhaus_slider_set_soft(g->highlights, p->highlights);
   dt_bauhaus_slider_set_soft(g->whites, p->whites);
   dt_bauhaus_slider_set_soft(g->speculars, p->speculars);
+  --darktable.gui->reset;
 }
 
 
@@ -1668,17 +1670,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
-  update_exposure_sliders(g, p);
-
-  dt_bauhaus_combobox_set(g->method, p->method);
-  dt_bauhaus_combobox_set(g->details, p->details);
-  dt_bauhaus_slider_set_soft(g->blending, p->blending);
-  dt_bauhaus_slider_set_soft(g->feathering, p->feathering);
   dt_bauhaus_slider_set_soft(g->smoothing, logf(p->smoothing) / logf(sqrtf(2.0f)) - 1.0f);
-  dt_bauhaus_slider_set_soft(g->iterations, p->iterations);
-  dt_bauhaus_slider_set_soft(g->quantization, p->quantization);
-  dt_bauhaus_slider_set_soft(g->contrast_boost, p->contrast_boost);
-  dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
 
   show_guiding_controls(self);
   invalidate_luminance_cache(self);
@@ -2173,9 +2165,7 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
   if(commit)
   {
     // Update GUI with new params
-    ++darktable.gui->reset;
     update_exposure_sliders(g, p);
-    --darktable.gui->reset;
 
     dt_dev_add_history_item(darktable.develop, self, FALSE);
   }
@@ -2882,9 +2872,7 @@ static gboolean area_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gp
   if(g->area_dragging)
   {
     // cursor left area : force commit to avoid glitches
-    ++darktable.gui->reset;
     update_exposure_sliders(g, p);
-    --darktable.gui->reset;
 
     dt_dev_add_history_item(darktable.develop, self, FALSE);
   }
@@ -2927,9 +2915,7 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
     p->speculars = d->speculars;
 
     // update UI sliders
-    ++darktable.gui->reset;
     update_exposure_sliders(g, p);
-    --darktable.gui->reset;
 
     // Redraw graph
     gtk_widget_queue_draw(self->widget);
@@ -3023,9 +3009,7 @@ static gboolean area_button_release(GtkWidget *widget, GdkEventButton *event, gp
     if(g->area_dragging)
     {
       // Update GUI with new params
-      ++darktable.gui->reset;
       update_exposure_sliders(g, p);
-      --darktable.gui->reset;
 
       dt_dev_add_history_item(darktable.develop, self, FALSE);
 

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -229,7 +229,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->contrast = dt_bauhaus_slider_from_params(self, "contrast");
 
   g->Fsize = dt_bauhaus_slider_from_params(self, "Fsize");
-  dt_bauhaus_slider_set_format(g->Fsize, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->Fsize, "%");
 }
 }
 

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -222,14 +222,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void gui_update(struct dt_iop_module_t *self)
-{
-  dt_iop_tonemapping_gui_data_t *g = (dt_iop_tonemapping_gui_data_t *)self->gui_data;
-  dt_iop_tonemapping_params_t *p = (dt_iop_tonemapping_params_t *)self->params;
-  dt_bauhaus_slider_set(g->contrast, p->contrast);
-  dt_bauhaus_slider_set(g->Fsize, p->Fsize);
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_tonemapping_gui_data_t *g = IOP_GUI_ALLOC(tonemapping);

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -580,7 +580,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->factor, .1);
   dt_bauhaus_slider_set_digits(g->factor, 2);
   // Additional parameters determine how the value will be shown.
-  dt_bauhaus_slider_set_format(g->factor, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->factor, "%");
   // For a percentage, use factor 100.
   dt_bauhaus_slider_set_factor(g->factor, -100.0f);
   dt_bauhaus_slider_set_offset(g->factor, 100.0f);

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -414,7 +414,7 @@ static void extra_callback(GtkWidget *w, dt_iop_module_t *self)
   // Setting a widget value will trigger a callback that will update params.
   // If this is not desirable (because it might result in a cycle) then use
   // ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->factor, p->factor + extra);
+  dt_bauhaus_slider_set(g->factor, p->factor + extra);
   // and reverse with --darktable.gui->reset;
 
   // If any params updated directly, not via a callback, then

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -596,7 +596,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Any widgets that are _not_ directly linked to a field need to have a custom callback
   // function set up to respond to the "value-changed" signal.
-  g->extra = dt_bauhaus_slider_new_with_range(self, -0.5, 0.5, .01, 0, 2);
+  g->extra = dt_bauhaus_slider_new_with_range(self, -0.5, 0.5, 0, 0, 2);
   dt_bauhaus_widget_set_label(g->extra, NULL, N_("extra"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->extra), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->extra), "value-changed", G_CALLBACK(extra_callback), self);

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -264,7 +264,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_velvia_gui_data_t *g = IOP_GUI_ALLOC(velvia);
 
   g->strength_scale = dt_bauhaus_slider_from_params(self, N_("strength"));
-  dt_bauhaus_slider_set_format(g->strength_scale, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->strength_scale, "%");
   gtk_widget_set_tooltip_text(g->strength_scale, _("the strength of saturation boost"));
 
   g->bias_scale = dt_bauhaus_slider_from_params(self, "bias");

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -219,7 +219,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_vibrance_gui_data_t *g = IOP_GUI_ALLOC(vibrance);
 
   g->amount_scale = dt_bauhaus_slider_from_params(self, "amount");
-  dt_bauhaus_slider_set_format(g->amount_scale, "%.0f%%");
+  dt_bauhaus_slider_set_format(g->amount_scale, "%");
   gtk_widget_set_tooltip_text(g->amount_scale, _("the amount of vibrance"));
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -968,17 +968,8 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
-  dt_bauhaus_slider_set(g->scale, p->scale);
-  dt_bauhaus_slider_set(g->falloff_scale, p->falloff_scale);
-  dt_bauhaus_slider_set(g->brightness, p->brightness);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-  dt_bauhaus_slider_set(g->center_x, p->center.x);
-  dt_bauhaus_slider_set(g->center_y, p->center.y);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->autoratio), p->autoratio);
-  dt_bauhaus_slider_set(g->whratio, p->whratio);
-  dt_bauhaus_slider_set(g->shape, p->shape);
   gtk_widget_set_sensitive(GTK_WIDGET(g->whratio), !p->autoratio);
-  dt_bauhaus_combobox_set(g->dithering, p->dithering);
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -993,8 +993,8 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->center_y, 3);
   dt_bauhaus_slider_set_digits(g->whratio, 3);
 
-  dt_bauhaus_slider_set_format(g->scale, "%.02f%%");
-  dt_bauhaus_slider_set_format(g->falloff_scale, "%.02f%%");
+  dt_bauhaus_slider_set_format(g->scale, "%");
+  dt_bauhaus_slider_set_format(g->falloff_scale, "%");
 
   gtk_widget_set_tooltip_text(g->scale, _("the radii scale of vignette for start of fall-off"));
   gtk_widget_set_tooltip_text(g->falloff_scale, _("the radii scale of vignette for end of fall-off"));

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1126,12 +1126,12 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Add opacity/scale sliders to table
   g->opacity = dt_bauhaus_slider_from_params(self, N_("opacity"));
-  dt_bauhaus_slider_set_format(g->opacity, "%.f%%");
+  dt_bauhaus_slider_set_format(g->opacity, "%");
   g->scale = dt_bauhaus_slider_from_params(self, N_("scale"));
   dt_bauhaus_slider_set_soft_max(g->scale, 100.0);
-  dt_bauhaus_slider_set_format(g->scale, "%.f%%");
+  dt_bauhaus_slider_set_format(g->scale, "%");
   g->rotate = dt_bauhaus_slider_from_params(self, "rotate");
-  dt_bauhaus_slider_set_format(g->rotate, "%.02f°");
+  dt_bauhaus_slider_set_format(g->rotate, "°");
 
   g->sizeto = dt_bauhaus_combobox_from_params(self, "sizeto");
 //  dt_bauhaus_combobox_add(g->sizeto, C_("size", "image"));

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1021,18 +1021,12 @@ void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
-  dt_bauhaus_slider_set(g->opacity, p->opacity);
-  dt_bauhaus_slider_set_soft(g->scale, p->scale);
-  dt_bauhaus_slider_set(g->rotate, p->rotate);
-  dt_bauhaus_slider_set(g->x_offset, p->xoffset);
-  dt_bauhaus_slider_set(g->y_offset, p->yoffset);
   for(int i = 0; i < 9; i++)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->align[i]), FALSE);
   }
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->align[p->alignment]), TRUE);
   _combo_box_set_active_text(g, p->filename);
-  dt_bauhaus_combobox_set(g->sizeto, p->sizeto);
   gtk_entry_set_text(GTK_ENTRY(g->text), p->text);
   GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpick), &color);

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -153,20 +153,13 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
-static void _set_flag(GtkWidget *w, GtkStateFlags flag, gboolean over)
-{
-  int flags = gtk_widget_get_state_flags(w);
-  if(over)
-    flags |= flag;
-  else
-    flags &= ~flag;
-
-  gtk_widget_set_state_flags(w, flags, TRUE);
-}
-
 static gboolean _event_box_enter_leave(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
-  _set_flag(widget, GTK_STATE_FLAG_PRELIGHT, (event->type == GDK_ENTER_NOTIFY));
+  if(event->type == GDK_ENTER_NOTIFY)
+    gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_PRELIGHT, FALSE);
+  else
+    gtk_widget_unset_state_flags(widget, GTK_STATE_FLAG_PRELIGHT);
+
   return FALSE;
 }
 

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -494,7 +494,6 @@ static void _name_editing_done(GtkCellEditable *editable, dt_lib_module_t *self)
   g_object_get(editable, "editing-canceled", &canceled, NULL);
   const gchar *name = gtk_entry_get_text(GTK_ENTRY(editable));
   const gboolean reset = name[0] ? FALSE : TRUE;
-  dt_control_key_accelerators_on(darktable.control);
   GtkTreeIter iter;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->view));
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->view));
@@ -649,8 +648,6 @@ static void _name_start_editing(GtkCellRenderer *renderer, GtkCellEditable *edit
     gtk_tree_path_free(new_path);
 
     g_signal_connect(G_OBJECT(editable), "editing-done", G_CALLBACK(_name_editing_done), self);
-    // grab all keys for edition
-    dt_control_key_accelerators_off(darktable.control);
   }
 }
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -765,16 +765,9 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
   g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
 }
 
-static void _tree_cell_editing_started(GtkCellRenderer *cell, GtkCellEditable *editable, const gchar *path,
-                                       gpointer data)
-{
-  dt_control_key_accelerators_off(darktable.control);
-}
-
 static void _tree_cell_edited(GtkCellRendererText *cell, gchar *path_string, gchar *new_text,
                               dt_lib_module_t *self)
 {
-  dt_control_key_accelerators_on(darktable.control);
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
   GtkTreeIter iter;
@@ -1731,7 +1724,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_TEXT);
   gtk_tree_view_column_add_attribute(col, renderer, "editable", TREE_EDITABLE);
-  g_signal_connect(renderer, "editing-started", (GCallback)_tree_cell_editing_started, self);
   g_signal_connect(renderer, "edited", (GCallback)_tree_cell_edited, self);
   renderer = gtk_cell_renderer_pixbuf_new();
   gtk_tree_view_column_pack_end(col, renderer, FALSE);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -895,8 +895,10 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
     if(GTK_IS_ENTRY(event_widget))
       break;
 
-    if(event->button.button != GDK_BUTTON_PRIMARY)
+    if(event->button.button == GDK_BUTTON_SECONDARY)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
+    else if(event->button.button == GDK_BUTTON_MIDDLE)
+      dt_shortcut_dispatcher(event_widget, event, data);
     else if(dt_modifier_is(event->button.state, GDK_CONTROL_MASK))
     {
       if(darktable.develop)

--- a/src/libs/tools/viewswitcher.c
+++ b/src/libs/tools/viewswitcher.c
@@ -174,26 +174,16 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
-static void _lib_viewswitcher_enter_notify_callback(GtkWidget *w, GdkEventCrossing *e, gpointer user_data)
+static void _lib_viewswitcher_enter_leave_notify_callback(GtkWidget *w, GdkEventCrossing *e, gpointer user_data)
 {
   GtkLabel *l = (GtkLabel *)user_data;
 
   /* if not active view lets highlight */
-  if(strcmp(g_object_get_data(G_OBJECT(w), "view-label"), dt_view_manager_name(darktable.view_manager)))
-  {
-    gtk_widget_set_state_flags(GTK_WIDGET(l), GTK_STATE_FLAG_PRELIGHT, TRUE);
-  }
-}
-
-static void _lib_viewswitcher_leave_notify_callback(GtkWidget *w, GdkEventCrossing *e, gpointer user_data)
-{
-  GtkLabel *l = (GtkLabel *)user_data;
-
-  /* if not active view lets set default */
-  if(strcmp(g_object_get_data(G_OBJECT(w), "view-label"), dt_view_manager_name(darktable.view_manager)))
-  {
-    gtk_widget_set_state_flags(GTK_WIDGET(l), GTK_STATE_FLAG_NORMAL, TRUE);
-  }
+  if(e->type == GDK_ENTER_NOTIFY &&
+     strcmp(g_object_get_data(G_OBJECT(w), "view-label"), dt_view_manager_name(darktable.view_manager)))
+    gtk_widget_set_state_flags(GTK_WIDGET(l), GTK_STATE_FLAG_PRELIGHT, FALSE);
+  else
+    gtk_widget_unset_state_flags(GTK_WIDGET(l), GTK_STATE_FLAG_PRELIGHT);
 }
 
 static void _lib_viewswitcher_view_cannot_change_callback(gpointer instance, dt_view_t *old_view,
@@ -277,8 +267,8 @@ static GtkWidget *_lib_viewswitcher_create_label(dt_view_t *view)
   /* set enter/leave notify events and connect signals */
   gtk_widget_add_events(GTK_WIDGET(eb), GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
 
-  g_signal_connect(G_OBJECT(eb), "enter-notify-event", G_CALLBACK(_lib_viewswitcher_enter_notify_callback), b);
-  g_signal_connect(G_OBJECT(eb), "leave-notify-event", G_CALLBACK(_lib_viewswitcher_leave_notify_callback), b);
+  g_signal_connect(G_OBJECT(eb), "enter-notify-event", G_CALLBACK(_lib_viewswitcher_enter_leave_notify_callback), b);
+  g_signal_connect(G_OBJECT(eb), "leave-notify-event", G_CALLBACK(_lib_viewswitcher_enter_leave_notify_callback), b);
 
   return eb;
 }

--- a/src/lua/widget/combobox.c
+++ b/src/lua/widget/combobox.c
@@ -72,9 +72,7 @@ static int combobox_numindex(lua_State*L)
     lua_pushnil(L);
     return 1;
   }
-  const GList *entries = dt_bauhaus_combobox_get_entries(combobox->widget);
-  dt_bauhaus_combobox_entry_t *entry = (dt_bauhaus_combobox_entry_t *)g_list_nth_data((GList *)entries, key - 1);
-  lua_pushstring(L, entry->label);
+  lua_pushstring(L, dt_bauhaus_combobox_get_entry(combobox->widget, key - 1));
   return 1;
 }
 

--- a/src/lua/widget/slider.c
+++ b/src/lua/widget/slider.c
@@ -140,7 +140,7 @@ static int value_member(lua_State *L)
   luaA_to(L,lua_slider,&slider,1);
   if(lua_gettop(L) > 2) {
     float value = luaL_checknumber(L,3);
-    dt_bauhaus_slider_set_soft(slider->widget,value);
+    dt_bauhaus_slider_set(slider->widget,value);
     return 0;
   }
   lua_pushnumber(L,dt_bauhaus_slider_get(slider->widget));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2315,7 +2315,6 @@ void gui_init(dt_view_t *self)
                                  dev->rawoverexposed.mode, rawoverexposed_mode_callback, dev,
                                  N_("mark with CFA color"), N_("mark with solid color"), N_("false color"));
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(mode), TRUE, TRUE, 0);
-    gtk_widget_set_state_flags(mode, GTK_STATE_FLAG_SELECTED, TRUE);
 
     /* color scheme */
     // FIXME can't use DT_BAUHAUS_COMBOBOX_NEW_FULL because of (unnecessary?) translation context
@@ -2331,7 +2330,6 @@ void gui_init(dt_view_t *self)
         _("select the solid color to indicate over exposure.\nwill only be used if mode = mark with solid color"));
     g_signal_connect(G_OBJECT(colorscheme), "value-changed", G_CALLBACK(rawoverexposed_colorscheme_callback), dev);
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(colorscheme), TRUE, TRUE, 0);
-    gtk_widget_set_state_flags(colorscheme, GTK_STATE_FLAG_SELECTED, TRUE);
 
     /* threshold */
     GtkWidget *threshold = dt_bauhaus_slider_new_action(DT_ACTION(self), 0.0, 2.0, 0.01, 1.0, 3);
@@ -2372,7 +2370,6 @@ void gui_init(dt_view_t *self)
                                  dev->overexposed.mode, mode_callback, dev,
                                  N_("full gamut"), N_("any RGB channel"), N_("luminance only"), N_("saturation only"));
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(mode), TRUE, TRUE, 0);
-    gtk_widget_set_state_flags(mode, GTK_STATE_FLAG_SELECTED, TRUE);
 
     /* color scheme */
     DT_BAUHAUS_COMBOBOX_NEW_FULL(colorscheme, self, N_("overexposed"), N_("color scheme"),
@@ -2380,7 +2377,6 @@ void gui_init(dt_view_t *self)
                                  dev->overexposed.colorscheme, colorscheme_callback, dev,
                                  N_("black & white"), N_("red & blue"), N_("purple & green"));
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(colorscheme), TRUE, TRUE, 0);
-    gtk_widget_set_state_flags(colorscheme, GTK_STATE_FLAG_SELECTED, TRUE);
 
     /* lower */
     GtkWidget *lower = dt_bauhaus_slider_new_action(DT_ACTION(self), -32., -4., 1., -12.69, 2);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2385,7 +2385,7 @@ void gui_init(dt_view_t *self)
     /* lower */
     GtkWidget *lower = dt_bauhaus_slider_new_action(DT_ACTION(self), -32., -4., 1., -12.69, 2);
     dt_bauhaus_slider_set(lower, dev->overexposed.lower);
-    dt_bauhaus_slider_set_format(lower, _("%+.2f EV"));
+    dt_bauhaus_slider_set_format(lower, _(" EV"));
     dt_bauhaus_widget_set_label(lower, N_("overexposed"), N_("lower threshold"));
     gtk_widget_set_tooltip_text(lower, _("clipping threshold for the black point,\n"
                                          "in EV, relatively to white (0 EV).\n"
@@ -2402,7 +2402,7 @@ void gui_init(dt_view_t *self)
     /* upper */
     GtkWidget *upper = dt_bauhaus_slider_new_action(DT_ACTION(self), 0.0, 100.0, 0.1, 99.99, 2);
     dt_bauhaus_slider_set(upper, dev->overexposed.upper);
-    dt_bauhaus_slider_set_format(upper, "%.2f%%");
+    dt_bauhaus_slider_set_format(upper, "%");
     dt_bauhaus_widget_set_label(upper, N_("overexposed"), N_("upper threshold"));
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(upper, _("clipping threshold for the white point.\n"

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -241,9 +241,6 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
   dt_view_t *old_view = vm->current_view;
   dt_view_t *new_view = (dt_view_t *)nv; // views belong to us, we can de-const them :-)
 
-  // Before switching views, restore accelerators if disabled
-  if(!darktable.control->key_accelerators_on) dt_control_key_accelerators_on(darktable.control);
-
   // reset the cursor to the default one
   dt_control_change_cursor(GDK_LEFT_PTR);
 


### PR DESCRIPTION
This builds on Input NG to achieve several improvements to the bauhaus widgets, especially sliders.

It makes the step size (used for scrolling, keyboard moves and shortcuts) depend on the current range of the slider. Basically 1/100 of the range (unless it straddles zero) rounded to 1 or 5. Initially this will be the soft range, but it can be extended to the hard range (by typing a number in the popup, as before, or "forcing" the boundary by holding shift+ctrl while scrolling or scrolling over the left or right end of the slider) or "zoomed", via shortcuts or by scrolling in the popup. The step size in a zoomed range will be smaller, so this achieves more accuracy and might make the current situation for some modules, where the step is basically the same as the smallest digit, unnecessary.

But for those that like the current steps; each widget step can now be tailored individually (with a speed that is stored in shortcutsrc and can be edited in a new category in the shortcuts dialog/preference tab). If the scaling with current range is switched off (in prefs/misc/scale slider step with min/max) then importing this shortcuts file [shortcutsrc.legacyspeeds.txt](https://github.com/darktable-org/darktable/files/8181677/shortcutsrc.legacyspeeds.txt) exactly restores previous behavior.
To change a widget's speed, switch to shortcut mapping mode, hover over the widget and scroll. You will see a toast giving new speed as *10, *100, *1000 or *.1, *.01, *.001. Clicking on the widget allows setting any speed in the dialog. To create a speed adjustment in the preferences/dialog; double click a slider action (as if assigning a shortcut) but scroll without first pressing a key.

Shift+scroll and ctrl+scroll still apply a *10 or *.1 adjustment (on top of the individually set adjustment as described above). These factors can be changed under fallbacks/value. 

Since all sliders now can have a zoomed range, it is never safe to set a value without checking min/max. So the distinction between `dt_bauhaus_slider_set` and `dt_bauhaus_slider_set_soft` has disappeared; the latter has been removed. This opportunity was used to remove most explicit updates for iop bauhaus widgets in gui_update by using the actions list to refresh all of them. The widgets themselves now contain a pointer to the params field they are linked to which also makes updating params simpler.

Gradients get zoomed in bauhaus itself, so there is no need anymore to adjust them in the module based on current min/max. This would no longer work, because the zoom can now change without a value change and therefore without the module getting notified.

The last significant clean-up simplifies the formats for slider values. Instead of having to specify the complete printf format (including number of digits), just the extension is set (%,°,EV,mm etc) and all the accepted digits are shown. This gets rid of the phenomenon that sometimes 10 scroll steps (or more!) were needed for a visible change. This also enforces the convention that if the (hard) range straddles zero (-1 .. +1) that the positive values are shown _with_ the sign.

A small UX improvement; bauhaus now correctly highlights the hovered widget (which will receive a scroll or shortcut mapping). @Nilvus I had to adjust the grey theme to create a small difference.

closes #7989
 