### PR TITLE
channelmixerrgb: add missing default clauses

### DIFF
--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -186,6 +186,7 @@ static inline float4 luma_chroma(const float4 input, const float4 saturation, co
       } \
       case DT_ADAPTATION_RGB: \
       case DT_ADAPTATION_LAST: \
+      default: \
       { \
         XYZ = matrix_product_float4(LMS, RGB_to_XYZ); \
         break; \
@@ -214,6 +215,7 @@ static inline float4 luma_chroma(const float4 input, const float4 saturation, co
     } \
     case DT_ADAPTATION_RGB: \
     case DT_ADAPTATION_LAST: \
+    default: \
     { \
       LMS = matrix_product_float4(XYZ, XYZ_to_RGB); \
       break; \
@@ -336,6 +338,7 @@ static inline float4 chroma_adapt_RGB(const float4 RGB,
     } \
     case DT_ADAPTATION_RGB: \
     case DT_ADAPTATION_LAST: \
+    default: \
     { \
       XYZ = chroma_adapt_RGB(RGB, RGB_to_XYZ, MIX); \
       break; \

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -117,6 +117,7 @@ static inline void convert_any_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_align
     case DT_ADAPTATION_XYZ:
     case DT_ADAPTATION_RGB:
     case DT_ADAPTATION_LAST:
+    default:
     {
       // special case : just pass through.
       XYZ[0] = LMS[0];
@@ -151,6 +152,7 @@ static inline void convert_any_XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_align
     case DT_ADAPTATION_XYZ:
     case DT_ADAPTATION_RGB:
     case DT_ADAPTATION_LAST:
+    default:
     {
       // special case : just pass through.
       LMS[0] = XYZ[0];

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -762,6 +762,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       }
       case DT_ADAPTATION_RGB:
       case DT_ADAPTATION_LAST:
+      default:
       {
         // No white balance.
 
@@ -771,11 +772,6 @@ static inline void loop_switch(const float *const restrict in, float *const rest
         // Convert from RGB to XYZ
         dot_product(temp_one, RGB_to_XYZ, temp_two);
 
-        for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) temp_one[c] = temp_two[c];
-        break;
-      }
-      default:
-      {
         for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) temp_one[c] = temp_two[c];
         break;
       }
@@ -799,6 +795,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
       }
       case DT_ADAPTATION_RGB:
       case DT_ADAPTATION_LAST:
+      default:
       {
         // Convert from XYZ to RGB
         dot_product(temp_two, XYZ_to_RGB, temp_one);
@@ -841,6 +838,7 @@ static inline void loop_switch(const float *const restrict in, float *const rest
         }
         case DT_ADAPTATION_RGB:
         case DT_ADAPTATION_LAST:
+        default:
         {
           // Convert from RBG to XYZ
           dot_product(temp_two, RGB_to_XYZ, temp_one);
@@ -1604,6 +1602,7 @@ void extract_color_checker(const float *const restrict in, float *const restrict
       }
       case DT_ADAPTATION_RGB:
       case DT_ADAPTATION_LAST:
+      default:
       {
         // No white balance.
         for(size_t c = 0; c < 3; ++c) temp[c] = LMS[c];
@@ -1996,6 +1995,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
       break;
     }
     case DT_ADAPTATION_LAST:
+    default:
     {
       break;
     }
@@ -2097,6 +2097,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
      }
     case DT_ADAPTATION_RGB:
     case DT_ADAPTATION_LAST:
+    default:
     {
       kernel = gd->kernel_channelmixer_rgb_rgb;
       break;
@@ -2957,6 +2958,7 @@ static void update_illuminants(dt_iop_module_t *self)
       break;
     }
     case DT_ILLUMINANT_LAST:
+    default:
     {
       break;
     }


### PR DESCRIPTION
This came up when trying out some optimization flags. The compiler gets confused when the default clauses are missing and may warn about using uninitialized variables. Hopefully the default clauses also help the compiler to reason about the code and optimize it better.