### PR TITLE
Fix premature darktable-gen-noiseprofile exit

### DIFF
--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -450,7 +450,7 @@ export_large_jpeg() {
 	tool_installed darktable-cli
 
 	rm -f "$output" "$xmp"
-	darktable-cli "$input" "$output" &> /tmp/dt_output.log  || echo $(cat /tmp/dt_output.log); exit 1
+	darktable-cli "$input" "$output" &> /tmp/dt_output.log  || (echo $(cat /tmp/dt_output.log); exit 1)
 	rm -f "$xmp"
 }
 


### PR DESCRIPTION
`darktable-gen-noiseprofile` quits after each `-large.jpg` generation due to stray `exit 1`.