### PR TITLE
import_session: for win32 don't lower the path

### DIFF
--- a/src/common/film.c
+++ b/src/common/film.c
@@ -90,7 +90,11 @@ int32_t dt_film_get_id(const char *folder)
   int32_t filmroll_id = -1;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+#ifdef WIN32
+                              "SELECT id FROM main.film_rolls WHERE folder LIKE ?1",
+#else
                               "SELECT id FROM main.film_rolls WHERE folder = ?1",
+#endif
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, folder, -1, SQLITE_STATIC);
   if(sqlite3_step(stmt) == SQLITE_ROW) filmroll_id = sqlite3_column_int(stmt, 0);

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -319,23 +319,16 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
     return NULL;
   }
 
-
+  gchar *new_path = dt_variables_expand(self->vp, pattern, FALSE);
 #ifdef WIN32
-  gchar *s1 = dt_variables_expand(self->vp, pattern, FALSE);
-  gchar *new_path = g_ascii_strdown(s1, -1);
   if(new_path && (strlen(new_path) > 1))
   {
     const char first = g_ascii_toupper(new_path[0]);
     if(first >= 'A' && first <= 'Z' && new_path[1] == ':') // path format is <drive letter>:\path\to\file
       new_path[0] = first;                                 // drive letter in uppercase looks nicer
-  g_free(s1);
   }
-#else
-  gchar *new_path = dt_variables_expand(self->vp, pattern, FALSE);
 #endif
-
   g_free(pattern);
-
 
   /* did the session path change ? */
   if(self->current_path && strcmp(self->current_path, new_path) == 0)

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -311,7 +311,7 @@ static const char *_import_session_path(struct dt_import_session_t *self, gboole
     self->current_path = NULL;
     return NULL;
   }
-  /* check if expanded path differs from current */
+
   gchar *pattern = _import_session_path_pattern();
   if(pattern == NULL)
   {

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -76,7 +76,6 @@ static gboolean _import_session_initialize_filmroll(dt_import_session_t *self, c
     _import_session_cleanup_filmroll(self);
     return TRUE;
   }
-
   /* open one or initialize a filmroll for the session */
   self->film = (dt_film_t *)g_malloc0(sizeof(dt_film_t));
   const int32_t film_id = dt_film_new(self->film, path);
@@ -86,10 +85,20 @@ static gboolean _import_session_initialize_filmroll(dt_import_session_t *self, c
     _import_session_cleanup_filmroll(self);
     return TRUE;
   }
-
   /* every thing is good lets setup current path */
+#ifdef _WIN32
+  else
+  {
+    // keep the existing film path (case)
+    g_free(path);
+    g_free(self->current_path);
+    dt_film_t *film = self->film;
+    self->current_path = g_strdup(film->dirname);
+  }
+#else
   g_free(self->current_path);
   self->current_path = path;
+#endif
 
   return FALSE;
 }


### PR DESCRIPTION
attempt to fix #11188

I don't see the necessity to lower the path case, even for windows. So I've removed this part.

Not tested on windows. That would be great if a windows user could test it. TIA.