### PR TITLE
print view: graphical image coordinates overlay

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3007,6 +3007,19 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/print/print/unit</name>
+    <type>
+      <enum>
+	<option>mm</option>
+	<option>cm</option>
+	<option>inch</option>
+      </enum>
+    </type>
+    <default>mm</default>
+    <shortdescription>measurement units</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/print/print/top_margin</name>
     <type min="-50" max="500">float</type>
     <default>17</default>

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -81,6 +81,7 @@ typedef enum _unit_t
 
 static const float units[UNIT_N] = { 1.0f, 0.1f, 1.0f/25.4f };
 static const gchar *_unit_names[] = { N_("mm"), N_("cm"), N_("inch"), NULL };
+static const char *_unit_precision[UNIT_N] = { "%0.0f", "%0.1f", "%0.1f" };
 
 typedef struct dt_lib_print_settings_t
 {
@@ -1881,10 +1882,10 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     const double text_h = DT_PIXEL_APPLY_DPI(16+2);
     const double margin = DT_PIXEL_APPLY_DPI(6);
     const double dash = DT_PIXEL_APPLY_DPI(3.0);
+    const char *precision = _unit_precision[ps->unit];
 
-    // FIXME: # of significant digits should be 0 for mm, 1 for cm, 2 for inch
     // FIXME: here and elsewhere eliminate hardcoded RGB values -- use CSS
-    snprintf(dimensions, sizeof(dimensions), "%.2f", dx1);
+    snprintf(dimensions, sizeof(dimensions), precision, dx1);
     pango_layout_set_text(layout, dimensions, -1);
     pango_layout_get_pixel_extents(layout, NULL, &ext);
     double xp = x1 - ext.width * 0.5 - margin;
@@ -1901,7 +1902,7 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     cairo_move_to(cr, xp + margin, ps->imgs.screen.page.y + 2 * margin);
     pango_cairo_show_layout(cr, layout);
 
-    snprintf(dimensions, sizeof(dimensions), "%.2f", dy1);
+    snprintf(dimensions, sizeof(dimensions), precision, dy1);
     pango_layout_set_text(layout, dimensions, -1);
     pango_layout_get_pixel_extents(layout, NULL, &ext);
     double yp = CLAMP(y1, ps->imgs.screen.page.y + 2 * margin + ext.width * 0.5,
@@ -1927,7 +1928,7 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     pango_cairo_show_layout(cr, layout);
     cairo_restore(cr);
 
-    snprintf(dimensions, sizeof(dimensions), "%.2f", dx2);
+    snprintf(dimensions, sizeof(dimensions), precision, dx2);
     pango_layout_set_text(layout, dimensions, -1);
     pango_layout_get_pixel_extents(layout, NULL, &ext);
     xp = x2 - ext.width * 0.5 - margin;
@@ -1944,7 +1945,7 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     cairo_move_to(cr, xp + margin, ps->imgs.screen.page.y + ps->imgs.screen.page.height - text_h - 2 * margin);
     pango_cairo_show_layout(cr, layout);
 
-    snprintf(dimensions, sizeof(dimensions), "%.2f", dy2);
+    snprintf(dimensions, sizeof(dimensions), precision, dy2);
     pango_layout_set_text(layout, dimensions, -1);
     xp += ext.width + 2 * margin;
     pango_layout_get_pixel_extents(layout, NULL, &ext);
@@ -1972,8 +1973,8 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     cairo_restore(cr);
 
     // display width and height
-    // FIXME: display these embedded in the frame lines rather than above/below?
-    snprintf(dimensions, sizeof(dimensions), "%.2f", dwidth);
+    // FIXME: display these embedded in the frame lines rather than above/below? -- or at least slightly closer to what they measure
+    snprintf(dimensions, sizeof(dimensions), precision, dwidth);
     pango_layout_set_text(layout, dimensions, -1);
     pango_layout_get_pixel_extents(layout, NULL, &ext);
     xp = (x1 + x2 - ext.width) * .5;
@@ -1988,7 +1989,7 @@ void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, i
     cairo_move_to(cr, xp, yp);
     pango_cairo_show_layout(cr, layout);
 
-    snprintf(dimensions, sizeof(dimensions), "%.2f", dheight);
+    snprintf(dimensions, sizeof(dimensions), precision, dheight);
     pango_layout_set_text(layout, dimensions, -1);
     pango_layout_get_pixel_extents(layout, NULL, &ext);
     if(x1 > text_h + margin * 5)


### PR DESCRIPTION
In print view, the center view currently can overlay coordinates of an image area in the form of:

`(x_top, y_top) -> (x_bottom, y_bottom) | (w x h)`

For the sake of legibility, this PR shows these coordinates graphically. The width/height values are embedded in the rectangular outline of the image area. Instead of displaying the coordinates of the image area's corners, the image margins are displayed, in the hope that these will be more useful during page layout.

The resolution of these numbers now varies depending on the display units: mm's are displayed as whole numbers, while cm/inch display to the nearest 0.1 unit.

The print units chosen by the user are now stored in config as an enum rather than as an int, and have an entry in darktableconfig.xml.in.

Coordinates overlay as in current code:

![image](https://user-images.githubusercontent.com/2311860/161371701-f0b8b58b-68d7-4ab2-adab-aecbc8e479b6.png)

With this PR:

![image](https://user-images.githubusercontent.com/2311860/161371562-d5825204-c45d-465f-84bb-ba8b8cbafc4f.png)
