### PR TITLE
The darktable library contains only information about the image, not the image itself

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -369,7 +369,7 @@
     <name>ask_before_remove</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>ask before removing image information from the library</shortdescription>
+    <shortdescription>ask before removing images from the library</shortdescription>
     <longdescription>always ask the user before removing image information from the library</longdescription>
   </dtconfig>
   <dtconfig prefs="security" section="general">

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -369,8 +369,8 @@
     <name>ask_before_remove</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>ask before removing images from the library</shortdescription>
-    <longdescription>always ask the user before any image is removed from the library</longdescription>
+    <shortdescription>ask before removing image information from the library</shortdescription>
+    <longdescription>always ask the user before removing image information from the library</longdescription>
   </dtconfig>
   <dtconfig prefs="security" section="general">
     <name>ask_before_delete</name>


### PR DESCRIPTION
It is better to avoid ambiguity in the wording.
See also https://github.com/darktable-org/dtdocs/pull/444