### PR TITLE
Diffuse optimizations

### DIFF
--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -279,12 +279,10 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     // compute the update
     float4 acc = (float4)0.f;
     for(int k = 0; k < 4; k++) acc += derivatives[k] * ((float *)&ABCD)[k];
-    float4 hf = read_imagef(HF, samplerA, (int2)(x, y));
-    acc = (hf * strength + acc / variance);
+    acc = (neighbour_pixel_HF[4] * strength + acc / variance);
 
     // update the solution
-    float4 lf = read_imagef(LF, samplerA, (int2)(x, y));
-    out = fmax(acc + lf, 0.f);
+    out = fmax(acc + neighbour_pixel_LF[4], 0.f);
   }
   else
   {

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -214,10 +214,9 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
       }
 
     // build the local anisotropic convolution filters for gradients and laplacians
-    float4 gradient[2], laplacian[2];
-    find_gradient(neighbour_pixel_LF, gradient);
-    find_gradient(neighbour_pixel_HF, laplacian);
 
+    float4 gradient[2];
+    find_gradient(neighbour_pixel_LF, gradient);
     const float4 magnitude_grad = native_sqrt(sqf(gradient[0]) + sqf(gradient[1]));
     // Compute cos(arg(grad)) = dx / hypot - force arg(grad) = 0 if hypot == 0
     gradient[0] = (magnitude_grad != 0.f) ? gradient[0] / magnitude_grad
@@ -226,7 +225,12 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     gradient[1] = (magnitude_grad != 0.f) ? gradient[1] / magnitude_grad
                                           : 0.f; // sin(0)
     // Warning : now gradient[2] = { cos(arg(grad)) , sin(arg(grad)) }
+    const float4 cos_theta_grad_sq = sqf(gradient[0]);
+    const float4 sin_theta_grad_sq = sqf(gradient[1]);
+    const float4 cos_theta_sin_theta_grad = gradient[0] * gradient[1];
 
+    float4 laplacian[2];
+    find_gradient(neighbour_pixel_HF, laplacian);
     const float4 magnitude_lapl = native_sqrt(sqf(laplacian[0]) + sqf(laplacian[1]));
     // Compute cos(arg(lapl)) = dx / hypot - force arg(lapl) = 0 if hypot == 0
     laplacian[0] = (magnitude_lapl != 0.f) ? laplacian[0] / magnitude_lapl
@@ -235,10 +239,6 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     laplacian[1] = (magnitude_lapl != 0.f) ? laplacian[1] / magnitude_lapl
                                            : 0.f; // sin(0)
     // Warning : now laplacian[2] = { cos(arg(lapl)) , sin(arg(lapl)) }
-
-    const float4 cos_theta_grad_sq = sqf(gradient[0]);
-    const float4 sin_theta_grad_sq = sqf(gradient[1]);
-    const float4 cos_theta_sin_theta_grad = gradient[0] * gradient[1];
     const float4 cos_theta_lapl_sq = sqf(laplacian[0]);
     const float4 sin_theta_lapl_sq = sqf(laplacian[1]);
     const float4 cos_theta_sin_theta_lapl = laplacian[0] * laplacian[1];

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -701,7 +701,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
         dt_aligned_pixel_t cos_theta_sin_theta_grad;
         for_each_channel(c)
         {
-          float magnitude_grad = sqrtf(sqf(gradient[0][c]) + sqf(gradient[1][c]));
+          const float magnitude_grad = dt_fast_hypotf(gradient[0][c], gradient[1][c]);
           c2[0][c] = -magnitude_grad * anisotropy[0];
           c2[2][c] = -magnitude_grad * anisotropy[2];
           // Compute cos(arg(grad)) = dx / hypot - force arg(grad) = 0 if hypot == 0
@@ -721,7 +721,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
         dt_aligned_pixel_t cos_theta_sin_theta_lapl;
         for_each_channel(c)
         {
-          float magnitude_lapl = sqrtf(sqf(laplacian[0][c]) + sqf(laplacian[1][c]));
+          const float magnitude_lapl = dt_fast_hypotf(laplacian[0][c], laplacian[1][c]);
           c2[1][c] = -magnitude_lapl * anisotropy[1];
           c2[3][c] = -magnitude_lapl * anisotropy[3];
           // Compute cos(arg(lapl)) = dx / hypot - force arg(lapl) = 0 if hypot == 0

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -754,10 +754,9 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
         // c² in https://www.researchgate.net/publication/220663968
         dt_aligned_pixel_t c2[4];
         // build the local anisotropic convolution filters for gradients and laplacians
-        dt_aligned_pixel_t gradient[2], laplacian[2]; // x, y for each channel
-        find_gradients(neighbour_pixel_LF, gradient);
-        find_gradients(neighbour_pixel_HF, laplacian);
 
+        dt_aligned_pixel_t gradient[2]; // x, y for each channel
+        find_gradients(neighbour_pixel_LF, gradient);
         dt_aligned_pixel_t cos_theta_grad_sq;
         dt_aligned_pixel_t sin_theta_grad_sq;
         dt_aligned_pixel_t cos_theta_sin_theta_grad;
@@ -776,6 +775,8 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
           cos_theta_sin_theta_grad[c] = gradient[0][c] * gradient[1][c];
         }
 
+        dt_aligned_pixel_t laplacian[2]; // x, y for each channel
+        find_gradients(neighbour_pixel_HF, laplacian);
         dt_aligned_pixel_t cos_theta_lapl_sq;
         dt_aligned_pixel_t sin_theta_lapl_sq;
         dt_aligned_pixel_t cos_theta_sin_theta_lapl;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -841,9 +841,9 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
         }
         for_each_channel(c, aligned(acc,HF,LF,variance,out))
         {
-          acc[c] = (HF[index + c] * strength + acc[c] / variance[c]);
+          acc[c] = (neighbour_pixel_HF[4][c] * strength + acc[c] / variance[c]);
           // update the solution
-          out[index + c] = fmaxf(acc[c] + LF[index + c], 0.f);
+          out[index + c] = fmaxf(acc[c] + neighbour_pixel_LF[4][c], 0.f);
         }
       }
       else


### PR DESCRIPTION
In the current `diffuse` code there is a separate function for calculating the isotropic Laplacian (when the anisotropy coefficient is 0) and another for calculating the anisotropic case. This PR modifies the anisotropic kernel such that it reduces to the isotropic Laplacian (Oono & Puri) case when the anisotropy coefficient is zero.

This simplified the code a lot and reduced some branching, possibly leading to better vectorizability. This also opened up a few opportunities to simplify the code.

Perf gain on my system (i7-6600U, integrated Intel GPU) for `Release` build on the `diffuse` integration test is 1.54x (quite suprising actually). CPU path gained 1.14x.

The change of the anisotropic introduces a minor change in the module output, breaking old edits. However I think it's strictly for the better because more information is now utilized when computing the Laplacian.

Integration test results:
```
      Expected CPU vs. current CPU report :
      ----------------------------------
      Max dE                   : 17.64795
      Avg dE                   : 0.70384
      Std dE                   : 0.59500
      ----------------------------------
      Pixels below avg + 0 std : 61.35 %
      Pixels below avg + 1 std : 89.80 %
      Pixels below avg + 3 std : 98.36 %
      Pixels below avg + 6 std : 99.71 %
      Pixels below avg + 9 std : 99.93 %
      ----------------------------------
      Pixels above tolerance   : 2.05 %
```
In practice, I couldn't tell the expected image and the one with this PR apart. This is supported by these low average dE numbers.