### PR TITLE
Some bauhaus improvement but not only

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -54,8 +54,7 @@
 
 /* GTK Buttons and tabs */
 @define-color button_bg @grey_40;
-@define-color button_fg @fg_color;
-@define-color button_checked_bg @grey_55;
+@define-color button_checked_bg @grey_60;
 @define-color button_checked_fg @grey_95;
 @define-color button_hover_bg @grey_65;
 @define-color button_hover_fg @grey_25;

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -46,7 +46,8 @@
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_35;
 @define-color bauhaus_fill @grey_55;
-@define-color bauhaus_bg_hover @grey_65;
+@define-color bauhaus_bg_hover @grey_70;
+@define-color bauhaus_fg_hover @grey_95;
 @define-color bauhaus_fg_selected @grey_85;
 @define-color bauhaus_fg_disabled alpha(@bauhaus_fg, 0.4);
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.4);

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -36,21 +36,15 @@
 
 /* Modules box (plugins) */
 @define-color plugin_bg_color @grey_35;
-@define-color plugin_fg_color @fg_color;
 @define-color plugin_label_color @grey_70;
 @define-color collapsible_bg_color @grey_40;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_bg @bg_color;
-@define-color bauhaus_fg @fg_color;
-@define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_35;
 @define-color bauhaus_fill @grey_55;
 @define-color bauhaus_bg_hover @grey_70;
 @define-color bauhaus_fg_hover @grey_95;
 @define-color bauhaus_fg_selected @grey_85;
-@define-color bauhaus_fg_disabled alpha(@bauhaus_fg, 0.4);
-@define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.4);
 
 /* GTK Buttons and tabs */
 @define-color button_bg @grey_40;
@@ -65,7 +59,6 @@
 @define-color field_active_bg @grey_40;
 @define-color field_active_fg @grey_90;
 @define-color field_selected_bg @grey_55;
-@define-color field_selected_fg @button_checked_fg;
 @define-color field_hover_bg @grey_65;
 @define-color field_hover_fg @grey_20;
 
@@ -77,9 +70,6 @@
 /* Views */
 @define-color darkroom_bg_color @grey_60;
 @define-color darkroom_preview_bg_color @grey_50;
-@define-color print_bg_color @darkroom_bg_color;
-@define-color lighttable_bg_color @darkroom_bg_color;
-@define-color lighttable_preview_bg_color @darkroom_preview_bg_color;
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -53,7 +53,6 @@
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.4);
 
 /* GTK Buttons and tabs */
-@define-color button_border @grey_45;
 @define-color button_bg @grey_40;
 @define-color button_fg @fg_color;
 @define-color button_checked_bg @grey_55;
@@ -66,9 +65,9 @@
 @define-color field_fg @grey_80;
 @define-color field_active_bg @grey_40;
 @define-color field_active_fg @grey_90;
-@define-color field_selected_bg @grey_50;
+@define-color field_selected_bg @grey_55;
 @define-color field_selected_fg @button_checked_fg;
-@define-color field_hover_bg @grey_60;
+@define-color field_hover_bg @grey_65;
 @define-color field_hover_fg @grey_20;
 
 /* Tooltips and contextual helpers */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -55,10 +55,9 @@
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.5);
 
 /* GTK Buttons and tabs */
-@define-color button_border @grey_60;
 @define-color button_bg @grey_55;
 @define-color button_fg @fg_color;
-@define-color button_checked_bg @grey_70;
+@define-color button_checked_bg @grey_65;
 @define-color button_checked_fg @grey_100;
 @define-color button_hover_fg @grey_25;
 
@@ -67,9 +66,9 @@
 @define-color field_fg @grey_95;
 @define-color field_active_bg @grey_50;
 @define-color field_active_fg @grey_95;
-@define-color field_selected_bg @grey_60;
+@define-color field_selected_bg @grey_65;
 @define-color field_selected_fg @button_checked_fg;
-@define-color field_hover_bg @grey_70;
+@define-color field_hover_bg @grey_75;
 @define-color field_hover_fg @grey_35;
 
 /* Tooltips and contextual helpers */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -56,10 +56,10 @@
 
 /* GTK Buttons and tabs */
 @define-color button_bg @grey_55;
-@define-color button_fg @fg_color;
 @define-color button_checked_bg @grey_65;
 @define-color button_checked_fg @grey_100;
-@define-color button_hover_fg @grey_25;
+@define-color button_hover_bg @grey_70;
+@define-color button_hover_fg @grey_30;
 
 /* text fields */
 @define-color field_bg @grey_45;
@@ -67,7 +67,7 @@
 @define-color field_active_bg @grey_50;
 @define-color field_active_fg @grey_95;
 @define-color field_selected_bg @grey_65;
-@define-color field_selected_fg @grey_80;
+@define-color field_selected_fg @button_checked_fg;
 @define-color field_hover_bg @grey_75;
 @define-color field_hover_fg @grey_35;
 

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -60,7 +60,6 @@
 @define-color button_fg @fg_color;
 @define-color button_checked_bg @grey_70;
 @define-color button_checked_fg @grey_100;
-@define-color button_hover_bg @grey_75;
 @define-color button_hover_fg @grey_25;
 
 /* text fields */
