### PR TITLE
Rework the IOP tooltip to ensure proper layout.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2383,18 +2383,10 @@ gboolean _iop_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keybo
   if(des[1]) gtk_widget_set_name(label, "section_label");
   gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
 
-#ifdef _WIN32
-  // TODO: a windows dev is needed to find 4 icons properly rendered
-  const char *icon_purpose = "•";
-  const char *icon_input   = "•";
-  const char *icon_process = "•";
-  const char *icon_output  = "•";
-#else
   const char *icon_purpose = "⟳";
   const char *icon_input   = "⇥";
   const char *icon_process = "⟴";
   const char *icon_output  = "↦";
-#endif
 
   const char *icons[4] = {icon_purpose, icon_input, icon_process, icon_output};
   const char *ilabs[4] = {_("purpose"), _("input"), _("process"), _("output")};

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -123,9 +123,9 @@ static int default_operation_tags_filter(void)
   return 0;
 }
 
-static const char *default_description(struct dt_iop_module_t *self)
+static const char **default_description(struct dt_iop_module_t *self)
 {
-  return g_strdup("");
+  return NULL;
 }
 
 static const char *default_aliases(void)
@@ -2363,6 +2363,71 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
   }
 }
 
+gboolean _iop_tooltip_callback(GtkWidget* self, gint x, gint y, gboolean keyboard_mode,
+                               GtkTooltip* tooltip, gpointer user_data)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)user_data;
+
+  const char **des = module->description(module);
+
+  if(!des) return FALSE;
+
+  GtkWidget *ht = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *grid = gtk_grid_new();
+  gtk_grid_set_column_homogeneous(GTK_GRID(grid), FALSE);
+  gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(10));
+  gtk_widget_set_hexpand(grid, FALSE);
+
+  GtkWidget *label = gtk_label_new(des[0]?des[0]:"");
+  // if there is no more description, do not add a separator
+  if(des[1]) gtk_widget_set_name(label, "section_label");
+  gtk_box_pack_start(GTK_BOX(ht), label, FALSE, FALSE, 0);
+
+#ifdef _WIN32
+  // TODO: a windows dev is needed to find 4 icons properly rendered
+  const char *icon_purpose = "•";
+  const char *icon_input   = "•";
+  const char *icon_process = "•";
+  const char *icon_output  = "•";
+#else
+  const char *icon_purpose = "⟳";
+  const char *icon_input   = "⇥";
+  const char *icon_process = "⟴";
+  const char *icon_output  = "↦";
+#endif
+
+  const char *icons[4] = {icon_purpose, icon_input, icon_process, icon_output};
+  const char *ilabs[4] = {_("purpose"), _("input"), _("process"), _("output")};
+
+  for(int k=1; k<5; k++)
+  {
+    if(des[k])
+    {
+      label = gtk_label_new(icons[k-1]);
+      gtk_widget_set_halign(label, GTK_ALIGN_START);
+      gtk_grid_attach(GTK_GRID(grid), label, 0, k, 1, 1);
+
+      label = gtk_label_new(ilabs[k-1]);
+      gtk_widget_set_halign(label, GTK_ALIGN_START);
+      gtk_grid_attach(GTK_GRID(grid), label, 1, k, 1, 1);
+
+      label = gtk_label_new(":");
+      gtk_widget_set_halign(label, GTK_ALIGN_START);
+      gtk_grid_attach(GTK_GRID(grid), label, 2, k, 1, 1);
+
+      label = gtk_label_new(des[k]);
+      gtk_widget_set_halign(label, GTK_ALIGN_START);
+      gtk_grid_attach(GTK_GRID(grid), label, 3, k, 1, 1);
+    }
+  }
+
+  gtk_box_pack_start(GTK_BOX(ht), grid, FALSE, FALSE, 0);
+  gtk_widget_show_all(ht);
+
+  gtk_tooltip_set_custom(tooltip, ht);
+  return TRUE;
+}
+
 void dt_iop_gui_set_expander(dt_iop_module_t *module)
 {
   char tooltip[512];
@@ -2413,9 +2478,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(lab, module->deprecated_msg());
   else
   {
-    gchar *description = (char *)module->description(module);
-    gtk_widget_set_tooltip_text(lab, description);
-    g_free(description);
+    g_signal_connect(lab, "query-tooltip", G_CALLBACK(_iop_tooltip_callback), module);
   }
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_LABEL]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
@@ -3064,66 +3127,18 @@ char *dt_iop_warning_message(const char *message)
     return g_strdup(message);
 }
 
