### PR TITLE
colors filter: restore last state equivalent

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1378,12 +1378,12 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         // clang-format on
       else
       {
-        // test the "integer" case (used by filters)
-        const int val = atoi(escaped_text);
-        if(val != 0 || !g_strcmp0(escaped_text, "0"))
+        // test the "mask" case (used by filters)
+        if(g_str_has_prefix(text, "0x"))
         {
-          const int colors_set = val & 0xFF;
-          const int colors_unset = (val & 0xFF00) >> 8;
+          const int val = strtol(&escaped_text[2], NULL, 16);
+          const int colors_set = val & 0xFFF;
+          const int colors_unset = (val & 0xFFF000) >> 12;
           const gboolean op = val & 0x80000000;
           if(op) // AND
           {

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -22,6 +22,11 @@
 
 #define CPF_USER_DATA_INCLUDE CPF_USER_DATA
 #define CPF_USER_DATA_EXCLUDE CPF_USER_DATA << 1
+#define CL_AND_MASK 0x80000000
+#define CL_ALL_EXCLUDED 0x1F000       // all excluded but grey
+#define CL_GREY_EXCLUDED 0x20000      // grey excluded
+#define CL_ALL_INCLUDED 0x1F          // all included but grey
+#define CL_GREY_INCLUDED 0x20         // grey included
 
 typedef struct _widgets_colors_t
 {
@@ -31,171 +36,78 @@ typedef struct _widgets_colors_t
   GtkWidget *operator;
 } _widgets_colors_t;
 
-static void _colors_update_last_label(_widgets_colors_t *colors)
+static gboolean _colors_update(dt_lib_filtering_rule_t *rule);
+static int _get_mask(const char *text)
 {
-  gboolean all_sel = TRUE;
-  gboolean all_unsel = TRUE;
-  for(int i = 0; i < DT_COLORLABELS_LAST; i++)
-  {
-    const int sel_value = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(colors->colors[i]), "sel_value"));
-    if(sel_value == 1)
-    {
-      all_unsel = FALSE;
-    }
-    else if(sel_value == 2)
-    {
-      all_sel = FALSE;
-    }
-    else
-    {
-      all_sel = FALSE;
-      all_unsel = FALSE;
-    }
-  }
-  // we update the last button
-  int mask = DT_COLORLABELS_LAST;
-  if(all_sel)
-    mask |= CPF_USER_DATA_INCLUDE;
-  else if(all_unsel)
-    mask |= CPF_USER_DATA_EXCLUDE;
-
-  const int sel_value = all_sel ? 1 : (all_unsel ? 2 : 0);
-  g_object_set_data(G_OBJECT(colors->colors[DT_COLORLABELS_LAST]), "sel_value", GINT_TO_POINTER(sel_value));
-  dtgtk_button_set_paint(DTGTK_BUTTON(colors->colors[DT_COLORLABELS_LAST]), dtgtk_cairo_paint_label_sel, mask,
-                         NULL);
-  gtk_widget_queue_draw(colors->colors[DT_COLORLABELS_LAST]);
-}
-
-static void _colors_synchronise(_widgets_colors_t *source)
-{
-  _widgets_colors_t *dest = NULL;
-  if(source == source->rule->w_specific_top)
-    dest = source->rule->w_specific;
+  if(g_str_has_prefix(text, "0x"))
+    return strtol(&text[2], NULL, 16);
   else
-    dest = source->rule->w_specific_top;
-
-  if(dest)
-  {
-    source->rule->manual_widget_set++;
-    for(int k = 0; k < DT_COLORLABELS_LAST; k++)
-    {
-      const int sel_value = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(source->colors[k]), "sel_value"));
-      g_object_set_data(G_OBJECT(dest->colors[k]), "sel_value", GINT_TO_POINTER(sel_value));
-      GtkDarktableButton *bt = DTGTK_BUTTON(source->colors[k]);
-      dtgtk_button_set_paint(DTGTK_BUTTON(dest->colors[k]), dtgtk_cairo_paint_label_sel, bt->icon_flags, NULL);
-      gtk_widget_queue_draw(dest->colors[k]);
-    }
-
-    _colors_update_last_label(dest);
-
-    const gboolean and_op = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(source->operator), "sel_value"));
-    g_object_set_data(G_OBJECT(dest->operator), "sel_value", GINT_TO_POINTER(and_op));
-    dtgtk_button_set_paint(DTGTK_BUTTON(dest->operator), and_op ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0,
-                           NULL);
-    gtk_widget_set_sensitive(dest->operator, gtk_widget_get_sensitive(source->operator));
-    gtk_widget_queue_draw(dest->operator);
-    source->rule->manual_widget_set--;
-  }
+    return 0;
 }
 
