### PR TITLE
RFC Getting rid of colorbalance layout in preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3441,7 +3441,7 @@
     <shortdescription>saturation factor of the color zones background</shortdescription>
     <longdescription>higher value means more saturated backgrounds in color zones</longdescription>
   </dtconfig>
-  <dtconfig prefs="darkroom" section="modules">
+  <dtconfig>
     <name>plugins/darkroom/colorbalance/layout</name>
     <type>
       <enum>


### PR DESCRIPTION
As we can easily modify the layout in the module itself - tooltip is correct -
with one click there is no need to offer this option in the preferences.

We keep the conf data to remember the user defined view nevertheless.