### PR TITLE
iso_12646: fully fix middle-grey value

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -578,7 +578,7 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // force middle grey in background
-      cairo_set_source_rgb(cr, 0.5, 0.5, 0.5);
+      cairo_set_source_rgb(cr, 0.4663, 0.4663, 0.4663);
     }
     else
     {


### PR DESCRIPTION
Completes the work started in 75cd1ed2f and resolves #12010.