### PR TITLE
variables: make $(MAKER) and $(MODEL) available at import time

### DIFF
--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "common/darktable.h"
+#include "common/image.h"
 
 #include <glib.h>
 
@@ -202,11 +203,11 @@ typedef struct dt_camctl_listener_t
 
   /** Invoked before images are fetched from camera and when tethered capture fetching an image. \note That
    * only one listener should implement this at time... */
-  const char *(*request_image_path)(const dt_camera_t *camera, char *exif_time, void *data);
+  const char *(*request_image_path)(const dt_camera_t *camera, const dt_image_basic_exif_t *basic_exif, void *data);
 
   /** Invoked before images are fetched from camera and when tethered capture fetching an image. \note That
    * only one listener should implement this at time... */
-  const char *(*request_image_filename)(const dt_camera_t *camera, const char *filename, const char *exif_time,
+  const char *(*request_image_filename)(const dt_camera_t *camera, const char *filename, const dt_image_basic_exif_t *basic_exif,
                                         void *data);
 
   /** Invoked when a image is downloaded while in tethered mode or by import */
@@ -331,4 +332,3 @@ void dt_camctl_camera_build_property_menu(const dt_camctl_t *c, const dt_camera_
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/datetime.h
+++ b/src/common/datetime.h
@@ -20,7 +20,6 @@
 #include <glib.h>
 #include "common/image.h"
 
-#define DT_DATETIME_LENGTH 24       // includes msec
 #define DT_DATETIME_EXIF_LENGTH 20  // exif format string length
 
 // The GTimeSpan saved in db is an offset to datetime_origin (0001:01:01 00:00:00)

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -108,8 +108,8 @@ unsigned char *dt_exif_xmp_decode(const char *input, const int len, int *output_
 /** look for color space hints in data and tell the caller if it's sRGB, AdobeRGB or something else. used for mipmaps */
 dt_colorspaces_color_profile_type_t dt_exif_get_color_space(const uint8_t *data, size_t size);
 
-/** look for datetime_taken in data. used for gphoto downloads */
-void dt_exif_get_datetime_taken(const uint8_t *data, size_t size, char *datetime_taken);
+/** look for basic info in data. used import jobs */
+void dt_exif_get_basic_data(const uint8_t *data, size_t size, dt_image_basic_exif_t *basic_exif);
 
 #ifdef __cplusplus
 }
@@ -120,4 +120,3 @@ void dt_exif_get_datetime_taken(const uint8_t *data, size_t size, char *datetime
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -270,6 +270,13 @@ typedef struct dt_image_t
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;
 
+typedef struct dt_image_basic_exif_t
+{
+  char datetime[24];  // must be equal to DT_DATETIME_LENGTH
+  char maker[64];
+  char model[64];
+} dt_image_basic_exif_t;
+
 // image buffer operations:
 /** inits basic values to sensible defaults. */
 void dt_image_init(dt_image_t *img);
@@ -452,4 +459,3 @@ void dt_image_check_camera_missing_sample(const struct dt_image_t *img);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -270,9 +270,12 @@ typedef struct dt_image_t
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;
 
+// should be in datetime.h, workaround to solve cross references 
+#define DT_DATETIME_LENGTH 24       // includes msec
+
 typedef struct dt_image_basic_exif_t
 {
-  char datetime[24];  // must be equal to DT_DATETIME_LENGTH
+  char datetime[DT_DATETIME_LENGTH];
   char maker[64];
   char model[64];
 } dt_image_basic_exif_t;

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "common/film.h"
+#include "common/image.h"
 #include "common/import_session.h"
 #include "common/variables.h"
 #include "control/conf.h"
@@ -220,10 +221,9 @@ void dt_import_session_set_time(struct dt_import_session_t *self, const char *ti
 }
 
 
-void
-dt_import_session_set_exif_time(struct dt_import_session_t *self, const char *exif_time)
+void dt_import_session_set_exif_basic_info(struct dt_import_session_t *self, const dt_image_basic_exif_t *basic_exif)
 {
-  dt_variables_set_exif_time(self->vp, exif_time);
+  dt_variables_set_exif_basic_info(self->vp, basic_exif);
 }
 
 
@@ -381,4 +381,3 @@ const char *dt_import_session_path(struct dt_import_session_t *self, gboolean cu
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/import_session.h
+++ b/src/common/import_session.h
@@ -42,8 +42,8 @@ void dt_import_session_set_name(struct dt_import_session_t *self, const char *na
 */
 void dt_import_session_set_time(struct dt_import_session_t *self, const char *time);
 
-/** \brief set the timestamp for EXIF variables */
-void dt_import_session_set_exif_time(struct dt_import_session_t *self, const char *exif_time);
+/** \brief set the basic exif info for EXIF variables */
+void dt_import_session_set_exif_basic_info(struct dt_import_session_t *self, const dt_image_basic_exif_t *basic_exif);
 
 /** \brief set the original filename
     \remark This is used to expand $(FILE_X) variables. */
@@ -69,4 +69,3 @@ const char *dt_import_session_path(struct dt_import_session_t *self, gboolean cu
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -20,6 +20,7 @@
 
 #include <glib.h>
 #include <stdint.h>
+#include "common/image.h"
 
 typedef struct dt_variables_params_t
 {

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -56,8 +56,8 @@ void dt_variables_set_max_width_height(dt_variables_params_t *params, int max_wi
 void dt_variables_set_upscale(dt_variables_params_t *params, gboolean upscale);
 /** set the time in a dt_variables_params_t. */
 void dt_variables_set_time(dt_variables_params_t *params, const char *time);
-/** set the time to use for EXIF variables */
-void dt_variables_set_exif_time(dt_variables_params_t *params, const char *time);
+/** set the basic info to use for EXIF variables */
+void dt_variables_set_exif_basic_info(dt_variables_params_t *params, const dt_image_basic_exif_t *basic_exif);
 /** set flags for tags to be exported */
 void dt_variables_set_tags_flags(dt_variables_params_t *params, uint32_t flags);
 
@@ -71,4 +71,3 @@ void dt_variables_reset_sequence(dt_variables_params_t *params);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -268,7 +268,7 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *in_p
 }
 
 static const char *_camera_request_image_filename(const dt_camera_t *camera, const char *filename,
-                                                  const char *exif_time, void *data)
+                                                  const dt_image_basic_exif_t *basic_exif, void *data)
 {
   const gchar *file;
   struct dt_camera_shared_t *shared;
@@ -276,8 +276,7 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   const gboolean use_filename = dt_conf_get_bool("session/use_filename");
 
   dt_import_session_set_filename(shared->session, filename);
-  if(exif_time && exif_time[0])
-    dt_import_session_set_exif_time(shared->session, exif_time);
+  dt_import_session_set_exif_basic_info(shared->session, basic_exif);
   file = dt_import_session_filename(shared->session, use_filename);
 
   if(file == NULL) return NULL;
@@ -285,12 +284,11 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   return g_strdup(file);
 }
 
-static const char *_camera_request_image_path(const dt_camera_t *camera, char *exif_time, void *data)
+static const char *_camera_request_image_path(const dt_camera_t *camera, const dt_image_basic_exif_t *basic_exif, void *data)
 {
   struct dt_camera_shared_t *shared;
   shared = (struct dt_camera_shared_t *)data;
-  if(exif_time && exif_time[0])
-    dt_import_session_set_exif_time(shared->session, exif_time);
+  dt_import_session_set_exif_basic_info(shared->session, basic_exif);
   return dt_import_session_path(shared->session, FALSE);
 }
 
@@ -389,4 +387,3 @@ dt_job_t *dt_camera_import_job_create(GList *images, struct dt_camera_t *camera,
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2062,7 +2062,7 @@ static int _control_import_image_copy(const char *filename,
 {
   char *data = NULL;
   gsize size = 0;
-  char exif_time[DT_DATETIME_LENGTH];
+  dt_image_basic_exif_t basic_exif = {0};
   gboolean res = TRUE;
   if(!g_file_get_contents(filename, &data, &size, NULL))
   {
@@ -2078,17 +2078,15 @@ static int _control_import_image_copy(const char *filename,
   else
   {
     char *basename = g_path_get_basename(filename);
-    dt_exif_get_datetime_taken((uint8_t *)data, size, exif_time);
+    dt_exif_get_basic_data((uint8_t *)data, size, &basic_exif);
 
-    if(!exif_time[0])
+    if(!basic_exif.datetime[0])
     { // if no exif datetime try file datetime
       struct stat statbuf;
       if(!stat(filename, &statbuf))
-        dt_datetime_unix_to_exif(exif_time, sizeof(exif_time), &statbuf.st_mtime);
+        dt_datetime_unix_to_exif(basic_exif.datetime, sizeof(basic_exif.datetime), &statbuf.st_mtime);
     }
-
-    if(exif_time[0])
-      dt_import_session_set_exif_time(session, exif_time);
+    dt_import_session_set_exif_basic_info(session, &basic_exif);
     dt_import_session_set_filename(session, basename);
     const char *output_path = dt_import_session_path(session, FALSE);
     const gboolean use_filename = dt_conf_get_bool("session/use_filename");

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -465,7 +465,7 @@ static void _capture_mipmaps_updated_signal_callback(gpointer instance, int imgi
 
 /** callbacks to deal with images taken in tethering mode */
 static const char *_camera_request_image_filename(const dt_camera_t *camera, const char *filename,
-                                                  const char *exif_time, void *data)
+                                                  const dt_image_basic_exif_t *basic_exif, void *data)
 {
   struct dt_capture_t *lib = (dt_capture_t *)data;
 
@@ -479,7 +479,7 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   return g_strdup(file);
 }
 
-static const char *_camera_request_image_path(const dt_camera_t *camera, char *exif_time, void *data)
+static const char *_camera_request_image_path(const dt_camera_t *camera, const dt_image_basic_exif_t *basic_exif, void *data)
 {
   struct dt_capture_t *lib = (dt_capture_t *)data;
   return dt_import_session_path(lib->session, FALSE);
@@ -642,4 +642,3 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
attempt to fix #11209

Needs probably more tests.
Replaces dt_variables_set_exif_time() by dt_variables_set_exif_basic().

I've an issue on cross references of image.h and datetime.h, so I cannot use properly DT_DATETIME_LENGTH (see image.h line 275). Any advice is welcome.
