### PR TITLE
Windows: switch GraphicsMagick to Q16

### DIFF
--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -725,7 +725,6 @@ Section "-Core installation"
    ; set variable for local machine
    WriteRegExpandStr ${env_hklm} CAMLIBS "$INSTDIR\lib\libgphoto2\@CPACK_NSIS_GPHOTO2_VERSION@"
    WriteRegExpandStr ${env_hklm} IOLIBS $INSTDIR\lib\libgphoto2_port\0.12.0
-   WriteRegExpandStr ${env_hklm} MAGICK_HOME $INSTDIR\lib\GraphicsMagick-@CPACK_NSIS_GRAPHICSMAGICK_VERSION@\modules-Q8\coders
 
   !insertmacro MUI_STARTMENU_WRITE_END
 

--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -256,8 +256,8 @@ if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
   # Add GraphicsMagick libraries
   if(GraphicsMagick_FOUND)
     install(DIRECTORY
-        "${MINGW_PATH}/../lib/GraphicsMagick-${GraphicsMagick_PKGCONF_VERSION}/modules-Q8/coders"
-        DESTINATION lib/GraphicsMagick-${GraphicsMagick_PKGCONF_VERSION}/modules-Q8/
+        "${MINGW_PATH}/../lib/GraphicsMagick-${GraphicsMagick_PKGCONF_VERSION}/modules-Q16/coders"
+        DESTINATION lib/GraphicsMagick-${GraphicsMagick_PKGCONF_VERSION}/modules-Q16/
         COMPONENT DTApplication
         FILES_MATCHING PATTERN "*"
         PATTERN "*.a" EXCLUDE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -520,10 +520,6 @@ if(USE_GRAPHICSMAGICK)
     set(DT_SUPPORTED_EXTENSIONS ${DT_SUPPORTED_EXTENSIONS} gif jpc jp2 bmp dcm jng miff mng pbm pnm ppm pgm CACHE INTERNAL "")
     include_directories(SYSTEM ${GraphicsMagick_INCLUDE_DIRS})
     list(APPEND LIBS ${GraphicsMagick_LIBRARIES})
-    # CPack ignores variables you define in your CMakeLists.txt file,
-    # and only variables ${CPACK_*} are correctly used.
-    # so this needs to be saved by adding another variable with a name beginning with CPACK
-    set(CPACK_NSIS_GRAPHICSMAGICK_VERSION ${GraphicsMagick_PKGCONF_VERSION} CACHE STRING "GM version string")
   endif(GraphicsMagick_FOUND)
 endif(USE_GRAPHICSMAGICK)
 
@@ -532,10 +528,10 @@ if(USE_IMAGEMAGICK AND NOT GraphicsMagick_FOUND)
   find_package(PkgConfig)
   pkg_check_modules(ImageMagick MagickWand QUIET)
   if(ImageMagick_FOUND)
-    add_definitions(-DHAVE_IMAGEMAGICK ${ImageMagick_CFLAGS_OTHER})
     if(NOT ImageMagick_VERSION VERSION_GREATER 7)
-      message(FATAL "ImageMagick version must be >= 7")
+      message(FATAL_ERROR "ImageMagick version must be >= 7")
     endif(NOT ImageMagick_VERSION VERSION_GREATER 7)
+    add_definitions(-DHAVE_IMAGEMAGICK ${ImageMagick_CFLAGS_OTHER})
     include_directories(SYSTEM ${ImageMagick_INCLUDE_DIRS})
     find_library(ImageMagick_LIBRARY ${ImageMagick_LIBRARIES} HINTS ${ImageMagick_LIBDIR})
     list(APPEND LIBS ${ImageMagick_LIBRARY})


### PR DESCRIPTION
@wpferguson FYI; the `%MAGICK_HOME%` variable is not needed, as the MSYS2 package is of [default "installed" type](http://hg.code.sf.net/p/graphicsmagick/code/file/828ffc28c1c6/configure.ac#l464) and relocatable

@TurboGit This fixes the nightly build