### PR TITLE
buttons flags cleanup

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -76,7 +76,7 @@
       - don't change css on hover (for dt_module_btn)
       - ex : colorlabels on header/footer bar
   - dt_ignore_fg_state
-      - don't change foreground color on state change
+      - don't change foreground color on state change and don't use bg if checked
       - ex : polarity buttons in blending ui
   - dt_module_btn:
       - set for all icons (button widget without text on it)
@@ -294,6 +294,7 @@ box *
 .dt_module_btn:disabled,
 .dt_transparent_background,
 .dt_transparent_background:checked,
+.dt_ignore_fg_state:checked,
 filechooser .sidebar-button,
 popover #bauhaus_combobox,
 overshoot,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -461,7 +461,8 @@ spinbutton>button
   font-size: 0.7em;
 }
 
-.dt_module_button
+.dt_module_button,
+.dt_ignore_fg_state:checked
 {
   background-color: transparent;
   border: 0;
@@ -637,7 +638,7 @@ spinbutton>button
 
 /* Labels of controls sections in modules */
 #section_label,
-#section_label *
+#section_label label
 {
   padding: 0;
   color: @section_label;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -70,12 +70,25 @@
   * some classes had been set on darktable, they all began with a dot. Before adding classes or ids, check what exist before
 
   * on those classes, some general ones had been set and should be added to your widget on Gtk code:
-  - dt_transparent_background: use it on a widget to set transparent background (except on hover) and no border
-  - dt_no_hover: don't change css on hover (for dt_module_btn)
-  - dt_module_btn: set for all icons (button widget without text on it)
-  - section_expander: use it for all expanders you could add on a module
-  - search: use it for all search box
-  - dt_bauhaus_alignment: used for some icons related to bauhaus widget (color picker for auto-tune setting in filmic or mask on same module and tone equalizer actually ; could be used so if an icon related to a bauhaus is not aligned by default)
+  - dt_transparent_background:
+      - use it on a widget to set transparent background (except on hover) and no border
+  - dt_no_hover:
+      - don't change css on hover (for dt_module_btn)
+      - ex : colorlabels on header/footer bar
+  - dt_checked_background:
+      - apply a background if the button is checked (toggled)
+      - ex : mode buttons in lighttable footer bar
+  - dt_module_btn:
+      - set for all icons (button widget without text on it)
+      - ex : btn in module header
+      - for toggle button this is combined with a "standard" "toggle" class
+  - section_expander:
+      - use it for all expanders you could add on a module
+  - search:
+      - use it for all search box
+  - dt_bauhaus_alignment:
+      - used for icons that needs to be aligned with bauhaus widgets in libs
+      - ex : color picker for auto-tune setting in filmic or mask on same module and tone equalizer
 
   * the list above is not exhausting. Those are main ones set actually and should be completed if needed. You could see other classes on this file
 ***/

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -75,9 +75,9 @@
   - dt_no_hover:
       - don't change css on hover (for dt_module_btn)
       - ex : colorlabels on header/footer bar
-  - dt_checked_background:
-      - apply a background if the button is checked (toggled)
-      - ex : mode buttons in lighttable footer bar
+  - dt_ignore_fg_state
+      - don't change foreground color on state change
+      - ex : polarity buttons in blending ui
   - dt_module_btn:
       - set for all icons (button widget without text on it)
       - ex : btn in module header
@@ -362,17 +362,23 @@ button
   margin: 0 0.07em;
 }
 
+.dt_module_btn,
+.dt_ignore_fg_state:checked
+{
+  color: alpha(@button_fg, 0.5);
+}
+
 /* Precise default buttons margins on side panels */
 #iop-plugin-ui button,
 #lib-plugin-ui button
 {
-  margin: 2px;  /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
+  margin: 2px 2px 2px 0;  /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
 }
 
 /* fix misalignment for specific icons related to bauhaus widgets */
-.dt_bauhaus_alignment
+#iop-plugin-ui .dt_bauhaus_alignment
 {
-  padding: 0.07em;
+  padding: 0.14em;
   min-height: 1.4em;
   min-width: 1.4em;
   margin: 0;
@@ -476,18 +482,6 @@ spinbutton>button
   font-size: 0.7em;
 }
 
-.dt_module_btn,
-.dt_ignore_fg_state:checked
-{
-  background-color: transparent;
-  border: 0;
-  color: alpha(@button_fg, 0.5);
-}
-
-.dt_module_btn:checked
-{
-  background-color: transparent;
-}
 /*------------------------
   - Main header settings -
   ------------------------*/
@@ -590,12 +584,6 @@ spinbutton>button
 {
   border: none;
   font-size: 1.2em;
-}
-
-/* icon buttons in modules main body */
-#lib-plugin-ui-main viewport
-{
-  margin-left: 0.14em;
 }
 
 /* Add some space to aerate if a notebook follows a widget (like for example in filmic rgb module */
@@ -750,7 +738,7 @@ spinbutton>button
 }
 
 /* set background color and color of scope/histogram buttons */
-#main-histogram .dt_module_btn
+#main-histogram .dt_module_btn:not(.toggle)
 {
   color: alpha(@button_checked_fg, 0.56);
   background-color: alpha(darker(@button_bg),0.8);
@@ -1043,44 +1031,31 @@ notebook tabs,
 }
 
 /* set sizes of "buttons" in modules and blending tabs ; and guides lines too */
-#modules-tabs .dt_module_btn
+#modules-tabs .toggle
 {
   min-height: 2em;
 }
 
-#blending-tabs .dt_module_btn,
-#guides-line .dt_module_btn
+#iop-plugin-ui #blending-tabs .dt_module_btn,
+#guides-line .toggle
 {
   min-height: 1.3em;
-  padding: 0.28em;
 }
 
 #modules-tabs .dt_module_btn,   /* This is needed separately to set a minimal width if panel is really narrow */
-#blending-tabs .dt_module_btn,
+#iop-plugin-ui #blending-tabs .dt_module_btn,
 #guides-line .dt_module_btn
 {
+  border-radius: 0;
   min-width: 1.5em;
+  margin: 0;
 }
 
 /* reduce and align now hamburger menu of modules and blending tabs */
-#blending-tabs .dt_module_btn,
+#iop-plugin-ui #blending-tabs .dt_module_btn,
 #modules-tabs .dt_module_btn
 {
-  padding: 0.2em 0.5em;
-}
-
-#blending-tabs .dt_module_btn
-{
-  font-size: 0.8em;
-}
-
-/* do not apply border-radius to group modules icons and masks icons */
-#modules-tabs button,
-#blending-tabs button,
-#guides-line button
-{
-  border-radius: 0;
-  margin: 0;
+  padding: 0.3em;
 }
 
 /* Set notebook tabs */
@@ -1761,8 +1736,7 @@ combobox window *:selected,
 #recent-collection-button:active,
 #recent-collection-button:checked,
 #recent-collection-button:selected,
-messagedialog .default,  /* this show that a button in confirmation action pop-up has the focus (no by default) */
-.dt_checked_background:checked
+messagedialog .default  /* this show that a button in confirmation action pop-up has the focus (no by default) */
 {
   background-color: @button_checked_bg;
   color: @button_checked_fg;
@@ -1787,7 +1761,7 @@ notebook tab:hover,
 radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
 #collapsible spinbutton button:hover,
-#main-histogram .dt_module_btn:hover,
+#main-histogram .dt_module_btn:hover:not(.toggle),
 #non-flat:hover,
 #preferences_box .sidebar :hover,
 #recent-collection-button:hover,
@@ -1808,11 +1782,6 @@ combobox window *:hover,
 #header-toolbar #bauhaus_combobox:hover
 {
   color: shade(@fg_color, 1.2);
-}
-
-.dt_module_button:hover
-{
-  color: alpha(@button_hover_fg, 0.6);
 }
 
 /* workaround for a macOS quartz GTK backend bug
@@ -2598,12 +2567,12 @@ Details :
   margin-right: 0.6em;
 }
 
-#footer-toolbar .dt_module_btn
+#footer-toolbar .toggle
 {
   margin: 0 0.2em;
 }
 
-#lighttable_layouts_box .dt_module_btn
+#lighttable_layouts_box .toggle
 {
   margin: 0 0.4em;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -461,6 +461,13 @@ spinbutton>button
   font-size: 0.7em;
 }
 
+.dt_module_button
+{
+  background-color: transparent;
+  border: 0;
+  color: alpha(@button_fg, 0.5);
+}
+
 /*------------------------
   - Main header settings -
   ------------------------*/
@@ -1780,6 +1787,11 @@ combobox window *:hover,
 #header-toolbar #bauhaus_combobox:hover
 {
   color: shade(@fg_color, 1.2);
+}
+
+.dt_module_button:hover
+{
+  color: alpha(@button_hover_fg, 0.6);
 }
 
 /* workaround for a macOS quartz GTK backend bug

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -70,7 +70,8 @@
   * some classes had been set on darktable, they all began with a dot. Before adding classes or ids, check what exist before
 
   * on those classes, some general ones had been set and should be added to your widget on Gtk code:
-  - dt_transparent_background: use it on a widget to set transparent background and border
+  - dt_transparent_background: use it on a widget to set transparent background (except on hover) and no border
+  - dt_no_hover: don't change css on hover (for dt_module_btn)
   - dt_module_btn: set for all icons (button widget without text on it)
   - section_expander: use it for all expanders you could add on a module
   - search: use it for all search box
@@ -374,6 +375,7 @@ spinbutton *:disabled,
 {
   background-color: transparent;
   border: 0.07em solid shade(@button_border, 0.9);
+  color: @disabled_fg_color;
 }
 
 /* Default extra margin for icons optical alignment */
@@ -461,7 +463,7 @@ spinbutton>button
   font-size: 0.7em;
 }
 
-.dt_module_button,
+.dt_module_btn,
 .dt_ignore_fg_state:checked
 {
   background-color: transparent;
@@ -469,8 +471,7 @@ spinbutton>button
   color: alpha(@button_fg, 0.5);
 }
 
-.dt_toggle_button:checked,
-.dt_button:checked
+.dt_module_btn:checked
 {
   background-color: transparent;
 }
@@ -525,12 +526,12 @@ spinbutton>button
   margin: 12px; /* not real pixels. This is used as a percent extra space and couldn't be scalable */
 }
 
-#footer-toolbar #lib-label-colors #dt-button
+#lib-label-colors .dt_module_btn
 {
   opacity: 0.6;
 }
 
-#footer-toolbar #lib-label-colors #dt-button:hover
+#lib-label-colors .dt_module_btn:hover
 {
   opacity: 1;
 }
@@ -736,7 +737,7 @@ spinbutton>button
 }
 
 /* set background color and color of scope/histogram buttons */
-#main-histogram #dt-button
+#main-histogram .dt_module_btn
 {
   color: alpha(@button_checked_fg, 0.56);
   background-color: alpha(darker(@button_bg),0.8);
@@ -1029,33 +1030,33 @@ notebook tabs,
 }
 
 /* set sizes of "buttons" in modules and blending tabs ; and guides lines too */
-#modules-tabs #dt-toggle-button
+#modules-tabs .dt_module_btn
 {
   min-height: 2em;
 }
 
 #blending-tabs .dt_module_btn,
-#guides-line #dt-toggle-button
+#guides-line .dt_module_btn
 {
   min-height: 1.3em;
   padding: 0.28em;
 }
 
-#modules-tabs #dt-toggle-button,   /* This is needed separately to set a minimal width if panel is really narrow */
-#blending-tabs #dt-toggle-button,
-#guides-line #dt-toggle-button
+#modules-tabs .dt_module_btn,   /* This is needed separately to set a minimal width if panel is really narrow */
+#blending-tabs .dt_module_btn,
+#guides-line .dt_module_btn
 {
   min-width: 1.5em;
 }
 
 /* reduce and align now hamburger menu of modules and blending tabs */
-#blending-tabs #dt-button,
-#modules-tabs #dt-button
+#blending-tabs .dt_module_btn,
+#modules-tabs .dt_module_btn
 {
   padding: 0.2em 0.5em;
 }
 
-#blending-tabs #dt-button
+#blending-tabs .dt_module_btn
 {
   font-size: 0.8em;
 }
@@ -1311,7 +1312,7 @@ dialog scrollbar
   font-weight: bold;
 }
 
-#modulegroups-groups-title #dt-button
+#modulegroups-groups-title .dt_module_btn
 {
   margin-left: 0.56em;
 }
@@ -1373,7 +1374,7 @@ box #modulegroups-iop-header:last-child
   background-color: @grey_30;
 }
 
-#modulegroups-icons-popup #dt-button
+#modulegroups-icons-popup .dt_module_btn
 {
   min-width: 1.6em;
   min-height: 1.6em;
@@ -1478,7 +1479,7 @@ filechooser row:hover .sidebar-icon
 #basics-box-labels #basics-link,
 #basics-box-labels #basics-header-box:first-child,
 #basics-box-labels #section_label,
-#modulegroups-header #dt-button,
+#modulegroups-header .dt_module_btn,
 #thumb_localcopy:active
 {
   border: none;
@@ -1568,7 +1569,7 @@ border-bottom: 0.07em solid alpha(@selected_bg_color, 0.75);
   margin: 0.07em 0.28em;
 }
 
-#background_job_eventbox #dt-button
+#background_job_eventbox .dt_module_btn
 {
   border: 0;
 }
@@ -1765,7 +1766,7 @@ messagedialog .default,  /* this show that a button in confirmation action pop-u
 /* Hover states, some needed background only */
 .dt_history_items:hover,
 .dt_transparent_background:hover,
-button:hover:not(.combo),
+button:hover:not(.combo):not(.dt_no_hover),
 filechooser row:hover,
 menuitem:hover,
 menuitem:hover > *:not(check),
@@ -1773,7 +1774,7 @@ notebook tab:hover,
 radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
 #collapsible spinbutton button:hover,
-#main-histogram #dt-button:hover,
+#main-histogram .dt_module_btn:hover,
 #non-flat:hover,
 #preferences_box .sidebar :hover,
 #recent-collection-button:hover,
@@ -2584,12 +2585,12 @@ Details :
   margin-right: 0.6em;
 }
 
-#footer-toolbar #dt-toggle-button
+#footer-toolbar .dt_module_btn
 {
   margin: 0 0.2em;
 }
 
-#lighttable_layouts_box #dt-toggle-button
+#lighttable_layouts_box .dt_module_btn
 {
   margin: 0 0.4em;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -366,7 +366,7 @@ button
 .dt_module_btn,
 .dt_ignore_fg_state:checked
 {
-  color: alpha(@button_fg, 0.5);
+  color: alpha(@button_fg, 0.55);
 }
 
 /* Precise default buttons margins on side panels */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -468,6 +468,11 @@ spinbutton>button
   color: alpha(@button_fg, 0.5);
 }
 
+.dt_toggle_button:checked,
+.dt_button:checked
+{
+  background-color: transparent;
+}
 /*------------------------
   - Main header settings -
   ------------------------*/
@@ -1741,7 +1746,8 @@ combobox window *:selected,
 #recent-collection-button:active,
 #recent-collection-button:checked,
 #recent-collection-button:selected,
-messagedialog .default  /* this show that a button in confirmation action pop-up has the focus (no by default) */
+messagedialog .default,  /* this show that a button in confirmation action pop-up has the focus (no by default) */
+.dt_checked_background:checked
 {
   background-color: @button_checked_bg;
   color: @button_checked_fg;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2263,6 +2263,15 @@ Details :
 /*--------------------
   - Thumbnails infos -
   --------------------*/
+
+/* set some padding for some icons */
+#thumb_star,
+#thumb_reject,
+#thumb_colorlabels
+{
+  padding : 12.5px; /* percent of the full size */
+}
+
 /* By default, the extension is hidden */
 #thumb_ext
 {

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2176,7 +2176,8 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
                                                    in_out ? "blend-upper" : "blend-lower"));
       gtk_box_pack_start(GTK_BOX(slider_box), GTK_WIDGET(sl->slider), TRUE, TRUE, 0);
 
-      sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_IGNORE_FG_STATE, NULL);
+      sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
+      gtk_style_context_add_class(gtk_widget_get_style_context(sl->polarity), "dt_ignore_fg_state");
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
 
@@ -2326,8 +2327,8 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
     bd->masks_polarity = dt_iop_togglebutton_new(module, "blend`tools", N_("toggle polarity of drawn mask"), NULL,
                                                  G_CALLBACK(_blendop_masks_polarity_callback),
                                                  FALSE, 0, 0, dtgtk_cairo_paint_plusminus, hbox);
-    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_polarity), dtgtk_cairo_paint_plusminus,
-                                 CPF_IGNORE_FG_STATE, NULL);
+    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_polarity), dtgtk_cairo_paint_plusminus, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_polarity), "dt_ignore_fg_state");
 
     GtkWidget *abox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools", N_("show and edit mask elements"), N_("show and edit in restricted mode"),
@@ -2506,7 +2507,8 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
     dt_bauhaus_combobox_add_populate_fct(bd->raster_combo, _raster_combo_populate);
     gtk_box_pack_start(GTK_BOX(hbox), bd->raster_combo, TRUE, TRUE, 0);
 
-    bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_IGNORE_FG_STATE, NULL);
+    bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->raster_polarity), "dt_ignore_fg_state");
     gtk_widget_set_tooltip_text(bd->raster_polarity, _("toggle polarity of raster mask"));
     g_signal_connect(G_OBJECT(bd->raster_polarity), "toggled", G_CALLBACK(_raster_polarity_callback), module);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_polarity), FALSE);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2975,12 +2975,14 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     // DEVELOP_MASK_DISABLED
     but = dt_iop_togglebutton_new(module, "blend`masks", N_("off"), NULL, G_CALLBACK(_blendop_masks_modes_none_clicked),
                                   FALSE, 0, 0, dtgtk_cairo_paint_cancel, NULL);
+    dt_gui_add_class(but, "dt_checked_background");
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED));
     bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
 
     // DEVELOP_MASK_ENABLED
     but = dt_iop_togglebutton_new(module, "blend`masks", N_("uniformly"), NULL, G_CALLBACK(_blendop_masks_modes_uni_toggled),
                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_uniform, NULL);
+    dt_gui_add_class(but, "dt_checked_background");
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED));
     bd->masks_modes_toggles  = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
 
@@ -2988,6 +2990,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("drawn mask"), NULL, G_CALLBACK(_blendop_masks_modes_drawn_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_drawn, NULL);
+      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
     }
@@ -2995,6 +2998,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("parametric mask"), NULL, G_CALLBACK(_blendop_masks_modes_param_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_parametric, NULL);
+      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
@@ -3004,6 +3008,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("drawn & parametric mask"), NULL, G_CALLBACK(_blendop_masks_modes_both_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_drawn_and_parametric, NULL);
+      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
@@ -3013,6 +3018,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("raster mask"), NULL, G_CALLBACK(_blendop_masks_modes_raster_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_raster, NULL);
+      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2164,7 +2164,6 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     GtkWidget *btn = dt_iop_togglebutton_new(module, "blend`tools", N_("invert all channel's polarities"), NULL,
                                              G_CALLBACK(_blendop_blendif_invert), FALSE, 0, 0,
                                              dtgtk_cairo_paint_invert, header);
-    dt_gui_add_class(btn, "dt_transparent_background");
     dt_gui_add_class(btn, "dt_ignore_fg_state");
 
     gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(header), TRUE, FALSE, 0);
@@ -2180,7 +2179,6 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(slider_box), GTK_WIDGET(sl->slider), TRUE, TRUE, 0);
 
       sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
-      dt_gui_add_class(sl->polarity, "dt_transparent_background");
       dt_gui_add_class(sl->polarity, "dt_ignore_fg_state");
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
@@ -2333,7 +2331,6 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
                                                  FALSE, 0, 0, dtgtk_cairo_paint_plusminus, hbox);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_polarity), dtgtk_cairo_paint_plusminus, 0, NULL);
     dt_gui_add_class(bd->masks_polarity, "dt_ignore_fg_state");
