### PR TITLE
make delete/edit action on presets avoid rebuilding the whole tree

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -662,6 +662,7 @@ static module_and_parent *_update_tree_model_line(GtkTreeModel *tree_model, GtkT
   {
     if(g_strcmp0(last_module, operation) != 0)
     {
+      // the first-level entry (the module) must be added
       gtk_tree_store_insert_with_values(GTK_TREE_STORE(tree_model), iter, NULL, -1,
                          P_ROWID_COLUMN, 0, P_OPERATION_COLUMN, "", P_MODULE_COLUMN,
                          _(module), P_EDITABLE_COLUMN, NULL, P_NAME_COLUMN, "", P_MODEL_COLUMN, "",

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -364,6 +364,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 
+    g->action = DT_ACTION_EFFECT_EDIT;
     if(g->callback) ((void (*)(dt_gui_presets_edit_dialog_t *))g->callback)(g);
   }
   else if(response_id == GTK_RESPONSE_YES && g->old_id)
@@ -393,6 +394,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
   {
     dt_gui_presets_confirm_and_delete(GTK_WIDGET(dialog), g->original_name, g->operation, g->old_id);
 
+    g->action = DT_ACTION_EFFECT_DELETE;
     if(g->callback) ((void (*)(dt_gui_presets_edit_dialog_t *))g->callback)(g);
   }
 

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -49,6 +49,7 @@ typedef struct dt_gui_presets_edit_dialog_t
   gchar *module_name;
   gchar *operation;
   int op_version;
+  int action;
 
   GtkEntry *name, *description;
   GtkCheckButton *autoapply, *filter;


### PR DESCRIPTION
fixes #9956 

When deleting a preset or modifying it in the preferences, the db whas updated, and then the whole presets tree was cleared+refilled.

As suggested in the (deleted) TODO, now the single row is deleted/updated

Perhaps some pointer is still to be freed, I need help in this matter.