### PR TITLE
Make async pixelpipe device specific too

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -232,13 +232,6 @@
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>opencl_async_pixelpipe</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>run OpenCL pixelpipe asynchronously</shortdescription>
-    <longdescription>if set to TRUE OpenCL pixelpipe will not be synchronized on a per-module basis. this can improve pixelpipe latency. however, potential OpenCL errors would be detected late; in such a case the complete pixelpipe needs to be reprocessed instead of only a single module. export pixelpipe will always be run synchronously.</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>opencl_device_priority</name>
     <type>string</type>
     <default>*/!0,*/*/*/!0,*</default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1732,14 +1732,14 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
 
-  if(old < 8)
+  if(old < 9)
   {
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("some global config values relevant for OpenCL performance are not used any longer."), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("instead you will find 'per device' data in 'cldevice_v1_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("instead you will find 'per device' data in 'cldevice_v2_canonical-name'. content is:"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("  'avoid_atomics'  'micro_nap'  'pinned_memory'  'roundupwd'  'roundupht'  'eventhandles' 'magic'"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _(" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'magic'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
     g_strlcat(info, _("you may tune as before except 'magic'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -156,7 +156,7 @@ typedef unsigned int u_int;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 8
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 9
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -994,8 +994,7 @@ int nlmeans_denoise_cl(const dt_nlmeans_param_t *const params, const int devid,
     err = nlmeans_cl_accu(devid,params->kernel_accu,dev_in,dev_U4_tt,dev_out,q,height,width,sizes);
     if(err != CL_SUCCESS) break;
 
-    if(!darktable.opencl->async_pixelpipe || params->pipetype == DT_DEV_PIXELPIPE_EXPORT)
-      dt_opencl_finish(devid);
+    dt_opencl_finish_sync_pipe(devid, params->pipetype);
 
     // indirectly give gpu some air to breathe (and to do display related stuff)
     dt_iop_nap(dt_opencl_micro_nap(devid));
@@ -1090,8 +1089,7 @@ int nlmeans_denoiseprofile_cl(const dt_nlmeans_param_t *const params, const int 
     err = nlmeans_cl_accu(devid,params->kernel_accu,dev_in,dev_U4_tt,dev_out,q,height,width,sizes);
     if(err != CL_SUCCESS) break;
 
-    if(!darktable.opencl->async_pixelpipe || params->pipetype == DT_DEV_PIXELPIPE_EXPORT)
-      dt_opencl_finish(devid);
+    dt_opencl_finish_sync_pipe(devid, params->pipetype);
 
     // indirectly give gpu some air to breathe (and to do display related stuff)
     dt_iop_nap(dt_opencl_micro_nap(devid));

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -147,7 +147,7 @@ int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_in
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
-             "[dt_opencl_get_device_info] could not query the actual size in bytes of info %d: %d\n", param_name, err);
+             "[dt_opencl_get_device_info] could not query the actual size in bytes of info %d: %s\n", param_name, cl_errstr(err));
     goto error;
   }
 
@@ -168,8 +168,8 @@ int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_in
     if(!ptr)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_get_device_info] memory allocation failed! tried to allocate %zu bytes for data %d: %d",
-               *param_value_size, param_name, err);
+               "[dt_opencl_get_device_info] memory allocation failed! tried to allocate %zu bytes for data %d: %s",
+               *param_value_size, param_name, cl_errstr(err));
       err = CL_OUT_OF_HOST_MEMORY;
       goto error;
     }
@@ -182,7 +182,7 @@ int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_in
   err = (cl->dlocl->symbols->dt_clGetDeviceInfo)(device, param_name, *param_value_size, *param_value, NULL);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_get_device_info] could not query info %d: %d\n", param_name, err);
+    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_get_device_info] could not query info %d: %s\n", param_name, cl_errstr(err));
     goto error;
   }
 
@@ -364,7 +364,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   err = dt_opencl_get_device_info(cl, devid, CL_DEVICE_VENDOR, (void **)&vendor, &vendor_size);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get vendor name of device %d: %d\n", k, err);
+    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get vendor name of device %d: %s\n", k, cl_errstr(err));
     res = -1;
     goto end;
   }
