### PR TITLE
OpenCl compiler options improvements

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -57,6 +57,11 @@
 #define ROUNDUPDWD(a, b) dt_opencl_dev_roundup_width(a, b)
 #define ROUNDUPDHT(a, b) dt_opencl_dev_roundup_height(a, b)
 
+#define DT_OPENCL_DEFAULT_COMPILE_INTEL ("-cl-fast-relaxed-math")
+#define DT_OPENCL_DEFAULT_COMPILE_AMD ("-cl-fast-relaxed-math")
+#define DT_OPENCL_DEFAULT_COMPILE_NVIDIA ("-cl-fast-relaxed-math")
+#define DT_OPENCL_DEFAULT_COMPILE ("-cl-fast-relaxed-math")
+
 typedef enum dt_opencl_memory_t
 {
   OPENCL_MEMORY_ADD,


### PR DESCRIPTION
The new OpenCl system relies on per-device settings, this should also be implemented for the compiler options.

1) The old system read compiler options from a key depending on the
  a) device id, this is not good at all as the id can change whenever a device is plugged in or out.
     This method has gone.
  b) canonical name (cname), that had a bugfix so all old specific options depending on that are not valid any more.
     Instead a per_device compiler option is read from: "cldevice_v3_cname_building", the naming closely reflects
     the key chosen for per_device config data.

2) We have slightly simpler code as we use const strings if possible

3) We might later want default compiler settings chosen "per vendor".
   In opencl.h some macros are defined for this atm, they are used to build the devid->options string
   For now they are all the same as default "-cl-fast-relaxed-math"