### PR TITLE
Fix preferences->darkroom->demosaicing

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2318,13 +2318,13 @@
     <type>
       <enum>
         <option>always bilinear (fast)</option>
-        <option>at most RCD (reasonable)</option>
+        <option>default</option>
         <option>full (possibly slow)</option>
       </enum>
     </type>
-    <default>at most RCD (reasonable)</default>
+    <default>default</default>
     <shortdescription>demosaicing for zoomed out darkroom mode</shortdescription>
-    <longdescription>interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, but not as sharp. middle ground is using RCD + interpolation modes specified on the 'pixel interpolator' option (processing tab), full will use exactly the settings for full-size export. X-Trans sensors use VNG rather than RCD as middle ground.</longdescription>
+    <longdescription>demosaicer when not viewing 1:1 in darkroom mode: 'bilinear' is fast but slightly blurry. 'default' uses the default demosaicer for the used sensor (RCD or Markesteijn). 'full' will use exactly the settings as for full-size export.</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>preview_downsampling</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1687,17 +1687,26 @@ void dt_configure_runtime_performance(const int old, char *info)
 
   if(!dt_conf_key_not_empty("plugins/darkroom/demosaic/quality"))
   {
-    dt_conf_set_string("plugins/darkroom/demosaic/quality", (sufficient) ? "at most RCD (reasonable)" : "always bilinear (fast)");
+    dt_conf_set_string("plugins/darkroom/demosaic/quality", (sufficient) ? "default" : "always bilinear (fast)");
     dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] plugins/darkroom/demosaic/quality=%s",
-      (sufficient) ? "at most RCD (reasonable)" : "always bilinear (fast)");
+      (sufficient) ? "default" : "always bilinear (fast)");
   }
   else if(old == 2)
   {
     const gchar *demosaic_quality = dt_conf_get_string_const("plugins/darkroom/demosaic/quality");
     if(!strcmp(demosaic_quality, "always bilinear (fast)"))
     {
-      dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most RCD (reasonable)");
-      dt_print(DT_DEBUG_DEV, "[dt_configure_performance] override: plugins/darkroom/demosaic/quality=at most RCD (reasonable)\n");
+      dt_conf_set_string("plugins/darkroom/demosaic/quality", "default");
+      dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] override: plugins/darkroom/demosaic/quality=default\n");
+    }
+  }
+  else if(old < 12)
+  {
+    const gchar *demosaic_quality = dt_conf_get_string_const("plugins/darkroom/demosaic/quality");
+    if(!strcmp(demosaic_quality, "at most RCD (reasonable)"))
+    {
+      dt_conf_set_string("plugins/darkroom/demosaic/quality", "default");
+      dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] override: plugins/darkroom/demosaic/quality=default\n");
     }
   }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -156,7 +156,7 @@ typedef unsigned int u_int;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 11
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 12
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:


### PR DESCRIPTION
The tooltip and the naming of the menu was wrong.
Using `default` instead of `at most RCD` which was only true for bayer sensors.

The reference to interpolators was at least very misleading.