### PR TITLE
Show modules with a transition

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3551,7 +3551,7 @@
   <dtconfig prefs="misc" section="interface">
     <name>ui/transition_duration</name>
     <type min="0" max="1000">int</type>
-    <default>250</default>
+    <default>150</default>
     <shortdescription>duration of the ui transitions in ms</shortdescription>
     <longdescription>how long the transitions take (in ms) for toggling modules and other ui elements</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3548,4 +3548,11 @@
     <shortdescription>order or exclude midi devices</shortdescription>
     <longdescription>comma-separated list of device name fragments that if matched load midi device at id given by location in list or if preceded by - prevent matching devices from loading. add encoding and number of knobs like 'BeatStep:63:16'</longdescription>
   </dtconfig>
+  <dtconfig prefs="misc" section="interface">
+    <name>ui/transition_duration</name>
+    <type min="0" max="1000">int</type>
+    <default>250</default>
+    <shortdescription>duration of the ui transitions in ms</shortdescription>
+    <longdescription>how long the transitions take (in ms) for toggling modules and other ui elements</longdescription>
+  </dtconfig>
 </dtconfiglist>

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -730,9 +730,6 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
                           module->expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
     dt_iop_gui_set_expanded(module, TRUE, FALSE);
 
-    if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-        darktable.gui->scroll_to[1] = module->expander;
-
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
 
     if(copy_params)
@@ -990,9 +987,6 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
     if(gtk_toggle_button_get_active(togglebutton))
     {
       module->enabled = 1;
-
-      if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-        darktable.gui->scroll_to[1] = module->expander;
 
       if(!basics && dt_conf_get_bool("darkroom/ui/activate_expand") && !module->expanded)
         dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
@@ -2048,11 +2042,8 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
     }
     else
     {
-      // make gtk scroll to the module once it updated its allocation size
-      if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-        darktable.gui->scroll_to[1] = module->expander;
-
-      const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != (!dt_modifier_is(e->state, GDK_SHIFT_MASK));
+      const gboolean collapse_others
+          = !dt_conf_get_bool("darkroom/ui/single_module") != (!dt_modifier_is(e->state, GDK_SHIFT_MASK));
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 
       // rebuild the accelerators

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2001,7 +2001,12 @@ void dt_iop_gui_update_expanded(dt_iop_module_t *module)
 
   const gboolean expanded = module->expanded;
 
+  /* don't show with transition when entering this view */
+  char *conf_name = "ui/transition_duration";
+  guint transition_duration = dt_conf_get_int(conf_name);
+  dt_conf_set_int(conf_name, 0);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->expander), expanded);
+  dt_conf_set_int(conf_name, transition_duration);
 }
 
 static gboolean _iop_plugin_body_button_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -130,11 +130,7 @@ typedef struct _smoothScrollData
 static gboolean _scrolled_window_tick_callback(GtkWidget *scrolled_window, GdkFrameClock *clock, gpointer user_data)
 {
   smoothScrollData *data = (smoothScrollData *)user_data;
-  if(!GTK_IS_ADJUSTMENT(data->adjustment))
-  {
-    free(data);
-    return G_SOURCE_REMOVE;
-  }
+  if(!GTK_IS_ADJUSTMENT(data->adjustment)) return G_SOURCE_REMOVE;
 
   gint64 now = gdk_frame_clock_get_frame_time(clock);
   gdouble current_pos = gtk_adjustment_get_value(data->adjustment);
@@ -155,7 +151,6 @@ static gboolean _scrolled_window_tick_callback(GtkWidget *scrolled_window, GdkFr
   {
     gtk_adjustment_set_value(data->adjustment, data->end);
 
-    free(data);
     return G_SOURCE_REMOVE;
   }
 }
@@ -211,7 +206,8 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   g_return_val_if_fail(GTK_IS_WIDGET(header), NULL);
   g_return_val_if_fail(GTK_IS_WIDGET(body), NULL);
 
-  expander = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
+  expander
+      = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
   expander->expanded = -1;
   expander->header = header;
   expander->body = body;

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -109,7 +109,8 @@ static void dtgtk_expander_init(GtkDarktableExpander *expander)
 // this should work as long as everything happens in the gui thread
 static void dtgtk_expander_scroll(GtkRevealer *widget)
 {
-  if(!dt_conf_get_bool("lighttable/ui/scroll_to_module") && !dt_conf_get_bool("darkroom/ui/scroll_to_module")) return;
+  if(!dt_conf_get_bool("lighttable/ui/scroll_to_module") && !dt_conf_get_bool("darkroom/ui/scroll_to_module"))
+    return;
 
   GtkAllocation allocation;
 
@@ -119,6 +120,8 @@ static void dtgtk_expander_scroll(GtkRevealer *widget)
 
   GtkWidget *viewport = gtk_widget_get_parent(box);
   GtkWidget *scrolled_window = gtk_widget_get_parent(viewport);
+  if(!GTK_IS_SCROLLED_WINDOW(scrolled_window)) return; // may not be part of a panel yet
+
   GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(scrolled_window));
 
   gtk_widget_get_allocation(expander, &allocation);

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -87,6 +87,20 @@ gboolean dtgtk_expander_get_expanded(GtkDarktableExpander *expander)
   return expander->expanded;
 }
 
