### PR TITLE
Disable embedded opencl platforms

### DIFF
--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -64,9 +64,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
     library = name;
     module = dt_gmodule_open(library);
     if(module == NULL)
-      dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not find opencl runtime library '%s'\n", library);
+      dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
     else
-      dt_print(DT_DEBUG_OPENCL, "[opencl_init] found opencl runtime library '%s'\n", library);
+      dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
   }
   else
   {
@@ -76,9 +76,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
       library = *iter;
       module = dt_gmodule_open(library);
       if(module == NULL)
-        dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not find opencl runtime library '%s'\n", library);
+        dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
       else
-        dt_print(DT_DEBUG_OPENCL, "[opencl_init] found opencl runtime library '%s'\n", library);
+        dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
       iter++;
     }
   }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -744,12 +744,31 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
     cl_platform_id platform = all_platforms[n];
     // get the number of GPU devices available to the platforms
     // the other common option is CL_DEVICE_TYPE_GPU/CPU (but the latter doesn't work with the nvidia drivers)
-    err = (cl->dlocl->symbols->dt_clGetDeviceIDs)(platform, CL_DEVICE_TYPE_ALL, 0, NULL,
-                                                  &(all_num_devices[n]));
+    err = (cl->dlocl->symbols->dt_clGetDeviceIDs)(platform, CL_DEVICE_TYPE_ALL, 0, NULL, &(all_num_devices[n]));
     if(err != CL_SUCCESS)
     {
       all_num_devices[n] = 0;
       dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get device id size: %d\n", err);
+    }
+    else
+    {
+      char profile[64] = { 0 };
+      size_t profile_size;
+      err = (cl->dlocl->symbols->dt_clGetPlatformInfo)(platform, CL_PLATFORM_PROFILE, 64, profile, &profile_size);
+      if(err != CL_SUCCESS)
+      {
+        all_num_devices[n] = 0;
+        dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get profile: %d\n", err);
+      }
+      else
+      {
+        // fprintf(stderr, "%s\n", profile);
+        if(strcmp("FULL_PROFILE", profile) != 0)
+        {
+          all_num_devices[n] = 0;
+          dt_print(DT_DEBUG_OPENCL, "[opencl_init] platform %i is not FULL_PROFILE\n", n);
+        }
+      }
     }
   }
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -139,7 +139,10 @@ typedef struct dt_opencl_device_t
   int pinned_memory;
   // in OpenCL processing round width/height of global work groups to a multiple of this value.
   // reasonable values are powers of 2. this parameter can have high impact on OpenCL performance.
-  int clroundup;  
+  int clroundup;
+
+  // A bitfield that identifies the type of OpenCL device
+  unsigned int cltype;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;


### PR DESCRIPTION
embedded platform might not be common around for machines wanting to run dt but there are a number of restrictions that make dt not working correctly. (or we would have to do a large number of tests)
(see https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#opencl-embedded-profile)

Also some more -d opencl corrections done.