### PR TITLE
filtering: custom rating-tooltip

### DIFF
--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1716,35 +1716,6 @@ gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range)
   if((range->bounds & DT_RANGE_BOUND_MIN) && (range->bounds & DT_RANGE_BOUND_MAX)) return g_strdup(_("all"));
 
   gchar *txt = NULL;
-  if((range->bounds & DT_RANGE_BOUND_MIN)) 
-    range->select_min_r = range->min_r;
-  if((range->bounds & DT_RANGE_BOUND_MAX)) 
-    range->select_max_r = range->max_r;
-    
-  if(range->select_min_r == range->select_max_r)
-    return range->print(range->select_min_r, TRUE);
-
-  // custom text for rating widget
-  if(range->min_r == -1)
-  {
-    int rating_min = (int)floor(range->select_min_r);
-    int rating_max = (int)floor(range->select_max_r);
-
-    if(rating_min == -1 && rating_max == 0)
-      return g_strdup_printf("%s + %s", _("rejected"), _("not rated"));
-
-    if(range->bounds & DT_RANGE_BOUND_MIN)
-      return g_strdup_printf("<= %s + %s", range->print(range->select_max_r, TRUE), _("rejected"));
-    else if(range->bounds & DT_RANGE_BOUND_MAX)
-    {
-      if(rating_min == 0)
-        return g_strdup(_("all except rejected"));
-      else
-        return g_strdup_printf(">= %s", range->print(range->select_min_r, TRUE));    
-    }
-    else if(rating_min == 0)
-      return g_strdup_printf("<= %s", range->print(range->select_max_r, TRUE));
-  }
 
   if(range->bounds & DT_RANGE_BOUND_MIN)
     txt = g_strdup(_("min"));
@@ -1771,6 +1742,37 @@ gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range)
     txt = dt_util_dstrcat(txt, "%s", range->print(range->select_max_r, TRUE));
 
   return txt;
+}
+
+gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *range)
+{
+  if((range->bounds & DT_RANGE_BOUND_MIN)) 
+    range->select_min_r = range->min_r;
+  if((range->bounds & DT_RANGE_BOUND_MAX)) 
+    range->select_max_r = range->max_r;
+    
+  if(range->select_min_r == range->select_max_r)
+    return g_strdup_printf("%s %s", range->print(range->select_min_r, TRUE), _("only"));
+
+  int rating_min = (int)floor(range->select_min_r);
+  int rating_max = (int)floor(range->select_max_r);
+
+  if(rating_min == -1 && rating_max == 0)
+    return g_strdup_printf("%s + %s", _("rejected"), _("not rated"));
+
+  if(range->bounds & DT_RANGE_BOUND_MIN)
+    return g_strdup_printf("≤%s + %s", range->print(range->select_max_r, TRUE), _("rejected"));
+  else if(range->bounds & DT_RANGE_BOUND_MAX)
+  {
+    if(rating_min == 0)
+      return g_strdup(_("all except rejected"));
+    else
+      return g_strdup_printf("≥%s", range->print(range->select_min_r, TRUE));    
+  }
+  else if(rating_min == 0)
+    return g_strdup_printf("≤%s", range->print(range->select_max_r, TRUE));
+
+  return dtgtk_range_select_get_bounds_pretty(range);
 }
 
 void dtgtk_range_select_set_selection(GtkDarktableRangeSelect *range, const dt_range_bounds_t bounds,

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1746,6 +1746,8 @@ gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range)
 
 gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *range)
 {
+  if((range->bounds & DT_RANGE_BOUND_MIN) && (range->bounds & DT_RANGE_BOUND_MAX)) return g_strdup(_("all images"));
+
   if((range->bounds & DT_RANGE_BOUND_MIN)) 
     range->select_min_r = range->min_r;
   if((range->bounds & DT_RANGE_BOUND_MAX)) 
@@ -1754,8 +1756,8 @@ gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *rang
   if(range->select_min_r == range->select_max_r)
     return g_strdup_printf("%s %s", range->print(range->select_min_r, TRUE), _("only"));
 
-  int rating_min = (int)floor(range->select_min_r);
-  int rating_max = (int)floor(range->select_max_r);
+  const int rating_min = (int)floor(range->select_min_r);
+  const int rating_max = (int)floor(range->select_max_r);
 
   if(rating_min == -1 && rating_max == 0)
     return g_strdup_printf("%s + %s", _("rejected"), _("not rated"));

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -230,6 +230,10 @@ static gboolean _default_decode_date_func(const gchar *text, double *value)
   }
   return FALSE;
 }
