### PR TITLE
crop : ensure preview_pipe is finished before getting values

### DIFF
--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -176,10 +176,11 @@ static int _gui_has_focus(struct dt_iop_module_t *self)
 static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop_crop_params_t *p)
 {
   if(darktable.gui->reset) return;
+  if(self->dev->preview_status != DT_DEV_PIXELPIPE_VALID) return;
+
   g->cropping = 0;
   const dt_boundingbox_t old = { p->cx, p->cy, p->cw, p->ch };
   const float eps = 1e-6f; // threshold to avoid rounding errors
-
   if(!self->enabled)
   {
     // first time crop, if any data is stored in p, it's obsolete:
@@ -219,6 +220,7 @@ static int _set_max_clip(struct dt_iop_module_t *self)
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
   if(g->clip_max_pipe_hash == self->dev->preview_pipe->backbuf_hash) return 1;
+  if(self->dev->preview_status != DT_DEV_PIXELPIPE_VALID) return 1;
 
   // we want to know the size of the actual buffer
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
@@ -388,11 +390,11 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
   if(!g) return; // seems that sometimes, g can be undefined for some reason...
   g->preview_ready = TRUE;
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
   if(self->dev->gui_module != self)
   {
     dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
   }
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
   // force max size to be recomputed
   g->clip_max_pipe_hash = 0;
 }
@@ -416,7 +418,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       g->clip_h = CLAMPF(p->ch - p->cy, 0.1f, 1.0f - g->clip_y);
       g->preview_ready = FALSE;
     }
-    else
+    else if(g->preview_ready)
     {
       // hack : commit_box use distort_transform routines with gui values to get params
       // but this values are accurate only if crop is the gui_module...


### PR DESCRIPTION
this fix #11615 

@TurboGit : review carefully, as I'm not a mutex specialist ;) The problem is that in some situations, we try to get values like preview_pipe sizes although the pipe is still processing...
I've first try to use `DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED` signal, but that was not working as this doesn't fire if the pipe is already finished...