### PR TITLE
Finish resource level stuff

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -187,7 +187,7 @@
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - Use `small` if you are simultaneously using applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - Use `large` if you want darktable to take most of your systems resources for performance. Probably best option while exporting images.\n - unrestricted: darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - small: should be used if you are simultaneously running applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - large: is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.\n - unrestricted: should only be used for developing extremely large images as darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution and not recommended for general use!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -183,13 +183,11 @@
         <option>default</option>
         <option>large</option>
         <option>unrestricted</option>
-        <option>mini (debug)</option>
-        <option>reference (debug)</option>
       </enum>
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - Use `small` if you are simultaneously using applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - Use `large` if you want darktable to take most of your systems resources for performance. Probably best option while exporting images.\n\nspecial modes used for tests and debugging:\n\n - mini: darktable takes 0.5 GB ram and 0.25GB video ram\n - reference: - darktable takes 8GB ram and 2GB video ram\n - unrestricted: darktable will take almost all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - Use `small` if you are simultaneously using applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - Use `large` if you want darktable to take most of your systems resources for performance. Probably best option while exporting images.\n - unrestricted: darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -282,7 +282,8 @@ typedef struct dt_sys_resources_t
 {
   size_t total_memory;
   size_t mipmap_memory;
-  int *fractions; // fractions are calculated as res=input / 1024  * fraction
+  int *fractions;   // fractions are calculated as res=input / 1024  * fraction
+  int *refresource; // for the debug resource modes we use fixed settings
   int group;
   int level;
   int tunecl;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2103,7 +2103,8 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   darktable.dtresources.group = 4 * darktable.dtresources.level; 
-  
+  if((darktable.dtresources.tunecl == 0) && (pipe->devid >= 0) && darktable.opencl->inited)
+    darktable.opencl->dev[pipe->devid].tuned_available = 0;
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2103,8 +2103,10 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   darktable.dtresources.group = 4 * darktable.dtresources.level; 
+#ifdef HAVE_OPENCL
   if((darktable.dtresources.tunecl == 0) && (pipe->devid >= 0) && darktable.opencl->inited)
     darktable.opencl->dev[pipe->devid].tuned_available = 0;
+#endif
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU


### PR DESCRIPTION
- The gui should not expose the "debug modes" as it's not helpfull for normal users
  and should only be used for devel, tests and debugging via --conf
- refactored the debugging modes in a clear way
- introduce another debugging mode "notebook" simulating a common 8GB machine with integrated graphics
- improve reported memory also after changing the "tuning cl" button
- pipeline resets found available memory to 0 if tuning cl mode is off,
  this allows recalculation whenever you switch tuning mode to ON
- the opencl setting for unrestricted is simply bad, changed to 900 as for large.