### PR TITLE
Fix Mexican skin tone detection in color picker

### DIFF
--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -92,7 +92,8 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
                                             { .name = _("Thai"),      .ethnicity = ETHNIE_THAI },
                                             { .name = _("Kurdish"),   .ethnicity = ETHNIE_KURDISH },
                                             { .name = _("Caucasian"), .ethnicity = ETHNIE_CAUCASIAN },
-                                            { .name = _("African-american"), .ethnicity = ETHNIE_AFRICAN_AM } };
+                                            { .name = _("African-american"), .ethnicity = ETHNIE_AFRICAN_AM },
+                                            { .name = _("Mexican"),   .ethnicity = ETHNIE_MEXICAN } };
 
   const skin_color_t skin[SKINS] = {
     { .name = _("forearm"),


### PR DESCRIPTION
Before this fix color picker displayed  `average (NULL) skin tone`  for Mexican skin tone.

@TurboGit Yes, I know, this is another string freeze violation. But we really should introduce string for Mexicans, it would be rather insulting to name them "(NULL)". And then my idea is the same as in #11977: better to give translators a chance to keep up with the translation than not give them a chance to translate at all.
