### PR TITLE
Integrate driver blacklisting into per-device struct

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -246,13 +246,6 @@
     <longdescription>time period (in units of 5ms) after which we give up try-locking an opencl device for mandatory use. defaults to 400 (2 seconds).</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>opencl_disable_drivers_blacklist</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>whether to allow some partial opencl implementations to be used or not</shortdescription>
-    <longdescription>not all opencl implementations are fully-functional, there are at least two, which are not production-quality yet: pocl and beignet; therefore at this point in time, it is better to explicitly blacklist them by default. can be changed by setting this configuration option to TRUE (needs a restart).</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>opencl_checksum</name>
     <type>string</type>
     <default></default>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -467,10 +467,10 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   cl->crc = crc32(cl->crc, (const unsigned char *)infostr, strlen(infostr));
 
   const gboolean newdevice = dt_opencl_read_device_config(dev);
-  const gboolean blacklist = dt_opencl_check_driver_blacklist(deviceversion);
+  const gboolean is_blacklisted = dt_opencl_check_driver_blacklist(deviceversion);
 
   // disable device for now if this is the first time detected and blacklisted too.
-  if(newdevice && blacklist)
+  if(newdevice && is_blacklisted)
   {
     // To keep installations we look for the old blacklist conf key
     const gboolean old_blacklist = dt_conf_get_bool("opencl_disable_drivers_blacklist");
@@ -535,7 +535,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
       (type & CL_DEVICE_TYPE_ACCELERATOR)                 ? ", Accelerator" : "" );
     fprintf(stderr, "     DEFAULT DEVICE:           %s\n", (type & CL_DEVICE_TYPE_DEFAULT) ? "Yes" : "No");
     fprintf(stderr, "     DRIVER VERSION:           %s\n", driverversion);
-    fprintf(stderr, "     DEVICE VERSION:           %s%s\n", deviceversion, (blacklist) ? ", blacklist" : "");
+    fprintf(stderr, "     DEVICE VERSION:           %s%s\n", deviceversion, (is_blacklisted) ? ", blacklisted" : "");
   }
 
   dt_pthread_mutex_init(&cl->dev[dev].lock, NULL);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -188,7 +188,7 @@ typedef struct dt_opencl_device_t
   int asyncmode;
 
   // a device might be turned off by force by setting this value to 1
-  int disabled; 
+  // also used for blacklisted drivers 
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -188,7 +188,8 @@ typedef struct dt_opencl_device_t
   int asyncmode;
 
   // a device might be turned off by force by setting this value to 1
-  // also used for blacklisted drivers 
+  // also used for blacklisted drivers
+  int disabled;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;

--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -42,9 +42,8 @@ static const gchar *bad_opencl_drivers[] =
   // clang-format on
 };
 
-// 0 - ok
-// else it is blacklisted
-int dt_opencl_check_driver_blacklist(const char *device_version)
+// returns TRUE if blacklisted
+gboolean dt_opencl_check_driver_blacklist(const char *device_version)
 {
   gchar *device = g_ascii_strdown(device_version, -1);
 
@@ -54,12 +53,12 @@ int dt_opencl_check_driver_blacklist(const char *device_version)
 
     // oops, found in black list
     g_free(device);
-    return 1;
+    return TRUE;
   }
 
   // did not find in the black list, guess it's ok.
   g_free(device);
-  return 0;
+  return FALSE;
 }
 
 // clang-format off


### PR DESCRIPTION
As we now have a per-device disabled flag we can integrate driver blacklisting into that.

If a driver is marked as blacklisted we just set the driver->disabled flag in case we have a freshly detected device. Here we take care about an existing old-style use_blacklist_driver conf key to keep dt installations with an activated blacklisted driver running.

- some minor debug output mods
- make the blacklist test a gboolean