### PR TITLE
fix overlay color cycling

### DIFF
--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -732,6 +732,8 @@ GtkWidget *dt_guides_popover(dt_view_t *self, GtkWidget *button)
                                N_("yellow"),
                                N_("cyan"),
                                N_("magenta"));
+  // NOTE: any change in the number of entries above will require a corresponding change in _overlay_cycle_callback
+  // in src/views/darkroom.c
   gtk_box_pack_start(GTK_BOX(vbox), darktable.view_manager->guides_colors, TRUE, TRUE, 0);
 
   GtkWidget *contrast = darktable.view_manager->guides_contrast = dt_bauhaus_slider_new_action(DT_ACTION(self), 0, 1, 0.005, 0.5, 3);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2010,7 +2010,7 @@ static void _brush_opacity_down_callback(dt_action_t *action)
 static void _overlay_cycle_callback(dt_action_t *action)
 {
   const int currentval = dt_conf_get_int("darkroom/ui/overlay_color");
-  const int nextval = (currentval + 1) % 5; // colors can go from 0 to 5
+  const int nextval = (currentval + 1) % 6; // colors can go from 0 to 5
   dt_conf_set_int("darkroom/ui/overlay_color", nextval);
   dt_guides_set_overlay_colors();
   dt_control_queue_redraw_center();


### PR DESCRIPTION
Ctrl-O was skipping magenta for the overlay/guides color due to an incorrect modulus operation (x%5 produces values 0...4, not 0...5).
Also added a cross-reference comment in case of a future update in the number of colors available.