### PR TITLE
New set to simplify code by better use of class + minor glitches fix

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -90,13 +90,6 @@
 @define-color graph_grid @grey_20;
 @define-color inset_histogram alpha(@grey_80, 0.50);
 
-/* Adjust color of top shown infos on darkroom */
-#log-msg,
-#toast-msg
-{
-  background-color: rgba(90,90,90,0.6);
-}
-
 /* Set background on thumbnails hover overlays */
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom,

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -111,13 +111,6 @@
   color: shade(@plugin_fg_color, 0.8);
 }
 
-/* Adjust color of top shown infos on darkroom */
-#log-msg,
-#toast-msg
-{
-  background-color: rgba(110,110,110,0.6);
-}
-
 /* Set background on thumbnails hover overlays */
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom,

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -61,7 +61,7 @@
 /* text fields */
 @define-color field_bg @grey_45;
 @define-color field_fg @grey_95;
-@define-color field_active_bg @grey_50;
+@define-color field_active_bg @grey_55;
 @define-color field_active_fg @grey_95;
 @define-color field_selected_bg @grey_65;
 @define-color field_hover_bg @grey_75;

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -111,6 +111,18 @@
   color: shade(@plugin_fg_color, 0.8);
 }
 
+/* hover effect on combo and bauhaus */
+.combo:hover,
+.combo:hover cellview,
+combobox window *:hover,
+#bauhaus_combobox:hover,
+#bauhaus_slider:hover,
+#collapsible .combo:hover,
+#header-toolbar #bauhaus_combobox:hover
+{
+  color: shade(@fg_color, 0.94);
+}
+
 /* Set background on thumbnails hover overlays */
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom,

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -23,7 +23,7 @@
 /* Perceptually uniform grey gradient */
 
 /* General */
-@define-color selected_bg_color @grey_55; /* legacy stuff */
+@define-color selected_bg_color @grey_60; /* legacy stuff */
 @define-color border_color @grey_40; /* border, when used */
 @define-color bg_color @grey_45; /* general background */
 @define-color fg_color @grey_95; /* general text */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -23,7 +23,7 @@
 /* Perceptually uniform grey gradient */
 
 /* General */
-@define-color selected_bg_color @grey_60; /* legacy stuff */
+@define-color selected_bg_color @grey_55; /* legacy stuff */
 @define-color border_color @grey_40; /* border, when used */
 @define-color bg_color @grey_45; /* general background */
 @define-color fg_color @grey_95; /* general text */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1521,7 +1521,7 @@ padding: 0.14em;
 
 #dt-map-location
 {
-border-bottom: 0.07em solid @selected_bg_color;
+border-bottom: 0.07em solid alpha(@selected_bg_color, 0.75);
 }
 
 #dt-map-location:hover

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -260,6 +260,8 @@ box *
 
 /* Set no background and no border. And avoid undershoot and overshoot having too much empty space at top/bottom of sidepanels when scrolled */
 .accels_window_box treeview,
+.dt_module_btn,
+.dt_module_btn:disabled,
 .dt_transparent_background,
 .dt_transparent_background:checked,
 filechooser .sidebar-button,
@@ -312,6 +314,25 @@ textview
   background-color: alpha(@fg_color, 0.09);
 }
 
+/* Set same settings on all those items */
+.combo,
+.combo *,
+button
+{
+  min-height: 1em;
+  min-width: 1em;
+}
+
+/* Buttons in modules header, near the module name */
+.dt_module_btn
+{
+  min-height: 1.15em;
+  min-width: 1.15em;
+  padding: 0.06em;
+  margin: 0 0.07em;
+}
+
+/* set disabled options of above settings */
 button:disabled,
 spinbutton *:disabled,
 #collapsible .combo:disabled,
@@ -320,15 +341,6 @@ spinbutton *:disabled,
 {
   background-color: transparent;
   border: 0.07em solid shade(@button_border, 0.9);
-}
-
-/* Set same settings on all those items */
-.combo,
-.combo *,
-button
-{
-  min-height: 1em;
-  min-width: 1em;
 }
 
 /* Default extra margin for icons optical alignment */
@@ -559,24 +571,6 @@ l
 #lib-plugin-ui button
 {
   margin: 2px;  /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
-}
-
-/* Buttons in modules header, near the module name */
-#module-preset-button,
-#module-reset-button,
-#module-enable-button,
-#module-mask-indicator,
-#module-instance-button,
-#module-collapse-button,
-#module-always-enabled-button,
-#module-always-disabled-button
-{
-  /* background-color: transparent; this doesn't work */
-  min-height: 1.15em;
-  min-width: 1.15em;
-  padding: 0.06em;
-  margin: 0 0.07em;
-  border: 0;
 }
 
 /* Gradient sliders */
@@ -1473,15 +1467,16 @@ filechooser row:hover .sidebar-icon
   padding: 0.28em 0.84em;
 }
 
-#basics-box #module-enable-button,
-#basics-box-labels #module-enable-button,
+#basics-box .dt_module_btn,
+#basics-box-labels .dt_module_btn,
 #basics-link
 {
   margin: 0 0.56em;
-  padding: 0.28em;
+  padding: 0.42em;
 }
 
 .combo,
+#basics-box-labels #basics-link,
 #basics-box-labels #basics-header-box:first-child,
 #basics-box-labels #section_label,
 #modulegroups-header #dt-button,
@@ -1821,9 +1816,7 @@ button:checked cellview
 }
 
 /* Set submenus */
-menuitem > *,
-#module-always-enabled-button,
-#module-enable-button
+menuitem > *
 {
     color: @fg_color;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -63,6 +63,22 @@
   * create optical margins by aligning content properly, not by using borders.
 ***/
 
+/*** Using classes and ids :
+
+  * classes are used to set same settings for multiples and differents widgets in the UI.
+  * ids are used to set a name to a specific widget and so allow to set CSS for this widget
+  * some classes had been set on darktable, they all began with a dot. Before adding classes or ids, check what exist before
+
+  * on those classes, some general ones had been set and should be added to your widget on Gtk code:
+  - dt_transparent_background: use it on a widget to set transparent background and border
+  - dt_module_btn: set for all icons (button widget without text on it)
+  - section_expander: use it for all expanders you could add on a module
+  - search: use it for all search box
+  - dt_bauhaus_alignment: used for some icons related to bauhaus widget (color picker for auto-tune setting in filmic or mask on same module and tone equalizer actually ; could be used so if an icon related to a bauhaus is not aligned by default)
+
+  * the list above is not exhausting. Those are main ones set actually and should be completed if needed. You could see other classes on this file
+***/
+
 /*--------------------------------------
   - Define default colors and settings -
   --------------------------------------*/
@@ -89,7 +105,7 @@
 @define-color collapsible_bg_color @grey_25;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_bg @bg_color;
+@define-color bauhaus_bg shade(@bg_color, 1.06);
 @define-color bauhaus_fg @fg_color;
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_20;
@@ -1242,7 +1258,8 @@ dialog scrollbar
   margin: 0.35em 1.05em 1.05em 1.05em;
 }
 
-#preferences_box #preset_controls button
+#preferences_box #preset_controls button,
+#preferences_box #shortcut_controls check
 {
   margin-right: 0.21em;
 }
@@ -1494,7 +1511,7 @@ padding: 0.14em;
 
 #dt-map-location
 {
-border-bottom: 0.07em solid @button_border;
+border-bottom: 0.07em solid @selected_bg_color;
 }
 
 #dt-map-location:hover

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -545,7 +545,6 @@ spinbutton>button
 #blending-box #show_mask_button,
 #blending-box #keep-active,
 #non-flat,
-#color-picker-button,
 #picker-black,
 #picker-grey,
 #picker-white,
@@ -1674,11 +1673,16 @@ cell:selected
 .dt_messages
 {
   color: @log_fg_color;
-  font-size: 1em;
   font-weight: bold;
-  background-color: alpha(@bg_color,0.6);
-  padding: 0.56em 1.4em;
-  border-radius: 0.56em;
+  background-color: alpha(@plugin_bg_color,0.5);
+  padding: 0.35em 0.7em;
+  border-radius: 0.35em;
+}
+
+/* then set infos shown on top of the image on darkroom, like for example opacity in drawn masks */
+.top .dt_messages
+{
+  border-radius: 0 0 0.56em 0.56em;
 }
 
 /* Set some specific fonts */
@@ -1698,9 +1702,17 @@ cell:selected
   ---------------------*/
 /** Module in darkroom left panel **/
 /* the main color picker button */
+#color-picker-button
+{
+  min-height: 1.5em;
+  min-width: 1.5em;
+  border: 0;
+}
+
 #color-picker-area
 {
   min-height: 5em;
+  margin-bottom: 0.14em;
 }
 
 #live-sample

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1602,7 +1602,7 @@ cell:selected
 /* then the switches */
 .dt_history_switch
 {
-  font-size: 0.75em;
+  font-size: 0.7em;
   margin-left: 0.42em;
   border: 0;
 }
@@ -1617,7 +1617,7 @@ cell:selected
 /* then deprecated switch to suit to other icons */
 #left #history-switch-deprecated
 {
-  font-size: 0.65em;
+  font-size: 0.6em;
 }
 
 #history-tooltip,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -102,7 +102,7 @@
 
 /* GTK Buttons and tabs */
 @define-color button_bg @grey_25;
-@define-color button_border shade(@button_bg, 1.05);
+@define-color button_border shade(@button_bg, 1.04);
 @define-color button_fg @fg_color;
 @define-color button_checked_bg @grey_45;
 @define-color button_checked_fg @grey_85;
@@ -294,7 +294,8 @@ undershoot.right,
 button,
 checkbutton check,
 entry,
-textview
+textview,
+#non-flat
 {
   padding: 2px; /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
   border: 0.07em solid @button_border;
@@ -326,10 +327,26 @@ button
 /* Buttons in modules header, near the module name */
 .dt_module_btn
 {
-  min-height: 1.15em;
-  min-width: 1.15em;
-  padding: 0.06em;
+  min-height: 1.2em;
+  min-width: 1.2em;
+  padding: 0.14em;
   margin: 0 0.07em;
+}
+
+/* Precise default buttons margins on side panels */
+#iop-plugin-ui button,
+#lib-plugin-ui button
+{
+  margin: 2px;  /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
+}
+
+/* fix misalignment for specific icons related to bauhaus widgets */
+.dt_bauhaus_alignment
+{
+  padding: 0.07em;
+  min-height: 1.4em;
+  min-width: 1.4em;
+  margin: 0;
 }
 
 /* set disabled options of above settings */
@@ -337,6 +354,7 @@ button:disabled,
 spinbutton *:disabled,
 #collapsible .combo:disabled,
 #collapsible spinbutton button:disabled,
+#non-flat:disabled,
 #recent-collection-button:disabled
 {
   background-color: transparent;
@@ -447,20 +465,17 @@ spinbutton>button
 #header-toolbar,
 #footer-toolbar
 {
-  padding: 0.2em 0.4em;
+  padding: 0.14em 0.28em;
 }
 
 /* Set toolbars buttons in lighttable and darkroom */
-#header-toolbar #dt-toggle-button,
-#header-toolbar #dt-button,
-#footer-toolbar #dt-toggle-button,
-#footer-toolbar #dt-button
+#header-toolbar .dt_module_btn,
+#footer-toolbar .dt_module_btn
 {
   padding: 0.07em;
   min-height: 2.4em; /* align toolbox button height on comboboxe's one */
   min-width: 2.4em;
   font-size: .75em;
-  border: 0;
 }
 
 /* Rating stars on left footer toolbar on lighttable view */
@@ -472,10 +487,12 @@ spinbutton>button
 }
 
 /* Set default button spacing  in toolbars and modules */
+.section-expander #button-canvas,
 #header-toolbar #button-canvas,
 #footer-toolbar #button-canvas,
 #module-header #button-canvas,
-#modules-tabs #button-canvas
+#modules-tabs #button-canvas,
+#lib-collect-entry + .dt_module_btn #button-canvas
 {
   margin: 12px; /* not real pixels. This is used as a percent extra space and couldn't be scalable */
 }
@@ -493,7 +510,6 @@ spinbutton>button
 /*---------------------------
   - Side panels and modules -
   ---------------------------*/
-
 /* Frame around modules boxes */
 /*** NOTE: bauhaus controls inherit their font properties from there ***/
 #lib-plugin-ui,
@@ -535,26 +551,6 @@ spinbutton>button
 }
 
 /* icon buttons in modules main body */