-static void _colors_changed(GtkWidget *widget, gpointer user_data)
+static void _set_mask(dt_lib_filtering_rule_t *rule , const int mask, const gboolean signal)
 {
-  _widgets_colors_t *colors = (_widgets_colors_t *)user_data;
-  if(colors->rule->manual_widget_set) return;
-
-  int nb = 0;
-  int mask = 0;
-
-  for(int k = 0; k < DT_COLORLABELS_LAST; k++)
-  {
-    const int sel_value = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(colors->colors[k]), "sel_value"));
-    if(sel_value)
-    {
-      nb++;
-      mask = sel_value == 1 ? (mask | 1 << k) : (mask | 1 << (8 + k));
-    }
-  }
-
-  const gboolean and_op = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(colors->operator), "sel_value"));
-  dtgtk_button_set_paint(DTGTK_BUTTON(colors->operator), and_op ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0,
-                         NULL);
-  gtk_widget_set_sensitive(colors->operator, nb> 1);
-
-  _colors_update_last_label(colors);
-
-  if(and_op || nb <= 1) mask |= 0x80000000;
-
-  gchar *txt = g_strdup_printf("%d", mask);
-  _rule_set_raw_text(colors->rule, txt, TRUE);
+  gchar *txt = g_strdup_printf("0x%x", mask);
+  _rule_set_raw_text(rule, txt, signal);
   g_free(txt);
 }
 
-static gboolean _colors_clicked(GtkWidget *w, GdkEventButton *e, gpointer user_data)
+static gboolean _colors_clicked(GtkWidget *w, GdkEventButton *e, _widgets_colors_t *colors)
 {
-  _widgets_colors_t *colors = g_object_get_data(G_OBJECT(w), "colors_self");
-  const int k = GPOINTER_TO_INT(user_data);
-
-  int sel_value = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sel_value"));
-  if(sel_value)
-    sel_value = 0;
-  else if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
-    sel_value = 2;
-  else if(dt_modifier_is(e->state, 0))
-    sel_value = 1;
-  const int mask = sel_value == 0 ? 0 : sel_value == 1 ? CPF_USER_DATA_INCLUDE : CPF_USER_DATA_EXCLUDE;
-
+  dt_lib_filtering_rule_t *rule = colors->rule;
+  const int mask = _get_mask(rule->raw_text);
+  const int k = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "colors_index"));
+  const int mask_k = (1 << k) | (1 << (k + 12));
+  int new_mask = mask_k;
   if(k == DT_COLORLABELS_LAST)
   {
-    g_object_set_data(G_OBJECT(colors->colors[DT_COLORLABELS_LAST]), "sel_value", GINT_TO_POINTER(sel_value));
-    for(int i = 0; i < DT_COLORLABELS_LAST; i++)
-    {
-      g_object_set_data(G_OBJECT(colors->colors[i]), "sel_value", GINT_TO_POINTER(sel_value));
-      dtgtk_button_set_paint(DTGTK_BUTTON(colors->colors[i]), dtgtk_cairo_paint_label_sel, (i | mask), NULL);
-      gtk_widget_queue_draw(colors->colors[i]);
-    }
+    if(mask & mask_k)
+      new_mask = 0;
+    else if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
+      new_mask = CL_ALL_EXCLUDED | CL_GREY_EXCLUDED;
+    else if(dt_modifier_is(e->state, 0))
+      new_mask = CL_ALL_INCLUDED | CL_GREY_INCLUDED;
+    new_mask |= (mask & CL_AND_MASK);
   }
   else
   {
-    g_object_set_data(G_OBJECT(colors->colors[DT_COLORLABELS_LAST]), "sel_value", GINT_TO_POINTER(0));
-    g_object_set_data(G_OBJECT(w), "sel_value", GINT_TO_POINTER(sel_value));
-    dtgtk_button_set_paint(DTGTK_BUTTON(w), dtgtk_cairo_paint_label_sel, (k | mask), NULL);
-    gtk_widget_queue_draw(w);
+    if(mask & mask_k)
+      new_mask = 0;
+    else if(dt_modifier_is(e->state, GDK_CONTROL_MASK))
+      new_mask = 1 << (k + 12);
+    else if(dt_modifier_is(e->state, 0))
+      new_mask = 1 << k;
+    new_mask |= (mask & ~mask_k);
   }
 
