### PR TITLE
filters : always show the pin icon

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -462,7 +462,8 @@ separator
   opacity: 0.6;
 }
 
-.dt_dimmed:hover /* to set full opacity when hovering those items */
+.dt_dimmed:hover, /* to set full opacity when hovering those items */
+.dt_dimmed:checked
 {
   opacity: 1;
 }
@@ -1327,6 +1328,12 @@ filechooser row:hover .sidebar-icon
 #range-current
 {
   padding: 0.2em;
+}
+
+#collect-header-box button
+{
+  margin-left: 0;
+  margin-right: 0;
 }
 
 /*------------


### PR DESCRIPTION
considering the recent feedbacks, there's clearly a need for more obvious way to pin filter into the top bar.
Here is a first step, by making the pin icon always visible, and not "hidden" under ctrl-click.
For the close and disable btn, they are only shown for un-pin rules, as a rule can't be removed or disabled when pinned (this is explained in the tooltips)

Here's a screenshot (first rule is pinned, not the second one) :
![Capture d’écran_2022-05-15_15-44-00](https://user-images.githubusercontent.com/1818223/168476230-ecb65a71-fda2-4b16-9a79-eaf24d295a92.png)