### PR TITLE
OpenCL fixes regarding runtime changing of tuning settings

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -389,11 +389,12 @@ static inline size_t _get_total_memory()
 
 static size_t _get_mipmap_size()
 {
-  const int level = darktable.dtresources.level;
+  dt_sys_resources_t *res = &darktable.dtresources;
+  const int level = res->level;
   if(level < 0)
-    return darktable.dtresources.refresource[4*(-level-1) + 2] * 1024lu * 1024lu;
-  const int fraction = darktable.dtresources.fractions[darktable.dtresources.group + 2];
-  return darktable.dtresources.total_memory / 1024lu * fraction;
+    return res->refresource[4*(-level-1) + 2] * 1024lu * 1024lu;
+  const int fraction = res->fractions[res->group + 2];
+  return res->total_memory / 1024lu * fraction;
 }
 
 void check_resourcelevel(const char *key, int *fractions, const int level)
@@ -1102,16 +1103,17 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   check_resourcelevel("resource_large", fractions, 2);
   check_resourcelevel("resource_unrestricted", fractions, 3);
 
-  darktable.dtresources.fractions = fractions;
-  darktable.dtresources.refresource = ref_resources;
-  darktable.dtresources.total_memory = _get_total_memory() * 1024lu;
+  dt_sys_resources_t *res = &darktable.dtresources;
+  res->fractions = fractions;
+  res->refresource = ref_resources;
+  res->total_memory = _get_total_memory() * 1024lu;
 
   char *config_info = calloc(1, DT_PERF_INFOSIZE);
   if(last_configure_version != DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION)
     dt_configure_runtime_performance(last_configure_version, config_info);
 
   dt_get_sysresource_level();
-  darktable.dtresources.mipmap_memory = _get_mipmap_size();
+  res->mipmap_memory = _get_mipmap_size();
   // initialize collection query
   darktable.collection = dt_collection_new(NULL);
 
@@ -1318,6 +1320,7 @@ void dt_get_sysresource_level()
   static int oldlevel = -999;
   static int oldtunecl = -999;
 
+  dt_sys_resources_t *res = &darktable.dtresources;
   const int tunecl = dt_opencl_get_tuning_mode();
   int level = 1;
   const char *config = dt_conf_get_string_const("resourcelevel");
@@ -1340,29 +1343,23 @@ void dt_get_sysresource_level()
     else if(!strcmp(config, "notebook"))     level = -3;
   }
   const gboolean mod = ((level != oldlevel) || (oldtunecl != tunecl));
-  darktable.dtresources.level = oldlevel = level;
+  res->level = oldlevel = level;
   oldtunecl = tunecl;
