### PR TITLE
specify midi config params in darktablerc

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3451,7 +3451,7 @@
     <shortdescription>height of the collect list</shortdescription>
     <longdescription>maximum height the collect list in lighttable will grow to before scrolling</longdescription>
   </dtconfig>
-  <dtconfig>
+  <dtconfig prefs="misc" section="interface" capability="midi">
     <name>plugins/midi/devices</name>
     <type>string</type>
     <default></default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3456,6 +3456,6 @@
     <type>string</type>
     <default></default>
     <shortdescription>order or exclude midi devices</shortdescription>
-    <longdescription>comma-separated list of device name fragments that if matched load midi device at id given by location in list or if preceded by - prevent matching devices from loading</longdescription>
+    <longdescription>comma-separated list of device name fragments that if matched load midi device at id given by location in list or if preceded by - prevent matching devices from loading. add encoding and number of knobs like 'BeatStep:63:16'</longdescription>
   </dtconfig>
 </dtconfiglist>

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -546,6 +546,8 @@ static gboolean _timeout_midi_update(gpointer user_data)
 
 void gui_init(dt_lib_module_t *self)
 {
+  dt_capabilities_add("midi");
+
   if(!self->widget)
   {
     self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);


### PR DESCRIPTION
For midi devices that use relative rather than absolute knobs and require an encoding; allow putting this in darktablerc so that it doesn't have to be set at initialisation each time (by turning the knob down 5 steps slowly).
Also read number of knobs if provided, so they will light up immediately instead of only being recognised after being pressed once.

The Loupedeck(+) uses 127 encoding, so you add something like
`plugins/midi/devices=Loupedeck:127`
For other devices it will tell you when turning a knob down 5x at startup. Often they are configurable so might not be universal for everybody using the same device.

Should this string be exposed in the preference dialog? Under miscellaneous/interface? Either way will need to be documented in the midi topic in dtdocs.
