### PR TITLE
RFC remove plugins/darkroom/temperature/button_bar from perferences UI

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3386,7 +3386,7 @@
     <shortdescription>Geotagging search URL</shortdescription>
     <longdescription>this can be changed when the default OpenStreetMap search URL is broken</longdescription>
   </dtconfig>
-  <dtconfig prefs="darkroom" section="modules">
+  <dtconfig>
     <name>plugins/darkroom/temperature/colored_sliders</name>
     <type>
       <enum>


### PR DESCRIPTION
Configuring the slider color representation can also be done inside the module
with a single click and is kept in a conf key.

No need to expose this in the perferences UI

Open for discussion ...