### PR TITLE
Improve debugging aids for tiling

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -126,7 +126,7 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch,imageio,input,\n");
   printf("      ioporder,lighttable,lua,masks,memory,nan,opencl,params,perf,demosaic\n");
-  printf("      pwstorage,print,signal,sql,undo,act_on}\n");
+  printf("      pwstorage,print,signal,sql,undo,act_on,tiling}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
 #ifdef DT_HAVE_SIGNAL_TRACE
@@ -684,6 +684,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_DEMOSAIC;
         else if(!strcmp(argv[k + 1], "act_on"))
           darktable.unmuted |= DT_DEBUG_ACT_ON;
+        else if(!strcmp(argv[k + 1], "tiling"))
+          darktable.unmuted |= DT_DEBUG_TILING;
         else
           return usage(argv[0]);
         k++;
@@ -1076,8 +1078,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   */
   static int ref_resources[12] = {
       8192,  32,  512, 2048,   // reference
-      1024,   2,  128,  400,   // mini system
-      4096,  32,  512,  400,   // simple notebook with integrated graphics
+      1024,   2,  128,  200,   // mini system
+      4096,  32,  512,  200,   // simple notebook with integrated graphics
   };
 
   /* This is where the sync is to be done if the enum for pref resourcelevel in darktableconfig.xml.in is changed.

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -269,7 +269,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_SIGNAL         = 1 << 20,
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
-  DT_DEBUG_ACT_ON         = 1 << 23
+  DT_DEBUG_ACT_ON         = 1 << 23,
+  DT_DEBUG_TILING         = 1 << 24
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1396,7 +1396,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       const gboolean possible = (cl_px > dx * border) || (cl_px > dy * border) || (cl_px > border * border);
       if(!possible)
       {
-        dt_print(DT_DEBUG_OPENCL, "[dt_dev_pixelpipe_process_rec] CL: tiling impossible in module `%s'. avail=%.1fM, requ=%.1fM (%ix%i). overlap=%i\n",
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING, "[dt_dev_pixelpipe_process_rec] CL: tiling impossible in module `%s'. avail=%.1fM, requ=%.1fM (%ix%i). overlap=%i\n",
             module->op, cl_px / 1e6f, dx*dy / 1e6f, (int)dx, (int)dy, (int)tiling.overlap);
         possible_cl = FALSE;
       }


### PR DESCRIPTION
- the opencl memory for "mini" and "notebook" should be set to smaller values to enforce tiling for
  most images in demosaicer.
- add a -d tiling option
- make all dt_print information relevant to tiling testing this flag too

Currently working on #6517 - still trying to understand what's going on in `_default_process_tiling_cl_roi` and `_default_process_tiling_roi`  . So far: it's not (only) xyalign and `modify_roi_in` using 3 ...

I think this might help also for other tiling related debugging ...