@@ -374,7 +374,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   err = dt_opencl_get_device_info(cl, devid, CL_DEVICE_NAME, (void **)&infostr, &infostr_size);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get device name of device %d: %d\n", k, err);
+    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get device name of device %d: %s\n", k, cl_errstr(err));
     res = -1;
     goto end;
   }
@@ -382,7 +382,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   err = dt_opencl_get_device_info(cl, devid, CL_DRIVER_VERSION, (void **)&driverversion, &driverversion_size);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get driver version of device %d `%s': %d\n", k, infostr, err);
+    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get driver version of device %d `%s': %s\n", k, infostr, cl_errstr(err));
     res = -1;
     goto end;
   }
@@ -390,7 +390,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   err = dt_opencl_get_device_info(cl, devid, CL_DEVICE_VERSION, (void **)&deviceversion, &deviceversion_size);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get device version of device %d `%s': %d\n", k, infostr, err);
+    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not get device version of device %d `%s': %s\n", k, infostr, cl_errstr(err));
     res = -1;
     goto end;
   }
@@ -537,7 +537,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   cl->dev[dev].context = (cl->dlocl->symbols->dt_clCreateContext)(0, 1, &devid, NULL, NULL, &err);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not create context for device %d: %d\n", k, err);
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not create context for device %d: %s\n", k, cl_errstr(err));
     res = -1;
     goto end;
   }
@@ -546,7 +546,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
       cl->dev[dev].context, devid, (darktable.unmuted & DT_DEBUG_PERF) ? CL_QUEUE_PROFILING_ENABLE : 0, &err);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not create command queue for device %d: %d\n", k, err);
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not create command queue for device %d: %s\n", k, cl_errstr(err));
     res = -1;
     goto end;
   }
@@ -808,7 +808,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   err = (cl->dlocl->symbols->dt_clGetPlatformIDs)(DT_OPENCL_MAX_PLATFORMS, all_platforms, &num_platforms);
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get platforms: %d\n", err);
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get platforms: %s\n", cl_errstr(err));
     goto finally;
   }
 
@@ -829,7 +829,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
     if(err != CL_SUCCESS)
     {
       all_num_devices[n] = 0;
-      dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get device id size: %d\n", err);
+      dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get device id size: %s\n", cl_errstr(err));
     }
     else
     {
@@ -839,7 +839,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
       if(err != CL_SUCCESS)
       {
         all_num_devices[n] = 0;
-        dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get profile: %d\n", err);
+        dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get profile: %s\n", cl_errstr(err));
       }
       else
       {
@@ -883,7 +883,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
       if(err != CL_SUCCESS)
       {
         num_devices -= all_num_devices[n];
-        dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get devices list: %d\n", err);
+        dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not get devices list: %s\n", cl_errstr(err));
       }
       devs += all_num_devices[n];
     }
@@ -1883,8 +1883,8 @@ int dt_opencl_load_program(const int dev, const int prog, const char *filename, 
           if(err != CL_SUCCESS)
           {
             dt_print(DT_DEBUG_OPENCL,
-                     "[opencl_load_program] could not load cached binary program from file '%s' MD5: '%s'! (%d)\n",
-                     binname, md5sum, err);
+                     "[opencl_load_program] could not load cached binary program from file '%s' MD5: '%s'! (%s)\n",
+                     binname, md5sum, cl_errstr(err));
           }
           else
           {
@@ -1924,8 +1924,8 @@ int dt_opencl_load_program(const int dev, const int prog, const char *filename, 
     free(file);
     if(err != CL_SUCCESS)
     {
-      dt_print(DT_DEBUG_OPENCL, "[opencl_load_source] could not create program from file `%s'! (%d)\n",
-               filename, err);
+      dt_print(DT_DEBUG_OPENCL, "[opencl_load_source] could not create program from file `%s'! (%s)\n",
+               filename, cl_errstr(err));
       return 0;
     }
     else
@@ -1954,7 +1954,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
   err = (cl->dlocl->symbols->dt_clBuildProgram)(program, 1, &(cl->dev[dev].devid), cl->dev[dev].options, 0, 0);
 
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] could not build program: %d\n", err);
+    dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] could not build program: %s\n", cl_errstr(err));
   else
     dt_vprint(DT_DEBUG_OPENCL, "[opencl_build_program] successfully built program\n");
 
@@ -1997,7 +1997,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
                                                       &numdev, NULL);
       if(err != CL_SUCCESS)
       {
-        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_NUM_DEVICES failed: %d\n", err);
+        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_NUM_DEVICES failed: %s\n", cl_errstr(err));
         return CL_SUCCESS;
       }
 
