### PR TITLE
Fix blending togglebutton shortcuts

### DIFF
--- a/src/common/action.h
+++ b/src/common/action.h
@@ -27,6 +27,7 @@ typedef enum dt_action_type_t
   DT_ACTION_TYPE_VIEW,
   DT_ACTION_TYPE_LIB,
   DT_ACTION_TYPE_IOP,
+  DT_ACTION_TYPE_BLEND,
   // ==== all below need to be freed and own their strings
   DT_ACTION_TYPE_SECTION,
   // ==== all above split off chains

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -60,6 +60,7 @@ dt_help_url urls_db[] =
   {"masks_blending_op",          "darkroom/masking-and-blending/masks/drawn-and-parametric/"},
   {"masks_blending",             "darkroom/masking-and-blending/overview/"},
   {"masks_combined",             "darkroom/masking-and-blending/masks/drawn-and-parametric/"},
+  {"masks_refinement",           "darkroom/masking-and-blending/masks/refinement-controls/"},
   {"duplicate",                  "module-reference/utility-modules/darkroom/duplicate-manager/"},
   {"location",                   "module-reference/utility-modules/map/find-location/"},
   {"map_settings",               "module-reference/utility-modules/map/map-settings/"},

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -111,7 +111,7 @@ void dt_control_init(dt_control_t *s)
   s->actions_thumb = (dt_action_t){ DT_ACTION_TYPE_CATEGORY, "thumbtable", C_("accel", "thumbtable"), .owner = &s->actions_views };
   s->actions_libs = (dt_action_t){ DT_ACTION_TYPE_CATEGORY, "lib", C_("accel", "utility modules"), .next = &s->actions_iops };
   s->actions_iops = (dt_action_t){ DT_ACTION_TYPE_CATEGORY, "iop", C_("accel", "processing modules"), .next = &s->actions_lua, .target = &s->actions_blend };
-  s->actions_blend = (dt_action_t){ DT_ACTION_TYPE_CATEGORY, "blend", C_("accel", "blending"), .owner = &s->actions_iops };
+  s->actions_blend = (dt_action_t){ DT_ACTION_TYPE_BLEND, "blend", C_("accel", "blending"), .owner = &s->actions_iops };
   s->actions_lua = (dt_action_t){ DT_ACTION_TYPE_CATEGORY, "lua", C_("accel", "lua scripts"), .next = &s->actions_fallbacks };
   s->actions_fallbacks = (dt_action_t){ DT_ACTION_TYPE_CATEGORY, "fallbacks", C_("accel", "fallbacks") };
   s->actions = &s->actions_global;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3083,6 +3083,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                       _("how to combine individual drawn mask and different channels of parametric mask"));
     g_signal_connect(G_OBJECT(bd->masks_combine_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_combine_callback), bd);
+    dt_gui_add_help_link(GTK_WIDGET(bd->masks_combine_combo), dt_get_help_url("masks_combined"));
 
     bd->masks_invert_combo = _combobox_new_from_list(module, _("invert mask"), dt_develop_invert_mask_names, NULL,
                                                      _("apply mask in normal or inverted mode"));
