### PR TITLE
Improving pixelpipe cache

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1347,7 +1347,7 @@ void dt_get_sysresource_level()
   res->level = oldlevel = level;
   oldtunecl = tunecl;
   res->tunemode = tunecl;
-  if(mod && (darktable.unmuted & (DT_DEBUG_MEMORY | DT_DEBUG_OPENCL)))
+  if(mod && (darktable.unmuted & (DT_DEBUG_MEMORY | DT_DEBUG_OPENCL | DT_DEBUG_DEV)))
   {
     const int oldgrp = res->group;
     res->group = 4 * level;
@@ -1356,6 +1356,7 @@ void dt_get_sysresource_level()
     fprintf(stderr,"  mipmap cache:    %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
     fprintf(stderr,"  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
     fprintf(stderr,"  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
+    fprintf(stderr,"  iop cache:       %luMB\n", dt_get_iopcache_mem() / 1024lu / 1024lu);
 #ifdef HAVE_OPENCL
     fprintf(stderr,"  OpenCL tune mem: %s\n", ((tunecl & DT_OPENCL_TUNE_MEMSIZE) && (level >= 0)) ? "WANTED" : "OFF");
     fprintf(stderr,"  OpenCL pinned:   %s\n", ((tunecl & DT_OPENCL_TUNE_PINNED) && (level >= 0)) ? "WANTED" : "OFF");
@@ -1660,6 +1661,13 @@ size_t dt_get_singlebuffer_mem()
 
   const int fraction = res->fractions[res->group + 1];
   return MAX(2lu * 1024lu * 1024lu, total_mem / 1024lu * fraction);
+}
+
+size_t dt_get_iopcache_mem()
+{
+  dt_sys_resources_t *res = &darktable.dtresources;
+  const size_t cachemb = res->total_memory / 1024lu / 1024lu / 20lu;
+  return MIN(6000lu, MAX(400lu, cachemb)) * 1024lu * 1024lu;
 }
 
 void dt_configure_runtime_performance(const int old, char *info)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -369,6 +369,7 @@ void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((fo
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();
+size_t dt_get_iopcache_mem();
 
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -350,6 +350,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->histogram_stats.pixels = 0;
   module->multi_priority = 0;
   module->iop_order = 0;
+  module->cache_next_important = FALSE;
   for(int k = 0; k < 3; k++)
   {
     module->picked_color[k] = module->picked_output_color[k] = 0.0f;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -108,7 +108,9 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_ALLOW_FAST_PIPE = 1 << 12,   // Module can work with a fast pipe
   IOP_FLAGS_UNSAFE_COPY = 1 << 13,       // Unsafe to copy as part of history
   IOP_FLAGS_GUIDES_SPECIAL_DRAW = 1 << 14, // handle the grid drawing directly
-  IOP_FLAGS_GUIDES_WIDGET = 1 << 15        // require the guides widget
+  IOP_FLAGS_GUIDES_WIDGET = 1 << 15,       // require the guides widget
+  IOP_FLAGS_CACHE_IMPORTANT_NOW = 1 << 16, // hints for higher priority in iop cache
+  IOP_FLAGS_CACHE_IMPORTANT_NEXT = 1 << 17  
 } dt_iop_flags_t;
 
 /** status of a module*/
@@ -298,7 +300,8 @@ typedef struct dt_iop_module_t
   void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
                         const struct dt_iop_roi_t *const roi_out);
-
+  // hint for higher io cache priority
+  gboolean cache_next_important;
   // introspection related data
   gboolean have_introspection;
 } dt_iop_module_t;

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -323,6 +323,10 @@ void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data
   {
     if(cache->data[k] == data)
     {
+      dt_vprint(DT_DEBUG_DEV, "[dt_dev_pixelpipe_cache_reweight] %i->%i, `%s'->`%s'\n",
+        cache->used[k], -cache->entries,
+        cache->modname[k] ? cache->modname[k] : "??",
+        modname ? modname : "??");
       cache->used[k] = -cache->entries;
       cache->modname[k] = modname;
     }
@@ -349,8 +353,8 @@ void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache, char *pipetyp
     for(int k = 0; k < cache->entries; k++)
     {
       if(cache->size[k])
-        fprintf(stderr, "  cacheline%3d,%4luMB, weight%3d, `%s', hash %" PRIu64 " (%" PRIu64 ")\n",
-          k, cache->size[k] / 1024lu / 1024lu, cache->used[k], cache->modname[k] ? cache->modname[k] : "no module name", cache->hash[k], cache->basichash[k]);
+        fprintf(stderr, " [%s]%3d,%4luMB, weight%4d, `%s', hash %" PRIu64 " (%" PRIu64 ")\n",
+          pipetype, k, cache->size[k] / 1024lu / 1024lu, cache->used[k], cache->modname[k] ? cache->modname[k] : "no module name", cache->hash[k], cache->basichash[k]);
     }
   }
   dt_print(DT_DEBUG_DEV, "[dt_dev_pixelpipe_process %s] done, cachemem=%luMB, limit=%luMB, hitrate=%.2f\n",

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -226,8 +226,8 @@ static int _get_free_cacheline(dt_dev_pixelpipe_cache_t *cache, size_t size)
  
     cache->size[oldest] = 0;
     cache->data[oldest] = NULL;
-    cache->hash[oldest] = 0;
-    cache->basichash[oldest] = 0;
+    cache->hash[oldest] = -1;
+    cache->basichash[oldest] = -1;
     cache->used[oldest] = 1;
     oldest = _get_oldest_cacheline(cache);
   }
@@ -317,13 +317,14 @@ void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint6
   }
 }
 
-void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data)
+void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data, char *modname)
 {
   for(int k = 0; k < cache->entries; k++)
   {
     if(cache->data[k] == data)
     {
       cache->used[k] = -cache->entries;
+      cache->modname[k] = modname;
     }
   }
 }

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -33,9 +33,11 @@
 //   ping, pong, and priority buffer (focused plugin)
 // - drop read by the time another is requested (with priority, drop that, or alternating ping and pong?)
 
