### PR TITLE
Segmentation based highlights recovery (V4)

### DIFF
--- a/src/common/distance_transform.h
+++ b/src/common/distance_transform.h
@@ -51,14 +51,6 @@
    The returned float of this function is the maximum calculated distance
 */
 
-#include "common/imagebuf.h"
-
-// We don't want to use the SIMD version as we might access unaligned memory
-static inline float sqrf(float a)
-{
-  return a * a;
-}
-
 typedef enum dt_distance_transform_t
 {
   DT_DISTANCE_TRANSFORM_NONE = 0,
@@ -75,11 +67,11 @@ static void _image_distance_transform(const float *f, float *z, float *d, int *v
   z[1] = DT_DISTANCE_TRANSFORM_MAX;
   for(int q = 1; q <= n-1; q++)
   {
-    float s = (f[q] + sqrf((float)q)) - (f[v[k]] + sqrf((float)v[k]));
+    float s = (f[q] + sqf((float)q)) - (f[v[k]] + sqf((float)v[k]));
     while(s <= z[k] * (float)(2*q - 2*v[k]))
     {
       k--;
-      s = (f[q] + sqrf((float)q)) - (f[v[k]] + sqrf((float)v[k]));
+      s = (f[q] + sqf((float)q)) - (f[v[k]] + sqf((float)v[k]));
     }
     s /= (float)(2*q - 2*v[k]);
     k++;
@@ -93,7 +85,7 @@ static void _image_distance_transform(const float *f, float *z, float *d, int *v
   {
     while(z[k+1] < (float)q)
       k++;
-    d[q] = sqrf((float)(q-v[k])) + f[v[k]];
+    d[q] = sqf((float)(q-v[k])) + f[v[k]];
   }
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2009,7 +2009,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case DT_IOP_HIGHLIGHTS_RECOVERY:
     {
       int vmode = 0;
-      if(g != NULL) vmode = ((g->show_borders) ? 1 : 0) | ((g->show_bads) ? 2 : 0);
+      if((g != NULL) && fullpipe) vmode = ((g->show_borders) ? 1 : 0) | ((g->show_bads) ? 2 : 0);
 
       process_recovery(piece, ivoid, ovoid, roi_in, roi_out, filters, data, vmode);
       if(vmode)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2036,9 +2036,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 
   // update processed maximum
-  if(data->mode !=  DT_IOP_HIGHLIGHTS_LAPLACIAN)
+  if((data->mode != DT_IOP_HIGHLIGHTS_LAPLACIAN) && (data->mode != DT_IOP_HIGHLIGHTS_RECOVERY))
   {
-    // The guided laplacian is the only mode that keeps signal scene-referred and doesn't clip highlights to 1
+    // The guided laplacian and recovery modes keep signal scene-referred and don't clip highlights to 1
     // For the other modes, we need to notify the pipeline that white point has changed
     const float m = fmaxf(fmaxf(piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1]),
                           piece->pipe->dsc.processed_maximum[2]);

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -521,9 +521,6 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
     }
   }
 
-  for(int i = 0; i < HL_SENSOR_PLANES; i++)
-    dt_masks_extend_border(plane[i], pwidth, pheight, HLBORDER);
-
   float max_correction = 1.0f;
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -462,7 +462,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   }
 
   for(int p = 0; p < HL_SENSOR_PLANES; p++)
-    calc_plane_candidates(plane[p], cmask[p], refavg[p], &isegments[p], pwidth, pheight, coeffs[p], 1.0f - sqrf(data->reconstructing));
+    calc_plane_candidates(plane[p], cmask[p], refavg[p], &isegments[p], pwidth, pheight, coeffs[p], 1.0f - sqrf(data->candidating));
 
   dt_get_times(&time2);
 

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -284,7 +284,7 @@ static inline int pos2plane(const int row, const int col, const uint32_t filters
 
 static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         const uint32_t filters, dt_iop_highlights_data_t *data)
+                         const uint32_t filters, dt_iop_highlights_data_t *data, const int vmode)
 {
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -412,9 +412,9 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   dt_omp_sharedconst(pwidth, pheight) \
   schedule(static) collapse(2)
 #endif
-  for(int row = HLBORDER; row < pheight - HLBORDER; row++)
+  for(int row = 4; row < pheight - 4; row++)
   {
-    for(int col = HLBORDER; col < pwidth - HLBORDER; col++)
+    for(int col = 4; col < pwidth - 4; col++)
     {
       const size_t i = row * pwidth + col;
       for(int p = 0; p < HL_REF_PLANES; p++)

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -1,0 +1,607 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+Highlights recovery
+
+** Overview **
+
+The new highlight recovery algorithm only works for standard bayer sensors.
+It has been developed in collaboration by Iain and garagecoder from the gmic team and Hanno Schwalm from dt.
+
+The original idea was presented by Iain in pixls.us in: https://discuss.pixls.us/t/highlight-recovery-teaser/17670
+
+and has been extensively discussed over the last months, a number of different approaches had been evaluated.
+
+Prototyping and testing ideas has been done by Iain using gmic, Hanno and garagecoder did the implementation and integration
+into dt’s codebase.
+No other external modules (like gmic …) are used, the current code has been tuned for performance using omp,
+no OpenCL codepath yet.
+
+** Main ideas **
+
+The algorithm follows these basic ideas:
+1. We understand the bayer data as superpixels, each having one red, one blue and two green photosites
+2. We analyse all data on the channels independently so resulting in 4 color-planes
+3. We want to keep details as much as possible
+4. In all 4 color planes we look for isolated areas being clipped (segments).
+   These segments also include the unclipped photosites at the borders.
+   Inside these segments we look for a candidate to represent the value we take for restoration.
+   Choosing the candidate is done at all non-clipped locations of a segment, the best candidate is selected via a weighing
+   function - the weight is derived from
+   - the local standard deviation in a 5x5 area and
+   - the median value of unclipped positions also in a 5x5 area.
+   The best candidate points to the location in the color plane holding the reference value.
+   If there is no good candidate we use an averaging approximation over the whole segment.
+5. A core principle is to inpaint pseudo-chromacity, calculated by subtracting opponent channel means rather than luminance.
+6. Cube root is used instead of logarithm for better stability, which suffices for an estimate.
+
+The chosen segmentation algorithm works like this:
+1. Doing the segmentation in every color plane.
+2. Remove single clipped photosites for stability
+3. To combine small segments for a shared candidate we use a morphological closing operation, the radius of that UI op
+   can be chosen interactively between 0 and 8.
+4. The segmentation algorithm uses a modified floodfill, it also takes care of the surrounding rectangle of every segment
+   and marks the segment borders.
+5. After segmentation we check every segment for
+   - the segment's best candidate via the weighing function
+   - the candidates location
+*/
+
+/* Ideas to be checked
+   1. can we check for close segments after combining in other ways to find a common best candidate?
+   2. the "best candidate" for bad segments is just so-so. Can we look for close segments here too and take that candidate?
+   3. Should the weighing function also take the other planes in account? 
+*/
+
+#define HL_SENSOR_PLANES 4
+#define HL_REF_PLANES 4
+#define HL_FLOAT_PLANES (HL_SENSOR_PLANES + HL_REF_PLANES)
+#define HLMAXSEGMENTS 0x4000
+#define HLBORDER 8
+
+#ifdef __GNUC__
+  #pragma GCC push_options
+  #pragma GCC optimize ("finite-math-only")
+#endif
+
+static size_t plane_size(size_t width, size_t height)
+{
+  return (size_t) dt_round_size((width + 4) * (height + 4), 16);
+}
+
+typedef enum dt_iop_highlights_plane_t
+{
+  DT_IO_PLANE_RED = 0,          // $DESCRIPTION: "red"
+  DT_IO_PLANE_GREEN1 = 1,       // $DESCRIPTION: "green1"
+  DT_IO_PLANE_GREEN2 = 2,       // $DESCRIPTION: "green2"
+  DT_IO_PLANE_BLUE = 3,         // $DESCRIPTION: "blue"
+} dt_iop_highlights_plane_t;
+
+#include "iop/segmentation.h"
+
+static inline float sqrf(const float a)
+{
+  return a*a;
+}
+
+static inline float local_std_deviation(const float *p, const int w)
+{
+  const int w2 = 2*w;
+  const float av = 0.04f *
+      (p[-w2-2] + p[-w2-1] + p[-w2] + p[-w2+1] + p[-w2+2] +
+       p[-w-2]  + p[-w-1]  + p[-w]  + p[-w+1]  + p[-w+2] +
+       p[-2]    + p[-1]    + p[0]   + p[1]     + p[2] +
+       p[w-2]   + p[w-1]   + p[w]   + p[w+1]   + p[w+2] +
+       p[w2-2]  + p[w2-1]  + p[w2]  + p[w2+1]  + p[w2+2]);
+  return sqrtf(0.04f *
+      (sqrf(p[-w2-2]-av) + sqrf(p[-w2-1]-av) + sqrf(p[-w2]-av) + sqrf(p[-w2+1]-av) + sqrf(p[-w2+2]-av) +
+       sqrf(p[-w-2]-av)  + sqrf(p[-w-1]-av)  + sqrf(p[-w]-av)  + sqrf(p[-w+1]-av)  + sqrf(p[-w+2]-av) +
+       sqrf(p[-2]-av)    + sqrf(p[-1]-av)    + sqrf(p[0]-av)   + sqrf(p[1]-av)     + sqrf(p[2]-av) +
+       sqrf(p[w-2]-av)   + sqrf(p[w-1]-av)   + sqrf(p[w]-av)   + sqrf(p[w+1]-av)   + sqrf(p[w+2]-av) +
+       sqrf(p[w2-2]-av)  + sqrf(p[w2-1]-av)  + sqrf(p[w2]-av)  + sqrf(p[w2+1]-av)  + sqrf(p[w2+2]-av)));
+}
+
+static inline float local_smoothness(const float *p, const int w)
+{
+  return sqrf(1.0f - fmaxf(0.0f, fminf(1.0f, 2.0f * local_std_deviation(p, w))));
+}
+
+static float calc_weight(const float *s, const char *lmask, const size_t loc, const int w, const float clipval)
+{
+  const float smoothness = local_smoothness(&s[loc], w);
+  float val = 0.0f;
+  for(int y = -1; y < 2; y++)
+  {
+    for(int x = -1; x < 2; x++)
+      val += s[loc + y*w + x] * 0.11111f;
+  }
+  const float sval = fminf(clipval, val) / clipval;
+  return smoothness * sval;
+}
+
+static void prepare_smooth_singles(char *lmask, float *src, const float *ref, const size_t width, const size_t height, const float clipval)
+{
+  const size_t p_size = plane_size(width, height);
+  float *tmp = dt_alloc_align_float(p_size);
+  char *mtmp = dt_alloc_align(16, p_size * sizeof(char));
+  if(tmp == NULL || mtmp == NULL) return;
+
+  dt_iop_image_copy(tmp, src, width * height);
+  memcpy(mtmp, lmask, width * height * sizeof (char));   
+
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(src, ref, tmp, lmask, mtmp) \
+  dt_omp_sharedconst(width, height, clipval) \
+  schedule(static)
+#endif
+  for(size_t row = HLBORDER; row < height - HLBORDER; row++)
+  {
+    for(size_t col = HLBORDER, ix = row * width + col; col < width - HLBORDER; col++, ix++)
+    {
+      if(lmask[ix] == 1) // we only take care of clipped locations
+      {
+        float sum = 0.0f;
+        float cnt = 0.0f;
+        for(int y = -1; y < 2; y++) // we look for surrounding unclipped in 3x3 area
+        {
+          for(int x = -1; x < 2; x++)
+          {
+            const int pos = ix + y*width + x;
+            const gboolean unclipped = (lmask[pos] == 0);
+            cnt += (unclipped) ? 1.0f : 0.0f;
+            sum += (unclipped) ? src[pos] - ref[pos] : 0.0f;
+          }
+        }
+        if(cnt > 4.0f)
+        {
+          if(local_std_deviation(&ref[ix], width) < 0.005f) // arbitrary from tests
+          {
+            tmp[ix] = fmaxf(clipval, ref[ix] + (sum / cnt));
+            mtmp[ix] = 0;
+          }
+        }
+      }
+    }
+  }
+  memcpy(lmask, mtmp, width * height * sizeof(char));   
+  dt_iop_image_copy(src, tmp, width * height);
+
+  dt_masks_extend_border(src, width, height, HLBORDER);
+  dt_free_align(tmp);
+  dt_free_align(mtmp);
+}
+
+static void calc_plane_candidates(const float *s, char *lmask, const float *ref, dt_iop_segmentation_t *seg, const int width, const int height, const float clipval, const float refval)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(s, lmask, ref, seg) \
+  dt_omp_sharedconst(width, height, clipval, refval) \
+  schedule(dynamic)
+#endif
+  for(int id = 2; id < seg->nr + 2; id++)
+  {
+    int *segmap    = seg->data;
+    size_t testref = 0;
+    float testweight = 0.0f;
+    for(int row = seg->ymin[id] -2 ; row < seg->ymax[id] + 3; row++)
+    {
+      for(int col = seg->xmin[id] -2; col < seg->xmax[id] + 3; col++)
+      {
+        const size_t pos = row * width + col;
+        const int sid = segmap[pos] & (HLMAXSEGMENTS-1);
+        if((sid == id) && (lmask[pos] == 0)) // we test for a) being in segment and b) unclipped
+        {
+          const float wht = calc_weight(s, lmask, pos, width, clipval);
+          if(wht > testweight)
+          {
+            testweight = wht;
+            testref = pos;
+          }        
+        }
+      }
+    }
+
+    if(testref && (testweight > refval)) // We have found a reference location
+    {
+      seg->ref[id] = testref;
+      segmap[testref] = 2*HLMAXSEGMENTS + id;
+      float sum  = 0.0f;
+      float pix = 0.0f;
+      const float weights[5][5] = {
+        { 1.0f,  4.0f,  6.0f,  4.0f, 1.0f },
+        { 4.0f, 16.0f, 24.0f, 16.0f, 4.0f },
+        { 6.0f, 24.0f, 36.0f, 24.0f, 6.0f },
+        { 4.0f, 16.0f, 24.0f, 16.0f, 4.0f },
+        { 1.0f,  4.0f,  6.0f,  4.0f, 1.0f }};
+      for(int y = -2; y < 3; y++)
+      {
+        for(int x = -2; x < 3; x++)
+        {
+          const size_t pos = testref + y*width + x;
+          const gboolean unclipped = (lmask[pos] == 0);
+          sum += (unclipped) ? s[pos] * weights[y+2][x+2] : 0.0f;
+          pix += (unclipped) ? weights[y+2][x+2] : 0.0f;
+        }
+      }
+      seg->val1[id] = fminf(clipval, sum / fmaxf(1.0f, pix));
+      seg->val2[id] = ref[testref];
+    }
+    else
+    {
+#if FALSE
+      float maxval = 0.0f;
+      float msum = 0.0f;
+      float pix  = 0.0f;
+      for(int row = seg->ymin[id]; row < seg->ymax[id] + 1; row++)
+      {
+        for(int col = seg->xmin[id]; col < seg->xmax[id] + 1; col++)
+        {
+          const size_t pos = row * width + col;
+          const int sid = segmap[pos] & (HLMAXSEGMENTS-1);
+          if(id == sid) // we look for all in-segment locations
+          {
+            msum += ref[pos];
+            maxval = fmaxf(maxval, s[pos]);
+            pix  += 1.0;
+          }
+        }
+      }
+      seg->val1[id] = maxval;
+      seg->val2[id] = msum / fmaxf(1.0f, pix);
+#else
+      seg->val1[id] = clipval;
+      seg->val2[id] = clipval;
+#endif
+    }
+  }
+}
+
+static inline int pos2plane(const int row, const int col, const uint32_t filters)
+{
+  const int c = FC(row, col, filters);
+  if(c == 0)      return 0;
+  else if(c == 2) return 3;
+  else return 1 + (row&1);
+}
+
+static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         const uint32_t filters, dt_iop_highlights_data_t *data)
+{
+  const float *const in = (const float *const)ivoid;
+  float *const out = (float *const)ovoid;
+
+  const float clipval = 0.987f * data->clip;
+  const int combining = (int) data->combine;
+
+  const int width = roi_out->width;
+  const int height = roi_out->height;
+
+  const int pwidth  = ((width + 1 ) / 2) + (2 * HLBORDER);
+  const int pheight = ((height + 1) / 2) + (2 * HLBORDER);
+
+  const size_t p_size = plane_size(pwidth, pheight);
+
+  const int p_off  = (HLBORDER * pwidth) + HLBORDER;
+
+  dt_iop_image_copy(out, in, width * height);
+
+  if(filters == 0 || filters == 9u) return;
+
+  float *fbuffer = dt_alloc_align_float(HL_FLOAT_PLANES * p_size);
+  char *mbuffer = dt_alloc_align(16, HL_SENSOR_PLANES * p_size * sizeof(char));
+
+  if(!fbuffer || !mbuffer)
+  {
+    fprintf(stderr, "[highlights reconstruction in recovery mode] internal buffer allocation problem\n");
+    dt_free_align(fbuffer);
+    dt_free_align(mbuffer);
+    return;
+  }
+
+  dt_times_t time0 = { 0 }, time1 = { 0 }, time2 = { 0 }, time3 = { 0 };
+  dt_get_times(&time0);
+
+  dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};  
+  // make sure we have wb coeffs
+  if((icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f))
+  {
+    fprintf(stderr, "[highlights reconstruction in recovery mode] no white balance coeffs found, choosing stupid defaults\n");
+    icoeffs[0] = 2.0f;
+    icoeffs[1] = 1.0f;
+    icoeffs[2] = 1.5f;
+  }
+  const dt_aligned_pixel_t coeffs = { powf(clipval * icoeffs[0], 1.0f / 3.0f), powf(clipval * icoeffs[1], 1.0f / 3.0f), powf(clipval * icoeffs[1], 1.0f / 3.0f), powf(clipval * icoeffs[2], 1.0f / 3.0f)};
+
+  float *plane[HL_FLOAT_PLANES];
+  char  *cmask[HL_SENSOR_PLANES];
+  for(int i = 0; i < HL_FLOAT_PLANES; i++)
+  {
+    plane[i] = fbuffer + i * p_size;
+    if(i < HL_SENSOR_PLANES) cmask[i] = mbuffer + i * p_size;
+  }
+
+  float *refavg[HL_REF_PLANES];
+  for(int i = 0; i < HL_REF_PLANES; i++)
+  {
+    refavg[i] = plane[HL_SENSOR_PLANES + i];
+  }
+
+/* 
+  We fill the planes [0-3] by the data from the photosites.
+  These will be modified by the reconstruction algorithm and eventually written to out.
+  The size of input rectangle can be odd meaning the planes might be not exactly of equal size
+  so we possibly fill latest row/col by previous.
+*/
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in, plane) \
+  dt_omp_sharedconst(width, p_off, height, pwidth, filters) \
+  schedule(simd:static) aligned(in, plane : 64)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, i = row*width; col < width; col++, i++)
+    {
+      const int p = pos2plane(row, col, filters);
+      const size_t o = (row/2)*pwidth + (col/2) + p_off;
+      const float val = powf(fmaxf(0.0f, in[i]), 1.0f / 3.0f);
+      plane[p][o] = val;
+
+      if(col >= width-2)      plane[p][o+1] = val;
+      if(row >= height-2)     plane[p][o+pwidth] = val;
+    }
+  }
+
+  for(int i = 0; i < HL_SENSOR_PLANES; i++)
+    dt_masks_extend_border(plane[i], pwidth, pheight, HLBORDER);
+
+  dt_iop_segmentation_t isegments[HL_SENSOR_PLANES];
+  for(int i = 0; i < HL_SENSOR_PLANES; i++)
+    dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HLMAXSEGMENTS);
+
+  gboolean has_clipped = FALSE;
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  reduction( | : has_clipped) \
+  dt_omp_firstprivate(plane, cmask, isegments, coeffs) \
+  dt_omp_sharedconst(pwidth, pheight) \
+  schedule(static) collapse(2)
+#endif
+  for(size_t i = 0; i < pwidth * pheight; i++)
+  {
+    for(int p = 0; p < HL_SENSOR_PLANES; p++)
+    {
+      const gboolean clipped = (plane[p][i] >= coeffs[p]);
+      cmask[p][i]          = (clipped) ? 1 : 0;
+      isegments[p].data[i] = (clipped) ? 1 : 0;
+      has_clipped |= clipped;
+    }
+  }
+
+  if(!has_clipped) goto finish;
+
+  // Calculate opponent channel weighted means
+  const float weights[4][4] = {
+    { 0.0f, 0.25f, 0.25f, 0.5f },
+    { 0.5f,  0.0f,  0.0f, 0.5f },
+    { 0.5f,  0.0f,  0.0f, 0.5f },
+    { 0.5f, 0.25f, 0.25f, 0.0f },
+  };
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(plane, refavg, weights) \
+  dt_omp_sharedconst(pwidth, pheight) \
+  schedule(static) collapse(2)
+#endif
+  for(int row = HLBORDER; row < pheight - HLBORDER; row++)
+  {
+    for(int col = HLBORDER; col < pwidth - HLBORDER; col++)
+    {
+      const size_t i = row * pwidth + col;
+      for(int p = 0; p < HL_REF_PLANES; p++)
+      {
+        refavg[p][i] = 0.125f * (
+          weights[p][0] * (4.0f * plane[0][i] + plane[0][i-1] + plane[0][i+1] + plane[0][i-pwidth] + plane[0][i+pwidth]) +
+          weights[p][1] * (4.0f * plane[1][i] + plane[1][i-1] + plane[1][i+1] + plane[1][i-pwidth] + plane[1][i+pwidth]) +
+          weights[p][2] * (4.0f * plane[2][i] + plane[2][i-1] + plane[2][i+1] + plane[2][i-pwidth] + plane[2][i+pwidth]) +
+          weights[p][3] * (4.0f * plane[3][i] + plane[3][i-1] + plane[3][i+1] + plane[3][i-pwidth] + plane[3][i+pwidth]));
+      }
+    }
+  }
+
+  dt_get_times(&time1);
+
+  for(int p = 0; p < HL_SENSOR_PLANES; p++)
+  {
+    prepare_smooth_singles(cmask[p], plane[p], refavg[p], pwidth, pheight, coeffs[p]);
+
+    // We prefer to have slightly wider segment borders for a possibly better chosen candidate
+#if TRUE
+    if(combining > 0)
+    {
+      dt_image_transform_dilate(isegments[p].data, pwidth, pheight, combining, HLBORDER);
+      if(combining > 1)
+        dt_image_transform_erode(isegments[p].data, pwidth, pheight, combining-1, HLBORDER);
+    }
+#else
+    dt_image_transform_closing(isegments[p].data, pwidth, pheight, combining, HLBORDER);
+#endif
+  }
+  if(dt_get_num_threads() >= HL_SENSOR_PLANES)
+  {
+#ifdef _OPENMP
+  #pragma omp parallel num_threads(HL_SENSOR_PLANES)
+#endif
+    {
+      segmentize_plane(&isegments[dt_get_thread_num()], pwidth, pheight);
+    }
+  }
+  else
+  {
+    for(int p = 0; p < HL_SENSOR_PLANES; p++)
+      segmentize_plane(&isegments[p], pwidth, pheight);
+  }
+
+  for(int p = 0; p < HL_SENSOR_PLANES; p++)
+    calc_plane_candidates(plane[p], cmask[p], refavg[p], &isegments[p], pwidth, pheight, coeffs[p], 1.0f - sqrf(data->reconstructing));
+
+  dt_get_times(&time2);
+
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(plane, refavg, isegments, cmask, coeffs) \
+  dt_omp_sharedconst(pheight, pwidth, p_size) \
+  schedule(static)
+#endif
+  for(int row = HLBORDER; row < pheight - HLBORDER; row++)
+  {
+    for(int col = HLBORDER; col < pwidth - HLBORDER; col++)
+    {
+      const size_t ix = row * pwidth + col;
+
+      float candidates[4]   = { 0.0f, 0.0f, 0.0f, 0.0f };
+      float cand_reference[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+      for(int p = 0; p < HL_SENSOR_PLANES; p++)
+      {
+        if(cmask[p][ix] == 1)
+        {
+          const int pid = isegments[p].data[ix] & (HLMAXSEGMENTS-1);
+          if((pid > 1) && (pid < isegments[p].nr+2)) // segmented
+          {
+            candidates[p]   = isegments[p].val1[pid];
+            cand_reference[p] = isegments[p].val2[pid];
+          }
+          else if(pid == 0)
+          {
+            float mval = 0.0f;
+            float msum = 0.0f;
+            float pix  = 0.0f;
+            for(int y = -2; y < 3; y++)
+            {
+              for(int x = -2; x < 3; x++)
+              {
+                const size_t pos = ix + y*pwidth +x;
+                if(cmask[p][pos] == 0)
+                {
+                  mval  = fmaxf(mval, plane[p][pos]);
+                  msum += refavg[p][pos];
+                  pix  += 1.0f;
+                }
+              }
+            }
+            if(pix > 0.0f)
+            {
+              candidates[p]   = mval;
+              cand_reference[p] = fminf(coeffs[p], msum / pix);
+            }
+            else
+            {
+              candidates[p]   = coeffs[p];
+              cand_reference[p] = fminf(coeffs[p], refavg[p][ix]);
+            }
+          }
+        }
+      }
+
+      for(int p = 0; p < HL_SENSOR_PLANES; p++)
+      {
+        if(cmask[p][ix] != 0)
+        {
+          float current_reference = 0.0f;
+          float candidate = 0.0f;
+
+          if((p == DT_IO_PLANE_GREEN1 || p == DT_IO_PLANE_GREEN2) && (cmask[DT_IO_PLANE_GREEN1][ix] == 1) && (cmask[DT_IO_PLANE_GREEN2][ix] == 1))
+          {
+            // we take the median of greens candidates.          
+            if((candidates[DT_IO_PLANE_GREEN1] >= 0.0f) && (cand_reference[DT_IO_PLANE_GREEN1] >= 0.0f) &&
+               (candidates[DT_IO_PLANE_GREEN2] >= 0.0f) && (cand_reference[DT_IO_PLANE_GREEN2] >= 0.0f))                  
+            {
+              candidate = 0.5f * (candidates[DT_IO_PLANE_GREEN1] + candidates[DT_IO_PLANE_GREEN2]);
+              current_reference = 0.5f * (cand_reference[DT_IO_PLANE_GREEN1] + cand_reference[DT_IO_PLANE_GREEN2]);
+            }
+          }
+          else
+          {
+            candidate = candidates[p];
+            current_reference = cand_reference[p];
+          }
+          const float val = candidate + refavg[p][ix] - current_reference;
+          plane[p][ix] = fmaxf(coeffs[p], val);
+        }
+      }
+    }
+  }
+
+  for(int i = 0; i < HL_SENSOR_PLANES; i++)
+    dt_masks_extend_border(plane[i], pwidth, pheight, HLBORDER);
+
+  float max_correction = 1.0f;
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  reduction(max : max_correction) \
+  dt_omp_firstprivate(out, plane) \
+  dt_omp_sharedconst(width, height, pwidth, p_off, filters) \
+  schedule(static)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, o = row * width; col < width; col++, o++)
+    {
+      const size_t i = (row/2)*pwidth + (col/2) + p_off;
+      const int p = pos2plane(row, col, filters);
+
+      const float val = powf(plane[p][i], 3.0f);
+      const float ratio = val / fmaxf(1e-12, out[o]);
+      out[o] = val;
+      max_correction = fmaxf(max_correction, ratio);
+    }
+  }
+
+  for(int k = 0; k < 4; k++)
+    piece->pipe->dsc.processed_maximum[k] *= max_correction;
+
+  dt_get_times(&time3);
+  dt_print(DT_DEBUG_PERF, "[Highlight recovery] %.1fMpix, max=%1.2f, combine=%i, segs %ir %ig %ig %ib. Times: init %.3fs, segmentize %.3fs, paint %.3fs\n",
+       (float) (width * height) / 1.0e6f, max_correction, combining,
+       isegments[0].nr, isegments[1].nr, isegments[2].nr, isegments[3].nr, 
+       time1.clock - time0.clock, time2.clock - time1.clock, time3.clock - time2.clock);
+
+  finish:
+  for(int i = 0; i < HL_SENSOR_PLANES; i++)
+    dt_segmentation_free_struct(&isegments[i]);
+
+  dt_free_align(fbuffer);
+  dt_free_align(mbuffer);
+}
+
+#ifdef __GNUC__
+  #pragma GCC pop_options
+#endif
+
+#undef HL_SENSOR_PLANES
+#undef HL_REF_PLANES
+#undef HL_FLOAT_PLANES
+#undef HLFPLANES
+#undef HLMAXSEGMENTS
+#undef HLBORDER
+

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -571,7 +571,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
       const int p = pos2plane(row, col, filters);
 
       const float val = powf(plane[p][i], 3.0f);
