### PR TITLE
Implement lazy check for CL tuned memory

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -693,11 +693,8 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(ch >= 3);
   assert(w >= 1);
 
-  // estimate required memory for OpenCL code path with a safety factor of 5/4
-  const size_t singlebuf = (size_t)width * height * sizeof(float);
-  const size_t required  = singlebuf * 18 * 5 / 4;
-  const gboolean fits = (dt_opencl_buffer_fits_device(devid, singlebuf) &&
-                         (dt_opencl_get_device_available(devid) > required));
+  // estimate required memory for OpenCL code path with a safety factor of 1.25
+  const gboolean fits = dt_opencl_image_fits_device(devid, width, height, sizeof(float), 18.0f * 1.25f, 0);
 
   int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   if(fits)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -451,8 +451,6 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
 /** check if image size fit into limits given by OpenCL runtime */
 gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
-/** check if buffer fits into limits given by OpenCL runtime */
-gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required);
 
 /** get available memory for the device */
 cl_ulong dt_opencl_get_device_available(const int devid);
@@ -596,10 +594,6 @@ static inline int dt_opencl_update_settings(void)
 }
 static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)
-{
-  return FALSE;
-}
-static inline gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
 {
   return FALSE;
 }


### PR DESCRIPTION
As can be read from @MStraeten log in #11606 the penalty for checking available CL memory
with mem-tuning=on can be pretty large for some devices/drivers leading to a significant
performance regression on such systems.

As a reminder - we need to know the available memory on cl devices to make sure we switch
early into tiling mode if memory is not sufficient to avoid very costly fallbacks to cpu code.

As cl memory allocation mostly uses a late-allocate mode (meaning an allocation error is not
returned immediately but later when a clkernel uses the memory) we have to do a "brute-force"
check (allocate & access-memory) to know for sure. **this** test is time costly.

To avoid the costly memory check (it may be not necessary if the available memory is guaranteed
by the resourlevel setting and a sufficiently large graphics card) we now check first in
`dt_opencl_image_fits_device()` if the static settings are fitting already and only do the
full memory check if we have to tile anyway and want to find out the maximum possible tilesize.

In guided_filter we check for a fit via `dt_opencl_image_fits_device()`, code is easier and we can reduce the number of opencl exposed functions.