-int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size)
+gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size, size_t limit)
 {
   cache->entries = entries;
+  cache->allmem = 0;
+  cache->memlimit = limit;
   cache->data = (void **)calloc(entries, sizeof(void *));
   cache->size = (size_t *)calloc(entries, sizeof(size_t));
   cache->dsc = (dt_iop_buffer_dsc_t *)calloc(entries, sizeof(dt_iop_buffer_dsc_t));
@@ -45,6 +47,7 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
   cache->basichash = (uint64_t *)calloc(entries, sizeof(uint64_t));
   cache->hash = (uint64_t *)calloc(entries, sizeof(uint64_t));
   cache->used = (int32_t *)calloc(entries, sizeof(int32_t));
+  cache->modname = (char **)calloc(entries, sizeof(char *));
   for(int k = 0; k < entries; k++)
   {
     cache->size[k] = size;
@@ -57,13 +60,15 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
 #endif
       ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
     }
-    else cache->data[k] = 0;
+    else cache->data[k] = NULL;
+    cache->allmem += size;
     cache->basichash[k] = -1;
     cache->hash[k] = -1;
     cache->used[k] = 0;
+    cache->modname[k] = NULL;
   }
   cache->queries = cache->misses = 0;
-  return 1;
+  return TRUE;
 
 alloc_memory_fail:
   //  dt_dev_pixelpipe_cache_cleanup(cache);
@@ -77,7 +82,8 @@ alloc_memory_fail:
     cache->size[k] = 0;
     cache->data[k] = NULL;
   }
-  return 0;
+  cache->allmem = 0;
+  return FALSE;
 }
 
 void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache)
@@ -89,6 +95,7 @@ void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache)
   free(cache->hash);
   free(cache->used);
   free(cache->size);
+  free(cache->modname);
 }
 
 uint64_t dt_dev_pixelpipe_cache_basichash(int imgid, struct dt_dev_pixelpipe_t *pipe, int module)
@@ -167,42 +174,79 @@ uint64_t dt_dev_pixelpipe_cache_hash(int imgid, const dt_iop_roi_t *roi, dt_dev_
   return hash;
 }
 
-int dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash)
+gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash)
 {
   // search for hash in cache
   for(int32_t k = 0; k < cache->entries; k++)
-    if(cache->hash[k] == hash) return 1;
-  return 0;
+    if(cache->hash[k] == hash) return TRUE;
+  return FALSE;
 }
 
