### PR TITLE
remove unnecessary section labels in crop and white balance modules

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1412,7 +1412,7 @@ void dt_bauhaus_combobox_set_text(GtkWidget *widget, const char *text)
 static void _bauhaus_combobox_set(dt_bauhaus_widget_t *w, const int pos, const gboolean mute)
 {
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
-  d->active = CLAMP(pos, -1, d->entries->len - 1);
+  d->active = CLAMP(pos, -1, (int)d->entries->len - 1);
   gtk_widget_queue_draw(GTK_WIDGET(w));
 
   if(!darktable.gui->reset && !mute)

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1051,11 +1051,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *box_enabled = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  GtkWidget *lb = dt_ui_section_label_new(_("crop settings"));
-  GtkStyleContext *context = gtk_widget_get_style_context(lb);
-  gtk_style_context_add_class(context, "section_label_top");
-  gtk_box_pack_start(GTK_BOX(box_enabled), lb, TRUE, TRUE, 0);
-
   dt_iop_crop_aspect_t aspects[] = {
     { _("freehand"), 0, 0 },
     { _("original image"), 1, 0 },


### PR DESCRIPTION
Removed the "crop settings" section header in the crop module which states too much the obvious.

Similarly, removed "white balance settings" from the white balance module. This more or less required moving the buttons to the top of the module, but to me this makes more sense anyway; from top down is more granular control.
![image](https://user-images.githubusercontent.com/1549490/157133574-ac5a84bb-3b21-49ce-9817-3bb652482525.png)
@johnny-bit do you disagree? I'm happy to think of different approaches.

Also fixes a bug in bauhaus introduced in #11257 that broke editable comboboxes (like the aspect in crop).