-#iop-plugin-ui-main #dt-button,
-#iop-plugin-ui-main #dt-toggle-button,
-#iop-plugin-ui-main #keep-active,
-#lib-plugin-ui-main #dt-button,
-#lib-plugin-ui-main #dt-toggle-button,
-#blending-box #dt-button,
-#blending-box #dt-toggle-button,
-#blending-box #show_mask_button,
-#blending-box #keep-active,
-#non-flat,
-#picker-black,
-#picker-grey,
-#picker-white,
-#basics-widget #dt-button
-{
-  min-height: 1.2em;
-  min-width: 1.2em;
-  border: 0;
-}
-
 #lib-plugin-ui-main viewport
 {
   margin-left: 0.14em;
@@ -564,13 +560,6 @@ spinbutton>button
 #iop-plugin-ui-main widget + notebook
 {
   margin-top: 0.5em;
-}
-
-/* Precise default buttons margins on side panels */
-#iop-plugin-ui button,
-#lib-plugin-ui button
-{
-  margin: 2px;  /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
 }
 
 /* Gradient sliders */
@@ -708,7 +697,6 @@ spinbutton>button
 /*-------------------
   - Scope/Histogram -
   -------------------*/
-
 #main-histogram buttonbox
 {
   margin-top: 0.5em;   /* spacing between histogram buttons and top of scope */
@@ -778,7 +766,6 @@ spinbutton>button
 /*------------------
   - Dialog windows -
   ------------------*/
-
 /* Set default settings */
 dialog
 {
@@ -858,7 +845,6 @@ dialog headerbar entry
 /*--------------------------------------------------------
   - Bauhaus controls (sliders and comboboxes in modules) -
   --------------------------------------------------------*/
-
 #bauhaus_popup
 {
   color: @bauhaus_fg;
@@ -891,28 +877,9 @@ popover #bauhaus_slider
   padding: 0.14em 0 0.14em 0.42em;
 }
 
-#blending-box #dt-toggle-button
-{
-  margin-top: 0;
-}
-
-/* fix misalignment for specific icons related to bauhaus widgets */
-.dt_bauhaus_alignment,
-.dt_iop_toggle #dt-toggle-button
-{
-  margin: 0;
-  padding: 0.28em 0.07em;
-}
-
-.dt_bauhaus_alignment #button-canvas
-{
-  margin: 0;
-}
-
 /*---------------------------------------
   - Context menu, tooltips & comboboxes -
   ---------------------------------------*/
-
 /*** Basically everything that pops out/over on UI ***/
 combobox button,
 #iop-plugin-ui combobox button,
@@ -947,18 +914,13 @@ dialog combobox window,
 }
 
 /* fix for menuitem in bottom toolbar mainly */
-menu menuitem
-{
-  margin-left: -0.42em;
-}
-
 menuitem > arrow
 {
-  padding-right: 0.28em;
+  padding-right: 0.42em;
   border: 0;
 }
 
-/* but do not apply to menu item related to sort of combobox like metadata presets in import module */
+/* and set menuitem related to sort of combobox like metadata presets in import module */
 #gtk-combobox-popup-menu menuitem,
 #view_dropdown button,
 #view_dropdown menuitem,
@@ -1011,7 +973,6 @@ combobox separator
 /*----------------------
   - GTK Notebooks tabs -
   ----------------------*/
-
 notebook tabs,
 #modules-tabs,
 #blending-tabs,
@@ -1028,53 +989,44 @@ notebook tabs,
   background-color: @field_active_bg;
 }
 
+/* set sizes of "buttons" in modules and blending tabs ; and guides lines too */
 #modules-tabs #dt-toggle-button
 {
   min-height: 2em;
-  padding: 0.1em;
 }
 
-#blending-tabs #dt-toggle-button,
+#blending-tabs .dt_module_btn,
 #guides-line #dt-toggle-button
 {
-  font-size: 0.8em;
-  min-height: 1.55em;
-  padding: 0.45em;
+  min-height: 1.3em;
+  padding: 0.28em;
 }
 
 #modules-tabs #dt-toggle-button,   /* This is needed separately to set a minimal width if panel is really narrow */
-#blending-tabs #dt-toggle-button
-{
-  min-width: 0em;
-  padding-left: 0.2em;
-  padding-right: 0.2em;
-}
-
+#blending-tabs #dt-toggle-button,
 #guides-line #dt-toggle-button
 {
-  min-width: 1.55em;
+  min-width: 1.5em;
+}
+
+/* reduce and align now hamburger menu of modules and blending tabs */
+#blending-tabs #dt-button,
+#modules-tabs #dt-button
+{
+  padding: 0.2em 0.5em;
 }
 
 #blending-tabs #dt-button
 {
   font-size: 0.8em;
-  margin: 0;
 }
 
-#blending-tabs #dt-button,
-#modules-tabs #dt-button
-{
-  min-width: 1.25em;
-  padding: 0.25em 0.5em;
-}
-
-/* Do not apply border-radius to group modules icons and masks icons */
+/* do not apply border-radius to group modules icons and masks icons */
 #modules-tabs button,
 #blending-tabs button,
 #guides-line button
 {
   border-radius: 0;
-  border: 0;
   margin: 0;
 }
 
@@ -1095,7 +1047,6 @@ notebook header /* add space between notebook tabs and options below */
 /*--------------------------
   - GTK sliders and scales -
   --------------------------*/
-
 /*** WARNING : sliders IN modules are bauhaus (from a custom lib in darktable), not standard GTK sliders (see below) ***/
 
 #lib-plugin-ui scrollbar slider,
@@ -1151,7 +1102,6 @@ dialog scrollbar
 /*--------------------------
   - Accels window reminder -
   --------------------------*/
-
 .accels_window_cat_title
 {
    background-color: transparent;
@@ -1177,7 +1127,6 @@ dialog scrollbar
 /*-------------------------------------
   - Preferences dialog window options -
   -------------------------------------*/
-
 #preferences_notebook *
 {
   margin: 0; /* reset default dialog margin to all items. And needed to have an hover and selected effect on all width of categories in sidebar */
@@ -1301,7 +1250,6 @@ dialog scrollbar
 /*--------------------------------
   - Module layouts manager dialog -
   --------------------------------*/
-
 /* set top box header */
 #modulegroups_editor_setting
 {
@@ -1395,7 +1343,6 @@ box #modulegroups-iop-header:last-child
 /*---------------------------------------------------------------
   - Set sidebars settings on preferences window and filechooser -
   ---------------------------------------------------------------*/
-
 /* Set default sidebars settings */
 filechooser .sidebar,
 #preferences_box .sidebar scrolledwindow
@@ -2087,7 +2034,6 @@ Details :
 /*----------------------------
   - Thumbtable Main Settings -
   ----------------------------*/
-
 /* Background */
 .dt_thumbtable,
 .dt_culling,
@@ -2270,7 +2216,6 @@ Details :
 /*--------------------
   - Thumbnails infos -
   --------------------*/
-
 /* By default, the extension is hidden */
 #thumb_ext
 {

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1636,7 +1636,7 @@ cell:selected
 /* then the switches */
 .dt_history_switch
 {
-  font-size: 0.7em;
+  font-size: 0.75em;
   margin-left: 0.42em;
   border: 0;
 }
@@ -1651,7 +1651,7 @@ cell:selected
 /* then deprecated switch to suit to other icons */
 #left #history-switch-deprecated
 {
-  font-size: 0.6em;
+  font-size: 0.65em;
 }
 
 #history-tooltip,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -259,6 +259,7 @@ box *
 }
 
 /* Set no background and no border. And avoid undershoot and overshoot having too much empty space at top/bottom of sidepanels when scrolled */
+.accels_window_box treeview,
 .dt_transparent_background,
 .dt_transparent_background:checked,
 filechooser .sidebar-button,
@@ -300,6 +301,15 @@ textview
   color: @button_fg;
   font-weight: normal;
   font-family: sans-serif;
+}
+
+/* then set specific background color for all text zones and combo */
+.combo,
+entry,
+spinbutton button,
+textview
+{
+  background-color: alpha(@fg_color, 0.09);
 }
 
 button:disabled,
@@ -599,16 +609,10 @@ l
   padding: 0.5em;
 }
 
-#module-header entry
-{
-  background-color: @field_active_bg;
-}
-
 /* Labels in modules */
 #iop-panel-label,
 #lib-panel-label
 {
-  background-color: @bg_color;
   color: @plugin_label_color;
   padding: 0 0.14em 0.14em 0.45em;
   font-weight: normal;
@@ -705,15 +709,6 @@ l
   border: none;
   margin-top: 0.14em;
   padding: 0.07em 0;
-}
-
-#collapsible .combo,
-#collapsible entry,
-#collapsible spinbutton button,
-#collapsible textview
-{
-  background-color: shade(@button_border, 1.06);
-  border: 0.07em solid shade(@field_active_bg, 1.06);
 }
 
 /*-------------------
@@ -1116,11 +1111,6 @@ scale contents trough
   min-height: 0.5em;
 }
 
-scale entry
-{
-  background-color: @field_bg;
-}
-
 scale contents trough highlight
 {
   background-color: @button_bg;
@@ -1170,11 +1160,6 @@ dialog scrollbar
    font-size: 0.9em;
    padding-top: 0.07em;
    padding-right: 0.7em;
-}
-
-.accels_window_box treeview
-{
-   background-color: transparent;
 }
 
 .accels_window_stick

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -345,7 +345,6 @@ button
 {
   min-height: 1.2em;
   min-width: 1.2em;
-  padding: 0.14em;
   margin: 0 0.07em;
 }
 
@@ -728,11 +727,7 @@ spinbutton>button
 {
   color: alpha(@button_checked_fg, 0.56);
   background-color: alpha(darker(@button_bg),0.8);
-}
-
-#main-histogram #dt-button:hover
-{
-  color: @button_fg;
+  border: 0.07em solid alpha(@button_bg, 0.33);
 }
 
 /* set channel buttons at inactive state */
@@ -751,7 +746,7 @@ spinbutton>button
   background-color: alpha(@graph_blue, 0.2);
 }
 
-/* set now them to active state */
+/* set now them active state */
 #red-channel-button:checked
 {
   background-color: alpha(@graph_red, 0.66);
@@ -770,13 +765,23 @@ spinbutton>button
 /* set border of all active color channel buttons */
 #main-histogram .toggle:checked
 {
-  border-color: alpha(@button_checked_fg, 0.33);    /* just set a really tight border to better check quickly active state*/
+  border: 0.07em solid alpha(@button_checked_fg, 0.15);    /* just set a really tight border to better check quickly active state*/
 }
 
-#main-histogram #dt-button:disabled,
-#main-histogram .toggle:disabled
+/* set now hover state */
+#red-channel-button:hover
 {
-  opacity: 0.2;
+  background-color: alpha(@graph_red, 0.5);
+}
+
+#green-channel-button:hover
+{
+  background-color: alpha(@graph_green, 0.5);
+}
+
+#blue-channel-button:hover
+{
+  background-color: alpha(@graph_blue, 0.5);
 }
 
 /*------------------
@@ -885,6 +890,11 @@ popover #bauhaus_slider
 #bauhaus_slider
 {
   margin: 0.1em 0;
+}
+
+#bauhaus_slider
+{
+  margin-bottom: 0.14em;
 }
 
 .bauhaus_slider_popup,
@@ -1739,6 +1749,7 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 }
 
 /* Hover states, some needed background only */
+.dt_history_items:hover,
 .dt_transparent_background:hover,
 button:hover:not(.combo),
 filechooser row:hover,
@@ -1748,7 +1759,8 @@ notebook tab:hover,
 radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
 #collapsible spinbutton button:hover,
-.dt_history_items:hover,
+#main-histogram #dt-button:hover,
+#non-flat:hover,
 #preferences_box .sidebar :hover,
 #recent-collection-button:hover,
 #view_label:hover,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -545,6 +545,7 @@ spinbutton>button
 #blending-box #show_mask_button,
 #blending-box #keep-active,
 #non-flat,
+#color-picker-button,
 #picker-black,
 #picker-grey,
 #picker-white,
@@ -554,7 +555,7 @@ spinbutton>button
   min-width: 1.2em;
   border: 0;
 }
-l
+
 #lib-plugin-ui-main viewport
 {
   margin-left: 0.14em;
@@ -877,6 +878,18 @@ popover #bauhaus_slider
 #bauhaus_slider
 {
   background-color: @plugin_bg_color;
+}
+
+#bauhaus_combobox,
+#bauhaus_slider
+{
+  margin: 0.1em 0;
+}
+
+.bauhaus_slider_popup,
+.bauhaus_combo_popup
+{
+  padding: 0.14em 0 0.14em 0.42em;
 }
 
 #blending-box #dt-toggle-button
@@ -1683,42 +1696,17 @@ cell:selected
 /*---------------------
   - Set color pickers -
   ---------------------*/
-
 /** Module in darkroom left panel **/
 /* the main color picker button */
-#color-picker-button
-{
-  min-height: 2em;
-  min-width: 1.7em;
-  padding: 0.07em;
-  border: 0;
-}
-
 #color-picker-area
 {
-  min-height: 7em;
-  min-width: 7em;
-}
-
-.picker-module button
-{
-  padding: 0;
-}
-
-.picker-module combobox,
-.picker-module combobox button
-{
-  padding-top: 0;
-  padding-bottom: 0;
-  border: 0;
+  min-height: 5em;
 }
 
 #live-sample
 {
-  padding: 0;
-  margin: 0 0.21em 0.21em 0;
-  min-height: 1em;
-  min-width: 3em;
+  margin: 0.21em 0.21em 0.21em 0;
+  min-width: 2em;
 }
 
 /* Color picker visibility for levels and rgb levels modules.
@@ -1961,12 +1949,6 @@ treeview#delete-dialog:selected
 #bauhaus_combobox *:selected
 {
   color: shade(@bauhaus_fg_selected, 1.2);
-}
-
-.bauhaus_slider_popup,
-.bauhaus_combo_popup
-{
-  padding: 0.14em 0 0.14em 0.42em;
 }
 
 /* Notebooks states */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -492,7 +492,7 @@ spinbutton>button
 #iop-plugin-ui-main,
 #lib-plugin-ui-main
 {
-  padding: 0.35em 0.7em;
+  padding: 0.28em 0.7em;
 }
 
 /* Frame around blending boxes */
@@ -562,12 +562,6 @@ l
   border-color: transparent;
   font-weight: normal;
   border: 0;
-}
-
-#history-number
-{
-  padding-right: 0.28em;
-  font-family: monospace;
 }
 
 /* Precise default buttons margins on side panels */
@@ -919,6 +913,19 @@ popover #bauhaus_slider
 #blending-box #dt-toggle-button
 {
   margin-top: 0;
+}
+
+/* fix misalignment for specific icons related to bauhaus widgets */
+.dt_bauhaus_alignment,
+.dt_iop_toggle #dt-toggle-button
+{
+  margin: 0;
+  padding: 0.21em 0.07em;
+}
+
+.dt_bauhaus_alignment #button-canvas
+{
+  margin: 0;
 }
 
 /*---------------------------------------
@@ -1516,6 +1523,7 @@ filechooser row:hover .sidebar-icon
   padding: 0.28em;
 }
 
+.combo,
 #basics-box-labels #basics-header-box:first-child,
 #basics-box-labels #section_label,
 #basics-link
@@ -1644,14 +1652,26 @@ cell:selected
 }
 
 /* Set below spacing between history items in darkroom */
+/* the history number */
+#history-number
+{
+  padding: 0.14em 0.35em 0 0;
+  font-family: monospace;
+}
+
 /* the label buttons */
 #left #history-button,
 #left #history-button-enabled,
 #left #history-button-always-enabled,
-#left #history-button-default-enabled
+#left #history-button-default-enabled,
+#left #history-switch,
+#left #history-switch-enabled,
+#left #history-switch-always-enabled,
+#left #history-switch-default-enabled,
+#left #history-switch-deprecated
 {
-  padding: 0.07em 0.21em 0.14em 0.21em;
-  margin: 0 0.07em 0.07em 0.07em;
+  padding: 0.14em;
+  margin: 0;
 }
 
 /* then the switches */
@@ -1661,17 +1681,11 @@ cell:selected
 #left #history-switch-default-enabled,
 #left #history-switch-deprecated
 {
-  font-size: 0.6em;
+  font-size: 0.5em;
   min-width: 1.2em;
   min-height: 1.2em;
-  padding: 0.15em;
-  margin: 0.07em 0.14em 0.14em 0.14em; /* align switches with create style icon */
+  margin-left: 0.42em;
   border: 0;
-}
-
-#left #history-switch-deprecated
-{
-  font-size: 0.5em;
 }
 
 #history-tooltip,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -259,19 +259,20 @@ box *
 }
 
 /* Set no background and no border. And avoid undershoot and overshoot having too much empty space at top/bottom of sidepanels when scrolled */
-undershoot,
-undershoot.top,
-undershoot.bottom,
-undershoot.left,
-undershoot.right,
+.dt_transparent_background,
+.dt_transparent_background:checked,
+filechooser .sidebar-button,
+popover #bauhaus_combobox,
 overshoot,
 overshoot.top,
 overshoot.bottom,
 overshoot.left,
 overshoot.right,
