### PR TITLE
Getting rid of DT_DEBUG_IOPORDER

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -126,7 +126,7 @@ static int usage(const char *argv0)
   printf("  --conf <key>=<value>\n");
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch,imageio,input,\n");
-  printf("      ioporder,lighttable,lua,masks,memory,nan,opencl,params,perf,demosaic\n");
+  printf("      lighttable,lua,masks,memory,nan,opencl,params,perf,demosaic\n");
   printf("      pwstorage,print,signal,sql,undo,act_on,tiling,verbose}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
@@ -672,8 +672,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_PRINT; // print errors are reported on console
         else if(!strcmp(argv[k + 1], "camsupport"))
           darktable.unmuted |= DT_DEBUG_CAMERA_SUPPORT; // camera support warnings are reported on console
-        else if(!strcmp(argv[k + 1], "ioporder"))
-          darktable.unmuted |= DT_DEBUG_IOPORDER; // iop order information are reported on console
         else if(!strcmp(argv[k + 1], "imageio"))
           darktable.unmuted |= DT_DEBUG_IMAGEIO; // image importing or exporting messages on console
         else if(!strcmp(argv[k + 1], "undo"))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -263,15 +263,14 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_INPUT          = 1 << 14,
   DT_DEBUG_PRINT          = 1 << 15,
   DT_DEBUG_CAMERA_SUPPORT = 1 << 16,
-  DT_DEBUG_IOPORDER       = 1 << 17,
-  DT_DEBUG_IMAGEIO        = 1 << 18,
-  DT_DEBUG_UNDO           = 1 << 19,
-  DT_DEBUG_SIGNAL         = 1 << 20,
-  DT_DEBUG_PARAMS         = 1 << 21,
-  DT_DEBUG_DEMOSAIC       = 1 << 22,
-  DT_DEBUG_ACT_ON         = 1 << 23,
-  DT_DEBUG_TILING         = 1 << 24,
-  DT_DEBUG_VERBOSE        = 1 << 25
+  DT_DEBUG_IMAGEIO        = 1 << 17,
+  DT_DEBUG_UNDO           = 1 << 18,
+  DT_DEBUG_SIGNAL         = 1 << 19,
+  DT_DEBUG_PARAMS         = 1 << 20,
+  DT_DEBUG_DEMOSAIC       = 1 << 21,
+  DT_DEBUG_ACT_ON         = 1 << 22,
+  DT_DEBUG_TILING         = 1 << 23,
+  DT_DEBUG_VERBOSE        = 1 << 24
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -34,8 +34,6 @@
 #include "develop/masks.h"
 #include "gui/hist_dialog.h"
 
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
-
 void dt_history_item_free(gpointer data)
 {
   dt_history_item_t *item = (dt_history_item_t *)data;
@@ -511,7 +509,6 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
 
   if(ops)
   {
-    if (DT_IOP_ORDER_INFO) fprintf(stderr," selected ops");
     // copy only selected history entries
     for(const GList *l = g_list_last(ops); l; l = g_list_previous(l))
     {
@@ -523,9 +520,6 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
       {
         if (!dt_iop_is_hidden(hist->module))
         {
-          if (DT_IOP_ORDER_INFO)
-            fprintf(stderr,"\n  module %20s, multiprio %i",  hist->module->op, hist->module->multi_priority);
-
           mod_list = g_list_prepend(mod_list, hist->module);
         }
       }
@@ -533,7 +527,6 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   }
   else
   {
-    if (DT_IOP_ORDER_INFO) fprintf(stderr," all modules");
     // we will copy all modules
     for(GList *modules_src = dev_src->iop; modules_src; modules_src = g_list_next(modules_src))
     {
@@ -551,7 +544,6 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
       }
     }
   }
-  if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
 
   mod_list = g_list_reverse(mod_list);   // list was built in reverse order, so un-reverse it
 
@@ -1803,8 +1795,6 @@ gboolean dt_history_delete_on_list(const GList *list, gboolean undo)
   if(undo) dt_undo_end_group(darktable.undo);
   return TRUE;
 }
-
-#undef DT_IOP_ORDER_INFO
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -32,8 +32,6 @@
 
 #define DT_IOP_ORDER_VERSION 5
 
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
-
 static void _ioppr_reset_iop_order(GList *iop_order_list);
 
 /** Note :
@@ -2201,8 +2199,6 @@ GList *dt_ioppr_deserialize_iop_order_list(const char *buf, size_t size)
   g_list_free_full(iop_order_list, free);
   return NULL;
 }
-
-#undef DT_IOP_ORDER_INFO
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -39,8 +39,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
-
 typedef struct
 {
   GString *name;
@@ -847,9 +845,6 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
 
     dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 1");
 
-    if (DT_IOP_ORDER_INFO)
-      fprintf(stderr,"\n^^^^^ Apply style on image %i, history size %i",imgid,dev_dest->history_end);
-
     // go through all entries in style
     // clang-format off
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -896,8 +891,6 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
     }
 
     g_list_free_full(si_list, dt_style_item_free);
-
-    if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv --> look for written history below\n");
 
     dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 2");
 
@@ -1593,8 +1586,6 @@ dt_style_t *dt_styles_get_by_name(const char *name)
     return NULL;
   }
 }
-
-#undef DT_IOP_ORDER_INFO
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -46,7 +46,6 @@
 #define DT_DEV_AVERAGE_DELAY_START 250
 #define DT_DEV_PREVIEW_AVERAGE_DELAY_START 50
 #define DT_DEV_AVERAGE_DELAY_COUNT 5
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
 
 void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
@@ -1313,22 +1312,12 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
   // write history entries
 
   GList *history = dev->history;
-  if (DT_IOP_ORDER_INFO)
-    fprintf(stderr,"\n^^^^ Writing history image: %i, iop version: %i",imgid,dev->iop_order_version);
   for(int i = 0; history; i++)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
     (void)dt_dev_write_history_item(imgid, hist, i);
-    if (DT_IOP_ORDER_INFO)
-    {
-      fprintf(stderr,"\n%20s, num %i, order %d, v(%i), multiprio %i",
-              hist->module->op,i,hist->iop_order,hist->module->version(),hist->multi_priority);
-      if (hist->enabled) fprintf(stderr,", enabled");
-    }
     history = g_list_next(history);
   }
-  if (DT_IOP_ORDER_INFO)
-    fprintf(stderr,"\nvvvv\n");
 
   // update history end
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -55,7 +55,6 @@ DT_MODULE(1)
 // if a preset cannot be loaded or the current preset deleted, this is the fallback preset
 
 #define PADDING 2
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
 
 #include "modulegroups.h"
 
@@ -825,9 +824,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
                                   ? gtk_entry_get_text(GTK_ENTRY(d->text_entry))
                                   : NULL;
 
-  if (DT_IOP_ORDER_INFO)
-    fprintf(stderr,"\n^^^^^ modulegroups");
-
   // update basic button selection too
   g_signal_handlers_block_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->basic_btn), d->current == DT_MODULEGROUP_BASICS);
@@ -862,12 +858,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
      */
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
     GtkWidget *w = module->expander;
-
-    if((DT_IOP_ORDER_INFO) && (module->enabled))
-    {
-      fprintf(stderr, "\n%20s %d", module->op, module->iop_order);
-      if(dt_iop_is_hidden(module)) fprintf(stderr, ", hidden");
-    }
 
       /* skip modules without an gui */
       if(dt_iop_is_hidden(module)) continue;
@@ -974,7 +964,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
       }
 
   }
-  if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
   // now that visibility has been updated set multi-show
   dt_dev_modules_update_multishow(darktable.develop);
 


### PR DESCRIPTION
Another residule of times with ioporder problems can go imho.
No bug involved, just code cleanup.