### PR TITLE
Fix missing padding and icons on some overlays with shortest code

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -72,6 +72,7 @@
 
 /* Lighttable and film-strip */
 @define-color thumbnail_bg_color @grey_55;
+@define-color thumbnail_bottom_bg_color @grey_45;
 @define-color thumbnail_star_bg_color @grey_40;
 @define-color thumbnail_star_hover_color @grey_85;
 @define-color thumbnail_fg_color @grey_60;
@@ -95,7 +96,7 @@
 .dt_overlays_mixed #thumb-main:hover #thumb-bottom,
 .dt_overlays_hover #thumb-main:hover #thumb-bottom
 {
-  background-image: linear-gradient(rgba(212, 212, 212, 0.7) 0%, rgba(212, 212, 212, 0.7) 90%,rgba(212, 212, 212, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
+  background-image: linear-gradient(rgba(226, 226, 226, 0.7) 0%, rgba(226, 226, 226, 0.7) 90%,rgba(226, 226, 226, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
 }
 
 /* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */
@@ -104,13 +105,5 @@
 .dt_overlays_always#preview #thumb-bottom,
 .dt_overlays_always_extended#preview #thumb-bottom
 {
-  background-image: linear-gradient(rgba(198, 198, 198, 0.2) 0%, rgba(198, 198, 198, 0.1) 5%, rgba(198, 198, 198, 0) 100%);
-}
-
-.dt_overlays_always#culling #thumb-main:hover #thumb-bottom,
-.dt_overlays_always_extended#culling #thumb-main:hover #thumb-bottom,
-.dt_overlays_always#preview #thumb-main:hover #thumb-bottom,
-.dt_overlays_always_extended#preview #thumb-main:hover #thumb-bottom
-{
-  background-image: linear-gradient(rgba(218, 218, 218, 0.4) 0%, rgba(218, 218, 218, 0.2) 5%, rgba(198, 198, 198, 0) 100%);
+  background-color: shade(@lighttable_bg_color, 1.05);
 }

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -121,20 +121,3 @@ combobox window *:hover
 {
   background-image: linear-gradient(rgba(241, 241, 241, 0.7) 0%, rgba(241, 241, 241, 0.7) 90%,rgba(241, 241, 241, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
 }
-
-/* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */
-.dt_overlays_always#culling #thumb-bottom,
-.dt_overlays_always_extended#culling #thumb-bottom,
-.dt_overlays_always#preview #thumb-bottom,
-.dt_overlays_always_extended#preview #thumb-bottom
-{
-  background-image: linear-gradient(rgba(226, 226, 226, 0.2) 0%, rgba(226, 226, 226, 0.1) 5%, rgba(226, 226, 226, 0) 100%);
-}
-
-.dt_overlays_always#culling #thumb-main:hover #thumb-bottom,
-.dt_overlays_always_extended#culling #thumb-main:hover #thumb-bottom,
-.dt_overlays_always#preview #thumb-main:hover #thumb-bottom,
-.dt_overlays_always_extended#preview #thumb-main:hover #thumb-bottom
-{
-  background-image: linear-gradient(rgba(246, 246, 246, 0.4) 0%, rgba(246, 246, 246, 0.2) 5%, rgba(226, 226, 226, 0) 100%);
-}

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -811,6 +811,11 @@ menuitem check:selected
   padding: 0.42em 0 0 0.42em;   /* set only padding on top and left margin due to some default hardcoded spacing on bottom and place for icons on some bauhaus on the right */
 }
 
+.dt_bauhaus_popup_right /* set right padding for specific popup with no hardcoded right space due to icons place */
+{
+  padding-right: 0.42em;
+}
+
 /* fix for menuitem in bottom toolbar mainly */
 menuitem > arrow
 {
@@ -1856,7 +1861,7 @@ Details :
   color: @border_color;
 }
 
-/* Set border color around thumbnails */
+/* Set border color around grouped thumbnails */
 .dt_group_left #thumb-back,
 #thumb-main.dt_group_left:selected #thumb-back
 {
@@ -1914,7 +1919,7 @@ Details :
   border : 0.07em solid transparent; /* to not overlay thumb borders */
 }
 
-/* Set outside margins in thumbnails about bottom infos area */
+/* Set outside margins in grouped thumbnails about bottom infos area */
 .dt_group_left #thumb-bottom
 {
   border-left-width: 0.14em;
@@ -1957,8 +1962,8 @@ Details :
 /* Reset color icons to be hidden in following modes, including culling/preview overlays hover block*/
 .dt_overlays_none .dt_thumb_btn,
 .dt_overlays_none #thumb-main:hover .dt_thumb_btn,
-.dt_overlays_hover .dt_thumb_btn,
-.dt_overlays_hover_extended .dt_thumb_btn,
+.dt_overlays_hover #thumb-main .dt_thumb_btn,
+.dt_overlays_hover_extended #thumb-main .dt_thumb_btn,
 .dt_overlays_hover_block #thumb-main .dt_thumb_btn,
 #thumb-ext  /* by default, the extension is hidden */
 {
@@ -1986,30 +1991,29 @@ Details :
 }
 
 /* Set hover and selected color icons, extension name and text infos */
-.dt_overlays_always #thumb-main:hover #thumb-ext,
-.dt_overlays_always #thumb-main:selected #thumb-ext,
-.dt_overlays_always_extended #thumb-main:hover #thumb-ext,
-.dt_overlays_always_extended #thumb-main:selected #thumb-ext,
-.dt_overlays_mixed #thumb-main:hover #thumb-ext,
-.dt_overlays_mixed #thumb-main:selected #thumb-ext,
+.dt_overlays_hover #thumb-main:hover #thumb-ext,
 .dt_overlays_hover #thumb-main:hover .dt_thumb_btn,
+.dt_overlays_hover_extended #thumb-main:hover #thumb-ext,
 .dt_overlays_hover_extended #thumb-main:hover .dt_thumb_btn,
 .dt_overlays_hover_extended #thumb-main:hover #thumb-bottom-label,
+.dt_overlays_always #thumb-main:hover #thumb-ext,
+.dt_overlays_always #thumb-main:selected #thumb-ext,
 .dt_overlays_always #thumb-main:hover .dt_thumb_btn,
 .dt_overlays_always #thumb-main:selected .dt_thumb_btn,
+.dt_overlays_always_extended #thumb-main:hover #thumb-ext,
+.dt_overlays_always_extended #thumb-main:selected #thumb-ext,
 .dt_overlays_always_extended #thumb-main:hover .dt_thumb_btn,
 .dt_overlays_always_extended #thumb-main:selected .dt_thumb_btn,
 .dt_overlays_always_extended #thumb-main:hover #thumb-bottom-label,
 .dt_overlays_always_extended #thumb-main:selected #thumb-bottom-label,
+.dt_overlays_mixed #thumb-main:hover #thumb-ext,
+.dt_overlays_mixed #thumb-main:selected #thumb-ext,
 .dt_overlays_mixed #thumb-main:hover .dt_thumb_btn,
 .dt_overlays_mixed #thumb-main:selected .dt_thumb_btn,
 .dt_overlays_mixed #thumb-main:hover #thumb-bottom-label,
-.dt_overlays_hover_block #thumb-image:hover .dt_thumb_btn,
-.dt_overlays_hover_block #thumb-image:hover .dt_thumb_btn:active,
-.dt_overlays_hover_block #thumb-image:hover #thumb-audio,
-.dt_overlays_hover_block #thumb-image:hover #thumb-altered,
-.dt_overlays_hover_block #thumb-image:hover #thumb-localcopy,
-.dt_overlays_hover_block #thumb-image:hover #thumb-bottom-label
+.dt_overlays_hover_block #thumb-main:hover .dt_thumb_btn,
+.dt_overlays_hover_block #thumb-main:hover .dt_thumb_btn:active,
+.dt_overlays_hover_block #thumb-main:hover #thumb-bottom-label
 {
   color: @thumbnail_font_color;
 }
@@ -2065,6 +2069,10 @@ Details :
 }
 
 /* Set hover group and audio effect */
+.dt_overlays_hover #thumb-main:hover #thumb-group:hover,
+.dt_overlays_hover #thumb-main:hover #thumb-audio:hover,
+.dt_overlays_hover_extended #thumb-main:hover #thumb-group:hover,
+.dt_overlays_hover_extended #thumb-main:hover #thumb-audio:hover,
 .dt_overlays_always #thumb-main:hover #thumb-group:hover,
 .dt_overlays_always #thumb-main:hover #thumb-audio:hover,
 .dt_overlays_always_extended #thumb-main:hover #thumb-group:hover,
@@ -2129,12 +2137,6 @@ Details :
 /*---------------------------------------------------------
   - Hide icons on all lighttable modes and duplicate ones -
   ---------------------------------------------------------*/
-.dt_overlays_hover #thumb-main:hover #thumb-group,
-.dt_overlays_hover #thumb-main:hover #thumb-altered,
-.dt_overlays_hover #thumb-main:hover #thumb-audio,
-.dt_overlays_hover_extended #thumb-main:hover #thumb-group,
-.dt_overlays_hover_extended #thumb-main:hover #thumb-altered,
-.dt_overlays_hover_extended #thumb-main:hover #thumb-audio,
 .dt_culling #thumb-ext,
 .dt_culling #thumb-main:selected #thumb-ext,
 .dt_culling #thumb-main:hover #thumb-ext,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1835,12 +1835,12 @@ Details :
   -----------------*/
 #thumb-image
 {
-  margin: 1.8em 1.2em; /* not real pixels. This is used as a per thousand of the thumb size and couldn't be scalable */
+  margin: 12px 10px; /* not real pixels. This is used as a per thousand of the thumb size and couldn't be scalable */
 }
 
-.dt_thumbnails_2 #thumb-image /* update consistently margins if big thumbnails (less images per row) are shown */
+.dt_thumbnails_1 #thumb-image
 {
-  margin: 1em 0.75em;
+  margin: 18px 16px; /* not real pixels. This is used as a per thousand of the thumb size and couldn't be scalable */
 }
 
 /* Set top margin on active image in filmstrip */
@@ -1938,7 +1938,7 @@ Details :
 .dt_overlays_mixed #thumb-main:hover #thumb-bottom,
 .dt_overlays_hover #thumb-main:hover #thumb-bottom
 {
-  background-image: linear-gradient(rgba(198, 198, 198, 0.7) 0%, rgba(198, 198, 198, 0.7) 90%,rgba(198, 198, 198, 0) 100%);  /* rgb color needs to be set to same color as #thumb-back hover background */
+  background-image: linear-gradient(rgba(212, 212, 212, 0.7) 0%, rgba(212, 212, 212, 0.7) 90%,rgba(212, 212, 212, 0) 100%);  /* rgb color needs to be set to same color as #thumb-back hover background */
 }
 
 /* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
@@ -2217,17 +2217,7 @@ Details :
 .dt_overlays_always#preview #thumb-bottom,
 .dt_overlays_always_extended#preview #thumb-bottom
 {
-  border-radius: 0.21em;
-  border-top: 0.07em solid @lighttable_bg_color;
-  background-image: linear-gradient(rgba(171, 171, 171, 0.2) 0%, rgba(171, 171, 171, 0.1) 5%, rgba(171, 171, 171, 0) 100%);
-}
-
-.dt_overlays_always#culling #thumb-main:hover #thumb-bottom,
-.dt_overlays_always_extended#culling #thumb-main:hover #thumb-bottom,
-.dt_overlays_always#preview #thumb-main:hover #thumb-bottom,
-.dt_overlays_always_extended#preview #thumb-main:hover #thumb-bottom
-{
-  background-image: linear-gradient(rgba(191, 191, 191, 0.4) 0%, rgba(191, 191, 191, 0.2) 5%, rgba(171, 171, 171, 0) 100%);
+  background-color: shade(@lighttable_bg_color, 1.1);
 }
 
 /* Set zoom info */

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2482,9 +2482,9 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
   // let's update the css class depending on the source widget type
   // this allow to set different padding for example
   if(w->show_quad)
-    gtk_style_context_remove_class(context, "bauhaus-popup-no-quad");
+    gtk_style_context_remove_class(context, "dt_bauhaus_popup_right");
   else
-    gtk_style_context_add_class(context, "bauhaus-popup-no-quad");
+    gtk_style_context_add_class(context, "dt_bauhaus_popup_right");
 
   const GtkStateFlags state = gtk_widget_get_state_flags(darktable.bauhaus->popup_area);
   gtk_style_context_get_padding(context, state, darktable.bauhaus->popup_padding);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1608,6 +1608,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     gtk_widget_set_margin_top(thumb->w_bottom, thumb->img_margin->bottom);
     gtk_widget_set_valign(thumb->w_bottom_eb, GTK_ALIGN_END);
     gtk_widget_set_halign(thumb->w_bottom_eb, GTK_ALIGN_CENTER);
+    gtk_widget_set_margin_start(thumb->w_bottom_eb, 0);
 
     // reject icon
     const int margin_b_icons = MAX(0, thumb->img_margin->bottom - icon_size * 0.125 - 1);


### PR DESCRIPTION
Fix missing right padding on some popup (see and, or... popup on new  filters) and better and shortest fix found for missing icons on some overlays pointed by #11835

So will close @aurelienpierre PR #11835