-    dt_gui_add_class(bd->masks_polarity, "dt_transparent_background");
 
     GtkWidget *abox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools", N_("show and edit mask elements"), N_("show and edit in restricted mode"),
@@ -2509,7 +2506,6 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
     dt_gui_add_class(bd->raster_polarity, "dt_ignore_fg_state");
-    dt_gui_add_class(bd->raster_polarity, "dt_transparent_background");
     gtk_widget_set_tooltip_text(bd->raster_polarity, _("toggle polarity of raster mask"));
     g_signal_connect(G_OBJECT(bd->raster_polarity), "toggled", G_CALLBACK(_raster_polarity_callback), module);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_polarity), FALSE);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2155,8 +2155,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->colorpicker_set_values = dt_color_picker_new(module, DT_COLOR_PICKER_AREA, header);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->colorpicker_set_values),
-                                 dtgtk_cairo_paint_colorpicker_set_values,
-                                 CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+                                 dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
     gtk_widget_set_tooltip_text(bd->colorpicker_set_values, _("set the range based on an area from the image\n"
                                                               "drag to use the input image\n"
                                                               "ctrl+drag to use the output image"));
@@ -2177,8 +2176,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
                                                    in_out ? "blend-upper" : "blend-lower"));
       gtk_box_pack_start(GTK_BOX(slider_box), GTK_WIDGET(sl->slider), TRUE, TRUE, 0);
 
-      sl->polarity
-          = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
+      sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_IGNORE_FG_STATE, NULL);
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
 
@@ -2329,7 +2327,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
                                                  G_CALLBACK(_blendop_masks_polarity_callback),
                                                  FALSE, 0, 0, dtgtk_cairo_paint_plusminus, hbox);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_polarity), dtgtk_cairo_paint_plusminus,
-                                 CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
+                                 CPF_IGNORE_FG_STATE, NULL);
 
     GtkWidget *abox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools", N_("show and edit mask elements"), N_("show and edit in restricted mode"),
@@ -2340,26 +2338,31 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
     bd->masks_shapes[0] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add gradient"), N_("add multiple gradients"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_gradient, abox);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[0]), "dt_checked_background");
 
     bd->masks_type[4] = DT_MASKS_BRUSH;
     bd->masks_shapes[4] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add brush"), N_("add multiple brush strokes"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_brush, abox);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[4]), "dt_checked_background");
 
     bd->masks_type[1] = DT_MASKS_PATH;
     bd->masks_shapes[1] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add path"), N_("add multiple paths"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_path, abox);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[1]), "dt_checked_background");
 
     bd->masks_type[2] = DT_MASKS_ELLIPSE;
     bd->masks_shapes[2] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add ellipse"), N_("add multiple ellipses"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_ellipse, abox);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[2]), "dt_checked_background");
 
     bd->masks_type[3] = DT_MASKS_CIRCLE;
     bd->masks_shapes[3] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add circle"), N_("add multiple circles"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_circle, abox);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[3]), "dt_checked_background");
 
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(hbox), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(abox), TRUE, TRUE, 0);
@@ -2503,8 +2506,7 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
     dt_bauhaus_combobox_add_populate_fct(bd->raster_combo, _raster_combo_populate);
     gtk_box_pack_start(GTK_BOX(hbox), bd->raster_combo, TRUE, TRUE, 0);
 
-    bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE,
-                                                 NULL);
+    bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_IGNORE_FG_STATE, NULL);
     gtk_widget_set_tooltip_text(bd->raster_polarity, _("toggle polarity of raster mask"));
     g_signal_connect(G_OBJECT(bd->raster_polarity), "toggled", G_CALLBACK(_raster_polarity_callback), module);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_polarity), FALSE);
@@ -3014,7 +3016,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
     }
 
-    GtkWidget *presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
+    GtkWidget *presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
     gtk_widget_set_tooltip_text(presets_button, _("blending options"));
     if(bd->blendif_support)
     {

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2177,7 +2177,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(slider_box), GTK_WIDGET(sl->slider), TRUE, TRUE, 0);
 
       sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
-      gtk_style_context_add_class(gtk_widget_get_style_context(sl->polarity), "dt_ignore_fg_state");
+      dt_gui_add_class(sl->polarity, "dt_ignore_fg_state");
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
 
@@ -2328,7 +2328,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
                                                  G_CALLBACK(_blendop_masks_polarity_callback),
                                                  FALSE, 0, 0, dtgtk_cairo_paint_plusminus, hbox);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_polarity), dtgtk_cairo_paint_plusminus, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_polarity), "dt_ignore_fg_state");
+    dt_gui_add_class(bd->masks_polarity, "dt_ignore_fg_state");
 
     GtkWidget *abox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools", N_("show and edit mask elements"), N_("show and edit in restricted mode"),
@@ -2339,31 +2339,31 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
     bd->masks_shapes[0] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add gradient"), N_("add multiple gradients"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_gradient, abox);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[0]), "dt_checked_background");
+    dt_gui_add_class(bd->masks_shapes[0], "dt_checked_background");
 
     bd->masks_type[4] = DT_MASKS_BRUSH;
     bd->masks_shapes[4] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add brush"), N_("add multiple brush strokes"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_brush, abox);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[4]), "dt_checked_background");
+    dt_gui_add_class(bd->masks_shapes[4], "dt_checked_background");
 
     bd->masks_type[1] = DT_MASKS_PATH;
     bd->masks_shapes[1] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add path"), N_("add multiple paths"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_path, abox);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[1]), "dt_checked_background");
+    dt_gui_add_class(bd->masks_shapes[1], "dt_checked_background");
 
     bd->masks_type[2] = DT_MASKS_ELLIPSE;
     bd->masks_shapes[2] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add ellipse"), N_("add multiple ellipses"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_ellipse, abox);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[2]), "dt_checked_background");
+    dt_gui_add_class(bd->masks_shapes[2], "dt_checked_background");
 
     bd->masks_type[3] = DT_MASKS_CIRCLE;
     bd->masks_shapes[3] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add circle"), N_("add multiple circles"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_circle, abox);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->masks_shapes[3]), "dt_checked_background");
+    dt_gui_add_class(bd->masks_shapes[3], "dt_checked_background");
 
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(hbox), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(abox), TRUE, TRUE, 0);
@@ -2508,7 +2508,7 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(hbox), bd->raster_combo, TRUE, TRUE, 0);
 
     bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bd->raster_polarity), "dt_ignore_fg_state");
+    dt_gui_add_class(bd->raster_polarity, "dt_ignore_fg_state");
     gtk_widget_set_tooltip_text(bd->raster_polarity, _("toggle polarity of raster mask"));
     g_signal_connect(G_OBJECT(bd->raster_polarity), "toggled", G_CALLBACK(_raster_polarity_callback), module);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_polarity), FALSE);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2156,13 +2156,16 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     bd->colorpicker_set_values = dt_color_picker_new(module, DT_COLOR_PICKER_AREA, header);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->colorpicker_set_values),
                                  dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
+    dt_gui_add_class(bd->colorpicker_set_values, "dt_transparent_background");
     gtk_widget_set_tooltip_text(bd->colorpicker_set_values, _("set the range based on an area from the image\n"
                                                               "drag to use the input image\n"
                                                               "ctrl+drag to use the output image"));
 
-    dt_iop_togglebutton_new(module, "blend`tools", N_("invert all channel's polarities"), NULL,
-                            G_CALLBACK(_blendop_blendif_invert), FALSE, 0, 0,
-                            dtgtk_cairo_paint_invert, header);
+    GtkWidget *btn = dt_iop_togglebutton_new(module, "blend`tools", N_("invert all channel's polarities"), NULL,
+                                             G_CALLBACK(_blendop_blendif_invert), FALSE, 0, 0,
+                                             dtgtk_cairo_paint_invert, header);
+    dt_gui_add_class(btn, "dt_transparent_background");
+    dt_gui_add_class(btn, "dt_ignore_fg_state");
 
     gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(header), TRUE, FALSE, 0);
 
@@ -2177,6 +2180,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(slider_box), GTK_WIDGET(sl->slider), TRUE, TRUE, 0);
 
       sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
+      dt_gui_add_class(sl->polarity, "dt_transparent_background");
       dt_gui_add_class(sl->polarity, "dt_ignore_fg_state");
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
@@ -2329,6 +2333,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
                                                  FALSE, 0, 0, dtgtk_cairo_paint_plusminus, hbox);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->masks_polarity), dtgtk_cairo_paint_plusminus, 0, NULL);
     dt_gui_add_class(bd->masks_polarity, "dt_ignore_fg_state");
+    dt_gui_add_class(bd->masks_polarity, "dt_transparent_background");
 
     GtkWidget *abox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     bd->masks_edit = dt_iop_togglebutton_new(module, "blend`tools", N_("show and edit mask elements"), N_("show and edit in restricted mode"),
@@ -2339,31 +2344,26 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
     bd->masks_shapes[0] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add gradient"), N_("add multiple gradients"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_gradient, abox);
-    dt_gui_add_class(bd->masks_shapes[0], "dt_checked_background");
 
     bd->masks_type[4] = DT_MASKS_BRUSH;
     bd->masks_shapes[4] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add brush"), N_("add multiple brush strokes"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_brush, abox);
-    dt_gui_add_class(bd->masks_shapes[4], "dt_checked_background");
 
     bd->masks_type[1] = DT_MASKS_PATH;
     bd->masks_shapes[1] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add path"), N_("add multiple paths"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_path, abox);
-    dt_gui_add_class(bd->masks_shapes[1], "dt_checked_background");
 
     bd->masks_type[2] = DT_MASKS_ELLIPSE;
     bd->masks_shapes[2] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add ellipse"), N_("add multiple ellipses"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_ellipse, abox);
-    dt_gui_add_class(bd->masks_shapes[2], "dt_checked_background");
 
     bd->masks_type[3] = DT_MASKS_CIRCLE;
     bd->masks_shapes[3] = dt_iop_togglebutton_new(module, "blend`shapes", N_("add circle"), N_("add multiple circles"),
                                                   G_CALLBACK(_blendop_masks_add_shape),
                                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_circle, abox);
-    dt_gui_add_class(bd->masks_shapes[3], "dt_checked_background");
 
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(hbox), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(abox), TRUE, TRUE, 0);
@@ -2509,6 +2509,7 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->raster_polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
     dt_gui_add_class(bd->raster_polarity, "dt_ignore_fg_state");
+    dt_gui_add_class(bd->raster_polarity, "dt_transparent_background");
     gtk_widget_set_tooltip_text(bd->raster_polarity, _("toggle polarity of raster mask"));
     g_signal_connect(G_OBJECT(bd->raster_polarity), "toggled", G_CALLBACK(_raster_polarity_callback), module);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_polarity), FALSE);
@@ -2975,14 +2976,12 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     // DEVELOP_MASK_DISABLED
     but = dt_iop_togglebutton_new(module, "blend`masks", N_("off"), NULL, G_CALLBACK(_blendop_masks_modes_none_clicked),
                                   FALSE, 0, 0, dtgtk_cairo_paint_cancel, NULL);
-    dt_gui_add_class(but, "dt_checked_background");
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED));
     bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
 
     // DEVELOP_MASK_ENABLED
     but = dt_iop_togglebutton_new(module, "blend`masks", N_("uniformly"), NULL, G_CALLBACK(_blendop_masks_modes_uni_toggled),
                                   FALSE, 0, 0, dtgtk_cairo_paint_masks_uniform, NULL);
-    dt_gui_add_class(but, "dt_checked_background");
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED));
     bd->masks_modes_toggles  = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
 
@@ -2990,7 +2989,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("drawn mask"), NULL, G_CALLBACK(_blendop_masks_modes_drawn_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_drawn, NULL);
-      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
     }
@@ -2998,7 +2996,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("parametric mask"), NULL, G_CALLBACK(_blendop_masks_modes_param_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_parametric, NULL);
-      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
@@ -3008,7 +3005,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("drawn & parametric mask"), NULL, G_CALLBACK(_blendop_masks_modes_both_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_drawn_and_parametric, NULL);
-      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
@@ -3018,7 +3014,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     {
       but = dt_iop_togglebutton_new(module, "blend`masks", N_("raster mask"), NULL, G_CALLBACK(_blendop_masks_modes_raster_toggled),
                                     FALSE, 0, 0, dtgtk_cairo_paint_masks_raster, NULL);
-      dt_gui_add_class(but, "dt_checked_background");
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
@@ -3134,10 +3129,12 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(bd->showmask, _("display mask and/or color channel. ctrl+click to display mask, "
                                                 "shift+click to display channel. hover over parametric mask slider to "
                                                 "select channel for display"));
+    dt_gui_add_class(bd->showmask, "dt_transparent_background");
 
     bd->suppress = dt_iop_togglebutton_new(module, "blend`tools", N_("temporarily switch off blend mask"), NULL, G_CALLBACK(_blendop_blendif_suppress_toggled),
                                            FALSE, 0, 0, dtgtk_cairo_paint_eye_toggle, hbox);
     gtk_widget_set_tooltip_text(bd->suppress, _("temporarily switch off blend mask. only for module in focus"));
+    dt_gui_add_class(bd->suppress, "dt_transparent_background");
 
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(box), TRUE, TRUE, 0);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1097,6 +1097,7 @@ void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
   // set on/off icon
   if(module->default_enabled && module->hide_enable_button)
   {
+<<<<<<< HEAD
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
                                  dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
   }
@@ -1109,6 +1110,20 @@ void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
   {
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
                                  dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
+=======
+    gtk_widget_set_name(w, "module-always-enabled-button");
+    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w), dtgtk_cairo_paint_switch_on, 0, module);
+  }
+  else if(!module->default_enabled && module->hide_enable_button)
+  {
+    gtk_widget_set_name(w, "module-always-disabled-button");
+    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w), dtgtk_cairo_paint_switch_off, 0, module);
+  }
+  else
+  {
+    gtk_widget_set_name(w, "module-enable-button");
+    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w), dtgtk_cairo_paint_switch, 0, module);
+>>>>>>> 8b4e68185 (remove unused drawing flags now managed by css)
   }
 }
 
@@ -2326,9 +2341,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
   }
   else if(show)
   {
-    module->mask_indicator = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask,
-                                                    CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    dt_gui_add_class(module->mask_indicator, "dt_module_btn");
+    module->mask_indicator = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, 0, NULL);
     g_signal_connect(G_OBJECT(module->mask_indicator), "toggled",
                      G_CALLBACK(_display_mask_indicator_callback), module);
     g_signal_connect(G_OBJECT(module->mask_indicator), "query-tooltip",
@@ -2414,7 +2427,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
 
   /* add multi instances menu button */
-  hw[IOP_MODULE_INSTANCE] = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT, NULL);
+  hw[IOP_MODULE_INSTANCE] = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, 0, NULL);
   module->multimenu_button = GTK_WIDGET(hw[IOP_MODULE_INSTANCE]);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]),
                               _("multiple instance actions\nright-click creates new instance"));
@@ -2427,7 +2440,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   dt_gui_add_help_link(expander, dt_get_help_url(module->op));
 
   /* add reset button */
-  hw[IOP_MODULE_RESET] = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT, NULL);
+  hw[IOP_MODULE_RESET] = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
   module->reset_button = GTK_WIDGET(hw[IOP_MODULE_RESET]);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_RESET]), _("reset parameters\nctrl+click to reapply any automatic presets"));
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event", G_CALLBACK(_gui_reset_callback), module);
@@ -2436,7 +2449,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_RESET]), "dt_module_btn");
 
   /* add preset button if module has implementation */
-  hw[IOP_MODULE_PRESETS] = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
+  hw[IOP_MODULE_PRESETS] = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
   module->presets_button = GTK_WIDGET(hw[IOP_MODULE_PRESETS]);
   if(!(module->flags() & IOP_FLAGS_ONE_INSTANCE))
     gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), _("presets\nright-click to apply on new instance"));
@@ -2446,8 +2459,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "dt_module_btn");
 
   /* add enabled button */
-  hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch,
-                                                 CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
+  hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, module);
   dt_iop_gui_set_enable_button_icon(hw[IOP_MODULE_SWITCH], module);
 
   gchar *module_label = dt_history_item_get_name(module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1097,33 +1097,15 @@ void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
   // set on/off icon
   if(module->default_enabled && module->hide_enable_button)
   {
-<<<<<<< HEAD
-    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
-                                 dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
-  }
-  else if(!module->default_enabled && module->hide_enable_button)
-  {
-    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
-                                 dtgtk_cairo_paint_switch_off, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
-  }
-  else
-  {
-    dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w),
-                                 dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, module);
-=======
-    gtk_widget_set_name(w, "module-always-enabled-button");
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w), dtgtk_cairo_paint_switch_on, 0, module);
   }
   else if(!module->default_enabled && module->hide_enable_button)
   {
-    gtk_widget_set_name(w, "module-always-disabled-button");
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w), dtgtk_cairo_paint_switch_off, 0, module);
   }
   else
   {
-    gtk_widget_set_name(w, "module-enable-button");
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(w), dtgtk_cairo_paint_switch, 0, module);
->>>>>>> 8b4e68185 (remove unused drawing flags now managed by css)
   }
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2324,6 +2324,7 @@ void add_remove_mask_indicator(dt_iop_module_t *module, gboolean add)
   else if(show)
   {
     module->mask_indicator = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, 0, NULL);
+    dt_gui_add_class(module->mask_indicator, "dt_transparent_background");
     g_signal_connect(G_OBJECT(module->mask_indicator), "toggled",
                      G_CALLBACK(_display_mask_indicator_callback), module);
     g_signal_connect(G_OBJECT(module->mask_indicator), "query-tooltip",
@@ -2442,6 +2443,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
 
   /* add enabled button */
   hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, module);
+  dt_gui_add_class(hw[IOP_MODULE_SWITCH], "dt_transparent_background");
   dt_iop_gui_set_enable_button_icon(hw[IOP_MODULE_SWITCH], module);
 
   gchar *module_label = dt_history_item_get_name(module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2418,7 +2418,6 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_INSTANCE));
-  dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]), "dt_module_btn");
 
   dt_gui_add_help_link(expander, dt_get_help_url(module->op));
 
@@ -2429,7 +2428,6 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event", G_CALLBACK(_gui_reset_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
-  dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_RESET]), "dt_module_btn");
 
   /* add preset button if module has implementation */
   hw[IOP_MODULE_PRESETS] = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
