### PR TITLE
Getting rid of `darktable|problem|history-compress'

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -913,18 +913,6 @@ char *dt_history_get_items_as_string(const int32_t imgid)
   return result;
 }
 
-void dt_history_set_compress_problem(const int32_t imgid, const gboolean set)
-{
-  guint tagid = 0;
-  char tagname[64];
-  snprintf(tagname, sizeof(tagname), "darktable|problem|history-compress");
-  dt_tag_new(tagname, &tagid);
-  if (set)
-    dt_tag_attach(tagid, imgid, FALSE, FALSE);
-  else
-    dt_tag_detach(tagid, imgid, FALSE, FALSE);
-}
-
 static int dt_history_end_attop(const int32_t imgid)
 {
   int size=0;
@@ -1170,9 +1158,8 @@ int dt_history_compress_on_list(const GList *imgs)
     const int imgid = GPOINTER_TO_INT(l->data);
     dt_lock_image(imgid);
     const int test = dt_history_end_attop(imgid);
-    if (test == 1) // we do a compression and we know for sure history_end is at the top!
+    if(test == 1) // we do a compression and we know for sure history_end is at the top!
     {
-      dt_history_set_compress_problem(imgid, FALSE);
       dt_history_compress_on_image(imgid);
 
       // now the modules are in right order but need renumbering to remove leaks
@@ -1234,13 +1221,8 @@ int dt_history_compress_on_list(const GList *imgs)
 
       dt_image_write_sidecar_file(imgid);
     }
-    if (test == 0) // no compression as history_end is right in the middle of history
-    {
+    if(test == 0) // no compression as history_end is right in the middle of history
       uncompressed++;
-      dt_history_set_compress_problem(imgid, TRUE);
-    }
-    if (test == -1)
-      dt_history_set_compress_problem(imgid, FALSE);
 
     dt_unlock_image(imgid);
     dt_history_hash_write_from_history(imgid, DT_HISTORY_HASH_CURRENT);

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -100,8 +100,6 @@ void dt_history_compress_on_image(const int32_t imgid);
 /** truncate history stack */
 void dt_history_truncate_on_image(const int32_t imgid, const int32_t history_end);
 
-/* set or clear a tag representing an error state while compressing history */
-void dt_history_set_compress_problem(const int32_t imgid, const gboolean set);
 /* duplicate an history list */
 GList *dt_history_duplicate(GList *hist);
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -727,9 +727,6 @@ void dt_dev_load_image(dt_develop_t *dev, const uint32_t imgid)
 
   dev->first_load = FALSE;
 
-  // Loading an image means we do some developing and so remove the darktable|problem|history-compress tag
-  dt_history_set_compress_problem(imgid, FALSE);
-
   dt_unlock_image(imgid);
 }
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -180,7 +180,6 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 
 static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 {
-  const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
   if(!imgs) return;  // do nothing if no images to be acted on
 
@@ -188,20 +187,8 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, imgs);
   dt_control_queue_redraw_center();
-  if (missing)
-  {
-    GtkWidget *dialog = gtk_message_dialog_new(
-    GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_CLOSE,
-    ngettext("no history compression of 1 image.\nsee tag: darktable|problem|history-compress",
-             "no history compression of %d images.\nsee tag: darktable|problem|history-compress", missing ), missing);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), _("history compression warning"));
-    gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
+  if(missing)
+    dt_control_log(_("no history compression of %d image%s"), missing, (missing == 1) ? "" : "s");
 }
 
 


### PR DESCRIPTION
When the iop-order managing was changed there were some intermediate master versions resulting in big problems
with the history, so in https://github.com/darktable-org/darktable/commit/e2f8f9f0f405e0c3f92248d64ce570c8c8491bba
a tag was introduces allowing users to check for history-compression problems.

These problems are long gone now, so the old code can go, just in case a message via `dt_control_log()` is shown.

Fixes #11637