### PR TITLE
darktable-bench: updates for v4.0 release

### DIFF
--- a/src/tests/benchmark/README.txt
+++ b/src/tests/benchmark/README.txt
@@ -137,10 +137,13 @@ Thruput Sidecar dt           Hardware
 ~645    3.4     3.4.0        32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
 ~690    3.4     3.6.0        32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
 720     3.4     3.7.0+440    32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
+713     3.4     3.9.0+1630   32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
 
 659     3.6     3.7.0+440    32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
+661     3.6     3.9.0+1630   32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
 
 644	3.8	3.7.0+1370   32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
+666     3.8     3.9.0+1630   32-core AMD Threadripper 3970X, 64GB PC3600, no GPU
 
 [*] darktable 3.2.1 using the v3.4 sidecar skips two modules which
   didn't yet exist, so this number is actually over-reporting the

--- a/src/tests/benchmark/darktable-bench
+++ b/src/tests/benchmark/darktable-bench
@@ -243,12 +243,17 @@ def run_benchmark(program,image,xmp,args):
       arglist = arglist + ["--disable-opencl"]
    os.environ['LANG'] = 'C'
    os.environ['LC_ALL'] = 'C'
-   trace = subprocess.check_output([program]+arglist,stdin=None,stderr=subprocess.PIPE,env=os.environ)
+   try:
+      trace = subprocess.check_output([program]+arglist,stdin=None,stderr=subprocess.PIPE,env=os.environ)
+      pixpipe = 0.0
+   except KeyboardInterrupt as e:
+      print('KeyboardInterrupt')
+      trace = ''
+      pixpipe = -1.0
    if trace:
       trace = trace.decode('utf-8').split('\n')
    loadtime = 0.0
    savetime = -1
-   pixpipe = 0.0
    gpu = False
    for t in trace:
       if 'GPU' in t:
@@ -321,18 +326,22 @@ def main():
    total = 0.0
    pixpipe = 0.0
    used_gpu = False
+   reps_run = 0
    for rep in range(args.reps):
       if args.reps > 1:
          print('     run #',rep+1,end='')
       p, t, g = run_benchmark(args.program,args.image,args.xmp,args)
+      if p < 0.0:
+         continue
       pixpipe += p
       total += t
+      reps_run += 1
       if g:
          used_gpu = True
       if args.reps > 1:
          print(f': {p:7.3f} pixpipe,  {t:7.3f} total')
-   total = total / args.reps
-   pixpipe = pixpipe / args.reps
+   total = total / reps_run if reps_run > 0 else 999.9
+   pixpipe = pixpipe / reps_run if reps_run > 0 else 999.9
    print_performance(pixpipe,total,get_version(args.program),args.version,args.image_base,args.threads,used_gpu)
    cleanup(args)
    return


### PR DESCRIPTION
darktable-bench script now traps KeyboardInterrupt while running
darktable-cli and omits that run from calculations if the user pressed
Ctrl-C.

Added new benchmark results.