### PR TITLE
png: try to get colorspace from cICP chunk as well

### DIFF
--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -203,12 +203,9 @@ int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorsp
     goto out;
   }
 
-  if(avif_image.icc.size > 0)
+  avifRWData *icc = &avif_image.icc;
+  if(icc->size && icc->data)
   {
-    avifRWData *icc = &avif_image.icc;
-
-    if(icc->data == NULL) goto out;
-
     *out = (uint8_t *)g_malloc0(icc->size);
     memcpy(*out, icc->data, icc->size);
     size = icc->size;
@@ -260,4 +257,3 @@ out:
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -57,6 +57,11 @@ int read_header(const char *filename, dt_imageio_png_t *png)
     return 1;
   }
 
+  /* TODO: gate by version once known cICP chunk read support is added to libpng */
+#ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED
+  png_set_keep_unknown_chunks(png->png_ptr, 3, (png_const_bytep) "cICP", 1);
+#endif
+
   png->info_ptr = png_create_info_struct(png->png_ptr);
   if(!png->info_ptr)
   {
@@ -212,12 +217,17 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   return DT_IMAGEIO_OK;
 }
 
-int dt_imageio_png_read_profile(const char *filename, uint8_t **out)
+int dt_imageio_png_read_profile(const char *filename, uint8_t **out, dt_colorspaces_cicp_t *cicp)
 {
+  /* set default return values */
+  *out = NULL;
+  cicp->color_primaries = DT_CICP_COLOR_PRIMARIES_UNSPECIFIED;
+  cicp->transfer_characteristics = DT_CICP_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+  cicp->matrix_coefficients = DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED;
+
   dt_imageio_png_t image;
   png_charp name;
-  int compression_type;
-  png_uint_32 proflen;
+  png_uint_32 proflen = 0;
 
 #if PNG_LIBPNG_VER >= 10500 /* 1.5.0 */
   png_bytep profile;
@@ -229,16 +239,35 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out)
 
   if(read_header(filename, &image) != 0) return DT_IMAGEIO_FILE_CORRUPTED;
 
+  /* TODO: also add check for known cICP chunk read support once added to libpng */
+#ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED
+  png_unknown_chunkp unknowns = NULL;
+  const int num = png_get_unknown_chunks(image.png_ptr, image.info_ptr, &unknowns);
+  for(size_t c = 0; c < num; ++c)
+    if(!strcmp((const char *)unknowns[c].name, "cICP"))
+    {
+      /* only RGB (i.e. matrix coeffs 0 in data[2]) and full range (1 in data[3]) pixel values are supported by the
+       * loader above and dt color management */
+      if(!unknowns[c].data[2] && unknowns[c].data[3])
+      {
+        cicp->color_primaries = (dt_colorspaces_cicp_color_primaries_t)unknowns[c].data[0];
+        cicp->transfer_characteristics = (dt_colorspaces_cicp_transfer_characteristics_t)unknowns[c].data[1];
+        cicp->matrix_coefficients = (dt_colorspaces_cicp_matrix_coefficients_t)unknowns[c].data[2];
+      }
+      else
+        dt_print(DT_DEBUG_IMAGEIO, "[png_open] encountered YUV and/or narrow-range image `%s', assuming unknown CICP\n", filename);
+      break;
+    }
+#endif
+
 #ifdef PNG_iCCP_SUPPORTED
   if(png_get_valid(image.png_ptr, image.info_ptr, PNG_INFO_iCCP) != 0
-     && png_get_iCCP(image.png_ptr, image.info_ptr, &name, &compression_type, &profile, &proflen) != 0)
+     && png_get_iCCP(image.png_ptr, image.info_ptr, &name, NULL, &profile, &proflen) != 0)
   {
     *out = (uint8_t *)g_malloc(proflen);
     memcpy(*out, profile, proflen);
   }
-  else
 #endif
-    proflen = 0;
 
   png_destroy_read_struct(&image.png_ptr, &image.info_ptr, NULL);
   fclose(image.f);
@@ -251,4 +280,3 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/imageio_png.h
+++ b/src/common/imageio_png.h
@@ -38,11 +38,10 @@ int read_header(const char *filename, dt_imageio_png_t *png);
 int read_image(dt_imageio_png_t *png, void *out);
 
 dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