-int dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
+gboolean dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
                                          const uint64_t hash, const size_t size,
-                                         void **data, dt_iop_buffer_dsc_t **dsc)
+                                         void **data, dt_iop_buffer_dsc_t **dsc, char *modname)
 {
-  return dt_dev_pixelpipe_cache_get_weighted(cache, basichash, hash, size, data, dsc, -cache->entries);
+  return dt_dev_pixelpipe_cache_get_weighted(cache, basichash, hash, size, data, dsc, -cache->entries, modname);
 }
 
-int dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
-                               const size_t size, void **data, dt_iop_buffer_dsc_t **dsc)
+gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
+                               const size_t size, void **data, dt_iop_buffer_dsc_t **dsc, char *modname)
 {
-  return dt_dev_pixelpipe_cache_get_weighted(cache, basichash, hash, size, data, dsc, 0);
+  return dt_dev_pixelpipe_cache_get_weighted(cache, basichash, hash, size, data, dsc, 0, modname);
 }
 
-int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
-                                        const size_t size, void **data, dt_iop_buffer_dsc_t **dsc, int weight)
+static int _get_oldest_cacheline(dt_dev_pixelpipe_cache_t *cache)
+{
+  int weight = -1;
+  int id = -1;
+  for(int k = 0; k < cache->entries; k++)
+  {
+    if(cache->used[k] > weight)
+    {
+      weight = cache->used[k];
+      id = k;
+    }
+  }
+  return id;
+}
+
+static int _get_free_cacheline(dt_dev_pixelpipe_cache_t *cache, size_t size)
+{
+  int oldest = _get_oldest_cacheline(cache);
+  if((cache->memlimit == 0) || ((cache->memlimit - cache->allmem) >= size))
+    return oldest;
+
+  int cnt = 0;
+   while(((cache->memlimit - cache->allmem) < size) && (cnt < cache->entries))
+  {
+    cnt++;
+    // we have to free & invalidate cachelines until there is enough mem available
+    dt_free_align(cache->data[oldest]);
+    cache->allmem -= cache->size[oldest];
+ 
+    cache->size[oldest] = 0;
+    cache->data[oldest] = NULL;
+    cache->hash[oldest] = 0;
+    cache->basichash[oldest] = 0;
+    cache->used[oldest] = 1;
+    oldest = _get_oldest_cacheline(cache);
+  }
+
+  dt_print(DT_DEBUG_DEV, "[get_free_cachelines] removed %i, ->line %i, cachemem=%luMB, limit=%luMB\n",
+    cnt, oldest, cache->allmem / 1024lu / 1024lu, cache->memlimit / 1024lu / 1024lu); 
+  return oldest;
+}
+
+gboolean dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
+                                        const size_t size, void **data, dt_iop_buffer_dsc_t **dsc, int weight, char *name)
 {
   cache->queries++;
   *data = NULL;
-  int max_used = -1, max = 0;
   size_t sz = 0;
+
   for(int k = 0; k < cache->entries; k++)
   {
     // search for hash in cache
-    if(cache->used[k] > max_used)
-    {
-      max_used = cache->used[k];
-      max = k;
-    }
     cache->used[k]++; // age all entries
     if(cache->hash[k] == hash)
     {
@@ -219,13 +263,14 @@ int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const u
   if(!*data || sz < size)
   {
     // kill LRU entry
-    // printf("[pixelpipe_cache_get] hash not found, returning slot %d/%d age %d\n", max, cache->entries,
-    // weight);
+    const int max = _get_free_cacheline(cache, size);
     if(cache->size[max] < size)
     {
       dt_free_align(cache->data[max]);
+      cache->allmem -= cache->size[max];
       cache->data[max] = (void *)dt_alloc_align(64, size);
       cache->size[max] = size;
+      cache->allmem += cache->size[max];
     }
     *data = cache->data[max];
     sz = cache->size[max];
@@ -240,11 +285,12 @@ int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const u
     cache->basichash[max] = basichash;
     cache->hash[max] = hash;
     cache->used[max] = weight;
+    cache->modname[max] = name;
     cache->misses++;
-    return 1;
+    return TRUE;
   }
   else
-    return 0;
+    return FALSE;
 }
 
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache)
@@ -295,15 +341,20 @@ void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *da
   }
 }
 