-#ifdef HAVE_OPENCL
-  darktable.dtresources.tunememory  = (tunecl & DT_OPENCL_TUNE_MEMSIZE) ? 1 : 0;
-  darktable.dtresources.tunepinning = (tunecl & DT_OPENCL_TUNE_PINNED) ? 1 : 0;
-#else
-  darktable.dtresources.tunememory  = 0;
-  darktable.dtresources.tunepinning = 0;
-#endif
-  if(mod && (darktable.unmuted & DT_DEBUG_MEMORY))
+  res->tunemode = tunecl;
+  if(mod && (darktable.unmuted & (DT_DEBUG_MEMORY | DT_DEBUG_OPENCL)))
   {
-    const int oldgrp = darktable.dtresources.group;
-    darktable.dtresources.group = 4 * level;
+    const int oldgrp = res->group;
+    res->group = 4 * level;
     fprintf(stderr,"[dt_get_sysresource_level] switched to %i as `%s'\n", level, config);
-    fprintf(stderr,"  total mem:       %luMB\n", darktable.dtresources.total_memory / 1024lu / 1024lu);
+    fprintf(stderr,"  total mem:       %luMB\n", res->total_memory / 1024lu / 1024lu);
     fprintf(stderr,"  mipmap cache:    %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
     fprintf(stderr,"  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
     fprintf(stderr,"  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
 #ifdef HAVE_OPENCL
-    fprintf(stderr,"  OpenCL tune mem: %s\n", ((darktable.dtresources.tunememory) && (level >= 0)) ? "ON" : "OFF");
-    fprintf(stderr,"  OpenCL pinned:   %s\n", ((darktable.dtresources.tunepinning) && (level >= 0)) ? "ON" : "OFF");
+    fprintf(stderr,"  OpenCL tune mem: %s\n", ((tunecl & DT_OPENCL_TUNE_MEMSIZE) && (level >= 0)) ? "WANTED" : "OFF");
+    fprintf(stderr,"  OpenCL pinned:   %s\n", ((tunecl & DT_OPENCL_TUNE_PINNED) && (level >= 0)) ? "WANTED" : "OFF");
 #endif
-    darktable.dtresources.group = oldgrp;
+    res->group = oldgrp;
   }
 }
 
@@ -1642,23 +1639,25 @@ int dt_worker_threads()
 
 size_t dt_get_available_mem()
 {
-  const int level = darktable.dtresources.level;
-  const size_t total_mem = darktable.dtresources.total_memory;
+  dt_sys_resources_t *res = &darktable.dtresources;
+  const int level = res->level;
+  const size_t total_mem = res->total_memory;
   if(level < 0)
-    return darktable.dtresources.refresource[4*(-level-1)] * 1024lu * 1024lu;
+    return res->refresource[4*(-level-1)] * 1024lu * 1024lu;
 
-  const int fraction = darktable.dtresources.fractions[darktable.dtresources.group];
+  const int fraction = res->fractions[darktable.dtresources.group];
   return MAX(512lu * 1024lu * 1024lu, total_mem / 1024lu * fraction);
 }
 
 size_t dt_get_singlebuffer_mem()
 {
-  const int level = darktable.dtresources.level;
-  const size_t total_mem = darktable.dtresources.total_memory;
+  dt_sys_resources_t *res = &darktable.dtresources;
+  const int level = res->level;
+  const size_t total_mem = res->total_memory;
   if(level < 0)
-    return darktable.dtresources.refresource[4*(-level-1) + 1] * 1024lu * 1024lu;
+    return res->refresource[4*(-level-1) + 1] * 1024lu * 1024lu;
 
-  const int fraction = darktable.dtresources.fractions[darktable.dtresources.group + 1];
+  const int fraction = res->fractions[res->group + 1];
   return MAX(2lu * 1024lu * 1024lu, total_mem / 1024lu * fraction);
 }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -289,8 +289,7 @@ typedef struct dt_sys_resources_t
   int *refresource; // for the debug resource modes we use fixed settings
   int group;
   int level;
-  int tunememory;
-  int tunepinning;
+  int tunemode;
 } dt_sys_resources_t;
 
 typedef struct darktable_t

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2361,7 +2361,7 @@ int dt_opencl_read_host_from_device_raw(const int devid, void *host, void *devic
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Read Image (from device to host)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueReadImage)(darktable.opencl->dev[devid].cmd_queue,
-                                                                   device, blocking, origin, region, rowpitch,
+                                                                   device, blocking ? CL_TRUE : CL_FALSE, origin, region, rowpitch,
                                                                    0, host, 0, NULL, eventp);
 }
 
@@ -2406,7 +2406,7 @@ int dt_opencl_write_host_to_device_raw(const int devid, void *host, void *device
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Image (from host to device)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteImage)(darktable.opencl->dev[devid].cmd_queue,
-                                                                    device, blocking, origin, region,
+                                                                    device, blocking ? CL_TRUE : CL_FALSE, origin, region,
                                                                     rowpitch, 0, host, 0, NULL, eventp);
 }
 