-.dt_transparent_background,
-.dt_transparent_background:checked,
-popover #bauhaus_combobox,
+undershoot,
+undershoot.top,
+undershoot.bottom,
+undershoot.left,
+undershoot.right,
 #usercss_box textview,
 #view_dropdown .combo
 {
@@ -451,17 +452,10 @@ spinbutton>button
 /* Set default button spacing  in toolbars and modules */
 #header-toolbar #button-canvas,
 #footer-toolbar #button-canvas,
-#control-button #button-canvas,
 #module-header #button-canvas,
 #modules-tabs #button-canvas
 {
   margin: 12px; /* not real pixels. This is used as a percent extra space and couldn't be scalable */
-}
-
-/* Set color labels on left footer toolbar on lighttable view */
-#footer-toolbar #lib-label-colors #button-canvas
-{
-  margin: 16px; /* not real pixels. This is used as a percent extra space and couldn't be scalable */
 }
 
 #footer-toolbar #lib-label-colors #dt-button
@@ -548,20 +542,6 @@ l
 #iop-plugin-ui-main widget + notebook
 {
   margin-top: 0.5em;
-}
-
-/* Set history (darkroom) and recent collections (lighttable) modules, that make use of a
-   list of GTK buttons, to not look like action buttons */
-#recent-collection-button,
-#history-button,
-#history-button-enabled,
-#history-button-always-enabled,
-#history-button-default-enabled
-{
-  background-color: transparent;
-  border-color: transparent;
-  font-weight: normal;
-  border: 0;
 }
 
 /* Precise default buttons margins on side panels */
@@ -920,7 +900,7 @@ popover #bauhaus_slider
 .dt_iop_toggle #dt-toggle-button
 {
   margin: 0;
-  padding: 0.21em 0.07em;
+  padding: 0.28em 0.07em;
 }
 
 .dt_bauhaus_alignment #button-canvas
@@ -1408,11 +1388,6 @@ box #modulegroups-iop-header:last-child
   border: 0;
 }
 
-#modulegroups-header #dt-button
-{
-  border: 0;
-}
-
 #modulegroups-icons-popup
 {
   padding: 0.5em;
@@ -1454,8 +1429,6 @@ filechooser .sidebar-label
 filechooser .sidebar-button /* set icons displayed in the right of the sidebar, like eject buttons */
 {
   margin-right: 0.28em;
-  background-color: transparent;
-  border: 0;
 }
 
 filechooser row
@@ -1526,7 +1499,8 @@ filechooser row:hover .sidebar-icon
 .combo,
 #basics-box-labels #basics-header-box:first-child,
 #basics-box-labels #section_label,
-#basics-link
+#modulegroups-header #dt-button,
+#thumb_localcopy:active
 {
   border: none;
 }
@@ -1652,40 +1626,32 @@ cell:selected
 }
 
 /* Set below spacing between history items in darkroom */
-/* the history number */
-#history-number
-{
-  padding: 0.14em 0.35em 0 0;
-  font-family: monospace;
-}
-
 /* the label buttons */
-#left #history-button,
-#left #history-button-enabled,
-#left #history-button-always-enabled,
-#left #history-button-default-enabled,
-#left #history-switch,
-#left #history-switch-enabled,
-#left #history-switch-always-enabled,
-#left #history-switch-default-enabled,
-#left #history-switch-deprecated
+.dt_history_items
 {
-  padding: 0.14em;
+  padding: 0;
   margin: 0;
 }
 
 /* then the switches */
-#left #history-switch,
-#left #history-switch-enabled,
-#left #history-switch-always-enabled,
-#left #history-switch-default-enabled,
-#left #history-switch-deprecated
+.dt_history_switch
 {
-  font-size: 0.5em;
-  min-width: 1.2em;
-  min-height: 1.2em;
+  font-size: 0.7em;
   margin-left: 0.42em;
   border: 0;
+}
+
+/* the history number */
+#history-number
+{
+  padding-right: 0.35em;
+  font-family: monospace;
+}
+
+/* then deprecated switch to suit to other icons */
+#left #history-switch-deprecated
+{
+  font-size: 0.6em;
 }
 
 #history-tooltip,
@@ -1712,22 +1678,14 @@ cell:selected
 }
 
 /* Set messages shown on bottom middle of the UI. For example "loading image..." or "working on..." */
-#log-msg,
-#toast-msg
+.dt_messages
 {
   color: @log_fg_color;
   font-size: 1em;
   font-weight: bold;
-  background-color: rgba(75,75,75,0.6);
+  background-color: alpha(@bg_color,0.6);
   padding: 0.56em 1.4em;
   border-radius: 0.56em;
-}
-
- /* then set infos shown on top of the image on darkroom, like for example opacity in drawn masks */
-#toast-msg
-{
-  padding: 0.14em 1em 0.28em 1em;
-  border-radius: 0 0 0.56em 0.56em;
 }
 
 /* Set some specific fonts */
@@ -1816,20 +1774,11 @@ menuitem:active,
 menuitem:selected,
 combobox window *:active,
 combobox window *:selected,
-#history-button:active,
-#history-button-enabled:active,
-#history-button-always-enabled:active,
-#history-button-default-enabled:active,
-#recent-collection-button:checked,
-#history-button:checked,
-#history-button-enabled:checked,
-#history-button-always-enabled:checked,
-#history-button-default-enabled:checked,
-#history-button:selected,
-#history-button-enabled:selected,
-#history-button-always-enabled:selected,
-#history-button-default-enabled:selected,
+.dt_history_items:active,
+.dt_history_items:checked,
+.dt_history_items:selected,
 #recent-collection-button:active,
+#recent-collection-button:checked,
 #recent-collection-button:selected,
 messagedialog .default  /* this show that a button in confirmation action pop-up has the focus (no by default) */
 {
@@ -1838,18 +1787,9 @@ messagedialog .default  /* this show that a button in confirmation action pop-up
 }
 
 /* History currently selected button */
-#history-button:active *,
-#history-button-enabled:active *,
-#history-button-always-enabled:active *,
-#history-button-default-enabled:active *,
-#history-button:checked *,
-#history-button-enabled:checked *,
-#history-button-always-enabled:checked *,
-#history-button-default-enabled:checked *,
-#history-button:selected *,
-#history-button-enabled:selected *,
-#history-button-always-enabled:selected *,
-#history-button-default-enabled:selected *
+.dt_history_items:active *,
+.dt_history_items:checked *,
+.dt_history_items:selected *
 {
   color: @button_checked_fg;
 }
@@ -1864,10 +1804,7 @@ notebook tab:hover,
 radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
 #collapsible spinbutton button:hover,
-#history-button:hover,
-#history-button-enabled:hover,
-#history-button-always-enabled:hover,
-#history-button-default-enabled:hover,
+.dt_history_items:hover,
 #preferences_box .sidebar :hover,
 #recent-collection-button:hover,
 #view_label:hover,
@@ -1928,9 +1865,7 @@ menuitem > *,
 
 /* Deprecated/always-on switch are visible */
 #history-switch-deprecated:disabled,
-#history-switch-always-enabled:disabled,
-#history-switch-enabled:disabled,
-#history-switch-default-enabled:disabled
+.dt_history_switch:disabled
 {
   color: @plugin_label_color;
 }
@@ -2531,11 +2466,6 @@ Details :
 {
   border-top : 0.07em solid @lighttable_bg_color;
   border-right : 0.07em solid @lighttable_bg_color;
-}
-
-#thumb_localcopy:active
-{
-  border: none;
 }
 
 .dt_group_right #thumb_localcopy

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -994,19 +994,6 @@ gchar *dt_str_replace(const char *string, const char *search, const char *replac
   return res;
 }
 
-// set class function to add CSS classes with just a simple line call
-void dt_util_add_class(GtkWidget *widget, const gchar *class_name)
-{
-  GtkStyleContext *context = gtk_widget_get_style_context(widget);
-  gtk_style_context_add_class(context, class_name);
-}
-
-void dt_util_remove_class(GtkWidget *widget, const gchar *class_name)
-{
-  GtkStyleContext *context = gtk_widget_get_style_context(widget);
-  gtk_style_context_remove_class(context, class_name);
-}
-
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -1001,6 +1001,12 @@ void dt_util_add_class(GtkWidget *widget, const gchar *class_name)
   gtk_style_context_add_class(context, class_name);
 }
 
+void dt_util_remove_class(GtkWidget *widget, const gchar *class_name)
+{
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+  gtk_style_context_remove_class(context, class_name);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -994,6 +994,13 @@ gchar *dt_str_replace(const char *string, const char *search, const char *replac
   return res;
 }
 
+// set class function to add CSS classes with just a simple line call
+void dt_util_add_class(GtkWidget *widget, const gchar *class_name)
+{
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+  gtk_style_context_add_class(context, class_name);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -113,10 +113,6 @@ char *dt_copy_filename_extension(const char *filename1, const char *filename2);
 // replaces all occurences of a substring in a string
 gchar *dt_str_replace(const char *string, const char *search, const char *replace);
 
-// call class function to add or remove CSS classes
-void dt_util_add_class(GtkWidget *widget, const gchar *class_name);
-void dt_util_remove_class(GtkWidget *widget, const gchar *class_name);
-
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -113,8 +113,9 @@ char *dt_copy_filename_extension(const char *filename1, const char *filename2);
 // replaces all occurences of a substring in a string
 gchar *dt_str_replace(const char *string, const char *search, const char *replace);
 
-// call class function to add CSS classes
+// call class function to add or remove CSS classes
 void dt_util_add_class(GtkWidget *widget, const gchar *class_name);
+void dt_util_remove_class(GtkWidget *widget, const gchar *class_name);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -113,6 +113,9 @@ char *dt_copy_filename_extension(const char *filename1, const char *filename2);
 // replaces all occurences of a substring in a string
 gchar *dt_str_replace(const char *string, const char *search, const char *replace);
 
+// call class function to add CSS classes
+void dt_util_add_class(GtkWidget *widget, const gchar *class_name);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3124,7 +3124,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(bd->showmask, _("display mask and/or color channel. ctrl+click to display mask, "
                                                 "shift+click to display channel. hover over parametric mask slider to "
                                                 "select channel for display"));
-    gtk_widget_set_name(bd->showmask, "show_mask_button");
 
     bd->suppress = dt_iop_togglebutton_new(module, "blend`tools", N_("temporarily switch off blend mask"), NULL, G_CALLBACK(_blendop_blendif_suppress_toggled),
                                            FALSE, 0, 0, dtgtk_cairo_paint_eye_toggle, hbox);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1711,11 +1711,11 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     if(module_cst == DEVELOP_BLEND_CS_LAB)
     {
       mi = gtk_check_menu_item_new_with_label(_("Lab"));
-      dt_util_add_class(mi, "check-menu-item");
+      dt_gui_add_class(mi, "check-menu-item");
       if(module_blend_cst == DEVELOP_BLEND_CS_LAB)
       {
         gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-        dt_util_add_class(mi, "active-menu-item");
+        dt_gui_add_class(mi, "active-menu-item");
       }
       g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_LAB), NULL);
       g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
@@ -1723,22 +1723,22 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     }
 
     mi = gtk_check_menu_item_new_with_label(_("RGB (display)"));
-    dt_util_add_class(mi, "check-menu-item");
+    dt_gui_add_class(mi, "check-menu-item");
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_DISPLAY)
     {
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-      dt_util_add_class(mi, "active-menu-item");
+      dt_gui_add_class(mi, "active-menu-item");
     }
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_DISPLAY), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
     mi = gtk_check_menu_item_new_with_label(_("RGB (scene)"));
-    dt_util_add_class(mi, "check-menu-item");
+    dt_gui_add_class(mi, "check-menu-item");
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_SCENE)
     {
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-      dt_util_add_class(mi, "active-menu-item");
+      dt_gui_add_class(mi, "active-menu-item");
     }
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_SCENE), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1711,11 +1711,11 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     if(module_cst == DEVELOP_BLEND_CS_LAB)
     {
       mi = gtk_check_menu_item_new_with_label(_("Lab"));
-      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "check-menu-item");
+      dt_util_add_class(mi, "check-menu-item");
       if(module_blend_cst == DEVELOP_BLEND_CS_LAB)
       {
         gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-        gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+        dt_util_add_class(mi, "active-menu-item");
       }
       g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_LAB), NULL);
       g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
@@ -1723,22 +1723,22 @@ static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, 
     }
 
     mi = gtk_check_menu_item_new_with_label(_("RGB (display)"));
-    gtk_style_context_add_class(gtk_widget_get_style_context(mi), "check-menu-item");
+    dt_util_add_class(mi, "check-menu-item");
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_DISPLAY)
     {
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+      dt_util_add_class(mi, "active-menu-item");
     }
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_DISPLAY), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
     mi = gtk_check_menu_item_new_with_label(_("RGB (scene)"));
-    gtk_style_context_add_class(gtk_widget_get_style_context(mi), "check-menu-item");
+    dt_util_add_class(mi, "check-menu-item");
     if(module_blend_cst == DEVELOP_BLEND_CS_RGB_SCENE)
     {
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+      dt_util_add_class(mi, "active-menu-item");
     }
     g_object_set_data_full(G_OBJECT(mi), "dt-blend-cst", GINT_TO_POINTER(DEVELOP_BLEND_CS_RGB_SCENE), NULL);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_blendif_select_colorspace), module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1110,7 +1110,6 @@ void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
                                  dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
   }
-  dt_util_add_class(w, "dt_module_btn");
 }
 
 void dt_iop_gui_set_enable_button(dt_iop_module_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1860,7 +1860,6 @@ static void _presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
   dt_gui_menu_popup(darktable.gui->presets_popup_menu, GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
 }
 
-
 void dt_iop_request_focus(dt_iop_module_t *module)
 {
   dt_iop_module_t *out_focus_module = darktable.develop->gui_module;
@@ -1898,8 +1897,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
 
     // we also remove the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(out_focus_module));
-    GtkStyleContext *context = gtk_widget_get_style_context(iop_w);
-    gtk_style_context_remove_class(context, "dt_module_focus");
+    dt_util_remove_class(iop_w, "dt_module_focus");
 
     // if the module change the image size, we update the final sizes
     if(out_focus_module->modify_roi_out) dt_image_update_final_size(darktable.develop->preview_pipe->output_imgid);
@@ -1921,8 +1919,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
 
     // we also add the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(darktable.develop->gui_module));
-    GtkStyleContext *context = gtk_widget_get_style_context(iop_w);
-    gtk_style_context_add_class(context, "dt_module_focus");
+    dt_util_add_class(iop_w, "dt_module_focus");
   }
 
   /* update sticky accels window */
@@ -1935,7 +1932,6 @@ void dt_iop_request_focus(dt_iop_module_t *module)
   dt_control_change_cursor(GDK_LEFT_PTR);
   dt_control_queue_redraw_center();
 }
-
 
 /*
  * NEW EXPANDER

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1097,22 +1097,20 @@ void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
   // set on/off icon
   if(module->default_enabled && module->hide_enable_button)
   {
-    gtk_widget_set_name(w, "module-always-enabled-button");
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
                                  dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
   }
   else if(!module->default_enabled && module->hide_enable_button)
   {
-    gtk_widget_set_name(w, "module-always-disabled-button");
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
                                  dtgtk_cairo_paint_switch_off, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
   }
   else
   {
-    gtk_widget_set_name(w, "module-enable-button");
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
                                  dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
   }
+  dt_util_add_class(w, "dt_module_btn");
 }
 
 void dt_iop_gui_set_enable_button(dt_iop_module_t *module)
@@ -2331,7 +2329,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
   {
     module->mask_indicator = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask,
                                                     CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    gtk_widget_set_name(module->mask_indicator, "module-mask-indicator");
+    dt_util_add_class(module->mask_indicator, "dt_module_btn");
     g_signal_connect(G_OBJECT(module->mask_indicator), "toggled",
                      G_CALLBACK(_display_mask_indicator_callback), module);
     g_signal_connect(G_OBJECT(module->mask_indicator), "query-tooltip",
@@ -2425,8 +2423,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_INSTANCE));
-
-  gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]), "module-instance-button");
+  dt_util_add_class(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]), "dt_module_btn");
 
   dt_gui_add_help_link(expander, dt_get_help_url(module->op));
 
@@ -2437,7 +2434,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event", G_CALLBACK(_gui_reset_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
-  gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_RESET]), "module-reset-button");
+  dt_util_add_class(GTK_WIDGET(hw[IOP_MODULE_RESET]), "dt_module_btn");
 
   /* add preset button if module has implementation */
   hw[IOP_MODULE_PRESETS] = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
