### PR TITLE
improve bauhaus combo popup positioning at monitor edges

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2073,7 +2073,7 @@ treeview#delete-dialog:selected
 }
 .bauhaus_combo_popup
 {
-  padding: 2px 0px 0px 2px;
+  padding: 2px 0px 2px 2px;
 }
 #bauhaus-combobox
 {

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1798,8 +1798,8 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
       // only set to what's in the filtered list.
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       const int active = darktable.bauhaus->end_mouse_y >= 0
-                             ? (darktable.bauhaus->end_mouse_y / darktable.bauhaus->line_height)
-                             : d->active;
+                       ? ((darktable.bauhaus->end_mouse_y - w->top_gap) / darktable.bauhaus->line_height)
+                       : d->active;
       int k = 0, i = 0, kk = 0, match = 1;
 
       gchar *keys = g_utf8_casefold(darktable.bauhaus->keys, -1);
@@ -1988,7 +1988,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       gboolean first_label = TRUE;
       gboolean show_box_label = TRUE;
       int k = 0, i = 0;
-      const int hovered = darktable.bauhaus->mouse_y / darktable.bauhaus->line_height;
+      const int hovered = (darktable.bauhaus->mouse_y - w->top_gap) / darktable.bauhaus->line_height;
       gchar *keys = g_utf8_casefold(darktable.bauhaus->keys, -1);
       const PangoEllipsizeMode ellipsis = d->entries_ellipsis;
       ht = darktable.bauhaus->line_height;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2369,7 +2369,7 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
       darktable.bauhaus->change_active = 1;
       if(!d->entries->len) return;
       tmp.height = darktable.bauhaus->line_height * d->entries->len;
-      if(w->margin) tmp.height += w->margin->top + w->margin->bottom;
+      if(w->margin) tmp.height += w->margin->top + w->margin->bottom + w->top_gap;
       tmp.width *= d->scale;
 
       GtkAllocation allocation_w;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -197,7 +197,7 @@ typedef struct dt_bauhaus_t
   float mouse_x, mouse_y;
   // time when the popup window was opened. this is sortof a hack to
   // detect `double clicks between windows' to reset the combobox.
-  double opentime;
+  guint32 opentime;
   // pointer position when popup window is closed
   float end_mouse_x, end_mouse_y;
   // used to determine whether the user crossed the line already.


### PR DESCRIPTION
fixes #11355

this fixes three things:
- if part of a bauhaus popup (for example combobox for filter/sort) is off the screen, then moving the mouse towards the screen edge will also show more of the popup.
- when you click&drag on a combo and then release on a different row, the row will get selected (also highlighting will work when dragging). so click-move-release instead of click-release-move-click-release
- double clicking a combo resets (this _sometimes_ worked previously)

Also, fix a memory leak by calling gtk_border_free on margin and padding and take the opportunity to merge combo_destroy and slider_destroy into one widget-class finalize. The problem could have been avoided by directly embedding margin and padding in dt_bauhaus_widget_t (instead of a pointer) but I guess that saves some memory for people who never show the side panels (and only costs two pointers and one level of indirection for everybody else).