### PR TITLE
add an import option to remove imported images from camera

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -939,6 +939,13 @@
     <longdescription>when having raw+JPEG images together in one directory it makes no sense to import both. with this flag one can ignore all JPEGs found.</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
+    <name>ui_last/import_delete_imported</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>delete imported images</shortdescription>
+    <longdescription>automatically delete imported images from camera, so that you haven't to delete them manually</longdescription>
+  </dtconfig>
+  <dtconfig ui="yes">
     <name>ui_last/import_apply_metadata</name>
     <type>bool</type>
     <default>false</default>

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1159,9 +1159,22 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
     }
 
     if(!g_file_set_contents(output, data, size, NULL))
-       dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to write file %s\n", output);
+    {
+      dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to write file %s\n", output);
+    }
     else
+    {
+      if(dt_conf_get_bool("ui_last/import_delete_imported"))
+      {
+        // delete the file in camera
+        if((res = gp_camera_file_delete(cam->gpcam, folder, filename, NULL)) < GP_OK)
+        {
+          dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to delete image in camera: %s\n", gp_result_as_string(res));
+        }
+      }
+
       _dispatch_camera_image_downloaded(c, cam, folder, filename, output);
+    }
 
     gp_file_free(camfile);
     g_free(prev_output);
@@ -2052,4 +2065,3 @@ static void _dispatch_camera_error(const dt_camctl_t *c, const dt_camera_t *came
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1750,8 +1750,12 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   }
   GtkWidget *ignore_jpegs = dt_gui_preferences_bool(grid, "ui_last/import_ignore_jpegs", col++, line, TRUE);
   gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
-  d->delete_imported = dt_gui_preferences_bool(grid, "ui_last/import_delete_imported", col++, line, TRUE);
-  gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line++), TRUE);
+  if(d->import_case == DT_IMPORT_CAMERA)
+  {
+    d->delete_imported = dt_gui_preferences_bool(grid, "ui_last/import_delete_imported", col++, line, TRUE);
+    gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
+  }
+  line++;
   g_signal_connect(G_OBJECT(ignore_jpegs), "toggled", G_CALLBACK(_ignore_jpegs_toggled), self);
   gtk_box_pack_start(GTK_BOX(rbox), GTK_WIDGET(grid), FALSE, FALSE, 8);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -130,7 +130,7 @@ typedef struct dt_lib_import_t
   GtkButton *mount_camera;
   GtkButton *unmount_camera;
 
-  GtkWidget *ignore_exif, *rating, *apply_metadata, *recursive;
+  GtkWidget *ignore_exif, *delete_imported, *rating, *apply_metadata, *recursive;
   GtkWidget *import_new;
   dt_import_metadata_t metadata;
   GtkBox *devices;
@@ -1749,6 +1749,8 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
     g_signal_connect(G_OBJECT(d->recursive), "toggled", G_CALLBACK(_recursive_toggled), self);
   }
   GtkWidget *ignore_jpegs = dt_gui_preferences_bool(grid, "ui_last/import_ignore_jpegs", col++, line, TRUE);
+  gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line), TRUE);
+  d->delete_imported = dt_gui_preferences_bool(grid, "ui_last/import_delete_imported", col++, line, TRUE);
   gtk_widget_set_hexpand(gtk_grid_get_child_at(grid, col++, line++), TRUE);
   g_signal_connect(G_OBJECT(ignore_jpegs), "toggled", G_CALLBACK(_ignore_jpegs_toggled), self);
   gtk_box_pack_start(GTK_BOX(rbox), GTK_WIDGET(grid), FALSE, FALSE, 8);
@@ -2067,6 +2069,7 @@ const struct
   int type;
 } _pref[] = {
   {"ui_last/import_ignore_jpegs",       "ignore_jpegs",       DT_BOOL},
+  {"ui_last/import_delete_imported",    "delete_imported",    DT_BOOL},
   {"ui_last/import_apply_metadata",     "apply_metadata",     DT_BOOL},
   {"ui_last/import_recursive",          "recursive",          DT_BOOL},
   {"ui_last/ignore_exif_rating",        "ignore_exif_rating", DT_BOOL},
@@ -2282,4 +2285,3 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
I think this is a good enhancement to darktable: the new option works exactly like in gthumb, and is saved across sessions.

Selecting the new checkbox, the imported images will be deleted from the camera during the import loop. Clearly: only if the import of the image has completed correctly.

If the new checkbox isn't selected (default), darktable will work exactly as before.

Fixes #11769