### PR TITLE
collection: remove empty textsearch queries

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1938,7 +1938,8 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       case DT_COLLECTION_PROP_TEXTSEARCH: // text search
       {
         // clang-format off
-        query = g_strdup_printf("(id IN (SELECT id FROM main.meta_data WHERE value LIKE '%s'"
+        if(g_strcmp0(escaped_text, "%%") != 0)
+          query = g_strdup_printf("(id IN (SELECT id FROM main.meta_data WHERE value LIKE '%s'"
                                 " UNION SELECT imgid AS id FROM main.tagged_images AS ti, data.tags AS t"
                                 "   WHERE t.id=ti.tagid AND (t.name LIKE '%s' OR t.synonyms LIKE '%s')"
                                 " UNION SELECT id FROM main.images"


### PR DESCRIPTION
On startup, I get up to five queries like 
`SELECT COUNT(DISTINCT mi.id) FROM (SELECT  id, group_id, film_id, filename, datetime_taken,   flags, version,  position, aspect_ratio,  maker, model, lens, aperture, exposure, focal_length,  iso, import_timestamp, change_timestamp,  export_timestamp, print_timestamp  FROM images AS mi  ) AS mi WHERE   (flags & 256) != 256  AND  (1=1 AND (film_id IN (SELECT id FROM film_rolls WHERE folder LIKE '/home/hans/Photos')) AND (1=1) AND (id IN (SELECT id FROM meta_data WHERE value LIKE '%%' UNION SELECT imgid AS id FROM tagged_images AS ti, data.tags AS t   WHERE t.id=ti.tagid AND (t.name LIKE '%%' OR t.synonyms LIKE '%%') UNION SELECT id FROM images   WHERE filename LIKE '%%' UNION SELECT i.id FROM images AS i, film_rolls AS fr   WHERE fr.id=i.film_id AND fr.folder LIKE '%%'))) ORDER BY filename, version LIMIT ?1, ?2`
eating roughly 100ms each. Querying with `%%` wildcard obviously matches always, but I don't see any actual use for this (I virtually don't use filtering, though). Collection expert(s) needed.