### PR TITLE
filtering : add grouping filter

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1313,6 +1313,20 @@ void dt_bauhaus_combobox_add_full(GtkWidget *widget, const char *text, dt_bauhau
   if(d->active < 0) d->active = 0;
 }
 
+gboolean dt_bauhaus_combobox_set_entry_label(GtkWidget *widget, const int pos, const gchar *label)
+{
+  // change the text to show for the entry
+  // note that this doesn't break shortcuts but their names in the shortcut panel will remain the initial one
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_COMBOBOX) return FALSE;
+  dt_bauhaus_combobox_data_t *d = &w->data.combobox;
+  if(!d || pos < 0 || pos >= d->entries->len) return FALSE;
+  dt_bauhaus_combobox_entry_t *entry = g_ptr_array_index(d->entries, pos);
+  g_free(entry->label);
+  entry->label = g_strdup(label);
+  return TRUE;
+}
+
 void dt_bauhaus_combobox_set_entries_ellipsis(GtkWidget *widget, PangoEllipsizeMode ellipis)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -346,6 +346,7 @@ void dt_bauhaus_combobox_add_section(GtkWidget *widget, const char *text);
 void dt_bauhaus_combobox_add_aligned(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align);
 void dt_bauhaus_combobox_add_full(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align,
                                   gpointer data, void (*free_func)(void *data), gboolean sensitive);
+gboolean dt_bauhaus_combobox_set_entry_label(GtkWidget *widget, const int pos, const gchar *label);
 void dt_bauhaus_combobox_set(GtkWidget *w, int pos);
 gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *w, const char *text);
 gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *w, int value);

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1502,11 +1502,18 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       break;
 
     case DT_COLLECTION_PROP_LOCAL_COPY: // local copy
-      // clang-format off
-      query = g_strdup_printf("(id %s IN (SELECT id AS imgid FROM main.images WHERE (flags & %d))) ",
-                              (strcmp(escaped_text, _("not copied locally")) == 0) ? "not" : "",
-                              DT_IMAGE_LOCAL_COPY);
-      // clang-format on
+      if(!g_strcmp0(escaped_text, _("not copied locally")) || !g_strcmp0(escaped_text, "$NO_LOCAL_COPY"))
+      {
+        query = g_strdup_printf("(flags & %d = 0) ", DT_IMAGE_LOCAL_COPY);
+      }
+      else if(!g_strcmp0(escaped_text, _("copied locally")) || !g_strcmp0(escaped_text, "$LOCAL_COPY"))
+      {
+        query = g_strdup_printf("(flags & %d) ", DT_IMAGE_LOCAL_COPY);
+      }
+      else // by default, we select all the images
+      {
+        query = g_strdup("1 = 1");
+      }
       break;
 
     case DT_COLLECTION_PROP_ASPECT_RATIO: // aspect ratio

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1911,9 +1911,16 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     case DT_COLLECTION_PROP_ORDER: // module order
       {
         int i = 0;
-        for(i = 0; i < DT_IOP_ORDER_LAST; i++)
+        if(strlen(escaped_text) > 1 && g_str_has_prefix(escaped_text, "$"))
         {
-          if(strcmp(escaped_text, _(dt_iop_order_string(i))) == 0) break;
+          i = atoi(escaped_text + 1);
+        }
+        else
+        {
+          for(i = 0; i < DT_IOP_ORDER_LAST; i++)
+          {
+            if(strcmp(escaped_text, _(dt_iop_order_string(i))) == 0) break;
+          }
         }
         if(i < DT_IOP_ORDER_LAST)
           // clang-format off

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -191,6 +191,7 @@ typedef struct _filter_t
 #include "libs/filters/exposure.c"
 #include "libs/filters/filename.c"
 #include "libs/filters/focal.c"
+#include "libs/filters/grouping.c"
 #include "libs/filters/iso.c"
 #include "libs/filters/rating.c"
 #include "libs/filters/ratio.c"
@@ -209,7 +210,8 @@ static _filter_t filters[] = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_i
                                { DT_COLLECTION_PROP_APERTURE, _aperture_widget_init, _aperture_update },
                                { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update },
                                { DT_COLLECTION_PROP_ISO, _iso_widget_init, _iso_update },
-                               { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update } };
+                               { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
+                               { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {
@@ -875,13 +877,12 @@ static gboolean _rule_show_popup(GtkWidget *widget, dt_lib_filtering_rule_t *rul
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_ISO);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_ASPECT_RATIO);
 
-  /* TO BE restored once the filters will be implemented
   _popup_add_item(spop, _("darktable"), 0, TRUE, NULL, NULL, self, 0.0);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_GROUPING);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_LOCAL_COPY);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_HISTORY);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_MODULE);
-  ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_ORDER);*/
+  ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_ORDER);
 
   dt_gui_menu_popup(GTK_MENU(spop), widget, GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH);
   return TRUE;
@@ -957,13 +958,12 @@ static void _rule_populate_prop_combo(dt_lib_filtering_rule_t *rule)
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ISO);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ASPECT_RATIO);
 