@@ -2006,7 +2006,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
                                                       sizeof(cl_device_id) * numdev, devices, NULL);
       if(err != CL_SUCCESS)
       {
-        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_DEVICES failed: %d\n", err);
+        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_DEVICES failed: %s\n", cl_errstr(err));
         free(devices);
         return CL_SUCCESS;
       }
@@ -2016,7 +2016,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
                                                       sizeof(size_t) * numdev, binary_sizes, NULL);
       if(err != CL_SUCCESS)
       {
-        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_BINARY_SIZES failed: %d\n", err);
+        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_BINARY_SIZES failed: %s\n", cl_errstr(err));
         free(binary_sizes);
         free(devices);
         return CL_SUCCESS;
@@ -2028,7 +2028,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
                                                       sizeof(unsigned char *) * numdev, binaries, NULL);
       if(err != CL_SUCCESS)
       {
-        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_BINARIES failed: %d\n", err);
+        dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] CL_PROGRAM_BINARIES failed: %s\n", cl_errstr(err));
         goto ret;
       }
 
@@ -2091,7 +2091,7 @@ int dt_opencl_create_kernel(const int prog, const char *name)
             = (cl->dlocl->symbols->dt_clCreateKernel)(cl->dev[dev].program[prog], name, &err);
         if(err != CL_SUCCESS)
         {
-          dt_print(DT_DEBUG_OPENCL, "[opencl_create_kernel] could not create kernel `%s'! (%d)\n", name, err);
+          dt_print(DT_DEBUG_OPENCL, "[opencl_create_kernel] could not create kernel `%s'! (%s)\n", name, cl_errstr(err));
           cl->dev[dev].kernel_used[k] = 0;
           goto error;
         }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1110,6 +1110,10 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
                                     "successful and %d events lost, max event=%d\n",
             cl->dev[i].name, i, cl->dev[i].totalsuccess, cl->dev[i].totalevents, cl->dev[i].totallost,
             cl->dev[i].maxeventslot);
+          if(cl->dev[i].maxeventslot >= 1024)
+            fprintf(stderr, "Your OpenCl device '%s' had used up to %d events while processing. This might be safe\n"
+                            "but there is currently no correct check implemented. Take care!\n",
+                             cl->dev[i].name, cl->dev[i].maxeventslot); 
         }
         else
         {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -259,6 +259,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
 /** cleans up the opencl subsystem. */
 void dt_opencl_cleanup(dt_opencl_t *cl);
 
+const char *cl_errstr(cl_int error);
 /** both finish functions return TRUE in case of success */
 /** cleans up command queue. */
 int dt_opencl_finish(const int devid);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -166,6 +166,8 @@ typedef struct dt_opencl_device_t
   int event_handles;
   // opencl_events enabled for the device
   int use_events;
+  // async pixelpipe mode for device
+  int asyncmode;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;
@@ -183,7 +185,6 @@ typedef struct dt_opencl_t
 {
   dt_pthread_mutex_t lock;
   int inited;
-  int async_pixelpipe;
   int print_statistics;
   dt_opencl_sync_cache_t sync_cache;
   int enabled;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -167,6 +167,9 @@ typedef struct dt_opencl_device_t
   // opencl_events enabled for the device
   int use_events;
   // async pixelpipe mode for device
+  // if set to TRUE OpenCL pixelpipe will not be synchronized on a per-module basis. this can improve pixelpipe latency.
+  // however, potential OpenCL errors would be detected late; in such a case the complete pixelpipe needs to be reprocessed
+  // instead of only a single module. export pixelpipe will always be run synchronously.
   int asyncmode;
 } dt_opencl_device_t;
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -259,8 +259,11 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
 /** cleans up the opencl subsystem. */
 void dt_opencl_cleanup(dt_opencl_t *cl);
 
+/** both finish functions return TRUE in case of success */
 /** cleans up command queue. */
 int dt_opencl_finish(const int devid);
+/** cleans up command queue if in synchron mode or while exporting */
+int dt_opencl_finish_sync_pipe(const int devid, const int pipetype);
 
 /** enqueues a synchronization point. */
 int dt_opencl_enqueue_barrier(const int devid);
@@ -479,7 +482,11 @@ static inline void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl
 static inline void dt_opencl_cleanup(dt_opencl_t *cl)
 {
 }
-static inline int dt_opencl_finish(const int devid)
+static inline gboolean dt_opencl_finish(const int devid)
+{
+  return -1;
+}
+static inline gboolean dt_opencl_finish_sync_pipe(const int devid, const int pipetype)
 {
   return -1;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1610,8 +1610,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             /* late opencl error */
             dt_print(
                 DT_DEBUG_OPENCL,
-                "[opencl_pixelpipe (a)] late opencl error detected while copying back to cpu buffer: %d\n",
-                err);
+                "[opencl_pixelpipe (a)] late opencl error detected while copying back to cpu buffer: %s\n", cl_errstr(err));
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = 1;
             return 1;
@@ -1777,8 +1776,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             {
               /* late opencl error, not likely to happen here */
               dt_print(DT_DEBUG_OPENCL, "[opencl_pixelpipe (e)] late opencl error detected while copying "
-                                        "back to cpu buffer: %d\n",
-                       err);
+                                        "back to cpu buffer: %s\n", cl_errstr(err));
               /* that's all we do here, we later make sure to invalidate cache line */
             }
             else
