### PR TITLE
Fix noise calib script

### DIFF
--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -480,11 +480,11 @@ check_exposure() {
 	convert_flags_gm="-process analyze= -format %[BrightnessMean] info:-"
 
 	if convert -version | grep ImageMagick &>/dev/null; then
-		over=$(convert -threshold 99% "$input" $convert_flags_im)
-		under=$(convert -negate -threshold 99% "$input" $convert_flags_im)
+		over=$(convert -threshold 99% "$input" $convert_flags_im | awk '{ print int($1) }')
+		under=$(convert -negate -threshold 99% "$input" $convert_flags_im | awk '{ print int($1) }')
 	else
-		over=$(convert -threshold 99% "$input" $convert_flags_gm)
-		under=$(convert -negate -threshold 99% "$input" $convert_flags_gm)
+		over=$(convert -threshold 99% "$input" $convert_flags_gm | awk '{ print int($1) }')
+		under=$(convert -negate -threshold 99% "$input" $convert_flags_gm | awk '{ print int($1) }')
 	fi
 
 	if [ "$over" ] && [ "$over" -lt $pixel_percentile ]; then

--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -450,7 +450,7 @@ export_large_jpeg() {
 	tool_installed darktable-cli
 
 	rm -f "$output" "$xmp"
-	darktable-cli "$input" "$output" 1>/dev/null 2>&1
+	darktable-cli "$input" "$output" &> /tmp/dt_output.log  || echo $(cat /tmp/dt_output.log); exit 1
 	rm -f "$xmp"
 }
 


### PR DESCRIPTION
According to my write-up on the mysteries of the noise-calibration script (https://github.com/darktable-org/darktable/issues/7651#issuecomment-1032911519) I forgot [in my last PR](https://github.com/darktable-org/darktable/pull/11088) to cast the ImageMagick / GraphicsMagick output to integer for comparison by bash.

Fixes: https://github.com/darktable-org/darktable/issues/11328
