### PR TITLE
Fix darkroom background

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -66,8 +66,6 @@
 @define-color log_fg_color @grey_90;
 
 /* Views */
-@define-color darkroom_bg_color @grey_60;
-@define-color darkroom_preview_bg_color @grey_50;
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -37,7 +37,7 @@
 @define-color scroll_bar_bg @grey_40;
 
 /* Modules box (plugins) */
-@define-color plugin_bg_color @grey_50;
+@define-color plugin_bg_color shade(@darkroom_bg_color, 0.95);
 @define-color plugin_label_color @grey_80;
 @define-color collapsible_bg_color @grey_55;
 
@@ -70,8 +70,6 @@
 @define-color log_fg_color @grey_95;
 
 /* Views */
-@define-color darkroom_bg_color @grey_75;
-@define-color darkroom_preview_bg_color @grey_65;
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -174,8 +174,8 @@ Why that? Just because it's a developer choice and most classes use underscore i
 @define-color log_fg_color @grey_85;
 
 /* Views */
-@define-color darkroom_bg_color @grey_45;
-@define-color darkroom_preview_bg_color @grey_35;
+@define-color darkroom_bg_color @grey_50;    /* this need to be middle grey to correctly work on images. And for all themes */
+@define-color darkroom_preview_bg_color @grey_45;
 @define-color print_bg_color @darkroom_bg_color;
 @define-color lighttable_bg_color @darkroom_bg_color;
 @define-color lighttable_preview_bg_color @darkroom_preview_bg_color;


### PR DESCRIPTION
Simple fix. This starts by using ISO 12646 function on darkroom (bulb icon) where I see an issue as background should be middle grey (and so set here in Gtk code) but plugin_bg_color was also set to middle grey in grey theme.

See issue in darktable master (that this PR fix) with that screenshot:

![image](https://user-images.githubusercontent.com/45535283/172119266-7bac7479-9e7f-4cb5-a63c-aa4b74483785.png)

This issue so fix that and as even in standard mode, background should be middle grey. That was the goal but never really done. This so fix that too.

@elstoc: for your future screenshots updates of the manual.