### PR TITLE
add shortcuts for rating and colors filters

### DIFF
--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1641,8 +1641,7 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
   // the graph band
   range->band = gtk_drawing_area_new();
   gtk_widget_set_events(range->band, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
-                                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
-                                         | GDK_POINTER_MOTION_MASK);
+                                         | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
   g_signal_connect(G_OBJECT(range->band), "draw", G_CALLBACK(_event_band_draw), range);
   g_signal_connect(G_OBJECT(range->band), "button-press-event", G_CALLBACK(_event_band_press), range);
   g_signal_connect(G_OBJECT(range->band), "button-release-event", G_CALLBACK(_event_band_release), range);
@@ -1707,7 +1706,7 @@ GType dtgtk_range_select_get_type()
       (GInstanceInitFunc)_range_select_init,
     };
     dtgtk_range_select_type
-        = g_type_register_static(GTK_TYPE_BIN, "GtkDarktableRangeSelect", &dtgtk_range_select_info, 0);
+        = g_type_register_static(GTK_TYPE_EVENT_BOX, "GtkDarktableRangeSelect", &dtgtk_range_select_info, 0);
   }
   return dtgtk_range_select_type;
 }

--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -64,7 +64,7 @@ typedef enum dt_range_type_t
 
 typedef struct _GtkDarktableRangeSelect
 {
-  GtkBin widget;
+  GtkEventBox widget;
 
   dt_range_type_t type;
 
@@ -120,7 +120,7 @@ typedef struct _GtkDarktableRangeSelect
 
 typedef struct _GtkDarktableRangeSelectClass
 {
-  GtkBoxClass parent_class;
+  GtkEventBoxClass parent_class;
 } GtkDarktableRangeSelectClass;
 
 GType dtgtk_range_select_get_type(void);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2153,9 +2153,9 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   // Save the shortcuts before editing
   dt_shortcuts_save(".edit", FALSE);
 
-  _selected_action = g_hash_table_lookup(darktable.control->widgets, widget);
-  if(!_selected_action && widget)
-    _selected_action = g_hash_table_lookup(darktable.control->widgets, gtk_widget_get_parent(widget));
+  GtkWidget *widget_or_parent = widget;
+  while(!(_selected_action = g_hash_table_lookup(darktable.control->widgets, widget_or_parent)) && widget_or_parent)
+    widget_or_parent = gtk_widget_get_parent(widget_or_parent);
   darktable.control->element = -1;
 
   GtkWidget *container = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
@@ -3071,7 +3071,7 @@ static float _process_action(dt_action_t *action, int instance,
     if(definition && definition->process
         && (action->type < DT_ACTION_TYPE_WIDGET
             || definition->no_widget
-            || !_widget_invisible(action_target)))
+            || (action_target && !_widget_invisible(action_target))))
     {
       if(!isnan(move_size) &&
          (definition->elements[element].effects != dt_action_effect_value || effect != DT_ACTION_EFFECT_SET))

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1899,6 +1899,20 @@ void gui_init(dt_lib_module_t *self)
   d->nb_rules = 0;
   d->params = (dt_lib_filtering_params_t *)g_malloc0(sizeof(dt_lib_filtering_params_t));
 
+  darktable.control->accel_initialising = TRUE;
+  const int nb = sizeof(filters) / sizeof(_filter_t);
+  for(int i = 0; i < nb; i++)
+  {
+    dt_lib_filtering_rule_t temp_rule;
+    temp_rule.w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+    filters[i].widget_init(&temp_rule, filters[i].prop, "", self, FALSE);
+
+    gtk_widget_destroy(temp_rule.w_special_box);
+    g_free(temp_rule.w_specific);
+  }
+  darktable.control->accel_initialising = FALSE;
+
   for(int i = 0; i < DT_COLLECTION_MAX_RULES; i++)
   {
     d->rule[i].num = i;

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -172,6 +172,7 @@ static void _colors_operator_clicked(GtkWidget *w, _widgets_colors_t *colors)
   const gboolean and_op = !GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sel_value"));
   g_object_set_data(G_OBJECT(w), "sel_value", GINT_TO_POINTER(and_op));
   dtgtk_button_set_paint(DTGTK_BUTTON(w), and_op ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0, NULL);
+  gtk_widget_queue_draw(w);
   _colors_changed(w, colors);
   _colors_synchronise(colors);
 }


### PR DESCRIPTION
fixes #11562

You can visual assign shortcuts to a specific rating or color without using the shortcuts/prefs dialog. Color shortcuts normally toggle selecting the color. To switch to excluding it, change the effect in the shortcuts dialog (click on the widget) to ctrl-toggle.

A rating shortcut will select the lower bound of the range, unless it is already selected, in which case it will toggle the upper bound to max. To select all images, press shift+r (lower bound=rejected) and if _only_ rejecteds are shown, press it again to show rejected -> max. You can switch the _effect_ to _cap_ to change to maximum of the range.

If you have fallbacks enabled, pressing any of the rating shortcuts (for example shift+1) and scrolling up or down increases/decreases the minimum rating. If a midi button with a light is mapped to a rating, it will light up if the rating falls in the selected range. If a midi rotor is mapped, it's light will indicate the minimum of the range (on the x-touch).