@@ -2439,7 +2437,6 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "clicked", G_CALLBACK(_presets_popup_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
-  dt_gui_add_class(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "dt_module_btn");
 
   /* add enabled button */
   hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, module);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -271,7 +271,7 @@ GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, c
                                    GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
                                    DTGTKCairoPaintIconFunc paint, GtkWidget *box)
 {
-  GtkWidget *w = dtgtk_togglebutton_new(paint, CPF_STYLE_FLAT, NULL);
+  GtkWidget *w = dtgtk_togglebutton_new(paint, 0, NULL);
   g_signal_connect(G_OBJECT(w), "button-press-event", callback, self);
 
   if(!ctrl_label)
@@ -299,7 +299,7 @@ GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
 
   if(paint)
   {
-    button = dtgtk_button_new(paint, CPF_STYLE_FLAT | paintflags, NULL);
+    button = dtgtk_button_new(paint, paintflags, NULL);
     gtk_widget_set_tooltip_text(button, _(label));
   }
   else

--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -122,7 +122,6 @@ GtkWidget *dtgtk_button_new(DTGTKCairoPaintIconFunc paint, gint paintflags, void
   button->canvas = gtk_drawing_area_new();
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
   dt_gui_add_class(GTK_WIDGET(button), "dt_module_btn");
-  gtk_widget_set_name(GTK_WIDGET(button), "dt-button");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
   return (GtkWidget *)button;
 }

--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -74,17 +74,8 @@ static gboolean _button_draw(GtkWidget *widget, cairo_t *cr)
   int cwidth = width - margin.left - margin.right;
   int cheight = height - margin.top - margin.bottom;
 
-  /* draw standard button background if not transparent */
-  if(flags & CPF_STYLE_FLAT)
-  {
-    if(flags & CPF_PRELIGHT)
-      gtk_render_background(context, cr, startx, starty, cwidth, cheight);
-    else if (!(flags & CPF_ACTIVE))
-      fg_color.alpha = CLAMP(fg_color.alpha / 2.0, 0.3, 1.0);
-  }
-  else if(!(flags & CPF_BG_TRANSPARENT))
-    gtk_render_background(context, cr, startx, starty, cwidth, cheight);
-
+  /* draw standard button background and borders */
+  gtk_render_background(context, cr, startx, starty, cwidth, cheight);
   gtk_render_frame(context, cr, startx, starty, cwidth, cheight);
   gdk_cairo_set_source_rgba(cr, &fg_color);
 
@@ -168,30 +159,6 @@ void dtgtk_button_set_active(GtkDarktableButton *button, gboolean active)
     button->icon_flags |= CPF_ACTIVE;
   else
     button->icon_flags &= ~CPF_ACTIVE;
-}
-
-void dtgtk_button_override_color(GtkDarktableButton *button, GdkRGBA *color)
-{
-  g_return_if_fail(button != NULL);
-  if(color)
-  {
-    button->fg = *color;
-    button->icon_flags |= CPF_CUSTOM_FG;
-  }
-  else
-    button->icon_flags &= ~CPF_CUSTOM_FG;
-}
-
-void dtgtk_button_override_background_color(GtkDarktableButton *button, GdkRGBA *color)
-{
-  g_return_if_fail(button != NULL);
-  if(color)
-  {
-    button->bg = *color;
-    button->icon_flags |= CPF_CUSTOM_BG;
-  }
-  else
-    button->icon_flags &= ~CPF_CUSTOM_BG;
 }
 
 // clang-format off

--- a/src/dtgtk/button.h
+++ b/src/dtgtk/button.h
@@ -55,10 +55,6 @@ GtkWidget *dtgtk_button_new(DTGTKCairoPaintIconFunc paint, gint paintflags, void
 void dtgtk_button_set_paint(GtkDarktableButton *button, DTGTKCairoPaintIconFunc paint, gint paintflags, void *paintdata);
 /** set the active state of the button icon */
 void dtgtk_button_set_active(GtkDarktableButton *button, gboolean active);
-/** overwrite the foreground color, or NULL to reset it */
-void dtgtk_button_override_color(GtkDarktableButton *button, GdkRGBA *color);
-/** overwrite the background color, or NULL to reset it */
-void dtgtk_button_override_background_color(GtkDarktableButton *button, GdkRGBA *color);
 
 G_END_DECLS
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1535,22 +1535,19 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   PREAMBLE(0.9, 1, 0, 0)
 
   const double r = 0.4;
-  const float alpha = flags & CPF_PRELIGHT ? 1.0 : 0.6;
   const dt_colorlabels_enum color = (flags & 7);
 
   if(color < DT_COLORLABELS_LAST)
   {
-    cairo_set_source_rgba(cr, darktable.bauhaus->colorlabels[color].red,
-                          darktable.bauhaus->colorlabels[color].green, darktable.bauhaus->colorlabels[color].blue,
-                          alpha);
+    set_color(cr, darktable.bauhaus->colorlabels[color]);
   }
   else
   {
-    cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, alpha);
+    cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, 1.0);
   }
 
   /* make blue color label icon more visible and well balanced with other colors */
-  if(flags & CPF_DIRECTION_RIGHT)
+  if(flags & CPF_LABEL_BLUE)
   {
     cairo_set_line_width(cr, 1.2 * cairo_get_line_width(cr));
   }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1750,35 +1750,35 @@ void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h,
 
   const float r = 0.18;
 
-  if(flags & CPF_DIRECTION_UP)
+  if(flags & CPF_LABEL_RED)
   {
     cairo_arc(cr, r, r, r, 0, 2.0f * M_PI);
     set_color(cr, colorlabels[DT_COLORLABELS_RED]);
     cairo_fill(cr);
   }
 
-  if(flags & CPF_DIRECTION_DOWN)
+  if(flags & CPF_LABEL_YELLOW)
   {
     cairo_arc(cr, 1.0 - r, r, r, 0, 2.0f * M_PI);
     set_color(cr, colorlabels[DT_COLORLABELS_YELLOW]);
     cairo_fill(cr);
   }
 
-  if(flags & CPF_DIRECTION_LEFT)
+  if(flags & CPF_LABEL_GREEN)
   {
     cairo_arc(cr, 0.5, 0.5, r, 0, 2.0f * M_PI);
     set_color(cr, colorlabels[DT_COLORLABELS_GREEN]);
     cairo_fill(cr);
   }
 
-  if(flags & CPF_DIRECTION_RIGHT)
+  if(flags & CPF_LABEL_BLUE)
   {
     cairo_arc(cr, r, 1.0 - r, r, 0, 2.0f * M_PI);
     set_color(cr, colorlabels[DT_COLORLABELS_BLUE]);
     cairo_fill(cr);
   }
 
-  if(flags & CPF_BG_TRANSPARENT)
+  if(flags & CPF_LABEL_PURPLE)
   {
     cairo_arc(cr, 1.0 - r, 1.0 - r, r, 0, 2.0f * M_PI);
     set_color(cr, colorlabels[DT_COLORLABELS_PURPLE]);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -192,7 +192,7 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
 
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 1, 0, 0)
+  PREAMBLE(1, 1.2, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.05);
   cairo_line_to(cr, 0.1, 0.95);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -39,14 +39,6 @@
 #define FINISH { cairo_identity_matrix(cr); \
                  cairo_restore(cr); }
 
-const GdkRGBA _colorlabels[]
-  = { {.red = 0.9, .green = 0.0, .blue = 0.0, .alpha = 1.0 }, // red
-      {.red = 0.9, .green = 0.9, .blue = 0.0, .alpha = 1.0 }, // yellow
-      {.red = 0.0, .green = 0.9, .blue = 0.0, .alpha = 1.0 }, // green
-      {.red = 0.0, .green = 0.1, .blue = 0.9, .alpha = 1.0 }, // blue (need a little green here to improve contrast of blue label in darker theme especially while being good in other themes)
-      {.red = 0.9, .green = 0.0, .blue = 0.9, .alpha = 1.0 }, // purple
-    };
-
 void dtgtk_cairo_paint_empty(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 1, 0, 0)
@@ -1508,9 +1500,7 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
   if(color < DT_COLORLABELS_LAST)
   {
-    const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
-
-    set_color(cr, colorlabels[color]);
+    set_color(cr, darktable.bauhaus->colorlabels[color]);
   }
   else
   {
@@ -1547,11 +1537,12 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   const double r = 0.4;
   const float alpha = flags & CPF_PRELIGHT ? 1.0 : 0.6;
   const dt_colorlabels_enum color = (flags & 7);
-  const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
 
   if(color < DT_COLORLABELS_LAST)
   {
-    cairo_set_source_rgba(cr, colorlabels[color].red, colorlabels[color].green, colorlabels[color].blue, alpha);
+    cairo_set_source_rgba(cr, darktable.bauhaus->colorlabels[color].red,
+                          darktable.bauhaus->colorlabels[color].green, darktable.bauhaus->colorlabels[color].blue,
+                          alpha);
   }
   else
   {
@@ -1563,7 +1554,7 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   {
     cairo_set_line_width(cr, 1.2 * cairo_get_line_width(cr));
   }
-  
+
   /* then improve hover effect for same blue icon */
   if (flags & CPF_PRELIGHT)
   {
@@ -1746,42 +1737,40 @@ void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h,
 {
   PREAMBLE(1.1, 1, 0, 0)
 
-  const GdkRGBA *colorlabels = data != NULL ? data : _colorlabels;
-
   const float r = 0.18;
 
   if(flags & CPF_LABEL_RED)
   {
     cairo_arc(cr, r, r, r, 0, 2.0f * M_PI);
-    set_color(cr, colorlabels[DT_COLORLABELS_RED]);
+    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_RED]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_LABEL_YELLOW)
   {
     cairo_arc(cr, 1.0 - r, r, r, 0, 2.0f * M_PI);
-    set_color(cr, colorlabels[DT_COLORLABELS_YELLOW]);
+    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_YELLOW]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_LABEL_GREEN)
   {
     cairo_arc(cr, 0.5, 0.5, r, 0, 2.0f * M_PI);
-    set_color(cr, colorlabels[DT_COLORLABELS_GREEN]);
+    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_GREEN]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_LABEL_BLUE)
   {
     cairo_arc(cr, r, 1.0 - r, r, 0, 2.0f * M_PI);
-    set_color(cr, colorlabels[DT_COLORLABELS_BLUE]);
+    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_BLUE]);
     cairo_fill(cr);
   }
 
   if(flags & CPF_LABEL_PURPLE)
   {
     cairo_arc(cr, 1.0 - r, 1.0 - r, r, 0, 2.0f * M_PI);
-    set_color(cr, colorlabels[DT_COLORLABELS_PURPLE]);
+    set_color(cr, darktable.bauhaus->colorlabels[DT_COLORLABELS_PURPLE]);
     cairo_fill(cr);
   }
 

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -33,14 +33,15 @@ typedef enum dtgtk_cairo_paint_flags_t
   CPF_ACTIVE = 1 << 4,
   CPF_PRELIGHT = 1 << 5,
   CPF_IGNORE_FG_STATE = 1 << 6,    // Ignore state when setting foregroundcolor
-  CPF_BG_TRANSPARENT = 1 << 7,     // transparent background
-  CPF_STYLE_FLAT = 1 << 8,         // flat style widget
-  CPF_STYLE_BOX = 1 << 9,          // boxed style widget
   CPF_DO_NOT_USE_BORDER = 1 << 10, // do not paint inner border
-  CPF_CUSTOM_BG = 1 << 11,
-  CPF_CUSTOM_FG = 1 << 12,
   CPF_FOCUS = 1 << 13,
-  CPF_SPECIAL_FLAG = 1 << 14 // this needs to be the last one. also update shift in dtgtk_cairo_paint_alignment
+  CPF_SPECIAL_FLAG = 1 << 14, // this needs to be the last one. also update shift in dtgtk_cairo_paint_alignment
+
+  CPF_LABEL_RED = CPF_DIRECTION_UP,
+  CPF_LABEL_YELLOW = CPF_DIRECTION_DOWN,
+  CPF_LABEL_GREEN = CPF_DIRECTION_LEFT,
+  CPF_LABEL_BLUE = CPF_DIRECTION_RIGHT,
+  CPF_LABEL_PURPLE = 1 << 7
 } dtgtk_cairo_paint_flags_t;
 
 

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -32,11 +32,11 @@ typedef enum dtgtk_cairo_paint_flags_t
   CPF_DIRECTION_RIGHT = 1 << 3,
   CPF_ACTIVE = 1 << 4,
   CPF_PRELIGHT = 1 << 5,
-  CPF_IGNORE_FG_STATE = 1 << 6,    // Ignore state when setting foregroundcolor
-  CPF_DO_NOT_USE_BORDER = 1 << 10, // do not paint inner border
+  CPF_IGNORE_FG_STATE = 1 << 6, // Ignore state when setting foregroundcolor
   CPF_FOCUS = 1 << 13,
   CPF_SPECIAL_FLAG = 1 << 14, // this needs to be the last one. also update shift in dtgtk_cairo_paint_alignment
 
+  // colorlabels
   CPF_LABEL_RED = CPF_DIRECTION_UP,
   CPF_LABEL_YELLOW = CPF_DIRECTION_DOWN,
   CPF_LABEL_GREEN = CPF_DIRECTION_LEFT,

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -32,7 +32,6 @@ typedef enum dtgtk_cairo_paint_flags_t
   CPF_DIRECTION_RIGHT = 1 << 3,
   CPF_ACTIVE = 1 << 4,
   CPF_PRELIGHT = 1 << 5,
-  CPF_IGNORE_FG_STATE = 1 << 6, // Ignore state when setting foregroundcolor
   CPF_FOCUS = 1 << 13,
   CPF_SPECIAL_FLAG = 1 << 14, // this needs to be the last one. also update shift in dtgtk_cairo_paint_alignment
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -188,15 +188,15 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
     const int col = sqlite3_column_int(darktable.view_manager->statements.get_color, 0);
     // we reuse CPF_* flags, as we'll pass them to the paint fct after
     if(col == 0)
-      thumb->colorlabels |= CPF_DIRECTION_UP;
+      thumb->colorlabels |= CPF_LABEL_RED;
     else if(col == 1)
-      thumb->colorlabels |= CPF_DIRECTION_DOWN;
+      thumb->colorlabels |= CPF_LABEL_YELLOW;
     else if(col == 2)
-      thumb->colorlabels |= CPF_DIRECTION_LEFT;
+      thumb->colorlabels |= CPF_LABEL_GREEN;
     else if(col == 3)
-      thumb->colorlabels |= CPF_DIRECTION_RIGHT;
+      thumb->colorlabels |= CPF_LABEL_BLUE;
     else if(col == 4)
-      thumb->colorlabels |= CPF_BG_TRANSPARENT;
+      thumb->colorlabels |= CPF_LABEL_PURPLE;
   }
   if(thumb->w_color)
   {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1380,7 +1380,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     }
 
     // the color labels
-    thumb->w_color = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_label_flower, thumb->colorlabels, &darktable.bauhaus->colorlabels);
+    thumb->w_color = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_label_flower, thumb->colorlabels, NULL);
     gtk_widget_set_name(thumb->w_color, "thumb_colorlabels");
     gtk_widget_set_valign(thumb->w_color, GTK_ALIGN_END);
     gtk_widget_set_halign(thumb->w_color, GTK_ALIGN_END);
@@ -1390,7 +1390,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_color);
 
     // the local copy indicator
-    thumb->w_local_copy = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_local_copy, CPF_DO_NOT_USE_BORDER, NULL);
+    thumb->w_local_copy = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_local_copy, 0, NULL);
     gtk_widget_set_name(thumb->w_local_copy, "thumb_localcopy");
     gtk_widget_set_tooltip_text(thumb->w_local_copy, _("local copy"));
     gtk_widget_set_valign(thumb->w_local_copy, GTK_ALIGN_START);
@@ -1403,7 +1403,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_local_copy);
 
     // the altered icon
-    thumb->w_altered = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_altered, CPF_DO_NOT_USE_BORDER, NULL);
+    thumb->w_altered = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_altered, 0, NULL);
     gtk_widget_set_name(thumb->w_altered, "thumb_altered");
     gtk_widget_set_valign(thumb->w_altered, GTK_ALIGN_START);
     gtk_widget_set_halign(thumb->w_altered, GTK_ALIGN_END);
@@ -1413,7 +1413,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_altered);
 
     // the group bouton
-    thumb->w_group = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_grouping, CPF_DO_NOT_USE_BORDER, NULL);
+    thumb->w_group = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_grouping, 0, NULL);
     gtk_widget_set_name(thumb->w_group, "thumb_group");
     g_signal_connect(G_OBJECT(thumb->w_group), "button-release-event", G_CALLBACK(_event_grouping_release), thumb);
     g_signal_connect(G_OBJECT(thumb->w_group), "enter-notify-event", G_CALLBACK(_event_btn_enter_leave), thumb);
@@ -1424,7 +1424,7 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
     gtk_overlay_add_overlay(GTK_OVERLAY(overlays_parent), thumb->w_group);
 
     // the sound icon
-    thumb->w_audio = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_audio, CPF_DO_NOT_USE_BORDER, NULL);
+    thumb->w_audio = dtgtk_thumbnail_btn_new(dtgtk_cairo_paint_audio, 0, NULL);
     gtk_widget_set_name(thumb->w_audio, "thumb_audio");
     g_signal_connect(G_OBJECT(thumb->w_audio), "button-release-event", G_CALLBACK(_event_audio_release), thumb);
     g_signal_connect(G_OBJECT(thumb->w_audio), "enter-notify-event", G_CALLBACK(_event_btn_enter_leave), thumb);

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -78,17 +78,16 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
     else
       flags &= ~CPF_ACTIVE;
 
-    if(flags & CPF_DO_NOT_USE_BORDER)
-    {
-      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0, 0, allocation.width, allocation.height, flags,
-                                        DTGTK_THUMBNAIL_BTN(widget)->icon_data ? DTGTK_THUMBNAIL_BTN(widget)->icon_data : bg_color);
-    }
-    else
-    {
-      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0.125 * allocation.width, 0.125 * allocation.height,
-                                        0.75 * allocation.width, 0.75 * allocation.height, flags,
-                                        DTGTK_THUMBNAIL_BTN(widget)->icon_data ? DTGTK_THUMBNAIL_BTN(widget)->icon_data : bg_color);
-    }
+    GtkBorder padding;
+    gtk_style_context_get_padding(context, state, &padding);
+    // padding is a percent of the full size
+    const float icon_x = padding.left * allocation.width / 100.0f;
+    const float icon_y = padding.top * allocation.height / 100.0f;
+    const float icon_w = allocation.width - (padding.left + padding.right) * allocation.width / 100.0f;
+    const float icon_h = allocation.height - (padding.top + padding.bottom) * allocation.height / 100.0f;
+    DTGTK_THUMBNAIL_BTN(widget)->icon(
+        cr, icon_x, icon_y, icon_w, icon_h, flags,
+        DTGTK_THUMBNAIL_BTN(widget)->icon_data ? DTGTK_THUMBNAIL_BTN(widget)->icon_data : bg_color);
   }
   // and eventually the image border
   cairo_restore(cr);

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -41,17 +41,11 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   g_return_val_if_fail(widget != NULL, FALSE);
   g_return_val_if_fail(DTGTK_IS_TOGGLEBUTTON(widget), FALSE);
 
-  GtkDarktableToggleButton *button = DTGTK_TOGGLEBUTTON(widget);
-
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
 
   GdkRGBA fg_color;
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
-
-  if(button->icon_flags & CPF_IGNORE_FG_STATE)
-    gtk_style_context_get_color(context, state & ~GTK_STATE_FLAG_SELECTED, &fg_color);
-  else
-    gtk_style_context_get_color(context, state, &fg_color);
+  gtk_style_context_get_color(context, state, &fg_color);
 
   /* fetch flags */
   int flags = DTGTK_TOGGLEBUTTON(widget)->icon_flags;

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -48,9 +48,7 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   GdkRGBA fg_color;
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
 
-  if(button->icon_flags & CPF_CUSTOM_FG)
-    fg_color = button->fg;
-  else if(button->icon_flags & CPF_IGNORE_FG_STATE)
+  if(button->icon_flags & CPF_IGNORE_FG_STATE)
     gtk_style_context_get_color(context, state & ~GTK_STATE_FLAG_SELECTED, &fg_color);
   else
     gtk_style_context_get_color(context, state, &fg_color);
@@ -98,22 +96,8 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   int cwidth = width - margin.left - margin.right;
   int cheight = height - margin.top - margin.bottom;
 
