### PR TITLE
make maximum tile number depending on resourcelevel

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -421,13 +421,6 @@
     <shortdescription>round OpenCL work group sizes to a multiple of</shortdescription>
     <longdescription>in OpenCL processing round width/height of global work groups to a multiple of this value. reasonable values are powers of 2. this parameter can have high impact on OpenCL performance.</longdescription>
   </dtconfig>
-  <dtconfig>
-    <name>maximum_number_tiles</name>
-    <type>int</type>
-    <default>10000</default>
-    <shortdescription>assumed maximum sane number of tiles</shortdescription>
-    <longdescription>if during tiling this number is exceeded darktable assumes that tiling is not possible and falls back to untiled processing - with all system memory limits taking full effect. in case you want to process huge images you may want to increase this number.</longdescription>
-  </dtconfig>
   <dtconfig prefs="security" section="general">
     <name>ask_before_remove</name>
     <type>bool</type>

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -91,6 +91,18 @@ static inline int _align_close(int n, int a)
   return (off > a/2) ? a - off : -off;    
 }
 
+/* 
+  _maximum_number_tiles is the assumed maximum sane number of tiles
+  if during tiling this number is exceeded darktable assumes that tiling is not possible and falls back
+  to untiled processing - with all system memory limits taking full effect.
+  For huge images like stitched panos the user might choose resourcelevel="unrestricted", in that
+  case the allowed number of tiles is practically unlimited
+*/
+static inline int _maximum_number_tiles()
+{
+  return (darktable.dtresources.level == 3) ? 0x40000000 : 10000;
+}
+
 static inline void _print_roi(const dt_iop_roi_t *roi, const char *label)
 {
   if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & DT_DEBUG_TILING))
@@ -696,7 +708,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   const int tiles_y = height < roi_in->height ? ceilf(roi_in->height / (float)tile_ht) : 1;
 
   /* sanity check: don't run wild on too many tiles */
-  if(tiles_x * tiles_y > dt_conf_get_int("maximum_number_tiles"))
+  if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING, "[default_process_tiling_ptp] gave up tiling for module '%s'. too many tiles: %d x %d\n",
              self->op, tiles_x, tiles_y);
@@ -967,7 +979,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
                   : 1;
 
   /* sanity check: don't run wild on too many tiles */
-  if(tiles_x * tiles_y > dt_conf_get_int("maximum_number_tiles"))
+  if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING, "[default_process_tiling_roi] gave up tiling for module '%s'. too many tiles: %d x %d\n",
              self->op, tiles_x, tiles_y);
@@ -1299,7 +1311,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   const int tiles_y = height < roi_in->height ? ceilf(roi_in->height / (float)tile_ht) : 1;
 
   /* sanity check: don't run wild on too many tiles */
-  if(tiles_x * tiles_y > dt_conf_get_int("maximum_number_tiles"))
+  if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING, "[default_process_tiling_cl_ptp] aborted tiling for module '%s'. too many tiles: %d x %d\n",
              self->op, tiles_x, tiles_y);
@@ -1657,7 +1669,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
                   : 1;
 
   /* sanity check: don't run wild on too many tiles */
-  if(tiles_x * tiles_y > dt_conf_get_int("maximum_number_tiles"))
+  if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
              "[default_process_tiling_cl_roi] aborted tiling for module '%s'. too many tiles: %dx%d\n",


### PR DESCRIPTION
We have the config option "maximum_number_tiles" giving a sane number of tiles that could be processed.
This is just a safety margin and needs to be adjusted only for very rare cases handling huge images with
large overlaps. The user was asked to change the setting for such cases.

In this pr this is changed automatically depending on resourlevel="unrestricted"