### PR TITLE
bauhaus fixes

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2329,6 +2329,7 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
 
   GtkAllocation tmp;
   gtk_widget_get_allocation(widget, &tmp);
+  gboolean w_valid = TRUE;
   if(tmp.width == 1)
   {
     if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_RIGHT, widget))
@@ -2338,11 +2339,15 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
     else
       tmp.width = 300;
     tmp.width -= INNER_PADDING * 2;
+    w_valid = FALSE;
   }
 
   // by default, we want the popup to be exactly the size of the widget content
-  tmp.width -= w->margin->left + w->margin->right + w->padding->left + w->padding->right;
-  tmp.height -= w->margin->top + w->margin->bottom + w->padding->top + w->padding->bottom;
+  if(w_valid)
+  {
+    tmp.width = MAX(1, tmp.width - (w->margin->left + w->margin->right + w->padding->left + w->padding->right));
+    tmp.height = MAX(1, tmp.height - (w->margin->top + w->margin->bottom + w->padding->top + w->padding->bottom));
+  }
 
   GdkWindow *widget_window = gtk_widget_get_window(widget);
 
@@ -2377,7 +2382,7 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
       darktable.bauhaus->change_active = 1;
       if(!d->entries->len) return;
       tmp.height = darktable.bauhaus->line_height * d->entries->len;
-      tmp.height += w->margin->top + w->margin->bottom;
+      if(w_valid) tmp.height += w->margin->top + w->margin->bottom;
       tmp.width *= d->scale;
 
       GtkAllocation allocation_w;
@@ -2394,8 +2399,11 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
   }
 
   // by default, we want the popup to be exactly at the position of the widget content
-  wx += w->margin->left + w->padding->left;
-  wy += w->margin->top + w->padding->top;
+  if(w_valid)
+  {
+    wx += w->margin->left + w->padding->left;
+    wy += w->margin->top + w->padding->top;
+  }
 
   // we update the popup padding defined in css
   if(!darktable.bauhaus->popup_padding) darktable.bauhaus->popup_padding = gtk_border_new();

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2198,7 +2198,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
           show_pango_text(w, context, cr, text, w3 - darktable.bauhaus->quad_width - INNER_PADDING, w->top_gap,
                           available_width * (1.0f - ratio), TRUE, FALSE, combo_ellipsis, FALSE, FALSE, NULL, NULL);
         else
-          show_pango_text(w, context, cr, 0, INNER_PADDING, w->top_gap, available_width * (1.0f - ratio), FALSE,
+          show_pango_text(w, context, cr, text, INNER_PADDING, w->top_gap, available_width * (1.0f - ratio), FALSE,
                           FALSE, combo_ellipsis, FALSE, FALSE, NULL, NULL);
       }
       else
@@ -2209,7 +2209,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
           show_pango_text(w, context, cr, text, w3 - darktable.bauhaus->quad_width - INNER_PADDING, w->top_gap, 0,
                           TRUE, FALSE, combo_ellipsis, FALSE, FALSE, NULL, NULL);
         else
-          show_pango_text(w, context, cr, 0, INNER_PADDING, w->top_gap, 0, FALSE, FALSE, combo_ellipsis, FALSE,
+          show_pango_text(w, context, cr, text, INNER_PADDING, w->top_gap, 0, FALSE, FALSE, combo_ellipsis, FALSE,
                           FALSE, NULL, NULL);
       }
       g_free(label_text);


### PR DESCRIPTION
this fix #11374 

- 2 stupid typo for left aligned combobox
- fix also a crsh if we try to show bauhaus popup with shortcut and the widget itself is not realized (see @dterrahe comment https://github.com/darktable-org/darktable/pull/11359#issuecomment-1074368549)