### PR TITLE
Fix issue with % in darktable settings texts

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -201,7 +201,7 @@
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50%% of your systems resources and gives darktable enough to be still performant.\n - small: should be used if you are simultaneously running applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - large: is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.\n - unrestricted: should only be used for developing extremely large images as darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution and not recommended for general use!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50% of your systems resources and gives darktable enough to be still performant.\n - small: should be used if you are simultaneously running applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - large: is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.\n - unrestricted: should only be used for developing extremely large images as darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution and not recommended for general use!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>
@@ -1867,7 +1867,7 @@
     <type min="0" max="100">int</type>
     <default>50</default>
     <shortdescription>suggested tags level of confidence</shortdescription>
-    <longdescription>level of confidence to include the tag in the suggestions list, 0: all associated tags, 99: 99%% matching associated tags, 100: no matching tag to show only recent tags (faster)</longdescription>
+    <longdescription>level of confidence to include the tag in the suggestions list, 0: all associated tags, 99: 99% matching associated tags, 100: no matching tag to show only recent tags (faster)</longdescription>
   </dtconfig>
   <dtconfig dialog="tagging">
     <name>plugins/lighttable/tagging/nb_recent_tags</name>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -527,6 +527,10 @@ gboolean restart_required = FALSE;
   <xsl:apply-templates select="." mode="tab"/>
   <xsl:text>    gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);</xsl:text>
   <xsl:if test="longdescription != ''">
+    <xsl:if test="contains(longdescription,'%')">
+      <xsl:text>    
+    /* xgettext:no-c-format */</xsl:text>
+    </xsl:if>
     <xsl:text>&#xA;    g_object_set(widget, "tooltip-text", _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"), (gchar *)0);</xsl:text>
   </xsl:if>
         <xsl:choose>


### PR DESCRIPTION
gettext by default treats % as a start of printf-style format string. This treatment can be turned off by inserting line with special comment

`/* xgettext:no-c-format */
`

before line that contains %-including string.
