### PR TITLE
improve sortby icon and better collapsible …

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2720,7 +2720,7 @@ Details :
 #collapsible,
 #collapsible #bauhaus-slider
 {
-  background-color: shade(@collapsible_bg_color, 1.06);
+  background-color: shade(@collapsible_bg_color, 1.04);
 }
 
 /* for the import parameters to be more aligned with the imports buttons */

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -200,7 +200,7 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
 
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.8, 0.8, 0, 0)
+  PREAMBLE(0.9, 1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.05);
   cairo_line_to(cr, 0.1, 0.95);


### PR DESCRIPTION
2 small updates:
- due to new bauhaus update, improve sortby icon size
- in collapsible section, I finally find background on grey theme a little too bright. So just update it to make it more well balanced in all themes