@@ -2447,7 +2444,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "clicked", G_CALLBACK(_presets_popup_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
-  gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "module-preset-button");
+  dt_util_add_class(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "dt_module_btn");
 
   /* add enabled button */
   hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch,

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1894,7 +1894,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
 
     // we also remove the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(out_focus_module));
-    dt_util_remove_class(iop_w, "dt_module_focus");
+    dt_gui_remove_class(iop_w, "dt_module_focus");
 
     // if the module change the image size, we update the final sizes
     if(out_focus_module->modify_roi_out) dt_image_update_final_size(darktable.develop->preview_pipe->output_imgid);
@@ -1916,7 +1916,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
 
     // we also add the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(darktable.develop->gui_module));
-    dt_util_add_class(iop_w, "dt_module_focus");
+    dt_gui_add_class(iop_w, "dt_module_focus");
   }
 
   /* update sticky accels window */
@@ -2328,7 +2328,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
   {
     module->mask_indicator = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask,
                                                     CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    dt_util_add_class(module->mask_indicator, "dt_module_btn");
+    dt_gui_add_class(module->mask_indicator, "dt_module_btn");
     g_signal_connect(G_OBJECT(module->mask_indicator), "toggled",
                      G_CALLBACK(_display_mask_indicator_callback), module);
     g_signal_connect(G_OBJECT(module->mask_indicator), "query-tooltip",
@@ -2422,7 +2422,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_INSTANCE));
-  dt_util_add_class(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]), "dt_module_btn");
+  dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]), "dt_module_btn");
 
   dt_gui_add_help_link(expander, dt_get_help_url(module->op));
 
@@ -2433,7 +2433,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event", G_CALLBACK(_gui_reset_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
-  dt_util_add_class(GTK_WIDGET(hw[IOP_MODULE_RESET]), "dt_module_btn");
+  dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_RESET]), "dt_module_btn");
 
   /* add preset button if module has implementation */
   hw[IOP_MODULE_PRESETS] = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
@@ -2443,7 +2443,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "clicked", G_CALLBACK(_presets_popup_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
-  dt_util_add_class(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "dt_module_btn");
+  dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "dt_module_btn");
 
   /* add enabled button */
   hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch,

--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -130,7 +130,7 @@ GtkWidget *dtgtk_button_new(DTGTKCairoPaintIconFunc paint, gint paintflags, void
   button->icon_data = paintdata;
   button->canvas = gtk_drawing_area_new();
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
-  dt_util_add_class(GTK_WIDGET(button), "dt_module_btn");
+  dt_gui_add_class(GTK_WIDGET(button), "dt_module_btn");
   gtk_widget_set_name(GTK_WIDGET(button), "dt-button");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
   return (GtkWidget *)button;

--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -130,6 +130,7 @@ GtkWidget *dtgtk_button_new(DTGTKCairoPaintIconFunc paint, gint paintflags, void
   button->icon_data = paintdata;
   button->canvas = gtk_drawing_area_new();
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
+  dt_util_add_class(GTK_WIDGET(button), "dt_module_btn");
   gtk_widget_set_name(GTK_WIDGET(button), "dt-button");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
   return (GtkWidget *)button;

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -839,9 +839,9 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   else
     gtk_widget_set_name(table->widget, "culling");
   if(mode == DT_CULLING_MODE_PREVIEW)
-    dt_util_add_class(table->widget, "dt_preview");
+    dt_gui_add_class(table->widget, "dt_preview");
   else
-    dt_util_add_class(table->widget, "dt_culling");
+    dt_gui_add_class(table->widget, "dt_culling");
 
   // overlays
   gchar *otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", table->mode);
@@ -849,7 +849,7 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   g_free(otxt);
 
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
-  dt_util_add_class(table->widget, cl0);
+  dt_gui_add_class(table->widget, cl0);
   free(cl0);
 
   otxt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
@@ -1747,8 +1747,8 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
   gchar *cl1 = _thumbs_get_overlays_class(over);
 
-  dt_util_remove_class(table->widget, cl0);
-  dt_util_add_class(table->widget, cl1);
+  dt_gui_remove_class(table->widget, cl0);
+  dt_gui_add_class(table->widget, cl1);
 
   txt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
   int timeout = 2;

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -838,11 +838,10 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
     gtk_widget_set_name(table->widget, "preview");
   else
     gtk_widget_set_name(table->widget, "culling");
-  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
   if(mode == DT_CULLING_MODE_PREVIEW)
-    gtk_style_context_add_class(context, "dt_preview");
+    dt_util_add_class(table->widget, "dt_preview");
   else
-    gtk_style_context_add_class(context, "dt_culling");
+    dt_util_add_class(table->widget, "dt_culling");
 
   // overlays
   gchar *otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", table->mode);
@@ -850,7 +849,7 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   g_free(otxt);
 
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
-  gtk_style_context_add_class(context, cl0);
+  dt_util_add_class(table->widget, cl0);
   free(cl0);
 
   otxt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
@@ -1748,9 +1747,8 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
   gchar *cl1 = _thumbs_get_overlays_class(over);
 
-  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
-  gtk_style_context_remove_class(context, cl0);
-  gtk_style_context_add_class(context, cl1);
+  dt_util_remove_class(table->widget, cl0);
+  dt_util_add_class(table->widget, cl1);
 
   txt = g_strdup_printf("plugins/lighttable/overlays/culling_block_timeout/%d", table->mode);
   int timeout = 2;

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -695,7 +695,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new(gint positions)
   gslider = g_object_new(_gradient_slider_get_type(), NULL);
   gslider->positions = positions;
   _gradient_slider_set_defaults(gslider);
-  dt_util_add_class(GTK_WIDGET(gslider), "dt_gslider_multivalue");
+  dt_gui_add_class(GTK_WIDGET(gslider), "dt_gslider_multivalue");
   return (GtkWidget *)gslider;
 }
 
@@ -727,7 +727,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new_with_color(GdkRGBA start, GdkRGB
   gc->position = 1.0;
   memcpy(&gc->color, &end, sizeof(GdkRGBA));
   gslider->colors = g_list_append(gslider->colors, gc);
-  dt_util_add_class(GTK_WIDGET(gslider), "dt_gslider_multivalue");
+  dt_gui_add_class(GTK_WIDGET(gslider), "dt_gslider_multivalue");
   return (GtkWidget *)gslider;
 }
 
@@ -913,7 +913,7 @@ void dtgtk_gradient_slider_multivalue_set_scale_callback(GtkDarktableGradientSli
 GtkWidget *dtgtk_gradient_slider_new()
 {
   GtkWidget *gslider = dtgtk_gradient_slider_multivalue_new(1);
-  dt_util_add_class(gslider, "dt_gslider");
+  dt_gui_add_class(gslider, "dt_gslider");
   return gslider;
 }
 
@@ -928,7 +928,7 @@ GtkWidget *dtgtk_gradient_slider_new_with_name(gchar *name)
 GtkWidget *dtgtk_gradient_slider_new_with_color(GdkRGBA start, GdkRGBA end)
 {
   GtkWidget *gslider = dtgtk_gradient_slider_multivalue_new_with_color(start, end, 1);
-  dt_util_add_class(gslider, "dt_gslider");
+  dt_gui_add_class(gslider, "dt_gslider");
   return gslider;
 }
 

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -695,10 +695,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new(gint positions)
   gslider = g_object_new(_gradient_slider_get_type(), NULL);
   gslider->positions = positions;
   _gradient_slider_set_defaults(gslider);
-
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(gslider));
-  gtk_style_context_add_class(context, "dt_gslider_multivalue");
-
+  dt_util_add_class(GTK_WIDGET(gslider), "dt_gslider_multivalue");
   return (GtkWidget *)gslider;
 }
 
@@ -730,10 +727,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new_with_color(GdkRGBA start, GdkRGB
   gc->position = 1.0;
   memcpy(&gc->color, &end, sizeof(GdkRGBA));
   gslider->colors = g_list_append(gslider->colors, gc);
-
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(gslider));
-  gtk_style_context_add_class(context, "dt_gslider_multivalue");
-
+  dt_util_add_class(GTK_WIDGET(gslider), "dt_gslider_multivalue");
   return (GtkWidget *)gslider;
 }
 
@@ -919,10 +913,7 @@ void dtgtk_gradient_slider_multivalue_set_scale_callback(GtkDarktableGradientSli
 GtkWidget *dtgtk_gradient_slider_new()
 {
   GtkWidget *gslider = dtgtk_gradient_slider_multivalue_new(1);
-
-  GtkStyleContext *context = gtk_widget_get_style_context(gslider);
-  gtk_style_context_add_class(context, "dt_gslider");
-
+  dt_util_add_class(gslider, "dt_gslider");
   return gslider;
 }
 
@@ -937,10 +928,7 @@ GtkWidget *dtgtk_gradient_slider_new_with_name(gchar *name)
 GtkWidget *dtgtk_gradient_slider_new_with_color(GdkRGBA start, GdkRGBA end)
 {
   GtkWidget *gslider = dtgtk_gradient_slider_multivalue_new_with_color(start, end, 1);
-
-  GtkStyleContext *context = gtk_widget_get_style_context(gslider);
-  gtk_style_context_add_class(context, "dt_gslider");
-
+  dt_util_add_class(gslider, "dt_gslider");
   return gslider;
 }
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -172,7 +172,7 @@ void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 1, 0, 0)
+  PREAMBLE(0.75, 1, 0, 0)
 
   /* initialize rotation and flip matrices */
   cairo_matrix_t hflip_matrix;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -200,7 +200,7 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
 
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.9, 1, 0, 0)
+  PREAMBLE(1, 1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.05);
   cairo_line_to(cr, 0.1, 0.95);
@@ -1542,7 +1542,7 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   #define CPF_USER_DATA_INCLUDE CPF_USER_DATA
   #define CPF_USER_DATA_EXCLUDE CPF_USER_DATA << 1
-  PREAMBLE(1, 1, 0, 0)
+  PREAMBLE(0.9, 1, 0, 0)
 
   const double r = 0.4;
   const float alpha = flags & CPF_PRELIGHT ? 1.0 : 0.6;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -172,7 +172,7 @@ void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.75, 1, 0, 0)
+  PREAMBLE(1, 1, 0, 0)
 
   /* initialize rotation and flip matrices */
   cairo_matrix_t hflip_matrix;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -143,9 +143,9 @@ static void _thumb_update_rating_class(dt_thumbnail_t *thumb)
   {
     gchar *cn = g_strdup_printf("dt_thumbnail_rating_%d", i);
     if(thumb->rating == i)
-      dt_util_add_class(thumb->w_main, cn);
+      dt_gui_add_class(thumb->w_main, cn);
     else
-      dt_util_remove_class(thumb->w_main, cn);
+      dt_gui_remove_class(thumb->w_main, cn);
     g_free(cn);
   }
 }
@@ -1286,9 +1286,9 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_image_box), evt_image);
     thumb->w_image = gtk_drawing_area_new();
     if(thumb->container == DT_THUMBNAIL_CONTAINER_PREVIEW)
-      dt_util_add_class(thumb->w_image, "dt_preview_thumb_image");
+      dt_gui_add_class(thumb->w_image, "dt_preview_thumb_image");
     else if(thumb->container == DT_THUMBNAIL_CONTAINER_CULLING)
-      dt_util_add_class(thumb->w_image, "dt_culling_thumb_image");
+      dt_gui_add_class(thumb->w_image, "dt_culling_thumb_image");
     gtk_widget_set_name(thumb->w_image, "thumb_image");
     gtk_widget_set_valign(thumb->w_image, GTK_ALIGN_CENTER);
     gtk_widget_set_halign(thumb->w_image, GTK_ALIGN_CENTER);
@@ -1864,21 +1864,21 @@ void dt_thumbnail_set_group_border(dt_thumbnail_t *thumb, dt_thumbnail_border_t 
 {
   if(border == DT_THUMBNAIL_BORDER_NONE)
   {
-    dt_util_remove_class(thumb->w_main, "dt_group_left");
-    dt_util_remove_class(thumb->w_main, "dt_group_top");
-    dt_util_remove_class(thumb->w_main, "dt_group_right");
-    dt_util_remove_class(thumb->w_main, "dt_group_bottom");
+    dt_gui_remove_class(thumb->w_main, "dt_group_left");
+    dt_gui_remove_class(thumb->w_main, "dt_group_top");
+    dt_gui_remove_class(thumb->w_main, "dt_group_right");
+    dt_gui_remove_class(thumb->w_main, "dt_group_bottom");
     thumb->group_borders = DT_THUMBNAIL_BORDER_NONE;
     return;
   }
   else if(border & DT_THUMBNAIL_BORDER_LEFT)
-    dt_util_add_class(thumb->w_main, "dt_group_left");
+    dt_gui_add_class(thumb->w_main, "dt_group_left");
   else if(border & DT_THUMBNAIL_BORDER_TOP)
-    dt_util_add_class(thumb->w_main, "dt_group_top");
+    dt_gui_add_class(thumb->w_main, "dt_group_top");
   else if(border & DT_THUMBNAIL_BORDER_RIGHT)
-    dt_util_add_class(thumb->w_main, "dt_group_right");
+    dt_gui_add_class(thumb->w_main, "dt_group_right");
   else if(border & DT_THUMBNAIL_BORDER_BOTTOM)
-    dt_util_add_class(thumb->w_main, "dt_group_bottom");
+    dt_gui_add_class(thumb->w_main, "dt_group_bottom");
 
   thumb->group_borders |= border;
 }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -139,14 +139,13 @@ static void _thumb_update_rating_class(dt_thumbnail_t *thumb)
 {
   if(!thumb->w_main) return;
 
-  GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_main);
   for(int i = DT_VIEW_DESERT; i <= DT_VIEW_REJECT; i++)
   {
     gchar *cn = g_strdup_printf("dt_thumbnail_rating_%d", i);
     if(thumb->rating == i)
-      gtk_style_context_add_class(context, cn);
+      dt_util_add_class(thumb->w_main, cn);
     else
-      gtk_style_context_remove_class(context, cn);
+      dt_util_remove_class(thumb->w_main, cn);
     g_free(cn);
   }
 }
@@ -1286,11 +1285,10 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     gtk_widget_show(evt_image);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_image_box), evt_image);
     thumb->w_image = gtk_drawing_area_new();
-    GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_image);
     if(thumb->container == DT_THUMBNAIL_CONTAINER_PREVIEW)
-      gtk_style_context_add_class(context, "dt_preview_thumb_image");
+      dt_util_add_class(thumb->w_image, "dt_preview_thumb_image");
     else if(thumb->container == DT_THUMBNAIL_CONTAINER_CULLING)
