### PR TITLE
Fix possible free() errors in dt_opencl_events_get_slot()

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 #define DT_OPENCL_MAX_KERNELS 512
 #define DT_OPENCL_EVENTLISTSIZE 256
 #define DT_OPENCL_EVENTNAMELENGTH 64
-#define DT_OPENCL_MAX_EVENTS 256
 #define DT_OPENCL_MAX_ERRORS 5
 #define DT_OPENCL_MAX_INCLUDES 7
 #define DT_OPENCL_VENDOR_AMD 4098


### PR DESCRIPTION
- when we calloc the eventlist and eventtags we might run into an allocation error, as free
is not stable on all OS if called with NULL we have to check here.

- added some debug information

Still not sure if the code for a growing buffer is absolutely safe as is. Sure the code section is
mutex-protected upstream, i guess we might want to do a realloc instead of alloc & memcpy here as
the cl driver might want access to old addresses?

@TurboGit (pinging you here as i can't find a button to request a review) could you review that code section?