### PR TITLE
increase heal iteration limit

### DIFF
--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -352,7 +352,7 @@ static void _heal_laplace_loop(float *const restrict red_pixels, float *const re
    */
   const float w = ((2.0f - 1.0f / (0.1575f * sqrtf(nmask) + 0.8f)) * .25f);
 
-  const int max_iter = 1000;
+  const int max_iter = 2000;
   const float epsilon = (0.1 / 255);
   const float err_exit = epsilon * epsilon * w * w;
 


### PR DESCRIPTION
Partially fixes #11447 by allowing the adaptation to diffuse further from the edges of the healed region, but does change integration test 0075 results (the ellipse at upper right is quite noticeably darker as it gets adapted closer to the source region colors).

We don't want to make the limit too high, as that will excessively slow down large heals as well as those which don't fully converge on their own.
