### PR TITLE
range : fix set bounds min-max value

### DIFF
--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1540,13 +1540,12 @@ static gboolean _event_band_press(GtkWidget *w, GdkEventButton *e, gpointer user
     if(range->mouse_inside == HOVER_MAX)
     {
       range->bounds &= ~DT_RANGE_BOUND_MAX;
-      range->select_min_r += 0.0001;
       range->select_max_r = pos_r;
     }
     else if(range->mouse_inside == HOVER_MIN)
     {
       range->bounds &= ~DT_RANGE_BOUND_MIN;
-      range->select_min_r = range->select_max_r + 0.0001;
+      range->select_min_r = range->select_max_r;
       range->select_max_r = pos_r;
     }
     else if(dt_modifier_is(e->state, GDK_SHIFT_MASK))


### PR DESCRIPTION
this fix an issue raised here : https://github.com/darktable-org/darktable/issues/11747#issuecomment-1120217576
where if we set a rating range, say 2->4 and we want to move the max bound, the star n°2 is not filled anymore...