### PR TITLE
Use extra optimizations header where applicable

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -16,6 +16,10 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef __GNUC__
+#pragma GCC optimize ("finite-math-only")
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -32,9 +36,6 @@
 #include <xmmintrin.h>
 #endif
 
-#ifdef __GNUC__
-#pragma GCC optimize ("finite-math-only")
-#endif
 
 #if defined(__SSE__)
 #define DT_PREFETCH(addr) _mm_prefetch(addr, _MM_HINT_T2)

--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -344,10 +344,7 @@ static inline void XYZ_adapt_D50(const dt_aligned_pixel_t lms_in,
 
   // Precomputed D50 primaries in XYZ for camera WB adjustment
   const dt_aligned_pixel_t D50 = { 0.9642119944211994f, 1.0f, 0.8251882845188288f, 0.f };
-
-  lms_out[0] = lms_in[0] * D50[0] / origin_illuminant[0];
-  lms_out[1] = lms_in[1] * D50[1] / origin_illuminant[1];
-  lms_out[2] = lms_in[2] * D50[2] / origin_illuminant[2];
+  for_each_channel(c) lms_out[c] = lms_in[c] * D50[c] / origin_illuminant[c];
 }
 
 /* Pre-solved matrices to adjust white point for triplets in CIE XYZ 1931 2° observer */
@@ -432,11 +429,10 @@ static inline void chroma_adapt_pixel(const dt_aligned_pixel_t in, dt_aligned_pi
     }
     case DT_ADAPTATION_XYZ:
     {
-      for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) temp_one[c] = in[c];
+      for_each_channel(c) temp_one[c] = in[c];
       downscale_vector(temp_one, Y);
-      XYZ_adapt_D50(temp_one, illuminant, temp_two);
-      upscale_vector(temp_two, Y);
-      for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; ++c) out[c] = temp_two[c];
+      XYZ_adapt_D50(temp_one, illuminant, out);
+      upscale_vector(out, Y);
       break;
     }
     case DT_ADAPTATION_RGB:

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -36,22 +39,6 @@
 
 static void _ioppr_reset_iop_order(GList *iop_order_list);
 
-/** Note :
- * we do not use finite-math-only and fast-math because divisions by zero are not manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-#if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "fp-contract=fast", \
-                      "tree-vectorize")
-#endif
 
 const char *iop_order_string[] =
 {

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -31,23 +34,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-/** Note :
- * we do not use finite-math-only and fast-math because divisions by zero are not manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-#if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "fp-contract=fast", \
-                      "tree-vectorize")
-#endif
 
 
 static void _mark_as_nonmatrix_profile(dt_iop_order_iccprofile_info_t *const profile_info)

--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -16,14 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(__GNUC__)
-#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
-                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
-                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller", "tree-loop-vectorize",    \
-                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
-                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
-                     "fast-math", "no-math-errno")
-#endif
+#include "common/extra_optimizations.h"
 
 #include "common/colorspaces_inline_conversions.h"
 #include "common/imagebuf.h"

--- a/src/develop/blends/blendif_raw.c
+++ b/src/develop/blends/blendif_raw.c
@@ -16,14 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(__GNUC__)
-#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
-                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
-                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller", "tree-loop-vectorize",    \
-                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
-                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
-                     "fast-math", "no-math-errno")
-#endif
+#include "common/extra_optimizations.h"
 
 #include "common/imagebuf.h"
 #include "common/math.h"

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -16,14 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(__GNUC__)
-#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
-                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
-                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller", "tree-loop-vectorize",    \
-                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
-                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
-                     "fast-math", "no-math-errno")
-#endif
+#include "common/extra_optimizations.h"
 
 #include "common/colorspaces_inline_conversions.h"
 #include "common/imagebuf.h"

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -16,14 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(__GNUC__)
-#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
-                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
-                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller", "tree-loop-vectorize",    \
-                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
-                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
-                     "fast-math", "no-math-errno")
-#endif
+#include "common/extra_optimizations.h"
 
 #include "common/colorspaces_inline_conversions.h"
 #include "common/imagebuf.h"

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3732,7 +3732,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
   if(work_profile == NULL) return;
 
   // Convert to XYZ
-  dt_aligned_pixel_t XYZ;
+  dt_aligned_pixel_t XYZ = { 0.f };
   dot_product(RGB, work_profile->matrix_in, XYZ);
   dt_XYZ_to_sRGB(XYZ, g->spot_RGB);
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -16,6 +16,8 @@
   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -48,23 +50,6 @@
 #include <time.h>
 
 DT_MODULE_INTROSPECTION(3, dt_iop_channelmixer_rgb_params_t)
-
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-#if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math", \
-                      "tree-vectorize", "no-math-errno")
-#endif
 
 
 #define CHANNEL_SIZE 4

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -15,6 +15,9 @@
    You should have received a copy of the GNU General Public License
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -91,21 +94,6 @@ DT_MODULE_INTROSPECTION(5, dt_iop_filmicrgb_params_t)
  * is prone to enforce.
  *
  * */
-
-
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-#if defined(__GNUC__)
-#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
-                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
-                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller",                           \
-                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
-                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
-                     "fast-math", "no-math-errno")
-#endif
 
 
 typedef enum dt_iop_filmicrgb_methods_type_t

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include "common/extra_optimizations.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -40,16 +43,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math")
-#endif
 
 /** DOCUMENTATION
  *


### PR DESCRIPTION
Use the `extra_optimizations.h` header in files where there are GCC optimization `#pragma`s with the same flags. Move the inclusion of the pragma to top in order to have the same optimizations also for functions in included headers.

Also move the optimization pragma in `box_filters.c` to the very top for the same reason.

https://github.com/darktable-org/darktable/pull/11917 has to go in before this one.