-      const float ratio = val / fmaxf(1e-12, out[o]);
+      const float ratio = val / fmaxf(1.0f, out[o]);
       out[o] = val;
       max_correction = fmaxf(max_correction, ratio);
 
@@ -589,7 +589,7 @@ static void process_recovery(dt_dev_pixelpipe_iop_t *piece, const void *const iv
     }
   }
 
-  for(int k = 0; k < 4; k++)
+  for(int k = 0; k < 3; k++)
     piece->pipe->dsc.processed_maximum[k] *= max_correction;
 
   dt_get_times(&time3);

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -1,0 +1,624 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* Internal segmentation algorithms
+   All segmentation stuff works on int32 arrays, to allow performant operations we use an additional border.
+
+   Morphological closing operation supporting radius up to 8, tuned for performance
+
+   The segmentation algorithm uses a modified floodfill, while floddfilling it
+   - also takes keeps track of the surrounding rectangle of every segment and
+   - marks the segment border locations.
+
+   Hanno Schwalm 2022/05
+*/
+
+typedef struct dt_pos_t
+{
+  int xpos;
+  int ypos;
+} dt_pos_t;
+
+typedef struct dt_iop_segmentation_t
+{
+  int *data;      // holding segment id's for every location
+  int *size;      // size of segment      
+  int *xmin;      // bounding rectangle for each segment
+  int *xmax;
+  int *ymin;
+  int *ymax;
+  size_t *ref;    // possibly a reference point for location
+  float *val1;
+  float *val2;  
+  int nr;         // number of found segments
+} dt_iop_segmentation_t;
+
+typedef struct dt_ff_stack_t
+{
+  int pos;
+  dt_pos_t *el;
+} dt_ff_stack_t;
+
+static inline void push_stack(int xpos, int ypos, dt_ff_stack_t *stack)
+{
+  const int i = stack->pos;
+  stack->el[i].xpos = xpos;
+  stack->el[i].ypos = ypos;
+  stack->pos++;
+}
+
+static inline dt_pos_t * pop_stack(dt_ff_stack_t *stack)
+{
+  if(stack->pos > 0) stack->pos--;  
+  return &stack->el[stack->pos];
+}
+
+void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, const int height, const int segments)
+{
+  seg->nr = 0;
+  seg->data =   dt_alloc_align(64, width * height * sizeof(int));
+  seg->size =   dt_alloc_align(64, segments * sizeof(int));
+  seg->xmin =   dt_alloc_align(64, segments * sizeof(int));
+  seg->xmax =   dt_alloc_align(64, segments * sizeof(int));
+  seg->ymin =   dt_alloc_align(64, segments * sizeof(int));
+  seg->ymax =   dt_alloc_align(64, segments * sizeof(int));
+  seg->ref =    dt_alloc_align(64, segments * sizeof(size_t));
+  seg->val1 =   dt_alloc_align_float(segments);
+  seg->val2 =   dt_alloc_align_float(segments);
+}
+
+void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
+{
+  dt_free_align(seg->data);
+  dt_free_align(seg->size);
+  dt_free_align(seg->xmin);
+  dt_free_align(seg->ymin);
+  dt_free_align(seg->xmax);
+  dt_free_align(seg->ymax);
+  dt_free_align(seg->ref);
+  dt_free_align(seg->val1);
+  dt_free_align(seg->val2);
+}
+
+static inline int _test_dilate(const int *img, const int i, const int w1, const int radius)
+{
+  int retval = 0;
+  retval = img[i-w1-1] | img[i-w1] | img[i-w1+1] |
+           img[i-1]    | img[i]    | img[i+1] |
+           img[i+w1-1] | img[i+w1] | img[i+w1+1];
+  if(retval || (radius < 2)) return retval;
+
+  const int w2 = 2*w1;
+  retval = img[i-w2-1] | img[i-w2]   | img[i-w2+1] |
+           img[i-w1-2] | img[i-w1+2] | 
+           img[i-2]    | img[i+2] |
+           img[i+w1-2] | img[i+w1+2] |
+           img[i+w2-1] | img[i+w2]   | img[i+w2+1];
+  if(retval || (radius < 3)) return retval;
+
+  const int w3 = 3*w1;
+  retval = img[i-w3-2] | img[i-w3-1] | img[i-w3] | img[i-w3+1] | img[i-w3+2] |
+           img[i-w2-3] | img[i-w2-2] | img[i-w2+2] | img[i-w2+3] |
+           img[i-w1-3] | img[i-w1+3] | 
+           img[i-3]    | img[i+3]    | 
+           img[i+w1-3] | img[i+w1+3] | 
+           img[i+w2-3] | img[i+w2-2] | img[i+w2+2] | img[i+w2+3] |
+           img[i+w3-2] | img[i+w3-1] | img[i+w3] | img[i+w3+1] | img[i+w3+2]; 
+  if(retval || (radius < 4)) return retval;
+
+  const int w4 = 4*w1;
+  retval = img[i-w4-2] | img[i-w4-1] | img[i-w4] | img[i-w4+1] | img[i-w4+2] |
+           img[i-w3-3] | img[i-w3+3] |
+           img[i-w2-4] | img[i-w2+4] | 
+           img[i-w1-4] | img[i-w1+4] | 
+           img[i-4]    | img[i+4] | 
+           img[i+w1-4] | img[i+w1+4] | 
+           img[i+w2-4] | img[i+w2+4] | 
+           img[i+w3-3] | img[i+w3+3] |
+           img[i+w4-2] | img[i+w4-1] | img[i+w4] | img[i+w4+1] | img[i+w4+2]; 
+  if(retval || (radius < 5)) return retval;
+
+  const int w5 = 5*w1;
+  retval = img[i-w5-2] | img[i-w5-1] | img[i-w5] | img[i-w5+1] | img[i-w5+2] |
+           img[i-w4-4] | img[i-w4+4] |
+           img[i-w3-4] | img[i-w3+4] |
+           img[i-w2-5] | img[i-w2+5] | 
+           img[i-w1-5] | img[i-w1+5] | 
+           img[i-5]    | img[i+5] | 
+           img[i+w1-5] | img[i+w1+5] | 
+           img[i+w2-5] | img[i+w2+5] |  
+           img[i+w3-4] | img[i+w3+4] | 
+           img[i+w4-4] | img[i+w4+4] |
+           img[i+w5-2] | img[i+w5-1] | img[i+w5] | img[i+w5+1] | img[i+w5+2]; 
+  if(retval || (radius < 6)) return retval;
+
+  const int w6 = 6*w1;
+  retval = img[i-w6-2] | img[i-w6-1] | img[i-w6] | img[i-w6+1] | img[i-w6+2] |
+           img[i-w5-4] | img[i-w5-3] | img[i-w5+3] | img[i-w5+4] |
+           img[i-w4-5] | img[i-w4+5] |
+           img[i-w3-5] | img[i-w3+5] |
+           img[i-w2-6] | img[i-w2+6] | 
+           img[i-w1-6] | img[i-w1+6] | 
+           img[i-6]    | img[i+6] | 
+           img[i+w1-6] | img[i+w1+6] | 
+           img[i+w2-6] | img[i+w2+6] |  
+           img[i+w3-5] | img[i+w3+5] | 
+           img[i+w4-5] | img[i+w4+5] |
+           img[i+w5-4] | img[i+w5-3] | img[i+w5+3] | img[i+w5+4] |
+           img[i+w6-2] | img[i+w6-1] | img[i+w6] | img[i+w6+1] | img[i+w6+2] ;
+  if(retval || (radius < 7)) return retval;
+
+  const int w7 = 7*w1;
+  retval = img[i-w7-3] | img[i-w7-2] | img[i-w7-1] | img[i-w7] | img[i-w7+1] | img[i-w7+2] | img[i-w7+3] | 
+           img[i-w6-4] | img[i-w6-3] | img[i-w6+3] | img[i-w6+4] | 
+           img[i-w5-5] | img[i-w5+5] |
+           img[i-w4-6] | img[i-w4+6] |
+           img[i-w3-6] | img[i-w3+6] |
+           img[i-w2-7] | img[i-w2+7] | 
+           img[i-w1-7] | img[i-w1+7] | 
+           img[i-7]    | img[i+7] | 
+           img[i+w1-7] | img[i+w1+7] | 
+           img[i+w2-7] | img[i+w2+7] |  
+           img[i+w3-6] | img[i+w3+6] | 
+           img[i+w4-6] | img[i+w4+6] |
+           img[i+w5-5] | img[i+w5+5] |
+           img[i+w6-4] | img[i+w6-3] | img[i+w6+3] | img[i+w6+4] | 
+           img[i+w7-3] | img[i+w7-2] | img[i+w7-1] | img[i+w7] | img[i+w7+1] | img[i+w7+2] | img[i+w7+3];
+  if(retval || (radius < 8)) return retval;
+
+  const int w8 = 8*w1;
+  retval = img[i-w8-3] | img[i-w8-2] | img[i-w8-1] | img[i-w8] | img[i-w8+1] | img[i-w8+2] | img[i-w8-3] | 
+           img[i-w7-5] | img[i-w7-4] | img[i-w7+4] | img[i-w7+5] | 
+           img[i-w6-6] | img[i-w6-5] | img[i-w6+5] | img[i-w6+6] | 
+           img[i-w5-7] | img[i-w5-6] | img[i-w5+6] | img[i-w5+7] | 
+           img[i-w4-7] | img[i-w4+7] |
+           img[i-w3-8] | img[i-w3-7] | img[i-w3+7] | img[i-w3+8] | 
+           img[i-w2-8] | img[i-w2+8] | 
+           img[i-w1-8] | img[i-w1+8] | 
+           img[i-8]    | img[i+8] | 
+           img[i+w1-8] | img[i+w1+8] | 
+           img[i+w2-8] | img[i+w2+8] |  
+           img[i+w3-8] | img[i+w3-7] | img[i+w3+7] | img[i+w3+8] | 
+           img[i+w4-7] | img[i+w4+7] |
+           img[i+w5-7] | img[i+w5-6] | img[i+w5+6] | img[i+w5+7] | 
+           img[i+w6-6] | img[i+w6-5] | img[i+w6+5] | img[i+w6+6] | 
+           img[i+w7-5] | img[i+w7-4] | img[i+w7+4] | img[i+w7+5] | 
+           img[i+w8-3] | img[i+w8-2] | img[i+w8-1] | img[i+w8] | img[i+w8+1] | img[i+w8+2] | img[i+w8+3];
+
+  return retval;
+}
+
+static inline void _dilating(const int *img, int *o, const int w1, const int height, const int border, const int radius)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, border, radius) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+      o[i] = _test_dilate(img, i, w1, radius);
+  }
+}
+
+static inline int _test_erode(const int *img, const int i, const int w1, const int radius)
+{
+  int retval = 1;
+  retval =     img[i-w1-1] & img[i-w1] & img[i-w1+1] &
+               img[i-1]    & img[i]    & img[i+1] &
+               img[i+w1-1] & img[i+w1] & img[i+w1+1];
+  if((retval == 0) || (radius < 2)) return retval;
+
+  const int w2 = 2*w1;
+  retval = img[i-w2-1] & img[i-w2]   & img[i-w2+1] &
+           img[i-w1-2] & img[i-w1+2] & 
+           img[i-2]    & img[i+2] &
+           img[i+w1-2] & img[i+w1+2] &
+           img[i+w2-1] & img[i+w2]   & img[i+w2+1];
+
+  if((retval == 0) || (radius < 3)) return retval;
+
+  const int w3 = 3*w1;
+  retval = img[i-w3-2] & img[i-w3-1] & img[i-w3] & img[i-w3+1] & img[i-w3+2] &
+           img[i-w2-3] & img[i-w2-2] & img[i-w2+2] & img[i-w2+3] &
+           img[i-w1-3] & img[i-w1+3] & 
+           img[i-3]    & img[i+3]    & 
+           img[i+w1-3] & img[i+w1+3] & 
+           img[i+w2-3] & img[i+w2-2] & img[i+w2+2] & img[i+w2+3] &
+           img[i+w3-2] & img[i+w3-1] & img[i+w3] & img[i+w3+1] & img[i+w3+2]; 
+  if((retval == 0) || (radius < 4)) return retval;
+
+  const int w4 = 4*w1;
+  retval = img[i-w4-2] & img[i-w4-1] & img[i-w4] & img[i-w4+1] & img[i-w4+2] &
+           img[i-w3-3] & img[i-w3+3] &
+           img[i-w2-4] & img[i-w2+4] & 
+           img[i-w1-4] & img[i-w1+4] & 
+           img[i-4]    & img[i+4] & 
+           img[i+w1-4] & img[i+w1+4] & 
+           img[i+w2-4] & img[i+w2+4] & 
+           img[i+w3-3] & img[i+w3+3] &
+           img[i+w4-2] & img[i+w4-1] & img[i+w4] & img[i+w4+1] & img[i+w4+2]; 
+  if((retval == 0) || (radius < 5)) return retval;
+
+  const int w5 = 5*w1;
+  retval = img[i-w5-2] & img[i-w5-1] & img[i-w5] & img[i-w5+1] & img[i-w5+2] &
+           img[i-w4-4] & img[i-w4+4] &
+           img[i-w3-4] & img[i-w3+4] &
+           img[i-w2-5] & img[i-w2+5] & 
+           img[i-w1-5] & img[i-w1+5] & 
+           img[i-5]    & img[i+5] & 
+           img[i+w1-5] & img[i+w1+5] & 
+           img[i+w2-5] & img[i+w2+5] &  
+           img[i+w3-4] & img[i+w3+4] & 
+           img[i+w4-4] & img[i+w4+4] &
+           img[i+w5-2] & img[i+w5-1] & img[i+w5] & img[i+w5+1] & img[i+w5+2]; 
+  if((retval == 0) || (radius < 6)) return retval;
+
+  const int w6 = 6*w1;
+  retval = img[i-w6-2] & img[i-w6-1] & img[i-w6] & img[i-w6+1] & img[i-w6+2] &
+           img[i-w5-4] & img[i-w5-3] & img[i-w5+3] & img[i-w5+4] &
+           img[i-w4-5] & img[i-w4+5] &
+           img[i-w3-5] & img[i-w3+5] &
+           img[i-w2-6] & img[i-w2+6] & 
+           img[i-w1-6] & img[i-w1+6] & 
+           img[i-6]    & img[i+6] & 
+           img[i+w1-6] & img[i+w1+6] & 
+           img[i+w2-6] & img[i+w2+6] &  
+           img[i+w3-5] & img[i+w3+5] & 
+           img[i+w4-5] & img[i+w4+5] &
+           img[i+w5-4] & img[i+w5-3] & img[i+w5+3] & img[i+w5+4] &
+           img[i+w6-2] & img[i+w6-1] & img[i+w6] & img[i+w6+1] & img[i+w6+2] ;
+  if((retval == 0) || (radius < 7)) return retval;
+
+  const int w7 = 7*w1;
+  retval = img[i-w7-3] & img[i-w7-2] & img[i-w7-1] & img[i-w7] & img[i-w7+1] & img[i-w7+2] & img[i-w7+3] & 
+           img[i-w6-4] & img[i-w6-3] & img[i-w6+3] & img[i-w6+4] & 
+           img[i-w5-5] & img[i-w5+5] &
+           img[i-w4-6] & img[i-w4+6] &
+           img[i-w3-6] & img[i-w3+6] &
+           img[i-w2-7] & img[i-w2+7] & 
+           img[i-w1-7] & img[i-w1+7] & 
+           img[i-7]    & img[i+7] & 
+           img[i+w1-7] & img[i+w1+7] & 
+           img[i+w2-7] & img[i+w2+7] &  
+           img[i+w3-6] & img[i+w3+6] & 
+           img[i+w4-6] & img[i+w4+6] &
+           img[i+w5-5] & img[i+w5+5] &
+           img[i+w6-4] & img[i+w6-3] & img[i+w6+3] & img[i+w6+4] & 
+           img[i+w7-3] & img[i+w7-2] & img[i+w7-1] & img[i+w7] & img[i+w7+1] & img[i+w7+2] & img[i+w7+3];
+  if((retval == 0) || (radius < 8)) return retval;
+
+  const int w8 = 8*w1;
+  retval = img[i-w8-3] & img[i-w8-2] & img[i-w8-1] & img[i-w8] & img[i-w8+1] & img[i-w8+2] & img[i-w8-3] & 
+           img[i-w7-5] & img[i-w7-4] & img[i-w7+4] & img[i-w7+5] & 
+           img[i-w6-6] & img[i-w6-5] & img[i-w6+5] & img[i-w6+6] & 
+           img[i-w5-7] & img[i-w5-6] & img[i-w5+6] & img[i-w5+7] & 
+           img[i-w4-7] & img[i-w4+7] &
+           img[i-w3-8] & img[i-w3-7] & img[i-w3+7] & img[i-w3+8] & 
+           img[i-w2-8] & img[i-w2+8] & 
+           img[i-w1-8] & img[i-w1+8] & 
+           img[i-8]    & img[i+8] & 
+           img[i+w1-8] & img[i+w1+8] & 
+           img[i+w2-8] & img[i+w2+8] &  
+           img[i+w3-8] & img[i+w3-7] & img[i+w3+7] & img[i+w3+8] & 
+           img[i+w4-7] & img[i+w4+7] &
+           img[i+w5-7] & img[i+w5-6] & img[i+w5+6] & img[i+w5+7] & 
+           img[i+w6-6] & img[i+w6-5] & img[i+w6+5] & img[i+w6+6] & 
+           img[i+w7-5] & img[i+w7-4] & img[i+w7+4] & img[i+w7+5] & 
+           img[i+w8-3] & img[i+w8-2] & img[i+w8-1] & img[i+w8] & img[i+w8+1] & img[i+w8+2] & img[i+w8+3];
+
+  return retval;
+}
+
+static inline void _eroding(const int *img, int *o, const int w1, const int height, const int border, const int radius)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(img, o) \
+  dt_omp_sharedconst(height, w1, border, radius) \
+  schedule(simd:static) aligned(o, img : 64)
+#endif
+  for(int row = border; row < height - border; row++)
+  {
+    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+      o[i] = _test_erode(img, i, w1, radius);
+  }
+}
+
+
+static inline void _intimage_borderfill(int *d, const int width, const int height, const int val, const int border)
+{
+  for(int i = 0; i < border * width; i++)                            
+    d[i] = val;
+  for(int i = (height - border - 1) * width; i < width*height; i++)
+    d[i] = val;
+  for(int row = border; row < height - border; row++)
+  {
+    int *p1 = d + row*width;
+    int *p2 = d + (row+1)*width - border;
+    for(int i = 0; i < border; i++)
+      p1[i] = p2[i] = val;
+  }
+}
+
+void dt_image_transform_dilate(int *img, const int width, const int height, const int radius, const int border)
+{
+  if(radius < 1) return;
+  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
+  if(!tmp) return;
+
+  _intimage_borderfill(img, width, height, 0, border);
+  _dilating(img, tmp, width, height, border, radius);
+  memcpy(img, tmp, width*height * sizeof(int));
+  dt_free_align(tmp);
+}
+  
+void dt_image_transform_erode(int *img, const int width, const int height, const int radius, const int border)
+{
+  if(radius < 1) return;
+  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
+  if(!tmp) return;
+
+  _intimage_borderfill(img, width, height, 1, border);
+  _eroding(img, tmp, width, height, border, radius);
+  memcpy(img, tmp, width*height * sizeof(int));
+  dt_free_align(tmp);
+}
+  
+void dt_image_transform_closing(int *img, const int width, const int height, const int radius, const int border)
+{
+  if(radius < 1) return;
+  dt_image_transform_dilate(img, width, height, radius, border);
+  dt_image_transform_erode(img, width, height, radius, border);
+}
+
+static int floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, const int w, const int h, const int id, dt_ff_stack_t *stack)
+{
+  if((id < 2) || (id >= HLMAXSEGMENTS - 1)) return 0;
+
+  int *d = seg->data;
+
+  int xp = 0;
+  int yp = 0;
+  size_t rp = 0;
+  int min_x = xin;
+  int max_x = xin;
+  int min_y = yin;
+  int max_y = yin;
+
+  int cnt = 0;
+  stack->pos = 0;
+
+  seg->size[id] = 0;
+  seg->ref[id] = 0;
+  seg->val1[id] = 0.0f;
+  seg->val2[id] = 0.0f;
+  seg->xmin[id] = min_x;
+  seg->xmax[id] = max_x;
+  seg->ymin[id] = min_y;
+  seg->ymax[id] = max_y;
+
+  push_stack(xin, yin, stack);
+  while(stack->pos)
+  {
+    dt_pos_t *coord = pop_stack(stack);
+    const int x = coord->xpos;
+    const int y = coord->ypos;
+    if(d[y*w+x] == 1)
+    {
+      int yUp = y - 1, yDown = y + 1;
+      gboolean lastXUp = FALSE, lastXDown = FALSE, firstXUp = FALSE, firstXDown = FALSE;
+      d[y*w+x] = id;
+      cnt++;
+      if(yUp >= HLBORDER && d[yUp*w+x] == 1)
+      {
+        push_stack(x, yUp, stack); firstXUp = lastXUp = TRUE;
+      }
+      else
+      {
+        xp = x;
+        yp = yUp;
+        rp = yp*w + xp;
+        if(xp > HLBORDER+2 && d[rp] == 0)
+        {
+          min_x = MIN(min_x, xp);
+          max_x = MAX(max_x, xp);
+          min_y = MIN(min_y, yp);
+          max_y = MAX(max_y, yp);
+          d[rp] = HLMAXSEGMENTS+id;
+        }
+      }
+      
+      if(yDown < h-HLBORDER && d[yDown*w+x] == 1)
+      {
+        push_stack(x, yDown, stack); firstXDown = lastXDown = TRUE;
+      }
+      else
+      {
+        xp = x;
+        yp = yDown;
+        rp = yp*w + xp;
+        if(yp < h-HLBORDER-3 && d[rp] == 0)
+        {
+          min_x = MIN(min_x, xp);
+          max_x = MAX(max_x, xp);
+          min_y = MIN(min_y, yp);
+          max_y = MAX(max_y, yp);
+          d[rp] = HLMAXSEGMENTS+id;
+        }
+      }
+      
+      int xr = x + 1;
+      while(xr < w-HLBORDER && d[y*w+xr] == 1)
+      {
+        d[y*w+xr] = id;
+        cnt++;
+        if(yUp >= HLBORDER && d[yUp*w + xr] == 1)
+        {
+          if(!lastXUp) { push_stack(xr, yUp, stack); lastXUp = TRUE; }
+        }
+        else
+        {
+          xp = xr;
+          yp = yUp;
+          rp = yp*w + xp;
+          if(yp > HLBORDER+2 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXUp = FALSE;
+        }
+
+        if(yDown < h-HLBORDER && d[yDown*w+xr] == 1)
+        {
+          if(!lastXDown) { push_stack(xr, yDown, stack); lastXDown = TRUE; }
+        }
+        else
+        {
+          xp = xr;
+          yp = yDown;
+          rp = yp*w + xp;
+          if(yp < h-HLBORDER-3 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXDown = FALSE;
+        }
+        xr++;
+      }
+
+      xp = xr;
+      yp = y;
+      rp = yp*w + xp;
+      if(xp < w-HLBORDER-3 && d[rp] == 0) 
+      {
+        min_x = MIN(min_x, xp);
+        max_x = MAX(max_x, xp);
+        min_y = MIN(min_y, yp);
+        max_y = MAX(max_y, yp);
+        d[rp] = HLMAXSEGMENTS+id;
+      }
+
+      int xl = x - 1;
+      lastXUp = firstXUp;
+      lastXDown = firstXDown;
+      while(xl >= HLBORDER && d[y*w+xl] == 1)
+      {
+        d[y*w+xl] = id;
+        cnt++;
+        if(yUp >= HLBORDER && d[yUp*w+xl] == 1)
+        {
+          if(!lastXUp) { push_stack(xl, yUp, stack); lastXUp = TRUE; }
+        }
+        else
+        {
+          xp = xl;
+          yp = yUp;
+          rp = yp*w + xp;
+          if(yp > HLBORDER+2 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXUp = FALSE;
+        }
+
+        if(yDown < h-HLBORDER && d[yDown*w+xl] == 1)
+        {
+          if(!lastXDown) { push_stack(xl, yDown, stack); lastXDown = TRUE; }
+        }
+        else
+        {
+          xp = xl;
+          yp = yDown;
+          rp = yp*w + xp;
+          if(yp < h-HLBORDER-3 && d[rp] == 0)
+          {
+            min_x = MIN(min_x, xp);
+            max_x = MAX(max_x, xp);
+            min_y = MIN(min_y, yp);
+            max_y = MAX(max_y, yp);
+            d[rp] = HLMAXSEGMENTS+id;
+          }
+          lastXDown = FALSE;
+        }
+        xl--;
+      }
+
+      d[y*w+x] = id;
+
+      xp = xl;
+      yp = y;
+      rp = yp*w + xp;
+      if(xp > HLBORDER+2 && d[rp] == 0)
+      {
+        min_x = MIN(min_x, xp);
+        max_x = MAX(max_x, xp);
+        min_y = MIN(min_y, yp);
+        max_y = MAX(max_y, yp);
+        d[rp] = HLMAXSEGMENTS+id;
+      }
+      cnt++;
+    }
+  }
+
+  seg->size[id] = cnt;
+  seg->xmin[id] = min_x;
+  seg->xmax[id] = max_x;
+  seg->ymin[id] = min_y;
+  seg->ymax[id] = max_y;
+  if(cnt) seg->nr += 1;
+  return cnt;
+}
+
+static void segmentize_plane(dt_iop_segmentation_t *seg, const int width, const int height)
+{
+  dt_ff_stack_t stack;  
+  stack.el = dt_alloc_align(16, width * height * sizeof(int));
+  if(!stack.el) return;
+ 
+  int id = 2;
+  for(int row = HLBORDER; row < height - HLBORDER; row++)
+  {
+    for(int col = HLBORDER; col < width - HLBORDER; col++)
+    {
+      if(id >= HLMAXSEGMENTS-1) goto finish;
+      if(seg->data[width * row + col] == 1)
+      {
+        if(floodfill_segmentize(row, col, seg, width, height, id, &stack) > 0) id++;
+      }
+    }
+  }
+
+  finish:
+  dt_free_align(stack.el);
+}
+

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -385,8 +385,15 @@ void dt_image_transform_erode(int *img, const int width, const int height, const
 void dt_image_transform_closing(int *img, const int width, const int height, const int radius, const int border)
 {
   if(radius < 1) return;
-  dt_image_transform_dilate(img, width, height, radius, border);
-  dt_image_transform_erode(img, width, height, radius, border);
+  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
+  if(!tmp) return;
+
+  _intimage_borderfill(img, width, height, 0, border);
+  _dilating(img, tmp, width, height, border, radius);
+ 
+  _intimage_borderfill(tmp, width, height, 1, border);
+  _eroding(tmp, img, width, height, border, radius);
+  dt_free_align(tmp);
 }
 
 static int floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, const int w, const int h, const int id, dt_ff_stack_t *stack)


### PR DESCRIPTION
This highlights recovery algorithms is based on ideas from Iain from the gmic team and has been
developed in collaboration with Iain and garagecoder (also from gmic).
It only works for bayer sensors and handles both spatial highlights and larger clipped areas equally.
No other external libraries are used, the code has been tuned for performance using omp, no
OpenCL codepath.

The user interface has two sliders (both with a knob to visualize the effect for user feedback),
the highlights module version has **not** changed so you can try out this pr without hassle.

Personally i have been using the new algorithm for months now, results (for me) are better than
what the other algos do in most cases, performance (on my 5yrs 8core intel) is kept well under
control taking less than 1 sec on 45Mpix images in all cases.

**How does the algo work**
We understand the bayer data as superpixels, each having one red, one blue and two green photosites,
we analyse all data on the channels independently so resulting in 4 color-**planes**.

In all 4 color planes we look for isolated areas being clipped (segments), these segments also include the
unclipped photosites at the borders. To combine small segments we use a morphological closing operation,
the radius of that UI op can be chosen interactively between 0 and 8.

Inside these segments (well - in fact precisely at unclipped locations at the borders) we look for a
**candidate** to represent the value we take for restoration. Choosing the **best** candidate is done via
a weighing function based on a) the local standard deviation in a 5x5 area as we want a candidate from a
smooth part, b) the median value of unclipped positions also in a 5x5 area as candidates from a dark
border section are often bad and c) a weighing threshold presented in the user interface as **candidates**.

