### PR TITLE
Spelling of grayscale as one word is much more common

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1318,7 +1318,7 @@
     <type>
       <enum>
         <option>false color</option>
-        <option>gray scale</option>
+        <option>grayscale</option>
       </enum>
     </type>
     <default>false color</default>


### PR DESCRIPTION
See https://books.google.com/ngrams/graph?content=grayscale+image%2Cgray+scale+image