### PR TITLE
RFC: getting rid of the 'auto-apply sharpen' option in preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3265,13 +3265,6 @@
     <longdescription>use the per-camera basecurve by default instead of the generic manufacturer one if there is one available (needs a restart).\nthis option is taken into account when the \"auto-apply pixel workflow defaults\" is set to \"display-referred\".\nto prevent auto-apply basecurve presets \"auto-apply pixel workflow defaults\" should be set to \"none\"</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="general">
-    <name>plugins/darkroom/sharpen/auto_apply</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription>auto-apply sharpen</shortdescription>
-    <longdescription>this added sharpen is not recommended on cameras without a low-pass filter. you should disable this option if you use one of those more recent cameras or sharpen your images with other means.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="processing" section="general">
     <name>ui/detect_mono_exif</name>
     <type>bool</type>
     <default>false</default>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1462,7 +1462,6 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     // note that images without history don't get hash and are considered as basic
     sqlite3_stmt *h_stmt;
     const gboolean basecurve_auto_apply = dt_conf_is_equal("plugins/darkroom/workflow", "display-referred");
-    const gboolean sharpen_auto_apply = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
     // clang-format off
     char *query = g_strdup_printf(
                             "SELECT id, CASE WHEN imgid IS NULL THEN 0 ELSE 1 END as altered "
@@ -1471,10 +1470,9 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
                             "LEFT JOIN (SELECT DISTINCT imgid FROM main.images JOIN main.history ON imgid = id "
                             "           WHERE num < history_end AND enabled = 1"
                             "             AND operation NOT IN ('flip', 'dither', 'highlights', 'rawprepare', "
-                            "             'colorin', 'colorout', 'gamma', 'demosaic', 'temperature'%s%s)) "
+                            "             'colorin', 'colorout', 'gamma', 'demosaic', 'temperature'%s)) "
                             "ON imgid = id",
-                             basecurve_auto_apply ? ", 'basecurve'" : "",
-                             sharpen_auto_apply ? ", 'sharpen'" : "");
+                             basecurve_auto_apply ? ", 'basecurve'" : "");
     // clang-format on
     TRY_PREPARE(h_stmt, query,
                 "[init] can't prepare selecting history for history_hash migration\n");

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2883,8 +2883,6 @@ static gboolean _image_altered_deprecated(const uint32_t imgid)
   const gboolean basecurve_auto_apply =
     dt_conf_is_equal("plugins/darkroom/workflow", "display-referred");
 
-  const gboolean sharpen_auto_apply = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
-
   char query[1024] = { 0 };
 
   // clang-format off
@@ -2893,9 +2891,8 @@ static gboolean _image_altered_deprecated(const uint32_t imgid)
            " FROM main.history, main.images"
            " WHERE id=?1 AND imgid=id AND num<history_end AND enabled=1"
            "       AND operation NOT IN ('flip', 'dither', 'highlights', 'rawprepare',"
-           "                             'colorin', 'colorout', 'gamma', 'demosaic', 'temperature'%s%s)",
-           basecurve_auto_apply ? ", 'basecurve'" : "",
-           sharpen_auto_apply ? ", 'sharpen'" : "");
+           "                             'colorin', 'colorout', 'gamma', 'demosaic', 'temperature'%s)",
+           basecurve_auto_apply ? ", 'basecurve'" : "");
   // clang-format on
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1471,17 +1471,15 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   const gboolean auto_apply_filmic = is_raw && is_scene_referred;
   const gboolean auto_apply_cat = has_matrix && is_modern_chroma;
-  const gboolean auto_apply_sharpen = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
 
-  if(auto_apply_filmic || auto_apply_sharpen || auto_apply_cat)
+  if(auto_apply_filmic || auto_apply_cat)
   {
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
-      if(((auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0)
-          || (auto_apply_sharpen && strcmp(module->op, "sharpen") == 0)
-          || (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
+      if(((auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0) ||
+          (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
          && !dt_history_check_module_exists(imgid, module->op, FALSE)
          && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
       {


### PR DESCRIPTION
As
1. for the vast majority of cameras around the sharpen module is not suggested to be used
2. we now have better ways to sharpen as in D&S for those sensors that would require it

i suggest to completely remove the option from preferences menu.

Open for discussion ...