After finding the best candidate for every segment in every plane we inpaint data on every clipped photosite.
The core principle is to inpaint pseudo-chromacity, calculated by subtracting opponent channel means rather
than luminance. (For better stability we calculate data in cube roots for an estimate btw.)

The inpainted data are not in the normalized 0->1 range any more, so in dt speech or as AP would probably say
are scene-referred.

**Problems and possibly how to treat**
1. As you might imagine the segmentation is based on the clipping threshold. Thus also the candidate selection
and inpainting is based on this. So you might have to play with the clip value for best results. (there is
some code increasing border stability but still needs UI feeding)
2. Due to dt's region-of-interest concept the inpainted colors might be vastly wrong while zooming in.
3. As we don't do any AI on content (i tested an additional felzenzwalb segmentation btw) connecting segments
via the morphological combine function might not work good enough, if you find such a problem you will have
to find other ways to handle highlights.
4. Segments surrounded by 'wide' dark borders (or in other words can't be connected via the morphological
combining) always have to rely on some basic inpainting without a good candidate.
This is mostly "better than nothing" but in some cases it simply doesn't work well. You should try to tune
the candidates slider here. A 'classic' situation would be bright lights like color lamps in a mostly very
dark image.
5. Images with difficult lighting situations (see 'bar and bottles' in the testset) are heavy stuff but the
other algos also struggle badly here.
6. The segmentation analyses the whole region-of-interest so tiling does not work in this algorithm. The memory footprint
of the algo thus might be too high for low-mem systems (<8GB) 


