### PR TITLE
filmic v6 bugfixes

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -629,7 +629,7 @@ static inline float4 filmic_split_v4(const float4 i,
     // Filmic S curve on the max RGB
     // Apply the transfer function of the display
     output[c] = native_powr(clamp(filmic_spline(output[c], M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
-                       display_black,
+                       0.f,  // individual components can always go to zero, luminance is clamped later
                        display_white), output_power);
   }
 

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -531,11 +531,13 @@ static inline float4 gamut_mapping(float4 Ych_final, float4 Ych_original,
   Ych_final = filmic_desaturate_v4(Ych_original, Ych_final, saturation);
   Ych_final = gamut_check_Yrg(Ych_final);
 
+  float4 output;
+
   if(!use_output_profile)
   {
     // Now, it is still possible that one channel > display white or < display black because of saturation.
     // We have already clipped Y, so we know that any problem now is caused by c
-    return gamut_check_RGB(input_matrix, output_matrix, display_black, display_white, Ych_final);
+    output = gamut_check_RGB(input_matrix, output_matrix, display_black, display_white, Ych_final);
   }
   else
   {
@@ -547,8 +549,10 @@ static inline float4 gamut_mapping(float4 Ych_final, float4 Ych_original,
     const float4 LMS = matrix_product_float4(export_RGB, export_input_matrix);
 
     // Go from CIE LMS 2006 D65 to pipeline RGB D50
-    return matrix_product_float4(LMS, output_matrix);
+    output = matrix_product_float4(LMS, output_matrix);
   }
+
+  return output;
 }
 
 

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -510,7 +510,7 @@ static inline float4 gamut_check_RGB(constant const float *const matrix_in, cons
   return clamp(RGB_out, 0.f, display_white);
 }
 
-static inline float4 gamut_mapping(float4 Ych_final, float4 Ych_original, float4 pix_out,
+static inline float4 gamut_mapping(float4 Ych_final, float4 Ych_original,
                                    constant const float *const input_matrix,
                                    constant const float *const output_matrix,
                                    constant const float *const export_input_matrix,
@@ -535,22 +535,20 @@ static inline float4 gamut_mapping(float4 Ych_final, float4 Ych_original, float4
   {
     // Now, it is still possible that one channel > display white or < display black because of saturation.
     // We have already clipped Y, so we know that any problem now is caused by c
-    pix_out = gamut_check_RGB(input_matrix, output_matrix, display_black, display_white, Ych_final);
+    return gamut_check_RGB(input_matrix, output_matrix, display_black, display_white, Ych_final);
   }
   else
   {
     // Now, it is still possible that one channel > display white or < display black because of saturation.
     // We have already clipped Y, so we know that any problem now is caused by c
-    pix_out = gamut_check_RGB(export_input_matrix, export_output_matrix, display_black, display_white, Ych_final);
+    const float4 export_RGB = gamut_check_RGB(export_input_matrix, export_output_matrix, display_black, display_white, Ych_final);
 
     // Go from export RGB to CIE LMS 2006 D65
-    const float4 LMS = matrix_product_float4(pix_out, export_input_matrix);
+    const float4 LMS = matrix_product_float4(export_RGB, export_input_matrix);
 
     // Go from CIE LMS 2006 D65 to pipeline RGB D50
-    pix_out = matrix_product_float4(LMS, output_matrix);
+    return matrix_product_float4(LMS, output_matrix);
   }
-
-  return pix_out;
 }
 
 
@@ -598,10 +596,9 @@ static inline float4 filmic_chroma_v4(const float4 i,
   // Get final Ych in Kirk/Filmlight Yrg
   float4 Ych_final = pipe_RGB_to_Ych(o, matrix_in);
 
-  o = gamut_mapping(Ych_final, Ych_original, o, matrix_in, matrix_out,
-                    export_matrix_in, export_matrix_out,
-                    display_black, display_white, saturation, use_output_profile);
-  return o;
+  return gamut_mapping(Ych_final, Ych_original, matrix_in, matrix_out,
+                       export_matrix_in, export_matrix_out,
+                       display_black, display_white, saturation, use_output_profile);
 }
 
 static inline float4 filmic_split_v4(const float4 i,
@@ -618,20 +615,23 @@ static inline float4 filmic_split_v4(const float4 i,
                                      const int use_output_profile,
                                      constant const float *const export_matrix_in, constant const float *const export_matrix_out)
 {
-  float *input = (float *)&i;
   float4 o;
-  float *output = (float *)&o;
-  for(int c = 0; c < 3; c++)
-  {
-    // Log tonemapping
-    output[c] = log_tonemapping_v2(input[c], grey_value, black_exposure, dynamic_range);
 
-    // Filmic S curve on the max RGB
-    // Apply the transfer function of the display
-    output[c] = native_powr(clamp(filmic_spline(output[c], M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
-                       0.f,  // individual components can always go to zero, luminance is clamped later
-                       display_white), output_power);
-  }
+  // Log tonemapping
+  o.x = log_tonemapping_v2(i.x, grey_value, black_exposure, dynamic_range);
+  o.y = log_tonemapping_v2(i.y, grey_value, black_exposure, dynamic_range);
+  o.z = log_tonemapping_v2(i.z, grey_value, black_exposure, dynamic_range);
+  o.w = 0.f;
+
+  // Filmic S curve on individual channels
+  o.x = filmic_spline(o.x, M1, M2, M3, M4, M5, latitude_min, latitude_max, type);
+  o.y = filmic_spline(o.y, M1, M2, M3, M4, M5, latitude_min, latitude_max, type);
+  o.z = filmic_spline(o.z, M1, M2, M3, M4, M5, latitude_min, latitude_max, type);
+
+  // Clamp to [0, display_white]: we don't want to clamp individual channels to display_black
+  // as that would limit the max available saturation. Luminance is clipped to display_black later.
+  // Apply output power function afterwards.
+  o = native_powr(clamp(o, (float4)0.f, (float4)display_white), output_power);
 
   // Save Ych in Kirk/Filmlight Yrg
   float4 Ych_original = pipe_RGB_to_Ych(i, matrix_in);
@@ -641,10 +641,9 @@ static inline float4 filmic_split_v4(const float4 i,
 
   Ych_final.y = fmin(Ych_original.y, Ych_final.y);
 
-  o = gamut_mapping(Ych_final, Ych_original, o, matrix_in, matrix_out,
-                    export_matrix_in, export_matrix_out,
-                    display_black, display_white, saturation, use_output_profile);
-  return o;
+  return gamut_mapping(Ych_final, Ych_original, matrix_in, matrix_out,
+                       export_matrix_in, export_matrix_out,
+                       display_black, display_white, saturation, use_output_profile);
 }
 
 static inline float4 filmic_split_v1(const float4 i,

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -639,14 +639,7 @@ static inline float4 filmic_split_v4(const float4 i,
   // Get final Ych in Kirk/Filmlight Yrg
   float4 Ych_final = pipe_RGB_to_Ych(o, matrix_in);
 
-  // Force final hue and chroma to original
-  Ych_final.z = Ych_original.z;
   Ych_final.y = fmin(Ych_original.y, Ych_final.y);
-
-  // Clip luminance
-  Ych_final.x = clamp(Ych_final.x,
-                      CIE_Y_1931_to_CIE_Y_2006(display_black),
-                      CIE_Y_1931_to_CIE_Y_2006(display_white));
 
   o = gamut_mapping(Ych_final, Ych_original, o, matrix_in, matrix_out,
                     export_matrix_in, export_matrix_out,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -181,7 +181,7 @@ typedef struct dt_iop_filmicrgb_params_t
 {
   float grey_point_source;     // $MIN: 0 $MAX: 100 $DEFAULT: 18.45 $DESCRIPTION: "middle gray luminance"
   float black_point_source;    // $MIN: -16 $MAX: -0.1 $DEFAULT: -8.0 $DESCRIPTION: "black relative exposure"
-  float white_point_source;    // $MIN: 0 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
+  float white_point_source;    // $MIN: 0.1 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
   float reconstruct_threshold; // $MIN: -6.0 $MAX: 6.0 $DEFAULT: +3.0 $DESCRIPTION: "threshold"
   float reconstruct_feather;   // $MIN: 0.25 $MAX: 6.0 $DEFAULT: 3.0 $DESCRIPTION: "transition"
   float reconstruct_bloom_vs_details; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "bloom ↔ reconstruct"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1900,7 +1900,7 @@ static inline void filmic_split_v4(const float *const restrict in, float *const 
       // Apply the transfer function of the display
       pix_out[c] = powf(CLAMP(filmic_spline(pix_out[c], spline.M1, spline.M2, spline.M3, spline.M4, spline.M5,
                                                  spline.latitude_min, spline.latitude_max, spline.type),
-                              display_black,
+                              0.f,  // individual components can always go to zero, luminance is clamped later
                               display_white), data->output_power);
     }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1912,7 +1912,6 @@ static inline void filmic_split_v4(const float *const restrict in, float *const 
     dt_aligned_pixel_t Ych_final = { 0.f };
     pipe_RGB_to_Ych(pix_out, input_matrix, Ych_final);
 
-    // Force final hue and chroma to original
     Ych_final[1] = fminf(Ych_original[1], Ych_final[1]);
 
     gamut_mapping(Ych_final, Ych_original, pix_out, input_matrix, output_matrix, export_input_matrix,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1537,8 +1537,6 @@ static inline void Ych_to_pipe_RGB(const dt_aligned_pixel_t in, const dt_colorma
 
   // go from CIE LMS 2006 to pipeline RGB
   dot_product(LMS, matrix, out);
-
-  for_each_channel(c, aligned(out)) out[c] = fmaxf(out[c], 0.f);
 }
 
 static inline void filmic_desaturate_v4(const dt_aligned_pixel_t Ych_original, dt_aligned_pixel_t Ych_final, const float saturation)
@@ -1848,7 +1846,7 @@ static inline void filmic_chroma_v4(const float *const restrict in, float *const
                 data->output_power);
 
     // Restore RGB
-    for_each_channel(c,aligned(pix_out)) pix_out[c] = fmaxf(ratios[c] * norm, 0.f);
+    for_each_channel(c,aligned(pix_out)) pix_out[c] = ratios[c] * norm;
 
     // Save Ych in Kirk/Filmlight Yrg
     dt_aligned_pixel_t Ych_original = { 0.f };


### PR DESCRIPTION
I noticed discrepancies between the CPU and GPU versions of filmic v6. CPU version was clipping negatives off of the RGB values at a couple of spots. We don't probably want to do that since full-blown gamut mapping is run in the end.

Additionally, clip the individual channels to zero instead of `display_black` in v6 split mode. Luminance is clipped to `display_black` later.

pinging @aurelienpierre for review.

Integration tests that have filmic v6 enabled will have to be updated.

Last commit also fixes https://github.com/darktable-org/darktable/issues/11937.