### PR TITLE
Add a -d verbose option

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -270,7 +270,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_PARAMS         = 1 << 21,
   DT_DEBUG_DEMOSAIC       = 1 << 22,
   DT_DEBUG_ACT_ON         = 1 << 23,
-  DT_DEBUG_TILING         = 1 << 24
+  DT_DEBUG_TILING         = 1 << 24,
+  DT_DEBUG_VERBOSE        = 1 << 25
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t
@@ -360,6 +361,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 void dt_get_sysresource_level();
 void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
+void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();


### PR DESCRIPTION
For debugging we might need extra verbose output to log.

Adds a DT_DEBUG_VERBOSE flag controlled via `-d verbose`, it has to be added in a seperate step after `-d all' as it should not be default.

`dt_vprint()` is the output function behaving as `dt_print` but testing also for verbose flag.

The tiling code makes use of it for now.