### PR TITLE
Support compiling for RISC-V 64 architecture

### DIFF
--- a/src/common/cpuid.c
+++ b/src/common/cpuid.c
@@ -76,6 +76,12 @@ dt_cpu_flags_t dt_detect_cpu_features()
   g_mutex_unlock(&lock);
   return cpuflags;
 }
+#elif defined(__riscv) && __riscv_xlen == 64
+dt_cpu_flags_t dt_detect_cpu_features()
+{
+  static dt_cpu_flags_t cpuflags = 0;
+  return cpuflags;
+}
 #else
 dt_cpu_flags_t dt_detect_cpu_features()
 {

--- a/src/is_supported_platform.h
+++ b/src/is_supported_platform.h
@@ -48,7 +48,7 @@
 #define DT_SUPPORTED_RISCV64 0
 #endif
 
-#if DT_SUPPORTED_X86 && DT_SUPPORTED_ARMv8A && DT_SUPPORTED_PPC64 && DT_SUPPORTED_RISCV64
+#if (DT_SUPPORTED_X86 + DT_SUPPORTED_ARMv8A + DT_SUPPORTED_PPC64 + DT_SUPPORTED_RISCV64) > 1
 #error "Looks like hardware platform detection macros are broken?"
 #endif
 


### PR DESCRIPTION
This PR makes the project able to compile for RISC-V 64 architecture.

I only confirmed that it compiles ok on Arch Linux RISC-V with [build script](https://github.com/archlinux/svntogit-community/blob/5e139631db51a3ed40611cfc589a77ba8d4aab33/trunk/PKGBUILD), but did not test if it works properly.