+void dtgtk_expander_set_transition_duration(GtkDarktableExpander *expander, guint duration)
+{
+  g_return_if_fail(DTGTK_IS_EXPANDER(expander));
+
+  gtk_revealer_set_transition_duration(GTK_REVEALER(expander->revealer), duration);
+}
+
+guint dtgtk_expander_get_transition_duration(GtkDarktableExpander *expander)
+{
+  g_return_val_if_fail(DTGTK_IS_EXPANDER(expander), 0);
+
+  return gtk_revealer_get_transition_duration(GTK_REVEALER(expander->revealer));
+}
+
 static void dtgtk_expander_init(GtkDarktableExpander *expander)
 {
 }

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -76,6 +76,8 @@ void dtgtk_expander_set_expanded(GtkDarktableExpander *expander, gboolean expand
 
     if(revealer)
     {
+      uint32_t transition_duration = dt_conf_get_int("ui/transition_duration");
+      gtk_revealer_set_transition_duration(GTK_REVEALER(expander->revealer), transition_duration);
       gtk_revealer_set_reveal_child(GTK_REVEALER(revealer), expander->expanded);
     }
   }

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -17,6 +17,7 @@
 */
 
 #include "dtgtk/expander.h"
+#include "control/conf.h"
 
 #include <gtk/gtk.h>
 
@@ -106,13 +107,15 @@ static void dtgtk_expander_init(GtkDarktableExpander *expander)
 }
 
 // this should work as long as everything happens in the gui thread
-static gboolean dtgtk_expander_scroll(GtkRevealer *widget)
+static void dtgtk_expander_scroll(GtkRevealer *widget)
 {
+  if(!dt_conf_get_bool("lighttable/ui/scroll_to_module") && !dt_conf_get_bool("darkroom/ui/scroll_to_module")) return;
+
   GtkAllocation allocation;
 
   GtkWidget *expander = gtk_widget_get_parent(GTK_WIDGET(widget));
   GtkWidget *box = gtk_widget_get_parent(expander);
-  if(!GTK_IS_WIDGET(box)) return FALSE; // it may not have been added to a box yet
+  if(!GTK_IS_WIDGET(box)) return; // it may not have been added to a box yet
 
   GtkWidget *viewport = gtk_widget_get_parent(box);
   GtkWidget *scrolled_window = gtk_widget_get_parent(viewport);
@@ -120,8 +123,6 @@ static gboolean dtgtk_expander_scroll(GtkRevealer *widget)
 
   gtk_widget_get_allocation(expander, &allocation);
   gtk_adjustment_set_value(adjustment, allocation.y);
-
-  return TRUE;
 }
 
 // public functions

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -19,7 +19,6 @@
 #include "dtgtk/expander.h"
 #include "control/conf.h"
 
-#include <gdk/gdk.h>
 #include <gtk/gtk.h>
 
 G_DEFINE_TYPE(GtkDarktableExpander, dtgtk_expander, GTK_TYPE_BOX);
@@ -109,75 +108,6 @@ static void dtgtk_expander_init(GtkDarktableExpander *expander)
 {
 }
 