-void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache)
+void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache, char *pipetype)
 {
-  for(int k = 0; k < cache->entries; k++)
+  if(darktable.unmuted & DT_DEBUG_VERBOSE)
   {
-    printf("pixelpipe cacheline %d ", k);
-    printf("used %d by %" PRIu64 " (%" PRIu64 ")", cache->used[k], cache->hash[k], cache->basichash[k]);
-    printf("\n");
+    for(int k = 0; k < cache->entries; k++)
+    {
+      if(cache->size[k])
+        fprintf(stderr, "  cacheline%3d,%4luMB, weight%3d, `%s', hash %" PRIu64 " (%" PRIu64 ")\n",
+          k, cache->size[k] / 1024lu / 1024lu, cache->used[k], cache->modname[k] ? cache->modname[k] : "no module name", cache->hash[k], cache->basichash[k]);
+    }
   }
-  printf("cache hit rate so far: %.3f\n", (cache->queries - cache->misses) / (float)cache->queries);
+  dt_print(DT_DEBUG_DEV, "[dt_dev_pixelpipe_process %s] done, cachemem=%luMB, limit=%luMB, hitrate=%.2f\n",
+    pipetype, cache->allmem / 1024lu / 1024lu, cache->memlimit / 1024lu / 1024lu, 
+    (cache->queries - cache->misses) / (float)cache->queries);
 }
 
 // clang-format off

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -33,6 +33,8 @@ struct dt_iop_roi_t;
 typedef struct dt_dev_pixelpipe_cache_t
 {
   int32_t entries;
+  size_t allmem;
+  size_t memlimit;
   void **data;
   size_t *size;
   struct dt_iop_buffer_dsc_t *dsc;
@@ -42,6 +44,8 @@ typedef struct dt_dev_pixelpipe_cache_t
 #ifdef HAVE_OPENCL
   void **gpu_mem;
 #endif
+  // debugging helpers
+  char **modname; 
   // profiling:
   uint64_t queries;
   uint64_t misses;
@@ -50,7 +54,7 @@ typedef struct dt_dev_pixelpipe_cache_t
 /** constructs a new cache with given cache line count (entries) and float buffer entry size in bytes.
   \param[out] returns 0 if fail to allocate mem cache.
 */
-int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size);
+gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size, size_t limit);
 void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th. */
@@ -65,20 +69,23 @@ void dt_dev_pixelpipe_cache_fullhash(int imgid, const dt_iop_roi_t *roi, struct 
 uint64_t dt_dev_pixelpipe_cache_basichash_prior(int imgid, struct dt_dev_pixelpipe_t *pipe,
                                                 const struct dt_iop_module_t *const module);
 
-/** returns the float data buffer for the given hash from the cache. if the hash does not match any
-  * cache line, the least recently used cache line will be cleared and an empty buffer is returned
-  * together with a non-zero return value. */
-int dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
-                               const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc);
-int dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
+/** returns a float data buffer in 'data' for the given hash from the cache.
+  If the hash does not match any cache line, the line with lowest weight will be cleared and an empty buffer is returned.
+  Returned flag is TRUE for a new buffer
+*/
+gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
+                               const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname);
+
+gboolean dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
                                          const uint64_t hash, const size_t size,
-                                         void **data, struct dt_iop_buffer_dsc_t **dsc);
-int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
+                                         void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname);
+
+gboolean dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
                                         const uint64_t hash, const size_t size,
-                                        void **data, struct dt_iop_buffer_dsc_t **dsc, int weight);
+                                        void **data, struct dt_iop_buffer_dsc_t **dsc, int weight, char *modname);
 
 /** test availability of a cache line without destroying another, if it is not found. */
-int dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash);
+gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash);
 
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
@@ -93,7 +100,7 @@ void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data
 void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data);
 
 /** print out cache lines/hashes (debug). */
-void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache);
+void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache, char *pipetype);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -94,7 +94,7 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
 void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint64_t basichash);
 
 /** makes this buffer very important after it has been pulled from the cache. */
