### PR TITLE
OpenCL preferences setting decoupled from pixelpipe

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1143,6 +1143,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
 #ifdef HAVE_OPENCL
   dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+  dt_opencl_update_settings();
 #endif
 
   darktable.points = (dt_points_t *)calloc(1, sizeof(dt_points_t));

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2989,15 +2989,6 @@ int dt_opencl_update_settings(void)
     dt_opencl_apply_scheduling_profile(profile);
   }
 
-  dt_opencl_sync_cache_t sync = dt_opencl_get_sync_cache();
-
-  if(cl->sync_cache != sync)
-  {
-    const char *pstr = dt_conf_get_string_const("opencl_synch_cache");
-    dt_print(DT_DEBUG_OPENCL, "[opencl_update_synch_cache] sync cache set to %s\n", pstr);
-    cl->sync_cache = sync;
-  }
-
   return (cl->enabled && !cl->stopped);
 }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2963,33 +2963,30 @@ void dt_opencl_disable(void)
   dt_conf_set_bool("opencl", FALSE);
 }
 
-
-/** update enabled flag and profile with value from preferences, returns enabled flag */
-int dt_opencl_update_settings(void)
+/** runtime check for cl system running */
+gboolean dt_opencl_running(void)
 {
   dt_opencl_t *cl = darktable.opencl;
-  // FIXME: This pulls in prefs every time the pixelpipe runs. Instead have a callback for DT_SIGNAL_PREFERENCES_CHANGE?
+  if(!cl) return FALSE;
   if(!cl->inited) return FALSE;
-  const int prefs = dt_conf_get_bool("opencl");
+  return (cl->enabled && !cl->stopped);
+}
 
-  if(cl->enabled != prefs)
-  {
-    cl->enabled = prefs;
-    cl->stopped = 0;
-    cl->error_count = 0;
-    dt_print(DT_DEBUG_OPENCL, "[opencl_update_enabled] enabled flag set to %s\n", prefs ? "ON" : "OFF");
-  }
+/** update enabled flag and profile with value from preferences */
+void dt_opencl_update_settings(void)
+{
+  dt_opencl_t *cl = darktable.opencl;
+  if(!cl) return;
+  if(!cl->inited) return;
+
+  cl->enabled = dt_conf_get_bool("opencl");
+  cl->stopped = 0;
+  cl->error_count = 0;
 
   dt_opencl_scheduling_profile_t profile = dt_opencl_get_scheduling_profile();
-
-  if(cl->scheduling_profile != profile)
-  {
-    const char *pstr = dt_conf_get_string_const("opencl_scheduling_profile");
-    dt_print(DT_DEBUG_OPENCL, "[opencl_update_scheduling_profile] scheduling profile set to %s\n", pstr);
-    dt_opencl_apply_scheduling_profile(profile);
-  }
-
-  return (cl->enabled && !cl->stopped);
+  dt_opencl_apply_scheduling_profile(profile);
+  const char *pstr = dt_conf_get_string_const("opencl_scheduling_profile");
+  dt_vprint(DT_DEBUG_OPENCL, "[opencl_update_settings] scheduling profile set to %s\n", pstr);
 }
 
 /** read scheduling profile for config variables */

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -362,8 +362,11 @@ void dt_opencl_disable(void);
 /** get OpenCL tuning mode flags */
 int dt_opencl_get_tuning_mode(void);
 
-/** update enabled flag and profile with value from preferences, returns enabled flag */
-int dt_opencl_update_settings(void);
+/** runtime check for cl system running */
+gboolean dt_opencl_running(void);
+
+/** update enabled flag and profile with value from preferences */
+void dt_opencl_update_settings(void);
 
 /** HAVE_OPENCL mode only: copy and alloc buffers. */
 int dt_opencl_copy_device_to_host(const int devid, void *host, void *device, const int width,
@@ -597,9 +600,13 @@ static inline int dt_opencl_get_tuning_mode(void)
 {
   return 0;
 }
-static inline int dt_opencl_update_settings(void)
+static inline gboolean dt_opencl_running(void)
 {
-  return 0;
+  return FALSE;
+}
+static inline void dt_opencl_update_settings(void)
+{
+  return ;
 }
 static inline gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const size_t height,
                                               const unsigned bpp, const float factor, const size_t overhead)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2151,7 +2151,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, int x,
                              float scale)
 {
   pipe->processing = 1;
-  pipe->opencl_enabled = dt_opencl_update_settings(); // update enabled flag and profile from preferences
+  pipe->opencl_enabled = dt_opencl_running();
   pipe->devid = (pipe->opencl_enabled) ? dt_opencl_lock_device(pipe->type)
                                        : -1; // try to get/lock opencl resource
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -723,6 +723,7 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
     dt_thumbnail_resize(th, th->width, th->height, TRUE, zoom_ratio);
   }
   dt_get_sysresource_level();
+  dt_opencl_update_settings();
   dt_configure_ppd_dpi(darktable.gui);
 }
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1287,6 +1287,7 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
 {
   if(!user_data) return;
   dt_get_sysresource_level();
+  dt_opencl_update_settings();
   dt_configure_ppd_dpi(darktable.gui);
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1888,6 +1888,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_visible(display_intent, FALSE);
   }
   dt_get_sysresource_level();
+  dt_opencl_update_settings();
   dt_configure_ppd_dpi(darktable.gui);
 }
 


### PR DESCRIPTION
Until now we used `int dt_opencl_update_settings(void)` in the pixelpipe testing for an up&running CL system also checking for possibly updated preferences.

Now we change the preferences via a signalled callback calling `void dt_opencl_update_settings(void);` and leave the testing for a minimal `gboolean dt_opencl_running(void)` thus pixelpipe has no possible overhead.

As the opencl sync mode is not exposed in preferences UI we just have to check that once when initializing the opencl subsystem.