-char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text, const char *purpose, const char *input, const char *process,
+const char **dt_iop_set_description(dt_iop_module_t *module, const char *main_text, const char *purpose, const char *input, const char *process,
                              const char *output)
 {
-#define TAB_SIZE 4.0
-#define P_TAB(n) (nb_tab + 1 - (int)ceilf((float)n / TAB_SIZE))
+  static const char *str_out[5] = {NULL, NULL, NULL, NULL, NULL};
 
-  const char *str_purpose = _("purpose");
-  const char *str_input   = _("input");
-  const char *str_process = _("process");
-  const char *str_output  = _("output");
+  str_out[0] = main_text;
+  str_out[1] = purpose;
+  str_out[2] = input;
+  str_out[3] = process;
+  str_out[4] = output;
 
-  const int len_purpose = g_utf8_strlen(str_purpose, -1);
-  const int len_input   = g_utf8_strlen(str_input, -1);
-  const int len_process = g_utf8_strlen(str_process, -1);
-  const int len_output  = g_utf8_strlen(str_output, -1);
-
-  const int max = MAX(len_purpose,
-                      MAX(len_input, MAX(len_process, len_output)));
-  const int nb_tab = ceilf((float)max / TAB_SIZE);
-
-#ifdef _WIN32
-  // TODO: a windows dev is needed to find 4 icons properly rendered
-  const char *icon_purpose = "•";
-  const char *icon_input   = "•";
-  const char *icon_process = "•";
-  const char *icon_output  = "•";
-#else
-  const char *icon_purpose = "⟳";
-  const char *icon_input   = "⇥";
-  const char *icon_process = "⟴";
-  const char *icon_output  = "↦";
-#endif
-
-  /* if the font can't display icons, default to nothing
-  * Unfortunately, getting the font from the font desc is another scavenger hunt
-  * into Gtk useless docs without examples. Good luck.
-  PangoFontDescription *desc = darktable.bauhaus->pango_font_desc;
-  if(!pango_font_has_char(desc->get_font(), g_utf8_to_ucs4(icon_purpose, 1)))
-    icon_purpose = icon_input = icon_process = icon_output = "";
-  */
-
-  // align on tabs
-  const char *tabs = "\t\t\t\t\t\t\t\t\t\t";
-
-  char *str_out = g_strdup_printf
-    ("%s.\n\n"
-     "%s\t%s%.*s:\t%s\n"
-     "%s\t%s%.*s:\t%s\n"
-     "%s\t%s%.*s:\t%s\n"
-     "%s\t%s%.*s:\t%s",
-     main_text,
-     icon_purpose, str_purpose, P_TAB(len_purpose), tabs, purpose,
-     icon_input,   str_input,   P_TAB(len_input),   tabs, input,
-     icon_process, str_process, P_TAB(len_process), tabs, process,
-     icon_output,  str_output,  P_TAB(len_output),  tabs, output);
-
-  return str_out;
-
-#undef P_TAB
-#undef TAB_SIZE
+  return (const char **)str_out;
 }
 
 gboolean dt_iop_have_required_input_format(const int req_ch, struct dt_iop_module_t *const module, const int ch,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -477,9 +477,9 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *module,
                                        const char *stderr_message);
 
 // format modules description going in tooltips
