### PR TITLE
Correctly spell color space names

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -817,7 +817,7 @@ dt_ioppr_set_pipe_work_profile_info(struct dt_develop_t *dev,
 
   if(profile_info == NULL || isnan(profile_info->matrix_in[0][0]) || isnan(profile_info->matrix_out[0][0]))
   {
-    fprintf(stderr, "[dt_ioppr_set_pipe_work_profile_info] unsupported working profile %i %s, it will be replaced with linear rec2020\n", type, filename);
+    fprintf(stderr, "[dt_ioppr_set_pipe_work_profile_info] unsupported working profile %i %s, it will be replaced with linear Rec2020\n", type, filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }
   pipe->work_profile_info = profile_info;
@@ -839,7 +839,7 @@ dt_ioppr_set_pipe_input_profile_info(struct dt_develop_t *dev,
   {
     fprintf(stderr,
             "[dt_ioppr_set_pipe_input_profile_info] unsupported input profile %i %s, it will be replaced with "
-            "linear rec2020\n",
+            "linear Rec2020\n",
             type, filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -57,8 +57,8 @@ DT_MODULE_INTROSPECTION(3, dt_iop_colorbalance_params_t)
 
 typedef enum dt_iop_colorbalance_mode_t
 {
-  LIFT_GAMMA_GAIN = 0,    // $DESCRIPTION: "lift, gamma, gain (ProPhotoRGB)"
-  SLOPE_OFFSET_POWER = 1, // $DESCRIPTION: "slope, offset, power (ProPhotoRGB)"
+  LIFT_GAMMA_GAIN = 0,    // $DESCRIPTION: "lift, gamma, gain (ProPhoto RGB)"
+  SLOPE_OFFSET_POWER = 1, // $DESCRIPTION: "slope, offset, power (ProPhoto RGB)"
   LEGACY = 2              // $DESCRIPTION: "lift, gamma, gain (sRGB)"
 } dt_iop_colorbalance_mode_t;
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -55,9 +55,9 @@ typedef enum dt_iop_lut3d_colorspace_t
 {
   DT_IOP_SRGB = 0,    // $DESCRIPTION: "sRGB"
   DT_IOP_ARGB,        // $DESCRIPTION: "Adobe RGB"
-  DT_IOP_REC709,      // $DESCRIPTION: "gamma rec709 RGB"
-  DT_IOP_LIN_REC709,  // $DESCRIPTION: "linear rec709 RGB"
-  DT_IOP_LIN_REC2020, // $DESCRIPTION: "linear rec2020 RGB"
+  DT_IOP_REC709,      // $DESCRIPTION: "gamma Rec709 RGB"
+  DT_IOP_LIN_REC709,  // $DESCRIPTION: "linear Rec709 RGB"
+  DT_IOP_LIN_REC2020, // $DESCRIPTION: "linear Rec2020 RGB"
 } dt_iop_lut3d_colorspace_t;
 
 typedef enum dt_iop_lut3d_interpolation_t

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -581,7 +581,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
 
   if(!vs_prof || isnan(vs_prof->matrix_in[0][0]))
   {
-    fprintf(stderr, "[histogram] unsupported vectorscope profile %i %s, it will be replaced with linear rec2020\n", vs_prof->type, vs_prof->filename);
+    fprintf(stderr, "[histogram] unsupported vectorscope profile %i %s, it will be replaced with linear Rec2020\n", vs_prof->type, vs_prof->filename);
     vs_prof = dt_ioppr_add_profile_info_to_list(darktable.develop, DT_COLORSPACE_LIN_REC2020, "", DT_INTENT_RELATIVE_COLORIMETRIC);
   }
 


### PR DESCRIPTION
1. Color space names should be spelled with space before 'RGB' part. The only exception is sRGB because 's' in this case was not considered as the proper name of the color space, but was simply the initial letter of the word 'standard'.

2. Rec709 and Rec2020 should be spelled without forcing to lowercase.
