### PR TITLE
Fixing re-enabling of disabled OpenCL devices

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1519,6 +1519,18 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...)
   }
 }
 
+void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...)
+{
+  if(darktable.unmuted & thread)
+  {
+    va_list ap;
+    va_start(ap, msg);
+    vprintf(msg, ap);
+    va_end(ap);
+    fflush(stdout);
+  }
+}
+
 void dt_vprint(dt_debug_thread_t thread, const char *msg, ...)
 {
   if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & thread))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -363,6 +363,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 void dt_get_sysresource_level();
 void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
+void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 int dt_worker_threads();
 size_t dt_get_available_mem();

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -363,7 +363,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 void dt_get_sysresource_level();
 void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
+/* same as above but without time stamp : nts = no time stamp */
 void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
+/* same as above but requires additional DT_DEBUG_VERBOSE flag to be true */
 void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 int dt_worker_threads();
 size_t dt_get_available_mem();

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -572,11 +572,11 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   err = dt_opencl_get_device_info(cl, devid, CL_DEVICE_MAX_WORK_ITEM_SIZES, (void **)&infointtab, &infointtab_size);
   if(err == CL_SUCCESS)
   {
-    fprintf(stderr, "   MAX WORK ITEM SIZES:      [ ");
-    for(size_t i = 0; i < infoint; i++) fprintf(stderr, "%zu ", infointtab[i]);
+    dt_print_nts(DT_DEBUG_OPENCL, "   MAX WORK ITEM SIZES:      [ ");
+    for(size_t i = 0; i < infoint; i++) dt_print_nts(DT_DEBUG_OPENCL, "%zu ", infointtab[i]);
     free(infointtab);
     infointtab = NULL;
-    fprintf(stderr, "]\n");
+    dt_print_nts(DT_DEBUG_OPENCL, "]\n");
   }
   else
   {


### PR DESCRIPTION
All newly detected devices either being ON-CPU or blacklisted are automatically disabled.
Re-enabling by the user via changing the 'disable flag' did not work, is fixed now.

As we want to gather more information about devices and why things might not work, the
per-device information has been reorganized.
Also giving correct information about pinned transfer, mem tuning and performance data.