### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: darktable\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-13 10:50+0100\n"
-"PO-Revision-Date: 2022-03-16 10:13+0100\n"
+"POT-Creation-Date: 2022-04-05 19:08+0200\n"
+"PO-Revision-Date: 2022-04-08 19:59+0200\n"
 "Last-Translator: Martin Straeten <martin.straeten@gmail.com>\n"
 "Language-Team: German <>\n"
 "Language: de_DE\n"
@@ -16,152 +16,153 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-Bookmarks: 3066,376,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
-#: ../build/bin/preferences_gen.h:81 ../build/bin/preferences_gen.h:3891
-#: ../build/bin/preferences_gen.h:3927 ../build/bin/preferences_gen.h:3963
-#: ../build/bin/preferences_gen.h:3999 ../build/bin/preferences_gen.h:4035
-#: ../build/bin/preferences_gen.h:4071 ../build/bin/preferences_gen.h:4107
-#: ../build/bin/preferences_gen.h:4151 ../build/bin/preferences_gen.h:4246
-#: ../build/bin/preferences_gen.h:4341 ../build/bin/preferences_gen.h:4381
-#: ../build/bin/preferences_gen.h:4424 ../build/bin/preferences_gen.h:4496
-#: ../build/bin/preferences_gen.h:4576 ../build/bin/preferences_gen.h:4641
-#: ../build/bin/preferences_gen.h:4677 ../build/bin/preferences_gen.h:4720
-#: ../build/bin/preferences_gen.h:4794 ../build/bin/preferences_gen.h:4839
-#: ../build/bin/preferences_gen.h:4875 ../build/bin/preferences_gen.h:4940
-#: ../build/bin/preferences_gen.h:5010 ../build/bin/preferences_gen.h:5054
-#: ../build/bin/preferences_gen.h:5114 ../build/bin/preferences_gen.h:5150
-#: ../build/bin/preferences_gen.h:5186 ../build/bin/preferences_gen.h:5222
-#: ../build/bin/preferences_gen.h:5258 ../build/bin/preferences_gen.h:5294
-#: ../build/bin/preferences_gen.h:5330 ../build/bin/preferences_gen.h:5395
-#: ../build/bin/preferences_gen.h:5460 ../build/bin/preferences_gen.h:5550
-#: ../build/bin/preferences_gen.h:5586 ../build/bin/preferences_gen.h:5651
-#: ../build/bin/preferences_gen.h:5687 ../build/bin/preferences_gen.h:5752
-#: ../build/bin/preferences_gen.h:5822 ../build/bin/preferences_gen.h:5865
-#: ../build/bin/preferences_gen.h:5930 ../build/bin/preferences_gen.h:5990
-#: ../build/bin/preferences_gen.h:6026 ../build/bin/preferences_gen.h:6062
-#: ../build/bin/preferences_gen.h:6098 ../build/bin/preferences_gen.h:6142
-#: ../build/bin/preferences_gen.h:6212 ../build/bin/preferences_gen.h:6248
-#: ../build/bin/preferences_gen.h:6284 ../build/bin/preferences_gen.h:6320
-#: ../build/bin/preferences_gen.h:6362 ../build/bin/preferences_gen.h:6433
-#: ../build/bin/preferences_gen.h:6504 ../build/bin/preferences_gen.h:6540
-#: ../build/bin/preferences_gen.h:6576 ../build/bin/preferences_gen.h:6612
-#: ../build/bin/preferences_gen.h:6648 ../build/bin/preferences_gen.h:6684
-#: ../build/bin/preferences_gen.h:6720 ../build/bin/preferences_gen.h:6756
-#: ../build/bin/preferences_gen.h:6791 ../build/bin/preferences_gen.h:6826
-#: ../build/bin/preferences_gen.h:6862 ../build/bin/preferences_gen.h:6906
-#: ../build/bin/preferences_gen.h:6978 ../build/bin/preferences_gen.h:7047
-#: ../build/bin/preferences_gen.h:7132 ../build/bin/preferences_gen.h:7177
-#: ../build/bin/preferences_gen.h:7252 ../build/bin/preferences_gen.h:7305
-#: ../build/bin/preferences_gen.h:7370 ../build/bin/preferences_gen.h:7435
-#: ../build/bin/preferences_gen.h:7500 ../build/bin/preferences_gen.h:7536
-#: ../build/bin/preferences_gen.h:7572 ../build/bin/preferences_gen.h:7608
-#: ../build/bin/preferences_gen.h:7644 ../build/bin/preferences_gen.h:7704
-#: ../build/bin/preferences_gen.h:7777 ../build/bin/preferences_gen.h:7822
-#: ../build/bin/preferences_gen.h:7858 ../build/bin/preferences_gen.h:7894
-#: ../build/bin/preferences_gen.h:7930 ../build/bin/preferences_gen.h:7966
-#: ../build/bin/preferences_gen.h:8026 ../build/bin/preferences_gen.h:8070
-#: ../build/bin/preferences_gen.h:8114 ../build/bin/preferences_gen.h:8187
-#: ../build/bin/preferences_gen.h:8227 ../build/bin/preferences_gen.h:8267
-#: ../build/bin/preferences_gen.h:8303 ../build/bin/preferences_gen.h:8358
-#: ../build/bin/preferences_gen.h:8394 ../build/bin/preferences_gen.h:8454
-#: ../build/bin/preferences_gen.h:8500 ../build/bin/preferences_gen.h:8560
-#: ../build/bin/preferences_gen.h:8612 ../build/bin/preferences_gen.h:8690
-#: ../build/bin/preferences_gen.h:8736
+#: ../build/bin/preferences_gen.h:81 ../build/bin/preferences_gen.h:3970
+#: ../build/bin/preferences_gen.h:4006 ../build/bin/preferences_gen.h:4042
+#: ../build/bin/preferences_gen.h:4078 ../build/bin/preferences_gen.h:4114
+#: ../build/bin/preferences_gen.h:4150 ../build/bin/preferences_gen.h:4186
+#: ../build/bin/preferences_gen.h:4230 ../build/bin/preferences_gen.h:4325
+#: ../build/bin/preferences_gen.h:4420 ../build/bin/preferences_gen.h:4460
+#: ../build/bin/preferences_gen.h:4503 ../build/bin/preferences_gen.h:4575
+#: ../build/bin/preferences_gen.h:4655 ../build/bin/preferences_gen.h:4720
+#: ../build/bin/preferences_gen.h:4756 ../build/bin/preferences_gen.h:4799
+#: ../build/bin/preferences_gen.h:4873 ../build/bin/preferences_gen.h:4918
+#: ../build/bin/preferences_gen.h:4954 ../build/bin/preferences_gen.h:5019
+#: ../build/bin/preferences_gen.h:5089 ../build/bin/preferences_gen.h:5133
+#: ../build/bin/preferences_gen.h:5193 ../build/bin/preferences_gen.h:5229
+#: ../build/bin/preferences_gen.h:5265 ../build/bin/preferences_gen.h:5301
+#: ../build/bin/preferences_gen.h:5337 ../build/bin/preferences_gen.h:5373
+#: ../build/bin/preferences_gen.h:5409 ../build/bin/preferences_gen.h:5474
+#: ../build/bin/preferences_gen.h:5539 ../build/bin/preferences_gen.h:5629
+#: ../build/bin/preferences_gen.h:5665 ../build/bin/preferences_gen.h:5730
+#: ../build/bin/preferences_gen.h:5766 ../build/bin/preferences_gen.h:5831
+#: ../build/bin/preferences_gen.h:5901 ../build/bin/preferences_gen.h:5944
+#: ../build/bin/preferences_gen.h:6009 ../build/bin/preferences_gen.h:6069
+#: ../build/bin/preferences_gen.h:6105 ../build/bin/preferences_gen.h:6141
+#: ../build/bin/preferences_gen.h:6177 ../build/bin/preferences_gen.h:6221
+#: ../build/bin/preferences_gen.h:6291 ../build/bin/preferences_gen.h:6327
+#: ../build/bin/preferences_gen.h:6363 ../build/bin/preferences_gen.h:6399
+#: ../build/bin/preferences_gen.h:6441 ../build/bin/preferences_gen.h:6512
+#: ../build/bin/preferences_gen.h:6617 ../build/bin/preferences_gen.h:6653
+#: ../build/bin/preferences_gen.h:6689 ../build/bin/preferences_gen.h:6725
+#: ../build/bin/preferences_gen.h:6761 ../build/bin/preferences_gen.h:6797
+#: ../build/bin/preferences_gen.h:6833 ../build/bin/preferences_gen.h:6869
+#: ../build/bin/preferences_gen.h:6904 ../build/bin/preferences_gen.h:6939
+#: ../build/bin/preferences_gen.h:6975 ../build/bin/preferences_gen.h:7019
+#: ../build/bin/preferences_gen.h:7091 ../build/bin/preferences_gen.h:7160
+#: ../build/bin/preferences_gen.h:7245 ../build/bin/preferences_gen.h:7290
+#: ../build/bin/preferences_gen.h:7365 ../build/bin/preferences_gen.h:7418
+#: ../build/bin/preferences_gen.h:7483 ../build/bin/preferences_gen.h:7548
+#: ../build/bin/preferences_gen.h:7613 ../build/bin/preferences_gen.h:7649
+#: ../build/bin/preferences_gen.h:7685 ../build/bin/preferences_gen.h:7721
+#: ../build/bin/preferences_gen.h:7757 ../build/bin/preferences_gen.h:7793
+#: ../build/bin/preferences_gen.h:7853 ../build/bin/preferences_gen.h:7918
+#: ../build/bin/preferences_gen.h:7972 ../build/bin/preferences_gen.h:8017
+#: ../build/bin/preferences_gen.h:8053 ../build/bin/preferences_gen.h:8089
+#: ../build/bin/preferences_gen.h:8125 ../build/bin/preferences_gen.h:8161
+#: ../build/bin/preferences_gen.h:8221 ../build/bin/preferences_gen.h:8265
+#: ../build/bin/preferences_gen.h:8309 ../build/bin/preferences_gen.h:8382
+#: ../build/bin/preferences_gen.h:8422 ../build/bin/preferences_gen.h:8462
+#: ../build/bin/preferences_gen.h:8498 ../build/bin/preferences_gen.h:8553
+#: ../build/bin/preferences_gen.h:8589 ../build/bin/preferences_gen.h:8649
+#: ../build/bin/preferences_gen.h:8695 ../build/bin/preferences_gen.h:8755
+#: ../build/bin/preferences_gen.h:8807 ../build/bin/preferences_gen.h:8885
+#: ../build/bin/preferences_gen.h:8931
 msgid "this setting has been modified"
 msgstr "Diese Voreinstellung wurde angepasst"
 
-#: ../build/bin/preferences_gen.h:3871 ../src/gui/preferences.c:537
+#: ../build/bin/preferences_gen.h:3950 ../src/gui/preferences.c:537
 #: ../src/libs/tools/lighttable.c:68 ../src/views/lighttable.c:88
 msgid "lighttable"
 msgstr "Leuchttisch"
 
-#: ../build/bin/preferences_gen.h:3874 ../build/bin/preferences_gen.h:4479
-#: ../build/bin/preferences_gen.h:6487 ../src/gui/preferences.c:271
+#: ../build/bin/preferences_gen.h:3953 ../build/bin/preferences_gen.h:4558
+#: ../build/bin/preferences_gen.h:6600 ../src/gui/preferences.c:271
 msgid "general"
 msgstr "Allgemeines"
 
-#: ../build/bin/preferences_gen.h:3894
+#: ../build/bin/preferences_gen.h:3973
 msgid "hide built-in presets for utility modules"
 msgstr "Voreinstellung für Leuchttisch-Module ausblenden"
 
-#: ../build/bin/preferences_gen.h:3905 ../build/bin/preferences_gen.h:3941
-#: ../build/bin/preferences_gen.h:3977 ../build/bin/preferences_gen.h:4013
-#: ../build/bin/preferences_gen.h:4049 ../build/bin/preferences_gen.h:4085
-#: ../build/bin/preferences_gen.h:4121 ../build/bin/preferences_gen.h:4224
-#: ../build/bin/preferences_gen.h:4319 ../build/bin/preferences_gen.h:4359
-#: ../build/bin/preferences_gen.h:4402 ../build/bin/preferences_gen.h:4445
-#: ../build/bin/preferences_gen.h:4554 ../build/bin/preferences_gen.h:4619
-#: ../build/bin/preferences_gen.h:4655 ../build/bin/preferences_gen.h:4698
-#: ../build/bin/preferences_gen.h:4773 ../build/bin/preferences_gen.h:4853
-#: ../build/bin/preferences_gen.h:4918 ../build/bin/preferences_gen.h:4988
-#: ../build/bin/preferences_gen.h:5024 ../build/bin/preferences_gen.h:5092
-#: ../build/bin/preferences_gen.h:5128 ../build/bin/preferences_gen.h:5164
-#: ../build/bin/preferences_gen.h:5200 ../build/bin/preferences_gen.h:5236
-#: ../build/bin/preferences_gen.h:5272 ../build/bin/preferences_gen.h:5308
-#: ../build/bin/preferences_gen.h:5373 ../build/bin/preferences_gen.h:5438
-#: ../build/bin/preferences_gen.h:5528 ../build/bin/preferences_gen.h:5564
-#: ../build/bin/preferences_gen.h:5600 ../build/bin/preferences_gen.h:5665
-#: ../build/bin/preferences_gen.h:5730 ../build/bin/preferences_gen.h:5800
-#: ../build/bin/preferences_gen.h:5842 ../build/bin/preferences_gen.h:5908
-#: ../build/bin/preferences_gen.h:5968 ../build/bin/preferences_gen.h:6004
-#: ../build/bin/preferences_gen.h:6040 ../build/bin/preferences_gen.h:6076
-#: ../build/bin/preferences_gen.h:6112 ../build/bin/preferences_gen.h:6190
-#: ../build/bin/preferences_gen.h:6226 ../build/bin/preferences_gen.h:6262
-#: ../build/bin/preferences_gen.h:6298 ../build/bin/preferences_gen.h:6334
-#: ../build/bin/preferences_gen.h:6405 ../build/bin/preferences_gen.h:6447
-#: ../build/bin/preferences_gen.h:6518 ../build/bin/preferences_gen.h:6554
-#: ../build/bin/preferences_gen.h:6590 ../build/bin/preferences_gen.h:6626
-#: ../build/bin/preferences_gen.h:6662 ../build/bin/preferences_gen.h:6698
-#: ../build/bin/preferences_gen.h:6734 ../build/bin/preferences_gen.h:6770
-#: ../build/bin/preferences_gen.h:6805 ../build/bin/preferences_gen.h:6840
-#: ../build/bin/preferences_gen.h:6876 ../build/bin/preferences_gen.h:6956
-#: ../build/bin/preferences_gen.h:6996 ../build/bin/preferences_gen.h:7110
-#: ../build/bin/preferences_gen.h:7230 ../build/bin/preferences_gen.h:7348
-#: ../build/bin/preferences_gen.h:7413 ../build/bin/preferences_gen.h:7449
-#: ../build/bin/preferences_gen.h:7514 ../build/bin/preferences_gen.h:7550
-#: ../build/bin/preferences_gen.h:7586 ../build/bin/preferences_gen.h:7622
-#: ../build/bin/preferences_gen.h:7682 ../build/bin/preferences_gen.h:7747
-#: ../build/bin/preferences_gen.h:7791 ../build/bin/preferences_gen.h:7836
-#: ../build/bin/preferences_gen.h:7872 ../build/bin/preferences_gen.h:7908
-#: ../build/bin/preferences_gen.h:7944 ../build/bin/preferences_gen.h:8004
-#: ../build/bin/preferences_gen.h:8040 ../build/bin/preferences_gen.h:8084
-#: ../build/bin/preferences_gen.h:8205 ../build/bin/preferences_gen.h:8245
-#: ../build/bin/preferences_gen.h:8281 ../build/bin/preferences_gen.h:8321
-#: ../build/bin/preferences_gen.h:8372 ../build/bin/preferences_gen.h:8432
-#: ../build/bin/preferences_gen.h:8538 ../build/bin/preferences_gen.h:8574
+#: ../build/bin/preferences_gen.h:3984 ../build/bin/preferences_gen.h:4020
+#: ../build/bin/preferences_gen.h:4056 ../build/bin/preferences_gen.h:4092
+#: ../build/bin/preferences_gen.h:4128 ../build/bin/preferences_gen.h:4164
+#: ../build/bin/preferences_gen.h:4200 ../build/bin/preferences_gen.h:4303
+#: ../build/bin/preferences_gen.h:4398 ../build/bin/preferences_gen.h:4438
+#: ../build/bin/preferences_gen.h:4481 ../build/bin/preferences_gen.h:4524
+#: ../build/bin/preferences_gen.h:4633 ../build/bin/preferences_gen.h:4698
+#: ../build/bin/preferences_gen.h:4734 ../build/bin/preferences_gen.h:4777
+#: ../build/bin/preferences_gen.h:4852 ../build/bin/preferences_gen.h:4932
+#: ../build/bin/preferences_gen.h:4997 ../build/bin/preferences_gen.h:5067
+#: ../build/bin/preferences_gen.h:5103 ../build/bin/preferences_gen.h:5171
+#: ../build/bin/preferences_gen.h:5207 ../build/bin/preferences_gen.h:5243
+#: ../build/bin/preferences_gen.h:5279 ../build/bin/preferences_gen.h:5315
+#: ../build/bin/preferences_gen.h:5351 ../build/bin/preferences_gen.h:5387
+#: ../build/bin/preferences_gen.h:5452 ../build/bin/preferences_gen.h:5517
+#: ../build/bin/preferences_gen.h:5607 ../build/bin/preferences_gen.h:5643
+#: ../build/bin/preferences_gen.h:5679 ../build/bin/preferences_gen.h:5744
+#: ../build/bin/preferences_gen.h:5809 ../build/bin/preferences_gen.h:5879
+#: ../build/bin/preferences_gen.h:5921 ../build/bin/preferences_gen.h:5987
+#: ../build/bin/preferences_gen.h:6047 ../build/bin/preferences_gen.h:6083
+#: ../build/bin/preferences_gen.h:6119 ../build/bin/preferences_gen.h:6155
+#: ../build/bin/preferences_gen.h:6191 ../build/bin/preferences_gen.h:6269
+#: ../build/bin/preferences_gen.h:6305 ../build/bin/preferences_gen.h:6341
+#: ../build/bin/preferences_gen.h:6377 ../build/bin/preferences_gen.h:6413
+#: ../build/bin/preferences_gen.h:6484 ../build/bin/preferences_gen.h:6560
+#: ../build/bin/preferences_gen.h:6631 ../build/bin/preferences_gen.h:6667
+#: ../build/bin/preferences_gen.h:6703 ../build/bin/preferences_gen.h:6739
+#: ../build/bin/preferences_gen.h:6775 ../build/bin/preferences_gen.h:6811
+#: ../build/bin/preferences_gen.h:6847 ../build/bin/preferences_gen.h:6883
+#: ../build/bin/preferences_gen.h:6918 ../build/bin/preferences_gen.h:6953
+#: ../build/bin/preferences_gen.h:6989 ../build/bin/preferences_gen.h:7069
+#: ../build/bin/preferences_gen.h:7109 ../build/bin/preferences_gen.h:7223
+#: ../build/bin/preferences_gen.h:7343 ../build/bin/preferences_gen.h:7461
+#: ../build/bin/preferences_gen.h:7526 ../build/bin/preferences_gen.h:7562
+#: ../build/bin/preferences_gen.h:7627 ../build/bin/preferences_gen.h:7663
+#: ../build/bin/preferences_gen.h:7699 ../build/bin/preferences_gen.h:7735
+#: ../build/bin/preferences_gen.h:7771 ../build/bin/preferences_gen.h:7831
+#: ../build/bin/preferences_gen.h:7896 ../build/bin/preferences_gen.h:7936
+#: ../build/bin/preferences_gen.h:7986 ../build/bin/preferences_gen.h:8031
+#: ../build/bin/preferences_gen.h:8067 ../build/bin/preferences_gen.h:8103
+#: ../build/bin/preferences_gen.h:8139 ../build/bin/preferences_gen.h:8199
+#: ../build/bin/preferences_gen.h:8235 ../build/bin/preferences_gen.h:8279
+#: ../build/bin/preferences_gen.h:8400 ../build/bin/preferences_gen.h:8440
+#: ../build/bin/preferences_gen.h:8476 ../build/bin/preferences_gen.h:8516
+#: ../build/bin/preferences_gen.h:8567 ../build/bin/preferences_gen.h:8627
+#: ../build/bin/preferences_gen.h:8733 ../build/bin/preferences_gen.h:8769
 #: ../src/lua/preferences.c:682 ../src/lua/preferences.c:710
 #, c-format
 msgid "double click to reset to `%s'"
 msgstr "Doppelklick, um auf „%s” zurückzusetzen"
 
-#: ../build/bin/preferences_gen.h:3905 ../build/bin/preferences_gen.h:3941
-#: ../build/bin/preferences_gen.h:3977 ../build/bin/preferences_gen.h:4013
-#: ../build/bin/preferences_gen.h:4049 ../build/bin/preferences_gen.h:4121
-#: ../build/bin/preferences_gen.h:4655 ../build/bin/preferences_gen.h:4853
-#: ../build/bin/preferences_gen.h:5128 ../build/bin/preferences_gen.h:5272
-#: ../build/bin/preferences_gen.h:5600 ../build/bin/preferences_gen.h:5665
-#: ../build/bin/preferences_gen.h:6004 ../build/bin/preferences_gen.h:6076
-#: ../build/bin/preferences_gen.h:6226 ../build/bin/preferences_gen.h:6298
-#: ../build/bin/preferences_gen.h:6447 ../build/bin/preferences_gen.h:6734
-#: ../build/bin/preferences_gen.h:7449 ../build/bin/preferences_gen.h:7586
-#: ../build/bin/preferences_gen.h:7791 ../build/bin/preferences_gen.h:7872
-#: ../build/bin/preferences_gen.h:7908 ../build/bin/preferences_gen.h:7944
-#: ../build/bin/preferences_gen.h:8040 ../build/bin/preferences_gen.h:8281
-#: ../build/bin/preferences_gen.h:8372
+#: ../build/bin/preferences_gen.h:3984 ../build/bin/preferences_gen.h:4020
+#: ../build/bin/preferences_gen.h:4056 ../build/bin/preferences_gen.h:4092
+#: ../build/bin/preferences_gen.h:4128 ../build/bin/preferences_gen.h:4200
+#: ../build/bin/preferences_gen.h:4734 ../build/bin/preferences_gen.h:4932
+#: ../build/bin/preferences_gen.h:5207 ../build/bin/preferences_gen.h:5351
+#: ../build/bin/preferences_gen.h:5679 ../build/bin/preferences_gen.h:5744
+#: ../build/bin/preferences_gen.h:6083 ../build/bin/preferences_gen.h:6155
+#: ../build/bin/preferences_gen.h:6305 ../build/bin/preferences_gen.h:6377
+#: ../build/bin/preferences_gen.h:6847 ../build/bin/preferences_gen.h:7562
+#: ../build/bin/preferences_gen.h:7735 ../build/bin/preferences_gen.h:7986
+#: ../build/bin/preferences_gen.h:8067 ../build/bin/preferences_gen.h:8103
+#: ../build/bin/preferences_gen.h:8139 ../build/bin/preferences_gen.h:8235
+#: ../build/bin/preferences_gen.h:8476 ../build/bin/preferences_gen.h:8567
 msgctxt "preferences"
 msgid "FALSE"
 msgstr "NEIN"
 
-#: ../build/bin/preferences_gen.h:3908
+#: ../build/bin/preferences_gen.h:3987
 msgid "hides built-in presets of utility modules in presets menu."
 msgstr ""
 "Verbirgt eingebaute Voreinstellungen im Voreinstellungsmenü und im "
 "Favoritenmenü."
 
-#: ../build/bin/preferences_gen.h:3930
+#: ../build/bin/preferences_gen.h:4009
 msgid "use single-click in the collections module"
 msgstr "Auswahl mit Einfachklick in „Sammlungen“ Liste"
 
-#: ../build/bin/preferences_gen.h:3944
+#: ../build/bin/preferences_gen.h:4023
 msgid ""
 "check this option to use single-click to select items in the collections "
 "module. this will allow you to do range selections for date-time and numeric "
@@ -172,21 +173,21 @@ msgstr ""
 "Dies erlaubt die Mehrfachauswahl für „Datum/Uhrzeit” und numerische Werte "
 "wie „ISO”, „Blende” etc."
 
-#: ../build/bin/preferences_gen.h:3966
+#: ../build/bin/preferences_gen.h:4045
 msgid "expand a single utility module at a time"
 msgstr "nur ein Leuchttisch-Modul wird eingeblendet"
 
-#: ../build/bin/preferences_gen.h:3980
+#: ../build/bin/preferences_gen.h:4059
 msgid "this option toggles the behavior of shift clicking in lighttable mode"
 msgstr ""
 "Diese Option schaltet das Verhalten von Umschalt+Klick in der Leuchttisch-"
 "Ansicht um"
 
-#: ../build/bin/preferences_gen.h:4002
+#: ../build/bin/preferences_gen.h:4081
 msgid "scroll to utility modules when expanded/collapsed"
 msgstr "zu Leuchttisch-Modul scrollen, wenn es ein-/ausgeblendet wird"
 
-#: ../build/bin/preferences_gen.h:4016 ../build/bin/preferences_gen.h:5311
+#: ../build/bin/preferences_gen.h:4095 ../build/bin/preferences_gen.h:5390
 msgid ""
 "when this option is enabled then darktable will try to scroll the module to "
 "the top of the visible list"
@@ -194,124 +195,124 @@ msgstr ""
 "Wenn diese Option aktiviert ist, wird versucht, das entsprechende Modul nach "
 "oben in den sichtbaren Bereich der Liste zu scrollen"
 
-#: ../build/bin/preferences_gen.h:4038
+#: ../build/bin/preferences_gen.h:4117
 msgid "rating an image one star twice will not zero out the rating"
 msgstr "doppelte Bewertung mit einem Stern setzt nicht null Sterne"
 
-#: ../build/bin/preferences_gen.h:4052
+#: ../build/bin/preferences_gen.h:4131
 msgid ""
 "defines whether rating an image one star twice will zero out star rating"
 msgstr ""
 "definiert, dass die doppelte Bewertung eines Bildes mit einem Stern diese "
 "nicht auf null setzt"
 
-#: ../build/bin/preferences_gen.h:4074 ../build/bin/preferences_gen.h:4842
+#: ../build/bin/preferences_gen.h:4153 ../build/bin/preferences_gen.h:4921
 msgid "show scrollbars for central view"
 msgstr "zeige Scrollbalken für die mittlere Bildansicht"
 
-#: ../build/bin/preferences_gen.h:4085 ../build/bin/preferences_gen.h:5024
-#: ../build/bin/preferences_gen.h:5164 ../build/bin/preferences_gen.h:5200
-#: ../build/bin/preferences_gen.h:5236 ../build/bin/preferences_gen.h:5308
-#: ../build/bin/preferences_gen.h:5564 ../build/bin/preferences_gen.h:6040
-#: ../build/bin/preferences_gen.h:6112 ../build/bin/preferences_gen.h:6262
-#: ../build/bin/preferences_gen.h:6334 ../build/bin/preferences_gen.h:6518
-#: ../build/bin/preferences_gen.h:6554 ../build/bin/preferences_gen.h:6590
-#: ../build/bin/preferences_gen.h:6626 ../build/bin/preferences_gen.h:6662
-#: ../build/bin/preferences_gen.h:6698 ../build/bin/preferences_gen.h:6770
-#: ../build/bin/preferences_gen.h:6805 ../build/bin/preferences_gen.h:6840
-#: ../build/bin/preferences_gen.h:6876 ../build/bin/preferences_gen.h:7514
-#: ../build/bin/preferences_gen.h:7550 ../build/bin/preferences_gen.h:7622
-#: ../build/bin/preferences_gen.h:7836 ../build/bin/preferences_gen.h:8084
-#: ../build/bin/preferences_gen.h:8574
+#: ../build/bin/preferences_gen.h:4164 ../build/bin/preferences_gen.h:5103
+#: ../build/bin/preferences_gen.h:5243 ../build/bin/preferences_gen.h:5279
+#: ../build/bin/preferences_gen.h:5315 ../build/bin/preferences_gen.h:5387
+#: ../build/bin/preferences_gen.h:5643 ../build/bin/preferences_gen.h:6119
+#: ../build/bin/preferences_gen.h:6191 ../build/bin/preferences_gen.h:6341
+#: ../build/bin/preferences_gen.h:6413 ../build/bin/preferences_gen.h:6631
+#: ../build/bin/preferences_gen.h:6667 ../build/bin/preferences_gen.h:6703
+#: ../build/bin/preferences_gen.h:6739 ../build/bin/preferences_gen.h:6775
+#: ../build/bin/preferences_gen.h:6811 ../build/bin/preferences_gen.h:6883
+#: ../build/bin/preferences_gen.h:6918 ../build/bin/preferences_gen.h:6953
+#: ../build/bin/preferences_gen.h:6989 ../build/bin/preferences_gen.h:7627
+#: ../build/bin/preferences_gen.h:7663 ../build/bin/preferences_gen.h:7699
+#: ../build/bin/preferences_gen.h:7771 ../build/bin/preferences_gen.h:8031
+#: ../build/bin/preferences_gen.h:8279 ../build/bin/preferences_gen.h:8769
 msgctxt "preferences"
 msgid "TRUE"
 msgstr "JA"
 
-#: ../build/bin/preferences_gen.h:4088 ../build/bin/preferences_gen.h:4856
+#: ../build/bin/preferences_gen.h:4167 ../build/bin/preferences_gen.h:4935
 msgid "defines whether scrollbars should be displayed"
 msgstr "Definiert, ob Scrollbalken angezeigt werden sollen"
 
-#: ../build/bin/preferences_gen.h:4110
+#: ../build/bin/preferences_gen.h:4189
 msgid "show image time with milliseconds"
 msgstr "Bildzeit mit Millisekunden anzeigen"
 
-#: ../build/bin/preferences_gen.h:4124
+#: ../build/bin/preferences_gen.h:4203
 msgid "defines whether time should be displayed with milliseconds"
 msgstr "Definiert, ob die Zeit mit Millisekunden angezeigt werden soll"
 
-#: ../build/bin/preferences_gen.h:4134
+#: ../build/bin/preferences_gen.h:4213
 msgid "thumbnails"
 msgstr "Vorschaubilder"
 
-#: ../build/bin/preferences_gen.h:4154
+#: ../build/bin/preferences_gen.h:4233
 msgid "use raw file instead of embedded JPEG from size"
 msgstr "Vorschaubilder aus RAW statt eingebettetem JPEG ab Größe"
 
-#: ../build/bin/preferences_gen.h:4165 ../build/bin/preferences_gen.h:4260
-#: ../build/bin/preferences_gen.h:5474 ../build/bin/preferences_gen.h:5528
-#: ../build/bin/preferences_gen.h:7389 ../build/bin/conf_gen.h:393
-#: ../build/bin/conf_gen.h:1093 ../build/bin/conf_gen.h:1109
-#: ../build/bin/conf_gen.h:2985
+#: ../build/bin/preferences_gen.h:4244 ../build/bin/preferences_gen.h:4339
+#: ../build/bin/preferences_gen.h:5553 ../build/bin/preferences_gen.h:5607
+#: ../build/bin/preferences_gen.h:7502 ../build/bin/conf_gen.h:381
+#: ../build/bin/conf_gen.h:1074 ../build/bin/conf_gen.h:1090
+#: ../build/bin/conf_gen.h:2976
 msgctxt "preferences"
 msgid "always"
 msgstr "immer"
 
-#: ../build/bin/preferences_gen.h:4170 ../build/bin/preferences_gen.h:4265
-#: ../build/bin/preferences_gen.h:6156 ../build/bin/conf_gen.h:280
-#: ../build/bin/conf_gen.h:1094 ../build/bin/conf_gen.h:1110
+#: ../build/bin/preferences_gen.h:4249 ../build/bin/preferences_gen.h:4344
+#: ../build/bin/preferences_gen.h:6235 ../build/bin/conf_gen.h:286
+#: ../build/bin/conf_gen.h:1075 ../build/bin/conf_gen.h:1091
 msgctxt "preferences"
 msgid "small"
 msgstr "klein"
 
-#: ../build/bin/preferences_gen.h:4175 ../build/bin/preferences_gen.h:4270
-#: ../build/bin/conf_gen.h:1095 ../build/bin/conf_gen.h:1111
+#: ../build/bin/preferences_gen.h:4254 ../build/bin/preferences_gen.h:4349
+#: ../build/bin/conf_gen.h:1076 ../build/bin/conf_gen.h:1092
 msgctxt "preferences"
 msgid "VGA"
 msgstr "VGA"
 
-#: ../build/bin/preferences_gen.h:4180 ../build/bin/preferences_gen.h:4275
-#: ../build/bin/preferences_gen.h:4319 ../build/bin/conf_gen.h:1096
-#: ../build/bin/conf_gen.h:1112
+#: ../build/bin/preferences_gen.h:4259 ../build/bin/preferences_gen.h:4354
+#: ../build/bin/preferences_gen.h:4398 ../build/bin/conf_gen.h:1077
+#: ../build/bin/conf_gen.h:1093
 msgctxt "preferences"
 msgid "720p"
 msgstr "720p"
 
-#: ../build/bin/preferences_gen.h:4185 ../build/bin/preferences_gen.h:4280
-#: ../build/bin/conf_gen.h:1097 ../build/bin/conf_gen.h:1113
+#: ../build/bin/preferences_gen.h:4264 ../build/bin/preferences_gen.h:4359
+#: ../build/bin/conf_gen.h:1078 ../build/bin/conf_gen.h:1094
 msgctxt "preferences"
 msgid "1080p"
 msgstr "1080p"
 
-#: ../build/bin/preferences_gen.h:4190 ../build/bin/preferences_gen.h:4285
-#: ../build/bin/conf_gen.h:1098 ../build/bin/conf_gen.h:1114
+#: ../build/bin/preferences_gen.h:4269 ../build/bin/preferences_gen.h:4364
+#: ../build/bin/conf_gen.h:1079 ../build/bin/conf_gen.h:1095
 msgctxt "preferences"
 msgid "WQXGA"
 msgstr "WQXGA"
 
-#: ../build/bin/preferences_gen.h:4195 ../build/bin/preferences_gen.h:4290
-#: ../build/bin/conf_gen.h:1099 ../build/bin/conf_gen.h:1115
+#: ../build/bin/preferences_gen.h:4274 ../build/bin/preferences_gen.h:4369
+#: ../build/bin/conf_gen.h:1080 ../build/bin/conf_gen.h:1096
 msgctxt "preferences"
 msgid "4K"
 msgstr "4K"
 
-#: ../build/bin/preferences_gen.h:4200 ../build/bin/preferences_gen.h:4295
-#: ../build/bin/conf_gen.h:1100 ../build/bin/conf_gen.h:1116
+#: ../build/bin/preferences_gen.h:4279 ../build/bin/preferences_gen.h:4374
+#: ../build/bin/conf_gen.h:1081 ../build/bin/conf_gen.h:1097
 msgctxt "preferences"
 msgid "5K"
 msgstr "5K"
 
-#: ../build/bin/preferences_gen.h:4205 ../build/bin/preferences_gen.h:4224
-#: ../build/bin/preferences_gen.h:4300 ../build/bin/preferences_gen.h:7061
-#: ../build/bin/preferences_gen.h:7191 ../build/bin/preferences_gen.h:7319
-#: ../build/bin/preferences_gen.h:7384 ../build/bin/conf_gen.h:208
-#: ../build/bin/conf_gen.h:228 ../build/bin/conf_gen.h:382
-#: ../build/bin/conf_gen.h:392 ../build/bin/conf_gen.h:1101
-#: ../build/bin/conf_gen.h:1117
+#: ../build/bin/preferences_gen.h:4284 ../build/bin/preferences_gen.h:4303
+#: ../build/bin/preferences_gen.h:4379 ../build/bin/preferences_gen.h:7174
+#: ../build/bin/preferences_gen.h:7304 ../build/bin/preferences_gen.h:7432
+#: ../build/bin/preferences_gen.h:7497 ../build/bin/conf_gen.h:214
+#: ../build/bin/conf_gen.h:234 ../build/bin/conf_gen.h:370
+#: ../build/bin/conf_gen.h:380 ../build/bin/conf_gen.h:1082
+#: ../build/bin/conf_gen.h:1098
 msgctxt "preferences"
 msgid "never"
 msgstr "nie"
 
-#: ../build/bin/preferences_gen.h:4227
+#: ../build/bin/preferences_gen.h:4306
 msgid ""
 "if the thumbnail size is greater than this value, it will be processed using "
 "raw file instead of the embedded preview JPEG (better but slower).\n"
@@ -324,11 +325,11 @@ msgstr ""
 "Für die beste Qualität sollte „immer“ ausgewählt sein. (Weitere Infos siehe "
 "Benutzerdokumentation)"
 
-#: ../build/bin/preferences_gen.h:4249
+#: ../build/bin/preferences_gen.h:4328
 msgid "high quality processing from size"
 msgstr "hochqualitatives Entwickeln für Vorschaubilder ab Größe"
 
-#: ../build/bin/preferences_gen.h:4322
+#: ../build/bin/preferences_gen.h:4401
 msgid ""
 "if the thumbnail size is greater than this value, it will be processed using "
 "the full quality rendering path (better but slower).\n"
@@ -341,11 +342,11 @@ msgstr ""
 "Für die beste Qualität sollte „immer“ ausgewählt sein. (Weitere Infos siehe "
 "Benutzerdokumentation)"
 
-#: ../build/bin/preferences_gen.h:4344
+#: ../build/bin/preferences_gen.h:4423
 msgid "delimiters for size categories"
 msgstr "Grenzwerte für größenabhängige Einstellungen"
 
-#: ../build/bin/preferences_gen.h:4362
+#: ../build/bin/preferences_gen.h:4441
 msgid ""
 "size categories are used to be able to set different overlays and css values "
 "depending of the size of the thumbnail, separated by |. for example, 120|400 "
@@ -356,59 +357,59 @@ msgstr ""
 "Die Größen werden durch | getrennt. Der Default „120|400“ definiert 3 "
 "Kategorien: 0px->120px, 120px->400px und >400px"
 
-#: ../build/bin/preferences_gen.h:4384
+#: ../build/bin/preferences_gen.h:4463
 msgid "pattern for the thumbnail extended overlay text"
 msgstr "Schema der erweiterten Bildinfos in Vorschaubildern"
 
-#: ../build/bin/preferences_gen.h:4405 ../build/bin/preferences_gen.h:4448
+#: ../build/bin/preferences_gen.h:4484 ../build/bin/preferences_gen.h:4527
 msgid "see manual to know all the tags you can use."
 msgstr "Siehe Handbuch, um mehr über die Platzhalter zu erfahren."
 
-#: ../build/bin/preferences_gen.h:4427
+#: ../build/bin/preferences_gen.h:4506
 msgid "pattern for the thumbnail tooltip (empty to disable)"
 msgstr "Schema der Kurzinfos beim Überfahren Vorschaubildern mit der Maus"
 
-#: ../build/bin/preferences_gen.h:4476 ../src/gui/preferences.c:537
+#: ../build/bin/preferences_gen.h:4555 ../src/gui/preferences.c:537
 #: ../src/views/darkroom.c:108
 msgid "darkroom"
 msgstr "Dunkelkammer"
 
-#: ../build/bin/preferences_gen.h:4499
+#: ../build/bin/preferences_gen.h:4578
 msgid "pen pressure control for brush masks"
 msgstr "Drucksensitivität des Stiftes für Pinsel-Masken"
 
-#: ../build/bin/preferences_gen.h:4510 ../build/bin/preferences_gen.h:4554
-#: ../build/bin/conf_gen.h:1143
+#: ../build/bin/preferences_gen.h:4589 ../build/bin/preferences_gen.h:4633
+#: ../build/bin/conf_gen.h:1124
 msgctxt "preferences"
 msgid "off"
 msgstr "aus"
 
-#: ../build/bin/preferences_gen.h:4515 ../build/bin/conf_gen.h:1144
+#: ../build/bin/preferences_gen.h:4594 ../build/bin/conf_gen.h:1125
 msgctxt "preferences"
 msgid "hardness (relative)"
 msgstr "Härte (relativ)"
 
-#: ../build/bin/preferences_gen.h:4520 ../build/bin/conf_gen.h:1145
+#: ../build/bin/preferences_gen.h:4599 ../build/bin/conf_gen.h:1126
 msgctxt "preferences"
 msgid "hardness (absolute)"
 msgstr "Härte (absolut)"
 
-#: ../build/bin/preferences_gen.h:4525 ../build/bin/conf_gen.h:1146
+#: ../build/bin/preferences_gen.h:4604 ../build/bin/conf_gen.h:1127
 msgctxt "preferences"
 msgid "opacity (relative)"
 msgstr "Deckkraft (relativ)"
 
-#: ../build/bin/preferences_gen.h:4530 ../build/bin/conf_gen.h:1147
+#: ../build/bin/preferences_gen.h:4609 ../build/bin/conf_gen.h:1128
 msgctxt "preferences"
 msgid "opacity (absolute)"
 msgstr "Deckkraft (absolut)"
 
-#: ../build/bin/preferences_gen.h:4535 ../build/bin/conf_gen.h:1148
+#: ../build/bin/preferences_gen.h:4614 ../build/bin/conf_gen.h:1129
 msgctxt "preferences"
 msgid "brush size (relative)"
 msgstr "Pinselgröße (relativ)"
 
-#: ../build/bin/preferences_gen.h:4557
+#: ../build/bin/preferences_gen.h:4636
 msgid ""
 "off - pressure reading ignored, hardness/opacity/brush size - pressure "
 "reading controls specified attribute, absolute/relative - pressure reading "
@@ -420,27 +421,27 @@ msgstr ""
 "• „absolut”, „relativ”: Druck-Wert wird direkt als Wert benutzt oder mit "
 "vordefinierten Einstellungen multipliziert"
 
-#: ../build/bin/preferences_gen.h:4579
+#: ../build/bin/preferences_gen.h:4658
 msgid "smoothing of brush strokes"
 msgstr "Begradigen von Pinselstrichen"
 
-#: ../build/bin/preferences_gen.h:4590 ../build/bin/conf_gen.h:1156
+#: ../build/bin/preferences_gen.h:4669 ../build/bin/conf_gen.h:1137
 msgctxt "preferences"
 msgid "low"
 msgstr "gering"
 
-#: ../build/bin/preferences_gen.h:4595 ../build/bin/preferences_gen.h:4619
-#: ../build/bin/conf_gen.h:1157
+#: ../build/bin/preferences_gen.h:4674 ../build/bin/preferences_gen.h:4698
+#: ../build/bin/conf_gen.h:1138
 msgctxt "preferences"
 msgid "medium"
 msgstr "mittel"
 
-#: ../build/bin/preferences_gen.h:4600 ../build/bin/conf_gen.h:1158
+#: ../build/bin/preferences_gen.h:4679 ../build/bin/conf_gen.h:1139
 msgctxt "preferences"
 msgid "high"
 msgstr "hoch"
 
-#: ../build/bin/preferences_gen.h:4622
+#: ../build/bin/preferences_gen.h:4701
 msgid ""
 "sets level for smoothing of brush strokes. stronger smoothing leads to less "
 "nodes and easier editing but with lower control of accuracy."
@@ -449,11 +450,11 @@ msgstr ""
 "Stärkere Begradigung führt zu weniger Knoten und vereinfachtem Editieren, "
 "bedeutet aber zugleich eine geringere Kontrolle über die Genauigkeit."
 
-#: ../build/bin/preferences_gen.h:4644
+#: ../build/bin/preferences_gen.h:4723
 msgid "scroll down to increase mask parameters"
 msgstr "nach unten scrollen, um die Maskenparameter zu erhöhen"
 
-#: ../build/bin/preferences_gen.h:4658
+#: ../build/bin/preferences_gen.h:4737
 msgid ""
 "when using the mouse scroll wheel to change mask parameters, scroll down to "
 "increase the mask size, feather size, opacity, brush hardness and gradient "
@@ -465,57 +466,57 @@ msgstr ""
 "durch Scrollen nach unten erhöht werden.\n"
 "Standardmäßig erhöht ein Scrollen nach oben diese Parameter."
 
-#: ../build/bin/preferences_gen.h:4680
+#: ../build/bin/preferences_gen.h:4759
 msgid "pattern for the image information line"
 msgstr "Beschriftung der Bildinformationszeile"
 
-#: ../build/bin/preferences_gen.h:4701
+#: ../build/bin/preferences_gen.h:4780
 msgid "see manual for a list of the tags you can use."
 msgstr "Siehe Handbuch, um mehr über hier verwendbare Platzhalter zu erfahren."
 
-#: ../build/bin/preferences_gen.h:4723
+#: ../build/bin/preferences_gen.h:4802
 msgid "position of the image information line"
 msgstr "Position der Bildinformationszeile"
 
-#: ../build/bin/preferences_gen.h:4734 ../build/bin/conf_gen.h:1187
+#: ../build/bin/preferences_gen.h:4813 ../build/bin/conf_gen.h:1168
 msgctxt "preferences"
 msgid "top left"
 msgstr "oben links"
 
-#: ../build/bin/preferences_gen.h:4739 ../build/bin/conf_gen.h:1188
+#: ../build/bin/preferences_gen.h:4818 ../build/bin/conf_gen.h:1169
 msgctxt "preferences"
 msgid "top right"
 msgstr "oben rechts"
 
-#: ../build/bin/preferences_gen.h:4744 ../build/bin/conf_gen.h:1189
+#: ../build/bin/preferences_gen.h:4823 ../build/bin/conf_gen.h:1170
 msgctxt "preferences"
 msgid "top center"
 msgstr "oben mittig"
 
-#: ../build/bin/preferences_gen.h:4749 ../build/bin/preferences_gen.h:4773
-#: ../build/bin/conf_gen.h:1190
+#: ../build/bin/preferences_gen.h:4828 ../build/bin/preferences_gen.h:4852
+#: ../build/bin/conf_gen.h:1171
 msgctxt "preferences"
 msgid "bottom"
 msgstr "unten"
 
-#: ../build/bin/preferences_gen.h:4754 ../build/bin/conf_gen.h:1191
+#: ../build/bin/preferences_gen.h:4833 ../build/bin/conf_gen.h:1172
 msgctxt "preferences"
 msgid "hidden"
 msgstr "verborgen"
 
-#: ../build/bin/preferences_gen.h:4797
+#: ../build/bin/preferences_gen.h:4876
 msgid "border around image in darkroom mode"
 msgstr "Rand um Bild in Dunkelkammer-Ansicht"
 
-#: ../build/bin/preferences_gen.h:4817 ../build/bin/preferences_gen.h:7155
-#: ../build/bin/preferences_gen.h:7275 ../build/bin/preferences_gen.h:8137
-#: ../build/bin/preferences_gen.h:8478 ../build/bin/preferences_gen.h:8636
-#: ../build/bin/preferences_gen.h:8714 ../build/bin/preferences_gen.h:8760
+#: ../build/bin/preferences_gen.h:4896 ../build/bin/preferences_gen.h:7268
+#: ../build/bin/preferences_gen.h:7388 ../build/bin/preferences_gen.h:8332
+#: ../build/bin/preferences_gen.h:8673 ../build/bin/preferences_gen.h:8831
+#: ../build/bin/preferences_gen.h:8909 ../build/bin/preferences_gen.h:8955
 #, c-format
 msgid "double click to reset to `%d'"
 msgstr "Doppelklick, um auf „%d” zurückzusetzen"
 
-#: ../build/bin/preferences_gen.h:4820
+#: ../build/bin/preferences_gen.h:4899
 msgid ""
 "process the image in darkroom mode with a small border. set to 0 if you "
 "don't want any border."
@@ -523,27 +524,27 @@ msgstr ""
 "Zeige das Bild in Dunkelkammer-Ansicht mit einem kleinen Rand. \n"
 "Auf 0 setzen, wenn kein Rand erwünscht ist."
 
-#: ../build/bin/preferences_gen.h:4878
+#: ../build/bin/preferences_gen.h:4957
 msgid "demosaicing for zoomed out darkroom mode"
 msgstr "Methode zum Entrastern in der herausgezoomten Dunkelkammer"
 
-#: ../build/bin/preferences_gen.h:4889 ../build/bin/conf_gen.h:2014
+#: ../build/bin/preferences_gen.h:4968 ../build/bin/conf_gen.h:1995
 msgctxt "preferences"
 msgid "always bilinear (fast)"
 msgstr "immer bilinear (schnell)"
 
-#: ../build/bin/preferences_gen.h:4894 ../build/bin/preferences_gen.h:4918
-#: ../build/bin/conf_gen.h:2015
+#: ../build/bin/preferences_gen.h:4973 ../build/bin/preferences_gen.h:4997
+#: ../build/bin/conf_gen.h:1996
 msgctxt "preferences"
 msgid "at most RCD (reasonable)"
 msgstr "höchstens PPG (sinnvoll)"
 
-#: ../build/bin/preferences_gen.h:4899 ../build/bin/conf_gen.h:2016
+#: ../build/bin/preferences_gen.h:4978 ../build/bin/conf_gen.h:1997
 msgctxt "preferences"
 msgid "full (possibly slow)"
 msgstr "vollständig (eventuell langsam)"
 
-#: ../build/bin/preferences_gen.h:4921
+#: ../build/bin/preferences_gen.h:5000
 msgid ""
 "interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, "
 "but not as sharp. middle ground is using RCD + interpolation modes specified "
@@ -559,42 +560,42 @@ msgstr ""
 "unskalierte Export. \n"
 "X-Trans-Sensoren verwenden VNG und nicht RCD als Mittelweg."
 
-#: ../build/bin/preferences_gen.h:4943
+#: ../build/bin/preferences_gen.h:5022
 msgid "reduce resolution of preview image"
 msgstr "Auflösung des Vorschaubildes reduzieren"
 
-#: ../build/bin/preferences_gen.h:4954 ../build/bin/preferences_gen.h:4988
-#: ../build/bin/conf_gen.h:2024
+#: ../build/bin/preferences_gen.h:5033 ../build/bin/preferences_gen.h:5067
+#: ../build/bin/conf_gen.h:2005
 msgctxt "preferences"
 msgid "original"
 msgstr "Originalgröße"
 
-#: ../build/bin/preferences_gen.h:4959 ../build/bin/conf_gen.h:2025
+#: ../build/bin/preferences_gen.h:5038 ../build/bin/conf_gen.h:2006
 msgctxt "preferences"
 msgid "to 1/2"
 msgstr "auf die Hälfte"
 
-#: ../build/bin/preferences_gen.h:4964 ../build/bin/conf_gen.h:2026
+#: ../build/bin/preferences_gen.h:5043 ../build/bin/conf_gen.h:2007
 msgctxt "preferences"
 msgid "to 1/3"
 msgstr "auf ein Drittel"
 
-#: ../build/bin/preferences_gen.h:4969 ../build/bin/conf_gen.h:2027
+#: ../build/bin/preferences_gen.h:5048 ../build/bin/conf_gen.h:2008
 msgctxt "preferences"
 msgid "to 1/4"
 msgstr "auf ein Viertel"
 
-#: ../build/bin/preferences_gen.h:4991
+#: ../build/bin/preferences_gen.h:5070
 msgid "decrease to speed up preview rendering, may hinder accurate masking"
 msgstr ""
 "Verringern, um die Berechnung des Vorschaubildes zu beschleunigen, dies kann "
 "zu weniger genauen Maskierungen führen"
 
-#: ../build/bin/preferences_gen.h:5013
+#: ../build/bin/preferences_gen.h:5092
 msgid "show loading screen between images"
 msgstr "graues Zwischenbild beim Bilderwechsel"
 
-#: ../build/bin/preferences_gen.h:5027
+#: ../build/bin/preferences_gen.h:5106
 msgid ""
 "show gray loading screen when navigating between images in the darkroom\n"
 "disable to just show a toast message"
@@ -603,26 +604,26 @@ msgstr ""
 "Zwischenbild angezeigt bis das neue Bild geladen ist\n"
 "Deaktivieren, um nur eine Benachrichtigung anzuzeigen"
 
-#: ../build/bin/preferences_gen.h:5037
+#: ../build/bin/preferences_gen.h:5116
 msgid "modules"
 msgstr "Module"
 
-#: ../build/bin/preferences_gen.h:5057
+#: ../build/bin/preferences_gen.h:5136
 msgid "display of individual color channels"
 msgstr "Anzeige einzelner Farbkanäle"
 
-#: ../build/bin/preferences_gen.h:5068 ../build/bin/preferences_gen.h:5092
-#: ../build/bin/conf_gen.h:1172
+#: ../build/bin/preferences_gen.h:5147 ../build/bin/preferences_gen.h:5171
+#: ../build/bin/conf_gen.h:1153
 msgctxt "preferences"
 msgid "false color"
 msgstr "Falschfarben"
 
-#: ../build/bin/preferences_gen.h:5073 ../build/bin/conf_gen.h:1173
+#: ../build/bin/preferences_gen.h:5152 ../build/bin/conf_gen.h:1154
 msgctxt "preferences"
 msgid "gray scale"
 msgstr "Graustufen"
 
-#: ../build/bin/preferences_gen.h:5095
+#: ../build/bin/preferences_gen.h:5174
 msgid ""
 "defines how color channels are displayed when activated in the parametric "
 "masks feature."
@@ -630,11 +631,11 @@ msgstr ""
 "Legt fest, wie einzelne Farbkanäle angezeigt werden, sobald sie im Dialog "
 "der parametrischen Maske eingeschaltet wurden."
 
-#: ../build/bin/preferences_gen.h:5117
+#: ../build/bin/preferences_gen.h:5196
 msgid "hide built-in presets for processing modules"
 msgstr "Voreinstellung für Dunkelkammer-Module ausblenden"
 
-#: ../build/bin/preferences_gen.h:5131
+#: ../build/bin/preferences_gen.h:5210
 msgid ""
 "hides built-in presets of processing modules in both presets and favourites "
 "menu."
@@ -642,25 +643,25 @@ msgstr ""
 "Verbirgt eingebaute Voreinstellungen im Voreinstellungsmenü und im "
 "Favoritenmenü."
 
-#: ../build/bin/preferences_gen.h:5153 ../build/bin/preferences_gen.h:5167
+#: ../build/bin/preferences_gen.h:5232 ../build/bin/preferences_gen.h:5246
 msgid "show the guides widget in modules UI"
 msgstr "Hilfslinienfunktionalität in Moduleinstellungen anzeigen"
 
-#: ../build/bin/preferences_gen.h:5189
+#: ../build/bin/preferences_gen.h:5268
 msgid "expand a single processing module at a time"
 msgstr "nur ein Dunkelkammer-Modul wird eingeblendet"
 
-#: ../build/bin/preferences_gen.h:5203
+#: ../build/bin/preferences_gen.h:5282
 msgid "this option toggles the behavior of shift clicking in darkroom mode"
 msgstr ""
 "Diese Option schaltet das Verhalten von Umschalt+Klick in der Dunkelkammer-"
 "Ansicht um"
 
-#: ../build/bin/preferences_gen.h:5225
+#: ../build/bin/preferences_gen.h:5304
 msgid "only collapse modules in current group"
 msgstr "nur Module der aktuellen Gruppe ausblenden"
 
-#: ../build/bin/preferences_gen.h:5239
+#: ../build/bin/preferences_gen.h:5318
 msgid ""
 "if only expanding a single module at a time, only collapse other modules in "
 "the current group - ignore modules in other groups"
@@ -669,11 +670,11 @@ msgstr ""
 "Module der aktuellen Gruppe ausgeblendet nicht jedoch Module in den übrigen "
 "Gruppen"
 
-#: ../build/bin/preferences_gen.h:5261
+#: ../build/bin/preferences_gen.h:5340
 msgid "expand the module when it is activated, and collapse it when disabled"
 msgstr "Modul einblenden, wenn aktiv; ausblenden, wenn inaktiv"
 
-#: ../build/bin/preferences_gen.h:5275
+#: ../build/bin/preferences_gen.h:5354
 msgid ""
 "this option allows to expand or collapse automatically the module when it is "
 "enabled or disabled."
@@ -681,31 +682,31 @@ msgstr ""
 "Diese Option erlaubt, Module automatisch ein- bzw. auszublenden wenn "
 "aktiviert bzw. deaktiviert."
 
-#: ../build/bin/preferences_gen.h:5297
+#: ../build/bin/preferences_gen.h:5376
 msgid "scroll to processing modules when expanded/collapsed"
 msgstr "zu Dunkelkammer-Modul scrollen, wenn es ein-/ausgeblendet wird"
 
-#: ../build/bin/preferences_gen.h:5333
+#: ../build/bin/preferences_gen.h:5412
 msgid "white balance slider colors"
 msgstr "Farben der Weißabgleichregler"
 
-#: ../build/bin/preferences_gen.h:5344 ../build/bin/preferences_gen.h:5373
-#: ../build/bin/conf_gen.h:2927
+#: ../build/bin/preferences_gen.h:5423 ../build/bin/preferences_gen.h:5452
+#: ../build/bin/conf_gen.h:2918
 msgctxt "preferences"
 msgid "no color"
 msgstr "keine Farbe"
 
-#: ../build/bin/preferences_gen.h:5349 ../build/bin/conf_gen.h:2928
+#: ../build/bin/preferences_gen.h:5428 ../build/bin/conf_gen.h:2919
 msgctxt "preferences"
 msgid "illuminant color"
 msgstr "Farbe der Lichtquelle"
 
-#: ../build/bin/preferences_gen.h:5354 ../build/bin/conf_gen.h:2929
+#: ../build/bin/preferences_gen.h:5433 ../build/bin/conf_gen.h:2920
 msgctxt "preferences"
 msgid "effect emulation"
 msgstr "Emulation der Farbänderung"
 
-#: ../build/bin/preferences_gen.h:5376
+#: ../build/bin/preferences_gen.h:5455
 msgid ""
 "visual indication of temperature adjustments.\n"
 "in 'illuminant color' mode slider colors represent the color of the light "
@@ -720,27 +721,27 @@ msgstr ""
 "Auswirkung auf die Bildszene, die eine Verschiebung der Farbtemperatur zur "
 "Folge hat."
 
-#: ../build/bin/preferences_gen.h:5398
+#: ../build/bin/preferences_gen.h:5477
 msgid "colorbalance slider block layout"
 msgstr "Layout der Regler im Modul „Farbbalance”"
 
-#: ../build/bin/preferences_gen.h:5409 ../build/bin/preferences_gen.h:5438
-#: ../build/bin/conf_gen.h:2975
+#: ../build/bin/preferences_gen.h:5488 ../build/bin/preferences_gen.h:5517
+#: ../build/bin/conf_gen.h:2966
 msgctxt "preferences"
 msgid "list"
 msgstr "Liste"
 
-#: ../build/bin/preferences_gen.h:5414 ../build/bin/conf_gen.h:2976
+#: ../build/bin/preferences_gen.h:5493 ../build/bin/conf_gen.h:2967
 msgctxt "preferences"
 msgid "tabs"
 msgstr "Tabs"
 
-#: ../build/bin/preferences_gen.h:5419 ../build/bin/conf_gen.h:2977
+#: ../build/bin/preferences_gen.h:5498 ../build/bin/conf_gen.h:2968
 msgctxt "preferences"
 msgid "columns"
 msgstr "Spalten"
 
-#: ../build/bin/preferences_gen.h:5441
+#: ../build/bin/preferences_gen.h:5520
 msgid ""
 "choose how to organise the slider blocks for lift, gamma and gain:\n"
 "list - all sliders are shown in one long list (with headers),\n"
@@ -755,49 +756,49 @@ msgstr ""
 "• „Spalten”: Die Reglerblöcke werden in schmalen Blöcken nebeneinander "
 "dargestellt."
 
-#: ../build/bin/preferences_gen.h:5463
+#: ../build/bin/preferences_gen.h:5542
 msgid "show right-side buttons in processing module headers"
 msgstr "Anzeige der rechten Schaltflächen in der Modul-Zeile"
 
-#: ../build/bin/preferences_gen.h:5479 ../build/bin/conf_gen.h:2986
+#: ../build/bin/preferences_gen.h:5558 ../build/bin/conf_gen.h:2977
 msgctxt "preferences"
 msgid "active"
 msgstr "aktive"
 
-#: ../build/bin/preferences_gen.h:5484 ../build/bin/conf_gen.h:2987
+#: ../build/bin/preferences_gen.h:5563 ../build/bin/conf_gen.h:2978
 msgctxt "preferences"
 msgid "dim"
 msgstr "dunkel"
 
-#: ../build/bin/preferences_gen.h:5489 ../build/bin/preferences_gen.h:6920
-#: ../build/bin/preferences_gen.h:6956 ../build/bin/conf_gen.h:2310
-#: ../build/bin/conf_gen.h:2988
+#: ../build/bin/preferences_gen.h:5568 ../build/bin/preferences_gen.h:7033
+#: ../build/bin/preferences_gen.h:7069 ../build/bin/conf_gen.h:2291
+#: ../build/bin/conf_gen.h:2979
 msgctxt "preferences"
 msgid "auto"
 msgstr "automatisch"
 
-#: ../build/bin/preferences_gen.h:5494 ../build/bin/conf_gen.h:2989
+#: ../build/bin/preferences_gen.h:5573 ../build/bin/conf_gen.h:2980
 msgctxt "preferences"
 msgid "fade"
 msgstr "ausblenden"
 
-#: ../build/bin/preferences_gen.h:5499 ../build/bin/conf_gen.h:2990
+#: ../build/bin/preferences_gen.h:5578 ../build/bin/conf_gen.h:2981
 msgctxt "preferences"
 msgid "fit"
 msgstr "einpassen"
 
 # ist das eine passende Übersetzung?
-#: ../build/bin/preferences_gen.h:5504 ../build/bin/conf_gen.h:2991
+#: ../build/bin/preferences_gen.h:5583 ../build/bin/conf_gen.h:2982
 msgctxt "preferences"
 msgid "smooth"
 msgstr "einpassen & ausblenden"
 
-#: ../build/bin/preferences_gen.h:5509 ../build/bin/conf_gen.h:2992
+#: ../build/bin/preferences_gen.h:5588 ../build/bin/conf_gen.h:2983
 msgctxt "preferences"
 msgid "glide"
 msgstr "einpassen & gleitend ausblenden"
 
-#: ../build/bin/preferences_gen.h:5531
+#: ../build/bin/preferences_gen.h:5610
 msgid ""
 "when the mouse is not over a module, the multi-instance, reset and preset "
 "buttons can be hidden:\n"
@@ -824,11 +825,11 @@ msgstr ""
 "• „einpassen & gleitend ausblenden”: Blende Schaltflächen schrittweise aus, "
 "wenn Feld zu schmal für Modulname und Schaltflächen."
 
-#: ../build/bin/preferences_gen.h:5553
+#: ../build/bin/preferences_gen.h:5632
 msgid "show mask indicator in module headers"
 msgstr "Anzeige Indikator für Maske in der Modul-Zeile"
 
-#: ../build/bin/preferences_gen.h:5567
+#: ../build/bin/preferences_gen.h:5646
 msgid ""
 "if enabled, an icon will be shown in the header of any processing modules "
 "that have a mask applied"
@@ -836,11 +837,11 @@ msgstr ""
 "wenn ausgewählt wird in der Modul Zeile ein Icon eingeblendet, wenn dort "
 "eine Maske definiert ist"
 
-#: ../build/bin/preferences_gen.h:5589
+#: ../build/bin/preferences_gen.h:5668
 msgid "prompt for name on addition of new instance"
 msgstr "Instanzbenennung beim Hinzufügen einer neuen Instanz abfragen"
 
-#: ../build/bin/preferences_gen.h:5603
+#: ../build/bin/preferences_gen.h:5682
 msgid ""
 "if enabled, a rename prompt will be present for each new module instance "
 "(either new instance or duplicate)"
@@ -848,46 +849,46 @@ msgstr ""
 "wenn aktiviert, wird bei jeder neuen Modulinstanz (entweder neue Instanz "
 "oder Duplikat) das Eingabefeld der Benennung aktiviert"
 
-#: ../build/bin/preferences_gen.h:5631
+#: ../build/bin/preferences_gen.h:5710
 msgid "processing"
 msgstr "Bearbeitung"
 
-#: ../build/bin/preferences_gen.h:5634
+#: ../build/bin/preferences_gen.h:5713
 msgid "image processing"
 msgstr "Bildbearbeitung"
 
-#: ../build/bin/preferences_gen.h:5654
+#: ../build/bin/preferences_gen.h:5733
 msgid "always use LittleCMS 2 to apply output color profile"
 msgstr "benutze immer LittleCMS 2, um das Ausgabefarbprofil anzuwenden"
 
-#: ../build/bin/preferences_gen.h:5668
+#: ../build/bin/preferences_gen.h:5747
 msgid "this is slower than the default."
 msgstr "Dies ist langsamer als die Standardeinstellung."
 
-#: ../build/bin/preferences_gen.h:5690
+#: ../build/bin/preferences_gen.h:5769
 msgid "pixel interpolator (warp)"
 msgstr "Pixel-Interpolation (Verformung)"
 
-#: ../build/bin/preferences_gen.h:5701 ../build/bin/preferences_gen.h:5766
-#: ../build/bin/conf_gen.h:2041 ../build/bin/conf_gen.h:2051
+#: ../build/bin/preferences_gen.h:5780 ../build/bin/preferences_gen.h:5845
+#: ../build/bin/conf_gen.h:2022 ../build/bin/conf_gen.h:2032
 msgctxt "preferences"
 msgid "bilinear"
 msgstr "bilinear"
 
-#: ../build/bin/preferences_gen.h:5706 ../build/bin/preferences_gen.h:5730
-#: ../build/bin/preferences_gen.h:5771 ../build/bin/conf_gen.h:2042
-#: ../build/bin/conf_gen.h:2052
+#: ../build/bin/preferences_gen.h:5785 ../build/bin/preferences_gen.h:5809
+#: ../build/bin/preferences_gen.h:5850 ../build/bin/conf_gen.h:2023
+#: ../build/bin/conf_gen.h:2033
 msgctxt "preferences"
 msgid "bicubic"
 msgstr "bikubisch"
 
-#: ../build/bin/preferences_gen.h:5711 ../build/bin/preferences_gen.h:5776
-#: ../build/bin/conf_gen.h:2043 ../build/bin/conf_gen.h:2053
+#: ../build/bin/preferences_gen.h:5790 ../build/bin/preferences_gen.h:5855
+#: ../build/bin/conf_gen.h:2024 ../build/bin/conf_gen.h:2034
 msgctxt "preferences"
 msgid "lanczos2"
 msgstr "Lanczos2"
 
-#: ../build/bin/preferences_gen.h:5733
+#: ../build/bin/preferences_gen.h:5812
 msgid ""
 "pixel interpolator used in modules for rotation, lens correction, liquify, "
 "cropping and final scaling (bilinear, bicubic, lanczos2)."
@@ -896,30 +897,30 @@ msgstr ""
 "Verflüssigen, Zuschneiden und Skalieren benutzt wird (bilinear, bikubisch, "
 "Lanczos2)."
 
-#: ../build/bin/preferences_gen.h:5755
+#: ../build/bin/preferences_gen.h:5834
 msgid "pixel interpolator (scaling)"
 msgstr "Pixel-Interpolation (Skalierung)"
 
-#: ../build/bin/preferences_gen.h:5781 ../build/bin/preferences_gen.h:5800
-#: ../build/bin/conf_gen.h:2054
+#: ../build/bin/preferences_gen.h:5860 ../build/bin/preferences_gen.h:5879
+#: ../build/bin/conf_gen.h:2035
 msgctxt "preferences"
 msgid "lanczos3"
 msgstr "Lanczos3"
 
-#: ../build/bin/preferences_gen.h:5803
+#: ../build/bin/preferences_gen.h:5882
 msgid ""
 "pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3)."
 msgstr ""
 "Pixel-Interpolation, die bei Skalierung benutzt wird (bilinear, bikubisch, "
 "Lanczos2, Lanczos3)."
 
-#: ../build/bin/preferences_gen.h:5825
+#: ../build/bin/preferences_gen.h:5904
 msgid "3D lut root folder"
 msgstr "3D-LUT-Verzeichnis"
 
-#: ../build/bin/preferences_gen.h:5830 ../src/control/jobs/control_jobs.c:1677
-#: ../src/control/jobs/control_jobs.c:1739 ../src/gui/preferences.c:1033
-#: ../src/gui/presets.c:365 ../src/imageio/storage/disk.c:121
+#: ../build/bin/preferences_gen.h:5909 ../src/control/jobs/control_jobs.c:1679
+#: ../src/control/jobs/control_jobs.c:1741 ../src/gui/preferences.c:1034
+#: ../src/gui/presets.c:375 ../src/imageio/storage/disk.c:121
 #: ../src/imageio/storage/disk.c:188 ../src/imageio/storage/gallery.c:108
 #: ../src/imageio/storage/gallery.c:172 ../src/imageio/storage/latex.c:107
 #: ../src/imageio/storage/latex.c:171 ../src/libs/import.c:1525
@@ -928,7 +929,7 @@ msgstr "3D-LUT-Verzeichnis"
 msgid "select directory"
 msgstr "Verzeichnis wählen"
 
-#: ../build/bin/preferences_gen.h:5846
+#: ../build/bin/preferences_gen.h:5925
 msgid ""
 "this folder (and sub-folders) contains Lut files used by lut3d modules. "
 "(need a restart)."
@@ -937,29 +938,29 @@ msgstr ""
 "Dateien, die vom 3D LUT-Modul verwendet werden. Bei Änderung Neustart "
 "erforderlich."
 
-#: ../build/bin/preferences_gen.h:5868
+#: ../build/bin/preferences_gen.h:5947
 msgid "auto-apply pixel workflow defaults"
 msgstr "Arbeitsablauf-spezifische Einstellungen automatisch anwenden"
 
-#: ../build/bin/preferences_gen.h:5879 ../build/bin/preferences_gen.h:5908
-#: ../build/bin/conf_gen.h:2798
+#: ../build/bin/preferences_gen.h:5958 ../build/bin/preferences_gen.h:5987
+#: ../build/bin/conf_gen.h:2789
 msgctxt "preferences"
 msgid "scene-referred"
 msgstr "szenenbezogene Bearbeitung"
 
-#: ../build/bin/preferences_gen.h:5884 ../build/bin/conf_gen.h:2799
+#: ../build/bin/preferences_gen.h:5963 ../build/bin/conf_gen.h:2790
 msgctxt "preferences"
 msgid "display-referred"
 msgstr "anzeigebezogene Bearbeitung"
 
-#: ../build/bin/preferences_gen.h:5889 ../build/bin/preferences_gen.h:6925
-#: ../build/bin/conf_gen.h:641 ../build/bin/conf_gen.h:1739
-#: ../build/bin/conf_gen.h:2311 ../build/bin/conf_gen.h:2800
+#: ../build/bin/preferences_gen.h:5968 ../build/bin/preferences_gen.h:7038
+#: ../build/bin/conf_gen.h:622 ../build/bin/conf_gen.h:1720
+#: ../build/bin/conf_gen.h:2292 ../build/bin/conf_gen.h:2791
 msgctxt "preferences"
 msgid "none"
 msgstr "keines"
 
-#: ../build/bin/preferences_gen.h:5911
+#: ../build/bin/preferences_gen.h:5990
 msgid ""
 "scene-referred workflow is based on linear modules and will auto-apply "
 "filmic and exposure,\n"
@@ -974,22 +975,22 @@ msgstr ""
 "Hierfür wird das Modul „Basiskurve” automatisch angewandt und eine veraltete "
 "Modulreihenfolge eingestellt."
 
-#: ../build/bin/preferences_gen.h:5933
+#: ../build/bin/preferences_gen.h:6012
 msgid "auto-apply chromatic adaptation defaults"
 msgstr "automatische Einstellungen für chromatische Adaption"
 
-#: ../build/bin/preferences_gen.h:5944 ../build/bin/conf_gen.h:2808
+#: ../build/bin/preferences_gen.h:6023 ../build/bin/conf_gen.h:2799
 msgctxt "preferences"
 msgid "modern"
 msgstr "modern"
 
-#: ../build/bin/preferences_gen.h:5949 ../build/bin/preferences_gen.h:5968
-#: ../build/bin/conf_gen.h:2809
+#: ../build/bin/preferences_gen.h:6028 ../build/bin/preferences_gen.h:6047
+#: ../build/bin/conf_gen.h:2800
 msgctxt "preferences"
 msgid "legacy"
 msgstr "veraltet"
 
-#: ../build/bin/preferences_gen.h:5971
+#: ../build/bin/preferences_gen.h:6050
 msgid ""
 "legacy performs a basic chromatic adaptation using only the white balance "
 "module\n"
@@ -1001,11 +1002,11 @@ msgstr ""
 "„modern” kombiniert das „Weißabgleich” Modul mit „Farbkalibrierung”, um eine "
 "chromatische Adaption mit verbesserter Farbbehandlung durchzuführen"
 
-#: ../build/bin/preferences_gen.h:5993
+#: ../build/bin/preferences_gen.h:6072
 msgid "auto-apply per camera basecurve presets"
 msgstr "kameraspezifische Basiskurven automatisch anwenden"
 
-#: ../build/bin/preferences_gen.h:6007
+#: ../build/bin/preferences_gen.h:6086
 msgid ""
 "use the per-camera basecurve by default instead of the generic manufacturer "
 "one if there is one available (needs a restart).\n"
@@ -1024,11 +1025,11 @@ msgstr ""
 "„keines” unter „Arbeitsablauf-spezifische Einstellungen automatisch "
 "anwenden” auszuwählen."
 
-#: ../build/bin/preferences_gen.h:6029
+#: ../build/bin/preferences_gen.h:6108
 msgid "auto-apply sharpen"
 msgstr "Schärfung automatisch anwenden"
 
-#: ../build/bin/preferences_gen.h:6043
+#: ../build/bin/preferences_gen.h:6122
 msgid ""
 "this added sharpen is not recommended on cameras without a low-pass filter. "
 "you should disable this option if you use one of those more recent cameras "
@@ -1041,11 +1042,11 @@ msgstr ""
 "geschärft werden. \n"
 "Bei Änderung Neustart erforderlich."
 
-#: ../build/bin/preferences_gen.h:6065
+#: ../build/bin/preferences_gen.h:6144
 msgid "detect monochrome previews"
 msgstr "monochrome Vorschaubilder erkennen"
 
-#: ../build/bin/preferences_gen.h:6079
+#: ../build/bin/preferences_gen.h:6158
 msgid ""
 "many monochrome images can be identified via exif and preview data. beware: "
 "this slows down imports and reading exif data"
@@ -1054,11 +1055,11 @@ msgstr ""
 "Vorschaubilder erkannt werden\n"
 "Vorsicht: Dies verlangsamt den Import sowie das Lesen der EXIF-Metadaten"
 
-#: ../build/bin/preferences_gen.h:6101
+#: ../build/bin/preferences_gen.h:6180
 msgid "show warning messages"
 msgstr "Warnungen anzeigen"
 
-#: ../build/bin/preferences_gen.h:6115
+#: ../build/bin/preferences_gen.h:6194
 msgid ""
 "display messages in modules to warn beginner users when non-standard and "
 "possibly harmful settings are used in the pipeline.\n"
@@ -1070,32 +1071,32 @@ msgstr ""
 "Diese Meldungen können falsch-positiv sein und sollten ignoriert werden, "
 "wenn Du weisst, was Du tust. Mit dieser Option werden sie immer ausgeblendet."
 
-#: ../build/bin/preferences_gen.h:6125
+#: ../build/bin/preferences_gen.h:6204
 msgid "cpu / gpu / memory"
 msgstr "CPU/GPU/Speicher"
 
-#: ../build/bin/preferences_gen.h:6145
+#: ../build/bin/preferences_gen.h:6224
 msgid "darktable resources"
 msgstr "darktable Ressourcenzuweisung"
 
-#: ../build/bin/preferences_gen.h:6161 ../build/bin/preferences_gen.h:6190
-#: ../build/bin/preferences_gen.h:6376 ../build/bin/preferences_gen.h:6405
-#: ../build/bin/conf_gen.h:281 ../build/bin/conf_gen.h:429
+#: ../build/bin/preferences_gen.h:6240 ../build/bin/preferences_gen.h:6269
+#: ../build/bin/preferences_gen.h:6455 ../build/bin/preferences_gen.h:6484
+#: ../build/bin/conf_gen.h:287 ../build/bin/conf_gen.h:417
 msgctxt "preferences"
 msgid "default"
 msgstr "Standard"
 
-#: ../build/bin/preferences_gen.h:6166 ../build/bin/conf_gen.h:282
+#: ../build/bin/preferences_gen.h:6245 ../build/bin/conf_gen.h:288
 msgctxt "preferences"
 msgid "large"
 msgstr "groß"
 
-#: ../build/bin/preferences_gen.h:6171 ../build/bin/conf_gen.h:283
+#: ../build/bin/preferences_gen.h:6250 ../build/bin/conf_gen.h:289
 msgctxt "preferences"
 msgid "unrestricted"
 msgstr "unbegrenzt"
 
-#: ../build/bin/preferences_gen.h:6193
+#: ../build/bin/preferences_gen.h:6272
 #, c-format
 msgid ""
 "defines how much darktable may take from your system resources.\n"
@@ -1124,11 +1125,11 @@ msgstr ""
 "Swapping und unerwarteten Leistungseinbußen kommen kann. \n"
 "Mit Vorsicht zu verwenden und nicht für den allgemeinen Gebrauch empfohlen!"
 
-#: ../build/bin/preferences_gen.h:6215
+#: ../build/bin/preferences_gen.h:6294
 msgid "prefer performance over quality"
 msgstr "Geschwindigkeit gegenüber Qualität bevorzugen"
 
-#: ../build/bin/preferences_gen.h:6229
+#: ../build/bin/preferences_gen.h:6308
 msgid ""
 "if switched on, thumbnails and previews are rendered at lower quality but 4 "
 "times faster"
@@ -1136,11 +1137,11 @@ msgstr ""
 "Wenn aktiv werden Miniaturansichten und Vorschaubilder mit reduzierter "
 "Qualität aber vierfacher Geschwindigkeit berechnet."
 
-#: ../build/bin/preferences_gen.h:6251
+#: ../build/bin/preferences_gen.h:6330
 msgid "enable disk backend for thumbnail cache"
 msgstr "Festplattencache für Thumbnails benutzen"
 
-#: ../build/bin/preferences_gen.h:6265
+#: ../build/bin/preferences_gen.h:6344
 msgid ""
 "if enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -1159,11 +1160,11 @@ msgstr ""
 "Mit dem Kommandozeilenbefehl „darktable-generate-cache“ können die "
 "Thumbnails aller Sammlungen erzeugt werden."
 
-#: ../build/bin/preferences_gen.h:6287
+#: ../build/bin/preferences_gen.h:6366
 msgid "enable disk backend for full preview cache"
 msgstr "Festplattencache für Vorschaubilder benutzen"
 
-#: ../build/bin/preferences_gen.h:6301
+#: ../build/bin/preferences_gen.h:6380
 msgid ""
 "if enabled, write full preview to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -1180,11 +1181,11 @@ msgstr ""
 "Die Performance des Lichttisches wird stark erhöht, wenn Bilder in der "
 "Voransicht betrachtet werden."
 
-#: ../build/bin/preferences_gen.h:6323
+#: ../build/bin/preferences_gen.h:6402
 msgid "activate OpenCL support"
 msgstr "OpenCL-Unterstützung aktivieren"
 
-#: ../build/bin/preferences_gen.h:6337
+#: ../build/bin/preferences_gen.h:6416
 msgid ""
 "if found, use OpenCL runtime on your system for improved processing speed. "
 "can be switched on and off at any time."
@@ -1192,32 +1193,33 @@ msgstr ""
 "Benutze OpenCL-Laufzeitumgebung für schnellere Verarbeitung, sofern sie "
 "gefunden werden kann. Kann jederzeit an- und ausgeschaltet werden."
 
-#: ../build/bin/preferences_gen.h:6338 ../build/bin/preferences_gen.h:6409
-#: ../build/bin/preferences_gen.h:6451
+#: ../build/bin/preferences_gen.h:6417 ../build/bin/preferences_gen.h:6488
+#: ../build/bin/preferences_gen.h:6564 ../build/bin/preferences_gen.h:7940
 msgid "not available"
 msgstr "nicht verfügbar"
 
-#: ../build/bin/preferences_gen.h:6341 ../build/bin/preferences_gen.h:6345
-#: ../build/bin/preferences_gen.h:6412 ../build/bin/preferences_gen.h:6416
-#: ../build/bin/preferences_gen.h:6454 ../build/bin/preferences_gen.h:6458
+#: ../build/bin/preferences_gen.h:6420 ../build/bin/preferences_gen.h:6424
+#: ../build/bin/preferences_gen.h:6491 ../build/bin/preferences_gen.h:6495
+#: ../build/bin/preferences_gen.h:6567 ../build/bin/preferences_gen.h:6571
+#: ../build/bin/preferences_gen.h:7943 ../build/bin/preferences_gen.h:7947
 msgid "not available on this system"
 msgstr "auf diesem System nicht verfügbar"
 
-#: ../build/bin/preferences_gen.h:6365
+#: ../build/bin/preferences_gen.h:6444
 msgid "OpenCL scheduling profile"
 msgstr "OpenCL-Scheduler-Profil"
 
-#: ../build/bin/preferences_gen.h:6381 ../build/bin/conf_gen.h:430
+#: ../build/bin/preferences_gen.h:6460 ../build/bin/conf_gen.h:418
 msgctxt "preferences"
 msgid "multiple GPUs"
 msgstr "mehrere GPUs"
 
-#: ../build/bin/preferences_gen.h:6386 ../build/bin/conf_gen.h:431
+#: ../build/bin/preferences_gen.h:6465 ../build/bin/conf_gen.h:419
 msgctxt "preferences"
 msgid "very fast GPU"
 msgstr "sehr schnelle GPU"
 
-#: ../build/bin/preferences_gen.h:6408
+#: ../build/bin/preferences_gen.h:6487
 msgid ""
 "defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
 "systems. default - GPU processes full and CPU processes preview pipe "
@@ -1233,53 +1235,77 @@ msgstr ""
 "• sehr schnelle GPU: beide Pixelpipes werden nacheinander auf der selben GPU "
 "berechnet."
 
-#: ../build/bin/preferences_gen.h:6436
+#: ../build/bin/preferences_gen.h:6515
 msgid "tune OpenCL performance"
 msgstr "OpenCL Performance optimieren"
 
-#: ../build/bin/preferences_gen.h:6450
-msgid ""
-"if switched on, darktable tunes OpenCL for best performance, overrides "
-"static settings"
-msgstr ""
-"wenn eingeschaltet, optimiert darktable OpenCL für beste Leistung und "
-"übersteuert statische Einstellungen"
+#: ../build/bin/preferences_gen.h:6526 ../build/bin/preferences_gen.h:6560
+#: ../build/bin/conf_gen.h:427
+msgctxt "preferences"
+msgid "nothing"
+msgstr "nichts"
 
-#: ../build/bin/preferences_gen.h:6484
+#: ../build/bin/preferences_gen.h:6531 ../build/bin/conf_gen.h:428
+msgctxt "preferences"
+msgid "memory size"
+msgstr "Speichergröße"
+
+#: ../build/bin/preferences_gen.h:6536 ../build/bin/conf_gen.h:429
+msgctxt "preferences"
+msgid "memory transfer"
+msgstr "Speichertransfer"
+
+#: ../build/bin/preferences_gen.h:6541 ../build/bin/conf_gen.h:430
+msgctxt "preferences"
+msgid "memory size and transfer"
+msgstr "Speichergröße und -transfer"
+
+#: ../build/bin/preferences_gen.h:6563
+msgid ""
+"allows runtime tuning of OpenCL devices. 'memory size' tests for available "
+"graphics ram, 'memory transfer' tries a faster memory access mode (pinned "
+"memory) used for tiling."
+msgstr ""
+"ermöglicht die Abstimmung von OpenCL-Devices zur Laufzeit. \n"
+"'Speichergröße‘ testet den verfügbaren Grafikspeicher, \n"
+"'Speichertransfer’ versucht einen schnelleren Speicherzugriffsmodus (Pinned "
+"Memory), der für das Tiling verwendet wird."
+
+#: ../build/bin/preferences_gen.h:6597
 msgid "security"
 msgstr "Sicherheit"
 
-#: ../build/bin/preferences_gen.h:6507
+#: ../build/bin/preferences_gen.h:6620
 msgid "ask before removing images from the library"
 msgstr "fragen, bevor Bilder aus der Bibliothek entfernt werden"
 
-#: ../build/bin/preferences_gen.h:6521
+#: ../build/bin/preferences_gen.h:6634
 msgid "always ask the user before any image is removed from the library"
 msgstr "Immer nachfragen, bevor ein Bild aus der Bibliothek gelöscht wird."
 
-#: ../build/bin/preferences_gen.h:6543
+#: ../build/bin/preferences_gen.h:6656
 msgid "ask before deleting images from disk"
 msgstr "fragen, bevor Bilder von der Festplatte gelöscht werden"
 
-#: ../build/bin/preferences_gen.h:6557
+#: ../build/bin/preferences_gen.h:6670
 msgid "always ask the user before any image file is deleted"
 msgstr ""
 "Immer nachfragen, bevor eine Bilddatei von der Festplatte gelöscht wird"
 
-#: ../build/bin/preferences_gen.h:6579
+#: ../build/bin/preferences_gen.h:6692
 msgid "ask before discarding history stack"
 msgstr "fragen, bevor Verlaufsstapel von Bildern gelöscht werden"
 
-#: ../build/bin/preferences_gen.h:6593
+#: ../build/bin/preferences_gen.h:6706
 msgid "always ask the user before history stack is discarded on any image"
 msgstr ""
 "Immer nachfragen, bevor der Verlaufsstapel einer Bilddatei verworfen wird"
 
-#: ../build/bin/preferences_gen.h:6615
+#: ../build/bin/preferences_gen.h:6728
 msgid "try to use trash when deleting images"
 msgstr "benutze den Papierkorb beim Löschen (wenn möglich)"
 
-#: ../build/bin/preferences_gen.h:6629
+#: ../build/bin/preferences_gen.h:6742
 msgid ""
 "send files to trash instead of permanently deleting files on system that "
 "supports it"
@@ -1287,27 +1313,27 @@ msgstr ""
 "Verschiebe Bilder in den Papierkorb, statt sie permanent zu löschen, falls "
 "dies vom System unterstützt wird"
 
-#: ../build/bin/preferences_gen.h:6651
+#: ../build/bin/preferences_gen.h:6764
 msgid "ask before moving images from film roll folder"
 msgstr "fragen, bevor Bilder aus dem Filmrollen-Ordner verschoben werden"
 
-#: ../build/bin/preferences_gen.h:6665
+#: ../build/bin/preferences_gen.h:6778
 msgid "always ask the user before any image file is moved."
 msgstr "Immer nachfragen, bevor eine Bilddatei verschoben wird."
 
-#: ../build/bin/preferences_gen.h:6687
+#: ../build/bin/preferences_gen.h:6800
 msgid "ask before copying images to new film roll folder"
 msgstr "fragen, bevor Bilder in einen neuen Filmrollen-Ordner kopiert werden"
 
-#: ../build/bin/preferences_gen.h:6701
+#: ../build/bin/preferences_gen.h:6814
 msgid "always ask the user before any image file is copied."
 msgstr "Immer nachfragen, bevor eine Bilddatei kopiert wird."
 
-#: ../build/bin/preferences_gen.h:6723
+#: ../build/bin/preferences_gen.h:6836
 msgid "ask before removing empty folders"
 msgstr "fragen, bevor leere Verzeichnisse entfernt werden"
 
-#: ../build/bin/preferences_gen.h:6737
+#: ../build/bin/preferences_gen.h:6850
 msgid ""
 "always ask the user before removing any empty folder. this can happen after "
 "moving or deleting images."
@@ -1316,63 +1342,63 @@ msgstr ""
 "Leere Verzeichnisse können entstehen, wenn Bilder verschoben oder gelöscht "
 "werden."
 
-#: ../build/bin/preferences_gen.h:6759
+#: ../build/bin/preferences_gen.h:6872
 msgid "ask before deleting a tag"
 msgstr "fragen, bevor ein Tag gelöscht wird"
 
-#: ../build/bin/preferences_gen.h:6794
+#: ../build/bin/preferences_gen.h:6907
 msgid "ask before deleting a style"
 msgstr "fragen, bevor ein Stil gelöscht wird"
 
-#: ../build/bin/preferences_gen.h:6829
+#: ../build/bin/preferences_gen.h:6942
 msgid "ask before deleting a preset"
 msgstr "fragen, bevor eine Modul-Voreinstellung gelöscht wird"
 
-#: ../build/bin/preferences_gen.h:6843
+#: ../build/bin/preferences_gen.h:6956
 msgid "will ask for confirmation before deleting or overwriting a preset"
 msgstr ""
 "Immer nachfragen, bevor eine Modul-Voreinstellung gelöscht oder geändert "
 "wird."
 
-#: ../build/bin/preferences_gen.h:6865
+#: ../build/bin/preferences_gen.h:6978
 msgid "ask before exporting in overwrite mode"
 msgstr "fragen, im Überschreiben-Modus exportiert wird"
 
-#: ../build/bin/preferences_gen.h:6879
+#: ../build/bin/preferences_gen.h:6992
 msgid "will ask for confirmation before exporting files in overwrite mode"
 msgstr ""
 "Es wird immer nachgefragt, bevor im Überschreiben-Modus exportiert wird"
 
 #. italic
-#: ../build/bin/preferences_gen.h:6889 ../src/libs/tools/viewswitcher.c:149
+#: ../build/bin/preferences_gen.h:7002 ../src/libs/tools/viewswitcher.c:149
 msgid "other"
 msgstr "weitere"
 
-#: ../build/bin/preferences_gen.h:6909
+#: ../build/bin/preferences_gen.h:7022
 msgid "password storage backend to use"
 msgstr "Passwort-Speicher-Backend, das benutzt werden soll"
 
-#: ../build/bin/preferences_gen.h:6930 ../build/bin/conf_gen.h:2312
+#: ../build/bin/preferences_gen.h:7043 ../build/bin/conf_gen.h:2293
 msgctxt "preferences"
 msgid "libsecret"
 msgstr "libsecret"
 
-#: ../build/bin/preferences_gen.h:6936 ../build/bin/conf_gen.h:2313
+#: ../build/bin/preferences_gen.h:7049 ../build/bin/conf_gen.h:2294
 msgctxt "preferences"
 msgid "kwallet"
 msgstr "KWallet"
 
-#: ../build/bin/preferences_gen.h:6959
+#: ../build/bin/preferences_gen.h:7072
 msgid ""
 "the storage backend for password storage: auto, none, libsecret, kwallet"
 msgstr ""
 "Speicher-Backend für Passwörter: automatisch, keines, libsecret, KWallet"
 
-#: ../build/bin/preferences_gen.h:6981
+#: ../build/bin/preferences_gen.h:7094
 msgid "executable for playing audio files"
 msgstr "Programm zum Abspielen von Audiodateien"
 
-#: ../build/bin/preferences_gen.h:6999
+#: ../build/bin/preferences_gen.h:7112
 msgid ""
 "this external program is used to play audio files some cameras record to "
 "keep notes for images"
@@ -1380,51 +1406,51 @@ msgstr ""
 "Dieses externe Programm wird benutzt, um die Audiodateien abzuspielen, die "
 "einige Kameras für Notizen zu Bildern aufzeichnen"
 
-#: ../build/bin/preferences_gen.h:7027
+#: ../build/bin/preferences_gen.h:7140
 msgid "storage"
 msgstr "Speichern"
 
-#: ../build/bin/preferences_gen.h:7030 ../src/control/crawler.c:607
+#: ../build/bin/preferences_gen.h:7143 ../src/control/crawler.c:609
 msgid "database"
 msgstr "Datenbank"
 
-#: ../build/bin/preferences_gen.h:7050
+#: ../build/bin/preferences_gen.h:7163
 msgid "check for database maintenance"
 msgstr "prüfen, ob Datenbankwartung notwendig"
 
-#: ../build/bin/preferences_gen.h:7066 ../build/bin/conf_gen.h:209
+#: ../build/bin/preferences_gen.h:7179 ../build/bin/conf_gen.h:215
 msgctxt "preferences"
 msgid "on startup"
 msgstr "beim Start"
 
-#: ../build/bin/preferences_gen.h:7071 ../build/bin/preferences_gen.h:7110
-#: ../build/bin/preferences_gen.h:7211 ../build/bin/conf_gen.h:210
-#: ../build/bin/conf_gen.h:232
+#: ../build/bin/preferences_gen.h:7184 ../build/bin/preferences_gen.h:7223
+#: ../build/bin/preferences_gen.h:7324 ../build/bin/conf_gen.h:216
+#: ../build/bin/conf_gen.h:238
 msgctxt "preferences"
 msgid "on close"
 msgstr "beim Beenden"
 
-#: ../build/bin/preferences_gen.h:7076 ../build/bin/conf_gen.h:211
+#: ../build/bin/preferences_gen.h:7189 ../build/bin/conf_gen.h:217
 msgctxt "preferences"
 msgid "on both"
 msgstr "beim Start und beim Beenden"
 
-#: ../build/bin/preferences_gen.h:7081 ../build/bin/conf_gen.h:212
+#: ../build/bin/preferences_gen.h:7194 ../build/bin/conf_gen.h:218
 msgctxt "preferences"
 msgid "on startup (don't ask)"
 msgstr "beim Start (ohne Nachfrage)"
 
-#: ../build/bin/preferences_gen.h:7086 ../build/bin/conf_gen.h:213
+#: ../build/bin/preferences_gen.h:7199 ../build/bin/conf_gen.h:219
 msgctxt "preferences"
 msgid "on close (don't ask)"
 msgstr "beim Beenden (ohne Nachfrage)"
 
-#: ../build/bin/preferences_gen.h:7091 ../build/bin/conf_gen.h:214
+#: ../build/bin/preferences_gen.h:7204 ../build/bin/conf_gen.h:220
 msgctxt "preferences"
 msgid "on both (don't ask)"
 msgstr "beim Start und beim Beenden (ohne Nachfrage)"
 
-#: ../build/bin/preferences_gen.h:7113
+#: ../build/bin/preferences_gen.h:7226
 msgid ""
 "this option indicates when to check database fragmentation and perform "
 "maintenance"
@@ -1432,11 +1458,11 @@ msgstr ""
 "Diese Option bestimmt, zu welchem Zeitpunkt die Datenbank auf Fragmentierung "
 "überprüft und gegebenenfalls gewartet wird."
 
-#: ../build/bin/preferences_gen.h:7135
+#: ../build/bin/preferences_gen.h:7248
 msgid "database fragmentation ratio threshold"
 msgstr "Grenzwert für die Datenbankfragmentierungsrate"
 
-#: ../build/bin/preferences_gen.h:7158
+#: ../build/bin/preferences_gen.h:7271
 msgid ""
 "fragmentation ratio above which to ask or carry out automatically database "
 "maintenance"
@@ -1444,27 +1470,27 @@ msgstr ""
 "Fragmentierungsrate oberhalb derer der Nutzer gefragt wird, ob eine Wartung "
 "der Datenbank vorgenommen werden soll."
 
-#: ../build/bin/preferences_gen.h:7180
+#: ../build/bin/preferences_gen.h:7293
 msgid "create database snapshot"
 msgstr "Datenbankabzug erstellen"
 
-#: ../build/bin/preferences_gen.h:7196 ../build/bin/conf_gen.h:229
+#: ../build/bin/preferences_gen.h:7309 ../build/bin/conf_gen.h:235
 msgctxt "preferences"
 msgid "once a month"
 msgstr "monatlich"
 
-#: ../build/bin/preferences_gen.h:7201 ../build/bin/preferences_gen.h:7230
-#: ../build/bin/conf_gen.h:230
+#: ../build/bin/preferences_gen.h:7314 ../build/bin/preferences_gen.h:7343
+#: ../build/bin/conf_gen.h:236
 msgctxt "preferences"
 msgid "once a week"
 msgstr "wöchentlich"
 
-#: ../build/bin/preferences_gen.h:7206 ../build/bin/conf_gen.h:231
+#: ../build/bin/preferences_gen.h:7319 ../build/bin/conf_gen.h:237
 msgctxt "preferences"
 msgid "once a day"
 msgstr "täglich"
 
-#: ../build/bin/preferences_gen.h:7233
+#: ../build/bin/preferences_gen.h:7346
 msgid ""
 "database snapshots are created right before closing darktable. options allow "
 "you to choose how often to make snapshots:\n"
@@ -1488,11 +1514,11 @@ msgstr ""
 "• „beim Beenden”: Erstellt ein Datenbankabzug bei jedem Beenden von "
 "darktable."
 
-#: ../build/bin/preferences_gen.h:7255
+#: ../build/bin/preferences_gen.h:7368
 msgid "how many snapshots to keep"
 msgstr "Anzahl der aufbewahrten Datenbankabzüge"
 
-#: ../build/bin/preferences_gen.h:7278
+#: ../build/bin/preferences_gen.h:7391
 msgid ""
 "after successfully creating snapshot, how many older snapshots to keep "
 "(excluding mandatory version update ones). enter -1 to keep all snapshots\n"
@@ -1506,26 +1532,26 @@ msgstr ""
 "Beachte, dass Datenbankabzüge einen gewissen Speicherplatz benötigen und der "
 "jeweils neueste Abzug für eine erfolgreiche Wiederherstellung benötigt wird."
 
-#: ../build/bin/preferences_gen.h:7288 ../src/control/crawler.c:606
+#: ../build/bin/preferences_gen.h:7401 ../src/control/crawler.c:608
 msgid "xmp"
 msgstr "XMP-Begleitdateien"
 
-#: ../build/bin/preferences_gen.h:7308
+#: ../build/bin/preferences_gen.h:7421
 msgid "write sidecar file for each image"
 msgstr "für jedes Bild Begleitdatei schreiben"
 
-#: ../build/bin/preferences_gen.h:7324 ../build/bin/conf_gen.h:383
+#: ../build/bin/preferences_gen.h:7437 ../build/bin/conf_gen.h:371
 msgctxt "preferences"
 msgid "after edit"
 msgstr "nach Bearbeitung"
 
-#: ../build/bin/preferences_gen.h:7329 ../build/bin/preferences_gen.h:7348
-#: ../build/bin/conf_gen.h:384
+#: ../build/bin/preferences_gen.h:7442 ../build/bin/preferences_gen.h:7461
+#: ../build/bin/conf_gen.h:372
 msgctxt "preferences"
 msgid "on import"
 msgstr "beim Import"
 
-#: ../build/bin/preferences_gen.h:7351
+#: ../build/bin/preferences_gen.h:7464
 msgid ""
 "the sidecar files hold information about all your development steps to allow "
 "flawless re-importing of image files.\n"
@@ -1543,17 +1569,17 @@ msgstr ""
 " - beim Import: sofort nach dem Importieren des Bildes\n"
 " - nach Bearbeitung: nach jeder Benutzeränderung am Bild"
 
-#: ../build/bin/preferences_gen.h:7373
+#: ../build/bin/preferences_gen.h:7486
 msgid "store xmp tags in compressed format"
 msgstr "XMP-Tags komprimiert speichern"
 
-#: ../build/bin/preferences_gen.h:7394 ../build/bin/preferences_gen.h:7413
-#: ../build/bin/conf_gen.h:394
+#: ../build/bin/preferences_gen.h:7507 ../build/bin/preferences_gen.h:7526
+#: ../build/bin/conf_gen.h:382
 msgctxt "preferences"
 msgid "only large entries"
 msgstr "nur große Daten"
 
-#: ../build/bin/preferences_gen.h:7416
+#: ../build/bin/preferences_gen.h:7529
 msgid ""
 "entries in xmp tags can get rather large and may exceed the available space "
 "to store the history stack in output files. this option allows xmp tags to "
@@ -1565,11 +1591,11 @@ msgstr ""
 "Diese Option erlaubt es, die Daten in den XMP-Feldern zu komprimieren und so "
 "Speicherplatz zu sparen."
 
-#: ../build/bin/preferences_gen.h:7438
+#: ../build/bin/preferences_gen.h:7551
 msgid "look for updated xmp files on startup"
 msgstr "beim Start nach aktualisierten XMP-Dateien suchen"
 
-#: ../build/bin/preferences_gen.h:7452
+#: ../build/bin/preferences_gen.h:7565
 msgid ""
 "check file modification times of all xmp files on startup to check if any "
 "got updated in the meantime"
@@ -1577,39 +1603,51 @@ msgstr ""
 "Prüfe die Zeitstempel aller XMP-Dateien beim Start, um diejenigen zu finden, "
 "die zwischenzeitlich extern bearbeitet wurden."
 
-#: ../build/bin/preferences_gen.h:7480
+#: ../build/bin/preferences_gen.h:7593
 msgid "miscellaneous"
 msgstr "Verschiedenes"
 
-#: ../build/bin/preferences_gen.h:7483
+#: ../build/bin/preferences_gen.h:7596
 msgid "interface"
 msgstr "Benutzeroberfläche"
 
-#: ../build/bin/preferences_gen.h:7503
+#: ../build/bin/preferences_gen.h:7616
+msgid "load default shortcuts at startup"
+msgstr "Standard Shortcuts beim Start laden"
+
+#: ../build/bin/preferences_gen.h:7630
+msgid ""
+"load default shortcuts before user settings. switch off to prevent deleted "
+"defaults returning"
+msgstr ""
+"lädt Standard-Shortcuts vor den benutzerdefinierten. Ausschalten, um zu "
+"verhindern, dass gelöschte Standard-Shortcuts zurückkehren"
+
+#: ../build/bin/preferences_gen.h:7652
 msgid "scale slider step with min/max"
 msgstr "Skalierung der Reglerschritte mit Min/Max"
 
-#: ../build/bin/preferences_gen.h:7517
+#: ../build/bin/preferences_gen.h:7666
 msgid "vary bauhaus slider step size with min/max range"
 msgstr "variiert bauhaus Regler Schrittweite in einem sicheren min/max Bereich"
 
-#: ../build/bin/preferences_gen.h:7539
+#: ../build/bin/preferences_gen.h:7688
 msgid "sort built-in presets first"
 msgstr "eingebaute Voreinstellungen zuerst sortieren"
 
-#: ../build/bin/preferences_gen.h:7553
+#: ../build/bin/preferences_gen.h:7702
 msgid ""
 "whether to show built-in presets first before user's presets in presets menu."
 msgstr ""
 "Bestimmt ob, alle eingebauten Voreinstellungen vor den benutzerdefinierten "
 "Voreinstellungen im Voreinstellungsmenü gezeigt werden."
 
-#: ../build/bin/preferences_gen.h:7575
+#: ../build/bin/preferences_gen.h:7724
 msgid "mouse wheel scrolls modules side panel by default"
 msgstr ""
 "Mausrad blättert standardmäßig die Module der seitlichen Eingabefelder durch"
 
-#: ../build/bin/preferences_gen.h:7589
+#: ../build/bin/preferences_gen.h:7738
 msgid ""
 "when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to "
 "use mouse wheel for data entry.  when disabled, this behavior is reversed"
@@ -1619,11 +1657,11 @@ msgstr ""
 "gedrückter Tastenkombination Strg+Alt.\n"
 "Wenn deaktiviert, ist das Verhalten umgekehrt."
 
-#: ../build/bin/preferences_gen.h:7611
+#: ../build/bin/preferences_gen.h:7760
 msgid "always show panels' scrollbars"
 msgstr "zeige immer die Scrollbalken der Eingabefelder an"
 
-#: ../build/bin/preferences_gen.h:7625
+#: ../build/bin/preferences_gen.h:7774
 msgid ""
 "defines whether the panel scrollbars should be always visible or activated "
 "only depending on the content.  (need a restart)"
@@ -1631,46 +1669,46 @@ msgstr ""
 "Definiert, ob die Scrollbalken der Eingabefelder immer sichtbar sind oder "
 "abhängig vom Inhalt. Bei Änderung Neustart erforderlich."
 
-#: ../build/bin/preferences_gen.h:7647
+#: ../build/bin/preferences_gen.h:7796
 msgid "position of the scopes module"
 msgstr "Position des Histogramms/Scopes"
 
-#: ../build/bin/preferences_gen.h:7658 ../build/bin/conf_gen.h:2526
+#: ../build/bin/preferences_gen.h:7807 ../build/bin/conf_gen.h:2507
 msgctxt "preferences"
 msgid "left"
 msgstr "links"
 
-#: ../build/bin/preferences_gen.h:7663 ../build/bin/preferences_gen.h:7682
-#: ../build/bin/conf_gen.h:2527
+#: ../build/bin/preferences_gen.h:7812 ../build/bin/preferences_gen.h:7831
+#: ../build/bin/conf_gen.h:2508
 msgctxt "preferences"
 msgid "right"
 msgstr "rechts"
 
-#: ../build/bin/preferences_gen.h:7685
+#: ../build/bin/preferences_gen.h:7834
 msgid "position the scopes at the top-left or top-right of the screen"
 msgstr "Positionierung des Histogramms/Scopes links oder recht oben "
 
-#: ../build/bin/preferences_gen.h:7707
+#: ../build/bin/preferences_gen.h:7856
 msgid "method to use for getting the display profile"
 msgstr "Methode, um das Monitorprofil zu ermitteln"
 
-#: ../build/bin/preferences_gen.h:7718 ../build/bin/preferences_gen.h:7747
-#: ../build/bin/conf_gen.h:2760
+#: ../build/bin/preferences_gen.h:7867 ../build/bin/preferences_gen.h:7896
+#: ../build/bin/conf_gen.h:2751
 msgctxt "preferences"
 msgid "all"
 msgstr "alle"
 
-#: ../build/bin/preferences_gen.h:7723 ../build/bin/conf_gen.h:2761
+#: ../build/bin/preferences_gen.h:7872 ../build/bin/conf_gen.h:2752
 msgctxt "preferences"
 msgid "xatom"
 msgstr "XAtom"
 
-#: ../build/bin/preferences_gen.h:7728 ../build/bin/conf_gen.h:2762
+#: ../build/bin/preferences_gen.h:7877 ../build/bin/conf_gen.h:2753
 msgctxt "preferences"
 msgid "colord"
 msgstr "Colord"
 
-#: ../build/bin/preferences_gen.h:7750
+#: ../build/bin/preferences_gen.h:7899
 msgid ""
 "this option allows to force a specific means of getting the current display "
 "profile. this is useful when one alternative gives wrong results"
@@ -1679,18 +1717,34 @@ msgstr ""
 "Anzeigenprofils festzulegen. \n"
 "Dies ist hilfreich, wenn eine der Alternativen falsche Ergebnisse liefert."
 
+#: ../build/bin/preferences_gen.h:7921
+msgid "order or exclude midi devices"
+msgstr "Midi Devices anordnen oder ausschließen"
+
+#: ../build/bin/preferences_gen.h:7939
+msgid ""
+"comma-separated list of device name fragments that if matched load midi "
+"device at id given by location in list or if preceded by - prevent matching "
+"devices from loading. add encoding and number of knobs like 'BeatStep:63:16'"
+msgstr ""
+"kommaseparierte Liste von Midi Device-Namensfragmenten,\n"
+"Die ID des Midi-Devices ergibt sich anhand der Position des zum "
+"Namensfragment passenden Devices.\n"
+"Um ein Device auszuschließen ein '-' voranstellen. \n"
+"Kodierung und Anzahl der Regler wie z.B. 'BeatStep:63:16’ angeben"
+
 #. tags
-#: ../build/bin/preferences_gen.h:7760 ../src/develop/lightroom.c:1512
-#: ../src/gui/import_metadata.c:472 ../src/libs/export_metadata.c:331
+#: ../build/bin/preferences_gen.h:7955 ../src/develop/lightroom.c:1516
+#: ../src/gui/import_metadata.c:476 ../src/libs/export_metadata.c:331
 #: ../src/libs/image.c:568 ../src/libs/metadata_view.c:162
 msgid "tags"
 msgstr "Tags"
 
-#: ../build/bin/preferences_gen.h:7780
+#: ../build/bin/preferences_gen.h:7975
 msgid "omit hierarchy in simple tag lists"
 msgstr "Hierarchie in einfacher Tag-Liste auslassen"
 
-#: ../build/bin/preferences_gen.h:7794
+#: ../build/bin/preferences_gen.h:7989
 msgid ""
 "when creating XMP file the hierarchical tags are also added as a simple list "
 "of non-hierarchical ones to make them visible to some other programs. when "
@@ -1704,25 +1758,25 @@ msgstr ""
 "genommen und der Rest ignoriert. Von 'foo|bar|baz' wird also nur 'baz' "
 "eingefügt."
 
-#: ../build/bin/preferences_gen.h:7804
+#: ../build/bin/preferences_gen.h:7999
 msgid "shortcuts with multiple instances"
-msgstr "Kurzbefehle bei mehreren Modulinstanzen"
+msgstr "Shortcuts bei mehreren Modulinstanzen"
 
-#: ../build/bin/preferences_gen.h:7809
+#: ../build/bin/preferences_gen.h:8004
 msgid ""
 "where multiple module instances are present, these preferences control rules "
 "that are applied (in order) to decide which module instance shortcuts will "
 "be applied to"
 msgstr ""
-"Diese Einstellungen beeinflussen die Regeln, nach denen Kurzbefehle auf die "
+"Diese Einstellungen beeinflussen die Regeln, nach denen Shortcuts auf die "
 "Moduleinstellungen angewandt werden, wenn mehrere Instanzen eines Moduls "
 "vorhanden sind."
 
-#: ../build/bin/preferences_gen.h:7825
+#: ../build/bin/preferences_gen.h:8020
 msgid "prefer focused instance"
 msgstr "Modulinstanz mit Fokus bevorzugen"
 
-#: ../build/bin/preferences_gen.h:7839
+#: ../build/bin/preferences_gen.h:8034
 msgid ""
 "if an instance of the module has focus, apply shortcut to that instance\n"
 "note: blending shortcuts always apply to the focused instance"
@@ -1731,21 +1785,21 @@ msgstr ""
 "angewendet.\n"
 "Hinweis: Überblendkürzel gelten immer für die fokussierte Instanz"
 
-#: ../build/bin/preferences_gen.h:7861
+#: ../build/bin/preferences_gen.h:8056
 msgid "prefer expanded instances"
 msgstr "eingeblendete Modulinstanzen bevorzugen"
 
-#: ../build/bin/preferences_gen.h:7875
+#: ../build/bin/preferences_gen.h:8070
 msgid "if instances of the module are expanded, ignore collapsed instances"
 msgstr ""
 "Wenn Instanzen des Moduls eingeblendet sind, ignoriere ausgeblendete "
 "Modulinstanzen."
 
-#: ../build/bin/preferences_gen.h:7897
+#: ../build/bin/preferences_gen.h:8092
 msgid "prefer enabled instances"
 msgstr "aktive Modulinstanzen bevorzugen"
 
-#: ../build/bin/preferences_gen.h:7911
+#: ../build/bin/preferences_gen.h:8106
 msgid ""
 "after applying the above rule, if instances of the module are active, ignore "
 "inactive instances"
@@ -1753,11 +1807,11 @@ msgstr ""
 "Nachdem obige Regel angewandt wurde: Wenn Instanzen des Moduls aktiv sind, "
 "ignoriere inaktive Modulinstanzen."
 
-#: ../build/bin/preferences_gen.h:7933
+#: ../build/bin/preferences_gen.h:8128
 msgid "prefer unmasked instances"
 msgstr "Modulinstanzen mit lokalen Masken bevorzugen"
 
-#: ../build/bin/preferences_gen.h:7947
+#: ../build/bin/preferences_gen.h:8142
 msgid ""
 "after applying the above rules, if instances of the module are unmasked, "
 "ignore masked instances"
@@ -1766,94 +1820,94 @@ msgstr ""
 "lokale Masken verwenden, ignoriere Modulinstanzen, die lokale Masken "
 "verwenden."
 
-#: ../build/bin/preferences_gen.h:7969
+#: ../build/bin/preferences_gen.h:8164
 msgid "selection order"
 msgstr "Reihenfolge"
 
-#: ../build/bin/preferences_gen.h:7980 ../build/bin/conf_gen.h:158
+#: ../build/bin/preferences_gen.h:8175 ../build/bin/conf_gen.h:158
 msgctxt "preferences"
 msgid "first instance"
 msgstr "erste Instanz"
 
-#: ../build/bin/preferences_gen.h:7985 ../build/bin/preferences_gen.h:8004
+#: ../build/bin/preferences_gen.h:8180 ../build/bin/preferences_gen.h:8199
 #: ../build/bin/conf_gen.h:159
 msgctxt "preferences"
 msgid "last instance"
 msgstr "letzte Instanz"
 
-#: ../build/bin/preferences_gen.h:8007
+#: ../build/bin/preferences_gen.h:8202
 msgid ""
 "after applying the above rules, apply the shortcut based on its position in "
 "the pixelpipe"
 msgstr ""
-"Nachdem obige Regeln angewandt wurden: Wende die Kurzbefehle auf Module "
-"gemäß ihrer Position im Bearbeitungsstapel an."
+"Nachdem obige Regeln angewandt wurden: Wende die Shortcuts auf Module gemäß "
+"ihrer Position im Bearbeitungsstapel an."
 
-#: ../build/bin/preferences_gen.h:8029
+#: ../build/bin/preferences_gen.h:8224
 msgid "allow visual assignment to specific instances"
 msgstr "visuelle Zuordnung zu bestimmten Instanzen ermöglichen"
 
-#: ../build/bin/preferences_gen.h:8043
+#: ../build/bin/preferences_gen.h:8238
 msgid ""
 "when multiple instances are present on an image this allows shortcuts to be "
 "visually assigned to those specific instances\n"
 "otherwise shortcuts will always be assigned to the preferred instance"
 msgstr ""
-"Wenn mehrere Instanzen bei einem Bild vorhanden sind, können die Kurzbefehle "
+"Wenn mehrere Instanzen bei einem Bild vorhanden sind, können die Shortcuts "
 "visuell diesen spezifischen Instanzen zugewiesen werden.\n"
 "Andernfalls werden die Verknüpfungen immer der bevorzugten Instanz "
 "zugewiesen."
 
-#: ../build/bin/preferences_gen.h:8053
+#: ../build/bin/preferences_gen.h:8248
 msgid "map / geolocalization view"
 msgstr "Karte / Geolokalisierung"
 
-#: ../build/bin/preferences_gen.h:8073
+#: ../build/bin/preferences_gen.h:8268
 msgid "pretty print the image location"
 msgstr "Bildposition schön formatieren"
 
-#: ../build/bin/preferences_gen.h:8087
+#: ../build/bin/preferences_gen.h:8282
 msgid ""
 "show a more readable representation of the location in the image information "
 "module"
 msgstr ""
 "Zeige eine besser lesbare Darstellung der Position im Modul „Bildinformation“"
 
-#: ../build/bin/preferences_gen.h:8097
+#: ../build/bin/preferences_gen.h:8292
 msgid "slideshow view"
 msgstr "Diashow"
 
-#: ../build/bin/preferences_gen.h:8117
+#: ../build/bin/preferences_gen.h:8312
 msgid "waiting time between each picture in slideshow"
 msgstr "Wartezeit zwischen zwei Bildern in der Diashow"
 
-#: ../build/bin/preferences_gen.h:8167 ../src/control/jobs/control_jobs.c:2316
+#: ../build/bin/preferences_gen.h:8362 ../src/control/jobs/control_jobs.c:2325
 #: ../src/libs/import.c:172
 msgid "import"
 msgstr "Importieren"
 
 # zu frei?
-#: ../build/bin/preferences_gen.h:8170
+#: ../build/bin/preferences_gen.h:8365
 msgid "session options"
 msgstr "Sitzungs-Optionen"
 
-#: ../build/bin/preferences_gen.h:8190
+#: ../build/bin/preferences_gen.h:8385
 msgid "base directory naming pattern"
 msgstr "Namensformat des Wurzelverzeichnisses"
 
-#: ../build/bin/preferences_gen.h:8208 ../build/bin/preferences_gen.h:8248
+#: ../build/bin/preferences_gen.h:8403 ../build/bin/preferences_gen.h:8443
 msgid "part of full import path for an import session"
 msgstr "Teil eines vollständigen Import-Pfades beim Importieren"
 
-#: ../build/bin/preferences_gen.h:8230
+#: ../build/bin/preferences_gen.h:8425
 msgid "sub directory naming pattern"
 msgstr "Namensformat der Unterordner"
 
-#: ../build/bin/preferences_gen.h:8270
+#: ../build/bin/preferences_gen.h:8465
 msgid "keep original filename"
 msgstr "ursprünglichen Dateinamen erhalten"
 
-#: ../build/bin/preferences_gen.h:8284
+#: ../build/bin/preferences_gen.h:8479
 msgid ""
 "keep original filename instead of a pattern while importing from camera or "
 "card"
@@ -1861,39 +1915,39 @@ msgstr ""
 "den ursprünglichen Dateinamen erhalten statt Änderung gemäß Namensformat "
 "während Import von Kamera oder Karte"
 
-#: ../build/bin/preferences_gen.h:8306
+#: ../build/bin/preferences_gen.h:8501
 msgid "file naming pattern"
 msgstr "Namensformat der Dateien"
 
-#: ../build/bin/preferences_gen.h:8324
+#: ../build/bin/preferences_gen.h:8519
 msgid "file naming pattern used for a import session"
 msgstr "Namensformat für Dateien beim Importieren"
 
-#: ../build/bin/preferences_gen.h:8361
+#: ../build/bin/preferences_gen.h:8556
 msgid "do not set the 'uncategorized' entry for tags"
 msgstr "nicht 'Sonstige' als Tag verwenden"
 
-#: ../build/bin/preferences_gen.h:8375
+#: ../build/bin/preferences_gen.h:8570
 msgid ""
 "do not set the 'uncategorized' entry for tags which do not have children"
 msgstr "nicht 'Sonstige' als Tag verwenden, wenn es keine Detaillierung gibt"
 
-#: ../build/bin/preferences_gen.h:8397
+#: ../build/bin/preferences_gen.h:8592
 msgid "tags case sensitivity"
 msgstr "Groß- und Kleinschreibung für Tags"
 
-#: ../build/bin/preferences_gen.h:8408 ../build/bin/conf_gen.h:414
+#: ../build/bin/preferences_gen.h:8603 ../build/bin/conf_gen.h:402
 msgctxt "preferences"
 msgid "sensitive"
 msgstr "Groß- und Kleinschreibung beachten"
 
-#: ../build/bin/preferences_gen.h:8413 ../build/bin/preferences_gen.h:8432
-#: ../build/bin/conf_gen.h:415
+#: ../build/bin/preferences_gen.h:8608 ../build/bin/preferences_gen.h:8627
+#: ../build/bin/conf_gen.h:403
 msgctxt "preferences"
 msgid "insensitive"
 msgstr "Groß- und Kleinschreibung ignorieren"
 
-#: ../build/bin/preferences_gen.h:8435
+#: ../build/bin/preferences_gen.h:8630
 msgid ""
 "tags case sensitivity. without the Sqlite ICU extension, insensivity works "
 "only for the 26 latin letters"
@@ -1902,11 +1956,11 @@ msgstr ""
 "funktioniert die Nichtbeachtung der Groß/Kleinschreibung nur für die 26 "
 "lateinischen Buchstaben"
 
-#: ../build/bin/preferences_gen.h:8457
+#: ../build/bin/preferences_gen.h:8652
 msgid "number of folder levels to show in lists"
 msgstr "Anzahl Verzeichnis-Ebenen, die in der Liste angezeigt werden sollen"
 
-#: ../build/bin/preferences_gen.h:8481
+#: ../build/bin/preferences_gen.h:8676
 msgid ""
 "the number of folder levels to show in film roll names, starting from the "
 "right"
@@ -1914,30 +1968,30 @@ msgstr ""
 "Bestimmt die Anzahl an Verzeichnis-Ebenen, die im Filmrollennamen angezeigt "
 "werden sollen, beginnend von rechts"
 
-#: ../build/bin/preferences_gen.h:8503
+#: ../build/bin/preferences_gen.h:8698
 msgid "sort film rolls by"
 msgstr "Filmrolle sortieren nach"
 
-#: ../build/bin/preferences_gen.h:8514 ../build/bin/preferences_gen.h:8538
-#: ../build/bin/conf_gen.h:621
+#: ../build/bin/preferences_gen.h:8709 ../build/bin/preferences_gen.h:8733
+#: ../build/bin/conf_gen.h:602
 msgctxt "preferences"
 msgid "id"
 msgstr "ID"
 
-#: ../build/bin/preferences_gen.h:8519 ../build/bin/conf_gen.h:622
+#: ../build/bin/preferences_gen.h:8714 ../build/bin/conf_gen.h:603
 msgctxt "preferences"
 msgid "folder"
 msgstr "Verzeichnis"
 
-#: ../build/bin/preferences_gen.h:8541
+#: ../build/bin/preferences_gen.h:8736
 msgid "sets the collections-list order for film rolls"
 msgstr "Bestimmt die Sortierung der Bilder einer Filmrolle"
 
-#: ../build/bin/preferences_gen.h:8563
+#: ../build/bin/preferences_gen.h:8758
 msgid "sort collection descending"
 msgstr "Sammlung absteigend sortieren"
 
-#: ../build/bin/preferences_gen.h:8577
+#: ../build/bin/preferences_gen.h:8772
 msgid ""
 "sort the following collections in descending order: 'film roll' by folder, "
 "'folder', 'times' (e.g. 'date taken')"
@@ -1945,21 +1999,21 @@ msgstr ""
 "Sortierung der folgenden Sammlungen in absteigender Reihenfolge: 'Filmrolle' "
 "nach Ordnern, 'Ordner', 'Zeiten' (z. B. 'Aufnahmedatum')"
 
-#: ../build/bin/preferences_gen.h:8615
+#: ../build/bin/preferences_gen.h:8810
 msgid "number of collections to be stored"
 msgstr "Anzahl zu speichernder Sammlungen"
 
-#: ../build/bin/preferences_gen.h:8639
+#: ../build/bin/preferences_gen.h:8834
 msgid "the number of recent collections to store and show in this list"
 msgstr ""
 "Anzahl der Sammlungen, die in der Liste „kürzlich benutzter Sammlungen“ "
 "gespeichert werden"
 
-#: ../build/bin/preferences_gen.h:8693
+#: ../build/bin/preferences_gen.h:8888
 msgid "suggested tags level of confidence"
 msgstr "vorgeschlagene Tags Konfidenzlevel"
 
-#: ../build/bin/preferences_gen.h:8717
+#: ../build/bin/preferences_gen.h:8912
 #, c-format
 msgid ""
 "level of confidence to include the tag in the suggestions list, 0: all "
@@ -1972,11 +2026,11 @@ msgstr ""
 "100: kein übereinstimmendes Tag, um nur die neuesten Tags anzuzeigen "
 "(schneller)"
 
-#: ../build/bin/preferences_gen.h:8739
+#: ../build/bin/preferences_gen.h:8934
 msgid "number of recently attached tags"
 msgstr "Anzahl der zuletzt zugewiesenen Tags"
 
-#: ../build/bin/preferences_gen.h:8763
+#: ../build/bin/preferences_gen.h:8958
 msgid ""
 "number of recently attached tags which are included in the suggestions list. "
 "the value `-1' disables the recent list"
@@ -1985,74 +2039,74 @@ msgstr ""
 "werden. \n"
 "Der Wert `-1’ deaktiviert die Liste der zuletzt zugeordneten Tags."
 
-#: ../build/bin/conf_gen.h:445
+#: ../build/bin/conf_gen.h:438
 msgctxt "preferences"
 msgid "true"
 msgstr "Wahr"
 
-#: ../build/bin/conf_gen.h:446
+#: ../build/bin/conf_gen.h:439
 msgctxt "preferences"
 msgid "active module"
 msgstr "Aktives Modul"
 
-#: ../build/bin/conf_gen.h:447
+#: ../build/bin/conf_gen.h:440
 msgctxt "preferences"
 msgid "false"
 msgstr "Falsch"
 
-#: ../build/bin/conf_gen.h:636
+#: ../build/bin/conf_gen.h:617
 msgctxt "preferences"
 msgid "RGB"
 msgstr "RGB"
 
-#: ../build/bin/conf_gen.h:637
+#: ../build/bin/conf_gen.h:618
 msgctxt "preferences"
 msgid "Lab"
 msgstr "Lab"
 
-#: ../build/bin/conf_gen.h:638
+#: ../build/bin/conf_gen.h:619
 msgctxt "preferences"
 msgid "LCh"
 msgstr "LCh"
 
-#: ../build/bin/conf_gen.h:639
+#: ../build/bin/conf_gen.h:620
 msgctxt "preferences"
 msgid "HSL"
 msgstr "HSL"
 
-#: ../build/bin/conf_gen.h:640
+#: ../build/bin/conf_gen.h:621
 msgctxt "preferences"
 msgid "Hex"
 msgstr "Hex"
 
-#: ../build/bin/conf_gen.h:649
+#: ../build/bin/conf_gen.h:630
 msgctxt "preferences"
 msgid "mean"
 msgstr "Mittel"
 
-#: ../build/bin/conf_gen.h:650
+#: ../build/bin/conf_gen.h:631
 msgctxt "preferences"
 msgid "min"
 msgstr "min"
 
-#: ../build/bin/conf_gen.h:651
+#: ../build/bin/conf_gen.h:632
 msgctxt "preferences"
 msgid "max"
 msgstr "max"
 
-#: ../build/bin/conf_gen.h:839
+#: ../build/bin/conf_gen.h:820
 msgid "select only new pictures"
 msgstr "nur neue Bilder auswählen"
 
-#: ../build/bin/conf_gen.h:840
+#: ../build/bin/conf_gen.h:821
 msgid "only select images that have not already been imported"
 msgstr "Nur noch nicht importierte Bilder auswählen"
 
-#: ../build/bin/conf_gen.h:845
+#: ../build/bin/conf_gen.h:826
 msgid "ignore JPEG images"
 msgstr "JPEG-Dateien ignorieren"
 
-#: ../build/bin/conf_gen.h:846
+#: ../build/bin/conf_gen.h:827
 msgid ""
 "when having raw+JPEG images together in one directory it makes no sense to "
 "import both. with this flag one can ignore all JPEGs found."
@@ -2061,57 +2115,57 @@ msgstr ""
 "sinnvoll, beide zu importieren. \n"
 "Mit dieser Option können alle gefundenen JPEG-Bilder ignoriert werden."
 
-#: ../build/bin/conf_gen.h:851
+#: ../build/bin/conf_gen.h:832
 msgid "apply metadata"
 msgstr "Metadaten übernehmen"
 
-#: ../build/bin/conf_gen.h:852
+#: ../build/bin/conf_gen.h:833
 msgid "apply some metadata to all newly imported images."
 msgstr "Metadaten zu allen neu importierten Bildern hinzufügen."
 
-#: ../build/bin/conf_gen.h:857
+#: ../build/bin/conf_gen.h:838
 msgid "recursive directory"
 msgstr "inkl. Unterverzeichnisse"
 
-#: ../build/bin/conf_gen.h:858
+#: ../build/bin/conf_gen.h:839
 msgid "recursive directory traversal when importing filmrolls"
 msgstr "rekursiver Import von Verzeichnissen"
 
-#: ../build/bin/conf_gen.h:863
+#: ../build/bin/conf_gen.h:844
 msgid "creator to be applied when importing"
 msgstr "Urheber, der beim Import hinzugefügt werden soll"
 
-#: ../build/bin/conf_gen.h:869
+#: ../build/bin/conf_gen.h:850
 msgid "publisher to be applied when importing"
 msgstr "Herausgeber, der beim Import hinzugefügt werden soll"
 
-#: ../build/bin/conf_gen.h:875
+#: ../build/bin/conf_gen.h:856
 msgid "rights to be applied when importing"
 msgstr "Rechte, die beim Import hinzugefügt werden sollen"
 
-#: ../build/bin/conf_gen.h:881
+#: ../build/bin/conf_gen.h:862
 msgid "comma separated tags to be applied when importing"
 msgstr "Komma-separierte Tags, die beim Import hinzugefügt werden sollen"
 
-#: ../build/bin/conf_gen.h:887
+#: ../build/bin/conf_gen.h:868
 msgid "import tags from xmp"
 msgstr "Tags aus XMP-Datei importieren"
 
-#: ../build/bin/conf_gen.h:913
+#: ../build/bin/conf_gen.h:894
 msgid "initial rating"
 msgstr "Bewertung beim Import"
 
-#: ../build/bin/conf_gen.h:914
+#: ../build/bin/conf_gen.h:895
 msgid "initial star rating for all images when importing a filmroll"
 msgstr ""
 "initiale Bewertung (Anzahl von Sternen) aller Bilder in einer neu "
 "importierten Filmrolle"
 
-#: ../build/bin/conf_gen.h:919
+#: ../build/bin/conf_gen.h:900
 msgid "ignore exif rating"
 msgstr "Ignoriere Bewertung aus Exif Daten"
 
-#: ../build/bin/conf_gen.h:920
+#: ../build/bin/conf_gen.h:901
 msgid ""
 "ignore exif rating. if not set and exif rating is found, it overrides "
 "'initial rating'"
@@ -2119,19 +2173,19 @@ msgstr ""
 "Ignoriere Bewertung aus Exif Daten. Falls dieses Flag nicht gesetzt ist wird "
 "die Bewertung aus den Exif Daten übernommen, sofern es dort gesetzt ist."
 
-#: ../build/bin/conf_gen.h:925
+#: ../build/bin/conf_gen.h:906
 msgid "import job"
 msgstr "Importauftrag"
 
-#: ../build/bin/conf_gen.h:926
+#: ../build/bin/conf_gen.h:907
 msgid "name of the import job"
 msgstr "Name des Importauftrags"
 
-#: ../build/bin/conf_gen.h:931
+#: ../build/bin/conf_gen.h:912
 msgid "override today's date"
 msgstr "Heutiges Datum überschreiben"
 
-#: ../build/bin/conf_gen.h:932
+#: ../build/bin/conf_gen.h:913
 msgid ""
 "type a date in the form: YYYY:MM:DD[ hh:mm:ss[.sss]] if you want to override "
 "the current date/time used when expanding variables:\n"
@@ -2144,45 +2198,45 @@ msgstr ""
 "überschrieben werden soll:\n"
 "sonst das Feld leer lassen"
 
-#: ../build/bin/conf_gen.h:937
+#: ../build/bin/conf_gen.h:918
 msgid "keep this window open"
 msgstr "Dialog geöffnet lassen"
 
-#: ../build/bin/conf_gen.h:938
+#: ../build/bin/conf_gen.h:919
 msgid "keep this window open to run several imports"
 msgstr "Dialog für weitere Importe geöffnet halten"
 
-#: ../build/bin/conf_gen.h:1701
+#: ../build/bin/conf_gen.h:1682
 msgid "show OSD"
 msgstr "OSD anzeigen"
 
-#: ../build/bin/conf_gen.h:1702
+#: ../build/bin/conf_gen.h:1683
 msgid "toggle the visibility of the map overlays"
 msgstr "Sichtbarkeit der Karten-Überlagerungen umschalten"
 
-#: ../build/bin/conf_gen.h:1707
+#: ../build/bin/conf_gen.h:1688
 msgid "filtered images"
 msgstr "nur aktuelle Sammlung"
 
-#: ../build/bin/conf_gen.h:1708
+#: ../build/bin/conf_gen.h:1689
 msgid "when set limit the images drawn to the current filmstrip"
 msgstr ""
 "Zeige nur Bilder auf der Karte an, die Bestandteil der aktuellen Sammlung "
 "sind."
 
-#: ../build/bin/conf_gen.h:1715
+#: ../build/bin/conf_gen.h:1696
 msgid "max images"
 msgstr "Maximale Anzahl Bilder"
 
-#: ../build/bin/conf_gen.h:1716
+#: ../build/bin/conf_gen.h:1697
 msgid "the maximum number of image thumbnails drawn on the map"
 msgstr "maximale Anzahl Bilder, die auf der Karte gezeigt werden"
 
-#: ../build/bin/conf_gen.h:1723
+#: ../build/bin/conf_gen.h:1704
 msgid "group size factor"
 msgstr "Faktor Gruppengröße"
 
-#: ../build/bin/conf_gen.h:1724
+#: ../build/bin/conf_gen.h:1705
 msgid ""
 "increase or decrease the spatial size of images groups on the map. can "
 "influence the calculation time"
@@ -2190,11 +2244,11 @@ msgstr ""
 "vergrößern oder verkleinern der räumlichen Ausdehnung der Bildgruppen auf "
 "der Karte. Kann die Berechnungszeit beeinflussen"
 
-#: ../build/bin/conf_gen.h:1731
+#: ../build/bin/conf_gen.h:1712
 msgid "min images per group"
 msgstr "minimale Zahl Bilder je Gruppe"
 
-#: ../build/bin/conf_gen.h:1732
+#: ../build/bin/conf_gen.h:1713
 msgid ""
 "the minimum number of images to set up an images group. can influence the "
 "calculation time."
@@ -2202,21 +2256,21 @@ msgstr ""
 "minimale Anzahl von Bildern, um eine Bildgruppe einzurichten. Kann die "
 "Berechnungszeit beeinflussen."
 
-#: ../build/bin/conf_gen.h:1737
+#: ../build/bin/conf_gen.h:1718
 msgctxt "preferences"
 msgid "thumbnail"
 msgstr "Vorschaubild"
 
-#: ../build/bin/conf_gen.h:1738
+#: ../build/bin/conf_gen.h:1719
 msgctxt "preferences"
 msgid "count"
 msgstr "Anzahl"
 
-#: ../build/bin/conf_gen.h:1741
+#: ../build/bin/conf_gen.h:1722
 msgid "thumbnail display"
 msgstr "Vorschaubild Anzeige"
 
-#: ../build/bin/conf_gen.h:1742
+#: ../build/bin/conf_gen.h:1723
 msgid ""
 "three options are available: images thumbnails, only the count of images of "
 "the group or nothing"
@@ -2224,82 +2278,100 @@ msgstr ""
 "Es stehen drei Optionen zur Verfügung: Bilder-Miniaturansichten, nur Anzahl "
 "der Bilder der Gruppe oder nichts"
 
-#: ../build/bin/conf_gen.h:1753
+#: ../build/bin/conf_gen.h:1734
 msgid "max polygon points"
 msgstr "max Polygonpunkte"
 
-#: ../build/bin/conf_gen.h:1754
+#: ../build/bin/conf_gen.h:1735
 msgid ""
 "limit the number of points imported with polygon in find location module"
 msgstr ""
 "Begrenzung der Anzahl der importierten Punkte für ein Polygon im Modul "
 "„Position finden“"
 
-#: ../build/bin/conf_gen.h:2515
+#: ../build/bin/conf_gen.h:2496
 msgctxt "preferences"
 msgid "histogram"
 msgstr "Histogramm"
 
-#: ../build/bin/conf_gen.h:2516
+#: ../build/bin/conf_gen.h:2497
 msgctxt "preferences"
 msgid "waveform"
 msgstr "Waveform"
 
-#: ../build/bin/conf_gen.h:2517
+#: ../build/bin/conf_gen.h:2498
 msgctxt "preferences"
 msgid "rgb parade"
 msgstr "RGB Parade"
 
-#: ../build/bin/conf_gen.h:2518
+#: ../build/bin/conf_gen.h:2499
 msgctxt "preferences"
 msgid "vectorscope"
 msgstr "Vectorscope"
 
-#: ../build/bin/conf_gen.h:2535 ../build/bin/conf_gen.h:2571
+#: ../build/bin/conf_gen.h:2516 ../build/bin/conf_gen.h:2552
 msgctxt "preferences"
 msgid "logarithmic"
 msgstr "logarithmisch"
 
-#: ../build/bin/conf_gen.h:2536 ../build/bin/conf_gen.h:2572
+#: ../build/bin/conf_gen.h:2517 ../build/bin/conf_gen.h:2553
 msgctxt "preferences"
 msgid "linear"
 msgstr "linear"
 
-#: ../build/bin/conf_gen.h:2544
+#: ../build/bin/conf_gen.h:2525
 msgctxt "preferences"
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ../build/bin/conf_gen.h:2545
+#: ../build/bin/conf_gen.h:2526
 msgctxt "preferences"
 msgid "vertical"
 msgstr "vertikal"
 
-#: ../build/bin/conf_gen.h:2553
+#: ../build/bin/conf_gen.h:2534
 msgctxt "preferences"
 msgid "overlaid"
 msgstr "Überlagern"
 
-#: ../build/bin/conf_gen.h:2554
+#: ../build/bin/conf_gen.h:2535
 msgctxt "preferences"
 msgid "parade"
 msgstr "Parade"
 
-#: ../build/bin/conf_gen.h:2562
+#: ../build/bin/conf_gen.h:2543
 msgctxt "preferences"
 msgid "u*v*"
 msgstr "u*v*"
 
-#: ../build/bin/conf_gen.h:2563
+#: ../build/bin/conf_gen.h:2544
 msgctxt "preferences"
 msgid "AzBz"
 msgstr "AzBz"
 
-#: ../build/bin/conf_gen.h:2915
+#: ../build/bin/conf_gen.h:2709
+#| msgid "mm"
+msgctxt "preferences"
+msgid "mm"
+msgstr "mm"
+
+#: ../build/bin/conf_gen.h:2710
+#| msgid "cm"
+msgctxt "preferences"
+msgid "cm"
+msgstr "cm"
+
+#: ../build/bin/conf_gen.h:2711
+#| msgid "inch"
+msgctxt "preferences"
+msgid "inch"
+msgstr "inch"
+
+#: ../build/bin/conf_gen.h:2906
 msgid "camera time zone"
 msgstr "Zeitzone der Kamera"
 
-#: ../build/bin/conf_gen.h:2916
+#: ../build/bin/conf_gen.h:2907
 msgid ""
 "most cameras don't store the time zone in EXIF. give the correct time zone "
 "so the GPX data can be correctly matched"
@@ -2326,8 +2398,8 @@ msgstr "Scherung"
 #. focal length
 #: ../build/lib/darktable/plugins/introspection_ashift.c:148
 #: ../build/lib/darktable/plugins/introspection_ashift.c:291
-#: ../src/common/collection.c:781 ../src/gui/preferences.c:818
-#: ../src/gui/presets.c:590 ../src/libs/camera.c:569
+#: ../src/common/collection.c:826 ../src/gui/preferences.c:819
+#: ../src/gui/presets.c:600 ../src/libs/camera.c:569
 #: ../src/libs/metadata_view.c:143
 msgid "focal length"
 msgstr "Brennweite"
@@ -2373,9 +2445,9 @@ msgstr "spezifisch"
 #: ../build/lib/darktable/plugins/introspection_colorin.c:301
 #: ../build/lib/darktable/plugins/introspection_vignette.c:263
 #: ../src/develop/blend_gui.c:101 ../src/develop/blend_gui.c:124
-#: ../src/develop/blend_gui.c:2972 ../src/develop/develop.c:2239
-#: ../src/gui/accelerators.c:118 ../src/gui/accelerators.c:127
-#: ../src/gui/accelerators.c:195 ../src/imageio/format/avif.c:825
+#: ../src/develop/blend_gui.c:2972 ../src/develop/develop.c:2251
+#: ../src/gui/accelerators.c:119 ../src/gui/accelerators.c:128
+#: ../src/gui/accelerators.c:196 ../src/imageio/format/avif.c:825
 #: ../src/imageio/format/j2k.c:673 ../src/libs/live_view.c:427
 msgid "off"
 msgstr "aus"
@@ -2426,9 +2498,9 @@ msgstr "erhalte Farben"
 #: ../src/gui/guides.c:712 ../src/iop/basecurve.c:2082
 #: ../src/iop/channelmixerrgb.c:4227 ../src/iop/clipping.c:1918
 #: ../src/iop/clipping.c:2121 ../src/iop/clipping.c:2136
-#: ../src/iop/lens.cc:2268 ../src/iop/retouch.c:422 ../src/libs/collect.c:1863
+#: ../src/iop/lens.cc:2268 ../src/iop/retouch.c:422 ../src/libs/collect.c:1900
 #: ../src/libs/colorpicker.c:51 ../src/libs/export.c:1036
-#: ../src/libs/live_view.c:377 ../src/libs/print_settings.c:2481
+#: ../src/libs/live_view.c:377 ../src/libs/print_settings.c:2671
 msgid "none"
 msgstr "keine"
 
@@ -2438,14 +2510,14 @@ msgstr "keine"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:154
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:271
 #: ../src/develop/blend_gui.c:2007 ../src/develop/blend_gui.c:2026
-#: ../src/iop/colorbalancergb.c:1796 ../src/iop/colorbalancergb.c:1797
-#: ../src/iop/colorbalancergb.c:1798 ../src/iop/colorbalancergb.c:1799
+#: ../src/iop/colorbalancergb.c:1775 ../src/iop/colorbalancergb.c:1776
+#: ../src/iop/colorbalancergb.c:1777 ../src/iop/colorbalancergb.c:1778
 msgid "luminance"
 msgstr "Luminanz"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:264
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:251
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:533
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:534
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:253
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:155
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:272
@@ -2549,7 +2621,7 @@ msgstr "Geradlinigkeit"
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:144
 #: ../build/lib/darktable/plugins/introspection_watermark.c:118
 #: ../build/lib/darktable/plugins/introspection_watermark.c:235
-#: ../src/iop/ashift.c:5689
+#: ../src/iop/ashift.c:5692
 msgid "rotation"
 msgstr "Drehung"
 
@@ -2567,14 +2639,14 @@ msgstr "Krümmung"
 #: ../build/lib/darktable/plugins/introspection_blurs.c:206
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:81
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:148
-#: ../src/iop/colorbalancergb.c:1791 ../src/iop/colorbalancergb.c:1795
-#: ../src/iop/colorbalancergb.c:1799
+#: ../src/iop/colorbalancergb.c:1770 ../src/iop/colorbalancergb.c:1774
+#: ../src/iop/colorbalancergb.c:1778
 msgid "offset"
 msgstr "Offset"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:220
-#: ../src/common/collection.c:780 ../src/gui/preferences.c:802
-#: ../src/gui/presets.c:541 ../src/libs/metadata_view.c:139
+#: ../src/common/collection.c:825 ../src/gui/preferences.c:803
+#: ../src/gui/presets.c:551 ../src/libs/metadata_view.c:139
 msgid "lens"
 msgstr "Objektiv"
 
@@ -2583,7 +2655,7 @@ msgid "motion"
 msgstr "Bewegung"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:222
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:548
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:550
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:189
 #: ../build/lib/darktable/plugins/introspection_retouch.c:436
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:267
@@ -2592,13 +2664,13 @@ msgstr "Gauß"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:110
 #: ../build/lib/darktable/plugins/introspection_borders.c:251
-#: ../src/common/collection.c:785 ../src/libs/tools/filter.c:110
+#: ../src/common/collection.c:830 ../src/libs/tools/filter.c:110
 msgid "aspect ratio"
 msgstr "Seitenverhältnis"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:128
 #: ../build/lib/darktable/plugins/introspection_borders.c:263
-#: ../src/iop/flip.c:74 ../src/libs/print_settings.c:2172
+#: ../src/iop/flip.c:74 ../src/libs/print_settings.c:2365
 msgid "orientation"
 msgstr "Drehung"
 
@@ -2672,7 +2744,7 @@ msgstr "Referenzkanal"
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:67
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:132
 #: ../src/iop/atrous.c:1593 ../src/iop/bilateral.cc:301 ../src/iop/clahe.c:335
-#: ../src/iop/dither.c:886 ../src/iop/lowpass.c:575 ../src/iop/shadhi.c:684
+#: ../src/iop/dither.c:886 ../src/iop/lowpass.c:571 ../src/iop/shadhi.c:684
 #: ../src/iop/sharpen.c:448
 msgid "radius"
 msgstr "Radius"
@@ -2696,35 +2768,35 @@ msgid "very large chromatic aberration"
 msgstr "sehr starke Chromatische Aberration"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:158
-#: ../src/common/collection.c:1537 ../src/develop/blend_gui.c:1989
-#: ../src/develop/blend_gui.c:2016 ../src/develop/lightroom.c:830
-#: ../src/gui/gtk.c:3026 ../src/gui/guides.c:730 ../src/iop/bilateral.cc:305
+#: ../src/common/collection.c:1653 ../src/develop/blend_gui.c:1989
+#: ../src/develop/blend_gui.c:2016 ../src/develop/lightroom.c:834
+#: ../src/gui/gtk.c:3027 ../src/gui/guides.c:730 ../src/iop/bilateral.cc:305
 #: ../src/iop/channelmixer.c:625 ../src/iop/channelmixer.c:635
 #: ../src/iop/channelmixerrgb.c:4179 ../src/iop/colorzones.c:2302
 #: ../src/iop/temperature.c:1819 ../src/iop/temperature.c:1992
-#: ../src/libs/collect.c:1764
+#: ../src/libs/collect.c:1784
 msgid "red"
 msgstr "Rot"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:159
-#: ../src/common/collection.c:1541 ../src/develop/blend_gui.c:1992
-#: ../src/develop/blend_gui.c:2019 ../src/develop/lightroom.c:834
-#: ../src/gui/gtk.c:3027 ../src/gui/guides.c:731 ../src/iop/bilateral.cc:310
+#: ../src/common/collection.c:1657 ../src/develop/blend_gui.c:1992
+#: ../src/develop/blend_gui.c:2019 ../src/develop/lightroom.c:838
+#: ../src/gui/gtk.c:3028 ../src/gui/guides.c:731 ../src/iop/bilateral.cc:310
 #: ../src/iop/channelmixer.c:626 ../src/iop/channelmixer.c:641
 #: ../src/iop/channelmixerrgb.c:4180 ../src/iop/colorzones.c:2305
 #: ../src/iop/temperature.c:1803 ../src/iop/temperature.c:1821
-#: ../src/iop/temperature.c:1993 ../src/libs/collect.c:1764
+#: ../src/iop/temperature.c:1993 ../src/libs/collect.c:1784
 msgid "green"
 msgstr "Grün"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:160
-#: ../src/common/collection.c:1543 ../src/develop/blend_gui.c:1995
-#: ../src/develop/blend_gui.c:2022 ../src/develop/lightroom.c:836
-#: ../src/gui/gtk.c:3028 ../src/iop/bilateral.cc:315
+#: ../src/common/collection.c:1659 ../src/develop/blend_gui.c:1995
+#: ../src/develop/blend_gui.c:2022 ../src/develop/lightroom.c:840
+#: ../src/gui/gtk.c:3029 ../src/iop/bilateral.cc:315
 #: ../src/iop/channelmixer.c:627 ../src/iop/channelmixer.c:647
 #: ../src/iop/channelmixerrgb.c:4181 ../src/iop/colorzones.c:2307
 #: ../src/iop/temperature.c:1823 ../src/iop/temperature.c:1994
-#: ../src/libs/collect.c:1764
+#: ../src/libs/collect.c:1784
 msgid "blue"
 msgstr "Blau"
 
@@ -2968,7 +3040,7 @@ msgstr "Version 3 (2021)"
 #: ../build/lib/darktable/plugins/introspection_clipping.c:303
 #: ../build/lib/darktable/plugins/introspection_crop.c:61
 #: ../build/lib/darktable/plugins/introspection_crop.c:134
-#: ../src/gui/gtk.c:1565 ../src/iop/atrous.c:1589
+#: ../src/gui/gtk.c:1564 ../src/iop/atrous.c:1589
 msgid "left"
 msgstr "links"
 
@@ -2976,7 +3048,7 @@ msgstr "links"
 #: ../build/lib/darktable/plugins/introspection_clipping.c:307
 #: ../build/lib/darktable/plugins/introspection_crop.c:67
 #: ../build/lib/darktable/plugins/introspection_crop.c:138
-#: ../src/gui/accelerators.c:103 ../src/gui/gtk.c:1515
+#: ../src/gui/accelerators.c:104 ../src/gui/gtk.c:1514
 msgid "top"
 msgstr "oben"
 
@@ -2984,7 +3056,7 @@ msgstr "oben"
 #: ../build/lib/darktable/plugins/introspection_clipping.c:311
 #: ../build/lib/darktable/plugins/introspection_crop.c:73
 #: ../build/lib/darktable/plugins/introspection_crop.c:142
-#: ../src/gui/gtk.c:1579 ../src/iop/atrous.c:1588
+#: ../src/gui/gtk.c:1578 ../src/iop/atrous.c:1588
 msgid "right"
 msgstr "rechts"
 
@@ -2992,7 +3064,7 @@ msgstr "rechts"
 #: ../build/lib/darktable/plugins/introspection_clipping.c:315
 #: ../build/lib/darktable/plugins/introspection_crop.c:79
 #: ../build/lib/darktable/plugins/introspection_crop.c:146
-#: ../src/gui/accelerators.c:104 ../src/gui/gtk.c:1531
+#: ../src/gui/accelerators.c:105 ../src/gui/gtk.c:1530
 msgid "bottom"
 msgstr "unten"
 
@@ -3183,7 +3255,7 @@ msgstr "Kontrast-Graustützpunkt"
 #: ../src/gui/guides.c:738 ../src/iop/basicadj.c:593 ../src/iop/bilat.c:451
 #: ../src/iop/colisa.c:305 ../src/iop/colorbalance.c:1896
 #: ../src/iop/colorbalance.c:1902 ../src/iop/filmic.c:1649
-#: ../src/iop/filmicrgb.c:4000 ../src/iop/lowpass.c:577
+#: ../src/iop/filmicrgb.c:4424 ../src/iop/lowpass.c:573
 msgid "contrast"
 msgstr "Kontrast"
 
@@ -3204,23 +3276,23 @@ msgstr "Gamut beschneiden"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:302
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:201
-#: ../src/common/colorspaces.c:1651
+#: ../src/common/colorspaces.c:1655
 msgid "sRGB"
 msgstr "sRGB"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:303
-#: ../src/common/colorspaces.c:1427 ../src/common/colorspaces.c:1653
-#: ../src/libs/print_settings.c:1257
+#: ../src/common/colorspaces.c:1431 ../src/common/colorspaces.c:1657
+#: ../src/libs/print_settings.c:1292
 msgid "Adobe RGB (compatible)"
 msgstr "Adobe RGB (kompatibel)"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:304
-#: ../src/common/colorspaces.c:1432 ../src/common/colorspaces.c:1655
+#: ../src/common/colorspaces.c:1436 ../src/common/colorspaces.c:1659
 msgid "linear Rec709 RGB"
 msgstr "lineares Rec709-RGB"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:305
-#: ../src/common/colorspaces.c:1441 ../src/common/colorspaces.c:1657
+#: ../src/common/colorspaces.c:1445 ../src/common/colorspaces.c:1661
 msgid "linear Rec2020 RGB"
 msgstr "lineares Rec2020-RGB"
 
@@ -3275,9 +3347,9 @@ msgstr "gesättigte Farben"
 #: ../src/develop/blend_gui.c:1980 ../src/develop/blend_gui.c:1999
 #: ../src/develop/blend_gui.c:2034 ../src/iop/channelmixer.c:622
 #: ../src/iop/channelmixerrgb.c:4051 ../src/iop/channelmixerrgb.c:4141
-#: ../src/iop/colorbalance.c:1991 ../src/iop/colorbalancergb.c:1788
-#: ../src/iop/colorbalancergb.c:1789 ../src/iop/colorbalancergb.c:1790
-#: ../src/iop/colorbalancergb.c:1791 ../src/iop/colorize.c:344
+#: ../src/iop/colorbalance.c:1991 ../src/iop/colorbalancergb.c:1767
+#: ../src/iop/colorbalancergb.c:1768 ../src/iop/colorbalancergb.c:1769
+#: ../src/iop/colorbalancergb.c:1770 ../src/iop/colorize.c:344
 #: ../src/iop/colorreconstruction.c:1288 ../src/iop/colorzones.c:2433
 #: ../src/iop/splittoning.c:477
 msgid "hue"
@@ -3320,11 +3392,11 @@ msgstr "Helligkeit"
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:146
 #: ../src/develop/blend_gui.c:1976 ../src/iop/basicadj.c:610
 #: ../src/iop/channelmixer.c:623 ../src/iop/colisa.c:307
-#: ../src/iop/colorbalance.c:2008 ../src/iop/colorbalancergb.c:1806
-#: ../src/iop/colorbalancergb.c:1807 ../src/iop/colorbalancergb.c:1808
+#: ../src/iop/colorbalance.c:2008 ../src/iop/colorbalancergb.c:1785
+#: ../src/iop/colorbalancergb.c:1786 ../src/iop/colorbalancergb.c:1787
 #: ../src/iop/colorchecker.c:1376 ../src/iop/colorcontrast.c:94
 #: ../src/iop/colorcorrection.c:283 ../src/iop/colorize.c:357
-#: ../src/iop/colorzones.c:2432 ../src/iop/lowpass.c:579
+#: ../src/iop/colorzones.c:2432 ../src/iop/lowpass.c:575
 #: ../src/iop/soften.c:399 ../src/iop/splittoning.c:489 ../src/iop/velvia.c:84
 #: ../src/iop/vibrance.c:72 ../src/iop/vignette.c:982
 msgid "saturation"
@@ -3348,10 +3420,10 @@ msgstr "Kantenerkennungsradius"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:53
 #: ../build/lib/darktable/plugins/introspection_defringe.c:106
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:223
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:422
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:224
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:423
 #: ../src/iop/atrous.c:1643 ../src/iop/bloom.c:394
-#: ../src/iop/colorbalancergb.c:1749 ../src/iop/colorreconstruction.c:1284
+#: ../src/iop/colorbalancergb.c:1728 ../src/iop/colorreconstruction.c:1284
 #: ../src/iop/hotpixels.c:385 ../src/iop/sharpen.c:457
 msgid "threshold"
 msgstr "Schwellwert"
@@ -3482,8 +3554,8 @@ msgid "Markesteijn 3-pass + VNG"
 msgstr "Markesteijn 3-mal + VNG"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:232
-#: ../src/common/collection.c:1559 ../src/common/collection.c:1567
-#: ../src/libs/collect.c:1724
+#: ../src/common/collection.c:1678 ../src/common/collection.c:1686
+#: ../src/libs/collect.c:1738
 msgid "basic"
 msgstr "einfach"
 
@@ -3699,213 +3771,218 @@ msgstr "manuell"
 msgid "automatic"
 msgstr "automatisch"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:205
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:410
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:206
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:411
 #: ../src/iop/filmic.c:1594
 msgid "middle gray luminance"
 msgstr " Luminanz mittleres Grau"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:211
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:414
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:212
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:415
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:97
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:166
 #: ../src/iop/filmic.c:1617
 msgid "black relative exposure"
 msgstr "schwarz relative Belichtung"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:217
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:418
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:218
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:419
 #: ../src/iop/filmic.c:1605
 msgid "white relative exposure"
 msgstr "weiß relative Belichtung"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:229
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:426
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:230
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:427
 msgid "transition"
 msgstr "Übergang"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:235
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:430
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:236
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:431
 msgid "bloom ↔ reconstruct"
 msgstr "Ausblühen ↔ Rekonstruktion"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:241
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:434
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:242
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:435
 msgid "gray ↔ colorful details"
 msgstr "graue ↔ farbige Details"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:247
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:438
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:248
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:439
 msgid "structure ↔ texture"
 msgstr "Struktur ↔ Textur"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:253
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:442
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:254
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:443
 msgid "dynamic range scaling"
 msgstr "Skalierung des Dynamikbereichs"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:259
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:446
-#: ../src/iop/filmic.c:1748
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:260
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:447
+#: ../src/iop/filmic.c:1750
 msgid "target middle gray"
 msgstr "Zielwert für mittleres Grau"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:265
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:450
-#: ../src/iop/filmic.c:1739
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:266
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:451
+#: ../src/iop/filmic.c:1741
 msgid "target black luminance"
 msgstr "Zielwert für Schwarz-Luminanz"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:271
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:454
-#: ../src/iop/filmic.c:1757
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:272
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:455
+#: ../src/iop/filmic.c:1759
 msgid "target white luminance"
 msgstr "Zielwert für Weiß-Luminanz"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:277
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:458
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:278
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:459
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:69
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:140
 msgid "hardness"
 msgstr "Härte"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:295
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:470
-#: ../src/iop/filmic.c:1687 ../src/iop/filmicrgb.c:4173
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:296
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:471
+#: ../src/iop/filmic.c:1687 ../src/iop/filmicrgb.c:4597
 msgid "extreme luminance saturation"
 msgstr "Sättigung bei extremer Luminanz"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:301
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:474
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:302
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:475
 msgid "shadows ↔ highlights balance"
 msgstr "Schatten ↔ Spitzlichter-Balance"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:307
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:478
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:308
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:479
 msgid "add noise in highlights"
 msgstr "Rauschen in den Spitzlichtern hinzufügen"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:313
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:482
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:314
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:483
 msgid "preserve chrominance"
 msgstr "Chrominanz erhalten"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:319
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:486
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:320
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:487
 msgid "color science"
 msgstr "Farbbehandlung"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:325
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:490
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:326
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:491
 msgid "auto adjust hardness"
 msgstr "Härte automatisch anpassen"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:331
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:494
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:332
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:495
 msgid "use custom middle-gray values"
 msgstr "benutzerdefinierten Wert für mittleres Grau nutzen"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:337
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:498
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:338
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:499
 msgid "iterations of high-quality reconstruction"
 msgstr "Iterationen der Spitzlicht-Rekonstruktion"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:343
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:502
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:344
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:503
 msgid "type of noise"
 msgstr "Art des Rauschens"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:349
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:506
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:350
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:507
 msgid "contrast in shadows"
 msgstr "Kontrast in den Schatten"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:355
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:510
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:356
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:511
 msgid "contrast in highlights"
 msgstr "Kontrast in den Spitzlichtern"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:361
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:514
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:362
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:515
 msgid "compensate output ICC profile black point"
 msgstr "Schwarzpunkt des ICC-Ausgabeprofils kompensieren"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:367
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:518
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:368
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:519
 msgid "spline handling"
 msgstr "Spline-Behandlung"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:532
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:533
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:371
-#: ../src/common/database.c:2550 ../src/common/variables.c:590
+#: ../src/common/database.c:2713 ../src/common/variables.c:592
 #: ../src/develop/imageop_gui.c:196 ../src/imageio/format/pdf.c:647
 #: ../src/imageio/format/pdf.c:672 ../src/libs/export.c:1214
 #: ../src/libs/export.c:1220 ../src/libs/export.c:1227
-#: ../src/libs/metadata_view.c:672
+#: ../src/libs/metadata_view.c:678
 msgid "no"
 msgstr "nein"
 
 # wtf?
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:534
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:535
 msgid "luminance Y"
 msgstr "Luminanz Y"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:535
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:536
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:384
 msgid "RGB power norm"
 msgstr "RGB-Stärke-Standard"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:536
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:537
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:383
 msgid "RGB euclidean norm"
 msgstr "Euklidische Norm der RGB-Werte"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:537
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:538
 msgid "RGB euclidean norm (legacy)"
 msgstr "Euklidische Norm der RGB-Werte (alt)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:541
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:542
 msgid "v3 (2019)"
 msgstr "v3 (2019)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:542
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:543
 msgid "v4 (2020)"
 msgstr "v4 (2020)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:543
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:544
 msgid "v5 (2021)"
 msgstr "v5 (2021)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:547
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:545
+#| msgid "v4 (2020)"
+msgid "v6 (2022)"
+msgstr "v6 (2022)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:549
 msgid "uniform"
 msgstr "gleichverteilt"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:549
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:551
 msgid "poissonian"
 msgstr "Poisson-Verteilung"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:553
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:555
 msgid "hard"
 msgstr "hart"
 
 # nicht schön
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:554
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:556
 msgid "soft"
 msgstr "weich"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:555
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:557
 msgid "safe"
 msgstr "sicher"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:559
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:561
 msgid "v1 (2019)"
 msgstr "v1 (2019)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:560
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:562
 msgid "v2 (2020)"
 msgstr "v2 (2020)"
 
-#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:561
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:563
 msgid "v3 (2021)"
 msgstr "v3 (2021)"
 
@@ -3953,7 +4030,7 @@ msgstr "Mittenbetonung"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:80
 #: ../build/lib/darktable/plugins/introspection_highlights.c:139
-#: ../src/views/darkroom.c:2337
+#: ../src/views/darkroom.c:2341
 msgid "clipping threshold"
 msgstr "Abschneide-Schwellwert"
 
@@ -3995,8 +4072,8 @@ msgstr "durch 3 Nachbarpixel erkennen"
 #: ../src/iop/denoiseprofile.c:3668 ../src/iop/exposure.c:1072
 #: ../src/iop/levels.c:680 ../src/iop/profile_gamma.c:676
 #: ../src/libs/copy_history.c:388 ../src/libs/export.c:1308
-#: ../src/libs/image.c:606 ../src/libs/print_settings.c:2520
-#: ../src/libs/styles.c:850 ../src/views/darkroom.c:2313
+#: ../src/libs/image.c:606 ../src/libs/print_settings.c:2710
+#: ../src/libs/styles.c:850 ../src/views/darkroom.c:2317
 msgid "mode"
 msgstr "Modus"
 
@@ -4027,8 +4104,8 @@ msgstr "ungültig"
 
 #. move left/right/up/down
 #: ../build/lib/darktable/plugins/introspection_liquify.c:429
-#: ../src/views/darkroom.c:2213 ../src/views/darkroom.c:2619
-#: ../src/views/darkroom.c:2622 ../src/views/lighttable.c:760
+#: ../src/views/darkroom.c:2217 ../src/views/darkroom.c:2623
+#: ../src/views/darkroom.c:2626 ../src/views/lighttable.c:760
 #: ../src/views/lighttable.c:769 ../src/views/lighttable.c:1329
 #: ../src/views/lighttable.c:1333 ../src/views/lighttable.c:1337
 #: ../src/views/lighttable.c:1341 ../src/views/lighttable.c:1345
@@ -4218,8 +4295,8 @@ msgstr "Weißpunkt"
 #. exposure
 #: ../build/lib/darktable/plugins/introspection_relight.c:43
 #: ../build/lib/darktable/plugins/introspection_relight.c:98
-#: ../src/common/collection.c:784 ../src/gui/preferences.c:810
-#: ../src/gui/presets.c:560 ../src/iop/basicadj.c:584 ../src/iop/exposure.c:123
+#: ../src/common/collection.c:829 ../src/gui/preferences.c:811
+#: ../src/gui/presets.c:570 ../src/iop/basicadj.c:584 ../src/iop/exposure.c:123
 #: ../src/iop/exposure.c:1037 ../src/libs/metadata_view.c:141
 msgid "exposure"
 msgstr "Belichtung"
@@ -4232,7 +4309,7 @@ msgstr "Füllmodus"
 #: ../build/lib/darktable/plugins/introspection_retouch.c:279
 #: ../build/lib/darktable/plugins/introspection_retouch.c:414
 #: ../src/iop/basicadj.c:606 ../src/iop/channelmixerrgb.c:4184
-#: ../src/iop/colisa.c:306 ../src/iop/lowpass.c:578 ../src/iop/soften.c:403
+#: ../src/iop/colisa.c:306 ../src/iop/lowpass.c:574 ../src/iop/soften.c:403
 #: ../src/iop/vignette.c:981 ../src/libs/history.c:886
 msgid "brightness"
 msgstr "Helligkeit"
@@ -4271,7 +4348,7 @@ msgstr "löschen"
 #: ../build/lib/darktable/plugins/introspection_retouch.c:442
 #: ../src/gui/presets.c:59 ../src/iop/watermark.c:1106
 #: ../src/libs/colorpicker.c:298 ../src/libs/image.c:622
-#: ../src/libs/modulegroups.c:2407
+#: ../src/libs/modulegroups.c:2409
 msgid "color"
 msgstr "Farbe"
 
@@ -4344,8 +4421,8 @@ msgstr "dunkle Schatten"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:156
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:297
 #: ../src/iop/bilat.c:459 ../src/iop/colorbalance.c:2048
-#: ../src/iop/colorbalancergb.c:1804 ../src/iop/colorbalancergb.c:1808
-#: ../src/iop/colorbalancergb.c:1812 ../src/iop/shadhi.c:680
+#: ../src/iop/colorbalancergb.c:1783 ../src/iop/colorbalancergb.c:1787
+#: ../src/iop/colorbalancergb.c:1791 ../src/iop/shadhi.c:680
 #: ../src/iop/splittoning.c:526
 msgid "shadows"
 msgstr "Schatten"
@@ -4357,8 +4434,8 @@ msgstr "helle Schatten"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:168
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:305
-#: ../src/iop/colorbalance.c:2049 ../src/iop/colorbalancergb.c:1803
-#: ../src/iop/colorbalancergb.c:1807 ../src/iop/colorbalancergb.c:1811
+#: ../src/iop/colorbalance.c:2049 ../src/iop/colorbalancergb.c:1782
+#: ../src/iop/colorbalancergb.c:1786 ../src/iop/colorbalancergb.c:1790
 msgid "mid-tones"
 msgstr "Mitteltöne"
 
@@ -4370,8 +4447,8 @@ msgstr "dunkle Lichter"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:180
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:313
 #: ../src/iop/bilat.c:454 ../src/iop/colorbalance.c:2050
-#: ../src/iop/colorbalancergb.c:1802 ../src/iop/colorbalancergb.c:1806
-#: ../src/iop/colorbalancergb.c:1810 ../src/iop/monochrome.c:576
+#: ../src/iop/colorbalancergb.c:1781 ../src/iop/colorbalancergb.c:1785
+#: ../src/iop/colorbalancergb.c:1789 ../src/iop/monochrome.c:576
 #: ../src/iop/shadhi.c:681 ../src/iop/splittoning.c:528
 msgid "highlights"
 msgstr "Lichter"
@@ -4619,60 +4696,60 @@ msgstr "Zeige Bilder auf der Karte an"
 msgid "Print your images"
 msgstr "Drucke deine Bilder"
 
-#: ../src/bauhaus/bauhaus.c:3128
+#: ../src/bauhaus/bauhaus.c:3265
 msgid "button on"
 msgstr "Schaltfläche gedrückt"
 
-#: ../src/bauhaus/bauhaus.c:3128
+#: ../src/bauhaus/bauhaus.c:3265
 msgid "button off"
 msgstr "Schaltfläche nicht gedrückt"
 
-#: ../src/bauhaus/bauhaus.c:3301 ../src/gui/accelerators.c:266
+#: ../src/bauhaus/bauhaus.c:3434 ../src/gui/accelerators.c:268
 msgid "value"
 msgstr "Wert"
 
-#: ../src/bauhaus/bauhaus.c:3302 ../src/bauhaus/bauhaus.c:3308
-#: ../src/gui/accelerators.c:250
+#: ../src/bauhaus/bauhaus.c:3435 ../src/bauhaus/bauhaus.c:3441
+#: ../src/gui/accelerators.c:251
 msgid "button"
 msgstr "Schaltfläche"
 
-#: ../src/bauhaus/bauhaus.c:3303
+#: ../src/bauhaus/bauhaus.c:3436
 msgid "force"
 msgstr "Stärke"
 
-#: ../src/bauhaus/bauhaus.c:3304
+#: ../src/bauhaus/bauhaus.c:3437
 msgid "zoom"
 msgstr "Zoom"
 
-#: ../src/bauhaus/bauhaus.c:3307
+#: ../src/bauhaus/bauhaus.c:3440
 msgid "selection"
 msgstr "Auswahl"
 
-#: ../src/bauhaus/bauhaus.c:3326
+#: ../src/bauhaus/bauhaus.c:3459
 msgid "slider"
 msgstr "Regler"
 
-#: ../src/bauhaus/bauhaus.c:3331
+#: ../src/bauhaus/bauhaus.c:3464
 msgid "dropdown"
 msgstr "Dropdown"
 
-#: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1678
-#: ../src/control/jobs/control_jobs.c:1740 ../src/gui/accelerators.c:1785
-#: ../src/gui/accelerators.c:1859 ../src/gui/accelerators.c:1910
-#: ../src/gui/accelerators.c:1938 ../src/gui/accelerators.c:1997
-#: ../src/gui/hist_dialog.c:195 ../src/gui/preferences.c:995
-#: ../src/gui/preferences.c:1034 ../src/gui/presets.c:366
-#: ../src/gui/presets.c:466 ../src/gui/styles_dialog.c:420
+#: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1680
+#: ../src/control/jobs/control_jobs.c:1742 ../src/gui/accelerators.c:1796
+#: ../src/gui/accelerators.c:1872 ../src/gui/accelerators.c:1923
+#: ../src/gui/accelerators.c:1951 ../src/gui/accelerators.c:2010
+#: ../src/gui/hist_dialog.c:195 ../src/gui/preferences.c:996
+#: ../src/gui/preferences.c:1035 ../src/gui/presets.c:376
+#: ../src/gui/presets.c:476 ../src/gui/styles_dialog.c:420
 #: ../src/imageio/storage/disk.c:122 ../src/imageio/storage/gallery.c:109
 #: ../src/imageio/storage/latex.c:108 ../src/iop/lut3d.c:1557
-#: ../src/libs/collect.c:468 ../src/libs/copy_history.c:107
+#: ../src/libs/collect.c:463 ../src/libs/copy_history.c:107
 #: ../src/libs/geotagging.c:928 ../src/libs/import.c:1525
 #: ../src/libs/import.c:1628 ../src/libs/styles.c:399 ../src/libs/styles.c:534
 #: ../src/libs/tagging.c:2511 ../src/libs/tagging.c:2547
 msgid "_cancel"
 msgstr "_abbrechen"
 
-#: ../src/chart/main.c:504 ../src/gui/preferences.c:1034
+#: ../src/chart/main.c:504 ../src/gui/preferences.c:1035
 #: ../src/gui/styles_dialog.c:423 ../src/libs/styles.c:399
 msgid "_save"
 msgstr "_speichern"
@@ -4821,7 +4898,7 @@ msgid "failed to get parameters from format module, aborting export ..."
 msgstr ""
 "Konnte keine Einstellungen vom Format-Modul bekommen, breche Export ab …"
 
-#: ../src/common/camera_control.c:172
+#: ../src/common/camera_control.c:173
 #, c-format
 msgid ""
 "camera `%s' on port `%s' error %s\n"
@@ -4833,7 +4910,7 @@ msgstr ""
 "Bitte sicherstellen, dass die Kamera einen Zugriff zulässt und nicht "
 "anderweitig verbunden ist"
 
-#: ../src/common/camera_control.c:854
+#: ../src/common/camera_control.c:855
 #, c-format
 msgid ""
 "failed to initialize `%s' on port `%s', likely causes are: locked by another "
@@ -4842,7 +4919,7 @@ msgstr ""
 "Initialisierung von \"%s\" am Port \"%s\" fehlgeschlagen, mögliche Ursachen: "
 "durch eine andere Anwendung gesperrt, kein Zugriff auf Geräte usw."
 
-#: ../src/common/camera_control.c:865
+#: ../src/common/camera_control.c:866
 #, c-format
 msgid ""
 "`%s' on port `%s' is not interesting because it supports neither tethering "
@@ -4851,12 +4928,12 @@ msgstr ""
 "\"%s\" auf Port '%s' funktioniert nicht, da weder Tethering noch Import "
 "unterstützt werden"
 
-#: ../src/common/camera_control.c:915
+#: ../src/common/camera_control.c:916
 #, c-format
 msgid "camera `%s' on port `%s' disconnected while mounted"
 msgstr "Kamera '%s' am Port '%s' während der Verbindung getrennt"
 
-#: ../src/common/camera_control.c:922
+#: ../src/common/camera_control.c:923
 #, c-format
 msgid ""
 "camera `%s' on port `%s' needs to be remounted\n"
@@ -4866,161 +4943,161 @@ msgstr ""
 "Bitte sicherstellen, dass die Kamera einen Zugriff zulässt und nicht "
 "anderweitig verbunden ist"
 
-#: ../src/common/collection.c:729
+#: ../src/common/collection.c:774
 msgid "too much time to update aspect ratio for the collection"
 msgstr "zu viel Zeit um Seitenverhältnis der Sammlung zu aktualisieren"
 
-#: ../src/common/collection.c:768
+#: ../src/common/collection.c:813
 msgid "film roll"
 msgstr "Filmrolle"
 
-#: ../src/common/collection.c:769
+#: ../src/common/collection.c:814
 msgid "folder"
 msgstr "Verzeichnis"
 
-#: ../src/common/collection.c:770
+#: ../src/common/collection.c:815
 msgid "camera"
 msgstr "Kamera"
 
-#: ../src/common/collection.c:771 ../src/libs/export_metadata.c:189
+#: ../src/common/collection.c:816 ../src/libs/export_metadata.c:189
 msgid "tag"
 msgstr "Tagging"
 
-#: ../src/common/collection.c:772
+#: ../src/common/collection.c:817
 msgid "date taken"
 msgstr "Aufnahmedatum"
 
-#: ../src/common/collection.c:773
+#: ../src/common/collection.c:818
 msgid "date-time taken"
 msgstr "Aufnahmedatum und -uhrzeit"
 
-#: ../src/common/collection.c:774 ../src/libs/metadata_view.c:130
+#: ../src/common/collection.c:819 ../src/libs/metadata_view.c:130
 msgid "import timestamp"
 msgstr "Importzeitstempel"
 
-#: ../src/common/collection.c:775 ../src/libs/metadata_view.c:131
+#: ../src/common/collection.c:820 ../src/libs/metadata_view.c:131
 msgid "change timestamp"
 msgstr "Änderungszeitstempel"
 
-#: ../src/common/collection.c:776 ../src/libs/metadata_view.c:132
+#: ../src/common/collection.c:821 ../src/libs/metadata_view.c:132
 msgid "export timestamp"
 msgstr "Exportzeitstempel"
 
-#: ../src/common/collection.c:777 ../src/libs/metadata_view.c:133
+#: ../src/common/collection.c:822 ../src/libs/metadata_view.c:133
 msgid "print timestamp"
 msgstr "Druckzeitstempel"
 
-#: ../src/common/collection.c:778 ../src/libs/history.c:85
+#: ../src/common/collection.c:823 ../src/libs/history.c:85
 msgid "history"
 msgstr "Verlauf"
 
-#: ../src/common/collection.c:779 ../src/develop/lightroom.c:1546
+#: ../src/common/collection.c:824 ../src/develop/lightroom.c:1550
 #: ../src/libs/tools/filter.c:104
 msgid "color label"
 msgstr "Farbmarkierung"
 
 #. iso
-#: ../src/common/collection.c:782 ../src/gui/preferences.c:806
-#: ../src/gui/presets.c:547 ../src/libs/camera.c:577
+#: ../src/common/collection.c:827 ../src/gui/preferences.c:807
+#: ../src/gui/presets.c:557 ../src/libs/camera.c:577
 #: ../src/libs/metadata_view.c:145
 msgid "ISO"
 msgstr "ISO"
 
 #. aperture
-#: ../src/common/collection.c:783 ../src/gui/preferences.c:814
-#: ../src/gui/presets.c:575 ../src/libs/camera.c:564 ../src/libs/camera.c:566
+#: ../src/common/collection.c:828 ../src/gui/preferences.c:815
+#: ../src/gui/presets.c:585 ../src/libs/camera.c:564 ../src/libs/camera.c:566
 #: ../src/libs/metadata_view.c:140
 msgid "aperture"
 msgstr "Blende"
 
-#: ../src/common/collection.c:786 ../src/libs/metadata_view.c:126
+#: ../src/common/collection.c:831 ../src/libs/metadata_view.c:126
 #: ../src/libs/tools/filter.c:96
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../src/common/collection.c:787 ../src/develop/lightroom.c:1537
+#: ../src/common/collection.c:832 ../src/develop/lightroom.c:1541
 #: ../src/libs/geotagging.c:140
 msgid "geotagging"
 msgstr "Geotagging"
 
-#: ../src/common/collection.c:788
+#: ../src/common/collection.c:833
 msgid "grouping"
 msgstr "Gruppieren"
 
-#: ../src/common/collection.c:789 ../src/dtgtk/thumbnail.c:1395
+#: ../src/common/collection.c:834 ../src/dtgtk/thumbnail.c:1397
 #: ../src/libs/metadata_view.c:129 ../src/libs/metadata_view.c:338
 msgid "local copy"
 msgstr "lokale Kopie"
 
-#: ../src/common/collection.c:790 ../src/gui/preferences.c:782
+#: ../src/common/collection.c:835 ../src/gui/preferences.c:783
 msgid "module"
 msgstr "Modul"
 
-#: ../src/common/collection.c:791 ../src/gui/hist_dialog.c:280
+#: ../src/common/collection.c:836 ../src/gui/hist_dialog.c:280
 #: ../src/gui/styles_dialog.c:566 ../src/gui/styles_dialog.c:610
 #: ../src/libs/ioporder.c:40
 msgid "module order"
 msgstr "Modulsortierung"
 
-#: ../src/common/collection.c:792 ../src/common/ratings.c:300
-#: ../src/develop/lightroom.c:1521 ../src/libs/tools/filter.c:102
+#: ../src/common/collection.c:837 ../src/common/ratings.c:300
+#: ../src/develop/lightroom.c:1525 ../src/libs/tools/filter.c:102
 msgid "rating"
 msgstr "Bewertung"
 
-#: ../src/common/collection.c:1539 ../src/develop/lightroom.c:832
+#: ../src/common/collection.c:1655 ../src/develop/lightroom.c:836
 #: ../src/gui/guides.c:732 ../src/iop/colorzones.c:2304
-#: ../src/iop/temperature.c:1809 ../src/libs/collect.c:1764
+#: ../src/iop/temperature.c:1809 ../src/libs/collect.c:1784
 msgid "yellow"
 msgstr "Gelb"
 
-#: ../src/common/collection.c:1545 ../src/iop/colorzones.c:2308
-#: ../src/libs/collect.c:1764
+#: ../src/common/collection.c:1661 ../src/iop/colorzones.c:2308
+#: ../src/libs/collect.c:1784
 msgid "purple"
 msgstr "Violett"
 
-#: ../src/common/collection.c:1561 ../src/libs/collect.c:1724
+#: ../src/common/collection.c:1680 ../src/libs/collect.c:1738
 msgid "auto applied"
 msgstr "automatisch anwenden"
 
-#: ../src/common/collection.c:1563 ../src/libs/collect.c:1724
+#: ../src/common/collection.c:1682 ../src/libs/collect.c:1738
 msgid "altered"
 msgstr "geändert"
 
-#: ../src/common/collection.c:1575 ../src/common/collection.c:1658
-#: ../src/libs/collect.c:1211 ../src/libs/collect.c:1343
-#: ../src/libs/collect.c:1365 ../src/libs/collect.c:1470
-#: ../src/libs/collect.c:2398
+#: ../src/common/collection.c:1695 ../src/common/collection.c:1784
+#: ../src/libs/collect.c:1208 ../src/libs/collect.c:1347
+#: ../src/libs/collect.c:1371 ../src/libs/collect.c:1481
+#: ../src/libs/collect.c:2443
 msgid "not tagged"
 msgstr "nicht getaggt"
 
-#: ../src/common/collection.c:1576 ../src/libs/collect.c:1365
+#: ../src/common/collection.c:1696 ../src/libs/collect.c:1371
 #: ../src/libs/map_locations.c:765
 msgid "tagged"
 msgstr "getaggt"
 
-#: ../src/common/collection.c:1577
+#: ../src/common/collection.c:1697
 msgid "tagged*"
 msgstr "getaggt*"
 
-#: ../src/common/collection.c:1607 ../src/libs/collect.c:1736
+#: ../src/common/collection.c:1732 ../src/libs/collect.c:1752
 msgid "not copied locally"
 msgstr "nicht lokal kopiert"
 
 #. grouping
-#: ../src/common/collection.c:1905 ../src/libs/collect.c:1838
+#: ../src/common/collection.c:2025 ../src/libs/collect.c:1872
 msgid "group leaders"
 msgstr "Gruppenführer"
 
-#: ../src/common/collection.c:1999 ../src/libs/collect.c:1911
+#: ../src/common/collection.c:2133 ../src/libs/collect.c:1953
 msgid "not defined"
 msgstr "nicht definiert"
 
-#: ../src/common/collection.c:2281
+#: ../src/common/collection.c:2423
 #, c-format
 msgid "%d image of %d (#%d) in current collection is selected"
 msgstr "%d Bild von %d (#%d) ist in der aktuellen Sammlung ausgewählt"
 
-#: ../src/common/collection.c:2287
+#: ../src/common/collection.c:2429
 #, c-format
 msgid "%d image of %d in current collection is selected"
 msgid_plural "%d images of %d in current collection are selected"
@@ -5028,79 +5105,79 @@ msgstr[0] "%d Bild von %d ist in der aktuellen Sammlung ausgewählt"
 msgstr[1] "%d Bilder von %d sind in der aktuellen Sammlung ausgewählt"
 
 #. init the category profile with NULL profile, the actual profile must be retrieved dynamically by the caller
-#: ../src/common/colorspaces.c:1396 ../src/common/colorspaces.c:1685
+#: ../src/common/colorspaces.c:1400 ../src/common/colorspaces.c:1689
 msgid "work profile"
 msgstr "Arbeitsprofil"
 
-#: ../src/common/colorspaces.c:1399 ../src/common/colorspaces.c:1681
+#: ../src/common/colorspaces.c:1403 ../src/common/colorspaces.c:1685
 #: ../src/iop/colorout.c:879
 msgid "export profile"
 msgstr "Exportprofil"
 
-#: ../src/common/colorspaces.c:1403 ../src/common/colorspaces.c:1683
-#: ../src/views/darkroom.c:2481
+#: ../src/common/colorspaces.c:1407 ../src/common/colorspaces.c:1687
+#: ../src/views/darkroom.c:2485
 msgid "softproof profile"
 msgstr "Softproof-Profil"
 
-#: ../src/common/colorspaces.c:1409 ../src/common/colorspaces.c:1665
+#: ../src/common/colorspaces.c:1413 ../src/common/colorspaces.c:1669
 msgid "system display profile"
 msgstr "System-Bildschirmprofil"
 
-#: ../src/common/colorspaces.c:1412 ../src/common/colorspaces.c:1687
+#: ../src/common/colorspaces.c:1416 ../src/common/colorspaces.c:1691
 msgid "system display profile (second window)"
 msgstr "System-Bildschirmprofil (zweites Fenster)"
 
-#: ../src/common/colorspaces.c:1418
+#: ../src/common/colorspaces.c:1422
 msgid "sRGB (e.g. JPG)"
 msgstr "sRGB (z.B. JPEG)"
 
-#: ../src/common/colorspaces.c:1422 ../src/libs/print_settings.c:1250
+#: ../src/common/colorspaces.c:1426 ../src/libs/print_settings.c:1285
 msgid "sRGB (web-safe)"
 msgstr "sRGB (web-sicher)"
 
-#: ../src/common/colorspaces.c:1436 ../src/common/colorspaces.c:1689
+#: ../src/common/colorspaces.c:1440 ../src/common/colorspaces.c:1693
 msgid "Rec709 RGB"
 msgstr "Rec709 RGB"
 
-#: ../src/common/colorspaces.c:1446
+#: ../src/common/colorspaces.c:1450
 msgid "PQ Rec2020 RGB"
 msgstr "PQ Rec2020 RGB"
 
-#: ../src/common/colorspaces.c:1451
+#: ../src/common/colorspaces.c:1455
 msgid "HLG Rec2020 RGB"
 msgstr "HLG Rec2020 RGB"
 
-#: ../src/common/colorspaces.c:1456
+#: ../src/common/colorspaces.c:1460
 msgid "PQ P3 RGB"
 msgstr "PQ P3 RGB"
 
-#: ../src/common/colorspaces.c:1461
+#: ../src/common/colorspaces.c:1465
 msgid "HLG P3 RGB"
 msgstr "HLG P3 RGB"
 
-#: ../src/common/colorspaces.c:1466 ../src/common/colorspaces.c:1691
+#: ../src/common/colorspaces.c:1470 ../src/common/colorspaces.c:1695
 msgid "linear ProPhoto RGB"
 msgstr "lineares ProPhoto RGB"
 
-#: ../src/common/colorspaces.c:1471 ../src/common/colorspaces.c:1659
+#: ../src/common/colorspaces.c:1475 ../src/common/colorspaces.c:1663
 msgid "linear XYZ"
 msgstr "lineares XYZ"
 
-#: ../src/common/colorspaces.c:1475 ../src/common/colorspaces.c:1661
+#: ../src/common/colorspaces.c:1479 ../src/common/colorspaces.c:1665
 #: ../src/develop/blend_gui.c:95 ../src/develop/blend_gui.c:1713
 #: ../src/libs/colorpicker.c:51 ../src/libs/colorpicker.c:274
 msgid "Lab"
 msgstr "Lab"
 
-#: ../src/common/colorspaces.c:1480 ../src/common/colorspaces.c:1663
+#: ../src/common/colorspaces.c:1484 ../src/common/colorspaces.c:1667
 msgid "linear infrared BGR"
 msgstr "linears Infrarot-BGR"
 
-#: ../src/common/colorspaces.c:1484
+#: ../src/common/colorspaces.c:1488
 msgid "BRG (for testing)"
 msgstr "BRG (zum Testen)"
 
-#: ../src/common/colorspaces.c:1576
+#: ../src/common/colorspaces.c:1580
 #, c-format
 msgid ""
 "profile `%s' not usable as histogram profile. it has been replaced by sRGB!"
@@ -5108,47 +5185,47 @@ msgstr ""
 "Profil `%s’ kann nicht als Histogrammprofil verwendet werden. Es wurde durch "
 "sRGB ersetzt!"
 
-#: ../src/common/colorspaces.c:1667
+#: ../src/common/colorspaces.c:1671
 msgid "embedded ICC profile"
 msgstr "eingebettetes ICC-Profil"
 
-#: ../src/common/colorspaces.c:1669
+#: ../src/common/colorspaces.c:1673
 msgid "embedded matrix"
 msgstr "eingebettete Matrix"
 
-#: ../src/common/colorspaces.c:1671
+#: ../src/common/colorspaces.c:1675
 msgid "standard color matrix"
 msgstr "Standard-Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1673
+#: ../src/common/colorspaces.c:1677
 msgid "enhanced color matrix"
 msgstr "Erweiterte Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1675
+#: ../src/common/colorspaces.c:1679
 msgid "vendor color matrix"
 msgstr "Hersteller-Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1677
+#: ../src/common/colorspaces.c:1681
 msgid "alternate color matrix"
 msgstr "Alternative Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1679
+#: ../src/common/colorspaces.c:1683
 msgid "BRG (experimental)"
 msgstr "BRG (experimentell)"
 
-#: ../src/common/colorspaces.c:1693
+#: ../src/common/colorspaces.c:1697
 msgid "PQ Rec2020"
 msgstr "PQ Rec2020"
 
-#: ../src/common/colorspaces.c:1695
+#: ../src/common/colorspaces.c:1699
 msgid "HLG Rec2020"
 msgstr "HLG Rec2020"
 
-#: ../src/common/colorspaces.c:1697
+#: ../src/common/colorspaces.c:1701
 msgid "PQ P3"
 msgstr "PQ P3"
 
-#: ../src/common/colorspaces.c:1699
+#: ../src/common/colorspaces.c:1703
 msgid "HLG P3"
 msgstr "HLG P3"
 
@@ -5167,50 +5244,50 @@ msgstr "Fehler beim Erstellen der temporären Datei für Druckoptionen"
 msgid "printing on `%s' cancelled"
 msgstr "Drucken des Bildes auf „%s” abgebrochen"
 
-#: ../src/common/cups_print.c:571
+#: ../src/common/cups_print.c:572
 #, c-format
 msgid "error while printing `%s' on `%s'"
 msgstr "Fehler beim Drucken von Bild „%s” auf „%s”"
 
-#: ../src/common/cups_print.c:573
+#: ../src/common/cups_print.c:574
 #, c-format
 msgid "printing `%s' on `%s'"
 msgstr "drucke Bild „%s” auf „%s”"
 
-#: ../src/common/darktable.c:238
+#: ../src/common/darktable.c:240
 #, c-format
 msgid "found strange path `%s'"
 msgstr "Ungewöhnlicher Pfad „%s” gefunden"
 
-#: ../src/common/darktable.c:253
+#: ../src/common/darktable.c:255
 #, c-format
 msgid "error loading directory `%s'"
 msgstr "Fehler beim Laden von Verzeichnis „%s”"
 
-#: ../src/common/darktable.c:276
+#: ../src/common/darktable.c:278
 #, c-format
 msgid "file `%s' has unknown format!"
 msgstr "Datei „%s” hat ein unbekanntes Format!"
 
-#: ../src/common/darktable.c:289 ../src/control/jobs/control_jobs.c:2087
-#: ../src/control/jobs/control_jobs.c:2146
+#: ../src/common/darktable.c:291 ../src/control/jobs/control_jobs.c:2096
+#: ../src/control/jobs/control_jobs.c:2155
 #, c-format
 msgid "error loading file `%s'"
 msgstr "Fehler beim Laden von Datei „%s”"
 
-#: ../src/common/darktable.c:1289
+#: ../src/common/darktable.c:1295
 msgid "configuration information"
 msgstr "Information zur Konfiguration"
 
-#: ../src/common/darktable.c:1291
+#: ../src/common/darktable.c:1297
 msgid "show this information again"
 msgstr "diese Informationen erneut anzeigen"
 
-#: ../src/common/darktable.c:1291
+#: ../src/common/darktable.c:1297
 msgid "understood"
 msgstr "verstanden"
 
-#: ../src/common/darktable.c:1689
+#: ../src/common/darktable.c:1717
 msgid ""
 "the RCD demosaicer has been defined as default instead of PPG because of "
 "better quality and performance."
@@ -5218,13 +5295,13 @@ msgstr ""
 "Der RCD-Demosaicer wurde wegen seiner besseren Qualität und Performance "
 "anstelle von PPG als Standard definiert."
 
-#: ../src/common/darktable.c:1691
+#: ../src/common/darktable.c:1719
 msgid "see preferences/darkroom/demosaicing for zoomed out darkroom mode"
 msgstr ""
 "siehe Einstellungen/Dunkelkammer/Demosaicing für den herausgezoomten "
 "Dunkelkammermodus"
 
-#: ../src/common/darktable.c:1697
+#: ../src/common/darktable.c:1725
 msgid ""
 "the user interface and the underlying internals for tuning darktable "
 "performance have changed."
@@ -5232,7 +5309,7 @@ msgstr ""
 "Die Einstellmöglichkeiten und die zugrunde liegenden internen Funktionen zur "
 "Optimierung der darktable Performance haben sich geändert."
 
-#: ../src/common/darktable.c:1699
+#: ../src/common/darktable.c:1727
 msgid ""
 "you won't find headroom and friends any longer, instead in preferences/"
 "processing use:"
@@ -5240,15 +5317,41 @@ msgstr ""
 "direkte Einstellung von Headroom und so weiter sind nicht mehr vorgesehen, "
 "dafür gibt es in Voreinstellungen/Bearbeitung:"
 
-#: ../src/common/darktable.c:1701
+#: ../src/common/darktable.c:1729
 msgid "1) darktable resources"
 msgstr "1) darktable Ressourcenzuweisung"
 
-#: ../src/common/darktable.c:1703
+#: ../src/common/darktable.c:1731
 msgid "2) tune OpenCL performance"
 msgstr "2) OpenCL Performance optimieren"
 
-#: ../src/common/database.c:2522
+#: ../src/common/darktable.c:1738
+msgid ""
+"some global config values relevant for OpenCL performance are not used any "
+"longer."
+msgstr ""
+"einige globale Konfigurationswerte, die für die OpenCL-Leistung relevant "
+"sind, werden nicht mehr verwendet."
+
+#: ../src/common/darktable.c:1740
+msgid ""
+"instead you will find 'per device' data in 'cldevice_v0_canonical-name'. "
+"content is:"
+msgstr ""
+"Stattdessen stehen die gerätespezifischen Daten in „cldevice_v0_canonical-"
+"name“. Inhalte sind:"
+
+#: ../src/common/darktable.c:1742
+msgid ""
+"  'avoid_atomics'  'micro_nap'  'pinned_memory'  'roundupwd'  'roundupht'  "
+"'magic'"
+msgstr "  ‚avoid_atomics‘  ‚micro_nap‘  ‚pinned_memory‘  ‚roundupwd‘  ‚roundupht‘  ‚magic‘"
+
+#: ../src/common/darktable.c:1744
+msgid "you may tune as before except 'magic'"
+msgstr "tunen wie zuvor, aber ohne Automagisches Verhalten"
+
+#: ../src/common/database.c:2684
 #, c-format
 msgid ""
 "\n"
@@ -5304,14 +5407,15 @@ msgstr ""
 "sonst können schwerwiegende Inkonsistenzen in der Datenbank die Folge sein.</"
 "i>\n"
 
-#: ../src/common/database.c:2542
+#. clang-format on
+#: ../src/common/database.c:2705
 msgid "error starting darktable"
 msgstr "Fehler beim starten von darktable"
 
-#: ../src/common/database.c:2543 ../src/libs/collect.c:2904
+#: ../src/common/database.c:2706 ../src/libs/collect.c:2949
 #: ../src/libs/export_metadata.c:288 ../src/libs/import.c:1720
-#: ../src/libs/metadata.c:495 ../src/libs/metadata_view.c:1205
-#: ../src/libs/modulegroups.c:3507 ../src/libs/recentcollect.c:319
+#: ../src/libs/metadata.c:497 ../src/libs/metadata_view.c:1199
+#: ../src/libs/modulegroups.c:3515 ../src/libs/recentcollect.c:319
 #: ../src/libs/styles.c:445 ../src/libs/styles.c:628 ../src/libs/tagging.c:1506
 #: ../src/libs/tagging.c:1594 ../src/libs/tagging.c:1675
 #: ../src/libs/tagging.c:1805 ../src/libs/tagging.c:2079
@@ -5319,15 +5423,15 @@ msgstr "Fehler beim starten von darktable"
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: ../src/common/database.c:2543
+#: ../src/common/database.c:2706
 msgid "delete database lock files"
 msgstr "Datenbank Sperrdateien löschen"
 
-#: ../src/common/database.c:2549
+#: ../src/common/database.c:2712
 msgid "are you sure?"
 msgstr "Absolut sicher?"
 
-#: ../src/common/database.c:2550
+#: ../src/common/database.c:2713
 msgid ""
 "\n"
 "do you really want to delete the lock files?\n"
@@ -5335,20 +5439,20 @@ msgstr ""
 "\n"
 "Sollen die Sperrdateien wirklich gelöscht werden?\n"
 
-#: ../src/common/database.c:2550 ../src/common/database.c:3610
-#: ../src/common/variables.c:588 ../src/develop/imageop_gui.c:197
+#: ../src/common/database.c:2713 ../src/common/database.c:3773
+#: ../src/common/variables.c:590 ../src/develop/imageop_gui.c:197
 #: ../src/imageio/format/pdf.c:648 ../src/imageio/format/pdf.c:673
 #: ../src/libs/export.c:1215 ../src/libs/export.c:1221
-#: ../src/libs/export.c:1228 ../src/libs/metadata_view.c:672
+#: ../src/libs/export.c:1228 ../src/libs/metadata_view.c:678
 msgid "yes"
 msgstr "ja"
 
-#: ../src/common/database.c:2565 ../src/libs/export_metadata.c:164
+#: ../src/common/database.c:2728 ../src/libs/export_metadata.c:164
 #: ../src/libs/geotagging.c:811
 msgid "done"
 msgstr "erledigt"
 
-#: ../src/common/database.c:2566
+#: ../src/common/database.c:2729
 msgid ""
 "\n"
 "successfully deleted the lock files.\n"
@@ -5358,15 +5462,15 @@ msgstr ""
 "Sperrdateien erfolgreich gelöscht.\n"
 "darktable kann neu gestartet werden.\n"
 
-#: ../src/common/database.c:2567 ../src/common/database.c:2574
+#: ../src/common/database.c:2730 ../src/common/database.c:2737
 msgid "ok"
 msgstr "OK"
 
-#: ../src/common/database.c:2570 ../src/iop/cacorrect.c:1336
+#: ../src/common/database.c:2733 ../src/iop/cacorrect.c:1336
 msgid "error"
 msgstr "Fehler"
 
-#: ../src/common/database.c:2571
+#: ../src/common/database.c:2734
 #, c-format
 msgid ""
 "\n"
@@ -5380,7 +5484,7 @@ msgstr ""
 "Ggf. die Dateien <i>Data.db.lock</i> und <i>Library.db.lock</i> \n"
 "im Ordner <a href=\"file:///%s\">%s</a> manuell löschen.\n"
 
-#: ../src/common/database.c:2688
+#: ../src/common/database.c:2851
 #, c-format
 msgid ""
 "the database lock file contains a pid that seems to be alive in your system: "
@@ -5389,18 +5493,18 @@ msgstr ""
 "Die Datenbank-Lock-Datei enthält eine PID, die zu einem laufenden Programm "
 "passt: %d"
 
-#: ../src/common/database.c:2694
+#: ../src/common/database.c:2857
 #, c-format
 msgid "the database lock file seems to be empty"
 msgstr "Die Datenbank-Lock-Datei scheint leer zu sein"
 
-#: ../src/common/database.c:2702
+#: ../src/common/database.c:2865
 #, c-format
 msgid "error opening the database lock file for reading: %s"
 msgstr "Fehler beim Öffnen der Datenbank-Lock-Datei zum Lesen: %s"
 
 #. the database has to be upgraded, let's ask user
-#: ../src/common/database.c:2739
+#: ../src/common/database.c:2902
 #, c-format
 msgid ""
 "the database schema has to be upgraded for\n"
@@ -5419,21 +5523,21 @@ msgstr ""
 "\n"
 "Möchtest Du fortfahren oder jetzt beenden, um ein Backup zu erstellen\n"
 
-#: ../src/common/database.c:2747
+#: ../src/common/database.c:2910
 msgid "darktable - schema migration"
 msgstr "darktable - Datenbank Umstellung"
 
-#: ../src/common/database.c:2748 ../src/common/database.c:3061
-#: ../src/common/database.c:3079 ../src/common/database.c:3241
-#: ../src/common/database.c:3259
+#: ../src/common/database.c:2911 ../src/common/database.c:3224
+#: ../src/common/database.c:3242 ../src/common/database.c:3404
+#: ../src/common/database.c:3422
 msgid "close darktable"
 msgstr "darktable schließen"
 
-#: ../src/common/database.c:2748
+#: ../src/common/database.c:2911
 msgid "upgrade database"
 msgstr "Datenbank aktualisieren"
 
-#: ../src/common/database.c:3041 ../src/common/database.c:3221
+#: ../src/common/database.c:3204 ../src/common/database.c:3384
 #, c-format
 msgid ""
 "quick_check said:\n"
@@ -5442,21 +5546,21 @@ msgstr ""
 "quick_check ergab:\n"
 "%s \n"
 
-#: ../src/common/database.c:3058 ../src/common/database.c:3076
-#: ../src/common/database.c:3238 ../src/common/database.c:3256
+#: ../src/common/database.c:3221 ../src/common/database.c:3239
+#: ../src/common/database.c:3401 ../src/common/database.c:3419
 msgid "darktable - error opening database"
 msgstr "darktable - Fehler beim Öffnen der Datenbank"
 
-#: ../src/common/database.c:3063 ../src/common/database.c:3243
+#: ../src/common/database.c:3226 ../src/common/database.c:3406
 msgid "attempt restore"
 msgstr "Datenbank wiederherstellen"
 
-#: ../src/common/database.c:3065 ../src/common/database.c:3081
-#: ../src/common/database.c:3245 ../src/common/database.c:3261
+#: ../src/common/database.c:3228 ../src/common/database.c:3244
+#: ../src/common/database.c:3408 ../src/common/database.c:3424
 msgid "delete database"
 msgstr "Datenbank löschen"
 
-#: ../src/common/database.c:3069 ../src/common/database.c:3249
+#: ../src/common/database.c:3232 ../src/common/database.c:3412
 msgid ""
 "do you want to close darktable now to manually restore\n"
 "the database from a backup, attempt an automatic restore\n"
@@ -5470,7 +5574,7 @@ msgstr ""
 "versuchen.\n"
 "• Die beschädigte Datenbank löschen, um mit einer neuen Datenbank zu starten."
 
-#: ../src/common/database.c:3085 ../src/common/database.c:3265
+#: ../src/common/database.c:3248 ../src/common/database.c:3428
 msgid ""
 "do you want to close darktable now to manually restore\n"
 "the database from a backup or delete the corrupted database\n"
@@ -5481,7 +5585,7 @@ msgstr ""
 "wiederherzustellen.\n"
 "• Die beschädigte Datenbank löschen, um mit einer neuen Datenbank zu starten."
 
-#: ../src/common/database.c:3092 ../src/common/database.c:3270
+#: ../src/common/database.c:3255 ../src/common/database.c:3433
 #, c-format
 msgid ""
 "an error has occurred while trying to open the database from\n"
@@ -5498,19 +5602,19 @@ msgstr ""
 "aufgetreten. Möglicherweise ist die Datenbank beschädigt.\n"
 "%s%s"
 
-#: ../src/common/database.c:3588
+#: ../src/common/database.c:3751
 msgid "click later to be asked on next startup"
 msgstr "„später” klicken, um beim nächsten Start gefragt zu werden"
 
-#: ../src/common/database.c:3592
+#: ../src/common/database.c:3755
 msgid "click later to be asked when closing darktable"
 msgstr "„später” klicken, um beim Beenden gefragt zu werden"
 
-#: ../src/common/database.c:3596
+#: ../src/common/database.c:3759
 msgid "click later to be asked next time when closing darktable"
 msgstr "„später” klicken, um beim Beenden nochmals gefragt zu werden"
 
-#: ../src/common/database.c:3599
+#: ../src/common/database.c:3762
 #, c-format
 msgid ""
 "the database could use some maintenance\n"
@@ -5532,20 +5636,20 @@ msgstr ""
 "Einstellungen zur Datenbankwartung können unter „Speichern” in den darktable-"
 "Voreinstellungen vorgenommen werden."
 
-#: ../src/common/database.c:3609
+#: ../src/common/database.c:3772
 msgid "darktable - schema maintenance"
 msgstr "darktable - Datenbank Wartung"
 
-#: ../src/common/database.c:3610
+#: ../src/common/database.c:3773
 msgid "later"
 msgstr "später"
 
-#: ../src/common/exif.cc:4244
+#: ../src/common/exif.cc:4290
 #, c-format
 msgid "cannot read xmp file '%s': '%s'"
 msgstr "konnte xmp Datei „%s“ nicht lesen: „%s“"
 
-#: ../src/common/exif.cc:4296
+#: ../src/common/exif.cc:4342
 #, c-format
 msgid "cannot write xmp file '%s': '%s'"
 msgstr "konnte xmp Datei „%s“ nicht schreiben: „%s“"
@@ -5556,32 +5660,32 @@ msgstr ""
 "Dem schnellen geführten Filter konnte kein Speicher zuweisen werden, "
 "überprüfe die RAM-Einstellungen."
 
-#: ../src/common/film.c:305
+#: ../src/common/film.c:342
 msgid "do you want to remove this empty directory?"
 msgid_plural "do you want to remove these empty directories?"
 msgstr[0] "Soll dieses leere Verzeichnis entfernt werden?"
 msgstr[1] "Sollen diese leeren Verzeichnisse entfernt werden?"
 
-#: ../src/common/film.c:312
+#: ../src/common/film.c:349
 msgid "remove empty directory?"
 msgid_plural "remove empty directories?"
 msgstr[0] "leeres Verzeichnis entfernen?"
 msgstr[1] "leere Verzeichnisse entfernen?"
 
-#: ../src/common/film.c:331 ../src/gui/preferences.c:790
+#: ../src/common/film.c:368 ../src/gui/preferences.c:791
 #: ../src/gui/styles_dialog.c:447 ../src/libs/geotagging.c:829
 #: ../src/libs/import.c:1570
 msgid "name"
 msgstr "Name"
 
-#: ../src/common/film.c:437
+#: ../src/common/film.c:474
 msgid ""
 "cannot remove film roll having local copies with non accessible originals"
 msgstr ""
 "Filmrolle kann nicht entfernt werden, so lange lokale Kopien existieren, für "
 "die kein Zugriff auf die Originale besteht"
 
-#: ../src/common/history.c:743
+#: ../src/common/history.c:755
 msgid "you need to copy history from an image before you paste it onto another"
 msgstr ""
 "Es muss erst der Verlauf eines Bildes kopiert werden, bevor er auf ein "
@@ -5606,88 +5710,88 @@ msgstr ""
 "<h1>Danke,</h1><p>es sollte alles funktioniert haben, Du kannst den Browser "
 "jetzt <b>schließen</b> und in darktable <b>weiter machen</b>.</p>"
 
-#: ../src/common/image.c:297
+#: ../src/common/image.c:296
 msgid "orphaned image"
 msgstr "verwaistes Bild"
 
-#: ../src/common/image.c:538
+#: ../src/common/image.c:541
 #, c-format
 msgid "geo-location undone for %d images"
 msgstr "Geolokalisierung für %d Bilder zurück gesetzt"
 
-#: ../src/common/image.c:539
+#: ../src/common/image.c:542
 #, c-format
 msgid "geo-location re-applied to %d images"
 msgstr "Geolokalisierung für %d Bilder wieder zugeordnet"
 
-#: ../src/common/image.c:558
+#: ../src/common/image.c:561
 #, c-format
 msgid "date/time undone for %d images"
 msgstr "Datum/Zeit für %d zurück gesetzt"
 
-#: ../src/common/image.c:559
+#: ../src/common/image.c:562
 #, c-format
 msgid "date/time re-applied to %d images"
 msgstr "setze Datum/Zeit für %d wieder zugeordnet"
 
-#: ../src/common/image.c:1949
+#: ../src/common/image.c:1988
 #, c-format
 msgid "cannot access local copy `%s'"
 msgstr "auf lokale Kopie „%s” kann nicht zugegriffen werden."
 
-#: ../src/common/image.c:1956
+#: ../src/common/image.c:1995
 #, c-format
 msgid "cannot write local copy `%s'"
 msgstr "lokale Kopie „%s” kann nicht erzeugt werden."
 
-#: ../src/common/image.c:1963
+#: ../src/common/image.c:2002
 #, c-format
 msgid "error moving local copy `%s' -> `%s'"
 msgstr "Fehler beim Verschieben lokaler Kopie „%s” auf „%s”"
 
-#: ../src/common/image.c:1979
+#: ../src/common/image.c:2018
 #, c-format
 msgid "error moving `%s': file not found"
 msgstr "Fehler beim Verschieben „%s”: Datei nicht gefunden"
 
-#: ../src/common/image.c:1989
+#: ../src/common/image.c:2028
 #, c-format
 msgid "error moving `%s' -> `%s': file exists"
 msgstr "Fehler beim Verschieben „%s” auf „%s”: Datei existiert bereits"
 
-#: ../src/common/image.c:1993
+#: ../src/common/image.c:2032
 #, c-format
 msgid "error moving `%s' -> `%s'"
 msgstr "Fehler beim Verschieben „%s” auf „%s”"
 
-#: ../src/common/image.c:2291
+#: ../src/common/image.c:2346
 msgid "cannot create local copy when the original file is not accessible."
 msgstr ""
 "lokale Kopie kann nicht erzeugt werden, wenn die Originaldatei nicht "
 "zugänglich ist."
 
-#: ../src/common/image.c:2305
+#: ../src/common/image.c:2360
 msgid "cannot create local copy."
 msgstr "lokale Kopie kann nicht erzeugt werden."
 
-#: ../src/common/image.c:2377 ../src/control/jobs/control_jobs.c:766
+#: ../src/common/image.c:2434 ../src/control/jobs/control_jobs.c:768
 msgid "cannot remove local copy when the original file is not accessible."
 msgstr ""
 "lokale Kopie kann nicht entfernt werden, wenn die Originaldatei nicht "
 "zugänglich ist."
 
-#: ../src/common/image.c:2542
+#: ../src/common/image.c:2599
 #, c-format
 msgid "%d local copy has been synchronized"
 msgid_plural "%d local copies have been synchronized"
 msgstr[0] "%d lokale Kopie wurde synchronisiert"
 msgstr[1] "%d lokale Kopien wurden synchronisiert"
 
-#: ../src/common/image.c:2731
+#: ../src/common/image.c:2788
 msgid "<b>WARNING</b> : camera is missing samples!"
 msgstr "<b>WARNUNG</b>: Es fehlen Beispielbilder für die Kamera!"
 
-#: ../src/common/image.c:2732
+#: ../src/common/image.c:2789
 msgid ""
 "You must provide samples in <a href='https://raw.pixls.us/'>https://raw."
 "pixls.us/</a>"
@@ -5695,7 +5799,7 @@ msgstr ""
 "Bitte unter <a href='https://raw.pixls.us/'>https://raw.pixls.us/</a> "
 "Beispielbilder bereitstellen"
 
-#: ../src/common/image.c:2733
+#: ../src/common/image.c:2790
 #, c-format
 msgid ""
 "for `%s' `%s'\n"
@@ -5704,7 +5808,7 @@ msgstr ""
 "für `%s’ `%s’\n"
 "in so vielen Formaten/Komprimierungen/Bit-Stufen wie möglich"
 
-#: ../src/common/image.c:2736
+#: ../src/common/image.c:2793
 msgid "or the <b>RAW won't be readable</b> in next version."
 msgstr ""
 "sonst ist das <b>RAW </b> in der nächsten Version <b>nicht mehr lesbar </b>."
@@ -5738,7 +5842,7 @@ msgstr "Exportieren"
 msgid "cannot find the style '%s' to apply during export."
 msgstr "Stil „%s” kann zum Exportieren nicht gefunden werden."
 
-#: ../src/common/import_session.c:283
+#: ../src/common/import_session.c:294
 msgid ""
 "couldn't expand to a unique filename for session, please check your import "
 "session settings."
@@ -5746,11 +5850,11 @@ msgstr ""
 "Konnte keinen einmaligen Dateinamen für die Sitzung generieren, bitte die "
 "Import-Sitzungs-Einstellungen überprüfen."
 
-#: ../src/common/import_session.c:364
+#: ../src/common/import_session.c:373
 msgid "requested session path not available. device not mounted?"
 msgstr "angeforderter Sitzungspfad nicht verfügbar. Gerät nicht verbunden?"
 
-#: ../src/common/iop_order.c:59 ../src/libs/ioporder.c:206
+#: ../src/common/iop_order.c:59 ../src/libs/ioporder.c:208
 msgid "legacy"
 msgstr "veraltet"
 
@@ -5816,40 +5920,40 @@ msgstr "generische Poisson-Verteilung"
 msgid "noiseprofile file `%s' is not valid"
 msgstr "Rauschprofildatei „%s“ ist defekt"
 
-#: ../src/common/opencl.c:813
+#: ../src/common/opencl.c:936
 msgid ""
 "due to a slow GPU hardware acceleration via opencl has been de-activated"
 msgstr ""
 "OpenCL-Hardware-Beschleunigung wurde aufgrund einer langsamen GPU deaktiviert"
 
-#: ../src/common/opencl.c:820
+#: ../src/common/opencl.c:943
 msgid ""
 "multiple GPUs detected - opencl scheduling profile has been set accordingly"
 msgstr ""
 "mehrere GPUs gefunden – OpenCL-Scheduler-Profil wurde entsprechend gesetzt"
 
-#: ../src/common/opencl.c:827
+#: ../src/common/opencl.c:950
 msgid ""
 "very fast GPU detected - opencl scheduling profile has been set accordingly"
 msgstr ""
 "Sehr schnelle GPU gefunden – OpenCL-Scheduler-Profil wurde entsprechend "
 "gesetzt"
 
-#: ../src/common/opencl.c:834
+#: ../src/common/opencl.c:957
 msgid "opencl scheduling profile set to default"
 msgstr "OpenCL-Scheduler-Profil wurde auf den Standardwert gesetzt"
 
 #: ../src/common/pdf.h:88 ../src/iop/lens.cc:1916
-#: ../src/libs/print_settings.c:2179
+#: ../src/libs/print_settings.c:83
 msgid "mm"
 msgstr "mm"
 
 #: ../src/common/pdf.h:89 ../src/libs/export.c:533 ../src/libs/export.c:1170
-#: ../src/libs/print_settings.c:2180
+#: ../src/libs/print_settings.c:83
 msgid "cm"
 msgstr "cm"
 
-#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:2181
+#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:83
 msgid "inch"
 msgstr "inch"
 
@@ -5956,77 +6060,77 @@ msgstr "Fünf"
 msgid "reject"
 msgstr "verwerfen"
 
-#: ../src/common/styles.c:228
+#: ../src/common/styles.c:232
 #, c-format
 msgid "style with name '%s' already exists"
 msgstr "Stil mit dem Namen „%s” existiert bereits"
 
 #. freed by _destroy_style_shortcut_callback
-#: ../src/common/styles.c:409 ../src/common/styles.c:500
-#: ../src/common/styles.c:583 ../src/common/styles.c:1001
-#: ../src/common/styles.c:1571 ../src/common/styles.c:1592
+#: ../src/common/styles.c:417 ../src/common/styles.c:512
+#: ../src/common/styles.c:599 ../src/common/styles.c:1019
+#: ../src/common/styles.c:1599 ../src/common/styles.c:1620
 #, c-format
 msgctxt "accel"
 msgid "styles/apply %s"
 msgstr "Stile/%s anwenden"
 
-#: ../src/common/styles.c:410
+#: ../src/common/styles.c:418
 #, c-format
 msgctxt "accel"
 msgid "apply %s"
 msgstr "%s Anwenden"
 
-#: ../src/common/styles.c:506 ../src/gui/styles_dialog.c:233
+#: ../src/common/styles.c:518 ../src/gui/styles_dialog.c:233
 #, c-format
 msgid "style named '%s' successfully created"
 msgstr "Stil mit dem Namen „%s” erfolgreich angelegt"
 
-#: ../src/common/styles.c:644 ../src/common/styles.c:672
-#: ../src/common/styles.c:711
+#: ../src/common/styles.c:660 ../src/common/styles.c:688
+#: ../src/common/styles.c:727
 msgid "no image selected!"
 msgstr "Kein Bild ausgewählt!"
 
-#: ../src/common/styles.c:648
+#: ../src/common/styles.c:664
 #, c-format
 msgid "style %s successfully applied!"
 msgstr "Stil „%s” erfolgreich angewendet!"
 
-#: ../src/common/styles.c:662
+#: ../src/common/styles.c:678
 msgid "no images nor styles selected!"
 msgstr "Kein Bild oder Stil ausgewählt!"
 
-#: ../src/common/styles.c:667
+#: ../src/common/styles.c:683
 msgid "no styles selected!"
 msgstr "Kein Stil ausgewählt!"
 
-#: ../src/common/styles.c:697
+#: ../src/common/styles.c:713
 msgid "style successfully applied!"
 msgid_plural "styles successfully applied!"
 msgstr[0] "Stil erfolgreich angewandt."
 msgstr[1] "Stile erfolgreich angewandt."
 
-#: ../src/common/styles.c:768
+#: ../src/common/styles.c:784
 #, c-format
 msgid "module `%s' version mismatch: %d != %d"
 msgstr "Modul „%s” hat Versionskonflikt: %d ≠ %d"
 
-#: ../src/common/styles.c:1206
+#: ../src/common/styles.c:1230
 #, c-format
 msgid "failed to overwrite style file for %s"
 msgstr "Fehler beim Überschreiben der Stil-Datei für „%s”"
 
-#: ../src/common/styles.c:1212
+#: ../src/common/styles.c:1236
 #, c-format
 msgid "style file for %s exists"
 msgstr "Stil-Datei für „%s” existiert bereits"
 
-#: ../src/common/styles.c:1460
+#: ../src/common/styles.c:1488
 #, c-format
 msgid "style %s was successfully imported"
 msgstr "Stil „%s” erfolgreich importiert"
 
 #. Failed to open file, clean up.
-#: ../src/common/styles.c:1504
+#: ../src/common/styles.c:1532
 #, c-format
 msgid "could not read file `%s'"
 msgstr "Konnte Datei „%s” nicht lesen!"
@@ -6039,16 +6143,16 @@ msgstr "über Null"
 msgid "below sea level"
 msgstr "unter Null"
 
-#: ../src/common/utility.c:555 ../src/libs/metadata_view.c:881
+#: ../src/common/utility.c:555 ../src/libs/metadata_view.c:875
 msgid "m"
 msgstr "m"
 
-#: ../src/control/control.c:66 ../src/gui/accelerators.c:125
-#: ../src/views/darkroom.c:2099
+#: ../src/control/control.c:66 ../src/gui/accelerators.c:126
+#: ../src/views/darkroom.c:2103
 msgid "hold"
 msgstr "halten"
 
-#: ../src/control/control.c:102 ../src/control/control.c:135
+#: ../src/control/control.c:102 ../src/control/control.c:136
 msgid "modifiers"
 msgstr "Modifikatortasten"
 
@@ -6093,21 +6197,21 @@ msgctxt "accel"
 msgid "fallbacks"
 msgstr "Fallback"
 
-#: ../src/control/control.c:132
+#: ../src/control/control.c:133
 msgid "show accels window"
 msgstr "zeige Tastenbelegungsübersicht"
 
-#: ../src/control/control.c:293
+#: ../src/control/control.c:294
 msgid "working..."
 msgstr "arbeite ..."
 
-#: ../src/control/crawler.c:357
+#: ../src/control/crawler.c:359
 #, c-format
-msgid "ERROR: %s NOT synced XMP → DB"
-msgstr "Fehler: %s XMP → DB nicht synchronisiert"
+msgid "ERROR: %s NOT synced XMP → DB"
+msgstr "ERROR: %s XMP → DB nicht synchronisiert"
 
-#: ../src/control/crawler.c:358 ../src/control/crawler.c:409
-#: ../src/control/crawler.c:461
+#: ../src/control/crawler.c:360 ../src/control/crawler.c:411
+#: ../src/control/crawler.c:463
 msgid ""
 "ERROR: cannot write the database. the destination may be full, offline or "
 "read-only."
@@ -6115,18 +6219,18 @@ msgstr ""
 "Fehler: In die Datenbank kann nicht geschrieben werden. Das Ziel kann "
 "gesperrt sein."
 
-#: ../src/control/crawler.c:363
+#: ../src/control/crawler.c:365
 #, c-format
-msgid "SUCCESS: %s synced XMP → DB"
-msgstr "Erfolgreich: %s XMP → DB synchronisiert"
+msgid "SUCCESS: %s synced XMP → DB"
+msgstr "SUCCESS: %s XMP → DB synchronisiert"
 
-#: ../src/control/crawler.c:380
+#: ../src/control/crawler.c:382
 #, c-format
-msgid "ERROR: %s NOT synced DB → XMP"
-msgstr "Fehler: %s DB → XMP nicht synchronisiert"
+msgid "ERROR: %s NOT synced DB → XMP"
+msgstr "ERROR: %s DB → XMP nicht synchronisiert"
 
-#: ../src/control/crawler.c:381 ../src/control/crawler.c:424
-#: ../src/control/crawler.c:475
+#: ../src/control/crawler.c:383 ../src/control/crawler.c:426
+#: ../src/control/crawler.c:477
 #, c-format
 msgid ""
 "ERROR: cannot write %s \n"
@@ -6135,162 +6239,162 @@ msgstr ""
 "Fehler: kann %s nicht schreiben \n"
 "Das Ziel kann voll, offline oder schreibgeschützt sein."
 
-#: ../src/control/crawler.c:386
+#: ../src/control/crawler.c:388
 #, c-format
-msgid "SUCCESS: %s synced DB → XMP"
-msgstr "Erfolgreich: %s DB → XMP synchronisiert"
+msgid "SUCCESS: %s synced DB → XMP"
+msgstr "SUCCESS: %s DB → XMP synchronisiert"
 
-#: ../src/control/crawler.c:408
+#: ../src/control/crawler.c:410
 #, c-format
-msgid "ERROR: %s NOT synced new (XMP) → old (DB)"
-msgstr "Fehler: %s neu (XMP) → alt (DB) nicht synchronisiert"
+msgid "ERROR: %s NOT synced new (XMP) → old (DB)"
+msgstr "ERROR: %s neu (XMP) → alt (DB) nicht synchronisiert"
 
-#: ../src/control/crawler.c:413
+#: ../src/control/crawler.c:415
 #, c-format
-msgid "SUCCESS: %s synced new (XMP) → old (DB)"
-msgstr "Erfolgreich: %s neu (XMP) → alt (DB) synchronisiert"
+msgid "SUCCESS: %s synced new (XMP) → old (DB)"
+msgstr "SUCCESS: %s neu (XMP) → alt (DB) synchronisiert"
 
-#: ../src/control/crawler.c:423
+#: ../src/control/crawler.c:425
 #, c-format
-msgid "ERROR: %s NOT synced new (DB) → old (XMP)"
-msgstr "Fehler: %s neu (DB) → alt (XMP) nicht synchronisiert"
+msgid "ERROR: %s NOT synced new (DB) → old (XMP)"
+msgstr "ERROR: %s neu (DB) → alt (XMP) nicht synchronisiert"
 
-#: ../src/control/crawler.c:428
+#: ../src/control/crawler.c:430
 #, c-format
-msgid "SUCCESS: %s synced new (DB) → old (XMP)"
-msgstr "Erfolgreich: %s neu (DB) → alt (XMP) synchronisiert"
+msgid "SUCCESS: %s synced new (DB) → old (XMP)"
+msgstr "SUCCESS: %s neu (DB) → alt (XMP) synchronisiert"
 
-#: ../src/control/crawler.c:436 ../src/control/crawler.c:487
+#: ../src/control/crawler.c:438 ../src/control/crawler.c:489
 #, c-format
-msgid "EXCEPTION: %s has inconsistent timestamps"
-msgstr "Ausnahmefall: %s hat inkonsistente Zeitstempel"
+msgid "EXCEPTION: %s has inconsistent timestamps"
+msgstr "EXCEPTION: %s hat inkonsistente Zeitstempel"
 
-#: ../src/control/crawler.c:460
+#: ../src/control/crawler.c:462
 #, c-format
-msgid "ERROR: %s NOT synced old (XMP) → new (DB)"
-msgstr "Fehler: %s alt (XMP) → neu (DB) nicht synchronisiert"
+msgid "ERROR: %s NOT synced old (XMP) → new (DB)"
+msgstr "ERROR: %s alt (XMP) → neu (DB) nicht synchronisiert"
 
-#: ../src/control/crawler.c:465
+#: ../src/control/crawler.c:467
 #, c-format
-msgid "SUCCESS: %s synced old (XMP) → new (DB)"
-msgstr "Erfolgreich: %s alt (XMP) → neu (DB) synchronisiert"
+msgid "SUCCESS: %s synced old (XMP) → new (DB)"
+msgstr "SUCCESS: %s alt (XMP) → neu (DB) synchronisiert"
 
-#: ../src/control/crawler.c:474
+#: ../src/control/crawler.c:476
 #, c-format
-msgid "ERROR: %s NOT synced old (DB) → new (XMP)"
-msgstr "Fehler: %s alt (DB) → neu (XMP) nicht synchronisiert"
+msgid "ERROR: %s NOT synced old (DB) → new (XMP)"
+msgstr "ERROR: %s alt (DB) → neu (XMP) nicht synchronisiert"
 
-#: ../src/control/crawler.c:479
+#: ../src/control/crawler.c:481
 #, c-format
-msgid "SUCCESS: %s synced old (DB) → new (XMP)"
-msgstr "Erfolgreich: %s alt (DB) → neu (XMP) synchronisiert"
+msgid "SUCCESS: %s synced old (DB) → new (XMP)"
+msgstr "SUCCESS: %s alt (DB) → neu (XMP) synchronisiert"
 
-#: ../src/control/crawler.c:558
+#: ../src/control/crawler.c:560
 #, c-format
 msgid "%id %02dh %02dm %02ds"
 msgstr "%it %02dh %02dm %02ds"
 
-#: ../src/control/crawler.c:623
+#: ../src/control/crawler.c:625
 msgid "path"
 msgstr "Pfad"
 
-#: ../src/control/crawler.c:631
+#: ../src/control/crawler.c:633
 msgid "xmp timestamp"
 msgstr "XMP-Zeitstempel"
 
-#: ../src/control/crawler.c:635
+#: ../src/control/crawler.c:637
 msgid "database timestamp"
 msgstr "Datenbank-Zeitstempel"
 
-#: ../src/control/crawler.c:639
+#: ../src/control/crawler.c:641
 msgid "newest"
 msgstr "Neueste"
 
-#: ../src/control/crawler.c:644
+#: ../src/control/crawler.c:646
 msgid "time difference"
 msgstr "Zeitdifferenz"
 
-#: ../src/control/crawler.c:654
+#: ../src/control/crawler.c:656
 msgid "updated xmp sidecar files found"
 msgstr "aktualisierte XMP-Begleitdateien gefunden"
 
-#: ../src/control/crawler.c:655
+#: ../src/control/crawler.c:657
 msgid "_close"
 msgstr "_Schließen"
 
 #. action-box
-#: ../src/control/crawler.c:669 ../src/libs/import.c:1739
+#: ../src/control/crawler.c:671 ../src/libs/import.c:1739
 #: ../src/libs/select.c:134
 msgid "select all"
 msgstr "alles auswählen"
 
-#: ../src/control/crawler.c:670 ../src/libs/import.c:1743
+#: ../src/control/crawler.c:672 ../src/libs/import.c:1743
 #: ../src/libs/select.c:138
 msgid "select none"
 msgstr "nichts auswählen"
 
-#: ../src/control/crawler.c:671 ../src/libs/select.c:142
+#: ../src/control/crawler.c:673 ../src/libs/select.c:142
 msgid "invert selection"
 msgstr "Auswahl invertieren"
 
-#: ../src/control/crawler.c:683
+#: ../src/control/crawler.c:685
 msgid "on the selection:"
 msgstr "für Auswahl:"
 
-#: ../src/control/crawler.c:684
+#: ../src/control/crawler.c:686
 msgid "keep the xmp edit"
 msgstr " XMP Bearbeitung behalten "
 
-#: ../src/control/crawler.c:685
+#: ../src/control/crawler.c:687
 msgid "keep the database edit"
 msgstr "Bearbeitung aus Datenbank behalten"
 
-#: ../src/control/crawler.c:686
+#: ../src/control/crawler.c:688
 msgid "keep the newest edit"
 msgstr "neueste Bearbeitung behalten"
 
-#: ../src/control/crawler.c:687
+#: ../src/control/crawler.c:689
 msgid "keep the oldest edit"
 msgstr "älteste Bearbeitung behalten"
 
-#: ../src/control/crawler.c:709
+#: ../src/control/crawler.c:711
 msgid "synchronization log"
 msgstr "Synchonisationsprotokoll"
 
-#: ../src/control/jobs/camera_jobs.c:79
+#: ../src/control/jobs/camera_jobs.c:80
 #, c-format
 msgid "capturing %d image"
 msgid_plural "capturing %d images"
 msgstr[0] "%d Bild aufnehmen"
 msgstr[1] "%d Bilder aufnehmen"
 
-#: ../src/control/jobs/camera_jobs.c:113
+#: ../src/control/jobs/camera_jobs.c:114
 msgid "please set your camera to manual mode first!"
 msgstr "Bitte die Kamera erst auf manuellen Modus einstellen!"
 
-#: ../src/control/jobs/camera_jobs.c:210
+#: ../src/control/jobs/camera_jobs.c:211
 msgid "capture images"
 msgstr "Bilder aufnehmen"
 
-#: ../src/control/jobs/camera_jobs.c:244
+#: ../src/control/jobs/camera_jobs.c:245
 #, c-format
 msgid "%d/%d imported to %s"
 msgid_plural "%d/%d imported to %s"
 msgstr[0] "%d/%d nach %s importiert"
 msgstr[1] "%d/%d nach %s importiert"
 
-#: ../src/control/jobs/camera_jobs.c:299
+#: ../src/control/jobs/camera_jobs.c:300
 msgid "starting to import images from camera"
 msgstr "Starte Import der Bilder von der Kamera"
 
-#: ../src/control/jobs/camera_jobs.c:310
+#: ../src/control/jobs/camera_jobs.c:311
 #, c-format
 msgid "importing %d image from camera"
 msgid_plural "importing %d images from camera"
 msgstr[0] "%d Bild von Kamera importieren"
 msgstr[1] "%d Bilder von Kamera importieren"
 
-#: ../src/control/jobs/camera_jobs.c:370
+#: ../src/control/jobs/camera_jobs.c:371
 msgid "import images from camera"
 msgstr "Bilder von Kamera importieren"
 
@@ -6348,161 +6452,161 @@ msgid_plural "setting %d monochrome images"
 msgstr[0] "kennzeichne %d monochromes Bild"
 msgstr[1] "kennzeichne %d monochrome Bilder"
 
-#: ../src/control/jobs/control_jobs.c:742
+#: ../src/control/jobs/control_jobs.c:744
 #, c-format
 msgid "removing %d image"
 msgid_plural "removing %d images"
 msgstr[0] "%d Bild entfernen"
 msgstr[1] "%d Bilder entfernen"
 
-#: ../src/control/jobs/control_jobs.c:846
+#: ../src/control/jobs/control_jobs.c:848
 #, c-format
 msgid "could not send %s to trash%s%s"
 msgstr "Konnte „%s” nicht in den Papierkorb verschieben%s%s"
 
-#: ../src/control/jobs/control_jobs.c:847
+#: ../src/control/jobs/control_jobs.c:849
 #, c-format
 msgid "could not physically delete %s%s%s"
 msgstr "Konnte „%s” nicht physisch von der Festplatte löschen%s%s"
 
-#: ../src/control/jobs/control_jobs.c:857
+#: ../src/control/jobs/control_jobs.c:859
 msgid "physically delete"
 msgstr "physisch von der Festplatte löschen"
 
-#: ../src/control/jobs/control_jobs.c:858
+#: ../src/control/jobs/control_jobs.c:860
 msgid "physically delete all files"
 msgstr "alle Dateien physisch von der Festplatte löschen"
 
-#: ../src/control/jobs/control_jobs.c:860
+#: ../src/control/jobs/control_jobs.c:862
 msgid "only remove from the image library"
 msgstr "nur aus der Bildbibliothek entfernen"
 
-#: ../src/control/jobs/control_jobs.c:861
+#: ../src/control/jobs/control_jobs.c:863
 msgid "skip to next file"
 msgstr "zur nächsten Datei gehen"
 
-#: ../src/control/jobs/control_jobs.c:862
+#: ../src/control/jobs/control_jobs.c:864
 msgid "stop process"
 msgstr "Prozess abbrechen"
 
-#: ../src/control/jobs/control_jobs.c:867
+#: ../src/control/jobs/control_jobs.c:869
 msgid "trashing error"
 msgstr "Fehler beim Verschieben in den Papierkorb"
 
-#: ../src/control/jobs/control_jobs.c:868
+#: ../src/control/jobs/control_jobs.c:870
 msgid "deletion error"
 msgstr "Fehler beim Löschen"
 
-#: ../src/control/jobs/control_jobs.c:1010
+#: ../src/control/jobs/control_jobs.c:1012
 #, c-format
 msgid "trashing %d image"
 msgid_plural "trashing %d images"
 msgstr[0] "%d Bild in den Papierkorb verschieben"
 msgstr[1] "%d Bilder in den Papierkorb verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1012
+#: ../src/control/jobs/control_jobs.c:1014
 #, c-format
 msgid "deleting %d image"
 msgid_plural "deleting %d images"
 msgstr[0] "%d Bild löschen"
 msgstr[1] "%d Bilder löschen"
 
-#: ../src/control/jobs/control_jobs.c:1138
+#: ../src/control/jobs/control_jobs.c:1140
 msgid "failed to parse GPX file"
 msgstr "Fehler beim lesen der GPX-Datei"
 
-#: ../src/control/jobs/control_jobs.c:1185
+#: ../src/control/jobs/control_jobs.c:1187
 #, c-format
 msgid "applied matched GPX location onto %d image"
 msgid_plural "applied matched GPX location onto %d images"
 msgstr[0] "passende GPX-Position auf %d Bild angewandt"
 msgstr[1] "passende GPX-Position auf %d Bilder angewandt"
 
-#: ../src/control/jobs/control_jobs.c:1202
+#: ../src/control/jobs/control_jobs.c:1204
 #, c-format
 msgid "moving %d image"
 msgstr "%d Bild verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1203
+#: ../src/control/jobs/control_jobs.c:1205
 #, c-format
 msgid "moving %d images"
 msgstr "%d Bilder verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1208
+#: ../src/control/jobs/control_jobs.c:1210
 #, c-format
 msgid "copying %d image"
 msgstr "%d Bild kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1209
+#: ../src/control/jobs/control_jobs.c:1211
 #, c-format
 msgid "copying %d images"
 msgstr "%d Bilder kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1224
+#: ../src/control/jobs/control_jobs.c:1226
 #, c-format
 msgid "creating local copy of %d image"
 msgid_plural "creating local copies of %d images"
 msgstr[0] "lokale Kopie von %d Bild anlegen"
 msgstr[1] "lokale Kopien von %d Bildern anlegen"
 
-#: ../src/control/jobs/control_jobs.c:1227
+#: ../src/control/jobs/control_jobs.c:1229
 #, c-format
 msgid "removing local copy of %d image"
 msgid_plural "removing local copies of %d images"
 msgstr[0] "lokale Kopie von %d Bild entfernen"
 msgstr[1] "lokale Kopien von %d Bildern entfernen"
 
-#: ../src/control/jobs/control_jobs.c:1274
+#: ../src/control/jobs/control_jobs.c:1276
 #, c-format
 msgid "refreshing info for %d image"
 msgid_plural "refreshing info for %d images"
 msgstr[0] "Information des Bildes %d aktualisieren"
 msgstr[1] "Informationen der Bilder %d aktualisieren"
 
-#: ../src/control/jobs/control_jobs.c:1360
+#: ../src/control/jobs/control_jobs.c:1362
 #, c-format
 msgid "exporting %d image.."
 msgid_plural "exporting %d images.."
 msgstr[0] "exportiere %d Bild ..."
 msgstr[1] "exportiere %d Bilder ..."
 
-#: ../src/control/jobs/control_jobs.c:1362
+#: ../src/control/jobs/control_jobs.c:1364
 msgid "no image to export"
 msgstr "keine Bilder zum exportieren gefunden"
 
-#: ../src/control/jobs/control_jobs.c:1394
+#: ../src/control/jobs/control_jobs.c:1396
 #, c-format
 msgid "exporting %d / %d to %s"
 msgstr "exportiere Bild %d / %d nach „%s”"
 
-#: ../src/control/jobs/control_jobs.c:1415 ../src/views/darkroom.c:834
+#: ../src/control/jobs/control_jobs.c:1417 ../src/views/darkroom.c:834
 #: ../src/views/print.c:337
 #, c-format
 msgid "image `%s' is currently unavailable"
 msgstr "Bild „%s” ist momentan nicht verfügbar"
 
-#: ../src/control/jobs/control_jobs.c:1507
+#: ../src/control/jobs/control_jobs.c:1509
 msgid "merge hdr image"
 msgstr "HDR-Bild zusammenfassen"
 
-#: ../src/control/jobs/control_jobs.c:1521
+#: ../src/control/jobs/control_jobs.c:1523
 msgid "duplicate images"
 msgstr "Bilder duplizieren"
 
-#: ../src/control/jobs/control_jobs.c:1527
+#: ../src/control/jobs/control_jobs.c:1529
 msgid "flip images"
 msgstr "Bilder spiegeln"
 
-#: ../src/control/jobs/control_jobs.c:1534
+#: ../src/control/jobs/control_jobs.c:1536
 msgid "set monochrome images"
 msgstr "monochrome Bilder kennzeichnen"
 
 #. get all selected images now, to avoid the set changing during ui interaction
-#: ../src/control/jobs/control_jobs.c:1541
+#: ../src/control/jobs/control_jobs.c:1543
 msgid "remove images"
 msgstr "Bilder entfernen"
 
-#: ../src/control/jobs/control_jobs.c:1558
+#: ../src/control/jobs/control_jobs.c:1560
 #, c-format
 msgid ""
 "do you really want to remove %d image from darktable\n"
@@ -6515,21 +6619,21 @@ msgstr[0] ""
 msgstr[1] ""
 "Sollen %d Bilder aus der Sammlung entfernt werden (ohne Löschen der Dateien)?"
 
-#: ../src/control/jobs/control_jobs.c:1565
+#: ../src/control/jobs/control_jobs.c:1567
 msgid "remove image?"
 msgstr "Bilde entfernen?"
 
-#: ../src/control/jobs/control_jobs.c:1565
+#: ../src/control/jobs/control_jobs.c:1567
 msgid "remove images?"
 msgstr "Bilder entfernen?"
 
 #. first get all selected images, to avoid the set changing during ui interaction
-#: ../src/control/jobs/control_jobs.c:1581
-#: ../src/control/jobs/control_jobs.c:1625
+#: ../src/control/jobs/control_jobs.c:1583
+#: ../src/control/jobs/control_jobs.c:1627
 msgid "delete images"
 msgstr "Bilder löschen"
 
-#: ../src/control/jobs/control_jobs.c:1601
+#: ../src/control/jobs/control_jobs.c:1603
 #, c-format
 msgid ""
 "do you really want to physically delete %d image\n"
@@ -6544,7 +6648,7 @@ msgstr[1] ""
 "Sollen %d Bilder physisch von der Festplatte gelöscht werden (Papierkorb "
 "verwenden, falls möglich)?"
 
-#: ../src/control/jobs/control_jobs.c:1603
+#: ../src/control/jobs/control_jobs.c:1605
 #, c-format
 msgid "do you really want to physically delete %d image from disk?"
 msgid_plural "do you really want to physically delete %d images from disk?"
@@ -6552,16 +6656,16 @@ msgstr[0] "Soll %d Bild physisch von der Festplatte gelöscht werden?"
 msgstr[1] ""
 "Sollen %d ausgewählte Bilder physisch von der Festplatte gelöscht werden?"
 
-#: ../src/control/jobs/control_jobs.c:1610
-#: ../src/control/jobs/control_jobs.c:1648
+#: ../src/control/jobs/control_jobs.c:1612
+#: ../src/control/jobs/control_jobs.c:1650
 msgid "delete image?"
 msgstr "Bild löschen?"
 
-#: ../src/control/jobs/control_jobs.c:1610
+#: ../src/control/jobs/control_jobs.c:1612
 msgid "delete images?"
 msgstr "Bilder löschen?"
 
-#: ../src/control/jobs/control_jobs.c:1642
+#: ../src/control/jobs/control_jobs.c:1644
 msgid ""
 "do you really want to physically delete selected image (using trash if "
 "possible)?"
@@ -6569,21 +6673,21 @@ msgstr ""
 "Soll das ausgewählte Bild physisch von der Festplatte gelöscht werden "
 "(Papierkorb verwenden, falls möglich)?"
 
-#: ../src/control/jobs/control_jobs.c:1643
+#: ../src/control/jobs/control_jobs.c:1645
 msgid "do you really want to physically delete selected image from disk?"
 msgstr ""
 "sollen die ausgewählten Bilder physisch von der Festplatte gelöscht werden?"
 
-#: ../src/control/jobs/control_jobs.c:1666
+#: ../src/control/jobs/control_jobs.c:1668
 msgid "move images"
 msgstr "Bilder verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1678
-#: ../src/control/jobs/control_jobs.c:1740
+#: ../src/control/jobs/control_jobs.c:1680
+#: ../src/control/jobs/control_jobs.c:1742
 msgid "_select as destination"
 msgstr "als Ziel _wählen"
 
-#: ../src/control/jobs/control_jobs.c:1698
+#: ../src/control/jobs/control_jobs.c:1700
 #, c-format
 msgid ""
 "do you really want to physically move %d image to %s?\n"
@@ -6598,17 +6702,17 @@ msgstr[1] ""
 "Sollen %d Bilder wirklich physisch nach „%s” verschoben werden?\n"
 "(Alle nicht ausgewählten Duplikate werden auch verschoben.)"
 
-#: ../src/control/jobs/control_jobs.c:1707
+#: ../src/control/jobs/control_jobs.c:1709
 msgid "move image?"
 msgid_plural "move images?"
 msgstr[0] "Bild verschieben?"
 msgstr[1] "Bilder verschieben?"
 
-#: ../src/control/jobs/control_jobs.c:1728
+#: ../src/control/jobs/control_jobs.c:1730
 msgid "copy images"
 msgstr "Bilder kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1760
+#: ../src/control/jobs/control_jobs.c:1762
 #, c-format
 msgid "do you really want to physically copy %d image to %s?"
 msgid_plural "do you really want to physically copy %d images to %s?"
@@ -6616,95 +6720,95 @@ msgstr[0] "Soll das %d Bild physisch nach %s kopiert werden?"
 msgstr[1] ""
 "Sollen die %d ausgewählten Bilder wirklich physisch nach %s kopiert werden?"
 
-#: ../src/control/jobs/control_jobs.c:1766
+#: ../src/control/jobs/control_jobs.c:1768
 msgid "copy image?"
 msgid_plural "copy images?"
 msgstr[0] "Bild kopieren?"
 msgstr[1] "Bilder kopieren?"
 
-#: ../src/control/jobs/control_jobs.c:1786
-#: ../src/control/jobs/control_jobs.c:1794
+#: ../src/control/jobs/control_jobs.c:1788
+#: ../src/control/jobs/control_jobs.c:1796
 msgid "local copy images"
 msgstr "Bilder lokal kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1801 ../src/libs/image.c:614
+#: ../src/control/jobs/control_jobs.c:1803 ../src/libs/image.c:614
 msgid "refresh exif"
 msgstr "Exif-Daten aktualisieren"
 
-#: ../src/control/jobs/control_jobs.c:1865
+#: ../src/control/jobs/control_jobs.c:1867
 #, c-format
 msgid "failed to get parameters from storage module `%s', aborting export.."
 msgstr ""
 "Konnte keine Einstellungen vom Speicher-Modul „%s” bekommen, breche Export "
 "ab.."
 
-#: ../src/control/jobs/control_jobs.c:1881
+#: ../src/control/jobs/control_jobs.c:1883
 msgid "export images"
 msgstr "Bilder exportieren"
 
-#: ../src/control/jobs/control_jobs.c:1928
+#: ../src/control/jobs/control_jobs.c:1930
 #, c-format
 msgid "adding time offset to %d image"
 msgstr "füge Zeitversatz zu %d Bild hinzu"
 
-#: ../src/control/jobs/control_jobs.c:1928
+#: ../src/control/jobs/control_jobs.c:1930
 #, c-format
 msgid "setting date/time of %d image"
 msgstr "setze Datum/Zeit für %d Bild"
 
-#: ../src/control/jobs/control_jobs.c:1929
+#: ../src/control/jobs/control_jobs.c:1931
 #, c-format
 msgid "adding time offset to %d images"
 msgstr "füge Zeitversatz zu %d Bildern hinzu"
 
-#: ../src/control/jobs/control_jobs.c:1929
+#: ../src/control/jobs/control_jobs.c:1931
 #, c-format
 msgid "setting date/time of %d images"
 msgstr "setze Datum/Zeit für %d Bilder"
 
-#: ../src/control/jobs/control_jobs.c:1970
+#: ../src/control/jobs/control_jobs.c:1972
 #, c-format
 msgid "added time offset to %d image"
 msgstr "Zeitversatz zu %d Bild hinzugefügt"
 
-#: ../src/control/jobs/control_jobs.c:1970
+#: ../src/control/jobs/control_jobs.c:1972
 #, c-format
 msgid "set date/time of %d image"
 msgstr "setze Datum/Zeit für %d Bild"
 
-#: ../src/control/jobs/control_jobs.c:1971
+#: ../src/control/jobs/control_jobs.c:1973
 #, c-format
 msgid "added time offset to %d images"
 msgstr "Zeitversatz zu %d Bildern hinzugefügt"
 
-#: ../src/control/jobs/control_jobs.c:1971
+#: ../src/control/jobs/control_jobs.c:1973
 #, c-format
 msgid "set date/time of %d images"
 msgstr "setze Datum/Zeit für %d Bildern"
 
-#: ../src/control/jobs/control_jobs.c:2012
+#: ../src/control/jobs/control_jobs.c:2014
 msgid "time offset"
 msgstr "Zeitversatz"
 
-#: ../src/control/jobs/control_jobs.c:2040 ../src/libs/copy_history.c:401
+#: ../src/control/jobs/control_jobs.c:2042 ../src/libs/copy_history.c:401
 msgid "write sidecar files"
 msgstr "XMP schreiben"
 
-#: ../src/control/jobs/control_jobs.c:2225 ../src/control/jobs/film_jobs.c:297
+#: ../src/control/jobs/control_jobs.c:2234 ../src/control/jobs/film_jobs.c:297
 #, c-format
 msgid "importing %d image"
 msgid_plural "importing %d images"
 msgstr[0] "Importiere %d Bild"
 msgstr[1] "Importiere %d Bilder"
 
-#: ../src/control/jobs/control_jobs.c:2261
+#: ../src/control/jobs/control_jobs.c:2270
 #, c-format
 msgid "importing %d/%d image"
 msgid_plural "importing %d/%d images"
 msgstr[0] "Importiere %d/%d Bild"
 msgstr[1] "Importiere %d/%d Bilder"
 
-#: ../src/control/jobs/control_jobs.c:2269
+#: ../src/control/jobs/control_jobs.c:2278
 #, c-format
 msgid "imported %d image"
 msgid_plural "imported %d images"
@@ -6942,7 +7046,7 @@ msgid "reverse"
 msgstr "umgekehrt"
 
 #: ../src/develop/blend_gui.c:93 ../src/imageio/format/webp.c:357
-#: ../src/libs/metadata.c:494 ../src/libs/metadata_view.c:1204
+#: ../src/libs/metadata.c:496 ../src/libs/metadata_view.c:1198
 msgid "default"
 msgstr "Standard"
 
@@ -6964,17 +7068,17 @@ msgid "uniformly"
 msgstr "einheitlich"
 
 #: ../src/develop/blend_gui.c:103 ../src/develop/blend_gui.c:2319
-#: ../src/develop/blend_gui.c:2985 ../src/develop/imageop.c:2281
+#: ../src/develop/blend_gui.c:2985 ../src/develop/imageop.c:2285
 msgid "drawn mask"
 msgstr "gezeichnete Maske"
 
 #: ../src/develop/blend_gui.c:104 ../src/develop/blend_gui.c:2130
-#: ../src/develop/blend_gui.c:2992 ../src/develop/imageop.c:2283
+#: ../src/develop/blend_gui.c:2992 ../src/develop/imageop.c:2287
 msgid "parametric mask"
 msgstr "parametrische Maske"
 
 #: ../src/develop/blend_gui.c:105 ../src/develop/blend_gui.c:2499
-#: ../src/develop/blend_gui.c:3010 ../src/develop/imageop.c:2285
+#: ../src/develop/blend_gui.c:3010 ../src/develop/imageop.c:2289
 msgid "raster mask"
 msgstr "Raster-Maske"
 
@@ -7014,21 +7118,21 @@ msgstr "Output nach Weichzeichnen"
 msgid "input after blur"
 msgstr "Input nach Weichzeichnen"
 
-#: ../src/develop/blend_gui.c:125 ../src/develop/develop.c:2239
-#: ../src/gui/accelerators.c:117 ../src/gui/accelerators.c:126
-#: ../src/gui/accelerators.c:195 ../src/imageio/format/avif.c:823
+#: ../src/develop/blend_gui.c:125 ../src/develop/develop.c:2251
+#: ../src/gui/accelerators.c:118 ../src/gui/accelerators.c:127
+#: ../src/gui/accelerators.c:196 ../src/imageio/format/avif.c:823
 #: ../src/libs/live_view.c:428
 msgid "on"
 msgstr "ein"
 
 #: ../src/develop/blend_gui.c:856 ../src/develop/blend_gui.c:2188
-#: ../src/develop/imageop.c:3070 ../src/iop/channelmixerrgb.c:4102
+#: ../src/develop/imageop.c:3074 ../src/iop/channelmixerrgb.c:4102
 #: ../src/iop/exposure.c:1104
 msgid "input"
 msgstr "Input"
 
 #: ../src/develop/blend_gui.c:856 ../src/develop/blend_gui.c:2188
-#: ../src/develop/imageop.c:3072
+#: ../src/develop/imageop.c:3076
 msgid "output"
 msgstr "Output"
 
@@ -7166,10 +7270,10 @@ msgstr "Regler für Chrominanz-Kanal (von HSL)"
 
 #: ../src/develop/blend_gui.c:2003 ../src/develop/blend_gui.c:2030
 #: ../src/iop/atrous.c:1739 ../src/iop/channelmixerrgb.c:4057
-#: ../src/iop/channelmixerrgb.c:4148 ../src/iop/colorbalancergb.c:1792
-#: ../src/iop/colorbalancergb.c:1793 ../src/iop/colorbalancergb.c:1794
-#: ../src/iop/colorbalancergb.c:1795 ../src/iop/colorbalancergb.c:1802
-#: ../src/iop/colorbalancergb.c:1803 ../src/iop/colorbalancergb.c:1804
+#: ../src/iop/channelmixerrgb.c:4148 ../src/iop/colorbalancergb.c:1771
+#: ../src/iop/colorbalancergb.c:1772 ../src/iop/colorbalancergb.c:1773
+#: ../src/iop/colorbalancergb.c:1774 ../src/iop/colorbalancergb.c:1781
+#: ../src/iop/colorbalancergb.c:1782 ../src/iop/colorbalancergb.c:1783
 #: ../src/iop/equalizer.c:391 ../src/iop/nlmeans.c:523
 msgid "chroma"
 msgstr "Chrominanz"
@@ -7279,20 +7383,20 @@ msgstr ""
 "„m” drücken, um die Anzeige der Maske ein- oder auszuschalten"
 
 #: ../src/develop/blend_gui.c:2226 ../src/develop/blend_gui.c:3054
-#: ../src/iop/basicadj.c:586 ../src/iop/colorbalancergb.c:1753
+#: ../src/iop/basicadj.c:586 ../src/iop/colorbalancergb.c:1732
 #: ../src/iop/exposure.c:1040 ../src/iop/exposure.c:1053
 #: ../src/iop/filmic.c:1607 ../src/iop/filmic.c:1619 ../src/iop/filmic.c:1659
-#: ../src/iop/filmicrgb.c:3892 ../src/iop/filmicrgb.c:3902
-#: ../src/iop/filmicrgb.c:3935 ../src/iop/filmicrgb.c:3945
+#: ../src/iop/filmicrgb.c:4314 ../src/iop/filmicrgb.c:4324
+#: ../src/iop/filmicrgb.c:4360 ../src/iop/filmicrgb.c:4370
 #: ../src/iop/graduatednd.c:1098 ../src/iop/negadoctor.c:983
 #: ../src/iop/profile_gamma.c:651 ../src/iop/profile_gamma.c:657
-#: ../src/iop/relight.c:267 ../src/iop/soften.c:404 ../src/iop/toneequal.c:3130
-#: ../src/iop/toneequal.c:3133 ../src/iop/toneequal.c:3136
-#: ../src/iop/toneequal.c:3139 ../src/iop/toneequal.c:3142
-#: ../src/iop/toneequal.c:3145 ../src/iop/toneequal.c:3148
-#: ../src/iop/toneequal.c:3151 ../src/iop/toneequal.c:3154
-#: ../src/iop/toneequal.c:3248 ../src/iop/toneequal.c:3255
-#: ../src/iop/toneequal.c:3265 ../src/views/darkroom.c:2384
+#: ../src/iop/relight.c:267 ../src/iop/soften.c:404 ../src/iop/toneequal.c:3131
+#: ../src/iop/toneequal.c:3134 ../src/iop/toneequal.c:3137
+#: ../src/iop/toneequal.c:3140 ../src/iop/toneequal.c:3143
+#: ../src/iop/toneequal.c:3146 ../src/iop/toneequal.c:3149
+#: ../src/iop/toneequal.c:3152 ../src/iop/toneequal.c:3155
+#: ../src/iop/toneequal.c:3249 ../src/iop/toneequal.c:3256
+#: ../src/iop/toneequal.c:3266 ../src/views/darkroom.c:2388
 msgid " EV"
 msgstr " EV"
 
@@ -7587,7 +7691,7 @@ msgstr "Maskierung vorübergehend ausschalten"
 msgid "temporarily switch off blend mask. only for module in focus"
 msgstr "Maskierung des aktiven Moduls vorübergehend ausschalten"
 
-#: ../src/develop/develop.c:1520 ../src/gui/presets.c:944
+#: ../src/develop/develop.c:1524 ../src/gui/presets.c:960
 msgid "display-referred default"
 msgstr "Vorgabe anzeigebezogene Bearbeitung"
 
@@ -7595,12 +7699,12 @@ msgstr "Vorgabe anzeigebezogene Bearbeitung"
 #. For scene-referred workflow, since filmic doesn't brighten as base curve does,
 #. we need an initial exposure boost. This might be too much in some cases but…
 #. (the preset name is used in develop.c)
-#: ../src/develop/develop.c:1522 ../src/gui/presets.c:946
+#: ../src/develop/develop.c:1526 ../src/gui/presets.c:962
 #: ../src/iop/exposure.c:290 ../src/iop/exposure.c:299
 msgid "scene-referred default"
 msgstr "Vorgabe szenenbezogene Bearbeitung"
 
-#: ../src/develop/develop.c:1993
+#: ../src/develop/develop.c:2005
 #, c-format
 msgid "%s: module `%s' version mismatch: %d != %d"
 msgstr "%s: Modul „%s” hat unpassende Version: %d != %d"
@@ -7613,63 +7717,63 @@ msgstr "neue Instanz"
 msgid "duplicate instance"
 msgstr "Instanz duplizieren"
 
-#: ../src/develop/imageop.c:939 ../src/develop/imageop.c:3237
+#: ../src/develop/imageop.c:939 ../src/develop/imageop.c:3241
 #: ../src/libs/masks.c:1098
 msgid "move up"
 msgstr "aufwärtsschieben"
 
-#: ../src/develop/imageop.c:945 ../src/develop/imageop.c:3238
+#: ../src/develop/imageop.c:945 ../src/develop/imageop.c:3242
 #: ../src/libs/masks.c:1101
 msgid "move down"
 msgstr "abwärtsschieben"
 
 #. TODO??? this SHOULD be named "delete group" but because of string freeze for 3.8
 #. we can only do that after 3.8 is released.
-#: ../src/develop/imageop.c:951 ../src/develop/imageop.c:3240
-#: ../src/gui/accelerators.c:140 ../src/gui/presets.c:467
+#: ../src/develop/imageop.c:951 ../src/develop/imageop.c:3244
+#: ../src/gui/accelerators.c:141 ../src/gui/presets.c:477
 #: ../src/libs/image.c:185 ../src/libs/masks.c:1055 ../src/libs/tagging.c:1506
 #: ../src/libs/tagging.c:1594
 msgid "delete"
 msgstr "löschen"
 
-#: ../src/develop/imageop.c:958 ../src/develop/imageop.c:3241
-#: ../src/libs/modulegroups.c:3507 ../src/libs/modulegroups.c:3863
+#: ../src/develop/imageop.c:958 ../src/develop/imageop.c:3245
+#: ../src/libs/modulegroups.c:3515 ../src/libs/modulegroups.c:3879
 msgid "rename"
 msgstr "umbenennen"
 
-#: ../src/develop/imageop.c:1024 ../src/develop/imageop.c:2458
+#: ../src/develop/imageop.c:1024 ../src/develop/imageop.c:2462
 #, c-format
 msgid "%s is switched on"
 msgstr "%s ist eingeschaltet"
 
-#: ../src/develop/imageop.c:1024 ../src/develop/imageop.c:2458
+#: ../src/develop/imageop.c:1024 ../src/develop/imageop.c:2462
 #, c-format
 msgid "%s is switched off"
 msgstr "%s ist ausgeschaltet"
 
-#: ../src/develop/imageop.c:2275
+#: ../src/develop/imageop.c:2279
 msgid "unknown mask"
 msgstr "unbekannte Maske"
 
-#: ../src/develop/imageop.c:2279
+#: ../src/develop/imageop.c:2283
 msgid "drawn + parametric mask"
 msgstr "gezeichnete & parametrische Maske"
 
-#: ../src/develop/imageop.c:2288
+#: ../src/develop/imageop.c:2292
 #, c-format
 msgid "this module has a `%s'"
 msgstr "Dieses Modul hat eine `%s’"
 
-#: ../src/develop/imageop.c:2293
+#: ../src/develop/imageop.c:2297
 #, c-format
 msgid "taken from module %s"
 msgstr "Übernommen vom Modul %s"
 
-#: ../src/develop/imageop.c:2298
+#: ../src/develop/imageop.c:2302
 msgid "click to display (module must be activated first)"
 msgstr "zum Anzeigen anklicken (Modul muss erst aktiviert werden)"
 
-#: ../src/develop/imageop.c:2423
+#: ../src/develop/imageop.c:2427
 msgid ""
 "multiple instance actions\n"
 "right-click creates new instance"
@@ -7677,7 +7781,7 @@ msgstr ""
 "Multi-Instanz Aktionen\n"
 "Rechtsklick erzeugt neue Instanz"
 
-#: ../src/develop/imageop.c:2436
+#: ../src/develop/imageop.c:2440
 msgid ""
 "reset parameters\n"
 "ctrl+click to reapply any automatic presets"
@@ -7685,7 +7789,7 @@ msgstr ""
 "Einstellungen zurücksetzen\n"
 "Strg+Klick wendet automatische Voreinstellungen erneut an."
 
-#: ../src/develop/imageop.c:2446
+#: ../src/develop/imageop.c:2450
 msgid ""
 "presets\n"
 "right-click to apply on new instance"
@@ -7693,23 +7797,23 @@ msgstr ""
 "Voreinstellungen\n"
 "Rechtsklick, um auf eine neue Instanz anzuwenden"
 
-#: ../src/develop/imageop.c:2688 ../src/develop/imageop.c:2710
+#: ../src/develop/imageop.c:2692 ../src/develop/imageop.c:2714
 msgid "ERROR"
 msgstr "Fehler"
 
-#: ../src/develop/imageop.c:3069
+#: ../src/develop/imageop.c:3073
 msgid "purpose"
 msgstr "Kategorie"
 
-#: ../src/develop/imageop.c:3071
+#: ../src/develop/imageop.c:3075
 msgid "process"
 msgstr "Bearbeitung"
 
-#: ../src/develop/imageop.c:3141
+#: ../src/develop/imageop.c:3145
 msgid "unsupported input"
 msgstr "nicht unterstütztes Eingabedatenformat"
 
-#: ../src/develop/imageop.c:3142
+#: ../src/develop/imageop.c:3146
 msgid ""
 "you have placed this module at\n"
 "a position in the pipeline where\n"
@@ -7719,49 +7823,49 @@ msgstr ""
 "das Modul wurde an eine Position verschoben, \n"
 "in dem das Datenformat nicht den Anforderungen genügt."
 
-#: ../src/develop/imageop.c:3236 ../src/develop/imageop.c:3246
-#: ../src/gui/accelerators.c:136 ../src/libs/lib.c:1264
+#: ../src/develop/imageop.c:3240 ../src/develop/imageop.c:3250
+#: ../src/gui/accelerators.c:137 ../src/libs/lib.c:1296
 msgid "show"
 msgstr "anzeigen"
 
-#: ../src/develop/imageop.c:3239 ../src/libs/modulegroups.c:3357
-#: ../src/libs/modulegroups.c:3481 ../src/libs/modulegroups.c:3866
+#: ../src/develop/imageop.c:3243 ../src/libs/modulegroups.c:3361
+#: ../src/libs/modulegroups.c:3487 ../src/libs/modulegroups.c:3882
 #: ../src/libs/tagging.c:3307
 msgid "new"
 msgstr "neu"
 
-#: ../src/develop/imageop.c:3242 ../src/libs/duplicate.c:546
-#: ../src/libs/image.c:510 ../src/libs/modulegroups.c:3860
+#: ../src/develop/imageop.c:3246 ../src/libs/duplicate.c:548
+#: ../src/libs/image.c:510 ../src/libs/modulegroups.c:3876
 msgid "duplicate"
 msgstr "duplizieren"
 
-#: ../src/develop/imageop.c:3247
+#: ../src/develop/imageop.c:3251
 msgid "enable"
 msgstr "aktivieren"
 
 # keine Ahnung, ob das passt, konnte den String in der GUI nicht finden.
-#: ../src/develop/imageop.c:3248
+#: ../src/develop/imageop.c:3252
 msgid "focus"
 msgstr "Fokus"
 
-#: ../src/develop/imageop.c:3249 ../src/gui/accelerators.c:2120
+#: ../src/develop/imageop.c:3253 ../src/gui/accelerators.c:2133
 msgid "instance"
 msgstr "Instanz"
 
-#: ../src/develop/imageop.c:3250 ../src/gui/accelerators.c:102
-#: ../src/gui/accelerators.c:111 ../src/iop/atrous.c:1583
-#: ../src/libs/lib.c:1265 ../src/libs/modulegroups.c:3935
+#: ../src/develop/imageop.c:3254 ../src/gui/accelerators.c:103
+#: ../src/gui/accelerators.c:112 ../src/iop/atrous.c:1583
+#: ../src/libs/lib.c:1297 ../src/libs/modulegroups.c:3951
 msgid "reset"
 msgstr "zurücksetzen"
 
 #. Adding the outer container
-#: ../src/develop/imageop.c:3251 ../src/gui/preferences.c:772
-#: ../src/libs/lib.c:1266
+#: ../src/develop/imageop.c:3255 ../src/gui/preferences.c:773
+#: ../src/libs/lib.c:1298
 msgid "presets"
 msgstr "Voreinstellungen"
 
 # keine Ahnung, ob das passt, konnte den String in der GUI nicht finden.
-#: ../src/develop/imageop.c:3263
+#: ../src/develop/imageop.c:3267
 msgid "processing module"
 msgstr "Bearbeitungsmodule"
 
@@ -7774,17 +7878,17 @@ msgstr ""
 "%s\n"
 "Strg+Klick für %s"
 
-#: ../src/develop/lightroom.c:1079
+#: ../src/develop/lightroom.c:1083
 msgid "cannot find lightroom XMP!"
 msgstr "Lightroom-XMP kann nicht gefunden werden!"
 
-#: ../src/develop/lightroom.c:1111 ../src/develop/lightroom.c:1133
-#: ../src/develop/lightroom.c:1153
+#: ../src/develop/lightroom.c:1115 ../src/develop/lightroom.c:1137
+#: ../src/develop/lightroom.c:1157
 #, c-format
 msgid "`%s' not a lightroom XMP!"
 msgstr "„%s” ist kein Lightroom-XMP!"
 
-#: ../src/develop/lightroom.c:1552
+#: ../src/develop/lightroom.c:1556
 #, c-format
 msgid "%s has been imported"
 msgid_plural "%s have been imported"
@@ -7987,25 +8091,25 @@ msgstr "[SHAPE] Form entfernen"
 msgid "copy of %s"
 msgstr "Kopie von %s"
 
-#: ../src/develop/masks/masks.c:916
+#: ../src/develop/masks/masks.c:918
 #, c-format
 msgid "%s: mask version mismatch: %d != %d"
 msgstr "%s: Maske hat unpassende Version: %d != %d"
 
-#: ../src/develop/masks/masks.c:1145 ../src/develop/masks/masks.c:1757
+#: ../src/develop/masks/masks.c:1150 ../src/develop/masks/masks.c:1762
 #, c-format
 msgid "opacity: %d%%"
 msgstr "Deckkraft: %d%%"
 
-#: ../src/develop/masks/masks.c:1515 ../src/libs/masks.c:1029
+#: ../src/develop/masks/masks.c:1520 ../src/libs/masks.c:1029
 msgid "add existing shape"
 msgstr "bestehende Form hinzufügen"
 
-#: ../src/develop/masks/masks.c:1537
+#: ../src/develop/masks/masks.c:1542
 msgid "use same shapes as"
 msgstr "gleiche Form verwenden wie"
 
-#: ../src/develop/masks/masks.c:1835
+#: ../src/develop/masks/masks.c:1840
 msgid "masks can not contain themselves"
 msgstr "Masken können sich nicht selbst enthalten"
 
@@ -8124,7 +8228,7 @@ msgstr ""
 "Vermutlich eine Folge einer Voreinstellung, eines Stils oder Kopieren und "
 "Einfügen eines Verlaufs"
 
-#: ../src/develop/pixelpipe_hb.c:2247
+#: ../src/develop/pixelpipe_hb.c:2250
 msgid ""
 "darktable discovered problems with your OpenCL setup; disabling OpenCL for "
 "this session!"
@@ -8132,34 +8236,34 @@ msgstr ""
 "darktable hat Probleme mit OpenCL festgestellt; OpenCL wird für diese "
 "Sitzung deaktiviert!"
 
-#: ../src/develop/tiling.c:820 ../src/develop/tiling.c:1160
+#: ../src/develop/tiling.c:833 ../src/develop/tiling.c:1167
 #, c-format
 msgid "tiling failed for module '%s'. output might be garbled."
 msgstr ""
-"Kachelung für Modul „%s” fehlgeschlagen. Die Ausgabe könnte fehlerhaft sein."
+"Tiling für Modul „%s” fehlgeschlagen. Die Ausgabe könnte fehlerhaft sein."
 
-#: ../src/dtgtk/culling.c:228
+#: ../src/dtgtk/culling.c:232
 msgid "you have reached the start of your selection"
 msgstr "Anfang der Auswahl erreicht"
 
-#: ../src/dtgtk/culling.c:237
+#: ../src/dtgtk/culling.c:241
 msgid "you have reached the start of your collection"
 msgstr "Anfang der Sammlung erreicht"
 
-#: ../src/dtgtk/culling.c:278
+#: ../src/dtgtk/culling.c:286
 msgid "you have reached the end of your selection"
 msgstr "Ende der Auswahl erreicht"
 
-#: ../src/dtgtk/culling.c:301
+#: ../src/dtgtk/culling.c:311
 msgid "you have reached the end of your collection"
 msgstr "Ende der Sammlung erreicht"
 
-#: ../src/dtgtk/culling.c:395
+#: ../src/dtgtk/culling.c:405
 #, c-format
 msgid "zooming is limited to %d images"
 msgstr "Zoom ist auf %d Bilder beschränkt"
 
-#: ../src/dtgtk/culling.c:984
+#: ../src/dtgtk/culling.c:1000
 msgid "no image selected !"
 msgstr "Kein Bild ausgewählt!"
 
@@ -8167,7 +8271,7 @@ msgstr "Kein Bild ausgewählt!"
 msgid "double-click to reset"
 msgstr "Doppelklick zum Zurücksetzen"
 
-#: ../src/dtgtk/thumbnail.c:89 ../src/dtgtk/thumbnail.c:117
+#: ../src/dtgtk/thumbnail.c:89 ../src/dtgtk/thumbnail.c:119
 msgid "current"
 msgstr "dieses Bild"
 
@@ -8184,42 +8288,42 @@ msgstr ""
 "hier klicken, um dieses Bild als Gruppenleiter festzulegen\n"
 
 #. and the number of grouped images
-#: ../src/dtgtk/thumbnail.c:128
+#: ../src/dtgtk/thumbnail.c:130
 msgid "grouped images"
 msgstr "gruppierte Bilder"
 
-#: ../src/dtgtk/thumbnail.c:710 ../src/dtgtk/thumbnail.c:1444
-#: ../src/iop/ashift.c:5765 ../src/iop/ashift.c:5832 ../src/iop/ashift.c:5833
-#: ../src/iop/ashift.c:5834
+#: ../src/dtgtk/thumbnail.c:712 ../src/dtgtk/thumbnail.c:1446
+#: ../src/iop/ashift.c:5768 ../src/iop/ashift.c:5835 ../src/iop/ashift.c:5836
+#: ../src/iop/ashift.c:5837
 msgid "fit"
 msgstr "einpassen"
 
-#: ../src/dtgtk/thumbtable.c:980 ../src/views/slideshow.c:376
+#: ../src/dtgtk/thumbtable.c:984 ../src/views/slideshow.c:376
 msgid "there are no images in this collection"
 msgstr "Diese Sammlung enthält keine Bilder"
 
-#: ../src/dtgtk/thumbtable.c:987
+#: ../src/dtgtk/thumbtable.c:991
 msgid "if you have not imported any images yet"
 msgstr "Falls noch keine Bilder importiert wurden"
 
-#: ../src/dtgtk/thumbtable.c:991
+#: ../src/dtgtk/thumbtable.c:995
 msgid "you can do so in the import module"
 msgstr "Kann im Import-Modul erfolgen"
 
-#: ../src/dtgtk/thumbtable.c:999
+#: ../src/dtgtk/thumbtable.c:1003
 msgid "try to relax the filter settings in the top panel"
 msgstr "Filterregeln in der oberen Leiste anpassen"
 
-#: ../src/dtgtk/thumbtable.c:1008
+#: ../src/dtgtk/thumbtable.c:1012
 msgid "or add images in the collections module in the left panel"
 msgstr "oder Bilder links im Sammlungen-Modul hinzufügen"
 
-#: ../src/dtgtk/thumbtable.c:1249
+#: ../src/dtgtk/thumbtable.c:1253
 msgid ""
 "you have changed the settings related to how thumbnails are generated.\n"
 msgstr "Du hast die Einstellungen zur Miniaturbildergenerierung geändert.\n"
 
-#: ../src/dtgtk/thumbtable.c:1251
+#: ../src/dtgtk/thumbtable.c:1255
 msgid ""
 "all cached thumbnails need to be invalidated.\n"
 "\n"
@@ -8227,7 +8331,7 @@ msgstr ""
 "alle gespeicherte Miniaturbilder müssen ungültig gesetzt werden.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1253
+#: ../src/dtgtk/thumbtable.c:1257
 #, c-format
 msgid ""
 "cached thumbnails starting from level %d need to be invalidated.\n"
@@ -8236,7 +8340,7 @@ msgstr ""
 "gespeicherte Miniaturbilder ab Level %d müssen ungültig gesetzt werden.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1256
+#: ../src/dtgtk/thumbtable.c:1260
 #, c-format
 msgid ""
 "cached thumbnails below level %d need to be invalidated.\n"
@@ -8246,7 +8350,7 @@ msgstr ""
 "werden.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1258
+#: ../src/dtgtk/thumbtable.c:1262
 #, c-format
 msgid ""
 "cached thumbnails between level %d and %d need to be invalidated.\n"
@@ -8256,89 +8360,89 @@ msgstr ""
 "werden.\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1261
+#: ../src/dtgtk/thumbtable.c:1265
 msgid "do you want to do that now?"
 msgstr "Willst Du das jetzt machen?"
 
-#: ../src/dtgtk/thumbtable.c:1269
+#: ../src/dtgtk/thumbtable.c:1273
 msgid "cached thumbnails invalidation"
 msgstr "Ungültigsetzen von gespeicherten Miniaturbildern"
 
 #. setup rating key accelerators
-#: ../src/dtgtk/thumbtable.c:2372 ../src/dtgtk/thumbtable.c:2373
-#: ../src/dtgtk/thumbtable.c:2374 ../src/dtgtk/thumbtable.c:2375
-#: ../src/dtgtk/thumbtable.c:2376 ../src/dtgtk/thumbtable.c:2377
-#: ../src/dtgtk/thumbtable.c:2378
+#: ../src/dtgtk/thumbtable.c:2380 ../src/dtgtk/thumbtable.c:2381
+#: ../src/dtgtk/thumbtable.c:2382 ../src/dtgtk/thumbtable.c:2383
+#: ../src/dtgtk/thumbtable.c:2384 ../src/dtgtk/thumbtable.c:2385
+#: ../src/dtgtk/thumbtable.c:2386
 msgctxt "accel"
 msgid "rating"
 msgstr "Bewertung"
 
 #. setup history key accelerators
-#: ../src/dtgtk/thumbtable.c:2381
+#: ../src/dtgtk/thumbtable.c:2389
 msgctxt "accel"
 msgid "copy history"
 msgstr "Verlauf kopieren"
 
-#: ../src/dtgtk/thumbtable.c:2382
+#: ../src/dtgtk/thumbtable.c:2390
 msgctxt "accel"
 msgid "copy history parts"
 msgstr "Verlauf teilweise kopieren"
 
-#: ../src/dtgtk/thumbtable.c:2384
+#: ../src/dtgtk/thumbtable.c:2392
 msgctxt "accel"
 msgid "paste history"
 msgstr "Verlauf einfügen"
 
-#: ../src/dtgtk/thumbtable.c:2385
+#: ../src/dtgtk/thumbtable.c:2393
 msgctxt "accel"
 msgid "paste history parts"
 msgstr "Verlauf teilweise einfügen"
 
-#: ../src/dtgtk/thumbtable.c:2387
+#: ../src/dtgtk/thumbtable.c:2395
 msgctxt "accel"
 msgid "discard history"
 msgstr "Verlauf verwerfen"
 
-#: ../src/dtgtk/thumbtable.c:2389
+#: ../src/dtgtk/thumbtable.c:2397
 msgctxt "accel"
 msgid "duplicate image"
 msgstr "Bild duplizieren"
 
-#: ../src/dtgtk/thumbtable.c:2390
+#: ../src/dtgtk/thumbtable.c:2398
 msgctxt "accel"
 msgid "duplicate image virgin"
 msgstr "Bilder unbearbeitet duplizieren"
 
 #. setup color label accelerators
-#: ../src/dtgtk/thumbtable.c:2394 ../src/dtgtk/thumbtable.c:2395
-#: ../src/dtgtk/thumbtable.c:2396 ../src/dtgtk/thumbtable.c:2397
-#: ../src/dtgtk/thumbtable.c:2398
+#: ../src/dtgtk/thumbtable.c:2402 ../src/dtgtk/thumbtable.c:2403
+#: ../src/dtgtk/thumbtable.c:2404 ../src/dtgtk/thumbtable.c:2405
+#: ../src/dtgtk/thumbtable.c:2406
 msgctxt "accel"
 msgid "color label"
 msgstr "Farbmarkierung"
 
 #. setup selection accelerators
-#: ../src/dtgtk/thumbtable.c:2401 ../src/libs/select.c:377
+#: ../src/dtgtk/thumbtable.c:2409 ../src/libs/select.c:377
 msgctxt "accel"
 msgid "select all"
 msgstr "alles auswählen"
 
-#: ../src/dtgtk/thumbtable.c:2402 ../src/libs/select.c:378
+#: ../src/dtgtk/thumbtable.c:2410 ../src/libs/select.c:378
 msgctxt "accel"
 msgid "select none"
 msgstr "nichts auswählen"
 
-#: ../src/dtgtk/thumbtable.c:2404 ../src/libs/select.c:379
+#: ../src/dtgtk/thumbtable.c:2412 ../src/libs/select.c:379
 msgctxt "accel"
 msgid "invert selection"
 msgstr "Auswahl invertieren"
 
-#: ../src/dtgtk/thumbtable.c:2405 ../src/libs/select.c:380
+#: ../src/dtgtk/thumbtable.c:2413 ../src/libs/select.c:380
 msgctxt "accel"
 msgid "select film roll"
 msgstr "Filmrolle auswählen"
 
-#: ../src/dtgtk/thumbtable.c:2406 ../src/libs/select.c:381
+#: ../src/dtgtk/thumbtable.c:2414 ../src/libs/select.c:381
 msgctxt "accel"
 msgid "select untouched"
 msgstr "Unbearbeitete auswählen"
@@ -8457,7 +8561,7 @@ msgstr "Abendsonne"
 msgid "underwater"
 msgstr "unter Wasser"
 
-#: ../src/external/wb_presets.c:77 ../src/views/darkroom.c:2378
+#: ../src/external/wb_presets.c:77 ../src/views/darkroom.c:2382
 msgid "black & white"
 msgstr "schwarz & weiß"
 
@@ -8541,352 +8645,356 @@ msgstr "Fehler: Stelle sicher, dass min_mip <= max_mip ist\n"
 msgid "creating complete lighttable thumbnail cache\n"
 msgstr "erzeuge vollständigen Leuchttisch-Vorschau-Cache\n"
 
-#: ../src/gui/accelerators.c:72 ../src/views/view.c:1180
+#: ../src/gui/accelerators.c:73 ../src/views/view.c:1180
 msgid "scroll"
 msgstr "scrollen"
 
-#: ../src/gui/accelerators.c:73
+#: ../src/gui/accelerators.c:74
 msgid "pan"
 msgstr "verschieben"
 
-#: ../src/gui/accelerators.c:74 ../src/iop/ashift.c:5420
-#: ../src/iop/ashift.c:5421 ../src/iop/ashift.c:5523 ../src/iop/ashift.c:5524
-#: ../src/iop/ashift.c:5833 ../src/iop/clipping.c:1920
+#: ../src/gui/accelerators.c:75 ../src/iop/ashift.c:5423
+#: ../src/iop/ashift.c:5424 ../src/iop/ashift.c:5526 ../src/iop/ashift.c:5527
+#: ../src/iop/ashift.c:5836 ../src/iop/clipping.c:1920
 #: ../src/iop/clipping.c:2122 ../src/iop/clipping.c:2138
-#: ../src/views/darkroom.c:2619 ../src/views/lighttable.c:1333
+#: ../src/views/darkroom.c:2623 ../src/views/lighttable.c:1333
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ../src/gui/accelerators.c:75 ../src/iop/ashift.c:5420
-#: ../src/iop/ashift.c:5421 ../src/iop/ashift.c:5523 ../src/iop/ashift.c:5524
-#: ../src/iop/ashift.c:5832 ../src/iop/clipping.c:1919
+#: ../src/gui/accelerators.c:76 ../src/iop/ashift.c:5423
+#: ../src/iop/ashift.c:5424 ../src/iop/ashift.c:5526 ../src/iop/ashift.c:5527
+#: ../src/iop/ashift.c:5835 ../src/iop/clipping.c:1919
 #: ../src/iop/clipping.c:2123 ../src/iop/clipping.c:2137
-#: ../src/views/darkroom.c:2622 ../src/views/lighttable.c:1337
+#: ../src/views/darkroom.c:2626 ../src/views/lighttable.c:1337
 msgid "vertical"
 msgstr "vertikal"
 
-#: ../src/gui/accelerators.c:76
+#: ../src/gui/accelerators.c:77
 msgid "diagonal"
 msgstr "diagonal"
 
-#: ../src/gui/accelerators.c:77
+#: ../src/gui/accelerators.c:78
 msgid "skew"
 msgstr "Schräg"
 
-#: ../src/gui/accelerators.c:78
+#: ../src/gui/accelerators.c:79
 msgid "leftright"
 msgstr "Links/rechts"
 
-#: ../src/gui/accelerators.c:79
+#: ../src/gui/accelerators.c:80
 msgid "updown"
 msgstr "auf/ab"
 
-#: ../src/gui/accelerators.c:80
+#: ../src/gui/accelerators.c:81
 msgid "pgupdown"
 msgstr "Bildauf/ab"
 
-#: ../src/gui/accelerators.c:88 ../src/views/view.c:1164
+#: ../src/gui/accelerators.c:89 ../src/views/view.c:1164
 msgid "shift"
 msgstr "shift"
 
-#: ../src/gui/accelerators.c:89 ../src/views/view.c:1165
+#: ../src/gui/accelerators.c:90 ../src/views/view.c:1165
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/gui/accelerators.c:90 ../src/views/view.c:1166
+#: ../src/gui/accelerators.c:91 ../src/views/view.c:1166
 msgid "alt"
 msgstr "alt"
 
-#: ../src/gui/accelerators.c:91
+#: ../src/gui/accelerators.c:92
 msgid "cmd"
 msgstr "cmd"
 
-#: ../src/gui/accelerators.c:92
+#: ../src/gui/accelerators.c:93
 msgid "altgr"
 msgstr "altgr"
 
-#: ../src/gui/accelerators.c:99 ../src/gui/accelerators.c:141
+#: ../src/gui/accelerators.c:100 ../src/gui/accelerators.c:142
 #: ../src/libs/tagging.c:1804
 msgid "edit"
 msgstr "bearbeiten"
 
-#: ../src/gui/accelerators.c:100 ../src/gui/accelerators.c:544
+#: ../src/gui/accelerators.c:101 ../src/gui/accelerators.c:550
 msgid "up"
 msgstr "auf"
 
-#: ../src/gui/accelerators.c:101 ../src/gui/accelerators.c:544
+#: ../src/gui/accelerators.c:102 ../src/gui/accelerators.c:550
 msgid "down"
 msgstr "ab"
 
-#: ../src/gui/accelerators.c:105
+#: ../src/gui/accelerators.c:106
 msgid "set"
 msgstr "setzen"
 
-#: ../src/gui/accelerators.c:108
+#: ../src/gui/accelerators.c:109
 msgid "popup"
 msgstr "popup"
 
-#: ../src/gui/accelerators.c:109 ../src/gui/accelerators.c:138
-#: ../src/gui/gtk.c:2955 ../src/views/lighttable.c:755
+#: ../src/gui/accelerators.c:110 ../src/gui/accelerators.c:139
+#: ../src/gui/gtk.c:2954 ../src/views/lighttable.c:755
 msgid "next"
 msgstr "nächster"
 
-#: ../src/gui/accelerators.c:110 ../src/gui/accelerators.c:137
-#: ../src/gui/gtk.c:2956 ../src/views/lighttable.c:756
+#: ../src/gui/accelerators.c:111 ../src/gui/accelerators.c:138
+#: ../src/gui/gtk.c:2955 ../src/views/lighttable.c:756
 msgid "previous"
 msgstr "vorheriger"
 
-#: ../src/gui/accelerators.c:112 ../src/gui/accelerators.c:1111
+#: ../src/gui/accelerators.c:113 ../src/gui/accelerators.c:1117
 msgid "last"
 msgstr "letzter"
 
-#: ../src/gui/accelerators.c:113 ../src/gui/accelerators.c:1110
+#: ../src/gui/accelerators.c:114 ../src/gui/accelerators.c:1116
 msgid "first"
 msgstr "erster"
 
-#: ../src/gui/accelerators.c:116 ../src/gui/accelerators.c:128
-#: ../src/gui/accelerators.c:238 ../src/views/darkroom.c:2296
-#: ../src/views/darkroom.c:2351
+#: ../src/gui/accelerators.c:117 ../src/gui/accelerators.c:129
+#: ../src/gui/accelerators.c:239 ../src/views/darkroom.c:2300
+#: ../src/views/darkroom.c:2355
 msgid "toggle"
 msgstr "umschalten"
 
-#: ../src/gui/accelerators.c:119
+#: ../src/gui/accelerators.c:120
 msgid "ctrl-toggle"
 msgstr "ctrl-umschalten"
 
-#: ../src/gui/accelerators.c:120
+#: ../src/gui/accelerators.c:121
 msgid "ctrl-on"
 msgstr "ctrl-on"
 
-#: ../src/gui/accelerators.c:121
+#: ../src/gui/accelerators.c:122
 msgid "right-toggle"
 msgstr "rechts-umschalten"
 
-#: ../src/gui/accelerators.c:122
+#: ../src/gui/accelerators.c:123
 msgid "right-on"
 msgstr "rechts-an"
 
-#: ../src/gui/accelerators.c:131 ../src/gui/gtk.c:2954
+#: ../src/gui/accelerators.c:132 ../src/gui/gtk.c:2953
 msgid "activate"
 msgstr "aktivieren"
 
-#: ../src/gui/accelerators.c:132
+#: ../src/gui/accelerators.c:133
 msgid "ctrl-activate"
 msgstr "ctrl-aktivieren"
 
-#: ../src/gui/accelerators.c:133
+#: ../src/gui/accelerators.c:134
 msgid "right-activate"
 msgstr "rechts-aktivieren"
 
-#: ../src/gui/accelerators.c:139
+#: ../src/gui/accelerators.c:140
 msgid "store"
 msgstr "speichern"
 
-#: ../src/gui/accelerators.c:142 ../src/gui/styles_dialog.c:509
+#: ../src/gui/accelerators.c:143 ../src/gui/styles_dialog.c:509
 msgid "update"
 msgstr "aktualisieren"
 
-#: ../src/gui/accelerators.c:143 ../src/libs/tools/global_toolbox.c:61
+#: ../src/gui/accelerators.c:144 ../src/libs/tools/global_toolbox.c:61
 msgid "preferences"
 msgstr "Voreinstellungen"
 
 #. apply button
-#: ../src/gui/accelerators.c:146 ../src/iop/colortransfer.c:670
-#: ../src/libs/metadata.c:761 ../src/libs/styles.c:889
+#: ../src/gui/accelerators.c:147 ../src/iop/colortransfer.c:670
+#: ../src/libs/metadata.c:763 ../src/libs/styles.c:889
 msgid "apply"
 msgstr "anwenden"
 
-#: ../src/gui/accelerators.c:147
+#: ../src/gui/accelerators.c:148
 msgid "apply on new instance"
 msgstr "auf neue Instanz anwenden"
 
-#: ../src/gui/accelerators.c:458
+#: ../src/gui/accelerators.c:455
+msgid "tablet button"
+msgstr "Tablett Taste"
+
+#: ../src/gui/accelerators.c:464
 msgid "unknown driver"
 msgstr "unbekannter Treiber"
 
-#: ../src/gui/accelerators.c:525
+#: ../src/gui/accelerators.c:531
 msgid "long"
 msgstr "lang"
 
-#: ../src/gui/accelerators.c:526
+#: ../src/gui/accelerators.c:532
 msgid "double-press"
 msgstr "doppelt drücken"
 
-#: ../src/gui/accelerators.c:527
+#: ../src/gui/accelerators.c:533
 msgid "triple-press"
 msgstr "dreifach drücken"
 
-#: ../src/gui/accelerators.c:528
+#: ../src/gui/accelerators.c:534
 msgid "press"
 msgstr "drücken"
 
-#: ../src/gui/accelerators.c:532
+#: ../src/gui/accelerators.c:538
 msgctxt "accel"
 msgid "left"
 msgstr "links"
 
-#: ../src/gui/accelerators.c:533
+#: ../src/gui/accelerators.c:539
 msgctxt "accel"
 msgid "right"
 msgstr "rechts"
 
-#: ../src/gui/accelerators.c:534
+#: ../src/gui/accelerators.c:540
 msgctxt "accel"
 msgid "middle"
 msgstr "mittel"
 
-#: ../src/gui/accelerators.c:535
+#: ../src/gui/accelerators.c:541
 msgctxt "accel"
 msgid "long"
 msgstr "lang"
 
-#: ../src/gui/accelerators.c:536
+#: ../src/gui/accelerators.c:542
 msgctxt "accel"
 msgid "double-click"
 msgstr "Doppelklick"
 
-#: ../src/gui/accelerators.c:537
+#: ../src/gui/accelerators.c:543
 msgctxt "accel"
 msgid "triple-click"
 msgstr "Dreifachklick"
 
-#: ../src/gui/accelerators.c:538
+#: ../src/gui/accelerators.c:544
 msgid "click"
 msgstr "klick"
 
-#: ../src/gui/accelerators.c:566
+#: ../src/gui/accelerators.c:572
 msgid "first instance"
 msgstr "erste Instanz"
 
-#: ../src/gui/accelerators.c:568
+#: ../src/gui/accelerators.c:574
 msgid "last instance"
 msgstr "letzte Instanz"
 
-#: ../src/gui/accelerators.c:570
+#: ../src/gui/accelerators.c:576
 msgid "relative instance"
 msgstr "relative Instanz"
 
-#: ../src/gui/accelerators.c:597 ../src/gui/accelerators.c:841
-#: ../src/gui/accelerators.c:2110 ../src/gui/accelerators.c:2978
+#: ../src/gui/accelerators.c:603 ../src/gui/accelerators.c:847
+#: ../src/gui/accelerators.c:2123 ../src/gui/accelerators.c:2993
 msgid "speed"
 msgstr "Geschwindigkeit"
 
-#: ../src/gui/accelerators.c:655
+#: ../src/gui/accelerators.c:661
 msgid ""
 "press Del to delete selected shortcut\n"
 "double-click to add new shortcut\n"
 "start typing for incremental search"
 msgstr ""
-"Entf drücken, um ausgewählten Kurzbefehl zu löschen\n"
-"Doppelklick, um neuen Kurzbefehl festzulegen.\n"
+"Entf drücken, um ausgewählten Shortcut zu löschen\n"
+"Doppelklick, um neuen Shortcut festzulegen.\n"
 "Tippen, um inkrementelle Suche zu starten"
 
-#: ../src/gui/accelerators.c:670
+#: ../src/gui/accelerators.c:676
 msgid ""
 "click to filter shortcut list\n"
 "double-click to define new shortcut\n"
 "start typing for incremental search"
 msgstr ""
-"Klicken, um Liste der Kurzbefehle zu filtern\n"
-"Doppelklick, um neuen Kurzbefehl festzulegen.\n"
+"Klicken, um Liste der Shortcut zu filtern\n"
+"Doppelklick, um neuen Shortcut festzulegen.\n"
 "Tippen, um inkrementelle Suche zu starten"
 
-#: ../src/gui/accelerators.c:689
+#: ../src/gui/accelerators.c:695
 msgid ""
 "press keys with mouse click and scroll or move combinations to create a "
 "shortcut"
 msgstr ""
-"Tastendruck mit Mausklick und Scrollen oder Bewegungen, um einen Kurzbefehl "
-"zu erstellen"
+"Tastendruck mit Mausklick und Scrollen oder Bewegungen, um einen Shortcut zu "
+"erstellen"
 
-#: ../src/gui/accelerators.c:690
+#: ../src/gui/accelerators.c:696
 msgid "click to open shortcut configuration"
-msgstr "Klick um Kurzbefehleinstellungen zu öffnen"
+msgstr "Klick um Shortcut Einstellungen zu öffnen"
 
-#: ../src/gui/accelerators.c:691
+#: ../src/gui/accelerators.c:697
 msgid "ctrl+click to add to quick access panel\n"
 msgstr "Strg+Klick zum Hinzufügen zur Schnellzugriffsgruppe\n"
 
-#: ../src/gui/accelerators.c:692
+#: ../src/gui/accelerators.c:698
 msgid "ctrl+click to remove from quick access panel\n"
 msgstr "Strg+Klick zum Entfernen aus Schnellzugriffsgruppe\n"
 
-#: ../src/gui/accelerators.c:693
+#: ../src/gui/accelerators.c:699
 msgid "scroll to change default speed"
 msgstr "Scrollen, um die Standardgeschwindigkeit zu ändern"
 
-#: ../src/gui/accelerators.c:694
+#: ../src/gui/accelerators.c:700
 msgid "right click to exit mapping mode"
 msgstr "Rechtsklick um Zuweisungsmodus zu beenden"
 
-#: ../src/gui/accelerators.c:838
+#: ../src/gui/accelerators.c:844
 msgid "active view"
 msgstr "Aktive Sicht"
 
-#: ../src/gui/accelerators.c:839
+#: ../src/gui/accelerators.c:845
 msgid "other views"
 msgstr "andere Ansichten"
 
-#: ../src/gui/accelerators.c:840
+#: ../src/gui/accelerators.c:846
 msgid "fallbacks"
 msgstr "Fallbacks"
 
-#: ../src/gui/accelerators.c:991
+#: ../src/gui/accelerators.c:997
 msgid "shortcut for move exists with single effect"
-msgstr "Kurzbefehl für Bewegung mit einer Auswirkung existiert"
+msgstr "Shortcut für Bewegung mit einer Auswirkung existiert"
 
-#: ../src/gui/accelerators.c:992
+#: ../src/gui/accelerators.c:998
 msgid "create separate shortcuts for up and down move?"
-msgstr "separate Kurzbefehle für auf/ab-Bewegung erzeugen?"
+msgstr "separate Shortcuts für auf/ab-Bewegung erzeugen?"
 
-#: ../src/gui/accelerators.c:1015
+#: ../src/gui/accelerators.c:1021
 #, c-format
 msgid "%s, speed reset"
 msgstr "%s, speed reset"
 
-#: ../src/gui/accelerators.c:1024
+#: ../src/gui/accelerators.c:1030
 msgid "shortcut exists with different settings"
-msgstr "Kurzbefehl existiert mit anderer Einstellung"
+msgstr "Shortcut existiert mit anderer Einstellung"
 
-#: ../src/gui/accelerators.c:1025
+#: ../src/gui/accelerators.c:1031
 msgid "reset the settings of the shortcut?"
-msgstr "Einstellung des Kurzbefehls zurücksetzen?"
+msgstr "Einstellung des Shortcuts zurücksetzen?"
 
-#: ../src/gui/accelerators.c:1036
+#: ../src/gui/accelerators.c:1042
 msgid "shortcut already exists"
-msgstr "Kurzbefehl existiert bereits"
+msgstr "Shortcut existiert bereits"
 
-#: ../src/gui/accelerators.c:1037
+#: ../src/gui/accelerators.c:1043
 msgid "remove the shortcut?"
-msgstr "Kurzbefehl entfernen?"
+msgstr "Shortcut entfernen?"
 
-#: ../src/gui/accelerators.c:1070
+#: ../src/gui/accelerators.c:1076
 msgid "remove these existing shortcuts?"
-msgstr "diese vorhandenen Kurzbefehle entfernen?"
+msgstr "diese vorhandenen Shortcuts entfernen?"
 
-#: ../src/gui/accelerators.c:1072
+#: ../src/gui/accelerators.c:1078
 msgid "clashing shortcuts exist"
-msgstr "Kurzbefehlkonflikt existiert"
+msgstr "widersprüchlicher Shortcut existiert"
 
 #. or 3, but change char relative[] = "-2" to "-1"
 #. NUM_INSTANCES
-#: ../src/gui/accelerators.c:1109
+#: ../src/gui/accelerators.c:1115
 msgid "preferred"
 msgstr "bevorzugt"
 
-#: ../src/gui/accelerators.c:1112
+#: ../src/gui/accelerators.c:1118
 msgid "second"
 msgstr "zweite"
 
-#: ../src/gui/accelerators.c:1113
+#: ../src/gui/accelerators.c:1119
 msgid "last but one"
 msgstr "vorletzte"
 
-#: ../src/gui/accelerators.c:1255 ../src/gui/accelerators.c:1309
+#: ../src/gui/accelerators.c:1261 ../src/gui/accelerators.c:1315
 msgid "(unchanged)"
 msgstr "<nicht geändert>"
 
-#: ../src/gui/accelerators.c:1404
+#: ../src/gui/accelerators.c:1410
 msgid ""
 "define a shortcut by pressing a key, optionally combined with modifier keys "
 "(ctrl/shift/alt)\n"
@@ -8899,8 +9007,8 @@ msgid ""
 "\n"
 "right-click to cancel"
 msgstr ""
-"Definieren Sie einen Kurzbefehl durch Drücken einer Taste, optional "
-"kombiniert mit Modifikatortasten (Strg/shift/alt)\n"
+"einen Shortcut durch Drücken einer Taste definieren; optional kombiniert mit "
+"Modifikatortasten (Strg/shift/alt)\n"
 "eine Taste kann doppelt oder dreifach gedrückt werden, mit einem langen "
 "letzten Druck\n"
 "während die Taste gehalten wird, kann eine Kombination von Maustasten "
@@ -8912,160 +9020,160 @@ msgstr ""
 "\n"
 "Rechtsklick zum Abbrechen"
 
-#: ../src/gui/accelerators.c:1451
+#: ../src/gui/accelerators.c:1457
 msgid "removing shortcut"
-msgstr "Kurzbefehl wird entfernt"
+msgstr "Shortcut wird entfernt"
 
-#: ../src/gui/accelerators.c:1452
+#: ../src/gui/accelerators.c:1458
 msgid "remove the selected shortcut?"
-msgstr "selektierten Kurzbefehl entfernen?"
+msgstr "selektierten Shortcut entfernen?"
 
-#: ../src/gui/accelerators.c:1782
+#: ../src/gui/accelerators.c:1793
 msgid "restore shortcuts"
-msgstr "Kurzbefehle wiederherstellen"
+msgstr "Shortcuts wiederherstellen"
 
-#: ../src/gui/accelerators.c:1786
+#: ../src/gui/accelerators.c:1797
 msgid "_defaults"
 msgstr "_Standard"
 
-#: ../src/gui/accelerators.c:1787
+#: ../src/gui/accelerators.c:1798
 msgid "_startup"
 msgstr "_beim Start"
 
-#: ../src/gui/accelerators.c:1788
+#: ../src/gui/accelerators.c:1799
 msgid "_edits"
 msgstr "_vor Änderung"
 
-#: ../src/gui/accelerators.c:1793
+#: ../src/gui/accelerators.c:1804
 msgid ""
 "restore default shortcuts\n"
 "  or as at startup\n"
 "  or when the configuration dialog was opened\n"
 msgstr ""
-"Standard-Kurzbefehle wiederherstellen\n"
+"Standard-Shortcuts wiederherstellen\n"
 "  oder wie beim Start\n"
 "  oder wie beim Öffnen des Einstellungsdialogs\n"
 
-#: ../src/gui/accelerators.c:1796
+#: ../src/gui/accelerators.c:1807
 msgid ""
 "clear all newer shortcuts\n"
 "(instead of just restoring changed ones)"
 msgstr ""
-"alle neueren Kurzbefehle löschen\n"
+"alle neueren Shortcuts löschen\n"
 "(anstatt nur die geänderten wiederherzustellen)"
 
-#: ../src/gui/accelerators.c:1848 ../src/gui/preferences.c:875
-#: ../src/libs/tools/global_toolbox.c:842
+#: ../src/gui/accelerators.c:1861 ../src/gui/preferences.c:876
+#: ../src/libs/tools/global_toolbox.c:843
 msgid "shortcuts"
-msgstr "Kurzbefehle"
+msgstr "Shortcuts"
 
-#: ../src/gui/accelerators.c:1857
+#: ../src/gui/accelerators.c:1870
 msgid "export shortcuts"
-msgstr "Kurzbefehle exportieren"
+msgstr "Shortcuts exportieren"
 
-#: ../src/gui/accelerators.c:1860 ../src/gui/accelerators.c:1939
-#: ../src/gui/hist_dialog.c:198 ../src/gui/presets.c:467
+#: ../src/gui/accelerators.c:1873 ../src/gui/accelerators.c:1952
+#: ../src/gui/hist_dialog.c:198 ../src/gui/presets.c:477
 msgid "_ok"
 msgstr "_OK"
 
-#: ../src/gui/accelerators.c:1865
+#: ../src/gui/accelerators.c:1878
 msgid ""
 "export all shortcuts to a file\n"
 "or just for one selected device\n"
 msgstr ""
-"alle Kurzbefehle in eine Datei exportieren\n"
+"alle Shortcuts in eine Datei exportieren\n"
 "oder nur für ein ausgewähltes Gerät\n"
 
-#: ../src/gui/accelerators.c:1870 ../src/gui/accelerators.c:1949
-#: ../src/gui/gtk.c:3025 ../src/imageio/format/pdf.c:659
+#: ../src/gui/accelerators.c:1883 ../src/gui/accelerators.c:1962
+#: ../src/gui/gtk.c:3026 ../src/imageio/format/pdf.c:659
 #: ../src/iop/denoiseprofile.c:3584 ../src/iop/lens.cc:2274
 #: ../src/iop/rawdenoise.c:904 ../src/libs/tools/filter.c:400
 msgid "all"
 msgstr "alles"
 
-#: ../src/gui/accelerators.c:1871 ../src/gui/accelerators.c:1950
+#: ../src/gui/accelerators.c:1884 ../src/gui/accelerators.c:1963
 msgid "keyboard"
 msgstr "Tastatur"
 
-#: ../src/gui/accelerators.c:1883
+#: ../src/gui/accelerators.c:1896
 msgid "device id"
 msgstr "Geräte ID"
 
-#: ../src/gui/accelerators.c:1909
+#: ../src/gui/accelerators.c:1922
 msgid "select file to export"
 msgstr "Datei zum exportieren wählen"
 
-#: ../src/gui/accelerators.c:1910 ../src/libs/tagging.c:2547
+#: ../src/gui/accelerators.c:1923 ../src/libs/tagging.c:2547
 msgid "_export"
 msgstr "_exportieren"
 
-#: ../src/gui/accelerators.c:1936
+#: ../src/gui/accelerators.c:1949
 msgid "import shortcuts"
-msgstr "Kurzbefehle importieren"
+msgstr "Shortcuts importieren"
 
-#: ../src/gui/accelerators.c:1944
+#: ../src/gui/accelerators.c:1957
 msgid ""
 "import all shortcuts from a file\n"
 "or just for one selected device\n"
 msgstr ""
-"alle Kurzbefehle aus einer Datei importieren\n"
+"alle Shortcuts aus einer Datei importieren\n"
 "oder nur für ein ausgewähltes Gerät\n"
 
-#: ../src/gui/accelerators.c:1962
+#: ../src/gui/accelerators.c:1975
 msgid "id in file"
 msgstr "ID in Datei"
 
-#: ../src/gui/accelerators.c:1968
+#: ../src/gui/accelerators.c:1981
 msgid "id when loaded"
 msgstr "ID nach Laden"
 
-#: ../src/gui/accelerators.c:1972
+#: ../src/gui/accelerators.c:1985
 msgid "clear device first"
 msgstr "Zuweisungen für Gerät vorher löschen"
 
-#: ../src/gui/accelerators.c:1996
+#: ../src/gui/accelerators.c:2009
 msgid "select file to import"
 msgstr "Datei zum importieren wählen"
 
-#: ../src/gui/accelerators.c:1997 ../src/libs/tagging.c:2511
+#: ../src/gui/accelerators.c:2010 ../src/libs/tagging.c:2511
 msgid "_import"
 msgstr "_importieren"
 
-#: ../src/gui/accelerators.c:2070
+#: ../src/gui/accelerators.c:2083
 msgid "search shortcuts list"
-msgstr "suche Kurzbefehle"
+msgstr "suche Shortcuts"
 
-#: ../src/gui/accelerators.c:2071
+#: ../src/gui/accelerators.c:2084
 msgid ""
 "incrementally search the list of shortcuts\n"
 "press up or down keys to cycle through matches"
 msgstr ""
-"schrittweise Suche in der Liste der Kurzbefehle\n"
+"schrittweise Suche in der Liste der Shortcuts\n"
 "mit auf- oder ab-Pfeiltaste durch die Treffer blättern"
 
 #. Setting up the cell renderers
-#: ../src/gui/accelerators.c:2086 ../src/views/view.c:1373
+#: ../src/gui/accelerators.c:2099 ../src/views/view.c:1373
 msgid "shortcut"
-msgstr "Kurzbefehl"
+msgstr "Shortcut"
 
-#: ../src/gui/accelerators.c:2088 ../src/gui/accelerators.c:2176
+#: ../src/gui/accelerators.c:2101 ../src/gui/accelerators.c:2189
 #: ../src/views/view.c:1375
 msgid "action"
 msgstr "Aktion"
 
-#: ../src/gui/accelerators.c:2097
+#: ../src/gui/accelerators.c:2110
 msgid "element"
 msgstr "Element"
 
-#: ../src/gui/accelerators.c:2104
+#: ../src/gui/accelerators.c:2117
 msgid "effect"
 msgstr "Effekt"
 
-#: ../src/gui/accelerators.c:2161
+#: ../src/gui/accelerators.c:2174
 msgid "search actions list"
 msgstr "suche Aktion"
 
-#: ../src/gui/accelerators.c:2162
+#: ../src/gui/accelerators.c:2175
 msgid ""
 "incrementally search the list of actions\n"
 "press up or down keys to cycle through matches"
@@ -9074,80 +9182,80 @@ msgstr ""
 "Drücken Sie die Aufwärts- oder Abwärts-Taste, um durch die Treffer zu "
 "blättern"
 
-#: ../src/gui/accelerators.c:2182 ../src/gui/guides.c:719
+#: ../src/gui/accelerators.c:2195 ../src/gui/guides.c:719
 #: ../src/libs/export_metadata.c:192
 msgid "type"
 msgstr "Typ"
 
-#: ../src/gui/accelerators.c:2217
+#: ../src/gui/accelerators.c:2230
 msgid "enable fallbacks"
 msgstr "Fallbacks aktivieren"
 
-#: ../src/gui/accelerators.c:2218
+#: ../src/gui/accelerators.c:2231
 msgid ""
 "enables default meanings for additional buttons, modifiers or moves\n"
 "when used in combination with a base shortcut"
 msgstr ""
 "aktiviert Standardverhalten für zusätzliche Tasten, Modifikatoren oder "
 "Bewegungen\n"
-"bei Verwendung in Kombination mit einem Basis-Kurzbefehl"
+"bei Verwendung in Kombination mit einem Basis-Shortcut"
 
-#: ../src/gui/accelerators.c:2224
+#: ../src/gui/accelerators.c:2237
 msgid "restore..."
 msgstr "wiederherstellen..."
 
-#: ../src/gui/accelerators.c:2225
+#: ../src/gui/accelerators.c:2238
 msgid "restore default shortcuts or previous state"
-msgstr "Kurzbefehle auf Standard oder vorliegen Stand zurücksetzen"
+msgstr "Shortcuts auf Standard oder vorliegen Stand zurücksetzen"
 
-#: ../src/gui/accelerators.c:2229
+#: ../src/gui/accelerators.c:2242
 msgid "import..."
 msgstr "importieren…"
 
-#: ../src/gui/accelerators.c:2230
+#: ../src/gui/accelerators.c:2243
 msgid "fully or partially import shortcuts from file"
-msgstr "Kurzbefehle teilweise oder vollständig aus Datei importieren"
+msgstr "Shortcuts teilweise oder vollständig aus Datei importieren"
 
 #. export button
-#: ../src/gui/accelerators.c:2234 ../src/libs/styles.c:884
+#: ../src/gui/accelerators.c:2247 ../src/libs/styles.c:884
 msgid "export..."
 msgstr "exportieren…"
 
-#: ../src/gui/accelerators.c:2235
+#: ../src/gui/accelerators.c:2248
 msgid "fully or partially export shortcuts to file"
-msgstr "Kurzbefehle teilweise oder vollständig in Datei exportieren"
+msgstr "Shortcuts teilweise oder vollständig in Datei exportieren"
 
-#: ../src/gui/accelerators.c:2643
+#: ../src/gui/accelerators.c:2658
 msgid "input devices reinitialised"
 msgstr "Eingabegerät neu initialisiert "
 
-#: ../src/gui/accelerators.c:2858
+#: ../src/gui/accelerators.c:2873
 msgid "fallback to move"
 msgstr "Fallback zur Bewegung"
 
-#: ../src/gui/accelerators.c:3050
+#: ../src/gui/accelerators.c:3065
 #, c-format
 msgid "%s not assigned"
 msgstr "%s nicht zugewiesen"
 
-#: ../src/gui/accelerators.c:3202
+#: ../src/gui/accelerators.c:3217
 #, c-format
 msgid "%s assigned to %s"
 msgstr "%s zugewiesen an %s"
 
-#: ../src/gui/gtk.c:160 ../src/views/darkroom.c:4663
+#: ../src/gui/gtk.c:159 ../src/views/darkroom.c:4667
 msgid "darktable - darkroom preview"
 msgstr "darktable - Dunkelkammer Vorschau"
 
-#: ../src/gui/gtk.c:173
+#: ../src/gui/gtk.c:172
 msgid "tooltips off"
 msgstr "Kurzinfos aus"
 
-#: ../src/gui/gtk.c:175
+#: ../src/gui/gtk.c:174
 msgid "tooltips on"
 msgstr "Kurzinfos an"
 
-#: ../src/gui/gtk.c:180
+#: ../src/gui/gtk.c:179
 msgid ""
 "tooltip visibility can only be toggled if compositing is enabled in your "
 "window manager"
@@ -9155,167 +9263,167 @@ msgstr ""
 "Die Sichtbarkeit der Kurzinfos kann nur geändert werden, wenn der "
 "Fenstermanager Composing unterstützt."
 
-#: ../src/gui/gtk.c:818
+#: ../src/gui/gtk.c:817
 msgid "closing darktable..."
 msgstr "schließe darktable ..."
 
 #. register keys for view switching
-#: ../src/gui/gtk.c:1209
+#: ../src/gui/gtk.c:1208
 msgctxt "accel"
 msgid "switch views/tethering"
 msgstr "Ansicht wechseln/Thethering"
 
-#: ../src/gui/gtk.c:1210
+#: ../src/gui/gtk.c:1209
 msgctxt "accel"
 msgid "switch views/lighttable"
 msgstr "Ansicht wechseln/Leuchttisch"
 
-#: ../src/gui/gtk.c:1211
+#: ../src/gui/gtk.c:1210
 msgctxt "accel"
 msgid "switch views/darkroom"
 msgstr "Ansicht wechseln/Dunkelkammer"
 
-#: ../src/gui/gtk.c:1212
+#: ../src/gui/gtk.c:1211
 msgctxt "accel"
 msgid "switch views/map"
 msgstr "Ansicht wechseln/Karte"
 
-#: ../src/gui/gtk.c:1213
+#: ../src/gui/gtk.c:1212
 msgctxt "accel"
 msgid "switch views/slideshow"
 msgstr "Ansicht wechseln/Diashow"
 
-#: ../src/gui/gtk.c:1214
+#: ../src/gui/gtk.c:1213
 msgctxt "accel"
 msgid "switch views/print"
 msgstr "Ansicht wechseln/Drucken"
 
 #. an action that does nothing - used for overriding/removing default shortcuts
-#: ../src/gui/gtk.c:1217
+#: ../src/gui/gtk.c:1216
 msgctxt "accel"
 msgid "no-op"
 msgstr "nichts"
 
 #. register ctrl-q to quit:
-#: ../src/gui/gtk.c:1244
+#: ../src/gui/gtk.c:1243
 msgctxt "accel"
 msgid "quit"
 msgstr "darktable beenden"
 
 #. Full-screen accelerator (no ESC handler here to enable quit-slideshow using ESC)
-#: ../src/gui/gtk.c:1249
+#: ../src/gui/gtk.c:1248
 msgctxt "accel"
 msgid "fullscreen"
 msgstr "Vollbild"
 
 #. Side-border hide/show
-#: ../src/gui/gtk.c:1255
+#: ../src/gui/gtk.c:1254
 msgctxt "accel"
 msgid "panels/all"
 msgstr "Panel/alle"
 
-#: ../src/gui/gtk.c:1259
+#: ../src/gui/gtk.c:1258
 msgctxt "accel"
 msgid "panels/collapsing controls"
 msgstr "Panel/Steuersymbol ein-/ausblenden"
 
-#: ../src/gui/gtk.c:1263
+#: ../src/gui/gtk.c:1262
 msgctxt "accel"
 msgid "panels/left"
 msgstr "Panel/links"
 
-#: ../src/gui/gtk.c:1267
+#: ../src/gui/gtk.c:1266
 msgctxt "accel"
 msgid "panels/right"
 msgstr "Panel/rechts"
 
-#: ../src/gui/gtk.c:1271
+#: ../src/gui/gtk.c:1270
 msgctxt "accel"
 msgid "panels/top"
 msgstr "Panel/oben"
 
-#: ../src/gui/gtk.c:1275
+#: ../src/gui/gtk.c:1274
 msgctxt "accel"
 msgid "panels/bottom"
 msgstr "Panel/unten"
 
 #. specific top/bottom toggles
-#: ../src/gui/gtk.c:1280
+#: ../src/gui/gtk.c:1279
 msgctxt "accel"
 msgid "panels/header"
 msgstr "Panel/Titel"
 
-#: ../src/gui/gtk.c:1283
+#: ../src/gui/gtk.c:1282
 msgctxt "accel"
 msgid "panels/filmstrip and timeline"
 msgstr "Panel/Filmstreifen bzw. Zeitleiste"
 
-#: ../src/gui/gtk.c:1287
+#: ../src/gui/gtk.c:1286
 msgctxt "accel"
 msgid "panels/top toolbar"
 msgstr "Panel/obere Werkzeugleiste"
 
-#: ../src/gui/gtk.c:1291
+#: ../src/gui/gtk.c:1290
 msgctxt "accel"
 msgid "panels/bottom toolbar"
 msgstr "Panel/untere Werkzeugleiste"
 
-#: ../src/gui/gtk.c:1295
+#: ../src/gui/gtk.c:1294
 msgctxt "accel"
 msgid "panels/all top"
 msgstr "Panel/alle oben"
 
-#: ../src/gui/gtk.c:1299
+#: ../src/gui/gtk.c:1298
 msgctxt "accel"
 msgid "panels/all bottom"
 msgstr "Panel/alle unten"
 
 #. accels window
-#: ../src/gui/gtk.c:1304
+#: ../src/gui/gtk.c:1303
 msgctxt "accel"
 msgid "show accels window"
 msgstr "zeige Tastenbelegungsfenster"
 
 #. View-switch
-#: ../src/gui/gtk.c:1307
+#: ../src/gui/gtk.c:1306
 msgctxt "accel"
 msgid "toggle tooltip visibility"
 msgstr "Kurzinfo ein-/ausblenden"
 
 #. reinitialise input devices
-#: ../src/gui/gtk.c:1313
+#: ../src/gui/gtk.c:1312
 msgctxt "accel"
 msgid "reinitialise input devices"
 msgstr "Eingabegeräte neu initialisieren"
 
-#: ../src/gui/gtk.c:1354
+#: ../src/gui/gtk.c:1353
 msgid "toggle focus-peaking mode"
 msgstr "Fokuserkennung ein-/ausschalten"
 
 #. toggle focus peaking everywhere
-#: ../src/gui/gtk.c:1359
+#: ../src/gui/gtk.c:1358
 msgctxt "accel"
 msgid "toggle focus peaking"
 msgstr "Fokuserkennung ein-/ausschalten"
 
-#: ../src/gui/gtk.c:1515 ../src/gui/gtk.c:1531 ../src/gui/gtk.c:1565
-#: ../src/gui/gtk.c:1579
+#: ../src/gui/gtk.c:1514 ../src/gui/gtk.c:1530 ../src/gui/gtk.c:1564
+#: ../src/gui/gtk.c:1578
 msgid "panels"
 msgstr "Panel"
 
 #. font name can only use period as decimal separator
 #. but printf format strings use comma for some locales, so replace comma with period
-#: ../src/gui/gtk.c:2705
+#: ../src/gui/gtk.c:2704
 #, c-format
 msgid "%.1f"
 msgstr "%.1f"
 
-#: ../src/gui/gtk.c:2707
+#: ../src/gui/gtk.c:2706
 #, c-format
 msgid "Sans %s"
 msgstr "Sans %s"
 
-#: ../src/gui/gtk.c:3032 ../src/gui/gtk.c:3037 ../src/gui/gtk.c:3042
+#: ../src/gui/gtk.c:3033 ../src/gui/gtk.c:3038 ../src/gui/gtk.c:3043
 msgid "tabs"
 msgstr "Tabs"
 
@@ -9626,7 +9734,7 @@ msgstr "Drittelregel"
 msgid "metering"
 msgstr "Messung"
 
-#: ../src/gui/guides.c:33 ../src/iop/ashift.c:5744
+#: ../src/gui/guides.c:33 ../src/iop/ashift.c:5747
 msgid "perspective"
 msgstr "Perspektive"
 
@@ -9704,7 +9812,7 @@ msgstr "horizontal"
 msgid "vertically"
 msgstr "vertikal"
 
-#: ../src/gui/guides.c:715 ../src/iop/ashift.c:5834 ../src/iop/clipping.c:2124
+#: ../src/gui/guides.c:715 ../src/iop/ashift.c:5837 ../src/iop/clipping.c:2124
 #: ../src/iop/colorbalance.c:1866
 msgid "both"
 msgstr "beides"
@@ -9787,11 +9895,11 @@ msgid "can't copy history out of unaltered image"
 msgstr "Kann keinen Verlauf aus unbearbeitetem Bild kopieren"
 
 #. grid headers
-#: ../src/gui/import_metadata.c:413
+#: ../src/gui/import_metadata.c:417
 msgid "metadata presets"
 msgstr "Voreinstellungen"
 
-#: ../src/gui/import_metadata.c:416
+#: ../src/gui/import_metadata.c:420
 msgid ""
 "metadata to be applied per default\n"
 "double-click on a label to clear the corresponding entry\n"
@@ -9801,11 +9909,11 @@ msgstr ""
 "Doppelklick auf die Bezeichnung löscht den entsprechenden Eintrag\n"
 "Doppelklick auf 'Voreinstellungen' löscht alle Einträge"
 
-#: ../src/gui/import_metadata.c:426
+#: ../src/gui/import_metadata.c:430
 msgid "from xmp"
 msgstr "aus XMP"
 
-#: ../src/gui/import_metadata.c:429
+#: ../src/gui/import_metadata.c:433
 msgid ""
 "selected metadata are imported from image and override the default value\n"
 " this drives also the 'look for updated xmp files' and 'load sidecar file' "
@@ -9819,11 +9927,11 @@ msgstr ""
 "korrespondierende XMP-Datei geändert wurde."
 
 #. tags
-#: ../src/gui/import_metadata.c:465
+#: ../src/gui/import_metadata.c:469
 msgid "tag presets"
 msgstr "Tag Voreinst."
 
-#: ../src/gui/import_metadata.c:479
+#: ../src/gui/import_metadata.c:483
 msgid "comma separated list of tags"
 msgstr "Liste komma-separierter Tags"
 
@@ -9922,27 +10030,27 @@ msgstr ""
 "wirksam werden."
 
 #. exif
-#: ../src/gui/preferences.c:794 ../src/gui/presets.c:525
+#: ../src/gui/preferences.c:795 ../src/gui/presets.c:535
 #: ../src/libs/metadata_view.c:137
 msgid "model"
 msgstr "Modell"
 
-#: ../src/gui/preferences.c:798 ../src/gui/presets.c:533
+#: ../src/gui/preferences.c:799 ../src/gui/presets.c:543
 #: ../src/libs/metadata_view.c:138
 msgid "maker"
 msgstr "Hersteller"
 
-#: ../src/gui/preferences.c:823 ../src/iop/ashift.c:5837
+#: ../src/gui/preferences.c:824 ../src/iop/ashift.c:5840
 #: ../src/iop/basicadj.c:618 ../src/iop/borders.c:1041 ../src/iop/levels.c:637
 #: ../src/iop/rgblevels.c:1066
 msgid "auto"
 msgstr "auto"
 
-#: ../src/gui/preferences.c:835
+#: ../src/gui/preferences.c:836
 msgid "search presets list"
 msgstr "durchsuche Voreinstellungen"
 
-#: ../src/gui/preferences.c:836
+#: ../src/gui/preferences.c:837
 msgid ""
 "incrementally search the list of presets\n"
 "press up or down keys to cycle through matches"
@@ -9950,36 +10058,36 @@ msgstr ""
 "schrittweise Suche in der Liste der Voreinstellungen\n"
 "mit auf- oder ab-Pfeiltaste durch die Treffer blättern"
 
-#: ../src/gui/preferences.c:842
+#: ../src/gui/preferences.c:843
 msgctxt "preferences"
 msgid "import..."
 msgstr "importieren"
 
-#: ../src/gui/preferences.c:846
+#: ../src/gui/preferences.c:847
 msgctxt "preferences"
 msgid "export..."
 msgstr "exportieren..."
 
-#: ../src/gui/preferences.c:983
+#: ../src/gui/preferences.c:984
 #, c-format
 msgid "failed to import preset %s"
 msgstr "Voreinstellung %s konnte nicht importiert werden"
 
-#: ../src/gui/preferences.c:994
+#: ../src/gui/preferences.c:995
 msgid "select preset(s) to import"
 msgstr "Voreinstellung(en) zum importieren wählen"
 
-#: ../src/gui/preferences.c:995 ../src/libs/collect.c:468
+#: ../src/gui/preferences.c:996 ../src/libs/collect.c:463
 #: ../src/libs/copy_history.c:107 ../src/libs/geotagging.c:929
 #: ../src/libs/import.c:1525 ../src/libs/import.c:1628 ../src/libs/styles.c:534
 msgid "_open"
 msgstr "Ö_ffnen"
 
-#: ../src/gui/preferences.c:1004
+#: ../src/gui/preferences.c:1005
 msgid "darktable preset files"
 msgstr "darktable Voreinstellungsdatei"
 
-#: ../src/gui/preferences.c:1009 ../src/iop/lut3d.c:1588
+#: ../src/gui/preferences.c:1010 ../src/iop/lut3d.c:1588
 #: ../src/libs/copy_history.c:144 ../src/libs/geotagging.c:945
 #: ../src/libs/styles.c:548
 msgid "all files"
@@ -10002,39 +10110,41 @@ msgstr "HDR"
 msgid "monochrome"
 msgstr "Monochrom"
 
-#: ../src/gui/presets.c:161
+#: ../src/gui/presets.c:165
 #, c-format
 msgid "preset `%s' is write-protected, can't delete!"
 msgstr ""
 "Voreinstellung „%s” ist schreibgeschützt und kann nicht gelöscht werden"
 
-#: ../src/gui/presets.c:173 ../src/gui/presets.c:403 ../src/libs/lib.c:240
-#: ../src/libs/modulegroups.c:3742
+#: ../src/gui/presets.c:177 ../src/gui/presets.c:413 ../src/libs/lib.c:248
+#: ../src/libs/modulegroups.c:3756
 #, c-format
 msgid "do you really want to delete the preset `%s'?"
 msgstr "Soll die Voreinstellung „%s” wirklich gelöscht werden?"
 
-#: ../src/gui/presets.c:177 ../src/gui/presets.c:408 ../src/libs/lib.c:244
-#: ../src/libs/modulegroups.c:3746
+#: ../src/gui/presets.c:181 ../src/gui/presets.c:418 ../src/libs/lib.c:252
+#: ../src/libs/modulegroups.c:3760
 msgid "delete preset?"
 msgstr "Voreinstellung löschen?"
 
 #. add new preset
 #. then show edit dialog
-#: ../src/gui/presets.c:206 ../src/gui/presets.c:844 ../src/gui/presets.c:850
-#: ../src/libs/lib.c:189 ../src/libs/lib.c:204 ../src/libs/lib.c:215
+#. clang-format on
+#. then show edit dialog
+#: ../src/gui/presets.c:210 ../src/gui/presets.c:856 ../src/gui/presets.c:862
+#: ../src/libs/lib.c:195 ../src/libs/lib.c:212 ../src/libs/lib.c:223
 msgid "new preset"
 msgstr "neue Voreinstellung"
 
-#: ../src/gui/presets.c:211
+#: ../src/gui/presets.c:215
 msgid "please give preset a name"
 msgstr "Gib der Voreinstellung einen Namen"
 
-#: ../src/gui/presets.c:216
+#: ../src/gui/presets.c:220
 msgid "unnamed preset"
 msgstr "unbenannte Voreinstellung"
 
-#: ../src/gui/presets.c:243
+#: ../src/gui/presets.c:249
 #, c-format
 msgid ""
 "preset `%s' already exists.\n"
@@ -10043,46 +10153,46 @@ msgstr ""
 "Voreinstellung „%s” existiert bereits.\n"
 "Soll sie überschrieben werden?"
 
-#: ../src/gui/presets.c:248
+#: ../src/gui/presets.c:254
 msgid "overwrite preset?"
 msgstr "Voreinstellung überschreiben?"
 
-#: ../src/gui/presets.c:366 ../src/imageio/storage/disk.c:122
+#: ../src/gui/presets.c:376 ../src/imageio/storage/disk.c:122
 #: ../src/imageio/storage/gallery.c:109 ../src/imageio/storage/latex.c:108
 msgid "_select as output destination"
 msgstr "als Ausgabeziel _wählen"
 
-#: ../src/gui/presets.c:374
+#: ../src/gui/presets.c:384
 #, c-format
 msgid "preset %s was successfully exported"
 msgstr "Voreinstellung „%s” erfolgreich exportiert"
 
-#: ../src/gui/presets.c:463
+#: ../src/gui/presets.c:473
 #, c-format
 msgid "edit `%s' for module `%s'"
 msgstr "Bearbeite „%s“ des Moduls „%s“"
 
-#: ../src/gui/presets.c:466
+#: ../src/gui/presets.c:476
 msgid "_export..."
 msgstr "exportieren"
 
-#: ../src/gui/presets.c:484
+#: ../src/gui/presets.c:494
 msgid "name of the preset"
 msgstr "Name der Voreinstellung"
 
-#: ../src/gui/presets.c:492
+#: ../src/gui/presets.c:502
 msgid "description or further information"
 msgstr "Beschreibung für weitere Information"
 
-#: ../src/gui/presets.c:495
+#: ../src/gui/presets.c:505
 msgid "auto apply this preset to matching images"
 msgstr "Diese Voreinstellung automatisch auf passende Bilder anwenden"
 
-#: ../src/gui/presets.c:498
+#: ../src/gui/presets.c:508
 msgid "only show this preset for matching images"
 msgstr "Diese Voreinstellung nur für passende Bilder anzeigen"
 
-#: ../src/gui/presets.c:499
+#: ../src/gui/presets.c:509
 msgid ""
 "be very careful with this option. this might be the last time you see your "
 "preset."
@@ -10090,116 +10200,116 @@ msgstr ""
 "Mit dieser Option sehr vorsichtig sein. Es könnte das letzte Mal sein, dass "
 "diese Voreinstellung angezeigt wird."
 
-#: ../src/gui/presets.c:524
+#: ../src/gui/presets.c:534
 #, no-c-format
 msgid "string to match model (use % as wildcard)"
 msgstr ""
 "Zeichenkette, auf die das Modell passen muss („%” als Platzhalter benutzen)"
 
-#: ../src/gui/presets.c:532
+#: ../src/gui/presets.c:542
 #, no-c-format
 msgid "string to match maker (use % as wildcard)"
 msgstr ""
 "Zeichenkette, auf die der Hersteller passen muss („%” als Platzhalter "
 "benutzen)"
 
-#: ../src/gui/presets.c:540
+#: ../src/gui/presets.c:550
 #, no-c-format
 msgid "string to match lens (use % as wildcard)"
 msgstr ""
 "Zeichenkette, auf die das Objektiv passen muss („%” als Platzhalter benutzen)"
 
-#: ../src/gui/presets.c:550
+#: ../src/gui/presets.c:560
 msgid "minimum ISO value"
 msgstr "Mindest-ISO-Wert"
 
-#: ../src/gui/presets.c:553
+#: ../src/gui/presets.c:563
 msgid "maximum ISO value"
 msgstr "Maximal-ISO-Wert"
 
-#: ../src/gui/presets.c:564
+#: ../src/gui/presets.c:574
 msgid "minimum exposure time"
 msgstr "Mindest-Belichtungszeit"
 
-#: ../src/gui/presets.c:565
+#: ../src/gui/presets.c:575
 msgid "maximum exposure time"
 msgstr "Maximal-Belichtungszeit"
 
-#: ../src/gui/presets.c:579
+#: ../src/gui/presets.c:589
 msgid "minimum aperture value"
 msgstr "Mindest-Blendenwert"
 
-#: ../src/gui/presets.c:580
+#: ../src/gui/presets.c:590
 msgid "maximum aperture value"
 msgstr "Maximal-Blendenwert"
 
-#: ../src/gui/presets.c:596
+#: ../src/gui/presets.c:606
 msgid "minimum focal length"
 msgstr "Mindest-Brennweite"
 
-#: ../src/gui/presets.c:597
+#: ../src/gui/presets.c:607
 msgid "maximum focal length"
 msgstr "Maximal-Brennweite"
 
 #. raw/hdr/ldr/mono/color
-#: ../src/gui/presets.c:603 ../src/imageio/format/j2k.c:652
+#: ../src/gui/presets.c:613 ../src/imageio/format/j2k.c:652
 msgid "format"
 msgstr "Format"
 
-#: ../src/gui/presets.c:606
+#: ../src/gui/presets.c:616
 msgid "select image types you want this preset to be available for"
 msgstr ""
 "Bildtypen auswählen für welche, diese Voreinstellung verfügbar sein soll"
 
-#: ../src/gui/presets.c:779
+#: ../src/gui/presets.c:791
 #, c-format
 msgid "preset `%s' is write-protected! can't edit it!"
 msgstr ""
 "Voreinstellung „%s” ist schreibgeschützt und kann nicht geändert werden"
 
-#: ../src/gui/presets.c:808 ../src/libs/lib.c:157
+#: ../src/gui/presets.c:820 ../src/libs/lib.c:161
 #, c-format
 msgid "do you really want to update the preset `%s'?"
 msgstr "Soll die Voreinstellung „%s” aktualisiert werden?"
 
-#: ../src/gui/presets.c:812 ../src/libs/lib.c:161
+#: ../src/gui/presets.c:824 ../src/libs/lib.c:165
 msgid "update preset?"
 msgstr "Voreinstellung aktualisieren?"
 
-#: ../src/gui/presets.c:1081 ../src/libs/modulegroups.c:3828
-#: ../src/libs/modulegroups.c:3837
+#: ../src/gui/presets.c:1097 ../src/libs/modulegroups.c:3844
+#: ../src/libs/modulegroups.c:3853
 msgid "manage module layouts"
 msgstr "Modullayouts verwalten"
 
-#: ../src/gui/presets.c:1089
+#: ../src/gui/presets.c:1105
 msgid "manage quick presets"
 msgstr "Voreinstellungen für Schnellzugriff auswählen"
 
-#: ../src/gui/presets.c:1259
+#: ../src/gui/presets.c:1279
 msgid "manage quick presets list..."
 msgstr "Schnellzugriffliste bearbeiten"
 
-#: ../src/gui/presets.c:1392
+#: ../src/gui/presets.c:1414
 msgid "(default)"
 msgstr "(Standard)"
 
-#: ../src/gui/presets.c:1413
+#: ../src/gui/presets.c:1435
 msgid "disabled: wrong module version"
 msgstr "deaktiviert: falsche Modul-Version"
 
-#: ../src/gui/presets.c:1438 ../src/libs/lib.c:511
+#: ../src/gui/presets.c:1460 ../src/libs/lib.c:531
 msgid "edit this preset.."
 msgstr "Diese Voreinstellung bearbeiten.."
 
-#: ../src/gui/presets.c:1442 ../src/libs/lib.c:515
+#: ../src/gui/presets.c:1464 ../src/libs/lib.c:535
 msgid "delete this preset"
 msgstr "Diese Voreinstellung löschen"
 
-#: ../src/gui/presets.c:1448 ../src/libs/lib.c:523
+#: ../src/gui/presets.c:1470 ../src/libs/lib.c:543
 msgid "store new preset.."
 msgstr "neue Voreinstellung speichern"
 
-#: ../src/gui/presets.c:1454 ../src/libs/lib.c:535
+#: ../src/gui/presets.c:1476 ../src/libs/lib.c:555
 msgid "update preset"
 msgstr "aktualisiere Voreinstellung"
 
@@ -10305,7 +10415,7 @@ msgstr "Speichern als Graustufen reduziert die Größe für Schwarz-Weiß-Bilder
 
 #: ../src/imageio/format/avif.c:821
 msgid "tiling"
-msgstr "kacheln"
+msgstr "Tiling"
 
 #: ../src/imageio/format/avif.c:829
 msgid ""
@@ -10493,7 +10603,7 @@ msgid "enter the title of the pdf"
 msgstr "Titel des PDFs eingeben"
 
 #. // papers
-#: ../src/imageio/format/pdf.c:592 ../src/libs/print_settings.c:2164
+#: ../src/imageio/format/pdf.c:592 ../src/libs/print_settings.c:2357
 msgid "paper size"
 msgstr "Papierformat"
 
@@ -10512,12 +10622,12 @@ msgid "page orientation"
 msgstr "Seitenausrichtung"
 
 #: ../src/imageio/format/pdf.c:608 ../src/iop/borders.c:1042
-#: ../src/libs/collect.c:281 ../src/libs/print_settings.c:2173
+#: ../src/libs/collect.c:282 ../src/libs/print_settings.c:2366
 msgid "portrait"
 msgstr "Hochformat"
 
 #: ../src/imageio/format/pdf.c:609 ../src/iop/borders.c:1043
-#: ../src/libs/collect.c:276 ../src/libs/print_settings.c:2174
+#: ../src/libs/collect.c:277 ../src/libs/print_settings.c:2367
 msgid "landscape"
 msgstr "Querformat"
 
@@ -10976,7 +11086,7 @@ msgstr "Korrekturen oder Effekte"
 #: ../src/iop/channelmixerrgb.c:236 ../src/iop/clipping.c:321
 #: ../src/iop/clipping.c:323 ../src/iop/colorbalancergb.c:172
 #: ../src/iop/colorin.c:139 ../src/iop/crop.c:139 ../src/iop/crop.c:140
-#: ../src/iop/demosaic.c:227 ../src/iop/denoiseprofile.c:721
+#: ../src/iop/demosaic.c:230 ../src/iop/denoiseprofile.c:721
 #: ../src/iop/denoiseprofile.c:723 ../src/iop/diffuse.c:142
 #: ../src/iop/diffuse.c:143 ../src/iop/exposure.c:131 ../src/iop/exposure.c:133
 #: ../src/iop/flip.c:106 ../src/iop/flip.c:107 ../src/iop/hazeremoval.c:112
@@ -11029,23 +11139,23 @@ msgstr "automatische Korrektur fehlgeschlagen, bitte manuell korrigieren"
 msgid "only %d lines can be saved in parameters"
 msgstr "nur %d Zeilen können in Parametern gespeichert werden"
 
-#: ../src/iop/ashift.c:5420 ../src/iop/ashift.c:5421 ../src/iop/ashift.c:5523
-#: ../src/iop/ashift.c:5524
+#: ../src/iop/ashift.c:5423 ../src/iop/ashift.c:5424 ../src/iop/ashift.c:5526
+#: ../src/iop/ashift.c:5527
 #, c-format
 msgid "lens shift (%s)"
 msgstr "Objektivverschiebung (%s)"
 
-#: ../src/iop/ashift.c:5701
+#: ../src/iop/ashift.c:5704
 msgid "manual perspective"
 msgstr "manuelle Einstellungen"
 
 # etwas zu frei übersetzt?
-#: ../src/iop/ashift.c:5751 ../src/iop/ashift.c:5835 ../src/iop/ashift.c:5836
-#: ../src/iop/ashift.c:5837
+#: ../src/iop/ashift.c:5754 ../src/iop/ashift.c:5838 ../src/iop/ashift.c:5839
+#: ../src/iop/ashift.c:5840
 msgid "structure"
 msgstr "Fluchtlinien"
 
-#: ../src/iop/ashift.c:5784
+#: ../src/iop/ashift.c:5787
 msgid ""
 "rotate image\n"
 "right-click and drag to define a horizontal or vertical line by drawing on "
@@ -11055,19 +11165,19 @@ msgstr ""
 "Rechtscklick und ziehen, um eine horizontale oder vertikale Linie auf dem "
 "Bild zu ziehen"
 
-#: ../src/iop/ashift.c:5785 ../src/iop/ashift.c:5786
+#: ../src/iop/ashift.c:5788 ../src/iop/ashift.c:5789
 msgid "apply lens shift correction in one direction"
 msgstr "Objektivverschiebung in eine Richtung korrigieren"
 
-#: ../src/iop/ashift.c:5787
+#: ../src/iop/ashift.c:5790
 msgid "shear the image along one diagonal"
 msgstr "Bild entlang einer Diagonalen scheren"
 
-#: ../src/iop/ashift.c:5788 ../src/iop/clipping.c:2145
+#: ../src/iop/ashift.c:5791 ../src/iop/clipping.c:2145
 msgid "automatically crop to avoid black edges"
 msgstr "Automatisch zuschneiden, um schwarze Ränder zu vermeiden"
 
-#: ../src/iop/ashift.c:5789
+#: ../src/iop/ashift.c:5792
 msgid ""
 "lens model of the perspective correction: generic or according to the focal "
 "length"
@@ -11075,13 +11185,13 @@ msgstr ""
 "Objektiv-Modell der perspektivischen Korrektur: generisch oder in "
 "Abhängigkeit von der Brennweite"
 
-#: ../src/iop/ashift.c:5791
+#: ../src/iop/ashift.c:5794
 msgid "focal length of the lens, default value set from exif data if available"
 msgstr ""
 "Brennweite des Objektivs, standardmäßig auf den Werten der EXIF-Daten so "
 "weit verfügbar"
 
-#: ../src/iop/ashift.c:5793
+#: ../src/iop/ashift.c:5796
 msgid ""
 "crop factor of the camera sensor, default value set from exif data if "
 "available, manual setting is often required"
@@ -11089,7 +11199,7 @@ msgstr ""
 "Crop-Faktor des Sensors, standardmäßig auf den Werten der EXIF-Daten so weit "
 "vorhanden. Häufig muss dieser Wert angepasst werden"
 
-#: ../src/iop/ashift.c:5796
+#: ../src/iop/ashift.c:5799
 msgid ""
 "the level of lens dependent correction, set to maximum for full lens "
 "dependency, set to zero for the generic case"
@@ -11097,13 +11207,13 @@ msgstr ""
 "der Anteil der Objektivabhängigkeit der Korrektur, auf maximum setzen für "
 "volle Abhängigkeit, oder auf Null für den generischen Fall"
 
-#: ../src/iop/ashift.c:5798
+#: ../src/iop/ashift.c:5801
 msgid "adjust aspect ratio of image by horizontal and vertical scaling"
 msgstr ""
 "Seitenverhältnis des Bildes durch horizontales und vertikales Skalieren "
 "anpassen"
 
-#: ../src/iop/ashift.c:5799
+#: ../src/iop/ashift.c:5802
 msgid ""
 "automatically correct for vertical perspective distortion\n"
 "ctrl+click to only fit rotation\n"
@@ -11113,7 +11223,7 @@ msgstr ""
 "Strg+Klick um nur die Drehung anzupassen\n"
 "Umschalt+Klick um nur die Objektivverschiebung anzupassen"
 
-#: ../src/iop/ashift.c:5802
+#: ../src/iop/ashift.c:5805
 msgid ""
 "automatically correct for horizontal perspective distortion\n"
 "ctrl+click to only fit rotation\n"
@@ -11123,7 +11233,7 @@ msgstr ""
 "Strg+Klick, um nur die Drehung anzupassen\n"
 "Umschalt+Klick, um nur die Objektivverschiebung anzupassen"
 
-#: ../src/iop/ashift.c:5805
+#: ../src/iop/ashift.c:5808
 msgid ""
 "automatically correct for vertical and horizontal perspective distortions; "
 "fitting rotation,lens shift in both directions, and shear\n"
@@ -11138,7 +11248,7 @@ msgstr ""
 "Umschalt+Klick, um nur die Objektivverschiebung anzupassen\n"
 "Strg+Umschalt+Klick, um nur Drehung und Objektivverschiebung anzupassen"
 
-#: ../src/iop/ashift.c:5811
+#: ../src/iop/ashift.c:5814
 msgid ""
 "automatically analyse line structure in image\n"
 "ctrl+click for an additional edge enhancement\n"
@@ -11150,43 +11260,43 @@ msgstr ""
 "Umschalt+Klick für eine zusätzliche Detail-Verbesserung\n"
 "Strg+Umschalt+Klick für eine Kombination beider Methoden"
 
-#: ../src/iop/ashift.c:5815
+#: ../src/iop/ashift.c:5818
 msgid "manually define perspective rectangle"
 msgstr "Rechteck für Perspektive manuell definieren"
 
-#: ../src/iop/ashift.c:5816
+#: ../src/iop/ashift.c:5819
 msgid "manually draw structure lines"
 msgstr "Strukturlinien manuell zeichnen"
 
-#: ../src/iop/ashift.c:5835
+#: ../src/iop/ashift.c:5838
 msgid "rectangle"
 msgstr "Rechteck"
 
-#: ../src/iop/ashift.c:5836
+#: ../src/iop/ashift.c:5839
 msgid "lines"
 msgstr "Linien"
 
-#: ../src/iop/ashift.c:5860 ../src/iop/clipping.c:3381
+#: ../src/iop/ashift.c:5863 ../src/iop/clipping.c:3381
 #, c-format
 msgid "[%s] define/rotate horizon"
 msgstr "[%s] Horizont definieren/drehen"
 
-#: ../src/iop/ashift.c:5861
+#: ../src/iop/ashift.c:5864
 #, c-format
 msgid "[%s on segment] select segment"
 msgstr "[%s on segment] Segment auswählen"
 
-#: ../src/iop/ashift.c:5863
+#: ../src/iop/ashift.c:5866
 #, c-format
 msgid "[%s on segment] unselect segment"
 msgstr "[%s on segment] Segment abwählen"
 
-#: ../src/iop/ashift.c:5865
+#: ../src/iop/ashift.c:5868
 #, c-format
 msgid "[%s] select all segments from zone"
 msgstr "[%s] alle Segmente aus Region auswählen"
 
-#: ../src/iop/ashift.c:5867
+#: ../src/iop/ashift.c:5870
 #, c-format
 msgid "[%s] unselect all segments from zone"
 msgstr "[%s] alle Segmente aus Region abwählen"
@@ -11204,7 +11314,7 @@ msgid "add or remove local contrast, sharpness, acutance"
 msgstr "lokalen Kontrast, Schärfe, Konturschärfe hinzufügen oder entfernen"
 
 #: ../src/iop/atrous.c:139 ../src/iop/bilateral.cc:99 ../src/iop/diffuse.c:142
-#: ../src/iop/exposure.c:130 ../src/iop/filmicrgb.c:352
+#: ../src/iop/exposure.c:130 ../src/iop/filmicrgb.c:354
 #: ../src/iop/graduatednd.c:150 ../src/iop/negadoctor.c:156
 #: ../src/iop/rgbcurve.c:142 ../src/iop/rgblevels.c:122 ../src/iop/shadhi.c:197
 #: ../src/iop/tonecurve.c:213 ../src/iop/toneequal.c:321
@@ -11377,10 +11487,10 @@ msgstr ""
 "Dies beeinflusst, wie sich Abweichungen von der Neutraleinstellung in den "
 "Luminanz- und Chrominanz-Tabs auf das Bild auswirken."
 
-#: ../src/iop/atrous.c:1757 ../src/iop/colorbalancergb.c:1716
-#: ../src/iop/colorzones.c:2507 ../src/iop/filmicrgb.c:3859
+#: ../src/iop/atrous.c:1757 ../src/iop/colorbalancergb.c:1695
+#: ../src/iop/colorzones.c:2507 ../src/iop/filmicrgb.c:4281
 #: ../src/iop/lowlight.c:836 ../src/iop/rawdenoise.c:932
-#: ../src/iop/toneequal.c:3175
+#: ../src/iop/toneequal.c:3176
 msgid "graph"
 msgstr "Grafik"
 
@@ -11497,7 +11607,7 @@ msgstr "linear, RGB, anzeigebezogen"
 
 #: ../src/iop/basecurve.c:341 ../src/iop/basicadj.c:148
 #: ../src/iop/colorbalance.c:161 ../src/iop/colorbalancergb.c:173
-#: ../src/iop/dither.c:105 ../src/iop/filmicrgb.c:354
+#: ../src/iop/dither.c:105 ../src/iop/filmicrgb.c:356
 #: ../src/iop/graduatednd.c:152 ../src/iop/negadoctor.c:158
 #: ../src/iop/profile_gamma.c:103 ../src/iop/rgbcurve.c:144
 #: ../src/iop/rgblevels.c:124 ../src/iop/vignette.c:160
@@ -11506,7 +11616,7 @@ msgid "non-linear, RGB"
 msgstr "nichtlinear, RGB"
 
 #: ../src/iop/basecurve.c:342 ../src/iop/dither.c:104 ../src/iop/dither.c:106
-#: ../src/iop/filmicrgb.c:355 ../src/iop/graduatednd.c:153
+#: ../src/iop/filmicrgb.c:357 ../src/iop/graduatednd.c:153
 #: ../src/iop/negadoctor.c:159 ../src/iop/profile_gamma.c:104
 #: ../src/iop/rgblevels.c:125 ../src/iop/vignette.c:159
 #: ../src/iop/vignette.c:161 ../src/iop/watermark.c:298
@@ -11860,7 +11970,7 @@ msgid "4:3"
 msgstr "4:3"
 
 #: ../src/iop/borders.c:970 ../src/iop/clipping.c:2149 ../src/iop/crop.c:1057
-#: ../src/libs/collect.c:271
+#: ../src/libs/collect.c:272
 msgid "square"
 msgstr "quadratisch"
 
@@ -11987,7 +12097,7 @@ msgstr "Korrektur der chromatischen Aberration für Bayer Sensoren"
 
 #: ../src/iop/cacorrect.c:89 ../src/iop/cacorrect.c:91
 #: ../src/iop/cacorrectrgb.c:168 ../src/iop/cacorrectrgb.c:170
-#: ../src/iop/demosaic.c:225 ../src/iop/highlights.c:85
+#: ../src/iop/demosaic.c:228 ../src/iop/highlights.c:85
 #: ../src/iop/highlights.c:87 ../src/iop/hotpixels.c:74
 #: ../src/iop/hotpixels.c:76 ../src/iop/rawdenoise.c:131
 #: ../src/iop/rawdenoise.c:133 ../src/iop/rawprepare.c:111
@@ -11997,7 +12107,7 @@ msgid "linear, raw, scene-referred"
 msgstr "linear, RAW, szenenbezogen"
 
 #: ../src/iop/cacorrect.c:90 ../src/iop/cacorrectrgb.c:169
-#: ../src/iop/demosaic.c:226 ../src/iop/invert.c:124
+#: ../src/iop/demosaic.c:229 ../src/iop/invert.c:124
 #: ../src/iop/rawdenoise.c:132 ../src/iop/rawprepare.c:112
 #: ../src/iop/temperature.c:201
 msgid "linear, raw"
@@ -12149,7 +12259,7 @@ msgid "censorize license plates and body parts for privacy"
 msgstr "verpixelt Nummernschilder und Körperteile für mehr Privatsphäre"
 
 #: ../src/iop/censorize.c:84 ../src/iop/colorin.c:137
-#: ../src/iop/filmicrgb.c:353 ../src/iop/graduatednd.c:151
+#: ../src/iop/filmicrgb.c:355 ../src/iop/graduatednd.c:151
 msgid "linear or non-linear, RGB, scene-referred"
 msgstr "linear oder nichtlinear, RGB, szenenbezogen"
 
@@ -12157,36 +12267,36 @@ msgstr "linear oder nichtlinear, RGB, szenenbezogen"
 msgid "special, RGB, scene-referred"
 msgstr "RGB, szenenbezogen"
 
-#: ../src/iop/censorize.c:409
+#: ../src/iop/censorize.c:405
 msgid "radius_1"
 msgstr "radius_1"
 
-#: ../src/iop/censorize.c:411
+#: ../src/iop/censorize.c:407
 msgid "pixelate"
 msgstr "pixelate"
 
-#: ../src/iop/censorize.c:413
+#: ../src/iop/censorize.c:409
 msgid "radius_2"
 msgstr "radius_2"
 
-#: ../src/iop/censorize.c:415
+#: ../src/iop/censorize.c:411
 msgid "noise"
 msgstr "noise"
 
-#: ../src/iop/censorize.c:417
+#: ../src/iop/censorize.c:413
 msgid "radius of gaussian blur before pixellation"
 msgstr "Radius des Gaußschen Weichzeichners vor Verpixelung"
 
-#: ../src/iop/censorize.c:418
+#: ../src/iop/censorize.c:414
 msgid "radius of gaussian blur after pixellation"
 msgstr "Radius des Gaußschen Weichzeichners nach Verpixelung"
 
 # Ugh ...
-#: ../src/iop/censorize.c:419
+#: ../src/iop/censorize.c:415
 msgid "radius of the intermediate pixellation"
 msgstr "Göße der Pixel"
 
-#: ../src/iop/censorize.c:420
+#: ../src/iop/censorize.c:416
 msgid "amount of noise to add at the end"
 msgstr "Menge des hinzugefügten Rauschens"
 
@@ -12560,9 +12670,9 @@ msgstr ""
 
 #. //////////////////////// PAGE SETTINGS
 #: ../src/iop/channelmixerrgb.c:4002 ../src/iop/clipping.c:2115
-#: ../src/iop/colorbalancergb.c:1529 ../src/iop/filmicrgb.c:3874
-#: ../src/iop/negadoctor.c:802 ../src/iop/toneequal.c:3123
-#: ../src/libs/image.c:475 ../src/libs/print_settings.c:2158
+#: ../src/iop/colorbalancergb.c:1508 ../src/iop/filmicrgb.c:4296
+#: ../src/iop/negadoctor.c:802 ../src/iop/toneequal.c:3124
+#: ../src/libs/image.c:475 ../src/libs/print_settings.c:2351
 #: ../src/views/lighttable.c:1341
 msgid "page"
 msgstr "Seite"
@@ -13239,7 +13349,7 @@ msgid "RGBL"
 msgstr "RGBL"
 
 #. Page master
-#: ../src/iop/colorbalance.c:1877 ../src/iop/colorbalancergb.c:1532
+#: ../src/iop/colorbalance.c:1877 ../src/iop/colorbalancergb.c:1511
 msgid "master"
 msgstr "Allgemein"
 
@@ -13349,239 +13459,239 @@ msgstr ""
 msgid "add basic colorfulness"
 msgstr "Grundeinstellung Farbigkeit "
 
-#: ../src/iop/colorbalancergb.c:772
+#: ../src/iop/colorbalancergb.c:751
 msgid "colorbalance works only on RGB input"
 msgstr "Farbbalance funktioniert nur mit RGB-Input"
 
-#: ../src/iop/colorbalancergb.c:1211 ../src/iop/colorzones.c:2203
+#: ../src/iop/colorbalancergb.c:1190 ../src/iop/colorzones.c:2203
 #: ../src/iop/retouch.c:1817 ../src/iop/toneequal.c:1886
 msgid "cannot display masks when the blending mask is displayed"
 msgstr ""
 "Kann Maske nicht anzeigen, solange die Maske zum Überblenden aktiviert ist"
 
-#: ../src/iop/colorbalancergb.c:1532
+#: ../src/iop/colorbalancergb.c:1511
 msgid "global grading"
 msgstr "globales Color Grading"
 
-#: ../src/iop/colorbalancergb.c:1536
+#: ../src/iop/colorbalancergb.c:1515
 msgid "rotate all hues by an angle, at the same luminance"
 msgstr "rotiert alle Farbtöne um einen Winkel, bei gleicher Helligkeit"
 
-#: ../src/iop/colorbalancergb.c:1542
+#: ../src/iop/colorbalancergb.c:1521
 msgid "increase colorfulness mostly on low-chroma colors"
 msgstr "Erhöhung der Farbigkeit vor allem bei unbunten Farben"
 
-#: ../src/iop/colorbalancergb.c:1548
+#: ../src/iop/colorbalancergb.c:1527
 msgid "increase the contrast at constant chromaticity"
 msgstr "den Kontrast bei konstanter Farbigkeit erhöhen"
 
-#: ../src/iop/colorbalancergb.c:1552
+#: ../src/iop/colorbalancergb.c:1531
 msgid "linear chroma grading"
 msgstr "Lineares Chroma Grading"
 
-#: ../src/iop/colorbalancergb.c:1558
+#: ../src/iop/colorbalancergb.c:1537
 msgid "increase colorfulness at same luminance globally"
 msgstr "Farbigkeit bei gleicher Leuchtdichte global erhöhen"
 
-#: ../src/iop/colorbalancergb.c:1563
+#: ../src/iop/colorbalancergb.c:1542
 msgid "increase colorfulness at same luminance mostly in shadows"
 msgstr "Erhöhung der Farbigkeit bei gleicher Leuchtdichte vor allem in Tiefen"
 
-#: ../src/iop/colorbalancergb.c:1568
+#: ../src/iop/colorbalancergb.c:1547
 msgid "increase colorfulness at same luminance mostly in mid-tones"
 msgstr ""
 "Erhöhung der Farbigkeit bei gleicher Leuchtdichte vor allem in Mitteltönen"
 
-#: ../src/iop/colorbalancergb.c:1573
+#: ../src/iop/colorbalancergb.c:1552
 msgid "increase colorfulness at same luminance mostly in highlights"
 msgstr ""
 "Erhöhung der Farbigkeit bei gleicher Leuchtdichte vor allem in Lichtern"
 
-#: ../src/iop/colorbalancergb.c:1575
+#: ../src/iop/colorbalancergb.c:1554
 msgid "perceptual saturation grading"
 msgstr "perzeptive Farbsättigung"
 
-#: ../src/iop/colorbalancergb.c:1581
+#: ../src/iop/colorbalancergb.c:1560
 msgid "add or remove saturation by an absolute amount"
 msgstr "Sättigung um einen absoluten Betrag erhöhen oder verringern"
 
-#: ../src/iop/colorbalancergb.c:1587 ../src/iop/colorbalancergb.c:1593
-#: ../src/iop/colorbalancergb.c:1599
+#: ../src/iop/colorbalancergb.c:1566 ../src/iop/colorbalancergb.c:1572
+#: ../src/iop/colorbalancergb.c:1578
 msgid ""
 "increase or decrease saturation proportionally to the original pixel "
 "saturation"
 msgstr "Sättigung proportional zum ursprünglichen Wert erhöhen oder verringern"
 
-#: ../src/iop/colorbalancergb.c:1601
+#: ../src/iop/colorbalancergb.c:1580
 msgid "perceptual brilliance grading"
 msgstr "perzeptive Farbbrillianz"
 
-#: ../src/iop/colorbalancergb.c:1607
+#: ../src/iop/colorbalancergb.c:1586
 msgid "add or remove brilliance by an absolute amount"
 msgstr "Farbbrillianz um einen absoluten Betrag erhöhen oder verringern"
 
-#: ../src/iop/colorbalancergb.c:1613 ../src/iop/colorbalancergb.c:1619
-#: ../src/iop/colorbalancergb.c:1625
+#: ../src/iop/colorbalancergb.c:1592 ../src/iop/colorbalancergb.c:1598
+#: ../src/iop/colorbalancergb.c:1604
 msgid ""
 "increase or decrease brilliance proportionally to the original pixel "
 "brilliance"
 msgstr "Brillianz proportional zum ursprünglichen Wert erhöhen oder verringern"
 
 #. Page 4-ways
-#: ../src/iop/colorbalancergb.c:1628
+#: ../src/iop/colorbalancergb.c:1607
 msgid "4 ways"
 msgstr "4 HSL"
 
-#: ../src/iop/colorbalancergb.c:1628
+#: ../src/iop/colorbalancergb.c:1607
 msgid "selective color grading"
 msgstr "selektives Color Grading"
 
-#: ../src/iop/colorbalancergb.c:1630
+#: ../src/iop/colorbalancergb.c:1609
 msgid "global offset"
 msgstr "Globale Anpassung"
 
-#: ../src/iop/colorbalancergb.c:1636
+#: ../src/iop/colorbalancergb.c:1615
 msgid "global luminance offset"
 msgstr "Globale Helligkeitsanpassung"
 
-#: ../src/iop/colorbalancergb.c:1641
+#: ../src/iop/colorbalancergb.c:1620
 msgid "hue of the global color offset"
 msgstr "Farbton der globalen Farbanpassung"
 
-#: ../src/iop/colorbalancergb.c:1647
+#: ../src/iop/colorbalancergb.c:1626
 msgid "chroma of the global color offset"
 msgstr "Chrominanz der globalen Farbanpassung"
 
-#: ../src/iop/colorbalancergb.c:1649
+#: ../src/iop/colorbalancergb.c:1628
 msgid "shadows lift"
 msgstr "Schatten - Lift"
 
-#: ../src/iop/colorbalancergb.c:1655
+#: ../src/iop/colorbalancergb.c:1634
 msgid "luminance gain in shadows"
 msgstr "Helligkeitsanpassung in den Schatten"
 
-#: ../src/iop/colorbalancergb.c:1660
+#: ../src/iop/colorbalancergb.c:1639
 msgid "hue of the color gain in shadows"
 msgstr "Farbton der Farbanpassung im Schatten"
 
-#: ../src/iop/colorbalancergb.c:1666
+#: ../src/iop/colorbalancergb.c:1645
 msgid "chroma of the color gain in shadows"
 msgstr "Chrominanz der Farbanpassung im Schatten"
 
-#: ../src/iop/colorbalancergb.c:1668
+#: ../src/iop/colorbalancergb.c:1647
 msgid "highlights gain"
 msgstr "Lichter - Gain"
 
-#: ../src/iop/colorbalancergb.c:1674
+#: ../src/iop/colorbalancergb.c:1653
 msgid "luminance gain in highlights"
 msgstr "Helligkeitsanpassung in den Lichter"
 
-#: ../src/iop/colorbalancergb.c:1679
+#: ../src/iop/colorbalancergb.c:1658
 msgid "hue of the color gain in highlights"
 msgstr "Farbton der Farbanpassung in den Lichtern"
 
-#: ../src/iop/colorbalancergb.c:1685
+#: ../src/iop/colorbalancergb.c:1664
 msgid "chroma of the color gain in highlights"
 msgstr "Chrominanz der Farbanpassung in den Lichtern"
 
-#: ../src/iop/colorbalancergb.c:1687 ../src/iop/colorbalancergb.c:1789
-#: ../src/iop/colorbalancergb.c:1793 ../src/iop/colorbalancergb.c:1797
+#: ../src/iop/colorbalancergb.c:1666 ../src/iop/colorbalancergb.c:1768
+#: ../src/iop/colorbalancergb.c:1772 ../src/iop/colorbalancergb.c:1776
 msgid "power"
 msgstr "Mitten - Power"
 
-#: ../src/iop/colorbalancergb.c:1693
+#: ../src/iop/colorbalancergb.c:1672
 msgid "luminance exponent in mid-tones"
 msgstr "Luminanzexponent in den Mitteltönen"
 
-#: ../src/iop/colorbalancergb.c:1698
+#: ../src/iop/colorbalancergb.c:1677
 msgid "hue of the color exponent in mid-tones"
 msgstr "Farbton der Farbanpassung in den Mitteltönen"
 
-#: ../src/iop/colorbalancergb.c:1704
+#: ../src/iop/colorbalancergb.c:1683
 msgid "chroma of the color exponent in mid-tones"
 msgstr "Chrominanz der Farbanpassung in den Mitteltönen"
 
 #. Page masks
-#: ../src/iop/colorbalancergb.c:1709
+#: ../src/iop/colorbalancergb.c:1688
 msgid "masks"
 msgstr "Maskierung"
 
-#: ../src/iop/colorbalancergb.c:1709
+#: ../src/iop/colorbalancergb.c:1688
 msgid "isolate luminances"
 msgstr "Helligkeitswerte isolieren"
 
-#: ../src/iop/colorbalancergb.c:1711
+#: ../src/iop/colorbalancergb.c:1690
 msgid "luminance ranges"
 msgstr "Verlauf der Luminanzmasken"
 
-#: ../src/iop/colorbalancergb.c:1725
+#: ../src/iop/colorbalancergb.c:1704
 msgid "weight of the shadows over the whole tonal range"
 msgstr "Gewichtung der Schatten über den Tonwertbereich"
 
-#: ../src/iop/colorbalancergb.c:1734
+#: ../src/iop/colorbalancergb.c:1713
 msgid "position of the middle-gray reference for masking"
 msgstr "Position der Mittelgrau Referenz für die Maskierung"
 
-#: ../src/iop/colorbalancergb.c:1743
+#: ../src/iop/colorbalancergb.c:1722
 msgid "weights of highlights over the whole tonal range"
 msgstr "Gewichtung der Lichter über den Tonwertbereich"
 
-#: ../src/iop/colorbalancergb.c:1754
+#: ../src/iop/colorbalancergb.c:1733
 msgid "peak white luminance value used to normalize the power function"
 msgstr ""
 "Maximalwert der Weißluminanz, der zur Normalisierung der Potenzfunktion "
 "verwendet wird"
 
-#: ../src/iop/colorbalancergb.c:1760
+#: ../src/iop/colorbalancergb.c:1739
 msgid "peak gray luminance value used to normalize the power function"
 msgstr ""
 "Maximalwert der Grauluminanz, der zur Normalisierung der Potenzfunktion "
 "verwendet wird"
 
-#: ../src/iop/colorbalancergb.c:1762
+#: ../src/iop/colorbalancergb.c:1741
 msgid "mask preview settings"
 msgstr "Maskenvorschaueinstellungen"
 
-#: ../src/iop/colorbalancergb.c:1765
+#: ../src/iop/colorbalancergb.c:1744
 msgid "checkerboard color 1"
 msgstr "Schachbrettmuster Farbe 1"
 
-#: ../src/iop/colorbalancergb.c:1768 ../src/iop/colorbalancergb.c:1777
+#: ../src/iop/colorbalancergb.c:1747 ../src/iop/colorbalancergb.c:1756
 msgid "select color of the checkerboard from a swatch"
 msgstr "Farbe des Schachbrettmusters auswählen"
 
-#: ../src/iop/colorbalancergb.c:1774
+#: ../src/iop/colorbalancergb.c:1753
 msgid "checkerboard color 2"
 msgstr "Schachbrettmuster Farbe 2"
 
-#: ../src/iop/colorbalancergb.c:1784
+#: ../src/iop/colorbalancergb.c:1763
 msgid "checkerboard size"
 msgstr "Schachbrettmustergröße"
 
-#: ../src/iop/colorbalancergb.c:1788 ../src/iop/colorbalancergb.c:1792
-#: ../src/iop/colorbalancergb.c:1796
+#: ../src/iop/colorbalancergb.c:1767 ../src/iop/colorbalancergb.c:1771
+#: ../src/iop/colorbalancergb.c:1775
 msgid "lift"
 msgstr "Lift"
 
-#: ../src/iop/colorbalancergb.c:1790 ../src/iop/colorbalancergb.c:1794
-#: ../src/iop/colorbalancergb.c:1798
+#: ../src/iop/colorbalancergb.c:1769 ../src/iop/colorbalancergb.c:1773
+#: ../src/iop/colorbalancergb.c:1777
 msgid "gain"
 msgstr "Gain"
 
-#: ../src/iop/colorbalancergb.c:1801
+#: ../src/iop/colorbalancergb.c:1780
 msgid "global chroma"
 msgstr "Chroma Global"
 
-#: ../src/iop/colorbalancergb.c:1805 ../src/iop/filmic.c:1677
+#: ../src/iop/colorbalancergb.c:1784 ../src/iop/filmic.c:1677
 msgid "global saturation"
 msgstr "Sättigung Global"
 
-#: ../src/iop/colorbalancergb.c:1809
+#: ../src/iop/colorbalancergb.c:1788
 msgid "global brilliance"
 msgstr "Brillianz Global"
 
-#: ../src/iop/colorbalancergb.c:1810 ../src/iop/colorbalancergb.c:1811
-#: ../src/iop/colorbalancergb.c:1812
+#: ../src/iop/colorbalancergb.c:1789 ../src/iop/colorbalancergb.c:1790
+#: ../src/iop/colorbalancergb.c:1791
 msgid "brilliance"
 msgstr "Brillianz"
 
@@ -13812,7 +13922,7 @@ msgstr ""
 "Konvertiert RGB Eingangswerte in den Arbeitsfarbraum\n"
 "basierend auf Farbprofilen "
 
-#: ../src/iop/colorin.c:136 ../src/iop/colorout.c:92 ../src/iop/demosaic.c:224
+#: ../src/iop/colorin.c:136 ../src/iop/colorout.c:92 ../src/iop/demosaic.c:227
 #: ../src/iop/rawprepare.c:110
 msgid "mandatory"
 msgstr "obligatorisch"
@@ -13973,30 +14083,30 @@ msgid "output intent"
 msgstr "Ausgabevorsatz"
 
 #: ../src/iop/colorout.c:867 ../src/libs/export.c:1265
-#: ../src/libs/print_settings.c:2132 ../src/libs/print_settings.c:2466
-#: ../src/views/darkroom.c:2454 ../src/views/darkroom.c:2461
+#: ../src/libs/print_settings.c:2325 ../src/libs/print_settings.c:2656
+#: ../src/views/darkroom.c:2458 ../src/views/darkroom.c:2465
 #: ../src/views/lighttable.c:1253 ../src/views/lighttable.c:1260
 msgid "perceptual"
 msgstr "Wahrnehmung"
 
 #: ../src/iop/colorout.c:868 ../src/libs/export.c:1266
-#: ../src/libs/print_settings.c:2133 ../src/libs/print_settings.c:2467
-#: ../src/views/darkroom.c:2455 ../src/views/darkroom.c:2462
+#: ../src/libs/print_settings.c:2326 ../src/libs/print_settings.c:2657
+#: ../src/views/darkroom.c:2459 ../src/views/darkroom.c:2466
 #: ../src/views/lighttable.c:1254 ../src/views/lighttable.c:1261
 msgid "relative colorimetric"
 msgstr "relativ Farbmetrisch"
 
 #: ../src/iop/colorout.c:869 ../src/libs/export.c:1267
-#: ../src/libs/print_settings.c:2134 ../src/libs/print_settings.c:2468
-#: ../src/views/darkroom.c:2456 ../src/views/darkroom.c:2463
+#: ../src/libs/print_settings.c:2327 ../src/libs/print_settings.c:2658
+#: ../src/views/darkroom.c:2460 ../src/views/darkroom.c:2467
 #: ../src/views/lighttable.c:1255 ../src/views/lighttable.c:1262
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "Sättigung"
 
 #: ../src/iop/colorout.c:870 ../src/libs/export.c:1268
-#: ../src/libs/print_settings.c:2135 ../src/libs/print_settings.c:2469
-#: ../src/views/darkroom.c:2457 ../src/views/darkroom.c:2464
+#: ../src/libs/print_settings.c:2328 ../src/libs/print_settings.c:2659
+#: ../src/views/darkroom.c:2461 ../src/views/darkroom.c:2468
 #: ../src/views/lighttable.c:1256 ../src/views/lighttable.c:1263
 msgid "absolute colorimetric"
 msgstr "absolut Farbmetrisch"
@@ -14078,7 +14188,7 @@ msgctxt "accel"
 msgid "acquire"
 msgstr "Berechnen"
 
-#: ../src/iop/colortransfer.c:130 ../src/libs/metadata.c:637
+#: ../src/iop/colortransfer.c:130 ../src/libs/metadata.c:639
 #: ../src/libs/styles.c:78
 msgctxt "accel"
 msgid "apply"
@@ -14292,11 +14402,11 @@ msgid "threshold for defringe, higher values mean less defringing"
 msgstr ""
 "Schwellwert der Farbsaumentfernung, höhere Werte führen zu weniger Änderung"
 
-#: ../src/iop/demosaic.c:218
+#: ../src/iop/demosaic.c:221
 msgid "demosaic"
 msgstr "Entrastern"
 
-#: ../src/iop/demosaic.c:223
+#: ../src/iop/demosaic.c:226
 msgid "reconstruct full RGB pixels from a sensor color filter array reading"
 msgstr ""
 "Rekonstruktion der RGB Pixel aus Helligkeitswerten eines Sensors mit "
@@ -14452,7 +14562,7 @@ msgid "variance computed on the blue channel"
 msgstr "berechnete Varianz des Blau-Kanal"
 
 #: ../src/iop/denoiseprofile.c:3661 ../src/libs/export.c:1240
-#: ../src/libs/print_settings.c:2080 ../src/libs/print_settings.c:2417
+#: ../src/libs/print_settings.c:2273 ../src/libs/print_settings.c:2607
 msgid "profile"
 msgstr "Profil"
 
@@ -15101,7 +15211,7 @@ msgstr ""
 "An die durchschnittliche Helligkeit des Objektes anpassen.\n"
 "Mit Ausnahme bei Gegenlichtsituationen sollte diese etwa 18% betragen."
 
-#: ../src/iop/filmic.c:1608 ../src/iop/filmicrgb.c:3894
+#: ../src/iop/filmic.c:1608 ../src/iop/filmicrgb.c:4316
 msgid ""
 "number of stops between middle gray and pure white.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
@@ -15111,7 +15221,7 @@ msgstr ""
 "Entspricht einer Messung, welche ein Belichtungsmesser liefern würde.\n"
 "So anpassen, dass Spitzlichter nicht abgeschnitten werden."
 
-#: ../src/iop/filmic.c:1620 ../src/iop/filmicrgb.c:3904
+#: ../src/iop/filmic.c:1620 ../src/iop/filmicrgb.c:4326
 msgid ""
 "number of stops between middle gray and pure black.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
@@ -15131,8 +15241,8 @@ msgstr ""
 "Den berechneten Dynamikbereich vergrößern oder verkleinern.\n"
 "Nützlich in Verbindung mit „Auto-Tune-Levels”."
 
-#: ../src/iop/filmic.c:1637 ../src/iop/filmicrgb.c:3917
-#: ../src/iop/profile_gamma.c:667
+#: ../src/iop/filmic.c:1637 ../src/iop/filmicrgb.c:4339
+#: ../src/iop/filmicrgb.c:4342 ../src/iop/profile_gamma.c:667
 msgid "auto tune levels"
 msgstr "Auto-Tune-Levels"
 
@@ -15153,7 +15263,7 @@ msgstr ""
 msgid "filmic S curve"
 msgstr "Filmic S-Kurve"
 
-#: ../src/iop/filmic.c:1651 ../src/iop/filmicrgb.c:4003
+#: ../src/iop/filmic.c:1651 ../src/iop/filmicrgb.c:4427
 msgid ""
 "slope of the linear part of the curve\n"
 "affects mostly the mid-tones"
@@ -15162,7 +15272,7 @@ msgstr ""
 "wirkt sich hauptsächlich auf die Mitten aus"
 
 #. geotagging
-#: ../src/iop/filmic.c:1658 ../src/iop/filmicrgb.c:4012
+#: ../src/iop/filmic.c:1658 ../src/iop/filmicrgb.c:4436
 #: ../src/libs/metadata_view.c:157
 msgid "latitude"
 msgstr "Breite"
@@ -15181,7 +15291,7 @@ msgstr ""
 msgid "shadows/highlights balance"
 msgstr "Schatten/Spitzlichter-Balance"
 
-#: ../src/iop/filmic.c:1671 ../src/iop/filmicrgb.c:4023
+#: ../src/iop/filmic.c:1671 ../src/iop/filmicrgb.c:4447
 msgid ""
 "slides the latitude along the slope\n"
 "to give more room to shadows or highlights.\n"
@@ -15213,8 +15323,8 @@ msgstr ""
 "Verringern wenn Schatten/Spitzlichter übersättigt sind."
 
 #: ../src/iop/filmic.c:1701 ../src/libs/export.c:1263
-#: ../src/libs/print_settings.c:2131 ../src/libs/print_settings.c:2463
-#: ../src/views/darkroom.c:2453 ../src/views/lighttable.c:1252
+#: ../src/libs/print_settings.c:2324 ../src/libs/print_settings.c:2653
+#: ../src/views/darkroom.c:2457 ../src/views/lighttable.c:1252
 #: ../src/views/lighttable.c:1259
 msgid "intent"
 msgstr "Vorsatz"
@@ -15263,7 +15373,7 @@ msgstr ""
 msgid "destination/display"
 msgstr "Ziel/Anzeige"
 
-#: ../src/iop/filmic.c:1742 ../src/iop/filmicrgb.c:4042
+#: ../src/iop/filmic.c:1744 ../src/iop/filmicrgb.c:4466
 msgid ""
 "luminance of output pure black, this should be 0%\n"
 "except if you want a faded look"
@@ -15271,7 +15381,7 @@ msgstr ""
 "Luminanz der Ausgabe reinschwarz sollte 0% sein,\n"
 "außer ein verblasster Look ist erwünscht."
 
-#: ../src/iop/filmic.c:1751 ../src/iop/filmicrgb.c:4049
+#: ../src/iop/filmic.c:1753 ../src/iop/filmicrgb.c:4473
 msgid ""
 "middle gray value of the target display or color space.\n"
 "you should never touch that unless you know what you are doing."
@@ -15279,7 +15389,7 @@ msgstr ""
 "Mittlerer Grauwert der Zielanzeige oder des Farbraums.\n"
 "Sollte nicht geändert werden, es sei denn, Du weißt, was Du tust."
 
-#: ../src/iop/filmic.c:1760 ../src/iop/filmicrgb.c:4056
+#: ../src/iop/filmic.c:1762 ../src/iop/filmicrgb.c:4480
 msgid ""
 "luminance of output pure white, this should be 100%\n"
 "except if you want a faded look"
@@ -15287,11 +15397,11 @@ msgstr ""
 "Luminanz der Ausgabe reinweiß sollte 100% sein,\n"
 "außer ein verblasster Look ist erwünscht."
 
-#: ../src/iop/filmic.c:1766
+#: ../src/iop/filmic.c:1768
 msgid "target gamma"
 msgstr "Ziel-Gamma"
 
-#: ../src/iop/filmic.c:1768
+#: ../src/iop/filmic.c:1770
 msgid ""
 "power or gamma of the transfer function\n"
 "of the display or color space.\n"
@@ -15301,17 +15411,17 @@ msgstr ""
 "des Displays oder des Farbraums.\n"
 "Sollte nicht geändert werden, es sei denn, Du weisst, was Du tust."
 
-#: ../src/iop/filmicrgb.c:339
+#: ../src/iop/filmicrgb.c:341
 msgid "filmic rgb"
 msgstr "Filmic RGB"
 
 # inhaltgerechte Übersetzung view transformation  ?
-#: ../src/iop/filmicrgb.c:344
+#: ../src/iop/filmicrgb.c:346
 msgid "tone mapping|curve|view transform|contrast|saturation|highlights"
 msgstr ""
 "Tonemapping|Tonwertkurve|Bildtransformation|Kontrast|Sättigung|Spitzlichter"
 
-#: ../src/iop/filmicrgb.c:349
+#: ../src/iop/filmicrgb.c:351
 msgid ""
 "apply a view transform to prepare the scene-referred pipeline\n"
 "for display on SDR screens and paper prints\n"
@@ -15322,7 +15432,7 @@ msgstr ""
 "Analog zu „klassischem“ Film durch Kompression von dunklen Schatten und "
 "hellen Lichtern."
 
-#: ../src/iop/filmicrgb.c:1209
+#: ../src/iop/filmicrgb.c:1211
 msgid ""
 "filmic highlights reconstruction failed to allocate memory, check your RAM "
 "settings"
@@ -15330,71 +15440,71 @@ msgstr ""
 "Filmic Spitzlichtrekonstruktion konnte kein Speicher zuweisen werden, "
 "überprüfe die RAM-Einstellungen."
 
-#: ../src/iop/filmicrgb.c:1577 ../src/iop/filmicrgb.c:1854
+#: ../src/iop/filmicrgb.c:1941 ../src/iop/filmicrgb.c:2227
 msgid "filmic works only on RGB input"
 msgstr "Filmic funktioniert nur mit RGB-Eingabedaten."
 
-#: ../src/iop/filmicrgb.c:1712
+#: ../src/iop/filmicrgb.c:2085
 msgid "filmic highlights reconstruction failed to allocate memory on GPU"
 msgstr "Filmic Spitzlichtrekonstruktion konnte keinen GPU Speicher allokieren."
 
-#: ../src/iop/filmicrgb.c:2899
+#: ../src/iop/filmicrgb.c:3320
 msgid "look only"
 msgstr "nur Aussehen"
 
-#: ../src/iop/filmicrgb.c:2901
+#: ../src/iop/filmicrgb.c:3322
 msgid "look + mapping (lin)"
 msgstr "Basiskurve (lin.)"
 
-#: ../src/iop/filmicrgb.c:2903
+#: ../src/iop/filmicrgb.c:3324
 msgid "look + mapping (log)"
 msgstr "Basiskurve (log.)"
 
-#: ../src/iop/filmicrgb.c:2905
+#: ../src/iop/filmicrgb.c:3326
 msgid "dynamic range mapping"
 msgstr "Abbildung des Dynamikbereichs"
 
-#: ../src/iop/filmicrgb.c:3272
+#: ../src/iop/filmicrgb.c:3693
 #, c-format
 msgid "(%.0f %%)"
 msgstr "(%.0f %%)"
 
-#: ../src/iop/filmicrgb.c:3288
+#: ../src/iop/filmicrgb.c:3709
 #, no-c-format
 msgid "% display"
 msgstr "% Anzeige"
 
-#: ../src/iop/filmicrgb.c:3299
+#: ../src/iop/filmicrgb.c:3721
 msgid "EV scene"
 msgstr "EV Aufnahme"
 
-#: ../src/iop/filmicrgb.c:3303
+#: ../src/iop/filmicrgb.c:3725
 #, no-c-format
 msgid "% camera"
 msgstr "% Kamera"
 
 #. Page DISPLAY
-#: ../src/iop/filmicrgb.c:3339 ../src/iop/filmicrgb.c:4036
+#: ../src/iop/filmicrgb.c:3761 ../src/iop/filmicrgb.c:4460
 msgid "display"
 msgstr "Anzeige"
 
 #. axis legend
-#: ../src/iop/filmicrgb.c:3348
+#: ../src/iop/filmicrgb.c:3770
 msgid "(%)"
 msgstr "(%)"
 
 #. Page SCENE
-#: ../src/iop/filmicrgb.c:3357 ../src/iop/filmicrgb.c:3877
+#: ../src/iop/filmicrgb.c:3779 ../src/iop/filmicrgb.c:4299
 msgid "scene"
 msgstr "Aufnahme"
 
 #. axis legend
-#: ../src/iop/filmicrgb.c:3366
+#: ../src/iop/filmicrgb.c:3788
 msgid "(EV)"
 msgstr "(EV)"
 
 #. we are over the graph area
-#: ../src/iop/filmicrgb.c:3795
+#: ../src/iop/filmicrgb.c:4217
 msgid ""
 "use the parameters below to set the nodes.\n"
 "the bright curve is the filmic tone mapping curve\n"
@@ -15405,11 +15515,11 @@ msgstr ""
 "Die helle Kurve ist die Dynamikkompressionskurve. \n"
 "Die dunkle Kurve ist die Entsättigungskurve."
 
-#: ../src/iop/filmicrgb.c:3801
+#: ../src/iop/filmicrgb.c:4223
 msgid "toggle axis labels and values display"
 msgstr "Achsenbeschriftung ein-/ausschalten"
 
-#: ../src/iop/filmicrgb.c:3805
+#: ../src/iop/filmicrgb.c:4227
 msgid ""
 "cycle through graph views.\n"
 "left click: cycle forward.\n"
@@ -15421,7 +15531,7 @@ msgstr ""
 "Rechtsklick: rückwärts.\n"
 "Doppelklick: Wechsel zu „nur Aussehen“."
 
-#: ../src/iop/filmicrgb.c:3884
+#: ../src/iop/filmicrgb.c:4306
 msgid ""
 "adjust to match the average luminance of the image's subject.\n"
 "the value entered here will then be remapped to 18.45%.\n"
@@ -15431,7 +15541,7 @@ msgstr ""
 "Der hier eingegebene Wert wird dabei auf 18,45% umgerechnet.\n"
 "Reduzierung des Werts erhöht die Gesamthelligkeit."
 
-#: ../src/iop/filmicrgb.c:3912
+#: ../src/iop/filmicrgb.c:4334
 msgid ""
 "symmetrically enlarge or shrink the computed dynamic range.\n"
 "useful to give a safety margin to extreme luminances."
@@ -15439,7 +15549,7 @@ msgstr ""
 "Den berechneten Dynamikbereich vergrößern oder verkleinern.\n"
 "Nützlich, um extremer Luminanz einen sicheren Spielraum zu geben."
 
-#: ../src/iop/filmicrgb.c:3918
+#: ../src/iop/filmicrgb.c:4343
 msgid ""
 "try to optimize the settings with some statistical assumptions.\n"
 "this will fit the luminance range inside the histogram bounds.\n"
@@ -15460,15 +15570,15 @@ msgstr ""
 "Vergewissere Dich, die Annahmen zu verstehen, bevor Du es verwendest."
 
 #. Page RECONSTRUCT
-#: ../src/iop/filmicrgb.c:3927
+#: ../src/iop/filmicrgb.c:4352
 msgid "reconstruct"
 msgstr "Rekonstruieren"
 
-#: ../src/iop/filmicrgb.c:3929
+#: ../src/iop/filmicrgb.c:4354
 msgid "highlights clipping"
 msgstr "Spitzlichtkompression"
 
-#: ../src/iop/filmicrgb.c:3937
+#: ../src/iop/filmicrgb.c:4362
 msgid ""
 "set the exposure threshold upon which\n"
 "clipped highlights get reconstructed.\n"
@@ -15485,7 +15595,7 @@ msgstr ""
 "einzubeziehen, \n"
 "erhöhen für kleinere Bereiche."
 
-#: ../src/iop/filmicrgb.c:3947
+#: ../src/iop/filmicrgb.c:4372
 msgid ""
 "soften the transition between clipped highlights and valid pixels.\n"
 "decrease to make the transition harder and sharper,\n"
@@ -15495,15 +15605,15 @@ msgstr ""
 "Verringern, um den Übergang härter und schärfer zu machen, \n"
 "vergrößern, um ihn weicher und unschärfer zu gestalten."
 
-#: ../src/iop/filmicrgb.c:3953
+#: ../src/iop/filmicrgb.c:4378 ../src/iop/filmicrgb.c:4379
 msgid "display highlight reconstruction mask"
 msgstr "Maske der Spitzlicht-Rekonstruktion anzeigen"
 
-#: ../src/iop/filmicrgb.c:3960 ../src/iop/splittoning.c:533
+#: ../src/iop/filmicrgb.c:4384 ../src/iop/splittoning.c:533
 msgid "balance"
 msgstr "Ausgleich"
 
-#: ../src/iop/filmicrgb.c:3967
+#: ../src/iop/filmicrgb.c:4391
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -15520,7 +15630,7 @@ msgstr ""
 "wenn wenigstens ein RGB-Komponenten nicht abgeschnitten wird, vergrößern,\n"
 "wenn alle RGB-Komponenten über größere Bildbereiche abgeschnitten werden."
 
-#: ../src/iop/filmicrgb.c:3978
+#: ../src/iop/filmicrgb.c:4402
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -15536,7 +15646,7 @@ msgstr ""
 "%0 entspricht einer Gleichgewichtung beider Methoden. Für mehr Details Wert "
 "anheben, verringern für mehr Unschärfe."
 
-#: ../src/iop/filmicrgb.c:3990
+#: ../src/iop/filmicrgb.c:4414
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -15554,11 +15664,11 @@ msgstr ""
 "verringern falls Spitzlichter in Magenta oder außerhalb des Gamut auftreten."
 
 #. Page LOOK
-#: ../src/iop/filmicrgb.c:3998
+#: ../src/iop/filmicrgb.c:4422
 msgid "look"
 msgstr "Aussehen"
 
-#: ../src/iop/filmicrgb.c:4008
+#: ../src/iop/filmicrgb.c:4432
 msgid ""
 "equivalent to paper grade in analog.\n"
 "increase to make highlights brighter and less compressed.\n"
@@ -15568,7 +15678,7 @@ msgstr ""
 "Vergrößern, um die Spitzlichter aufzuhellen und weniger zu komprimieren. \n"
 "Verringern, um die Spitzlichter zu dämpfen."
 
-#: ../src/iop/filmicrgb.c:4016
+#: ../src/iop/filmicrgb.c:4440
 msgid ""
 "width of the linear domain in the middle of the curve,\n"
 "increase to get more contrast and less desaturation at extreme luminances,\n"
@@ -15581,7 +15691,7 @@ msgstr ""
 "Im mittleren Bereich findet keine Entsättigung statt.\n"
 "Hat keine Auswirkungen auf die Mitteltöne."
 
-#: ../src/iop/filmicrgb.c:4031 ../src/iop/filmicrgb.c:4174
+#: ../src/iop/filmicrgb.c:4455 ../src/iop/filmicrgb.c:4598
 msgid ""
 "desaturates the output of the module\n"
 "specifically at extreme luminances.\n"
@@ -15593,13 +15703,13 @@ msgstr ""
 "nicht ausreichend gesättigt sind."
 
 #. Page OPTIONS
-#: ../src/iop/filmicrgb.c:4060
+#: ../src/iop/filmicrgb.c:4484
 msgid "options"
 msgstr "Optionen"
 
 # Was bedeutet „same as color balance”?
 # => meint evtl. "wie im Modul Farbbalance"?
-#: ../src/iop/filmicrgb.c:4065
+#: ../src/iop/filmicrgb.c:4489
 msgid ""
 "v3 is darktable 3.0 desaturation method, same as color balance.\n"
 "v4 is a newer desaturation method, based on spectral purity of light."
@@ -15608,7 +15718,7 @@ msgstr ""
 "V4 ist eine neuere Entsättigungsmethode basierend auf der spektralen "
 "Reinheit des Lichts."
 
-#: ../src/iop/filmicrgb.c:4069
+#: ../src/iop/filmicrgb.c:4493
 msgid ""
 "ensure the original color are preserved.\n"
 "may reinforce chromatic aberrations and chroma noise,\n"
@@ -15618,7 +15728,7 @@ msgstr ""
 "Kann chromatische Aberrationen der Linse verstärken.\n"
 "Sättigung muss manuell angepasst werden, wenn dieser Modus aktiviert wird.\n"
 
-#: ../src/iop/filmicrgb.c:4075
+#: ../src/iop/filmicrgb.c:4499
 msgid ""
 "choose the desired curvature of the filmic spline in highlights.\n"
 "hard uses a high curvature resulting in more tonal compression.\n"
@@ -15630,7 +15740,7 @@ msgstr ""
 "„weich” benutzt eine schwächere Krümmung, was eine geringere tonale "
 "Kompression bewirkt."
 
-#: ../src/iop/filmicrgb.c:4080
+#: ../src/iop/filmicrgb.c:4504
 msgid ""
 "choose the desired curvature of the filmic spline in shadows.\n"
 "hard uses a high curvature resulting in more tonal compression.\n"
@@ -15642,7 +15752,7 @@ msgstr ""
 "„weich” benutzt eine schwächere Krümmung, was eine geringere tonale "
 "Kompression bewirkt."
 
-#: ../src/iop/filmicrgb.c:4085
+#: ../src/iop/filmicrgb.c:4509
 #, c-format
 msgid ""
 "enable to input custom middle-gray values.\n"
@@ -15655,7 +15765,7 @@ msgstr ""
 "Belichtung im Modul „Belichtung” anpassen. \n"
 "Deaktivieren, um 18,45%% als Standardwert für mittleres Grau zu verwenden."
 
-#: ../src/iop/filmicrgb.c:4092
+#: ../src/iop/filmicrgb.c:4516
 msgid ""
 "enable to auto-set the look hardness depending on the scene white and black "
 "points.\n"
@@ -15668,7 +15778,7 @@ msgstr ""
 "was die Einstellung der Filmic-Parameter vereinfacht. \n"
 "Für mehr manuelle Kontrolle abschalten."
 
-#: ../src/iop/filmicrgb.c:4098
+#: ../src/iop/filmicrgb.c:4522
 msgid ""
 "run extra passes of chromaticity reconstruction.\n"
 "more iterations means more color propagation from neighbourhood.\n"
@@ -15681,7 +15791,7 @@ msgstr ""
 "Dies ist langsamer, ergibt aber neutralere Lichter und hilft in schwierigen "
 "Fällen von magenta-farbenen Spitzlichtern."
 
-#: ../src/iop/filmicrgb.c:4105
+#: ../src/iop/filmicrgb.c:4529
 msgid ""
 "add statistical noise in reconstructed highlights.\n"
 "this avoids highlights to look too smooth\n"
@@ -15693,7 +15803,7 @@ msgstr ""
 "wenn das Bild ein Grundrauschen aufweist, \n"
 "sodass die Spitzlichter sich in die restlichen Bildbereiche einfügen."
 
-#: ../src/iop/filmicrgb.c:4112
+#: ../src/iop/filmicrgb.c:4536
 msgid ""
 "choose the statistical distribution of noise.\n"
 "this is useful to match natural sensor noise pattern.\n"
@@ -15702,11 +15812,11 @@ msgstr ""
 "Dies ist nützlich zur Anpassung an das natürliche Rauschverhalten des "
 "Sensors.\n"
 
-#: ../src/iop/filmicrgb.c:4180
+#: ../src/iop/filmicrgb.c:4604
 msgid "mid-tones saturation"
 msgstr "Sättigung der Mitten"
 
-#: ../src/iop/filmicrgb.c:4181
+#: ../src/iop/filmicrgb.c:4605
 msgid ""
 "desaturates the output of the module\n"
 "specifically at medium luminances.\n"
@@ -16258,7 +16368,7 @@ msgstr "Skalierung"
 msgid "auto scale"
 msgstr "automatisch skalieren"
 
-#: ../src/iop/lens.cc:2402 ../src/libs/modulegroups.c:2408
+#: ../src/iop/lens.cc:2402 ../src/libs/modulegroups.c:2410
 msgid "correct"
 msgstr "korrigieren"
 
@@ -16550,27 +16660,27 @@ msgstr "Tiefpass"
 msgid "isolate low frequencies in the image"
 msgstr "isoliert niedrigfrequente Bildpartien"
 
-#: ../src/iop/lowpass.c:556
+#: ../src/iop/lowpass.c:552
 msgid "local contrast mask"
 msgstr "Maske aus lokalem Kontrast"
 
-#: ../src/iop/lowpass.c:581
+#: ../src/iop/lowpass.c:577
 msgid "radius of gaussian/bilateral blur"
 msgstr "Radius des Gaußschen/bilateralen Weichzeichners"
 
-#: ../src/iop/lowpass.c:582
+#: ../src/iop/lowpass.c:578
 msgid "contrast of lowpass filter"
 msgstr "Kontrast des Tiefpassfilters"
 
-#: ../src/iop/lowpass.c:583
+#: ../src/iop/lowpass.c:579
 msgid "brightness adjustment of lowpass filter"
 msgstr "Helligkeitsanpassung des Tiefpassfilters"
 
-#: ../src/iop/lowpass.c:584
+#: ../src/iop/lowpass.c:580
 msgid "color saturation of lowpass filter"
 msgstr "Farbsättigung des Tiefpassfilters"
 
-#: ../src/iop/lowpass.c:585
+#: ../src/iop/lowpass.c:581
 msgid "which filter to use for blurring"
 msgstr "Filter, der zum Weichzeichnen genutzt wird"
 
@@ -17043,9 +17153,9 @@ msgstr "wie stark sollen die Farben geglättet werden"
 #. * let's fill the encapsulating widgets
 #. preview mode
 #. color scheme
-#: ../src/iop/overexposed.c:72 ../src/views/darkroom.c:2351
-#: ../src/views/darkroom.c:2368 ../src/views/darkroom.c:2375
-#: ../src/views/darkroom.c:2385 ../src/views/darkroom.c:2402
+#: ../src/iop/overexposed.c:72 ../src/views/darkroom.c:2355
+#: ../src/views/darkroom.c:2372 ../src/views/darkroom.c:2379
+#: ../src/views/darkroom.c:2389 ../src/views/darkroom.c:2406
 msgid "overexposed"
 msgstr "Überbelichtet"
 
@@ -17154,9 +17264,9 @@ msgstr ""
 
 #. * let's fill the encapsulating widgets
 #. mode of operation
-#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2296
-#: ../src/views/darkroom.c:2313 ../src/views/darkroom.c:2322
-#: ../src/views/darkroom.c:2337
+#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2300
+#: ../src/views/darkroom.c:2317 ../src/views/darkroom.c:2326
+#: ../src/views/darkroom.c:2341
 msgid "raw overexposed"
 msgstr "Raw-Überbelichtet"
 
@@ -17257,7 +17367,7 @@ msgid "toggle tool for picking median lightness in image"
 msgstr "mittlere Helligkeit im Bild wählen"
 
 #: ../src/iop/relight.c:284 ../src/libs/metadata_view.c:147
-#: ../src/libs/print_settings.c:2196
+#: ../src/libs/print_settings.c:2385
 msgid "width"
 msgstr "Breite"
 
@@ -18159,64 +18269,64 @@ msgid "[%s over image] change tone exposure in small steps"
 msgstr "[%s über Bild] selektive Belichtungsänderung in kleinen Schritten"
 
 #. Simple view
-#: ../src/iop/toneequal.c:3127 ../src/iop/toneequal.c:3156
-#: ../src/iop/toneequal.c:3157 ../src/iop/toneequal.c:3158
-#: ../src/iop/toneequal.c:3159 ../src/iop/toneequal.c:3160
-#: ../src/iop/toneequal.c:3161 ../src/iop/toneequal.c:3162
-#: ../src/iop/toneequal.c:3163 ../src/iop/toneequal.c:3164
+#: ../src/iop/toneequal.c:3128 ../src/iop/toneequal.c:3157
+#: ../src/iop/toneequal.c:3158 ../src/iop/toneequal.c:3159
+#: ../src/iop/toneequal.c:3160 ../src/iop/toneequal.c:3161
+#: ../src/iop/toneequal.c:3162 ../src/iop/toneequal.c:3163
+#: ../src/iop/toneequal.c:3164 ../src/iop/toneequal.c:3165
 msgid "simple"
 msgstr "einfach"
 
-#: ../src/iop/toneequal.c:3156
+#: ../src/iop/toneequal.c:3157
 msgid "-8 EV"
 msgstr "-8 EV"
 
-#: ../src/iop/toneequal.c:3157
+#: ../src/iop/toneequal.c:3158
 msgid "-7 EV"
 msgstr "-7 EV"
 
-#: ../src/iop/toneequal.c:3158
+#: ../src/iop/toneequal.c:3159
 msgid "-6 EV"
 msgstr "-6 EV"
 
-#: ../src/iop/toneequal.c:3159
+#: ../src/iop/toneequal.c:3160
 msgid "-5 EV"
 msgstr "-5 EV"
 
-#: ../src/iop/toneequal.c:3160
+#: ../src/iop/toneequal.c:3161
 msgid "-4 EV"
 msgstr "-4 EV"
 
-#: ../src/iop/toneequal.c:3161
+#: ../src/iop/toneequal.c:3162
 msgid "-3 EV"
 msgstr "-3 EV"
 
-#: ../src/iop/toneequal.c:3162
+#: ../src/iop/toneequal.c:3163
 msgid "-2 EV"
 msgstr "-2 EV"
 
-#: ../src/iop/toneequal.c:3163
+#: ../src/iop/toneequal.c:3164
 msgid "-1 EV"
 msgstr "-1 EV"
 
-#: ../src/iop/toneequal.c:3164
+#: ../src/iop/toneequal.c:3165
 msgid "+0 EV"
 msgstr "+0 EV"
 
 #. Advanced view
-#: ../src/iop/toneequal.c:3168
+#: ../src/iop/toneequal.c:3169
 msgid "advanced"
 msgstr "erweitert"
 
-#: ../src/iop/toneequal.c:3187
+#: ../src/iop/toneequal.c:3188
 msgid "double-click to reset the curve"
 msgstr "Doppelklick setzt Kurve zurück"
 
-#: ../src/iop/toneequal.c:3191
+#: ../src/iop/toneequal.c:3192
 msgid "curve smoothing"
 msgstr "Kurvenglättung"
 
-#: ../src/iop/toneequal.c:3192
+#: ../src/iop/toneequal.c:3193
 msgid ""
 "positive values will produce more progressive tone transitions\n"
 "but the curve might become oscillatory in some settings.\n"
@@ -18230,11 +18340,11 @@ msgstr ""
 "beeinträchtigen."
 
 #. Masking options
-#: ../src/iop/toneequal.c:3201
+#: ../src/iop/toneequal.c:3202
 msgid "masking"
 msgstr "Maskierung"
 
-#: ../src/iop/toneequal.c:3205
+#: ../src/iop/toneequal.c:3206
 msgid ""
 "preview the mask and chose the estimator that gives you the\n"
 "higher contrast between areas to dodge and areas to burn"
@@ -18242,15 +18352,15 @@ msgstr ""
 "Vorschau der Maske und Auswahl der Schätzfunktion, ergibt einen\n"
 "höheren Kontrast zwischen den zu vermeidenden und ausgebrannten Bereichen."
 
-#: ../src/iop/toneequal.c:3208
+#: ../src/iop/toneequal.c:3209
 msgid "details"
 msgstr "Details"
 
-#: ../src/iop/toneequal.c:3209
+#: ../src/iop/toneequal.c:3210
 msgid "preserve details"
 msgstr "Details erhalten"
 
-#: ../src/iop/toneequal.c:3210
+#: ../src/iop/toneequal.c:3211
 msgid ""
 "'no' affects global and local contrast (safe if you only add contrast)\n"
 "'guided filter' only affects global contrast and tries to preserve local "
@@ -18275,7 +18385,7 @@ msgstr ""
 "„gemittelter eigf“ ist ein geometrisches Mittel aus den Methoden „nein“ und "
 "„eigf“"
 
-#: ../src/iop/toneequal.c:3218
+#: ../src/iop/toneequal.c:3219
 msgid ""
 "number of passes of guided filter to apply\n"
 "helps diffusing the edges of the filter at the expense of speed"
@@ -18283,7 +18393,7 @@ msgstr ""
 "Anzahl der Durchgänge des geführten Filters hilft, die Kanten auf Kosten der "
 "Geschwindigkeit zu streuen."
 
-#: ../src/iop/toneequal.c:3224
+#: ../src/iop/toneequal.c:3225
 msgid ""
 "diameter of the blur in percent of the largest image size\n"
 "warning: big values of this parameter can make the darkroom\n"
@@ -18293,7 +18403,7 @@ msgstr ""
 "Warnung: Große Werte dieses Parameters können die Vorschau in der "
 "Dunkelkammer verlangsamen, wenn das Entrauschen (Profil) verwendet wird."
 
-#: ../src/iop/toneequal.c:3230
+#: ../src/iop/toneequal.c:3231
 msgid ""
 "precision of the feathering :\n"
 "higher values force the mask to follow edges more closely\n"
@@ -18307,11 +18417,11 @@ msgstr ""
 "Niedrigere Werte ergeben weichere Gradienten und eine bessere Glättung, kann "
 "aber zu ungenauen Rändern und Halos führen."
 
-#: ../src/iop/toneequal.c:3236
+#: ../src/iop/toneequal.c:3237
 msgid "mask post-processing"
 msgstr "Maskennachbearbeitung"
 
-#: ../src/iop/toneequal.c:3243
+#: ../src/iop/toneequal.c:3244
 msgid ""
 "mask histogram span between the first and last deciles.\n"
 "the central line shows the average. orange bars appear at extrema if "
@@ -18321,7 +18431,7 @@ msgstr ""
 "Mittellinie zeigt den Mittelwert an. \n"
 "Orangefarbene Balken erscheinen bei Extrema, wenn es zu Beschneidungen kommt."
 
-#: ../src/iop/toneequal.c:3249
+#: ../src/iop/toneequal.c:3250
 msgid ""
 "0 disables the quantization.\n"
 "higher values posterize the luminance mask to help the guiding\n"
@@ -18332,7 +18442,7 @@ msgstr ""
 "zusammenhängende \n"
 "Bereiche zu erzeugen, wenn hohe Ausblende-Werte verwendet werden."
 
-#: ../src/iop/toneequal.c:3256
+#: ../src/iop/toneequal.c:3257
 msgid ""
 "use this to slide the mask average exposure along channels\n"
 "for a better control of the exposure correction with the available nodes.\n"
@@ -18344,7 +18454,7 @@ msgstr ""
 "steuern.\n"
 "Der Zauberstab passt die durchschnittliche Belichtung automatisch an"
 
-#: ../src/iop/toneequal.c:3266
+#: ../src/iop/toneequal.c:3267
 msgid ""
 "use this to counter the averaging effect of the guided filter\n"
 "and dilate the mask contrast around -4EV\n"
@@ -18359,7 +18469,7 @@ msgstr ""
 "zur besseren Kontrolle der Belichtungskorrektur.\n"
 "Der Zauberstab passt den Kontrast automatisch an"
 
-#: ../src/iop/toneequal.c:3286 ../src/iop/toneequal.c:3290
+#: ../src/iop/toneequal.c:3287 ../src/iop/toneequal.c:3288
 msgid "display exposure mask"
 msgstr "Belichtungsmasken anzeigen"
 
@@ -18567,7 +18677,7 @@ msgstr "Platzierung"
 msgid "size is relative to"
 msgstr "Größe ist relativ zu"
 
-#: ../src/iop/watermark.c:1141 ../src/libs/print_settings.c:2325
+#: ../src/iop/watermark.c:1141 ../src/libs/print_settings.c:2514
 msgid "alignment"
 msgstr "Position"
 
@@ -18743,68 +18853,68 @@ msgstr "Verschlusszeit"
 msgid "WB"
 msgstr "Weißabgleich"
 
-#: ../src/libs/collect.c:130
+#: ../src/libs/collect.c:131
 msgid "collections"
 msgstr "Sammlungen"
 
-#: ../src/libs/collect.c:307
+#: ../src/libs/collect.c:299
 msgid "imported: today"
 msgstr "importiert: heute"
 
-#: ../src/libs/collect.c:312
+#: ../src/libs/collect.c:304
 msgid "imported: last 24h"
 msgstr "importiert: letzte 24 Stunden"
 
-#: ../src/libs/collect.c:317
+#: ../src/libs/collect.c:309
 msgid "imported: last 30 days"
 msgstr "importiert: letzte 30 Tage"
 
-#: ../src/libs/collect.c:323
+#: ../src/libs/collect.c:315
 msgid "taken: today"
 msgstr "aufgenommen: heute"
 
-#: ../src/libs/collect.c:328
+#: ../src/libs/collect.c:320
 msgid "taken: last 24h"
 msgstr "aufgenommen: letzte 24 Stunden"
 
-#: ../src/libs/collect.c:333
+#: ../src/libs/collect.c:325
 msgid "taken: last 30 days"
 msgstr "aufgenommen: letzte 30 Tage"
 
-#: ../src/libs/collect.c:467
+#: ../src/libs/collect.c:462
 msgid "search filmroll"
 msgstr "Filmrolle suchen"
 
-#: ../src/libs/collect.c:550
+#: ../src/libs/collect.c:545
 #, c-format
 msgid "problem selecting new path for the filmroll in %s"
 msgstr "Problem beim Auswählen des neuen Pfads für die Filmrolle in %s"
 
-#: ../src/libs/collect.c:611
+#: ../src/libs/collect.c:608
 msgid "search filmroll..."
 msgstr "Filmrolle suchen ..."
 
-#: ../src/libs/collect.c:615
+#: ../src/libs/collect.c:612
 msgid "remove..."
 msgstr "entfernen ..."
 
-#: ../src/libs/collect.c:1245
+#: ../src/libs/collect.c:1242
 msgid "uncategorized"
 msgstr "Sonstige"
 
-#: ../src/libs/collect.c:1736
+#: ../src/libs/collect.c:1752
 msgid "copied locally"
 msgstr "lokal kopiert"
 
-#: ../src/libs/collect.c:1838
+#: ../src/libs/collect.c:1872
 msgid "group followers"
 msgstr "Gruppenmitglieder"
 
-#: ../src/libs/collect.c:2102
+#: ../src/libs/collect.c:2147
 msgid "use <, <=, >, >=, <>, =, [;] as operators"
 msgstr "Erlaubte Operatoren sind <, <=, >, >=, <>, = und [;]."
 
-#: ../src/libs/collect.c:2106
+#: ../src/libs/collect.c:2151
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "star rating: 0-5\n"
@@ -18814,7 +18924,7 @@ msgstr ""
 "Sterne-Bewertung: 0-5\n"
 "abgelehnte Bilder: -1"
 
-#: ../src/libs/collect.c:2113
+#: ../src/libs/collect.c:2158
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
@@ -18823,12 +18933,12 @@ msgstr ""
 "Datumsangaben erfolgen in der Form JJJJ:MM:DD hh:mm:ss.sss (nur das Jahr ist "
 "zwingend erforderlich)."
 
-#: ../src/libs/collect.c:2120
+#: ../src/libs/collect.c:2165
 #, no-c-format
 msgid "use `%' as wildcard and `,' to separate values"
 msgstr "„%” als Platzhalter und „,“ als Trennzeichen benutzen"
 
-#: ../src/libs/collect.c:2126
+#: ../src/libs/collect.c:2171
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -18841,7 +18951,7 @@ msgstr ""
 "Umschalt+Klick, um nur die aktuelle Hierarchie einzuschließen (kein Suffix)\n"
 "Strg+Klick, um nur Unterhierarchien einzuschließen (Suffix `|%’)"
 
-#: ../src/libs/collect.c:2138
+#: ../src/libs/collect.c:2183
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -18854,7 +18964,7 @@ msgstr ""
 "Umschalt+Klick, um nur den aktuellen Ort einzuschließen (kein Suffix)\n"
 "Strg+Klick, um nur Unterorte einzuschließen (Suffix `|%’)"
 
-#: ../src/libs/collect.c:2150
+#: ../src/libs/collect.c:2195
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -18867,80 +18977,80 @@ msgstr ""
 "Umschalt+Klick, um nur den aktuellen Ordner einzuschließen (kein Suffix)\n"
 "Strg+Klick, um nur Unterordner einzuschließen (Suffix `|%’)"
 
-#: ../src/libs/collect.c:2161
+#: ../src/libs/collect.c:2206
 #, no-c-format
 msgid "use `%' as wildcard"
 msgstr "„%” als Platzhalter benutzen"
 
-#: ../src/libs/collect.c:2214 ../src/libs/collect.c:2229
-#: ../src/libs/collect.c:2789
+#: ../src/libs/collect.c:2259 ../src/libs/collect.c:2274
+#: ../src/libs/collect.c:2834
 msgid "clear this rule"
 msgstr "diese Regel löschen"
 
-#: ../src/libs/collect.c:2218
+#: ../src/libs/collect.c:2263
 msgid "clear this rule or add new rules"
 msgstr "diese Regel löschen oder weitere Regeln hinzufügen"
 
-#: ../src/libs/collect.c:2795
+#: ../src/libs/collect.c:2840
 msgid "narrow down search"
 msgstr "Suche verfeinern"
 
-#: ../src/libs/collect.c:2800
+#: ../src/libs/collect.c:2845
 msgid "add more images"
 msgstr "mehr Bilder hinzufügen"
 
-#: ../src/libs/collect.c:2805
+#: ../src/libs/collect.c:2850
 msgid "exclude images"
 msgstr "Bilder ausschließen"
 
-#: ../src/libs/collect.c:2812
+#: ../src/libs/collect.c:2857
 msgid "change to: and"
 msgstr "ändere zu: UND"
 
-#: ../src/libs/collect.c:2817
+#: ../src/libs/collect.c:2862
 msgid "change to: or"
 msgstr "ändere zu: ODER"
 
-#: ../src/libs/collect.c:2822
+#: ../src/libs/collect.c:2867
 msgid "change to: except"
 msgstr "ändere zu: AUSSER"
 
-#: ../src/libs/collect.c:2848
+#: ../src/libs/collect.c:2893
 msgid "files"
 msgstr "Dateien"
 
-#: ../src/libs/collect.c:2853 ../src/libs/export_metadata.c:310
-#: ../src/libs/image.c:479 ../src/libs/image.c:584 ../src/libs/metadata.c:536
-#: ../src/libs/metadata_view.c:1237
+#: ../src/libs/collect.c:2898 ../src/libs/export_metadata.c:310
+#: ../src/libs/image.c:479 ../src/libs/image.c:584 ../src/libs/metadata.c:538
+#: ../src/libs/metadata_view.c:1231
 msgid "metadata"
 msgstr "Metadaten"
 
-#: ../src/libs/collect.c:2872
+#: ../src/libs/collect.c:2917
 msgid "times"
 msgstr "Datum/Uhrzeit"
 
-#: ../src/libs/collect.c:2880
+#: ../src/libs/collect.c:2925
 msgid "capture details"
 msgstr "Aufnahmeparameter"
 
-#: ../src/libs/collect.c:2889 ../src/libs/tools/darktable.c:65
+#: ../src/libs/collect.c:2934 ../src/libs/tools/darktable.c:65
 msgid "darktable"
 msgstr "darktable"
 
-#: ../src/libs/collect.c:2902
+#: ../src/libs/collect.c:2947
 msgid "collections settings"
 msgstr "Einstellungen „Sammlungen“"
 
-#: ../src/libs/collect.c:2905 ../src/libs/export_metadata.c:288
-#: ../src/libs/metadata.c:495 ../src/libs/metadata_view.c:1205
+#: ../src/libs/collect.c:2950 ../src/libs/export_metadata.c:288
+#: ../src/libs/metadata.c:497 ../src/libs/metadata_view.c:1199
 #: ../src/libs/recentcollect.c:320 ../src/libs/tagging.c:1675
 #: ../src/libs/tagging.c:1805 ../src/libs/tagging.c:2079
 #: ../src/libs/tagging.c:3546
 msgid "save"
 msgstr "Speichern"
 
-#: ../src/libs/collect.c:2920 ../src/libs/export.c:1059
-#: ../src/libs/metadata.c:630 ../src/libs/metadata_view.c:1317
+#: ../src/libs/collect.c:2965 ../src/libs/export.c:1059
+#: ../src/libs/metadata.c:632 ../src/libs/metadata_view.c:1311
 #: ../src/libs/recentcollect.c:383 ../src/libs/tagging.c:3568
 msgid "preferences..."
 msgstr "Voreinstellungen"
@@ -19205,17 +19315,17 @@ msgstr "Duplikat-Manager"
 msgid "preview is only possible for zoom lower than 200%%"
 msgstr "Vorschau ist nur bei Zoomstufe kleiner 200% möglich"
 
-#: ../src/libs/duplicate.c:543 ../src/libs/history.c:1015
+#: ../src/libs/duplicate.c:545 ../src/libs/history.c:1015
 #: ../src/libs/snapshots.c:459
 msgid "original"
 msgstr "Original"
 
-#: ../src/libs/duplicate.c:543
+#: ../src/libs/duplicate.c:545
 msgid "create a 'virgin' duplicate of the image without any development"
 msgstr ""
 "Erstellt ein „jungfräuliches” Duplikat des Bildes ohne jegliche Entwicklung"
 
-#: ../src/libs/duplicate.c:546
+#: ../src/libs/duplicate.c:548
 msgid "create a duplicate of the image with same history stack"
 msgstr "Erstellt ein Duplikat des Bildes mit dem gleichen Verlaufsstapel"
 
@@ -19340,11 +19450,11 @@ msgstr ""
 "bestimmten Ausgabeformaten unterstützt."
 
 #: ../src/libs/export.c:1242 ../src/libs/export.c:1264
-#: ../src/libs/print_settings.c:2420 ../src/libs/print_settings.c:2465
+#: ../src/libs/print_settings.c:2610 ../src/libs/print_settings.c:2655
 msgid "image settings"
 msgstr "Bildeinstellungen"
 
-#: ../src/libs/export.c:1254 ../src/libs/print_settings.c:2454
+#: ../src/libs/export.c:1254 ../src/libs/print_settings.c:2644
 #, c-format
 msgid "output ICC profiles in %s or %s"
 msgstr "Ausgabe-ICC-Profile in %s oder %s"
@@ -19382,7 +19492,7 @@ msgstr ""
 "Zielmediums an und tut nichts anderes. Wird hauptsächlich beim Proofing von "
 "Farben verwendet. (nicht für die Fotografie geeignet)."
 
-#: ../src/libs/export.c:1300 ../src/libs/print_settings.c:2479
+#: ../src/libs/export.c:1300 ../src/libs/print_settings.c:2669
 msgid "style"
 msgstr "Stil"
 
@@ -19390,15 +19500,15 @@ msgstr "Stil"
 msgid "temporary style to use while exporting"
 msgstr "Stil, der beim Export vorübergehend angewandt werden soll"
 
-#: ../src/libs/export.c:1312 ../src/libs/print_settings.c:2522
+#: ../src/libs/export.c:1312 ../src/libs/print_settings.c:2712
 msgid "replace history"
 msgstr "Verlauf ersetzen"
 
-#: ../src/libs/export.c:1313 ../src/libs/print_settings.c:2523
+#: ../src/libs/export.c:1313 ../src/libs/print_settings.c:2713
 msgid "append history"
 msgstr "Verlauf hinzufügen"
 
-#: ../src/libs/export.c:1318 ../src/libs/print_settings.c:2530
+#: ../src/libs/export.c:1318 ../src/libs/print_settings.c:2720
 msgid ""
 "whether the style items are appended to the history or replacing the history"
 msgstr ""
@@ -19623,7 +19733,7 @@ msgstr "Bilder"
 msgid "open GPX file"
 msgstr "GPX-Datei öffnen"
 
-#: ../src/libs/geotagging.c:927 ../src/views/darkroom.c:2166
+#: ../src/libs/geotagging.c:927 ../src/views/darkroom.c:2170
 #: ../src/views/lighttable.c:652
 msgid "preview"
 msgstr "Vorschau"
@@ -19970,12 +20080,12 @@ msgstr "parametrische Ausgabemaske:"
 msgid "parametric input mask:"
 msgstr "parametrische Eingabemaske:"
 
-#: ../src/libs/history.c:1224
+#: ../src/libs/history.c:1226
 msgid "do you really want to clear history of current image?"
 msgstr ""
 "Soll der Bearbeitungsverlauf des aktuellen Bildes wirklich gelöscht werden?"
 
-#: ../src/libs/history.c:1229
+#: ../src/libs/history.c:1231
 msgid "delete image's history?"
 msgstr "Bearbeitungsverlauf des Bildes löschen?"
 
@@ -19997,7 +20107,7 @@ msgid "physically delete from disk immediately"
 msgstr "physisch sofort von der Festplatte löschen"
 
 #. delete
-#: ../src/libs/image.c:490 ../src/libs/modulegroups.c:3857
+#: ../src/libs/image.c:490 ../src/libs/modulegroups.c:3873
 #: ../src/libs/styles.c:874
 msgid "remove"
 msgstr "entfernen"
@@ -20443,35 +20553,35 @@ msgstr ""
 msgid "parameters"
 msgstr "Einstellungen"
 
-#: ../src/libs/ioporder.c:193
+#: ../src/libs/ioporder.c:195
 msgid "v3.0"
 msgstr "V3.0"
 
-#: ../src/libs/ioporder.c:211
+#: ../src/libs/ioporder.c:213
 msgid "v3.0 for RAW input (default)"
 msgstr "v3.0 für RAW Bilder (default)"
 
-#: ../src/libs/ioporder.c:216
+#: ../src/libs/ioporder.c:218
 msgid "v3.0 for JPEG/non-RAW input"
 msgstr "v3.0 für JPEG/nicht-RAW Bilder"
 
-#: ../src/libs/lib.c:371
+#: ../src/libs/lib.c:387
 msgid "deleting preset for obsolete module"
 msgstr "lösche Voreinstellung für obsoletes Modul"
 
-#: ../src/libs/lib.c:502
+#: ../src/libs/lib.c:522
 msgid "manage presets..."
 msgstr "Voreinstellungen bearbeiten…"
 
-#: ../src/libs/lib.c:527
+#: ../src/libs/lib.c:547
 msgid "nothing to save"
 msgstr "nichts zu speichern"
 
-#: ../src/libs/lib.c:1000
+#: ../src/libs/lib.c:1030
 msgid "show module"
 msgstr "Modul zeigen"
 
-#: ../src/libs/lib.c:1276
+#: ../src/libs/lib.c:1308
 msgid "utility module"
 msgstr "Hilfsmodule"
 
@@ -20835,19 +20945,19 @@ msgstr "Verfügbare Formen"
 msgid "metadata editor"
 msgstr "Metadaten-Editor"
 
-#: ../src/libs/metadata.c:127 ../src/libs/metadata.c:388
+#: ../src/libs/metadata.c:127 ../src/libs/metadata.c:390
 msgid "<leave unchanged>"
 msgstr "<nicht ändern>"
 
-#: ../src/libs/metadata.c:493 ../src/libs/metadata_view.c:1203
+#: ../src/libs/metadata.c:495 ../src/libs/metadata_view.c:1197
 msgid "metadata settings"
 msgstr "Metadaten-Einstellungen"
 
-#: ../src/libs/metadata.c:542 ../src/libs/metadata_view.c:1248
+#: ../src/libs/metadata.c:544 ../src/libs/metadata_view.c:1242
 msgid "visible"
 msgstr "sichtbar"
 
-#: ../src/libs/metadata.c:547
+#: ../src/libs/metadata.c:549
 msgid ""
 "tick if the corresponding metadata is of interest for you\n"
 "it will be visible from metadata editor, collection and import module\n"
@@ -20857,19 +20967,19 @@ msgstr ""
 "Diese Metadaten sind in den Modulen „Metadaten-Editor”, „Importieren”,"
 "„Sammlungen” sichtbar und werden auch exportiert."
 
-#: ../src/libs/metadata.c:552 ../src/libs/tagging.c:1705
+#: ../src/libs/metadata.c:554 ../src/libs/tagging.c:1705
 #: ../src/libs/tagging.c:1849
 msgid "private"
 msgstr "privat"
 
-#: ../src/libs/metadata.c:557
+#: ../src/libs/metadata.c:559
 msgid ""
 "tick if you want to keep this information private (not exported with images)"
 msgstr ""
 "Auswählen, wenn diese Informationen vertraulich gehalten und nicht beim "
 "Export in die exportierten Bilder geschrieben werden sollen."
 
-#: ../src/libs/metadata.c:716
+#: ../src/libs/metadata.c:718
 msgid ""
 "metadata text. ctrl-wheel scroll to resize the text box\n"
 " ctrl-enter inserts a new line (caution, may not be compatible with standard "
@@ -20888,66 +20998,66 @@ msgstr ""
 "ausgewählt werden. \n"
 "Mit Escape die Auswahl abbrechen."
 
-#: ../src/libs/metadata.c:761
+#: ../src/libs/metadata.c:763
 msgid "write metadata for selected images"
 msgstr "Metadaten für ausgewählte Bilder schreiben"
 
 #. <title>\0<description>\0<rights>\0<creator>\0<publisher>
-#: ../src/libs/metadata.c:818
+#: ../src/libs/metadata.c:820
 msgid "CC BY"
 msgstr "CC BY"
 
-#: ../src/libs/metadata.c:818
+#: ../src/libs/metadata.c:820
 msgid "Creative Commons Attribution (CC BY)"
 msgstr "Creative Commons Namensnennung (CC-BY)"
 
-#: ../src/libs/metadata.c:819
+#: ../src/libs/metadata.c:821
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: ../src/libs/metadata.c:819
+#: ../src/libs/metadata.c:821
 msgid "Creative Commons Attribution-ShareAlike (CC BY-SA)"
 msgstr ""
 "Creative Commons Namensnennung, Weitergabe unter gleichen Bedingungen (CC-BY-"
 "SA)"
 
-#: ../src/libs/metadata.c:820
+#: ../src/libs/metadata.c:822
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: ../src/libs/metadata.c:820
+#: ../src/libs/metadata.c:822
 msgid "Creative Commons Attribution-NoDerivs (CC BY-ND)"
 msgstr "Creative Commons Namensnennung, keine Bearbeitung (CC-BY-ND)"
 
-#: ../src/libs/metadata.c:821
+#: ../src/libs/metadata.c:823
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: ../src/libs/metadata.c:821
+#: ../src/libs/metadata.c:823
 msgid "Creative Commons Attribution-NonCommercial (CC BY-NC)"
 msgstr "Creative Commons Namensnennung, nicht kommerziell (CC-BY-NC)"
 
-#: ../src/libs/metadata.c:822
+#: ../src/libs/metadata.c:824
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: ../src/libs/metadata.c:823
+#: ../src/libs/metadata.c:825
 msgid "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)"
 msgstr ""
 "Creative Commons Namensnennung, nicht kommerziell, Weitergabe unter gleichen "
 "Bedingungen (CC-BY-NC-SA)"
 
-#: ../src/libs/metadata.c:824
+#: ../src/libs/metadata.c:826
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: ../src/libs/metadata.c:825
+#: ../src/libs/metadata.c:827
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"
 msgstr ""
 "Creative Commons Namensnennung, nicht kommerziell, keine Bearbeitung (CC-BY-"
 "NC-ND)"
 
-#: ../src/libs/metadata.c:826
+#: ../src/libs/metadata.c:828
 msgid "all rights reserved"
 msgstr "alle Rechte vorbehalten"
 
@@ -20980,7 +21090,7 @@ msgstr "Fokus-Entfernung"
 msgid "datetime"
 msgstr "Datum/Uhrzeit"
 
-#: ../src/libs/metadata_view.c:148 ../src/libs/print_settings.c:2200
+#: ../src/libs/metadata_view.c:148 ../src/libs/print_settings.c:2389
 msgid "height"
 msgstr "Höhe"
 
@@ -21052,11 +21162,11 @@ msgstr[1] "Bild hat %d Sterne"
 msgid "loader: %s"
 msgstr "geladen mit: „%s”"
 
-#: ../src/libs/metadata_view.c:625
+#: ../src/libs/metadata_view.c:631
 msgid "<various values>"
 msgstr "<verschiedene Werte>"
 
-#: ../src/libs/metadata_view.c:638
+#: ../src/libs/metadata_view.c:644
 #, c-format
 msgid ""
 "double-click to jump to film roll\n"
@@ -21066,22 +21176,22 @@ msgstr ""
 "%s\n"
 "zu springen"
 
-#: ../src/libs/metadata_view.c:742
+#: ../src/libs/metadata_view.c:736
 #, c-format
 msgid "%+.2f EV"
 msgstr "%+.2f EV"
 
-#: ../src/libs/metadata_view.c:756
+#: ../src/libs/metadata_view.c:750
 #, c-format
 msgid "%.2f m"
 msgstr "%.2f m"
 
-#: ../src/libs/metadata_view.c:1042
+#: ../src/libs/metadata_view.c:1036
 msgctxt "accel"
 msgid "jump to film roll"
 msgstr "zu Filmrolle springen"
 
-#: ../src/libs/metadata_view.c:1243
+#: ../src/libs/metadata_view.c:1237
 msgid ""
 "drag and drop one row at a time until you get the desired order\n"
 "untick to hide metadata which are not of interest for you\n"
@@ -21111,7 +21221,7 @@ msgstr "Modulgruppen"
 #. FIXME don't check here if on/off is enabled, because it depends on image (reload_defaults)
 #. respond later to image changed signal
 #: ../src/libs/modulegroups.c:314 ../src/libs/modulegroups.c:326
-#: ../src/libs/modulegroups.c:2510 ../src/libs/modulegroups.c:2512
+#: ../src/libs/modulegroups.c:2512 ../src/libs/modulegroups.c:2514
 msgid "on-off"
 msgstr "an-aus"
 
@@ -21143,150 +21253,150 @@ msgstr "(einige Funktionen sind möglicherweise nur im Vollmodul verfügbar)"
 msgid "go to the full version of the %s module"
 msgstr "zur Vollversion des Modul %s wechseln"
 
-#: ../src/libs/modulegroups.c:1576 ../src/libs/modulegroups.c:1660
-#: ../src/libs/modulegroups.c:1696 ../src/libs/modulegroups.c:1746
-#: ../src/libs/modulegroups.c:1911
+#: ../src/libs/modulegroups.c:1578 ../src/libs/modulegroups.c:1662
+#: ../src/libs/modulegroups.c:1698 ../src/libs/modulegroups.c:1748
+#: ../src/libs/modulegroups.c:1913
 msgctxt "modulegroup"
 msgid "base"
 msgstr "Basisbearbeitung"
 
-#: ../src/libs/modulegroups.c:1595
+#: ../src/libs/modulegroups.c:1597
 msgctxt "modulegroup"
 msgid "tone"
 msgstr "Tonwerte"
 
-#: ../src/libs/modulegroups.c:1603 ../src/libs/modulegroups.c:1710
-#: ../src/libs/modulegroups.c:1756
+#: ../src/libs/modulegroups.c:1605 ../src/libs/modulegroups.c:1712
+#: ../src/libs/modulegroups.c:1758
 msgctxt "modulegroup"
 msgid "color"
 msgstr "Farbe"
 
-#: ../src/libs/modulegroups.c:1618 ../src/libs/modulegroups.c:1718
-#: ../src/libs/modulegroups.c:1761
+#: ../src/libs/modulegroups.c:1620 ../src/libs/modulegroups.c:1720
+#: ../src/libs/modulegroups.c:1763
 msgctxt "modulegroup"
 msgid "correct"
 msgstr "Korrekturen"
 
-#: ../src/libs/modulegroups.c:1636 ../src/libs/modulegroups.c:1730
-#: ../src/libs/modulegroups.c:1773 ../src/libs/modulegroups.c:2411
+#: ../src/libs/modulegroups.c:1638 ../src/libs/modulegroups.c:1732
+#: ../src/libs/modulegroups.c:1775 ../src/libs/modulegroups.c:2413
 msgctxt "modulegroup"
 msgid "effect"
 msgstr "Effekte"
 
-#: ../src/libs/modulegroups.c:1654
+#: ../src/libs/modulegroups.c:1656
 msgid "modules: all"
 msgstr "Module: alle"
 
-#: ../src/libs/modulegroups.c:1675 ../src/libs/modulegroups.c:1822
+#: ../src/libs/modulegroups.c:1677 ../src/libs/modulegroups.c:1824
 msgctxt "modulegroup"
 msgid "grading"
 msgstr "Farbkorrektur"
 
-#: ../src/libs/modulegroups.c:1683 ../src/libs/modulegroups.c:1840
-#: ../src/libs/modulegroups.c:2415
+#: ../src/libs/modulegroups.c:1685 ../src/libs/modulegroups.c:1842
+#: ../src/libs/modulegroups.c:2417
 msgctxt "modulegroup"
 msgid "effects"
 msgstr "Effekte"
 
 # rather loose translation as beginner/Anfänger may have some negative connotation
-#: ../src/libs/modulegroups.c:1691
+#: ../src/libs/modulegroups.c:1693
 msgid "workflow: beginner"
 msgstr "Workflow: vereinfacht"
 
-#: ../src/libs/modulegroups.c:1740
+#: ../src/libs/modulegroups.c:1742
 msgid "workflow: display-referred"
 msgstr "Workflow: anzeigebezogen"
 
-#: ../src/libs/modulegroups.c:1783
+#: ../src/libs/modulegroups.c:1785
 msgid "workflow: scene-referred"
 msgstr "Workflow: szenenbezogen"
 
-#: ../src/libs/modulegroups.c:1789
+#: ../src/libs/modulegroups.c:1791
 msgctxt "modulegroup"
 msgid "technical"
 msgstr "Technisch"
 
-#: ../src/libs/modulegroups.c:1865
+#: ../src/libs/modulegroups.c:1867
 msgid "search only"
 msgstr "nur Modulsuche"
 
-#: ../src/libs/modulegroups.c:1871 ../src/libs/modulegroups.c:2179
-#: ../src/libs/modulegroups.c:2663
+#: ../src/libs/modulegroups.c:1873 ../src/libs/modulegroups.c:2181
+#: ../src/libs/modulegroups.c:2665
 msgctxt "modulegroup"
 msgid "deprecated"
 msgstr "veraltet"
 
-#: ../src/libs/modulegroups.c:1886
+#: ../src/libs/modulegroups.c:1888
 msgid "previous config"
 msgstr "vorherige Einstellung"
 
-#: ../src/libs/modulegroups.c:1887
+#: ../src/libs/modulegroups.c:1889
 msgid "previous layout"
 msgstr "vorheriges Layout"
 
-#: ../src/libs/modulegroups.c:1891
+#: ../src/libs/modulegroups.c:1893
 msgid "previous config with new layout"
 msgstr "vorherige Einstellung mit neuem Layout"
 
-#: ../src/libs/modulegroups.c:2046 ../src/libs/modulegroups.c:2563
+#: ../src/libs/modulegroups.c:2048 ../src/libs/modulegroups.c:2565
 msgid "remove this widget"
 msgstr "dieses Modul entfernen"
 
-#: ../src/libs/modulegroups.c:2197 ../src/libs/modulegroups.c:2437
+#: ../src/libs/modulegroups.c:2199 ../src/libs/modulegroups.c:2439
 msgid "remove this module"
 msgstr "dieses Modul entfernen"
 
 #. does it belong to recommended modules ?
-#: ../src/libs/modulegroups.c:2406
+#: ../src/libs/modulegroups.c:2408
 msgid "base"
 msgstr "Basisbearbeitung"
 
-#: ../src/libs/modulegroups.c:2409
+#: ../src/libs/modulegroups.c:2411
 msgid "tone"
 msgstr "Tonwerte"
 
-#: ../src/libs/modulegroups.c:2412
+#: ../src/libs/modulegroups.c:2414
 msgid "technical"
 msgstr "Technisch"
 
-#: ../src/libs/modulegroups.c:2413
+#: ../src/libs/modulegroups.c:2415
 msgid "grading"
 msgstr "Farbkorrektur"
 
-#: ../src/libs/modulegroups.c:2419 ../src/libs/modulegroups.c:2427
+#: ../src/libs/modulegroups.c:2421 ../src/libs/modulegroups.c:2429
 msgid "add this module"
 msgstr "dieses Modul hinzuzufügen"
 
 #. show the submenu with all the modules
-#: ../src/libs/modulegroups.c:2449 ../src/libs/modulegroups.c:2623
+#: ../src/libs/modulegroups.c:2451 ../src/libs/modulegroups.c:2625
 msgid "all available modules"
 msgstr "alle Module"
 
-#: ../src/libs/modulegroups.c:2457
+#: ../src/libs/modulegroups.c:2459
 msgid "add module"
 msgstr "Modul hinzufügen"
 
-#: ../src/libs/modulegroups.c:2462
+#: ../src/libs/modulegroups.c:2464
 msgid "remove module"
 msgstr "Modul entfernen"
 
-#: ../src/libs/modulegroups.c:2572 ../src/libs/modulegroups.c:2579
+#: ../src/libs/modulegroups.c:2574 ../src/libs/modulegroups.c:2581
 msgid "add this widget"
 msgstr "dieses Widget entfernen"
 
-#: ../src/libs/modulegroups.c:2607
+#: ../src/libs/modulegroups.c:2609
 msgid "add widget"
 msgstr "Widget hinzufügen"
 
-#: ../src/libs/modulegroups.c:2612
+#: ../src/libs/modulegroups.c:2614
 msgid "remove widget"
 msgstr "Widget entfernen"
 
-#: ../src/libs/modulegroups.c:2698
+#: ../src/libs/modulegroups.c:2700
 msgid "show all history modules"
 msgstr "alle im Verlauf enthaltene Module anzeigen"
 
-#: ../src/libs/modulegroups.c:2701 ../src/libs/modulegroups.c:3886
+#: ../src/libs/modulegroups.c:2703 ../src/libs/modulegroups.c:3902
 msgid ""
 "show modules that are present in the history stack, regardless of whether or "
 "not they are currently enabled"
@@ -21294,7 +21404,7 @@ msgstr ""
 "Module anzeigen, die im Verlaufsstapel vorhanden sind, \n"
 "unabhängig davon, ob sie derzeit aktiviert sind oder nicht"
 
-#: ../src/libs/modulegroups.c:2790
+#: ../src/libs/modulegroups.c:2794
 msgid ""
 "the following modules are deprecated because they have internal design "
 "mistakes which can't be solved and alternative modules which solve them.\n"
@@ -21304,15 +21414,15 @@ msgstr ""
 "die nicht behoben werden können und die durch Alternativen abgelöst werden.\n"
 "Sie werden für neue Bearbeitungen in der nächsten Version entfernt."
 
-#: ../src/libs/modulegroups.c:2820
+#: ../src/libs/modulegroups.c:2824
 msgid "quick access panel"
 msgstr "Schnellzugriffsgruppe"
 
-#: ../src/libs/modulegroups.c:2830
+#: ../src/libs/modulegroups.c:2834
 msgid "show only active modules"
 msgstr "eingeschaltete Module"
 
-#: ../src/libs/modulegroups.c:2835
+#: ../src/libs/modulegroups.c:2839
 msgid ""
 "presets\n"
 "ctrl+click to manage"
@@ -21320,15 +21430,15 @@ msgstr ""
 "Modulgruppen\n"
 "Strg+Klick zum Anpassen"
 
-#: ../src/libs/modulegroups.c:2842
+#: ../src/libs/modulegroups.c:2846
 msgid "search modules by name or tag"
 msgstr "Modul nach Namen oder Stichwort suchen"
 
-#: ../src/libs/modulegroups.c:2847
+#: ../src/libs/modulegroups.c:2851
 msgid "clear text"
 msgstr "Text löschen"
 
-#: ../src/libs/modulegroups.c:2855
+#: ../src/libs/modulegroups.c:2859
 msgid ""
 "the following modules are deprecated because they have internal design "
 "mistakes which can't be solved and alternative modules which solve them.\n"
@@ -21338,131 +21448,131 @@ msgstr ""
 "die nicht behoben werden können und die durch Alternativen abgelöst werden.\n"
 "Sie werden für neue Bearbeitungen in der nächsten Version entfernt."
 
-#: ../src/libs/modulegroups.c:3094
+#: ../src/libs/modulegroups.c:3098
 msgid "basic icon"
 msgstr "Symbol „Basisbearbeitung”"
 
-#: ../src/libs/modulegroups.c:3104
+#: ../src/libs/modulegroups.c:3108
 msgid "active icon"
 msgstr "Symbol „aktiv”"
 
-#: ../src/libs/modulegroups.c:3114
+#: ../src/libs/modulegroups.c:3118
 msgid "color icon"
 msgstr "Symbol „Farbe”"
 
-#: ../src/libs/modulegroups.c:3124
+#: ../src/libs/modulegroups.c:3128
 msgid "correct icon"
 msgstr "Symbol „Korrekturen”"
 
-#: ../src/libs/modulegroups.c:3134
+#: ../src/libs/modulegroups.c:3138
 msgid "effect icon"
 msgstr "Symbol „Effekte”"
 
-#: ../src/libs/modulegroups.c:3144
+#: ../src/libs/modulegroups.c:3148
 msgid "favorites icon"
 msgstr "Symbol „Favoriten”"
 
-#: ../src/libs/modulegroups.c:3154
+#: ../src/libs/modulegroups.c:3158
 msgid "tone icon"
 msgstr "Symbol „Tonwerte”"
 
-#: ../src/libs/modulegroups.c:3164
+#: ../src/libs/modulegroups.c:3168
 msgid "grading icon"
 msgstr "Symbol „Farbkorrektur”"
 
-#: ../src/libs/modulegroups.c:3174
+#: ../src/libs/modulegroups.c:3178
 msgid "technical icon"
 msgstr "Symbol „Technisch”"
 
-#: ../src/libs/modulegroups.c:3207
+#: ../src/libs/modulegroups.c:3211
 msgid "quick access panel widgets"
 msgstr "Schnellzugriff Widgets"
 
-#: ../src/libs/modulegroups.c:3209
+#: ../src/libs/modulegroups.c:3213
 msgid "quick access"
 msgstr "Schnellzugriff"
 
-#: ../src/libs/modulegroups.c:3230
+#: ../src/libs/modulegroups.c:3234
 msgid "add widget to the quick access panel"
 msgstr "Widget zur Schnellzugriffsgruppe hinzufügen"
 
-#: ../src/libs/modulegroups.c:3262
+#: ../src/libs/modulegroups.c:3266
 msgid "group icon"
 msgstr "Gruppensymbol"
 
-#: ../src/libs/modulegroups.c:3271
+#: ../src/libs/modulegroups.c:3275
 msgid "group name"
 msgstr "Gruppenname"
 
-#: ../src/libs/modulegroups.c:3282
+#: ../src/libs/modulegroups.c:3286
 msgid "remove group"
 msgstr "Gruppe entfernen"
 
-#: ../src/libs/modulegroups.c:3309
+#: ../src/libs/modulegroups.c:3313
 msgid "move group to the left"
 msgstr "Gruppe nach links verschieben"
 
-#: ../src/libs/modulegroups.c:3318
+#: ../src/libs/modulegroups.c:3322
 msgid "add module to the group"
 msgstr "Modul zur Gruppe hinzufügen"
 
-#: ../src/libs/modulegroups.c:3330
+#: ../src/libs/modulegroups.c:3334
 msgid "move group to the right"
 msgstr "Gruppe nach rechts verschieben"
 
-#: ../src/libs/modulegroups.c:3506
+#: ../src/libs/modulegroups.c:3514
 msgid "rename preset"
 msgstr "Voreinstellung umbenennen"
 
-#: ../src/libs/modulegroups.c:3513
+#: ../src/libs/modulegroups.c:3521
 msgid "new preset name :"
 msgstr "neuer Name der Voreinstellung:"
 
-#: ../src/libs/modulegroups.c:3514
+#: ../src/libs/modulegroups.c:3522
 msgid "a preset with this name already exists !"
 msgstr "Voreinstellung mit dem Namen „%s” existiert bereits!"
 
-#: ../src/libs/modulegroups.c:3850
+#: ../src/libs/modulegroups.c:3866
 msgid "preset : "
 msgstr "Voreinstellung:"
 
-#: ../src/libs/modulegroups.c:3857
+#: ../src/libs/modulegroups.c:3873
 msgid "remove the preset"
 msgstr "Voreinstellung entfernen"
 
-#: ../src/libs/modulegroups.c:3860
+#: ../src/libs/modulegroups.c:3876
 msgid "duplicate the preset"
 msgstr "Voreinstellung duplizieren"
 
-#: ../src/libs/modulegroups.c:3863
+#: ../src/libs/modulegroups.c:3879
 msgid "rename the preset"
 msgstr "Voreinstellung umbenennen"
 
-#: ../src/libs/modulegroups.c:3866
+#: ../src/libs/modulegroups.c:3882
 msgid "create a new empty preset"
 msgstr "neue leere Voreinstellung"
 
-#: ../src/libs/modulegroups.c:3874
+#: ../src/libs/modulegroups.c:3890
 msgid "show search line"
 msgstr "zeige Suchfeld"
 
-#: ../src/libs/modulegroups.c:3878
+#: ../src/libs/modulegroups.c:3894
 msgid "show quick access panel"
 msgstr "Schnellzugriffsgruppe anzeigen"
 
-#: ../src/libs/modulegroups.c:3882
+#: ../src/libs/modulegroups.c:3898
 msgid "show all history modules in active group"
 msgstr "alle Verlaufsmodule in Gruppe der aktiven Module anzeigen"
 
-#: ../src/libs/modulegroups.c:3895
+#: ../src/libs/modulegroups.c:3911
 msgid "auto-apply this preset"
 msgstr "Voreinstellung automatisch anwenden"
 
-#: ../src/libs/modulegroups.c:3911
+#: ../src/libs/modulegroups.c:3927
 msgid "module groups"
 msgstr "Modulgruppen"
 
-#: ../src/libs/modulegroups.c:3929
+#: ../src/libs/modulegroups.c:3945
 msgid ""
 "this is a built-in read-only preset. duplicate it if you want to make changes"
 msgstr ""
@@ -21511,101 +21621,105 @@ msgid "hide navigation thumbnail"
 msgstr "Navigationsvorschaubild ausblenden"
 
 #. //////////////////////// PRINT SETTINGS
-#: ../src/libs/print_settings.c:46 ../src/libs/print_settings.c:2410
+#: ../src/libs/print_settings.c:46 ../src/libs/print_settings.c:2600
 msgid "print settings"
 msgstr "Druckeinstellungen"
 
 #. FIXME: ellipsize title/printer as the export completed message is ellipsized
-#: ../src/libs/print_settings.c:302 ../src/libs/print_settings.c:679
+#: ../src/libs/print_settings.c:336 ../src/libs/print_settings.c:713
 #, c-format
 msgid "processing `%s' for `%s'"
 msgstr "Verarbeiten von „%s” für „%s”"
 
-#: ../src/libs/print_settings.c:330
+#: ../src/libs/print_settings.c:364
 #, c-format
 msgid "cannot open printer profile `%s'"
 msgstr "Konnte Druckerprofile „%s” nicht öffnen"
 
-#: ../src/libs/print_settings.c:339
+#: ../src/libs/print_settings.c:373
 #, c-format
 msgid "error getting output profile for image %d"
 msgstr "Fehler für das Ausgabeprofils des Bildes %d"
 
-#: ../src/libs/print_settings.c:348
+#: ../src/libs/print_settings.c:382
 #, c-format
 msgid "cannot apply printer profile `%s'"
 msgstr "Konnte Druckerprofile „%s” nicht anwenden"
 
-#: ../src/libs/print_settings.c:501
+#: ../src/libs/print_settings.c:535
 msgid "failed to create temporary pdf for printing"
 msgstr "Fehler beim Erstellen der temporären PDF-Datei für den Druck"
 
-#: ../src/libs/print_settings.c:547
+#: ../src/libs/print_settings.c:581
 msgid "maximum image per page reached"
 msgstr "Maximale Bilder je Seite erreicht"
 
-#: ../src/libs/print_settings.c:634
+#: ../src/libs/print_settings.c:668
 msgid "cannot print until a picture is selected"
 msgstr "vor dem Drucken ein Bild auswählen"
 
-#: ../src/libs/print_settings.c:639
+#: ../src/libs/print_settings.c:673
 msgid "cannot print until a printer is selected"
 msgstr "vor dem Drucken einen Drucker auswählen"
 
-#: ../src/libs/print_settings.c:644
+#: ../src/libs/print_settings.c:678
 msgid "cannot print until a paper is selected"
 msgstr "vor dem Drucken ein Papierformat auswählen"
 
 #. in this case no need to release from cache what we couldn't get
-#: ../src/libs/print_settings.c:671
+#: ../src/libs/print_settings.c:705
 #, c-format
 msgid "cannot get image %d for printing"
 msgstr "erhalte Bild %d nicht zum Drucken"
 
-#: ../src/libs/print_settings.c:837
+#: ../src/libs/print_settings.c:875
 #, c-format
 msgid "%3.2f (dpi:%d)"
 msgstr "%3.2f (DPI:%d)"
 
-#: ../src/libs/print_settings.c:2060 ../src/libs/print_settings.c:2072
-#: ../src/libs/print_settings.c:2080 ../src/libs/print_settings.c:2131
+#: ../src/libs/print_settings.c:2253 ../src/libs/print_settings.c:2265
+#: ../src/libs/print_settings.c:2273 ../src/libs/print_settings.c:2324
 msgid "printer"
 msgstr "Drucker"
 
-#: ../src/libs/print_settings.c:2072
+#: ../src/libs/print_settings.c:2265
 msgid "media"
 msgstr "Medium"
 
-#: ../src/libs/print_settings.c:2090
+#: ../src/libs/print_settings.c:2283
 msgid "color management in printer driver"
 msgstr "Farbverwaltung im Druckertreiber"
 
-#: ../src/libs/print_settings.c:2122
+#: ../src/libs/print_settings.c:2315
 #, c-format
 msgid "printer ICC profiles in %s or %s"
 msgstr "Drucker-ICC-Profile in %s oder %s"
 
-#: ../src/libs/print_settings.c:2144
+#: ../src/libs/print_settings.c:2337
 msgid "black point compensation"
 msgstr "Tiefenkompensation"
 
-#: ../src/libs/print_settings.c:2152
+#: ../src/libs/print_settings.c:2345
 msgid "activate black point compensation when applying the printer profile"
 msgstr "aktiviere Tiefenkompensation wenn das Druckerprofile angewandt wird"
 
-#: ../src/libs/print_settings.c:2194
+#: ../src/libs/print_settings.c:2375
+msgid "measurement units"
+msgstr "Maßeinheiten"
+
+#: ../src/libs/print_settings.c:2383
 msgid "image width/height"
 msgstr "Bildbreite/-höhe"
 
-#: ../src/libs/print_settings.c:2198
+#: ../src/libs/print_settings.c:2387
 msgid " x "
 msgstr " x "
 
-#: ../src/libs/print_settings.c:2206
+#: ../src/libs/print_settings.c:2395
 msgid "scale factor"
 msgstr "Skalierungsfaktor"
 
-#: ../src/libs/print_settings.c:2211
+#: ../src/libs/print_settings.c:2400
 msgid ""
 "image scale factor from native printer DPI:\n"
 " < 1 means that it is downscaled (best quality)\n"
@@ -21618,46 +21732,46 @@ msgstr ""
 "ein zu großer Wert kann zu schlechter Druckqualität führen"
 
 #. d->b_top  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2225
+#: ../src/libs/print_settings.c:2414
 msgid "top margin"
 msgstr "oberer Rand"
 
 #. d->b_left  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2229
+#: ../src/libs/print_settings.c:2418
 msgid "left margin"
 msgstr "linker Rand"
 
-#: ../src/libs/print_settings.c:2232
+#: ../src/libs/print_settings.c:2421
 msgid "lock"
 msgstr "sperren"
 
-#: ../src/libs/print_settings.c:2233
+#: ../src/libs/print_settings.c:2422
 msgid "change all margins uniformly"
 msgstr "alle Ränder einheitlich ändern"
 
 #. d->b_right  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2237
+#: ../src/libs/print_settings.c:2426
 msgid "right margin"
 msgstr "rechter Rand"
 
 #. d->b_bottom  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:2241
+#: ../src/libs/print_settings.c:2430
 msgid "bottom margin"
 msgstr "unterer Rand"
 
-#: ../src/libs/print_settings.c:2274
+#: ../src/libs/print_settings.c:2463
 msgid "display grid"
 msgstr "Zeige Raster"
 
-#: ../src/libs/print_settings.c:2284
+#: ../src/libs/print_settings.c:2473
 msgid "snap to grid"
 msgstr "am Raster ausrichten"
 
-#: ../src/libs/print_settings.c:2294
+#: ../src/libs/print_settings.c:2483
 msgid "borderless mode required"
 msgstr "Randlosmodus erforderlich"
 
-#: ../src/libs/print_settings.c:2297
+#: ../src/libs/print_settings.c:2486
 msgid ""
 "indicates that the borderless mode should be activated\n"
 "in the printer driver because the selected margins are\n"
@@ -21668,15 +21782,15 @@ msgstr ""
 "geringer sind als die Hardware-Ränder des Druckers"
 
 #. pack image dimension hbox here
-#: ../src/libs/print_settings.c:2304
+#: ../src/libs/print_settings.c:2493
 msgid "image layout"
 msgstr "Bild Layout"
 
-#: ../src/libs/print_settings.c:2341
+#: ../src/libs/print_settings.c:2530
 msgid "new image area"
 msgstr "neuer Bildbereich"
 
-#: ../src/libs/print_settings.c:2342
+#: ../src/libs/print_settings.c:2531
 msgid ""
 "add a new image area on the page\n"
 "click and drag on the page to place the area\n"
@@ -21687,56 +21801,56 @@ msgstr ""
 "per drag&drop können Bilder aus dem Filmstreifen in den Bildbereich "
 "übernommen werden"
 
-#: ../src/libs/print_settings.c:2348
+#: ../src/libs/print_settings.c:2537
 msgid "delete image area"
 msgstr "Bildbereich löschen"
 
-#: ../src/libs/print_settings.c:2349
+#: ../src/libs/print_settings.c:2538
 msgid "delete the currently selected image area"
 msgstr "den aktuell ausgewählten Bildbereich löschen"
 
-#: ../src/libs/print_settings.c:2353
+#: ../src/libs/print_settings.c:2542
 msgid "clear layout"
 msgstr "Layout löschen"
 
-#: ../src/libs/print_settings.c:2354
+#: ../src/libs/print_settings.c:2543
 msgid "remove all image area from the page"
 msgstr "alle Bildbereiche auf der Seite entfernen"
 
 #. d->b_x = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2369
+#: ../src/libs/print_settings.c:2559
 msgid "image area x origin (in current unit)"
 msgstr "Bildbereich x Ursprung (in aktueller Einheit)"
 
 #. d->b_y = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2373
+#: ../src/libs/print_settings.c:2563
 msgid "image area y origin (in current unit)"
 msgstr "Bildbereich y Ursprung (in aktueller Einheit)"
 
 #. d->b_width = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2384
+#: ../src/libs/print_settings.c:2574
 msgid "image area width (in current unit)"
 msgstr "Bildbereich Breite (in aktueller Einheit)"
 
 #. d->b_height = gtk_spin_button_new_with_range(0, 1000, 1);
-#: ../src/libs/print_settings.c:2388
+#: ../src/libs/print_settings.c:2578
 msgid "image area height (in current unit)"
 msgstr "Bildbereich Höhe (in aktueller Einheit)"
 
-#: ../src/libs/print_settings.c:2501
+#: ../src/libs/print_settings.c:2691
 msgid "temporary style to use while printing"
 msgstr "Stil, der beim Drucken vorübergehend angewandt werden soll"
 
 #. Print button
-#: ../src/libs/print_settings.c:2538
+#: ../src/libs/print_settings.c:2728
 msgid "print"
 msgstr "drucken"
 
-#: ../src/libs/print_settings.c:2540
+#: ../src/libs/print_settings.c:2730
 msgid "print with current settings"
 msgstr "mit aktuellen Einstellungen drucken"
 
-#: ../src/libs/print_settings.c:3065
+#: ../src/libs/print_settings.c:3263
 msgctxt "accel"
 msgid "print"
 msgstr "Drucken"
@@ -22362,7 +22476,7 @@ msgstr "Wechseln zwischen Liste mit / ohne Vorschlag"
 msgid ""
 "tag shortcut is not active with tag tree view. please switch to list view"
 msgstr ""
-"Tag Kurzbefehl in der Baumansicht nicht aktiv. Bitte zur Listenansicht "
+"Tag Shortcut in der Baumansicht nicht aktiv. Bitte zur Listenansicht "
 "wechseln."
 
 #: ../src/libs/tagging.c:3543
@@ -22465,7 +22579,7 @@ msgid ""
 "filter by images color label\n"
 "click to toggle the color label selection\n"
 "ctrl+click to exclude the color label\n"
-"the grey button affects all color labels"
+"the gray button affects all color labels"
 msgstr ""
 "Bilder nach Farbmarkierung filtern\n"
 "Klicken, um die Auswahl der Farbmarkierung umzuschalten\n"
@@ -22547,12 +22661,12 @@ msgid "overlays not available here..."
 msgstr "Bildinfos nicht verfügbar"
 
 #: ../src/libs/tools/global_toolbox.c:406
-#: ../src/libs/tools/global_toolbox.c:555
+#: ../src/libs/tools/global_toolbox.c:556
 msgid "expand grouped images"
 msgstr "gruppierte Bilder anzeigen"
 
 #: ../src/libs/tools/global_toolbox.c:408
-#: ../src/libs/tools/global_toolbox.c:557
+#: ../src/libs/tools/global_toolbox.c:558
 msgid "collapse grouped images"
 msgstr "gruppierte Bilder zusammenfassen"
 
@@ -22611,95 +22725,99 @@ msgstr ""
 #: ../src/libs/tools/global_toolbox.c:517
 msgid ""
 "define shortcuts\n"
+"ctrl+click to switch off overwrite confirmations\n"
+"\n"
 "hover over a widget and press keys with mouse click and scroll or move "
 "combinations\n"
 "repeat same combination again to delete mapping\n"
 "click on a widget, module or screen area to open the dialog for further "
 "configuration"
 msgstr ""
-"Kurzbefehle definieren\n"
-"Den Mauszeiger über ein Widget bewegen und die Taste drücken in "
-"Kombinationen mit Mausklick und Scrollen oder Verschieben\n"
+"Shortcuts definieren\n"
+"Strg+Klick zum Abschalten von Überschreibungsbestätigungen\n"
+"\n"
+"Mauszeiger über ein Widget bewegen und Tasten drücken in Kombinationen mit "
+"Mausklick und Scrollen oder Verschieben\n"
 "Gleiche Kombination wiederholen, um Zuordnung zu löschen\n"
 "Auf ein Widget, ein Modul oder einen Bildschirmbereich klicken, um den "
 "Dialog zur weiteren Konfiguration zu öffnen"
 
-#: ../src/libs/tools/global_toolbox.c:532
+#: ../src/libs/tools/global_toolbox.c:533
 msgid "show global preferences"
 msgstr "zeige globale Voreinstellungen"
 
-#: ../src/libs/tools/global_toolbox.c:662
+#: ../src/libs/tools/global_toolbox.c:663
 #, c-format
 msgid "do you want to access `%s'?"
 msgstr "Soll auf „%s” zugegriffen werden?"
 
-#: ../src/libs/tools/global_toolbox.c:667
+#: ../src/libs/tools/global_toolbox.c:668
 msgid "access the online usermanual?"
 msgstr "Auf das Online-Benutzerhandbuch zugreifen?"
 
-#: ../src/libs/tools/global_toolbox.c:739
+#: ../src/libs/tools/global_toolbox.c:740
 msgid "help url opened in web browser"
 msgstr "Hilfe-URL wird in Webbrowser geöffnet."
 
-#: ../src/libs/tools/global_toolbox.c:743
+#: ../src/libs/tools/global_toolbox.c:744
 msgid "error while opening help url in web browser"
 msgstr "Fehler beim Laden der Hilfe-URL in Webbrowser."
 
-#: ../src/libs/tools/global_toolbox.c:754
+#: ../src/libs/tools/global_toolbox.c:755
 msgid "there is no help available for this element"
 msgstr "Für dieses Element ist keine Hilfe verfügbar"
 
-#: ../src/libs/tools/global_toolbox.c:973
+#: ../src/libs/tools/global_toolbox.c:978
 msgctxt "accel"
 msgid "grouping"
 msgstr "Gruppieren"
 
-#: ../src/libs/tools/global_toolbox.c:974
+#: ../src/libs/tools/global_toolbox.c:979
 msgctxt "accel"
 msgid "thumbnail overlays options"
 msgstr "Einstellung für Bildinfo-EInblendung"
 
-#: ../src/libs/tools/global_toolbox.c:975
+#: ../src/libs/tools/global_toolbox.c:980
 msgctxt "accel"
 msgid "preferences"
 msgstr "Voreinstellungen"
 
-#: ../src/libs/tools/global_toolbox.c:976
+#: ../src/libs/tools/global_toolbox.c:981
 msgctxt "accel"
 msgid "shortcuts"
-msgstr "Kurzbefehle"
+msgstr "Shortcuts"
 
-#: ../src/libs/tools/global_toolbox.c:978
+#: ../src/libs/tools/global_toolbox.c:983
 msgctxt "accel"
 msgid "thumbnail overlays/no overlays"
 msgstr "Bildinfos/keine Bildinfos"
 
-#: ../src/libs/tools/global_toolbox.c:979
+#: ../src/libs/tools/global_toolbox.c:984
 msgctxt "accel"
 msgid "thumbnail overlays/overlays on mouse hover"
 msgstr "Bildinfos/Bildinfos bei Überfahren mit Maus"
 
-#: ../src/libs/tools/global_toolbox.c:980
+#: ../src/libs/tools/global_toolbox.c:985
 msgctxt "accel"
 msgid "thumbnail overlays/extended overlays on mouse hover"
 msgstr "Bildinfos/erweiterte Bildinfos bei Überfahren mit Maus"
 
-#: ../src/libs/tools/global_toolbox.c:981
+#: ../src/libs/tools/global_toolbox.c:986
 msgctxt "accel"
 msgid "thumbnail overlays/permanent overlays"
 msgstr "Bildinfos/permanente Bildinfos"
 
-#: ../src/libs/tools/global_toolbox.c:982
+#: ../src/libs/tools/global_toolbox.c:987
 msgctxt "accel"
 msgid "thumbnail overlays/permanent extended overlays"
 msgstr "Bildinfos/permanente erweiterte Bildinfos"
 
-#: ../src/libs/tools/global_toolbox.c:983
+#: ../src/libs/tools/global_toolbox.c:988
 msgctxt "accel"
 msgid "thumbnail overlays/permanent overlays extended on mouse hover"
 msgstr "Bildinfos/permanente Bildinfos erweitert bei Überfahren mit Maus"
 
-#: ../src/libs/tools/global_toolbox.c:984
+#: ../src/libs/tools/global_toolbox.c:989
 msgctxt "accel"
 msgid "thumbnail overlays/overlays block on mouse hover"
 msgstr "Bildinfos/überlagerte Box mit Bildinfos bei Überfahren mit Maus"
@@ -22787,16 +22905,16 @@ msgstr "aktuelle Sicht verlassen"
 msgid "module toolbox"
 msgstr "Modul-Toolbox"
 
-#: ../src/libs/tools/timeline.c:111
+#: ../src/libs/tools/timeline.c:102
 msgid "timeline"
 msgstr "Zeitleiste"
 
-#: ../src/libs/tools/timeline.c:1458
+#: ../src/libs/tools/timeline.c:1388
 msgctxt "accel"
 msgid "start selection"
 msgstr "Auswahl starten"
 
-#: ../src/libs/tools/timeline.c:1459
+#: ../src/libs/tools/timeline.c:1389
 msgctxt "accel"
 msgid "stop selection"
 msgstr "Auswahl beenden"
@@ -22881,37 +22999,37 @@ msgstr "Softproof"
 msgid "no image to open !"
 msgstr "Kein Bild zum Öffnen ausgewählt!"
 
-#: ../src/views/darkroom.c:1312
+#: ../src/views/darkroom.c:1316
 msgid "no userdefined presets for favorite modules were found"
 msgstr ""
 "keine benutzerdefinierten Voreinstellungen für Favoriten-Module gefunden"
 
-#: ../src/views/darkroom.c:1317
+#: ../src/views/darkroom.c:1321
 #, c-format
 msgid "applied style `%s' on current image"
 msgstr "Stil „%s” auf aktuelles Bild angewandt"
 
-#: ../src/views/darkroom.c:1442
+#: ../src/views/darkroom.c:1446
 msgid "no styles have been created yet"
 msgstr "es wurde noch kein Stil angelegt"
 
-#: ../src/views/darkroom.c:2258
+#: ../src/views/darkroom.c:2262
 msgid "quick access to presets"
 msgstr "Schnellzugriff auf Voreinstellungen"
 
-#: ../src/views/darkroom.c:2267
+#: ../src/views/darkroom.c:2271
 msgid "quick access for applying any of your styles"
 msgstr "Schnellzugriff, um einen Stil anzuwenden"
 
-#: ../src/views/darkroom.c:2277
+#: ../src/views/darkroom.c:2281
 msgid "display a second darkroom image window"
 msgstr "ein zweites Dunkelkammer-Vorschaufenster anzeigen"
 
-#: ../src/views/darkroom.c:2285
+#: ../src/views/darkroom.c:2289
 msgid "toggle ISO 12646 color assessment conditions"
 msgstr "Bedingungen zur Farbbeurteilung nach ISO 12646 herstellen"
 
-#: ../src/views/darkroom.c:2298
+#: ../src/views/darkroom.c:2302
 msgid ""
 "toggle raw over exposed indication\n"
 "right click for options"
@@ -22919,47 +23037,47 @@ msgstr ""
 "Anzeige von Über-/Unterbelichtung der Raw-Werte,\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2314
+#: ../src/views/darkroom.c:2318
 msgid "select how to mark the clipped pixels"
 msgstr "auswählen, wie überbelichtete Pixel markiert werden sollen"
 
-#: ../src/views/darkroom.c:2316
+#: ../src/views/darkroom.c:2320
 msgid "mark with CFA color"
 msgstr "mit CFA-Farben markieren"
 
-#: ../src/views/darkroom.c:2316
+#: ../src/views/darkroom.c:2320
 msgid "mark with solid color"
 msgstr "mit fester Farbe markieren"
 
-#: ../src/views/darkroom.c:2316
+#: ../src/views/darkroom.c:2320
 msgid "false color"
 msgstr "Falschfarben"
 
-#: ../src/views/darkroom.c:2322 ../src/views/darkroom.c:2375
+#: ../src/views/darkroom.c:2326 ../src/views/darkroom.c:2379
 msgid "color scheme"
 msgstr "Farbzusammenstellung"
 
-#: ../src/views/darkroom.c:2323
+#: ../src/views/darkroom.c:2327
 msgctxt "solidcolor"
 msgid "red"
 msgstr "Rot"
 
-#: ../src/views/darkroom.c:2324
+#: ../src/views/darkroom.c:2328
 msgctxt "solidcolor"
 msgid "green"
 msgstr "Grün"
 
-#: ../src/views/darkroom.c:2325
+#: ../src/views/darkroom.c:2329
 msgctxt "solidcolor"
 msgid "blue"
 msgstr "Blau"
 
-#: ../src/views/darkroom.c:2326
+#: ../src/views/darkroom.c:2330
 msgctxt "solidcolor"
 msgid "black"
 msgstr "Schwarz"
 
-#: ../src/views/darkroom.c:2330
+#: ../src/views/darkroom.c:2334
 msgid ""
 "select the solid color to indicate over exposure.\n"
 "will only be used if mode = mark with solid color"
@@ -22967,7 +23085,7 @@ msgstr ""
 "feste Farbe zum Markieren der Überbelichtung auswählen.\n"
 "wird nur im entsprechenden Modus benutzt"
 
-#: ../src/views/darkroom.c:2339
+#: ../src/views/darkroom.c:2343
 msgid ""
 "threshold of what shall be considered overexposed\n"
 "1.0 - white level\n"
@@ -22977,7 +23095,7 @@ msgstr ""
 "1,0 – Weißwert\n"
 "0,0 – Schwarzwert"
 
-#: ../src/views/darkroom.c:2353
+#: ../src/views/darkroom.c:2357
 msgid ""
 "toggle clipping indication\n"
 "right click for options"
@@ -22985,11 +23103,11 @@ msgstr ""
 "Anzeige von Über-/Unterschreitung der Farbwerte,\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2368
+#: ../src/views/darkroom.c:2372
 msgid "clipping preview mode"
 msgstr "Abschneidevoransicht"
 
-#: ../src/views/darkroom.c:2369
+#: ../src/views/darkroom.c:2373
 msgid ""
 "select the metric you want to preview\n"
 "full gamut is the combination of all other modes"
@@ -22997,41 +23115,41 @@ msgstr ""
 "Legt die angezeigte Metrik fest. \n"
 "„voller Gamut” ist eine Kombination aller anderen Metriken"
 
-#: ../src/views/darkroom.c:2371
+#: ../src/views/darkroom.c:2375
 msgid "full gamut"
 msgstr "voller Gamut"
 
-#: ../src/views/darkroom.c:2371
+#: ../src/views/darkroom.c:2375
 msgid "any RGB channel"
 msgstr "beliebiger RGB-Kanal"
 
 # wtf?
-#: ../src/views/darkroom.c:2371
+#: ../src/views/darkroom.c:2375
 msgid "luminance only"
 msgstr "nur Luminanz"
 
-#: ../src/views/darkroom.c:2371
+#: ../src/views/darkroom.c:2375
 msgid "saturation only"
 msgstr "nur Sättigung"
 
-#: ../src/views/darkroom.c:2376
+#: ../src/views/darkroom.c:2380
 msgid "select colors to indicate clipping"
 msgstr ""
 "Farben wählen, mit denen über-/unterbelichtete Bereiche gekennzeichnet werden"
 
-#: ../src/views/darkroom.c:2378
+#: ../src/views/darkroom.c:2382
 msgid "red & blue"
 msgstr "Rot & Blau"
 
-#: ../src/views/darkroom.c:2378
+#: ../src/views/darkroom.c:2382
 msgid "purple & green"
 msgstr "Violett & Grün"
 
-#: ../src/views/darkroom.c:2385
+#: ../src/views/darkroom.c:2389
 msgid "lower threshold"
 msgstr "unterer Schwellwert"
 
-#: ../src/views/darkroom.c:2386
+#: ../src/views/darkroom.c:2390
 msgid ""
 "clipping threshold for the black point,\n"
 "in EV, relatively to white (0 EV).\n"
@@ -23051,12 +23169,12 @@ msgstr ""
 "Typische Farbglanzdrucke erzeugen Schwarz bei -8,00 EV.\n"
 "Typische Hochglanz-Schwarz-Weiß- Drucke erzeugen Schwarz bei -9,00 EV."
 
-#: ../src/views/darkroom.c:2402
+#: ../src/views/darkroom.c:2406
 msgid "upper threshold"
 msgstr "oberer Schwellwert"
 
 # wft: peak medium luminance
-#: ../src/views/darkroom.c:2404
+#: ../src/views/darkroom.c:2408
 #, no-c-format
 msgid ""
 "clipping threshold for the white point.\n"
@@ -23065,7 +23183,7 @@ msgstr ""
 "Abschneidewert für den Weißpunkt.\n"
 "100% ist die mittlere Spitzenluminanz."
 
-#: ../src/views/darkroom.c:2419
+#: ../src/views/darkroom.c:2423
 msgid ""
 "toggle softproofing\n"
 "right click for profile options"
@@ -23073,7 +23191,7 @@ msgstr ""
 "Softproof,\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2430
+#: ../src/views/darkroom.c:2434
 msgid ""
 "toggle gamut checking\n"
 "right click for profile options"
@@ -23081,49 +23199,49 @@ msgstr ""
 "Gamutüberprüfung,\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2453 ../src/views/darkroom.c:2460
-#: ../src/views/darkroom.c:2479 ../src/views/darkroom.c:2480
-#: ../src/views/darkroom.c:2481 ../src/views/darkroom.c:2482
+#: ../src/views/darkroom.c:2457 ../src/views/darkroom.c:2464
+#: ../src/views/darkroom.c:2483 ../src/views/darkroom.c:2484
+#: ../src/views/darkroom.c:2485 ../src/views/darkroom.c:2486
 msgid "profiles"
 msgstr "Profile"
 
-#: ../src/views/darkroom.c:2460
+#: ../src/views/darkroom.c:2464
 msgid "preview intent"
 msgstr "Vorschau Intent"
 
-#: ../src/views/darkroom.c:2479 ../src/views/lighttable.c:1266
+#: ../src/views/darkroom.c:2483 ../src/views/lighttable.c:1266
 msgid "display profile"
 msgstr "Anzeigeprofil"
 
-#: ../src/views/darkroom.c:2480 ../src/views/lighttable.c:1269
+#: ../src/views/darkroom.c:2484 ../src/views/lighttable.c:1269
 msgid "preview display profile"
 msgstr "Vorschau Anzeigeprofil"
 
-#: ../src/views/darkroom.c:2482
+#: ../src/views/darkroom.c:2486
 msgid "histogram profile"
 msgstr "Histogrammprofil"
 
-#: ../src/views/darkroom.c:2546 ../src/views/lighttable.c:1305
+#: ../src/views/darkroom.c:2550 ../src/views/lighttable.c:1305
 #, c-format
 msgid "display ICC profiles in %s or %s"
 msgstr "Anzeige-ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2549 ../src/views/lighttable.c:1308
+#: ../src/views/darkroom.c:2553 ../src/views/lighttable.c:1308
 #, c-format
 msgid "preview display ICC profiles in %s or %s"
 msgstr "Vorschau Anzeige-ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2552
+#: ../src/views/darkroom.c:2556
 #, c-format
 msgid "softproof ICC profiles in %s or %s"
 msgstr "Softproof-ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2555
+#: ../src/views/darkroom.c:2559
 #, c-format
 msgid "histogram and color picker ICC profiles in %s or %s"
 msgstr "Histogramm und Farbwähler ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2592
+#: ../src/views/darkroom.c:2596
 msgid ""
 "toggle guide lines\n"
 "right click for guides options"
@@ -23132,201 +23250,201 @@ msgstr ""
 "Rechtsklick für Hilfslinienoptionen"
 
 #. Fullscreen preview key
-#: ../src/views/darkroom.c:2611
+#: ../src/views/darkroom.c:2615
 msgctxt "accel"
 msgid "full preview"
 msgstr "Vollbildvorschau"
 
 #. add an option to allow skip mouse events while editing masks
-#: ../src/views/darkroom.c:2615
+#: ../src/views/darkroom.c:2619
 msgctxt "accel"
 msgid "allow to pan & zoom while editing masks"
 msgstr "erlaube Verschieben und Zoomen während Maskenbearbeitung"
 
-#: ../src/views/darkroom.c:3820
+#: ../src/views/darkroom.c:3824
 msgid "keyboard shortcut slider precision: fine"
 msgstr "Reglerschrittweite: fein"
 
-#: ../src/views/darkroom.c:3822
+#: ../src/views/darkroom.c:3826
 msgid "keyboard shortcut slider precision: normal"
 msgstr "Reglerschrittweite: normal"
 
-#: ../src/views/darkroom.c:3824
+#: ../src/views/darkroom.c:3828
 msgid "keyboard shortcut slider precision: coarse"
 msgstr "Reglerschrittweite: grob"
 
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:3861
+#: ../src/views/darkroom.c:3865
 msgctxt "accel"
 msgid "zoom close-up"
 msgstr "Zoom auf 100%"
 
-#: ../src/views/darkroom.c:3862
+#: ../src/views/darkroom.c:3866
 msgctxt "accel"
 msgid "zoom fill"
 msgstr "Ansicht füllen"
 
-#: ../src/views/darkroom.c:3863
+#: ../src/views/darkroom.c:3867
 msgctxt "accel"
 msgid "zoom fit"
 msgstr "Ansicht einpassen"
 
 #. zoom in/out
 #. zoom in/out/min/max
-#: ../src/views/darkroom.c:3866 ../src/views/lighttable.c:829
+#: ../src/views/darkroom.c:3870 ../src/views/lighttable.c:829
 msgctxt "accel"
 msgid "zoom in"
 msgstr "heranzoomen"
 
-#: ../src/views/darkroom.c:3867 ../src/views/lighttable.c:831
+#: ../src/views/darkroom.c:3871 ../src/views/lighttable.c:831
 msgctxt "accel"
 msgid "zoom out"
 msgstr "herauszoomen"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:3870
+#: ../src/views/darkroom.c:3874
 msgctxt "accel"
 msgid "image forward"
 msgstr "nächstes Bild"
 
-#: ../src/views/darkroom.c:3871
+#: ../src/views/darkroom.c:3875
 msgctxt "accel"
 msgid "image back"
 msgstr "vorheriges Bild"
 
 #. toggle ISO 12646 color assessment condition
-#: ../src/views/darkroom.c:3874
+#: ../src/views/darkroom.c:3878
 msgctxt "accel"
 msgid "color assessment"
 msgstr "Farbbeurteilung"
 
 #. toggle raw overexposure indication
-#: ../src/views/darkroom.c:3877
+#: ../src/views/darkroom.c:3881
 msgctxt "accel"
 msgid "raw overexposed/toggle"
 msgstr "Raw-Überbelichtungsanzeige ein/ausschalten"
 
 #. toggle overexposure indication
-#: ../src/views/darkroom.c:3880
+#: ../src/views/darkroom.c:3884
 msgctxt "accel"
 msgid "overexposed/toggle"
 msgstr "Überbelichtungsanzeige ein/ausschalten"
 
 #. cycle overlay colors
-#: ../src/views/darkroom.c:3883
+#: ../src/views/darkroom.c:3887
 msgctxt "accel"
 msgid "cycle overlay colors"
 msgstr "Überlagerungsfarbe zyklisch ändern"
 
 #. toggle softproofing
-#: ../src/views/darkroom.c:3886
+#: ../src/views/darkroom.c:3890
 msgctxt "accel"
 msgid "softproof"
 msgstr "Softproof"
 
 #. toggle gamut check
-#: ../src/views/darkroom.c:3889
+#: ../src/views/darkroom.c:3893
 msgctxt "accel"
 msgid "gamut check"
 msgstr "Gamut überprüfen"
 
 #. toggle visibility of drawn masks for current gui module
-#: ../src/views/darkroom.c:3892
+#: ../src/views/darkroom.c:3896
 msgctxt "accel"
 msgid "show drawn masks"
 msgstr "gezeichnete Maske anzeigen"
 
 #. toggle visibility of guide lines
-#: ../src/views/darkroom.c:3895
+#: ../src/views/darkroom.c:3899
 msgctxt "accel"
 msgid "guide lines/toggle"
 msgstr "Hilfslinien/Schalter"
 
 #. toggle visibility of second window
-#: ../src/views/darkroom.c:3898
+#: ../src/views/darkroom.c:3902
 msgctxt "accel"
 msgid "second window"
 msgstr "zweites Fenster"
 
 #. brush size +/-
-#: ../src/views/darkroom.c:3901
+#: ../src/views/darkroom.c:3905
 msgctxt "accel"
 msgid "increase brush size"
 msgstr "Größe des Pinsels erhöhen"
 
-#: ../src/views/darkroom.c:3902
+#: ../src/views/darkroom.c:3906
 msgctxt "accel"
 msgid "decrease brush size"
 msgstr "Größe des Pinsels verringern"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:3905
+#: ../src/views/darkroom.c:3909
 msgctxt "accel"
 msgid "increase brush hardness"
 msgstr "Härte des Pinsels erhöhen"
 
-#: ../src/views/darkroom.c:3906
+#: ../src/views/darkroom.c:3910
 msgctxt "accel"
 msgid "decrease brush hardness"
 msgstr "Härte des Pinsels verringern"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:3909
+#: ../src/views/darkroom.c:3913
 msgctxt "accel"
 msgid "increase brush opacity"
 msgstr "Deckkraft des Pinsels erhöhen"
 
-#: ../src/views/darkroom.c:3910
+#: ../src/views/darkroom.c:3914
 msgctxt "accel"
 msgid "decrease brush opacity"
 msgstr "Deckkraft des Pinsels verringern"
 
 #. undo/redo
-#: ../src/views/darkroom.c:3913 ../src/views/lighttable.c:821
+#: ../src/views/darkroom.c:3917 ../src/views/lighttable.c:821
 #: ../src/views/map.c:2087
 msgctxt "accel"
 msgid "undo"
 msgstr "rückgängig"
 
-#: ../src/views/darkroom.c:3914 ../src/views/lighttable.c:822
+#: ../src/views/darkroom.c:3918 ../src/views/lighttable.c:822
 #: ../src/views/map.c:2088
 msgctxt "accel"
 msgid "redo"
 msgstr "wiederherstellen"
 
 #. set focus to the search modules text box
-#: ../src/views/darkroom.c:3917
+#: ../src/views/darkroom.c:3921
 msgctxt "accel"
 msgid "search modules"
 msgstr "suche Modul"
 
 #. change the precision for adjusting sliders with keyboard shortcuts
-#: ../src/views/darkroom.c:3920
+#: ../src/views/darkroom.c:3924
 msgctxt "accel"
 msgid "change keyboard shortcut slider precision"
-msgstr "Schrittweite für Schieberegler via Kurzbefehl ändern"
+msgstr "Schrittweite für Schieberegler via Shortcut ändern"
 
-#: ../src/views/darkroom.c:4010
+#: ../src/views/darkroom.c:4014
 msgid "switch to lighttable"
 msgstr "zum Leuchttisch wechseln"
 
-#: ../src/views/darkroom.c:4011 ../src/views/lighttable.c:969
+#: ../src/views/darkroom.c:4015 ../src/views/lighttable.c:969
 msgid "zoom in the image"
 msgstr "im Bild zoomen"
 
-#: ../src/views/darkroom.c:4012
+#: ../src/views/darkroom.c:4016
 msgid "unbounded zoom in the image"
 msgstr "im Bild unbegrenzt Zoomen"
 
-#: ../src/views/darkroom.c:4013
+#: ../src/views/darkroom.c:4017
 msgid "zoom to 100% 200% and back"
 msgstr "auf zoomen 100%, 200% und zurück"
 
-#: ../src/views/darkroom.c:4015
+#: ../src/views/darkroom.c:4019
 msgid "[modules] expand module without closing others"
 msgstr "Modul einblenden, ohne andere zu schließen"
 
-#: ../src/views/darkroom.c:4017
+#: ../src/views/darkroom.c:4021
 msgid "[modules] change module position in pipe"
 msgstr "Modul an eine andere Position im Bearbeitungsstapel verschieben"
 
@@ -23455,15 +23573,15 @@ msgstr "Kurzvorschau"
 msgid "map"
 msgstr "Karte"
 
-#: ../src/views/map.c:2824
+#: ../src/views/map.c:2828
 msgid "[on image] open in darkroom"
 msgstr "in der Dunkelkammer öffnen"
 
-#: ../src/views/map.c:2825
+#: ../src/views/map.c:2829
 msgid "[on map] zoom map"
 msgstr "Karte skalieren"
 
-#: ../src/views/map.c:2826
+#: ../src/views/map.c:2830
 msgid "move image location"
 msgstr "Bild verschieben"
 
@@ -23601,6 +23719,13 @@ msgstr ""
 #: ../src/views/view.c:1331
 msgid "mouse actions"
 msgstr "Mausaktionen"
+
+#~ msgid ""
+#~ "if switched on, darktable tunes OpenCL for best performance, overrides "
+#~ "static settings"
+#~ msgstr ""
+#~ "wenn eingeschaltet, optimiert darktable OpenCL für beste Leistung und "
+#~ "übersteuert statische Einstellungen"
 
 #~ msgid "darktable - run performance configuration?"
 #~ msgstr "darktable - Geschwindigkeitseinstellungen anpassen?"


### PR DESCRIPTION
some new translations
- consistent use of "Shortcut" as a terminus technicus instead of "Kurzbefehle" 
- consistent use of "Tiling" as a terminus technicus instead of "Kachelung"