-      gtk_style_context_add_class(context, "dt_culling_thumb_image");
+      dt_util_add_class(thumb->w_image, "dt_culling_thumb_image");
     gtk_widget_set_name(thumb->w_image, "thumb_image");
     gtk_widget_set_valign(thumb->w_image, GTK_ALIGN_CENTER);
     gtk_widget_set_halign(thumb->w_image, GTK_ALIGN_CENTER);
@@ -1864,24 +1862,23 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
 
 void dt_thumbnail_set_group_border(dt_thumbnail_t *thumb, dt_thumbnail_border_t border)
 {
-  GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_main);
   if(border == DT_THUMBNAIL_BORDER_NONE)
   {
-    gtk_style_context_remove_class(context, "dt_group_left");
-    gtk_style_context_remove_class(context, "dt_group_top");
-    gtk_style_context_remove_class(context, "dt_group_right");
-    gtk_style_context_remove_class(context, "dt_group_bottom");
+    dt_util_remove_class(thumb->w_main, "dt_group_left");
+    dt_util_remove_class(thumb->w_main, "dt_group_top");
+    dt_util_remove_class(thumb->w_main, "dt_group_right");
+    dt_util_remove_class(thumb->w_main, "dt_group_bottom");
     thumb->group_borders = DT_THUMBNAIL_BORDER_NONE;
     return;
   }
   else if(border & DT_THUMBNAIL_BORDER_LEFT)
-    gtk_style_context_add_class(context, "dt_group_left");
+    dt_util_add_class(thumb->w_main, "dt_group_left");
   else if(border & DT_THUMBNAIL_BORDER_TOP)
-    gtk_style_context_add_class(context, "dt_group_top");
+    dt_util_add_class(thumb->w_main, "dt_group_top");
   else if(border & DT_THUMBNAIL_BORDER_RIGHT)
-    gtk_style_context_add_class(context, "dt_group_right");
+    dt_util_add_class(thumb->w_main, "dt_group_right");
   else if(border & DT_THUMBNAIL_BORDER_BOTTOM)
