### PR TITLE
range : reset bounds correctly when typing in entries

### DIFF
--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -657,12 +657,17 @@ static void _bound_change(GtkDarktableRangeSelect *range, const gchar *val, cons
     {
       if(bound == BOUND_MIN)
       {
-        if(range->bounds & DT_RANGE_BOUND_MAX) range->bounds = DT_RANGE_BOUND_MAX;
+        range->bounds &= ~DT_RANGE_BOUND_MIN;
+        range->bounds &= ~DT_RANGE_BOUND_MIN_RELATIVE;
+        range->bounds &= ~DT_RANGE_BOUND_FIXED;
         range->select_min_r = v;
       }
       else if(bound == BOUND_MAX)
       {
-        if(range->bounds & DT_RANGE_BOUND_MIN) range->bounds = DT_RANGE_BOUND_MIN;
+        range->bounds &= ~DT_RANGE_BOUND_MAX;
+        range->bounds &= ~DT_RANGE_BOUND_MAX_RELATIVE;
+        range->bounds &= ~DT_RANGE_BOUND_MAX_NOW;
+        range->bounds &= ~DT_RANGE_BOUND_FIXED;
         range->select_max_r = v;
       }
       else if(bound == BOUND_MIDDLE)


### PR DESCRIPTION
This fix an issue when changing directly the range value by typing in the entries : 
- Add a "capture time" filter (works with other filters too)
- ensure that the current values in the entries are "min" and "max" Otherwise double-click on the band to set them like that
- change the "min" entry by anything valid (ex : `2021:05`) and validate by pressing enter or clicking outside the entry
- change the "max" entry by anything valid (ex : `2022:01`) and validate by pressing enter or clicking outside the entry
- see that the value are immediately returning to "max"
- same can be reproduced by changing the second entry first, then the first one
