### PR TITLE
light up midi modifier keys when real shift/ctrl/alt pressed

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -89,7 +89,7 @@ static float _action_process_modifiers(gpointer target, dt_action_element_t elem
     }
   }
 
-  return (dt_modifier_shortcuts & mask) != 0;
+  return ((dt_modifier_shortcuts | dt_key_modifier_state()) & mask) != 0;
 }
 
 const dt_action_element_def_t _action_elements_modifiers[]


### PR DESCRIPTION
In inputNG you can have additional modifier keys by mapping them to global/modifiers and setting the _element_ to shift, ctrl or alt. This is especially useful for midi devices. If you have multiple devices that have these additional modifiers, and if your midi buttons have lights in them, then pressing the additional ctrl on one device lights up the corresponding ctrl key on the other device.

This simple PR _also_ makes a midi modifier light up if the _real_ keyboard Shift, Ctrl or Alt key are pressed.

This also highlights that the AltGr key (the Alt that is located to the _right_ of the spacebar) switches on both the ctrl and alt modifiers. So you can scroll side panels with just that one key instead of pressing Ctrl&Alt together (if you don't use "mouse wheel scrolls modules side panel by default"). Not necessarily _useful_ but _interesting_.