### PR TITLE
filtering: change default rating-selection

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -480,7 +480,7 @@
   <dtconfig>
     <name>plugins/lighttable/filtering/item0</name>
     <type>int</type>
-    <default>32</default>
+    <default>34</default>
     <shortdescription>first filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -258,7 +258,7 @@ void init_presets(dt_lib_module_t *self)
   }
 
   // initial preset
-  CLEAR_PARAMS(_PRESET_ALL, DT_COLLECTION_PROP_RATING, DT_COLLECTION_SORT_DATETIME);
+  CLEAR_PARAMS(_PRESET_ALL, DT_COLLECTION_PROP_RATING_LEGACY, DT_COLLECTION_SORT_DATETIME);
   params.rules = 3;
   params.rule[0].topbar = 1;
   params.rule[1].item = DT_COLLECTION_PROP_COLORLABEL;


### PR DESCRIPTION
After discussions on github and irc, I am firmly convinced, that it's too early to set the new rating-selection as default.

There's nothing wrong with the old version, and there is valid critisism, that it's not easy to see + understand what's currently selected.

And because I love the new selection-method, I am sure it would be a shot in the foot to use it as default too early with the current flaws.

Improving the tooltip (#11848) is still helpful, but it does not solve the initial problem.

So I see two solutions:
- reverting
- changing the default


This PR does the latter: it sets the default to the current rating-selection method using the dropdown.