@@ -2466,7 +2466,7 @@ int dt_opencl_read_buffer_from_device(const int devid, void *host, void *device,
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Read Buffer (from device to host)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueReadBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, device, blocking, offset, size, host, 0, NULL, eventp);
+      darktable.opencl->dev[devid].cmd_queue, device, blocking ? CL_TRUE : CL_FALSE, offset, size, host, 0, NULL, eventp);
 }
 
 int dt_opencl_write_buffer_to_device(const int devid, void *host, void *device, const size_t offset,
@@ -2477,7 +2477,7 @@ int dt_opencl_write_buffer_to_device(const int devid, void *host, void *device, 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Buffer (from host to device)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, device, blocking, offset, size, host, 0, NULL, eventp);
+      darktable.opencl->dev[devid].cmd_queue, device, blocking ? CL_TRUE : CL_FALSE, offset, size, host, 0, NULL, eventp);
 }
 
 
@@ -2553,7 +2553,7 @@ void *dt_opencl_map_buffer(const int devid, cl_mem buffer, const int blocking, c
   void *ptr;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Map Buffer]");
   ptr = (darktable.opencl->dlocl->symbols->dt_clEnqueueMapBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, buffer, blocking, flags, offset, size, 0, NULL, eventp, &err);
+      darktable.opencl->dev[devid].cmd_queue, buffer, blocking ? CL_TRUE : CL_FALSE, flags, offset, size, 0, NULL, eventp, &err);
   if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl map buffer] could not map buffer on device %d: %s\n", devid, cl_errstr(err));
   return ptr;
 }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -140,12 +140,10 @@ const char *cl_errstr(cl_int error)
 int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_info param_name, void **param_value,
                               size_t *param_value_size)
 {
-  cl_int err;
-
   *param_value_size = SIZE_MAX;
 
   // 1. figure out how much memory is needed
-  err = (cl->dlocl->symbols->dt_clGetDeviceInfo)(device, param_name, 0, NULL, param_value_size);
+  cl_int err = (cl->dlocl->symbols->dt_clGetDeviceInfo)(device, param_name, 0, NULL, param_value_size);
   if(err != CL_SUCCESS)
   {
     dt_print(DT_DEBUG_OPENCL,
@@ -1776,7 +1774,7 @@ int dt_opencl_lock_device(const int pipetype)
 
       dt_iop_nap(usec);
     }
-    dt_print(DT_DEBUG_OPENCL, "[opencl_lock_device] reached opencl_mandatory_timeout trying to lock mandatory device, fallback to CPU");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_lock_device] reached opencl_mandatory_timeout trying to lock mandatory device, fallback to CPU\n");
   }
   else
   {
@@ -2294,14 +2292,13 @@ int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const int kernel, cons
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || dev < 0) return -1;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return -1;
-  int err;
+
   char buf[256];
   buf[0] = '\0';
   if(darktable.unmuted & DT_DEBUG_OPENCL)
-    (cl->dlocl->symbols->dt_clGetKernelInfo)(cl->dev[dev].kernel[kernel], CL_KERNEL_FUNCTION_NAME, 256, buf,
-                                            NULL);
+    (cl->dlocl->symbols->dt_clGetKernelInfo)(cl->dev[dev].kernel[kernel], CL_KERNEL_FUNCTION_NAME, 256, buf, NULL);
   cl_event *eventp = dt_opencl_events_get_slot(dev, buf);
-  err = (cl->dlocl->symbols->dt_clEnqueueNDRangeKernel)(cl->dev[dev].cmd_queue, cl->dev[dev].kernel[kernel],
+  cl_int err = (cl->dlocl->symbols->dt_clEnqueueNDRangeKernel)(cl->dev[dev].cmd_queue, cl->dev[dev].kernel[kernel],
                                                         2, NULL, sizes, local, 0, NULL, eventp);
 
   if(err != CL_SUCCESS)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2863,13 +2863,15 @@ void dt_opencl_check_tuning(const int devid)
     cl->dev[devid].used_available = res->refresource[4*(-level-1) + 3] * 1024lu * 1024lu;
     if(info)
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_MEMORY,
-         "[dt_opencl_check_tuning] reference mode %i, use %luMB on device `%s' id=%i\n",
-         level, cl->dev[devid].used_available / 1024lu / 1024lu, cl->dev[devid].name, devid);
+         "[dt_opencl_check_tuning] reference mode %i, use %luMB (pinning=%s) on device `%s' id=%i\n",
+         level, cl->dev[devid].used_available / 1024lu / 1024lu,
+         (cl->dev[devid].tuneactive & DT_OPENCL_TUNE_PINNED) ? "ON" : "OFF",
+         cl->dev[devid].name, devid);
     return;
   }
 
   const size_t allmem = cl->dev[devid].max_global_mem;