-  /* draw standard button background if not transparent nor flat styled */
-  if((flags & CPF_STYLE_FLAT))
-  {
-    if((flags & CPF_PRELIGHT) || ((flags & CPF_ACTIVE) && !(flags & CPF_BG_TRANSPARENT)))
-    {
-      // When CPF_BG_TRANSPARENT is set, change the background on
-      // PRELIGHT, but not on ACTIVE
-      if(!(flags & CPF_BG_TRANSPARENT) || (flags & CPF_PRELIGHT))
-        gtk_render_background(context, cr, startx, starty, cwidth, cheight);
-    }
-    if(!(flags & CPF_ACTIVE) || (flags & CPF_IGNORE_FG_STATE))
-      fg_color.alpha = CLAMP(fg_color.alpha / 2.0, 0.3, 1.0);
-  }
-  else if(!(flags & CPF_BG_TRANSPARENT))
-    gtk_render_background(context, cr, startx, starty, cwidth, cheight);
-
+  /* draw standard button background and borders */
+  gtk_render_background(context, cr, startx, starty, cwidth, cheight);
   gtk_render_frame(context, cr, startx, starty, cwidth, cheight);
 
   gdk_cairo_set_source_rgba(cr, &fg_color);
@@ -193,30 +177,6 @@ void dtgtk_togglebutton_set_paint(GtkDarktableToggleButton *button, DTGTKCairoPa
   button->icon = paint;
   button->icon_flags = paintflags;
   button->icon_data = paintdata;
-}
-
-void dtgtk_togglebutton_override_color(GtkDarktableToggleButton *button, GdkRGBA *color)
-{
-  g_return_if_fail(button != NULL);
-  if(color)
-  {
-    button->fg = *color;
-    button->icon_flags |= CPF_CUSTOM_FG;
-  }
-  else
-    button->icon_flags &= ~CPF_CUSTOM_FG;
-}
-
-void dtgtk_togglebutton_override_background_color(GtkDarktableToggleButton *button, GdkRGBA *color)
-{
-  g_return_if_fail(button != NULL);
-  if(color)
-  {
-    button->bg = *color;
-    button->icon_flags |= CPF_CUSTOM_BG;
-  }
-  else
-    button->icon_flags &= ~CPF_CUSTOM_BG;
 }
 
 // clang-format off

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -140,7 +140,6 @@ GtkWidget *dtgtk_togglebutton_new(DTGTKCairoPaintIconFunc paint, gint paintflags
   button->canvas = gtk_drawing_area_new();
   gtk_container_add(GTK_CONTAINER(button), button->canvas);
   dt_gui_add_class(GTK_WIDGET(button), "dt_module_btn");
-  gtk_widget_set_name(GTK_WIDGET(button), "dt-toggle-button");
   gtk_widget_set_name(GTK_WIDGET(button->canvas), "button-canvas");
   return (GtkWidget *)button;
 }

--- a/src/dtgtk/togglebutton.h
+++ b/src/dtgtk/togglebutton.h
@@ -34,7 +34,7 @@ typedef struct _GtkDarktableToggleButton
   DTGTKCairoPaintIconFunc icon;
   gint icon_flags;
   void *icon_data;
-  GdkRGBA bg, fg;
+  GdkRGBA bg;
   GtkWidget *canvas;
 } GtkDarktableToggleButton;
 
@@ -51,10 +51,6 @@ GtkWidget *dtgtk_togglebutton_new(DTGTKCairoPaintIconFunc paint, gint paintflag,
 /** Set the paint function and paint flags */
 void dtgtk_togglebutton_set_paint(GtkDarktableToggleButton *button, DTGTKCairoPaintIconFunc paint,
                                   gint paintflags, void *paintdata);
-/** overwrite the foreground color, or NULL to reset it */
-void dtgtk_togglebutton_override_color(GtkDarktableToggleButton *button, GdkRGBA *color);
-/** overwrite the background color, or NULL to reset it */
-void dtgtk_togglebutton_override_background_color(GtkDarktableToggleButton *button, GdkRGBA *color);
 
 G_END_DECLS
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -336,7 +336,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
 
   if(w == NULL || GTK_IS_BOX(w))
   {
-    GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+    GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
     _init_picker(color_picker, module, kind, button);
     if(init_cst)
       color_picker->picker_cst = cst;
@@ -348,7 +348,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   }
   else
   {
-    dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+    dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, 0, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
     _init_picker(color_picker, module, kind, w);
     if(init_cst)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -337,6 +337,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   if(w == NULL || GTK_IS_BOX(w))
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
+    dt_gui_add_class(button, "dt_transparent_background");
     _init_picker(color_picker, module, kind, button);
     if(init_cst)
       color_picker->picker_cst = cst;

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -508,7 +508,7 @@ static inline GdkPixbuf *dt_draw_paint_to_pixbuf
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dim, dim);
   cairo_t *cr = cairo_create(cst);
   gdk_cairo_set_source_rgba(cr, &fg_color);
-  (*dtgtk_cairo_paint_fct)(cr, 0, 0, dim, dim, flags | CPF_DO_NOT_USE_BORDER, NULL);
+  (*dtgtk_cairo_paint_fct)(cr, 0, 0, dim, dim, flags, NULL);
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, dim, dim);

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -508,7 +508,7 @@ static inline GdkPixbuf *dt_draw_paint_to_pixbuf
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dim, dim);
   cairo_t *cr = cairo_create(cst);
   gdk_cairo_set_source_rgba(cr, &fg_color);
-  (*dtgtk_cairo_paint_fct)(cr, 0, 0, dim, dim, flags | CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  (*dtgtk_cairo_paint_fct)(cr, 0, 0, dim, dim, flags | CPF_DO_NOT_USE_BORDER, NULL);
   cairo_destroy(cr);
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, dim, dim);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1362,7 +1362,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   // create focus-peaking button
   darktable.gui->focus_peaking_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_focus_peaking, 0, NULL);
-  dt_gui_add_class(darktable.gui->focus_peaking_button, "dt_checked_background");
   gtk_widget_set_tooltip_text(darktable.gui->focus_peaking_button, _("toggle focus-peaking mode"));
   g_signal_connect(G_OBJECT(darktable.gui->focus_peaking_button), "clicked", G_CALLBACK(_focuspeaking_switch_button_callback), NULL);
   _update_focus_peaking_button();
@@ -3375,6 +3374,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   cs->toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow,
                                       (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
+  dt_gui_add_class(cs->toggle, "dt_transparent_background");
   dt_gui_add_class(cs->toggle, "dt_ignore_fg_state");
 
   cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3374,7 +3374,6 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   cs->toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow,
                                       (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
-  dt_gui_add_class(cs->toggle, "dt_transparent_background");
   dt_gui_add_class(cs->toggle, "dt_ignore_fg_state");
 
   cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1362,8 +1362,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   // create focus-peaking button
   darktable.gui->focus_peaking_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_focus_peaking, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(darktable.gui->focus_peaking_button),
-                              "dt_checked_background");
+  dt_gui_add_class(darktable.gui->focus_peaking_button, "dt_checked_background");
   gtk_widget_set_tooltip_text(darktable.gui->focus_peaking_button, _("toggle focus-peaking mode"));
   g_signal_connect(G_OBJECT(darktable.gui->focus_peaking_button), "clicked", G_CALLBACK(_focuspeaking_switch_button_callback), NULL);
   _update_focus_peaking_button();

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1361,7 +1361,9 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_control_change_cursor(GDK_LEFT_PTR);
 
   // create focus-peaking button
-  darktable.gui->focus_peaking_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_focus_peaking, CPF_STYLE_FLAT, NULL);
+  darktable.gui->focus_peaking_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_focus_peaking, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(darktable.gui->focus_peaking_button),
+                              "dt_checked_background");
   gtk_widget_set_tooltip_text(darktable.gui->focus_peaking_button, _("toggle focus-peaking mode"));
   g_signal_connect(G_OBJECT(darktable.gui->focus_peaking_button), "clicked", G_CALLBACK(_focuspeaking_switch_button_callback), NULL);
   _update_focus_peaking_button();
@@ -3321,9 +3323,8 @@ static void _coeffs_button_changed(GtkDarktableToggleButton *widget, gpointer us
 
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cs->toggle));
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), active);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(cs->toggle),
-                               dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(cs->toggle), dtgtk_cairo_paint_solid_arrow,
+                               (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   dt_conf_set_bool(cs->confname, active);
 }
 
@@ -3341,7 +3342,7 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs)
 {
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cs->toggle));
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(cs->toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
+                               (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), active);
 
   if(active)
@@ -3372,9 +3373,8 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   dt_gui_add_class(destdisp_head, "section-expander");
   gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
 
-  cs->toggle = dtgtk_togglebutton_new
-    (dtgtk_cairo_paint_solid_arrow,
-     CPF_STYLE_BOX | (expanded?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
+  cs->toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow,
+                                      (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
   dt_gui_add_class(cs->toggle, "dt_transparent_background");
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3376,7 +3376,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   cs->toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow,
                                       (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), expanded);
-  dt_gui_add_class(cs->toggle, "dt_transparent_background");
+  dt_gui_add_class(cs->toggle, "dt_ignore_fg_state");
 
   cs->container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
   gtk_widget_set_name(GTK_WIDGET(cs->container), "collapsible");

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -654,7 +654,7 @@ static void _settings_flip_changed(GtkWidget *w, _guides_settings_t *gw)
 void dt_guides_set_overlay_colors()
 {
   const int overlay_color = dt_conf_get_int("darkroom/ui/overlay_color");
-  
+
   darktable.gui->overlay_contrast = dt_conf_get_float("darkroom/ui/overlay_contrast");
 
   darktable.gui->overlay_red = darktable.gui->overlay_green = darktable.gui->overlay_blue = 0.0f;
@@ -898,7 +898,7 @@ void dt_guides_init_module_widget(GtkWidget *iopw, struct dt_iop_module_t *modul
 
   g_signal_connect(G_OBJECT(cb), "toggled", G_CALLBACK(_settings_autoshow_change2), module);
   gtk_widget_set_tooltip_text(cb, _("show guide overlay when this module has focus"));
-  GtkWidget *ic = dtgtk_button_new(dtgtk_cairo_paint_grid, CPF_STYLE_FLAT, NULL);
+  GtkWidget *ic = dtgtk_button_new(dtgtk_cairo_paint_grid, 0, NULL);
   gtk_widget_set_tooltip_text(ic, _("change global guide settings\nnote that these settings are applied globally "
                                     "and will impact any module that shows guide overlays"));
   g_signal_connect(G_OBJECT(ic), "clicked", G_CALLBACK(_settings_autoshow_menu), module);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5753,29 +5753,29 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_grid_attach(auto_grid, dt_ui_label_new(_("structure")), 0, 0, 1, 1);
 
-  g->structure_lines = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT, NULL);
+  g->structure_lines = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, 0, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->structure_lines), TRUE);
   gtk_grid_attach(auto_grid, g->structure_lines, 1, 0, 1, 1);
 
-  g->structure_quad = dtgtk_togglebutton_new(dtgtk_cairo_paint_draw_structure, CPF_STYLE_FLAT, NULL);
+  g->structure_quad = dtgtk_togglebutton_new(dtgtk_cairo_paint_draw_structure, 0, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->structure_quad), TRUE);
   gtk_grid_attach(auto_grid, g->structure_quad, 2, 0, 1, 1);
 
-  g->structure_auto = dtgtk_togglebutton_new(dtgtk_cairo_paint_structure, CPF_STYLE_FLAT, NULL);
+  g->structure_auto = dtgtk_togglebutton_new(dtgtk_cairo_paint_structure, 0, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->structure_auto), TRUE);
   gtk_grid_attach(auto_grid, g->structure_auto, 3, 0, 1, 1);
 
   gtk_grid_attach(auto_grid, dt_ui_label_new(_("fit")), 0, 1, 1, 1);
 
-  g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
+  g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, 1, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_v), TRUE);
   gtk_grid_attach(auto_grid, g->fit_v, 1, 1, 1, 1);
 
-  g->fit_h = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 2, NULL);
+  g->fit_h = dtgtk_button_new(dtgtk_cairo_paint_perspective, 2, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_h), TRUE);
   gtk_grid_attach(auto_grid, g->fit_h, 2, 1, 1, 1);
 
-  g->fit_both = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 3, NULL);
+  g->fit_both = dtgtk_button_new(dtgtk_cairo_paint_perspective, 3, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_both), TRUE);
   gtk_grid_attach(auto_grid, g->fit_both, 3, 1, 1, 1);
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -621,6 +621,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(autolevels_box), g->bt_auto_levels, TRUE, TRUE, 0);
 
   g->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
+  dt_gui_add_class(g->bt_select_region, "dt_transparent_background");
   gtk_widget_set_tooltip_text(g->bt_select_region,
                               _("apply auto exposure based on a region defined by the user\n"
                                 "click and drag to draw the area\n"

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -620,7 +620,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_size_request(g->bt_auto_levels, -1, DT_PIXEL_APPLY_DPI(24));
   gtk_box_pack_start(GTK_BOX(autolevels_box), g->bt_auto_levels, TRUE, TRUE, 0);
 
-  g->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  g->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
   gtk_widget_set_tooltip_text(g->bt_select_region,
                               _("apply auto exposure based on a region defined by the user\n"
                                 "click and drag to draw the area\n"

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4248,17 +4248,17 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *toolbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
 
-  g->button_commit = dtgtk_button_new(dtgtk_cairo_paint_check_mark, CPF_STYLE_BOX, NULL);
+  g->button_commit = dtgtk_button_new(dtgtk_cairo_paint_check_mark, 0, NULL);
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_commit), FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->button_commit, _("accept the computed profile and set it in the module"));
   g_signal_connect(G_OBJECT(g->button_commit), "button-press-event", G_CALLBACK(commit_profile_callback), (gpointer)self);
 
-  g->button_profile = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_STYLE_BOX, NULL);
+  g->button_profile = dtgtk_button_new(dtgtk_cairo_paint_refresh, 0, NULL);
   g_signal_connect(G_OBJECT(g->button_profile), "button-press-event", G_CALLBACK(run_profile_callback), (gpointer)self);
   gtk_widget_set_tooltip_text(g->button_profile, _("recompute the profile"));
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_profile), FALSE, FALSE, 0);
 
-  g->button_validate = dtgtk_button_new(dtgtk_cairo_paint_softproof, CPF_STYLE_BOX, NULL);
+  g->button_validate = dtgtk_button_new(dtgtk_cairo_paint_softproof, 0, NULL);
   g_signal_connect(G_OBJECT(g->button_validate), "button-press-event", G_CALLBACK(run_validation_callback), (gpointer)self);
   gtk_widget_set_tooltip_text(g->button_validate, _("check the output delta E"));
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_validate), FALSE, FALSE, 0);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1702,7 +1702,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
   dt_bauhaus_slider_set_format(g->shadows_weight, "%");
   gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
-  dt_bauhaus_widget_set_quad_paint(g->shadows_weight, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->shadows_weight, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->shadows_weight, TRUE);
   g_signal_connect(G_OBJECT(g->shadows_weight), "quad-pressed", G_CALLBACK(mask_callback), self);
 
@@ -1710,7 +1710,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->mask_grey_fulcrum, 4);
   dt_bauhaus_slider_set_format(g->mask_grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->mask_grey_fulcrum, _("position of the middle-gray reference for masking"));
-  dt_bauhaus_widget_set_quad_paint(g->mask_grey_fulcrum, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->mask_grey_fulcrum, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->mask_grey_fulcrum, TRUE);
   g_signal_connect(G_OBJECT(g->mask_grey_fulcrum), "quad-pressed", G_CALLBACK(mask_callback), self);
 
@@ -1718,7 +1718,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
   dt_bauhaus_slider_set_format(g->highlights_weight, "%");
   gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
-  dt_bauhaus_widget_set_quad_paint(g->highlights_weight, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->highlights_weight, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->highlights_weight, TRUE);
   g_signal_connect(G_OBJECT(g->highlights_weight), "quad-pressed", G_CALLBACK(mask_callback), self);
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1702,8 +1702,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->shadows_weight, 4);
   dt_bauhaus_slider_set_format(g->shadows_weight, "%");
   gtk_widget_set_tooltip_text(g->shadows_weight, _("weight of the shadows over the whole tonal range"));
-  dt_bauhaus_widget_set_quad_paint(g->shadows_weight, dtgtk_cairo_paint_showmask,
-                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->shadows_weight, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->shadows_weight, TRUE);
   g_signal_connect(G_OBJECT(g->shadows_weight), "quad-pressed", G_CALLBACK(mask_callback), self);
 
@@ -1711,8 +1710,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->mask_grey_fulcrum, 4);
   dt_bauhaus_slider_set_format(g->mask_grey_fulcrum, "%");
   gtk_widget_set_tooltip_text(g->mask_grey_fulcrum, _("position of the middle-gray reference for masking"));
-  dt_bauhaus_widget_set_quad_paint(g->mask_grey_fulcrum, dtgtk_cairo_paint_showmask,
-                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->mask_grey_fulcrum, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->mask_grey_fulcrum, TRUE);
   g_signal_connect(G_OBJECT(g->mask_grey_fulcrum), "quad-pressed", G_CALLBACK(mask_callback), self);
 
@@ -1720,8 +1718,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->highlights_weight, 4);
   dt_bauhaus_slider_set_format(g->highlights_weight, "%");
   gtk_widget_set_tooltip_text(g->highlights_weight, _("weights of highlights over the whole tonal range"));
-  dt_bauhaus_widget_set_quad_paint(g->highlights_weight, dtgtk_cairo_paint_showmask,
-                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->highlights_weight, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->highlights_weight, TRUE);
   g_signal_connect(G_OBJECT(g->highlights_weight), "quad-pressed", G_CALLBACK(mask_callback), self);
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2444,8 +2444,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_name(c->colorpicker, "keep-active");
   c->colorpicker_set_values = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, hbox, IOP_CS_LCH);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
-                               dtgtk_cairo_paint_colorpicker_set_values,
-                               CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+                               dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
   gtk_widget_set_size_request(c->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(c->colorpicker_set_values, _("create a curve based on an area from the image\n"
                                                            "drag to create a flat curve\n"
@@ -2478,8 +2477,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->chk_edit_by_area), "toggled", G_CALLBACK(_edit_by_area_callback), self);
 
   // display selection
-  c->bt_showmask
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT, NULL);
+  c->bt_showmask = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, 0, NULL);
   gtk_widget_set_tooltip_text(c->bt_showmask, _("display selection"));
   g_signal_connect(G_OBJECT(c->bt_showmask), "toggled", G_CALLBACK(_display_mask_callback), self);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->bt_showmask), FALSE);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2445,6 +2445,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->colorpicker_set_values = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, hbox, IOP_CS_LCH);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
                                dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
+  dt_gui_add_class(c->colorpicker_set_values, "dt_transparent_background");
   gtk_widget_set_size_request(c->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(c->colorpicker_set_values, _("create a curve based on an area from the image\n"
                                                            "drag to create a flat curve\n"
@@ -2478,6 +2479,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // display selection
   c->bt_showmask = dtgtk_togglebutton_new(dtgtk_cairo_paint_showmask, 0, NULL);
+  dt_gui_add_class(c->bt_showmask, "dt_transparent_background");
   gtk_widget_set_tooltip_text(c->bt_showmask, _("display selection"));
   g_signal_connect(G_OBJECT(c->bt_showmask), "toggled", G_CALLBACK(_display_mask_callback), self);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->bt_showmask), FALSE);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5785,7 +5785,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                 "set to 1.0 for flat content"));
   g->dual_mask = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->dual_mask, NULL, N_("display blending mask"));
-  dt_bauhaus_widget_set_quad_paint(g->dual_mask, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->dual_mask, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->dual_mask, TRUE);
   g_signal_connect(G_OBJECT(g->dual_mask), "quad-pressed", G_CALLBACK(show_mask_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->dual_mask, FALSE, FALSE, 0);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3012,7 +3012,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       else if(demosaicing_method == DT_IOP_DEMOSAIC_FDC && (qual_flags & DEMOSAIC_XTRANS_FULL))
         xtrans_fdc_interpolate(self, tmp, pixels, &roo, &roi, xtrans);
       else if(demosaicing_method >= DT_IOP_DEMOSAIC_MARKESTEIJN && (qual_flags & DEMOSAIC_XTRANS_FULL))
-        xtrans_markesteijn_interpolate(tmp, pixels, &roo, &roi, xtrans, passes); 
+        xtrans_markesteijn_interpolate(tmp, pixels, &roo, &roi, xtrans, passes);
       else
         vng_interpolate(tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans, qual_flags & DEMOSAIC_ONLY_VNG_LINEAR);
     }
