### PR TITLE
Integrate pinned memory transfer into "tune OpenCL performance"

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -360,11 +360,18 @@
     <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems. default - GPU processes full and CPU processes preview pipe (adaptable by config parameters); multiple GPUs - process both pixelpipes in parallel on two different GPUs; very fast GPU - process both pixelpipes sequentially on the GPU.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" capability="opencl">
-    <name>tuneopencl</name>
-    <type>bool</type>
-    <default>false</default>
+    <name>opencl_tuning_mode</name>
+    <type>
+      <enum>
+        <option>nothing</option>
+        <option>memory size</option>
+        <option>memory transfer</option>
+        <option>memory size and transfer</option>
+      </enum>
+    </type>
+    <default>nothing</default>
     <shortdescription>tune OpenCL performance</shortdescription>
-    <longdescription>if switched on, darktable tunes OpenCL for best performance, overrides static settings</longdescription>
+    <longdescription>allows runtime tuning of OpenCL devices. 'memory size' tests for available graphics ram, 'memory transfer' tries a faster memory access mode (pinned memory) used for tiling.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_synch_cache</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1318,7 +1318,7 @@ void dt_get_sysresource_level()
   static int oldlevel = -999;
   static int oldtunecl = -999;
 
-  const int tunecl = dt_conf_get_bool("tuneopencl");
+  const int tunecl = dt_opencl_get_tuning_mode();
   int level = 1;
   const char *config = dt_conf_get_string_const("resourcelevel");
   /** These levels must correspond with preferences in xml.in
@@ -1341,18 +1341,23 @@ void dt_get_sysresource_level()
   }
   const gboolean mod = ((level != oldlevel) || (oldtunecl != tunecl));
   darktable.dtresources.level = oldlevel = level;
-  darktable.dtresources.tunecl = oldtunecl = tunecl;
+  oldtunecl = tunecl;
+  darktable.dtresources.tunememory  = (tunecl & DT_OPENCL_TUNE_MEMSIZE) ? 1 : 0;
+  darktable.dtresources.tunepinning = (tunecl & DT_OPENCL_TUNE_PINNED) ? 1 : 0;
 
   if(mod && (darktable.unmuted & DT_DEBUG_MEMORY))
   {
     const int oldgrp = darktable.dtresources.group;
     darktable.dtresources.group = 4 * level;
     fprintf(stderr,"[dt_get_sysresource_level] switched to %i as `%s'\n", level, config);
-    fprintf(stderr,"  total mem:     %luMB\n", darktable.dtresources.total_memory / 1024lu / 1024lu);
-    fprintf(stderr,"  mipmap cache:  %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
-    fprintf(stderr,"  available mem: %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
-    fprintf(stderr,"  singlebuff:    %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
-    fprintf(stderr,"  OpenCL tuning: %s\n", (tunecl && (level >= 0)) ? "ON" : "OFF");
+    fprintf(stderr,"  total mem:        %luMB\n", darktable.dtresources.total_memory / 1024lu / 1024lu);
+    fprintf(stderr,"  mipmap cache:     %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
+    fprintf(stderr,"  available mem:    %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
+    fprintf(stderr,"  singlebuff:       %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
+#ifdef HAVE_OPENCL
+    fprintf(stderr,"  OpenCL available: %s\n", ((darktable.dtresources.tunememory) && (level >= 0)) ? "ON" : "OFF");
+    fprintf(stderr,"  OpenCL pinned:    %s\n", ((darktable.dtresources.tunepinning) && (level >= 0)) ? "ON" : "OFF");
+#endif
     darktable.dtresources.group = oldgrp;
   }
 }

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1342,9 +1342,13 @@ void dt_get_sysresource_level()
   const gboolean mod = ((level != oldlevel) || (oldtunecl != tunecl));
   darktable.dtresources.level = oldlevel = level;
   oldtunecl = tunecl;
+#ifdef HAVE_OPENCL
   darktable.dtresources.tunememory  = (tunecl & DT_OPENCL_TUNE_MEMSIZE) ? 1 : 0;
   darktable.dtresources.tunepinning = (tunecl & DT_OPENCL_TUNE_PINNED) ? 1 : 0;
-
+#else
+  darktable.dtresources.tunememory  = 0;
+  darktable.dtresources.tunepinning = 0;
+#endif
   if(mod && (darktable.unmuted & DT_DEBUG_MEMORY))
   {
     const int oldgrp = darktable.dtresources.group;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -289,7 +289,8 @@ typedef struct dt_sys_resources_t
   int *refresource; // for the debug resource modes we use fixed settings
   int group;
   int level;
-  int tunecl;
+  int tunememory;
+  int tunepinning;
 } dt_sys_resources_t;
 
 typedef struct darktable_t

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2664,7 +2664,7 @@ cl_ulong dt_opencl_get_device_available(const int devid)
     return available;
   }
   const size_t allmem = darktable.opencl->dev[devid].max_global_mem;
-  const gboolean tuned = darktable.dtresources.tunecl && (level > 0);
+  const gboolean tuned = darktable.dtresources.tunememory && (level > 0);
   const gboolean board = darktable.opencl->dev[devid].cltype & CL_DEVICE_TYPE_CPU;
   if(tuned && !board)
   {
@@ -2681,7 +2681,7 @@ cl_ulong dt_opencl_get_device_available(const int devid)
   }
 
   if(mod)
-    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_MEMORY, "[dt_opencl_get_device_available] use %luMB (tune=%s, cpu=%s) as available on device %i\n",
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_MEMORY, "[dt_opencl_get_device_available] use %luMB (tune=%s, CPU=%s) as available on device %i\n",
        available / 1024lu / 1024lu, (tuned) ? "ON" : "OFF", (board) ? "yes" : "no", devid);
   return available;
 }
@@ -2834,6 +2834,19 @@ static dt_opencl_scheduling_profile_t dt_opencl_get_scheduling_profile(void)
     profile = OPENCL_PROFILE_VERYFAST_GPU;
 
   return profile;
+}
+
+int dt_opencl_get_tuning_mode(void)
+{
+  int res = DT_OPENCL_TUNE_NOTHING;
+  const char *pstr = dt_conf_get_string_const("opencl_tuning_mode");
+  if(pstr)
+  {
+    if(!strcmp(pstr, "memory size"))                   res = DT_OPENCL_TUNE_MEMSIZE;
+    else if(!strcmp(pstr, "memory transfer"))          res = DT_OPENCL_TUNE_PINNED;
+    else if(!strcmp(pstr, "memory size and transfer")) res = DT_OPENCL_TUNE_MEMSIZE | DT_OPENCL_TUNE_PINNED;
+  }
+  return res;  
 }
 
 /** read config of when/if to synch to cache */

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -84,6 +84,12 @@ typedef struct dt_opencl_eventtag_t
   char tag[DT_OPENCL_EVENTNAMELENGTH];
 } dt_opencl_eventtag_t;
 