-    gtk_style_context_add_class(context, "dt_group_bottom");
+    dt_util_add_class(thumb->w_main, "dt_group_bottom");
 
   thumb->group_borders |= border;
 }

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -118,7 +118,7 @@ GtkWidget *dtgtk_thumbnail_btn_new(DTGTKCairoPaintIconFunc paint, gint paintflag
 {
   GtkDarktableThumbnailBtn *button;
   button = g_object_new(dtgtk_thumbnail_btn_get_type(), NULL);
-  dt_util_add_class(GTK_WIDGET(button), "dt_thumb_btn");
+  dt_gui_add_class(GTK_WIDGET(button), "dt_thumb_btn");
   button->icon = paint;
   button->icon_flags = paintflags;
   button->icon_data = paintdata;

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -118,8 +118,7 @@ GtkWidget *dtgtk_thumbnail_btn_new(DTGTKCairoPaintIconFunc paint, gint paintflag
 {
   GtkDarktableThumbnailBtn *button;
   button = g_object_new(dtgtk_thumbnail_btn_get_type(), NULL);
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(button));
-  gtk_style_context_add_class(context, "dt_thumb_btn");
+  dt_util_add_class(GTK_WIDGET(button), "dt_thumb_btn");
   button->icon = paint;
   button->icon_flags = paintflags;
   button->icon_data = paintdata;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -100,9 +100,8 @@ static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
   // we change the class that indicate the thumb size
   gchar *c0 = g_strdup_printf("dt_thumbnails_%d", table->prefs_size);
   gchar *c1 = g_strdup_printf("dt_thumbnails_%d", ns);
-  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
-  gtk_style_context_remove_class(context, c0);
-  gtk_style_context_add_class(context, c1);
+  dt_util_remove_class(table->widget, c0);
+  dt_util_add_class(table->widget, c1);
   g_free(c0);
   g_free(c1);
   table->prefs_size = ns;
@@ -140,9 +139,8 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
   gchar *cl1 = _thumbs_get_overlays_class(over);
 
-  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
-  gtk_style_context_remove_class(context, cl0);
-  gtk_style_context_add_class(context, cl1);
+  dt_util_remove_class(table->widget, cl0);
+  dt_util_add_class(table->widget, cl1);
 
   txt = g_strdup_printf("plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
   int timeout = 2;
@@ -1775,8 +1773,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
   if(darktable.collection->params.sort == DT_COLLECTION_SORT_CUSTOM_ORDER && table->mode != DT_THUMBTABLE_MODE_ZOOM)
   {
     // we set the class correctly
-    GtkStyleContext *tablecontext = gtk_widget_get_style_context(table->widget);
-    gtk_style_context_add_class(tablecontext, "dt_thumbtable_reorder");
+    dt_util_add_class(table->widget, "dt_thumbtable_reorder");
   }
 }
 
@@ -1841,8 +1838,7 @@ static void _event_dnd_end(GtkWidget *widget, GdkDragContext *context, gpointer 
     table->drag_list = NULL;
   }
   // in any case, with reset the reordering class if any
-  GtkStyleContext *tablecontext = gtk_widget_get_style_context(table->widget);
-  gtk_style_context_remove_class(tablecontext, "dt_thumbtable_reorder");
+  dt_util_remove_class(table->widget, "dt_thumbtable_reorder");
 }
 
 dt_thumbtable_t *dt_thumbtable_new()
@@ -1859,14 +1855,13 @@ dt_thumbtable_t *dt_thumbtable_new()
 
   // set css name and class
   gtk_widget_set_name(table->widget, "thumbtable_filemanager");
-  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
-  gtk_style_context_add_class(context, "dt_thumbtable");
-  if(dt_conf_get_bool("lighttable/ui/expose_statuses")) gtk_style_context_add_class(context, "dt_show_overlays");
+  dt_util_add_class(table->widget, "dt_thumbtable");
+  if(dt_conf_get_bool("lighttable/ui/expose_statuses")) dt_util_add_class(table->widget, "dt_show_overlays");
 
   // overlays mode
   table->overlays = DT_THUMBNAIL_OVERLAYS_NONE;
   gchar *cl = _thumbs_get_overlays_class(table->overlays);
-  gtk_style_context_add_class(context, cl);
+  dt_util_add_class(table->widget, cl);
   g_free(cl);
 
   table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/recentcollect/pos0"));
@@ -2052,8 +2047,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       if(tl)
       {
         dt_thumbnail_t *thumb = (dt_thumbnail_t *)tl->data;
-        GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_main);
-        gtk_style_context_remove_class(context, "dt_last_active");
+        dt_util_remove_class(thumb->w_main, "dt_last_active");
         thumb->rowid = nrow; // this may have changed
         // we set new position/size if needed
         if(thumb->x != posx || thumb->y != posy)
@@ -2114,8 +2108,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
         dt_thumbnail_t *th = _thumbtable_get_thumb(table, GPOINTER_TO_INT(l->data));
         if(th)
         {
-          GtkStyleContext *context = gtk_widget_get_style_context(th->w_main);
-          gtk_style_context_add_class(context, "dt_last_active");
+          dt_util_add_class(th->w_main, "dt_last_active");
           th->active = FALSE;
           dt_thumbnail_update_infos(th);
         }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -100,8 +100,8 @@ static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
   // we change the class that indicate the thumb size
   gchar *c0 = g_strdup_printf("dt_thumbnails_%d", table->prefs_size);
   gchar *c1 = g_strdup_printf("dt_thumbnails_%d", ns);
-  dt_util_remove_class(table->widget, c0);
-  dt_util_add_class(table->widget, c1);
+  dt_gui_remove_class(table->widget, c0);
+  dt_gui_add_class(table->widget, c1);
   g_free(c0);
   g_free(c1);
   table->prefs_size = ns;
@@ -139,8 +139,8 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
   gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
   gchar *cl1 = _thumbs_get_overlays_class(over);
 
-  dt_util_remove_class(table->widget, cl0);
-  dt_util_add_class(table->widget, cl1);
+  dt_gui_remove_class(table->widget, cl0);
+  dt_gui_add_class(table->widget, cl1);
 
   txt = g_strdup_printf("plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
   int timeout = 2;
@@ -1773,7 +1773,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
   if(darktable.collection->params.sort == DT_COLLECTION_SORT_CUSTOM_ORDER && table->mode != DT_THUMBTABLE_MODE_ZOOM)
   {
     // we set the class correctly
-    dt_util_add_class(table->widget, "dt_thumbtable_reorder");
+    dt_gui_add_class(table->widget, "dt_thumbtable_reorder");
   }
 }
 
@@ -1838,7 +1838,7 @@ static void _event_dnd_end(GtkWidget *widget, GdkDragContext *context, gpointer 
     table->drag_list = NULL;
   }
   // in any case, with reset the reordering class if any
-  dt_util_remove_class(table->widget, "dt_thumbtable_reorder");
+  dt_gui_remove_class(table->widget, "dt_thumbtable_reorder");
 }
 
 dt_thumbtable_t *dt_thumbtable_new()
@@ -1855,13 +1855,13 @@ dt_thumbtable_t *dt_thumbtable_new()
 
   // set css name and class
   gtk_widget_set_name(table->widget, "thumbtable_filemanager");
-  dt_util_add_class(table->widget, "dt_thumbtable");
-  if(dt_conf_get_bool("lighttable/ui/expose_statuses")) dt_util_add_class(table->widget, "dt_show_overlays");
+  dt_gui_add_class(table->widget, "dt_thumbtable");
+  if(dt_conf_get_bool("lighttable/ui/expose_statuses")) dt_gui_add_class(table->widget, "dt_show_overlays");
 
   // overlays mode
   table->overlays = DT_THUMBNAIL_OVERLAYS_NONE;
   gchar *cl = _thumbs_get_overlays_class(table->overlays);
-  dt_util_add_class(table->widget, cl);
+  dt_gui_add_class(table->widget, cl);
   g_free(cl);
 
   table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/recentcollect/pos0"));
@@ -2047,7 +2047,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       if(tl)
       {
         dt_thumbnail_t *thumb = (dt_thumbnail_t *)tl->data;
-        dt_util_remove_class(thumb->w_main, "dt_last_active");
+        dt_gui_remove_class(thumb->w_main, "dt_last_active");
         thumb->rowid = nrow; // this may have changed
         // we set new position/size if needed
         if(thumb->x != posx || thumb->y != posy)
@@ -2108,7 +2108,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
         dt_thumbnail_t *th = _thumbtable_get_thumb(table, GPOINTER_TO_INT(l->data));
         if(th)
         {
-          dt_util_add_class(th->w_main, "dt_last_active");
+          dt_gui_add_class(th->w_main, "dt_last_active");
           th->active = FALSE;
           dt_thumbnail_update_infos(th);
         }

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -161,7 +161,7 @@ GtkWidget *dtgtk_togglebutton_new(DTGTKCairoPaintIconFunc paint, gint paintflags
   button->icon_data = paintdata;
   button->canvas = gtk_drawing_area_new();
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
-  dt_util_add_class(GTK_WIDGET(button), "dt_module_btn");
+  dt_gui_add_class(GTK_WIDGET(button), "dt_module_btn");
   gtk_widget_set_name(GTK_WIDGET(button), "dt-toggle-button");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
   return (GtkWidget *)button;

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -161,6 +161,7 @@ GtkWidget *dtgtk_togglebutton_new(DTGTKCairoPaintIconFunc paint, gint paintflags
   button->icon_data = paintdata;
   button->canvas = gtk_drawing_area_new();
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
+  dt_util_add_class(GTK_WIDGET(button), "dt_module_btn");
   gtk_widget_set_name(GTK_WIDGET(button), "dt-toggle-button");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
   return (GtkWidget *)button;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -812,8 +812,7 @@ void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t color, float opacity
 void dt_gui_gtk_quit()
 {
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkStyleContext *context = gtk_widget_get_style_context(win);
-  gtk_style_context_add_class(context, "dt_gui_quit");
+  dt_util_add_class(win, "dt_gui_quit");
   gtk_window_set_title(GTK_WINDOW(win), _("closing darktable..."));
 
   // Write out windows dimension
@@ -3357,8 +3356,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   GtkWidget *header_evb = gtk_event_box_new();
   GtkWidget *destdisp = dt_ui_section_label_new(label);
   gtk_widget_set_name(destdisp, "collapsible-label");
-  GtkStyleContext *context = gtk_widget_get_style_context(destdisp_head);
-  gtk_style_context_add_class(context, "section-expander");
+  dt_util_add_class(destdisp_head, "section-expander");
   gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
 
   cs->toggle = dtgtk_togglebutton_new
@@ -3366,8 +3364,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
      CPF_STYLE_BOX | (expanded?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
   gtk_widget_set_name(cs->toggle, "control-button");
-  context = gtk_widget_get_style_context(cs->toggle);
-  gtk_style_context_add_class(context, "dt_transparent_background");
+  dt_util_add_class(cs->toggle, "dt_transparent_background");
 
   cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
   gtk_widget_set_name(GTK_WIDGET(cs->container), "collapsible");

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -127,6 +127,19 @@ static void _ui_widget_redraw_callback(gpointer instance, GtkWidget *widget);
 static void _ui_log_redraw_callback(gpointer instance, GtkWidget *widget);
 static void _ui_toast_redraw_callback(gpointer instance, GtkWidget *widget);
 
+// set class function to add CSS classes with just a simple line call
+void dt_gui_add_class(GtkWidget *widget, const gchar *class_name)
+{
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+  gtk_style_context_add_class(context, class_name);
+}
+
+void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name)
+{
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+  gtk_style_context_remove_class(context, class_name);
+}
+
 /*
  * OLD UI API
  */
@@ -812,7 +825,7 @@ void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t color, float opacity
 void dt_gui_gtk_quit()
 {
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  dt_util_add_class(win, "dt_gui_quit");
+  dt_gui_add_class(win, "dt_gui_quit");
   gtk_window_set_title(GTK_WINDOW(win), _("closing darktable..."));
 
   // Write out windows dimension
@@ -1629,7 +1642,7 @@ static void _init_main_table(GtkWidget *container)
   g_signal_connect(G_OBJECT(eb), "button-press-event", G_CALLBACK(_ui_log_button_press_event),
                    darktable.gui->ui->log_msg);
   gtk_label_set_ellipsize(GTK_LABEL(darktable.gui->ui->log_msg), PANGO_ELLIPSIZE_MIDDLE);
-  dt_util_add_class(darktable.gui->ui->log_msg, "dt_messages");
+  dt_gui_add_class(darktable.gui->ui->log_msg, "dt_messages");
   gtk_container_add(GTK_CONTAINER(eb), darktable.gui->ui->log_msg);
   gtk_widget_set_valign(eb, GTK_ALIGN_END);
   gtk_widget_set_halign(eb, GTK_ALIGN_CENTER);
@@ -1650,7 +1663,7 @@ static void _init_main_table(GtkWidget *container)
   gtk_label_set_attributes(GTK_LABEL(darktable.gui->ui->toast_msg), attrlist);
   pango_attr_list_unref(attrlist);
 
-  dt_util_add_class(darktable.gui->ui->toast_msg, "dt_messages");
+  dt_gui_add_class(darktable.gui->ui->toast_msg, "dt_messages");
   gtk_container_add(GTK_CONTAINER(eb), darktable.gui->ui->toast_msg);
   gtk_widget_set_valign(eb, GTK_ALIGN_START);
   gtk_widget_set_halign(eb, GTK_ALIGN_CENTER);
@@ -3356,14 +3369,14 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   GtkWidget *header_evb = gtk_event_box_new();
   GtkWidget *destdisp = dt_ui_section_label_new(label);
   gtk_widget_set_name(destdisp, "collapsible-label");
-  dt_util_add_class(destdisp_head, "section-expander");
+  dt_gui_add_class(destdisp_head, "section-expander");
   gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
 
   cs->toggle = dtgtk_togglebutton_new
     (dtgtk_cairo_paint_solid_arrow,
      CPF_STYLE_BOX | (expanded?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
-  dt_util_add_class(cs->toggle, "dt_transparent_background");
+  dt_gui_add_class(cs->toggle, "dt_transparent_background");
 
   cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
   gtk_widget_set_name(GTK_WIDGET(cs->container), "collapsible");

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1629,7 +1629,7 @@ static void _init_main_table(GtkWidget *container)
   g_signal_connect(G_OBJECT(eb), "button-press-event", G_CALLBACK(_ui_log_button_press_event),
                    darktable.gui->ui->log_msg);
   gtk_label_set_ellipsize(GTK_LABEL(darktable.gui->ui->log_msg), PANGO_ELLIPSIZE_MIDDLE);
-  gtk_widget_set_name(darktable.gui->ui->log_msg, "log-msg");
+  dt_util_add_class(darktable.gui->ui->log_msg, "dt_messages");
   gtk_container_add(GTK_CONTAINER(eb), darktable.gui->ui->log_msg);
   gtk_widget_set_valign(eb, GTK_ALIGN_END);
   gtk_widget_set_halign(eb, GTK_ALIGN_CENTER);
@@ -1650,7 +1650,7 @@ static void _init_main_table(GtkWidget *container)
   gtk_label_set_attributes(GTK_LABEL(darktable.gui->ui->toast_msg), attrlist);
   pango_attr_list_unref(attrlist);
 
-  gtk_widget_set_name(darktable.gui->ui->toast_msg, "toast-msg");
+  dt_util_add_class(darktable.gui->ui->toast_msg, "dt_messages");
   gtk_container_add(GTK_CONTAINER(eb), darktable.gui->ui->toast_msg);
   gtk_widget_set_valign(eb, GTK_ALIGN_START);
   gtk_widget_set_halign(eb, GTK_ALIGN_CENTER);
@@ -3363,7 +3363,6 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
     (dtgtk_cairo_paint_solid_arrow,
      CPF_STYLE_BOX | (expanded?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
-  gtk_widget_set_name(cs->toggle, "control-button");
   dt_util_add_class(cs->toggle, "dt_transparent_background");
 
   cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -466,6 +466,10 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 // routine to hide the collapsible section
 void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
 
+// call class function to add or remove CSS classes
+void dt_gui_add_class(GtkWidget *widget, const gchar *class_name);
+void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1415,7 +1415,7 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32_t
     else
       label = g_strdup(name);
     mi = gtk_check_menu_item_new_with_label(label);
-    dt_util_add_class(mi, "check-menu-item");
+    dt_gui_add_class(mi, "check-menu-item");
     g_free(label);
 
     if(module
@@ -1425,7 +1425,7 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32_t
     {
       active_preset = cnt;
       writeprotect = sqlite3_column_int(stmt, 2);
-      dt_util_add_class(mi, "active-menu-item");
+      dt_gui_add_class(mi, "active-menu-item");
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
     }
 

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1415,7 +1415,7 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32_t
     else
       label = g_strdup(name);
     mi = gtk_check_menu_item_new_with_label(label);
-    gtk_style_context_add_class(gtk_widget_get_style_context(mi), "check-menu-item");
+    dt_util_add_class(mi, "check-menu-item");
     g_free(label);
 
     if(module
@@ -1425,7 +1425,7 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32_t
     {
       active_preset = cnt;
       writeprotect = sqlite3_column_int(stmt, 2);
-      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+      dt_util_add_class(mi, "active-menu-item");
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
     }
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1779,7 +1779,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
       for(int i=0; i<3; i++)
       {
         gtk_widget_set_name(label[i], "section_label");
-        gtk_style_context_add_class(gtk_widget_get_style_context(label[i]), "section_label_top");
+        dt_util_add_class(label[i], "section_label_top");
 
         gtk_container_add(GTK_CONTAINER(new_container), label[i]);
         if(old_container) gtk_widget_show(label[i]);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1779,7 +1779,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
       for(int i=0; i<3; i++)
       {
         gtk_widget_set_name(label[i], "section_label");
-        dt_util_add_class(label[i], "section_label_top");
+        dt_gui_add_class(label[i], "section_label_top");
 
         gtk_container_add(GTK_CONTAINER(new_container), label[i]);
         if(old_container) gtk_widget_show(label[i]);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1731,8 +1731,7 @@ void gui_init(dt_iop_module_t *self)
   g->extra_expander = dtgtk_expander_new(destdisp_head, extra_options);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), g->extra_expander, FALSE, FALSE, 0);
-  GtkStyleContext *context = gtk_widget_get_style_context(self->widget);
-  gtk_style_context_add_class(context, "dt_transparent_background");
+  dt_util_add_class(self->widget, "dt_transparent_background");
 
   g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1730,7 +1730,7 @@ void gui_init(dt_iop_module_t *self)
   g->extra_expander = dtgtk_expander_new(destdisp_head, extra_options);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), g->extra_expander, FALSE, FALSE, 0);
-  dt_util_add_class(self->widget, "dt_transparent_background");
+  dt_gui_add_class(self->widget, "dt_transparent_background");
 
   g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1723,7 +1723,6 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *destdisp = dt_ui_section_label_new(_("destination/display"));
   g->extra_toggle =
     dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_widget_set_name(GTK_WIDGET(g->extra_toggle), "control-button");
   GtkWidget *extra_options = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   gtk_box_pack_start(GTK_BOX(destdisp_head), destdisp, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(destdisp_head), g->extra_toggle, FALSE, FALSE, 0);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4340,7 +4340,7 @@ void gui_init(dt_iop_module_t *self)
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), g->auto_button, FALSE, FALSE, 0);
   dt_action_define_iop(self, NULL, N_("auto tune levels"), GTK_WIDGET(g->auto_button), &dt_action_def_button);
-  dt_util_add_class(g->auto_button, "dt_bauhaus_alignment");
+  dt_gui_add_class(g->auto_button, "dt_bauhaus_alignment");
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\n"
@@ -4353,7 +4353,7 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("reconstruct"), NULL);
 
   GtkWidget *label = dt_ui_section_label_new(_("highlights clipping"));
-  dt_util_add_class(GTK_WIDGET(label), "section_label_top");
+  dt_gui_add_class(GTK_WIDGET(label), "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_threshold = dt_bauhaus_slider_from_params(self, "reconstruct_threshold");
@@ -4379,7 +4379,7 @@ void gui_init(dt_iop_module_t *self)
   g->show_highlight_mask = dt_iop_togglebutton_new(self, NULL, N_("display highlight reconstruction mask"), NULL, G_CALLBACK(show_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_highlight_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_util_add_class(g->show_highlight_mask, "dt_bauhaus_alignment");
+  dt_gui_add_class(g->show_highlight_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   label = dt_ui_section_label_new(_("balance"));

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4340,6 +4340,7 @@ void gui_init(dt_iop_module_t *self)
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), g->auto_button, FALSE, FALSE, 0);
   dt_action_define_iop(self, NULL, N_("auto tune levels"), GTK_WIDGET(g->auto_button), &dt_action_def_button);
+  dt_util_add_class(g->auto_button, "dt_bauhaus_alignment");
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\n"
@@ -4379,6 +4380,7 @@ void gui_init(dt_iop_module_t *self)
   g->show_highlight_mask = dt_iop_togglebutton_new(self, NULL, N_("display highlight reconstruction mask"), NULL, G_CALLBACK(show_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_highlight_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_util_add_class(g->show_highlight_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   label = dt_ui_section_label_new(_("balance"));

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4353,8 +4353,7 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("reconstruct"), NULL);
 
   GtkWidget *label = dt_ui_section_label_new(_("highlights clipping"));
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
-  gtk_style_context_add_class(context, "section_label_top");
+  dt_util_add_class(GTK_WIDGET(label), "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_threshold = dt_bauhaus_slider_from_params(self, "reconstruct_threshold");

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -468,7 +468,7 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
 
   if(top)
   {
-    dt_util_add_class(GTK_WIDGET(label), "section_label_top");
+    dt_gui_add_class(GTK_WIDGET(label), "section_label_top");
   }
 
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -468,8 +468,7 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
 
   if(top)
   {
-    GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
-    gtk_style_context_add_class(context, "section_label_top");
+    dt_util_add_class(GTK_WIDGET(label), "section_label_top");
   }
 
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1932,6 +1932,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance to camera reference point\nin most cases it should be D65"));
 
   g->buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0); // put buttons at top. fill later.
+  dt_util_add_class(g->buttonbar, "dt_iop_toggle");
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_d65, TRUE, TRUE, 0);
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_user, TRUE, TRUE, 0);
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->colorpicker, TRUE, TRUE, 0);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1960,8 +1960,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *temp_label_box = gtk_event_box_new();
   g->temp_label = dt_ui_section_label_new(_("scene illuminant temp"));
   gtk_widget_set_tooltip_text(g->temp_label, _("click to cycle color mode on sliders"));
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(g->temp_label));
-  gtk_style_context_add_class(context, "section_label_top");
+  dt_util_add_class(GTK_WIDGET(g->temp_label), "section_label_top");
   gtk_container_add(GTK_CONTAINER(temp_label_box), g->temp_label);
 
   g_signal_connect(G_OBJECT(temp_label_box), "button-release-event", G_CALLBACK(temp_label_click), self);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1932,7 +1932,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance to camera reference point\nin most cases it should be D65"));
 
   g->buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0); // put buttons at top. fill later.
-  dt_util_add_class(g->buttonbar, "dt_iop_toggle");
+  dt_gui_add_class(g->buttonbar, "dt_iop_toggle");
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_d65, TRUE, TRUE, 0);
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_user, TRUE, TRUE, 0);
   gtk_box_pack_end(GTK_BOX(g->buttonbar), g->colorpicker, TRUE, TRUE, 0);
@@ -1960,7 +1960,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *temp_label_box = gtk_event_box_new();
   g->temp_label = dt_ui_section_label_new(_("scene illuminant temp"));
   gtk_widget_set_tooltip_text(g->temp_label, _("click to cycle color mode on sliders"));
-  dt_util_add_class(GTK_WIDGET(g->temp_label), "section_label_top");
+  dt_gui_add_class(GTK_WIDGET(g->temp_label), "section_label_top");
   gtk_container_add(GTK_CONTAINER(temp_label_box), g->temp_label);
 
   g_signal_connect(G_OBJECT(temp_label_box), "button-release-event", G_CALLBACK(temp_label_click), self);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3288,6 +3288,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->show_luminance_mask = dt_iop_togglebutton_new(self, NULL, N_("display exposure mask"), NULL, G_CALLBACK(show_luminance_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_util_add_class(g->show_luminance_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   // Force UI redraws when pipe starts/finishes computing and switch cursors

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3288,7 +3288,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->show_luminance_mask = dt_iop_togglebutton_new(self, NULL, N_("display exposure mask"), NULL, G_CALLBACK(show_luminance_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_util_add_class(g->show_luminance_mask, "dt_bauhaus_alignment");
+  dt_gui_add_class(g->show_luminance_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   // Force UI redraws when pipe starts/finishes computing and switch cursors

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3052,7 +3052,6 @@ void gui_init(dt_lib_module_t *self)
     gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
 
     w = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
-    gtk_widget_set_name(GTK_WIDGET(w), "control-button");
     d->rule[i].button = w;
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);
     g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(popup_button_callback), d->rule + i);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3056,7 +3056,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);
     g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(popup_button_callback), d->rule + i);
     gtk_box_pack_start(box, w, FALSE, FALSE, 0);
-    dt_util_add_class(w, "dt_transparent_background");
+    dt_gui_add_class(w, "dt_transparent_background");
   }
 
   GtkTreeView *view = GTK_TREE_VIEW(gtk_tree_view_new());

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3057,8 +3057,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);
     g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(popup_button_callback), d->rule + i);
     gtk_box_pack_start(box, w, FALSE, FALSE, 0);
-    GtkStyleContext *context = gtk_widget_get_style_context(w);
-    gtk_style_context_add_class(context, "dt_transparent_background");
+    dt_util_add_class(w, "dt_transparent_background");
   }
 
   GtkTreeView *view = GTK_TREE_VIEW(gtk_tree_view_new());

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -556,8 +556,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Setting up the GUI
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  GtkStyleContext *context = gtk_widget_get_style_context(self->widget);
-  gtk_style_context_add_class(context, "picker-module");
+  dt_util_add_class(self->widget, "picker-module");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   // The color patch
@@ -642,8 +641,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Adding the live samples section
   label = dt_ui_section_label_new(_("live samples"));
-  context = gtk_widget_get_style_context(GTK_WIDGET(label));
-  gtk_style_context_add_class(context, "section_label_top");
+  dt_util_add_class(GTK_WIDGET(label), "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
 

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -556,7 +556,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Setting up the GUI
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  dt_util_add_class(self->widget, "picker-module");
+  dt_gui_add_class(self->widget, "picker-module");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   // The color patch
@@ -641,7 +641,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Adding the live samples section
   label = dt_ui_section_label_new(_("live samples"));
-  dt_util_add_class(GTK_WIDGET(label), "section_label_top");
+  dt_gui_add_class(GTK_WIDGET(label), "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -419,10 +419,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
   {
     GtkWidget *hb = gtk_grid_new();
     const int imgid = sqlite3_column_int(stmt, 1);
-
-    GtkStyleContext *context = gtk_widget_get_style_context(hb);
-    gtk_style_context_add_class(context, "dt_overlays_always");
-
+    dt_util_add_class(hb, "dt_overlays_always");
     dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, IMG_TO_FIT, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
                                              DT_THUMBNAIL_CONTAINER_LIGHTTABLE, TRUE);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
@@ -535,8 +532,7 @@ void gui_init(dt_lib_module_t *self)
   d->preview_height = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  GtkStyleContext *context = gtk_widget_get_style_context(self->widget);
-  gtk_style_context_add_class(context, "duplicate-ui");
+  dt_util_add_class(self->widget, "duplicate-ui");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   d->duplicate_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -419,7 +419,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
   {
     GtkWidget *hb = gtk_grid_new();
     const int imgid = sqlite3_column_int(stmt, 1);
-    dt_util_add_class(hb, "dt_overlays_always");
+    dt_gui_add_class(hb, "dt_overlays_always");
     dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, IMG_TO_FIT, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
                                              DT_THUMBNAIL_CONTAINER_LIGHTTABLE, TRUE);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
@@ -532,7 +532,7 @@ void gui_init(dt_lib_module_t *self)
   d->preview_height = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  dt_util_add_class(self->widget, "duplicate-ui");
+  dt_gui_add_class(self->widget, "duplicate-ui");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   d->duplicate_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1070,7 +1070,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   GtkWidget *label = dt_ui_section_label_new(_("storage options"));
-  dt_util_add_class(GTK_WIDGET(label), "section_label_top");
+  dt_gui_add_class(GTK_WIDGET(label), "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
   dt_gui_add_help_link(self->widget, dt_get_help_url("export"));
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1070,8 +1070,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   GtkWidget *label = dt_ui_section_label_new(_("storage options"));
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
-  gtk_style_context_add_class(context, "section_label_top");
+  dt_util_add_class(GTK_WIDGET(label), "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
   dt_gui_add_help_link(self->widget, dt_get_help_url("export"));
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -189,7 +189,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   g_snprintf(numlab, sizeof(numlab), "%2d", num + 1);
   GtkWidget *numwidget = gtk_label_new(numlab);
   gtk_widget_set_name(numwidget, "history-number");
-  dt_util_add_class(numwidget, "dt_history_items");
+  dt_gui_add_class(numwidget, "dt_history_items");
 
   GtkWidget *onoff = NULL;
 
@@ -202,7 +202,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   if(always_on)
   {
     onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    dt_util_add_class(widget, "dt_transparent_background");
+    dt_gui_add_class(widget, "dt_transparent_background");
     gtk_widget_set_name(onoff, "history-switch-always-enabled");
     gtk_widget_set_name(widget, "history-button-always-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), TRUE);
@@ -211,7 +211,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   else if(default_enabled)
   {
     onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    dt_util_add_class(widget, "dt_transparent_background");
+    dt_gui_add_class(widget, "dt_transparent_background");
     gtk_widget_set_name(onoff, "history-switch-default-enabled");
     gtk_widget_set_name(widget, "history-button-default-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
@@ -230,12 +230,12 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
       onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
       gtk_widget_set_name(onoff, enabled ? "history-switch-enabled" : "history-switch");
     }
-    dt_util_add_class(widget, enabled ? "dt_transparent_background" : "dt_transparent_background");
+    dt_gui_add_class(widget, enabled ? "dt_transparent_background" : "dt_transparent_background");
     gtk_widget_set_name(widget, enabled ? "history-button-enabled" : "history-button");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
   }
-  dt_util_add_class(onoff, "dt_history_switch");
-  dt_util_add_class(widget, "dt_history_items");
+  dt_gui_add_class(onoff, "dt_history_switch");
+  dt_gui_add_class(widget, "dt_history_items");
 
   gtk_widget_set_sensitive(onoff, FALSE);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -189,6 +189,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   g_snprintf(numlab, sizeof(numlab), "%2d", num + 1);
   GtkWidget *numwidget = gtk_label_new(numlab);
   gtk_widget_set_name(numwidget, "history-number");
+  dt_util_add_class(numwidget, "dt_history_items");
 
   GtkWidget *onoff = NULL;
 
@@ -201,6 +202,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   if(always_on)
   {
     onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+    dt_util_add_class(widget, "dt_transparent_background");
     gtk_widget_set_name(onoff, "history-switch-always-enabled");
     gtk_widget_set_name(widget, "history-button-always-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), TRUE);
@@ -209,6 +211,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   else if(default_enabled)
   {
     onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+    dt_util_add_class(widget, "dt_transparent_background");
     gtk_widget_set_name(onoff, "history-switch-default-enabled");
     gtk_widget_set_name(widget, "history-button-default-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
@@ -227,9 +230,12 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
       onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
       gtk_widget_set_name(onoff, enabled ? "history-switch-enabled" : "history-switch");
     }
+    dt_util_add_class(widget, enabled ? "dt_transparent_background" : "dt_transparent_background");
     gtk_widget_set_name(widget, enabled ? "history-button-enabled" : "history-button");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
   }
+  dt_util_add_class(onoff, "dt_history_switch");
+  dt_util_add_class(widget, "dt_history_items");
 
   gtk_widget_set_sensitive(onoff, FALSE);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1029,7 +1029,6 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   module->arrow = dtgtk_button_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(module->arrow, _("show module"));
   g_signal_connect(G_OBJECT(module->arrow), "button-press-event", G_CALLBACK(_lib_plugin_header_button_press), module);
-  dt_util_add_class(module->arrow, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->arrow, NULL);
   gtk_box_pack_start(GTK_BOX(header), module->arrow, FALSE, FALSE, 0);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1029,7 +1029,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   module->arrow = dtgtk_button_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(module->arrow, _("show module"));
   g_signal_connect(G_OBJECT(module->arrow), "button-press-event", G_CALLBACK(_lib_plugin_header_button_press), module);
-  gtk_widget_set_name(module->arrow, "module-collapse-button");
+  dt_util_add_class(module->arrow, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->arrow, NULL);
   gtk_box_pack_start(GTK_BOX(header), module->arrow, FALSE, FALSE, 0);
 
@@ -1051,7 +1051,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(module->presets_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
   if(!module->get_params && !module->set_preferences) gtk_widget_set_sensitive(GTK_WIDGET(module->presets_button), FALSE);
-  gtk_widget_set_name(GTK_WIDGET(module->presets_button), "module-preset-button");
+  dt_util_add_class(module->presets_button, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->presets_button, NULL);
   gtk_box_pack_end(GTK_BOX(header), module->presets_button, FALSE, FALSE, 0);
 
@@ -1061,7 +1061,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(module->reset_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
   if(!module->gui_reset) gtk_widget_set_sensitive(module->reset_button, FALSE);
-  gtk_widget_set_name(module->reset_button, "module-reset-button");
+  dt_util_add_class(module->reset_button, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->reset_button, NULL);
   gtk_box_pack_end(GTK_BOX(header), module->reset_button, FALSE, FALSE, 0);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -495,9 +495,9 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo)
       active_preset = cnt;
       selected_writeprotect = writeprotect;
       mi = gtk_check_menu_item_new_with_label(name);
-      dt_util_add_class(mi, "check-menu-item");
+      dt_gui_add_class(mi, "check-menu-item");
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-      dt_util_add_class(mi, "active-menu-item");
+      dt_gui_add_class(mi, "active-menu-item");
     }
     else
     {
@@ -1050,7 +1050,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(module->presets_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
   if(!module->get_params && !module->set_preferences) gtk_widget_set_sensitive(GTK_WIDGET(module->presets_button), FALSE);
-  dt_util_add_class(module->presets_button, "dt_module_btn");
+  dt_gui_add_class(module->presets_button, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->presets_button, NULL);
   gtk_box_pack_end(GTK_BOX(header), module->presets_button, FALSE, FALSE, 0);
 
@@ -1060,7 +1060,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(module->reset_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
   if(!module->gui_reset) gtk_widget_set_sensitive(module->reset_button, FALSE);
-  dt_util_add_class(module->reset_button, "dt_module_btn");
+  dt_gui_add_class(module->reset_button, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->reset_button, NULL);
   gtk_box_pack_end(GTK_BOX(header), module->reset_button, FALSE, FALSE, 0);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -495,9 +495,9 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo)
       active_preset = cnt;
       selected_writeprotect = writeprotect;
       mi = gtk_check_menu_item_new_with_label(name);
-      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "check-menu-item");
+      dt_util_add_class(mi, "check-menu-item");
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), TRUE);
-      gtk_style_context_add_class(gtk_widget_get_style_context(mi), "active-menu-item");
+      dt_util_add_class(mi, "active-menu-item");
     }
     else
     {

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -641,7 +641,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       // we add the on-off button
       GtkWidget *btn
           = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, item->module);
-      dt_util_add_class(btn, "dt_module_btn");
+      dt_gui_add_class(btn, "dt_module_btn");
       gtk_widget_set_valign(btn, GTK_ALIGN_CENTER);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->module->off)));
@@ -2043,7 +2043,7 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
           if(!d->edit_ro)
           {
             GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-            dt_util_add_class(btn, "dt_module_btn");
+            dt_gui_add_class(btn, "dt_module_btn");
             gtk_widget_set_tooltip_text(btn, _("remove this widget"));
             g_object_set_data(G_OBJECT(btn), "widget_id", item->id);
             g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_basics_remove), self);
@@ -2195,7 +2195,7 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
         {
           GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
           gtk_widget_set_name(btn, "module-reset-button");
-          dt_util_add_class(btn, "dt_module_btn");
+          dt_gui_add_class(btn, "dt_module_btn");
           gtk_widget_set_tooltip_text(btn, _("remove this module"));
           g_object_set_data(G_OBJECT(btn), "module_name", module->op);
           g_object_set_data(G_OBJECT(btn), "group", gr);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -474,7 +474,6 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       // because it create too much pb to remove the button from the expander
       GtkWidget *btn
           = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, item->module);
-      dt_util_add_class(btn, "dt_module_btn");
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->widget)));
       g_signal_connect(G_OBJECT(btn), "toggled", G_CALLBACK(_basics_on_off_callback), item);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -474,7 +474,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       // because it create too much pb to remove the button from the expander
       GtkWidget *btn
           = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, item->module);
