### PR TITLE
Fix various typos

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -309,7 +309,7 @@
     </type>
     <default>insensitive</default>
     <shortdescription>tags case sensitivity</shortdescription>
-    <longdescription>tags case sensitivity. without the Sqlite ICU extension, insensivity works only for the 26 latin letters</longdescription>
+    <longdescription>tags case sensitivity. without the Sqlite ICU extension, insensitivity works only for the 26 latin letters</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" capability="opencl">
     <name>opencl</name>

--- a/data/noiseprofiles.json
+++ b/data/noiseprofiles.json
@@ -6454,7 +6454,7 @@
           ]
         },
         {
-          "comment": "k-70 contributed by daniel, graphs don't match very well, but this sems to be pentax specific",
+          "comment": "k-70 contributed by daniel, graphs don't match very well, but this seems to be pentax specific",
           "model": "K-70",
           "profiles": [
             {"name": "K-70 iso 100", "iso": 100, "a": [6.01190019431127e-06, 3.01649635178941e-06, 6.71684918826677e-06], "b": [6.88088720028027e-09, 1.23212106450433e-09, 9.03697050283415e-09]},

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -66,13 +66,13 @@
 /*** Naming class and ids:
   - classes should be named with underscores, starting by dt_ then what class does (main function). See below.
   Note that some remains with hyphens, they are Gtk ones and can't be changed. It's so also a good way to distinguish Gtk classes to darktable classes.
-  - ids will be used with hyphens, with so item part name (for exemple: bauhaus-slider)
+  - ids will be used with hyphens, with so item part name (for example: bauhaus-slider)
 Why that? Just because it's a developer choice and most classes use underscore in code and id use hyphens. So make it easy and, more important, consistent to avoid being confused and make mistake that would cause bug just by wrong typing.
 ***/
 
 /*** Using classes and ids :
 
-  * classes are used to set same settings for multiples and differents widgets in the UI.
+  * classes are used to set same settings for multiples and different widgets in the UI.
   * ids are used to set a name to a specific widget and so allow to set CSS for this widget
   * some classes had been set on darktable, they all began with a dot. Before adding classes or ids, check what exist before
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2204,7 +2204,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
       float combo_height = 0;
       show_pango_text(w, context, cr, text, available_width, 0, 0, TRUE, TRUE, combo_ellipsis, FALSE, FALSE,
                       &combo_width, &combo_height);
-      // we want to center the text verticaly
+      // we want to center the text vertically
       w->top_gap = floor((h3 - fmaxf(label_height, combo_height)) / 2.0f);
       //check if they fit
       if((label_width + combo_width) > available_width)
@@ -2444,7 +2444,7 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
       darktable.bauhaus->change_active = 1;
       if(!d->entries->len) return;
       tmp.height = darktable.bauhaus->line_height * d->entries->len;
-      // if the popup is detached, we show the lable in any cases, in a special line
+      // if the popup is detached, we show the label in any cases, in a special line
       if(w->detached_popup) tmp.height += darktable.bauhaus->line_height;
       if(w->margin) tmp.height += w->margin->top + w->margin->bottom + w->top_gap;
 

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -49,7 +49,7 @@ typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
 // A macro which gives us a configurable shorthand to produce the optimal performance when processing all of the
 // channels in a pixel.  Its first argument is the name of the variable to be used inside the 'for' loop it creates,
 // while the optional second argument is a set of OpenMP directives, typically specifying variable alignment.
-// If indexing off of the begining of any buffer allocated with dt's image or aligned allocation functions, the
+// If indexing off of the beginning of any buffer allocated with dt's image or aligned allocation functions, the
 // alignment to specify is 64; otherwise, use 16, as there may have been an odd number of pixels from the start.
 // Sample usage:
 //         for_each_channel(k,aligned(src,dest:16))

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -512,7 +512,7 @@ static inline float get_tint_from_tinted_xy(const float x, const float y, const 
 #endif
 static inline void xy_to_uv(const float xy[2], float uv[2])
 {
-  // Convert to CIE1960 Yuv color space, usefull to compute CCT
+  // Convert to CIE1960 Yuv color space, useful to compute CCT
   // https://en.wikipedia.org/wiki/CIE_1960_color_space
   const float denom = 12.f * xy[1] - 1.882f * xy[0] + 2.9088f;
   uv[0] = 5.5932f * xy[0] + 1.9116 * xy[1];

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -760,7 +760,7 @@ static void _popup_date_tree_selection_change(GtkTreeView *self, GtkDarktableRan
   }
   else
   {
-    // intialize value depending of the source widget
+    // initialize value depending of the source widget
     if(gtk_popover_get_default_widget(GTK_POPOVER(pop->popup)) == range->entry_max)
     {
       m = 12;
@@ -1051,7 +1051,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
 static void _popup_item_activate(GtkWidget *w, gpointer user_data)
 {
   GtkDarktableRangeSelect *range = (GtkDarktableRangeSelect *)user_data;
-  // retrive block and source values
+  // retrieve block and source values
   GtkWidget *source = GTK_WIDGET(g_object_get_data(G_OBJECT(w), "source_widget"));
   _range_block *blo = (_range_block *)g_object_get_data(G_OBJECT(w), "range_block");
 
@@ -1318,7 +1318,7 @@ static gboolean _event_band_draw(GtkWidget *widget, cairo_t *cr, gpointer user_d
                      range->alloc_margin.height);
 
     // draw the rectangles on the surface
-    // we have to do some clever things in order to packed together blocks that wiil be shown at the same place
+    // we have to do some clever things in order to packed together blocks that will be shown at the same place
     // (see above)
     dt_gui_gtk_set_source_rgba(scr, DT_GUI_COLOR_RANGE_GRAPH, 1.0);
     bl_min_px = 0;
@@ -1416,7 +1416,7 @@ static gboolean _event_band_draw(GtkWidget *widget, cairo_t *cr, gpointer user_d
       last = icon->posx;
     }
     min_percent = MIN(min_percent, (100 - last) * 2);
-    // we want to let some marging between icons
+    // we want to let some margin between icons
     min_percent *= 0.9;
     // and we don't want to exceed 60% of the height
     const int size = MIN(range->alloc_padding.height * 0.6, range->alloc_padding.width * min_percent / 100);

--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -76,7 +76,7 @@ struct _GtkDarktableRangeSelect
   double step_bd;        // minimal step value in band reference
 
   double select_min_r;      // low bound of the selection
-  double select_max_r;      // hight bound of the selection
+  double select_max_r;      // high bound of the selection
   dt_datetime_t select_relative_date_r; // relative date
   dt_range_bounds_t bounds; // type of selection bounds
 
@@ -90,7 +90,7 @@ struct _GtkDarktableRangeSelect
   GtkWidget *entry_max;
   GtkWidget *band;
 
-  // fonction used to translate "real" value into band positions
+  // function used to translate "real" value into band positions
   // this allow to have special value repartitions on the band
   // if NULL, band values == real values
   DTGTKTranslateValueFunc value_to_band;
@@ -137,7 +137,7 @@ void dtgtk_range_select_set_selection(GtkDarktableRangeSelect *range, const dt_r
 // directly decode raw_text and apply it to selection
 void dtgtk_range_select_set_selection_from_raw_text(GtkDarktableRangeSelect *range, const gchar *txt,
                                                     gboolean signal);
-// get selction range
+// get selection range
 dt_range_bounds_t dtgtk_range_select_get_selection(GtkDarktableRangeSelect *range, double *min_r, double *max_r);
 
 // get the text used for collection queries
@@ -154,7 +154,7 @@ void dtgtk_range_select_add_range_block(GtkDarktableRangeSelect *range, const do
 void dtgtk_range_select_reset_blocks(GtkDarktableRangeSelect *range);
 
 // set the function to switch from real value to band value
-// this is usefull to have non-linear value repartitions
+// this is useful to have non-linear value repartitions
 void dtgtk_range_select_set_band_func(GtkDarktableRangeSelect *range, DTGTKTranslateValueFunc value_from_band,
                                       DTGTKTranslateValueFunc value_to_band);
 // set functions to switch between real values and text representation

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3806,7 +3806,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     dt_aligned_pixel_t XYZ_output = { 0.f };
     chroma_adapt_pixel(XYZ, XYZ_output, LMS_illuminant, adaptation, pp);
 
-    // Optionaly, apply the channel mixing
+    // Optionally, apply the channel mixing
     if(use_mixing)
     {
       dt_aligned_pixel_t LMS_output = { 0.f };
@@ -3855,7 +3855,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
     for(int c = 0; c < 3; c++) XYZ_target[c] /= Y_target;
     convert_any_XYZ_to_LMS(XYZ_target, LMS_target, p->adaptation);
 
-    // optionaly, apply the inverse mixing on the target
+    // optionally, apply the inverse mixing on the target
     if(use_mixing)
     {
       // Repack the MIX matrix to 3×3 to support the pseudoinverse function

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -841,7 +841,7 @@ static gboolean _rule_show_popup(GtkWidget *widget, dt_lib_filtering_rule_t *rul
   GtkMenuShell *spop = GTK_MENU_SHELL(gtk_menu_new());
   gtk_widget_set_size_request(GTK_WIDGET(spop), 200, -1);
 
-  // the differents categories
+  // the different categories
   _popup_add_item(spop, _("files"), 0, TRUE, NULL, NULL, self, 0.0);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_FILMROLL);
   ADD_COLLECT_ENTRY(spop, DT_COLLECTION_PROP_FOLDERS);
@@ -1976,7 +1976,7 @@ void gui_init(dt_lib_module_t *self)
   d->rules_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), d->rules_box, FALSE, TRUE, 0);
 
-  // the botton buttons for the rules
+  // the bottom buttons for the rules
   GtkWidget *bhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_set_homogeneous(GTK_BOX(bhbox), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), bhbox, TRUE, TRUE, 0);
@@ -1996,7 +1996,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->sort_box, "filter-sort-box");
   gtk_box_pack_start(GTK_BOX(self->widget), d->sort_box, TRUE, TRUE, 0);
 
-  // the botton buttons for the sort
+  // the bottom buttons for the sort
   bhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_set_homogeneous(GTK_BOX(bhbox), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), bhbox, TRUE, TRUE, 0);

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -106,7 +106,7 @@ void _filename_tree_update(_widgets_filename_t *filename)
   gtk_list_store_clear(GTK_LIST_STORE(ext_model));
 
   // how do we separate filename and extension directly in sqlite :
-  // starting exemple : 'nice.bird.cr2'
+  // starting example : 'nice.bird.cr2'
   // replace(filename, '.', '') => nicebirdcr2 (remove all the point)
   // rtrim(filename, replace(filename, '.', '')) => nice.bird. (remove ending chars presents in 'nice.bird.cr2' and
   // 'nicebirdcr2') rtrim(rtrim(filename, replace(filename, '.', '')), '.') => nice.bird (remove ending '.')

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -658,7 +658,7 @@ static int _block_get_at_zoom(dt_lib_module_t *self, int width)
 
   int w = 0;
 
-  // if selection start/stop if lower than the begining of the strip
+  // if selection start/stop if lower than the beginning of the strip
   if(_time_compare_at_zoom(strip->start_t, strip->time_pos, strip->zoom) < 0) strip->start_x = -2;
   if(_time_compare_at_zoom(strip->stop_t, strip->time_pos, strip->zoom) < 0) strip->stop_x = -1;
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,./src/external,./src/common,./data/pswp,./tools/lua_doc/old_api -L ba,bloc,detailled,dinamic,eacg,hist,initiales,ist,inout,liquify,ro,uint,ue,webp`