-/* From clutter-easing.c, based on Robert Penner's
- * infamous easing equations, MIT license.
- */
-gdouble ease_out_cubic(gdouble t)
-{
-  gdouble p = t - 1;
-  return p * p * p + 1;
-}
-
-typedef struct _smoothScrollData
-{
-  GtkAdjustment *adjustment;
-  gdouble start;
-  gdouble end;
-  gint64 start_time;
-  gint64 end_time;
-} smoothScrollData;
-
-static gboolean _scrolled_window_tick_callback(GtkWidget *scrolled_window, GdkFrameClock *clock, gpointer user_data)
-{
-  smoothScrollData *data = (smoothScrollData *)user_data;
-  if(!GTK_IS_ADJUSTMENT(data->adjustment)) return G_SOURCE_REMOVE;
-
-  gint64 now = gdk_frame_clock_get_frame_time(clock);
-  gdouble current_pos = gtk_adjustment_get_value(data->adjustment);
-
-  if(now < data->end_time && current_pos != data->end)
-  {
-    gdouble t = (gdouble)(now - data->start_time) / (gdouble)(data->end_time - data->start_time);
-    t = ease_out_cubic(t);
-
-    if(data->start > data->end)
-      gtk_adjustment_set_value(data->adjustment, data->start - t * (data->start - data->end));
-    else
-      gtk_adjustment_set_value(data->adjustment, data->start + t * (data->end - data->start));
-
-    return G_SOURCE_CONTINUE;
-  }
-  else
-  {
-    gtk_adjustment_set_value(data->adjustment, data->end);
-
-    return G_SOURCE_REMOVE;
-  }
-}
-
-void _scrolled_window_smooth_scroll(GtkWidget *scrolled_window, int target, guint duration)
-{
-  GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(scrolled_window));
-  if(!GTK_IS_ADJUSTMENT(adjustment)) return;
-
-  GdkFrameClock *clock = gtk_widget_get_frame_clock(scrolled_window);
-  if(!clock) return;
-
-  gdouble start = gtk_adjustment_get_value(adjustment);
-  gdouble end = target;
-  gint64 start_time = gdk_frame_clock_get_frame_time(clock);
-  gint64 end_time = start_time + 1000 * duration;
-
-  smoothScrollData *data = malloc(sizeof(smoothScrollData));
-  data->adjustment = adjustment;
-  data->start = start;
-  data->end = end;
-  data->start_time = start_time;
-  data->end_time = end_time;
-
-  gtk_widget_add_tick_callback(scrolled_window, (GtkTickCallback)_scrolled_window_tick_callback, data, NULL);
-}
-
 // this should work as long as everything happens in the gui thread
 static void dtgtk_expander_scroll(GtkRevealer *widget)
 {
@@ -194,8 +124,10 @@ static void dtgtk_expander_scroll(GtkRevealer *widget)
   GtkWidget *scrolled_window = gtk_widget_get_parent(viewport);
   if(!GTK_IS_SCROLLED_WINDOW(scrolled_window)) return; // may not be part of a panel yet
 
+  GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(scrolled_window));
+
   gtk_widget_get_allocation(expander, &allocation);
-  _scrolled_window_smooth_scroll(scrolled_window, allocation.y, dt_conf_get_int("ui/transition_duration"));
+  gtk_adjustment_set_value(adjustment, allocation.y);
 }
 
 // public functions

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -130,7 +130,11 @@ typedef struct _smoothScrollData
 static gboolean _scrolled_window_tick_callback(GtkWidget *scrolled_window, GdkFrameClock *clock, gpointer user_data)
 {
   smoothScrollData *data = (smoothScrollData *)user_data;
-  if(!GTK_IS_ADJUSTMENT(data->adjustment)) return G_SOURCE_REMOVE;
+  if(!GTK_IS_ADJUSTMENT(data->adjustment))
+  {
+    free(data);
+    return G_SOURCE_REMOVE;
+  }
 
   gint64 now = gdk_frame_clock_get_frame_time(clock);
   gdouble current_pos = gtk_adjustment_get_value(data->adjustment);
@@ -151,6 +155,7 @@ static gboolean _scrolled_window_tick_callback(GtkWidget *scrolled_window, GdkFr
   {
     gtk_adjustment_set_value(data->adjustment, data->end);
 
+    free(data);
     return G_SOURCE_REMOVE;
   }
 }
@@ -206,8 +211,7 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   g_return_val_if_fail(GTK_IS_WIDGET(header), NULL);
   g_return_val_if_fail(GTK_IS_WIDGET(body), NULL);
 
-  expander
-      = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
+  expander = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
   expander->expanded = -1;
   expander->header = header;
   expander->body = body;

--- a/src/dtgtk/expander.h
+++ b/src/dtgtk/expander.h
@@ -59,6 +59,8 @@ GtkWidget *dtgtk_expander_get_body_event_box(GtkDarktableExpander *expander);
 
 void dtgtk_expander_set_expanded(GtkDarktableExpander *expander, gboolean expanded);
 gboolean dtgtk_expander_get_expanded(GtkDarktableExpander *expander);
+void dtgtk_expander_set_transition_duration(GtkDarktableExpander *expander, guint duration);
+guint dtgtk_expander_get_transition_duration(GtkDarktableExpander *expander);
 
 GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body);
 

