### PR TITLE
color calib/exposure: remember expand status

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3464,7 +3464,7 @@ void gui_update(struct dt_iop_module_t *self)
   g->is_profiling_started = FALSE;
 
   dt_gui_hide_collapsible_section(&g->cs);
-  dt_gui_hide_collapsible_section(&g->csspot);
+  dt_gui_update_collapsible_section(&g->csspot);
 
   g->spot_RGB[0] = 0.f;
   g->spot_RGB[1] = 0.f;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -598,7 +598,7 @@ void gui_update(struct dt_iop_module_t *self)
       break;
   }
 
-  dt_gui_hide_collapsible_section(&g->cs);
+  dt_gui_update_collapsible_section(&g->cs);
 }
 
 void init_global(dt_iop_module_so_t *module)


### PR DESCRIPTION
Remember expand status for collapsible "spot mapping" sections, as discussed in #11649. 

I've left the color checker section unchanged since this makes more sense to use only for a single image.