+static gchar *_default_current_text_func(GtkDarktableRangeSelect *range, const double current)
+{
+  return range->print(current, TRUE);
+}
 
 static void _date_tree_count_func(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
                                   GtkTreeIter *iter, gpointer data)
@@ -1452,16 +1456,7 @@ static gboolean _event_band_draw(GtkWidget *widget, cairo_t *cr, gpointer user_d
     cairo_move_to(cr, posx_px, range->alloc_padding.y);
     cairo_line_to(cr, posx_px, range->alloc_padding.height + range->alloc_padding.y);
     cairo_stroke(cr);
-    gchar *txt = range->print(current_value_r, TRUE);
-
-    // custom tooltip for rating widget
-    if(range->min_r == -1) 
-      txt = g_strdup_printf("<b>%s: %s</b> (%s: %s)", 
-        _("selected"),
-        g_markup_escape_text(dtgtk_range_select_get_bounds_pretty(range), -1), 
-        _("hovered"),
-        g_markup_escape_text(txt, -1));
-
+    gchar *txt = range->current_text(range, current_value_r);
     if(range->cur_window && range->cur_label) gtk_label_set_markup(GTK_LABEL(range->cur_label), txt);
     g_free(txt);
   }
@@ -1650,6 +1645,7 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
   range->value_to_band = _default_value_translator;
   range->print = (type == DT_RANGE_TYPE_NUMERIC) ? _default_print_func : _default_print_date_func;
   range->decode = (type == DT_RANGE_TYPE_NUMERIC) ? _default_decode_func : _default_decode_date_func;
+  range->current_text = _default_current_text_func;
   range->show_entries = show_entries;
   range->type = type;
   range->alloc_main.width = 0;

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1754,7 +1754,12 @@ gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *rang
     range->select_max_r = range->max_r;
     
   if(range->select_min_r == range->select_max_r)
-    return g_strdup_printf("%s %s", range->print(range->select_min_r, TRUE), _("only"));
+  {
+    gchar *printed_min = range->print(range->select_min_r, TRUE);
+    gchar *min_only = g_strdup_printf("%s %s", printed_min, _("only"));
+    g_free(printed_min);
+    return min_only;
+  }
 
   const int rating_min = (int)floor(range->select_min_r);
   const int rating_max = (int)floor(range->select_max_r);
@@ -1763,16 +1768,31 @@ gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *rang
     return g_strdup_printf("%s + %s", _("rejected"), _("not rated"));
 
   if(range->bounds & DT_RANGE_BOUND_MIN)
-    return g_strdup_printf("≤%s + %s", range->print(range->select_max_r, TRUE), _("rejected"));
+  {
+    gchar *printed_max = range->print(range->select_max_r, TRUE);
+    gchar *lt_max_rejected = g_strdup_printf("≤%s + %s", printed_max, _("rejected"));
+    g_free(printed_max);
+    return lt_max_rejected;
+  }
   else if(range->bounds & DT_RANGE_BOUND_MAX)
   {
     if(rating_min == 0)
       return g_strdup(_("all except rejected"));
     else
-      return g_strdup_printf("≥%s", range->print(range->select_min_r, TRUE));    
+    {
+      gchar *printed_min = range->print(range->select_min_r, TRUE);
+      gchar *gt_min = g_strdup_printf("≥%s", printed_min);
+      g_free(printed_min);
+      return gt_min;
+    }
   }
   else if(rating_min == 0)
-    return g_strdup_printf("≤%s", range->print(range->select_max_r, TRUE));
+  {
+    gchar *printed_max = range->print(range->select_max_r, TRUE);
+    gchar *lt_max = g_strdup_printf("≤%s", range->print(range->select_max_r, TRUE));
+    g_free(printed_max);
+    return lt_max;
+  }
 
   return dtgtk_range_select_get_bounds_pretty(range);
 }

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1744,59 +1744,6 @@ gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range)
   return txt;
 }
 
-gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *range)
-{
-  if((range->bounds & DT_RANGE_BOUND_MIN) && (range->bounds & DT_RANGE_BOUND_MAX)) return g_strdup(_("all images"));
-
-  if((range->bounds & DT_RANGE_BOUND_MIN)) 
-    range->select_min_r = range->min_r;
-  if((range->bounds & DT_RANGE_BOUND_MAX)) 
-    range->select_max_r = range->max_r;
-    
-  if(range->select_min_r == range->select_max_r)
-  {
-    gchar *printed_min = range->print(range->select_min_r, TRUE);
-    gchar *min_only = g_strdup_printf("%s %s", printed_min, _("only"));
-    g_free(printed_min);
-    return min_only;
-  }
-
-  const int rating_min = (int)floor(range->select_min_r);
-  const int rating_max = (int)floor(range->select_max_r);
-
-  if(rating_min == -1 && rating_max == 0)
-    return g_strdup_printf("%s + %s", _("rejected"), _("not rated"));
-
-  if(range->bounds & DT_RANGE_BOUND_MIN)
-  {
-    gchar *printed_max = range->print(range->select_max_r, TRUE);
-    gchar *lt_max_rejected = g_strdup_printf("≤%s + %s", printed_max, _("rejected"));
-    g_free(printed_max);
-    return lt_max_rejected;
-  }
-  else if(range->bounds & DT_RANGE_BOUND_MAX)
-  {
-    if(rating_min == 0)
-      return g_strdup(_("all except rejected"));
-    else
-    {
-      gchar *printed_min = range->print(range->select_min_r, TRUE);
-      gchar *gt_min = g_strdup_printf("≥%s", printed_min);
-      g_free(printed_min);
-      return gt_min;
-    }
-  }
-  else if(rating_min == 0)
-  {
-    gchar *printed_max = range->print(range->select_max_r, TRUE);
-    gchar *lt_max = g_strdup_printf("≤%s", range->print(range->select_max_r, TRUE));
-    g_free(printed_max);
-    return lt_max;
-  }
-
-  return dtgtk_range_select_get_bounds_pretty(range);
-}
-
 void dtgtk_range_select_set_selection(GtkDarktableRangeSelect *range, const dt_range_bounds_t bounds,
                                       const double min_r, const double max_r, gboolean signal,
                                       gboolean round_values)

--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -179,6 +179,7 @@ void dtgtk_range_select_redraw(GtkDarktableRangeSelect *range);
 
 // get a human readable text for bounds
 gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range);
+gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *range);
 G_END_DECLS
 
 // clang-format off

--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -44,6 +44,8 @@ G_BEGIN_DECLS
 typedef double (*DTGTKTranslateValueFunc)(const double value);
 typedef gchar *(*DTGTKPrintValueFunc)(const double value, const gboolean detailled);
 typedef gboolean (*DTGTKDecodeValueFunc)(const gchar *text, double *value);
+typedef struct _GtkDarktableRangeSelect GtkDarktableRangeSelect;
+typedef gchar *(*DTGTKCurrentTextFunc)(GtkDarktableRangeSelect *range, const double current);
 
 typedef enum dt_range_bounds_t
 {
@@ -62,7 +64,7 @@ typedef enum dt_range_type_t
   DT_RANGE_TYPE_DATETIME
 } dt_range_type_t;
 
-typedef struct _GtkDarktableRangeSelect
+struct _GtkDarktableRangeSelect
 {
   GtkEventBox widget;
 
@@ -100,7 +102,7 @@ typedef struct _GtkDarktableRangeSelect
   // print function has detailled mode for extended infos
   DTGTKPrintValueFunc print;
   DTGTKDecodeValueFunc decode;
-
+  DTGTKCurrentTextFunc current_text;
   GList *blocks;
   GList *icons;
   GList *markers;
@@ -116,7 +118,7 @@ typedef struct _GtkDarktableRangeSelect
   GtkWidget *cur_label;
 
   struct _range_date_popup *date_popup;
-} GtkDarktableRangeSelect;
+};
 
 typedef struct _GtkDarktableRangeSelectClass
 {

--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -179,7 +179,6 @@ void dtgtk_range_select_redraw(GtkDarktableRangeSelect *range);
 
 // get a human readable text for bounds
 gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range);
-gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *range);
 G_END_DECLS
 
 // clang-format off

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -647,12 +647,13 @@ static void _range_set_tooltip(_widgets_range_t *special)
 {
   // we recreate the tooltip
   gchar *val = dtgtk_range_select_get_bounds_pretty(DTGTK_RANGE_SELECT(special->range_select));
-  gchar *txt = g_strdup_printf("<b>%s</b>\n%s\n%s\n%s%s",
+  gchar *txt = g_strdup_printf("<b>%s</b>\n%s\n%s",
                                dt_collection_name(special->rule->prop),
                                _("click or click&#38;drag to select one or multiple values"),
-                               _("right-click opens a menu to select the available values"),
-                               _("<b><i>actual selection: </i></b>"),
-                               val);
+                               _("right-click opens a menu to select the available values"));
+
+  if(special->rule->prop != DT_COLLECTION_PROP_RATING)
+    txt = g_strdup_printf("%s\n<b><i>%s:</i></b> %s", txt, _("actual selection"), val);
   gtk_widget_set_tooltip_markup(special->range_select, txt);
   g_free(txt);
   g_free(val);

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -104,6 +104,15 @@ static gchar *_rating_print_func(const double value, const gboolean detailled)
   return g_strdup_printf("%.0lf", floor(value));
 }
 
+static gchar *_rating_current_text_func(GtkDarktableRangeSelect *range, const double current)
+{
+  return g_strdup_printf("<b>%s: %s</b> (%s: %s)", 
+        _("selected"),
+        g_markup_escape_text(dtgtk_range_select_get_bounds_pretty(range), -1), 
+        _("hovered"),
+        g_markup_escape_text(range->print(current, TRUE), -1));
+}
+
 static void _rating_paint_icon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   // first, we set the color depending on the flags
@@ -257,6 +266,7 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   dtgtk_range_select_add_icon(range, 78, 4, _rating_paint_icon, 0, NULL);
   dtgtk_range_select_add_icon(range, 93, 5, _rating_paint_icon, 0, NULL);
   range->print = _rating_print_func;
+  range->current_text = _rating_current_text_func;
 
   dtgtk_range_select_set_selection_from_raw_text(range, text, FALSE);
 

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -58,7 +58,7 @@ static gboolean _rating_update(dt_lib_filtering_rule_t *rule)
   dtgtk_range_select_add_range_block(range, 0.0, 1.0, DT_RANGE_BOUND_MAX, _("all except rejected"),
                                      nb[1] + nb[2] + nb[3] + nb[4] + nb[5] + nb[6]);
   dtgtk_range_select_add_range_block(range, -1.0, -1.0, DT_RANGE_BOUND_FIXED, _("rejected only"), nb[0]);
-  dtgtk_range_select_add_range_block(range, 0.0, 0.0, DT_RANGE_BOUND_FIXED, _("unstared only"), nb[1]);
+  dtgtk_range_select_add_range_block(range, 0.0, 0.0, DT_RANGE_BOUND_FIXED, _("not rated only"), nb[1]);
   dtgtk_range_select_add_range_block(range, 1.0, 5.0, DT_RANGE_BOUND_MAX, "★", nb[2]);
   dtgtk_range_select_add_range_block(range, 2.0, 5.0, DT_RANGE_BOUND_MAX, "★ ★", nb[3]);
   dtgtk_range_select_add_range_block(range, 3.0, 5.0, DT_RANGE_BOUND_MAX, "★ ★ ★", nb[4]);
@@ -73,7 +73,7 @@ static gboolean _rating_update(dt_lib_filtering_rule_t *rule)
     dtgtk_range_select_add_range_block(rangetop, 0.0, 1.0, DT_RANGE_BOUND_MAX, _("all except rejected"),
                                        nb[1] + nb[2] + nb[3] + nb[4] + nb[5] + nb[6]);
     dtgtk_range_select_add_range_block(rangetop, -1.0, -1.0, DT_RANGE_BOUND_FIXED, _("rejected only"), nb[0]);
-    dtgtk_range_select_add_range_block(rangetop, 0.0, 0.0, DT_RANGE_BOUND_FIXED, _("unstared only"), nb[1]);
+    dtgtk_range_select_add_range_block(rangetop, 0.0, 0.0, DT_RANGE_BOUND_FIXED, _("not rated only"), nb[1]);
     dtgtk_range_select_add_range_block(rangetop, 1.0, 5.0, DT_RANGE_BOUND_MAX, "★", nb[2]);
     dtgtk_range_select_add_range_block(rangetop, 2.0, 5.0, DT_RANGE_BOUND_MAX, "★ ★", nb[3]);
     dtgtk_range_select_add_range_block(rangetop, 3.0, 5.0, DT_RANGE_BOUND_MAX, "★ ★ ★", nb[4]);
@@ -99,16 +99,6 @@ static gchar *_rating_print_func(const double value, const gboolean detailled)
         return g_strdup(_("rejected"));
       case 0:
         return g_strdup(_("not rated"));
