### PR TITLE
Connect lib and view accels at startup to match action elements/effect

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -762,6 +762,7 @@ static void dt_lib_init_module(void *m)
   {
     if(module->init_key_accels) module->init_key_accels(module);
     module->gui_init(module);
+    if(module->connect_key_accels) module->connect_key_accels(module);
     g_object_ref_sink(module->widget);
   }
 }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -97,6 +97,7 @@ void dt_view_manager_gui_init(dt_view_manager_t *vm)
   {
     dt_view_t *view = (dt_view_t *)iter->data;
     if(view->gui_init) view->gui_init(view);
+    if(view->connect_key_accels) view->connect_key_accels(view);
   }
 }
 


### PR DESCRIPTION
fixes #11252

One of these cases where the "justification" is (much) longer than the fix itself:

Once upon a time, long ago...

(well, not that long ago, until just before input ng got merged actually) dt tried to shoehorn its shortcut approach into the gtk accelerator framework which had a totally different philosophy. As a result, every time a view switch occurs, all accelerators for that view needed to be reinitialised. But since in between (and at startup) the full list needed to be known (to enable loading all the shortcuts from file or change them in preferences) the process of setting up and connecting accelerators was split in two functions. And they referred to shortcuts by strings that needed to match or it wouldn't work (without errors) and one of them was translated and the other was not. And if the string matched the one that was already used in the gui (for widgets) then it needed to be translated twice (since they used different contexts). But at least each shortcut only did one thing, so as soon as you set up the string, loading and preffing was fine).

Input ng wanted to extend the abilities of shortcuts which meant doing everything three times was infeasible. Also, it knows about views so can enable/disable shortcuts internally. Plus since most shortcuts (not all!) are linked to widgets, setting them up at the same time (in gui_init) made the process much easier. Only one string translation too.

But for the non-widget shortcuts it still supports the old init/connect_accel infrastructure (and its translation context). This all needs to be cleaned up; they can all "just be moved into gui_init". Accept we'd want to clean up the old translation context at the same time or it gets _very_ confusing.

The problem in the linked bug arises because some shortcuts where linked to buttons and those now have extra options (that init_accel doesn't know about). So they should have been moved into gui_init at the time, but I didn't want to do this because that also meant moving over some translations piece by piece instead of in one big bang. I forgot that now at load time not enough is known about the shortcut to match its elements and effects.

This PR basically treats `init_key_accels` and `connect_key_accels` as one unit with `gui_init`; it always calls all three together. While waiting for me to find the energy to do a cleanup that nobody cares about and that will annoy all the translators.