@@ -118,6 +117,34 @@
 #history-button *
 {
   color: shade(@plugin_fg_color, 0.8);
+}
+
+/* Hover states, some needed background only */
+.dt_transparent_background:hover,
+button:hover,
+menuitem:hover,
+menuitem:hover > *:not(check),
+combobox window *:hover,
+#bauhaus_combobox:hover,
+radiobutton:hover label,
+#history-button:hover,
+#history-button-enabled:hover,
+#history-button-always-enabled:hover,
+#history-button-default-enabled:hover,
+#iop-plugin-ui button:hover,
+#lib-plugin-ui button:hover,
+#recent-collection-button:hover,
+#view_label:hover,
+#view_dropdown menuitem:hover,
+#view_dropdown .combo:hover
+{
+  background-color: shade(@button_bg, 1.1);
+  background-image: none;
+}
+
+#header-toolbar #bauhaus_combobox:hover
+{
+  background-color: @button_bg;
 }
 
 /* Adjust color of top shown infos on darkroom */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -139,12 +139,16 @@ radiobutton:hover label,
 #view_dropdown .combo:hover
 {
   background-color: shade(@button_bg, 1.1);
-  background-image: none;
 }
 
 #header-toolbar #bauhaus_combobox:hover
 {
   background-color: @button_bg;
+}
+
+#collapsible .combo:hover
+{
+  background-color: shade(@button_bg, 1.25);
 }
 
 /* Adjust color of top shown infos on darkroom */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -38,14 +38,11 @@
 
 /* Modules box (plugins) */
 @define-color plugin_bg_color @grey_50;
-@define-color plugin_fg_color @fg_color;
 @define-color plugin_label_color @grey_80;
 @define-color collapsible_bg_color @grey_55;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_bg @bg_color;
 @define-color bauhaus_fg shade(@fg_color, 0.95);
-@define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_50;
 @define-color bauhaus_fill @grey_70;
 @define-color bauhaus_bg_hover @grey_80;
@@ -67,7 +64,6 @@
 @define-color field_active_bg @grey_50;
 @define-color field_active_fg @grey_95;
 @define-color field_selected_bg @grey_65;
-@define-color field_selected_fg @button_checked_fg;
 @define-color field_hover_bg @grey_75;
 @define-color field_hover_fg @grey_35;
 
@@ -79,9 +75,6 @@
 /* Views */
 @define-color darkroom_bg_color @grey_75;
 @define-color darkroom_preview_bg_color @grey_65;
-@define-color print_bg_color @darkroom_bg_color;
-@define-color lighttable_bg_color @darkroom_bg_color;
-@define-color lighttable_preview_bg_color @darkroom_preview_bg_color;
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -67,7 +67,7 @@
 @define-color field_active_bg @grey_50;
 @define-color field_active_fg @grey_95;
 @define-color field_selected_bg @grey_65;
-@define-color field_selected_fg @button_checked_fg;
+@define-color field_selected_fg @grey_80;
 @define-color field_hover_bg @grey_75;
 @define-color field_hover_fg @grey_35;
 

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -48,9 +48,9 @@
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_50;
 @define-color bauhaus_fill @grey_70;
-@define-color bauhaus_bg_hover @grey_65;
-@define-color bauhaus_fg_hover @grey_85;
-@define-color bauhaus_fg_selected @grey_85;
+@define-color bauhaus_bg_hover @grey_80;
+@define-color bauhaus_fg_hover @grey_100;
+@define-color bauhaus_fg_selected @grey_75;
 @define-color bauhaus_fg_disabled alpha(@bauhaus_fg, 0.5);
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.5);
 
@@ -117,38 +117,6 @@
 #history-button *
 {
   color: shade(@plugin_fg_color, 0.8);
-}
-
-/* Hover states, some needed background only */
-.dt_transparent_background:hover,
-button:hover,
-menuitem:hover,
-menuitem:hover > *:not(check),
-combobox window *:hover,
-#bauhaus_combobox:hover,
-radiobutton:hover label,
-#history-button:hover,
-#history-button-enabled:hover,
-#history-button-always-enabled:hover,
-#history-button-default-enabled:hover,
-#iop-plugin-ui button:hover,
-#lib-plugin-ui button:hover,
-#recent-collection-button:hover,
-#view_label:hover,
-#view_dropdown menuitem:hover,
-#view_dropdown .combo:hover
-{
-  background-color: shade(@button_bg, 1.1);
-}
-
-#header-toolbar #bauhaus_combobox:hover
-{
-  background-color: @button_bg;
-}
-
-#collapsible .combo:hover
-{
-  background-color: shade(@button_bg, 1.25);
 }
 
 /* Adjust color of top shown infos on darkroom */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -300,28 +300,27 @@ textview
   font-family: sans-serif;
 }
 
-button:disabled
+button:disabled,
+#collapsible .combo:disabled,
+#recent-collection-button:disabled
 {
+  background-color: transparent;
   border: 0.07em solid shade(@button_border, 0.95);
+}
+
+/* Set same settings on all those items */
+.combo,
+.combo *,
+button
+{
+  min-height: 1em;
+  min-width: 1em;
 }
 
 /* Default extra margin for icons optical alignment */
 #button-canvas
 {
   margin: 5px; /* not real pixels. This is used as a percent extra space and couldn't be scalable */
-}
-
-/* Set same settings on all those items */
-button,
-#modules-tabs button,
-#blending-tabs button,
-combobox,
-combobox button,
-combobox *,
-#control-button
-{
-  min-height: 1em;
-  min-width: 1em;
 }
 
 /* Default text fields and text boxes */
@@ -677,6 +676,48 @@ l
   padding: 0 0.35em 0 0.21em;
 }
 
+/* Collapsible sections on lib & iop modules */
+#collapse-block
+{
+  margin: 0.14em 0;
+}
+
+#collapsible
+{
+  padding: 0.14em 0.28em 0.28em 0.42em;
+  border: 0.07em solid shade(@collapsible_bg_color, 0.85);
+  border-top: 0;
+}
+
+#collapsible,
+#collapsible #bauhaus_slider
+{
+  background-color: shade(@collapsible_bg_color, 1.04);
+}
+
+/* for the import parameters to be more aligned with the imports buttons */
+#lib-plugin-ui #collapse-block
+{
+  margin: 0.42em 0.07em;
+}
+
+#collapse-block .section-expander,
+#collapsible-label
+{
+  background-color: shade(@collapsible_bg_color, 0.96);
+  border: none;
+  margin-top: 0.14em;
+  padding: 0.07em 0;
+}
+
+#collapsible .combo,
+#collapsible entry,
+#collapsible textview
+{
+  background-color: shade(@button_border, 1.06);
+  border: 0.07em solid shade(@field_active_bg, 1.06);
+}
+
 /*-------------------
   - Scope/Histogram -
   -------------------*/