-  _colors_changed(w, colors);
-  _colors_synchronise(colors);
+  if((new_mask & CL_ALL_EXCLUDED) == CL_ALL_EXCLUDED)
+    new_mask |= CL_GREY_EXCLUDED;
+  else
+    new_mask &= ~CL_GREY_EXCLUDED;
+  if((new_mask & CL_ALL_INCLUDED) == CL_ALL_INCLUDED)
+    new_mask |= CL_GREY_INCLUDED;
+  else
+    new_mask &= ~CL_GREY_INCLUDED;
+
+  _set_mask(colors->rule, new_mask, TRUE);
+  _colors_update(rule);
   return FALSE;
 }
 
 static void _colors_operator_clicked(GtkWidget *w, _widgets_colors_t *colors)
 {
-  const gboolean and_op = !GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sel_value"));
-  g_object_set_data(G_OBJECT(w), "sel_value", GINT_TO_POINTER(and_op));
-  dtgtk_button_set_paint(DTGTK_BUTTON(w), and_op ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0, NULL);
-  gtk_widget_queue_draw(w);
-  _colors_changed(w, colors);
-  _colors_synchronise(colors);
-}
-
-static void _colors_reset(_widgets_colors_t *colors)
-{
-  for(int i = 0; i < DT_COLORLABELS_LAST; i++)
-  {
-    g_object_set_data(G_OBJECT(colors->colors[i]), "sel_value", GINT_TO_POINTER(0));
-    dtgtk_button_set_paint(DTGTK_BUTTON(colors->colors[i]), dtgtk_cairo_paint_label_sel, i, NULL);
-    gtk_widget_queue_draw(colors->colors[i]);
-  }
-  g_object_set_data(G_OBJECT(colors->operator), "sel_value", GINT_TO_POINTER(1));
-  dtgtk_button_set_paint(DTGTK_BUTTON(colors->operator), dtgtk_cairo_paint_and, 0, NULL);
-  gtk_widget_set_sensitive(colors->operator, FALSE);
+  dt_lib_filtering_rule_t *rule = colors->rule;
+  const int mask = _get_mask(rule->raw_text);
+  _set_mask(colors->rule, mask ^ CL_AND_MASK, TRUE);
+  _colors_update(rule);
 }
 
 static gchar *_colors_pretty_print(const gchar *raw_txt)
 {
   gchar *txt = NULL;
-  const int val = atoi(raw_txt);
-  const int colors_set = val & 0xFF;
-  const int colors_unset = (val & 0xFF00) >> 8;
+  const int val = _get_mask(raw_txt);
+  const int colors_set = val & (CL_ALL_INCLUDED | CL_GREY_INCLUDED);
+  const int colors_unset = (val & (CL_ALL_EXCLUDED | CL_GREY_EXCLUDED)) >> 12;
   // we update the colors icons
   int nb = 0;
   for(int i = 0; i < DT_COLORLABELS_LAST; i++)
@@ -253,60 +165,40 @@ static gboolean _colors_update(dt_lib_filtering_rule_t *rule)
   rule->manual_widget_set++;
   _widgets_colors_t *colors = (_widgets_colors_t *)rule->w_specific;
   _widgets_colors_t *colorstop = (_widgets_colors_t *)rule->w_specific_top;
-  const int val = atoi(rule->raw_text);
-  const int colors_set = val & 0xFF;
-  const int colors_unset = (val & 0xFF00) >> 8;
-  const gboolean op = val & 0x80000000;
-  // we update the colors icons
-  int nb = 0;
-  for(int i = 0; i < DT_COLORLABELS_LAST; i++)
-  {
-    const int id = 1 << i;
-    int mask = 0;
-    int sel_value = 0;
-    if(colors_set & id)
-    {
-      mask = CPF_USER_DATA_INCLUDE;
-      sel_value = 1;
-      nb++;
-    }
-    else if(colors_unset & id)
-    {
-      mask = CPF_USER_DATA_EXCLUDE;
-      sel_value = 2;
-      nb++;
-    }
 
-    g_object_set_data(G_OBJECT(colors->colors[i]), "sel_value", GINT_TO_POINTER(sel_value));
-    dtgtk_button_set_paint(DTGTK_BUTTON(colors->colors[i]), dtgtk_cairo_paint_label_sel, (i | mask), NULL);
+  const int mask = _get_mask(rule->raw_text);
+  int mask_excluded = 0x1000;
+  int mask_included = 1;
+  int nb = 0;
+  for(int i = 0; i <= DT_COLORLABELS_LAST; i++)
+  {
+    const int i_mask = mask & mask_excluded ? CPF_USER_DATA_EXCLUDE : mask & mask_included ? CPF_USER_DATA_INCLUDE : 0;
+    dtgtk_button_set_paint(DTGTK_BUTTON(colors->colors[i]), dtgtk_cairo_paint_label_sel, (i | i_mask), NULL);
     gtk_widget_queue_draw(colors->colors[i]);
     if(colorstop)
     {
-      g_object_set_data(G_OBJECT(colorstop->colors[i]), "sel_value", GINT_TO_POINTER(sel_value));
-      dtgtk_button_set_paint(DTGTK_BUTTON(colorstop->colors[i]), dtgtk_cairo_paint_label_sel, (i | mask), NULL);
+      dtgtk_button_set_paint(DTGTK_BUTTON(colorstop->colors[i]), dtgtk_cairo_paint_label_sel, (i | i_mask), NULL);
       gtk_widget_queue_draw(colorstop->colors[i]);
     }
+    if((mask & mask_excluded) || (mask & mask_included))
+      nb++;
+    mask_excluded <<= 1;
+    mask_included <<= 1;
   }
-  // we update the last button
-  _colors_update_last_label(colors);
-  if(colorstop) _colors_update_last_label(colorstop);
-
-  // we update the operator
-  g_object_set_data(G_OBJECT(colors->operator), "sel_value", GINT_TO_POINTER(op));
-  dtgtk_button_set_paint(DTGTK_BUTTON(colors->operator), op ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0,
-                         NULL);
+  if(nb <= 1)
+    _set_mask(colors->rule, mask | CL_AND_MASK, FALSE);
+  dtgtk_button_set_paint(DTGTK_BUTTON(colors->operator),
+                         (mask & CL_AND_MASK) ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0, NULL);
+  gtk_widget_set_sensitive(colors->operator, nb > 1);
   gtk_widget_queue_draw(colors->operator);
-  gtk_widget_set_sensitive(colors->operator, nb> 1);
   if(colorstop)
   {
-    g_object_set_data(G_OBJECT(colorstop->operator), "sel_value", GINT_TO_POINTER(op));
-    dtgtk_button_set_paint(DTGTK_BUTTON(colorstop->operator), op ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0,
-                           NULL);
+    dtgtk_button_set_paint(DTGTK_BUTTON(colorstop->operator),
+                           (mask & CL_AND_MASK) ? dtgtk_cairo_paint_and : dtgtk_cairo_paint_or, 0, NULL);
+    gtk_widget_set_sensitive(colorstop->operator, nb > 1);
     gtk_widget_queue_draw(colorstop->operator);
-    gtk_widget_set_sensitive(colorstop->operator, nb> 1);
   }
 
-  _colors_synchronise(colors);
   rule->manual_widget_set--;
 
   return TRUE;
@@ -324,26 +216,36 @@ static float _action_process_colors(gpointer target, dt_action_element_t element
 
   _widgets_colors_t *colors = g_object_get_data(G_OBJECT(target), "colors_self");
   GtkWidget *w = element ? colors->colors[element - 1] : colors->operator;
-  int sel_value = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sel_value"));
+  dt_lib_filtering_rule_t *rule = colors->rule;
+  const int mask_k = (1 << (element - 1)) | (1 << (element - 1 + 12));
+  int mask = _get_mask(rule->raw_text) & (element ? mask_k : CL_AND_MASK);
 
   if(!isnan(move_size))
   {
     GdkEventButton e = { .state = effect == DT_ACTION_EFFECT_TOGGLE_CTRL ? GDK_CONTROL_MASK : 0 };
 
-    if((!sel_value || (effect != DT_ACTION_EFFECT_ON && effect != DT_ACTION_EFFECT_ON_CTRL))
-       && (sel_value || effect != DT_ACTION_EFFECT_OFF))
+    if((!mask || (effect != DT_ACTION_EFFECT_ON && effect != DT_ACTION_EFFECT_ON_CTRL))
+       && (mask || effect != DT_ACTION_EFFECT_OFF))
     {
       if(element)
-        _colors_clicked(w, &e, GINT_TO_POINTER(element - 1));
+        _colors_clicked(w, &e, colors);
       else
         _colors_operator_clicked(w, colors);
     }
 
-    sel_value = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "sel_value"));
+    mask = _get_mask(rule->raw_text) & (element ? mask_k : CL_AND_MASK);
   }
 
-  return sel_value != 0;
+  return mask != 0;
 }
