### PR TITLE
print: allow for exporting to linear Rec2020

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1294,6 +1294,15 @@ static GList* _get_profiles()
   prof->ppos = -2;
   list = g_list_prepend(list, prof);
 
+  // chances are this is the working profile, and hence reasonable to
+  // use as the export profile before we convert to printer profile
+  prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
+  prof->type = DT_COLORSPACE_LIN_REC2020;
+  dt_utf8_strlcpy(prof->name, _("linear Rec2020 RGB"), sizeof(prof->name));
+  prof->pos = -2;
+  prof->ppos = -2;
+  list = g_list_prepend(list, prof);
+
   // add the profiles from datadir/color/out/*.icc
   for(GList *iter = darktable.color_profiles->profiles; iter; iter = g_list_next(iter))
   {


### PR DESCRIPTION
Chances are that Rec.2020 is the working profile, and hence this is a reasonable gamut into which to export, compared to the extant choices of sRGB and Adobe RGB.

As colorout currently uses Lab as its input colorspace, there will still be an unneeded colorspace hop (working profile -> Lab -> Rec2020) during the colorout iop in export.

Some questions about the efficacy of this:

1. Would it be better (or an addition improvement) to allow for export to "working profile"?
2. So long as colorspace conversions to sRGB and Adobe RGB are unbounded and the conversion isn't perceptual, does the gamut of the export colorspace matter?
3. Why not just export directly to the printer profile, so that the ensuing conversion to printer profile is a no-op (assuming that conversion is relative colorimetric)?
4. Would exporting to Lab (the current input colorspace of colorout) be sensible, if colorout is the last iop in the pixelpipe? Or is the ideal that eventually colorout will take input in the working profile?

FWIW, I've ran test prints with a range of export profiles (sRGB, Adobe RGB, internal linear Rec2020, Rec2020 from Argyll, and a custom made printer profile) with conversion either perceptual or relative colorimetric. There are subtle differences, but it's hard to pin down which one is most "correct". (Though doing a perceptual intent in export and print conversions is most clearly _not_ correct.)