@@ -942,14 +983,6 @@ combobox label
   margin: 0 0.35em 0 0;
 }
 
-/* Menus options */
-menuitem button,
-popover button,
-tooltip button
-{
-  background-color: transparent;
-}
-
 /* Header and footer labels, especially for combobox */
 #header-toolbar label,
 #footer-toolbar label
@@ -986,7 +1019,7 @@ notebook tabs,
 #blending-tabs,
 #guides-line
 {
-  background-color: @button_border;
+  background-color: @field_active_bg;
 }
 
 #modules-tabs #dt-toggle-button
@@ -1495,14 +1528,9 @@ filechooser widget treeview
   color: @field_fg;
 }
 
-treeview header widget button,
-#iop-plugin-ui treeview header button,
-#lib-plugin-ui treeview header button,
-#preferences_notebook header button,
+treeview header widget button
 .accels_window_list header button
 {
-  background-color: @button_bg;
-  color: @button_fg;
   border: 0;
   border-radius: 0;
   padding: 0;
@@ -1510,9 +1538,6 @@ treeview header widget button,
 }
 
 treeview header label,
-#iop-plugin-ui treeview header label,
-#lib-plugin-ui treeview header label,
-#preferences_notebook header button label,
 .accels_window_list header button label
 {
   font-weight: bold;
@@ -1596,8 +1621,6 @@ progressbar progress
 }
 
 /* Checkbutton check state */
