### PR TITLE
rename filters for collections -> collection filters

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -222,7 +222,7 @@ static _filter_t *_filters_get(const dt_collection_properties_t prop)
 
 const char *name(dt_lib_module_t *self)
 {
-  return _("filters for collections");
+  return _("collection filters");
 }
 
 void init_presets(dt_lib_module_t *self)


### PR DESCRIPTION
this is more consistent with other modules and reads better in EN