### PR TITLE
Import metadata from commonly used keys

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1199,13 +1199,18 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     }
 
     // FIXME: Should the UserComment go into the description? Or do we need an extra field for this?
-    if(FIND_EXIF_TAG("Exif.Photo.UserComment") || FIND_EXIF_TAG("Exif.Image.ImageDescription"))
+    if(FIND_EXIF_TAG("Exif.Photo.UserComment"))
     {
       std::string str = pos->print(&exifData);
       Exiv2::CommentValue value(str);
       std::string str2 = value.comment();
       if(str2 != "binary comment")
         dt_metadata_set_import(img->id, "Xmp.dc.description", str2.c_str());
+    }
+    else if(FIND_EXIF_TAG("Exif.Image.ImageDescription"))
+    {
+      std::string str = pos->print(&exifData);
+      dt_metadata_set_import(img->id, "Xmp.dc.description", str.c_str());
     }
 
     if(FIND_EXIF_TAG("Exif.Image.Copyright"))

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -688,9 +688,7 @@ static bool _exif_decode_iptc_data(dt_image_t *img, Exiv2::IptcData &iptcData)
     }
     if(FIND_IPTC_TAG("Iptc.Application2.DateCreated"))
     {
-      char *date = strdup(pos->toString().c_str());
-      GString *datetime = g_string_new(date);
-      free(date);
+      GString *datetime = g_string_new(pos->toString().c_str());
 
       // FIXME: Workaround for exiv2 reading partial IPTC DateCreated in YYYYMMDD format
       if(g_regex_match_simple("^\\d{8}$", datetime->str, (GRegexCompileFlags)0, (GRegexMatchFlags)0))

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -598,7 +598,7 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
     }
 
     /* read timestamp from Xmp.exif.DateTimeOriginal */
-    if(FIND_XMP_TAG("Xmp.exif.DateTimeOriginal"))
+    if(FIND_XMP_TAG("Xmp.exif.DateTimeOriginal") || FIND_XMP_TAG("Xmp.photoshop.DateCreated"))
     {
       char *datetime = strdup(pos->toString().c_str());
       _sanitize_datetime(datetime);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -671,7 +671,12 @@ static bool _exif_decode_iptc_data(dt_image_t *img, Exiv2::IptcData &iptcData)
       std::string str = pos->print(/*&iptcData*/);
       dt_metadata_set_import(img->id, "Xmp.dc.rights", str.c_str());
     }
-    if(FIND_IPTC_TAG("Iptc.Application2.Writer"))
+    if(FIND_IPTC_TAG("Iptc.Application2.Byline"))
+    {
+      std::string str = pos->print(/*&iptcData*/);
+      dt_metadata_set_import(img->id, "Xmp.dc.creator", str.c_str());
+    }
+    else if(FIND_IPTC_TAG("Iptc.Application2.Writer"))
     {
       std::string str = pos->print(/*&iptcData*/);
       dt_metadata_set_import(img->id, "Xmp.dc.creator", str.c_str());

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -681,6 +681,30 @@ static bool _exif_decode_iptc_data(dt_image_t *img, Exiv2::IptcData &iptcData)
       std::string str = pos->print(/*&iptcData*/);
       dt_metadata_set_import(img->id, "Xmp.dc.creator", str.c_str());
     }
+    if(FIND_IPTC_TAG("Iptc.Application2.DateCreated"))
+    {
+      char *date = strdup(pos->toString().c_str());
+      GString *datetime = g_string_new(date);
+      free(date);
+
+      // FIXME: Workaround for exiv2 reading partial IPTC DateCreated in YYYYMMDD format
+      if(g_regex_match_simple("^\\d{8}$", datetime->str, (GRegexCompileFlags)0, (GRegexMatchFlags)0))
+      {
+        datetime = g_string_insert_c(datetime, 6, ':');
+        datetime = g_string_insert_c(datetime, 4, ':');
+      }
+
+      if(FIND_IPTC_TAG("Iptc.Application2.TimeCreated"))
+      {
+        char *time = strndup(pos->toString().c_str(), 8); // remove timezone at the end
+        datetime = g_string_append(datetime, " ");
+        datetime = g_string_append(datetime, time);
+        free(time);
+      }
+      _sanitize_datetime(datetime->str);
+      dt_datetime_exif_to_img(img, datetime->str);
+      g_string_free(datetime, TRUE);
+    }
 
     return true;
   }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1196,7 +1196,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     }
 
     // FIXME: Should the UserComment go into the description? Or do we need an extra field for this?
-    if(FIND_EXIF_TAG("Exif.Photo.UserComment"))
+    if(FIND_EXIF_TAG("Exif.Photo.UserComment") || FIND_EXIF_TAG("Exif.Image.ImageDescription"))
     {
       std::string str = pos->print(&exifData);
       Exiv2::CommentValue value(str);


### PR DESCRIPTION
Read datetime, description and creator from commonly used metadata keys. [(IPTC Photo Metadata Mapping Guidelines)](https://iptc.org/std/photometadata/documentation/mappingguidelines/#the-mappings)

My original use case was to get datetime for images that didn't have Exif information. I added a few more keys that came up when reading the IPTC guide. The most significant change is in reading _creator_ value from IPTC IIM. _By-line_ is preferred over _Writer/Editor_. This is what I would expect based on the description of the keys.

- _2:122 Writer/Editor_, Identification of the name of the person involved in the writing,
editing or correcting the objectdata or caption/abstract.
- _2:80 By-line_, Contains name of the creator of the objectdata, e.g. writer, pho-
tographer or graphic artist. [(IPTC - NAA INFORMATION INTERCHANGE MODEL)](https://iptc.org/std/IIM/4.2/specification/IIMV4.2.pdf)

Time zone information in IIM _TimeCreated_ is just removed. This is not good but dt doesn't handle time zone at the moment so this is a separate issue.