### PR TITLE
print: rely on cups-filter to autorotate images

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -556,7 +556,8 @@ void dt_print_file(const int32_t imgid, const char *filename, const char *job_ti
       num_options = cupsAddOption("Borderless", "true", num_options, &options);
     }
 
-    num_options = cupsAddOption("landscape", pinfo->page.landscape ? "true" : "false", num_options, &options);
+    // as cups-filter pdftopdf will autorotate the page, there is no
+    // need to set an option in the case of landscape mode images
   }
 
   // print lp options


### PR DESCRIPTION
The CUPS filter pdftopdf will autorotate the image to fit the paper size. Hence there is no need to specify in the CUPS options whether the image is landscape or portrait.

Somewhere between cups-filters v1.28.7 and v1.28.12, there was a change such that specifying `landscape=true` option resulted in an offset image, rather than being ignored. Not setting `landscape` at all is a workaround.

It's unclear if it is an improvement to rely on autorotate, or it is better to wait for an upstream fix (which may already be out via cups-filters 1.28.13).

Fixes #11416.