### PR TITLE
piwigo-export: update existing photos

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -102,6 +102,13 @@
     <shortdescription></shortdescription>
     <longdescription></longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>storage/piwigo/overwrite</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription></shortdescription>
+    <longdescription></longdescription>
+  </dtconfig>
   <dtconfig prefs="storage" section="database">
     <name>database/maintenance_check</name>
     <type>

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -123,7 +123,6 @@ typedef struct dt_storage_piwigo_params_t
 } dt_storage_piwigo_params_t;
 
 dt_storage_piwigo_conflict_actions_t conflict_action;
-char existing_image_id[10];
 
 /* low-level routine doing the HTTP POST request */
 static void _piwigo_api_post(_piwigo_api_context_t *ctx, GList *args, char *filename, gboolean isauth);
@@ -756,8 +755,7 @@ static char *_piwigo_api_get_image_id(dt_storage_piwigo_params_t *p, dt_image_t 
           {
             if(strcmp(img->filename, json_object_get_string_member(existing_image, "file")) == 0)
             {
-              sprintf(existing_image_id, "%d", (int) json_object_get_int_member(existing_image, "id"));
-              return existing_image_id;
+              return (char*) json_object_get_int_member(existing_image, "id");
             }
           }
         }
@@ -1124,7 +1122,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
         pwg_image_id = _piwigo_api_get_image_id(p, img);
       }
 
-      if(conflict_action==DT_PIWIGO_CONFLICT_METADATA)
+      if(conflict_action == DT_PIWIGO_CONFLICT_METADATA)
       {
         status = _piwigo_api_set_info(p, author, caption, description, pwg_image_id);
         if(!status)
@@ -1154,6 +1152,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           _piwigo_refresh_albums(ui, p->album);
         }
       }
+      g_free(pwg_image_id);
     }
     if(p->tags)
     {

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -118,10 +118,11 @@ typedef struct dt_storage_piwigo_params_t
   char *album;
   gboolean new_album;
   int privacy;
+  gboolean export_tags; // deprecated - let here not to change params size. to be removed on next version change
   gchar *tags;
-  dt_storage_piwigo_conflict_actions_t conflict_action;
 } dt_storage_piwigo_params_t;
 
+dt_storage_piwigo_conflict_actions_t conflict_action;
 char existing_image_id[10];
 
 /* low-level routine doing the HTTP POST request */
@@ -1118,12 +1119,12 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     {
       char *pwg_image_id = NULL;
 
-      if(p->conflict_action != DT_PIWIGO_CONFLICT_NOTHING)
+      if(conflict_action != DT_PIWIGO_CONFLICT_NOTHING)
       {
         pwg_image_id = _piwigo_api_get_image_id(p, img);
       }
 
-      if(p->conflict_action==DT_PIWIGO_CONFLICT_METADATA)
+      if(conflict_action==DT_PIWIGO_CONFLICT_METADATA)
       {
         status = _piwigo_api_set_info(p, author, caption, description, pwg_image_id);
         if(!status)
@@ -1133,7 +1134,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
           result = 1;
         }
       }
-      else if(pwg_image_id && p->conflict_action==DT_PIWIGO_CONFLICT_SKIP)
+      else if(pwg_image_id && conflict_action==DT_PIWIGO_CONFLICT_SKIP)
       {
         skipped = 1;
       }
@@ -1234,7 +1235,7 @@ void *get_params(dt_imageio_module_storage_t *self)
     p->album_id = 0;
     p->tags = NULL;
 
-    p->conflict_action = dt_bauhaus_combobox_get(ui->conflict_action);
+    conflict_action = dt_bauhaus_combobox_get(ui->conflict_action);
 
     switch(dt_bauhaus_combobox_get(ui->permission_list))
     {


### PR DESCRIPTION
First very small step towards #11400

Currently it's not possible to update already existing photos using piwigo-export.
The filename is randomized, and every export creates a new copy of the images.

With this PR, the filename in piwigo is the same as in darktable, and if the file already exists when exporting to piwigo, it will be updated instead of copied.