### PR TITLE
Better CSS code for buttons in widget filters

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1586,7 +1586,7 @@ treeview *:checked:not(check)
 /* History currently selected button ; they don't need to set background */
 .dt_history_items:active *,
 .dt_history_items:checked *,
-button.dt_transparent_background:checked:not(:disabled)
+button.dt_transparent_background:checked:not(:disabled):not(.dt_ignore_fg_state)
 {
   color: @field_selected_fg;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1333,12 +1333,6 @@ filechooser row:hover .sidebar-icon
 #collect-header-box button
 {
   margin-left: 0;
-  margin-right: 0;
-}
-
-#collect-header-box button:disabled
-{
-  color: @disabled_fg_color;
 }
 
 /*------------
@@ -1571,7 +1565,7 @@ progressbar progress
 .dt_history_items:active,
 .dt_history_items:checked,
 button:active,
-button:checked,
+button:checked:not(:disabled):not(.dt_transparent_background),
 button:selected,
 cell:selected,
 checkbutton check:checked,
@@ -1591,7 +1585,8 @@ treeview *:checked:not(check)
 
 /* History currently selected button ; they don't need to set background */
 .dt_history_items:active *,
-.dt_history_items:checked *
+.dt_history_items:checked *,
+button.dt_transparent_background:checked:not(:disabled)
 {
   color: @field_selected_fg;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1332,7 +1332,7 @@ filechooser row:hover .sidebar-icon
 
 #collect-header-box button
 {
-  margin-left: 0;
+  margin-right: 0;
 }
 
 /*------------

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2180,6 +2180,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
       sl->polarity = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, 0, NULL);
       dt_gui_add_class(sl->polarity, "dt_ignore_fg_state");
+      dt_gui_add_class(sl->polarity, "dt_transparent_background");
       gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
       gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
 


### PR DESCRIPTION
This optimize code and just add a little left margin (set back default left margin set to 0.07em) to have little space when hovering icons.

This fix also not wanted background on dt_transparent_background icons (like on/off here). Was previous wanted behavior I just see that I broke in my last CSS work (on darkroom modules and so on those widget filters).

@AlicVB and @TurboGit: please check as I've just copy/paste code tested on my side (on darktable master from OBS repository) directly here on github website.