### PR TITLE
String fixes (grammar and style)

### DIFF
--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -376,7 +376,7 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   gtk_entry_set_width_chars(GTK_ENTRY(filename->ext), (top) ? 5 : 0);
   gtk_widget_set_can_default(filename->ext, TRUE);
   gtk_entry_set_placeholder_text(GTK_ENTRY(filename->ext), _("extension"));
-  gtk_widget_set_tooltip_text(filename->ext, _("enter extension to search with starting dot.\n"
+  gtk_widget_set_tooltip_text(filename->ext, _("enter extension to search with starting dot\n"
                                                "multiple values can be separated by ','\n"
                                                "handled keywords: 'RAW', 'NOT RAW', 'LDR', 'HDR'\n"
                                                "\nright-click to get existing extensions"));

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -378,7 +378,7 @@ static void _filename_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   gtk_entry_set_placeholder_text(GTK_ENTRY(filename->ext), _("extension"));
   gtk_widget_set_tooltip_text(filename->ext, _("enter extension to search with starting dot.\n"
                                                "multiple values can be separated by ','\n"
-                                               "handled keyword : 'RAW' 'NOT RAW' 'LDR' 'HDR'\n"
+                                               "handled keywords: 'RAW', 'NOT RAW', 'LDR', 'HDR'\n"
                                                "\nright-click to get existing extensions"));
   gtk_box_pack_start(GTK_BOX(hb), filename->ext, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(filename->ext), "activate", G_CALLBACK(_filename_changed), filename);


### PR DESCRIPTION
As far as I can see, there is an unwritten rule to omit the full stop at the end of short sentences that fit in one line of tooltip (at least I saw commits with similar fixes). So, the second commit is for that.