-void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data);
+void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data, char *modname);
 
 /** mark the given cache line pointer as invalid. */
 void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -133,8 +133,7 @@ int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t
 int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 {
   // don't know which buffer size we're going to need, set to 0 (will be alloced on demand)
-  const size_t csize = MAX(256lu * 1024lu * 1024lu, darktable.dtresources.total_memory / 40lu);
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 32, csize);
+  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 32, dt_get_iopcache_mem() / 5lu);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   return res;
 }
@@ -150,10 +149,7 @@ int dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 int dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
   // don't know which buffer size we're going to need, set to 0 (will be alloced on demand)
-  // not sure what the best maximum size of the iop-cache buffer would be.
-  // At least 500MB is required and a 5% of global mem would be safe from what we take via resourcelevels.
-  const size_t csize = MAX(512lu * 1024lu * 1024lu, darktable.dtresources.total_memory / 20lu);
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, csize);
+  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, dt_get_iopcache_mem() * 4lu / 5lu);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }
@@ -1288,7 +1284,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     (void)dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, module ? module->so->op : NULL);
 
   if(important && module)
-    dt_print(DT_DEBUG_DEV, "[dev_pixelpipe] [%s] reserving high priority cacheline for `%s'\n", _pipe_type_to_str(pipe->type), module->op);
+    dt_print(DT_DEBUG_DEV, "[dev_pixelpipe] [%s] reserving high priority cacheline for `%s' (%luMB)\n",
+      _pipe_type_to_str(pipe->type), module->op, bufsize / 1024lu / 1024lu);
 
   if(dt_atomic_get_int(&pipe->shutdown))
   {

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -192,7 +192,7 @@ int dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width, int
 // distortions)
 int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height);
 // inits the pixelpipe with given cacheline size and number of entries.
-int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries);
+int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries, size_t memlimit);
 // constructs a new input buffer from given RGB float array.
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, float *input, int width,
                                 int height, float iscale);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -137,6 +137,9 @@ typedef struct dt_dev_pixelpipe_t
   struct dt_iop_roi_t rawdetail_mask_roi;
   int want_detail_mask;
 
+  // we have to keep track of the next processing module to use an iop cacheline with high priority
+  gboolean next_important_module;
+
   int output_imgid;
   // working?
   int processing;

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -552,6 +552,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   if(work_profile == NULL) return; // no point
 
+  self->cache_next_important = TRUE; // The cpu code is pretty heavy stuff so an importance hint 
+
   // work profile can't be fetched in commit_params since it is not yet initialised
   // work_profile->matrix_in === RGB_to_XYZ
   // work_profile->matrix_out === XYZ_to_RGB

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -146,7 +146,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_CACHE_IMPORTANT_NEXT;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1082,6 +1082,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const int diffusion_scales = num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
   const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
 
+  self->cache_next_important = ((data->iterations * (data->radius + data->radius_center)) > 16); 
+
   gboolean out_of_memory = FALSE;
 
   // wavelets scales buffers
@@ -1343,6 +1345,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int iterations = MAX(ceilf((float)data->iterations), 1);
   const int diffusion_scales = num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
   const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
+
+  self->cache_next_important = ((data->iterations * (data->radius + data->radius_center)) > 16); 
 
   // wavelets scales buffers
   cl_mem HF[MAX_NUM_SCALES];

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -157,7 +157,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_CACHE_IMPORTANT_NEXT;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
The pr increases the number of cachelines for the full pixelpipe to 64 thus increasing the likelyhood
of a cache hit. As this might lead to uncontrolled memory usage we have to limit the memory used in the cache.

In `dt_dev_pixelpipe_cache_t` we add two entries to take care of this, `allmem` and `memlimit`.

memlimit is a parameter when the cache is initialized, it may also be set to 0, this disables mem checks,
  (thats what we had before)

allmem is taken care of while allocating / deallocating cache memory.

In case of a requested cacheline size is exceeding memlimit we cleanup the cache by deallocating lowest-priority
buffers until we are fine.

To improve debugging - we might want to see the requesting/owning module - we keep track on this via
`**modname`, if there is no requesting mode we use const strings like "io-buffer" instead.

Related to #12120 but not solving it