-#lib-plugin-ui checkbutton check,
-#iop-plugin-ui checkbutton check,
 checkbutton check
 {
   margin: 0.35em 0.56em 0.35em 0;
@@ -1768,7 +1791,6 @@ menuitem:active,
 menuitem:selected,
 combobox window *:active,
 combobox window *:selected,
-#modules-tabs button:checked,
 #history-button:active,
 #history-button-enabled:active,
 #history-button-always-enabled:active,
@@ -1787,7 +1809,6 @@ combobox window *:selected,
 messagedialog .default  /* this show that a button in confirmation action pop-up has the focus (no by default) */
 {
   background-color: @button_checked_bg;
-  background-image: none;
   color: @button_checked_fg;
 }
 
@@ -1813,9 +1834,9 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 button:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
+radiobutton:hover label,
 combobox window *:hover,
 #bauhaus_combobox:hover,
-radiobutton:hover label,
 #history-button:hover,
 #history-button-enabled:hover,
 #history-button-always-enabled:hover,
@@ -1825,13 +1846,16 @@ radiobutton:hover label,
 #view_dropdown .combo:hover
 {
   background-color: shade(@button_bg, 1.33);
-  background-image: none;
 }
 
-#header-toolbar #bauhaus_combobox:hover,
-#modules-tabs button:hover
+#header-toolbar #bauhaus_combobox:hover
 {
   background-color: shade(@button_bg, 1.2);
+}
+
+#collapsible .combo:hover
+{
+  background-color: shade(@button_bg, 1.5);
 }
 
 /* workaround for a macOS quartz GTK backend bug
@@ -1859,15 +1883,6 @@ menuitem > *
 #history-button *
 {
   color: shade(@plugin_fg_color, 0.7);
-  background-color: transparent;
-}
-
-/* Disabled buttons */
-button:disabled,
-#collapsible .combo:disabled,
-#recent-collection-button:disabled
-{
-  color: @disabled_fg_color;
   background-color: transparent;
 }
 
@@ -1982,11 +1997,6 @@ treeview#delete-dialog:selected
 #view_label:disabled
 {
   color: @tooltip_bg_color;
-}
-
-#view_dropdown *:disabled
-{
-  color: @disabled_fg_color;
 }
 
 /* Sliders states */
@@ -2681,46 +2691,4 @@ Details :
 #lighttable_layouts_box #dt-toggle-button
 {
   margin: 0 0.4em;
-}
-
-/* Collapsible sections on lib & iop modules */
-#collapse-block
-{
-  margin: 0.14em 0;
-}
-
-#collapsible
-{
-  padding: 0.14em 0.28em 0.28em 0.42em;
-  border: 0.07em solid shade(@collapsible_bg_color, 0.85);
-  border-top: 0;
-}
-
-#collapsible,
-#collapsible #bauhaus_slider
-{
-  background-color: shade(@collapsible_bg_color, 1.04);
-}
-
-/* for the import parameters to be more aligned with the imports buttons */
-#lib-plugin-ui #collapse-block
-{
-  margin: 0.42em 0.07em;
-}
-
-#collapse-block .section-expander,
-#collapsible-label
-{
-  background-color: shade(@collapsible_bg_color, 0.96);
-  border: none;
-  margin-top: 0.14em;
-  padding: 0.07em 0;
-}
-
-#collapsible .combo,
-#collapsible entry,
-#collapsible textview
-{
-  background-color: shade(@button_border, 1.06);
-  border: 0.07em solid shade(@field_active_bg, 1.06);
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1827,7 +1827,7 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 
 /* Hover states, some needed background only */
 .dt_transparent_background:hover,
-button:hover,
+button:hover:not(.combo),
 filechooser row:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
@@ -1849,14 +1849,13 @@ treeview:not(#lutname) *:hover:not(check),
   color: shade(@fg_color, 1.15);
 }
 
-.combo,
+.combo:hover,
 combobox window *:hover,
 #bauhaus_combobox:hover,
 #collapsible .combo:hover,
 #header-toolbar #bauhaus_combobox:hover
 {
-  background-color: alpha(@bauhaus_bg_hover, 0.15);
-  color: shade(@fg_color, 1.15);
+  color: shade(@fg_color, 1.2);
 }
 
 /* workaround for a macOS quartz GTK backend bug
@@ -1991,8 +1990,7 @@ treeview#delete-dialog:selected
 }
 
 /* Sliders states */
-#bauhaus_popup:hover,
-#bauhaus_slider:hover
+#bauhaus_popup:hover
 {
   color: @bauhaus_fg_hover;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -104,7 +104,7 @@
 @define-color button_bg @grey_25;
 @define-color button_border shade(@button_bg, 1.05);
 @define-color button_fg @fg_color;
-@define-color button_checked_bg @grey_35;
+@define-color button_checked_bg @grey_45;
 @define-color button_checked_fg @grey_85;
 @define-color button_hover_bg @grey_50;
 @define-color button_hover_fg @grey_15;
@@ -335,17 +335,32 @@ textview
   padding: 0.14em;
 }
 
-entry selection
+label selection,
+textview text selection
 {
   background-color: @field_selected_bg;
 }
 
+entry selection
+{
+  background-color: shade(@field_selected_bg, 1.1);
+}
+
 /* Filter bar bauhaus-combobox and search box defaults */
-#header-toolbar #bauhaus_combobox,
-.search
+#header-toolbar #bauhaus_combobox
 {
   background-color: alpha(@fg_color, 0.05);
   border: none;
+}
+
+.search
+{
+  background-color: alpha(@fg_color, 0.12);
+}
+
+.search image:disabled
+{
+  color: shade(@fg_color, 0.75);
 }
 
 /* Checkbox */
@@ -896,6 +911,11 @@ popover #bauhaus_slider
   background-color: @tooltip_bg_color;
 }
 
+#bauhaus_slider
+{
+  background-color: @plugin_bg_color;
+}
+
 #blending-box #dt-toggle-button
 {
   margin-top: 0;
@@ -944,14 +964,9 @@ menu menuitem
   margin-left: -0.42em;
 }
 
-menu menuitem label
-{
-  margin-right: 0.42em;
-}
-
 menuitem > arrow
 {
-  padding-right: 0.14em;
+  padding-right: 0.28em;
   border: 0;
 }
 
@@ -1844,14 +1859,16 @@ treeview:not(#lutname) *:hover:not(check),
 #view_label:hover,
 #view_dropdown .combo:hover
 {
-  background-color: alpha(@button_hover_bg, 0.6);
-  border-color: alpha(@button_hover_bg, 0.6);
+  background-color: alpha(@button_hover_bg, 0.5);
+  border-color: transparent;
   color: shade(@fg_color, 1.15);
 }
 
 .combo:hover,
+.combo:hover cellview,
 combobox window *:hover,
 #bauhaus_combobox:hover,
+#bauhaus_slider:hover,
 #collapsible .combo:hover,
 #header-toolbar #bauhaus_combobox:hover
 {
@@ -1868,7 +1885,9 @@ button:checked cellview
 }
 
 /* Set submenus */
-menuitem > *
+menuitem > *,
+#module-always-enabled-button,
+#module-enable-button
 {
     color: @fg_color;
 }
@@ -2023,12 +2042,6 @@ treeview#delete-dialog:selected
   padding: 0.14em 0 0.14em 0.42em;
 }
 
-#bauhaus_combobox
-{
-  padding: 0.14em 0 0.14em 0.28em;
-  margin-left: -0.14em;   /* needed to align combobox to lines around when setting a padding left for spacing inside combobox ; set it half of padding left set line above */
-}
-
 /* Notebooks states */
 notebook tab:hover
 {
@@ -2064,14 +2077,6 @@ entry:active
 }
 
 entry:checked
-{
-  color: @field_selected_fg;
-  background-color: @field_selected_bg;
-}
-
-entry:selected,
-label selection,
-textview text selection
 {
   color: @field_selected_fg;
   background-color: @field_selected_bg;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -106,7 +106,6 @@
 @define-color button_fg @fg_color;
 @define-color button_checked_bg @grey_45;
 @define-color button_checked_fg @grey_85;
-@define-color button_hover_bg @grey_50;
 @define-color button_hover_fg @grey_15;
 
 /* text fields */
@@ -286,20 +285,22 @@ popover #bauhaus_combobox,
   min-width: 1.4em;
 }
 
-/* Default gtk buttons */
+/* Default gtk buttons and other entries */
 button,
-#add-color-button
+checkbutton check,
+entry,
+textview
 {
   padding: 2px; /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
   border: 0.07em solid @button_border;
+  border-radius: 0.21em;
   background-color: @button_bg;
   color: @button_fg;
   font-weight: normal;
   font-family: sans-serif;
 }
 
-button:disabled,
-#add-color-button:disabled
+button:disabled
 {
   border: 0.07em solid shade(@button_border, 0.95);
 }
@@ -312,16 +313,8 @@ button:disabled,
 
 /* Set same settings on all those items */
 button,
-#add-color-button,
-#dt-icon,
-entry,
-textview
-{
-  border-radius: 0.21em;
-}
-
-button,
-#add-color-button,
+#modules-tabs button,
+#blending-tabs button,
 combobox,
 combobox button,
 combobox *,
@@ -332,16 +325,6 @@ combobox *,
 }
 
 /* Default text fields and text boxes */
