### PR TITLE
Fresh new icons for better UI and minor fixes

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -80,8 +80,8 @@ box *
 }
 
 button,
-.section_label,
-.section_label *
+.dt_section_label,
+.dt_section_label *
 {
     font-family: "Roboto Medium", "Roboto",
                  "Segoe UI Semibold", "Segoe UI",

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -140,7 +140,8 @@ Why that? Just because it's a developer choice and most classes use underscore i
 @define-color collapsible_bg_color @grey_25;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_bg shade(@bg_color, 1.06);
+@define-color bauhaus_bg alpha(@bg_color, 0.55);
+@define-color bauhaus_fg @fg_color;       /* needed to correctly display color pickers in all states, even if they inherit @fg_color by default */
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_20;
 @define-color bauhaus_fill @grey_40;
@@ -608,7 +609,7 @@ dialog .sidebar row:selected:hover label,
 /* Collapsible sections on lib & iop modules */
 #collapse-block
 {
-  margin-top: 0.21em;
+  margin: 0.21em 0;
 }
 
 #collapsible
@@ -627,7 +628,7 @@ dialog .sidebar row:selected:hover label,
 .dt_section_expander,
 .dt_section_expander label
 {
-  background-color: shade(@collapsible_bg_color, 0.96);
+  background-color: @collapsible_bg_color;
   border: none;
   margin-top: 0.14em;
   padding: 0.07em 0;
@@ -1410,6 +1411,13 @@ border-bottom: 0.07em solid alpha(@selected_bg_color, 0.75);
   color: shade(@fg_color, 0.75);
 }
 
+/* set "buttons" combo in lens correction module */
+#lens-module .text-button
+{
+  background-color: alpha(@fg_color, 0.06);
+  min-height: 1em;
+}
+
 /* Progress bar on bottom left side when exporting, importing, etc... */
 #background-job-eventbox label
 {
@@ -1585,6 +1593,7 @@ notebook tab:hover,
 radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
 #dt-range-date-popup .text-button:hover,
+#lens-module .text-button:hover,
 #main-histogram .dt_module_btn:hover:not(.toggle),
 #non-flat:hover,
 #view-label:hover,

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -383,12 +383,10 @@ void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gi
 {
   PREAMBLE(1, 1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_move_to(cr, 0, 0);
-  cairo_line_to(cr, 1, 1);
-
-  cairo_move_to(cr, 0, 1);
-  cairo_line_to(cr, 1, 0);
+  cairo_move_to(cr, 0.1, 0.1);
+  cairo_line_to(cr, 0.9, 0.9);
+  cairo_move_to(cr, 0.1, 0.9);
+  cairo_line_to(cr, 0.9, 0.1);
   cairo_stroke(cr);
 
   FINISH
@@ -1464,17 +1462,12 @@ void dtgtk_cairo_paint_draw_structure(cairo_t *cr, gint x, gint y, gint w, gint 
 
 void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1.05, 1, 0, 0)
+  PREAMBLE(1, 1, 0, 0)
 
-  cairo_arc(cr, 0.5, 0.5, 0.5, 0, 2 * M_PI);
-  cairo_fill(cr);
-
-  cairo_set_source_rgba(cr, 0.2, 0.2, 0.2, 0.7);
-  cairo_move_to(cr, 0.65, 0.35);
-  cairo_line_to(cr, 0.35, 0.65);
-  cairo_stroke(cr);
-  cairo_move_to(cr, 0.65, 0.65);
-  cairo_line_to(cr, 0.35, 0.35);
+  cairo_move_to(cr, 0.85, 0.15);
+  cairo_line_to(cr, 0.15, 0.85);
+  cairo_move_to(cr, 0.15, 0.15);
+  cairo_line_to(cr, 0.85, 0.85);
   cairo_stroke(cr);
 
   FINISH
@@ -1625,7 +1618,7 @@ void dtgtk_cairo_paint_label_sel(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.9, 1, 0, 0)
+  PREAMBLE(0.95, 1, 0, 0)
 
   // the reject icon
   cairo_arc(cr, 0.5, 0.5, 0.5, 0.0, 2.0 * M_PI);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -49,7 +49,6 @@ static void _rounded_rectangle(cairo_t *cr)  // create rounded rectangle to use 
   cairo_arc (cr, 0.1, 0.9, 0.1, 90 * degrees, 180 * degrees);
   cairo_arc (cr, 0.1, 0.1, 0.1, 180 * degrees, 270 * degrees);
   cairo_close_path (cr);
-  cairo_stroke(cr);
 }
 
 void dtgtk_cairo_paint_empty(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
@@ -184,6 +183,30 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   cairo_move_to(cr, 0.2, 0.1);
   cairo_line_to(cr, 0.9, 0.5);
   cairo_line_to(cr, 0.2, 0.9);
+  cairo_fill(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_line_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  cairo_move_to(cr, 0.1, 0.5);
+  cairo_line_to(cr, 0.9, 0.5);
+  cairo_stroke(cr);
+
+  /* initialize flip matrices */
+  cairo_matrix_t hflip_matrix;
+  cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
+
+  /* scale and transform*/
+  if(flags & CPF_DIRECTION_LEFT) // Flip x transformation
+    cairo_transform(cr, &hflip_matrix);
+
+  cairo_move_to(cr, 0.4, 0.1);
+  cairo_line_to(cr, 0.0, 0.5);
+  cairo_line_to(cr, 0.4, 0.9);
   cairo_fill(cr);
 
   FINISH
@@ -400,6 +423,23 @@ void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   }
 
   cairo_identity_matrix(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_square_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  _rounded_rectangle(cr);
+  cairo_fill(cr);
+
+  cairo_set_source_rgba(cr, 0.2, 0.2, 0.2, 1.0);
+  cairo_move_to(cr, 0.5, 0.25);
+  cairo_line_to(cr, 0.5, 0.75);
+  cairo_move_to(cr, 0.25, 0.5);
+  cairo_line_to(cr, 0.75, 0.5);
+  cairo_stroke(cr);
 
   FINISH
 }
@@ -1304,15 +1344,21 @@ void dtgtk_cairo_paint_directory(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   PREAMBLE(1, 1, 0, 0);
 
-  cairo_scale(cr, 0.8, 0.8);
-  cairo_translate(cr, 0.1, 0.1);
+  const double degrees = M_PI / 180.0;
 
-  cairo_rectangle(cr, 0., 0., 1., 1.);
+  cairo_new_sub_path (cr);
+  cairo_arc (cr, 0.85, 0.35, 0.1, -90 * degrees, 0 * degrees);
+  cairo_arc (cr, 0.8, 0.75, 0.1, 0 * degrees, 90 * degrees);
+  cairo_arc (cr, 0.2, 0.75, 0.1, 90 * degrees, 180 * degrees);
+  cairo_arc (cr, 0.15, 0.35, 0.1, 180 * degrees, 270 * degrees);
+  cairo_close_path (cr);
   cairo_stroke(cr);
-  cairo_move_to(cr, 0., .2);
-  cairo_line_to(cr, .5, .2);
-  cairo_line_to(cr, .6, 0.);
-  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.1, 0.3);
+  cairo_arc (cr, 0.2, 0.15, 0.1, 180 * degrees, 270 * degrees);
+  cairo_arc (cr, 0.45, 0.15, 0.1, -90 * degrees, 0 * degrees);
+  cairo_curve_to(cr, 0.6, 0.15, 0.75, 0.25, 0.9, 0.25);
+  cairo_fill(cr);
 
   FINISH
 }
@@ -1420,11 +1466,15 @@ void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 {
   PREAMBLE(1.05, 1, 0, 0)
 
-  cairo_move_to(cr, 0.9, 0.1);
-  cairo_line_to(cr, 0.1, 0.9);
+  cairo_arc(cr, 0.5, 0.5, 0.5, 0, 2 * M_PI);
+  cairo_fill(cr);
+
+  cairo_set_source_rgba(cr, 0.2, 0.2, 0.2, 0.7);
+  cairo_move_to(cr, 0.65, 0.35);
+  cairo_line_to(cr, 0.35, 0.65);
   cairo_stroke(cr);
-  cairo_move_to(cr, 0.9, 0.9);
-  cairo_line_to(cr, 0.1, 0.1);
+  cairo_move_to(cr, 0.65, 0.65);
+  cairo_line_to(cr, 0.35, 0.35);
   cairo_stroke(cr);
 
   FINISH
@@ -2106,6 +2156,7 @@ void dtgtk_cairo_paint_overexposed(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
   /* outer rect */
   _rounded_rectangle(cr);
+  cairo_stroke(cr);
 
   FINISH
 }
@@ -2175,6 +2226,7 @@ void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint 
 
   /* outer rect */
   _rounded_rectangle(cr);
+  cairo_stroke(cr);
 
   FINISH
 }

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -55,6 +55,8 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
 void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a solid arrow left/right/up/down */
 void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
+/** Paint an arrow with a line */
+void dtgtk_cairo_paint_line_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
 /** Paint a sort by icon */
 void dtgtk_cairo_paint_sortby(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data);
 /** Paint a store icon */
@@ -79,6 +81,8 @@ void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gi
 void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Same as dtgtk_cairo_paint_plusminus, but render as a plus even when CFP_ACTIVE is disabled. */
 void dtgtk_cairo_paint_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a square plus icon */
+void dtgtk_cairo_paint_square_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a double arrow up/down */
 void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a simple plus icon */

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2313,6 +2313,7 @@ void gui_init(struct dt_iop_module_t *self)
   modifier->pos = ++pos;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+    gtk_widget_set_name(self->widget, "lens-module");
 
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -2321,7 +2322,8 @@ void gui_init(struct dt_iop_module_t *self)
                                       NULL, 0, hbox);
   g->find_camera_button = dt_iop_button_new(self, N_("find camera"),
                                             G_CALLBACK(camera_autosearch_clicked), FALSE, 0, (GdkModifierType)0,
-                                            dtgtk_cairo_paint_solid_triangle, CPF_DIRECTION_DOWN, NULL);
+                                            dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
+  dt_gui_add_class(g->find_camera_button, "dt_big_btn_canvas");
   gtk_box_pack_start(GTK_BOX(hbox), g->find_camera_button, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
@@ -2332,7 +2334,8 @@ void gui_init(struct dt_iop_module_t *self)
                                     NULL, 0, hbox);
   g->find_lens_button = dt_iop_button_new(self, N_("find lens"),
                                           G_CALLBACK(lens_autosearch_clicked), FALSE, 0, (GdkModifierType)0,
-                                          dtgtk_cairo_paint_solid_triangle, CPF_DIRECTION_DOWN, NULL);
+                                          dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
+  dt_gui_add_class(g->find_lens_button, "dt_big_btn_canvas");
   gtk_box_pack_start(GTK_BOX(hbox), g->find_lens_button, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -622,7 +622,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(label), "size-allocate", G_CALLBACK(_label_size_allocate_callback), &data->primary_sample);
   gtk_box_pack_start(GTK_BOX(sample_row), label, TRUE, TRUE, 0);
 
-  data->add_sample_button = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
+  data->add_sample_button = dtgtk_button_new(dtgtk_cairo_paint_square_plus, 0, NULL);
   ;
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
   g_signal_connect(G_OBJECT(data->add_sample_button), "clicked", G_CALLBACK(_add_sample), self);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -474,7 +474,7 @@ static void _add_sample(GtkButton *widget, dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(sample->output_label), "size-allocate", G_CALLBACK(_label_size_allocate_callback), sample);
   gtk_box_pack_start(GTK_BOX(container), sample->output_label, TRUE, TRUE, 0);
 
-  GtkWidget *delete_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_cancel, 0, NULL);
+  GtkWidget *delete_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_reject, 0, NULL);
   g_signal_connect(G_OBJECT(delete_button), "clicked", G_CALLBACK(_remove_sample_cb), sample);
   gtk_box_pack_start(GTK_BOX(container), delete_button, FALSE, FALSE, 0);
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -448,7 +448,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     g_signal_connect(G_OBJECT(tb), "focus-out-event", G_CALLBACK(_lib_duplicate_caption_out_callback), self);
     GtkWidget *lb = gtk_label_new (g_strdup(chl));
     gtk_widget_set_hexpand(lb, TRUE);