+typedef enum dt_opencl_tunemode_t
+{
+  DT_OPENCL_TUNE_NOTHING = 0,
+  DT_OPENCL_TUNE_MEMSIZE = 1,
+  DT_OPENCL_TUNE_PINNED  = 2
+} dt_opencl_tunemode_t;
 
 /**
  * to support multi-gpu and mixed systems with cpu support,
@@ -296,6 +302,9 @@ int dt_opencl_is_enabled(void);
 
 /** disable opencl */
 void dt_opencl_disable(void);
+
+/** get OpenCL tuning mode flags */
+int dt_opencl_get_tuning_mode(void);
 
 /** update enabled flag and profile with value from preferences, returns enabled flag */
 int dt_opencl_update_settings(void);
@@ -522,6 +531,11 @@ static inline int dt_opencl_is_enabled(void)
 }
 static inline void dt_opencl_disable(void)
 {
+}
+/** get OpenCL tuning mode flags */
+static inline int dt_opencl_get_tuning_mode(void)
+{
+  return 0;
 }
 static inline int dt_opencl_update_settings(void)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -91,6 +91,14 @@ typedef enum dt_opencl_tunemode_t
   DT_OPENCL_TUNE_PINNED  = 2
 } dt_opencl_tunemode_t;
 
+typedef enum dt_opencl_pinmode_t
+{
+  DT_OPENCL_PINNING_OFF = 0,
+  DT_OPENCL_PINNING_ON = 1,
+  DT_OPENCL_PINNING_DISABLED = 2,
+  DT_OPENCL_PINNING_ERROR = 4
+} dt_opencl_pinmode_t;
+
 /**
  * to support multi-gpu and mixed systems with cpu support,
  * we encapsulate devices and use separate command queues.
@@ -142,6 +150,11 @@ typedef struct dt_opencl_device_t
   // this can often be avoided by using indirect transfers via pinned memory.
   // other devices have more efficient direct memory transfer implementations.
   // AMD seems to belong to the first group, nvidia to the second.
+  // this holds a bitmask defined by dt_opencl_pinmode_t
+  // the device specific conf key might hold
+  // 0 -> disabled by default; might be switched on by tune for performance
+  // 1 -> enabled by default
+  // 2 -> disabled under all circumstances. This could/should be used if we give away / ship specific keys for buggy systems 
   int pinned_memory;
   // in OpenCL processing round width/height of global work groups to a multiple of these values.
   // reasonable values are powers of 2. this parameter can have high impact on OpenCL performance.

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2124,8 +2124,11 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   darktable.dtresources.group = 4 * darktable.dtresources.level;
 #ifdef HAVE_OPENCL
-  if((darktable.dtresources.tunecl == 0) && (pipe->devid >= 0) && darktable.opencl->inited)
+  if((darktable.dtresources.tunememory == 0) && (pipe->devid >= 0) && darktable.opencl->inited)
     darktable.opencl->dev[pipe->devid].tuned_available = 0;
+
+  if((darktable.dtresources.tunepinning != 0) && (pipe->devid >= 0) && darktable.opencl->inited)
+    darktable.opencl->dev[pipe->devid].pinned_memory = 1;
 #endif
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2128,7 +2128,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
     darktable.opencl->dev[pipe->devid].tuned_available = 0;
 
   if((darktable.dtresources.tunepinning != 0) && (pipe->devid >= 0) && darktable.opencl->inited)
-    darktable.opencl->dev[pipe->devid].pinned_memory = 1;
+    darktable.opencl->dev[pipe->devid].pinned_memory |= DT_OPENCL_PINNING_ON;
 #endif
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1316,8 +1316,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     return FALSE;
   }
 
-  dt_print(DT_DEBUG_TILING, "[default_process_tiling_cl_ptp] (%dx%d) tiles with max dimensions %dx%d, good %dx%d and overlap %d\n",
-           tiles_x, tiles_y, width, height, tile_wd, tile_ht, overlap);
+  dt_print(DT_DEBUG_TILING, "[default_process_tiling_cl_ptp] (%dx%d) tiles with max dimensions %dx%d, pinned=%s, good %dx%d and overlap %d\n",
+           tiles_x, tiles_y, width, height, (use_pinned_memory) ? "ON" : "OFF", tile_wd, tile_ht, overlap);
 
   /* store processed_maximum to be re-used and aggregated */
   dt_aligned_pixel_t processed_maximum_saved;