-.combo,
-checkbutton check,
-entry,
-textview
-{
-  color: @field_fg;
-  background-color: @button_bg;
-  border: 0.07em solid shade(@button_border, 0.94);
-}
-
 entry,
 textview
 {
@@ -1453,8 +1436,8 @@ filechooser row:hover .sidebar-icon
 filechooser row:hover,
 #preferences_box .sidebar :hover  /* be sure border is set but same color as background-color hover effect and for same reason as just above */
 {
-  border-left-color: @button_hover_bg;
-  background-color: @button_hover_bg;
+  border-left-color: @button_bg;
+  background-color: @button_bg;
 }
 
 #preferences_box .sidebar label
@@ -1785,6 +1768,7 @@ menuitem:active,
 menuitem:selected,
 combobox window *:active,
 combobox window *:selected,
+#modules-tabs button:checked,
 #history-button:active,
 #history-button-enabled:active,
 #history-button-always-enabled:active,
@@ -1798,8 +1782,6 @@ combobox window *:selected,
 #history-button-enabled:selected,
 #history-button-always-enabled:selected,
 #history-button-default-enabled:selected,
-#iop-plugin-ui button:active,
-#lib-plugin-ui button:active,
 #recent-collection-button:active,
 #recent-collection-button:selected,
 messagedialog .default  /* this show that a button in confirmation action pop-up has the focus (no by default) */
@@ -1829,55 +1811,27 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 /* Hover states, some needed background only */
 .dt_transparent_background:hover,
 button:hover,
-#add-color-button:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
 combobox window *:hover,
 #bauhaus_combobox:hover,
-#header-toolbar #bauhaus_combobox:hover,
 radiobutton:hover label,
-#control-button:hover,
 #history-button:hover,
 #history-button-enabled:hover,
 #history-button-always-enabled:hover,
 #history-button-default-enabled:hover,
-#iop-plugin-ui button:hover,
-#lib-plugin-ui button:hover,
 #recent-collection-button:hover,
 #view_label:hover,
-#view_dropdown menuitem:hover,
 #view_dropdown .combo:hover
 {
-  background-color: @button_hover_bg;
+  background-color: shade(@button_bg, 1.33);
   background-image: none;
 }
 
- /* and same for color as other needs only color setting */
-.combo:hover *,
-#bauhaus_combobox:hover,
 #header-toolbar #bauhaus_combobox:hover,
-button:hover,
-button:hover cellview,
-button:hover image,
-button:hover label,
-#blending-box button:hover, /* needed for hover effect for some blending mask box buttons */
-button:checked cellview,
-button:checked image,
-button:checked label,
-dialog row:hover label,
-menuitem:hover cellview,
-menuitem:hover > *,
-notebook tab:hover label,
-#control-button:hover,
-#history-button:hover *,
-#history-button-enabled:hover *,
-#history-button-always-enabled:hover *,
-#history-button-default-enabled:hover *,
-#recent-collection-button:hover,
-#view_label:hover,button:checked image,
-#view_dropdown menuitem:hover
+#modules-tabs button:hover
 {
-  color: @button_hover_fg;
+  background-color: shade(@button_bg, 1.2);
 }
 
 /* workaround for a macOS quartz GTK backend bug
@@ -2019,7 +1973,8 @@ treeview#delete-dialog:selected
 
 /* Views links states in header */
 #view_dropdown *:selected,
-#view_label:selected
+#view_label:selected,
+#view_label:hover
 {
   color: @button_fg;
 }
@@ -2093,7 +2048,7 @@ notebook tab:hover
 {
   border-bottom: 0.14em solid @button_hover_fg;
   color: @button_hover_fg;
-  background-color: @button_hover_bg;
+  background-color: @button_bg;
 }
 
 notebook tab:checked

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -94,7 +94,7 @@
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_20;
 @define-color bauhaus_fill @grey_40;
-@define-color bauhaus_bg_hover @grey_55;
+@define-color bauhaus_bg_hover @grey_60;
 @define-color bauhaus_fg_hover @grey_90;
 @define-color bauhaus_fg_selected @grey_80;
 @define-color bauhaus_fg_disabled alpha(@bauhaus_fg, 0.4);
@@ -285,7 +285,7 @@ popover #bauhaus_combobox,
   min-width: 1.4em;
 }
 
-/* Default gtk buttons and other entries */
+/* Default Gtk buttons and other entries */
 button,
 checkbutton check,
 entry,
@@ -337,12 +337,12 @@ entry selection
   background-color: @field_selected_bg;
 }
 
-/* Bauhaus-combobox and search box defaults */
+/* Filter bar bauhaus-combobox and search box defaults */
 #header-toolbar #bauhaus_combobox,
 .search
 {
-  background-color: shade(@button_bg, 0.9);
-  border: 0.07em solid shade(@bauhaus_indicator_border, 0.9);
+  background-color: alpha(@fg_color, 0.05);
+  border: none;
 }
 
 /* Checkbox */
@@ -885,12 +885,6 @@ dialog headerbar entry
 popover #bauhaus_slider
 {
   background-color: @tooltip_bg_color;
-}
-
-#iop-plugin-ui #bauhaus_slider,
-#lib-plugin-ui #bauhaus_slider
-{
-  background-color: @plugin_bg_color;
 }
 
 #blending-box #dt-toggle-button
@@ -1835,8 +1829,6 @@ button:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
 radiobutton:hover label,
-combobox window *:hover,
-#bauhaus_combobox:hover,
 #history-button:hover,
 #history-button-enabled:hover,
 #history-button-always-enabled:hover,
@@ -1845,17 +1837,19 @@ combobox window *:hover,
 #view_label:hover,
 #view_dropdown .combo:hover
 {
-  background-color: shade(@button_bg, 1.33);
+  background-color: shade(@button_bg, 1.15);
+  border-color: shade(@button_bg, 1.15);
+  color: shade(@fg_color, 1.15);
 }
 
-#header-toolbar #bauhaus_combobox:hover
-{
-  background-color: shade(@button_bg, 1.2);
-}
-
+.combo,
+combobox window *:hover,
+#bauhaus_combobox:hover,
+#header-toolbar #bauhaus_combobox:hover,
 #collapsible .combo:hover
 {
-  background-color: shade(@button_bg, 1.5);
+  background-color: alpha(@bauhaus_bg_hover, 0.15);
+  color: shade(@fg_color, 1.15);
 }
 
 /* workaround for a macOS quartz GTK backend bug

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -101,11 +101,12 @@
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.4);
 
 /* GTK Buttons and tabs */
-@define-color button_border @grey_30;
 @define-color button_bg @grey_25;
+@define-color button_border shade(@button_bg, 1.05);
 @define-color button_fg @fg_color;
-@define-color button_checked_bg @grey_45;
+@define-color button_checked_bg @grey_35;
 @define-color button_checked_fg @grey_85;
+@define-color button_hover_bg @grey_50;
 @define-color button_hover_fg @grey_15;
 
 /* text fields */
