### PR TITLE
BUGFIX fire pipeline reprocessing in two modules via gui_focus

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5769,9 +5769,10 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
   if(!in)
   {
+    const gboolean was_dualmask = dt_bauhaus_widget_get_quad_active(g->dual_thrs);
     dt_bauhaus_widget_set_quad_active(g->dual_thrs, FALSE);
     g->visual_mask = FALSE;
-    dt_dev_reprocess_center(self->dev);
+    if(was_dualmask) dt_dev_reprocess_center(self->dev);
   }
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5769,7 +5769,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
   if(!in)
   {
-    const gboolean was_dualmask = dt_bauhaus_widget_get_quad_active(g->dual_thrs);
+    const gboolean was_dualmask = g->visual_mask;
     dt_bauhaus_widget_set_quad_active(g->dual_thrs, FALSE);
     g->visual_mask = FALSE;
     if(was_dualmask) dt_dev_reprocess_center(self->dev);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2158,9 +2158,10 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(!in)
   {
+    const gboolean was_visualize = dt_bauhaus_widget_get_quad_active(g->clip);
     dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
     g->show_visualize = FALSE;
-    dt_dev_reprocess_center(self->dev);
+    if(was_visualize) dt_dev_reprocess_center(self->dev);
   }
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2158,7 +2158,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(!in)
   {
-    const gboolean was_visualize = dt_bauhaus_widget_get_quad_active(g->clip);
+    const gboolean was_visualize = g->show_visualize;
     dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
     g->show_visualize = FALSE;
     if(was_visualize) dt_dev_reprocess_center(self->dev);


### PR DESCRIPTION
The reprocessing only needs to be done if the mask button was switched on.
