### PR TITLE
Late OpenCL fixes for 4.0

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -234,6 +234,13 @@ void dt_opencl_write_device_config(const int devid)
     cl->dev[devid].benchmark);
   dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
+
+  // Also take care of extended device data, these are not only device specific but also depend on the devid
+  // to support systems with two similar cards.
+  g_snprintf(key, 254, "%s%i_%s", DT_CLDEVICE_HEAD, devid, cl->dev[devid].cname);
+  g_snprintf(dat, 510, "%i", cl->dev[devid].forced_headroom);
+  dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+  dt_conf_set_string(key, dat);
 }
 
 gboolean dt_opencl_read_device_config(const int devid)
@@ -297,6 +304,16 @@ gboolean dt_opencl_read_device_config(const int devid)
   cl->dev[devid].use_events = (cl->dev[devid].event_handles != 0) ? 1 : 0;
   cl->dev[devid].asyncmode &= 1;
   cl->dev[devid].disabled &= 1;
+
+  // Also take care of extended device data, these are not only device specific but also depend on the devid
+  g_snprintf(key, 254, "%s%i_%s", DT_CLDEVICE_HEAD, devid, cl->dev[devid].cname);
+  if(dt_conf_key_not_empty(key))
+  {
+    const gchar *dat = dt_conf_get_string_const(key);
+    int forced_headroom;
+    sscanf(dat, "%i", &forced_headroom);
+    if(forced_headroom > 0) cl->dev[devid].forced_headroom = forced_headroom;
+  }
   dt_opencl_write_device_config(devid);
   return !existing_device || !safety_ok;
 }
@@ -353,6 +370,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   cl->dev[dev].event_handles = 128;
   cl->dev[dev].asyncmode = 0;
   cl->dev[dev].disabled = 0;
+  cl->dev[dev].forced_headroom = 0;
   cl_device_id devid = cl->dev[dev].devid = devices[k];
 
   char *infostr = NULL;
@@ -593,6 +611,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   dt_print_nts(DT_DEBUG_OPENCL, "   ASYNC PIXELPIPE:          %s\n", (cl->dev[dev].asyncmode) ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL, "   PINNED MEMORY TRANSFER:   %s\n", pinning ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL, "   MEMORY TUNING:            %s\n", tuning ? "YES" : "NO");
+  dt_print_nts(DT_DEBUG_OPENCL, "   FORCED HEADROOM:          %i\n", cl->dev[dev].forced_headroom);
   dt_print_nts(DT_DEBUG_OPENCL, "   AVOID ATOMICS:            %s\n", (cl->dev[dev].avoid_atomics) ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL, "   MICRO NAP:                %i\n", cl->dev[dev].micro_nap);
   dt_print_nts(DT_DEBUG_OPENCL, "   ROUNDUP WIDTH:            %i\n", cl->dev[dev].clroundup_wd);
@@ -2812,9 +2831,14 @@ void dt_opencl_check_device_available(const int devid)
   const gboolean tuned = darktable.dtresources.tunememory && (level > 0);
   if(tuned)
   {
-    // we always leave a safety margin, at least 100MB for level large
-    _opencl_get_unused_device_mem(devid);
-    cl->dev[devid].used_available = cl->dev[devid].tuned_available * (32 - MAX(0, 2 - level)) / 32;
+    if(cl->dev[devid].forced_headroom)
+       cl->dev[devid].used_available = MAX(0ul, cl->dev[devid].max_global_mem - ((size_t)cl->dev[devid].forced_headroom * 1024ul * 1024ul));
+    else
+    {
+      // we always leave a safety margin, at least 200MB for level large
+      _opencl_get_unused_device_mem(devid);
+      cl->dev[devid].used_available = cl->dev[devid].tuned_available * (32 - MAX(0, 2 - level)) / 32;
+    }
   }
   else
   {
@@ -2828,7 +2852,7 @@ void dt_opencl_check_device_available(const int devid)
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_MEMORY,
        "[dt_opencl_check_device_available] use %luMB (tunemem=%s, pinning=%s) on device `%s' id=%i\n",
        cl->dev[devid].used_available / 1024lu / 1024lu, (tuned) ? "ON" : "OFF",
-       (cl->dev[devid].pinned_memory) ? "ON" : "OFF", cl->dev[devid].name, devid);
+       (cl->dev[devid].pinned_memory == DT_OPENCL_PINNING_ON) ? "ON" : "OFF", cl->dev[devid].name, devid);
 }
 
 cl_ulong dt_opencl_get_device_available(const int devid)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -198,6 +198,10 @@ typedef struct dt_opencl_device_t
   // a device might be turned off by force by setting this value to 1
   // also used for blacklisted drivers
   int disabled;
+
+  // Some devices are known to be unused by other apps so there is no need to test for available memory at all.
+  // Also some devices might behave badly with the checking code, in this case we could enforce a headroom here.
+  int forced_headroom;
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;


### PR DESCRIPTION
As references see #12001 and #12006

To make the story short here, there have been some issues related to nvidia 515 driver series that lead to crashes on some
machines if tuning for memory is switched on. The reason for this is not understood yet, maybe more a system configure problem than a dt bug...

If users switch off "memory size" they are safe - sadly at a cost of performance.

A new 'forced_headroom' in the per-device struct is introduced, the data is presented and read in from a new per-device
conf key, this key will be exposed in dt 4.2 plus some additional info. `cldevice_v4_devid_canoniocalname', it is required
for per_device settings that depend on dev order.

The `forced_headroom` had originally been intended for 4.2 to allow claiming complete graphics memory if the device is not
used by other apps or the os at all, this might be true on systems with more than one OpenCL device.
But it can also be used to set a safe headroom per device instead of fiddling with resources internals.

Supersedes #12006 as a sort-of-bugfix without string issues. 