### PR TITLE
added padding to dt_history_items label

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1484,6 +1484,10 @@ progressbar progress
   margin: 0.14em;
 }
 
+.dt_history_items label {
+    padding: 0em .21em 0em .21em; 
+}
+
 /* then the switches */
 .dt_history_switch:disabled /* state of those switch is always disabled */
 {

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1480,12 +1480,8 @@ progressbar progress
 /* the label buttons */
 .dt_history_items
 {
-  padding: 0;
+  padding: 0em .21em 0em .21em; 
   margin: 0.14em;
-}
-
-.dt_history_items label {
-    padding: 0em .21em 0em .21em; 
 }
 
 /* then the switches */
@@ -1500,7 +1496,7 @@ progressbar progress
 /* and the history number */
 #history-number
 {
-  padding-right: 0.35em;
+  padding: 0 0.35em 0 0;
 }
 
 /* deactivated switch buttons, make them less visible */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1467,7 +1467,7 @@ progressbar progress
 /* then set infos shown on top of the image on darkroom, like for example opacity in drawn masks */
 .top .dt_messages
 {
-  border-radius: 0 0 0.56em 0.56em;
+border-radius: 0 0 0.56em 0.56em;
 }
 
 /* Set some specific fonts */


### PR DESCRIPTION
i added this change before but looks like since then there where many changes to the theme and might of got lost anyways not sure, i added some left and right padding to the history items label 

before

![dtbf](https://user-images.githubusercontent.com/1070310/166866366-19453e28-abf5-4860-871c-3f2fdbb91d3a.png)

after

![dtpa](https://user-images.githubusercontent.com/1070310/166866354-49bd0dd9-9e6d-40d2-990a-272fc69e8da7.png)


