### PR TITLE
Fix opencl canonical name

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -248,7 +248,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
 
   cname_size = infostr_size;
   cname = malloc(cname_size);
-  _ascii_str_canonical(infostr, cname, sizeof(cname_size));
+  _ascii_str_canonical(infostr, cname, cname_size);
 
   if(!strncasecmp(vendor, "NVIDIA", 6))
   {


### PR DESCRIPTION
the canonical name to identify the device was crippled to sizeof(size_t) thus not
giving a correct id. In effect this might not return a correct device id in `_device_by_cname(const char *name)`

On most systems this did not matter but having two nvidia rtx cards would not be different.