### PR TITLE
Fix Tethering on Windows

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -264,7 +264,7 @@ static void _camera_process_job(const dt_camctl_t *c, const dt_camera_t *camera,
 
         char *output = g_build_filename(output_path, fname, (char *)NULL);
 
-        int handle = g_open(output, O_CREAT | O_WRONLY, 0666);
+        int handle = g_open(output, O_CREAT | O_WRONLY | O_BINARY, 0666);
         if(handle != -1)
         {
           gp_file_new_from_fd(&destination, handle);
@@ -1791,7 +1791,7 @@ static void _camera_poll_events(const dt_camctl_t *c, const dt_camera_t *cam)
 
         char *output = g_build_filename(output_path, fname, (char *)NULL);
 
-        int handle = g_open(output, O_CREAT | O_WRONLY, 0666);
+        int handle = g_open(output, O_CREAT | O_WRONLY | O_BINARY, 0666);
         if(handle != -1)
         {
           gp_file_new_from_fd(&destination, handle);


### PR DESCRIPTION
## Overview
This PR sets the `O_BINARY` flag on `g_open()` calls for tethered shooting. The lack of this flag caused `0x0D` bytes to be prepended to every occurrence of a `0x0A` byte in the saved files. (This occurred because without the `O_BINARY` flag, it was interpreting the `0x0A` bytes as linefeeds and adding a carriage return `0x0D` before them to make them windows compliant line endings. 🙃)

I reproduced this issue before fixing it and testing it via the manual windows local build process with a D800E on Windows 11.

This fixes #8318 and likely fixes #7963

## Detailed debugging info

I began testing by taking some photos while tethered and comparing the corrupt darktable NEF file to the NEF file saved on the SD card.

I noticed some odd file size differences:

![Screenshot 2022-03-06 235929](https://user-images.githubusercontent.com/2163396/157152111-48683d47-551b-486e-8b95-684d482b7019.png)

I then tore into the hex and found the following insertions in the byte data:
![Screenshot 2022-03-07 000051](https://user-images.githubusercontent.com/2163396/157152126-66b5a5f1-c660-4698-85b9-7c23fa1ec62e.png)

It seems like every instance of 0x0A is being prepended with 0x0D.  What an odd thing to happen! After a couple of seconds pondering this, I realized that those hex values rang a bell.

![Screenshot 2022-03-07 000319](https://user-images.githubusercontent.com/2163396/157152134-2314368e-98c6-4857-8a13-753d801919df.png)

The NEF byte data is having its linefeed characters 0x0A converted to the windows compatible carriage return linefeed combination 0x0D 0x0A. An NEF is not text and this obviously should not be happening.

To test the hypothesis, I then replaced all instances of 0x0D 0x0A in the tethered file with 0x0A in vscode using the hex editor extension. The files are now identical! YAY!!!

All we have to do is inform g_open() that these are binary files by specifying the `O_BINARY` flag and it will stop attempting to "fix the line endings" in this binary file.
