### PR TITLE
add switch to ignore default shortcuts at startup

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -71,8 +71,8 @@
     <name>accel/load_defaults</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>restore default shortcuts at startup</shortdescription>
-    <longdescription>load default shortcuts before user settings add/overwrite. switch off to prevent deleted defaults returning</longdescription>
+    <shortdescription>load default shortcuts at startup</shortdescription>
+    <longdescription>load default shortcuts before user settings. switch off to prevent deleted defaults returning</longdescription>
   </dtconfig>
   <dtconfig>
     <name>bauhaus/scale</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -67,6 +67,13 @@
     <shortdescription>enable shortcut fallbacks</shortdescription>
     <longdescription>enables default meanings for additional buttons, modifiers or moves when used in combination with a base shortcut</longdescription>
   </dtconfig>
+  <dtconfig prefs="misc" section="interface">
+    <name>accel/load_defaults</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>restore default shortcuts at startup</shortdescription>
+    <longdescription>load default shortcuts before user settings add/overwrite. switch off to prevent deleted defaults returning</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>bauhaus/scale</name>
     <type>float</type>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1234,8 +1234,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     // Save the default shortcuts
     dt_shortcuts_save(".defaults", FALSE);
 
-    // Then load any shortcuts if available
-    dt_shortcuts_load(NULL, FALSE); //
+    // Then load any shortcuts if available (wipe defaults first if requested)
+    dt_shortcuts_load(NULL, !dt_conf_get_bool("accel/load_defaults"));
 
     // Save the shortcuts including defaults
     dt_shortcuts_save(NULL, TRUE);

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -122,6 +122,7 @@ void dt_control_init(dt_control_t *s)
   s->shortcuts = g_sequence_new(g_free);
   s->enable_fallbacks = dt_conf_get_bool("accel/enable_fallbacks");
   s->mapping_widget = NULL;
+  s->confirm_mapping = TRUE;
   s->widget_definitions = g_ptr_array_new ();
   s->input_drivers = NULL;
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -132,6 +132,7 @@ typedef struct dt_control_t
   GSequence *shortcuts;
   gboolean enable_fallbacks;
   GtkWidget *mapping_widget;
+  gboolean confirm_mapping;
   dt_action_element_t element;
   GPtrArray *widget_definitions;
   GSList *input_drivers;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3186,7 +3186,7 @@ float dt_shortcut_move(dt_input_device_t id, guint time, guint move, double size
         GtkWidget *mapped_widget = darktable.control->mapping_widget;
 
         dt_shortcut_t s = _sc;
-        if(_insert_shortcut(&s, TRUE))
+        if(_insert_shortcut(&s, darktable.control->confirm_mapping))
         {
           dt_control_log(_("%s assigned to %s"),
                          _shortcut_description(&s), _action_description(&s, 2));

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1804,6 +1804,8 @@ static void _restore_clicked(GtkButton *button, gpointer user_data)
     dt_shortcuts_load(".edit", wipe);
     break;
   }
+
+  dt_shortcuts_save(NULL, FALSE);
 }
 
 static void _import_export_dev_changed(GtkComboBox *widget, gpointer user_data)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -515,6 +515,7 @@ void gui_init(dt_lib_module_t *self)
   dt_action_define(&darktable.control->actions_global, NULL, "shortcuts", d->keymap_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->keymap_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->keymap_button, _("define shortcuts\n"
+                                                  "ctrl+click to switch off overwrite confirmations\n\n"
                                                   "hover over a widget and press keys with mouse click and scroll or move combinations\n"
                                                   "repeat same combination again to delete mapping\n"
                                                   "click on a widget, module or screen area to open the dialog for further configuration"));
@@ -951,6 +952,8 @@ static void _lib_keymap_button_clicked(GtkWidget *widget, gpointer user_data)
 static gboolean _lib_keymap_button_press_release(GtkWidget *button, GdkEventButton *event, gpointer user_data)
 {
   static guint start_time = 0;
+
+  darktable.control->confirm_mapping = !dt_modifier_is(event->state, GDK_CONTROL_MASK);
 
   int delay = 0;
   g_object_get(gtk_settings_get_default(), "gtk-long-press-time", &delay, NULL);


### PR DESCRIPTION
fixes #10452 as per https://github.com/darktable-org/darktable/issues/10452#issuecomment-1059524606

@elstoc please suggest better phrasing if needed or a different location in prefs

This PR also adds a confirmationless mapping mode. If you press the shortcut button while holding ctrl, you can overwrite existing shortcuts without a dialog popping up. DANGER, obviously. @AxelG-DE I thought you might like this as it makes it quite fast to switch between two different sets of mappings for midi knobs. Obviously you can set up a shortcut to the shortcut button with the "ctrl-toggle" _effect_ so you get this behavior by default.