-      gtk_widget_set_name(btn, "module-enable-button");
+      dt_util_add_class(btn, "dt_module_btn");
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->widget)));
       g_signal_connect(G_OBJECT(btn), "toggled", G_CALLBACK(_basics_on_off_callback), item);
@@ -642,7 +642,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       // we add the on-off button
       GtkWidget *btn
           = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, item->module);
-      gtk_widget_set_name(btn, "module-enable-button");
+      dt_util_add_class(btn, "dt_module_btn");
       gtk_widget_set_valign(btn, GTK_ALIGN_CENTER);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->module->off)));
@@ -2044,7 +2044,7 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
           if(!d->edit_ro)
           {
             GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-            gtk_widget_set_name(btn, "module-reset-button");
+            dt_util_add_class(btn, "dt_module_btn");
             gtk_widget_set_tooltip_text(btn, _("remove this widget"));
             g_object_set_data(G_OBJECT(btn), "widget_id", item->id);
             g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_basics_remove), self);
@@ -2196,6 +2196,7 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
         {
           GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
           gtk_widget_set_name(btn, "module-reset-button");
+          dt_util_add_class(btn, "dt_module_btn");
           gtk_widget_set_tooltip_text(btn, _("remove this module"));
           g_object_set_data(G_OBJECT(btn), "module_name", module->op);
           g_object_set_data(G_OBJECT(btn), "group", gr);

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -423,6 +423,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_box_pack_start(GTK_BOX(box), item->button, FALSE, TRUE, 0);
     g_signal_connect(G_OBJECT(item->button), "clicked", G_CALLBACK(_button_pressed), (gpointer)self);
     gtk_widget_set_no_show_all(item->button, TRUE);
+    dt_util_add_class(GTK_WIDGET(item->button), "dt_transparent_background");
     gtk_widget_set_name(GTK_WIDGET(item->button), "recent-collection-button");
     gtk_widget_set_visible(item->button, FALSE);
   }

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -423,7 +423,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_box_pack_start(GTK_BOX(box), item->button, FALSE, TRUE, 0);
     g_signal_connect(G_OBJECT(item->button), "clicked", G_CALLBACK(_button_pressed), (gpointer)self);
     gtk_widget_set_no_show_all(item->button, TRUE);
-    dt_util_add_class(GTK_WIDGET(item->button), "dt_transparent_background");
+    dt_gui_add_class(GTK_WIDGET(item->button), "dt_transparent_background");
     gtk_widget_set_name(GTK_WIDGET(item->button), "recent-collection-button");
     gtk_widget_set_visible(item->button, FALSE);
   }

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -155,8 +155,8 @@ int position()
 
 static void _set_widget_dimmed(GtkWidget *widget, const gboolean dimmed)
 {
-  if(dimmed) dt_util_add_class(widget, "dt_dimmed");
-  else dt_util_remove_class(widget, "dt_dimmed");
+  if(dimmed) dt_gui_add_class(widget, "dt_dimmed");
+  else dt_gui_remove_class(widget, "dt_dimmed");
   gtk_widget_queue_draw(GTK_WIDGET(widget));
 }
 
@@ -407,7 +407,7 @@ void gui_init(dt_lib_module_t *self)
                                N_("all except rejected"));
   gtk_container_add(GTK_CONTAINER(overlay), d->stars);
   gtk_box_pack_start(GTK_BOX(hbox), overlay, FALSE, FALSE, 0);
-  dt_util_add_class(hbox, "quick_filter_box");
+  dt_gui_add_class(hbox, "quick_filter_box");
 
   // colorlabels filter
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -430,8 +430,8 @@ void gui_init(dt_lib_module_t *self)
                                               "\nor (∪): images with at least one of the selected color labels"));
   g_signal_connect(G_OBJECT(d->colors_op), "clicked", G_CALLBACK(_colors_operation_clicked), self);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 2);
-  dt_util_add_class(hbox, "quick_filter_box");
-  dt_util_add_class(hbox, "dt_font_resize_07");
+  dt_gui_add_class(hbox, "quick_filter_box");
+  dt_gui_add_class(hbox, "dt_font_resize_07");
 
   // text filter
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -454,9 +454,9 @@ void gui_init(dt_lib_module_t *self)
                                 "\nstarting or ending with a double quote disables the corresponding wildcard"
           /* xgettext:no-c-format */
                                 "\nis dimmed during the search execution"));
-  dt_util_add_class(d->text, "dt_transparent_background");
+  dt_gui_add_class(d->text, "dt_transparent_background");
   gtk_box_pack_start(GTK_BOX(hbox), d->text, FALSE, FALSE, 0);
-  dt_util_add_class(hbox, "quick_filter_box");
+  dt_gui_add_class(hbox, "quick_filter_box");
 
   /* sort combobox */
   label = gtk_label_new(_("sort by"));
@@ -470,8 +470,8 @@ void gui_init(dt_lib_module_t *self)
                                          _filter_get_items(sort), _lib_filter_sort_combobox_changed, self,
                                          _sort_names);
   gtk_box_pack_start(GTK_BOX(hbox), d->sort, FALSE, FALSE, 0);
-  dt_util_add_class(hbox, "quick_filter_box");
-  dt_util_add_class(hbox, "dt_font_resize_07");
+  dt_gui_add_class(hbox, "quick_filter_box");
+  dt_gui_add_class(hbox, "dt_font_resize_07");
 
   /* reverse order checkbutton */
   d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
@@ -479,7 +479,7 @@ void gui_init(dt_lib_module_t *self)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
                                  CPF_DIRECTION_DOWN, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), d->reverse, FALSE, FALSE, 0);
-  dt_util_add_class(d->reverse, "dt_transparent_background");
+  dt_gui_add_class(d->reverse, "dt_transparent_background");
 
   /* select the last value and connect callback */
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse),

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -155,9 +155,8 @@ int position()
 
 static void _set_widget_dimmed(GtkWidget *widget, const gboolean dimmed)
 {
-  GtkStyleContext *context = gtk_widget_get_style_context(widget);
-  if(dimmed) gtk_style_context_add_class(context, "dt_dimmed");
-  else gtk_style_context_remove_class(context, "dt_dimmed");
+  if(dimmed) dt_util_add_class(widget, "dt_dimmed");
+  else dt_util_remove_class(widget, "dt_dimmed");
   gtk_widget_queue_draw(GTK_WIDGET(widget));
 }
 
@@ -408,8 +407,7 @@ void gui_init(dt_lib_module_t *self)
                                N_("all except rejected"));
   gtk_container_add(GTK_CONTAINER(overlay), d->stars);
   gtk_box_pack_start(GTK_BOX(hbox), overlay, FALSE, FALSE, 0);
