### PR TITLE
Visualize clipped photosites in highlights module

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -114,7 +114,8 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz = 13 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz = 14 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz = 15 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3,  //show module's output without processing by later iops
+  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3,     // show module's output without processing by later iops
+  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRUMONO = 17 << 3, // as passthru but in color mode
   DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -114,8 +114,7 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz = 13 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz = 14 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz = 15 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3,     // show module's output without processing by later iops
-  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRUMONO = 17 << 3, // as passthru but in color mode
+  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3, // show module's output without processing by later iops
   DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2967,9 +2967,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     showmask = (g->show_mask);
     // take care of passthru modes
     if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
-      demosaicing_method = DT_IOP_DEMOSAIC_PPG;
-    else if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRUMONO)
-      demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
+      demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_RCD : DT_IOP_DEMOSAIC_MARKESTEIJN;
   }
 
   if((qual_flags & DEMOSAIC_MEDIUM_QUAL)
@@ -5138,9 +5136,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     showmask = (g->show_mask);
     // take care of passthru modes
     if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
-      demosaicing_method = DT_IOP_DEMOSAIC_PPG;
-    else if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRUMONO)
-      demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
+      demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_RCD : DT_IOP_DEMOSAIC_MARKESTEIJN;
   }
 
   const int qual_flags = demosaic_qual_flags(piece, &self->dev->image_storage, roi_out);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2161,10 +2161,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->clip, _("manually adjust the clipping threshold against "
                                          "magenta highlights (you shouldn't ever need to touch this)"));
 
-  g->visualize = dt_iop_togglebutton_new(self, N_("clip"), N_("visualize clipping"), NULL,
-                                           G_CALLBACK(visualize_callback), TRUE, 0, 0,
-                                           dtgtk_cairo_paint_showmask, box_raw);
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("visualize clipping")), TRUE, TRUE, 0);
+  g->visualize = dt_iop_togglebutton_new(self, NULL, N_("visualize clipping"), NULL,
+                                           G_CALLBACK(visualize_callback), FALSE, 0, 0,
+                                           dtgtk_cairo_paint_showmask, hbox);
   dt_gui_add_class(g->visualize, "dt_transparent_background");
+  dt_gui_add_class(g->visualize, "dt_bauhaus_alignment");
+  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   g->noise_level = dt_bauhaus_slider_from_params(self, "noise_level");
   gtk_widget_set_tooltip_text(g->noise_level, _("add noise to visually blend the reconstructed areas\n"

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -109,6 +109,8 @@ typedef struct dt_iop_highlights_gui_data_t
   GtkWidget *noise_level;
   GtkWidget *iterations;
   GtkWidget *scales;
+  GtkWidget *visualize;
+  int mask_display;
 } dt_iop_highlights_gui_data_t;
 
 typedef dt_iop_highlights_params_t dt_iop_highlights_data_t;
@@ -1838,16 +1840,56 @@ static void process_clip(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
   }
 }
 
+static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         const uint32_t filters, dt_iop_highlights_data_t *data)
+{
+  const float *const in = (const float *const)ivoid;
+  float *const out = (float *const)ovoid;
+  const size_t width = roi_out->width;
+  const size_t height = roi_out->height;
+  const float clip = data->clip;
+  const float clips[4] = { clip * piece->pipe->dsc.temperature.coeffs[RED],
+                           clip * piece->pipe->dsc.temperature.coeffs[GREEN],
+                           clip * piece->pipe->dsc.temperature.coeffs[BLUE],
+                           clip * piece->pipe->dsc.temperature.coeffs[GREEN] };  
+
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in, out) \
+  dt_omp_sharedconst(height, width, filters, clips) \
+  schedule(simd:static) aligned(in, out : 64)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, i = row*width; col < width; col++, i++)
+    {
+      const int c = FC(row, col, filters);
+      out[i] = (in[i] < clips[c]) ? 0.0f : 1.0f;
+    }
+  }
+}
+
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const uint32_t filters = piece->pipe->dsc.filters;
   dt_iop_highlights_data_t *data = (dt_iop_highlights_data_t *)piece->data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+
