### PR TITLE
CI: switch Windows builds to UCRT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,48 +387,49 @@ jobs:
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: ucrt64
           install: >-
             base-devel
             git
             intltool
-            mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-cmocka
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-nsis
-            mingw-w64-x86_64-dbus-glib
-            mingw-w64-x86_64-drmingw
-            mingw-w64-x86_64-exiv2
-            mingw-w64-x86_64-gettext
-            mingw-w64-x86_64-gmic
-            mingw-w64-x86_64-graphicsmagick
-            mingw-w64-x86_64-gtk3
-            mingw-w64-x86_64-iso-codes
-            mingw-w64-x86_64-lcms2
-            mingw-w64-x86_64-lensfun
-            mingw-w64-x86_64-libavif
-            mingw-w64-x86_64-libexif
-            mingw-w64-x86_64-libgphoto2
-            mingw-w64-x86_64-libheif
-            mingw-w64-x86_64-libjpeg-turbo
-            mingw-w64-x86_64-libsecret
-            mingw-w64-x86_64-libsoup
-            mingw-w64-x86_64-libwebp
-            mingw-w64-x86_64-libxml2
-            mingw-w64-x86_64-libxslt
-            mingw-w64-x86_64-lua
-            mingw-w64-x86_64-openexr
-            mingw-w64-x86_64-openjpeg2
-            mingw-w64-x86_64-osm-gps-map
-            mingw-w64-x86_64-portmidi
-            mingw-w64-x86_64-pugixml
-            mingw-w64-x86_64-python3
-            mingw-w64-x86_64-python3-jsonschema
-            mingw-w64-x86_64-python3-setuptools
-            mingw-w64-x86_64-python3-six
-            mingw-w64-x86_64-sqlite3
-            mingw-w64-x86_64-zlib
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            cmocka:p
+            ninja:p
+            nsis:p
+            dbus-glib:p
+            drmingw:p
+            exiv2:p
+            gettext:p
+            gmic:p
+            graphicsmagick:p
+            gtk3:p
+            iso-codes:p
+            lcms2:p
+            lensfun:p
+            libavif:p
+            libexif:p
+            libgphoto2:p
+            libheif:p
+            libjpeg-turbo:p
+            libsecret:p
+            libsoup:p
+            libwebp:p
+            libxml2:p
+            libxslt:p
+            lua:p
+            openexr:p
+            openjpeg2:p
+            osm-gps-map:p
+            portmidi:p
+            pugixml:p
+            python3:p
+            python3-jsonschema:p
+            python3-setuptools:p
+            python3-six:p
+            sqlite3:p
+            zlib:p
           update: true
       - run: git config --global core.autocrlf input
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,47 +34,48 @@ jobs:
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: ucrt64
           install: >-
             base-devel
             git
             intltool
-            mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-nsis
-            mingw-w64-x86_64-dbus-glib
-            mingw-w64-x86_64-drmingw
-            mingw-w64-x86_64-exiv2
-            mingw-w64-x86_64-gettext
-            mingw-w64-x86_64-gmic
-            mingw-w64-x86_64-graphicsmagick
-            mingw-w64-x86_64-gtk3
-            mingw-w64-x86_64-iso-codes
-            mingw-w64-x86_64-lcms2
-            mingw-w64-x86_64-lensfun
-            mingw-w64-x86_64-libavif
-            mingw-w64-x86_64-libexif
-            mingw-w64-x86_64-libgphoto2
-            mingw-w64-x86_64-libheif
-            mingw-w64-x86_64-libjpeg-turbo
-            mingw-w64-x86_64-libsecret
-            mingw-w64-x86_64-libsoup
-            mingw-w64-x86_64-libwebp
-            mingw-w64-x86_64-libxml2
-            mingw-w64-x86_64-libxslt
-            mingw-w64-x86_64-lua
-            mingw-w64-x86_64-openexr
-            mingw-w64-x86_64-openjpeg2
-            mingw-w64-x86_64-osm-gps-map
-            mingw-w64-x86_64-portmidi
-            mingw-w64-x86_64-pugixml
-            mingw-w64-x86_64-python3
-            mingw-w64-x86_64-python3-jsonschema
-            mingw-w64-x86_64-python3-setuptools
-            mingw-w64-x86_64-python3-six
-            mingw-w64-x86_64-sqlite3
-            mingw-w64-x86_64-zlib
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
+            nsis:p
+            dbus-glib:p
+            drmingw:p
+            exiv2:p
+            gettext:p
+            gmic:p
+            graphicsmagick:p
+            gtk3:p
+            iso-codes:p
+            lcms2:p
+            lensfun:p
+            libavif:p
+            libexif:p
+            libgphoto2:p
+            libheif:p
+            libjpeg-turbo:p
+            libsecret:p
+            libsoup:p
+            libwebp:p
+            libxml2:p
+            libxslt:p
+            lua:p
+            openexr:p
+            openjpeg2:p
+            osm-gps-map:p
+            portmidi:p
+            pugixml:p
+            python3:p
+            python3-jsonschema:p
+            python3-setuptools:p
+            python3-six:p
+            sqlite3:p
+            zlib:p
           update: true
       - run: git config --global core.autocrlf input
         shell: bash


### PR DESCRIPTION
Windows 7 was EOL'd in 2020, Windows 8.1 will be in Jan 2023 (i.e. dt 4.2 timeframe). Might as well switch now and start testing.

[UCRT can be installed on both Windows 7 and Windows 8.1 by if needed](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c), so these can still run darktable.

This replaces https://github.com/darktable-org/darktable/pull/9010