@@ -113,9 +114,9 @@
 @define-color field_fg @button_fg;
 @define-color field_active_bg @grey_30;
 @define-color field_active_fg @grey_80;
-@define-color field_selected_bg @grey_40;
+@define-color field_selected_bg @grey_45;
 @define-color field_selected_fg @button_checked_fg;
-@define-color field_hover_bg @grey_45;
+@define-color field_hover_bg @grey_55;
 @define-color field_hover_fg @grey_95;
 
 /* Tooltips and contextual helpers */
@@ -301,11 +302,13 @@ textview
 }
 
 button:disabled,
+spinbutton *:disabled,
 #collapsible .combo:disabled,
+#collapsible spinbutton button:disabled,
 #recent-collection-button:disabled
 {
   background-color: transparent;
-  border: 0.07em solid shade(@button_border, 0.95);
+  border: 0.07em solid shade(@button_border, 0.9);
 }
 
 /* Set same settings on all those items */
@@ -685,7 +688,7 @@ l
 #collapsible
 {
   padding: 0.14em 0.28em 0.28em 0.42em;
-  border: 0.07em solid shade(@collapsible_bg_color, 0.85);
+  border: 0.07em solid shade(@collapsible_bg_color, 1.05);
   border-top: 0;
 }
 
@@ -693,6 +696,11 @@ l
 #collapsible #bauhaus_slider
 {
   background-color: shade(@collapsible_bg_color, 1.04);
+}
+
+#import_metadata #collapsible
+{
+  background-color: @collapsible_bg_color;
 }
 
 /* for the import parameters to be more aligned with the imports buttons */
@@ -712,6 +720,7 @@ l
 
 #collapsible .combo,
 #collapsible entry,
+#collapsible spinbutton button,
 #collapsible textview
 {
   background-color: shade(@button_border, 1.06);
@@ -1460,13 +1469,6 @@ filechooser row:hover .sidebar-icon
   border-left-color: @field_hover_bg;   /* make the border left visible with chosen color if category on sidebar is selected */
 }
 