-  if((cl->dev[devid].tuneactive & DT_OPENCL_TUNE_MEMSIZE) && (level > 0))
+  if(cl->dev[devid].tuneactive & DT_OPENCL_TUNE_MEMSIZE)
   {
     if(cl->dev[devid].forced_headroom)
        cl->dev[devid].used_available = MAX(0ul, cl->dev[devid].max_global_mem - ((size_t)cl->dev[devid].forced_headroom * 1024ul * 1024ul));

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -105,8 +105,7 @@ typedef enum dt_opencl_pinmode_t
 {
   DT_OPENCL_PINNING_OFF = 0,
   DT_OPENCL_PINNING_ON = 1,
-  DT_OPENCL_PINNING_DISABLED = 2,
-  DT_OPENCL_PINNING_ERROR = 4
+  DT_OPENCL_PINNING_DISABLED = 2
 } dt_opencl_pinmode_t;
 
 /**
@@ -150,7 +149,10 @@ typedef struct dt_opencl_device_t
   size_t peak_memory;
   size_t tuned_available;
   size_t used_available;
-
+  // flags what tuning modes should be used
+  int tuneactive; 
+  // flags detected errors
+  int runtime_error;
   // if set to TRUE darktable will not use OpenCL kernels which contain atomic operations (example bilateral).
   // pixelpipe processing will be done on CPU for the affected modules.
   // useful (only for very old devices) if your OpenCL implementation freezes/crashes on atomics or if
@@ -459,7 +461,7 @@ gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const 
 /** get available memory for the device */
 cl_ulong dt_opencl_get_device_available(const int devid);
 /** check available memory for the device */
-void dt_opencl_check_device_available(const int devid);
+void dt_opencl_check_tuning(const int devid);
 
 /** get size of allocatable single buffer */
 cl_ulong dt_opencl_get_device_memalloc(const int devid);
@@ -493,7 +495,7 @@ void dt_opencl_write_device_config(const int devid);
 gboolean dt_opencl_read_device_config(const int devid);
 int dt_opencl_avoid_atomics(const int devid);
 int dt_opencl_micro_nap(const int devid);
-int dt_opencl_pinned_memory(const int devid);
+gboolean dt_opencl_use_pinned_memory(const int devid);
 
 #else
 #include "control/conf.h"
@@ -607,7 +609,7 @@ static inline size_t dt_opencl_get_device_available(const int devid)
 {
   return 0;
 }
-static inline void dt_opencl_check_device_available(const int devid)
+static inline void dt_opencl_check_tuning(const int devid)
 {
   return;
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -460,7 +460,8 @@ gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const 
                                 const float factor, const size_t overhead);
 /** get available memory for the device */
 cl_ulong dt_opencl_get_device_available(const int devid);
-/** check available memory for the device */
+
+/** check tuning settings and available memory for the device */
 void dt_opencl_check_tuning(const int devid);
 
 /** get size of allocatable single buffer */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1601,10 +1601,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         /* we might need to copy back valid image from device to host */
         if(cl_mem_input != NULL)
         {
-          cl_int err;
-
           /* copy back to CPU buffer, then clean unneeded buffer */
-          err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
+          cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
                                               in_bpp);
           if(err != CL_SUCCESS)
           {
@@ -1768,10 +1766,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
              && (pipe->type & DT_DEV_PIXELPIPE_EXPORT) != DT_DEV_PIXELPIPE_EXPORT
              && (pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL) != DT_DEV_PIXELPIPE_THUMBNAIL)
           {
-            cl_int err;
-
             /* copy input to host memory, so we can find it in cache */
-            err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width,
+            cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width,
                                                 roi_in.height, in_bpp);
             if(err != CL_SUCCESS)
             {
@@ -1822,12 +1818,10 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         /* check where our input buffer is located */
         if(cl_mem_input != NULL)
         {
-          cl_int err;
-
           /* copy back to host memory, then clean no longer needed opencl buffer.
              important info: in order to make this possible, opencl modules must
              not spoil their input buffer, even in case of errors. */
-          err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
+          cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
                                               in_bpp);
           if(err != CL_SUCCESS)
           {
@@ -1869,9 +1863,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       /* cleanup unneeded opencl buffer, and copy back to CPU buffer */
       if(cl_mem_input != NULL)
       {
-        cl_int err;
-
-        err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
+        cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input, roi_in.width, roi_in.height,
                                             in_bpp);
         // if (rand() % 5 == 0) err = !CL_SUCCESS; // Test code: simulate spurious failures
         if(err != CL_SUCCESS)
@@ -2134,9 +2126,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
   {
     if(*cl_mem_output != NULL)
     {
-      cl_int err;
-
-      err = dt_opencl_copy_device_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height,
+      cl_int err = dt_opencl_copy_device_to_host(pipe->devid, *output, *cl_mem_output, roi_out->width, roi_out->height,
                                           dt_iop_buffer_dsc_to_bpp(*out_format));
       dt_opencl_release_mem_object(*cl_mem_output);
       *cl_mem_output = NULL;
@@ -2424,20 +2414,14 @@ void dt_dev_clear_rawdetail_mask(dt_dev_pixelpipe_t *pipe)
 gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const rgb, const dt_iop_roi_t *const roi_in, const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
-  const gboolean info = ((darktable.unmuted & DT_DEBUG_MASKS) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
-
   if((p->want_detail_mask & DT_DEV_DETAIL_MASK_REQUIRED) == 0)
   {
     if(p->rawdetail_mask_data)
-    {
-      fprintf(stderr, "[dt_dev_write_rawdetail_mask] detail mask not required but found old data %p\n", p->rawdetail_mask_data);
       dt_dev_clear_rawdetail_mask(p);
-    }
     return FALSE;
   }
   if((p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) != mode) return FALSE;
 
-  if(info) fprintf(stderr, "[dt_dev_write_rawdetail_mask] %i (%ix%i), olddata %p", mode, roi_in->width, roi_in->height, p->rawdetail_mask_data);
   dt_dev_clear_rawdetail_mask(p);
 
   const int width = roi_in->width;
@@ -2458,11 +2442,11 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const
   }
   dt_masks_calc_rawdetail_mask(rgb, mask, tmp, width, height, wb);
   dt_free_align(tmp);
-  if(info) fprintf(stderr, " done\n");
+  dt_print(DT_DEBUG_MASKS, "[dt_dev_write_rawdetail_mask] %i (%ix%i)\n", mode, roi_in->width, roi_in->height);
   return FALSE;
 
   error:
-  if(info) fprintf(stderr, " ERROR\n");
+  fprintf(stderr, "[dt_dev_write_rawdetail_mask] couldn't write detail mask\n");
   dt_free_align(mask);
   dt_free_align(tmp);
   return TRUE;
@@ -2472,21 +2456,15 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const
 gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
-  const gboolean info = ((darktable.unmuted & DT_DEBUG_MASKS) && (piece->pipe->type == DT_DEV_PIXELPIPE_FULL));
-
   if((p->want_detail_mask & DT_DEV_DETAIL_MASK_REQUIRED) == 0)
   {
     if(p->rawdetail_mask_data)
-    {
-      if(info) fprintf(stderr, "[dt_dev_write_rawdetail_mask_cl] detail mask not required but found old data %p\n", p->rawdetail_mask_data);
       dt_dev_clear_rawdetail_mask(p);
-    }
     return FALSE;
   }
 
   if((p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) != mode) return FALSE;
 
-  if(info) fprintf(stderr, "[dt_dev_write_rawdetail_mask_cl] mode %i (%ix%i), olddata %p", mode, roi_in->width, roi_in->height, p->rawdetail_mask_data);
   dt_dev_clear_rawdetail_mask(p);
 
   const int width = roi_in->width;
@@ -2497,12 +2475,14 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
   float *mask = NULL;
   const int devid = p->devid;
 
+  cl_int err = CL_SUCCESS;
   mask = dt_alloc_align_float((size_t)width * height);
   if(mask == NULL) goto error;
   out = dt_opencl_alloc_device(devid, width, height, sizeof(float));
   if(out == NULL) goto error;
   tmp = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
   if(tmp == NULL) goto error;
+
   {
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;
     dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0],
@@ -2520,7 +2500,7 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
     dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(float), &wb[0]);
     dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(float), &wb[1]);
     dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(float), &wb[2]);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
+    err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }
   {
@@ -2530,12 +2510,12 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &out);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &width);
     dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(int), &height);