@@ -1835,8 +1833,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             /* late opencl error */
             dt_print(
                 DT_DEBUG_OPENCL,
-                "[opencl_pixelpipe (b)] late opencl error detected while copying back to cpu buffer: %d\n",
-                err);
+                "[opencl_pixelpipe (b)] late opencl error detected while copying back to cpu buffer: %s\n", cl_errstr(err));
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = 1;
             return 1;
@@ -1881,8 +1878,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           /* late opencl error */
           dt_print(
               DT_DEBUG_OPENCL,
-              "[opencl_pixelpipe (c)] late opencl error detected while copying back to cpu buffer: %d\n",
-              err);
+              "[opencl_pixelpipe (c)] late opencl error detected while copying back to cpu buffer: %s\n", cl_errstr(err));
           dt_opencl_release_mem_object(cl_mem_input);
           pipe->opencl_error = 1;
           return 1;
@@ -2152,8 +2148,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
       {
         /* this indicates a opencl problem earlier in the pipeline */
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl_pixelpipe (d)] late opencl error detected while copying back to cpu buffer: %d\n",
-                 err);
+                 "[opencl_pixelpipe (d)] late opencl error detected while copying back to cpu buffer: %s\n", cl_errstr(err));
         pipe->opencl_error = 1;
         ret = 1;
       }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1582,10 +1582,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         }
 
         /* synchronization point for opencl pipe */
-        if(success_opencl && (!darktable.opencl->async_pixelpipe
-                              || (pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT))
-          success_opencl = dt_opencl_finish(pipe->devid);
-
+        if(success_opencl)
+          success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
 
         if(dt_atomic_get_int(&pipe->shutdown))
         {
@@ -1728,9 +1726,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         }
 
         /* synchronization point for opencl pipe */
-        if(success_opencl && (!darktable.opencl->async_pixelpipe
-                              || (pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT))
-          success_opencl = dt_opencl_finish(pipe->devid);
+        if(success_opencl)
+          success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
 
         if(dt_atomic_get_int(&pipe->shutdown))
         {
@@ -1848,7 +1845,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             input_format->cst = input_cst_cl;
 
           /* this is a good place to release event handles as we anyhow need to move from gpu to cpu here */
-          (void)dt_opencl_finish(pipe->devid);
+          dt_opencl_finish(pipe->devid);
           dt_opencl_release_mem_object(cl_mem_input);
           valid_input_on_gpu_only = FALSE;
         }
@@ -1894,7 +1891,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           input_format->cst = input_cst_cl;
 
         /* this is a good place to release event handles as we anyhow need to move from gpu to cpu here */
-        (void)dt_opencl_finish(pipe->devid);
+        dt_opencl_finish(pipe->devid);
         dt_opencl_release_mem_object(cl_mem_input);
         valid_input_on_gpu_only = FALSE;
       }

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1512,8 +1512,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
       output = NULL;
 
       /* block until opencl queue has finished to free all used event handlers */
-      if(!darktable.opencl->async_pixelpipe || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT)
-        dt_opencl_finish(devid);
+      dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
     }
 
   /* copy back final processed_maximum */
