### PR TITLE
Correct code for eyes icons

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -907,7 +907,7 @@ void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  dtgtk_cairo_paint_eye_toggle(cr, x, y, w, h, flags | CPF_ACTIVE, data);
+  dtgtk_cairo_paint_eye_toggle(cr, x, y, w, h, flags & ~CPF_ACTIVE, data);
 }
 
 void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)


### PR DESCRIPTION
As a reminder, we want to not display cross bar on eye icon in copy & import dialog window. We so want that:
![Capture d’écran du 2022-04-26 21-25-37](https://user-images.githubusercontent.com/45535283/165388768-e7d443db-8566-4b37-b324-b3f06a78d662.png)

Not that:
![Capture d’écran du 2022-04-26 21-24-54](https://user-images.githubusercontent.com/45535283/165388806-4ef3b414-7b8d-4f8b-9d3d-f11dc764355c.png)

This fix that correctly. Thanks to @kmilos and @AlicVB help. @TurboGit quick and correct fix for my mistake.
