### PR TITLE
ability to add only subset of enum values to combobox

### DIFF
--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -23,6 +23,7 @@
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param);
 
 GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *param);
+GtkWidget *dt_bauhaus_combobox_from_params_enum_interval(dt_iop_module_t *self, const char *param, unsigned begin, unsigned end);
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param);
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5767,12 +5767,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  g->demosaic_method_bayer = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, 9);
+  g->demosaic_method_bayer = dt_bauhaus_combobox_from_params_enum_interval(self, "demosaicing_method", 0, 9);
   gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\nLMMSE is suited best for high ISO images.\ndual demosaicers double processing time."));
 
-  g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<9;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
+  g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params_enum_interval(self, "demosaicing_method", 9, 15);
   gtk_widget_set_tooltip_text(g->demosaic_method_xtrans, _("xtrans sensor demosaicing method, Markesteijn 3-pass and frequency domain chroma are slow.\ndual demosaicers double processing time."));
 
   g->median_thrs = dt_bauhaus_slider_from_params(self, "median_thrs");


### PR DESCRIPTION
in `demosaic.c` there is ugly way of adding only subset of enum params into combobox, so i created variant of `dt_bauhaus_combobox_from_params` that handles that.
it might be merged with original function