@@ -3179,8 +3180,10 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->blur_radius_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->brightness_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->contrast_slider, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(bd->bottom_box), TRUE, TRUE, 0);
-    dt_gui_add_help_link(GTK_WIDGET(bd->bottom_box), dt_get_help_url("masks_combined"));
+    GtkWidget* event_box = gtk_event_box_new();
+    dt_gui_add_help_link(event_box, dt_get_help_url("masks_refinement"));
+    gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->bottom_box));
+    gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(event_box), TRUE, TRUE, 0);
 
     gtk_widget_set_name(GTK_WIDGET(bd->top_box), "blending-box");
     gtk_widget_set_name(GTK_WIDGET(bd->masks_box), "blending-box");

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -415,26 +415,26 @@ static gboolean _gradient_slider_key_press_event(GtkWidget *widget, GdkEventKey 
 
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
+  int handled = FALSE;
+  float delta = -gslider->increment;
+  switch(event->keyval)
+  {
+    case GDK_KEY_Up:
+    case GDK_KEY_KP_Up:
+    case GDK_KEY_Right:
+    case GDK_KEY_KP_Right:
+      delta = gslider->increment;
+    case GDK_KEY_Down:
+    case GDK_KEY_KP_Down:
+    case GDK_KEY_Left:
+    case GDK_KEY_KP_Left:
+      handled = TRUE;
+  }
+
+  if(!handled) return FALSE;
+
   const gint selected = _get_active_marker(gslider);
   if(selected == -1) return TRUE;
-
-  int handled = 0;
-  float delta = 0.0f;
-
-  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up || event->keyval == GDK_KEY_Right
-     || event->keyval == GDK_KEY_KP_Right)
-  {
-    handled = 1;
-    delta = gslider->increment;
-  }
-  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down || event->keyval == GDK_KEY_Left
-          || event->keyval == GDK_KEY_KP_Left)
-  {
-    handled = 1;
-    delta = -gslider->increment;
-  }
-
-  if(!handled) return TRUE;
 
   return _gradient_slider_add_delta_internal(widget, delta, event->state, selected);
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -180,10 +180,12 @@ static float _action_process_toggle(gpointer target, dt_action_element_t element
     g_object_ref(event->button.window);
 
     // some togglebuttons connect to the clicked signal, others to toggled or button-press-event
-    if(!gtk_widget_event(target, event))
-      gtk_button_clicked(GTK_BUTTON(target));
+    // gtk_widget_event does not work when widgets are hidden in event boxes or some other conditions
+    gboolean handled;
+    g_signal_emit_by_name(G_OBJECT(target), "button-press-event", event, &handled);
+    if(!handled) gtk_button_clicked(GTK_BUTTON(target));
     event->type = GDK_BUTTON_RELEASE;
-    gtk_widget_event(target, event);
+    g_signal_emit_by_name(G_OBJECT(target), "button-release-event", event, &handled);
 
     gdk_event_free(event);
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4302,10 +4302,15 @@ float dt_accel_get_speed_multiplier(GtkWidget *widget, guint state)
 
 void dt_accel_connect_instance_iop(dt_iop_module_t *module)
 {
+  gboolean focused = darktable.develop->gui_module &&
+                     darktable.develop->gui_module->so == module->so;
+  dt_action_t *blend = &darktable.control->actions_blend;
   for(GSList *w = module->widget_list; w; w = w->next)
   {
     dt_action_target_t *referral = w->data;
-    referral->action->target = referral->target;
+    dt_action_t *ac = referral->action;
+    if(focused || (ac->owner != blend && ac->owner->owner != blend))
+      ac->target = referral->target;
   }
 }
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -795,10 +795,11 @@ static dt_view_type_flags_t _find_views(dt_action_t *action)
       }
     }
     break;
+  case DT_ACTION_TYPE_BLEND:
+    vws = DT_VIEW_DARKROOM;
+    break;
   case DT_ACTION_TYPE_CATEGORY:
-    if(owner == &darktable.control->actions_blend)
-      vws = DT_VIEW_DARKROOM;
-    else if(owner == &darktable.control->actions_fallbacks)
+    if(owner == &darktable.control->actions_fallbacks)
       vws = 0;
     else if(owner == &darktable.control->actions_lua)
       vws = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING |

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2129,12 +2129,8 @@ static GtkWidget *_ui_init_panel_container_center(GtkWidget *container, gboolean
   gtk_container_add(GTK_CONTAINER(container), widget);
 
   /* avoid scrolling with wheel, it's distracting (you'll end up over a control, and scroll it's value) */
-  container = widget;
-  widget = gtk_event_box_new();
-  gtk_widget_add_events(GTK_WIDGET(widget), darktable.gui->scroll_mask);
   g_signal_connect(G_OBJECT(widget), "scroll-event", G_CALLBACK(_ui_init_panel_container_center_scroll_event),
                    NULL);
-  gtk_container_add(GTK_CONTAINER(container), widget);
 
   /* create the container */
   container = widget;


### PR DESCRIPTION
fixes #11034

This should also fix togglebuttons elsewhere that stopped working when hidden. Turns out that this depends on whether these are in event_boxes that have visible window set or in a viewport. So _just_ testing if shortcuts "work for a hidden toggle" was not sufficient. Using `g_signal_emit_by_name `instead of `gtk_widget_event` solves this and I haven't noticed what it breaks yet.

This PR also correctly connects the blending shortcuts of the focused module. Unless you have "prefer focused instance" switched off, in which case it connects the preferred instance of the type of the focused module. This should make the blending shortcuts in sync with the specific module shortcuts. Hopefully in an intuitive way.

As a side node; I suspect that doing away with `dt_accel_connect_instance_iop `/ `dt_iop_connect_accels_multi` / `dt_iop_get_module_preferred_instance` completely and just always determining the applicable instance on the fly in accelerators.c `_process_action` would be the better (simpler/less complex, not noticeably slower) way, but that's too much work  now (especially testing).

Another interesting fix in here:
the blending input/output data channel sliders grab the focus when you hover over them, in order to be able to capture the magic M, A and C keys. But the gradient slider itself claims to handle _all_ keys (it really only handles arrows) and since focus is never returned, _all_ shortcuts are completely disabled (until the user move focus elsewhere). With this PR you still lose those MAC and arrow keys, but at least they have a visible impact so you can figure out what's going on.