### PR TITLE
No space before colon

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1282,7 +1282,7 @@
     <type>string</type>
     <default>120|400</default>
     <shortdescription>delimiters for size categories</shortdescription>
-    <longdescription>size categories are used to be able to set different overlays and css values depending of the size of the thumbnail, separated by |. for example, 120|400 means 3 categories of thumbnails : 0px->120px, 120px->400px and >400px</longdescription>
+    <longdescription>size categories are used to be able to set different overlays and css values depending of the size of the thumbnail, separated by |. for example, 120|400 means 3 categories of thumbnails: 0px->120px, 120px->400px and >400px</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/extended_pattern</name>

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2789,7 +2789,7 @@ float dt_image_get_exposure_bias(const struct dt_image_t *image_storage)
 
 char *dt_image_camera_missing_sample_message(const struct dt_image_t *img, gboolean logmsg)
 {
-  const char *T1 = _("<b>WARNING</b> : camera is missing samples!");
+  const char *T1 = _("<b>WARNING</b>: camera is missing samples!");
   const char *T2 = _("You must provide samples in <a href='https://raw.pixls.us/'>https://raw.pixls.us/</a>");
   char *T3 = g_strdup_printf(_("for `%s' `%s'\n"
                                "in as many format/compression/bit depths as possible"),

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1760,19 +1760,19 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   // Update GUI label
   g_free(g->delta_E_label_text);
   g->delta_E_label_text
-      = g_strdup_printf(_("\n<b>Profile quality report : %s</b>\n"
-                          "input  ΔE : \tavg. %.2f ; \tmax. %.2f\n"
-                          "WB ΔE : \tavg. %.2f ; \tmax. %.2f\n"
-                          "output ΔE : \tavg. %.2f ; \tmax. %.2f\n\n"
+      = g_strdup_printf(_("\n<b>Profile quality report: %s</b>\n"
+                          "input ΔE: \tavg. %.2f ; \tmax. %.2f\n"
+                          "WB ΔE: \tavg. %.2f; \tmax. %.2f\n"
+                          "output ΔE: \tavg. %.2f; \tmax. %.2f\n\n"
                           "<b>Profile data</b>\n"
-                          "illuminant :  \t%.0f K \t%s \n"
+                          "illuminant:  \t%.0f K \t%s\n"
                           "matrix in adaptation space:\n"
                           "<tt>%+.4f \t%+.4f \t%+.4f\n"
                           "%+.4f \t%+.4f \t%+.4f\n"
                           "%+.4f \t%+.4f \t%+.4f</tt>\n\n"
                           "<b>Normalization values</b>\n"
-                          "exposure compensation : \t%+.2f EV\n"
-                          "black offset : \t%+.4f"
+                          "exposure compensation: \t%+.2f EV\n"
+                          "black offset: \t%+.4f"
                           ),
                         diagnostic, pre_wb_delta_E, pre_wb_max_delta_E, post_wb_delta_E, post_wb_max_delta_E,
                         post_mix_delta_E, post_mix_max_delta_E, temperature, string, g->mix[0][0], g->mix[0][1],
@@ -1806,11 +1806,11 @@ void validate_color_checker(const float *const restrict in,
 
   // Update GUI label
   g_free(g->delta_E_label_text);
-  g->delta_E_label_text = g_strdup_printf(_("\n<b>Profile quality report : %s</b>\n"
-                                            "output ΔE : \tavg. %.2f ; \tmax. %.2f\n\n"
+  g->delta_E_label_text = g_strdup_printf(_("\n<b>Profile quality report: %s</b>\n"
+                                            "output ΔE: \tavg. %.2f; \tmax. %.2f\n\n"
                                             "<b>Normalization values</b>\n"
-                                            "exposure compensation : \t%+.2f EV\n"
-                                            "black offset : \t%+.4f"),
+                                            "exposure compensation: \t%+.2f EV\n"
+                                            "black offset: \t%+.4f"),
                                           diagnostic, pre_wb_delta_E, pre_wb_max_delta_E, log2f(extraction_result.exposure),
                                           extraction_result.black);
 
@@ -3743,7 +3743,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
   // Write report in GUI
   ++darktable.gui->reset;
   gtk_label_set_text(GTK_LABEL(g->Lch_origin),
-                     g_strdup_printf(_("L : \t%.1f %%\nh : \t%.1f °\nc : \t%.1f"),
+                     g_strdup_printf(_("L: \t%.1f %%\nh: \t%.1f °\nc: \t%.1f"),
                                      Lch[0], Lch[2] * 360.f, Lch[1] ));
   --darktable.gui->reset;
 
@@ -4110,7 +4110,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->origin_spot), "draw", G_CALLBACK(origin_color_draw), self);
   gtk_box_pack_start(GTK_BOX(vvbox), g->origin_spot, TRUE, TRUE, 0);
 
-  g->Lch_origin = gtk_label_new(_("L : \tN/A \nh : \tN/A\nc : \tN/A"));
+  g->Lch_origin = gtk_label_new(_("L: \tN/A\nh: \tN/A\nc: \tN/A"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->Lch_origin),
                               _("these LCh coordinates are computed from CIE Lab 1976 coordinates"));
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->Lch_origin), FALSE, FALSE, 0);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -365,7 +365,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.grey[1] = 1.f;
   p.grey[2] = 0.f;
 
-  dt_gui_presets_add_generic(_("B&W : luminance-based"), self->op,
+  dt_gui_presets_add_generic(_("B&W: luminance-based"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // film emulations
@@ -394,7 +394,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.grey[1] = 0.25958747f;
   p.grey[2] = 0.48737156f;
 
-  dt_gui_presets_add_generic(_("B&W : ILFORD HP5+"), self->op,
+  dt_gui_presets_add_generic(_("B&W: ILFORD HP5+"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // ILFORD Delta 100
@@ -403,7 +403,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.grey[1] = 0.25366007f;
   p.grey[2] = 0.50081619f;
 
-  dt_gui_presets_add_generic(_("B&W : ILFORD DELTA 100"), self->op,
+  dt_gui_presets_add_generic(_("B&W: ILFORD DELTA 100"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // ILFORD Delta 400 and 3200 - they have the same curve
@@ -413,7 +413,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.grey[1] = 0.23613559f;
   p.grey[2] = 0.52009729f;
 
-  dt_gui_presets_add_generic(_("B&W : ILFORD DELTA 400 - 3200"), self->op,
+  dt_gui_presets_add_generic(_("B&W: ILFORD DELTA 400 - 3200"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // ILFORD FP4+
@@ -422,7 +422,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.grey[1] = 0.22149272f;
   p.grey[2] = 0.53701643f;
 
-  dt_gui_presets_add_generic(_("B&W : ILFORD FP4+"), self->op,
+  dt_gui_presets_add_generic(_("B&W: ILFORD FP4+"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Fuji Acros 100
@@ -431,7 +431,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.grey[1] = 0.313f;
   p.grey[2] = 0.353f;
 
-  dt_gui_presets_add_generic(_("B&W : Fuji Acros 100"), self->op,
+  dt_gui_presets_add_generic(_("B&W: Fuji Acros 100"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Kodak ?

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1732,9 +1732,9 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
   const gchar *short_label_lgg[] = { C_("color", "lift"), C_("color", "gamma"), C_("color", "gain") };
   const gchar **short_label = (p->mode == SLOPE_OFFSET_POWER) ? short_label_ops : short_label_lgg;
   const gchar *long_label[]
-     = { N_("shadows : lift / offset"),
-         N_("mid-tones : gamma / power"),
-         N_("highlights : gain / slope") };
+     = { N_("shadows: lift / offset"),
+         N_("mid-tones: gamma / power"),
+         N_("highlights: gain / slope") };
 
   gchar *layout = dt_conf_get_string("plugins/darkroom/colorbalance/layout");
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3229,7 +3229,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->feathering = dt_bauhaus_slider_from_params(self, "feathering");
   dt_bauhaus_slider_set_soft_range(g->feathering, 0.1, 50.0);
-  gtk_widget_set_tooltip_text(g->feathering, _("precision of the feathering :\n"
+  gtk_widget_set_tooltip_text(g->feathering, _("precision of the feathering:\n"
                                                "higher values force the mask to follow edges more closely\n"
                                                "but may void the effect of the smoothing\n"
                                                "lower values give smoother gradients and better smoothing\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -450,13 +450,13 @@ void init_presets(dt_iop_module_so_t *self)
   p.quantization = 0.0f;
   p.exposure_boost = 0.0f;
   p.contrast_boost = 0.0f;
-  dt_gui_presets_add_generic(_("mask blending : all purposes"), self->op,
+  dt_gui_presets_add_generic(_("mask blending: all purposes"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.blending = 1.0f;
   p.feathering = 10.0f;
   p.iterations = 3;
-  dt_gui_presets_add_generic(_("mask blending : people with backlight"), self->op,
+  dt_gui_presets_add_generic(_("mask blending: people with backlight"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // Shadows/highlights presets
@@ -472,11 +472,11 @@ void init_presets(dt_iop_module_so_t *self)
   p.details = DT_TONEEQ_EIGF;
   p.feathering = 20.0f;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.65f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : strong"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): strong"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
   p.details = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
-  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : strong"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf): strong"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.details = DT_TONEEQ_EIGF;
@@ -484,11 +484,11 @@ void init_presets(dt_iop_module_so_t *self)
   p.feathering = 7.0f;
   p.iterations = 3;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.45f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : medium"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): medium"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
   p.details = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
-  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : medium"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf): medium"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.details = DT_TONEEQ_EIGF;
@@ -496,11 +496,11 @@ void init_presets(dt_iop_module_so_t *self)
   p.feathering = 1.0f;
   p.iterations = 1;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.25f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : soft"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): soft"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
   p.details = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
-  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : soft"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf): soft"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   // build the 1D contrast curves that revert the local compression of contrast above
@@ -536,7 +536,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.whites = 0.15f;
   p.speculars = 0.0f;
 
-  dt_gui_presets_add_generic(_("relight : fill-in"), self->op,
+  dt_gui_presets_add_generic(_("relight: fill-in"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1262,24 +1262,24 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->intent, _("absolute colorimetric"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->intent, FALSE, TRUE, 0);
 
-  tooltip = g_strdup_printf(_("• perceptual : "
+  tooltip = g_strdup_printf(_("• perceptual: "
                               "smoothly moves out-of-gamut colors into gamut,"
                               "preserving gradations, but distorts in-gamut colors in the process."
                               " note that perceptual is often a proprietary LUT that depends"
                               " on the destination space."
                               "\n\n"
 
-                              "• relative colorimetric : "
+                              "• relative colorimetric: "
                               "keeps luminance while reducing as little as possible saturation"
                               " until colors fit in gamut."
                               "\n\n"
 
-                              "• saturation : "
+                              "• saturation: "
                               "designed to present eye-catching business graphics"
                               " by preserving the saturation. (not suited for photography)."
                               "\n\n"
 
-                              "• absolute colorimetric : "
+                              "• absolute colorimetric: "
                               "adapt white point of the image to the white point of the"
                               " destination medium and do nothing else. mainly used when"
                               " proofing colors. (not suited for photography)."

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1081,16 +1081,16 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
       if(nb == 1)
       {
         gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
-        item = gtk_menu_item_new_with_label(_("mode : union"));
+        item = gtk_menu_item_new_with_label(_("mode: union"));
         g_signal_connect(item, "activate", (GCallback)_tree_union, self);
         gtk_menu_shell_append(menu, item);
-        item = gtk_menu_item_new_with_label(_("mode : intersection"));
+        item = gtk_menu_item_new_with_label(_("mode: intersection"));
         g_signal_connect(item, "activate", (GCallback)_tree_intersection, self);
         gtk_menu_shell_append(menu, item);
-        item = gtk_menu_item_new_with_label(_("mode : difference"));
+        item = gtk_menu_item_new_with_label(_("mode: difference"));
         g_signal_connect(item, "activate", (GCallback)_tree_difference, self);
         gtk_menu_shell_append(menu, item);
-        item = gtk_menu_item_new_with_label(_("mode : exclusion"));
+        item = gtk_menu_item_new_with_label(_("mode: exclusion"));
         g_signal_connect(item, "activate", (GCallback)_tree_exclusion, self);
         gtk_menu_shell_append(menu, item);
       }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3510,8 +3510,8 @@ static void _manage_editor_preset_action(GtkWidget *btn, dt_lib_module_t *self)
 #endif
   GtkWidget *bt_ok = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
   GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-  gtk_box_pack_start(GTK_BOX(content_area), gtk_label_new(_("new preset name :")), FALSE, TRUE, 0);
-  GtkWidget *lb = gtk_label_new(_("a preset with this name already exists !"));
+  gtk_box_pack_start(GTK_BOX(content_area), gtk_label_new(_("new preset name:")), FALSE, TRUE, 0);
+  GtkWidget *lb = gtk_label_new(_("a preset with this name already exists!"));
   GtkWidget *tb = gtk_entry_new();
   gtk_entry_set_text(GTK_ENTRY(tb), new_name);
   g_object_set_data(G_OBJECT(tb), "existing_names", names);
@@ -3856,7 +3856,7 @@ static void _manage_show_window(dt_lib_module_t *self)
   GtkWidget *vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_name(vb, "modulegroups-top-boxes");
   GtkWidget *hb2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(hb2), gtk_label_new(_("preset : ")), FALSE, TRUE, 2);
+  gtk_box_pack_start(GTK_BOX(hb2), gtk_label_new(_("preset: ")), FALSE, TRUE, 2);
   d->presets_combo = gtk_combo_box_text_new();
   g_signal_connect(G_OBJECT(d->presets_combo), "changed", G_CALLBACK(_manage_preset_change), self);
   gtk_box_pack_start(GTK_BOX(hb2), d->presets_combo, TRUE, TRUE, 2);


### PR DESCRIPTION
As a general rule, in English there is no space before and one space after a punctuation mark.

These changes will also improve the consistency of the interface, as in most cases in darktable UI there is no space before the colon.