-int dt_imageio_png_read_profile(const char *filename, uint8_t **out);
+int dt_imageio_png_read_profile(const char *filename, uint8_t **out, dt_colorspaces_cicp_t *cicp);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1803,7 +1803,7 @@ void reload_defaults(dt_iop_module_t *module)
   dt_colorspaces_color_profile_type_t color_profile = DT_COLORSPACE_NONE;
 
   // some file formats like jpeg can have an embedded color profile
-  // currently we only support jpeg, j2k, tiff and png
+  // currently we only support jpeg, j2k, tiff, png, avif, and heif
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, module->dev->image_storage.id, 'w');
 
   if(!img->profile)
@@ -1847,17 +1847,21 @@ void reload_defaults(dt_iop_module_t *module)
     }
     else if(!strcmp(ext, "png"))
     {
-      img->profile_size = dt_imageio_png_read_profile(filename, &img->profile);
-      color_profile = (img->profile_size > 0) ? DT_COLORSPACE_EMBEDDED_ICC : DT_COLORSPACE_NONE;
+      dt_colorspaces_cicp_t cicp;
+      img->profile_size = dt_imageio_png_read_profile(filename, &img->profile, &cicp);
+      /* PNG spec says try the cICP chunk first, but rather than ignoring, we also try any ICC profile present if
+       * CICP combo is unsupported */
+      if((color_profile = dt_colorspaces_cicp_to_type(&cicp, filename)) == DT_COLORSPACE_NONE)
+        color_profile = (img->profile_size > 0) ? DT_COLORSPACE_EMBEDDED_ICC : DT_COLORSPACE_NONE;
     }
 #ifdef HAVE_LIBAVIF
     else if(!strcmp(ext, "avif"))
     {
       dt_colorspaces_cicp_t cicp;
       img->profile_size = dt_imageio_avif_read_profile(filename, &img->profile, &cicp);
-      /* try the nclx box before falling back to any ICC profile */
-      if((color_profile = dt_colorspaces_cicp_to_type(&cicp, filename)) == DT_COLORSPACE_NONE)
-        color_profile = (img->profile_size > 0) ? DT_COLORSPACE_EMBEDDED_ICC : DT_COLORSPACE_NONE;
+      /* AVIF spec gives priority to ICC profile over CICP; only one valid kind is returned above anyway */
+      color_profile
+          = (img->profile_size > 0) ? DT_COLORSPACE_EMBEDDED_ICC : dt_colorspaces_cicp_to_type(&cicp, filename);
     }
 #endif
 #ifdef HAVE_LIBHEIF
@@ -1871,9 +1875,9 @@ void reload_defaults(dt_iop_module_t *module)
     {
       dt_colorspaces_cicp_t cicp;
       img->profile_size = dt_imageio_heif_read_profile(filename, &img->profile, &cicp);
-      /* try the nclx box before falling back to any ICC profile */
-      if((color_profile = dt_colorspaces_cicp_to_type(&cicp, filename)) == DT_COLORSPACE_NONE)
-        color_profile = (img->profile_size > 0) ? DT_COLORSPACE_EMBEDDED_ICC : DT_COLORSPACE_NONE;
+      /* HEIF spec gives priority to ICC profile over CICP; only one valid kind is returned above anyway */
+      color_profile
+          = (img->profile_size > 0) ? DT_COLORSPACE_EMBEDDED_ICC : dt_colorspaces_cicp_to_type(&cicp, filename);
     }
 #endif
     g_free(ext);
@@ -1897,7 +1901,7 @@ void reload_defaults(dt_iop_module_t *module)
     d->type = DT_COLORSPACE_ADOBERGB;
   else if(dt_image_is_ldr(img))
     d->type = DT_COLORSPACE_SRGB;
-  else if(!isnan(img->d65_color_matrix[0])) // image is DNG
+  else if(!isnan(img->d65_color_matrix[0])) // image is DNG, EXR, or RGBE
     d->type = DT_COLORSPACE_EMBEDDED_MATRIX;
   else if(dt_image_is_matrix_correction_supported(img)) // image is raw
     d->type = DT_COLORSPACE_STANDARD_MATRIX;
@@ -2097,4 +2101,3 @@ void gui_cleanup(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
This was added in the recent PNG spec revision: https://w3c.github.io/PNG-spec/#11cICP but not to libpng yet, so "unknown" chunk support is leveraged for the time being.

Also be more a bit more tolerant when decoding the AVIF color profile.