### PR TITLE
DT 4.0 might use fixed headroom instead of _opencl_get_unused_device_mem

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -314,6 +314,8 @@ gboolean dt_opencl_read_device_config(const int devid)
     sscanf(dat, "%i", &forced_headroom);
     if(forced_headroom > 0) cl->dev[devid].forced_headroom = forced_headroom;
   }
+  else // this is used if updating to 4.0 or fresh installs; see commenting _opencl_get_unused_device_mem()
+    cl->dev[devid].forced_headroom = 400;
   dt_opencl_write_device_config(devid);
   return !existing_device || !safety_ok;
 }
@@ -2730,6 +2732,7 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t actio
    clCreateBuffer does not tell an error condition if there is no memory available (this
    is according to standard), to make sure the buffer is really allocated in graphics mem we
    force a small memory access.
+   Note: This code seems to be bad at least for nvidia 515/16 drivers, the reason is not understood yet.
 */
 void _opencl_get_unused_device_mem(const int devid)
 {


### PR DESCRIPTION
As a reminder for those not fluent in cl memory management.

The pipeline code needs to know how much cl memory might be used by a module to decide about
1. no need to tile or 2. have to tile and how large the tiles can be, this is basically about avoiding
cpu fallbacks and thus performance drops.

The memory that dt is allowed to take is available memory (AM), this used to be calculated as
  physical memory (PM) - headroom (was a conf value) for all devices

Now we calculate it in non-memory-tuned modes as a fraction of PM

If we switch on "tuning memory" we look for a conf key and

a) if it is a positive int we take that as a fixed headroom per device, so almost the same as in pre 4.0
b) we check for available memory on the card by some sort of "brute force" check in
     _opencl_get_unused_device_mem()
   so users don't have to know or tell dt what memory other apps or the OS use.

So what is the problem?
At least for nvidia 515/16 drivers we could identify a problem exactly in the code for b) `_opencl_get_unused_device_mem` leading to crashes or instability in some cases.

The reason for this is unfortunately not understood yet, also i can't test and investigate further here as my distribution doesn't offer a stable 515 driver yet.
For me there are no hints in the nvidia release notes pointing into something solvable right now. some new memory stuff with khronos extensions not used here and a clang update ...

Personally on 510 drivers i had not a single issue over months with intensive testing opencl stuff, but ... What to do now?

We could leave 4.0 as it is now as "tune for memory" is not default and could be switched off immediately in the GUI.

Or - use this PR - that defaults to fixed headroom on fresh installs or updates; this would fix stability problems at a possible yet rather small performance drop.

Don't know really, just made this pr to open a discussion so close before 4.0, i would certainly like getting "votes" from long time devs that also worked on this code so @TurboGit @aurelienpierre @parafin ?  

See #12001