-filechooser row:hover,
-#preferences_box .sidebar :hover  /* be sure border is set but same color as background-color hover effect and for same reason as just above */
-{
-  border-left-color: @button_bg;
-  background-color: @button_bg;
-}
-
 #preferences_box .sidebar label
 {
   padding: 0.14em 0.84em;
@@ -1826,27 +1828,32 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 /* Hover states, some needed background only */
 .dt_transparent_background:hover,
 button:hover,
+filechooser row:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
+notebook tab:hover,
 radiobutton:hover label,
+treeview:not(#lutname) *:hover:not(check),
+#bauhaus_combobox:hover,
+#collapsible spinbutton button:hover,
 #history-button:hover,
 #history-button-enabled:hover,
 #history-button-always-enabled:hover,
 #history-button-default-enabled:hover,
+#preferences_box .sidebar :hover,
 #recent-collection-button:hover,
 #view_label:hover,
 #view_dropdown .combo:hover
 {
-  background-color: shade(@button_bg, 1.15);
-  border-color: shade(@button_bg, 1.15);
+  background-color: alpha(@button_hover_bg, 0.5);
+  border-color: alpha(@button_hover_bg, 0.5);
   color: shade(@fg_color, 1.15);
 }
 
 .combo,
 combobox window *:hover,
-#bauhaus_combobox:hover,
-#header-toolbar #bauhaus_combobox:hover,
-#collapsible .combo:hover
+#collapsible .combo:hover,
+#header-toolbar #bauhaus_combobox:hover
 {
   background-color: alpha(@bauhaus_bg_hover, 0.15);
   color: shade(@fg_color, 1.15);
@@ -1902,16 +1909,6 @@ menuitem check
 {
   background-color: @field_active_bg;
   border-color: @border_color;
-}
-
-treeview:not(#lutname) *:hover:not(check),
-filechooser .sidebar :hover .sidebar-button,  /* set here specific button hover like eject button in filechooser sidebar */
-#import_metadata title:hover,
-#import_metadata title:hover *,
-radiobutton:hover label  /* set hover effect on popover menu from star icon */
-{
-  background-color: @field_hover_bg;
-  color: @field_hover_fg;
 }
 
 treeview *:active,
@@ -2022,43 +2019,32 @@ treeview#delete-dialog:selected
   color: shade(@bauhaus_fg_selected, 1.2);
 }
 
-#bauhaus_slider
-{
- padding: 0px 0px 1px 0px;
-}
-.bauhaus_slider_popup
-{
-  padding: 2px 0px 2px 4px;
-}
+.bauhaus_slider_popup,
 .bauhaus_combo_popup
 {
-  padding: 2px 0px 2px 2px;
-}
-#bauhaus_combobox
-{
- padding: 2px 0px 2px 0px;
+  padding: 0.14em 0 0.14em 0.42em;
 }
 
-#lib-plugin-ui #bauhaus_combobox,
-#lib-plugin-ui #bauhaus_slider,
-#iop-plugin-ui #bauhaus_combobox,
-#iop-plugin-ui #bauhaus_slider
+#bauhaus_combobox
 {
-  margin-top : 1px;
+  padding: 0.14em 0 0.14em 0.28em;
+  margin-left: -0.14em;   /* needed to align combobox to lines around when setting a padding left for spacing inside combobox ; set it half of padding left set line above */
 }
 
 /* Notebooks states */
 notebook tab:hover
 {
-  border-bottom: 0.14em solid @button_hover_fg;
-  color: @button_hover_fg;
-  background-color: @button_bg;
+  border-bottom: 0.14em solid shade(@button_checked_fg, 0.7);
+}
+
+notebook tab:hover label
+{
+  color: shade(@button_checked_fg, 0.9);
 }
 
 notebook tab:checked
 {
   border-bottom: 0.14em solid @button_checked_fg;
-  color: @button_checked_fg;
 }
 
 notebook tab:checked label

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -271,7 +271,7 @@ overshoot.left,
 overshoot.right,
 .dt_transparent_background,
 .dt_transparent_background:checked,
-popover #bauhaus-combobox,
+popover #bauhaus_combobox,
 #usercss_box textview,
 #view_dropdown .combo
 {
@@ -356,7 +356,7 @@ entry selection
 }
 
 /* Bauhaus-combobox and search box defaults */
-#header-toolbar #bauhaus-combobox,
+#header-toolbar #bauhaus_combobox,
 .search
 {
   background-color: shade(@button_bg, 0.9);
@@ -848,23 +848,23 @@ dialog headerbar entry
   - Bauhaus controls (sliders and comboboxes in modules) -
   --------------------------------------------------------*/
 
-#bauhaus-popup
+#bauhaus_popup
 {
   color: @bauhaus_fg;
 }
 
-#bauhaus-popup:selected
+#bauhaus_popup:selected
 {
   color: @bauhaus_fg_selected;
 }
 
-popover #bauhaus-slider
+popover #bauhaus_slider
 {
   background-color: @tooltip_bg_color;
 }
 
-#iop-plugin-ui #bauhaus-slider,
-#lib-plugin-ui #bauhaus-slider
+#iop-plugin-ui #bauhaus_slider,
+#lib-plugin-ui #bauhaus_slider
 {
   background-color: @plugin_bg_color;
 }
@@ -899,8 +899,8 @@ tooltip,
 popover,
 combobox window,
 dialog combobox window,
-#bauhaus-combobox *,
-#bauhaus-slider *
+#bauhaus_combobox *,
+#bauhaus_slider *
 {
   opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
   background-color: @tooltip_bg_color;
@@ -1833,8 +1833,8 @@ button:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
 combobox window *:hover,
-#bauhaus-combobox:hover,
-#header-toolbar #bauhaus-combobox:hover,
+#bauhaus_combobox:hover,
+#header-toolbar #bauhaus_combobox:hover,
 radiobutton:hover label,
 #control-button:hover,
 #history-button:hover,
@@ -1854,8 +1854,8 @@ radiobutton:hover label,
 
  /* and same for color as other needs only color setting */
 .combo:hover *,
-#bauhaus-combobox:hover,
-#header-toolbar #bauhaus-combobox:hover,
+#bauhaus_combobox:hover,
+#header-toolbar #bauhaus_combobox:hover,
 button:hover,
 button:hover cellview,
 button:hover image,
@@ -2035,35 +2035,35 @@ treeview#delete-dialog:selected
 }
 
 /* Sliders states */
-#bauhaus-popup:hover,
-#bauhaus-slider:hover
+#bauhaus_popup:hover,
+#bauhaus_slider:hover
 {
   color: @bauhaus_fg_hover;
 }
 
-#bauhaus-popup:disabled,
-#bauhaus-combobox:disabled,
-#bauhaus-slider:disabled
+#bauhaus_popup:disabled,
+#bauhaus_combobox:disabled,
+#bauhaus_slider:disabled
 {
   color: @bauhaus_fg_disabled;
 }
 
-#bauhaus-popup:disabled
+#bauhaus_popup:disabled
 {
   color: @plugin_bg;
 }
 
-#bauhaus-combobox *
+#bauhaus_combobox *
 {
   color: shade(@bauhaus_fg, 0.8);
 }
 
-#bauhaus-combobox *:selected
+#bauhaus_combobox *:selected
 {
   color: shade(@bauhaus_fg_selected, 1.2);
 }
 
-#bauhaus-slider
+#bauhaus_slider
 {
  padding: 0px 0px 1px 0px;
 }
@@ -2075,15 +2075,15 @@ treeview#delete-dialog:selected
 {
   padding: 2px 0px 2px 2px;
 }
-#bauhaus-combobox
+#bauhaus_combobox
 {
  padding: 2px 0px 2px 0px;
 }
 
-#lib-plugin-ui #bauhaus-combobox,
-#lib-plugin-ui #bauhaus-slider,
-#iop-plugin-ui #bauhaus-combobox,
-#iop-plugin-ui #bauhaus-slider
+#lib-plugin-ui #bauhaus_combobox,
+#lib-plugin-ui #bauhaus_slider,
+#iop-plugin-ui #bauhaus_combobox,
+#iop-plugin-ui #bauhaus_slider
 {
   margin-top : 1px;
 }
@@ -2742,7 +2742,7 @@ Details :
 }
 
 #collapsible,
-#collapsible #bauhaus-slider
+#collapsible #bauhaus_slider
 {
   background-color: shade(@collapsible_bg_color, 1.04);
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1834,7 +1834,6 @@ menuitem:hover > *:not(check),
 notebook tab:hover,
 radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
-#bauhaus_combobox:hover,
 #collapsible spinbutton button:hover,
 #history-button:hover,
 #history-button-enabled:hover,
@@ -1845,13 +1844,14 @@ treeview:not(#lutname) *:hover:not(check),
 #view_label:hover,
 #view_dropdown .combo:hover
 {
-  background-color: alpha(@button_hover_bg, 0.5);
-  border-color: alpha(@button_hover_bg, 0.5);
+  background-color: alpha(@button_hover_bg, 0.6);
+  border-color: alpha(@button_hover_bg, 0.6);
   color: shade(@fg_color, 1.15);
 }
 
 .combo,
 combobox window *:hover,
+#bauhaus_combobox:hover,
 #collapsible .combo:hover,
 #header-toolbar #bauhaus_combobox:hover
 {

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -714,7 +714,7 @@ void dt_bauhaus_init()
   darktable.bauhaus->keys_cnt = 0;
   darktable.bauhaus->current = NULL;
   darktable.bauhaus->popup_area = gtk_drawing_area_new();
-  gtk_widget_set_name(darktable.bauhaus->popup_area, "bauhaus-popup");
+  gtk_widget_set_name(darktable.bauhaus->popup_area, "bauhaus_popup");
   darktable.bauhaus->pango_font_desc = NULL;
 
   dt_bauhaus_load_theme();
@@ -1185,7 +1185,7 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
   d->timeout_handle = 0;
   d->curve = _default_linear_curve;
 
-  gtk_widget_set_name(GTK_WIDGET(w), "bauhaus-slider");
+  gtk_widget_set_name(GTK_WIDGET(w), "bauhaus_slider");
 
   g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(dt_bauhaus_slider_button_press), NULL);
   g_signal_connect(G_OBJECT(w), "button-release-event", G_CALLBACK(dt_bauhaus_slider_button_release), NULL);
@@ -1234,7 +1234,7 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *sel
   d->populate = NULL;
   d->text = NULL;
 
-  gtk_widget_set_name(GTK_WIDGET(w), "bauhaus-combobox");
+  gtk_widget_set_name(GTK_WIDGET(w), "bauhaus_combobox");
 
   g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(dt_bauhaus_combobox_button_press), NULL);
   g_signal_connect(G_OBJECT(w), "motion-notify-event", G_CALLBACK(dt_bauhaus_combobox_motion_notify), NULL);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1558,6 +1558,13 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
     cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, alpha);
   }
 
+  /* make blue color label icon more visible and well balanced with other colors */
+  if(flags & CPF_DIRECTION_RIGHT)
+  {
+    cairo_set_line_width(cr, 1.2 * cairo_get_line_width(cr));
+  }
+  
+  /* then improve hover effect for same blue icon */
   if (flags & CPF_PRELIGHT)
   {
     cairo_set_line_width(cr, 1.2 * cairo_get_line_width(cr));
@@ -1568,7 +1575,6 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
     cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
     cairo_fill(cr);
   }
-
   else if(flags & CPF_USER_DATA_EXCLUDE)
   {
     /* fill base color */

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -43,7 +43,7 @@ const GdkRGBA _colorlabels[]
   = { {.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 }, // red
       {.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 }, // yellow
       {.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 }, // green
-      {.red = 0.0, .green = 0.0, .blue = 0.9, .alpha = 1.0 }, // blue
+      {.red = 0.0, .green = 0.1, .blue = 0.9, .alpha = 1.0 }, // blue (need a little green here to improve contrast of blue label in darker theme especially while being good in other themes)
       {.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 }, // purple
     };
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1558,11 +1558,17 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
     cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, alpha);
   }
 
+  if (flags & CPF_PRELIGHT)
+  {
+    cairo_set_line_width(cr, 1.2 * cairo_get_line_width(cr));
+  }
+
   if(flags & CPF_USER_DATA_INCLUDE)
   {
     cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
     cairo_fill(cr);
   }
+
   else if(flags & CPF_USER_DATA_EXCLUDE)
   {
     /* fill base color */

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3914,6 +3914,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("auto tune levels")), TRUE, TRUE, 0);
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), g->auto_button, FALSE, FALSE, 0);
+  dt_action_define_iop(self, NULL, N_("auto tune levels"), GTK_WIDGET(g->auto_button), &dt_action_def_button);
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1675,7 +1675,7 @@ void gui_update(struct dt_iop_module_t *self)
   show_guiding_controls(self);
   invalidate_luminance_cache(self);
 
