### PR TITLE
Reset cl device to defaults if conf key was invalid

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -282,10 +282,9 @@ gboolean dt_opencl_read_device_config(const int devid)
       cl->dev[devid].disabled = disabled;
       cl->dev[devid].benchmark = benchmark;
     }
-    else // if there is something wrong with the config disable the device
+    else // if there is something wrong with the found conf key reset to defaults
     {
       dt_print(DT_DEBUG_OPENCL, "[dt_opencl_read_device_config] malformed data '%s' for '%s'\n", dat, key);
-      cl->dev[devid].disabled = 1;
     }
   }
   // do some safety housekeeping


### PR DESCRIPTION
Users might leave an edited conf key in a bad state, like not clearing the data completely.
In such a case we can reset the device config data to defaults instead of disabling the device.

I came across this issue while investigating #12119 and a report on pixels.us.

Also for 4.01