### PR TITLE
Possibly avoid OpenCL available memory checks [sortof bugfix]

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -339,11 +339,15 @@
         <option>memory size</option>
         <option>memory transfer</option>
         <option>memory size and transfer</option>
+        <option>400 MB</option>
+        <option>400 MB and transfer</option>
+        <option>600 MB</option>
+        <option>600 MB and transfer</option>
       </enum>
     </type>
     <default>nothing</default>
     <shortdescription>tune OpenCL performance</shortdescription>
-    <longdescription>allows runtime tuning of OpenCL devices. 'memory size' tests for available graphics ram, 'memory transfer' tries a faster memory access mode (pinned memory) used for tiling.</longdescription>
+    <longdescription>allows runtime tuning of OpenCL devices. 'memory size' tests for available graphics ram, 'memory transfer' tries a faster memory access mode (pinned memory) used for tiling.\nyou may also select a fixed headroom mode</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_synch_cache</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1343,7 +1343,7 @@ void dt_get_sysresource_level()
   darktable.dtresources.level = oldlevel = level;
   oldtunecl = tunecl;
 #ifdef HAVE_OPENCL
-  darktable.dtresources.tunememory  = (tunecl & DT_OPENCL_TUNE_MEMSIZE) ? 1 : 0;
+  darktable.dtresources.tunememory  = tunecl / 2;
   darktable.dtresources.tunepinning = (tunecl & DT_OPENCL_TUNE_PINNED) ? 1 : 0;
 #else
   darktable.dtresources.tunememory  = 0;
@@ -1359,7 +1359,7 @@ void dt_get_sysresource_level()
     fprintf(stderr,"  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
     fprintf(stderr,"  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
 #ifdef HAVE_OPENCL
-    fprintf(stderr,"  OpenCL tune mem: %s\n", ((darktable.dtresources.tunememory) && (level >= 0)) ? "ON" : "OFF");
+    fprintf(stderr,"  OpenCL tune mem: %s\n", ((darktable.dtresources.tunememory == 1) && (level >= 0)) ? "ON" : "OFF");
     fprintf(stderr,"  OpenCL pinned:   %s\n", ((darktable.dtresources.tunepinning) && (level >= 0)) ? "ON" : "OFF");
 #endif
     darktable.dtresources.group = oldgrp;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -97,8 +97,8 @@ typedef struct dt_opencl_eventtag_t
 typedef enum dt_opencl_tunemode_t
 {
   DT_OPENCL_TUNE_NOTHING = 0,
-  DT_OPENCL_TUNE_MEMSIZE = 1,
-  DT_OPENCL_TUNE_PINNED  = 2
+  DT_OPENCL_TUNE_PINNED  = 1,
+  DT_OPENCL_TUNE_MEMSIZE = 2,
 } dt_opencl_tunemode_t;
 
 typedef enum dt_opencl_pinmode_t


### PR DESCRIPTION
Partly fixes #12001 

Since nvidia 515 driver series becoming available on some distributions there have been some users reporting darktable crashes related to OpenCL if the tune-for-memory option is active.

So far investigating the changelog of the driver plus bug reports, there seems to be no fast and best fix here. As the driver is very new (a major redesign so there might be bugs there) and the tuning for memory option had been used by many users without hassle for some time i would like to keep the code as is for 4.0 possibly requiring further fixes. 

In addition to the tuning CL existing options in the tuning CL performance there are 4 new entries offering common "fixed headrooms" plus transfer option.

As before this can be applied at runtime...