-  dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), g->mask_display);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
@@ -1871,7 +1871,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
 }
 
 
-static void show_luminance_mask_callback(GtkWidget *togglebutton, dt_iop_module_t *self)
+static void show_luminance_mask_callback(GtkWidget *togglebutton, GdkEventButton *event, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_request_focus(self);
@@ -1884,14 +1884,14 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton, dt_iop_module_
   if(self->request_mask_display)
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
-    dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), FALSE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), FALSE);
     g->mask_display = 0;
     return;
   }
   else
     g->mask_display = !g->mask_display;
 
-  dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), g->mask_display);
 //  dt_dev_reprocess_center(self->dev);
   dt_iop_refresh_center(self);
 
@@ -2424,7 +2424,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   {
     //lost focus - stop showing mask
     g->mask_display = FALSE;
-    dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), FALSE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), FALSE);
     dt_dev_reprocess_center(self->dev);
     dt_collection_hint_message(darktable.collection);
   }
@@ -3072,7 +3072,8 @@ static void _develop_ui_pipe_started_callback(gpointer instance, gpointer user_d
 
   ++darktable.gui->reset;
   dt_iop_gui_enter_critical_section(self);
-  dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), g->mask_display);
   dt_iop_gui_leave_critical_section(self);
   --darktable.gui->reset;
 }
@@ -3282,14 +3283,12 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->notebook), "button-press-event", G_CALLBACK(notebook_button_press), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
 
-  g->show_luminance_mask = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->show_luminance_mask, NULL, N_("display exposure mask"));
-  dt_bauhaus_widget_set_quad_paint(g->show_luminance_mask, dtgtk_cairo_paint_showmask,
-                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->show_luminance_mask, TRUE);
-  gtk_widget_set_tooltip_text(g->show_luminance_mask, _("display exposure mask"));
-  g_signal_connect(G_OBJECT(g->show_luminance_mask), "quad-pressed", G_CALLBACK(show_luminance_mask_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget),  g->show_luminance_mask, TRUE, TRUE, 0);
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("display exposure mask")), TRUE, TRUE, 0);
+  g->show_luminance_mask = dt_iop_togglebutton_new(self, NULL, N_("display exposure mask"), NULL, G_CALLBACK(show_luminance_mask_callback),
+                                           FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   // Force UI redraws when pipe starts/finishes computing and switch cursors
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,


### PR DESCRIPTION
New bauhaus improvement. After @AlicVB PR, this harmonize all bauhaus names, will be easier for next CSS work to deal with same type names.

Most important thing is that, after my bauhaus combobox CSS work, I see that some widget in filmic and tone equalizer use bauhaus combobox. I see combobox hover effect on them and it's not wanted as they are not combobox so I rewrite them. That allow picker and mask icon to have now hover effect. Nice thing!

Some things remains to test (and/or do) before merging that one:
- test CSS things added by @AlicVB
- and maybe more (or not)

Fix #11425
Fix #11396