### PR TITLE
README.md: more accurate definition of compatible compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ Building
 ### Dependencies
 
 Compatible compilers:
-* Clang: 8, 9, 10
-* GCC: 8, 9, 10
-* Mingw64: 6, 7
+* Clang: 8 and later
+* GCC: 8 and later
+* MinGW-w64: 6 and later
 
 Required dependencies (minimum version):
 * CMake 3.10


### PR DESCRIPTION
It will be enough to simply specify the minimum compatible version, there is no need to maintain a list of all versions.