+  const gboolean visualizing = (g != NULL) ? g->mask_display : FALSE;
+
+  if(visualizing)
+  {
+    process_visualize(piece, ivoid, ovoid, roi_in, roi_out, filters, data);
+    piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
+    piece->pipe->type |= DT_DEV_PIXELPIPE_FAST;
+    return;
+  }
 
   const float clip
       = data->clip * fminf(piece->pipe->dsc.processed_maximum[0],
                            fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
-  // const int ch = piece->colors;
 
   if(!filters)
   {
@@ -1955,12 +1997,17 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)p1;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
+
   memcpy(d, p, sizeof(*p));
+
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  const gboolean visualizing = (g != NULL) ? g->mask_display : FALSE;
 
   piece->process_cl_ready = 1;
 
-  // no OpenCL for DT_IOP_HIGHLIGHTS_INPAINT yet.
-  if(d->mode == DT_IOP_HIGHLIGHTS_INPAINT) piece->process_cl_ready = 0;
+  // no OpenCL for DT_IOP_HIGHLIGHTS_INPAINT and visualizing mode yet.
+  if(d->mode == DT_IOP_HIGHLIGHTS_INPAINT || visualizing)
+    piece->process_cl_ready = 0;
 }
 
 void init_global(dt_iop_module_so_t *module)
@@ -2015,11 +2062,13 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
 
   const gboolean bayer = (self->dev->image_storage.buf_dsc.filters != 9u);
+  const gboolean israw = (self->dev->image_storage.buf_dsc.filters != 0);
   dt_iop_highlights_mode_t mode = p->mode;
 
   gtk_widget_set_visible(g->noise_level, bayer && mode == DT_IOP_HIGHLIGHTS_LAPLACIAN);
   gtk_widget_set_visible(g->iterations, bayer && mode == DT_IOP_HIGHLIGHTS_LAPLACIAN);
   gtk_widget_set_visible(g->scales, bayer && mode == DT_IOP_HIGHLIGHTS_LAPLACIAN);
+  gtk_widget_set_visible(g->visualize, israw);
 
 
   // If guided laplacian mode was copied as part of the history of another pic, sanitize it
@@ -2034,11 +2083,13 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(struct dt_iop_module_t *self)
 {
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean monochrome = dt_image_is_monochrome(&self->dev->image_storage);
   // enable this per default if raw or sraw if not real monochrome
   self->default_enabled = dt_image_is_rawprepare_supported(&self->dev->image_storage) && !monochrome;
   self->hide_enable_button = monochrome;
   gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "default" : "monochrome");
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->visualize), FALSE);
   gui_changed(self, NULL, NULL);
 }
 
@@ -2071,6 +2122,32 @@ void reload_defaults(dt_iop_module_t *module)
   }
 }
 
+static gboolean visualize_callback(GtkToggleButton *togglebutton, GdkEventButton *event, dt_iop_module_t *module)
+{
+  if(darktable.gui->reset) return TRUE;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)module->gui_data;
+
+  g->mask_display = !gtk_toggle_button_get_active(togglebutton);
+
+  dt_iop_request_focus(module);
+
+  dt_iop_refresh_center(module);
+
+  gtk_toggle_button_set_active(togglebutton, g->mask_display);
+  return TRUE;
+}
+
+void gui_focus(struct dt_iop_module_t *self, gboolean in)
+{
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  if(!in)
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->visualize), 0);
+    g->mask_display = 0;
+    dt_dev_reprocess_center(self->dev);
+  }
+}
+
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_highlights_gui_data_t *g = IOP_GUI_ALLOC(highlights);
@@ -2083,6 +2160,11 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->clip, 3);
   gtk_widget_set_tooltip_text(g->clip, _("manually adjust the clipping threshold against "
                                          "magenta highlights (you shouldn't ever need to touch this)"));
+
+  g->visualize = dt_iop_togglebutton_new(self, N_("clip"), N_("visualize clipping"), NULL,
+                                           G_CALLBACK(visualize_callback), TRUE, 0, 0,
+                                           dtgtk_cairo_paint_showmask, box_raw);
+  dt_gui_add_class(g->visualize, "dt_transparent_background");
 
   g->noise_level = dt_bauhaus_slider_from_params(self, "noise_level");
   gtk_widget_set_tooltip_text(g->noise_level, _("add noise to visually blend the reconstructed areas\n"


### PR DESCRIPTION
While working on another highlights reconstruction algorithm - work is still going on - i came across the problem to see what photosites are clipped right in the module and depending on the setting of the clipping threshold.

There is now a single button, if switched on a false color image is shown (every photosite clipped gives a full value of 1, otherwise 0)

I found it very helpful, not absolutely sure whether other folks think so too. So - a suggestion.