-      case 1:
-        return g_strdup("★");
-      case 2:
-        return g_strdup("★ ★");
-      case 3:
-        return g_strdup("★ ★ ★");
-      case 4:
-        return g_strdup("★ ★ ★ ★");
-      case 5:
-        return g_strdup("★ ★ ★ ★ ★");
     }
   }
   return g_strdup_printf("%.0lf", floor(value));

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -106,10 +106,13 @@ static gchar *_rating_print_func(const double value, const gboolean detailled)
 
 static gchar *_rating_current_text_func(GtkDarktableRangeSelect *range, const double current)
 {
-  return g_strdup_printf("  <b>%s</b> | %s: %s  ", 
-        g_markup_escape_text(range->print(current, TRUE), -1),
-        _("selected"),
-        g_markup_escape_text(dtgtk_range_select_get_rating_bounds_pretty(range), -1));
+  gchar *hovered = range->print(current, TRUE);
+  gchar *selected = g_markup_escape_text(dtgtk_range_select_get_rating_bounds_pretty(range), -1);
+  gchar *rating_text = g_strdup_printf("  <b>%s</b> | %s: %s  ", 
+        g_markup_escape_text(hovered, -1), _("selected"), selected);
+  g_free(hovered);
+  g_free(selected);
+  return rating_text;
 }
 
 static void _rating_paint_icon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -104,7 +104,7 @@ static gchar *_rating_print_func(const double value, const gboolean detailled)
   return g_strdup_printf("%.0lf", floor(value));
 }
 
-static gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelect *range)
+static gchar *_rating_get_bounds_pretty(GtkDarktableRangeSelect *range)
 {
   if((range->bounds & DT_RANGE_BOUND_MIN) && (range->bounds & DT_RANGE_BOUND_MAX)) return g_strdup(_("all images"));
 
@@ -149,7 +149,7 @@ static gchar *dtgtk_range_select_get_rating_bounds_pretty(GtkDarktableRangeSelec
   else if(rating_min == 0)
   {
     gchar *printed_max = range->print(range->select_max_r, TRUE);
-    gchar *lt_max = g_strdup_printf("≤%s", range->print(range->select_max_r, TRUE));
+    gchar *lt_max = g_strdup_printf("≤%s", printed_max);
     g_free(printed_max);
     return lt_max;
   }
@@ -161,7 +161,7 @@ static gchar *_rating_current_text_func(GtkDarktableRangeSelect *range, const do
 {
   gchar *hovered = range->print(current, TRUE);
   gchar *hovered_escaped = g_markup_escape_text(hovered, -1);
-  gchar *selected = dtgtk_range_select_get_rating_bounds_pretty(range);
+  gchar *selected = _rating_get_bounds_pretty(range);
   gchar *selected_escaped = g_markup_escape_text(selected, -1);
 
   gchar *rating_text = g_strdup_printf("  <b>%s</b> | %s: %s  ", 

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -106,11 +106,10 @@ static gchar *_rating_print_func(const double value, const gboolean detailled)
 
 static gchar *_rating_current_text_func(GtkDarktableRangeSelect *range, const double current)
 {
-  return g_strdup_printf("<b>%s: %s</b> (%s: %s)", 
+  return g_strdup_printf("  <b>%s</b> | %s: %s  ", 
+        g_markup_escape_text(range->print(current, TRUE), -1),
         _("selected"),
-        g_markup_escape_text(dtgtk_range_select_get_bounds_pretty(range), -1), 
-        _("hovered"),
-        g_markup_escape_text(range->print(current, TRUE), -1));
+        g_markup_escape_text(dtgtk_range_select_get_rating_bounds_pretty(range), -1));
 }
 
 static void _rating_paint_icon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)


### PR DESCRIPTION
Hack for #11757 

I added a custom tooltip for the rating widget as suggested in [my mockup](https://github.com/darktable-org/darktable/issues/11757#issuecomment-1127924173)

It shows a pretty formatted selected-range and the hovered value in tooltip above the cursor: 

![image](https://user-images.githubusercontent.com/5677563/170082516-dab97b7d-89de-4979-bace-54cab86d6781.png)
(updated screenshot)

I know it's even more lines of code, and surely no perfectly clean code, but I see this as a temporary hack until a clean solution will be implemented for 4.2 (e.g. [proposal by AxelG-DE ](https://github.com/darktable-org/darktable/issues/11757#issuecomment-1120466989))
