### PR TITLE
Heal optimize

### DIFF
--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -234,7 +234,6 @@ static float _heal_laplace_iteration(float *const restrict active_pixels,
         }
       }
     }
-
   return err.v[0] + err.v[1] + err.v[2];
 }
 
@@ -250,7 +249,7 @@ static size_t _collect_color_runs(const float *const restrict mask, const size_t
   // non-negligible)
   if(start == 0 && mask[start])
   {
-    runs[2*count] = start_index /* + start/2 */;
+    runs[2*count] = start_index;
     runs[2*count+1] = 1;
     count++;
     masked++;
@@ -298,12 +297,16 @@ static size_t _collect_color_runs(const float *const restrict mask, const size_t
 }
 
 // convert one row of the opacity mask into a set of runs of opaque pixels of the form (start_index, count)
-static void _collect_runs(const float *const restrict mask, const size_t start_index, const size_t width,
-                          unsigned *const restrict runs1, size_t *count1,
-                          unsigned *const restrict runs2, size_t *count2, size_t *nmask)
+static void collect_runs(const int start, const float *const restrict mask, const size_t width, const size_t height,
+                         const size_t subwidth, unsigned *const restrict runs, size_t *count, size_t *nmask)
 {
-  *count1 = _collect_color_runs(mask, start_index, 0, width, runs1, *count1, nmask);
-  *count2 = _collect_color_runs(mask, start_index, 1, width, runs2, *count2, nmask);
+  for(size_t row = 0; row < height; row++)
+  {
+    const int parity = start ^ (row & 1);
+    const size_t index = (row + 1) * subwidth;
+    const size_t mask_index = row * width;
+    *count = _collect_color_runs(mask + mask_index, index, parity, width, runs, *count, nmask);
+  }
 }
 
 // Solve the laplace equation for pixels and store the result in-place.
@@ -326,25 +329,25 @@ static void _heal_laplace_loop(float *const restrict red_pixels, float *const re
     fprintf(stderr, "_heal_laplace_loop: error allocating memory for healing\n");
     goto cleanup;
   }
+  double start = dt_get_wtime();
 
   size_t num_red = 0;
   size_t num_black = 0;
-  size_t nmask = 0;
+  size_t nmask_red = 0;
+  size_t nmask_black = 0;
 
-  for(size_t row = 0; row < height; row++)
+#ifdef _OPENMP
+#pragma omp parallel sections
+#endif
   {
-    const int parity = (row & 1);
-    const size_t index = (row + 1) * subwidth; // each color only has half as many, and we've padded a row on top
-    const size_t mask_index = row * width;
-    if(parity)
-    {
-      _collect_runs(mask + mask_index, index, width, red_runs, &num_red, black_runs, &num_black, &nmask);
-    }
-    else
-    {
-      _collect_runs(mask + mask_index, index, width, black_runs, &num_black, red_runs, &num_red, &nmask);
-    }
+    collect_runs(1, mask, width, height, subwidth, red_runs, &num_red, &nmask_red);
+    #ifdef _OPENMP
+    #pragma omp section
+    #endif
+    collect_runs(0, mask, width, height, subwidth, black_runs, &num_black, &nmask_black);
   }
+  const size_t nmask = nmask_red + nmask_black;
+  fprintf(stderr,"* collect_runs: %4.3g  ms\n",1000.0*(dt_get_wtime()-start));
 
   /* Empirically optimal over-relaxation factor. (Benchmarked on
    * round brushes, at least. I don't know whether aspect ratio


### PR DESCRIPTION
Add a bit of parallelization to the setup for the retouch healing algorithm and eliminate one memory access per pixel.  Gives a small speedup on my Threadripper, potentially bigger speedups on systems with smaller caches.
```
Thr     AVmstr  AVpr    (%ch)                                                                                           
  1     7.3102  7.2642  -0.6%
  2     4.0330  4.0308  -0.1%
  4     2.1910  2.1554  -1.6%
  8     1.1980  1.1882  -0.8%
 12     0.8988  0.8848  -1.6%
 16     0.7372  0.7290  -1.1%
 24     0.5950  0.5854  -1.6%
 32     0.5370  0.5292  -1.5%
```
Integration test 0075 gets identical results with/without this PR.