-  /* TO BE restored once the filters will be implemented
   dt_bauhaus_combobox_add_section(w, _("darktable"));
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUPING);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LOCAL_COPY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_HISTORY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_MODULE);
-  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ORDER);*/
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ORDER);
 
 #undef ADD_COLLECT_ENTRY
 

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -193,6 +193,7 @@ typedef struct _filter_t
 #include "libs/filters/focal.c"
 #include "libs/filters/grouping.c"
 #include "libs/filters/iso.c"
+#include "libs/filters/local_copy.c"
 #include "libs/filters/rating.c"
 #include "libs/filters/ratio.c"
 #include "libs/filters/search.c"
@@ -211,7 +212,8 @@ static _filter_t filters[] = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_i
                                { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update },
                                { DT_COLLECTION_PROP_ISO, _iso_widget_init, _iso_update },
                                { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
-                               { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update } };
+                               { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update },
+                               { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -23,6 +23,7 @@
 #include "common/debug.h"
 #include "common/film.h"
 #include "common/history.h"
+#include "common/iop_order.h"
 #include "common/map_locations.h"
 #include "common/metadata.h"
 #include "common/utility.h"
@@ -195,6 +196,7 @@ typedef struct _filter_t
 #include "libs/filters/history.c"
 #include "libs/filters/iso.c"
 #include "libs/filters/local_copy.c"
+#include "libs/filters/module_order.c"
 #include "libs/filters/rating.c"
 #include "libs/filters/ratio.c"
 #include "libs/filters/search.c"
@@ -215,7 +217,8 @@ static _filter_t filters[] = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_i
                                { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
                                { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update },
                                { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
-                               { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update } };
+                               { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update },
+                               { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -192,6 +192,7 @@ typedef struct _filter_t
 #include "libs/filters/filename.c"
 #include "libs/filters/focal.c"
 #include "libs/filters/grouping.c"
+#include "libs/filters/history.c"
 #include "libs/filters/iso.c"
 #include "libs/filters/local_copy.c"
 #include "libs/filters/rating.c"
@@ -213,7 +214,8 @@ static _filter_t filters[] = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_i
                                { DT_COLLECTION_PROP_ISO, _iso_widget_init, _iso_update },
                                { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
                                { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update },
-                               { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update } };
+                               { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
+                               { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {

--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -1,0 +1,145 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  This file contains the necessary routines to implement a filter for the filtering module
+*/
+
+typedef struct _widgets_grouping_t
+{
+  dt_lib_filtering_rule_t *rule;
+
+  GtkWidget *combo;
+} _widgets_grouping_t;
+
+typedef enum _grouping_type_t
+{
+  _GROUPING_ALL = 0,
+  _GROUPING_ORPHAN,
+  _GROUPING_GROUP,
+  _GROUPING_LEADER,
+  _GROUPING_FOLLOWER
+} _grouping_type_t;
+
+static void _grouping_synchronise(_widgets_grouping_t *source)
+{
+  _widgets_grouping_t *dest = NULL;
+  if(source == source->rule->w_specific_top)
+    dest = source->rule->w_specific;
+  else
+    dest = source->rule->w_specific_top;
+
+  if(dest)
+  {
+    source->rule->manual_widget_set++;
+    const int val = dt_bauhaus_combobox_get(source->combo);
+    dt_bauhaus_combobox_set(dest->combo, val);
+    source->rule->manual_widget_set--;
+  }
+}
+
+static void _grouping_decode(const gchar *txt, int *val)
+{
+  if(!txt || strlen(txt) == 0) return;
+
+  if(!g_strcmp0(txt, "$NO_GROUP"))
+    *val = _GROUPING_ORPHAN;
+  else if(!g_strcmp0(txt, "$GROUP"))
+    *val = _GROUPING_GROUP;
+  else if(!g_strcmp0(txt, "$LEADER"))
+    *val = _GROUPING_LEADER;
+  else if(!g_strcmp0(txt, "$FOLLOWER"))
+    *val = _GROUPING_FOLLOWER;
+  else
+    *val = _GROUPING_ALL;
+}
+
+static void _grouping_changed(GtkWidget *widget, gpointer user_data)
+{
+  _widgets_grouping_t *grouping = (_widgets_grouping_t *)user_data;
+  if(grouping->rule->manual_widget_set) return;
+
+  const _grouping_type_t tp = dt_bauhaus_combobox_get(grouping->combo);
+  switch(tp)
+  {
+    case _GROUPING_ALL:
+      _rule_set_raw_text(grouping->rule, "", TRUE);
+      break;
+    case _GROUPING_ORPHAN:
+      _rule_set_raw_text(grouping->rule, "$NO_GROUP", TRUE);
+      break;
+    case _GROUPING_GROUP:
+      _rule_set_raw_text(grouping->rule, "$GROUP", TRUE);
+      break;
+    case _GROUPING_LEADER:
+      _rule_set_raw_text(grouping->rule, "$LEADER", TRUE);
+      break;
+    case _GROUPING_FOLLOWER:
+      _rule_set_raw_text(grouping->rule, "$FOLLOWER", TRUE);
+      break;
+  }
+  _grouping_synchronise(grouping);
+}
+
+static gboolean _grouping_update(dt_lib_filtering_rule_t *rule)
+{
+  if(!rule->w_specific) return FALSE;
+  int val = _GROUPING_ALL;
+  _grouping_decode(rule->raw_text, &val);
+
+  rule->manual_widget_set++;
+  _widgets_grouping_t *grouping = (_widgets_grouping_t *)rule->w_specific;
+  dt_bauhaus_combobox_set(grouping->combo, val);
+  rule->manual_widget_set--;
+
+  return TRUE;
+}
+
+static void _grouping_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+                                  const gchar *text, dt_lib_module_t *self, const gboolean top)
+{
+  _widgets_grouping_t *grouping = (_widgets_grouping_t *)g_malloc0(sizeof(_widgets_grouping_t));
+  grouping->rule = rule;
+
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(grouping->combo, self, NULL, N_("grouping filter"),
+                               _("select the type of grouped image to filter"), 0, (GtkCallback)_grouping_changed,
+                               grouping, N_("all images"), N_("orphan images"), N_("images in a group"),
+                               N_("group leaders"), N_("group followers"));
+  DT_BAUHAUS_WIDGET(grouping->combo)->show_label = FALSE;
+
+  if(top)
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), grouping->combo, TRUE, TRUE, 0);
+  else
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box), grouping->combo, TRUE, TRUE, 0);
+
+  if(top)
+  {
+    dt_gui_add_class(grouping->combo, "dt_quick_filter");
+  }
+
+  if(top)
+    rule->w_specific_top = grouping;
+  else
+    rule->w_specific = grouping;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/libs/filters/history.c
+++ b/src/libs/filters/history.c
@@ -1,0 +1,138 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  This file contains the necessary routines to implement a filter for the filtering module
+*/
+
+typedef struct _widgets_history_t
+{
+  dt_lib_filtering_rule_t *rule;
+
+  GtkWidget *combo;
+} _widgets_history_t;
+
+typedef enum _history_type_t
+{
+  _HISTORY_ALL = 0,
+  _HISTORY_BASIC,
+  _HISTORY_AUTO,
+  _HISTORY_ALTERED
+} _history_type_t;
+
+static void _history_synchronise(_widgets_history_t *source)
+{
+  _widgets_history_t *dest = NULL;
+  if(source == source->rule->w_specific_top)
+    dest = source->rule->w_specific;
+  else
+    dest = source->rule->w_specific_top;
+
+  if(dest)
+  {
+    source->rule->manual_widget_set++;
+    const int val = dt_bauhaus_combobox_get(source->combo);
+    dt_bauhaus_combobox_set(dest->combo, val);
+    source->rule->manual_widget_set--;
+  }
+}
+
+static void _history_decode(const gchar *txt, int *val)
+{
+  if(!txt || strlen(txt) == 0) return;
+
+  if(!g_strcmp0(txt, "$BASIC"))
+    *val = _HISTORY_BASIC;
+  else if(!g_strcmp0(txt, "$AUTO_APPLIED"))
+    *val = _HISTORY_AUTO;
+  else if(!g_strcmp0(txt, "$ALTERED"))
+    *val = _HISTORY_ALTERED;
+  else
+    *val = _HISTORY_ALL;
+}
+
+static void _history_changed(GtkWidget *widget, gpointer user_data)
+{
+  _widgets_history_t *history = (_widgets_history_t *)user_data;
+  if(history->rule->manual_widget_set) return;
+
+  const _history_type_t tp = dt_bauhaus_combobox_get(history->combo);
+  switch(tp)
+  {
+    case _HISTORY_ALL:
+      _rule_set_raw_text(history->rule, "", TRUE);
+      break;
+    case _HISTORY_BASIC:
+      _rule_set_raw_text(history->rule, "$BASIC", TRUE);
+      break;
+    case _HISTORY_AUTO:
+      _rule_set_raw_text(history->rule, "$AUTO_APPLIED", TRUE);
+      break;
+    case _HISTORY_ALTERED:
+      _rule_set_raw_text(history->rule, "$ALTERED", TRUE);
+      break;
+  }
+  _history_synchronise(history);
+}
+
+static gboolean _history_update(dt_lib_filtering_rule_t *rule)
+{
+  if(!rule->w_specific) return FALSE;
+  int val = _HISTORY_ALL;
+  _history_decode(rule->raw_text, &val);
+
+  rule->manual_widget_set++;
+  _widgets_history_t *history = (_widgets_history_t *)rule->w_specific;
+  dt_bauhaus_combobox_set(history->combo, val);
+  rule->manual_widget_set--;
+
+  return TRUE;
+}
+
+static void _history_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+                                 const gchar *text, dt_lib_module_t *self, const gboolean top)
+{
+  _widgets_history_t *history = (_widgets_history_t *)g_malloc0(sizeof(_widgets_history_t));
+  history->rule = rule;
+
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(history->combo, self, NULL, N_("history filter"), _("filter on history state"), 0,
+                               (GtkCallback)_history_changed, history, N_("all images"), N_("basic"),
+                               N_("auto applied"), N_("altered"));
+  DT_BAUHAUS_WIDGET(history->combo)->show_label = FALSE;
+
+  if(top)
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), history->combo, TRUE, TRUE, 0);
+  else
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box), history->combo, TRUE, TRUE, 0);
+
+  if(top)
+  {
+    dt_gui_add_class(history->combo, "dt_quick_filter");
+  }
+
+  if(top)
+    rule->w_specific_top = history;
+  else
+    rule->w_specific = history;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/libs/filters/local_copy.c
+++ b/src/libs/filters/local_copy.c
@@ -118,7 +118,6 @@ static gboolean _local_copy_update(dt_lib_filtering_rule_t *rule)
   }
   sqlite3_finalize(stmt);
 
