### PR TITLE
RFC: simplify database maintenance options in preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -103,6 +103,13 @@
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
+    <name>storage/piwigo/overwrite</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription></shortdescription>
+    <longdescription></longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>database/maintenance_freepage_ratio</name>
     <type>int</type>
     <default>25</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -124,7 +124,7 @@
     <shortdescription>create database snapshot</shortdescription>
     <longdescription>database snapshots are created right before closing darktable. options allow you to choose how often to make snapshots:\nnever - simply don't do snapshots. that way the only snapshots done are mandatory version-upgrade snapshots\nonce a month - create snapshot if a month has passed since last snapshot\nonce a week - create snapshot if 7 days had passed since last snapshot\nonce a day - create snapshot if over 24h passed since last snapshot\non close - create snapshot every time darktable is closed</longdescription>
   </dtconfig>
-  <dtconfig>
+  <dtconfig prefs="storage" section="database">
     <name>database/keep_snapshots</name>
     <type>int</type>
     <default>10</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -103,30 +103,6 @@
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
-    <name>storage/piwigo/overwrite</name>
-    <type>int</type>
-    <default>0</default>
-    <shortdescription></shortdescription>
-    <longdescription></longdescription>
-  </dtconfig>
-  <dtconfig prefs="storage" section="database">
-    <name>database/maintenance_check</name>
-    <type>
-      <enum>
-        <option>never</option>
-        <option>on startup</option>
-        <option>on close</option>
-        <option>on both</option>
-        <option>on startup (don't ask)</option>
-        <option>on close (don't ask)</option>
-        <option>on both (don't ask)</option>
-      </enum>
-    </type>
-    <default>on close</default>
-    <shortdescription>check for database maintenance</shortdescription>
-    <longdescription>this option indicates when to check database fragmentation and perform maintenance</longdescription>
-  </dtconfig>
-  <dtconfig prefs="storage" section="database">
     <name>database/maintenance_freepage_ratio</name>
     <type>int</type>
     <default>25</default>
@@ -148,7 +124,7 @@
     <shortdescription>create database snapshot</shortdescription>
     <longdescription>database snapshots are created right before closing darktable. options allow you to choose how often to make snapshots:\nnever - simply don't do snapshots. that way the only snapshots done are mandatory version-upgrade snapshots\nonce a month - create snapshot if a month has passed since last snapshot\nonce a week - create snapshot if 7 days had passed since last snapshot\nonce a day - create snapshot if over 24h passed since last snapshot\non close - create snapshot every time darktable is closed</longdescription>
   </dtconfig>
-  <dtconfig prefs="storage" section="database">
+  <dtconfig>
     <name>database/keep_snapshots</name>
     <type>int</type>
     <default>10</default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1064,12 +1064,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     return 1;
   }
 
-  //db maintenance on startup (if configured to do so)
-  if(dt_database_maybe_maintenance(darktable.db, init_gui, FALSE))
-  {
-    dt_database_perform_maintenance(darktable.db);
-  }
-
   // init darktable tags table
   dt_set_darktable_tags();
 
@@ -1412,7 +1406,7 @@ void dt_cleanup()
 
   // last chance to ask user for any input...
 
-  const gboolean perform_maintenance = dt_database_maybe_maintenance(darktable.db, init_gui, TRUE);
+  const gboolean perform_maintenance = dt_database_maybe_maintenance(darktable.db);
   const gboolean perform_snapshot = dt_database_maybe_snapshot(darktable.db);
   gchar **snaps_to_remove = NULL;
   if(perform_snapshot)

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3817,8 +3817,8 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db)
 
   const int freepage_ratio = dt_conf_get_int("database/maintenance_freepage_ratio");
 
-  if((main_free_percentage >= freepage_ratio) ||
-     (data_free_percentage >= freepage_ratio))
+  if((main_free_percentage >= freepage_ratio)
+     || (data_free_percentage >= freepage_ratio))
   {
     const guint64 calc_size = (main_free_count*main_page_size) + (data_free_count*data_page_size);
     dt_print(DT_DEBUG_SQL, "[db maintenance] maintenance, %" G_GUINT64_FORMAT " bytes to free.\n", calc_size);

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -37,7 +37,7 @@ void dt_database_show_error(const struct dt_database_t *db);
 /** perform pre-db-close optimizations (always call when quiting darktable) */
 void dt_database_optimize(const struct dt_database_t *);
 /** conditionally perfrom db maintenance */
-gboolean dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time);
+gboolean dt_database_maybe_maintenance(const struct dt_database_t *db);
 void dt_database_perform_maintenance(const struct dt_database_t *db);
 /** cleanup busy statements on closing dt, just before performing maintenance */
 void dt_database_cleanup_busy_statements(const struct dt_database_t *db);


### PR DESCRIPTION
Let's get rid of some very technical options here that add nothing for almost all users.

- database/keep_snapshots is now a hidden option, can still be tuned by people
  who insist on that (although i doubt there is a real benefit)

- database/maintenance_freepage_ratio is now also a hidden option that can be
  tuned still. (could just be a const as i see it)

- there is no sense in not-tuning the database at all if it's worth to do so,
  the database/maintenance_check option has gone and we always do work at
  closing dt.

- the database snapshot system has not been touched

Open for discussion ...