### PR TITLE
PDF export: fix crash or blank page

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2501,6 +2501,18 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/imageio/format/pdf/bpp</name>
+    <type>
+      <enum>
+        <option>8</option>
+        <option>16</option>
+      </enum>
+    </type>
+    <default>8</default>
+    <shortdescription>PDF bit depth (bpp)</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/imageio/format/pdf/compression</name>
     <type>int</type>
     <default>1</default>


### PR DESCRIPTION
Add conf XML for `plugins/imageio/format/pdf/bpp` with options 8 or 16 bit. Without this, PDF export defaults to a bpp of 0, which results in writing a 0 byte image stream. This causes an empty page with deflate compression, or a crash with ASCIIHex.

It's possible to make the PDF export GUI code a bit more succinct now that bpp is an enum, but this is a minimal fix, due to code freeze.

Fixes #11846.