+
+#undef CPF_USER_DATA_INCLUDE
+#undef CPF_USER_DATA_EXCLUDE
+#undef CL_AND_MASK
+#undef CL_ALL_EXCLUDED
+#undef CL_GREY_EXCLUDED
+#undef CL_ALL_INCLUDED
+#undef CL_GREY_INCLUDED
 
 const dt_action_element_def_t _action_elements_colors[]
   = { { N_("operator"), dt_action_effect_toggle },
@@ -376,6 +278,7 @@ static void _colors_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   for(int k = 0; k < DT_COLORLABELS_LAST + 1; k++)
   {
     colors->colors[k] = dtgtk_button_new(dtgtk_cairo_paint_label_sel, k, NULL);
+    g_object_set_data(G_OBJECT(colors->colors[k]), "colors_index", GINT_TO_POINTER(k));
     dt_gui_add_class(colors->colors[k], "dt_no_hover");
     dt_gui_add_class(colors->colors[k], "dt_dimmed");
     g_object_set_data(G_OBJECT(colors->colors[k]), "colors_self", colors);
@@ -384,14 +287,12 @@ static void _colors_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
                                                      "\nclick to toggle the color label selection"
                                                      "\nctrl+click to exclude the color label"
                                                      "\nthe gray button affects all color labels"));
