### PR TITLE
Ensure minimal requested tiling_cl

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2826,7 +2826,7 @@ gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const 
   if(!darktable.opencl->inited || devid < 0) return FALSE;
 
   const size_t required  = width * height * bpp;
-  const size_t total = factor * required + overhead;
+  const size_t total = fmaxf(2.0f, factor) * required + overhead;
 
   if((dt_opencl_get_device_memalloc(devid) < required) || (dt_opencl_get_device_available(devid) < total))
     return FALSE;  

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -2023,7 +2023,7 @@ void default_tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpi
       = ((float)roi_out->width * (float)roi_out->height) / ((float)roi_in->width * (float)roi_in->height);
 
   tiling->factor = 1.0f + ioratio;
-  tiling->factor_cl = tiling->factor;  // by default, we need the same memory on host or GPU
+  tiling->factor_cl = fmaxf(2.0f, tiling->factor); // at least have in & output buffer
   tiling->maxbuf = 1.0f;
   tiling->maxbuf_cl = tiling->maxbuf;
   tiling->overhead = 0;


### PR DESCRIPTION
Modules might have incorrectly calculated tiling->factor_cl or don't have a tiling_callback implemented.

At least make sure here for safety that in & output clbuffers are taken into account so have this set to
at least 2.0f.

Fixes #11072

While checking this there are a number of modules that don't implement a proper tiling_callback reporting required cl memory for untiled cl processing and rely on these settings. We won't notice in most cases but on systems with low cl memory (like on cpu intels) that might be a real desaster and would certainly lead to crashes we thought to be intel driver or windows related. (colorin, colorout, rawprepare are some examples)