### PR TITLE
text filter: don't add wildcards on empty entry

### DIFF
--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -187,20 +187,23 @@ static gboolean _text_entry_changed_wait(gpointer user_data)
       // by default adds start and end wildcard
       // ' or " removes the corresponding wildcard
       char start[2] = {0};
-      char *text;
+      char *text = NULL;
       const char *entry = gtk_entry_get_text(GTK_ENTRY(d->text));
       char *p = (char *)entry;
-      if(entry[0] == '"')
-        p++;
-      else
-        start[0] = '%';
-      if(entry[strlen(entry) - 1] == '"')
+      if(strlen(entry) > 1 && !(entry[0] == '"' && entry[1] == '"'))
       {
-        text = g_strconcat(start, (char *)p, NULL);
-        text[strlen(text) - 1] = '\0';
+        if(entry[0] == '"')
+          p++;
+        else if(entry[0])
+          start[0] = '%';
+        if(entry[strlen(entry) - 1] == '"')
+        {
+          text = g_strconcat(start, (char *)p, NULL);
+          text[strlen(text) - 1] = '\0';
+        }
+        else if(entry[0])
+          text = g_strconcat(start, (char *)p, "%", NULL);
       }
-      else
-        text = g_strconcat(start, (char *)p, "%", NULL);
 
       // avoids activating twice the same query
       if(g_strcmp0(dt_collection_get_text_filter(darktable.collection), text))


### PR DESCRIPTION
fixes #11254 partially

This solves the main issue: after text filtering grouping works again.
But, as said, during filtering, the grouping is still broken.
I suggest to merge this and keep the issue opened, as I haven't yet understood why.

