### PR TITLE
histogram: shrink display to not crop primary/secondary nodes

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -964,7 +964,8 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 {
   const float vs_radius = d->vectorscope_radius;
   const int diam_px = d->vectorscope_diameter_px;
-  const int min_size = MIN(width, height);
+  const double node_radius = DT_PIXEL_APPLY_DPI(2.);
+  const int min_size = MIN(width, height) - node_radius * 2.0;
   const double scale = min_size / (vs_radius * 2.);
 
   cairo_save(cr);
@@ -1048,7 +1049,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   {
     const float x = d->hue_ring[n][0][0];
     const float y = d->hue_ring[n][0][1];
-    cairo_arc(cr, x*scale, y*scale, DT_PIXEL_APPLY_DPI(2.), 0., M_PI * 2.);
+    cairo_arc(cr, x*scale, y*scale, node_radius, 0., M_PI * 2.);
     cairo_set_source(cr, bkgd_pat);
     cairo_fill_preserve(cr);
     set_color(cr, darktable.bauhaus->graph_grid);


### PR DESCRIPTION
Scale the histogram so that the edge of the outermost node is at the boundary of the widget. Previously it was scaled such that the center of the outermost node was at the edge.

Fixes #11381.

Before:

![2022-07-27 vectorscope git master](https://user-images.githubusercontent.com/2311860/181301580-a6b715f2-dc53-4497-b907-20bbf40482d8.png)

After:

![2022-07-27 vectorscope no clip nodes](https://user-images.githubusercontent.com/2311860/181301613-ae8d5f26-d70f-4092-89a5-58857d8fff4f.png)

This looks tidier to me, but at the same time we're now shrinking the vectorscope by a few pixels, to get in the outer edges of the node circle, and the vectorscope is already strained for vertical space.

It would be possible to recenter the vectorscope so that the highest/lowest nodes were at the top/bottom of the widget respectively, and scale it up. The advantage would be increase the size of the graph. The disadvantage would be that the center of the graph would no longer but at the center of the widget, which might be confusing when identifying neutral colors, plus this would add code complexity.

@todd-prior: In particular as you filed the bug, I'd be curious for thoughts.