### PR TITLE
Fix color names in the color vocabulary

### DIFF
--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -218,7 +218,7 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
   {
     // 0° - pinkish red
     if(step_L == 0) return _("deep purple");    // L = 10 %
-    if(step_L == 1) return _("fuschia");        // L = 30 %
+    if(step_L == 1) return _("fuchsia");        // L = 30 %
     if(step_L == 2) return _("medium magenta"); // L = 50 %
     if(step_L == 3) return _("violet pink");    // L = 70 %
     if(step_L == 4) return _("plum violet");    // L = 90 %

--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -298,7 +298,7 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
   else if(step_h == 9)
   {
     // 216° - medium blue
-    if(step_L == 0) return _("marine blue");
+    if(step_L == 0) return _("navy blue");
     if(step_L == 1) return _("teal");
     if(step_L == 2) return _("dark cyan");
     if(step_L == 3) return _("deep sky blue");

--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -264,7 +264,7 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
     // 120° - green
     if(step_L == 0) return _("dark green");
     if(step_L == 1) return _("forest green");
-    if(step_L == 2) return _("olivedrab");
+    if(step_L == 2) return _("olive drab");
     if(step_L == 3) return _("yellow green");
     if(step_L == 4) return _("pale green");
   }


### PR DESCRIPTION
Proofs:

- fuchsia vs fuschia
https://www.yourdictionary.com/fuschia

- navy vs marine
https://en.wikipedia.org/wiki/Navy_blue
("... it was initially called marine blue, but the name of the color soon changed to navy blue.")

- olive drab vs olivedrab
https://books.google.com/ngrams/graph?content=olive+drab%2Colivedrab&year_start=1800&year_end=2019&corpus=26&smoothing=3
