### PR TITLE
[Bugfix] Immediately write device conf after detection

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -703,19 +703,18 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   char *includemd5[DT_OPENCL_MAX_INCLUDES] = { NULL };
   dt_opencl_md5sum(clincludes, includemd5);
 
+  if(newdevice) // so far the device seems to be ok. Make sure to write&export the conf database to
+  {
+    dt_opencl_write_device_config(dev);
+    dt_conf_save(darktable.conf);
+  }
+
   // now load all darktable cl kernels.
   // TODO: compile as a job?
   tstart = dt_get_wtime();
   FILE *f = g_fopen(filename, "rb");
   if(f)
   {
-    if(newdevice) // so far the device seems to be ok. disable for now until kernels are fine.
-    {
-      cl->dev[dev].disabled = 1;
-      dt_opencl_write_device_config(dev);
-      dt_conf_save(darktable.conf);
-    }
-
     while(!feof(f))
     {
       int prog = -1;
@@ -788,9 +787,6 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   }
   for(int n = 0; n < DT_OPENCL_MAX_INCLUDES; n++) g_free(includemd5[n]);
   res = 0;
-
-  // we are safe now enabling the device
-  if(newdevice) cl->dev[dev].disabled = 0;
 
 end:
   // we always write the device config to keep track of disabled devices

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -832,6 +832,25 @@ gchar* dt_conf_expand_default_dir(const char *dir)
 
   return normalized_path;
 }
+void dt_conf_save(dt_conf_t *cf)
+{
+  FILE *f = g_fopen(cf->filename, "wb");
+  if(f)
+  {
+    GList *keys = g_hash_table_get_keys(cf->table);
+    GList *sorted = g_list_sort(keys, (GCompareFunc)g_strcmp0);
+
+    for(GList *iter = sorted; iter; iter = g_list_next(iter))
+    {
+      const gchar *key = (const gchar *)iter->data;
+      const gchar *val = (const gchar *)g_hash_table_lookup(cf->table, key);
+      dt_conf_print(key, val, f);
+    }
+
+    g_list_free(sorted);
+    fclose(f);
+  }
+}
 
 
 // clang-format off

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -98,6 +98,7 @@ gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *ch
 gboolean dt_conf_is_equal(const char *name, const char *value);
 void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries);
 void dt_conf_cleanup(dt_conf_t *cf);
+void dt_conf_save(dt_conf_t *cf);
 int dt_conf_key_exists(const char *key);
 gboolean dt_conf_key_not_empty(const char *key);
 GSList *dt_conf_all_string_entries(const char *dir);


### PR DESCRIPTION
While investigating crashing OpenCL devices on Fedora36 using Intel neo it became obvious

1. We might have wrongly liked libraries - probably not maintained in a perfect way
2. llvm 14 is not working good so far

Both leads to darktable silenty crashing.

This pr
1. checks for newly detected devices as before **but** before compiling the kernels it will write device config data with device as disabled and re-enables after compiling of kernels worked just fine.
2. to allow 1) i had to add a function writing the conf database at once instead of when dt finishes.


I would like a review here also from @parafin as there have been problems with compiling kernels all in one bunch on osx.

Fixes crashing dt 3.8 and master on fedora 36

@elstoc for documentation it would mean to add a line
"If after installing a new driver for the failing device you should remove the conf key for that specific device"

