### PR TITLE
Relax writing of CL scheduling profile

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1079,7 +1079,7 @@ finally:
           tgpumin = fminf(cl->dev[n].benchmark, tgpumin);
       }
 
-      if(!manually)
+      if(!manually && newcheck)
       {      
         if(tcpu <= 1.5f * tgpumin)
         {


### PR DESCRIPTION
As reported in #11607 the scheduling profile gets overwritten without good reason.
This should only be done if the device configuration has changed (by adding / removing a card)
or fresh installs.

Fixes #11607

