### PR TITLE
metadata: avoid to apply on hovered image instead of selection

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -18,6 +18,7 @@
 
 #include "common/metadata.h"
 #include "common/collection.h"
+#include "common/selection.h"
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "control/conf.h"
@@ -271,6 +272,19 @@ static void _write_metadata(GtkTextView *textview, dt_lib_module_t *self)
   }
 
   GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
+  // workaround: if hovered image instead of selected, aborts
+  if(imgs && !imgs->next)
+  {
+    GList *sels = dt_selection_get_list(darktable.selection, FALSE, FALSE);
+    if(sels && (sels->next || (!sels->next && GPOINTER_TO_INT(sels->data) != GPOINTER_TO_INT(imgs->data))))
+    {
+      g_list_free(sels);
+      g_list_free(imgs);
+      return;
+    }
+    g_list_free(sels);
+  }
+
   dt_metadata_set_list(imgs, key_value, TRUE);
 
   for(GList *l = key_value; l; l = l->next)
@@ -286,12 +300,11 @@ static void _write_metadata(GtkTextView *textview, dt_lib_module_t *self)
   dt_image_synch_xmps(imgs);
   g_list_free(imgs);
   _update(self);
+  d->editing = FALSE;
 }
 
 static void _apply_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
-  d->editing = FALSE;
   _write_metadata(NULL, self);
 }
 
@@ -321,14 +334,12 @@ static gboolean _key_pressed(GtkWidget *textview, GdkEventKey *event, dt_lib_mod
       case GDK_KEY_KP_Enter:
         _write_metadata(GTK_TEXT_VIEW(textview), self);
         _text_set_all_selected(GTK_TEXT_VIEW(textview), FALSE);
-        d->editing = FALSE;
         return TRUE;
         break;
       case GDK_KEY_Tab:
       case GDK_KEY_KP_Tab:
       case GDK_KEY_ISO_Left_Tab:
         _write_metadata(GTK_TEXT_VIEW(textview), self);
-        d->editing = FALSE;
         break;
       case GDK_KEY_Escape:
       {
@@ -437,7 +448,6 @@ static void _update_layout(dt_lib_module_t *self)
 void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
-  d->editing = FALSE;
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
     const gchar *name = dt_metadata_get_name_by_display_order(i);
@@ -713,7 +723,7 @@ void gui_init(dt_lib_module_t *self)
     g_object_set_data(G_OBJECT(buffer), "buffer_tv", GINT_TO_POINTER(textview));
     g_object_set_data(G_OBJECT(textview), "tv_index", GINT_TO_POINTER(i));
     g_object_set_data(G_OBJECT(textview), "tv_multiple", GINT_TO_POINTER(FALSE));
-    gtk_text_buffer_create_tag (gtk_text_view_get_buffer(GTK_TEXT_VIEW(textview)),
+    gtk_text_buffer_create_tag(gtk_text_view_get_buffer(GTK_TEXT_VIEW(textview)),
                                 "italic", "style", PANGO_STYLE_ITALIC, NULL);
 
     const char *name = (char *)dt_metadata_get_name_by_display_order(i);
@@ -962,4 +972,3 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "common/collection.h"
+#include "common/selection.h"
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/tags.h"
@@ -1356,6 +1357,19 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   if(!tag || tag[0] == '\0') return;
 
   GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
+  // workaround: if hovered image instead of selected, aborts
+  if(imgs && !imgs->next)
+  {
+    GList *sels = dt_selection_get_list(darktable.selection, FALSE, FALSE);
+    if(sels && (sels->next || (!sels->next && GPOINTER_TO_INT(sels->data) != GPOINTER_TO_INT(imgs->data))))
+    {
+      g_list_free(sels);
+      g_list_free(imgs);
+      return;
+    }
+    g_list_free(sels);
+  }
+
   const gboolean res = dt_tag_attach_string_list(tag, imgs, TRUE);
   if(res) dt_image_synch_xmps(imgs);
   g_list_free(imgs);
@@ -3530,4 +3544,3 @@ static void _save_last_tag_used(const char *tagnames, dt_lib_tagging_t *d)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
attempt to fixe #11589

This should fix the above issue but I see a remaining problem: when a non validated field loses the focus the edited value is lost. It should be saved and restored when the focus is given back. This change is bit complicated as it implies to differentiate visually a field currently edited from a field already validated. Would the subject of another PR.