### PR TITLE
Fix crash when trying to zoom in empty zoomable lighttable

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -746,15 +746,17 @@ static dt_thumbnail_t *_thumbtable_get_thumb(dt_thumbtable_t *table, int imgid)
   return NULL;
 }
 
-// change zoom value for the zoomable tumbtable
+// change zoom value for the zoomable thumbtable
 static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
 {
+  // nothing to do if thumbtable is empty
+  if(!table->list) return;
   // determine the center of the zoom
   int x = 0;
   int y = 0;
   if(table->mouse_inside)
   {
-    // if the mouse is inside the table, let's use his position
+    // if the mouse is inside the table, let's use its position
     gdk_window_get_origin(gtk_widget_get_window(table->widget), &x, &y);
     x = table->last_x - x;
     y = table->last_y - y;
@@ -808,6 +810,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
   if(changed > 0) _pos_compute_area(table);
 
   // we update all the values
+  // chained dereference is dangerous, but there was a check above in the code
   dt_thumbnail_t *first = (dt_thumbnail_t *)table->list->data;
   table->offset = first->rowid;
   table->offset_imgid = first->imgid;


### PR DESCRIPTION
When we are trying to zoom in empty zoomable lighttable mode darktable crashes. The root cause is the same as for #12118 - unguarded chained dereference.