### PR TITLE
skip loading shortcuts with speed zero

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -939,6 +939,9 @@ static gboolean _yes_no_dialog(gchar *title, gchar *question)
 
 static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
 {
+  if(!shortcut->speed && shortcut->effect != DT_ACTION_EFFECT_SET)
+    return FALSE;
+
   dt_shortcut_t *s = calloc(sizeof(dt_shortcut_t), 1);
   *s = *shortcut;
   s->views = _find_views(s->action);


### PR DESCRIPTION
(except in the valid case where the _effect_ is "set", which takes the speed as the new value).

fixes cases like https://github.com/darktable-org/darktable/pull/11257#issuecomment-1059264199