### PR TITLE
Fix guided_filter CL path

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -694,10 +694,10 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(w >= 1);
 
   // estimate required memory for OpenCL code path with a safety factor of 5/4
-  // avoid checking for available memory by headroom and used memory as unsafe.
-  // instead use safer version
-  const size_t required = (size_t)width * height * sizeof(float) * 18 * 5 / 4;
-  const gboolean fits = dt_opencl_buffer_fits_device(devid, required);
+  const size_t singlebuf = (size_t)width * height * sizeof(float);
+  const size_t required  = singlebuf * 18 * 5 / 4;
+  const gboolean fits = (dt_opencl_buffer_fits_device(devid, singlebuf) &&
+                         (dt_opencl_get_device_available(devid) > required));
 
   int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   if(fits)


### PR DESCRIPTION
Due to improper checks the guided_filter fall back to cpu very easily.

Isssue reported by @wpferguson in #11606 (comments)