### PR TITLE
less verbose midi and stop updates on unplug

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3126,9 +3126,9 @@ static float _process_shortcut(float move_size)
 {
   float return_value = NAN;
 
-  dt_print(DT_DEBUG_INPUT,
-           "  [_process_shortcut] processing shortcut: %s\n",
-           _shortcut_description(&_sc));
+  dt_vprint(DT_DEBUG_INPUT,
+            "  [_process_shortcut] processing shortcut: %s\n",
+            _shortcut_description(&_sc));
 
   dt_shortcut_t fsc = _sc;
   fsc.action = NULL;

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -153,6 +153,8 @@ void midi_write(midi_device *midi, gint channel, gint type, gint key, gint veloc
     if (pmerror != pmNoError)
     {
       g_print("Portmidi error: %s\n", Pm_GetErrorText(pmerror));
+      Pm_Close(midi->portmidi_out);
+      midi->portmidi_out = NULL;
     }
   }
 }
@@ -532,9 +534,10 @@ static gboolean _timeout_midi_update(gpointer user_data)
   {
     midi_device *midi = devices->data;
 
-    for(int i = 0; i < midi->num_knobs; i++) update_with_move(midi, 0, i + midi->first_knob, NAN);
+    for(int i = 0; i < midi->num_knobs && midi->portmidi_out; i++)
+      update_with_move(midi, 0, i + midi->first_knob, NAN);
 
-    for(int i = 0; i < midi->num_keys; i++)
+    for(int i = 0; i < midi->num_keys && midi->portmidi_out; i++)
       midi_write(midi, midi->is_x_touch_mini ? 0 : midi->channel, 0x9,
                  i + midi->first_light, dt_shortcut_key_active(midi->id, i + midi->first_key));
 


### PR DESCRIPTION
This stops continuous confusing messages on the console like
```
41.237489   [_process_shortcut] processing shortcut: 1:G0
41.238678   [_process_shortcut] processing shortcut: 1:G#0
41.239841   [_process_shortcut] processing shortcut: 1:A0
41.241043   [_process_shortcut] processing shortcut: 1:A#0
41.242272   [_process_shortcut] processing shortcut: 1:B0
41.475947   [_process_shortcut] processing shortcut: alt+1:CC1, down
41.476110   [_process_shortcut] processing shortcut: alt+1:CC2, down
41.476249   [_process_shortcut] processing shortcut: alt+1:CC3, down
41.476396   [_process_shortcut] processing shortcut: alt+1:CC4, down
41.476535   [_process_shortcut] processing shortcut: alt+1:CC5, down
```
when `-d input` is specified and midi devices are found (unless `-d verbose` is _also_ specified).
These messages show the updates being sent to attached midi devices to update their status lights based on the corresponding toggle buttons and sliders in the UI.

This patch also stops trying to send these updates as soon as an error has occurred (for example because the device was disconnected). Unfortunately this doesn't prevent (for me) dt crashing when you do this on Windows. This may need to be fixed in portmidi.