### PR TITLE
Fix CL memory requirement in retouch

### DIFF
--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -201,7 +201,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 }
 
 #if 0
-/** optional, only needed if tiling is permitted by setting IOP_FLAGS_ALLOW_TILING */
+/** optional, always needed if tiling is permitted by setting IOP_FLAGS_ALLOW_TILING
+    Also define this if the module uses more memory on the OpenCl device than the in& output buffers. 
+*/
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling)


### PR DESCRIPTION
Despite current docs in useless.c the information taken via tiling_callback is
necessary to calculate cl memory requirements in `dt_opencl_image_fits_device()`.

In the retouch module we might have large amounts of cl memory required, that might
lead to errors later in the pipeline resulting possibly in probelems or at least to
an avoidable performance drop because of cpu fallback.

After a short discussion in #11450 i checked opencl requirements and unfortunately it seems
that in addition to those two for in/out
- we require 4 roi-sized buffers for the wavelets part
- one more for in_retouch

We could do better (by checking all shape bounding boxes), at least this is a safety belt now.