### PR TITLE
Remove 'fswatch' from debug print options list of darktable's help text

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,6 @@ FILE(GLOB SOURCE_FILES
   "common/exif.cc"
   "common/film.c"
   "common/file_location.c"
-  "common/fswatch.c"
   "common/gaussian.c"
   "common/grouping.c"
   "common/guided_filter.c"

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -125,9 +125,9 @@ static int usage(const char *argv0)
   printf("  --cachedir <user cache directory>\n");
   printf("  --conf <key>=<value>\n");
   printf("  --configdir <user config directory>\n");
-  printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch,imageio,input,\n");
-  printf("      ioporder,lighttable,lua,masks,memory,nan,opencl,params,perf,demosaic\n");
-  printf("      pwstorage,print,signal,sql,undo,act_on,tiling,verbose}\n");
+  printf("  -d {all,act_on,cache,camctl,camsupport,control,demosaic,dev,imageio,\n");
+  printf("      input,ioporder,lighttable,lua,masks,memory,nan,opencl,params,\n");
+  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
   // clang-format on


### PR DESCRIPTION
The fswatch code was removed from darktable in commit 5ea3f9f, but the mention of the corresponding debug print option has been mistakenly re-added to the help text in fbc0ddb.

This PR removes the reference to this option as currently unimplemented and additionally reorders the options to appear in alphabetical order.
