### PR TITLE
increased #history-button padding

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1680,7 +1680,7 @@ cell:selected
 #left #history-button-always-enabled,
 #left #history-button-default-enabled
 {
-  padding: 0.07em 0.14em 0.14em 0.14em;
+  padding: 0.07em 0.21em 0.14em 0.21em;
   margin: 0 0.07em 0.07em 0.07em;
 }
 


### PR DESCRIPTION
all other places items have decent left padding but the history-button, wondering if we can increase it a bit so it fits better.

before
![default padding](https://user-images.githubusercontent.com/1070310/158234218-6ea1b7ae-2e3b-4986-9dfc-092bfac257f1.png)

after
![padding added](https://user-images.githubusercontent.com/1070310/158234223-cfb16849-4006-4b0f-80a5-8e43e2209523.png)


i tried but couldn't figure out how to revert the commit in my last PR :( so lets try this again :)
