### PR TITLE
Improve GPX spelling consistency

### DIFF
--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -272,7 +272,7 @@ void _gpx_parser_start_element(GMarkupParseContext *ctx, const gchar *element_na
   {
     if(gpx->current_track_point)
     {
-      fprintf(stderr, "broken gpx file, new trkpt element before the previous ended.\n");
+      fprintf(stderr, "broken GPX file, new trkpt element before the previous ended.\n");
       g_free(gpx->current_track_point);
     }
 
@@ -306,12 +306,12 @@ void _gpx_parser_start_element(GMarkupParseContext *ctx, const gchar *element_na
       /* validate that we actually got lon / lat attribute values */
       if(isnan(gpx->current_track_point->longitude) || isnan(gpx->current_track_point->latitude))
       {
-        fprintf(stderr, "broken gpx file, failed to get lon/lat attribute values for trkpt\n");
+        fprintf(stderr, "broken GPX file, failed to get lon/lat attribute values for trkpt\n");
         gpx->invalid_track_point = TRUE;
       }
     }
     else
-      fprintf(stderr, "broken gpx file, trkpt element doesn't have lon/lat attributes\n");
+      fprintf(stderr, "broken GPX file, trkpt element doesn't have lon/lat attributes\n");
 
     gpx->current_parser_element = GPX_PARSER_ELEMENT_TRKPT;
   }
@@ -345,7 +345,7 @@ end:
   return;
 
 element_error:
-  fprintf(stderr, "broken gpx file, element '%s' found outside of trkpt.\n", element_name);
+  fprintf(stderr, "broken GPX file, element '%s' found outside of trkpt.\n", element_name);
 }
 
 void _gpx_parser_end_element(GMarkupParseContext *context, const gchar *element_name, gpointer user_data,
@@ -398,7 +398,7 @@ void _gpx_parser_text(GMarkupParseContext *context, const gchar *text, gsize tex
     if(!gpx->current_track_point->time)
     {
       gpx->invalid_track_point = TRUE;
-      fprintf(stderr, "broken gpx file, failed to pars is8601 time '%s' for trackpoint\n", text);
+      fprintf(stderr, "broken GPX file, failed to pars is8601 time '%s' for trackpoint\n", text);
     }
     dt_gpx_track_segment_t *ts = (dt_gpx_track_segment_t *)gpx->trksegs->data;
     if(ts)

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1819,7 +1819,7 @@ void gui_init(dt_lib_module_t *self)
   d->map.gpx_section = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->map.gpx_section), TRUE, TRUE, 0);
 
-  label = dt_ui_section_label_new(_("gpx file"));
+  label = dt_ui_section_label_new(_("GPX file"));
   gtk_grid_attach(grid, label, 0, line++, 4, 1);
 
   d->map.gpx_button = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
@@ -1843,7 +1843,7 @@ void gui_init(dt_lib_module_t *self)
   g_object_unref(model);
   gtk_widget_set_name(d->map.gpx_view, "gpx_list");
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->map.gpx_view),
-                              _("list of track segments in the gpx file, for each segment:"
+                              _("list of track segments in the GPX file, for each segment:"
                                 "\n- the start date/time in local time (LT)"
                                 "\n- the number of track points"
                                 "\n- the number of matching images"


### PR DESCRIPTION
In darktable UI in most cases GPX is written in upper case, but in some places there is also spelling in lower case.