### PR TITLE
collect : ensure proper initialisation of history visibility

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1129,6 +1129,7 @@ static gchar *_get_lib_view_path(dt_lib_module_t *module, char *suffix)
 {
   if(!darktable.view_manager) return NULL;
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if(!cv) return NULL;
   // in lighttable, we store panels states per layout
   char lay[32] = "";
   if(g_strcmp0(cv->module_name, "lighttable") == 0)
@@ -1160,7 +1161,7 @@ void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible)
 {
   gchar *key = _get_lib_view_path(module, "_visible");
   GtkWidget *widget;
-  dt_conf_set_bool(key, visible);
+  if(key) dt_conf_set_bool(key, visible);
   g_free(key);
   if(module->widget)
   {

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -384,6 +384,8 @@ static void _update_visibility(dt_lib_module_t *self)
 {
   const gboolean hide = dt_conf_get_bool("plugins/lighttable/recentcollect/hide");
   dt_lib_set_visible(self, !hide);
+  // in case dt is starting, we need to set the visible value ourself
+  dt_conf_set_bool("plugins/lighttable/1/recentcollect_visible", !hide);
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -419,6 +421,7 @@ void gui_init(dt_lib_module_t *self)
 
   darktable.view_manager->proxy.module_recentcollect.module = self;
   darktable.view_manager->proxy.module_recentcollect.update_visibility = _update_visibility;
+  _update_visibility(self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)


### PR DESCRIPTION
this fix the visibility of the history btn / recent module at first start in the case where recent collect is loaded after collect.