### PR TITLE
Fix rating toggle behavior if not all images share the same rating

### DIFF
--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -24,11 +24,11 @@
 #define DT_VIEW_RATINGS_MASK 0x7
 // first three bits of dt_view_image_over_t
 
-/** get rating tfor the specified image */
+/** get rating for the specified image */
 int dt_ratings_get(const int imgid);
 
 /** apply rating to the specified image */
-void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean toggle_on,
+void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean single_star_toggle,
                                const gboolean undo_on, const gboolean group_on);
 
 /** apply rating to all images in the list */


### PR DESCRIPTION
This is a fix for #5138 (and is related to #10734, which was already fixed)
If you select multiple images (some of them are rejected and others are not) and click the reject button, it will now correctly reject all selected images. If you press it again, it will then unreject all images. 

Implemented logic in _ratings_apply to check if all images in the current selection share the 1-star or rejection label before toggling
it. If at least one image does not have the rating - we do not toggle.

Also, renamed the 'toggle_on' parameter to 'single_star_toggle' because
that describes better, what it does.