--- a/src/dtgtk/expander.h
+++ b/src/dtgtk/expander.h
@@ -36,6 +36,7 @@ typedef struct _GtkDarktableExpander
 {
   GtkBox box;
   gboolean expanded;
+  GtkWidget *revealer;
   GtkWidget *frame;
   GtkWidget *header;
   GtkWidget *header_evb;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1951,32 +1951,8 @@ static GtkWidget *_ui_init_panel_container_top(GtkWidget *container)
 static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget, GdkEventScroll *event)
 {
   // just make sure nothing happens unless ctrl-alt are pressed:
-  return (((event->state & gtk_accelerator_get_default_mod_mask()) != darktable.gui->sidebar_scroll_mask) != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
-}
-
-// this should work as long as everything happens in the gui thread
-static void _ui_panel_size_changed(GtkAdjustment *adjustment, GParamSpec *pspec, gpointer user_data)
-{
-  GtkAllocation allocation;
-  static float last_height[2] = { 0 };
-
-  int side = GPOINTER_TO_INT(user_data);
-
-  // don't do anything when the size didn't actually change.
-  const float height = gtk_adjustment_get_upper(adjustment) - gtk_adjustment_get_lower(adjustment);
-
-  if(height == last_height[side]) return;
-  last_height[side] = height;
-
-  if(!darktable.gui->scroll_to[side]) return;
-
-  if(GTK_IS_WIDGET(darktable.gui->scroll_to[side]))
-  {
-    gtk_widget_get_allocation(darktable.gui->scroll_to[side], &allocation);
-    gtk_adjustment_set_value(adjustment, allocation.y);
-  }
-
-  darktable.gui->scroll_to[side] = NULL;
+  return (((event->state & gtk_accelerator_get_default_mod_mask()) != darktable.gui->sidebar_scroll_mask)
+          != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
 }
 
 static GtkWidget *_ui_init_panel_container_center(GtkWidget *container, gboolean left)
@@ -1998,8 +1974,6 @@ static GtkWidget *_ui_init_panel_container_center(GtkWidget *container, gboolean
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(widget), GTK_POLICY_AUTOMATIC,
                                  dt_conf_get_bool("panel_scrollbars_always_visible")?GTK_POLICY_ALWAYS:GTK_POLICY_AUTOMATIC);
 
-  g_signal_connect(G_OBJECT(gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(widget))), "notify::lower",
-                   G_CALLBACK(_ui_panel_size_changed), GINT_TO_POINTER(left ? 1 : 0));
   // we want the left/right window border to scroll the module lists
   g_signal_connect(G_OBJECT(left ? darktable.gui->widgets.right_border : darktable.gui->widgets.left_border),
                    "scroll-event", G_CALLBACK(_borders_scrolled), widget);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -138,8 +138,6 @@ typedef struct dt_gui_gtk_t
   // store which gtkrc we loaded:
   char gtkrc[PATH_MAX];
 
-  GtkWidget *scroll_to[2]; // one for left, one for right
-
   gint scroll_mask;
   guint sidebar_scroll_mask;
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -878,6 +878,22 @@ gboolean dt_lib_gui_get_expanded(dt_lib_module_t *module)
   return dtgtk_expander_get_expanded(DTGTK_EXPANDER(module->expander));
 }
 
