### PR TITLE
Introduce seperate values for cl roundups

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1723,14 +1723,14 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
 
-  if(old < 6)
+  if(old < 7)
   {
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("some global config values relevant for OpenCL performance are not used any longer."), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("instead you will find 'per device' data in 'cldevice_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("instead you will find 'per device' data in 'cldevice_v0_canonical-name'. content is:"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("  'avoid_atomics'  'micro_nap'  'pinned_memory'  'clroundup'  'magic'"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("  'avoid_atomics'  'micro_nap'  'pinned_memory'  'roundupwd'  'roundupht'  'magic'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
     g_strlcat(info, _("you may tune as before except 'magic'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -156,7 +156,7 @@ typedef unsigned int u_int;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 6
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 7
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2749,9 +2749,14 @@ gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
 }
 
 /** round size to a multiple of the value given in the device specifig config parameter clroundup_wd/ht */
-int dt_opencl_dev_roundup(int size, const int devid, const int mode)
+int dt_opencl_dev_roundup_width(int size, const int devid)
 {
-  const int roundup = (mode) ? darktable.opencl->dev[devid].clroundup_ht : darktable.opencl->dev[devid].clroundup_wd;
+  const int roundup = darktable.opencl->dev[devid].clroundup_wd;
+  return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
+}
+int dt_opencl_dev_roundup_height(int size, const int devid)
+{
+  const int roundup = darktable.opencl->dev[devid].clroundup_ht;
   return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
 }
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -51,8 +51,8 @@
 #define ROUNDUP(a, n) ((a) % (n) == 0 ? (a) : ((a) / (n)+1) * (n))
 
 // use per device roundups here
-#define ROUNDUPDWD(a, b) dt_opencl_dev_roundup(a, b, 0)
-#define ROUNDUPDHT(a, b) dt_opencl_dev_roundup(a, b, 1)
+#define ROUNDUPDWD(a, b) dt_opencl_dev_roundup_width(a, b)
+#define ROUNDUPDHT(a, b) dt_opencl_dev_roundup_height(a, b)
 
 typedef enum dt_opencl_memory_t
 {
@@ -403,7 +403,8 @@ cl_ulong dt_opencl_get_device_available(const int devid);
 cl_ulong dt_opencl_get_device_memalloc(const int devid);
 
 /** round size to a multiple of the value given in the device specifig config parameter for opencl_size_roundup */
-int dt_opencl_dev_roundup(int size, const int devid, const int mode);
+int dt_opencl_dev_roundup_width(int size, const int devid);
+int dt_opencl_dev_roundup_height(int size, const int devid);
 
 /** get next free slot in eventlist and manage size of eventlist */
 cl_event *dt_opencl_events_get_slot(const int devid, const char *tag);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -51,8 +51,8 @@
 #define ROUNDUP(a, n) ((a) % (n) == 0 ? (a) : ((a) / (n)+1) * (n))
 
 // use per device roundups here
-#define ROUNDUPDWD(a, b) dt_opencl_dev_roundup(a, b)
-#define ROUNDUPDHT(a, b) dt_opencl_dev_roundup(a, b)
+#define ROUNDUPDWD(a, b) dt_opencl_dev_roundup(a, b, 0)
+#define ROUNDUPDHT(a, b) dt_opencl_dev_roundup(a, b, 1)
 
 typedef enum dt_opencl_memory_t
 {
@@ -137,10 +137,10 @@ typedef struct dt_opencl_device_t
   // other devices have more efficient direct memory transfer implementations.
   // AMD seems to belong to the first group, nvidia to the second.
   int pinned_memory;
-  // in OpenCL processing round width/height of global work groups to a multiple of this value.
+  // in OpenCL processing round width/height of global work groups to a multiple of these values.
   // reasonable values are powers of 2. this parameter can have high impact on OpenCL performance.
-  int clroundup;
-
+  int clroundup_wd;
+  int clroundup_ht;
   // A bitfield that identifies the type of OpenCL device
   unsigned int cltype;
 } dt_opencl_device_t;
@@ -403,7 +403,7 @@ cl_ulong dt_opencl_get_device_available(const int devid);
 cl_ulong dt_opencl_get_device_memalloc(const int devid);
 
 /** round size to a multiple of the value given in the device specifig config parameter for opencl_size_roundup */
-int dt_opencl_dev_roundup(int size, const int devid);
+int dt_opencl_dev_roundup(int size, const int devid, const int mode);
 
 /** get next free slot in eventlist and manage size of eventlist */
 cl_event *dt_opencl_events_get_slot(const int devid, const char *tag);


### PR DESCRIPTION
We have these functions/marcros for rounding up width & height all over the code,
until now we only used one parameter, default was 16

As we have both functions we use two roundups, one for height and one for width.

This leads to change of the device specific conf data, to make versioning possible later
the  key has changed to 'cldevice_v0_canonical-name' and there are two roundup fields.

@TurboGit almost finished for 4.0 :-)