### PR TITLE
tagging: do not collapse the tree when hovering the node selection column

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3001,8 +3001,6 @@ static gboolean _event_dnd_motion(GtkWidget *widget, GdkDragContext *context,
         if(!gtk_tree_view_row_expanded(tree, path))
           d->drag.expand_timeout = g_timeout_add(200, (GSourceFunc)_dnd_expand_timeout, self);
       }
-      else
-        gtk_tree_view_collapse_all(d->dictionary_view);
     }
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection(d->dictionary_view);


### PR DESCRIPTION
Currently you can open the destination node, open the source one and drag to destination, due to collapsing.
However there are situations where collapsing is useful (when the tree is large for example). We could add a control to allow dragging with and without collapsing. 
What do you think ?