### PR TITLE
fix DT_SIGNAL_IMAGES_ORDER_CHANGE definition

### DIFF
--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -129,7 +129,7 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     G_CALLBACK(_image_info_changed_destroy_callback), FALSE }, // DT_SIGNAL_IMAGE_INFO_CHANGED
   { "dt-style-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_STYLE_CHANGED
-  { "dt-images-order-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, pointer_arg, NULL,
+  { "dt-images-order-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL,
     FALSE }, // DT_SIGNAL_IMAGES_ORDER_CHANGE
   { "dt-filmrolls-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_FILMROLLS_CHANGED


### PR DESCRIPTION
this fix #11619 