### PR TITLE
fix time offset calculation when offset ist more than 36 minutes (32b…

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1894,7 +1894,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
 }
 
 static void _add_datetime_offset(const uint32_t imgid, const char *odt,
-                                 const long int offset, char *ndt)
+                                 const GTimeSpan offset, char *ndt)
 {
   // get the datetime_taken and calculate the new time
   GDateTime *datetime_original = dt_datetime_exif_to_gdatetime(odt, darktable.utc_tz);


### PR DESCRIPTION
…it integer overflow)

Bug (at least on Windows) when applying a time offset in the geotagging module when the offset is lager than about 36 minutes (2^31 microseconds). The 64 bit time offset got squeezed into a long int in the call to _add_datetime_offset which is only guaranteed to be 32 bits.

BTW: Is it recommended to open an issue before making a PR?