### PR TITLE
Tuning opencl dt4

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1083,7 +1083,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   static int ref_resources[12] = {
       8192,  32,  512, 2048,   // reference
       1024,   2,  128,  200,   // mini system
-      4096,  32,  512,  200,   // simple notebook with integrated graphics
+      4096,  32,  512, 1024,   // simple notebook with integrated graphics
   };
 
   /* This is where the sync is to be done if the enum for pref resourcelevel in darktableconfig.xml.in is changed.

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -693,11 +693,8 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   assert(ch >= 3);
   assert(w >= 1);
 
-  // estimate required memory for OpenCL code path with a safety factor of 5/4
-  const size_t singlebuf = (size_t)width * height * sizeof(float);
-  const size_t required  = singlebuf * 18 * 5 / 4;
-  const gboolean fits = (dt_opencl_buffer_fits_device(devid, singlebuf) &&
-                         (dt_opencl_get_device_available(devid) > required));
+  // estimate required memory for OpenCL code path with a safety factor of 1.25
+  const gboolean fits = dt_opencl_image_fits_device(devid, width, height, sizeof(float), 18.0f * 1.25f, 0);
 
   int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   if(fits)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2726,7 +2726,8 @@ void _opencl_get_unused_device_mem(const int devid)
   cl_mem tbuf[128];
   cl_int err = CL_SUCCESS;
 
-  while((available < (allmem - x_buff)) && (checked < 128) && (err == CL_SUCCESS))
+  // check for all memory except a safety margin that might be used by the driver itself.
+  while((available < (allmem - x_buff - 200lu * 1024lu * 1024lu)) && (checked < 128) && (err == CL_SUCCESS))
   {
     tbuf[checked] = (cl->dlocl->symbols->dt_clCreateBuffer)(cl->dev[devid].context, CL_MEM_READ_WRITE, x_buff, NULL, &err);
     if(err == CL_SUCCESS)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2848,7 +2848,7 @@ gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const 
   if(!cl->inited || devid < 0) return FALSE;
 
   const size_t required  = width * height * bpp;
-  const size_t total = fmaxf(2.0f, factor) * required + overhead;
+  const size_t total = factor * required + overhead;
 
   if(cl->dev[devid].max_image_width < width || cl->dev[devid].max_image_height < height)
     return FALSE;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -605,7 +605,7 @@ static inline size_t dt_opencl_get_device_available(const int devid)
 }
 static inline void dt_opencl_check_device_available(const int devid)
 {
-  return 0;
+  return;
 }
 static inline size_t dt_opencl_get_device_memalloc(const int devid)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -149,6 +149,7 @@ typedef struct dt_opencl_device_t
   size_t memory_in_use;
   size_t peak_memory;
   size_t tuned_available;
+  size_t used_available;
 
   // if set to TRUE darktable will not use OpenCL kernels which contain atomic operations (example bilateral).
   // pixelpipe processing will be done on CPU for the affected modules.
@@ -453,6 +454,8 @@ gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const 
                                 const float factor, const size_t overhead);
 /** get available memory for the device */
 cl_ulong dt_opencl_get_device_available(const int devid);
+/** check available memory for the device */
+void dt_opencl_check_device_available(const int devid);
 
 /** get size of allocatable single buffer */
 cl_ulong dt_opencl_get_device_memalloc(const int devid);
@@ -597,6 +600,10 @@ static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t
   return FALSE;
 }
 static inline size_t dt_opencl_get_device_available(const int devid)
+{
+  return 0;
+}
+static inline void dt_opencl_check_device_available(const int devid)
 {
   return 0;
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -451,9 +451,6 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
 /** check if image size fit into limits given by OpenCL runtime */
 gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height, const unsigned bpp,
                                 const float factor, const size_t overhead);
-/** check if buffer fits into limits given by OpenCL runtime */
-gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required);
-
 /** get available memory for the device */
 cl_ulong dt_opencl_get_device_available(const int devid);
 
@@ -596,10 +593,6 @@ static inline int dt_opencl_update_settings(void)
 }
 static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)
-{
-  return FALSE;
-}
-static inline gboolean dt_opencl_buffer_fits_device(const int devid, const size_t required)
 {
   return FALSE;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2119,11 +2119,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   darktable.dtresources.group = 4 * darktable.dtresources.level;
 #ifdef HAVE_OPENCL
-  if((darktable.dtresources.tunememory == 0) && (pipe->devid >= 0) && darktable.opencl->inited)
-    darktable.opencl->dev[pipe->devid].tuned_available = 0;
-
-  if((darktable.dtresources.tunepinning != 0) && (pipe->devid >= 0) && darktable.opencl->inited)
-    darktable.opencl->dev[pipe->devid].pinned_memory |= DT_OPENCL_PINNING_ON;
+  dt_opencl_check_device_available(pipe->devid);
 #endif
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
@@ -2148,7 +2144,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
       {
         /* this indicates a opencl problem earlier in the pipeline */
         dt_print(DT_DEBUG_OPENCL,
-                 "[opencl_pixelpipe (d)] late opencl error detected while copying back to cpu buffer: %s\n", cl_errstr(err));
+                 "[dt_dev_pixelpipe_process_rec_and_backcopy] late opencl error detected while copying back to cpu buffer: %s\n", cl_errstr(err));
         pipe->opencl_error = 1;
         ret = 1;
       }

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -2023,7 +2023,7 @@ void default_tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpi
       = ((float)roi_out->width * (float)roi_out->height) / ((float)roi_in->width * (float)roi_in->height);
 
   tiling->factor = 1.0f + ioratio;
-  tiling->factor_cl = fmaxf(2.0f, tiling->factor); // at least have in & output buffer
+  tiling->factor_cl = tiling->factor;
   tiling->maxbuf = 1.0f;
   tiling->maxbuf_cl = tiling->maxbuf;
   tiling->overhead = 0;


### PR DESCRIPTION
While testing #11703 here and by @AxelG-DE some issues became evident.
1. As noted by @MStraeten log in https://github.com/darktable-org/darktable/issues/11606 the penalty for checking available CL memory with mem-tuning=on can be pretty large for some devices/drivers leading to a significant performance regression on such systems.
2. "Instable" performance results reported by @AxelG-DE are due to checking for available memory while there is some cl memory already allocated by dt.

In this pr
1. the guided filter makes use of `dt_opencl_image_fits_device` in a better way than also testing for a buffer fitting. As this was the only place using `dt_opencl_buffer_fits_device()` we can completely get rid of that.
2. We calculate the available cl memory (depending on resourcelevel and tuning mode) only once via `dt_opencl_check_device_available` and later get that size via `dt_opencl_get_device_available()` which is just reading from the device struct. So this is a redesign
3. After testing the memory tuning extensively over the last weeks it became obvious that the calculation is a bit much on the conservative side. So a subtle increase of what we use for dt in all modes. 
4. some comments and debug info improvements

EDIT add comments for latest commits
5. Fix algorithm of calculating available memory - avoid not necessary tests if buffer won't fit anyway.