-char *dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
-                             const char *purpose, const char *input,
-                             const char *process, const char *output);
+const char **dt_iop_set_description(dt_iop_module_t *module, const char *main_text,
+                                    const char *purpose, const char *input,
+                                    const char *process, const char *output);
 
 static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
 {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -751,7 +751,12 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
       GtkWidget *label = gtk_label_new(NULL);
       GtkWidget *vbox = g_object_get_data(G_OBJECT(widget), "iopdes");
 
-      markup_text = dt_util_dstrcat(NULL, "\n%s", description);
+      markup_text = dt_util_dstrcat(NULL, "%s%s%s%s",
+                                    markup_text ? "\n" : "",
+                                    markup_text ? markup_text : "",
+                                    markup_text ? (description ? "\n\n" : "")
+                                                : (description ? "\n" : ""),
+                                    description ? description : "");
       gtk_label_set_markup(GTK_LABEL(label), markup_text);
       gtk_widget_set_halign(label, GTK_ALIGN_START);
 
@@ -4414,4 +4419,3 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_name)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -126,7 +126,7 @@ const char *aliases()
   return _("rotation|keystone|distortion|crop|reframe");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("rotate or distort perspective"),
                                       _("corrective or creative"),

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -133,7 +133,7 @@ const char *aliases()
   return _("sharpness|acutance|local contrast");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("add or remove local contrast, sharpness, acutance"),
                                       _("corrective and creative"),

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -332,7 +332,7 @@ const char *name()
   return _("base curve");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply a view transform based on personal or camera manufacturer look,\n"
                                         "for corrective purposes, to prepare images for display"),

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -140,7 +140,7 @@ const char *name()
   return _("basic adjustments");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply usual image adjustments"),
                                       _("creative"),

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -94,7 +94,7 @@ const char *name()
   return _("local contrast");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("manipulate local and global contrast separately"),
                                       _("creative"),

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -93,7 +93,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply edge-aware surface blur to denoise or smoothen textures"),
                                       _("corrective and creative"),

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -75,7 +75,7 @@ const char *name()
   return _("bloom");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply Orton effect for a dreamy aetherical look"),
                                       _("creative"),

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -86,7 +86,7 @@ const char *aliases()
   return _("blur|lens|motion");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self,
                                 _("simulate physically-accurate lens and motion blurs"),

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -181,7 +181,7 @@ const char *name()
   return _("framing");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("add solid borders or margins around the picture"),
                                       _("creative"),

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -82,7 +82,7 @@ const char *name()
   return _("raw chromatic aberrations");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("correct chromatic aberrations for Bayer sensors"),
                                       _("corrective"),

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -161,7 +161,7 @@ const char *name()
   return _("chromatic aberrations");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("correct chromatic aberrations"),
                                       _("corrective"),

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -77,7 +77,7 @@ name()
   return _("censorize");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("censorize license plates and body parts for privacy"),
                                       _("creative"),

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -131,7 +131,7 @@ const char *deprecated_msg()
   return _("this module is deprecated. please use the color calibration module instead.");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("perform color space corrections\n"
                                         "such as white balance, channels mixing\n"

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -225,7 +225,7 @@ const char *aliases()
   return _("channel mixer|white balance|monochrome");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("perform color space corrections\n"
                                         "such as white balance, channels mixing\n"

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -314,7 +314,7 @@ const char *aliases()
   return _("reframe|perspective|keystone|distortion");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("change the framing and correct the perspective"),
                                       _("corrective or creative"),

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -79,7 +79,7 @@ const char *name()
   return _("contrast brightness saturation");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("adjust the look of the image"),
                                       _("creative"),

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -153,7 +153,7 @@ const char *aliases()
   return _("lift gamma gain|cdl|color grading|contrast|saturation|hue");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("affect color, brightness and contrast"),
                                       _("corrective or creative"),

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -165,7 +165,7 @@ const char *aliases()
   return _("offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance|saturation");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("affect color, brightness and contrast"),
                                       _("corrective or creative"),

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -120,7 +120,7 @@ const char *aliases()
   return _("profile|lut|color grading");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("perform color space corrections and apply looks"),
                                       _("corrective or creative"),

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -94,7 +94,7 @@ const char *aliases()
   return _("saturation");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("increase saturation and separation between\n"
                                         "opposite colors"),

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -71,7 +71,7 @@ const char *name()
   return _("color correction");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("correct white balance selectively for blacks and whites"),
                                       _("corrective or creative"),

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -129,7 +129,7 @@ const char *name()
   return _("input color profile");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("convert any RGB input to pipeline reference RGB\n"
                                         "using color profiles to remap RGB values"),

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -99,7 +99,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("overlay a solid color on the image"),
                                       _("creative"),

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -147,7 +147,7 @@ const char *name()
   return _("color mapping");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("transfer a color palette and tonal repartition from one image to another"),
                                       _("creative"),

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -85,7 +85,7 @@ const char *name()
 }
 
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("convert pipeline reference RGB to any display RGB\n"
                                         "using color profiles to remap RGB values"),

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -129,7 +129,7 @@ const char *name()
   return _("color reconstruction");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("recover clipped highlights by propagating surrounding colors"),
                                       _("corrective"),

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -139,7 +139,7 @@ const char *name()
   return _("color zones");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("selectively shift hues, saturation and brightness of pixels"),
                                       _("creative"),

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -133,7 +133,7 @@ const char *aliases()
   return _("reframe|distortion");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("change the framing"), _("corrective or creative"),
                                 _("linear, RGB, scene-referred"), _("geometric, RGB"),

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -75,7 +75,7 @@ const char *aliases()
   return _("chromatic aberrations");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("attenuate chromatic aberration by desaturating edges"),
                                       _("corrective"),

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -221,7 +221,7 @@ const char *name()
   return _("demosaic");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("reconstruct full RGB pixels from a sensor color filter array reading"),
                                       _("mandatory"),

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -713,7 +713,7 @@ const char *name()
   return _("denoise (profiled)");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self,
                                 _("denoise using noise statistics profiled on sensors."),

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -132,7 +132,7 @@ const char *aliases()
   return _("diffusion|deconvolution|blur|sharpening");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self,
                                 _("simulate directional diffusion of light with heat transfer model\n"

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -97,7 +97,7 @@ const char *name()
   return _("dithering");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("reduce banding and posterization effects in output JPEGs by adding random noise"),
                                       _("corrective"),

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -123,14 +123,15 @@ const char *name()
   return _("exposure");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char** description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("redo the exposure of the shot as if you were still in-camera\n"
-                                        "using a color-safe brightening similar to increasing ISO setting"),
-                                      _("corrective and creative"),
-                                      _("linear, RGB, scene-referred"),
-                                      _("linear, RGB"),
-                                      _("linear, RGB, scene-referred"));
+  return dt_iop_set_description(self,
+                                _("redo the exposure of the shot as if you were still in-camera\n"
+                                  "using a color-safe brightening similar to increasing ISO setting"),
+                                _("corrective and creative"),
+                                _("linear, RGB, scene-referred"),
+                                _("linear, RGB"),
+                                _("linear, RGB, scene-referred"));
 }
 
 int default_group()

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -346,7 +346,7 @@ const char *aliases()
   return _("tone mapping|curve|view transform|contrast|saturation|highlights");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply a view transform to prepare the scene-referred pipeline\n"
                                         "for display on SDR screens and paper prints\n"

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -100,7 +100,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("flip or rotate image by step of 90 degrees"), _("corrective"),
                                 _("linear, RGB, scene-referred"), _("geometric, RGB"),

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -144,7 +144,7 @@ const char *name()
   return _("graduated density");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("simulate an optical graduated neutral density filter"),
                                       _("corrective and creative"),

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -419,7 +419,7 @@ const char *name()
   return _("grain");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("simulate silver grains from film"),
                                       _("creative"),

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -105,7 +105,7 @@ const char *aliases()
   return _("dehaze|defog|smoke|smog");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("remove fog and atmospheric hazing from pictures"),
                                       _("corrective"),

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -78,7 +78,7 @@ const char *name()
   return _("highlight reconstruction");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("avoid magenta highlights and try to recover highlights colors"),
                                       _("corrective"),

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -75,7 +75,7 @@ const char *name()
   return _("highpass");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("isolate high frequencies in the image"),
                                       _("creative"),

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -67,7 +67,7 @@ const char *name()
   return _("hot pixels");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("remove abnormally bright pixels by dampening them with neighbours"),
                                       _("corrective"),

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -116,7 +116,7 @@ const char *deprecated_msg()
   return _("this module is deprecated. please use the negadoctor module instead.");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("invert film negatives"),
                                       _("corrective"),

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -78,7 +78,7 @@ DEFAULT(int, flags, void);
 DEFAULT(const char *, deprecated_msg, void);
 
 /** get a descriptive text used for example in a tooltip in more modules */
