### PR TITLE
Remove twin line

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -33,7 +33,6 @@
 #include "common/ratings.h"
 #include "common/tags.h"
 #include "common/undo.h"
-#include "common/history.h"
 #include "common/selection.h"
 #include "common/datetime.h"
 #include "control/conf.h"


### PR DESCRIPTION
Indeed, this is probably not needed twice here. Removed line is already in line 26. Fix #11343