-    const int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
-    if(err != CL_SUCCESS) return FALSE;
+    err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
+    if(err != CL_SUCCESS) goto error;
   }
 
   {
-    const int err = dt_opencl_read_host_from_device(devid, mask, out, width, height, sizeof(float));
+    err = dt_opencl_read_host_from_device(devid, mask, out, width, height, sizeof(float));
     if(err != CL_SUCCESS) goto error;
   }
 
@@ -2544,11 +2524,11 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
 
   dt_opencl_release_mem_object(out);
   dt_opencl_release_mem_object(tmp);
-  if(info) fprintf(stderr, " done\n");
+  dt_print(DT_DEBUG_MASKS, "[dt_dev_write_rawdetail_mask_cl] mode %i (%ix%i)", mode, roi_in->width, roi_in->height);
   return FALSE;
 
   error:
-  if(info) fprintf(stderr, " ERROR\n");
+  fprintf(stderr, "[dt_dev_write_rawdetail_mask_cl] couldn't write detail mask: %s\n", cl_errstr(err));
   dt_dev_clear_rawdetail_mask(p);
   dt_opencl_release_mem_object(out);
   dt_opencl_release_mem_object(tmp);
@@ -2562,8 +2542,6 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
 float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, const dt_iop_module_t *target_module)
 {
   if(!pipe->rawdetail_mask_data) return NULL;
-  const gboolean info = ((darktable.unmuted & DT_DEBUG_MASKS) && (pipe->type == DT_DEV_PIXELPIPE_FULL));
-
   gboolean valid = FALSE;
   const int check = pipe->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED;
 
@@ -2584,7 +2562,7 @@ float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, co
   }
 
   if(!valid) return NULL;