-
   dt_bauhaus_combobox_set(local_copy->combo, val);
   rule->manual_widget_set--;
 

--- a/src/libs/filters/local_copy.c
+++ b/src/libs/filters/local_copy.c
@@ -1,0 +1,132 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  This file contains the necessary routines to implement a filter for the filtering module
+*/
+
+typedef struct _widgets_local_copy_t
+{
+  dt_lib_filtering_rule_t *rule;
+
+  GtkWidget *combo;
+} _widgets_local_copy_t;
+
+typedef enum _local_copy_type_t
+{
+  _LCP_ALL = 0,
+  _LCP_YES,
+  _LCP_NO
+} _local_copy_type_t;
+
+static void _local_copy_synchronise(_widgets_local_copy_t *source)
+{
+  _widgets_local_copy_t *dest = NULL;
+  if(source == source->rule->w_specific_top)
+    dest = source->rule->w_specific;
+  else
+    dest = source->rule->w_specific_top;
+
+  if(dest)
+  {
+    source->rule->manual_widget_set++;
+    const int val = dt_bauhaus_combobox_get(source->combo);
+    dt_bauhaus_combobox_set(dest->combo, val);
+    source->rule->manual_widget_set--;
+  }
+}
+
+static void _local_copy_decode(const gchar *txt, int *val)
+{
+  if(!txt || strlen(txt) == 0) return;
+
+  if(!g_strcmp0(txt, "$LOCAL_COPY"))
+    *val = _LCP_YES;
+  else if(!g_strcmp0(txt, "$NO_LOCAL_COPY"))
+    *val = _LCP_NO;
+  else
+    *val = _LCP_ALL;
+}
+
+static void _local_copy_changed(GtkWidget *widget, gpointer user_data)
+{
+  _widgets_local_copy_t *local_copy = (_widgets_local_copy_t *)user_data;
+  if(local_copy->rule->manual_widget_set) return;
+
+  const _local_copy_type_t tp = dt_bauhaus_combobox_get(local_copy->combo);
+  switch(tp)
+  {
+    case _LCP_ALL:
+      _rule_set_raw_text(local_copy->rule, "", TRUE);
+      break;
+    case _LCP_NO:
+      _rule_set_raw_text(local_copy->rule, "$NO_LOCAL_COPY", TRUE);
+      break;
+    case _LCP_YES:
+      _rule_set_raw_text(local_copy->rule, "$LOCAL_COPY", TRUE);
+      break;
+  }
+  _local_copy_synchronise(local_copy);
+}
+
+static gboolean _local_copy_update(dt_lib_filtering_rule_t *rule)
+{
+  if(!rule->w_specific) return FALSE;
+  int val = _LCP_ALL;
+  _local_copy_decode(rule->raw_text, &val);
+
+  rule->manual_widget_set++;
+  _widgets_local_copy_t *local_copy = (_widgets_local_copy_t *)rule->w_specific;
+  dt_bauhaus_combobox_set(local_copy->combo, val);
+  rule->manual_widget_set--;
+
+  return TRUE;
+}
+
+static void _local_copy_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+                                    const gchar *text, dt_lib_module_t *self, const gboolean top)
+{
+  _widgets_local_copy_t *local_copy = (_widgets_local_copy_t *)g_malloc0(sizeof(_widgets_local_copy_t));
+  local_copy->rule = rule;
+
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(local_copy->combo, self, NULL, N_("local_copy filter"),
+                               _("local copied state filter"), 0, (GtkCallback)_local_copy_changed, local_copy,
+                               N_("all images"), N_("copied locally"), N_("not copied locally"));
+  DT_BAUHAUS_WIDGET(local_copy->combo)->show_label = FALSE;
+
+  if(top)
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), local_copy->combo, TRUE, TRUE, 0);
+  else
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box), local_copy->combo, TRUE, TRUE, 0);
+
+  if(top)
+  {
+    dt_gui_add_class(local_copy->combo, "dt_quick_filter");
+  }
+
+  if(top)
+    rule->w_specific_top = local_copy;
+  else
+    rule->w_specific = local_copy;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/libs/filters/module_order.c
+++ b/src/libs/filters/module_order.c
@@ -1,0 +1,184 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  This file contains the necessary routines to implement a filter for the filtering module
+*/
+
+typedef struct _widgets_module_order_t
+{
+  dt_lib_filtering_rule_t *rule;
+
+  GtkWidget *combo;
+} _widgets_module_order_t;
+
+typedef enum _module_order_type_t
+{
+  _MORDER_ALL = 0,
+  _MORDER_CUSTOM,
+  _MORDER_LEGACY,
+  _MORDER_V30,
+  _MORDER_V30_JPG
+} _module_order_type_t;
+
+static char **_module_order_names = NULL;
+
+static void _module_order_synchronise(_widgets_module_order_t *source)
+{
+  _widgets_module_order_t *dest = NULL;
+  if(source == source->rule->w_specific_top)
+    dest = source->rule->w_specific;
+  else
+    dest = source->rule->w_specific_top;
+
+  if(dest)
+  {
+    source->rule->manual_widget_set++;
+    const int val = dt_bauhaus_combobox_get(source->combo);
+    dt_bauhaus_combobox_set(dest->combo, val);
+    source->rule->manual_widget_set--;
+  }
+}
+
+static void _module_order_decode(const gchar *txt, int *val)
+{
+  if(!txt || strlen(txt) == 0) return;
+
+  if(!g_strcmp0(txt, "$0"))
+    *val = _MORDER_CUSTOM;
+  else if(!g_strcmp0(txt, "$1"))
+    *val = _MORDER_LEGACY;
+  else if(!g_strcmp0(txt, "$2"))
+    *val = _MORDER_V30;
+  else if(!g_strcmp0(txt, "$3"))
+    *val = _MORDER_V30_JPG;
+  else
+    *val = _MORDER_ALL;
+}
+
+static void _module_order_changed(GtkWidget *widget, gpointer user_data)
+{
+  _widgets_module_order_t *module_order = (_widgets_module_order_t *)user_data;
+  if(module_order->rule->manual_widget_set) return;
+
+  const _module_order_type_t tp = dt_bauhaus_combobox_get(module_order->combo);
+  switch(tp)
+  {
+    case _MORDER_CUSTOM:
+      _rule_set_raw_text(module_order->rule, "$0", TRUE);
+      break;
+    case _MORDER_LEGACY:
+      _rule_set_raw_text(module_order->rule, "$1", TRUE);
+      break;
+    case _MORDER_V30:
+      _rule_set_raw_text(module_order->rule, "$2", TRUE);
+      break;
+    case _MORDER_V30_JPG:
+      _rule_set_raw_text(module_order->rule, "$3", TRUE);
+      break;
+    case _MORDER_ALL:
+      _rule_set_raw_text(module_order->rule, "", TRUE);
+      break;
+  }
+  _module_order_synchronise(module_order);
+}
+
+static gboolean _module_order_update(dt_lib_filtering_rule_t *rule)
+{
+  if(!rule->w_specific) return FALSE;
+  int val = _MORDER_ALL;
+  _module_order_decode(rule->raw_text, &val);
+
+  rule->manual_widget_set++;
+  _widgets_module_order_t *module_order = (_widgets_module_order_t *)rule->w_specific;
+  char query[1024] = { 0 };
+  // clang-format off
+  g_snprintf(query, sizeof(query),
+                   "SELECT mo.version, COUNT(*) "
+                   " FROM main.images as mi"
+                   " LEFT JOIN (SELECT imgid, version FROM main.module_order) AS mo"
+                   " ON mo.imgid = mi.id"
+                   " WHERE %s"
+                   " GROUP BY mo.version",
+                   rule->lib->last_where_ext);
+  // clang-format on
+  int counts[DT_IOP_ORDER_LAST + 1] = { 0 };
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const int count = sqlite3_column_int(stmt, 1);
+    const int v = (sqlite3_column_bytes(stmt, 0) == 0) ? DT_IOP_ORDER_LAST : sqlite3_column_int(stmt, 0);
+    counts[v] = count;
+  }
+  sqlite3_finalize(stmt);
+
+  for(int i = 0; i < DT_IOP_ORDER_LAST + 1; i++)
+  {
+    gchar *item = g_strdup_printf("%s (%d)", _(_module_order_names[i + 1]), counts[i]);
+    dt_bauhaus_combobox_set_entry_label(module_order->combo, i + 1, item);
+    g_free(item);
+  }
+
+  dt_bauhaus_combobox_set(module_order->combo, val);
+  rule->manual_widget_set--;
+
+  return TRUE;
+}
+
+static void _module_order_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+                                      const gchar *text, dt_lib_module_t *self, const gboolean top)
+{
+  _widgets_module_order_t *module_order = (_widgets_module_order_t *)g_malloc0(sizeof(_widgets_module_order_t));
+  module_order->rule = rule;
+
+  // is the table with all the order names is NULL, fill it
+  if(!_module_order_names)
+  {
+    _module_order_names = g_malloc0_n(DT_IOP_ORDER_LAST + 3, sizeof(char *));
+    _module_order_names[0] = g_strdup(N_("all images"));
+    for(int i = 0; i < DT_IOP_ORDER_LAST; i++) _module_order_names[i + 1] = g_strdup(N_(dt_iop_order_string(i)));
+
+    _module_order_names[DT_IOP_ORDER_LAST + 1] = g_strdup(N_("none"));
+  }
+  module_order->combo = dt_bauhaus_combobox_new_full(
+      DT_ACTION(self), NULL, N_("module_order filter"), _("filter images based on their module order"), 0,
+      (GtkCallback)_module_order_changed, module_order, (const char **)_module_order_names);
+  DT_BAUHAUS_WIDGET(module_order->combo)->show_label = FALSE;
+
+  if(top)
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), module_order->combo, TRUE, TRUE, 0);
+  else
+    gtk_box_pack_start(GTK_BOX(rule->w_special_box), module_order->combo, TRUE, TRUE, 0);
+
+  if(top)
+  {
+    dt_gui_add_class(module_order->combo, "dt_quick_filter");
+  }
+
+  if(top)
+    rule->w_specific_top = module_order;
+  else
+    rule->w_specific = module_order;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
This add a "grouping" filter in the new filtering module.
This is almost the same as the one in the collection module with some fix and enhancements. Here are the filters entry : 
- all images
- orphan images (the ones who are not in a "real" group)
- grouped (the ones who are in a "real" group, whatever they are leader or not)
- leader (the leaders of "real" groups)
- followers (the ones who are in a "real" group but not as the leader)

Here "real" group represent a group of more than 1 image (that's an issue with collect implementation : all images are in their own group of 1 image by default)

@dterrahe : as it use bauhaus combobox, the shortcuts are magically in place :)

@TurboGit : not sure if we want that for 4.0 or 4.2.
- If you agree with 4.0, I eventually have 2 other "straightforwards filters : history and local copy that I can add here or in another PR too)
- if you prefer to postpone for 4.2 (I don't mind) I'll update that PR with other filters as soon as they are done ;)