-    bt = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+    bt = dtgtk_button_new(dtgtk_cairo_paint_reject, 0, NULL);
     //    gtk_widget_set_halign(bt, GTK_ALIGN_END);
     g_object_set_data(G_OBJECT(bt), "imgid", GINT_TO_POINTER(imgid));
     g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_delete), self);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1208,7 +1208,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     gtk_box_pack_end(GTK_BOX(rule->w_btn_box), rule->w_off, FALSE, FALSE, 0);
 
     // remove button
-    rule->w_close = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+    rule->w_close = dtgtk_button_new(dtgtk_cairo_paint_reject, 0, NULL);
     gtk_widget_set_no_show_all(rule->w_close, TRUE);
     g_object_set_data(G_OBJECT(rule->w_close), "rule", rule);
     gtk_widget_set_tooltip_text(rule->w_close,
@@ -1665,7 +1665,7 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     g_signal_connect(G_OBJECT(sort->direction), "toggled", G_CALLBACK(_sort_reverse_changed), sort);
     dt_gui_add_class(sort->direction, "dt_ignore_fg_state");
 
-    sort->close = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+    sort->close = dtgtk_button_new(dtgtk_cairo_paint_reject, 0, NULL);
     gtk_widget_set_no_show_all(sort->close, TRUE);
     g_object_set_data(G_OBJECT(sort->close), "sort", sort);
     gtk_widget_set_tooltip_text(sort->close, _("remove this sort order"));

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2044,7 +2044,7 @@ static void _manage_editor_basics_update_list(dt_lib_module_t *self)
           gtk_box_pack_start(GTK_BOX(hb), lb, FALSE, TRUE, 0);
           if(!d->edit_ro)
           {
-            GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+            GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_reject, 0, NULL);
 
             gtk_widget_set_tooltip_text(btn, _("remove this widget"));
             g_object_set_data(G_OBJECT(btn), "widget_id", item->id);
@@ -2195,7 +2195,7 @@ static void _manage_editor_module_update_list(dt_lib_module_t *self, dt_lib_modu
         gtk_box_pack_start(GTK_BOX(hb), lb, FALSE, TRUE, 0);
         if(!d->edit_ro)
         {
-          GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+          GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_reject, 0, NULL);
           gtk_widget_set_tooltip_text(btn, _("remove this module"));
           g_object_set_data(G_OBJECT(btn), "module_name", module->op);
           g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -3277,7 +3277,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
   // remove button
   if(!d->edit_ro)
   {
-    btn = dtgtk_button_new(dtgtk_cairo_paint_cancel, 0, NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_reject, 0, NULL);
     gtk_widget_set_tooltip_text(btn, _("remove group"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
     g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_manage_editor_group_remove), self);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3225,7 +3225,7 @@ static GtkWidget *_manage_editor_group_init_basics_box(dt_lib_module_t *self)
   if(!d->edit_ro)
   {
     GtkWidget *hb4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT, NULL);
+    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_square_plus, CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add widget to the quick access panel"));
     gtk_widget_set_name(bt, "modulegroups-btn");
     g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_manage_editor_basics_add_popup), self);
@@ -3302,7 +3302,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
     GtkWidget *hb4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
     // left arrow
-    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_RIGHT, NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_line_arrow, CPF_DIRECTION_RIGHT, NULL);
     gtk_widget_set_name(btn, "modulegroups-btn");
     gtk_widget_set_tooltip_text(btn, _("move group to the left"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -3311,7 +3311,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
 
     // plus button
     GtkWidget *plusbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT, NULL);
+    GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_square_plus, CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_tooltip_text(bt, _("add module to the group"));
     gtk_widget_set_name(bt, "modulegroups-btn");
     g_object_set_data(G_OBJECT(bt), "group", gr);
@@ -3321,7 +3321,7 @@ static GtkWidget *_manage_editor_group_init_modules_box(dt_lib_module_t *self, d
     gtk_box_pack_start(GTK_BOX(hb4), plusbox, TRUE, TRUE, 0);
 
     //right arrow
-    btn = dtgtk_button_new(dtgtk_cairo_paint_arrow, CPF_DIRECTION_LEFT, NULL);
+    btn = dtgtk_button_new(dtgtk_cairo_paint_line_arrow, CPF_DIRECTION_LEFT, NULL);
     gtk_widget_set_name(btn, "modulegroups-btn");
     gtk_widget_set_tooltip_text(btn, _("move group to the right"));
     g_object_set_data(G_OBJECT(btn), "group", gr);
@@ -3911,7 +3911,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(hb, "modulegroups-groups-title");
   gtk_box_pack_start(GTK_BOX(hb), gtk_label_new(_("module groups")), FALSE, TRUE, 0);
-  d->preset_btn_add_group = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_DIRECTION_LEFT, NULL);
+  d->preset_btn_add_group = dtgtk_button_new(dtgtk_cairo_paint_square_plus, CPF_DIRECTION_LEFT, NULL);
   g_signal_connect(G_OBJECT(d->preset_btn_add_group), "button-press-event", G_CALLBACK(_manage_editor_group_add),
                    self);
   gtk_box_pack_start(GTK_BOX(hb), d->preset_btn_add_group, FALSE, FALSE, 0);


### PR DESCRIPTION
And a new set of icons updated. Hope you will like them.
I also fix some minor issues (like in darker CSS file, some forgotten update) and fix #11680 too.
Minor improvement on collapsible sections and more, the icons.

See before/after below.

New remove icon:
![Capture d’écran du 2022-04-29 18-15-45](https://user-images.githubusercontent.com/45535283/165984968-0678b39f-db8c-4634-b2f4-2fcc84a9aea4.png)
![Capture d’écran du 2022-04-29 18-21-20](https://user-images.githubusercontent.com/45535283/165984985-15ebaa7a-805f-495f-ba1c-ed79c9a19b40.png)

Icon used in modulegroups but see also new + and arrows icons:
![Capture d’écran du 2022-04-29 18-16-35](https://user-images.githubusercontent.com/45535283/165985022-74374294-e5aa-4e51-9f24-38290a2ee8c9.png)
![Capture d’écran du 2022-04-29 18-20-12](https://user-images.githubusercontent.com/45535283/165985035-3406782b-a2dc-408b-966f-be8036692ec7.png)

Result of new remove icon in blending tabs:
![Capture d’écran du 2022-04-29 18-16-54](https://user-images.githubusercontent.com/45535283/165985064-8f3cc2eb-994c-4eda-9dd1-7e28d4d3e751.png)
![Capture d’écran du 2022-04-29 18-19-54](https://user-images.githubusercontent.com/45535283/165985233-446b43c3-fbac-45e7-b7ee-ec427718b0d1.png)

A more readable folder icon:
![Capture d’écran du 2022-04-29 18-15-24](https://user-images.githubusercontent.com/45535283/165985284-e032f205-b678-4a0f-9645-eaecdeff7b56.png)
![Capture d’écran du 2022-04-29 18-20-34](https://user-images.githubusercontent.com/45535283/165985316-e7056629-de19-4975-8c47-d4246062924c.png)

And better lens correction module:
![Capture d’écran du 2022-04-29 18-17-46](https://user-images.githubusercontent.com/45535283/165985381-eb3edd42-3b68-4384-bb77-fa4a923a79c5.png)
![Capture d’écran du 2022-04-29 18-19-31](https://user-images.githubusercontent.com/45535283/165985398-4d79d013-513a-46da-8a0d-45a770301d10.png)

I should probably update other parts in following days, so I let this one as WIP by now.