+guint dt_lib_gui_get_transition_duration(dt_lib_module_t *module)
+{
+  if(!module->expandable(module)) return 0;
+  if(!module->expander) return 0;
+  if(!module->widget) return 0;
+
+  return dtgtk_expander_get_transition_duration(DTGTK_EXPANDER(module->expander));
+}
+
+void dt_lib_gui_set_transition_duration(dt_lib_module_t *module, guint duration)
+{
+  if(!module->expander || !module->arrow) return;
+
+  dtgtk_expander_set_transition_duration(DTGTK_EXPANDER(module->expander), duration);
+}
+
 static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)
 {
   if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return TRUE;

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -843,9 +843,6 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
   {
     /* register to receive draw events */
     darktable.lib->gui_module = module;
-
-    if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-      darktable.gui->scroll_to[1] = module->expander;
   }
   else
   {
@@ -905,15 +902,7 @@ static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
     /* bail out if module is static */
     if(!module->expandable(module)) return FALSE;
 
-    // make gtk scroll to the module once it updated its allocation size
     uint32_t container = module->container(module);
-    if(dt_conf_get_bool("lighttable/ui/scroll_to_module"))
-    {
-      if(container == DT_UI_CONTAINER_PANEL_LEFT_CENTER)
-        darktable.gui->scroll_to[0] = module->expander;
-      else if(container == DT_UI_CONTAINER_PANEL_RIGHT_CENTER)
-        darktable.gui->scroll_to[1] = module->expander;
-    }
 
     /* handle shiftclick on expander, hide all except this */
     if(!dt_conf_get_bool("lighttable/ui/single_module") != !dt_modifier_is(e->state, GDK_SHIFT_MASK))
@@ -963,13 +952,6 @@ static void show_module_callback(dt_lib_module_t *module)
 
   // make gtk scroll to the module once it updated its allocation size
   uint32_t container = module->container(module);
-  if(dt_conf_get_bool("lighttable/ui/scroll_to_module"))
-  {
-    if(container == DT_UI_CONTAINER_PANEL_LEFT_CENTER)
-      darktable.gui->scroll_to[0] = module->expander;
-    else if(container == DT_UI_CONTAINER_PANEL_RIGHT_CENTER)
-      darktable.gui->scroll_to[1] = module->expander;
-  }
 
   if(dt_conf_get_bool("lighttable/ui/single_module"))
   {

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -881,7 +881,7 @@ guint dt_lib_gui_get_transition_duration(dt_lib_module_t *module)
   if(!module->expander) return 0;
   if(!module->widget) return 0;
 
-  return dtgtk_expander_get_transition_duration(DTGTK_EXPANDER(module->expander));
+  return dt_conf_get_int("ui/transition_duration");
 }
 
 void dt_lib_gui_set_transition_duration(dt_lib_module_t *module, guint duration)
@@ -889,6 +889,7 @@ void dt_lib_gui_set_transition_duration(dt_lib_module_t *module, guint duration)
   if(!module->expander || !module->arrow) return;
 
   dtgtk_expander_set_transition_duration(DTGTK_EXPANDER(module->expander), duration);
+  dt_conf_set_int("ui/transition_duration", duration);
 }
 
 static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -117,6 +117,10 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module);
 void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded);
 /** get the expanded state of a plugin */
 gboolean dt_lib_gui_get_expanded(dt_lib_module_t *module);
+/** set the transition duration of the plugin expander */
+void dt_lib_gui_set_transition_duration(dt_lib_module_t *module, guint duration);
+/** get the transition duration of a plugin expander */
+guint dt_lib_gui_get_transition_duration(dt_lib_module_t *module);
 
 extern const struct dt_action_def_t dt_action_def_lib;
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -371,11 +371,16 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
       char var[1024];
       gboolean expanded = FALSE;
       gboolean visible = dt_lib_is_visible(plugin);
+      guint transition_duration = 0;
       if(plugin->expandable(plugin))
       {
         snprintf(var, sizeof(var), "plugins/%s/%s/expanded", new_view->module_name, plugin->plugin_name);
         expanded = dt_conf_get_bool(var);
+        /* prevent modules expanding with a transition */
+        transition_duration = dt_lib_gui_get_transition_duration(plugin);
+        dt_lib_gui_set_transition_duration(plugin, 0);
         dt_lib_gui_set_expanded(plugin, expanded);
+        dt_lib_gui_set_transition_duration(plugin, transition_duration);
         dt_lib_set_visible(plugin, visible);
       }
       else

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -242,9 +242,6 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
   // reset the cursor to the default one
   dt_control_change_cursor(GDK_LEFT_PTR);
 
-  // also ignore what scrolling there was previously happening
-  memset(darktable.gui->scroll_to, 0, sizeof(darktable.gui->scroll_to));
-
   // destroy old module list
 
   /*  clear the undo list, for now we do this unconditionally. At some point we will probably want to clear


### PR DESCRIPTION
This PR improves the UX of the modules by showing a simple transition when toggling them. [Here's a demo](https://imgur.com/l13mxeK).

I think what's missing might be an option to let the user configure the duration of the transitions, what do you think?