@@ -5785,7 +5785,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                 "set to 1.0 for flat content"));
   g->dual_mask = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->dual_mask, NULL, N_("display blending mask"));
-  dt_bauhaus_widget_set_quad_paint(g->dual_mask, dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->dual_mask, dtgtk_cairo_paint_showmask, CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->dual_mask, TRUE);
   g_signal_connect(G_OBJECT(g->dual_mask), "quad-pressed", G_CALLBACK(show_mask_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->dual_mask, FALSE, FALSE, 0);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1722,7 +1722,6 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
   GtkWidget *destdisp = dt_ui_section_label_new(_("destination/display"));
   g->extra_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_LEFT, NULL);
-  gtk_widget_set_name(GTK_WIDGET(g->extra_toggle), "control-button");
   GtkWidget *extra_options = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   gtk_box_pack_start(GTK_BOX(destdisp_head), destdisp, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(destdisp_head), g->extra_toggle, FALSE, FALSE, 0);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1457,7 +1457,7 @@ void gui_reset(dt_iop_module_t *self)
   dt_iop_color_picker_reset(self, TRUE);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), FALSE);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+                               CPF_DIRECTION_LEFT, NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->extra_toggle), FALSE);
 }
 
@@ -1570,7 +1570,7 @@ static void _extra_options_button_changed(GtkDarktableToggleButton *widget, gpoi
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->extra_toggle));
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), active);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
+                               (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
 }
 
 void gui_init(dt_iop_module_t *self)
@@ -1721,8 +1721,8 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
   GtkWidget *destdisp = dt_ui_section_label_new(_("destination/display"));
-  g->extra_toggle =
-    dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+  g->extra_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_LEFT, NULL);
+  gtk_widget_set_name(GTK_WIDGET(g->extra_toggle), "control-button");
   GtkWidget *extra_options = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   gtk_box_pack_start(GTK_BOX(destdisp_head), destdisp, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(destdisp_head), g->extra_toggle, FALSE, FALSE, 0);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3204,8 +3204,7 @@ void filmic_gui_draw_icon(cairo_t *cr, struct dt_iop_filmicrgb_gui_button_data_t
 
   const float scale = 0.85;
   cairo_scale(cr, scale, scale);
-  button->icon(cr, -scale * button->w / 2., -scale * button->h / 2., scale * button->w, scale * button->h,
-               CPF_DO_NOT_USE_BORDER, NULL);
+  button->icon(cr, -scale * button->w / 2., -scale * button->h / 2., scale * button->w, scale * button->h, 0, NULL);
   cairo_restore(cr);
 }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3205,7 +3205,7 @@ void filmic_gui_draw_icon(cairo_t *cr, struct dt_iop_filmicrgb_gui_button_data_t
   const float scale = 0.85;
   cairo_scale(cr, scale, scale);
   button->icon(cr, -scale * button->w / 2., -scale * button->h / 2., scale * button->w, scale * button->h,
-               CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+               CPF_DO_NOT_USE_BORDER, NULL);
   cairo_restore(cr);
 }
 
@@ -4378,7 +4378,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("display highlight reconstruction mask")), TRUE, TRUE, 0);
   g->show_highlight_mask = dt_iop_togglebutton_new(self, NULL, N_("display highlight reconstruction mask"), NULL, G_CALLBACK(show_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_highlight_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_highlight_mask), dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->show_highlight_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4379,6 +4379,7 @@ void gui_init(dt_iop_module_t *self)
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_highlight_mask), dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->show_highlight_mask, "dt_bauhaus_alignment");
+  dt_gui_add_class(g->show_highlight_mask, "dt_transparent_background");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   label = dt_ui_section_label_new(_("balance"));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2240,10 +2240,12 @@ void gui_init(dt_iop_module_t *self)
   g->bt_showmask = dt_iop_togglebutton_new(self, N_("editing"), N_("display masks"), NULL,
                                            G_CALLBACK(rt_showmask_callback), TRUE, 0, 0,
                                            dtgtk_cairo_paint_showmask, hbox_scale);
+  dt_gui_add_class(g->bt_showmask, "dt_transparent_background");
 
   g->bt_suppress = dt_iop_togglebutton_new(self, N_("editing"), N_("temporarily switch off shapes"), NULL,
                                            G_CALLBACK(rt_suppress_callback), TRUE, 0, 0,
                                            dtgtk_cairo_paint_eye_toggle, hbox_scale);
+  dt_gui_add_class(g->bt_suppress, "dt_transparent_background");
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
@@ -2262,6 +2264,7 @@ void gui_init(dt_iop_module_t *self)
   g->bt_display_wavelet_scale = dt_iop_togglebutton_new(self, N_("editing"), N_("display wavelet scale"), NULL,
                                                         G_CALLBACK(rt_display_wavelet_scale_callback), TRUE, 0, 0,
                                                         dtgtk_cairo_paint_display_wavelet_scale, hbox_scale);
+  dt_gui_add_class(g->bt_display_wavelet_scale, "dt_transparent_background");
 
   // preview single scale
   g->vbox_preview_scale = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1380,6 +1380,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker_set_values),
                                dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
+  dt_gui_add_class(g->colorpicker_set_values, "dt_transparent_background");
   gtk_widget_set_size_request(g->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(g->colorpicker_set_values, _("create a curve based on an area from the image\n"
                                                            "drag to create a flat curve\n"

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1379,8 +1379,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_name(g->colorpicker, "keep-active");
   g->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker_set_values),
-                               dtgtk_cairo_paint_colorpicker_set_values,
-                               CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+                               dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
   gtk_widget_set_size_request(g->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(g->colorpicker_set_values, _("create a curve based on an area from the image\n"
                                                            "drag to create a flat curve\n"

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1068,6 +1068,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(c->bt_auto_levels, _("apply auto levels"));
 
   c->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
+  dt_gui_add_class(c->bt_select_region, "dt_transparent_background");
   dt_action_define_iop(self, NULL, "auto region", c->bt_select_region, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(c->bt_select_region,
                               _("apply auto levels based on a region defined by the user\n"

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1067,7 +1067,7 @@ void gui_init(dt_iop_module_t *self)
   dt_action_define_iop(self, NULL, "auto levels", c->bt_auto_levels, &dt_action_def_button);
   gtk_widget_set_tooltip_text(c->bt_auto_levels, _("apply auto levels"));
 
-  c->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  c->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
   dt_action_define_iop(self, NULL, "auto region", c->bt_select_region, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(c->bt_select_region,
                               _("apply auto levels based on a region defined by the user\n"

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1917,7 +1917,7 @@ void gui_init(struct dt_iop_module_t *self)
   // actual kind of data we are using in the GUI (it is part of the pipeline).
   g->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, NULL, IOP_CS_NONE);
   dt_action_define_iop(self, N_("settings"), N_("from image area"), g->colorpicker, &dt_action_def_toggle);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, 0, NULL);
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
 
   g->btn_user = dt_iop_togglebutton_new(self, N_("settings"), N_("user modified"), NULL,

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1918,6 +1918,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->colorpicker = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_AREA, NULL, IOP_CS_NONE);
   dt_action_define_iop(self, N_("settings"), N_("from image area"), g->colorpicker, &dt_action_def_toggle);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker), dtgtk_cairo_paint_colorpicker, 0, NULL);
+  dt_gui_add_class(g->colorpicker, "dt_transparent_background");
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
 
   g->btn_user = dt_iop_togglebutton_new(self, N_("settings"), N_("user modified"), NULL,

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3287,6 +3287,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("display exposure mask")), TRUE, TRUE, 0);
   g->show_luminance_mask = dt_iop_togglebutton_new(self, NULL, N_("display exposure mask"), NULL, G_CALLBACK(show_luminance_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
+  dt_gui_add_class(g->show_luminance_mask, "dt_transparent_background");
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->show_luminance_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3257,7 +3257,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->exposure_boost, _("use this to slide the mask average exposure along channels\n"
                                                    "for a better control of the exposure correction with the available nodes.\n"
                                                    "the magic wand will auto-adjust the average exposure"));
-  dt_bauhaus_widget_set_quad_paint(g->exposure_boost, dtgtk_cairo_paint_wand, CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->exposure_boost, dtgtk_cairo_paint_wand, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->exposure_boost, FALSE);
   g_signal_connect(G_OBJECT(g->exposure_boost), "quad-pressed", G_CALLBACK(auto_adjust_exposure_boost), self);
 
@@ -3269,7 +3269,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                    "this allows to spread the exposure histogram over more channels\n"
                                                    "for a better control of the exposure correction.\n"
                                                    "the magic wand will auto-adjust the contrast"));
-  dt_bauhaus_widget_set_quad_paint(g->contrast_boost, dtgtk_cairo_paint_wand, CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->contrast_boost, dtgtk_cairo_paint_wand, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->contrast_boost, FALSE);
   g_signal_connect(G_OBJECT(g->contrast_boost), "quad-pressed", G_CALLBACK(auto_adjust_contrast_boost), self);
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3257,7 +3257,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->exposure_boost, _("use this to slide the mask average exposure along channels\n"
                                                    "for a better control of the exposure correction with the available nodes.\n"
                                                    "the magic wand will auto-adjust the average exposure"));
-  dt_bauhaus_widget_set_quad_paint(g->exposure_boost, dtgtk_cairo_paint_wand, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->exposure_boost, dtgtk_cairo_paint_wand, CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->exposure_boost, FALSE);
   g_signal_connect(G_OBJECT(g->exposure_boost), "quad-pressed", G_CALLBACK(auto_adjust_exposure_boost), self);
 
@@ -3269,7 +3269,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                    "this allows to spread the exposure histogram over more channels\n"
                                                    "for a better control of the exposure correction.\n"
                                                    "the magic wand will auto-adjust the contrast"));
-  dt_bauhaus_widget_set_quad_paint(g->contrast_boost, dtgtk_cairo_paint_wand, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_paint(g->contrast_boost, dtgtk_cairo_paint_wand, CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->contrast_boost, FALSE);
   g_signal_connect(G_OBJECT(g->contrast_boost), "quad-pressed", G_CALLBACK(auto_adjust_contrast_boost), self);
 
@@ -3287,7 +3287,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("display exposure mask")), TRUE, TRUE, 0);
   g->show_luminance_mask = dt_iop_togglebutton_new(self, NULL, N_("display exposure mask"), NULL, G_CALLBACK(show_luminance_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->show_luminance_mask, "dt_bauhaus_alignment");
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1067,7 +1067,7 @@ void gui_init(struct dt_iop_module_t *self)
   char *tooltip = g_strdup_printf(_("SVG watermarks in %s/watermarks or %s/watermarks"), configdir, datadir);
   gtk_widget_set_tooltip_text(g->watermarks, tooltip);
   g_free(tooltip);
-  g->refresh = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_STYLE_FLAT, NULL);
+  g->refresh = dtgtk_button_new(dtgtk_cairo_paint_refresh, 0, NULL);
 
   gtk_grid_attach(grid, label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(grid, g->watermarks, label, GTK_POS_RIGHT, 1, 1);
@@ -1145,7 +1145,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_set_column_spacing(GTK_GRID(bat), DT_PIXEL_APPLY_DPI(3));
   for(int i = 0; i < 9; i++)
   {
-    g->align[i] = dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment, CPF_STYLE_FLAT | (CPF_SPECIAL_FLAG << i), NULL);
+    g->align[i] = dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment, (CPF_SPECIAL_FLAG << i), NULL);
     gtk_grid_attach(GTK_GRID(bat), GTK_WIDGET(g->align[i]), 1 + i%3, i/3, 1, 1);
     g_signal_connect(G_OBJECT(g->align[i]), "toggled", G_CALLBACK(alignment_callback), self);
   }

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -235,7 +235,7 @@ static gboolean _cancellable_gui_thread(gpointer user_data)
   _cancellable_gui_thread_t *params = (_cancellable_gui_thread_t *)user_data;
 
   GtkBox *hbox = GTK_BOX(params->instance->hbox);
-  GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+  GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_lib_backgroundjobs_cancel_callback_new), params->progress);
   gtk_box_pack_start(hbox, GTK_WIDGET(button), FALSE, FALSE, 0);
   gtk_widget_show_all(button);

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -138,7 +138,7 @@ static dt_lib_camera_property_t *_lib_property_add_new(dt_lib_camera_t *lib, con
       dt_bauhaus_widget_set_label(prop->values, NULL, label);
       g_object_ref_sink(prop->values);
 
-      prop->osd = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT, NULL));
+      prop->osd = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, 0, NULL));
       g_object_ref_sink(prop->osd);
       gtk_widget_set_tooltip_text(GTK_WIDGET(prop->osd), _("toggle view property in center view"));
       do
@@ -449,12 +449,9 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(steps_label), 0, lib->gui.rows++, 1, 1);
 
   // capture modes buttons
-  lib->gui.toggle_timer = DTGTK_TOGGLEBUTTON(
-      dtgtk_togglebutton_new(dtgtk_cairo_paint_timer, CPF_STYLE_FLAT, NULL));
-  lib->gui.toggle_sequence = DTGTK_TOGGLEBUTTON(
-      dtgtk_togglebutton_new(dtgtk_cairo_paint_filmstrip, CPF_STYLE_FLAT, NULL));
-  lib->gui.toggle_bracket = DTGTK_TOGGLEBUTTON(
-      dtgtk_togglebutton_new(dtgtk_cairo_paint_bracket, CPF_STYLE_FLAT, NULL));
+  lib->gui.toggle_timer = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_timer, 0, NULL));
+  lib->gui.toggle_sequence = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_filmstrip, 0, NULL));
+  lib->gui.toggle_bracket = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_bracket, 0, NULL));
 
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   gtk_box_pack_start(hbox, GTK_WIDGET(lib->gui.toggle_timer), TRUE, TRUE, 0);

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -139,6 +139,7 @@ static dt_lib_camera_property_t *_lib_property_add_new(dt_lib_camera_t *lib, con
       g_object_ref_sink(prop->values);
 
       prop->osd = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, 0, NULL));
+      dt_gui_add_class(GTK_WIDGET(prop->osd), "dt_transparent_background");
       g_object_ref_sink(prop->osd);
       gtk_widget_set_tooltip_text(GTK_WIDGET(prop->osd), _("toggle view property in center view"));
       do

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2261,8 +2261,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
     else if(i == active)
     {
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule or add new rules"));
-      const gint flags = CPF_DIRECTION_DOWN | CPF_BG_TRANSPARENT | CPF_STYLE_FLAT;
-      dtgtk_button_set_paint(button, dtgtk_cairo_paint_solid_arrow, flags, NULL);
+      dtgtk_button_set_paint(button, dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
     }
     else
     {
@@ -3051,12 +3050,13 @@ void gui_init(dt_lib_module_t *self)
     gtk_box_pack_start(box, w, TRUE, TRUE, 0);
     gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
 
-    w = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
+    w = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
+    gtk_widget_set_name(GTK_WIDGET(w), "control-button");
+
     d->rule[i].button = w;
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);
     g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(popup_button_callback), d->rule + i);
     gtk_box_pack_start(box, w, FALSE, FALSE, 0);
-    dt_gui_add_class(w, "dt_transparent_background");
   }
 
   GtkTreeView *view = GTK_TREE_VIEW(gtk_tree_view_new());

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3051,7 +3051,6 @@ void gui_init(dt_lib_module_t *self)
     gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
 
     w = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
-    gtk_widget_set_name(GTK_WIDGET(w), "control-button");
 
     d->rule[i].button = w;
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -486,7 +486,7 @@ static void _add_sample(GtkButton *widget, dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(sample->output_label), "size-allocate", G_CALLBACK(_label_size_allocate_callback), sample);
   gtk_box_pack_start(GTK_BOX(container), sample->output_label, TRUE, TRUE, 0);
 
-  GtkWidget *delete_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+  GtkWidget *delete_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_cancel, 0, NULL);
   g_signal_connect(G_OBJECT(delete_button), "clicked", G_CALLBACK(_remove_sample_cb), sample);
   gtk_box_pack_start(GTK_BOX(container), delete_button, FALSE, FALSE, 0);
 
@@ -634,7 +634,8 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(label), "size-allocate", G_CALLBACK(_label_size_allocate_callback), &data->primary_sample);
   gtk_box_pack_start(GTK_BOX(sample_row), label, TRUE, TRUE, 0);
 
-  data->add_sample_button = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT, NULL);;
+  data->add_sample_button = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
+  ;
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
   g_signal_connect(G_OBJECT(data->add_sample_button), "clicked", G_CALLBACK(_add_sample), self);
   gtk_box_pack_end(GTK_BOX(sample_row), data->add_sample_button, FALSE, FALSE, 0);

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -448,8 +448,8 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     g_signal_connect(G_OBJECT(tb), "focus-out-event", G_CALLBACK(_lib_duplicate_caption_out_callback), self);
     GtkWidget *lb = gtk_label_new (g_strdup(chl));
     gtk_widget_set_hexpand(lb, TRUE);
-    bt = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-//    gtk_widget_set_halign(bt, GTK_ALIGN_END);
+    bt = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+    //    gtk_widget_set_halign(bt, GTK_ALIGN_END);
     g_object_set_data(G_OBJECT(bt), "imgid", GINT_TO_POINTER(imgid));
     g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_delete), self);
 

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -436,12 +436,12 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox), box, FALSE, TRUE, 0);
 
-  GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT, NULL);
+  GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(button, _("add an output metadata tag"));
   gtk_box_pack_end(GTK_BOX(box), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_add_tag_button_clicked), (gpointer)d);
 
-  button = dtgtk_button_new(dtgtk_cairo_paint_minus_simple, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_button_new(dtgtk_cairo_paint_minus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(button, _("delete metadata tag"));
   gtk_box_pack_end(GTK_BOX(box), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_delete_tag_button_clicked), (gpointer)d);

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1740,7 +1740,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, label, 0, line, 2, 1);
   gtk_widget_set_tooltip_text(label, _("offset or difference ([-]dd hh:mm:ss[.sss])"));
 
-  d->lock_offset = dtgtk_togglebutton_new(dtgtk_cairo_paint_lock, CPF_STYLE_FLAT, NULL);
+  d->lock_offset = dtgtk_togglebutton_new(dtgtk_cairo_paint_lock, 0, NULL);
   gtk_widget_set_tooltip_text(d->lock_offset, _("lock date/time offset value to apply it onto another selection"));
   gtk_widget_set_halign(d->lock_offset, GTK_ALIGN_START);
   gtk_grid_attach(grid, d->lock_offset, 2, line, 1, 1);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -195,6 +195,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
 
   /* create toggle button */
   GtkWidget *widget = gtk_toggle_button_new_with_label(label);
+  dt_gui_add_class(widget, "dt_transparent_background");
   GtkWidget *lab = gtk_bin_get_child(GTK_BIN(widget));
   gtk_widget_set_halign(lab, GTK_ALIGN_START);
   gtk_label_set_xalign(GTK_LABEL(lab), 0);
@@ -228,7 +229,6 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
       onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, 0, NULL);
       gtk_widget_set_name(onoff, enabled ? "history-switch-enabled" : "history-switch");
     }
