### PR TITLE
Reduce some padding and size for checkbox (and some other items)

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -348,7 +348,7 @@ entry,
 textview,
 #non-flat
 {
-  padding: 2px; /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
+  padding: 1px; /* this need to be kept as pixels for constant sizing and correct display with all font sizes */
   border: 1px solid @button_border; /* this too */
   border-radius: 0.21em;
   background-color: @button_bg;
@@ -393,8 +393,8 @@ header button,
 .text-button radio, /* this line and following one are needed to set good margin inside some buttons, especially in header buttons in about dialog window and on radio button and label inside star icon overlay menu */
 .text-button label
 {
-  min-height: 1.2em;
-  min-width: 1.2em;
+  min-height: 1.15em;
+  min-width: 1.15em;
   margin: 0.07em;
 }
 


### PR DESCRIPTION
This start to fix checkbox that are too big (something I forgot for 4.0...). When making tests for that, I finally found that those settings are better too for others items. This reduce their size and I think this make the UI a little more well-balanced while keeping space between items. Those items so take less place and UI remains aerate.

I tested that with small font size (9.0) and my default one (12.0) with Cantarell font on Gnome.

@elstoc: your feedback are especially welcomed. You could check checkbox but especially buttons in module headers and switch in history on darkroom.

I hope this will be good.