-DEFAULT(const char *, description, struct dt_iop_module_t *self);
+DEFAULT(const char **, description, struct dt_iop_module_t *self);
 
 DEFAULT(int, operation_tags, void);
 DEFAULT(int, operation_tags_filter, void);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -153,7 +153,7 @@ const char *aliases()
   return _("vignette|chromatic aberrations|distortion");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("correct lenses optical flaws"),
                                       _("corrective"),

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -125,7 +125,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("adjust black, white and mid-gray points"),
                                       _("creative"),

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -290,7 +290,7 @@ const char *name()
   return _("liquify");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("distort parts of the image"),
                                       _("creative"),

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -86,7 +86,7 @@ const char *name()
   return _("lowlight vision");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("simulate human night vision"),
                                       _("creative"),

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -127,7 +127,7 @@ const char *name()
   return _("lowpass");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("isolate low frequencies in the image"),
                                       _("creative"),

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -133,7 +133,7 @@ const char *name()
   return _("lut 3D");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("perform color space corrections and apply look"),
                                       _("corrective or creative"),

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -92,7 +92,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("quickly convert an image to black & white using a variable color filter"),
                                       _("creative"),

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -150,7 +150,7 @@ const char *aliases()
   return _("film|invert|negative|scan");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("invert film negative scans and simulate printing on paper"),
                                       _("corrective and creative"),

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -93,7 +93,7 @@ const char *aliases()
   return _("denoise (non-local means)");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply a poisson noise removal best suited for astrophotography"),
                                       _("corrective"),

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -95,7 +95,7 @@ const char *name()
   return _("unbreak input profile");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("correct input color profiles meant to be applied on non-linear RGB"),
                                       _("corrective"),

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -124,7 +124,7 @@ const char *name()
   return _("raw denoise");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("denoise the raw picture early in the pipeline"),
                                       _("corrective"),

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -104,7 +104,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RAW;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("sets technical specificities of the raw sensor.\n\ntouch with great care!"),
                                       _("mandatory"),

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -201,7 +201,7 @@ const char *aliases()
 }
 
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("remove and clone spots, perform split-frequency skin editing"),
                                       _("corrective"),

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -136,7 +136,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("alter an image’s tones using curves in RGB color space"),
                                       _("corrective and creative"),

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -116,7 +116,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("adjust black, white and mid-gray points in RGB color space"),
                                       _("corrective and creative"),

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -91,10 +91,12 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
-  return g_strdup(_("internal module to setup technical specificities of raw sensor.\n\n"
-                    "you should not touch values here !"));
+  return dt_iop_set_description(self,
+                                _("internal module to setup technical specificities of raw sensor.\n\n"
+                                  "you should not touch values here !"),
+                                NULL, NULL, NULL, NULL);
 }
 
 

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -75,10 +75,12 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
-  return g_strdup(_("internal module to setup technical specificities of raw sensor.\n\n"
-                    "you should not touch values here !"));
+  return dt_iop_set_description(self,
+                                _("internal module to setup technical specificities of raw sensor.\n\n"
+                                  "you should not touch values here !"),
+                                NULL, NULL, NULL, NULL);
 }
 
 static void transform(const dt_dev_pixelpipe_iop_t *const piece, float *p)

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -190,7 +190,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("modify the tonal range of the shadows and highlights\n"
                                         "of an image by enhancing local contrast."),

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -88,7 +88,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("sharpen the details in the image using a standard UnSharp Mask (USM)"),
                                       _("corrective"),

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -99,7 +99,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("create a softened image using the Orton effect"),
                                       _("creative"),

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -96,7 +96,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("use two specific colors for shadows and highlights and\n"
                                         "create a linear toning effect between them up to a pivot."),

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -61,7 +61,7 @@ const char *deprecated_msg()
   return _("this module is deprecated. please use the retouch module instead.");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("remove sensor dust spots"),
                                       _("corrective"),

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -193,7 +193,7 @@ const char *name()
   return C_("modulename", "white balance");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("scale raw RGB channels to balance white and help demosaicing"),
                                       _("corrective"),

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -207,7 +207,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("alter an image’s tones using curves"),
                                       _("corrective and creative"),

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -315,7 +315,7 @@ const char *aliases()
 }
 
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("relight the scene as if the lighting was done directly on the scene"),
                                       _("corrective and creative"),

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -99,7 +99,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("resaturate giving more weight to blacks, whites and low-saturation pixels"),
                                       _("creative"),

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -88,7 +88,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_LAB;
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("saturate and reduce the lightness of the most saturated pixels\n"
                                         "to make the colors more vivid."),

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -152,7 +152,7 @@ const char *name()
   return _("vignetting");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("simulate a lens fall-off close to edges"),
                                       _("creative"),

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -291,7 +291,7 @@ const char *name()
   return _("watermark");
 }
 
-const char *description(struct dt_iop_module_t *self)
+const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("overlay an SVG watermark like a signature on the picture"),
                                       _("creative"),


### PR DESCRIPTION
We new use a custom widget for the IOP tooltip. This make it possible
to use a grid and so have proper alignment for all columns and do not
depends on tab which anyway was not working properly as depending on
actual font size.