-    dt_gui_add_class(widget, enabled ? "dt_transparent_background" : "dt_transparent_background");
     gtk_widget_set_name(widget, enabled ? "history-button-enabled" : "history-button");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
   }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -201,8 +201,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   gtk_label_set_ellipsize(GTK_LABEL(lab), PANGO_ELLIPSIZE_END);
   if(always_on)
   {
-    onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    dt_gui_add_class(widget, "dt_transparent_background");
+    onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_on, 0, NULL);
     gtk_widget_set_name(onoff, "history-switch-always-enabled");
     gtk_widget_set_name(widget, "history-button-always-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), TRUE);
@@ -210,8 +209,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   }
   else if(default_enabled)
   {
-    onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-    dt_gui_add_class(widget, "dt_transparent_background");
+    onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, 0, NULL);
     gtk_widget_set_name(onoff, "history-switch-default-enabled");
     gtk_widget_set_name(widget, "history-button-default-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
@@ -221,13 +219,13 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   {
     if(deprecated)
     {
-      onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_deprecated, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+      onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_deprecated, 0, NULL);
       gtk_widget_set_name(onoff, "history-switch-deprecated");
       gtk_widget_set_tooltip_text(onoff, _("deprecated module"));
     }
     else
     {
-      onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+      onoff = dtgtk_button_new(dtgtk_cairo_paint_switch, 0, NULL);
       gtk_widget_set_name(onoff, enabled ? "history-switch-enabled" : "history-switch");
     }
     dt_gui_add_class(widget, enabled ? "dt_transparent_background" : "dt_transparent_background");

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1177,12 +1177,12 @@ static void _set_places_list(GtkWidget *places_paned, dt_lib_module_t* self)
   g_free(markup);
   gtk_box_pack_start(GTK_BOX(places_header), places_label, FALSE, FALSE, 0);
 
-  GtkWidget *places_reset = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT, NULL);
+  GtkWidget *places_reset = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
   gtk_widget_set_tooltip_text(places_reset, _("restore all default places you have removed by right-click"));
   g_signal_connect(places_reset, "clicked", G_CALLBACK(_places_reset_callback), self);
   gtk_box_pack_end(GTK_BOX(places_header), places_reset, FALSE, FALSE, 0);
 
-  GtkWidget *places_add = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT, NULL);
+  GtkWidget *places_add = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   gtk_widget_set_tooltip_text(places_add, _("add a custom place\n\nright-click on a place to remove it"));
   g_signal_connect(places_add, "clicked", G_CALLBACK(_lib_import_select_folder), self);
   gtk_box_pack_end(GTK_BOX(places_header), places_add, FALSE, FALSE, 0);
@@ -1591,7 +1591,7 @@ static void _set_files_list(GtkWidget *rbox, dt_lib_module_t* self)
   column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf",
                                                     DT_IMPORT_THUMB, NULL);
   gtk_tree_view_append_column(d->from.treeview, column);
-  GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT, NULL);
+  GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, 0, NULL);
   gtk_widget_show(button);
   header = gtk_tree_view_column_get_button(column);
   gtk_widget_set_tooltip_text(header, _("show/hide thumbnails"));

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1592,6 +1592,7 @@ static void _set_files_list(GtkWidget *rbox, dt_lib_module_t* self)
                                                     DT_IMPORT_THUMB, NULL);
   gtk_tree_view_append_column(d->from.treeview, column);
   GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, 0, NULL);
+  dt_gui_add_class(button, "dt_transparent_background");
   gtk_widget_show(button);
   header = gtk_tree_view_column_get_button(column);
   gtk_widget_set_tooltip_text(header, _("show/hide thumbnails"));

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -837,7 +837,7 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->expander), expanded);
 
   /* update expander arrow state */
-  gint flags = (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_RIGHT) | CPF_BG_TRANSPARENT | CPF_STYLE_FLAT;
+  gint flags = (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_RIGHT);
   dtgtk_button_set_paint(DTGTK_BUTTON(module->arrow), dtgtk_cairo_paint_solid_arrow, flags, NULL);
 
   /* show / hide plugin widget */
@@ -1026,7 +1026,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
    * initialize the header widgets
    */
   /* add the expand indicator icon */
-  module->arrow = dtgtk_button_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_FLAT, NULL);
+  module->arrow = dtgtk_button_new(dtgtk_cairo_paint_solid_arrow, 0, NULL);
   gtk_widget_set_tooltip_text(module->arrow, _("show module"));
   g_signal_connect(G_OBJECT(module->arrow), "button-press-event", G_CALLBACK(_lib_plugin_header_button_press), module);
   dt_action_define(&module->actions, NULL, NULL, module->arrow, NULL);
@@ -1045,7 +1045,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   gtk_box_pack_start(GTK_BOX(header), label_evb, FALSE, FALSE, 0);
 
   /* add preset button if module has implementation */
-  module->presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
+  module->presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
   g_signal_connect(G_OBJECT(module->presets_button), "clicked", G_CALLBACK(presets_popup_callback), module);
   g_signal_connect(G_OBJECT(module->presets_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
@@ -1055,7 +1055,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   gtk_box_pack_end(GTK_BOX(header), module->presets_button, FALSE, FALSE, 0);
 
   /* add reset button if module has implementation */
-  module->reset_button = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT, NULL);
+  module->reset_button = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
   g_signal_connect(G_OBJECT(module->reset_button), "clicked", G_CALLBACK(dt_lib_gui_reset_callback), module);
   g_signal_connect(G_OBJECT(module->reset_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1050,7 +1050,6 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(module->presets_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
   if(!module->get_params && !module->set_preferences) gtk_widget_set_sensitive(GTK_WIDGET(module->presets_button), FALSE);
-  dt_gui_add_class(module->presets_button, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->presets_button, NULL);
   gtk_box_pack_end(GTK_BOX(header), module->presets_button, FALSE, FALSE, 0);
 
@@ -1060,7 +1059,6 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(module->reset_button), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
   if(!module->gui_reset) gtk_widget_set_sensitive(module->reset_button, FALSE);
-  dt_gui_add_class(module->reset_button, "dt_module_btn");
   dt_action_define(&module->actions, NULL, NULL, module->reset_button, NULL);
   gtk_box_pack_end(GTK_BOX(header), module->reset_button, FALSE, FALSE, 0);
 

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -307,6 +307,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
   lib->live_view = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, 0, NULL);
+  dt_gui_add_class(lib->live_view, "dt_transparent_background");
   lib->live_view_zoom = dtgtk_button_new(dtgtk_cairo_paint_zoom, 0, NULL); // TODO: see _zoom_live_view_clicked
   lib->rotate_ccw = dtgtk_button_new(dtgtk_cairo_paint_refresh, 0, NULL);
   lib->rotate_cw = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_DIRECTION_UP, NULL);

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -306,14 +306,11 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, dt_get_help_url("tethering_live_view"));
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
-  lib->live_view = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT, NULL);
-  lib->live_view_zoom = dtgtk_button_new(
-      dtgtk_cairo_paint_zoom, CPF_STYLE_FLAT, NULL); // TODO: see _zoom_live_view_clicked
-  lib->rotate_ccw = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_STYLE_FLAT, NULL);
-  lib->rotate_cw = dtgtk_button_new(dtgtk_cairo_paint_refresh,
-                                    CPF_STYLE_FLAT | CPF_DIRECTION_UP, NULL);
-  lib->flip = dtgtk_togglebutton_new(dtgtk_cairo_paint_flip,
-                                     CPF_STYLE_FLAT | CPF_DIRECTION_UP, NULL);
+  lib->live_view = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, 0, NULL);
+  lib->live_view_zoom = dtgtk_button_new(dtgtk_cairo_paint_zoom, 0, NULL); // TODO: see _zoom_live_view_clicked
+  lib->rotate_ccw = dtgtk_button_new(dtgtk_cairo_paint_refresh, 0, NULL);
+  lib->rotate_cw = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_DIRECTION_UP, NULL);
+  lib->flip = dtgtk_togglebutton_new(dtgtk_cairo_paint_flip, CPF_DIRECTION_UP, NULL);
 
   gtk_box_pack_start(GTK_BOX(box), lib->live_view, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(box), lib->live_view_zoom, TRUE, TRUE, 0);
@@ -336,16 +333,12 @@ void gui_init(dt_lib_module_t *self)
   // focus buttons
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
-  lib->focus_in_big = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle,
-                                       CPF_STYLE_FLAT | CPF_DIRECTION_LEFT, NULL);
+  lib->focus_in_big = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle, CPF_DIRECTION_LEFT, NULL);
   lib->focus_in_small
-      = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_STYLE_FLAT
-                                                  | CPF_DIRECTION_LEFT, NULL); // TODO icon not centered
-  lib->auto_focus = dtgtk_button_new(dtgtk_cairo_paint_lock, CPF_STYLE_FLAT, NULL);
-  lib->focus_out_small = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_STYLE_FLAT
-                                                                   | CPF_DIRECTION_RIGHT, NULL); // TODO same here
-  lib->focus_out_big = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle,
-                                        CPF_STYLE_FLAT | CPF_DIRECTION_RIGHT, NULL);
+      = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_LEFT, NULL); // TODO icon not centered
+  lib->auto_focus = dtgtk_button_new(dtgtk_cairo_paint_lock, 0, NULL);
+  lib->focus_out_small = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_RIGHT, NULL); // TODO same here
+  lib->focus_out_big = dtgtk_button_new(dtgtk_cairo_paint_solid_triangle, CPF_DIRECTION_RIGHT, NULL);
 
   gtk_box_pack_start(GTK_BOX(box), lib->focus_in_big, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(box), lib->focus_in_small, TRUE, TRUE, 0);

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -347,8 +347,7 @@ static void _shape_button_clicked(GtkButton *button, dt_lib_module_t *self)
 
   g_signal_handler_block (d->shape_button, d->shape_button_handler);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->shape_button), FALSE);
-  dtgtk_togglebutton_set_paint((GtkDarktableToggleButton *)d->shape_button,
-                               location_shapes[shape], CPF_STYLE_FLAT, NULL);
+  dtgtk_togglebutton_set_paint((GtkDarktableToggleButton *)d->shape_button, location_shapes[shape], 0, NULL);
   g_signal_handler_unblock (d->shape_button, d->shape_button_handler);
 }
 
@@ -473,7 +472,7 @@ static void _view_map_location_changed(gpointer instance, GList *polygons, dt_li
   {
     g_signal_handler_block (d->shape_button, d->shape_button_handler);
     dtgtk_togglebutton_set_paint((GtkDarktableToggleButton *)d->shape_button,
-                                 location_shapes[MAP_LOCATION_SHAPE_ELLIPSE], CPF_STYLE_FLAT, NULL);
+                                 location_shapes[MAP_LOCATION_SHAPE_ELLIPSE], 0, NULL);
     g_signal_handler_unblock (d->shape_button, d->shape_button_handler);
     dt_conf_set_int("plugins/map/locationshape", MAP_LOCATION_SHAPE_ELLIPSE);
   }
@@ -980,7 +979,7 @@ void gui_init(dt_lib_module_t *self)
     shape = MAP_LOCATION_SHAPE_ELLIPSE;
     dt_conf_set_int("plugins/map/locationshape", shape);
   }
-  d->shape_button = dtgtk_togglebutton_new(location_shapes[shape], CPF_STYLE_FLAT, NULL);
+  d->shape_button = dtgtk_togglebutton_new(location_shapes[shape], 0, NULL);
   gtk_box_pack_start(hbox, d->shape_button, FALSE, TRUE, 0);
   d->shape_button_handler = g_signal_connect(G_OBJECT(d->shape_button), "clicked",
                                              G_CALLBACK(_shape_button_clicked), self);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1672,34 +1672,31 @@ void gui_init(dt_lib_module_t *self)
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
 
-  d->bt_gradient
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_gradient, CPF_STYLE_FLAT, NULL);
+  d->bt_gradient = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_gradient, 0, NULL);
   g_signal_connect(G_OBJECT(d->bt_gradient), "button-press-event", G_CALLBACK(_bt_add_gradient), self);
   gtk_widget_set_tooltip_text(d->bt_gradient, _("add gradient"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_gradient), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), d->bt_gradient, FALSE, FALSE, 0);
 
-  d->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT, NULL);
+  d->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, 0, NULL);
   g_signal_connect(G_OBJECT(d->bt_path), "button-press-event", G_CALLBACK(_bt_add_path), self);
   gtk_widget_set_tooltip_text(d->bt_path, _("add path"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_path), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), d->bt_path, FALSE, FALSE, 0);
 
-  d->bt_ellipse
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, CPF_STYLE_FLAT, NULL);
+  d->bt_ellipse = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, 0, NULL);
   g_signal_connect(G_OBJECT(d->bt_ellipse), "button-press-event", G_CALLBACK(_bt_add_ellipse), self);
   gtk_widget_set_tooltip_text(d->bt_ellipse, _("add ellipse"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_ellipse), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), d->bt_ellipse, FALSE, FALSE, 0);
 
-  d->bt_circle
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, CPF_STYLE_FLAT, NULL);
+  d->bt_circle = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, 0, NULL);
   g_signal_connect(G_OBJECT(d->bt_circle), "button-press-event", G_CALLBACK(_bt_add_circle), self);
   gtk_widget_set_tooltip_text(d->bt_circle, _("add circle"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_circle), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), d->bt_circle, FALSE, FALSE, 0);
 
-  d->bt_brush = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, CPF_STYLE_FLAT, NULL);
+  d->bt_brush = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, 0, NULL);
   g_signal_connect(G_OBJECT(d->bt_brush), "button-press-event", G_CALLBACK(_bt_add_brush), self);
   gtk_widget_set_tooltip_text(d->bt_brush, _("add brush"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->bt_brush), FALSE);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -472,8 +472,9 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
 
       // we create a new button linked with the real one
       // because it create too much pb to remove the button from the expander
-      GtkWidget *btn
-          = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, item->module);
+      GtkWidget *btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, item->module);
+      gtk_widget_set_name(btn, "module-enable-button");
+
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->widget)));
       g_signal_connect(G_OBJECT(btn), "toggled", G_CALLBACK(_basics_on_off_callback), item);
@@ -627,7 +628,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     gtk_widget_show_all(hbox_basic);
 
     // we create the link to the full iop
-    GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, CPF_STYLE_FLAT, NULL);
+    GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, 0, NULL);
     gtk_widget_show(wbt);
     gchar *tt = g_strdup_printf(_("go to the full version of the %s module"), item->module->name());
     gtk_widget_set_tooltip_text(wbt, tt);
@@ -639,9 +640,9 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     if(!compact_ui)
     {
       // we add the on-off button
-      GtkWidget *btn
-          = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, item->module);
-      dt_gui_add_class(btn, "dt_module_btn");
+      GtkWidget *btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, item->module);
+      gtk_widget_set_name(btn, "module-enable-button");
+
       gtk_widget_set_valign(btn, GTK_ALIGN_CENTER);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->module->off)));
@@ -2042,8 +2043,9 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
           gtk_box_pack_start(GTK_BOX(hb), lb, FALSE, TRUE, 0);
           if(!d->edit_ro)
           {
-            GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
-            dt_gui_add_class(btn, "dt_module_btn");
+            GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+            gtk_widget_set_name(btn, "module-reset-button");
+
             gtk_widget_set_tooltip_text(btn, _("remove this widget"));
             g_object_set_data(G_OBJECT(btn), "widget_id", item->id);
             g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_basics_remove), self);
@@ -2193,7 +2195,7 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
         gtk_box_pack_start(GTK_BOX(hb), lb, FALSE, TRUE, 0);
         if(!d->edit_ro)
         {
-          GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+          GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
           gtk_widget_set_name(btn, "module-reset-button");
           dt_gui_add_class(btn, "dt_module_btn");
           gtk_widget_set_tooltip_text(btn, _("remove this module"));
@@ -2808,8 +2810,6 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_widget_set_name(self->widget, "modules-tabs");
 
-  dtgtk_cairo_paint_flags_t pf = CPF_STYLE_FLAT;
-
   d->hbox_buttons = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   d->hbox_search_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
@@ -2818,7 +2818,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->hbox_buttons), d->hbox_groups, TRUE, TRUE, 0);
 
   // basic group button
-  d->basic_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_basics, pf, NULL);
+  d->basic_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_basics, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->basic_btn), "dt_checked_background");
   g_signal_connect(d->basic_btn, "button-press-event", G_CALLBACK(_manage_direct_basic_popup), self);
   g_signal_connect(d->basic_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->basic_btn, _("quick access panel"));
@@ -2828,14 +2829,15 @@ void gui_init(dt_lib_module_t *self)
   d->basics = NULL;
 
   // active group button
-  d->active_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_active, pf, NULL);
+  d->active_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_active, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->active_btn), "dt_checked_background");
   g_signal_connect(d->active_btn, "button-press-event", G_CALLBACK(_manage_direct_active_popup), self);
   g_signal_connect(d->active_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->active_btn, _("show only active modules"));
   gtk_box_pack_start(GTK_BOX(d->hbox_groups), d->active_btn, TRUE, TRUE, 0);
 
   // we load now the presets btn
-  self->presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
+  self->presets_button = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
   gtk_widget_set_tooltip_text(self->presets_button, _("presets\nctrl+click to manage"));
   gtk_box_pack_start(GTK_BOX(d->hbox_buttons), self->presets_button, FALSE, FALSE, 0);
   g_signal_connect(self->presets_button, "button-press-event", G_CALLBACK(_presets_pressed), self);
