### PR TITLE
Bauhaus label hide

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -151,6 +151,7 @@ typedef struct dt_bauhaus_widget_t
 
   // label text, short
   char label[256];
+  gboolean show_label;
   // section, short
   gchar *section;
   gboolean show_extended_label;
@@ -171,6 +172,9 @@ typedef struct dt_bauhaus_widget_t
   GtkBorder *margin, *padding;
   // gap to add to the top padding due to the vertical centering
   int top_gap;
+
+  // is the popup not attached to the main widget (shortcuts)
+  gboolean detached_popup;
 
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -602,45 +602,50 @@ static void _collection_update_aspect_ratio(const dt_collection_t *collection)
   }
 }
 
-const char *dt_collection_sort_name(dt_collection_sort_t sort)
+const char *dt_collection_sort_name_untranslated(dt_collection_sort_t sort)
 {
   switch(sort)
   {
     case DT_COLLECTION_SORT_FILENAME:
-      return _("filename");
+      return N_("filename");
     case DT_COLLECTION_SORT_DATETIME:
-      return _("capture time");
+      return N_("capture time");
     case DT_COLLECTION_SORT_IMPORT_TIMESTAMP:
-      return _("import time");
+      return N_("import time");
     case DT_COLLECTION_SORT_CHANGE_TIMESTAMP:
-      return _("last modification time");
+      return N_("last modification time");
     case DT_COLLECTION_SORT_EXPORT_TIMESTAMP:
-      return _("last export time");
+      return N_("last export time");
     case DT_COLLECTION_SORT_PRINT_TIMESTAMP:
-      return _("last print time");
+      return N_("last print time");
     case DT_COLLECTION_SORT_RATING:
-      return _("rating");
+      return N_("rating");
     case DT_COLLECTION_SORT_ID:
-      return _("id");
+      return N_("id");
     case DT_COLLECTION_SORT_COLOR:
-      return _("color label");
+      return N_("color label");
     case DT_COLLECTION_SORT_GROUP:
-      return _("group");
+      return N_("group");
     case DT_COLLECTION_SORT_PATH:
-      return _("full path");
+      return N_("full path");
     case DT_COLLECTION_SORT_CUSTOM_ORDER:
-      return _("custom sort");
+      return N_("custom sort");
     case DT_COLLECTION_SORT_TITLE:
-      return _("title");
+      return N_("title");
     case DT_COLLECTION_SORT_DESCRIPTION:
-      return _("description");
+      return N_("description");
     case DT_COLLECTION_SORT_ASPECT_RATIO:
-      return _("aspect ratio");
+      return N_("aspect ratio");
     case DT_COLLECTION_SORT_SHUFFLE:
-      return _("shuffle");
+      return N_("shuffle");
     default:
       return "";
   }
+};
+
+const char *dt_collection_sort_name(dt_collection_sort_t sort)
+{
+  return _(dt_collection_sort_name_untranslated(sort));
 };
 
 const char *dt_collection_name_untranslated(dt_collection_properties_t prop)

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -613,11 +613,11 @@ const char *dt_collection_sort_name_untranslated(dt_collection_sort_t sort)
     case DT_COLLECTION_SORT_IMPORT_TIMESTAMP:
       return N_("import time");
     case DT_COLLECTION_SORT_CHANGE_TIMESTAMP:
-      return N_("last modification time");
+      return N_("modification time");
     case DT_COLLECTION_SORT_EXPORT_TIMESTAMP:
-      return N_("last export time");
+      return N_("export time");
     case DT_COLLECTION_SORT_PRINT_TIMESTAMP:
-      return N_("last print time");
+      return N_("print time");
     case DT_COLLECTION_SORT_RATING:
       return N_("rating");
     case DT_COLLECTION_SORT_ID:
@@ -662,17 +662,17 @@ const char *dt_collection_name_untranslated(dt_collection_properties_t prop)
     case DT_COLLECTION_PROP_TAG:
       return N_("tag");
     case DT_COLLECTION_PROP_DAY:
-      return N_("date taken");
+      return N_("capture date");
     case DT_COLLECTION_PROP_TIME:
-      return N_("date-time taken");
+      return N_("capture time");
     case DT_COLLECTION_PROP_IMPORT_TIMESTAMP:
-      return N_("import timestamp");
+      return N_("import time");
     case DT_COLLECTION_PROP_CHANGE_TIMESTAMP:
-      return N_("change timestamp");
+      return N_("modification time");
     case DT_COLLECTION_PROP_EXPORT_TIMESTAMP:
-      return N_("export timestamp");
+      return N_("export time");
     case DT_COLLECTION_PROP_PRINT_TIMESTAMP:
-      return N_("print timestamp");
+      return N_("print time");
     case DT_COLLECTION_PROP_HISTORY:
       return N_("history");
     case DT_COLLECTION_PROP_COLORLABEL:

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -153,6 +153,7 @@ const char *dt_collection_name(dt_collection_properties_t prop);
 const char *dt_collection_name_untranslated(dt_collection_properties_t prop);
 /* returns the name for the given collection sort property */
 const char *dt_collection_sort_name(dt_collection_sort_t sort);
+const char *dt_collection_sort_name_untranslated(dt_collection_sort_t sort);
 
 /** instantiates a collection context, if clone equals NULL default query is constructed. */
 const dt_collection_t *dt_collection_new(const dt_collection_t *clone);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1629,7 +1629,13 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     sort->lib = d;
     sort->box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_widget_set_hexpand(sort->box, TRUE);
-    sort->sort = dt_bauhaus_combobox_new(NULL);
+    // we only allow shortcut for the first sort order, always visible
+    if(num == 0)
+      sort->sort = dt_bauhaus_combobox_new_action(DT_ACTION(self));
+    else
+      sort->sort = dt_bauhaus_combobox_new(NULL);
+    dt_bauhaus_widget_set_label(sort->sort, NULL, _("sort order"));
+    DT_BAUHAUS_WIDGET(sort->sort)->show_label = FALSE;
     gtk_widget_set_tooltip_text(sort->sort, _("determine the sort order of shown images"));
     g_signal_connect(G_OBJECT(sort->sort), "value-changed", G_CALLBACK(_sort_combobox_changed), sort);
 
@@ -1664,6 +1670,11 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     gtk_box_pack_start(GTK_BOX(sort->box), sort->direction, FALSE, TRUE, 0);
     g_signal_connect(G_OBJECT(sort->direction), "toggled", G_CALLBACK(_sort_reverse_changed), sort);
     dt_gui_add_class(sort->direction, "dt_ignore_fg_state");
+    if(num == 0)
+    {
+      dt_action_t *toggle = dt_action_section(DT_ACTION(self), N_("toggle"));
+      dt_action_define(toggle, NULL, _("sort direction"), sort->direction, &dt_action_def_toggle);
+    }
 
     sort->close = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
     gtk_widget_set_no_show_all(sort->close, TRUE);


### PR DESCRIPTION
this is a part of #11562 

this allow to define a bauhaus label but to not show it. This is useful for example to allow shortcuts for a combobox without visible label.
for the popup, the label is not shown if the popup is "attached" to the widget (majority of cases) but is shown on a new first line if the popup is "detached" (this is the case when a shortcut show the popup under the cursor). Note that for this last case, this PR also allow the label to be visible whatever the alignment of the items. This way we ensure to always see the label for an "off-context" popup.

second commit use that to implement shortcuts for the first sort order in the new filtering module.

@dterrahe : can you have a look ? TIA