### PR TITLE
Do not write extra newline when updating modelines

### DIFF
--- a/tools/update_modelines.py
+++ b/tools/update_modelines.py
@@ -74,7 +74,6 @@ class modelines_updater_t:
 			file.write(VIM_MODELINE)
 			file.write(KATE_MODELINE)
 			file.write(CLANG_ON)
-			file.write('\n')
 			
 	def update(self):
 		print('parsing {}'.format(self.filename));


### PR DESCRIPTION
@TurboGit  @maruncz `clang-format` removes it (i.e. wants only one newline at the EOF) and therefore can mark file as changed