@@ -2961,7 +2963,8 @@ static void _buttons_update(dt_lib_module_t *self)
   for(l = d->groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
-    GtkWidget *bt = dtgtk_togglebutton_new(_buttons_get_icon_fct(gr->icon), CPF_STYLE_FLAT, NULL);
+    GtkWidget *bt = dtgtk_togglebutton_new(_buttons_get_icon_fct(gr->icon), 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(bt), "dt_checked_background");
     g_object_set_data(G_OBJECT(bt), "group", gr);
     g_signal_connect(bt, "button-press-event", G_CALLBACK(_manage_direct_popup), self);
     g_signal_connect(bt, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
@@ -3077,8 +3080,7 @@ static void _manage_editor_group_icon_changed(GtkWidget *widget, GdkEventButton 
   gr->icon = g_strdup(ic);
   GtkWidget *pop = gtk_widget_get_parent(gtk_widget_get_parent(widget));
   GtkWidget *btn = gtk_popover_get_relative_to(GTK_POPOVER(pop));
-  dtgtk_button_set_paint(DTGTK_BUTTON(btn), _buttons_get_icon_fct(ic), CPF_STYLE_FLAT,
-                         NULL);
+  dtgtk_button_set_paint(DTGTK_BUTTON(btn), _buttons_get_icon_fct(ic), 0, NULL);
   gtk_popover_popdown(GTK_POPOVER(pop));
 }
 
@@ -3093,7 +3095,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
   GtkWidget *eb, *hb, *ic;
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_basic, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_basic, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("basic icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "basic");
@@ -3103,7 +3105,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_active, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_active, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("active icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "active");
@@ -3113,7 +3115,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_color, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_color, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("color icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "color");
@@ -3123,7 +3125,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_correct, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_correct, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("correct icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "correct");
@@ -3133,7 +3135,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_effect, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_effect, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("effect icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "effect");
@@ -3143,7 +3145,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_favorites, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_favorites, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("favorites icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "favorites");
@@ -3153,7 +3155,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_tone, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_tone, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("tone icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "tone");
@@ -3163,7 +3165,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_grading, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_grading, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("grading icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "grading");
@@ -3173,7 +3175,7 @@ static void _manage_editor_group_icon_popup(GtkWidget *btn, GdkEventButton *even
 
   eb = gtk_event_box_new();
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_technical, CPF_STYLE_FLAT, NULL);
+  ic = dtgtk_button_new(dtgtk_cairo_paint_modulegroup_technical, 0, NULL);
   gtk_box_pack_start(GTK_BOX(hb), ic, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("technical icon")), TRUE, TRUE, 0);
   g_object_set_data(G_OBJECT(eb), "ic_name", "technical");
@@ -3229,8 +3231,7 @@ static GtkWidget *_manage_editor_group_init_basics_box(dt_lib_module_t *self)
   if(!d->edit_ro)
   {
     GtkWidget *hb4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple,
-                                     CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add widget to the quick access panel"));
     gtk_widget_set_name(bt, "modulegroups-btn");
     g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_manage_editor_basics_add_popup), self);
@@ -3282,7 +3283,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   // remove button
   if(!d->edit_ro)
   {
-    btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
     gtk_widget_set_tooltip_text(btn, _("remove group"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
     g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_group_remove), self);
@@ -3307,8 +3308,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
     GtkWidget *hb4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
     // left arrow
-    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_RIGHT | CPF_STYLE_FLAT,
-                           NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_RIGHT, NULL);
     gtk_widget_set_name(btn, "modulegroups-btn");
     gtk_widget_set_tooltip_text(btn, _("move group to the left"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -3317,8 +3317,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
 
     // plus button
     GtkWidget *plusbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple,
-                                     CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add module to the group"));
     gtk_widget_set_name(bt, "modulegroups-btn");
     g_object_set_data(G_OBJECT(bt), "group", gr);
@@ -3328,8 +3327,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
     gtk_box_pack_start(GTK_BOX(hb4), plusbox, TRUE, TRUE, 0);
 
     //right arrow
-    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_LEFT | CPF_STYLE_FLAT,
-                           NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_name(btn, "modulegroups-btn");
     gtk_widget_set_tooltip_text(btn, _("move group to the right"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -3925,8 +3923,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(hb, "modulegroups-groups-title");
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("module groups")), FALSE, TRUE, 0);
-  d->preset_btn_add_group
-      = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT | CPF_STYLE_FLAT, NULL);
+  d->preset_btn_add_group = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT, NULL);
   g_signal_connect(G_OBJECT(d->preset_btn_add_group), "button-press-event", G_CALLBACK(_manage_editor_group_add),
                    self);
   gtk_box_pack_start(GTK_BOX(hb), d->preset_btn_add_group, FALSE, FALSE, 0);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -473,7 +473,6 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       // we create a new button linked with the real one
       // because it create too much pb to remove the button from the expander
       GtkWidget *btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, item->module);
-      gtk_widget_set_name(btn, "module-enable-button");
 
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
                                    gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(item->widget)));
@@ -641,7 +640,6 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     {
       // we add the on-off button
       GtkWidget *btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, 0, item->module);
-      gtk_widget_set_name(btn, "module-enable-button");
 
       gtk_widget_set_valign(btn, GTK_ALIGN_CENTER);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn),
@@ -2044,7 +2042,6 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
           if(!d->edit_ro)
           {
             GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
-            gtk_widget_set_name(btn, "module-reset-button");
 
             gtk_widget_set_tooltip_text(btn, _("remove this widget"));
             g_object_set_data(G_OBJECT(btn), "widget_id", item->id);
@@ -2196,8 +2193,6 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
         if(!d->edit_ro)
         {
           GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
-          gtk_widget_set_name(btn, "module-reset-button");
-          dt_gui_add_class(btn, "dt_module_btn");
           gtk_widget_set_tooltip_text(btn, _("remove this module"));
           g_object_set_data(G_OBJECT(btn), "module_name", module->op);
           g_object_set_data(G_OBJECT(btn), "group", gr);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2819,7 +2819,6 @@ void gui_init(dt_lib_module_t *self)
 
   // basic group button
   d->basic_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_basics, 0, NULL);
-  dt_gui_add_class(d->basic_btn, "dt_checked_background");
   g_signal_connect(d->basic_btn, "button-press-event", G_CALLBACK(_manage_direct_basic_popup), self);
   g_signal_connect(d->basic_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->basic_btn, _("quick access panel"));
@@ -2830,7 +2829,6 @@ void gui_init(dt_lib_module_t *self)
 
   // active group button
   d->active_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_active, 0, NULL);
-  dt_gui_add_class(d->active_btn, "dt_checked_background");
   g_signal_connect(d->active_btn, "button-press-event", G_CALLBACK(_manage_direct_active_popup), self);
   g_signal_connect(d->active_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->active_btn, _("show only active modules"));
@@ -2964,7 +2962,6 @@ static void _buttons_update(dt_lib_module_t *self)
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
     GtkWidget *bt = dtgtk_togglebutton_new(_buttons_get_icon_fct(gr->icon), 0, NULL);
-    dt_gui_add_class(bt, "dt_checked_background");
     g_object_set_data(G_OBJECT(bt), "group", gr);
     g_signal_connect(bt, "button-press-event", G_CALLBACK(_manage_direct_popup), self);
     g_signal_connect(bt, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2819,7 +2819,7 @@ void gui_init(dt_lib_module_t *self)
 
   // basic group button
   d->basic_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_basics, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->basic_btn), "dt_checked_background");
+  dt_gui_add_class(d->basic_btn, "dt_checked_background");
   g_signal_connect(d->basic_btn, "button-press-event", G_CALLBACK(_manage_direct_basic_popup), self);
   g_signal_connect(d->basic_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->basic_btn, _("quick access panel"));
@@ -2830,7 +2830,7 @@ void gui_init(dt_lib_module_t *self)
 
   // active group button
   d->active_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_active, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->active_btn), "dt_checked_background");
+  dt_gui_add_class(d->active_btn, "dt_checked_background");
   g_signal_connect(d->active_btn, "button-press-event", G_CALLBACK(_manage_direct_active_popup), self);
   g_signal_connect(d->active_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->active_btn, _("show only active modules"));
@@ -2964,7 +2964,7 @@ static void _buttons_update(dt_lib_module_t *self)
   {
     dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)l->data;
     GtkWidget *bt = dtgtk_togglebutton_new(_buttons_get_icon_fct(gr->icon), 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(bt), "dt_checked_background");
+    dt_gui_add_class(bt, "dt_checked_background");
     g_object_set_data(G_OBJECT(bt), "group", gr);
     g_signal_connect(bt, "button-press-event", G_CALLBACK(_manage_direct_popup), self);
     g_signal_connect(bt, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2505,7 +2505,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_set_column_spacing(bat, DT_PIXEL_APPLY_DPI(3));
   for(int i=0; i<9; i++)
   {
-    d->dtba[i] = DTGTK_TOGGLEBUTTON (dtgtk_togglebutton_new (dtgtk_cairo_paint_alignment,CPF_STYLE_FLAT|(CPF_SPECIAL_FLAG<<i), NULL));
+    d->dtba[i]
+        = DTGTK_TOGGLEBUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment, (CPF_SPECIAL_FLAG << i), NULL));
     gtk_grid_attach (GTK_GRID (bat), GTK_WIDGET (d->dtba[i]), (i%3), i/3, 1, 1);
     g_signal_connect (G_OBJECT (d->dtba[i]), "toggled",G_CALLBACK (_alignment_callback), self);
   }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3166,7 +3166,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->detach_button), "clicked", G_CALLBACK(_detach_button_clicked), (gpointer)self);
   gtk_box_pack_start(hbox, d->detach_button, TRUE, TRUE, 0);
 
-  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_minus_simple, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_minus_simple, 0, NULL);
   d->toggle_hide_button = button;
   gtk_widget_set_tooltip_text(button, _("toggle list with / without hierarchy"));
   dt_gui_add_help_link(button, dt_get_help_url("tagging"));
@@ -3174,7 +3174,7 @@ void gui_init(dt_lib_module_t *self)
   d->hide_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
                                             G_CALLBACK(_toggle_hide_button_callback), (gpointer)self);
 
-  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_sorting, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_sorting, 0, NULL);
   d->toggle_sort_button = button;
   gtk_widget_set_tooltip_text(button, _("toggle sort by name or by count"));
   dt_gui_add_help_link(button, dt_get_help_url("tagging"));
@@ -3182,7 +3182,7 @@ void gui_init(dt_lib_module_t *self)
   d->sort_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
                                             G_CALLBACK(_toggle_sort_button_callback), (gpointer)self);
 
-  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_check_mark, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_check_mark, 0, NULL);
   d->toggle_dttags_button = button;
   d->dttags_flag = FALSE;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->toggle_dttags_button), FALSE);
@@ -3215,7 +3215,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(w), "key-press-event", G_CALLBACK(_enter_key_pressed), (gpointer)self);
   d->entry = GTK_ENTRY(w);
 
-  button = dtgtk_button_new(dtgtk_cairo_paint_multiply_small, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_button_new(dtgtk_cairo_paint_multiply_small, 0, NULL);
   gtk_widget_set_tooltip_text(button, _("clear entry"));
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_clear_entry_button_callback), (gpointer)self);
@@ -3316,7 +3316,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(hbox, d->export_button, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(d->export_button), "clicked", G_CALLBACK(_export_button_clicked), (gpointer)self);
 
-  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_treelist, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_treelist, 0, NULL);
   d->toggle_tree_button = button;
   gtk_widget_set_tooltip_text(button, _("toggle list / tree view"));
   dt_gui_add_help_link(button, dt_get_help_url("tagging"));
@@ -3324,7 +3324,7 @@ void gui_init(dt_lib_module_t *self)
   d->tree_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
                                             G_CALLBACK(_toggle_tree_button_callback), (gpointer)self);
 
-  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT, NULL);
+  button = dtgtk_togglebutton_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   d->toggle_suggestion_button = button;
   gtk_widget_set_tooltip_text(button, _("toggle list with / without suggestion"));
   dt_gui_add_help_link(button, dt_get_help_url("tagging"));

--- a/src/libs/tools/battery_indicator.c
+++ b/src/libs/tools/battery_indicator.c
@@ -66,7 +66,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->fill = _get_fill();
 
-  self->widget = d->icon = dtgtk_icon_new(_paint_battery, CPF_DO_NOT_USE_BORDER, d);
+  self->widget = d->icon = dtgtk_icon_new(_paint_battery, 0, d);
   gtk_widget_set_size_request(d->icon, DT_PIXEL_APPLY_DPI(23), -1);
   gtk_widget_set_tooltip_text(d->icon, _("battery indicator"));
 

--- a/src/libs/tools/battery_indicator.c
+++ b/src/libs/tools/battery_indicator.c
@@ -66,7 +66,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->fill = _get_fill();
 
-  self->widget = d->icon = dtgtk_icon_new(_paint_battery, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, d);
+  self->widget = d->icon = dtgtk_icon_new(_paint_battery, CPF_DO_NOT_USE_BORDER, d);
   gtk_widget_set_size_request(d->icon, DT_PIXEL_APPLY_DPI(23), -1);
   gtk_widget_set_tooltip_text(d->icon, _("battery indicator"));
 

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -80,7 +80,8 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *button;
   for(int k = 0; k < 6; k++)
   {
-    button = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_BG_TRANSPARENT), &darktable.bauhaus->colorlabels);
+    button
+        = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_LABEL_PURPLE), &darktable.bauhaus->colorlabels);
     d->buttons[k] = button;
     gtk_widget_set_tooltip_text(button, _("toggle color label of selected images"));
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -82,6 +82,7 @@ void gui_init(dt_lib_module_t *self)
   {
     button = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_LABEL_PURPLE), NULL);
     d->buttons[k] = button;
+    dt_gui_add_class(d->buttons[k], "dt_no_hover");
     gtk_widget_set_tooltip_text(button, _("toggle color label of selected images"));
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
     g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_lib_colorlabels_button_clicked_callback),

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -80,8 +80,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *button;
   for(int k = 0; k < 6; k++)
   {
-    button
-        = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_LABEL_PURPLE), &darktable.bauhaus->colorlabels);
+    button = dtgtk_button_new(dtgtk_cairo_paint_label, (k | 8 | CPF_LABEL_PURPLE), NULL);
     d->buttons[k] = button;
     gtk_widget_set_tooltip_text(button, _("toggle color label of selected images"));
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -293,7 +293,7 @@ static void _update_colors_filter(dt_lib_module_t *self)
   {
     const int i_mask = mask & mask_excluded ? CPF_USER_DATA_EXCLUDE : mask & mask_included ? CPF_USER_DATA_INCLUDE : 0;
     dtgtk_button_set_paint(DTGTK_BUTTON(d->colors[i]), dtgtk_cairo_paint_label_sel,
-                          (i | i_mask | CPF_BG_TRANSPARENT), NULL);
+                           (i | i_mask | CPF_LABEL_PURPLE), NULL);
     gtk_widget_queue_draw(d->colors[i]);
     if((mask & mask_excluded) || (mask & mask_included))
       nb++;
@@ -306,8 +306,7 @@ static void _update_colors_filter(dt_lib_module_t *self)
     dt_collection_set_colors_filter(darktable.collection, mask);
   }
   dtgtk_button_set_paint(DTGTK_BUTTON(d->colors_op),
-                         (mask & CL_AND_MASK) ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or,
-                         CPF_STYLE_FLAT, NULL);
+                         (mask & CL_AND_MASK) ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0, NULL);
   gtk_widget_set_sensitive(d->colors_op, nb > 1);
 }
 
@@ -413,7 +412,7 @@ void gui_init(dt_lib_module_t *self)
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   for(int k = 0; k < DT_COLORLABELS_LAST + 1; k++)
   {
-    d->colors[k] = dtgtk_button_new(dtgtk_cairo_paint_label_sel, (k | CPF_BG_TRANSPARENT), NULL);
+    d->colors[k] = dtgtk_button_new(dtgtk_cairo_paint_label_sel, k, NULL);
     g_object_set_data(G_OBJECT(d->colors[k]), "colors_index", GINT_TO_POINTER(k));
     gtk_box_pack_start(GTK_BOX(hbox), d->colors[k], FALSE, FALSE, 0);
     gtk_widget_set_tooltip_text(d->colors[k], _("filter by images color label"
@@ -422,7 +421,7 @@ void gui_init(dt_lib_module_t *self)
                                                 "\nthe gray button affects all color labels"));
     g_signal_connect(G_OBJECT(d->colors[k]), "button-press-event", G_CALLBACK(_colorlabel_clicked), self);
   }
-  d->colors_op = dtgtk_button_new(dtgtk_cairo_paint_and, CPF_STYLE_FLAT, NULL);
+  d->colors_op = dtgtk_button_new(dtgtk_cairo_paint_and, 0, NULL);
   _update_colors_filter(self);
   gtk_box_pack_start(GTK_BOX(hbox), d->colors_op, FALSE, FALSE, 2);
   gtk_widget_set_tooltip_text(d->colors_op, _("filter by images color label"

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -480,7 +480,7 @@ void gui_init(dt_lib_module_t *self)
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(d->reverse), dtgtk_cairo_paint_sortby,
                                  CPF_DIRECTION_DOWN, NULL);
   gtk_box_pack_start(GTK_BOX(hbox), d->reverse, FALSE, FALSE, 0);
-  dt_gui_add_class(d->reverse, "dt_transparent_background");
+  dt_gui_add_class(d->reverse, "dt_ignore_fg_state");
 
   /* select the last value and connect callback */
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse),

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -413,6 +413,7 @@ void gui_init(dt_lib_module_t *self)
   for(int k = 0; k < DT_COLORLABELS_LAST + 1; k++)
   {
     d->colors[k] = dtgtk_button_new(dtgtk_cairo_paint_label_sel, k, NULL);
+    dt_gui_add_class(d->colors[k], "dt_no_hover");
     g_object_set_data(G_OBJECT(d->colors[k]), "colors_index", GINT_TO_POINTER(k));
     gtk_box_pack_start(GTK_BOX(hbox), d->colors[k], FALSE, FALSE, 0);
     gtk_widget_set_tooltip_text(d->colors[k], _("filter by images color label"
@@ -429,6 +430,7 @@ void gui_init(dt_lib_module_t *self)
                                               "\nor (∪): images with at least one of the selected color labels"));
   g_signal_connect(G_OBJECT(d->colors_op), "clicked", G_CALLBACK(_colors_operation_clicked), self);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 2);
+  gtk_widget_set_name(hbox, "lib-label-colors");
   dt_gui_add_class(hbox, "quick_filter_box");
   dt_gui_add_class(hbox, "dt_font_resize_07");
 

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -399,7 +399,8 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   /* create the grouping button */
-  d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, CPF_STYLE_FLAT, NULL);
+  d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->grouping_button), "dt_checked_background");
   dt_action_define(&darktable.control->actions_global, NULL, "grouping", d->grouping_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->grouping_button, FALSE, FALSE, 0);
   if(darktable.gui->grouping)
@@ -411,7 +412,7 @@ void gui_init(dt_lib_module_t *self)
                    NULL);
 
   /* create the "show/hide overlays" button */
-  d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT, NULL);
+  d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, 0, NULL);
   gtk_widget_set_tooltip_text(d->overlays_button, _("click to change the type of overlays shown on thumbnails"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->overlays_button, FALSE, FALSE, 0);
   d->over_popup = gtk_popover_new(d->overlays_button);
@@ -504,14 +505,16 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show(vbox);
 
   /* create the widget help button */
-  d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, CPF_STYLE_FLAT, NULL);
+  d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->help_button), "dt_checked_background");
   gtk_box_pack_start(GTK_BOX(self->widget), d->help_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->help_button, _("enable this, then click on a control element to see its online help"));
   g_signal_connect(G_OBJECT(d->help_button), "clicked", G_CALLBACK(_lib_help_button_clicked), d);
   dt_gui_add_help_link(d->help_button, dt_get_help_url("global_toolbox_help"));
 
   /* create the shortcuts button */
-  d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, CPF_STYLE_FLAT, NULL);
+  d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->keymap_button), "dt_checked_background");
   dt_action_define(&darktable.control->actions_global, NULL, "shortcuts", d->keymap_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->keymap_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->keymap_button, _("define shortcuts\n"
@@ -528,7 +531,7 @@ void gui_init(dt_lib_module_t *self)
   // that's done so that buttons added via Lua will come first.
 
   /* create the preference button */
-  d->preferences_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT, NULL);
+  d->preferences_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, 0, NULL);
   gtk_box_pack_end(GTK_BOX(self->widget), d->preferences_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->preferences_button, _("show global preferences"));
   g_signal_connect(G_OBJECT(d->preferences_button), "clicked", G_CALLBACK(_lib_preferences_button_clicked),

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -400,7 +400,6 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the grouping button */
   d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, 0, NULL);
-  dt_gui_add_class(d->grouping_button, "dt_checked_background");
   dt_action_define(&darktable.control->actions_global, NULL, "grouping", d->grouping_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->grouping_button, FALSE, FALSE, 0);
   if(darktable.gui->grouping)
@@ -506,7 +505,6 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the widget help button */
   d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, 0, NULL);
-  dt_gui_add_class(d->help_button, "dt_checked_background");
   gtk_box_pack_start(GTK_BOX(self->widget), d->help_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->help_button, _("enable this, then click on a control element to see its online help"));
   g_signal_connect(G_OBJECT(d->help_button), "clicked", G_CALLBACK(_lib_help_button_clicked), d);
@@ -514,7 +512,6 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the shortcuts button */
   d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, 0, NULL);
-  dt_gui_add_class(d->keymap_button, "dt_checked_background");
   dt_action_define(&darktable.control->actions_global, NULL, "shortcuts", d->keymap_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->keymap_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->keymap_button, _("define shortcuts\n"

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -400,7 +400,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the grouping button */
   d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->grouping_button), "dt_checked_background");
+  dt_gui_add_class(d->grouping_button, "dt_checked_background");
   dt_action_define(&darktable.control->actions_global, NULL, "grouping", d->grouping_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->grouping_button, FALSE, FALSE, 0);
   if(darktable.gui->grouping)
@@ -506,7 +506,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the widget help button */
   d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->help_button), "dt_checked_background");
+  dt_gui_add_class(d->help_button, "dt_checked_background");
   gtk_box_pack_start(GTK_BOX(self->widget), d->help_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->help_button, _("enable this, then click on a control element to see its online help"));
   g_signal_connect(G_OBJECT(d->help_button), "clicked", G_CALLBACK(_lib_help_button_clicked), d);
