### PR TITLE
bauhaus combobox : ensure full vertical align for real

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2064,6 +2064,23 @@ treeview#delete-dialog:selected
   color: shade(@bauhaus_fg_selected, 1.2);
 }
 
+#bauhaus-slider
+{
+ padding: 0px 0px 1px 0px;
+}
+.bauhaus_slider_popup
+{
+  padding: 2px 0px 2px 4px;
+}
+.bauhaus_combo_popup
+{
+  padding: 2px 0px 0px 2px;
+}
+#bauhaus-combobox
+{
+ padding: 2px 0px 2px 0px;
+}
+
 #lib-plugin-ui #bauhaus-combobox,
 #lib-plugin-ui #bauhaus-slider,
 #iop-plugin-ui #bauhaus-combobox,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2056,12 +2056,20 @@ treeview#delete-dialog:selected
 
 #bauhaus-combobox *
 {
-    color: shade(@bauhaus_fg, 0.8);
+  color: shade(@bauhaus_fg, 0.8);
 }
 
 #bauhaus-combobox *:selected
 {
-    color: shade(@bauhaus_fg_selected, 1.2);
+  color: shade(@bauhaus_fg_selected, 1.2);
+}
+
+#lib-plugin-ui #bauhaus-combobox,
+#lib-plugin-ui #bauhaus-slider,
+#iop-plugin-ui #bauhaus-combobox,
+#iop-plugin-ui #bauhaus-slider
+{
+  margin-top : 1px;
 }
 
 /* Notebooks states */

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1144,10 +1144,11 @@ static void dt_bauhaus_style_updated(GtkWidget *widget, gpointer user_data)
   }
   else if(w->type == DT_BAUHAUS_SLIDER)
   {
+    // the lower thing to draw is indicator. See dt_bauhaus_draw_baseline for compute details
     gtk_widget_set_size_request(widget, -1,
                                 w->margin->top + w->padding->top + w->margin->bottom + w->padding->bottom
                                     + INNER_PADDING + darktable.bauhaus->baseline_size
-                                    + darktable.bauhaus->line_height - darktable.bauhaus->border_width / 2.0f);
+                                    + darktable.bauhaus->line_height + 1.5f * darktable.bauhaus->border_width);
   }
 }
 
@@ -1766,7 +1767,7 @@ static void dt_bauhaus_draw_baseline(dt_bauhaus_widget_t *w, cairo_t *cr, float 
       cairo_arc(cr, slider_width - graduation_height, graduation_top, graduation_height, 0, 2 * M_PI);
     else
       cairo_arc(cr, origin, graduation_top, graduation_height, 0, 2 * M_PI);
-}
+  }
 
   cairo_fill(cr);
   cairo_restore(cr);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -167,6 +167,8 @@ typedef struct dt_bauhaus_widget_t
 
   // margin and padding structure, defined in css, retrieve on each draw
   GtkBorder *margin, *padding;
+  // gap to add to the top padding due to the vertical centering
+  int top_gap;
 
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;
@@ -214,9 +216,6 @@ typedef struct dt_bauhaus_t
 
   // appearance relevant stuff:
   // sizes and fonts:
-  float scale;                           // gui scale multiplier
-  float widget_space;                    // space between widgets in a module
-  float line_space;                      // space between lines of text in e.g. the combo box
   float line_height;                     // height of a line of text
   float marker_size;                     // height of the slider indicator
   float baseline_size;                   // height of the slider bar
@@ -224,6 +223,7 @@ typedef struct dt_bauhaus_t
   float quad_width;                      // width of the quad area to paint icons
   PangoFontDescription *pango_font_desc; // no need to recreate this for every string we want to print
   PangoFontDescription *pango_sec_font_desc; // as above but for section labels
+  GtkBorder *popup_padding;                  // padding of the popup. updated in show function
 
   // the slider popup has a blinking cursor
   guint cursor_timeout;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -165,6 +165,9 @@ typedef struct dt_bauhaus_widget_t
   // if a section label
   gboolean is_section;
 
+  // margin and padding structure, defined in css, retrieve on each draw
+  GtkBorder *margin, *padding;
+
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;
 } dt_bauhaus_widget_t;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3188,7 +3188,7 @@ static gboolean illuminant_color_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   // Margins
   const double INNER_PADDING = 4.0;
-  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(1.5);
   width -= 2* INNER_PADDING;
   height -= 2 * margin;
 
@@ -3228,7 +3228,7 @@ static gboolean target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user
 
   // Margins
   const double INNER_PADDING = 4.0;
-  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(1.5);
   width -= 2* INNER_PADDING;
   height -= 2 * margin;
 
@@ -3271,7 +3271,7 @@ static gboolean origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user
 
   // Margins
   const double INNER_PADDING = 4.0;
-  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(1.5);
   width -= 2* INNER_PADDING;
   height -= 2 * margin;
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -894,7 +894,7 @@ static gboolean _target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer use
 
   // Margins
   const double INNER_PADDING = 4.0;
-  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(1.5);
   width -= 2* INNER_PADDING;
   height -= 2 * margin;
 
@@ -938,7 +938,7 @@ static gboolean _origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer use
 
   // Margins
   const double INNER_PADDING = 4.0;
-  const float margin = 2. * DT_PIXEL_APPLY_DPI(darktable.bauhaus->line_space);
+  const float margin = 2. * DT_PIXEL_APPLY_DPI(1.5);
   width -= 2* INNER_PADDING;
   height -= 2 * margin;
 


### PR DESCRIPTION
this is a follow up of @TurboGit work on #11351 : 
this ensure vertical alignment of text in *all* situation, whatever the widget height (well, if I've done it right :))

I've done that by computing the height of the text to be sure to align it correctly.

Here's how it looks :
![Capture d’écran_2022-03-17_19-16-13](https://user-images.githubusercontent.com/1818223/158900706-d2e4bae1-f122-4014-b4b0-8a39eceb022c.png)
Line 1 : master before #11351 
Line 2 : master with #11351 
Line 3 : master with this PR
Line 4 : same but with a "forced" height to something big (just as a proof that it works)

Note that the text is aligned the same way as labels

There's still a small issue thought : currently bauhaus combobox apply an hardcoded margin of 1 px to the top only, so for small height with visible background-color, one may say that we should move the text 1 px down... but here the problem is clearly the hardcoded margin that should not be here and certainly not applied to the top only !
So next step is to remove that margin and to implement css margins instead... but not for this evening ;)
 