-    g_signal_connect(G_OBJECT(colors->colors[k]), "button-press-event", G_CALLBACK(_colors_clicked),
-                     GINT_TO_POINTER(k));
+    g_signal_connect(G_OBJECT(colors->colors[k]), "button-press-event", G_CALLBACK(_colors_clicked), colors);
     g_signal_connect(G_OBJECT(colors->colors[k]), "enter-notify-event", G_CALLBACK(_colors_enter_notify),
                      GINT_TO_POINTER(k));
     dt_action_define(DT_ACTION(self), N_("rules"), N_("color label"), colors->colors[k], &dt_action_def_colors_rule);
   }
   colors->operator= dtgtk_button_new(dtgtk_cairo_paint_and, 0, NULL);
-  _colors_reset(colors);
   gtk_box_pack_start(GTK_BOX(hbox), colors->operator, FALSE, FALSE, 2);
   gtk_widget_set_tooltip_text(colors->operator,
                               _("filter by images color label"


### PR DESCRIPTION
This catches up @AlicVB work to the last state of the colors filter PR.
- mask stored in hexa format instead of decimal integer
- a bit more room for possible future colors
- better logic on the widget itself


remains some work on _action_process_colors(). @dterrahe, sorry to bother you but I need some indication to finish this. Could you have a look please ?

