### PR TITLE
Treat extra pen tablet button clicks as key presses

### DIFF
--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -899,6 +899,8 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
     else if(event->button.button == GDK_BUTTON_MIDDLE)
       dt_shortcut_dispatcher(event_widget, event, data);
+    else if(event->button.button > 7)
+      break;
     else if(dt_modifier_is(event->button.state, GDK_CONTROL_MASK))
     {
       if(darktable.develop)


### PR DESCRIPTION
My huion pen tablet has a total of 8 buttons/keys along the left side. The first three of those are received as left, middle and right mouse clicks, but the others are sent as button 8, 9, 10, 11 and 12. This PR treats those as (keyboard) key presses; they can be used in any shortcut stand-alone (i.e. not just in combination with a normal keyboard press, like the mouse buttons). You could for example assign them to the "global/modifiers" action as an extra shift or ctrl key.

@aurelienpierre @elstoc I know you both use pen tablets. Would this be useful at all or is it easier to configure this using other tools? Tbh I've not looked into these too much yet; for example haven't figured out the best way to set up scrolling yet. Are you guys using xsetwacom? Is there a "guide" somewhere (just a simple writeup) how to use them most efficiently?