@@ -1953,8 +1952,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
       output = NULL;
 
       /* block until opencl queue has finished to free all used event handlers */
-      if(!darktable.opencl->async_pixelpipe || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT)
-        dt_opencl_finish(devid);
+      dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
     }
 
   /* copy back final processed_maximum */

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1539,8 +1539,8 @@ error:
   piece->pipe->tiling = 0;
   const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
-      "[default_process_tiling_opencl_ptp] couldn't run process_cl() for module '%s' in tiling mode:%s %d\n",
-      self->op, (pinning_error) ? " pinning problem" : "", err);
+      "[default_process_tiling_opencl_ptp] couldn't run process_cl() for module '%s' in tiling mode:%s %s\n",
+      self->op, (pinning_error) ? " pinning problem" : "", cl_errstr(err));
   if(pinning_error) darktable.opencl->dev[devid].pinned_memory |= DT_OPENCL_PINNING_ERROR;
   return FALSE;
 }
@@ -1978,8 +1978,8 @@ error:
   piece->pipe->tiling = 0;
   const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-      "[default_process_tiling_opencl_roi] couldn't run process_cl() for module '%s' in tiling mode:%s %d\n",
-      self->op, (pinning_error) ? " pinning problem" : "", err);
+      "[default_process_tiling_opencl_roi] couldn't run process_cl() for module '%s' in tiling mode:%s %s\n",
+      self->op, (pinning_error) ? " pinning problem" : "", cl_errstr(err));
   if(pinning_error) darktable.opencl->dev[devid].pinned_memory |= DT_OPENCL_PINNING_ERROR;
   return FALSE;
 }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -462,8 +462,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_addbuffers, sizes);
   if(err != CL_SUCCESS) goto error;
 
-  if(!darktable.opencl->async_pixelpipe || (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT)
-    dt_opencl_finish(devid);
+  dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
 
   dt_opencl_release_mem_object(dev_filter);
   dt_opencl_release_mem_object(dev_tmp);
@@ -603,8 +602,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_iop_nap(dt_opencl_micro_nap(devid));
   }
 
-  if(!darktable.opencl->async_pixelpipe || (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT)
-    dt_opencl_finish(devid);
+  dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
 
   dt_opencl_release_mem_object(dev_filter);
   dt_opencl_release_mem_object(dev_tmp);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2066,8 +2066,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_denoiseprofile_accu, sizes);
       if(err != CL_SUCCESS) goto error;
 
-      if(!darktable.opencl->async_pixelpipe || (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT)
-        dt_opencl_finish(devid);
+      dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
 
       // indirectly give gpu some air to breathe (and to do display related stuff)
       dt_iop_nap(dt_opencl_micro_nap(devid));
@@ -2579,9 +2578,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     }
   }
 
-  if(!darktable.opencl->async_pixelpipe || (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT) == DT_DEV_PIXELPIPE_EXPORT)
-    dt_opencl_finish(devid);
-
+  dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
 
   dt_opencl_release_mem_object(dev_r);
   dt_opencl_release_mem_object(dev_m);

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -340,8 +340,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_nlmeans_accu, sizes);
       if(err != CL_SUCCESS) goto error;
 
-      if(!darktable.opencl->async_pixelpipe || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT)
-        dt_opencl_finish(devid);
+      dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
 
       // indirectly give gpu some air to breathe (and to do display related stuff)
       dt_iop_nap(dt_opencl_micro_nap(devid));


### PR DESCRIPTION
The global `opencl_async_pixelpipe` setting is made device specific too and the setting is exposed via the device conf key too so it can be changed by the user.

To make the user aware of this
1. an updated device conf key `cldevice_v2_canonical-name` is used and
2. DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION has been updated.

The asynchronous handling is now done in the introduced `gboolean dt_opencl_finish_sync_pipe(const int devid, const int pipetype)` function.

Some more improved debugging info plus a warning about the maximum used event slot, we can't check for that in a safe way in OpenCl 1.2 but a research in https://opencl.gpuinfo.org/ shows this is a good starting point to report possible problems.