**Slider knobs**
Both give false-color representations in the darkroom display
1. combine: basically shows the segment borders. As these grow with combining segments you get an idea how
close segments are connected.
2. candidates: highlighted are segments without a 'good candidate'.



**Footnotes:**
1. Iain idea can be seen in https://discuss.pixls.us/t/highlight-recovery-teaser/17670 or in a
late video here https://discuss.pixls.us/t/next-live-meeting-saturday-16-july-12-00-utc/31507
2. A testset for severely highlights impaired images has been presented at https://discuss.pixls.us/t/highlight-recovery-test-set/28801
3. The here used segmentation algorithm is a novel algo based on a standard floodfill extended to a) fill in
segment identifiers, b) mark border locations and c) keep information of the bounding rectangle of a segment.
I also tried out a classic felzenzwalb but the chosen algo was safest. Please note that Iain used a watershed
algo in his prototype code.
4. The morphological operations have not been implemented in a 'general' way but are restricted to
a radius of 8 for performance reasons.
5. The 'reference plane' in Iain prototype used to be the minimum of all planes, as garagecoder suggested we
now use a color coeff based weighed average reference leading to much better color cast control. The cost in
quality is a subtle loss of details. To reduce chroma noise the values taken from individual channels are
slightly gaussian blurred.
6. Missing from Iain original idea is the 'recovery' in clipped areas, that might be added in the next version.
(That part of the code is surprisingly tricky if we want it to handle well all real-world situations. Existing preliminary
solutions are based on distance and border gradients.) 
  