### PR TITLE
pdf: don't update bytes_written twice

### DIFF
--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -301,7 +301,6 @@ static size_t _pdf_write_stream(dt_pdf_t *pdf, dt_pdf_stream_encoder_t encoder, 
       stream_size = _pdf_stream_encoder_Flate(pdf, data, len);
       break;
   }
-  pdf->bytes_written += stream_size;
   return stream_size;
 }
 


### PR DESCRIPTION
The caller of `_pdf_write_stream()` will take care of offseting `pdf->bytes_written` by its return value.

The double-addition to bytes-written resulted in CUPS logging warnings:

```
file is damaged
(offset ######): xref not found
Attempting to reconstruct cross-reference table
```