### PR TITLE
Add a consolidated header file for extra GCC optimization flags

### DIFF
--- a/src/common/extra_optimizations.h
+++ b/src/common/extra_optimizations.h
@@ -1,0 +1,35 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* Enable extra optimizations on GCC by including this header at the very beginning
+ * of your *.c file (before any other includes). This applies these optimizations for
+ * all of the source file.
+ * 
+ * we use finite-math-only because divisions by zero are manually avoided in the code,
+ * the rest is loop reorganization and vectorization optimization
+ **/
+
+#if defined(__GNUC__)
+#pragma GCC optimize ("unroll-loops", "split-loops", \
+                      "loop-nest-optimize", "tree-loop-im", \
+                      "tree-loop-ivcanon", "ira-loop-pressure", \
+                      "variable-expansion-in-unroller", \
+                      "ivopts", "finite-math-only")
+#endif

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -36,6 +36,7 @@
  **/
 
 #if defined(__GNUC__)
+#pragma GCC push_options
 #pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
                       "tree-loop-distribution", "no-strict-aliasing", \
                       "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
@@ -365,6 +366,11 @@ clean:
   if(ds_mask) dt_free_align(ds_mask);
   if(ds_image) dt_free_align(ds_image);
 }
+
+#if defined(__GNUC__)
+#pragma GCC pop_options
+#endif
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -29,23 +29,12 @@
 #include "common/darktable.h"
 #include "common/imagebuf.h"
 
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
+
+/* NOTE: this code complies with the optimizations in "common/extra_optimizations.h".
+ * Consider including that at the beginning of a *.c file where you use this
+ * header (provided the rest of the code complies).
  **/
 
-#if defined(__GNUC__)
-#pragma GCC push_options
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math")
-#endif
 
 #define MIN_FLOAT exp2f(-16.0f)
 
@@ -366,10 +355,6 @@ clean:
   if(ds_mask) dt_free_align(ds_mask);
   if(ds_image) dt_free_align(ds_image);
 }
-
-#if defined(__GNUC__)
-#pragma GCC pop_options
-#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -21,6 +21,11 @@
 #include "common/fast_guided_filter.h"
 #include "develop/openmp_maths.h"
 
+/* NOTE: this code complies with the optimizations in "common/extra_optimizations.h".
+ * Consider including that at the beginning of a *.c file where you use this
+ * header (provided the rest of the code complies).
+ **/
+
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif

--- a/src/common/luminance_mask.h
+++ b/src/common/luminance_mask.h
@@ -28,23 +28,11 @@
 #include "develop/imageop_math.h"
 
 
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
+/* NOTE: this code complies with the optimizations in "common/extra_optimizations.h".
+ * Consider including that at the beginning of a *.c file where you use this
+ * header (provided the rest of the code complies).
  **/
 
-#if defined(__GNUC__)
-#pragma GCC push_options
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math")
-#endif
 
 #define MIN_FLOAT exp2f(-16.0f)
 
@@ -314,9 +302,6 @@ static inline void luminance_mask(const float *const restrict in, float *const r
   }
 }
 
-#if defined(__GNUC__)
-#pragma GCC pop_options
-#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/luminance_mask.h
+++ b/src/common/luminance_mask.h
@@ -35,6 +35,7 @@
  **/
 
 #if defined(__GNUC__)
+#pragma GCC push_options
 #pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
                       "tree-loop-distribution", "no-strict-aliasing", \
                       "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
@@ -312,6 +313,11 @@ static inline void luminance_mask(const float *const restrict in, float *const r
       break;
   }
 }
+
+#if defined(__GNUC__)
+#pragma GCC pop_options
+#endif
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -16,6 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** this is the thumbnail class for the lighttable module.  */
+
+#include "common/extra_optimizations.h"
+
 #include "dtgtk/thumbnail.h"
 
 #include "bauhaus/bauhaus.h"

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -26,23 +26,6 @@
 #include "common/imagebuf.h"
 #include "develop/imageop_math.h"
 
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-
-#if defined(__GNUC__)
-#pragma GCC push_options
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math")
-#endif
 
 /* DOCUMENTATION
  *
@@ -439,9 +422,6 @@ static inline int pseudo_solve(float *const restrict A,
   return valid;
 }
 
-#if defined(__GNUC__)
-#pragma GCC pop_options
-#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -33,6 +33,7 @@
  **/
 
 #if defined(__GNUC__)
+#pragma GCC push_options
 #pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
                       "tree-loop-distribution", "no-strict-aliasing", \
                       "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
@@ -437,6 +438,11 @@ static inline int pseudo_solve(float *const restrict A,
 
   return valid;
 }
+
+#if defined(__GNUC__)
+#pragma GCC pop_options
+#endif
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -22,7 +22,6 @@
 #include "common/bspline.h"
 #include "common/darktable.h"
 #include "common/dwt.h"
-#include "common/fast_guided_filter.h"
 #include "common/gaussian.h"
 #include "common/image.h"
 #include "common/imagebuf.h"

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -15,6 +15,9 @@
    You should have received a copy of the GNU General Public License
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -68,6 +68,8 @@
  *
 ***/
 
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -112,23 +114,6 @@
 
 DT_MODULE_INTROSPECTION(2, dt_iop_toneequalizer_params_t)
 
-
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-#if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math", \
-                      "tree-vectorize")
-#endif
 
 #define UI_SAMPLES 256 // 128 is a bit small for 4K resolution
 #define CONTRAST_FULCRUM exp2f(-4.0f)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -16,6 +16,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** this is the view for the darkroom module.  */
+
+#include "common/extra_optimizations.h"
+
 #include "bauhaus/bauhaus.h"
 #include "common/collection.h"
 #include "common/colorspaces.h"

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -15,6 +15,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** this is the view for the lighttable module.  */
+
+#include "common/extra_optimizations.h"
+
 #include "bauhaus/bauhaus.h"
 #include "common/collection.h"
 #include "common/colorlabels.h"

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -16,6 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "common/extra_optimizations.h"
+
 #include "views/view.h"
 #include "bauhaus/bauhaus.h"
 #include "common/collection.h"


### PR DESCRIPTION
This prevents the attributes from propagating to whatever file includes
the header.

EDIT: implementation changed. Now there's a separate header file that contains the set of usually applied optimization flags that are found in many files. This can be included in the very beginning of a *.c file so that all included code get the same optimizations. This prevents missed inlining opportunities due to mismatching optimization flags.

Fixes https://github.com/darktable-org/darktable/issues/11899