-  GtkStyleContext *context = gtk_widget_get_style_context(hbox);
-  gtk_style_context_add_class(context, "quick_filter_box");
+  dt_util_add_class(hbox, "quick_filter_box");
 
   // colorlabels filter
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -432,9 +430,8 @@ void gui_init(dt_lib_module_t *self)
                                               "\nor (∪): images with at least one of the selected color labels"));
   g_signal_connect(G_OBJECT(d->colors_op), "clicked", G_CALLBACK(_colors_operation_clicked), self);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 2);
-  context = gtk_widget_get_style_context(hbox);
-  gtk_style_context_add_class(context, "quick_filter_box");
-  gtk_style_context_add_class(context, "dt_font_resize_07");
+  dt_util_add_class(hbox, "quick_filter_box");
+  dt_util_add_class(hbox, "dt_font_resize_07");
 
   // text filter
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -457,11 +454,9 @@ void gui_init(dt_lib_module_t *self)
                                 "\nstarting or ending with a double quote disables the corresponding wildcard"
           /* xgettext:no-c-format */
                                 "\nis dimmed during the search execution"));
-  context = gtk_widget_get_style_context(d->text);
-  gtk_style_context_add_class(context, "dt_transparent_background");
+  dt_util_add_class(d->text, "dt_transparent_background");
   gtk_box_pack_start(GTK_BOX(hbox), d->text, FALSE, FALSE, 0);
-  context = gtk_widget_get_style_context(hbox);
-  gtk_style_context_add_class(context, "quick_filter_box");
+  dt_util_add_class(hbox, "quick_filter_box");
 
   /* sort combobox */
   label = gtk_label_new(_("sort by"));
@@ -475,9 +470,8 @@ void gui_init(dt_lib_module_t *self)
                                          _filter_get_items(sort), _lib_filter_sort_combobox_changed, self,
                                          _sort_names);
   gtk_box_pack_start(GTK_BOX(hbox), d->sort, FALSE, FALSE, 0);
-  context = gtk_widget_get_style_context(hbox);
-  gtk_style_context_add_class(context, "quick_filter_box");
-  gtk_style_context_add_class(context, "dt_font_resize_07");
+  dt_util_add_class(hbox, "quick_filter_box");
+  dt_util_add_class(hbox, "dt_font_resize_07");
 
   /* reverse order checkbutton */
   d->reverse = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
@@ -485,8 +479,7 @@ void gui_init(dt_lib_module_t *self)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
                                  CPF_DIRECTION_DOWN, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), d->reverse, FALSE, FALSE, 0);
-  context = gtk_widget_get_style_context(d->reverse);
-  gtk_style_context_add_class(context, "dt_transparent_background");
+  dt_util_add_class(d->reverse, "dt_transparent_background");
 
   /* select the last value and connect callback */
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse),

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2723,10 +2723,9 @@ static void _on_drag_begin(GtkWidget *widget, GdkDragContext *context, gpointer 
       cairo_t *cr = cairo_create(surface);
 
       // hack to render not transparent
-      GtkStyleContext *style_context = gtk_widget_get_style_context(module_src->header);
-      gtk_style_context_add_class(style_context, "iop_drag_icon");
+      dt_util_add_class(module_src->header, "iop_drag_icon");
       gtk_widget_draw(module_src->header, cr);
-      gtk_style_context_remove_class(style_context, "iop_drag_icon");
+      dt_util_remove_class(module_src->header, "iop_drag_icon");
 
       // FIXME: this centers the icon on the mouse -- instead translate such that the label doesn't jump when mouse down?
       cairo_surface_set_device_offset(surface, -allocation_w.width * darktable.gui->ppd / 2, -allocation_w.height * darktable.gui->ppd / 2);
@@ -2785,19 +2784,17 @@ static gboolean _on_drag_motion(GtkWidget *widget, GdkDragContext *dc, gint x, g
 
     if(module->expander)
     {
-      GtkStyleContext *context = gtk_widget_get_style_context(module->expander);
-      gtk_style_context_remove_class(context, "iop_drop_after");
-      gtk_style_context_remove_class(context, "iop_drop_before");
+      dt_util_remove_class(module->expander, "iop_drop_after");
+      dt_util_remove_class(module->expander, "iop_drop_before");
     }
   }
 
   if(can_moved)
   {
-    GtkStyleContext *context = gtk_widget_get_style_context(module_dest->expander);
     if(module_src->iop_order < module_dest->iop_order)
-      gtk_style_context_add_class(context, "iop_drop_after");
+      dt_util_add_class(module_dest->expander, "iop_drop_after");
     else
-      gtk_style_context_add_class(context, "iop_drop_before");
+      dt_util_add_class(module_dest->expander, "iop_drop_before");
 
     gdk_drag_status(dc, GDK_ACTION_COPY, time);
     GtkWidget *w = g_object_get_data(G_OBJECT(widget), "highlighted");
@@ -2859,9 +2856,8 @@ static void _on_drag_data_received(GtkWidget *widget, GdkDragContext *dc, gint x
 
     if(module->expander)
     {
-      GtkStyleContext *context = gtk_widget_get_style_context(module->expander);
-      gtk_style_context_remove_class(context, "iop_drop_after");
-      gtk_style_context_remove_class(context, "iop_drop_before");
+      dt_util_remove_class(module->expander, "iop_drop_after");
+      dt_util_remove_class(module->expander, "iop_drop_before");
     }
   }
 
@@ -2902,9 +2898,8 @@ static void _on_drag_leave(GtkWidget *widget, GdkDragContext *dc, guint time, gp
 
     if(module->expander)
     {
-      GtkStyleContext *context = gtk_widget_get_style_context(module->expander);
-      gtk_style_context_remove_class(context, "iop_drop_after");
-      gtk_style_context_remove_class(context, "iop_drop_before");
+      dt_util_remove_class(module->expander, "iop_drop_after");
+      dt_util_remove_class(module->expander, "iop_drop_before");
     }
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2723,9 +2723,9 @@ static void _on_drag_begin(GtkWidget *widget, GdkDragContext *context, gpointer 
       cairo_t *cr = cairo_create(surface);
 
       // hack to render not transparent
-      dt_util_add_class(module_src->header, "iop_drag_icon");
+      dt_gui_add_class(module_src->header, "iop_drag_icon");
       gtk_widget_draw(module_src->header, cr);
-      dt_util_remove_class(module_src->header, "iop_drag_icon");
+      dt_gui_remove_class(module_src->header, "iop_drag_icon");
 
       // FIXME: this centers the icon on the mouse -- instead translate such that the label doesn't jump when mouse down?
       cairo_surface_set_device_offset(surface, -allocation_w.width * darktable.gui->ppd / 2, -allocation_w.height * darktable.gui->ppd / 2);
@@ -2784,17 +2784,17 @@ static gboolean _on_drag_motion(GtkWidget *widget, GdkDragContext *dc, gint x, g
 
     if(module->expander)
     {
-      dt_util_remove_class(module->expander, "iop_drop_after");
-      dt_util_remove_class(module->expander, "iop_drop_before");
+      dt_gui_remove_class(module->expander, "iop_drop_after");
+      dt_gui_remove_class(module->expander, "iop_drop_before");
     }
   }
 
   if(can_moved)
   {
     if(module_src->iop_order < module_dest->iop_order)
-      dt_util_add_class(module_dest->expander, "iop_drop_after");
+      dt_gui_add_class(module_dest->expander, "iop_drop_after");
     else
-      dt_util_add_class(module_dest->expander, "iop_drop_before");
+      dt_gui_add_class(module_dest->expander, "iop_drop_before");
 
     gdk_drag_status(dc, GDK_ACTION_COPY, time);
     GtkWidget *w = g_object_get_data(G_OBJECT(widget), "highlighted");
@@ -2856,8 +2856,8 @@ static void _on_drag_data_received(GtkWidget *widget, GdkDragContext *dc, gint x
 
     if(module->expander)
     {
-      dt_util_remove_class(module->expander, "iop_drop_after");
-      dt_util_remove_class(module->expander, "iop_drop_before");
+      dt_gui_remove_class(module->expander, "iop_drop_after");
+      dt_gui_remove_class(module->expander, "iop_drop_before");
     }
   }
 
@@ -2898,8 +2898,8 @@ static void _on_drag_leave(GtkWidget *widget, GdkDragContext *dc, guint time, gp
 
     if(module->expander)
     {
-      dt_util_remove_class(module->expander, "iop_drop_after");
-      dt_util_remove_class(module->expander, "iop_drop_before");
+      dt_gui_remove_class(module->expander, "iop_drop_after");
+      dt_gui_remove_class(module->expander, "iop_drop_before");
     }
   }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1211,7 +1211,7 @@ static void _accels_window_sticky(GtkWidget *widget, GdkEventButton *event, dt_v
 
   // creating new window
   GtkWindow *win = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
-  dt_util_add_class(GTK_WIDGET(win), "accels_window");
+  dt_gui_add_class(GTK_WIDGET(win), "accels_window");
   gtk_window_set_title(win, _("darktable - accels window"));
   GtkAllocation alloc;
   gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
@@ -1245,15 +1245,15 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(vm->accels_window.window);
 #endif
-  dt_util_add_class(vm->accels_window.window, "accels_window");
+  dt_gui_add_class(vm->accels_window.window, "accels_window");
 
   GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
-  dt_util_add_class(sw, "accels_window_scroll");
+  dt_gui_add_class(sw, "accels_window_scroll");
 
   GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
   vm->accels_window.flow_box = gtk_flow_box_new();
-  dt_util_add_class(vm->accels_window.flow_box, "accels_window_box");
+  dt_gui_add_class(vm->accels_window.flow_box, "accels_window_box");
   gtk_orientable_set_orientation(GTK_ORIENTABLE(vm->accels_window.flow_box), GTK_ORIENTATION_HORIZONTAL);
 
   gtk_box_pack_start(GTK_BOX(hb), vm->accels_window.flow_box, TRUE, TRUE, 0);
@@ -1265,7 +1265,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
                _("switch to a classic window which will stay open after key release"), (char *)NULL);
   g_signal_connect(G_OBJECT(vm->accels_window.sticky_btn), "button-press-event", G_CALLBACK(_accels_window_sticky),
                    vm);
-  dt_util_add_class(vm->accels_window.sticky_btn, "accels_window_stick");
+  dt_gui_add_class(vm->accels_window.sticky_btn, "accels_window_stick");
   gtk_box_pack_start(GTK_BOX(vb), vm->accels_window.sticky_btn, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, FALSE, 0);
 
@@ -1350,7 +1350,7 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     // the title
     GtkWidget *lb = gtk_label_new(category->label);
-    dt_util_add_class(lb, "accels_window_cat_title");
+    dt_gui_add_class(lb, "accels_window_cat_title");
     gtk_box_pack_start(GTK_BOX(box), lb, FALSE, FALSE, 0);
 
     // the list of accels
@@ -1359,7 +1359,7 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
     {
       GtkWidget *list = gtk_tree_view_new_with_model(model);
       g_object_unref(model);
-      dt_util_add_class(list, "accels_window_list");
+      dt_gui_add_class(list, "accels_window_list");
       GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
       GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("shortcut"), renderer, "text", 0, NULL);
       gtk_tree_view_append_column(GTK_TREE_VIEW(list), column);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1211,8 +1211,7 @@ static void _accels_window_sticky(GtkWidget *widget, GdkEventButton *event, dt_v
 
   // creating new window
   GtkWindow *win = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
-  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(win));
-  gtk_style_context_add_class(context, "accels_window");
+  dt_util_add_class(GTK_WIDGET(win), "accels_window");
   gtk_window_set_title(win, _("darktable - accels window"));
   GtkAllocation alloc;
   gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
@@ -1242,24 +1241,19 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 
   vm->accels_window.sticky = FALSE;
   vm->accels_window.prevent_refresh = FALSE;
-
-  GtkStyleContext *context;
   vm->accels_window.window = gtk_window_new(GTK_WINDOW_POPUP);
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(vm->accels_window.window);
 #endif
-  context = gtk_widget_get_style_context(vm->accels_window.window);
-  gtk_style_context_add_class(context, "accels_window");
+  dt_util_add_class(vm->accels_window.window, "accels_window");
 
   GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
-  context = gtk_widget_get_style_context(sw);
-  gtk_style_context_add_class(context, "accels_window_scroll");
+  dt_util_add_class(sw, "accels_window_scroll");
 
   GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
   vm->accels_window.flow_box = gtk_flow_box_new();
-  context = gtk_widget_get_style_context(vm->accels_window.flow_box);
-  gtk_style_context_add_class(context, "accels_window_box");
+  dt_util_add_class(vm->accels_window.flow_box, "accels_window_box");
   gtk_orientable_set_orientation(GTK_ORIENTABLE(vm->accels_window.flow_box), GTK_ORIENTATION_HORIZONTAL);
 
   gtk_box_pack_start(GTK_BOX(hb), vm->accels_window.flow_box, TRUE, TRUE, 0);
@@ -1271,8 +1265,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
                _("switch to a classic window which will stay open after key release"), (char *)NULL);
   g_signal_connect(G_OBJECT(vm->accels_window.sticky_btn), "button-press-event", G_CALLBACK(_accels_window_sticky),
                    vm);
-  context = gtk_widget_get_style_context(vm->accels_window.sticky_btn);
-  gtk_style_context_add_class(context, "accels_window_stick");
+  dt_util_add_class(vm->accels_window.sticky_btn, "accels_window_stick");
   gtk_box_pack_start(GTK_BOX(vb), vm->accels_window.sticky_btn, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, FALSE, 0);
 
@@ -1357,8 +1350,7 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     // the title
     GtkWidget *lb = gtk_label_new(category->label);
-    GtkStyleContext *context = gtk_widget_get_style_context(lb);
-    gtk_style_context_add_class(context, "accels_window_cat_title");
+    dt_util_add_class(lb, "accels_window_cat_title");
     gtk_box_pack_start(GTK_BOX(box), lb, FALSE, FALSE, 0);
 
     // the list of accels
@@ -1367,8 +1359,7 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
     {
       GtkWidget *list = gtk_tree_view_new_with_model(model);
       g_object_unref(model);
-      context = gtk_widget_get_style_context(list);
-      gtk_style_context_add_class(context, "accels_window_list");
+      dt_util_add_class(list, "accels_window_list");
       GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
       GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("shortcut"), renderer, "text", 0, NULL);
       gtk_tree_view_append_column(GTK_TREE_VIEW(list), column);


### PR DESCRIPTION
This fix some minor issues from my last PR, like blending tabs background color was same as module frame one for grey theme. Fix also known misalignment for icons on bauhaus lines I changed (filmicrgb and toneequal)

This also improve history stack with better status icon sizes and better alignment by setting together all items in each lines:

![image](https://user-images.githubusercontent.com/45535283/161425867-aa7aec54-5e09-404b-ad81-c0d7a565b3c3.png)

And more, this starting set classes in a better way by adding add and remove class functions. This save more more than 40 lines in Gtk code actually.

Next step will be, for that PR, to add new classes and reduce/simplify CSS code, beginning by setting a class for history stack items.

@AlicVB and @TurboGit: some review of my code, especially big change in class functions, is welcomed as soon as you can to be sure, I do not make mistake. Compiling is good on my side and on my testing, I didn't notice anything that could had been broken in the UI.

First time I changed so much files!