-  if(info) fprintf(stderr, "[dt_dev_distort_detail_mask] (%ix%i) for module %s: ", pipe->rawdetail_mask_roi.width, pipe->rawdetail_mask_roi.height, target_module->op);
+  dt_vprint(DT_DEBUG_MASKS, "[dt_dev_distort_detail_mask] (%ix%i) for module %s\n", pipe->rawdetail_mask_roi.width, pipe->rawdetail_mask_roi.height, target_module->op);
 
   float *resmask = src;
   float *inmask  = src;
@@ -2603,7 +2581,7 @@ float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, co
                     && module->processed_roi_in.height == 0))
         {
           float *tmp = dt_alloc_align_float((size_t)module->processed_roi_out.width * module->processed_roi_out.height);
-          if(info) fprintf(stderr," %s %ix%i -> %ix%i,", module->module->op, module->processed_roi_in.width, module->processed_roi_in.height, module->processed_roi_out.width, module->processed_roi_out.height);
+          dt_vprint(DT_DEBUG_MASKS, "   %s %ix%i -> %ix%i\n", module->module->op, module->processed_roi_in.width, module->processed_roi_in.height, module->processed_roi_out.width, module->processed_roi_out.height);
           module->module->distort_mask(module->module, module, inmask, tmp, &module->processed_roi_in, &module->processed_roi_out);
           resmask = tmp;
           if(inmask != src) dt_free_align(inmask);
@@ -2624,7 +2602,6 @@ float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, co
       }
     }
   }