@@ -1690,8 +1690,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
       roi_out->height % tiles_y == 0 ? roi_out->height / tiles_y : roi_out->height / tiles_y + 1, xyalign);
 
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_cl_roi] (%dx%d) tiles with max input dimensions %dx%d, good %ix%i\n",
-           tiles_x, tiles_y, width, height, tile_wd, tile_ht);
+           "[default_process_tiling_cl_roi] (%dx%d) tiles with max input dimensions %dx%d, pinned=%s, good %ix%i\n",
+           tiles_x, tiles_y, width, height, (use_pinned_memory) ? "ON" : "OFF", tile_wd, tile_ht);
 
 
   /* store processed_maximum to be re-used and aggregated */

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1229,7 +1229,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   self->tiling_callback(self, piece, roi_in, roi_out, &tiling);
 
   /* shall we use pinned memory transfers? */
-  gboolean use_pinned_memory = (dt_opencl_pinned_memory(devid) != 0);
+  gboolean use_pinned_memory = (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
   const int pinned_buffer_overhead = use_pinned_memory ? 2 : 0; // add two additional pinned memory buffers
                                                                 // which seemingly get allocated not only on
                                                                 // host but also on device (why???)
@@ -1538,11 +1538,11 @@ error:
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = 0;
-  const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) != 0);
+  const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
       "[default_process_tiling_opencl_ptp] couldn't run process_cl() for module '%s' in tiling mode:%s %d\n",
       self->op, (pinning_error) ? " pinning problem" : "", err);
-  if(pinning_error) darktable.opencl->dev[devid].pinned_memory = 0;
+  if(pinning_error) darktable.opencl->dev[devid].pinned_memory |= DT_OPENCL_PINNING_ERROR;
   return FALSE;
 }
 
@@ -1591,7 +1591,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   self->tiling_callback(self, piece, roi_in, roi_out, &tiling);
 
   /* shall we use pinned memory transfers? */
-  gboolean use_pinned_memory = (dt_opencl_pinned_memory(devid) != 0);
+  gboolean use_pinned_memory = (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
   const int pinned_buffer_overhead = use_pinned_memory ? 2 : 0; // add two additional pinned memory buffers
                                                                 // which seemingly get allocated not only on
                                                                 // host but also on device (why???)
@@ -1978,11 +1978,11 @@ error:
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = 0;
-  const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) != 0);
+  const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
       "[default_process_tiling_opencl_roi] couldn't run process_cl() for module '%s' in tiling mode:%s %d\n",
       self->op, (pinning_error) ? " pinning problem" : "", err);
-  if(pinning_error) darktable.opencl->dev[devid].pinned_memory = 0;
+  if(pinning_error) darktable.opencl->dev[devid].pinned_memory |= DT_OPENCL_PINNING_ERROR;
   return FALSE;
 }
 


### PR DESCRIPTION
I did a large number of performance checks related to tiled OpenCL code and rechecked again with latest code.

After late fixes for pinned memory transfer this is a) rocksolid now also on nvidia and b) if testing with simulating low graphics memory via `--conf resourcelevel="notebook"` there is a significant performance gain (~1.5 fold) for pinned transfer.

This pr modifies the "tune OpenCL performance" preference setting from a bool (that just meant check for available memory) to an enum allowing settings for
1. check for available memory and
2. prefer pinned memory transfer

allowing better default OpenCL performance if set to "memory size and transfer"

The nerd/user side has changed slightly, the setting for "pinned" in the device conf key can be set to
1. 0 -> pinned transfer is off by default
2. 1 -> pinned transfer is on by default
4. 2 -> pinned transfer is disabled (prference over setting in "tune OpenCL performance"

BTW if there is an error for pinned mode, it gets disabled for the session at runtime.

Also some minor fixes regarding
1. micro_nap (less conservative by default on non-CPU devices)
2. aligning sets for width & height are default 16 but can be changed to >= 2 instead of >4
