### PR TITLE
Rename orphan images to ungrouped

### DIFF
--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -141,7 +141,7 @@ static gboolean _grouping_update(dt_lib_filtering_rule_t *rule)
   gchar *item = g_strdup_printf("%s (%d)", _("ungrouped images"), nb_no_group);
   dt_bauhaus_combobox_set_entry_label(grouping->combo, 1, item);
   g_free(item);
-  item = g_strdup_printf("%s (%d)", _("images in a group"), nb_group);
+  item = g_strdup_printf("%s (%d)", _("grouped images"), nb_group);
   dt_bauhaus_combobox_set_entry_label(grouping->combo, 2, item);
   g_free(item);
   item = g_strdup_printf("%s (%d)", _("group leaders"), nb_leader);
@@ -166,7 +166,7 @@ static void _grouping_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(grouping->combo, self, NULL, N_("grouping filter"),
                                _("select the type of grouped image to filter"), 0, (GtkCallback)_grouping_changed,
-                               grouping, N_("all images"), N_("ungrouped images"), N_("images in a group"),
+                               grouping, N_("all images"), N_("ungrouped images"), N_("grouped images"),
                                N_("group leaders"), N_("group followers"));
   DT_BAUHAUS_WIDGET(grouping->combo)->show_label = FALSE;
 

--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -138,7 +138,7 @@ static gboolean _grouping_update(dt_lib_filtering_rule_t *rule)
   }
   sqlite3_finalize(stmt);
 
-  gchar *item = g_strdup_printf("%s (%d)", _("orphan images"), nb_no_group);
+  gchar *item = g_strdup_printf("%s (%d)", _("ungrouped images"), nb_no_group);
   dt_bauhaus_combobox_set_entry_label(grouping->combo, 1, item);
   g_free(item);
   item = g_strdup_printf("%s (%d)", _("images in a group"), nb_group);
@@ -166,7 +166,7 @@ static void _grouping_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(grouping->combo, self, NULL, N_("grouping filter"),
                                _("select the type of grouped image to filter"), 0, (GtkCallback)_grouping_changed,
-                               grouping, N_("all images"), N_("orphan images"), N_("images in a group"),
+                               grouping, N_("all images"), N_("ungrouped images"), N_("images in a group"),
                                N_("group leaders"), N_("group followers"));
   DT_BAUHAUS_WIDGET(grouping->combo)->show_label = FALSE;
 


### PR DESCRIPTION
The term "orphan images" is not very suitable in the context of image grouping for several reasons:

1. darktable already has the term "orphaned images", which, as far as can be seen from the source code, means images
for which there is no more "filmroll". It's not good that almost the same term in different part of the program means different thing.

2. While "orphaned images" has a clear meaning, "orphan images" sounds more like "images of the orphan kids", obviously not what the author meant.

3. This term (and concept of orphanhood) stand out from the logical series of terms. The context is as follows. We filter images by their grouping:
- images that are the leaders of the group
- images that are members of the group (followers, not leaders)
- image in the group (no matter in what role)
- image without group

That is, it would be best to simply call it "ungrouped images".