-  if(info) fprintf(stderr, " done\n");
   return resmask;
 }
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2120,7 +2120,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe, d
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   darktable.dtresources.group = 4 * darktable.dtresources.level;
 #ifdef HAVE_OPENCL
-  dt_opencl_check_device_available(pipe->devid);
+  dt_opencl_check_tuning(pipe->devid);
 #endif
   int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1229,7 +1229,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   self->tiling_callback(self, piece, roi_in, roi_out, &tiling);
 
   /* shall we use pinned memory transfers? */
-  gboolean use_pinned_memory = (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
+  gboolean use_pinned_memory = dt_opencl_use_pinned_memory(devid);
   const int pinned_buffer_overhead = use_pinned_memory ? 2 : 0; // add two additional pinned memory buffers
                                                                 // which seemingly get allocated not only on
                                                                 // host but also on device (why???)
@@ -1537,11 +1537,11 @@ error:
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = 0;
-  const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
+  const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
       "[default_process_tiling_opencl_ptp] couldn't run process_cl() for module '%s' in tiling mode:%s %s\n",
       self->op, (pinning_error) ? " pinning problem" : "", cl_errstr(err));
-  if(pinning_error) darktable.opencl->dev[devid].pinned_memory |= DT_OPENCL_PINNING_ERROR;
+  if(pinning_error) darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_PINNED;
   return FALSE;
 }
 
@@ -1590,7 +1590,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   self->tiling_callback(self, piece, roi_in, roi_out, &tiling);
 
   /* shall we use pinned memory transfers? */
-  gboolean use_pinned_memory = (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
+  gboolean use_pinned_memory = dt_opencl_use_pinned_memory(devid);
   const int pinned_buffer_overhead = use_pinned_memory ? 2 : 0; // add two additional pinned memory buffers
                                                                 // which seemingly get allocated not only on
                                                                 // host but also on device (why???)
@@ -1976,11 +1976,11 @@ error:
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = 0;
-  const gboolean pinning_error = (use_pinned_memory == FALSE) && (dt_opencl_pinned_memory(devid) == DT_OPENCL_PINNING_ON);
+  const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
       "[default_process_tiling_opencl_roi] couldn't run process_cl() for module '%s' in tiling mode:%s %s\n",
       self->op, (pinning_error) ? " pinning problem" : "", cl_errstr(err));
-  if(pinning_error) darktable.opencl->dev[devid].pinned_memory |= DT_OPENCL_PINNING_ERROR;
+  if(pinning_error) darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_PINNED;
   return FALSE;
 }
 


### PR DESCRIPTION
The runtime setting of transfer (pinning) did not work as intended and described in the manual.
In fact, you could switch it ON via gui but it stayed ON even if changed to OFF afterwards.

This required some changes. Also included in this pr

- dt_opencl_check_tuning(const int devid) does proper checks about
  a) gui settings
  b) runtime errors
  c) settings defined via device conf
  and sets runtime modes accordingly

- runtime errors for transfer or memory are kept as flags

- dt_opencl_check_device_available() renamed to dt_opencl_check_tuning() as this tells
  better what is done

- dt_opencl_use_pinned_memory() checks and returns a bool

- if a platform has no devices it gives understandable output about vendor and name

- logfile shows *intention* to do transfer or memory tuning as "WANTED" while gui changes and
  while cl device is initialized

- code readability

There is a bug fixed here but as no code is broken in a way leading to 'problems' and as there is also some code cleanup i would think this is for 4.0.1 and later master ...