### PR TITLE
Safer extending of OpenCl eventlist

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1354,13 +1354,13 @@ void dt_get_sysresource_level()
     const int oldgrp = darktable.dtresources.group;
     darktable.dtresources.group = 4 * level;
     fprintf(stderr,"[dt_get_sysresource_level] switched to %i as `%s'\n", level, config);
-    fprintf(stderr,"  total mem:        %luMB\n", darktable.dtresources.total_memory / 1024lu / 1024lu);
-    fprintf(stderr,"  mipmap cache:     %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
-    fprintf(stderr,"  available mem:    %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
-    fprintf(stderr,"  singlebuff:       %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
+    fprintf(stderr,"  total mem:       %luMB\n", darktable.dtresources.total_memory / 1024lu / 1024lu);
+    fprintf(stderr,"  mipmap cache:    %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
+    fprintf(stderr,"  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
+    fprintf(stderr,"  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
 #ifdef HAVE_OPENCL
-    fprintf(stderr,"  OpenCL available: %s\n", ((darktable.dtresources.tunememory) && (level >= 0)) ? "ON" : "OFF");
-    fprintf(stderr,"  OpenCL pinned:    %s\n", ((darktable.dtresources.tunepinning) && (level >= 0)) ? "ON" : "OFF");
+    fprintf(stderr,"  OpenCL tune mem: %s\n", ((darktable.dtresources.tunememory) && (level >= 0)) ? "ON" : "OFF");
+    fprintf(stderr,"  OpenCL pinned:   %s\n", ((darktable.dtresources.tunepinning) && (level >= 0)) ? "ON" : "OFF");
 #endif
     darktable.dtresources.group = oldgrp;
   }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 #define DT_OPENCL_MAX_KERNELS 512
 #define DT_OPENCL_EVENTLISTSIZE 256
 #define DT_OPENCL_EVENTNAMELENGTH 64
-#define DT_OPENCL_MAX_EVENTS 256
 #define DT_OPENCL_MAX_ERRORS 5
 #define DT_OPENCL_MAX_INCLUDES 7
 #define DT_OPENCL_VENDOR_AMD 4098
@@ -127,6 +126,7 @@ typedef struct dt_opencl_device_t
   int totalevents;
   int totalsuccess;
   int totallost;
+  int maxeventslot;
   int nvidia_sm_20;
   const char *vendor;
   const char *name;


### PR DESCRIPTION
In `cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)` we should check for
a required enlargement of the eventlist and do a `dt_opencl_events_flush(devid, 0)` before doing so.

As the number of event handles in the list can easily grow to several thousands if heavy tiling is involved,
unfortunately we can't check for a drivers restriction on the possible number of handles, (should be possible
with OpenCL >=V2) at least we now keep track of the maximum slot in use and report that later to get an idea
in bug reports.

The opencl_number_event_handles should be per-device, will require more analysis on unsynchronized opencl and
multiple devices, so not now.

Some more precise debugging info has been added too.