### PR TITLE
add back labels/actions to quick filter dropdowns

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3022,6 +3022,9 @@ void gui_init(dt_lib_module_t *self)
     d->rule[i].typing = FALSE;
 
     box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+    GtkBox *hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+    gtk_box_set_homogeneous(hbox, TRUE);
+    gtk_box_pack_start(box, GTK_WIDGET(hbox), TRUE, TRUE, 0);
     d->rule[i].hbox = GTK_WIDGET(box);
     gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
     gtk_widget_set_name(GTK_WIDGET(box), "lib-dtbutton");
@@ -3034,7 +3037,7 @@ void gui_init(dt_lib_module_t *self)
     if(_combo_get_active_collection(d->rule[i].combo) == DT_COLLECTION_PROP_MODULE) has_iop_name_rule = TRUE;
 
     g_signal_connect(G_OBJECT(d->rule[i].combo), "value-changed", G_CALLBACK(combo_changed), d->rule + i);
-    gtk_box_pack_start(box, d->rule[i].combo, TRUE, TRUE, 0);
+    gtk_box_pack_start(hbox, d->rule[i].combo, TRUE, TRUE, 0);
 
     w = gtk_entry_new();
     d->rule[i].text = w;
@@ -3046,7 +3049,7 @@ void gui_init(dt_lib_module_t *self)
     g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(entry_changed), d->rule + i);
     g_signal_connect(G_OBJECT(w), "activate", G_CALLBACK(entry_activated), d->rule + i);
     gtk_widget_set_name(GTK_WIDGET(w), "lib-collect-entry");
-    gtk_box_pack_start(box, w, TRUE, TRUE, 0);
+    gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
     gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
 
     w = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -382,7 +382,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 4);
   GtkWidget *overlay = gtk_overlay_new();
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->comparator, self, NULL, NULL,
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->comparator, self, NULL, N_("comparator"),
                                _("filter by images rating"),
                                dt_collection_get_rating_comparator(darktable.collection),
                                _lib_filter_comparator_changed, self,
@@ -392,12 +392,13 @@ void gui_init(dt_lib_module_t *self)
                                "≥", // DT_COLLECTION_RATING_COMP_GEQ,
                                ">", // DT_COLLECTION_RATING_COMP_GT,
                                "≠");// DT_COLLECTION_RATING_COMP_NE,
+  dt_bauhaus_widget_set_label(d->comparator, NULL, NULL);
   gtk_widget_set_halign(d->comparator, GTK_ALIGN_START);
   gtk_overlay_add_overlay(GTK_OVERLAY(overlay), d->comparator);
   gtk_overlay_set_overlay_pass_through(GTK_OVERLAY(overlay), d->comparator, TRUE);
 
   /* create the filter combobox */
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->stars, self, NULL, NULL,
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->stars, self, NULL, N_("ratings"),
                                _("filter by images rating"),
                                dt_collection_get_rating(darktable.collection),
                                _lib_filter_combobox_changed, self,
@@ -410,6 +411,7 @@ void gui_init(dt_lib_module_t *self)
                                "★ ★ ★ ★ ★",
                                N_("rejected only"),
                                N_("all except rejected"));
+  dt_bauhaus_widget_set_label(d->stars, NULL, NULL);
   gtk_container_add(GTK_CONTAINER(overlay), d->stars);
   gtk_box_pack_start(GTK_BOX(hbox), overlay, FALSE, FALSE, 0);
   dt_gui_add_class(hbox, "quick_filter_box");
@@ -466,13 +468,10 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_class(hbox, "quick_filter_box");
 
   /* sort combobox */
-  label = gtk_label_new(_("sort by"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 4);
   const dt_collection_sort_t sort = dt_collection_get_sort_field(darktable.collection);
-  d->sort = dt_bauhaus_combobox_new_full(DT_ACTION(self), NULL, NULL,
+  d->sort = dt_bauhaus_combobox_new_full(DT_ACTION(self), NULL, N_("sort by"),
                                          _("determine the sort order of shown images"),
                                          _filter_get_items(sort), _lib_filter_sort_combobox_changed, self,
                                          _sort_names);


### PR DESCRIPTION
As mentioned here https://github.com/darktable-org/darktable/pull/10694#issuecomment-1055787967 this is used for actions/shortcut definitions as well and has better ellipsizing.

![image](https://user-images.githubusercontent.com/1549490/157294689-f6dca457-44ce-4367-962e-486a3b568f81.png)

Since the >=, <= etc dropdown is overlayed on top of the ratings dropdown, I had to extend bauhaus to hide the label when a number of stars is selected (but still show it otherwise and when popped-up).

To further prevent things getting jumbled up or inaccessible when window is small, css now sets a min-width. The same might be useful for the sort combo, but it would force a minimum width on the application window (or cause confusing effects).

![image](https://user-images.githubusercontent.com/1549490/157294874-dfc1979d-654e-498d-b503-05664e3a16f8.png)

Maybe the "filter" label should be allowed to ellipsize away?

Side node; users who have set up shortcuts to the ratings dropdown will have to do so again since the name has changed (was "view").