### PR TITLE
fix crash from multi module with tabs undo

### DIFF
--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -381,8 +381,8 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
         gtk_widget_hide(mod->expander);
 
         // this is copied from dt_iop_gui_delete_callback(), not sure why the above sentence...
-        gtk_widget_destroy(mod->widget);
         dt_iop_gui_cleanup_module(mod);
+        gtk_widget_destroy(mod->widget);
       }
 
       iop_list = g_list_remove_link(iop_list, modules);


### PR DESCRIPTION
just fixes #11806 in an "obviously correct" way, so should be "safe". When multiple instances exist of a module that saves its tab status on exit (for example tone equaliser) then going back in history to when there was only one instance would crash, because the tab widget would already be deleted by the time its status was being read.

#10517 tried to fix a possible memory leak as well, because it seems the expander never gets deleted (only the widget it contains). But since further crashes were reported against that, the solution may need to be more intricate.