### PR TITLE
Fix reentrant call of gui_critical_section in exposure

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -982,9 +982,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *
 
   dt_aligned_pixel_t Lch_target = { 0.f };
 
-  dt_iop_gui_enter_critical_section(self);
   Lch_target[0] = dt_bauhaus_slider_get(g->lightness_spot);
-  dt_iop_gui_leave_critical_section(self);
 
   // Save the color on change
   dt_conf_set_float("darkroom/modules/exposure/lightness", Lch_target[0]);


### PR DESCRIPTION
Double click on histogram currently makes dt hang.

This is due to
`_drawable_button_press_callback` in histogram.c calling
`dt_dev_exposure_reset_defaults` in develop.c calling `exposure->gui_update(exposure)`

There we set the lightness_spot slider in a gui_critical_section but we have a callback
set for the slider `_spot_settings_changed_callback` thus hanging.

Fixes #11598 

I am not absolutely sure if this is the best way to fix. Other solutions would be a) avoid the critical_section in gui_update, b) do we need the critival section here at all or c) better use a counted mutex for critical section?  