### PR TITLE
BUG FIX: Allow proper overriding of blacklist in opencl.c

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -577,9 +577,11 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
     const gboolean old_blacklist = dt_conf_get_bool("opencl_disable_drivers_blacklist");
     cl->dev[dev].disabled |= (old_blacklist) ? 0 : 1;
     if(cl->dev[dev].disabled)
+    {
       dt_print_nts(DT_DEBUG_OPENCL, "   *** new device is blacklisted ***\n");   
-    res = -1;
-    goto end;
+      res = -1;
+      goto end;
+    }
   }
 
   dt_print_nts(DT_DEBUG_OPENCL, "   GLOBAL MEM SIZE:          %.0f MB\n", (double)cl->dev[dev].max_global_mem / 1024.0 / 1024.0);


### PR DESCRIPTION
Place all the lines following the if statement inside the if block so that we can properly override the blacklist in the first pass rather than having to run this method twice. 

I believe the original code is a mistake and all the lines need to be within the `if` block, otherwise, even if the `opencl_disable_drivers_blacklist` config key is set to `TRUE` in `darktablerc` it will still lead to a result of -1 and quit the function early, without setting up the device properly. But then if you run this function again (go through opencl initialisation again), on the second time it is not a new device, hence `newdevice == FALSE`, and hence skips ahead and continues the setup process.

This fix allows it to finish the setup of the device in the first round itself. I feel this is the correct approach and hence the original is a bug. Let me know if I am mistaken!