### PR TITLE
bauhaus : allow to hide the icon

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -72,6 +72,14 @@ static void bauhaus_request_focus(dt_bauhaus_widget_t *w)
   gtk_widget_set_state_flags(GTK_WIDGET(w), GTK_STATE_FLAG_FOCUSED, FALSE);
 }
 
+static float _widget_get_quad_width(dt_bauhaus_widget_t *w)
+{
+  if(w->show_quad)
+    return darktable.bauhaus->quad_width + INNER_PADDING;
+  else
+    return .0f;
+}
+
 static void _combobox_next_sensitive(dt_bauhaus_widget_t *w, int delta, const gboolean mute)
 {
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
@@ -243,27 +251,28 @@ static void _stop_cursor()
 
 static void dt_bauhaus_slider_set_normalized(dt_bauhaus_widget_t *w, float pos);
 
-static float slider_right_pos(float width)
+static float slider_right_pos(float width, dt_bauhaus_widget_t *w)
 {
   // relative position (in widget) of the right bound of the slider corrected with the inner padding
-  return 1.0f - (darktable.bauhaus->quad_width + INNER_PADDING) / width;
+  return 1.0f - _widget_get_quad_width(w) / width;
 }
 
-static float slider_coordinate(const float abs_position, const float width)
+static float slider_coordinate(const float abs_position, const float width, dt_bauhaus_widget_t *w)
 {
   // Translates an horizontal position relative to the slider
   // in an horizontal position relative to the widget
   const float left_bound = 0.0f;
-  const float right_bound = slider_right_pos(width); // exclude the quad area on the right
+  const float right_bound = slider_right_pos(width, w); // exclude the quad area on the right
   return (left_bound + abs_position * (right_bound - left_bound)) * width;
 }
 
 
-static float get_slider_line_offset(float pos, float scale, float x, float y, float ht, const int width)
+static float get_slider_line_offset(float pos, float scale, float x, float y, float ht, const int width,
+                                    dt_bauhaus_widget_t *w)
 {
   // ht is in [0,1] scale here
   const float l = 0.0f;
-  const float r = slider_right_pos(width);
+  const float r = slider_right_pos(width, w);
 
   float offset = 0.0f;
   // handle linear startup and rescale y to fit the whole range again
@@ -286,12 +295,12 @@ static float get_slider_line_offset(float pos, float scale, float x, float y, fl
 }
 
 // draw a loupe guideline for the quadratic zoom in in the slider interface:
-static void draw_slider_line(cairo_t *cr, float pos, float off, float scale, const int width,
-                             const int height, const int ht)
+static void draw_slider_line(cairo_t *cr, float pos, float off, float scale, const int width, const int height,
+                             const int ht, dt_bauhaus_widget_t *w)
 {
   // pos is normalized position [0,1], offset is on that scale.
   // ht is in pixels here
-  const float r = slider_right_pos(width);
+  const float r = slider_right_pos(width, w);
 
   const int steps = 64;
   cairo_move_to(cr, width * (pos + off) * r, ht * .7f);
@@ -448,7 +457,7 @@ static gboolean dt_bauhaus_popup_motion_notify(GtkWidget *widget, GdkEventMotion
       const dt_bauhaus_slider_data_t *d = &w->data.slider;
       const float mouse_off
           = get_slider_line_offset(d->oldpos, 5.0 * powf(10.0f, -d->digits) / (d->max - d->min) / d->factor,
-                                   ex / width, ey / height, ht / (float)height, allocation.width);
+                                   ex / width, ey / height, ht / (float)height, allocation.width, w);
       if(!darktable.bauhaus->change_active)
       {
         if((darktable.bauhaus->mouse_line_distance < 0 && mouse_off >= 0)
@@ -800,6 +809,7 @@ static void _bauhaus_widget_init(dt_bauhaus_widget_t *w, dt_iop_module_t *self)
   w->quad_paint = 0;
   w->quad_paint_data = NULL;
   w->quad_toggle = 0;
+  w->show_quad = TRUE;
 
   gtk_widget_add_events(GTK_WIDGET(w), GDK_POINTER_MOTION_MASK
                                        | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
@@ -1592,7 +1602,7 @@ static void dt_bauhaus_draw_indicator(dt_bauhaus_widget_t *w, float pos, cairo_t
   const float size = darktable.bauhaus->marker_size;
 
   cairo_save(cr);
-  cairo_translate(cr, slider_coordinate(pos, wd),
+  cairo_translate(cr, slider_coordinate(pos, wd, w),
                   darktable.bauhaus->line_height + INNER_PADDING
                       + (darktable.bauhaus->baseline_size - border_width) / 2.0f);
   cairo_scale(cr, 1.0f, -1.0f);
@@ -1624,6 +1634,7 @@ static void dt_bauhaus_draw_indicator(dt_bauhaus_widget_t *w, float pos, cairo_t
 
 static void dt_bauhaus_draw_quad(dt_bauhaus_widget_t *w, cairo_t *cr, const int width, const int height)
 {
+  if(!w->show_quad) return;
   const gboolean sensitive = gtk_widget_is_sensitive(GTK_WIDGET(w));
 
   if(w->quad_paint)
@@ -1684,7 +1695,7 @@ static void dt_bauhaus_draw_baseline(dt_bauhaus_widget_t *w, cairo_t *cr, float 
   // draw line for orientation in slider
   if(w->type != DT_BAUHAUS_SLIDER) return;
 
-  const float slider_width = width - darktable.bauhaus->quad_width - INNER_PADDING;
+  const float slider_width = width - _widget_get_quad_width(w);
   cairo_save(cr);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
 
@@ -1847,7 +1858,7 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
       const float mouse_off
           = get_slider_line_offset(d->oldpos, 5.0 * powf(10.0f, -d->digits) / (d->max - d->min) / d->factor,
                                    darktable.bauhaus->end_mouse_x / width, darktable.bauhaus->end_mouse_y / height,
-                                   base_height / (float)height, allocation_popup_window.width);
+                                   base_height / (float)height, allocation_popup_window.width, w);
       dt_bauhaus_slider_set_normalized(w, d->oldpos + mouse_off);
       d->oldpos = d->pos;
       break;
@@ -1929,7 +1940,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
         GdkRGBA fg_copy = *fg_color;
         fg_copy.alpha = scale / fabsf(off);
         set_color(cr, fg_copy);
-        draw_slider_line(cr, d->oldpos, off, scale, w2, h2, ht);
+        draw_slider_line(cr, d->oldpos, off, scale, w2, h2, ht, w);
         cairo_stroke(cr);
       }
       cairo_restore(cr);
@@ -1941,9 +1952,9 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       const float mouse_off
           = darktable.bauhaus->change_active
                 ? get_slider_line_offset(d->oldpos, scale, darktable.bauhaus->mouse_x / w2,
-                                         darktable.bauhaus->mouse_y / h2, ht / (float)h2, allocation.width)
+                                         darktable.bauhaus->mouse_y / h2, ht / (float)h2, allocation.width, w)
                 : 0.0f;
-      draw_slider_line(cr, d->oldpos, mouse_off, scale, w2, h2, ht);
+      draw_slider_line(cr, d->oldpos, mouse_off, scale, w2, h2, ht, w);
       cairo_stroke(cr);
       cairo_restore(cr);
 
@@ -1955,9 +1966,8 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
       char *text = dt_bauhaus_slider_get_text(GTK_WIDGET(w), dt_bauhaus_slider_get(GTK_WIDGET(w)));
       set_color(cr, *fg_color);
-      const float value_width
-          = show_pango_text(w, context, cr, text, w2 - darktable.bauhaus->quad_width - INNER_PADDING, 0, 0, TRUE,
-                            FALSE, PANGO_ELLIPSIZE_END, FALSE, FALSE, NULL, NULL);
+      const float value_width = show_pango_text(w, context, cr, text, w2 - _widget_get_quad_width(w), 0, 0, TRUE,
+                                                FALSE, PANGO_ELLIPSIZE_END, FALSE, FALSE, NULL, NULL);
       g_free(text);
       set_color(cr, text_color_insensitive);
       char *min = dt_bauhaus_slider_get_text(GTK_WIDGET(w), d->factor > 0 ? d->min : d->max);
@@ -1965,11 +1975,11 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
                       FALSE, NULL, NULL);
       g_free(min);
       char *max = dt_bauhaus_slider_get_text(GTK_WIDGET(w), d->factor > 0 ? d->max : d->min);
-      show_pango_text(w, context, cr, max, w2 - darktable.bauhaus->quad_width - INNER_PADDING, ht + INNER_PADDING,
-                      0, TRUE, FALSE, PANGO_ELLIPSIZE_END, FALSE, FALSE, NULL, NULL);
+      show_pango_text(w, context, cr, max, w2 - _widget_get_quad_width(w), ht + INNER_PADDING, 0, TRUE, FALSE,
+                      PANGO_ELLIPSIZE_END, FALSE, FALSE, NULL, NULL);
       g_free(max);
 
-      const float label_width = w2 - darktable.bauhaus->quad_width - INNER_PADDING * 2.0 - value_width;
+      const float label_width = w2 - _widget_get_quad_width(w) - INNER_PADDING - value_width;
       if(label_width > 0)
       {
         gchar *lb = _build_label(w);
@@ -1999,7 +2009,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
         gchar *text_cmp = g_utf8_casefold(entry->label, -1);
         if(!strncmp(text_cmp, keys, darktable.bauhaus->keys_cnt))
         {
-          float max_width = w2 - INNER_PADDING - darktable.bauhaus->quad_width;
+          float max_width = w2 - _widget_get_quad_width(w);
           if(first_label) max_width *= 0.8; // give the label at least some room
           float label_width = 0.0f;
           if(!entry->sensitive)
@@ -2022,7 +2032,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
           }
           else
             label_width
-                = show_pango_text(w, context, cr, entry->label, w2 - darktable.bauhaus->quad_width - INNER_PADDING,
+                = show_pango_text(w, context, cr, entry->label, w2 - _widget_get_quad_width(w),
                                   ht * k + w->top_gap, max_width, TRUE, FALSE, ellipsis, FALSE, FALSE, NULL, NULL);
 
           // prefer the entry over the label wrt. ellipsization when expanded
@@ -2045,9 +2055,8 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       {
         set_color(cr, text_color);
         gchar *lb = _build_label(w);
-        show_pango_text(w, context, cr, lb, 0, w->top_gap,
-                        w2 - INNER_PADDING - darktable.bauhaus->quad_width - first_label_width, FALSE, FALSE,
-                        PANGO_ELLIPSIZE_END, FALSE, TRUE, NULL, NULL);
+        show_pango_text(w, context, cr, lb, 0, w->top_gap, w2 - _widget_get_quad_width(w) - first_label_width,
+                        FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE, TRUE, NULL, NULL);
         g_free(lb);
       }
       g_free(keys);
@@ -2079,7 +2088,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
     pango_layout_set_text(layout, darktable.bauhaus->keys, -1);
     pango_layout_get_pixel_extents(layout, &ink, NULL);
-    cairo_move_to(cr, w2 - INNER_PADDING - darktable.bauhaus->quad_width - ink.width, h2 * 0.5 - size);
+    cairo_move_to(cr, w2 - _widget_get_quad_width(w) - ink.width, h2 * 0.5 - size);
     pango_cairo_show_layout(cr, layout);
     cairo_restore(cr);
     pango_font_description_free(desc);
@@ -2145,7 +2154,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
     {
       // draw label and quad area at right end
       set_color(cr, *text_color);
-      dt_bauhaus_draw_quad(w, cr, w3, h3);
+      if(w->show_quad) dt_bauhaus_draw_quad(w, cr, w3, h3);
 
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       const PangoEllipsizeMode combo_ellipsis = d->entries_ellipsis;
@@ -2157,7 +2166,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
       }
       set_color(cr, *text_color);
 
-      const float available_width = w3 - darktable.bauhaus->quad_width - INNER_PADDING;
+      const float available_width = w3 - _widget_get_quad_width(w);
 
       //calculate total widths of label and combobox
       gchar *label_text = _build_label(w);
@@ -2167,8 +2176,8 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
                       &label_width, &label_height);
       float combo_width = 0;
       float combo_height = 0;
-      show_pango_text(w, context, cr, text, w3 - darktable.bauhaus->quad_width - INNER_PADDING, 0, 0, TRUE, TRUE,
-                      combo_ellipsis, FALSE, FALSE, &combo_width, &combo_height);
+      show_pango_text(w, context, cr, text, w3 - _widget_get_quad_width(w), 0, 0, TRUE, TRUE, combo_ellipsis,
+                      FALSE, FALSE, &combo_width, &combo_height);
       // we want to center the text verticaly
       w->top_gap = floor((h3 - fmaxf(label_height, combo_height)) / 2.0f);
       //check if they fit
@@ -2179,7 +2188,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
         show_pango_text(w, context, cr, label_text, 0, w->top_gap, available_width * ratio - INNER_PADDING * 2,
                         FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE, TRUE, NULL, NULL);
         if(d->text_align == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT)
-          show_pango_text(w, context, cr, text, w3 - darktable.bauhaus->quad_width - INNER_PADDING, w->top_gap,
+          show_pango_text(w, context, cr, text, w3 - _widget_get_quad_width(w), w->top_gap,
                           available_width * (1.0f - ratio), TRUE, FALSE, combo_ellipsis, FALSE, FALSE, NULL, NULL);
         else
           show_pango_text(w, context, cr, text, INNER_PADDING, w->top_gap, available_width * (1.0f - ratio), FALSE,
@@ -2190,8 +2199,8 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
         show_pango_text(w, context, cr, label_text, 0, w->top_gap, 0, FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE,
                         TRUE, NULL, NULL);
         if(d->text_align == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT)
-          show_pango_text(w, context, cr, text, w3 - darktable.bauhaus->quad_width - INNER_PADDING, w->top_gap, 0,
-                          TRUE, FALSE, combo_ellipsis, FALSE, FALSE, NULL, NULL);
+          show_pango_text(w, context, cr, text, w3 - _widget_get_quad_width(w), w->top_gap, 0, TRUE, FALSE,
+                          combo_ellipsis, FALSE, FALSE, NULL, NULL);
         else
           show_pango_text(w, context, cr, text, INNER_PADDING, w->top_gap, 0, FALSE, FALSE, combo_ellipsis, FALSE,
                           FALSE, NULL, NULL);
@@ -2203,13 +2212,13 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
     {
       // line for orientation
       dt_bauhaus_draw_baseline(w, cr, w3);
-      dt_bauhaus_draw_quad(w, cr, w3, h3);
+      if(w->show_quad) dt_bauhaus_draw_quad(w, cr, w3, h3);
 
       float value_width = 0;
       if(gtk_widget_is_sensitive(widget))
       {
         cairo_save(cr);
-        cairo_rectangle(cr, 0, 0, w3 - darktable.bauhaus->quad_width - INNER_PADDING, h3 + INNER_PADDING);
+        cairo_rectangle(cr, 0, 0, w3 - _widget_get_quad_width(w), h3 + INNER_PADDING);
         cairo_clip(cr);
         dt_bauhaus_draw_indicator(w, w->data.slider.pos, cr, w3, *fg_color, *bg_color);
         cairo_restore(cr);
@@ -2218,14 +2227,14 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
 
         char *text = dt_bauhaus_slider_get_text(widget, dt_bauhaus_slider_get(widget));
         set_color(cr, *text_color);
-        value_width = show_pango_text(w, context, cr, text, w3 - darktable.bauhaus->quad_width - INNER_PADDING, 0,
-                                      0, TRUE, FALSE, PANGO_ELLIPSIZE_END, FALSE, FALSE, NULL, NULL);
+        value_width = show_pango_text(w, context, cr, text, w3 - _widget_get_quad_width(w), 0, 0, TRUE, FALSE,
+                                      PANGO_ELLIPSIZE_END, FALSE, FALSE, NULL, NULL);
         g_free(text);
       }
       // label on top of marker:
       gchar *label_text = _build_label(w);
       set_color(cr, *text_color);
-      const float label_width = w3 - darktable.bauhaus->quad_width - INNER_PADDING - value_width;
+      const float label_width = w3 - _widget_get_quad_width(w) - value_width;
       if(label_width > 0)
         show_pango_text(w, context, cr, label_text, 0, 0, label_width, FALSE, FALSE, PANGO_ELLIPSIZE_END, FALSE,
                         TRUE, NULL, NULL);
@@ -2275,8 +2284,8 @@ static void _get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *na
     pango_layout_set_text(layout, w->label, -1);
     pango_layout_get_size(layout, &pango_width, NULL);
     _margins_retrieve(w);
-    *natural_size += pango_width / PANGO_SCALE + darktable.bauhaus->quad_width + 3 * INNER_PADDING
-                     + w->margin->left + w->margin->right + w->padding->left + w->padding->right;
+    *natural_size += pango_width / PANGO_SCALE + _widget_get_quad_width(w) + 2 * INNER_PADDING + w->margin->left
+                     + w->margin->right + w->padding->left + w->padding->right;
 
     g_object_unref(layout);
   }
@@ -2341,7 +2350,7 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
 
   if(px < wx || px > wx + tmp.width)
   {
-    wx = px - (tmp.width - darktable.bauhaus->quad_width) / 2;
+    wx = px - (tmp.width - _widget_get_quad_width(w)) / 2;
     wy = py - darktable.bauhaus->line_height / 2;
   }
   else if(py < wy || py > wy + tmp.height)
@@ -2538,7 +2547,7 @@ static gboolean dt_bauhaus_combobox_button_press(GtkWidget *widget, GdkEventButt
   GtkAllocation tmp;
   gtk_widget_get_allocation(GTK_WIDGET(w), &tmp);
   const dt_bauhaus_combobox_data_t *d = &w->data.combobox;
-  if(w->quad_paint && (event->x > allocation.width - darktable.bauhaus->quad_width - INNER_PADDING))
+  if(w->quad_paint && (event->x > allocation.width - _widget_get_quad_width(w)))
   {
     dt_bauhaus_widget_press_quad(widget);
     return TRUE;
@@ -2982,8 +2991,7 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
   const int w3 = allocation.width - w->margin->left - w->padding->left - w->margin->right - w->padding->right;
   const double ex = event->x - w->margin->left - w->padding->left;
   const double ey = event->y - w->margin->top - w->padding->top;
-  if(event->x
-     > allocation.width - darktable.bauhaus->quad_width - INNER_PADDING - w->margin->right - w->padding->right)
+  if(event->x > allocation.width - _widget_get_quad_width(w) - w->margin->right - w->padding->right)
   {
     dt_bauhaus_widget_press_quad(widget);
     return TRUE;
@@ -3016,7 +3024,7 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
       }
       else if(ey > darktable.bauhaus->line_height)
       {
-        const float r = slider_right_pos((float)w3);
+        const float r = slider_right_pos((float)w3, w);
         dt_bauhaus_slider_set_normalized(w, (ex / w3) / r);
 
         darktable.bauhaus->mouse_x = NAN;
@@ -3031,8 +3039,7 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
         g_object_unref(layout);
         g_free(text);
 
-        if(ex > w3 - value_width / PANGO_SCALE - darktable.bauhaus->quad_width - INNER_PADDING)
-          dt_bauhaus_show_popup(widget);
+        if(ex > w3 - value_width / PANGO_SCALE - _widget_get_quad_width(w)) dt_bauhaus_show_popup(widget);
       }
     }
     return TRUE;
@@ -3069,7 +3076,7 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
   const double ex = event->x - w->margin->left - w->padding->left;
   if(d->is_dragging && event->state & GDK_BUTTON1_MASK)
   {
-    const float r = slider_right_pos((float)w3);
+    const float r = slider_right_pos((float)w3, w);
 
     if(isnan(darktable.bauhaus->mouse_x))
     {
@@ -3088,10 +3095,10 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
     }
   }
 
-  if(ex <= w3 - darktable.bauhaus->quad_width)
+  if(ex <= w3 - _widget_get_quad_width(w))
   {
     darktable.control->element
-        = ex > (0.1 * (w3 - darktable.bauhaus->quad_width)) && ex < (0.9 * (w3 - darktable.bauhaus->quad_width))
+        = ex > (0.1 * (w3 - _widget_get_quad_width(w))) && ex < (0.9 * (w3 - _widget_get_quad_width(w)))
               ? DT_ACTION_ELEMENT_VALUE
               : DT_ACTION_ELEMENT_FORCE;
   }
@@ -3103,12 +3110,13 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
 
 static gboolean dt_bauhaus_combobox_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
 
-  darktable.control->element = event->x <= allocation.width - darktable.bauhaus->quad_width
-                             ? DT_ACTION_ELEMENT_SELECTION
-                             : DT_ACTION_ELEMENT_BUTTON;
+  darktable.control->element = event->x <= allocation.width - _widget_get_quad_width(w)
+                                   ? DT_ACTION_ELEMENT_SELECTION
+                                   : DT_ACTION_ELEMENT_BUTTON;
 
   return TRUE;
 }

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -162,6 +162,8 @@ typedef struct dt_bauhaus_widget_t
   void *quad_paint_data;
   // quad is a toggle button?
   int quad_toggle;
+  // show quad icon or space
+  gboolean show_quad;
   // if a section label
   gboolean is_section;
 
@@ -264,6 +266,8 @@ void dt_bauhaus_widget_set_quad_toggle(GtkWidget *w, int toggle);
 void dt_bauhaus_widget_set_quad_active(GtkWidget *w, int active);
 // get active status for the quad toggle button:
 int dt_bauhaus_widget_get_quad_active(GtkWidget *w);
+// set quad visibility:
+void dt_bauhaus_widget_set_quad_visibility(GtkWidget *w, const gboolean visible);
 // set pointer to iop params field:
 void dt_bauhaus_widget_set_field(GtkWidget *w, gpointer field, dt_introspection_type_t field_type);
 


### PR DESCRIPTION
This will allow to use bauhaus sliders as "normal sliders" without a gap on the right.
I also will have the use of that for my filtering PR, in order to gain some lateral width and not to hack regular combobox.

Due to the fact that I don't think that this will be used widely, I've not added a public function to the bauhaus api. we'll have to use something like `DT_BAUHAUS_WIDGET(widget)->show_quad = FALSE;` but that's not a big deal imho