### PR TITLE
exif: drop the 6-byte Exif JPEG APP1 header

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1675,7 +1675,7 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
     read_metadata_threadsafe(image);
     Exiv2::ExifData &imgExifData = image->exifData();
     Exiv2::ExifData blobExifData;
-    Exiv2::ExifParser::decode(blobExifData, blob + 6, size);
+    Exiv2::ExifParser::decode(blobExifData, blob, size);
     Exiv2::ExifData::const_iterator end = blobExifData.end();
     Exiv2::ExifData::iterator it;
     for(Exiv2::ExifData::const_iterator i = blobExifData.begin(); i != end; ++i)
@@ -2035,15 +2035,14 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
 
     Exiv2::Blob blob;
     Exiv2::ExifParser::encode(blob, Exiv2::bigEndian, exifData);
-    const int length = blob.size();
-    *buf = (uint8_t *)malloc(length+6);
+    const size_t length = blob.size();
+    *buf = (uint8_t *)malloc(length);
     if (!*buf)
     {
       return 0;
     }
-    memcpy(*buf, "Exif\000\000", 6);
-    memcpy(*buf + 6, &(blob[0]), length);
-    return length + 6;
+    memcpy(*buf, &(blob[0]), length);
+    return length;
   }
   catch(Exiv2::AnyError &e)
   {

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -344,14 +344,14 @@ int write_image(dt_imageio_module_data_t *jpg_tmp, const char *filename, const v
 
   jpeg_start_compress(&(jpg->cinfo), TRUE);
 
-  if(imgid > 0)
+  cmsHPROFILE out_profile = dt_colorspaces_get_output_profile(imgid, over_type, over_filename)->profile;
+  uint32_t len = 0;
+  cmsSaveProfileToMem(out_profile, NULL, &len);
+  if(len > 0)
   {
-    cmsHPROFILE out_profile = dt_colorspaces_get_output_profile(imgid, over_type, over_filename)->profile;
-    uint32_t len = 0;
-    cmsSaveProfileToMem(out_profile, 0, &len);
-    if(len > 0)
+    unsigned char *buf = malloc(sizeof(unsigned char) * len);
+    if(buf)
     {
-      unsigned char *buf = malloc(sizeof(unsigned char) * len);
       cmsSaveProfileToMem(out_profile, buf, &len);
       write_icc_profile(&(jpg->cinfo), buf, len);
       free(buf);
@@ -599,4 +599,3 @@ void gui_reset(dt_imageio_module_format_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -167,25 +167,25 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
   // metadata has to be written before the pixels
 
   // embed icc profile
-  if(imgid > 0)
+  cmsHPROFILE out_profile = dt_colorspaces_get_output_profile(imgid, over_type, over_filename)->profile;
+  uint32_t len = 0;
+  cmsSaveProfileToMem(out_profile, NULL, &len);
+  if(len > 0)
   {
-    cmsHPROFILE out_profile = dt_colorspaces_get_output_profile(imgid, over_type, over_filename)->profile;
-    uint32_t len = 0;
-    cmsSaveProfileToMem(out_profile, 0, &len);
-    if(len > 0)
+    char *buf = malloc(sizeof(char) * len);
+    if(buf)
     {
-      char *buf = malloc(sizeof(char) * len);
-      char name[512] = { 0 };
       cmsSaveProfileToMem(out_profile, buf, &len);
+      char name[512] = { 0 };
       dt_colorspaces_get_profile_name(out_profile, "en", "US", name, sizeof(name));
 
       png_set_iCCP(png_ptr, info_ptr, *name ? name : "icc", 0,
 #if(PNG_LIBPNG_VER < 10500)
-                   (png_charp)buf,
+                    (png_charp)buf,
 #else
-                   (png_const_bytep)buf,
+                    (png_const_bytep)buf,
 #endif
-                   len);
+                    len);
       free(buf);
     }
   }
@@ -195,10 +195,13 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
   {
     /* The legacy tEXt chunk storage scheme implies the "Exif\0\0" APP1 prefix */
     uint8_t *buf = malloc(exif_len + 6);
-    memcpy(buf, "Exif\0\0", 6);
-    memcpy(buf + 6, exif, exif_len);
-    PNGwriteRawProfile(png_ptr, info_ptr, "exif", buf, exif_len + 6);
-    free(buf);
+    if(buf)
+    {
+      memcpy(buf, "Exif\0\0", 6);
+      memcpy(buf + 6, exif, exif_len);
+      PNGwriteRawProfile(png_ptr, info_ptr, "exif", buf, exif_len + 6);
+      free(buf);
+    }
   }
 
   png_write_info(png_ptr, info_ptr);

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -191,7 +191,15 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
   }
 
   // write exif data
-  PNGwriteRawProfile(png_ptr, info_ptr, "exif", exif, exif_len);
+  if(exif && exif_len > 0)
+  {
+    /* The legacy tEXt chunk storage scheme implies the "Exif\0\0" APP1 prefix */
+    uint8_t *buf = malloc(exif_len + 6);
+    memcpy(buf, "Exif\0\0", 6);
+    memcpy(buf + 6, exif, exif_len);
+    PNGwriteRawProfile(png_ptr, info_ptr, "exif", buf, exif_len + 6);
+    free(buf);
+  }
 
   png_write_info(png_ptr, info_ptr);
 
@@ -569,4 +577,3 @@ int flags(dt_imageio_module_data_t *data)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
The 6-byte header is only specified in the Exif spec for storing in JPEG APP1 