@@ -514,7 +514,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the shortcuts button */
   d->keymap_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_shortcut, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->keymap_button), "dt_checked_background");
+  dt_gui_add_class(d->keymap_button, "dt_checked_background");
   dt_action_define(&darktable.control->actions_global, NULL, "shortcuts", d->keymap_button, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), d->keymap_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->keymap_button, _("define shortcuts\n"

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -256,7 +256,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->layout_box, TRUE, TRUE, 0);
 
   d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_filemanager), "dt_checked_background");
+  dt_gui_add_class(d->layout_filemanager, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle filemanager layout", d->layout_filemanager, NULL);
   dt_gui_add_help_link(d->layout_filemanager, dt_get_help_url("layout_filemanager"));
@@ -266,7 +266,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_filemanager, TRUE, TRUE, 0);
 
   d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_zoomable), "dt_checked_background");
+  dt_gui_add_class(d->layout_zoomable, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle zoomable lighttable layout", d->layout_zoomable, NULL);
   dt_gui_add_help_link(d->layout_zoomable, dt_get_help_url("layout_zoomable"));
@@ -276,7 +276,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_zoomable, TRUE, TRUE, 0);
 
   d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_culling_fix), "dt_checked_background");
+  dt_gui_add_class(d->layout_culling_fix, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle culling mode", d->layout_culling_fix, NULL);
   dt_gui_add_help_link(d->layout_culling_fix, dt_get_help_url("layout_culling"));
@@ -285,7 +285,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_fix, TRUE, TRUE, 0);
 
   d->layout_culling_dynamic = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_culling_dynamic), "dt_checked_background");
+  dt_gui_add_class(d->layout_culling_dynamic, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle culling dynamic mode", d->layout_culling_dynamic, NULL);
   dt_gui_add_help_link(d->layout_culling_dynamic, dt_get_help_url("layout_culling"));
@@ -294,7 +294,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_dynamic, TRUE, TRUE, 0);
 
   d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_preview), "dt_checked_background");
+  dt_gui_add_class(d->layout_preview, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle sticky preview mode", d->layout_preview, NULL);
   dt_gui_add_help_link(d->layout_preview, dt_get_help_url("layout_preview"));

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -256,7 +256,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->layout_box, TRUE, TRUE, 0);
 
   d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, 0, NULL);
-  dt_gui_add_class(d->layout_filemanager, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle filemanager layout", d->layout_filemanager, NULL);
   dt_gui_add_help_link(d->layout_filemanager, dt_get_help_url("layout_filemanager"));
@@ -266,7 +265,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_filemanager, TRUE, TRUE, 0);
 
   d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, 0, NULL);
-  dt_gui_add_class(d->layout_zoomable, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle zoomable lighttable layout", d->layout_zoomable, NULL);
   dt_gui_add_help_link(d->layout_zoomable, dt_get_help_url("layout_zoomable"));
@@ -276,7 +274,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_zoomable, TRUE, TRUE, 0);
 
   d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, 0, NULL);
-  dt_gui_add_class(d->layout_culling_fix, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle culling mode", d->layout_culling_fix, NULL);
   dt_gui_add_help_link(d->layout_culling_fix, dt_get_help_url("layout_culling"));
@@ -285,7 +282,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_fix, TRUE, TRUE, 0);
 
   d->layout_culling_dynamic = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
-  dt_gui_add_class(d->layout_culling_dynamic, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle culling dynamic mode", d->layout_culling_dynamic, NULL);
   dt_gui_add_help_link(d->layout_culling_dynamic, dt_get_help_url("layout_culling"));
@@ -294,7 +290,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_dynamic, TRUE, TRUE, 0);
 
   d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, 0, NULL);
-  dt_gui_add_class(d->layout_preview, "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle sticky preview mode", d->layout_preview, NULL);
   dt_gui_add_help_link(d->layout_preview, dt_get_help_url("layout_preview"));

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -255,7 +255,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->layout_box, "lighttable_layouts_box");
   gtk_box_pack_start(GTK_BOX(self->widget), d->layout_box, TRUE, TRUE, 0);
 
-  d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, CPF_STYLE_FLAT, NULL);
+  d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_filemanager), "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle filemanager layout", d->layout_filemanager, NULL);
   dt_gui_add_help_link(d->layout_filemanager, dt_get_help_url("layout_filemanager"));
@@ -264,7 +265,8 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_filemanager, TRUE, TRUE, 0);
 
-  d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, CPF_STYLE_FLAT, NULL);
+  d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_zoomable), "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle zoomable lighttable layout", d->layout_zoomable, NULL);
   dt_gui_add_help_link(d->layout_zoomable, dt_get_help_url("layout_zoomable"));
@@ -273,7 +275,8 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_zoomable, TRUE, TRUE, 0);
 
-  d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, CPF_STYLE_FLAT, NULL);
+  d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_culling_fix), "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle culling mode", d->layout_culling_fix, NULL);
   dt_gui_add_help_link(d->layout_culling_fix, dt_get_help_url("layout_culling"));
@@ -281,8 +284,8 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_fix, TRUE, TRUE, 0);
 
-  d->layout_culling_dynamic
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, CPF_STYLE_FLAT, NULL);
+  d->layout_culling_dynamic = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_culling_dynamic), "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle culling dynamic mode", d->layout_culling_dynamic, NULL);
   dt_gui_add_help_link(d->layout_culling_dynamic, dt_get_help_url("layout_culling"));
@@ -290,7 +293,8 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_dynamic, TRUE, TRUE, 0);
 
-  d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, CPF_STYLE_FLAT, NULL);
+  d->layout_preview = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(d->layout_preview), "dt_checked_background");
   dt_action_define(&darktable.view_manager->proxy.lighttable.view->actions, NULL,
                    "toggle sticky preview mode", d->layout_preview, NULL);
   dt_gui_add_help_link(d->layout_preview, dt_get_help_url("layout_preview"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2273,7 +2273,7 @@ void gui_init(dt_view_t *self)
 
   /* create second window display button */
   dev->second_window.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_display2, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(dev->second_window.button), "dt_checked_background");
+  dt_gui_add_class(dev->second_window.button, "dt_checked_background");
   dt_action_define(&self->actions, NULL, "second window", dev->second_window.button, &dt_action_def_toggle);
   g_signal_connect(G_OBJECT(dev->second_window.button), "clicked", G_CALLBACK(_second_window_quickbutton_clicked),
                    dev);
@@ -2282,7 +2282,7 @@ void gui_init(dt_view_t *self)
 
   /* Enable ISO 12646-compliant colour assessment conditions */
   dev->iso_12646.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, 0, NULL);
-  gtk_style_context_add_class(gtk_widget_get_style_context(dev->iso_12646.button), "dt_checked_background");
+  dt_gui_add_class(dev->iso_12646.button, "dt_checked_background");
   dt_action_define(&self->actions, NULL, "color assessment", dev->iso_12646.button, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(dev->iso_12646.button,
                               _("toggle ISO 12646 color assessment conditions"));
@@ -2295,7 +2295,7 @@ void gui_init(dt_view_t *self)
   {
     // the button
     dev->rawoverexposed.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_rawoverexposed, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(dev->rawoverexposed.button), "dt_checked_background");
+    dt_gui_add_class(dev->rawoverexposed.button, "dt_checked_background");
     dt_action_define(&self->actions, N_("raw overexposed"), N_("toggle"), dev->rawoverexposed.button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->rawoverexposed.button,
                                 _("toggle raw over exposed indication\nright click for options"));
@@ -2350,7 +2350,7 @@ void gui_init(dt_view_t *self)
   {
     // the button
     dev->overexposed.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_overexposed, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(dev->overexposed.button), "dt_checked_background");
+    dt_gui_add_class(dev->overexposed.button, "dt_checked_background");
     dt_action_define(DT_ACTION(self), N_("overexposed"), N_("toggle"), dev->overexposed.button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->overexposed.button,
                                 _("toggle clipping indication\nright click for options"));
@@ -2416,8 +2416,7 @@ void gui_init(dt_view_t *self)
   {
     // the softproof button
     dev->profile.softproof_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_softproof, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(dev->profile.softproof_button),
-                                "dt_checked_background");
+    dt_gui_add_class(dev->profile.softproof_button, "dt_checked_background");
     dt_action_define(&self->actions, NULL, "softproof", dev->profile.softproof_button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->profile.softproof_button,
                                 _("toggle softproofing\nright click for profile options"));
@@ -2428,7 +2427,7 @@ void gui_init(dt_view_t *self)
 
     // the gamut check button
     dev->profile.gamut_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_gamut_check, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(dev->profile.gamut_button), "dt_checked_background");
+    dt_gui_add_class(dev->profile.gamut_button, "dt_checked_background");
     dt_action_define(&self->actions, NULL, "gamut check", dev->profile.gamut_button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->profile.gamut_button,
                  _("toggle gamut checking\nright click for profile options"));
@@ -2591,8 +2590,7 @@ void gui_init(dt_view_t *self)
   {
     // the button
     darktable.view_manager->guides_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_grid, 0, NULL);
-    gtk_style_context_add_class(gtk_widget_get_style_context(darktable.view_manager->guides_toggle),
-                                "dt_checked_background");
+    dt_gui_add_class(darktable.view_manager->guides_toggle, "dt_checked_background");
     dt_action_define(&self->actions, "guide lines", "toggle", darktable.view_manager->guides_toggle, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(darktable.view_manager->guides_toggle,
                                 _("toggle guide lines\nright click for guides options"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2273,7 +2273,6 @@ void gui_init(dt_view_t *self)
 
   /* create second window display button */
   dev->second_window.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_display2, 0, NULL);
-  dt_gui_add_class(dev->second_window.button, "dt_checked_background");
   dt_action_define(&self->actions, NULL, "second window", dev->second_window.button, &dt_action_def_toggle);
   g_signal_connect(G_OBJECT(dev->second_window.button), "clicked", G_CALLBACK(_second_window_quickbutton_clicked),
                    dev);
@@ -2282,7 +2281,6 @@ void gui_init(dt_view_t *self)
 
   /* Enable ISO 12646-compliant colour assessment conditions */
   dev->iso_12646.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, 0, NULL);
-  dt_gui_add_class(dev->iso_12646.button, "dt_checked_background");
   dt_action_define(&self->actions, NULL, "color assessment", dev->iso_12646.button, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(dev->iso_12646.button,
                               _("toggle ISO 12646 color assessment conditions"));
@@ -2295,7 +2293,6 @@ void gui_init(dt_view_t *self)
   {
     // the button
     dev->rawoverexposed.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_rawoverexposed, 0, NULL);
-    dt_gui_add_class(dev->rawoverexposed.button, "dt_checked_background");
     dt_action_define(&self->actions, N_("raw overexposed"), N_("toggle"), dev->rawoverexposed.button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->rawoverexposed.button,
                                 _("toggle raw over exposed indication\nright click for options"));
@@ -2350,7 +2347,6 @@ void gui_init(dt_view_t *self)
   {
     // the button
     dev->overexposed.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_overexposed, 0, NULL);
-    dt_gui_add_class(dev->overexposed.button, "dt_checked_background");
     dt_action_define(DT_ACTION(self), N_("overexposed"), N_("toggle"), dev->overexposed.button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->overexposed.button,
                                 _("toggle clipping indication\nright click for options"));
@@ -2416,7 +2412,6 @@ void gui_init(dt_view_t *self)
   {
     // the softproof button
     dev->profile.softproof_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_softproof, 0, NULL);
-    dt_gui_add_class(dev->profile.softproof_button, "dt_checked_background");
     dt_action_define(&self->actions, NULL, "softproof", dev->profile.softproof_button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->profile.softproof_button,
                                 _("toggle softproofing\nright click for profile options"));
@@ -2427,7 +2422,6 @@ void gui_init(dt_view_t *self)
 
     // the gamut check button
     dev->profile.gamut_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_gamut_check, 0, NULL);
-    dt_gui_add_class(dev->profile.gamut_button, "dt_checked_background");
     dt_action_define(&self->actions, NULL, "gamut check", dev->profile.gamut_button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->profile.gamut_button,
                  _("toggle gamut checking\nright click for profile options"));
@@ -2590,7 +2584,6 @@ void gui_init(dt_view_t *self)
   {
     // the button
     darktable.view_manager->guides_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_grid, 0, NULL);
-    dt_gui_add_class(darktable.view_manager->guides_toggle, "dt_checked_background");
     dt_action_define(&self->actions, "guide lines", "toggle", darktable.view_manager->guides_toggle, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(darktable.view_manager->guides_toggle,
                                 _("toggle guide lines\nright click for guides options"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2257,8 +2257,7 @@ void gui_init(dt_view_t *self)
    */
 
   /* create favorite plugin preset popup tool */
-  GtkWidget *favorite_presets
-      = dtgtk_button_new(dtgtk_cairo_paint_presets, CPF_STYLE_FLAT, NULL);
+  GtkWidget *favorite_presets = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
   gtk_widget_set_tooltip_text(favorite_presets, _("quick access to presets"));
   g_signal_connect(G_OBJECT(favorite_presets), "clicked", G_CALLBACK(_darkroom_ui_favorite_presets_popupmenu),
                    NULL);
@@ -2266,15 +2265,15 @@ void gui_init(dt_view_t *self)
   dt_view_manager_view_toolbox_add(darktable.view_manager, favorite_presets, DT_VIEW_DARKROOM);
 
   /* create quick styles popup menu tool */
-  GtkWidget *styles = dtgtk_button_new(dtgtk_cairo_paint_styles, CPF_STYLE_FLAT, NULL);
+  GtkWidget *styles = dtgtk_button_new(dtgtk_cairo_paint_styles, 0, NULL);
   g_signal_connect(G_OBJECT(styles), "clicked", G_CALLBACK(_darkroom_ui_apply_style_popupmenu), NULL);
   gtk_widget_set_tooltip_text(styles, _("quick access for applying any of your styles"));
   dt_gui_add_help_link(styles, dt_get_help_url("bottom_panel_styles"));
   dt_view_manager_view_toolbox_add(darktable.view_manager, styles, DT_VIEW_DARKROOM);
 
   /* create second window display button */
-  dev->second_window.button
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_display2, CPF_STYLE_FLAT, NULL);
+  dev->second_window.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_display2, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(dev->second_window.button), "dt_checked_background");
   dt_action_define(&self->actions, NULL, "second window", dev->second_window.button, &dt_action_def_toggle);
   g_signal_connect(G_OBJECT(dev->second_window.button), "clicked", G_CALLBACK(_second_window_quickbutton_clicked),
                    dev);
@@ -2282,8 +2281,8 @@ void gui_init(dt_view_t *self)
   dt_view_manager_view_toolbox_add(darktable.view_manager, dev->second_window.button, DT_VIEW_DARKROOM);
 
   /* Enable ISO 12646-compliant colour assessment conditions */
-  dev->iso_12646.button
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT, NULL);
+  dev->iso_12646.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, 0, NULL);
+  gtk_style_context_add_class(gtk_widget_get_style_context(dev->iso_12646.button), "dt_checked_background");
   dt_action_define(&self->actions, NULL, "color assessment", dev->iso_12646.button, &dt_action_def_toggle);
   gtk_widget_set_tooltip_text(dev->iso_12646.button,
                               _("toggle ISO 12646 color assessment conditions"));
@@ -2295,8 +2294,8 @@ void gui_init(dt_view_t *self)
   /* create rawoverexposed popup tool */
   {
     // the button
-    dev->rawoverexposed.button
-        = dtgtk_togglebutton_new(dtgtk_cairo_paint_rawoverexposed, CPF_STYLE_FLAT, NULL);
+    dev->rawoverexposed.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_rawoverexposed, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(dev->rawoverexposed.button), "dt_checked_background");
     dt_action_define(&self->actions, N_("raw overexposed"), N_("toggle"), dev->rawoverexposed.button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->rawoverexposed.button,
                                 _("toggle raw over exposed indication\nright click for options"));
@@ -2350,8 +2349,8 @@ void gui_init(dt_view_t *self)
   /* create overexposed popup tool */
   {
     // the button
-    dev->overexposed.button
-        = dtgtk_togglebutton_new(dtgtk_cairo_paint_overexposed, CPF_STYLE_FLAT, NULL);
+    dev->overexposed.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_overexposed, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(dev->overexposed.button), "dt_checked_background");
     dt_action_define(DT_ACTION(self), N_("overexposed"), N_("toggle"), dev->overexposed.button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->overexposed.button,
                                 _("toggle clipping indication\nright click for options"));
@@ -2416,8 +2415,9 @@ void gui_init(dt_view_t *self)
   /* create profile popup tool & buttons (softproof + gamut) */
   {
     // the softproof button
-    dev->profile.softproof_button =
-      dtgtk_togglebutton_new(dtgtk_cairo_paint_softproof, CPF_STYLE_FLAT, NULL);
+    dev->profile.softproof_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_softproof, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(dev->profile.softproof_button),
+                                "dt_checked_background");
     dt_action_define(&self->actions, NULL, "softproof", dev->profile.softproof_button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->profile.softproof_button,
                                 _("toggle softproofing\nright click for profile options"));
@@ -2427,8 +2427,8 @@ void gui_init(dt_view_t *self)
     dt_gui_add_help_link(dev->profile.softproof_button, dt_get_help_url("softproof"));
 
     // the gamut check button
-    dev->profile.gamut_button =
-      dtgtk_togglebutton_new(dtgtk_cairo_paint_gamut_check, CPF_STYLE_FLAT, NULL);
+    dev->profile.gamut_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_gamut_check, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(dev->profile.gamut_button), "dt_checked_background");
     dt_action_define(&self->actions, NULL, "gamut check", dev->profile.gamut_button, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(dev->profile.gamut_button,
                  _("toggle gamut checking\nright click for profile options"));
@@ -2590,7 +2590,9 @@ void gui_init(dt_view_t *self)
   /* create grid changer popup tool */
   {
     // the button
-    darktable.view_manager->guides_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_grid, CPF_STYLE_FLAT, NULL);
+    darktable.view_manager->guides_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_grid, 0, NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(darktable.view_manager->guides_toggle),
+                                "dt_checked_background");
     dt_action_define(&self->actions, "guide lines", "toggle", darktable.view_manager->guides_toggle, &dt_action_def_toggle);
     gtk_widget_set_tooltip_text(darktable.view_manager->guides_toggle,
                                 _("toggle guide lines\nright click for guides options"));

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1228,7 +1228,7 @@ void gui_init(dt_view_t *self)
                                      DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM);
 
   // create display profile button
-  GtkWidget *const profile_button = dtgtk_button_new(dtgtk_cairo_paint_display, CPF_STYLE_FLAT, NULL);
+  GtkWidget *const profile_button = dtgtk_button_new(dtgtk_cairo_paint_display, 0, NULL);
   gtk_widget_set_tooltip_text(profile_button, _("set display profile"));
   dt_view_manager_module_toolbox_add(darktable.view_manager, profile_button, DT_VIEW_LIGHTTABLE);
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1259,8 +1259,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
   gtk_box_pack_start(GTK_BOX(hb), vm->accels_window.flow_box, TRUE, TRUE, 0);
 
   GtkWidget *vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  vm->accels_window.sticky_btn
-      = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT, NULL);
+  vm->accels_window.sticky_btn = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, 0, NULL);
   g_object_set(G_OBJECT(vm->accels_window.sticky_btn), "tooltip-text",
                _("switch to a classic window which will stay open after key release"), (char *)NULL);
   g_signal_connect(G_OBJECT(vm->accels_window.sticky_btn), "button-press-event", G_CALLBACK(_accels_window_sticky),


### PR DESCRIPTION
fix #7968

This is a big cleanup in buttons/paint flags.
Currently we have lot of drawing flags which are used to "theme" the buttons. Now that all this is managed by css, better remove them, that will avoid a mix between hardcoded things and css ;)

I think that it doesn't change anything in the UI, but better test it twice, considering the amount of changes done in so many files !