### PR TITLE
The highlights clipping false color indicator gets OpenCL code

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -200,6 +200,22 @@ highlights_1f_clip (read_only image2d_t in, write_only image2d_t out, const int 
   write_imagef (out, (int2)(x, y), pixel);
 }
 
+kernel void
+highlights_false_color (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+                    const int rx, const int ry, const int filters, global const float *clips)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+  
+  const float ival = read_imagef(in, sampleri, (int2)(x, y)).x;
+  const int c = FC(y + ry, x + rx, filters);
+  float oval = (ival < clips[c]) ? 0.2f * ival : 1.0f;
+
+  write_imagef (out, (int2)(x, y), oval);
+}
+
 #define SQRT3 1.7320508075688772935274463415058723669f
 #define SQRT12 3.4641016151377545870548926830117447339f // 2*SQRT3
 kernel void

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -217,11 +217,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   // this works for bayer and X-Trans sensors
   if(visualizing)
   {
-    const gboolean unset = piece->pipe->dsc.temperature.coeffs[0] <= 0.0f;
-    float clips[4] = { d->clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[RED]),
-                       d->clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[GREEN]),
-                       d->clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[BLUE]),
-                       d->clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[GREEN]) };
+    const float *c = piece->pipe->dsc.temperature.coeffs;
+    float clips[4] = { d->clip * (c[RED]   <= 0.0f ? 1.0f : c[RED]),
+                       d->clip * (c[GREEN] <= 0.0f ? 1.0f : c[GREEN]),
+                       d->clip * (c[BLUE]  <= 0.0f ? 1.0f : c[BLUE]),
+                       d->clip * (c[GREEN] <= 0.0f ? 1.0f : c[GREEN]) };
 
     cl_mem dev_clips = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clips);
     if(dev_clips == NULL) goto error;
@@ -1884,11 +1884,11 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
   const size_t width = roi_out->width;
   const size_t height = roi_out->height;
   const float clip = data->clip;
-  const gboolean unset = piece->pipe->dsc.temperature.coeffs[0] <= 0.0f;
-  const float clips[4] = { clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[RED]),
-                           clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[GREEN]),
-                           clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[BLUE]),
-                           clip * (unset ? 1.0f : piece->pipe->dsc.temperature.coeffs[GREEN]) };
+  const float *cf = piece->pipe->dsc.temperature.coeffs;
+  const float clips[4] = { clip * (cf[RED]   <= 0.0f ? 1.0f : cf[RED]),
+                           clip * (cf[GREEN] <= 0.0f ? 1.0f : cf[GREEN]),
+                           clip * (cf[BLUE]  <= 0.0f ? 1.0f : cf[BLUE]),
+                           clip * (cf[GREEN] <= 0.0f ? 1.0f : cf[GREEN]) };
 
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -212,6 +212,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const gboolean visualizing = (g != NULL) ? g->show_visualize && fullpipe : FALSE;
 
   cl_int err = -999;
+  cl_mem dev_xtrans = NULL;
 
   // this works for bayer and X-Trans sensors
   if(visualizing)
@@ -242,8 +243,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_opencl_release_mem_object(dev_clips);
     return TRUE;
   }
-
-  cl_mem dev_xtrans = NULL;
 
   const float clip = d->clip
                      * fminf(piece->pipe->dsc.processed_maximum[0],


### PR DESCRIPTION
- just straight port to opencl
- in case there is no white balance module active use 1.0 instead of a coeff