### PR TITLE
Mark the UI label that was not marked for translation

### DIFF
--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1033,7 +1033,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   // the select line
   hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox0), hbox2, FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(hbox2), gtk_label_new("current date : "), FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox2), gtk_label_new(_("current date: ")), FALSE, TRUE, 0);
   pop->selection = gtk_entry_new();
   gtk_entry_set_alignment(GTK_ENTRY(pop->selection), 0.5);
   gtk_box_pack_start(GTK_BOX(hbox2), pop->selection, TRUE, TRUE, 0);


### PR DESCRIPTION
I firmly believe that such marking (as opposed to changing strings for translation or adding code with new strings) would be a good thing to do despite string freeze. The idea is that if we don't do this darktable UI in ALL languages will have one untranslated label, even if formally the translations are 100% complete. When marking this line now, a certain number of translators (perhaps even most of them) will have time for one string to translate.