### PR TITLE
bauhaus combox alignment

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -93,7 +93,8 @@ typedef struct dt_bauhaus_slider_data_t
 typedef enum dt_bauhaus_combobox_alignment_t
 {
   DT_BAUHAUS_COMBOBOX_ALIGN_LEFT = 0,
-  DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT = 1
+  DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT = 1,
+  DT_BAUHAUS_COMBOBOX_ALIGN_MIDDLE = 2
 } dt_bauhaus_combobox_alignment_t;
 
 // data portion for a combobox

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1266,6 +1266,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->intent, _("relative colorimetric"));
   dt_bauhaus_combobox_add(d->intent, C_("rendering intent", "saturation"));
   dt_bauhaus_combobox_add(d->intent, _("absolute colorimetric"));
+  dt_bauhaus_combobox_set_selected_text_align(d->intent, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
   gtk_box_pack_start(GTK_BOX(self->widget), d->intent, FALSE, TRUE, 0);
 
   tooltip = g_strdup_printf(_("• perceptual : "

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1266,7 +1266,6 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->intent, _("relative colorimetric"));
   dt_bauhaus_combobox_add(d->intent, C_("rendering intent", "saturation"));
   dt_bauhaus_combobox_add(d->intent, _("absolute colorimetric"));
-  dt_bauhaus_combobox_set_selected_text_align(d->intent, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
   gtk_box_pack_start(GTK_BOX(self->widget), d->intent, FALSE, TRUE, 0);
 
   tooltip = g_strdup_printf(_("• perceptual : "


### PR DESCRIPTION
this contain : 
- hide label if selected text is aligned on left (currently they are drawn at the same place)
- fix left align in combo popup for the first line
- implement middle alignment for bauhaus selected text and bauhaus popup (same as for left align : label is not drawn)

for information, I need last point to get a more consistent UI for my filtering module ;)