### PR TITLE
OpenCL device initializing reports platform information

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -32,6 +32,7 @@
 #define DT_OPENCL_VENDOR_AMD 4098
 #define DT_OPENCL_VENDOR_NVIDIA 4318
 #define DT_OPENCL_VENDOR_INTEL 0x8086u
+#define DT_OPENCL_CBUFFSIZE 1024
 
 // some pseudo error codes in dt opencl usage
 #define DT_OPENCL_DEFAULT_ERROR -999


### PR DESCRIPTION
There are buggy CL devics / platforms around which currently can't be completely detected
by blacklist checks as we have now.

In this pr we get the device 'platform name' and 'platform vendor name' and have both reported
so we can check in issues.