### PR TITLE
image flags : set image type from the beginning

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1505,6 +1505,9 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   // also need to set the no-legacy bit, to make sure we get the right presets (new ones)
   uint32_t flags = dt_conf_get_int("ui_last/import_initial_rating");
   flags |= DT_IMAGE_NO_LEGACY_PRESETS;
+  // and we set the type of image flag (from extension for now)
+  gchar *extension = g_strrstr(imgfname, ".");
+  flags |= dt_imageio_get_type_from_extension(extension);
   // set the bits in flags that indicate if any of the extra files (.txt, .wav) are present
   char *extra_file = dt_image_get_audio_path_from_path(normalized_filename);
   if(extra_file)

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -78,6 +78,45 @@
 #include "lua/image.h"
 #endif
 
+// note `dng` is not included anywhere as it can be anything. For this images we'll need to open it for "real"
+static const gchar *_supported_raw[]
+    = { "3fr", "ari", "arw", "bay", "cr2", "cr3", "crw", "dc2", "dcr", "erf", "fff",
+        "ia",  "iiq", "k25", "kc2", "kdc", "mdc", "mef", "mos", "mrw", "nef", "nrw",
+        "orf", "pef", "raf", "raw", "rw2", "rwl", "sr2", "srf", "srw", "sti", "x3f" };
+static const gchar *_supported_ldr[]
+    = { "bmp",  "bmq", "cap", "cine", "cs1", "dcm", "gif", "gpr", "j2c", "j2k", "jng", "jp2", "jpc", "jpeg", "jpg",
+        "miff", "mng", "ori", "pbm",  "pfm", "pgm", "png", "pnm", "ppm", "pxn", "qtk", "rdc", "tif", "tiff" };
+static const gchar *_supported_hdr[] = { "avif", "exr", "hdr", "heic", "heif", "hif", "pfm" };
+
+// get the type of image from its extension
+dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension)
+{
+  const char *ext = g_str_has_prefix(extension, ".") ? extension + 1 : extension;
+  for(const char **i = _supported_raw; *i != NULL; i++)
+  {
+    if(!g_ascii_strncasecmp(ext, *i, strlen(*i)))
+    {
+      return DT_IMAGE_RAW;
+    }
+  }
+  for(const char **i = _supported_hdr; *i != NULL; i++)
+  {
+    if(!g_ascii_strncasecmp(ext, *i, strlen(*i)))
+    {
+      return DT_IMAGE_HDR;
+    }
+  }
+  for(const char **i = _supported_ldr; *i != NULL; i++)
+  {
+    if(!g_ascii_strncasecmp(ext, *i, strlen(*i)))
+    {
+      return DT_IMAGE_LDR;
+    }
+  }
+  // default to 0
+  return 0;
+}
+
 // load a full-res thumbnail:
 int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *width, int32_t *height,
                                dt_colorspaces_color_profile_type_t *color_space)

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -114,6 +114,9 @@ gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
                                       char *mk, int mk_len, char *md, int md_len,
                                       char *al, int al_len);
 
+// get the type of image from its extension
+dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
this fix #11544

First : be careful on testing : this bump the database version, better backup first !

Currently, the image type flags `DT_IMAGE_RAW` `DT_IMAGE_HDR` `DT_IMAGE_LDR` are only set when we run the full pipe. That means that until then the flags contains no image type.
This cause issue with the "new" filename filter, but more than that this may cause other strange issue, for example with autoapplied preset in libs...

To fix that, this PR adds a new function that will determine the image type from the image extension. This has very low impact in term of timing, so we can do that without too much perf. loss inside the import routine.
Of course there will be case where this flags will not be fully accurate (`dng` can be lot of things...) but the immense majority of case that's right, and anyway, this flags will be replaced if needed as soon as the image is loaded in the pipe.

To fix the issues for already imported images, I've bumped the db version and the upgrade code add the flags if none are already set. Note that the upgrade can take a little time. In my test, it takes 2s. for 100K images. Is that a problem ? (if a sqlite specialist want to do it, I'm sure we can improve the upgrade routine)

As always, please review and test carefully. This touch a very sensitive area...