### PR TITLE
ashift: properly transform pts for the rotation computation.

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4807,6 +4807,9 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     g->straightening = FALSE;
     // adjust the line with possible current angle and flip on this module
     float pts[4] = { x, y, g->lastx, g->lasty };
+    dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe,
+                                      self->iop_order,
+                                      DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
 
     float dx = pts[0] - pts[2];
     float dy = pts[1] - pts[3];


### PR DESCRIPTION
Fixes #11360.